### PR TITLE
Fix hasStepSourceMaps to return false for Vercel production builds

### DIFF
--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -33,7 +33,12 @@ export function hasStepSourceMaps(): boolean {
     return false;
   }
 
-  // Vercel builds have proper source maps for all other frameworks, EXCEPT sveltekit
+  // Vercel production builds don't support step source maps
+  if (process.env.WORKFLOW_VERCEL_ENV === 'production') {
+    return false;
+  }
+
+  // Vercel preview builds have proper source maps for all other frameworks, EXCEPT sveltekit
   if (!isLocalDeployment()) {
     return appName !== 'sveltekit';
   }


### PR DESCRIPTION
## Summary

- Step sourcemaps don't work in Vercel production deployments, causing e2e tests to fail
- Updated `hasStepSourceMaps()` to return `false` when `WORKFLOW_VERCEL_ENV === 'production'`
- Preserved existing behavior for preview builds (returns `true` except for sveltekit)

This is a follow-up fix to PR #720 which introduced step sourcemap tests.