### PR TITLE
Transform step functions to single `useStep()` calls

### DIFF
--- a/.changeset/wide-wombats-poke.md
+++ b/.changeset/wide-wombats-poke.md
@@ -1,0 +1,6 @@
+---
+"@workflow/swc-plugin": patch
+"@workflow/core": patch
+---
+
+Transform step functions to single `useStep()` calls

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -175,4 +175,28 @@ describe('createUseStep', () => {
       ]
     `);
   });
+
+  it('should set the step function .name property correctly', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'step_completed',
+        correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          result: [undefined],
+        },
+        createdAt: new Date(),
+      },
+    ]);
+    const useStep = createUseStep(ctx);
+    const myStepFunction = useStep('step//input.js//my_step_function');
+
+    // Verify the .name property is set to the extracted function name from the step name
+    expect(myStepFunction.name).toBe('my_step_function');
+
+    // Also verify it works when called
+    await myStepFunction();
+    expect(ctx.onWorkflowError).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -11,7 +11,7 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
   return function useStep<Args extends Serializable[], Result>(
     stepName: string
   ) {
-    return (...args: Args): Promise<Result> => {
+    const stepFunction = (...args: Args): Promise<Result> => {
       const { promise, resolve, reject } = withResolvers<Result>();
 
       const correlationId = `step_${ctx.generateUlid()}`;
@@ -124,5 +124,13 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
 
       return promise;
     };
+
+    // Ensure the "name" property matches the original step function name
+    const functionName = stepName.split('//').pop();
+    Object.defineProperty(stepFunction, 'name', {
+      value: functionName,
+    });
+
+    return stepFunction;
   };
 }

--- a/packages/swc-plugin-workflow/transform/tests/errors/conflicting-directives/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/conflicting-directives/output-workflow.js
@@ -2,9 +2,7 @@
 /**__internal_workflows{"steps":{"input.js":{"test":{"stepId":"step//input.js//test"}}}}*/;
 'use step';
 'use workflow';
-export async function test() {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//test")();
-}
+export var test = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//test");
 Object.defineProperty(test, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
     value: "step//input.js//test",
     writable: false,

--- a/packages/swc-plugin-workflow/transform/tests/errors/forbidden-expressions/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/forbidden-expressions/output-workflow.js
@@ -1,10 +1,6 @@
 /**__internal_workflows{"steps":{"input.js":{"stepWithArguments":{"stepId":"step//input.js//stepWithArguments"},"stepWithThis":{"stepId":"step//input.js//stepWithThis"}}}}*/;
-export async function stepWithThis() {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepWithThis")();
-}
-export async function stepWithArguments() {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepWithArguments")();
-}
+export var stepWithThis = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepWithThis");
+export var stepWithArguments = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepWithArguments");
 class TestClass extends BaseClass {
     async stepMethod() {
         'use step';

--- a/packages/swc-plugin-workflow/transform/tests/errors/invalid-exports/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/invalid-exports/output-workflow.js
@@ -10,9 +10,7 @@ export class MyClass {
 }
 export * from './other';
 // This is ok
-export async function validStep() {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//validStep")();
-}
+export var validStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//validStep");
 Object.defineProperty(validStep, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
     value: "step//input.js//validStep",
     writable: false,

--- a/packages/swc-plugin-workflow/transform/tests/errors/misplaced-function-directive/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/misplaced-function-directive/output-workflow.js
@@ -1,7 +1,5 @@
 /**__internal_workflows{"steps":{"input.js":{"badStep":{"stepId":"step//input.js//badStep"}}}}*/;
-export async function badStep() {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//badStep")();
-}
+export var badStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//badStep");
 export const badWorkflow = async ()=>{
     console.log('hello');
     // Error: directive must be at the top of function

--- a/packages/swc-plugin-workflow/transform/tests/errors/non-async-functions/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/non-async-functions/output-workflow.js
@@ -17,9 +17,7 @@ const obj = {
     }
 };
 // These are ok
-export async function validStep() {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//validStep")();
-}
+export var validStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//validStep");
 export const validWorkflow = async ()=>{
     return 'test';
 };

--- a/packages/swc-plugin-workflow/transform/tests/fixture/destructuring/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/destructuring/output-workflow.js
@@ -1,49 +1,11 @@
 /**__internal_workflows{"steps":{"input.js":{"destructure":{"stepId":"step//input.js//destructure"},"multiple":{"stepId":"step//input.js//multiple"},"nested_destructure":{"stepId":"step//input.js//nested_destructure"},"process_array":{"stepId":"step//input.js//process_array"},"rest_top_level":{"stepId":"step//input.js//rest_top_level"},"with_defaults":{"stepId":"step//input.js//with_defaults"},"with_rest":{"stepId":"step//input.js//with_rest"}}}}*/;
-export async function destructure({ a, b }) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//destructure")({
-        a,
-        b
-    });
-}
-export async function process_array([first, second]) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//process_array")([
-        first,
-        second
-    ]);
-}
-export async function nested_destructure({ user: { name, age } }) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//nested_destructure")({
-        user: {
-            name,
-            age
-        }
-    });
-}
-export async function with_defaults({ x = 10, y = 20 }) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//with_defaults")({
-        x,
-        y
-    });
-}
-export async function with_rest({ a, b, ...rest }) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//with_rest")({
-        a,
-        b,
-        ...rest
-    });
-}
-export async function multiple({ a, b }, { c, d }) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//multiple")({
-        a,
-        b
-    }, {
-        c,
-        d
-    });
-}
-export async function rest_top_level(a, b, ...rest) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//rest_top_level")(a, b, ...rest);
-}
+export var destructure = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//destructure");
+export var process_array = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//process_array");
+export var nested_destructure = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//nested_destructure");
+export var with_defaults = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//with_defaults");
+export var with_rest = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//with_rest");
+export var multiple = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//multiple");
+export var rest_top_level = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//rest_top_level");
 Object.defineProperty(destructure, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
     value: "step//input.js//destructure",
     writable: false,

--- a/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/input.js
@@ -1,0 +1,15 @@
+let stepArrow = async () => {
+  'use step';
+  return 1;
+};
+
+export let exportedStepArrow = async () => {
+  'use step';
+  return 2;
+};
+
+export async function normalStep() {
+  'use step';
+  return 3;
+}
+

--- a/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-client.js
@@ -1,0 +1,10 @@
+/**__internal_workflows{"steps":{"input.js":{"exportedStepArrow":{"stepId":"step//input.js//exportedStepArrow"},"normalStep":{"stepId":"step//input.js//normalStep"},"stepArrow":{"stepId":"step//input.js//stepArrow"}}}}*/;
+let stepArrow = async ()=>{
+    return 1;
+};
+export let exportedStepArrow = async ()=>{
+    return 2;
+};
+export async function normalStep() {
+    return 3;
+}

--- a/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-step.js
@@ -1,0 +1,14 @@
+import { registerStepFunction } from "workflow/internal/private";
+/**__internal_workflows{"steps":{"input.js":{"exportedStepArrow":{"stepId":"step//input.js//exportedStepArrow"},"normalStep":{"stepId":"step//input.js//normalStep"},"stepArrow":{"stepId":"step//input.js//stepArrow"}}}}*/;
+let stepArrow = async ()=>{
+    return 1;
+};
+export let exportedStepArrow = async ()=>{
+    return 2;
+};
+export async function normalStep() {
+    return 3;
+}
+registerStepFunction("step//input.js//stepArrow", stepArrow);
+registerStepFunction("step//input.js//exportedStepArrow", exportedStepArrow);
+registerStepFunction("step//input.js//normalStep", normalStep);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-workflow.js
@@ -1,0 +1,22 @@
+/**__internal_workflows{"steps":{"input.js":{"exportedStepArrow":{"stepId":"step//input.js//exportedStepArrow"},"normalStep":{"stepId":"step//input.js//normalStep"},"stepArrow":{"stepId":"step//input.js//stepArrow"}}}}*/;
+let stepArrow = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepArrow");
+export let exportedStepArrow = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//exportedStepArrow");
+export var normalStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//normalStep");
+Object.defineProperty(stepArrow, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//stepArrow",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+Object.defineProperty(exportedStepArrow, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//exportedStepArrow",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+Object.defineProperty(normalStep, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//normalStep",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});

--- a/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/input.js
@@ -3,9 +3,16 @@ export async function stepFunction(a, b) {
   return a + b;
 }
 
+async function stepFunctionWithoutExport(a, b) {
+  'use step';
+  return a - b;
+}
+
 export async function workflowFunction(a, b) {
   'use workflow';
-  return stepFunction(a, b);
+  const result = await stepFunction(a, b);
+  const result2 = await stepFunctionWithoutExport(a, b);
+  return result + result2;
 }
 
 export async function normalFunction(a, b) {

--- a/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-client.js
@@ -1,6 +1,9 @@
-/**__internal_workflows{"workflows":{"input.js":{"workflowFunction":{"workflowId":"workflow//input.js//workflowFunction"}}},"steps":{"input.js":{"stepFunction":{"stepId":"step//input.js//stepFunction"}}}}*/;
+/**__internal_workflows{"workflows":{"input.js":{"workflowFunction":{"workflowId":"workflow//input.js//workflowFunction"}}},"steps":{"input.js":{"stepFunction":{"stepId":"step//input.js//stepFunction"},"stepFunctionWithoutExport":{"stepId":"step//input.js//stepFunctionWithoutExport"}}}}*/;
 export async function stepFunction(a, b) {
     return a + b;
+}
+async function stepFunctionWithoutExport(a, b) {
+    return a - b;
 }
 export async function workflowFunction(a, b) {
     throw new Error("You attempted to execute workflow workflowFunction function directly. To start a workflow, use start(workflowFunction) from workflow/api");

--- a/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-step.js
@@ -1,13 +1,19 @@
 import { registerStepFunction } from "workflow/internal/private";
-/**__internal_workflows{"workflows":{"input.js":{"workflowFunction":{"workflowId":"workflow//input.js//workflowFunction"}}},"steps":{"input.js":{"stepFunction":{"stepId":"step//input.js//stepFunction"}}}}*/;
+/**__internal_workflows{"workflows":{"input.js":{"workflowFunction":{"workflowId":"workflow//input.js//workflowFunction"}}},"steps":{"input.js":{"stepFunction":{"stepId":"step//input.js//stepFunction"},"stepFunctionWithoutExport":{"stepId":"step//input.js//stepFunctionWithoutExport"}}}}*/;
 export async function stepFunction(a, b) {
     return a + b;
 }
+async function stepFunctionWithoutExport(a, b) {
+    return a - b;
+}
 export async function workflowFunction(a, b) {
     'use workflow';
-    return stepFunction(a, b);
+    const result = await stepFunction(a, b);
+    const result2 = await stepFunctionWithoutExport(a, b);
+    return result + result2;
 }
 export async function normalFunction(a, b) {
     return a * b;
 }
 registerStepFunction("step//input.js//stepFunction", stepFunction);
+registerStepFunction("step//input.js//stepFunctionWithoutExport", stepFunctionWithoutExport);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-workflow.js
@@ -1,9 +1,10 @@
-/**__internal_workflows{"workflows":{"input.js":{"workflowFunction":{"workflowId":"workflow//input.js//workflowFunction"}}},"steps":{"input.js":{"stepFunction":{"stepId":"step//input.js//stepFunction"}}}}*/;
-export async function stepFunction(a, b) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepFunction")(a, b);
-}
+/**__internal_workflows{"workflows":{"input.js":{"workflowFunction":{"workflowId":"workflow//input.js//workflowFunction"}}},"steps":{"input.js":{"stepFunction":{"stepId":"step//input.js//stepFunction"},"stepFunctionWithoutExport":{"stepId":"step//input.js//stepFunctionWithoutExport"}}}}*/;
+export var stepFunction = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepFunction");
+var stepFunctionWithoutExport = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepFunctionWithoutExport");
 export async function workflowFunction(a, b) {
-    return stepFunction(a, b);
+    const result = await stepFunction(a, b);
+    const result2 = await stepFunctionWithoutExport(a, b);
+    return result + result2;
 }
 export async function normalFunction(a, b) {
     return a * b;
@@ -11,6 +12,12 @@ export async function normalFunction(a, b) {
 workflowFunction.workflowId = "workflow//input.js//workflowFunction";
 Object.defineProperty(stepFunction, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
     value: "step//input.js//stepFunction",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+Object.defineProperty(stepFunctionWithoutExport, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//stepFunctionWithoutExport",
     writable: false,
     enumerable: false,
     configurable: false

--- a/packages/swc-plugin-workflow/transform/tests/fixture/module-level-step/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/module-level-step/output-workflow.js
@@ -3,10 +3,8 @@
 const localArrow = async (input)=>{
     return input.bar;
 };
-export async function step(input) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//step")(input);
-}
-export const stepArrow = async (input)=>globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepArrow")(input);
+export var step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//step");
+export const stepArrow = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//stepArrow");
 Object.defineProperty(step, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
     value: "step//input.js//step",
     writable: false,

--- a/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/input.js
@@ -1,0 +1,16 @@
+const fn1 = async () => {
+  'use step';
+  return 1;
+}, fn2 = async () => {
+  'use step';
+  return 2;
+};
+
+export const fn3 = async () => {
+  'use step';
+  return 3;
+}, fn4 = async () => {
+  'use step';
+  return 4;
+};
+

--- a/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-client.js
@@ -1,0 +1,11 @@
+/**__internal_workflows{"steps":{"input.js":{"fn1":{"stepId":"step//input.js//fn1"},"fn2":{"stepId":"step//input.js//fn2"},"fn3":{"stepId":"step//input.js//fn3"},"fn4":{"stepId":"step//input.js//fn4"}}}}*/;
+const fn1 = async ()=>{
+    return 1;
+}, fn2 = async ()=>{
+    return 2;
+};
+export const fn3 = async ()=>{
+    return 3;
+}, fn4 = async ()=>{
+    return 4;
+};

--- a/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-step.js
@@ -1,0 +1,16 @@
+import { registerStepFunction } from "workflow/internal/private";
+/**__internal_workflows{"steps":{"input.js":{"fn1":{"stepId":"step//input.js//fn1"},"fn2":{"stepId":"step//input.js//fn2"},"fn3":{"stepId":"step//input.js//fn3"},"fn4":{"stepId":"step//input.js//fn4"}}}}*/;
+const fn1 = async ()=>{
+    return 1;
+}, fn2 = async ()=>{
+    return 2;
+};
+export const fn3 = async ()=>{
+    return 3;
+}, fn4 = async ()=>{
+    return 4;
+};
+registerStepFunction("step//input.js//fn1", fn1);
+registerStepFunction("step//input.js//fn2", fn2);
+registerStepFunction("step//input.js//fn3", fn3);
+registerStepFunction("step//input.js//fn4", fn4);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-workflow.js
@@ -1,0 +1,27 @@
+/**__internal_workflows{"steps":{"input.js":{"fn1":{"stepId":"step//input.js//fn1"},"fn2":{"stepId":"step//input.js//fn2"},"fn3":{"stepId":"step//input.js//fn3"},"fn4":{"stepId":"step//input.js//fn4"}}}}*/;
+const fn1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//fn1"), fn2 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//fn2");
+export const fn3 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//fn3"), fn4 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//fn4");
+Object.defineProperty(fn1, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//fn1",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+Object.defineProperty(fn2, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//fn2",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+Object.defineProperty(fn3, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//fn3",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+Object.defineProperty(fn4, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//fn4",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});

--- a/packages/swc-plugin-workflow/transform/tests/fixture/single-step/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/single-step/output-workflow.js
@@ -1,7 +1,5 @@
 /**__internal_workflows{"steps":{"input.js":{"add":{"stepId":"step//input.js//add"}}}}*/;
-export async function add(a, b) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//add")(a, b);
-}
+export var add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//add");
 Object.defineProperty(add, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
     value: "step//input.js//add",
     writable: false,

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-arrow-function/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-arrow-function/output-workflow.js
@@ -1,5 +1,5 @@
 /**__internal_workflows{"steps":{"input.js":{"multiply":{"stepId":"step//input.js//multiply"}}}}*/;
-export const multiply = async (a, b)=>globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//multiply")(a, b);
+export const multiply = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//multiply");
 Object.defineProperty(multiply, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
     value: "step//input.js//multiply",
     writable: false,

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-workflow.js
@@ -2,9 +2,7 @@ import { usefulHelper// do not remove
  } from './utils';
 import * as useful from './useful'; // do not remove
 /**__internal_workflows{"steps":{"input.js":{"processData":{"stepId":"step//input.js//processData"}}}}*/;
-export async function processData(data) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//processData")(data);
-}
+export var processData = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//processData");
 export function normalFunction() {
     // since this function is exported we can't remove it
     useful.doSomething();

--- a/packages/swc-plugin-workflow/transform/tests/fixture/unused-exports/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/unused-exports/output-workflow.js
@@ -10,9 +10,7 @@ export function formatData(data) {
     return unusedHelper(data);
 }
 // This step function uses the helper
-export async function processData(input) {
-    return globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//processData")(input);
-}
+export var processData = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//processData");
 // This is used internally
 function internalHelper(value) {
     return value * 2;

--- a/packages/swc-plugin-workflow/transform/tests/fixture/unused-variables-and-types/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/unused-variables-and-types/output-workflow.js
@@ -1,10 +1,5 @@
 /**__internal_workflows{"steps":{"input.js":{"sendRecipientEmail":{"stepId":"step//input.js//sendRecipientEmail"}}}}*/;
-export const sendRecipientEmail = async ({ recipientEmail, cardImage, cardText, rsvpReplies })=>globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//sendRecipientEmail")({
-        recipientEmail,
-        cardImage,
-        cardText,
-        rsvpReplies
-    });
+export const sendRecipientEmail = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//sendRecipientEmail");
 export function normalFunction() {
     return 'this stays because it is exported';
 }

--- a/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/input.js
@@ -1,0 +1,10 @@
+async function namedStep() {
+  'use step';
+  return 1;
+}
+
+export async function exportedNamedStep() {
+  'use step';
+  return 2;
+}
+

--- a/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-client.js
@@ -1,0 +1,7 @@
+/**__internal_workflows{"steps":{"input.js":{"exportedNamedStep":{"stepId":"step//input.js//exportedNamedStep"},"namedStep":{"stepId":"step//input.js//namedStep"}}}}*/;
+async function namedStep() {
+    return 1;
+}
+export async function exportedNamedStep() {
+    return 2;
+}

--- a/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-step.js
@@ -1,0 +1,10 @@
+import { registerStepFunction } from "workflow/internal/private";
+/**__internal_workflows{"steps":{"input.js":{"exportedNamedStep":{"stepId":"step//input.js//exportedNamedStep"},"namedStep":{"stepId":"step//input.js//namedStep"}}}}*/;
+async function namedStep() {
+    return 1;
+}
+export async function exportedNamedStep() {
+    return 2;
+}
+registerStepFunction("step//input.js//namedStep", namedStep);
+registerStepFunction("step//input.js//exportedNamedStep", exportedNamedStep);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-workflow.js
@@ -1,0 +1,15 @@
+/**__internal_workflows{"steps":{"input.js":{"exportedNamedStep":{"stepId":"step//input.js//exportedNamedStep"},"namedStep":{"stepId":"step//input.js//namedStep"}}}}*/;
+var namedStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//namedStep");
+export var exportedNamedStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//exportedNamedStep");
+Object.defineProperty(namedStep, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//namedStep",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});
+Object.defineProperty(exportedNamedStep, Symbol.for("WORKFLOW_STEP_FUNCTION_NAME"), {
+    value: "step//input.js//exportedNamedStep",
+    writable: false,
+    enumerable: false,
+    configurable: false
+});


### PR DESCRIPTION
- Modified SWC plugin to convert exported step functions to var/let/const declarations
- Instead of wrapping functions (calling `useStep` on every invocation), functions are now assigned directly to the result of `useStep()` call
- This ensures `useStep()` is called only once at module initialization per step function
- Applies to both file-level and function-level `'use step'` directives
- All step function exports now use pattern: `export var fn = globalThis[Symbol.for('WORKFLOW_USE_STEP')](stepId)`
- Updated all test fixtures to reflect the new transformation