### PR TITLE
set "paused" status when waiting for hooks

### DIFF
--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -112,6 +112,10 @@ export async function resumeHook<T = any>(
           }
         }
 
+        if (workflowRun.status === 'paused') {
+          await world.runs.update(hook.runId, { status: 'running' });
+        }
+
         // Re-trigger the workflow against the deployment ID associated
         // with the workflow run that the hook belongs to
         await world.queue(


### PR DESCRIPTION
currently, it seems like the "paused" status is never set. i'd expect a workflow to be paused when waiting for a hook or sleeping