### PR TITLE
fix(docs): correct typo "worklfow" → "workflow"

### DIFF
--- a/docs/app/(home)/components/use-cases-server.tsx
+++ b/docs/app/(home)/components/use-cases-server.tsx
@@ -85,7 +85,7 @@ export async function validatePaymentMethod(rideId) {
   const webhook = createWebhook();
 
   // Every webhook has a url that can be used to resume
-  // the worklfow
+  // the workflow
   await fetch("https://api.example-payments.com/validate-method", {
     method: "POST",
     body: JSON.stringify({ rideId, callback: webhook.url }),


### PR DESCRIPTION
## Summary
- Fixes a minor typo in a code comment within `use-cases-server.tsx` (worklfow → workflow).
## Notes
I was reading through the docs and spotted a small typo. Super cool stuff and congrats on the launch!
## Context
- You can see this typo at [useworkflow.dev,](https://useworkflow.dev) under the use cases section with "webhook" selected in dropdown.
<img width="1089" height="571" alt="Screenshot 2025-10-31 at 1 23 41 PM" src="https://github.com/user-attachments/assets/249dfc33-7a76-46bc-b4e0-b833018a80b7" />
