### PR TITLE
Bring back agent sitemap code

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -3,6 +3,7 @@ import { Navbar } from '@/components/geistdocs/navbar';
 import { GeistdocsProvider } from '@/components/geistdocs/provider';
 import { mono, sans } from '@/lib/geistdocs/fonts';
 import { cn } from '@/lib/utils';
+import { Metadata } from 'next';
 
 const Logo = () => (
   <span className="flex items-center gap-1.5 font-semibold text-foreground tracking-tight text-xl">
@@ -58,5 +59,9 @@ const Layout = ({ children }: LayoutProps<'/'>) => (
     </body>
   </html>
 );
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://useworkflow.dev'),
+};
 
 export default Layout;

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -14,11 +14,16 @@ export async function GET(
     notFound();
   }
 
-  return new Response(await getLLMText(page), {
-    headers: {
-      'Content-Type': 'text/markdown',
-    },
-  });
+  return new Response(
+    (await getLLMText(page)) +
+      `\n\n## Sitemap
+[Overview of all docs pages](/sitemap.md)\n`,
+    {
+      headers: {
+        'Content-Type': 'text/markdown',
+      },
+    }
+  );
 }
 
 export function generateStaticParams() {

--- a/docs/app/sitemap.md/route.ts
+++ b/docs/app/sitemap.md/route.ts
@@ -1,0 +1,46 @@
+import { source } from '@/lib/geistdocs/source';
+import type { Node, Root } from 'fumadocs-core/page-tree';
+
+export const revalidate = false;
+export const dynamic = 'force-static';
+
+export async function GET(_req: Request) {
+  let mdText = '';
+
+  function traverseTree(node: Node | Root, depth = 0) {
+    const indent = '  '.repeat(depth);
+
+    if ('type' in node) {
+      if (node.type === 'page') {
+        mdText += `${indent}- [${node.name}](${node.url})\n`;
+      } else if (node.type === 'folder') {
+        if (node.index) {
+          mdText += `${indent}- [${node.name}](${node.index.url})\n`;
+        } else {
+          mdText += `${indent}- ${node.name}\n`;
+        }
+        if (node.children.length > 0) {
+          for (const child of node.children) {
+            traverseTree(child, depth + 1);
+          }
+        }
+      }
+    } else {
+      // Root node
+      if (node.children.length > 0) {
+        for (const child of node.children) {
+          traverseTree(child, depth);
+        }
+      }
+    }
+  }
+
+  const tree = source.getPageTree();
+  traverseTree(tree, 0);
+
+  return new Response(mdText, {
+    headers: {
+      'Content-Type': 'text/markdown',
+    },
+  });
+}

--- a/docs/components/geistdocs/docs-page.tsx
+++ b/docs/components/geistdocs/docs-page.tsx
@@ -75,6 +75,12 @@ export const generatePageMetadata = (slug: PageProps['slug']) => {
   const metadata: Metadata = {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: page.url,
+      media: {
+        'text/markdown': `${page.url}.md`,
+      },
+    },
   };
 
   return metadata;


### PR DESCRIPTION
Original PR #108

This was deleted in a bad merge here https://github.com/vercel/workflow/commit/c0991b4ff795687bb477e96f6b4261a2c8a5bc61#diff-4f67490b6b20a5606964421a564836c3033f0ff2b0d90a41fe8822001d217f20

Also introduces proper canonical URLs and alternates for the MD responses.