### PR TITLE
docs: improve dark mode readability for info callouts

### DIFF
--- a/docs/components/ui/callout.tsx
+++ b/docs/components/ui/callout.tsx
@@ -13,7 +13,7 @@ export function Callout({ children, type = 'info' }: CalloutProps) {
         'bg-fd-error/25 text-fd-error border border-fd-error/20',
         type === 'wip' && 'bg-primary/5 border-primary/25 text-primary',
         type === 'info' &&
-          'bg-primary-blue/10 text-blue-900 border border-primary-blue/25',
+          'bg-primary-blue/10 dark:text-blue-100 text-blue-900 border border-primary-blue/25',
         type === 'warn' &&
           'bg-amber-600/15 text-amber-600 border border-amber-600/30',
         'rounded-md px-4 py-2 [&_p]:m-0 [&_p]:text-current flex items-start gap-2'


### PR DESCRIPTION
before:

<img width="839" height="280" alt="image" src="https://github.com/user-attachments/assets/a0c3d16d-e9b6-4aab-8554-89b33d730a59" />


after:

<img width="855" height="269" alt="image" src="https://github.com/user-attachments/assets/a377db91-c679-4ed7-88fc-235d549c3a05" />
