### PR TITLE
Support closure variables for serialized step functions

### DIFF
--- a/.changeset/bright-ducks-travel.md
+++ b/.changeset/bright-ducks-travel.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Support closure variables for serialized step functions

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -150,6 +150,16 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
       configurable: false,
     });
 
+    // Store the closure variables function for serialization
+    if (closureVarsFn) {
+      Object.defineProperty(stepFunction, '__closureVarsFn', {
+        value: closureVarsFn,
+        writable: false,
+        enumerable: false,
+        configurable: false,
+      });
+    }
+
     return stepFunction;
   };
 }

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-step.js
@@ -1,12 +1,12 @@
 import { registerStepFunction } from "workflow/internal/private";
 /**__internal_workflows{"workflows":{"input.js":{"example":{"workflowId":"workflow//input.js//example"}}},"steps":{"input.js":{"arrowStep":{"stepId":"step//input.js//arrowStep"},"helpers/objectStep":{"stepId":"step//input.js//helpers/objectStep"},"letArrowStep":{"stepId":"step//input.js//letArrowStep"},"step":{"stepId":"step//input.js//step"},"varArrowStep":{"stepId":"step//input.js//varArrowStep"}}}}*/;
 // Function declaration step
-async function step(a, b) {
+async function example$step(a, b) {
     return a + b;
 }
-var arrowStep = async (x, y)=>x * y;
-var letArrowStep = async (x, y)=>x - y;
-var varArrowStep = async (x, y)=>x / y;
+var example$arrowStep = async (x, y)=>x * y;
+var example$letArrowStep = async (x, y)=>x - y;
+var example$varArrowStep = async (x, y)=>x / y;
 var helpers$objectStep = async (x, y)=>{
     return x + y + 10;
 };
@@ -22,8 +22,8 @@ export async function example(a, b) {
     const val5 = await helpers.objectStep(a, b);
     return val + val2 + val3 + val4 + val5;
 }
-registerStepFunction("step//input.js//step", step);
-registerStepFunction("step//input.js//arrowStep", arrowStep);
-registerStepFunction("step//input.js//letArrowStep", letArrowStep);
-registerStepFunction("step//input.js//varArrowStep", varArrowStep);
+registerStepFunction("step//input.js//example/step", example$step);
+registerStepFunction("step//input.js//example/arrowStep", example$arrowStep);
+registerStepFunction("step//input.js//example/letArrowStep", example$letArrowStep);
+registerStepFunction("step//input.js//example/varArrowStep", example$varArrowStep);
 registerStepFunction("step//input.js//helpers/objectStep", helpers$objectStep);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-in-workflow/output-workflow.js
@@ -1,12 +1,12 @@
 /**__internal_workflows{"workflows":{"input.js":{"example":{"workflowId":"workflow//input.js//example"}}},"steps":{"input.js":{"arrowStep":{"stepId":"step//input.js//arrowStep"},"helpers/objectStep":{"stepId":"step//input.js//helpers/objectStep"},"letArrowStep":{"stepId":"step//input.js//letArrowStep"},"step":{"stepId":"step//input.js//step"},"varArrowStep":{"stepId":"step//input.js//varArrowStep"}}}}*/;
 export async function example(a, b) {
-    var step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//step");
+    var step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//example/step");
     // Arrow function with const
-    const arrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//arrowStep");
+    const arrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//example/arrowStep");
     // Arrow function with let
-    let letArrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//letArrowStep");
+    let letArrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//example/letArrowStep");
     // Arrow function with var
-    var varArrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//varArrowStep");
+    var varArrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//example/varArrowStep");
     // Object with step method
     const helpers = {
         objectStep: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//helpers/objectStep")

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-with-closure/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-with-closure/output-step.js
@@ -2,20 +2,20 @@ import { __private_getClosureVars, registerStepFunction } from "workflow/interna
 import { DurableAgent } from '@workflow/ai/agent';
 import { gateway } from 'ai';
 /**__internal_workflows{"workflows":{"input.js":{"wflow":{"workflowId":"workflow//input.js//wflow"}}},"steps":{"input.js":{"_anonymousStep0":{"stepId":"step//input.js//_anonymousStep0"},"_anonymousStep1":{"stepId":"step//input.js//_anonymousStep1"},"_anonymousStep2":{"stepId":"step//input.js//_anonymousStep2"},"namedStepWithClosureVars":{"stepId":"step//input.js//namedStepWithClosureVars"}}}}*/;
-async function namedStepWithClosureVars() {
+async function wflow$namedStepWithClosureVars() {
     const { count } = __private_getClosureVars();
     console.log('count', count);
 }
-var _anonymousStep0 = async ()=>{
+var wflow$_anonymousStep0 = async ()=>{
     const { count } = __private_getClosureVars();
     console.log('count', count);
     return gateway('openai/gpt-5');
 };
-async function _anonymousStep1() {
+async function wflow$_anonymousStep1() {
     const { count } = __private_getClosureVars();
     console.log('count', count);
 }
-async function _anonymousStep2() {
+async function wflow$_anonymousStep2() {
     const { count } = __private_getClosureVars();
     console.log('count', count);
 }
@@ -27,7 +27,7 @@ export async function wflow() {
         methodWithClosureVars: _anonymousStep2
     });
 }
-registerStepFunction("step//input.js//namedStepWithClosureVars", namedStepWithClosureVars);
-registerStepFunction("step//input.js//_anonymousStep0", _anonymousStep0);
-registerStepFunction("step//input.js//_anonymousStep1", _anonymousStep1);
-registerStepFunction("step//input.js//_anonymousStep2", _anonymousStep2);
+registerStepFunction("step//input.js//wflow/namedStepWithClosureVars", wflow$namedStepWithClosureVars);
+registerStepFunction("step//input.js//wflow/_anonymousStep0", wflow$_anonymousStep0);
+registerStepFunction("step//input.js//wflow/_anonymousStep1", wflow$_anonymousStep1);
+registerStepFunction("step//input.js//wflow/_anonymousStep2", wflow$_anonymousStep2);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-with-closure/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-with-closure/output-workflow.js
@@ -2,17 +2,17 @@ import { DurableAgent } from '@workflow/ai/agent';
 /**__internal_workflows{"workflows":{"input.js":{"wflow":{"workflowId":"workflow//input.js//wflow"}}},"steps":{"input.js":{"_anonymousStep0":{"stepId":"step//input.js//_anonymousStep0"},"_anonymousStep1":{"stepId":"step//input.js//_anonymousStep1"},"_anonymousStep2":{"stepId":"step//input.js//_anonymousStep2"},"namedStepWithClosureVars":{"stepId":"step//input.js//namedStepWithClosureVars"}}}}*/;
 export async function wflow() {
     let count = 42;
-    var namedStepWithClosureVars = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//namedStepWithClosureVars", ()=>({
+    var namedStepWithClosureVars = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//wflow/namedStepWithClosureVars", ()=>({
             count
         }));
     const agent = new DurableAgent({
-        arrowFunctionWithClosureVars: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//_anonymousStep0", ()=>({
+        arrowFunctionWithClosureVars: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//wflow/_anonymousStep0", ()=>({
                 count
             })),
-        namedFunctionWithClosureVars: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//_anonymousStep1", ()=>({
+        namedFunctionWithClosureVars: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//wflow/_anonymousStep1", ()=>({
                 count
             })),
