### PR TITLE
Generate the webhook route in the static builder

### DIFF
--- a/.changeset/light-rice-rush.md
+++ b/.changeset/light-rice-rush.md
@@ -1,0 +1,5 @@
+---
+"@workflow/cli": patch
+---
+
+Generate the webhook route in the static builder mode

--- a/packages/cli/src/lib/builders/vercel-static.ts
+++ b/packages/cli/src/lib/builders/vercel-static.ts
@@ -14,6 +14,7 @@ export class VercelStaticBuilder extends BaseBuilder {
     };
     await this.buildStepsBundle(options);
     await this.buildWorkflowsBundle(options);
+    await this.buildWebhookFunction();
 
     await this.buildClientLibrary();
   }
@@ -75,6 +76,25 @@ export class VercelStaticBuilder extends BaseBuilder {
       inputFiles,
       tsBaseUrl,
       tsPaths,
+    });
+  }
+
+  private async buildWebhookFunction(): Promise<void> {
+    console.log(
+      'Creating vercel API webhook bundle at',
+      this.config.webhookBundlePath
+    );
+
+    const webhookBundlePath = resolve(
+      this.config.workingDir,
+      this.config.webhookBundlePath
+    );
+
+    // Ensure directory exists
+    await mkdir(dirname(webhookBundlePath), { recursive: true });
+
+    await this.createWebhookBundle({
+      outfile: webhookBundlePath,
     });
   }
 }

--- a/packages/cli/src/lib/builders/webhook-route.test.ts
+++ b/packages/cli/src/lib/builders/webhook-route.test.ts
@@ -28,6 +28,7 @@ describe('Webhook route generation', () => {
         workingDir: testDir,
         stepsBundlePath: '',
         workflowsBundlePath: '',
+        webhookBundlePath: '',
         watch: false,
         externalPackages: [],
       };
@@ -72,6 +73,7 @@ describe('Webhook route generation', () => {
         workingDir: testDir,
         stepsBundlePath: '',
         workflowsBundlePath: '',
+        webhookBundlePath: '',
         watch: false,
         externalPackages: [],
       };
@@ -104,6 +106,7 @@ describe('Webhook route generation', () => {
         workingDir: testDir,
         stepsBundlePath: '',
         workflowsBundlePath: '',
+        webhookBundlePath: '',
         watch: false,
         externalPackages: [],
       };
@@ -137,6 +140,7 @@ describe('Webhook route generation', () => {
         workingDir: testDir,
         stepsBundlePath: '',
         workflowsBundlePath: '',
+        webhookBundlePath: '',
         watch: false,
         externalPackages: [],
       };
@@ -176,6 +180,7 @@ describe('Webhook route generation', () => {
         workingDir: testDir,
         stepsBundlePath: '',
         workflowsBundlePath: '',
+        webhookBundlePath: '',
         watch: false,
         externalPackages: [],
       };
@@ -217,6 +222,7 @@ describe('Webhook route generation', () => {
         workingDir: testDir,
         stepsBundlePath: '',
         workflowsBundlePath: '',
+        webhookBundlePath: '',
         watch: false,
         externalPackages: [],
       };
@@ -254,6 +260,7 @@ describe('Webhook route generation', () => {
         workingDir: testDir,
         stepsBundlePath: '',
         workflowsBundlePath: '',
+        webhookBundlePath: '',
         watch: false,
         externalPackages: [],
       };

--- a/packages/cli/src/lib/config/types.ts
+++ b/packages/cli/src/lib/config/types.ts
@@ -26,6 +26,7 @@ export interface WorkflowConfig {
   buildTarget: BuildTarget;
   stepsBundlePath: string;
   workflowsBundlePath: string;
+  webhookBundlePath: string;
 
   // Optionally generate a client library for workflow execution. The preferred
   // method of using workflow is to use a loader within a framework (like

--- a/packages/cli/src/lib/config/workflow-config.ts
+++ b/packages/cli/src/lib/config/workflow-config.ts
@@ -17,6 +17,7 @@ export const getWorkflowConfig = (
     buildTarget: buildTarget as BuildTarget,
     stepsBundlePath: './.well-known/workflow/v1/step.js',
     workflowsBundlePath: './.well-known/workflow/v1/flow.js',
+    webhookBundlePath: './.well-known/workflow/v1/webhook.js',
     workflowManifestPath: workflowManifest,
 
     // WIP: generate a client library to easily execute workflows/steps

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -90,8 +90,9 @@ export function withWorkflow({
         dirs: ['pages', 'app', 'src/pages', 'src/app'],
         workingDir: process.cwd(),
         buildTarget: 'next',
-        workflowsBundlePath: '',
-        stepsBundlePath: '',
+        workflowsBundlePath: '', // not used in base
+        stepsBundlePath: '', // not used in base
+        webhookBundlePath: '', // node used in base
         externalPackages: [
           ...require('next/dist/lib/server-external-packages.json'),
           ...(nextConfig.serverExternalPackages || []),

--- a/packages/nitro/src/builders.ts
+++ b/packages/nitro/src/builders.ts
@@ -9,6 +9,7 @@ const CommonBuildOptions = {
   buildTarget: 'next' as const, // unused in base
   stepsBundlePath: '', // unused in base
   workflowsBundlePath: '', // unused in base
+  webhookBundlePath: '', // unused in base
 };
 
 export class VercelBuilder extends VercelBuildOutputAPIBuilder {


### PR DESCRIPTION
`workflow build` was not generating the webhook route. This fixes that. Will follow up to rename the static builder from the old name, `vercel-static`