### PR TITLE
Revert extra stdlib re-export

### DIFF
--- a/.changeset/angry-windows-jog.md
+++ b/.changeset/angry-windows-jog.md
@@ -1,0 +1,5 @@
+---
+"workflow": patch
+---
+
+Revert extra stdlib re-export

--- a/packages/workflow/src/internal/builtins.ts
+++ b/packages/workflow/src/internal/builtins.ts
@@ -3,9 +3,6 @@
  * similar to "stdlib" except that are not meant to be imported by users, but are instead "just available"
  * alongside user defined steps. They are used internally by the runtime
  */
-// Re-export stdlib for discovery - needed because lazy discovery doesn't pick it up via eager scanning.
-// The workflow builder injects this as a builtin module available in the workflow runtime sandbox.
-export * from '../stdlib.js';
 
 export async function __builtin_response_array_buffer(res: Response) {
   'use step';


### PR DESCRIPTION
This isn't needed as users are meant to explicitly import these so discovery should work fine through normal import flow. 

x-ref: https://github.com/vercel/workflow/pull/640/files#r2642474364