### PR TITLE
Update next.mdx "Create Your First Workflow"

### DIFF
--- a/docs/content/docs/getting-started/next.mdx
+++ b/docs/content/docs/getting-started/next.mdx
@@ -110,7 +110,7 @@ This ensures that internal Workflow paths are not intercepted by your middleware
 
 ## Create Your First Workflow
 
-Create a new file for our first workflow.
+Create a new file for our first workflow:
 
 ```typescript title="workflows/user-signup.ts" lineNumbers
 import { sleep } from "workflow";


### PR DESCRIPTION
This detail messed me up. For a simple example I did something like this:

```ts
import { start } from 'workflow/api';
import { NextResponse } from "next/server";

export async function POST(request: Request) {
  const { input } = await request.json();
  const run = await start(workflowOne, [input]);

  return NextResponse.json({ input });
}


export async function workflowOne(input: string) {
  'use workflow';
  return { output: `input ${input}` };
}
```

And I got an obscure error:

```
app/api/do-something-1/route.ts:4217
      if (typeof __nccwpck_require__ !== "undefined") __nccwpck_require__.ab = __dirname + "/";
                                                                               ^

ReferenceError: __dirname is not defined
    at anonymous (node_modules/next/dist/compiled/ua-parser-js/ua-parser.js:2315:77)
    at node_modules/next/dist/compiled/ua-parser-js/ua-parser.js (node_modules/next/dist/compiled/ua-parser-js/ua-parser.js:2318:3)
    at __require (app/api/do-something-1/route.ts:9:50)
    at node_modules/next/dist/server/web/spec-extension/user-agent.js (app/api/do-something-1/route.ts:4249:64)
    at __require (app/api/do-something-1/route.ts:9:50)
    at node_modules/next/server.js (node_modules/next/server.js:5:25)
    at __require (app/api/do-something-1/route.ts:9:50)
    at anonymous (app/api/do-something-1/route.ts:2:29)
    at Script.runInContext (node:vm:149:12)
    at runInContext (node:vm:301:6)
```

The fix was to move the workflow into it's own file and not have it in `route.ts`