### PR TITLE
Validate cached workflows/steps and reduce build debounce

### DIFF
--- a/.changeset/moody-islands-stare.md
+++ b/.changeset/moody-islands-stare.md
@@ -1,0 +1,5 @@
+---
+"@workflow/next": patch
+---
+
+Validate cached workflows/steps and reduce build debounce

--- a/packages/next/src/builder.ts
+++ b/packages/next/src/builder.ts
@@ -2,6 +2,7 @@ import { constants } from 'node:fs';
 import { access, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import { join, resolve } from 'node:path';
+import { useStepPattern, useWorkflowPattern } from '@workflow/builders';
 import type { NextConfig } from 'next';
 import {
   createSocketServer,
@@ -67,9 +68,36 @@ export async function getNextBuilder() {
       try {
         const cacheContent = await readFile(cacheFile, 'utf-8');
         const cacheData = JSON.parse(cacheContent);
+
+        // Filter workflow files: check they exist and contain "use workflow"
+        const workflowFiles: string[] = [];
+        for (const file of cacheData.workflowFiles || []) {
+          try {
+            const content = await readFile(file, 'utf-8');
+            if (useWorkflowPattern.test(content)) {
+              workflowFiles.push(file);
+            }
+          } catch {
+            // File doesn't exist or can't be read, skip it
+          }
+        }
+
+        // Filter step files: check they exist and contain "use step"
+        const stepFiles: string[] = [];
+        for (const file of cacheData.stepFiles || []) {
+          try {
+            const content = await readFile(file, 'utf-8');
+            if (useStepPattern.test(content)) {
+              stepFiles.push(file);
+            }
+          } catch {
+            // File doesn't exist or can't be read, skip it
+          }
+        }
+
         return {
-          workflowFiles: cacheData.workflowFiles || [],
-          stepFiles: cacheData.stepFiles || [],
+          workflowFiles,
+          stepFiles,
         };
       } catch {
         // Cache file doesn't exist or is invalid, return null
@@ -261,7 +289,7 @@ export async function getNextBuilder() {
       const stepFiles = new Set<string>();
       let debounceTimer: NodeJS.Timeout | null = null;
       let buildTriggered = false;
-      const BUILD_DEBOUNCE_MS = this.isDevServer ? 500 : 2_000;
+      const BUILD_DEBOUNCE_MS = this.isDevServer ? 250 : 1_000;
 
       // Attempt to load cached workflows/steps from previous build
       const cache = await this.readWorkflowsCache();

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -180,6 +180,20 @@ async function waitForBuildComplete(): Promise<void> {
     socket.on('error', onError);
     socket.on('end', onEnd);
     socket.on('close', onClose);
+
+    const authToken = process.env.WORKFLOW_SOCKET_AUTH;
+
+    if (!authToken) {
+      throw new Error(
+        `Invariant: no socket auth token provided for workflow loader`
+      );
+    }
+    // we trigger a build here in case no other events trigger
+    // the build so that we aren't waiting until 60 second timeout
+    const message: SocketMessage = {
+      type: 'trigger-build',
+    };
+    socket.write(serializeMessage(message, authToken));
   });
 }
 


### PR DESCRIPTION
This ensures when we read step/workflows state from cache that we validate they are still valid before initial compile, this also tweaks the stubs build latency and adds signal when the stubs are waiting. 