### PR TITLE
Use "stepId" instead of `Symbol.for("STEP_FUNCTION_NAME_SYMBOL")` for annotating step functions

### DIFF
--- a/.changeset/tough-toys-shop.md
+++ b/.changeset/tough-toys-shop.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Use "stepId" instead of `Symbol.for("STEP_FUNCTION_NAME_SYMBOL")` for annotating step functions

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -12,7 +12,7 @@ import {
   getWorkflowReducers,
   hydrateWorkflowArguments,
 } from './serialization.js';
-import { STEP_FUNCTION_NAME_SYMBOL, STREAM_NAME_SYMBOL } from './symbols.js';
+import { STREAM_NAME_SYMBOL } from './symbols.js';
 import { createContext } from './vm/index.js';
 
 describe('getStreamType', () => {
@@ -793,27 +793,27 @@ describe('step function serialization', () => {
     fixedTimestamp: 1714857600000,
   });
 
-  it('should detect step function by checking for STEP_FUNCTION_NAME_SYMBOL', () => {
+  it('should detect step function by checking for stepId property', () => {
     const stepName = 'myStep';
     const stepFn = async (x: number) => x * 2;
 
-    // Attach the symbol like useStep() does
-    Object.defineProperty(stepFn, STEP_FUNCTION_NAME_SYMBOL, {
+    // Attach stepId like useStep() does
+    Object.defineProperty(stepFn, 'stepId', {
       value: stepName,
       writable: false,
       enumerable: false,
       configurable: false,
     });
 
-    // Verify the symbol is attached correctly
-    expect((stepFn as any)[STEP_FUNCTION_NAME_SYMBOL]).toBe(stepName);
+    // Verify the property is attached correctly
+    expect((stepFn as any).stepId).toBe(stepName);
   });
 
-  it('should not have STEP_FUNCTION_NAME_SYMBOL on regular functions', () => {
+  it('should not have stepId on regular functions', () => {
     const regularFn = async (x: number) => x * 2;
 
-    // Regular functions should not have the symbol
-    expect((regularFn as any)[STEP_FUNCTION_NAME_SYMBOL]).toBeUndefined();
+    // Regular functions should not have stepId
+    expect((regularFn as any).stepId).toBeUndefined();
   });
 
   it('should lookup registered step function by name', () => {
@@ -869,8 +869,8 @@ describe('step function serialization', () => {
     // Register the step function
     registerStepFunction(stepName, stepFn);
 
-    // Attach the symbol to the function (like the SWC compiler would)
-    Object.defineProperty(stepFn, STEP_FUNCTION_NAME_SYMBOL, {
+    // Attach stepId to the function (like useStep() does)
+    Object.defineProperty(stepFn, 'stepId', {
       value: stepName,
       writable: false,
       enumerable: false,
@@ -897,8 +897,8 @@ describe('step function serialization', () => {
     const stepName = 'step//workflows/test.ts//anotherStep';
     const stepFn = async () => 'result';
 
-    // Attach the symbol to the function (like the SWC compiler would)
-    Object.defineProperty(stepFn, STEP_FUNCTION_NAME_SYMBOL, {
+    // Attach stepId to the function (like useStep() does)
+    Object.defineProperty(stepFn, 'stepId', {
       value: stepName,
       writable: false,
       enumerable: false,

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -4,7 +4,6 @@ import { getStepFunction } from './private.js';
 import { getWorld } from './runtime/world.js';
 import {
   BODY_INIT_SYMBOL,
-  STEP_FUNCTION_NAME_SYMBOL,
   STREAM_NAME_SYMBOL,
   STREAM_TYPE_SYMBOL,
   WEBHOOK_RESPONSE_WRITABLE,
@@ -280,8 +279,8 @@ function getCommonReducers(global: Record<string, any> = globalThis) {
     Set: (value) => value instanceof global.Set && Array.from(value),
     StepFunction: (value) => {
       if (typeof value !== 'function') return false;
-      const stepName = value[STEP_FUNCTION_NAME_SYMBOL];
-      return typeof stepName === 'string' ? stepName : false;
+      const stepId = (value as any).stepId;
+      return typeof stepId === 'string' ? stepId : false;
     },
     URL: (value) => value instanceof global.URL && value.href,
     URLSearchParams: (value) => {

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -133,16 +133,12 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
     });
 
     // Add the step function identifier to the step function for serialization
-    Object.defineProperty(
-      stepFunction,
-      Symbol.for('WORKFLOW_STEP_FUNCTION_NAME'),
-      {
-        value: stepName,
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      }
-    );
+    Object.defineProperty(stepFunction, 'stepId', {
+      value: stepName,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
 
     return stepFunction;
   };

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -9,6 +9,3 @@ export const BODY_INIT_SYMBOL = Symbol.for('BODY_INIT');
 export const WEBHOOK_RESPONSE_WRITABLE = Symbol.for(
   'WEBHOOK_RESPONSE_WRITABLE'
 );
-export const STEP_FUNCTION_NAME_SYMBOL = Symbol.for(
-  'WORKFLOW_STEP_FUNCTION_NAME'
-);


### PR DESCRIPTION
Replace `Symbol.for("WORKFLOW_STEP_FUNCTION_NAME")` with a standard `stepId` property for step function annotation.

### What changed?

- Replaced the use of `STEP_FUNCTION_NAME_SYMBOL` (a Symbol) with a regular `stepId` property on step functions
- Updated the serialization logic to check for the `stepId` property instead of the Symbol
- Removed the `STEP_FUNCTION_NAME_SYMBOL` constant from symbols.ts
- Updated tests to reflect this change in implementation

### Why make this change?

This more closely resembles how Workflow functions are annotated with a `workflowId` property.