### PR TITLE
[docs] Remove framework support callout

### DIFF
--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -6,10 +6,6 @@ import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun } from '@/app/(home)/components
 
 # Getting Started
 
-<Callout>
-Currently, Workflow DevKit works best with Next.js. We're actively working on improving support for other frameworks, including a standalone/framework-less mode.
-</Callout>
-
 Start by choosing your framework. Each guide will walk you through the steps to install the dependencies and start running your first workflow.
 
 <Cards>


### PR DESCRIPTION
Let's drop this callout? Framework support is starting to become diverse enough that this note feels unnecessary.