### PR TITLE
break/close the http connection after finish is sent

### DIFF
--- a/packages/ai/src/workflow-chat-transport.ts
+++ b/packages/ai/src/workflow-chat-transport.ts
@@ -233,6 +233,7 @@ export class WorkflowChatTransport<UI_MESSAGE extends UIMessage>
 
         if (chunk.value.type === 'finish') {
           gotFinish = true;
+          await chunkStream.cancel().catch(() => {});
           break;
         }
       }
@@ -324,6 +325,7 @@ export class WorkflowChatTransport<UI_MESSAGE extends UIMessage>
 
           if (chunk.value.type === 'finish') {
             gotFinish = true;
+            await chunkStream.cancel().catch(() => {});
             break;
           }
         }


### PR DESCRIPTION
the server might keep the writer open, but the client receiving a "finish" should mean that the stream is done. new messages will create a new connection anyways (meaning: this connection isn't being reused, nor should it).