### PR TITLE
Revert "fix: import stripping in client mode for step functions"

### DIFF
--- a/.changeset/clear-ghosts-listen.md
+++ b/.changeset/clear-ghosts-listen.md
@@ -1,5 +1,0 @@
----
-"@workflow/swc-plugin": patch
----
-
-Fix a bug where imports were stripped in client mode for step functions being called from non-workflow code

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/input.js
@@ -1,12 +1,12 @@
-import { someHelper } from './helpers'; // removed in step/workflow mode, kept in client mode
+import { someHelper } from './helpers'; // should be removed
 import {
-  anotherHelper, // removed in step/workflow mode, kept in client mode
-  usefulHelper // always kept
+  anotherHelper, // should be removed
+  usefulHelper // do not remove
 } from './utils'; 
-import defaultExport from './default'; // removed in step/workflow mode, kept in client mode
-import * as something from './something'; // removed in step/workflow mode, kept in client mode
-import * as useful from './useful'; // always kept
-import 'dotenv/config' // removed in step/workflow mode, kept in client mode
+import defaultExport from './default'; // should be removed
+import * as something from './something'; // should be removed
+import * as useful from './useful'; // do not remove
+import 'dotenv/config' // should be removed
 
 export async function processData(data) {
   'use step';

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-client.js
@@ -1,21 +1,12 @@
-import { someHelper } from './helpers'; // removed in step/workflow mode, kept in client mode
-import { anotherHelper, usefulHelper// always kept
+import { usefulHelper// do not remove
  } from './utils';
-import defaultExport from './default'; // removed in step/workflow mode, kept in client mode
-import * as something from './something'; // removed in step/workflow mode, kept in client mode
-import * as useful from './useful'; // always kept
+import * as useful from './useful'; // do not remove
 /**__internal_workflows{"steps":{"input.js":{"processData":{"stepId":"step//input.js//processData"}}}}*/;
 export async function processData(data) {
     const result = someHelper(data);
     const transformed = anotherHelper(result);
     localFunction();
     return defaultExport(transformed);
-}
-function localFunction() {
-    // only used by the step, so it should be removed
-    // when the step body gets removed since it is not used
-    // anywhere anymore
-    something.doSomething();
 }
 export function normalFunction() {
     // since this function is exported we can't remove it

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-step.js
@@ -1,11 +1,11 @@
 import { registerStepFunction } from "workflow/internal/private";
-import { someHelper } from './helpers'; // removed in step/workflow mode, kept in client mode
-import { anotherHelper, usefulHelper// always kept
+import { someHelper } from './helpers'; // should be removed
+import { anotherHelper, usefulHelper// do not remove
  } from './utils';
-import defaultExport from './default'; // removed in step/workflow mode, kept in client mode
-import * as something from './something'; // removed in step/workflow mode, kept in client mode
-import * as useful from './useful'; // always kept
-import 'dotenv/config'; // removed in step/workflow mode, kept in client mode
+import defaultExport from './default'; // should be removed
+import * as something from './something'; // should be removed
+import * as useful from './useful'; // do not remove
+import 'dotenv/config'; // should be removed
 /**__internal_workflows{"steps":{"input.js":{"processData":{"stepId":"step//input.js//processData"}}}}*/;
 export async function processData(data) {
     const result = someHelper(data);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-workflow.js
@@ -1,6 +1,6 @@
-import { usefulHelper// always kept
+import { usefulHelper// do not remove
  } from './utils';
-import * as useful from './useful'; // always kept
+import * as useful from './useful'; // do not remove
 /**__internal_workflows{"steps":{"input.js":{"processData":{"stepId":"step//input.js//processData"}}}}*/;
 export var processData = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//processData");
 export function normalFunction() {

--- a/packages/swc-plugin-workflow/transform/tests/fixture/unused-exports/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/unused-exports/output-client.js
@@ -1,4 +1,3 @@
-import { helper } from './helper';
 import { unusedHelper } from './unused-helper';
 /**__internal_workflows{"steps":{"input.js":{"processData":{"stepId":"step//input.js//processData"}}}}*/;
 // This variable is exported but not used anywhere in this file

--- a/packages/swc-plugin-workflow/transform/tests/fixture/unused-variables-and-types/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/unused-variables-and-types/output-client.js
@@ -1,7 +1,4 @@
-import { Resend } from 'resend';
-import { generatePostcardEmailTemplate } from '@/lib/template';
 /**__internal_workflows{"steps":{"input.js":{"sendRecipientEmail":{"stepId":"step//input.js//sendRecipientEmail"}}}}*/;
-const resend = new Resend(process.env.RESEND_API_KEY);
 export const sendRecipientEmail = async ({ recipientEmail, cardImage, cardText, rsvpReplies })=>{
     const html = generatePostcardEmailTemplate({
         cardImage,


### PR DESCRIPTION
This seems to have broken client mode in Next.js so we need to revert to investigate what's causing the error.

Reverts vercel/workflow#563