### PR TITLE
Fix race condition in streamer when multiple writes share a promise runId

### DIFF
--- a/.changeset/quiet-streams-order.md
+++ b/.changeset/quiet-streams-order.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-local": patch
+---
+
+Fix race condition in streamer when multiple writes share a promise runId.

--- a/packages/world-local/src/streamer.test.ts
+++ b/packages/world-local/src/streamer.test.ts
@@ -102,8 +102,10 @@ describe('streamer', () => {
             const chunk = deserializeChunk(
               await fs.readFile(`${testDir}/streams/chunks/${file}`)
             );
-            const stream_id = String(file.split('-').at(-1)).split('.')[0];
-            const time = decodeTime(stream_id);
+            // Extract ULID from filename: "streamName-chnk_ULID.json"
+            const chunkIdPart = String(file.split('-').at(-1)).split('.')[0]; // "chnk_ULID"
+            const ulid = chunkIdPart.replace('chnk_', ''); // Just the ULID
+            const time = decodeTime(ulid);
             const timeDiff = time - lastTime;
             lastTime = time;
 


### PR DESCRIPTION
ULID generation now happens synchronously before awaiting the runId, ensuring chunks maintain their call order. This prevents race conditions when multiple write operations share the same promise runId.

The fix moves the ULID generation to occur before any await operations in both `writeToStream` and `closeStream` methods, preserving the sequence of operations even when multiple calls are waiting on the same promise.

This is an attempt to fix flaky unit test runs seen on Windows, such as here: https://github.com/vercel/workflow/actions/runs/20580915177/job/59108005932?pr=703