### PR TITLE
Update docs on step timeouts and workarounds

### DIFF
--- a/docs/content/docs/foundations/workflows-and-steps.mdx
+++ b/docs/content/docs/foundations/workflows-and-steps.mdx
@@ -74,6 +74,26 @@ async function chargePayment(order: Order) {
 
 By default, steps have a maximum of 3 retry attempts before they fail and propagate the error to the workflow. Learn more about errors and retrying in the [Errors & Retrying](/docs/foundations/errors-and-retries) page.
 
+<Callout type="info">
+**Step Timeout Limitations:** While workflow functions can run indefinitely by suspending between steps, individual step functions are subject to the maximum execution timeout of the platform they run on.
+
+For example, on Vercel, steps follow the [default serverless function timeout limits](https://vercel.com/docs/functions/runtimes#max-duration) (300 seconds by default, up to 800 seconds on Pro/Enterprise plans).
+
+**Workaround:** You can configure timeouts for workflow routes using `vercel.json`:
+
+```json
+{
+  "functions": {
+    "app/.well-known/workflow/**/*": {
+      "maxDuration": 800
+    }
+  }
+}
+```
+
+Note: More granular per-step timeout configuration is planned for a future release.
+</Callout>
+
 <Callout type="warning">
 **Important:** Due to serialization, parameters are passed by **value, not by reference**. If you pass an object or array to a step and mutate it, those changes will **not** be visible in the workflow context. Always return modified data from your step functions instead. See [Pass-by-Value Semantics](/docs/foundations/serialization#pass-by-value-semantics) for details and examples.
 </Callout>


### PR DESCRIPTION
Add a callout to the 'Step Functions' documentation to clarify step timeout limitations and provide a Vercel-specific workaround.

---
[Slack Thread](https://vercel.slack.com/archives/C06QB6ZPEQ6/p1764829806525069?thread_ts=1764829806.525069&cid=C06QB6ZPEQ6)

<a href="https://cursor.com/background-agent?bcId=bc-b6425353-9cd4-47a6-ba51-b0a45ac5a265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6425353-9cd4-47a6-ba51-b0a45ac5a265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

