### PR TITLE
perf: fix O(n²) wait completion algorithm

### DIFF
--- a/.changeset/fair-dodos-ring.md
+++ b/.changeset/fair-dodos-ring.md
@@ -1,0 +1,8 @@
+---
+"@workflow/core": patch
+---
+
+perf: fix O(n²) wait completion algorithm
+
+- Use Set for O(1) lookup of completed wait IDs instead of O(n) `.some()` per iteration
+- Create all wait_completed events in parallel with `Promise.all()` instead of sequentially


### PR DESCRIPTION
- Use Set for O(1) lookup of completed wait IDs instead of O(n) `.some()` per iteration
- Create all wait_completed events in parallel with `Promise.all()` instead of sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>