### PR TITLE
Use inline sourcemaps to prevent SWC read import error

### DIFF
--- a/.changeset/chatty-goats-fall.md
+++ b/.changeset/chatty-goats-fall.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Use inline sourcemaps to prevent SWC read import error

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "@workflow/tsconfig/base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "sourceMap": false,
+    "inlineSourceMap": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
In monorepos the SWC transform seems to incorrectly translate the source map path that is embedded in the `core` package's dist files and that causes a warning to be printed during build. Inlining the source maps fixes this. This seems like a band-aid solution to me and the real fix would be to address SWC's path resolving issue/configuration, but this could work as an interim solution <picture data-single-emoji=":itg:" title=":itg:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/itg/f8b72f662b066429.png" alt=":itg:" align="absmiddle"></picture> 

Fixes #338.