### PR TITLE
Checkout swc-plugin test fixture files with Unix newlines for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure consistent line endings for test input/output files
+# Use LF for all test files to ensure cross-platform consistency
+packages/swc-plugin-workflow/transform/tests/**/*.js text eol=lf
+packages/swc-plugin-workflow/transform/tests/**/*.stderr text eol=lf


### PR DESCRIPTION
### TL;DR

Added `.gitattributes` file to enforce LF line endings for `.stderr` test files.

### What changed?

Created a new `.gitattributes` file that specifies `.stderr` files should always use LF line endings regardless of the operating system.

### How to test?

1. Clone the repository on a Windows machine
2. Create or modify a `.stderr` file
3. Verify that Git maintains LF line endings for the file regardless of your Git configuration

### Why make this change?

This ensures consistent line endings for `.stderr` test files across different operating systems, which prevents test failures that might occur due to line ending differences between platforms (particularly Windows vs Unix-based systems).