### PR TITLE
Make `tools` optional in DurableAgent

### DIFF
--- a/.changeset/ninety-lions-grab.md
+++ b/.changeset/ninety-lions-grab.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+Make `tools` optional in DurableAgent

--- a/packages/ai/src/agent/durable-agent.ts
+++ b/packages/ai/src/agent/durable-agent.ts
@@ -30,7 +30,7 @@ export interface DurableAgentOptions {
    * Tools can be implemented as workflow steps for automatic retries and persistence,
    * or as regular workflow-level logic using core library features like sleep() and Hooks.
    */
-  tools: ToolSet;
+  tools?: ToolSet;
 
   /**
    * Optional system prompt to guide the agent's behavior.
@@ -98,7 +98,7 @@ export class DurableAgent {
 
   constructor(options: DurableAgentOptions) {
     this.model = options.model;
-    this.tools = options.tools;
+    this.tools = options.tools ?? {};
     this.system = options.system;
   }
 


### PR DESCRIPTION
Made the `tools` parameter optional in the `DurableAgent` class.

### What changed?

- Updated the `DurableAgentOptions` interface to make the `tools` property optional
- Modified the constructor to initialize `this.tools` with an empty object (`{}`) when `options.tools` is not provided