### PR TITLE
Move idempotency page down

### DIFF
--- a/docs/content/docs/foundations/meta.json
+++ b/docs/content/docs/foundations/meta.json
@@ -4,9 +4,9 @@
     "workflows-and-steps",
     "control-flow-patterns",
     "errors-and-retries",
-    "idempotency",
     "hooks",
-    "serialization"
+    "serialization",
+    "idempotency"
   ],
   "defaultOpen": true
 }


### PR DESCRIPTION
Just reordering the foundation page to show hooks and serialization further up