### PR TITLE
Add support for step functions nested inside of workflow functions

### DIFF
--- a/.changeset/yellow-cats-teach.md
+++ b/.changeset/yellow-cats-teach.md
@@ -1,0 +1,5 @@
+---
+"@workflow/swc-plugin": patch
+---
+
+Add support for step functions nested inside of workflow functions

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/input.js
@@ -1,0 +1,44 @@
+export async function example(a, b) {
+  "use workflow";
+
+  // Function declaration step
+  async function step(a, b) {
+    "use step";
+
+    return a + b;
+  }
+
+  // Arrow function with const
+  const arrowStep = async (x, y) => {
+    "use step";
+    return x * y;
+  };
+
+  // Arrow function with let
+  let letArrowStep = async (x, y) => {
+    "use step";
+    return x - y;
+  };
+
+  // Arrow function with var
+  var varArrowStep = async (x, y) => {
+    "use step";
+    return x / y;
+  };
+
+  // Object with step method
+  const helpers = {
+    async objectStep(x, y) {
+      "use step";
+      return x + y + 10;
+    }
+  };
+
+  const val = await step(a, b);
+  const val2 = await arrowStep(a, b);
+  const val3 = await letArrowStep(a, b);
+  const val4 = await varArrowStep(a, b);
+  const val5 = await helpers.objectStep(a, b);
+
+  return val + val2 + val3 + val4 + val5;
+}

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-client.js
@@ -1,0 +1,5 @@
+/**__internal_workflows{"workflows":{"input.js":{"example":{"workflowId":"workflow//input.js//example"}}}}*/;
+export async function example(a, b) {
+    throw new Error("You attempted to execute workflow example function directly. To start a workflow, use start(example) from workflow/api");
+}
+example.workflowId = "workflow//input.js//example";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-step.js
@@ -1,0 +1,35 @@
+import { registerStepFunction } from "workflow/internal/private";
+/**__internal_workflows{"workflows":{"input.js":{"example":{"workflowId":"workflow//input.js//example"}}},"steps":{"input.js":{"arrowStep":{"stepId":"step//input.js//arrowStep"},"helpers/objectStep":{"stepId":"step//input.js//helpers/objectStep"},"letArrowStep":{"stepId":"step//input.js//letArrowStep"},"step":{"stepId":"step//input.js//step"},"varArrowStep":{"stepId":"step//input.js//varArrowStep"}}}}*/;
+// Function declaration step
+async function step(a, b) {
+    return a + b;
+}
+async function arrowStep(x, y) {
+    return x * y;
+}
+async function letArrowStep(x, y) {
+    return x - y;
+}
+async function varArrowStep(x, y) {
+    return x / y;
+}
+var helpers$objectStep = async (x, y)=>{
+    return x + y + 10;
+};
+export async function example(a, b) {
+    // Object with step method
+    const helpers = {
+        objectStep: helpers$objectStep
+    };
+    const val = await step(a, b);
+    const val2 = await arrowStep(a, b);
+    const val3 = await letArrowStep(a, b);
+    const val4 = await varArrowStep(a, b);
+    const val5 = await helpers.objectStep(a, b);
+    return val + val2 + val3 + val4 + val5;
+}
+registerStepFunction("step//input.js//step", step);
+registerStepFunction("step//input.js//arrowStep", arrowStep);
+registerStepFunction("step//input.js//letArrowStep", letArrowStep);
+registerStepFunction("step//input.js//varArrowStep", varArrowStep);
+registerStepFunction("step//input.js//helpers/objectStep", helpers$objectStep);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-workflow.js
@@ -1,0 +1,21 @@
+/**__internal_workflows{"workflows":{"input.js":{"example":{"workflowId":"workflow//input.js//example"}}},"steps":{"input.js":{"arrowStep":{"stepId":"step//input.js//arrowStep"},"helpers/objectStep":{"stepId":"step//input.js//helpers/objectStep"},"letArrowStep":{"stepId":"step//input.js//letArrowStep"},"step":{"stepId":"step//input.js//step"},"varArrowStep":{"stepId":"step//input.js//varArrowStep"}}}}*/;
+export async function example(a, b) {
+    var step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//step");
+    // Arrow function with const
+    const arrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//arrowStep");
+    // Arrow function with let
+    let letArrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//letArrowStep");
+    // Arrow function with var
+    var varArrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//varArrowStep");
+    // Object with step method
+    const helpers = {
+        objectStep: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//helpers/objectStep")
+    };
+    const val = await step(a, b);
+    const val2 = await arrowStep(a, b);
+    const val3 = await letArrowStep(a, b);
+    const val4 = await varArrowStep(a, b);
+    const val5 = await helpers.objectStep(a, b);
+    return val + val2 + val3 + val4 + val5;
+}
+example.workflowId = "workflow//input.js//example";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/object-property-step/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/object-property-step/output-step.js
@@ -2,7 +2,7 @@ import { registerStepFunction } from "workflow/internal/private";
 import * as z from 'zod';
 import { tool } from 'ai';
 /**__internal_workflows{"steps":{"input.js":{"timeTool/execute":{"stepId":"step//input.js//timeTool/execute"},"weatherTool/execute":{"stepId":"step//input.js//weatherTool/execute"},"weatherTool2/execute":{"stepId":"step//input.js//weatherTool2/execute"}}}}*/;
-var weatherTool2$execute = async ({ location })=>{
+var weatherTool$execute = async ({ location })=>{
     return {
         location,
         temperature: 72 + Math.floor(Math.random() * 21) - 10
@@ -13,7 +13,7 @@ var timeTool$execute = async ()=>{
         time: new Date().toISOString()
     };
 };
-var weatherTool$execute = async ({ location })=>{
+var weatherTool2$execute = async ({ location })=>{
     return {
         location,
         temperature: 72 + Math.floor(Math.random() * 21) - 10


### PR DESCRIPTION
Added support for nested step functions inside workflow functions, improving the SWC plugin's ability to handle complex workflow patterns.

### What changed?

- Added support for nested step functions inside workflow functions
- Implemented hoisting of nested step functions in step mode
- Added tracking of default exports that need to be replaced with expressions
- Refactored function processing logic into a dedicated `process_stmt` method
- Fixed directive detection and removal in various contexts
- Improved handling of workflow functions with both file-level and inline directives
- Added conditional body replacement for workflow functions based on directive source
- Added test cases for nested step functions in workflow functions

### How to test?

1. Create a workflow function with a nested step function:
```javascript
export async function example(a, b) {
  "use workflow";

  async function step(a, b) {
    "use step";
    return a + b;
  }

  const val = await step(a, b);
  return val;
}
```

2. Verify the output in different modes:
   - Step mode: The nested step function is hoisted to module level
   - Workflow mode: The nested step function is replaced with a proxy reference
   - Client mode: The workflow function throws an error when called directly

### Why make this change?

This change enables more complex workflow patterns by allowing step functions to be defined inside workflow functions. Previously, all step functions had to be defined at the module level, which limited code organization options. With this change, developers can define step functions closer to where they're used, improving code readability and maintainability while still ensuring proper transformation for all execution modes.