### PR TITLE
fix(swc-plugin): specify import path of start function on error

### DIFF
--- a/.changeset/poor-eyes-build.md
+++ b/.changeset/poor-eyes-build.md
@@ -1,0 +1,5 @@
+---
+"@workflow/swc-plugin": patch
+---
+
+Specify import path of `start` function on error in SWC plugin

--- a/packages/swc-plugin-workflow/spec.md
+++ b/packages/swc-plugin-workflow/spec.md
@@ -29,6 +29,7 @@ registerStepFunction("step//input.js//add", add)
 ```
 
 **ID Generation:** Step IDs are generated using the format `step//{filepath}//{functionName}`, where:
+
 - `filepath` is the relative path to the file from the project root
 - `functionName` is the name of the step function
 
@@ -113,12 +114,13 @@ export async function add(a, b) {
 }
 
 export async function workflow(a, b) {
-  throw new Error("You attempted to execute workflow workflow function directly. To start a workflow, use start(workflow) from workflow");
+  throw new Error("You attempted to execute workflow workflow function directly. To start a workflow, use start(workflow) from workflow/api");
 }
 workflow.workflowId = "workflow//workflow/main.js//workflow";
 ```
 
 **ID Generation:**
+
 - Step functions use `runStep` with the function name (not the full ID)
 - Workflow functions throw an error if called directly and have the `workflowId` property attached using the format `workflow//{filepath}//{functionName}`
 
