### PR TITLE
refactor: standardize method naming and clarify log messages

### DIFF
--- a/.changeset/standardize-naming.md
+++ b/.changeset/standardize-naming.md
@@ -1,0 +1,6 @@
+---
+"@workflow/builders": patch
+"@workflow/cli": patch
+---
+
+Standardize method naming conventions

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -522,7 +522,7 @@ export const POST = workflowEntrypoint(workflowCode);`;
     await interimBundleCtx.dispose();
   }
 
-  protected async buildClientLibrary(): Promise<void> {
+  protected async createClientLibrary(): Promise<void> {
     if (!this.config.clientBundlePath) {
       // Silently exit since no client bundle was requested
       return;

--- a/packages/builders/src/standalone.ts
+++ b/packages/builders/src/standalone.ts
@@ -16,7 +16,7 @@ export class StandaloneBuilder extends BaseBuilder {
     await this.buildWorkflowsBundle(options);
     await this.buildWebhookFunction();
 
-    await this.buildClientLibrary();
+    await this.createClientLibrary();
   }
 
   private async buildStepsBundle({
@@ -28,10 +28,7 @@ export class StandaloneBuilder extends BaseBuilder {
     tsBaseUrl?: string;
     tsPaths?: Record<string, string[]>;
   }): Promise<void> {
-    console.log(
-      'Creating Vercel API steps bundle at',
-      this.config.stepsBundlePath
-    );
+    console.log('Creating steps bundle at', this.config.stepsBundlePath);
 
     const stepsBundlePath = resolve(
       this.config.workingDir,
@@ -59,7 +56,7 @@ export class StandaloneBuilder extends BaseBuilder {
     tsPaths?: Record<string, string[]>;
   }): Promise<void> {
     console.log(
-      'Creating vercel API workflows bundle at',
+      'Creating workflows bundle at',
       this.config.workflowsBundlePath
     );
 
@@ -80,10 +77,7 @@ export class StandaloneBuilder extends BaseBuilder {
   }
 
   private async buildWebhookFunction(): Promise<void> {
-    console.log(
-      'Creating vercel API webhook bundle at',
-      this.config.webhookBundlePath
-    );
+    console.log('Creating webhook bundle at', this.config.webhookBundlePath);
 
     const webhookBundlePath = resolve(
       this.config.workingDir,

--- a/packages/builders/src/vercel-build-output-api.ts
+++ b/packages/builders/src/vercel-build-output-api.ts
@@ -25,7 +25,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
     await this.buildWebhookFunction(options);
     await this.createBuildOutputConfig(outputDir);
 
-    await this.buildClientLibrary();
+    await this.createClientLibrary();
   }
 
   private async buildStepsFunction({

--- a/packages/cli/src/lib/builders/standalone.ts
+++ b/packages/cli/src/lib/builders/standalone.ts
@@ -16,7 +16,7 @@ export class StandaloneBuilder extends BaseBuilder {
     await this.buildWorkflowsBundle(options);
     await this.buildWebhookFunction();
 
-    await this.buildClientLibrary();
+    await this.createClientLibrary();
   }
 
   private async buildStepsBundle({
@@ -28,10 +28,7 @@ export class StandaloneBuilder extends BaseBuilder {
     tsBaseUrl?: string;
     tsPaths?: Record<string, string[]>;
   }): Promise<void> {
-    console.log(
-      'Creating Vercel API steps bundle at',
-      this.config.stepsBundlePath
-    );
+    console.log('Creating steps bundle at', this.config.stepsBundlePath);
 
     const stepsBundlePath = resolve(
       this.config.workingDir,
@@ -59,7 +56,7 @@ export class StandaloneBuilder extends BaseBuilder {
     tsPaths?: Record<string, string[]>;
   }): Promise<void> {
     console.log(
-      'Creating vercel API workflows bundle at',
+      'Creating workflows bundle at',
       this.config.workflowsBundlePath
     );
 
@@ -80,10 +77,7 @@ export class StandaloneBuilder extends BaseBuilder {
   }
 
   private async buildWebhookFunction(): Promise<void> {
-    console.log(
-      'Creating vercel API webhook bundle at',
-      this.config.webhookBundlePath
-    );
+    console.log('Creating webhook bundle at', this.config.webhookBundlePath);
 
     const webhookBundlePath = resolve(
       this.config.workingDir,

--- a/packages/cli/src/lib/builders/vercel-build-output-api.ts
+++ b/packages/cli/src/lib/builders/vercel-build-output-api.ts
@@ -28,7 +28,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
     await this.buildWebhookFunction(options);
     await this.createBuildOutputConfig(outputDir);
 
-    await this.buildClientLibrary();
+    await this.createClientLibrary();
   }
 
   private async buildStepsFunction({


### PR DESCRIPTION
Improves code consistency by standardizing method naming conventions and
clarifying log messages across builders.

Changes:
- Renamed buildClientLibrary() to createClientLibrary() in BaseBuilder to match
  the convention where "create" is used for protected/shared methods
- Updated all callers in StandaloneBuilder and VercelBuildOutputAPIBuilder
- Clarified log messages in StandaloneBuilder by removing "Vercel API" prefix
  since this builder is framework-agnostic

This establishes a clear pattern:
- Public/template methods in subclasses: build* (buildStepsFunction, etc.)
- Protected/shared methods in BaseBuilder: create* (createStepsBundle, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>