### PR TITLE
docs: fix typo in example link

### DIFF
--- a/docs/content/docs/foundations/control-flow-patterns.mdx
+++ b/docs/content/docs/foundations/control-flow-patterns.mdx
@@ -70,7 +70,7 @@ export async function runExternalTask(userId: string) {
 
 ## A full example
 
-Here's a simplified example taken from the [birthday card generator demo](https://github.com/vercel/workflow/tree/main/examples/birthday-card-generator), to illustrate how more complex orchestration can be modelled in promises.
+Here's a simplified example taken from the [birthday card generator demo](https://github.com/vercel/workflow-examples/tree/main/birthday-card-generator), to illustrate how more complex orchestration can be modelled in promises.
 
 ```typescript lineNumbers
 import { createWebhook, sleep } from "workflow"


### PR DESCRIPTION
The control flow patterns page had a dead link to an example in `vercel/workflow` instead of `vercel/workflow-examples`