### PR TITLE
Ignore rejections in `waitedUntil` promise

### DIFF
--- a/.changeset/famous-grapes-call.md
+++ b/.changeset/famous-grapes-call.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Ignore rejections in `waitedUntil` promise

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -71,6 +71,12 @@ export function getWorkflowRunStreamId(runId: string, namespace?: string) {
  */
 export async function waitedUntil<T>(fn: () => Promise<T>): Promise<T> {
   const result = fn();
-  waitUntil(result);
+  waitUntil(
+    result.catch(() => {
+      // Ignore error from the promise being rejected.
+      // It's expected that the invoker of `waitedUntil`
+      // will handle the error.
+    })
+  );
   return result;
 }


### PR DESCRIPTION
Improved error handling in the `waitedUntil` utility function by ignoring promise rejections.

This is relevant because for example in `resumeHook()`, I have a try/catch and am logging the error as a warning, but despite that the logs are _also_ rendering as an error because the underlying `waitUntil()` is logging the promise rejection as well:

![Screenshot 2025-11-28 at 00.58.50.png](https://app.graphite.com/user-attachments/assets/8666c6a8-a736-4763-8018-17a76ae56b8b.png)

I think it's safe to assume that when the `waitedUntil()` helper is being used then the caller is responsible for handling the promise rejection.