### PR TITLE
fix: docs code block styling

### DIFF
--- a/docs/app/(home)/components/implementation.tsx
+++ b/docs/app/(home)/components/implementation.tsx
@@ -75,7 +75,7 @@ export const Implementation = () => (
             lang="ts"
             codeblock={{
               className:
-                'shadow-none bg-background dark:bg-sidebar h-full rounded-md with-line-numbers',
+                'shadow-none !bg-background dark:bg-sidebar h-full rounded-md with-line-numbers',
             }}
           />
         </div>

--- a/docs/app/(home)/components/intro/intro.tsx
+++ b/docs/app/(home)/components/intro/intro.tsx
@@ -2,7 +2,6 @@ import { CodeBlock } from '@/components/code-block';
 import { IntroTabs } from './intro-tabs';
 import { NonWorkflowExample } from './non-workflow';
 import { WorkflowExample } from './workflow';
-import { WorkflowLogs } from './workflow-logs';
 
 const workflowCode = `export async function welcome(userId: string) {
   "use workflow";
@@ -129,7 +128,9 @@ export const Intro = async () => {
     <CodeBlock
       code={workflowCode}
       lang="ts"
-      codeblock={{ className: codeBlockClassname }}
+      codeblock={{
+        className: `shadow-none !bg-background ${codeBlockClassname}`,
+      }}
     />
   );
   const nonWorkflowCodeBlock = (
@@ -137,7 +138,7 @@ export const Intro = async () => {
       code={nonWorkflowCode}
       lang="ts"
       codeblock={{
-        className: `${codeBlockClassname} max-h-[310px] overflow-y-auto`,
+        className: `shadow-none !bg-background ${codeBlockClassname} max-h-[310px] overflow-y-auto`,
       }}
     />
   );

--- a/docs/app/(home)/components/use-cases-server.tsx
+++ b/docs/app/(home)/components/use-cases-server.tsx
@@ -161,7 +161,7 @@ export const UseCases = async () => {
           code={useCase.code}
           lang="ts"
           codeblock={{
-            className: 'shadow-none bg-background dark:bg-sidebar rounded-md',
+            className: 'shadow-none !bg-background dark:bg-sidebar rounded-md',
           }}
         />
       ),


### PR DESCRIPTION
codeblock background styles were inconsistent, i switched them to use `bg-background`:

## Before

<img width="648" height="470" alt="image" src="https://github.com/user-attachments/assets/7d549e44-bd98-4f90-9749-752f0d64c386" />

## After

<img width="633" height="389" alt="image" src="https://github.com/user-attachments/assets/bd458ee4-4e33-47c1-af25-3258868cbecd" />
