### PR TITLE
Reland sourcemap fix for workflow package

### DIFF
--- a/.changeset/thick-pants-deny.md
+++ b/.changeset/thick-pants-deny.md
@@ -1,0 +1,5 @@
+---
+"workflow": patch
+---
+
+Reland sourcemap fix for workflow package

--- a/packages/workflow/tsconfig.json
+++ b/packages/workflow/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "@workflow/tsconfig/base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "sourceMap": false,
+    // See https://github.com/vercel/workflow/pull/352
+    "inlineSourceMap": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
This was grouped in https://github.com/vercel/workflow/commit/307f4b0e41277f6b32afbfa361d8c6ca1b3d7f6c which we don't need to revert and is valid fix on it's own.