### PR TITLE
Remove unused dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1227,9 +1227,6 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.1(react@19.1.1)
-      react-markdown:
-        specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.1.13)(react@19.1.1)
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow
@@ -1294,9 +1291,6 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.1(react@19.1.1)
-      react-markdown:
-        specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.1.13)(react@19.1.1)
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow
@@ -23556,24 +23550,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
-
-  react-markdown@10.1.0(@types/react@19.1.13)(react@19.1.1):
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/react': 19.1.13
-      devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
-      html-url-attributes: 3.0.1
-      mdast-util-to-hast: 13.2.0
-      react: 19.1.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   react-markdown@10.1.0(@types/react@19.1.13)(react@19.2.0):
     dependencies:

--- a/workbench/nextjs-turbopack/package.json
+++ b/workbench/nextjs-turbopack/package.json
@@ -25,7 +25,6 @@
     "next": "16.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-markdown": "^10.1.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/workbench/nextjs-webpack/package.json
+++ b/workbench/nextjs-webpack/package.json
@@ -25,7 +25,6 @@
     "next": "16.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-markdown": "^10.1.0",
     "zod": "catalog:"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request removes the `react-markdown` package as a dependency from both the `workbench/nextjs-turbopack` and `workbench/nextjs-webpack` projects. The associated references to `react-markdown` have also been cleaned up from the `pnpm-lock.yaml` file, ensuring consistency across the codebase.

**Dependency cleanup:**

* Removed `react-markdown` from the dependencies in `workbench/nextjs-turbopack/package.json` and `workbench/nextjs-webpack/package.json`. [[1]](diffhunk://#diff-07511a2976d48fc789910551fa2c03f3944a91eaf3f2c295fec97bf6094947bdL28) [[2]](diffhunk://#diff-5d7533e7c40afb8704acd8a5d29782447941587e6e632288d3ee0afa0caf4ffeL28)
* Deleted all references to `react-markdown` in the `importers` section of `pnpm-lock.yaml`, preventing it from being installed in the workspace. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1230-L1232) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1297-L1299)
* Removed the `react-markdown@10.1.0(@types/react@19.1.13)(react@19.1.1)` entry from the `snapshots` section of `pnpm-lock.yaml`, eliminating its transitive dependencies.