### PR TITLE
Add e2e tests for postgres world

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -301,7 +301,7 @@ jobs:
         run: pnpm turbo run build --filter='!./workbench/*'
 
       - name: Setup PostgreSQL Database
-        run: cd packages/world-postgres && pnpm exec workflow-postgres-setup
+        run: ./packages/world-postgres/bin/setup.js
 
       - name: Run Build Tests
         run: pnpm vitest run packages/core/e2e/local-build.test.ts

--- a/packages/world-postgres/package.json
+++ b/packages/world-postgres/package.json
@@ -37,7 +37,7 @@
     "./migrations/*.sql": "./src/drizzle/migrations/*.sql"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x bin/setup.js",
     "dev": "tsc --watch",
     "clean": "tsc --build --clean && rm -rf dist",
     "test": "vitest run",


### PR DESCRIPTION
Let's start running all the e2e tests against the postgres world to make sure we don't break it as we continue shipping features (like we did with step retryAfter and timers)