### PR TITLE
Revert exporting `DurableAgent` from the root "@workflow/ai" package

### DIFF
--- a/.changeset/plain-parks-lick.md
+++ b/.changeset/plain-parks-lick.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+Revert exporting `DurableAgent` from the root "@workflow/ai" package

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -3,27 +3,3 @@
  */
 export type { ModelMessage } from 'ai';
 export * from './workflow-chat-transport.js';
-
-/**
- * Export DurableAgent and all its types.
- */
-export { DurableAgent, Output } from './agent/durable-agent.js';
-export type {
-  CompatibleLanguageModel,
-  DurableAgentOptions,
-  DurableAgentStreamOptions,
-  DurableAgentStreamResult,
-  DownloadFunction,
-  GenerationSettings,
-  OutputSpecification,
-  PrepareStepCallback,
-  PrepareStepInfo,
-  PrepareStepResult,
-  ProviderOptions,
-  StreamTextOnAbortCallback,
-  StreamTextOnErrorCallback,
-  StreamTextOnFinishCallback,
-  StreamTextTransform,
-  TelemetrySettings,
-  ToolCallRepairFunction,
-} from './agent/durable-agent.js';


### PR DESCRIPTION
In commit 26d9769335707985bddbb521d8f8e31bef7fe5ec there were exports added related to DurableAgent being re-exported from the root of the "@workflow/ai" package. This re-exporting is an error and should not have been added because it causes bundling issues with client-side frameworks (i.e. Next.js) due to usage of Node.js APIs.

Fixes #709.
Closes #710.