### PR TITLE
world-postgres: poll faster in pg-boss

### DIFF
--- a/.changeset/eight-emus-shave.md
+++ b/.changeset/eight-emus-shave.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-postgres": patch
+---
+
+poll faster in pg-boss, as it is a polling-based queue

--- a/.changeset/eight-emus-shave.md
+++ b/.changeset/eight-emus-shave.md
@@ -2,4 +2,4 @@
 "@workflow/world-postgres": patch
 ---
 
-poll faster in pg-boss, as it is a polling-based queue
+Increase polling interval for pg-boss to reduce interval between steps

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -84,7 +84,14 @@ export function createQueue(
     await createQueue(jobName);
     await Promise.all(
       Array.from({ length: config.queueConcurrency || 10 }, async () => {
-        await boss.work(jobName, work);
+        await boss.work(
+          jobName,
+          {
+            // turns out pg-boss is not using NOTIFY/LISTEN for job polling
+            pollingIntervalSeconds: 0.5,
+          },
+          work
+        );
       })
     );
 

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -87,7 +87,8 @@ export function createQueue(
         await boss.work(
           jobName,
           {
-            // turns out pg-boss is not using NOTIFY/LISTEN for job polling
+            // The default is 2s, which is far too slow for running steps in quick succession.
+            // The min is 0.5s, which is still too slow. We should move to a pg NOTIFY/LISTEN-based job system.
             pollingIntervalSeconds: 0.5,
           },
           work


### PR DESCRIPTION
turns out [pg-boss is not using LISTEN/NOTIFY](https://github.com/timgit/pg-boss/issues/24), which makes it a polling
queue management system. This means we need to tune the polling interval. The minimum is 0.5s,
so I set it like so. I believe this shows we need to drop pg-boss altogether.
