### PR TITLE
fix: correct proxy regex from Workflow docs setup

### DIFF
--- a/docs/content/docs/getting-started/next.mdx
+++ b/docs/content/docs/getting-started/next.mdx
@@ -112,7 +112,7 @@ export const config = {
   matcher: [
     // ... your existing matchers
     {
-      source: '/((?!_next/static|_next/image|favicon.ico|.well-known/workflow).*)', // [!code highlight]
+      source: '/((?!_next/static|_next/image|favicon.ico|.well-known/workflow/).*)', // [!code highlight]
     },
   ],
 };


### PR DESCRIPTION
Fixes unbalanced regex pattern in proxy.ts matcher for Workflow setup documentation, resolving "Invalid source: Unbalanced pattern" error on dev server startup.