### PR TITLE
chore: update license on sveltekit package json

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -10,7 +10,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/workflow.git",


### PR DESCRIPTION
updates `license` field in `package.json`. the actual `LICENSE` file was already Apache 2.0