### PR TITLE
Fix race conditions in webhook response handling

### DIFF
--- a/.changeset/webhook-response-body-fix.md
+++ b/.changeset/webhook-response-body-fix.md
@@ -1,0 +1,6 @@
+---
+"@workflow/world-local": patch
+---
+
+Fix race condition in streamer where close events arriving during disk reads would close the controller before data was enqueued. Close events are now buffered and processed after disk reads complete.
+


### PR DESCRIPTION
Fixed a race condition in the streamer where close events could arrive during disk reads, causing premature controller closure. This fixes the flakiness in the `webhookWorkflow` E2E test on "local" test suites.

### What changed?

- Added a `pendingClose` flag to buffer close events that arrive during disk reading
- Modified the `closeListener` function to set this flag instead of immediately closing the controller when disk reads are in progress
- Added logic to process any pending close events after disk reads complete

### Why make this change?

There was a race condition in the streamer where close events arriving during disk reads would close the controller before all data was enqueued. This could lead to incomplete data streams and potential data loss. This fix ensures that all data is properly processed before the stream is closed.