-        methodWithClosureVars: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//_anonymousStep2", ()=>({
+        methodWithClosureVars: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//wflow/_anonymousStep2", ()=>({
                 count
             }))
     });

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-steps-in-object-constructor/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-steps-in-object-constructor/output-step.js
@@ -3,8 +3,8 @@ import { DurableAgent } from '@workflow/ai/agent';
 import { gateway, tool } from 'ai';
 import * as z from 'zod';
 /**__internal_workflows{"workflows":{"input.js":{"test":{"workflowId":"workflow//input.js//test"}}},"steps":{"input.js":{"_anonymousStep0":{"stepId":"step//input.js//_anonymousStep0"},"_anonymousStep1":{"stepId":"step//input.js//_anonymousStep1"}}}}*/;
-var _anonymousStep0 = async ()=>gateway('openai/gpt-5');
-var _anonymousStep1 = async ({ location })=>`Weather in ${location}: Sunny, 72°F`;
+var test$_anonymousStep0 = async ()=>gateway('openai/gpt-5');
+var test$_anonymousStep1 = async ({ location })=>`Weather in ${location}: Sunny, 72°F`;
 export async function test() {
     'use workflow';
     const agent = new DurableAgent({
@@ -28,5 +28,5 @@ export async function test() {
         ]
     });
 }
