### PR TITLE
Change Vercel queue max visibility to 11 hours

### DIFF
--- a/.changeset/olive-signs-crash.md
+++ b/.changeset/olive-signs-crash.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": patch
+---
+
+Change Vercel queue max visibility to 11 hours

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -13,7 +13,7 @@ const MessageWrapper = z.object({
   queueName: ValidQueueName,
 });
 
-const VERCEL_QUEUE_MAX_VISIBILITY = 82800; // 23 hours in seconds
+const VERCEL_QUEUE_MAX_VISIBILITY = 39600; // 11 hours in seconds
 
 export function createQueue(config?: APIConfig): Queue {
   const { baseUrl, usingProxy } = getHttpUrl(config);


### PR DESCRIPTION
Reduced the Vercel queue max visibility timeout from 23 hours to 11 hours.

Fixes #511.