### PR TITLE
build: update build script to ignore docs and workbench

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "prepare": "husky",
-    "build": "turbo build --filter='./packages/*' --filter='docs' --filter='./workbench/*'",
+    "build": "turbo build --filter='./packages/*'",
     "test": "turbo test",
     "clean": "turbo clean",
     "typecheck": "turbo typecheck",


### PR DESCRIPTION
Update `build` script to avoid building docs and workbench apps (only builds packages)