-registerStepFunction("step//input.js//_anonymousStep0", _anonymousStep0);
-registerStepFunction("step//input.js//_anonymousStep1", _anonymousStep1);
+registerStepFunction("step//input.js//test/_anonymousStep0", test$_anonymousStep0);
+registerStepFunction("step//input.js//test/_anonymousStep1", test$_anonymousStep1);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-steps-in-object-constructor/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-steps-in-object-constructor/output-workflow.js
@@ -4,14 +4,14 @@ import * as z from 'zod';
 /**__internal_workflows{"workflows":{"input.js":{"test":{"workflowId":"workflow//input.js//test"}}},"steps":{"input.js":{"_anonymousStep0":{"stepId":"step//input.js//_anonymousStep0"},"_anonymousStep1":{"stepId":"step//input.js//_anonymousStep1"}}}}*/;
 export async function test() {
     const agent = new DurableAgent({
-        model: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//_anonymousStep0"),
+        model: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//test/_anonymousStep0"),
         tools: {
             getWeather: tool({
                 description: 'Get weather for a location',
                 inputSchema: z.object({
                     location: z.string()
                 }),
-                execute: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//_anonymousStep1")
+                execute: globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//test/_anonymousStep1")
             })
         }
     });

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -496,7 +496,7 @@ export async function hookCleanupTestWorkflow(
 
 export async function stepFunctionPassingWorkflow() {
   'use workflow';
-  // Pass a step function reference to another step
+  // Pass a step function reference to another step (without closure vars)
   const result = await stepWithStepFunctionArg(doubleNumber);
   return result;
 }
@@ -515,8 +515,37 @@ async function doubleNumber(x: number) {
 
 //////////////////////////////////////////////////////////
 
+export async function stepFunctionWithClosureWorkflow() {
+  'use workflow';
+  const multiplier = 3;
+  const prefix = 'Result: ';
+
+  // Create a step function that captures closure variables
+  const calculate = async (x: number) => {
+    'use step';
+    return `${prefix}${x * multiplier}`;
+  };
+
+  // Pass the step function (with closure vars) to another step
+  const result = await stepThatCallsStepFn(calculate, 7);
+  return result;
+}
+
+async function stepThatCallsStepFn(
+  stepFn: (x: number) => Promise<string>,
+  value: number
+) {
+  'use step';
+  // Call the passed step function - closure vars should be preserved
+  const result = await stepFn(value);
+  return `Wrapped: ${result}`;
+}
+
+//////////////////////////////////////////////////////////
+
 export async function closureVariableWorkflow(baseValue: number) {
   'use workflow';
+  // biome-ignore lint/style/useConst: Intentionally using `let` instead of `const`
   let multiplier = 3;
   const prefix = 'Result: ';
 


### PR DESCRIPTION
Added support for closure variables in serialized step functions, allowing step functions to access variables from their lexical scope when executed remotely.

### What changed?

- Modified the step function serialization format to include closure variables
- Updated the `StepFunction` reducer to capture and serialize closure variables
- Enhanced the `StepFunction` reviver to restore closure variables in the execution context
- Added a wrapper function that sets up the proper context with closure variables when the step function is invoked
- Added tests to verify that step functions can access closure variables after serialization and deserialization

### Why make this change?

Previously, serialized step functions could only access their arguments when executed remotely, but not variables from their lexical scope. This limitation made it difficult to write reusable step functions that needed to access shared configuration or context. This change enables more natural programming patterns by allowing step functions to access closure variables, making the code more intuitive and reducing the need to pass all context as function arguments.