### PR TITLE
Update withWorkflow and update docs

### DIFF
--- a/.changeset/thick-rockets-brake.md
+++ b/.changeset/thick-rockets-brake.md
@@ -1,0 +1,5 @@
+---
+"@workflow/next": patch
+---
+
+Update withWorkflow and expand documentation on usage

--- a/docs/content/docs/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/api-reference/workflow-next/with-workflow.mdx
@@ -17,6 +17,37 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   // … rest of your Next.js config
 };
- 
-export default withWorkflow(nextConfig); // [!code highlight]
+
+// not required but allows configuring workflow options
+const workflowConfig = {} 
+
+export default withWorkflow(nextConfig, workflowConfig); // [!code highlight]
 ```
+
+If you are exporting a function in your `next.config` you will need to ensure you call the function returned from `withWorkflow`.
+
+```typescript title="next.config.ts" lineNumbers
+import { NextConfig } from "next";
+import { withWorkflow } from "workflow/next";
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin();
+
+export default async function config(
+  phase: string,
+  ctx: {
+    defaultConfig: NextConfig
+  }
+): Promise<NextConfig> {
+  let nextConfig: NextConfig | typeof config = {};
+
+  for (const configModifier of [withNextIntl, withWorkflow]) {
+    nextConfig = configModifier(nextConfig);
+
+    if (typeof nextConfig === "function") {
+      nextConfig = await nextConfig(phase, ctx);
+    }
+  }
+  return nextConfig;
+}
+``` 


### PR DESCRIPTION
As noticed in https://github.com/vercel/workflow/issues/95 when a user is exporting a function from their `next.config` already they might not be aware that plugins can do this as well. This adds documentation for that case and also expands `withWorkflow` function to handle other plugins doing this as well. 

Closes: https://github.com/vercel/workflow/issues/95