### PR TITLE
refactor: deduplicate package.json and .vc-config.json generation

### DIFF
--- a/.changeset/deduplicate-configs.md
+++ b/.changeset/deduplicate-configs.md
@@ -1,0 +1,6 @@
+---
+"@workflow/builders": patch
+"@workflow/cli": patch
+---
+
+Deduplicate package.json and .vc-config.json generation

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -659,6 +659,62 @@ export const OPTIONS = handler;`;
     );
   }
 
+  /**
+   * Creates a package.json file with the specified module type.
+   */
+  protected async createPackageJson(
+    dir: string,
+    type: 'commonjs' | 'module'
+  ): Promise<void> {
+    const packageJson = { type };
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify(packageJson, null, 2)
+    );
+  }
+
+  /**
+   * Creates a .vc-config.json file for Vercel Build Output API functions.
+   */
+  protected async createVcConfig(
+    dir: string,
+    config: {
+      runtime?: string;
+      handler?: string;
+      launcherType?: string;
+      architecture?: string;
+      shouldAddHelpers?: boolean;
+      shouldAddSourcemapSupport?: boolean;
+      experimentalTriggers?: Array<{
+        type: string;
+        topic: string;
+        consumer: string;
+        maxDeliveries?: number;
+        retryAfterSeconds?: number;
+        initialDelaySeconds?: number;
+      }>;
+    }
+  ): Promise<void> {
+    const vcConfig = {
+      runtime: config.runtime ?? 'nodejs22.x',
+      handler: config.handler ?? 'index.js',
+      launcherType: config.launcherType ?? 'Nodejs',
+      architecture: config.architecture ?? 'arm64',
+      shouldAddHelpers: config.shouldAddHelpers ?? true,
+      ...(config.shouldAddSourcemapSupport !== undefined && {
+        shouldAddSourcemapSupport: config.shouldAddSourcemapSupport,
+      }),
+      ...(config.experimentalTriggers && {
+        experimentalTriggers: config.experimentalTriggers,
+      }),
+    };
+
+    await writeFile(
+      join(dir, '.vc-config.json'),
+      JSON.stringify(vcConfig, null, 2)
+    );
+  }
+
   private async createSwcGitignore(): Promise<void> {
     try {
       await writeFile(

--- a/packages/builders/src/vercel-build-output-api.ts
+++ b/packages/builders/src/vercel-build-output-api.ts
@@ -51,30 +51,12 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       tsPaths,
     });
 
-    // Create package.json for CommonJS
-    const packageJson = {
-      type: 'commonjs',
-    };
-    await writeFile(
-      join(stepsFuncDir, 'package.json'),
-      JSON.stringify(packageJson, null, 2)
-    );
-
-    // Create .vc-config.json for steps function
-    const stepsConfig = {
-      runtime: 'nodejs22.x',
-      handler: 'index.js',
-      launcherType: 'Nodejs',
-      architecture: 'arm64',
-      shouldAddHelpers: true,
+    // Create package.json and .vc-config.json for steps function
+    await this.createPackageJson(stepsFuncDir, 'commonjs');
+    await this.createVcConfig(stepsFuncDir, {
       shouldAddSourcemapSupport: true,
       experimentalTriggers: [STEP_QUEUE_TRIGGER],
-    };
-
-    await writeFile(
-      join(stepsFuncDir, '.vc-config.json'),
-      JSON.stringify(stepsConfig, null, 2)
-    );
+    });
   }
 
   private async buildWorkflowsFunction({
@@ -99,29 +81,11 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       tsPaths,
     });
 
-    // Create package.json for ESM support
-    const packageJson = {
-      type: 'commonjs',
-    };
-    await writeFile(
-      join(workflowsFuncDir, 'package.json'),
-      JSON.stringify(packageJson, null, 2)
-    );
-
-    // Create .vc-config.json for workflows function
-    const workflowsConfig = {
-      runtime: 'nodejs22.x',
-      handler: 'index.js',
-      launcherType: 'Nodejs',
-      architecture: 'arm64',
-      shouldAddHelpers: true,
+    // Create package.json and .vc-config.json for workflows function
+    await this.createPackageJson(workflowsFuncDir, 'commonjs');
+    await this.createVcConfig(workflowsFuncDir, {
       experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
-    };
-
-    await writeFile(
-      join(workflowsFuncDir, '.vc-config.json'),
-      JSON.stringify(workflowsConfig, null, 2)
-    );
+    });
   }
 
   private async buildWebhookFunction({
@@ -143,28 +107,11 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       bundle, // Build Output API needs bundling (except in tests)
     });
 
-    // Create package.json for CommonJS
-    const packageJson = {
-      type: 'commonjs',
-    };
-    await writeFile(
-      join(webhookFuncDir, 'package.json'),
-      JSON.stringify(packageJson, null, 2)
-    );
-
-    // Create .vc-config.json for webhook function
-    const webhookConfig = {
-      runtime: 'nodejs22.x',
-      handler: 'index.js',
-      launcherType: 'Nodejs',
-      architecture: 'arm64',
+    // Create package.json and .vc-config.json for webhook function
+    await this.createPackageJson(webhookFuncDir, 'commonjs');
+    await this.createVcConfig(webhookFuncDir, {
       shouldAddHelpers: false,
-    };
-
-    await writeFile(
-      join(webhookFuncDir, '.vc-config.json'),
-      JSON.stringify(webhookConfig, null, 2)
-    );
+    });
   }
 
   private async createBuildOutputConfig(outputDir: string): Promise<void> {

--- a/packages/cli/src/lib/builders/vercel-build-output-api.ts
+++ b/packages/cli/src/lib/builders/vercel-build-output-api.ts
@@ -54,30 +54,12 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       tsPaths,
     });
 
-    // Create package.json for CommonJS
-    const packageJson = {
-      type: 'commonjs',
-    };
-    await writeFile(
-      join(stepsFuncDir, 'package.json'),
-      JSON.stringify(packageJson, null, 2)
-    );
-
-    // Create .vc-config.json for steps function
-    const stepsConfig = {
-      runtime: 'nodejs22.x',
-      handler: 'index.js',
-      launcherType: 'Nodejs',
-      architecture: 'arm64',
-      shouldAddHelpers: true,
+    // Create package.json and .vc-config.json for steps function
+    await this.createPackageJson(stepsFuncDir, 'commonjs');
+    await this.createVcConfig(stepsFuncDir, {
       shouldAddSourcemapSupport: true,
       experimentalTriggers: [STEP_QUEUE_TRIGGER],
-    };
-
-    await writeFile(
-      join(stepsFuncDir, '.vc-config.json'),
-      JSON.stringify(stepsConfig, null, 2)
-    );
+    });
   }
 
   private async buildWorkflowsFunction({
@@ -102,29 +84,11 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       tsPaths,
     });
 
-    // Create package.json for ESM support
-    const packageJson = {
-      type: 'commonjs',
-    };
-    await writeFile(
-      join(workflowsFuncDir, 'package.json'),
-      JSON.stringify(packageJson, null, 2)
-    );
-
-    // Create .vc-config.json for workflows function
-    const workflowsConfig = {
-      runtime: 'nodejs22.x',
-      handler: 'index.js',
-      launcherType: 'Nodejs',
-      architecture: 'arm64',
-      shouldAddHelpers: true,
+    // Create package.json and .vc-config.json for workflows function
+    await this.createPackageJson(workflowsFuncDir, 'commonjs');
+    await this.createVcConfig(workflowsFuncDir, {
       experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
-    };
-
-    await writeFile(
-      join(workflowsFuncDir, '.vc-config.json'),
-      JSON.stringify(workflowsConfig, null, 2)
-    );
+    });
   }
 
   private async buildWebhookFunction({
@@ -146,28 +110,11 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       bundle, // Build Output API needs bundling (except in tests)
     });
 
-    // Create package.json for CommonJS
-    const packageJson = {
-      type: 'commonjs',
-    };
-    await writeFile(
-      join(webhookFuncDir, 'package.json'),
-      JSON.stringify(packageJson, null, 2)
-    );
-
-    // Create .vc-config.json for webhook function
-    const webhookConfig = {
-      runtime: 'nodejs22.x',
-      handler: 'index.js',
-      launcherType: 'Nodejs',
-      architecture: 'arm64',
+    // Create package.json and .vc-config.json for webhook function
+    await this.createPackageJson(webhookFuncDir, 'commonjs');
+    await this.createVcConfig(webhookFuncDir, {
       shouldAddHelpers: false,
-    };
-
-    await writeFile(
-      join(webhookFuncDir, '.vc-config.json'),
-      JSON.stringify(webhookConfig, null, 2)
-    );
+    });
   }
 
   private async createBuildOutputConfig(outputDir: string): Promise<void> {


### PR DESCRIPTION
Extracts repeated package.json and .vc-config.json generation logic into
reusable helper methods in BaseBuilder, eliminating code duplication across
VercelBuildOutputAPIBuilder.

Changes:
- Added createPackageJson() helper method to BaseBuilder
- Added createVcConfig() helper method with sensible defaults
- Updated VercelBuildOutputAPIBuilder (both in @workflow/builders and @workflow/cli)
  to use the new helper methods
- Reduced configuration code from ~20 lines per function to ~3 lines

This makes the build code more maintainable and ensures consistent configuration
across all Vercel Build Output API functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>