### PR TITLE
fix(ai): preserve providerMetadata as providerOptions in multi-turn tool calls

### DIFF
--- a/.changeset/fix-provider-metadata-tool-calls.md
+++ b/.changeset/fix-provider-metadata-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+fix: preserve providerMetadata in multi-turn tool calls for Gemini thinking models

--- a/packages/ai/src/agent/stream-text-iterator.test.ts
+++ b/packages/ai/src/agent/stream-text-iterator.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Tests for streamTextIterator
+ *
+ * These tests verify that providerMetadata from tool calls is correctly
+ * mapped to providerOptions in the conversation prompt, which is critical
+ * for providers like Gemini that require thoughtSignature to be preserved
+ * across multi-turn tool calls.
+ */
+import type {
+  LanguageModelV2Prompt,
+  LanguageModelV2ToolCall,
+  LanguageModelV2ToolResultPart,
+} from '@ai-sdk/provider';
+import type { StepResult, ToolSet, UIMessageChunk } from 'ai';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock doStreamStep
+vi.mock('./do-stream-step.js', () => ({
+  doStreamStep: vi.fn(),
+}));
+
+// Import after mocking
+const { streamTextIterator } = await import('./stream-text-iterator.js');
+const { doStreamStep } = await import('./do-stream-step.js');
+
+/**
+ * Helper to create a mock writable stream
+ */
+function createMockWritable(): WritableStream<UIMessageChunk> {
+  return new WritableStream({
+    write: vi.fn(),
+    close: vi.fn(),
+  });
+}
+
+/**
+ * Helper to create a minimal step result for testing
+ */
+function createMockStepResult(
+  overrides: Partial<StepResult<ToolSet>> = {}
+): StepResult<ToolSet> {
+  return {
+    content: [],
+    text: '',
+    reasoning: [],
+    reasoningText: undefined,
+    files: [],
+    sources: [],
+    toolCalls: [],
+    staticToolCalls: [],
+    dynamicToolCalls: [],
+    toolResults: [],
+    staticToolResults: [],
+    dynamicToolResults: [],
+    finishReason: 'stop',
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    warnings: [],
+    request: { body: '' },
+    response: {
+      id: 'test',
+      timestamp: new Date(),
+      modelId: 'test',
+      messages: [],
+    },
+    providerMetadata: {},
+    ...overrides,
+  };
+}
+
+describe('streamTextIterator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('providerMetadata to providerOptions mapping', () => {
+    it('should preserve providerMetadata as providerOptions in tool-call messages', async () => {
+      const mockWritable = createMockWritable();
+      const mockModel = vi.fn();
+
+      // Capture the conversation prompt passed to subsequent doStreamStep calls
+      let capturedPrompt: LanguageModelV2Prompt | undefined;
+
+      const toolCallWithMetadata: LanguageModelV2ToolCall = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'testTool',
+        input: '{"query":"test"}',
+        providerMetadata: {
+          google: {
+            thoughtSignature: 'sig_abc123_test_signature',
+          },
+        },
+      };
+
+      // First call returns tool-calls with providerMetadata
+      // Second call (after tool results) should receive the updated prompt
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce({
+          toolCalls: [toolCallWithMetadata],
+          finish: { finishReason: 'tool-calls' },
+          step: createMockStepResult({ finishReason: 'tool-calls' }),
+        })
+        .mockImplementationOnce(async (prompt) => {
+          // Capture the prompt on the second call to verify providerOptions
+          capturedPrompt = prompt;
+          return {
+            toolCalls: [],
+            finish: { finishReason: 'stop' },
+            step: createMockStepResult({ finishReason: 'stop' }),
+          };
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          testTool: {
+            description: 'A test tool',
+            execute: async () => ({ result: 'success' }),
+          },
+        } as ToolSet,
+        writable: mockWritable,
+        model: mockModel as any,
+      });
+
+      // First iteration - get tool calls
+      const firstResult = await iterator.next();
+      expect(firstResult.done).toBe(false);
+      expect(firstResult.value.toolCalls).toHaveLength(1);
+
+      // Provide tool results and continue
+      const toolResults: LanguageModelV2ToolResultPart[] = [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'testTool',
+          output: { type: 'text', value: '{"result":"success"}' },
+        },
+      ];
+
+      // Second iteration - should trigger second doStreamStep call
+      const secondResult = await iterator.next(toolResults);
+
+      // Verify the captured prompt contains providerOptions
+      expect(capturedPrompt).toBeDefined();
+
+      // Find the assistant message with tool calls
+      const assistantMessage = capturedPrompt?.find(
+        (msg) => msg.role === 'assistant'
+      );
+      expect(assistantMessage).toBeDefined();
+
+      // Verify the tool-call part has providerOptions mapped from providerMetadata
+      const toolCallPart = (assistantMessage?.content as any[])?.find(
+        (part) => part.type === 'tool-call'
+      );
+      expect(toolCallPart).toBeDefined();
+      expect(toolCallPart.providerOptions).toEqual({
+        google: {
+          thoughtSignature: 'sig_abc123_test_signature',
+        },
+      });
+    });
+
+    it('should not add providerOptions when providerMetadata is undefined', async () => {
+      const mockWritable = createMockWritable();
+      const mockModel = vi.fn();
+
+      let capturedPrompt: LanguageModelV2Prompt | undefined;
+
+      const toolCallWithoutMetadata: LanguageModelV2ToolCall = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'testTool',
+        input: '{"query":"test"}',
+        // No providerMetadata
+      };
+
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce({
+          toolCalls: [toolCallWithoutMetadata],
+          finish: { finishReason: 'tool-calls' },
+          step: createMockStepResult({ finishReason: 'tool-calls' }),
+        })
+        .mockImplementationOnce(async (prompt) => {
+          capturedPrompt = prompt;
+          return {
+            toolCalls: [],
+            finish: { finishReason: 'stop' },
+            step: createMockStepResult({ finishReason: 'stop' }),
+          };
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          testTool: {
+            description: 'A test tool',
+            execute: async () => ({ result: 'success' }),
+          },
+        } as ToolSet,
+        writable: mockWritable,
+        model: mockModel as any,
+      });
+
+      const firstResult = await iterator.next();
+      expect(firstResult.done).toBe(false);
+
+      const toolResults: LanguageModelV2ToolResultPart[] = [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'testTool',
+          output: { type: 'text', value: '{"result":"success"}' },
+        },
+      ];
+
+      await iterator.next(toolResults);
+
+      const assistantMessage = capturedPrompt?.find(
+        (msg) => msg.role === 'assistant'
+      );
+      const toolCallPart = (assistantMessage?.content as any[])?.find(
+        (part) => part.type === 'tool-call'
+      );
+
+      expect(toolCallPart).toBeDefined();
+      expect(toolCallPart.providerOptions).toBeUndefined();
+    });
+
+    it('should preserve providerMetadata for multiple parallel tool calls', async () => {
+      const mockWritable = createMockWritable();
+      const mockModel = vi.fn();
+
+      let capturedPrompt: LanguageModelV2Prompt | undefined;
+
+      const toolCalls: LanguageModelV2ToolCall[] = [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'weatherTool',
+          input: '{"city":"NYC"}',
+          providerMetadata: {
+            google: { thoughtSignature: 'sig_weather_123' },
+          },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'newsTool',
+          input: '{"topic":"tech"}',
+          providerMetadata: {
+            google: { thoughtSignature: 'sig_news_456' },
+          },
+        },
+      ];
+
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce({
+          toolCalls,
+          finish: { finishReason: 'tool-calls' },
+          step: createMockStepResult({ finishReason: 'tool-calls' }),
+        })
+        .mockImplementationOnce(async (prompt) => {
+          capturedPrompt = prompt;
+          return {
+            toolCalls: [],
+            finish: { finishReason: 'stop' },
+            step: createMockStepResult({ finishReason: 'stop' }),
+          };
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          weatherTool: {
+            description: 'Weather tool',
+            execute: async () => ({ temp: 72 }),
+          },
+          newsTool: {
+            description: 'News tool',
+            execute: async () => ({ headlines: [] }),
+          },
+        } as ToolSet,
+        writable: mockWritable,
+        model: mockModel as any,
+      });
+
+      const firstResult = await iterator.next();
+      expect(firstResult.done).toBe(false);
+      expect(firstResult.value.toolCalls).toHaveLength(2);
+
+      const toolResults: LanguageModelV2ToolResultPart[] = [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'weatherTool',
+          output: { type: 'text', value: '{"temp":72}' },
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-2',
+          toolName: 'newsTool',
+          output: { type: 'text', value: '{"headlines":[]}' },
+        },
+      ];
+
+      await iterator.next(toolResults);
+
+      const assistantMessage = capturedPrompt?.find(
+        (msg) => msg.role === 'assistant'
+      );
+      const toolCallParts = (assistantMessage?.content as any[])?.filter(
+        (part) => part.type === 'tool-call'
+      );
+
+      expect(toolCallParts).toHaveLength(2);
+
+      // Verify each tool call has its own providerOptions
+      const weatherToolCall = toolCallParts?.find(
+        (part) => part.toolName === 'weatherTool'
+      );
+      expect(weatherToolCall?.providerOptions).toEqual({
+        google: { thoughtSignature: 'sig_weather_123' },
+      });
+
+      const newsToolCall = toolCallParts?.find(
+        (part) => part.toolName === 'newsTool'
+      );
+      expect(newsToolCall?.providerOptions).toEqual({
+        google: { thoughtSignature: 'sig_news_456' },
+      });
+    });
+
+    it('should handle mixed tool calls with and without providerMetadata', async () => {
+      const mockWritable = createMockWritable();
+      const mockModel = vi.fn();
+
+      let capturedPrompt: LanguageModelV2Prompt | undefined;
+
+      const toolCalls: LanguageModelV2ToolCall[] = [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'toolWithMeta',
+          input: '{}',
+          providerMetadata: {
+            vertex: { thoughtSignature: 'sig_vertex_789' },
+          },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'toolWithoutMeta',
+          input: '{}',
+          // No providerMetadata
+        },
+      ];
+
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce({
+          toolCalls,
+          finish: { finishReason: 'tool-calls' },
+          step: createMockStepResult({ finishReason: 'tool-calls' }),
+        })
+        .mockImplementationOnce(async (prompt) => {
+          capturedPrompt = prompt;
+          return {
+            toolCalls: [],
+            finish: { finishReason: 'stop' },
+            step: createMockStepResult({ finishReason: 'stop' }),
+          };
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          toolWithMeta: {
+            description: 'Tool with metadata',
+            execute: async () => ({ ok: true }),
+          },
+          toolWithoutMeta: {
+            description: 'Tool without metadata',
+            execute: async () => ({ ok: true }),
+          },
+        } as ToolSet,
+        writable: mockWritable,
+        model: mockModel as any,
+      });
+
+      await iterator.next();
+
+      const toolResults: LanguageModelV2ToolResultPart[] = [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'toolWithMeta',
+          output: { type: 'text', value: '{"ok":true}' },
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-2',
+          toolName: 'toolWithoutMeta',
+          output: { type: 'text', value: '{"ok":true}' },
+        },
+      ];
+
+      await iterator.next(toolResults);
+
+      const assistantMessage = capturedPrompt?.find(
+        (msg) => msg.role === 'assistant'
+      );
+      const toolCallParts = (assistantMessage?.content as any[])?.filter(
+        (part) => part.type === 'tool-call'
+      );
+
+      const toolWithMeta = toolCallParts?.find(
+        (part) => part.toolName === 'toolWithMeta'
+      );
+      expect(toolWithMeta?.providerOptions).toEqual({
+        vertex: { thoughtSignature: 'sig_vertex_789' },
+      });
+
+      const toolWithoutMeta = toolCallParts?.find(
+        (part) => part.toolName === 'toolWithoutMeta'
+      );
+      expect(toolWithoutMeta?.providerOptions).toBeUndefined();
+    });
+  });
+});

