### PR TITLE
docs: add padding to children for better visual hierarchy

### DIFF
--- a/docs/components/geistdocs/sidebar.tsx
+++ b/docs/components/geistdocs/sidebar.tsx
@@ -60,7 +60,7 @@ export const Folder = ({ item, level, children }: FolderProps) => {
         {linkInner}
         <ChevronRightIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
       </CollapsibleTrigger>
-      <CollapsibleContent>
+      <CollapsibleContent className="pl-4">
         <ul>{children}</ul>
       </CollapsibleContent>
     </Collapsible>


### PR DESCRIPTION
before:

<img width="295" height="573" alt="image" src="https://github.com/user-attachments/assets/7cedf775-6659-4cb1-b00e-9c4c5f517bd1" />

after:

<img width="282" height="593" alt="image" src="https://github.com/user-attachments/assets/14d87641-ef20-46fe-9b8e-0bb2dd63cea4" />
