### PR TITLE
Make env readonly and frozen in vm

### DIFF
--- a/.changeset/hungry-suits-brake.md
+++ b/.changeset/hungry-suits-brake.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Make process.env in workflow context a readonly clone

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -86,7 +86,7 @@ export function createContext(options: CreateContextOptions) {
 
   // Propagate environment variables
   (g as any).process = {
-    env: process.env,
+    env: Object.freeze({ ...process.env }),
   };
 
   // Stateless + synchronous Web APIs that are made available inside the sandbox


### PR DESCRIPTION
Technically workflows can currently break determinism by writing to process.env. This prevents that.

We may also want to reconsider exposing env in workflow