--- a/packages/ai/src/agent/stream-text-iterator.ts
+++ b/packages/ai/src/agent/stream-text-iterator.ts
@@ -267,6 +267,10 @@ export async function* streamTextIterator({
         lastStepWasToolCalls = true;
 
         // Add assistant message with tool calls to the conversation
+        // Note: providerMetadata from the tool call is mapped to providerOptions
+        // in the prompt format, following the AI SDK convention. This is critical
+        // for providers like Gemini that require thoughtSignature to be preserved
+        // across multi-turn tool calls.
         conversationPrompt.push({
           role: 'assistant',
           content: toolCalls.map((toolCall) => ({
@@ -274,6 +278,9 @@ export async function* streamTextIterator({
             toolCallId: toolCall.toolCallId,
             toolName: toolCall.toolName,
             input: JSON.parse(toolCall.input),
+            ...(toolCall.providerMetadata != null
+              ? { providerOptions: toolCall.providerMetadata }
+              : {}),
           })),
         });
 


### PR DESCRIPTION
## Summary

- Fixes Gemini thinking models (e.g., `gemini-3-pro-preview`) that require `thoughtSignature` to be preserved across multi-turn tool calls
- Maps `providerMetadata` from tool call responses to `providerOptions` in the conversation prompt, following the AI SDK convention

## Problem

When using Gemini thinking models with tool calls, multi-turn conversations fail with:
```
function call is missing a thought_signature
```

This happens because `providerMetadata` (which contains `thoughtSignature`) from the tool call was not being passed back to the provider when reconstructing the conversation prompt.

## Solution

In `stream-text-iterator.ts`, when adding tool calls to the conversation history, we now map `providerMetadata` → `providerOptions`:

```typescript
conversationPrompt.push({
  role: 'assistant',
  content: toolCalls.map((toolCall) => ({
    type: 'tool-call',
    toolCallId: toolCall.toolCallId,
    toolName: toolCall.toolName,
    input: JSON.parse(toolCall.input),
    ...(toolCall.providerMetadata != null
      ? { providerOptions: toolCall.providerMetadata }
      : {}),
  })),
});
```

This follows the same pattern used in the AI SDK's `to-response-messages.ts`.

## Testing

Added comprehensive tests in `stream-text-iterator.test.ts`:
- Preserving providerMetadata as providerOptions in tool-call messages
- Not adding providerOptions when providerMetadata is undefined  
- Preserving providerMetadata for multiple parallel tool calls
- Handling mixed tool calls with and without providerMetadata

Fixes #727