### PR TITLE
fix: nitro duplicate building workflows on startup

### DIFF
--- a/.changeset/temp-nitro-fix.md
+++ b/.changeset/temp-nitro-fix.md
@@ -1,0 +1,5 @@
+---
+"@workflow/nitro": patch
+---
+
+Fix duplicate workflow builds on dev server startup by skipping initial dev:reload hook

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -50,13 +50,19 @@ export default {
     // Generate local bundles for dev and local prod
     if (!isVercelDeploy) {
       const builder = new LocalBuilder(nitro);
+      let isInitialBuild = true;
+
       nitro.hooks.hook('build:before', async () => {
         await builder.build();
       });
 
-      // Allows for HMR
+      // Allows for HMR - but skip the first dev:reload since build:before already ran
       if (nitro.options.dev) {
         nitro.hooks.hook('dev:reload', async () => {
+          if (isInitialBuild) {
+            isInitialBuild = false;
+            return;
+          }
           await builder.build();
         });
       }


### PR DESCRIPTION
nitro was building workflows on startup and dev:reload immediately after server starts