### PR TITLE
Better error when passing an invalid workflow value to `start()`

### DIFF
--- a/.changeset/green-clouds-search.md
+++ b/.changeset/green-clouds-search.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Better error when passing an invalid workflow value to `start()`

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -1,0 +1,70 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
+import { describe, expect, it, vi } from 'vitest';
+import { start } from './start.js';
+
+// Mock @vercel/functions
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn(),
+}));
+
+// Mock the world module with all required exports
+vi.mock('./world.js', () => ({
+  getWorld: vi.fn(),
+  getWorldHandlers: vi.fn(() => ({
+    createQueueHandler: vi.fn(() => vi.fn()),
+  })),
+}));
+
+describe('start', () => {
+  describe('error handling', () => {
+    it('should throw WorkflowRuntimeError when workflow is undefined', async () => {
+      await expect(
+        // @ts-expect-error - intentionally passing undefined
+        start(undefined, [])
+      ).rejects.toThrow(WorkflowRuntimeError);
+
+      await expect(
+        // @ts-expect-error - intentionally passing undefined
+        start(undefined, [])
+      ).rejects.toThrow(
+        `'start' received an invalid workflow function. Ensure the Workflow Development Kit is configured correctly and the function includes a 'use workflow' directive.`
+      );
+    });
+
+    it('should throw WorkflowRuntimeError when workflow is null', async () => {
+      await expect(
+        // @ts-expect-error - intentionally passing null
+        start(null, [])
+      ).rejects.toThrow(WorkflowRuntimeError);
+
+      await expect(
+        // @ts-expect-error - intentionally passing null
+        start(null, [])
+      ).rejects.toThrow(
+        `'start' received an invalid workflow function. Ensure the Workflow Development Kit is configured correctly and the function includes a 'use workflow' directive.`
+      );
+    });
+
+    it('should throw WorkflowRuntimeError when workflow has no workflowId', async () => {
+      const invalidWorkflow = () => Promise.resolve('result');
+
+      await expect(start(invalidWorkflow, [])).rejects.toThrow(
+        WorkflowRuntimeError
+      );
+
+      await expect(start(invalidWorkflow, [])).rejects.toThrow(
+        `'start' received an invalid workflow function. Ensure the Workflow Development Kit is configured correctly and the function includes a 'use workflow' directive.`
+      );
+    });
+
+    it('should throw WorkflowRuntimeError when workflow has empty string workflowId', async () => {
+      const invalidWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: '',
+      });
+
+      await expect(start(invalidWorkflow, [])).rejects.toThrow(
+        WorkflowRuntimeError
+      );
+    });
+  });
+});

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -59,7 +59,7 @@ export async function start<TArgs extends unknown[], TResult>(
 ) {
   return await waitedUntil(() => {
     // @ts-expect-error this field is added by our client transform
-    const workflowName = workflow.workflowId;
+    const workflowName = workflow?.workflowId;
 
     if (!workflowName) {
       throw new WorkflowRuntimeError(


### PR DESCRIPTION
Added better error handling when passing invalid workflow values to the `start()` function.