@@ -126,7 +128,7 @@ Upstream, this mode is typically used by a framework loader (like a Next.js/webp
 
 ## Notes
 
-* Instead of individually marking functions with 'use step' or 'use_workflow', you can also add the directive to the top of a file to mark all exports within that file as step functions or workflows
-* the directives must be at the very beginning of their function or module; above any other code including imports (comments above directives are OK). They must be written with single or double quotes, not backticks.
-* The arguments and return value of 'use step' and 'use workflow' must be serializable.
-* Because the underlying network calls are always asynchronous, 'use step' and 'use workflow' can only be used on async functions.
+- Instead of individually marking functions with 'use step' or 'use_workflow', you can also add the directive to the top of a file to mark all exports within that file as step functions or workflows
+- the directives must be at the very beginning of their function or module; above any other code including imports (comments above directives are OK). They must be written with single or double quotes, not backticks.
+- The arguments and return value of 'use step' and 'use workflow' must be serializable.
+- Because the underlying network calls are always asynchronous, 'use step' and 'use workflow' can only be used on async functions.

--- a/packages/swc-plugin-workflow/transform/src/lib.rs
+++ b/packages/swc-plugin-workflow/transform/src/lib.rs
@@ -2308,7 +2308,7 @@ impl VisitMut for StepTransform {
                                 self.remove_use_workflow_directive(&mut fn_decl.function.body);
                                 if let Some(body) = &mut fn_decl.function.body {
                                     let error_msg = format!(
-                                        "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow",
+                                        "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow/api",
                                         fn_name, fn_name
                                     );
                                     let error_expr = Expr::New(NewExpr {
@@ -2855,7 +2855,7 @@ impl VisitMut for StepTransform {
                                             );
                                             if let Some(body) = &mut fn_expr.function.body {
                                                 let error_msg = format!(
-                                                    "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow",
+                                                    "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow/api",
                                                     name, name
                                                 );
                                                 let error_expr = Expr::New(NewExpr {
@@ -2981,7 +2981,7 @@ impl VisitMut for StepTransform {
                                                 &mut arrow_expr.body,
                                             );
                                             let error_msg = format!(
-                                                "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow",
+                                                "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow/api",
                                                 name, name
                                             );
                                             let error_expr = Expr::New(NewExpr {
@@ -3169,7 +3169,7 @@ impl VisitMut for StepTransform {
                                     .unwrap_or_else(|| "defaultWorkflow".to_string());
                                 if let Some(body) = &mut fn_expr.function.body {
                                     let error_msg = format!(
-                                        "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow",
+                                        "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow/api",
                                         actual_name, actual_name
                                     );
                                     let error_expr = Expr::New(NewExpr {
@@ -3302,7 +3302,7 @@ impl VisitMut for StepTransform {
                                         );
                                         if let Some(body) = &mut fn_decl.function.body {
                                             let error_msg = format!(
-                                                "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow",
+                                                "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow/api",
                                                 fn_name, fn_name
                                             );
                                             let error_expr = Expr::New(NewExpr {
@@ -3438,7 +3438,7 @@ impl VisitMut for StepTransform {
                                                             &mut arrow_expr.body,
                                                         );
                                                         let error_msg = format!(
-                                                            "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow",
+                                                            "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow/api",
                                                             name, name
                                                         );
                                                         let error_expr = Expr::New(NewExpr {
@@ -3504,7 +3504,7 @@ impl VisitMut for StepTransform {
                                                             &mut fn_expr.function.body
                                                         {
                                                             let error_msg = format!(
-                                                                "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow",
+                                                                "You attempted to execute workflow {} function directly. To start a workflow, use start({}) from workflow/api",
                                                                 name, name
                                                             );
                                                             let error_expr = Expr::New(NewExpr {

--- a/packages/swc-plugin-workflow/transform/tests/errors/non-async-functions/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/non-async-functions/output-client.js
@@ -24,6 +24,6 @@ export async function validStep() {
     });
 }
 export const validWorkflow = async ()=>{
-    throw new Error("You attempted to execute workflow validWorkflow function directly. To start a workflow, use start(validWorkflow) from workflow");
+    throw new Error("You attempted to execute workflow validWorkflow function directly. To start a workflow, use start(validWorkflow) from workflow/api");
 };
 validWorkflow.workflowId = "workflow//input.js//validWorkflow";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-client.js
@@ -9,7 +9,7 @@ export async function stepFunction(a, b) {
     });
 }
 export async function workflowFunction(a, b) {
-    throw new Error("You attempted to execute workflow workflowFunction function directly. To start a workflow, use start(workflowFunction) from workflow");
+    throw new Error("You attempted to execute workflow workflowFunction function directly. To start a workflow, use start(workflowFunction) from workflow/api");
 }
 workflowFunction.workflowId = "workflow//input.js//workflowFunction";
 export async function normalFunction(a, b) {

--- a/packages/swc-plugin-workflow/transform/tests/fixture/single-workflow/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/single-workflow/output-client.js
@@ -1,5 +1,5 @@
 /**__internal_workflows{"workflows":{"input.js":{"workflow":{"workflowId":"workflow//input.js//workflow"}}}}*/;
 export async function workflow(a, b) {
-    throw new Error("You attempted to execute workflow workflow function directly. To start a workflow, use start(workflow) from workflow");
+    throw new Error("You attempted to execute workflow workflow function directly. To start a workflow, use start(workflow) from workflow/api");
 }
 workflow.workflowId = "workflow//input.js//workflow";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/workflow-arrow-function/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/workflow-arrow-function/output-client.js
@@ -1,5 +1,5 @@
 /**__internal_workflows{"workflows":{"input.js":{"processData":{"workflowId":"workflow//input.js//processData"}}}}*/;
 export const processData = async (data)=>{
-    throw new Error("You attempted to execute workflow processData function directly. To start a workflow, use start(processData) from workflow");
+    throw new Error("You attempted to execute workflow processData function directly. To start a workflow, use start(processData) from workflow/api");
 };
 processData.workflowId = "workflow//input.js//processData";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/workflow-client-property/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/workflow-client-property/output-client.js
@@ -1,20 +1,20 @@
 // Test workflow functions in client mode
 /**__internal_workflows{"workflows":{"input.js":{"arrowWorkflow":{"workflowId":"workflow//input.js//arrowWorkflow"},"defaultWorkflow":{"workflowId":"workflow//input.js//defaultWorkflow"},"internalWorkflow":{"workflowId":"workflow//input.js//internalWorkflow"},"myWorkflow":{"workflowId":"workflow//input.js//myWorkflow"}}}}*/;
 export async function myWorkflow() {
-    throw new Error("You attempted to execute workflow myWorkflow function directly. To start a workflow, use start(myWorkflow) from workflow");
+    throw new Error("You attempted to execute workflow myWorkflow function directly. To start a workflow, use start(myWorkflow) from workflow/api");
 }
 myWorkflow.workflowId = "workflow//input.js//myWorkflow";
 export const arrowWorkflow = async ()=>{
-    throw new Error("You attempted to execute workflow arrowWorkflow function directly. To start a workflow, use start(arrowWorkflow) from workflow");
+    throw new Error("You attempted to execute workflow arrowWorkflow function directly. To start a workflow, use start(arrowWorkflow) from workflow/api");
 };
 arrowWorkflow.workflowId = "workflow//input.js//arrowWorkflow";
 export default async function defaultWorkflow() {
-    throw new Error("You attempted to execute workflow defaultWorkflow function directly. To start a workflow, use start(defaultWorkflow) from workflow");
+    throw new Error("You attempted to execute workflow defaultWorkflow function directly. To start a workflow, use start(defaultWorkflow) from workflow/api");
 }
 defaultWorkflow.workflowId = "workflow//input.js//defaultWorkflow";
 // Non-export workflow function
 async function internalWorkflow() {
-    throw new Error("You attempted to execute workflow internalWorkflow function directly. To start a workflow, use start(internalWorkflow) from workflow");
+    throw new Error("You attempted to execute workflow internalWorkflow function directly. To start a workflow, use start(internalWorkflow) from workflow/api");
 }
 internalWorkflow.workflowId = "workflow//input.js//internalWorkflow";
 // Use the internal workflow to avoid lint warning


### PR DESCRIPTION
old `start` function error message was showing the wrong path for importing `start`