### PR TITLE
Fix: Export WorkflowChatTransport separately to prevent client-side bundling errors

### DIFF
--- a/.changeset/slow-hounds-matter.md
+++ b/.changeset/slow-hounds-matter.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+Export workflow-chat-transport separately to avoid server only packages from being bundled with client code.

--- a/docs/content/docs/ai/chat-session-modeling.mdx
+++ b/docs/content/docs/ai/chat-session-modeling.mdx
@@ -72,7 +72,7 @@ Chat messages need to be stored somewhere—typically a database. In this exampl
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai"; // [!code highlight]
+import { WorkflowChatTransport } from "@workflow/ai/transport"; // [!code highlight]
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
 
@@ -237,7 +237,7 @@ We can replace our `useChat` react hook with a custom hook that manages the chat
 
 import type { UIMessage } from "ai";
 import { useChat } from "@ai-sdk/react"; // [!code highlight]
-import { WorkflowChatTransport } from "@workflow/ai"; // [!code highlight]
+import { WorkflowChatTransport } from "@workflow/ai/transport"; // [!code highlight]
 import { useState, useCallback, useMemo } from "react";
 
 export function useMultiTurnChat() {

--- a/docs/content/docs/ai/resumable-streams.mdx
+++ b/docs/content/docs/ai/resumable-streams.mdx
@@ -87,7 +87,7 @@ Replace the default transport in AI-SDK's `useChat` with [`WorkflowChatTransport
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai"; // [!code highlight]
+import { WorkflowChatTransport } from "@workflow/ai/transport"; // [!code highlight]
 import { useMemo, useState } from "react";
 
 export default function ChatPage() {

--- a/docs/content/docs/api-reference/workflow-ai/workflow-chat-transport.mdx
+++ b/docs/content/docs/api-reference/workflow-ai/workflow-chat-transport.mdx
@@ -14,7 +14,7 @@ A chat transport implementation for the AI SDK that provides reliable message st
 
 ```typescript lineNumbers
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@workflow/ai/transport";
 
 export default function Chat() {
   const { messages, sendMessage } = useChat({
@@ -37,7 +37,7 @@ export default function Chat() {
 
 <TSDoc
 definition={`
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@workflow/ai/transport";
 export default WorkflowChatTransport;`}
 />
 
@@ -45,7 +45,7 @@ export default WorkflowChatTransport;`}
 
 <TSDoc
 definition={`
-import type { WorkflowChatTransportOptions } from "@workflow/ai";
+import type { WorkflowChatTransportOptions } from "@workflow/ai/transport";
 export default WorkflowChatTransportOptions;`}
 />
 
@@ -73,7 +73,7 @@ export default WorkflowChatTransportOptions;`}
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@workflow/ai/transport";
 import { useState } from "react";
 
 export default function BasicChat() {
@@ -116,7 +116,7 @@ export default function BasicChat() {
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@workflow/ai/transport";
 import { useMemo, useState } from "react";
 
 export default function ChatWithResumption() {
@@ -184,7 +184,7 @@ export default function ChatWithResumption() {
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@workflow/ai/transport";
 import { useState } from "react";
 
 export default function ChatWithCustomConfig() {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -49,6 +49,10 @@
     "./xai": {
       "types": "./dist/providers/xai.d.ts",
       "default": "./dist/providers/xai.js"
+    },
+    "./transport": {
+      "types": "./dist/workflow-chat-transport.d.ts",
+      "default": "./dist/workflow-chat-transport.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
This is a fix for #709. 

The issue was that when importing @workflow/ai, durable agent pulls in dependencies from @workflow/core which cannot be bundled for client components. 

This PR introduces a dedicated export path `@workflow/ai/transport` that exports only `WorkflowChatTransport` and its types. This isolates it from server-only dependencies.

I've also tried to update any reference in the docs and updated it. Let me know if there is anything else I need to do.