### PR TITLE
Special-case "server-only" and "client-only" packages as external

### DIFF
--- a/.changeset/slick-sheep-slide.md
+++ b/.changeset/slick-sheep-slide.md
@@ -1,0 +1,6 @@
+---
+"@workflow/builders": patch
+"@workflow/next": patch
+---
+
+Special-case "server-only" and "client-only" packages as external

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -123,6 +123,8 @@ export abstract class BaseBuilder {
         sourcemap: false,
         absWorkingDir: this.config.workingDir,
         logLevel: 'silent',
+        // External packages that should not be bundled during discovery
+        external: this.config.externalPackages || [],
       });
     } catch (_) {}
 
@@ -483,6 +485,8 @@ export abstract class BaseBuilder {
         // happens first, preventing false positives on Node.js imports in unused code paths
         createNodeModuleErrorPlugin(),
       ],
+      // External packages that should not be bundled (e.g., server-only, client-only for Next.js)
+      external: this.config.externalPackages || [],
     });
     const interimBundle = await interimBundleCtx.rebuild();
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -128,7 +128,15 @@ export function withWorkflow(
         workflowsBundlePath: '', // not used in base
         stepsBundlePath: '', // not used in base
         webhookBundlePath: '', // node used in base
-        externalPackages: [...(nextConfig.serverExternalPackages || [])],
+        externalPackages: [
+          // server-only and client-only are pseudo-packages handled by Next.js
+          // during its build process. We mark them as external to prevent esbuild
+          // from failing when bundling code that imports them.
+          // See: https://nextjs.org/docs/app/getting-started/server-and-client-components
+          'server-only',
+          'client-only',
+          ...(nextConfig.serverExternalPackages || []),
+        ],
       });
 
       await workflowBuilder.build();


### PR DESCRIPTION
Added special handling for "server-only" and "client-only" packages in the workflow builder system.

### What changed?

- Added support for external packages in the base builder's discovery and build processes
- Specifically marked "server-only" and "client-only" packages as external in the Next.js integration

### How to test?

1. Create a Next.js application that uses "server-only" or "client-only" imports
2. Verify that the workflow builder successfully processes these files without errors
3. Confirm that the Next.js build completes successfully with these imports

### Why make this change?

Next.js handles "server-only" and "client-only" as special pseudo-packages during its build process. Without marking these as external, esbuild would fail when trying to bundle code that imports them, as they don't exist as actual packages. This change prevents build failures when using these Next.js-specific features in applications using the workflow builder.