### PR TITLE
refactor: extract queue trigger configuration constants

### DIFF
--- a/.changeset/extract-queue-triggers.md
+++ b/.changeset/extract-queue-triggers.md
@@ -1,0 +1,7 @@
+---
+"@workflow/builders": patch
+"@workflow/cli": patch
+"@workflow/next": patch
+---
+
+Extract queue trigger configuration constants

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Queue trigger configuration for workflow step execution.
+ * Steps are queued to the __wkf_step_* topic.
+ */
+export const STEP_QUEUE_TRIGGER = {
+  type: 'queue/v1beta' as const,
+  topic: '__wkf_step_*',
+  consumer: 'default',
+  maxDeliveries: 64, // Maximum number of delivery attempts (default: 3)
+  retryAfterSeconds: 5, // Delay between retries (default: 60)
+  initialDelaySeconds: 0, // Initial delay before first delivery (default: 0)
+};
+
+/**
+ * Queue trigger configuration for workflow orchestration.
+ * Workflows are queued to the __wkf_workflow_* topic.
+ */
+export const WORKFLOW_QUEUE_TRIGGER = {
+  type: 'queue/v1beta' as const,
+  topic: '__wkf_workflow_*',
+  consumer: 'default',
+  maxDeliveries: 64, // Maximum number of delivery attempts (default: 3)
+  retryAfterSeconds: 5, // Delay between retries (default: 60)
+  initialDelaySeconds: 0, // Initial delay before first delivery (default: 0)
+};

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -8,3 +8,4 @@ export { applySwcTransform } from './apply-swc-transform.js';
 export { createDiscoverEntriesPlugin } from './discover-entries-esbuild-plugin.js';
 export { createNodeModuleErrorPlugin } from './node-module-esbuild-plugin.js';
 export { createSwcPlugin } from './swc-esbuild-plugin.js';
+export { STEP_QUEUE_TRIGGER, WORKFLOW_QUEUE_TRIGGER } from './constants.js';

--- a/packages/builders/src/vercel-build-output-api.ts
+++ b/packages/builders/src/vercel-build-output-api.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { BaseBuilder } from './base-builder.js';
+import { STEP_QUEUE_TRIGGER, WORKFLOW_QUEUE_TRIGGER } from './constants.js';
 
 export class VercelBuildOutputAPIBuilder extends BaseBuilder {
   async build(): Promise<void> {
@@ -67,16 +68,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       architecture: 'arm64',
       shouldAddHelpers: true,
       shouldAddSourcemapSupport: true,
-      experimentalTriggers: [
-        {
-          type: 'queue/v1beta',
-          topic: '__wkf_step_*',
-          consumer: 'default',
-          maxDeliveries: 64, // Optional: Maximum number of delivery attempts (default: 3)
-          retryAfterSeconds: 5, // Optional: Delay between retries (default: 60)
-          initialDelaySeconds: 0, // Optional: Initial delay before first delivery (default: 0)
-        },
-      ],
+      experimentalTriggers: [STEP_QUEUE_TRIGGER],
     };
 
     await writeFile(
@@ -123,16 +115,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       launcherType: 'Nodejs',
       architecture: 'arm64',
       shouldAddHelpers: true,
-      experimentalTriggers: [
-        {
-          type: 'queue/v1beta',
-          topic: '__wkf_workflow_*',
-          consumer: 'default',
-          maxDeliveries: 64, // Optional: Maximum number of delivery attempts (default: 3)
-          retryAfterSeconds: 5, // Optional: Delay between retries (default: 60)
-          initialDelaySeconds: 0, // Optional: Initial delay before first delivery (default: 0)
-        },
-      ],
+      experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
     };
 
     await writeFile(

--- a/packages/cli/src/lib/builders/vercel-build-output-api.ts
+++ b/packages/cli/src/lib/builders/vercel-build-output-api.ts
@@ -1,6 +1,10 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { BaseBuilder } from '@workflow/builders';
+import {
+  BaseBuilder,
+  STEP_QUEUE_TRIGGER,
+  WORKFLOW_QUEUE_TRIGGER,
+} from '@workflow/builders';
 
 export class VercelBuildOutputAPIBuilder extends BaseBuilder {
   async build(): Promise<void> {
@@ -67,16 +71,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       architecture: 'arm64',
       shouldAddHelpers: true,
       shouldAddSourcemapSupport: true,
-      experimentalTriggers: [
-        {
-          type: 'queue/v1beta',
-          topic: '__wkf_step_*',
-          consumer: 'default',
-          maxDeliveries: 64, // Optional: Maximum number of delivery attempts (default: 3)
-          retryAfterSeconds: 5, // Optional: Delay between retries (default: 60)
-          initialDelaySeconds: 0, // Optional: Initial delay before first delivery (default: 0)
-        },
-      ],
+      experimentalTriggers: [STEP_QUEUE_TRIGGER],
     };
 
     await writeFile(
@@ -123,16 +118,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       launcherType: 'Nodejs',
       architecture: 'arm64',
       shouldAddHelpers: true,
-      experimentalTriggers: [
-        {
-          type: 'queue/v1beta',
-          topic: '__wkf_workflow_*',
-          consumer: 'default',
-          maxDeliveries: 64, // Optional: Maximum number of delivery attempts (default: 3)
-          retryAfterSeconds: 5, // Optional: Delay between retries (default: 60)
-          initialDelaySeconds: 0, // Optional: Initial delay before first delivery (default: 0)
-        },
-      ],
+      experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
     };
 
     await writeFile(

--- a/packages/next/src/builder.ts
+++ b/packages/next/src/builder.ts
@@ -2,7 +2,11 @@ import { constants } from 'node:fs';
 import { access, mkdir, stat, writeFile } from 'node:fs/promises';
 import { extname, join, resolve } from 'node:path';
 import Watchpack from 'watchpack';
-import { BaseBuilder } from '@workflow/builders';
+import {
+  BaseBuilder,
+  STEP_QUEUE_TRIGGER,
+  WORKFLOW_QUEUE_TRIGGER,
+} from '@workflow/builders';
 
 export class NextBuilder extends BaseBuilder {
   async build() {
@@ -333,28 +337,10 @@ export class NextBuilder extends BaseBuilder {
     const generatedConfig = {
       version: '0',
       steps: {
-        experimentalTriggers: [
-          {
-            type: 'queue/v1beta',
-            topic: '__wkf_step_*',
-            consumer: 'default',
-            maxDeliveries: 64,
-            retryAfterSeconds: 5,
-            initialDelaySeconds: 0,
-          },
-        ],
+        experimentalTriggers: [STEP_QUEUE_TRIGGER],
       },
       workflows: {
-        experimentalTriggers: [
-          {
-            type: 'queue/v1beta',
-            topic: '__wkf_workflow_*',
-            consumer: 'default',
-            maxDeliveries: 64,
-            retryAfterSeconds: 5,
-            initialDelaySeconds: 0,
-          },
-        ],
+        experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
       },
     };
 


### PR DESCRIPTION
Consolidates duplicated queue trigger configurations into shared constants
in @workflow/builders package, eliminating repetition across multiple builders.

Changes:
- Created STEP_QUEUE_TRIGGER and WORKFLOW_QUEUE_TRIGGER constants
- Updated VercelBuildOutputAPIBuilder to use shared constants
- Updated NextBuilder (both in @workflow/next and @workflow/cli) to use constants
- Exported constants from @workflow/builders index

This ensures consistent queue configuration across all builders and makes
future updates to these settings easier to manage from a single location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>