### PR TITLE
Rename vercel static builder to standalone builder

### DIFF
--- a/.changeset/famous-jeans-itch.md
+++ b/.changeset/famous-jeans-itch.md
@@ -1,0 +1,5 @@
+---
+"@workflow/cli": patch
+---
+
+Rename vercel-static builder to standalone

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,7 +1,7 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../base.js';
 import { VercelBuildOutputAPIBuilder } from '../lib/builders/vercel-build-output-api.js';
-import { VercelStaticBuilder } from '../lib/builders/vercel-static.js';
+import { StandaloneBuilder } from '../lib/builders/standalone.js';
 import { type BuildTarget, isValidBuildTarget } from '../lib/config/types.js';
 import { getWorkflowConfig } from '../lib/config/workflow-config.js';
 
@@ -11,15 +11,15 @@ export default class Build extends BaseCommand {
   static examples = [
     '$ workflow build',
     '$ workflow build --target vercel-build-output-api',
-    '$ workflow build vercel-static',
+    '$ workflow build standalone',
   ];
 
   static flags = {
     target: Flags.string({
       char: 't',
       description: 'build target',
-      options: ['vercel-static', 'vercel-build-output-api'],
-      default: 'vercel-static',
+      options: ['standalone', 'vercel-build-output-api'],
+      default: 'standalone',
     }),
     'workflow-manifest': Flags.string({
       char: 'm',
@@ -59,10 +59,10 @@ export default class Build extends BaseCommand {
     // Validate build target
     if (!isValidBuildTarget(buildTarget)) {
       this.logWarn(
-        `Invalid target "${buildTarget}". Using default "vercel-static".`
+        `Invalid target "${buildTarget}". Using default "standalone".`
       );
-      this.logWarn('Valid targets: vercel-static, vercel-build-output-api');
-      buildTarget = 'vercel-static';
+      this.logWarn('Valid targets: standalone, vercel-build-output-api');
+      buildTarget = 'standalone';
     }
 
     this.logInfo(`Using target: ${buildTarget}`);
@@ -74,9 +74,9 @@ export default class Build extends BaseCommand {
 
     try {
       // Build using appropriate builder
-      if (config.buildTarget === 'vercel-static') {
-        this.logInfo('Building with VercelStaticBuilder');
-        const builder = new VercelStaticBuilder(config);
+      if (config.buildTarget === 'standalone') {
+        this.logInfo('Building with StandaloneBuilder');
+        const builder = new StandaloneBuilder(config);
         await builder.build();
       } else if (config.buildTarget === 'vercel-build-output-api') {
         this.logInfo('Building with VercelBuildOutputAPIBuilder');

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -16,8 +16,8 @@ export default class Dev extends BaseCommand {
     target: Flags.string({
       char: 't',
       description: 'build target for development',
-      options: ['vercel-static', 'vercel-build-output-api'],
-      default: 'vercel-static',
+      options: ['standalone', 'vercel-build-output-api'],
+      default: 'standalone',
     }),
   };
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -13,7 +13,7 @@ export default class Init extends BaseCommand {
   static flags = {
     template: Flags.string({
       description: 'template to use',
-      options: ['basic', 'nextjs', 'express'],
+      options: ['standalone', 'nextjs', 'express'],
     }),
     yes: Flags.boolean({
       char: 'y',

--- a/packages/cli/src/lib/builders/standalone.ts
+++ b/packages/cli/src/lib/builders/standalone.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { BaseBuilder } from './base-builder.js';
 
-export class VercelStaticBuilder extends BaseBuilder {
+export class StandaloneBuilder extends BaseBuilder {
   async build(): Promise<void> {
     const inputFiles = await this.getInputFiles();
     const tsConfig = await this.getTsConfigOptions();

--- a/packages/cli/src/lib/config/types.ts
+++ b/packages/cli/src/lib/config/types.ts
@@ -1,5 +1,5 @@
 export const validBuildTargets = [
-  'vercel-static',
+  'standalone',
   'vercel-build-output-api',
   'next',
 ] as const;
@@ -41,5 +41,5 @@ export interface WorkflowConfig {
 export function isValidBuildTarget(
   target: string | undefined
 ): target is BuildTarget {
-  return target === 'vercel-static' || target === 'vercel-build-output-api';
+  return target === 'standalone' || target === 'vercel-build-output-api';
 }

--- a/packages/cli/src/lib/config/workflow-config.ts
+++ b/packages/cli/src/lib/config/workflow-config.ts
@@ -8,7 +8,7 @@ export const getWorkflowConfig = (
     buildTarget?: BuildTarget;
     workflowManifest?: string;
   } = {
-    buildTarget: 'vercel-static',
+    buildTarget: 'standalone',
   }
 ) => {
   const config: WorkflowConfig = {


### PR DESCRIPTION
The "vercel-static" builder was an initial, deprecated builder - but it turns out it might be quite useful to simple builds and to understand how workflows works. It also has nothing to do with Vercel, so I'm renaming it to "standalone"