### PR TITLE
[docs] Add button link to X account

### DIFF
--- a/docs/components/geistdocs/navbar.tsx
+++ b/docs/components/geistdocs/navbar.tsx
@@ -9,6 +9,7 @@ import { MobileMenu } from './mobile-menu';
 import { RSSButton } from './rss-button';
 import { SearchButton } from './search';
 import { ThemeToggle } from './theme-toggle';
+import { XButton } from './x-button';
 
 type NavbarProps = {
   children: ReactNode;
@@ -34,6 +35,7 @@ export const Navbar = ({ children, items, suggestions }: NavbarProps) => (
       </div>
       <div className="hidden flex-1 shrink-0 items-center justify-end gap-1 md:flex">
         <RSSButton />
+        <XButton />
         <GitHubButton />
         <ThemeToggle />
         <SearchButton />

--- a/docs/components/geistdocs/x-button.tsx
+++ b/docs/components/geistdocs/x-button.tsx
@@ -1,0 +1,12 @@
+import { SiX } from '@icons-pack/react-simple-icons';
+import { Button } from '../ui/button';
+
+export const XButton = () => {
+  return (
+    <Button asChild size="icon-sm" type="button" variant="ghost">
+      <a href="https://x.com/workflowdevkit" rel="noopener" target="_blank">
+        <SiX className="size-4" />
+      </a>
+    </Button>
+  );
+};


### PR DESCRIPTION
Added an X (Twitter) button to the navbar in the documentation site.

### What changed?

- Created a new component `XButton` in `docs/components/geistdocs/x-button.tsx`
- Imported and added the `XButton` component to the navbar, positioned between the RSS and GitHub buttons
- The X button links to the Workflow Dev Kit Twitter account at https://x.com/workflowdevkit

### How to test?

1. Run the documentation site locally
2. Verify the X button appears in the navbar on desktop view (hidden on mobile)
3. Click the X button and confirm it opens the Workflow Dev Kit Twitter profile in a new tab

### Why make this change?

To improve social media presence and provide users with an additional way to follow updates and connect with the Workflow Dev Kit community through X/Twitter.