### PR TITLE
ci: fix verboseness on e2e tests

### DIFF
--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -95,9 +95,9 @@ jobs:
         run: |
           cd workbench/${{ inputs.app-name }} && pnpm dev &
           echo "Waiting for dev server to start..." && sleep 15
-          pnpm vitest run packages/core/e2e/dev.test.ts --reporter=json --outputFile=e2e-community-${{ inputs.world-id }}-dev.json || true
+          pnpm vitest run packages/core/e2e/dev.test.ts --reporter=default --reporter=json --outputFile=e2e-community-${{ inputs.world-id }}-dev.json || true
           sleep 10
-          pnpm vitest run packages/core/e2e/e2e.test.ts --reporter=json --outputFile=e2e-community-${{ inputs.world-id }}.json || true
+          pnpm vitest run packages/core/e2e/e2e.test.ts --reporter=default --reporter=json --outputFile=e2e-community-${{ inputs.world-id }}.json || true
         env:
           APP_NAME: ${{ inputs.app-name }}
           DEPLOYMENT_URL: "http://localhost:3000"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,7 +228,7 @@ jobs:
           environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
 
       - name: Run E2E Tests
-        run: pnpm run test:e2e --reporter=json --outputFile=e2e-vercel-prod-${{ matrix.app.name }}.json
+        run: pnpm run test:e2e --reporter=default --reporter=json --outputFile=e2e-vercel-prod-${{ matrix.app.name }}.json
         env:
           DEPLOYMENT_URL: ${{ steps.waitForDeployment.outputs.deployment-url }}
           APP_NAME: ${{ matrix.app.name }}
@@ -312,7 +312,7 @@ jobs:
           cd workbench/${{ matrix.app.name }} && pnpm dev &
           echo "starting tests in 10 seconds" && sleep 10
           pnpm vitest run packages/core/e2e/dev.test.ts && sleep 10
-          pnpm run test:e2e --reporter=json --outputFile=../../e2e-local-dev-${{ matrix.app.name }}.json
+          pnpm run test:e2e --reporter=default --reporter=json --outputFile=../../e2e-local-dev-${{ matrix.app.name }}.json
         env:
           APP_NAME: ${{ matrix.app.name }}
           DEPLOYMENT_URL: "http://localhost:${{ matrix.app.name == 'sveltekit' && '5173' || (matrix.app.name == 'astro' && '4321' || '3000') }}"
@@ -378,7 +378,7 @@ jobs:
         run: |
           cd workbench/${{ matrix.app.name }} && pnpm start &
           echo "starting tests in 10 seconds" && sleep 10
-          pnpm run test:e2e --reporter=json --outputFile=../../e2e-local-prod-${{ matrix.app.name }}.json
+          pnpm run test:e2e --reporter=default --reporter=json --outputFile=../../e2e-local-prod-${{ matrix.app.name }}.json
         env:
           APP_NAME: ${{ matrix.app.name }}
           DEPLOYMENT_URL: "http://localhost:${{ matrix.app.name == 'sveltekit' && '4173' || (matrix.app.name == 'astro' && '4321' || '3000') }}"
@@ -463,7 +463,7 @@ jobs:
         run: |
           cd workbench/${{ matrix.app.name }} && pnpm start &
           echo "starting tests in 10 seconds" && sleep 10
-          pnpm run test:e2e --reporter=json --outputFile=../../e2e-local-postgres-${{ matrix.app.name }}.json
+          pnpm run test:e2e --reporter=default --reporter=json --outputFile=../../e2e-local-postgres-${{ matrix.app.name }}.json
         env:
           APP_NAME: ${{ matrix.app.name }}
           DEPLOYMENT_URL: "http://localhost:${{ matrix.app.name == 'sveltekit' && '4173' || (matrix.app.name == 'astro' && '4321' || '3000') }}"
@@ -522,7 +522,7 @@ jobs:
           Start-Sleep -Seconds 15
           cd ../..
           pnpm vitest run packages/core/e2e/dev.test.ts
-          pnpm run test:e2e --reporter=json --outputFile=e2e-windows-nextjs-turbopack.json
+          pnpm run test:e2e --reporter=default --reporter=json --outputFile=e2e-windows-nextjs-turbopack.json
           Stop-Job $job
         shell: powershell
         env:


### PR DESCRIPTION
ci wasn't showing stdout/stderr and instead was just using `--reporter=json` so just outputting to a json file

this pr does both so we can see still see errors and logs in ci for e2e tests