### PR TITLE
Make serving LLMs to agents actually work and give them an index to navigate

### DIFF
--- a/docs/app/docs/sitemap.md/route.ts
+++ b/docs/app/docs/sitemap.md/route.ts
@@ -1,0 +1,46 @@
+import { source } from '@/lib/source';
+import type { Node, Root } from 'fumadocs-core/page-tree';
+
+export const revalidate = false;
+export const dynamic = 'force-static';
+
+export async function GET(_req: Request) {
+  let mdText = '';
+
+  function traverseTree(node: Node | Root, depth = 0) {
+    const indent = '  '.repeat(depth);
+
+    if ('type' in node) {
+      if (node.type === 'page') {
+        mdText += `${indent}- [${node.name}](${node.url})\n`;
+      } else if (node.type === 'folder') {
+        if (node.index) {
+          mdText += `${indent}- [${node.name}](${node.index.url})\n`;
+        } else {
+          mdText += `${indent}- ${node.name}\n`;
+        }
+        if (node.children.length > 0) {
+          for (const child of node.children) {
+            traverseTree(child, depth + 1);
+          }
+        }
+      }
+    } else {
+      // Root node
+      if (node.children.length > 0) {
+        for (const child of node.children) {
+          traverseTree(child, depth);
+        }
+      }
+    }
+  }
+
+  const tree = source.getPageTree();
+  traverseTree(tree, 0);
+
+  return new Response(mdText, {
+    headers: {
+      'Content-Type': 'text/markdown',
+    },
+  });
+}

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -12,11 +12,16 @@ export async function GET(
   const page = source.getPage(slug);
   if (!page) notFound();
 
-  return new Response(await getLLMText(page), {
-    headers: {
-      'Content-Type': 'text/markdown',
-    },
-  });
+  return new Response(
+    (await getLLMText(page)) +
+      `\n\n## Sitemap
+[Overview of all docs pages](/docs/sitemap.md)\n`,
+    {
+      headers: {
+        'Content-Type': 'text/markdown',
+      },
+    }
+  );
 }
 
 export function generateStaticParams() {

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -12,27 +12,34 @@ const config = {
     ignoreDuringBuilds: true,
   },
   async rewrites() {
-    return [
-      {
-        source: '/sitemap.xml',
-        destination: 'https://crawled-sitemap.vercel.sh/useworkflow.dev-.xml',
-      },
-      {
-        source: '/docs/:path*',
-        destination: '/llms.mdx/:path*',
-        has: [
-          {
-            type: 'header',
-            key: 'Accept',
-            value: '(.*)text/markdown(.*)',
-          },
-        ],
-      },
-      {
-        source: '/docs/:path*.(mdx|md)',
-        destination: '/llms.mdx/:path*',
-      },
-    ];
+    return {
+      beforeFiles: [
+        {
+          source: '/sitemap.xml',
+          destination: 'https://crawled-sitemap.vercel.sh/useworkflow.dev-.xml',
+        },
+        {
+          source: '/docs/:path*',
+          destination: '/llms.mdx/:path*',
+          has: [
+            {
+              type: 'header',
+              key: 'Accept',
+              // Have text/markdown or text/plain but before any text/html
+              // Note, that Claude Code currently requests text/plain
+              value:
+                '(?=.*(?:text/plain|text/markdown))(?!.*text/html.*(?:text/plain|text/markdown)).*',
+            },
+          ],
+        },
+      ],
+      afterFiles: [
+        {
+          source: '/docs/:path*.(mdx|md)',
+          destination: '/llms.mdx/:path*',
+        },
+      ],
+    };
   },
   redirects: () => {
     return [


### PR DESCRIPTION
- The original code was rewriting in the wrong phase and with the wrong regex for Claude
- I noticed that LLMs need a way to discover other pages efficiently, so I made a sitemap in markdown and linked it from every MD page at the bottom