### PR TITLE
Stop reading server externals internal list in Next.js

### DIFF
--- a/.changeset/forty-taxis-bet.md
+++ b/.changeset/forty-taxis-bet.md
@@ -1,0 +1,5 @@
+---
+"@workflow/next": patch
+---
+
+Stop reading server externals internal list

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -119,10 +119,7 @@ export function withWorkflow(
         workflowsBundlePath: '', // not used in base
         stepsBundlePath: '', // not used in base
         webhookBundlePath: '', // node used in base
-        externalPackages: [
-          ...require('next/dist/lib/server-external-packages.json'),
-          ...(nextConfig.serverExternalPackages || []),
-        ],
+        externalPackages: [...(nextConfig.serverExternalPackages || [])],
       });
 
       await workflowBuilder.build();


### PR DESCRIPTION
We don't need this anymore by default and was changed in recent Next.js versions as well.

fixes: https://github.com/vercel/workflow/issues/422