### PR TITLE
[cli] Only do interactive pagination when using the -i flag

### DIFF
--- a/.changeset/violet-bats-crash.md
+++ b/.changeset/violet-bats-crash.md
@@ -1,0 +1,5 @@
+---
+"@workflow/cli": patch
+---
+
+Add -i / --interactive flag for enabling pagination bindings, new default being off

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -239,6 +239,7 @@ function toInspectOptions(flags: any): InspectCLIOptions {
     workflowName: flags.workflowName,
     withData: flags.withData,
     backend: flags.backend,
+    interactive: flags.interactive,
   };
 }
 

--- a/packages/cli/src/lib/config/types.ts
+++ b/packages/cli/src/lib/config/types.ts
@@ -21,4 +21,5 @@ export type InspectCLIOptions = {
   withData?: boolean;
   backend?: string;
   disableRelativeDates?: boolean;
+  interactive?: boolean;
 };

--- a/packages/cli/src/lib/inspect/flags.ts
+++ b/packages/cli/src/lib/inspect/flags.ts
@@ -127,4 +127,12 @@ export const cliFlags = {
     helpLabel: '--limit',
     helpValue: 'NUMBER',
   }),
+  interactive: Flags.boolean({
+    description: 'Enable interactive pagination with keyboard controls',
+    required: false,
+    char: 'i',
+    default: false,
+    helpGroup: 'Output',
+    helpLabel: '-i, --interactive',
+  }),
 };

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -543,6 +543,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
 
   await setupListPagination<WorkflowRun>({
     initialCursor: opts.cursor,
+    interactive: opts.interactive,
     fetchPage: async (cursor) => {
       try {
         const runs = await world.runs.list({
@@ -680,6 +681,7 @@ export const listSteps = async (
 
   await setupListPagination<Step>({
     initialCursor: opts.cursor,
+    interactive: opts.interactive,
     fetchPage: async (cursor) => {
       logger.debug(`Fetching steps for run ${runId}`);
       try {
@@ -888,6 +890,7 @@ export const listEvents = async (
 
   await setupListPagination<Event>({
     initialCursor: opts.cursor,
+    interactive: opts.interactive,
     fetchPage: async (cursor) => {
       logger.debug(`Fetching events for run ${filterId}`);
       try {
@@ -957,6 +960,7 @@ export const listHooks = async (world: World, opts: InspectCLIOptions = {}) => {
   // Setup pagination with new mechanism
   await setupListPagination<Hook>({
     initialCursor: opts.cursor,
+    interactive: opts.interactive,
     fetchPage: async (cursor) => {
       if (!runId) {
         logger.debug('Fetching all hooks');


### PR DESCRIPTION
We noticed pagination behavior binding user input and clearing the screen seemed unexpected/disruptive, so I'm hiding it behind a flag, with the default behavior just showing the first page of any item.