### PR TITLE
Check step maxRetries at the beginning of the step handler

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -684,7 +684,7 @@ export const stepEntrypoint =
             // This handles edge cases where the step handler is invoked after max retries have been exceeded
             // (e.g., when the step repeatedly times out or fails before reaching the catch handler at line 822).
             // Without this check, the step would retry forever.
-            if (attempt >= maxRetries) {
+            if (attempt > maxRetries) {
               const errorMessage = `Step "${stepName}" exceeded max retries (${attempt} attempts)`;
               console.error(`[Workflows] "${workflowRunId}" - ${errorMessage}`);
               // Update step status first (idempotent), then create event
@@ -876,7 +876,7 @@ export const stepEntrypoint =
                   ...Attribute.StepMaxRetries(maxRetries),
                 });
 
-                if (attempt >= maxRetries) {
+                if (attempt > maxRetries) {
                   // Max retries reached
                   const errorStack = getErrorStack(err);
                   const stackLines = errorStack.split('\n').slice(0, 4);


### PR DESCRIPTION
Added a check for maximum retries before executing a workflow step to prevent infinite retries on timeouts.

### What changed?

- Added a `DEFAULT_STEP_MAX_RETRIES` constant set to 3
- Added a check for maximum retries before executing a step, which handles the case where a step keeps timing out before reaching the catch handler
- If maximum retries are exceeded, the step is marked as failed, an event is created, and the workflow is re-invoked to handle the failed step
- Refactored the code to use the new constant in multiple places for consistency

### How to test?

1. Create a workflow with a step that consistently times out
2. Verify that the step fails after the maximum number of retries (default 3)
3. Check that the appropriate error message is logged: `Step "{stepName}" failed after max retries (function timed out {attempt} times)`
4. Verify that the workflow continues execution after the step failure

### Why make this change?

Previously, steps that timed out before reaching the catch handler could retry indefinitely, causing workflows to hang. This change ensures that all steps respect the maximum retry limit, even in timeout scenarios, preventing infinite retry loops and improving workflow reliability.