### PR TITLE
[cli] Print notice on CLI startup when detecting an outdated version

### DIFF
--- a/packages/world-local/src/init.test.ts
+++ b/packages/world-local/src/init.test.ts
@@ -15,7 +15,6 @@ import {
   ensureDataDir,
   formatVersion,
   formatVersionFile,
-  getPackageInfo,
   initDataDir,
   type ParsedVersion,
   parseVersion,
@@ -166,39 +165,39 @@ describe('ensureDataDir', () => {
   });
 
   describe('directory creation', () => {
-    it('should create the directory if it does not exist', async () => {
+    it('should create the directory if it does not exist', () => {
       const dataDir = path.join(testBaseDir, 'new-data-dir');
       expect(existsSync(dataDir)).toBe(false);
 
-      await ensureDataDir(dataDir);
+      ensureDataDir(dataDir);
 
       expect(existsSync(dataDir)).toBe(true);
     });
 
-    it('should create nested directories recursively', async () => {
+    it('should create nested directories recursively', () => {
       const dataDir = path.join(testBaseDir, 'level1', 'level2', 'level3');
       expect(existsSync(dataDir)).toBe(false);
 
-      await ensureDataDir(dataDir);
+      ensureDataDir(dataDir);
 
       expect(existsSync(dataDir)).toBe(true);
     });
 
-    it('should not throw if the directory already exists', async () => {
+    it('should not throw if the directory already exists', () => {
       const dataDir = path.join(testBaseDir, 'existing-dir');
       mkdirSync(dataDir);
       expect(existsSync(dataDir)).toBe(true);
 
-      await expect(ensureDataDir(dataDir)).resolves.not.toThrow();
+      expect(() => ensureDataDir(dataDir)).not.toThrow();
     });
 
-    it('should handle relative paths by resolving to absolute paths', async () => {
+    it('should handle relative paths by resolving to absolute paths', () => {
       const originalCwd = process.cwd();
       try {
         process.chdir(testBaseDir);
         const relativeDir = 'relative-data-dir';
 
-        await ensureDataDir(relativeDir);
+        ensureDataDir(relativeDir);
 
         expect(existsSync(path.join(testBaseDir, relativeDir))).toBe(true);
       } finally {
@@ -212,16 +211,14 @@ describe('ensureDataDir', () => {
 
     it.skipIf(isWindows)(
       'should throw DataDirAccessError if directory is not readable',
-      async () => {
+      () => {
         const dataDir = path.join(testBaseDir, 'unreadable-dir');
         mkdirSync(dataDir);
         chmodSync(dataDir, 0o000);
 
         try {
-          await expect(ensureDataDir(dataDir)).rejects.toThrow(
-            DataDirAccessError
-          );
-          await expect(ensureDataDir(dataDir)).rejects.toThrow(/not readable/);
+          expect(() => ensureDataDir(dataDir)).toThrow(DataDirAccessError);
+          expect(() => ensureDataDir(dataDir)).toThrow(/not readable/);
         } finally {
           chmodSync(dataDir, 0o755);
         }
@@ -230,16 +227,14 @@ describe('ensureDataDir', () => {
 
     it.skipIf(isWindows)(
       'should throw DataDirAccessError if directory is not writable',
-      async () => {
+      () => {
         const dataDir = path.join(testBaseDir, 'readonly-dir');
         mkdirSync(dataDir);
         chmodSync(dataDir, 0o555);
 
         try {
-          await expect(ensureDataDir(dataDir)).rejects.toThrow(
-            DataDirAccessError
-          );
-          await expect(ensureDataDir(dataDir)).rejects.toThrow(/not writable/);
+          expect(() => ensureDataDir(dataDir)).toThrow(DataDirAccessError);
+          expect(() => ensureDataDir(dataDir)).toThrow(/not writable/);
         } finally {
           chmodSync(dataDir, 0o755);
         }
@@ -248,7 +243,7 @@ describe('ensureDataDir', () => {
 
     it.skipIf(isWindows)(
       'should throw DataDirAccessError if parent directory is not writable',
-      async () => {
+      () => {
         const parentDir = path.join(testBaseDir, 'readonly-parent');
         mkdirSync(parentDir);
         chmodSync(parentDir, 0o555);
@@ -256,10 +251,8 @@ describe('ensureDataDir', () => {
         const dataDir = path.join(parentDir, 'new-child-dir');
 
         try {
-          await expect(ensureDataDir(dataDir)).rejects.toThrow(
-            DataDirAccessError
-          );
-          await expect(ensureDataDir(dataDir)).rejects.toThrow(
+          expect(() => ensureDataDir(dataDir)).toThrow(DataDirAccessError);
+          expect(() => ensureDataDir(dataDir)).toThrow(
             /Failed to create data directory/
           );
         } finally {
@@ -270,7 +263,7 @@ describe('ensureDataDir', () => {
   });
 
   describe('DataDirAccessError', () => {
-    it('should include the data directory path in the error', async () => {
+    it('should include the data directory path in the error', () => {
       const dataDir = path.join(testBaseDir, 'readonly-parent-for-error');
       const isWindows = process.platform === 'win32';
 
@@ -281,7 +274,7 @@ describe('ensureDataDir', () => {
         const childDir = path.join(dataDir, 'child');
 
         try {
-          await ensureDataDir(childDir);
+          ensureDataDir(childDir);
         } catch (error) {
           expect(error).toBeInstanceOf(DataDirAccessError);
           expect((error as DataDirAccessError).dataDir).toBe(childDir);
@@ -291,7 +284,7 @@ describe('ensureDataDir', () => {
       }
     });
 
-    it('should include the error code when available', async () => {
+    it('should include the error code when available', () => {
       const isWindows = process.platform === 'win32';
 
       if (!isWindows) {
@@ -302,7 +295,7 @@ describe('ensureDataDir', () => {
         const dataDir = path.join(parentDir, 'child');
 
         try {
-          await ensureDataDir(dataDir);
+          ensureDataDir(dataDir);
         } catch (error) {
           expect(error).toBeInstanceOf(DataDirAccessError);
           expect((error as DataDirAccessError).code).toBeDefined();
@@ -314,28 +307,28 @@ describe('ensureDataDir', () => {
   });
 
   describe('edge cases', () => {
-    it('should handle empty string by creating directory at current path', async () => {
+    it('should handle empty string by creating directory at current path', () => {
       const originalCwd = process.cwd();
       try {
         process.chdir(testBaseDir);
-        await expect(ensureDataDir('.')).resolves.not.toThrow();
+        expect(() => ensureDataDir('.')).not.toThrow();
       } finally {
         process.chdir(originalCwd);
       }
     });
 
-    it('should handle paths with special characters', async () => {
+    it('should handle paths with special characters', () => {
       const dataDir = path.join(testBaseDir, 'special-chars-dir-@#$%');
 
-      await ensureDataDir(dataDir);
+      ensureDataDir(dataDir);
 
       expect(existsSync(dataDir)).toBe(true);
     });
 
-    it('should handle paths with spaces', async () => {
+    it('should handle paths with spaces', () => {
       const dataDir = path.join(testBaseDir, 'dir with spaces');
 
-      await ensureDataDir(dataDir);
+      ensureDataDir(dataDir);
 
       expect(existsSync(dataDir)).toBe(true);
     });
@@ -362,10 +355,10 @@ describe('initDataDir', () => {
     vi.restoreAllMocks();
   });
 
-  it('should create version.txt for new data directory', async () => {
+  it('should create version.txt for new data directory', () => {
     const dataDir = path.join(testBaseDir, 'new-data');
 
-    await initDataDir(dataDir);
+    initDataDir(dataDir);
 
     const versionPath = path.join(dataDir, 'version.txt');
     expect(existsSync(versionPath)).toBe(true);
@@ -374,29 +367,27 @@ describe('initDataDir', () => {
     expect(content).toMatch(/^@workflow\/world-local@\d+\.\d+\.\d+/);
   });
 
-  it('should not modify version.txt if version matches', async () => {
+  it('should not modify version.txt if version matches', () => {
     const dataDir = path.join(testBaseDir, 'existing-data');
     mkdirSync(dataDir, { recursive: true });
 
     // Write the current version
-    const packageInfo = await getPackageInfo();
     const versionPath = path.join(dataDir, 'version.txt');
-    const currentVersion = `${packageInfo.name}@${packageInfo.version}`;
-    writeFileSync(versionPath, currentVersion);
+    writeFileSync(versionPath, '@workflow/world-local@4.0.1-beta.20');
 
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await initDataDir(dataDir);
+    initDataDir(dataDir);
 
     // Should not log upgrade message since versions match
     expect(consoleSpy).not.toHaveBeenCalled();
 
     // File should remain unchanged
     const content = readFileSync(versionPath, 'utf-8');
-    expect(content).toBe(currentVersion);
+    expect(content).toBe('@workflow/world-local@4.0.1-beta.20');
   });
 
-  it('should call upgradeVersion when versions differ', async () => {
+  it('should call upgradeVersion when versions differ', () => {
     const dataDir = path.join(testBaseDir, 'old-data');
     mkdirSync(dataDir, { recursive: true });
 
@@ -406,7 +397,7 @@ describe('initDataDir', () => {
 
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await initDataDir(dataDir);
+    initDataDir(dataDir);
 
     // Should log upgrade message
     expect(consoleSpy).toHaveBeenCalledWith(
@@ -418,7 +409,7 @@ describe('initDataDir', () => {
     expect(content).toMatch(/^@workflow\/world-local@4\.0\.1/);
   });
 
-  it('should handle data directory with newer version', async () => {
+  it('should handle data directory with newer version', () => {
     const dataDir = path.join(testBaseDir, 'newer-data');
     mkdirSync(dataDir, { recursive: true });
 
@@ -429,7 +420,7 @@ describe('initDataDir', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     // This will call upgradeVersion which just logs for now
-    await initDataDir(dataDir);
+    initDataDir(dataDir);
 
     // Should log the upgrade message (even for "downgrades")
     expect(consoleSpy).toHaveBeenCalledWith(

--- a/packages/world-local/src/init.ts
+++ b/packages/world-local/src/init.ts
@@ -1,38 +1,18 @@
 import {
-  access,
+  accessSync,
   constants,
-  mkdir,
-  readFile,
-  unlink,
-  writeFile,
-} from 'node:fs/promises';
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+/** Package name for version tracking */
+export const PACKAGE_NAME = '@workflow/world-local';
 
-interface PackageInfo {
-  name: string;
-  version: string;
-}
-
-let cachedPackageInfo: PackageInfo | null = null;
-
-/**
- * Returns the package name and version from package.json.
- * The result is cached after the first read.
- */
-export async function getPackageInfo(): Promise<PackageInfo> {
-  if (cachedPackageInfo) {
-    return cachedPackageInfo;
-  }
-  const content = await readFile(
-    path.join(__dirname, '../package.json'),
-    'utf-8'
-  );
-  cachedPackageInfo = JSON.parse(content) as PackageInfo;
-  return cachedPackageInfo;
-}
+/** Current package version - imported at build time */
+export const PACKAGE_VERSION = '4.0.1-beta.20';
 
 /** Filename for storing version information in the data directory */
 const VERSION_FILENAME = 'version.txt';
@@ -177,12 +157,12 @@ export function upgradeVersion(
  * @param dataDir - The path to the data directory
  * @throws {DataDirAccessError} If the directory cannot be created or accessed
  */
-export async function ensureDataDir(dataDir: string): Promise<void> {
+export function ensureDataDir(dataDir: string): void {
   const absolutePath = path.resolve(dataDir);
 
   // Try to create the directory if it doesn't exist
   try {
-    await mkdir(absolutePath, { recursive: true });
+    mkdirSync(absolutePath, { recursive: true });
   } catch (error: unknown) {
     const nodeError = error as NodeJS.ErrnoException;
     // EEXIST is fine - directory already exists
@@ -197,7 +177,7 @@ export async function ensureDataDir(dataDir: string): Promise<void> {
 
   // Verify the directory is accessible (readable)
   try {
-    await access(absolutePath, constants.R_OK);
+    accessSync(absolutePath, constants.R_OK);
   } catch (error: unknown) {
     const nodeError = error as NodeJS.ErrnoException;
     throw new DataDirAccessError(
@@ -213,8 +193,8 @@ export async function ensureDataDir(dataDir: string): Promise<void> {
     `.workflow-write-test-${Date.now()}`
   );
   try {
-    await writeFile(testFile, '');
-    await unlink(testFile);
+    writeFileSync(testFile, '');
+    unlinkSync(testFile);
   } catch (error: unknown) {
     const nodeError = error as NodeJS.ErrnoException;
     throw new DataDirAccessError(
@@ -231,14 +211,14 @@ export async function ensureDataDir(dataDir: string): Promise<void> {
  * @param dataDir - Path to the data directory
  * @returns The parsed version info, or null if the file doesn't exist
  */
-async function readVersionFile(dataDir: string): Promise<{
+function readVersionFile(dataDir: string): {
   packageName: string;
   version: ParsedVersion;
-} | null> {
+} | null {
   const versionFilePath = path.join(path.resolve(dataDir), VERSION_FILENAME);
 
   try {
-    const content = await readFile(versionFilePath, 'utf-8');
+    const content = readFileSync(versionFilePath, 'utf-8');
     return parseVersionFile(content);
   } catch (error: unknown) {
     const nodeError = error as NodeJS.ErrnoException;
@@ -255,14 +235,10 @@ async function readVersionFile(dataDir: string): Promise<{
  * @param dataDir - Path to the data directory
  * @param version - The version to write
  */
-async function writeVersionFile(
-  dataDir: string,
-  version: ParsedVersion
-): Promise<void> {
+function writeVersionFile(dataDir: string, version: ParsedVersion): void {
   const versionFilePath = path.join(path.resolve(dataDir), VERSION_FILENAME);
-  const packageInfo = await getPackageInfo();
-  const content = formatVersionFile(packageInfo.name, version);
-  await writeFile(versionFilePath, content);
+  const content = formatVersionFile(PACKAGE_NAME, version);
+  writeFileSync(versionFilePath, content);
 }
 
 /**
@@ -290,19 +266,18 @@ function getSuggestedDowngradeVersion(
  * @param dataDir - The path to the data directory
  * @throws {DataDirAccessError} If the directory cannot be created or accessed
  */
-export async function initDataDir(dataDir: string): Promise<void> {
+export function initDataDir(dataDir: string): void {
   // First ensure the directory exists and is accessible
-  await ensureDataDir(dataDir);
+  ensureDataDir(dataDir);
 
-  const packageInfo = await getPackageInfo();
-  const currentVersion = parseVersion(packageInfo.version);
+  const currentVersion = parseVersion(PACKAGE_VERSION);
 
   // Read existing version file
-  const existingVersionInfo = await readVersionFile(dataDir);
+  const existingVersionInfo = readVersionFile(dataDir);
 
   if (existingVersionInfo === null) {
     // New data directory - write the current version
-    await writeVersionFile(dataDir, currentVersion);
+    writeVersionFile(dataDir, currentVersion);
     return;
   }
 
@@ -317,7 +292,7 @@ export async function initDataDir(dataDir: string): Promise<void> {
   try {
     upgradeVersion(oldVersion, currentVersion);
     // Upgrade succeeded - write the new version
-    await writeVersionFile(dataDir, currentVersion);
+    writeVersionFile(dataDir, currentVersion);
   } catch (error: unknown) {
     const suggestedVersion =
       error instanceof DataDirVersionError ? error.suggestedVersion : undefined;
@@ -333,7 +308,7 @@ export async function initDataDir(dataDir: string): Promise<void> {
     );
     console.error(
       `[world-local] Data is not compatible with the current version. ` +
-        `Please downgrade to ${packageInfo.name}@${downgradeTarget}`
+        `Please downgrade to ${PACKAGE_NAME}@${downgradeTarget}`
     );
 
     throw error;

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -7,7 +7,7 @@ import { Agent } from 'undici';
 import z from 'zod';
 import type { Config } from './config.js';
 import { resolveBaseUrl } from './config.js';
-import { getPackageInfo } from './init.js';
+import { PACKAGE_VERSION } from './init.js';
 
 // For local queue, there is no technical limit on the message visibility lifespan,
 // but the environment variable can be used for testing purposes to set a max visibility limit.
@@ -205,8 +205,7 @@ export function createQueue(config: Partial<Config>): Queue {
   };
 
   const getDeploymentId: Queue['getDeploymentId'] = async () => {
-    const packageInfo = await getPackageInfo();
-    return `dpl_local@${packageInfo.version}`;
+    return `dpl_local@${PACKAGE_VERSION}`;
   };
 
   return { queue, createQueueHandler, getDeploymentId };


### PR DESCRIPTION
This superseeds https://github.com/vercel/workflow/pull/657, which tried to use an npm plugin for this job, but was ugly and didn't work with pre-release versions, so I had claude implement it instead.

Essentially:
- First time you run the CLI it'll do a sync check to npm (failures being ignored) for new version, caching this for 3 days
- Update note will be displayed in message header on every invocation in interactive mode, where we would usually just display the version
  - This might not be good enough for notifying users consistently. If this code seems good, I can extract it into utils, and also import it in the builder code to print during build in a shorter format.
- Changing the package version busts the cache, so upgrading will reset the cache
- i.e. also users who upgrade to latest won't see the "new version is available" note until at the earliest 3 day after that
- The message _may_ be off if someone installs `@workflow/cli` globally separately from `workflow`, since `p i workflow@latest` wouldn't resolve the update warning, but this seems like a minor concern.

<img width="476" height="186" alt="image" src="https://github.com/user-attachments/assets/dd608dae-3bce-423a-8ff8-9061a46a06e8" />
