### PR TITLE
[web] Increase contrast on attribute items in sidebar

### DIFF
--- a/.changeset/fluffy-cats-matter.md
+++ b/.changeset/fluffy-cats-matter.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Increase contrast on attribute items in sidebar

--- a/packages/web-shared/src/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/sidebar/attribute-panel.tsx
@@ -570,7 +570,7 @@ export const AttributeBlock = ({
       <div className="flex items-center gap-1.5">
         <span
           className="text-[11px] font-medium"
-          style={{ color: 'var(--ds-gray-500)' }}
+          style={{ color: 'var(--ds-gray-700)' }}
         >
           {attribute}
         </span>
@@ -594,7 +594,7 @@ export const AttributeBlock = ({
       <div key={attribute} className="flex flex-col gap-0 my-2">
         <span
           className="text-xs font-medium"
-          style={{ color: 'var(--ds-gray-500)' }}
+          style={{ color: 'var(--ds-gray-700)' }}
         >
           {attribute}
         </span>
@@ -670,7 +670,7 @@ export const AttributePanel = ({
               >
                 <span
                   className="text-[11px] font-medium"
-                  style={{ color: 'var(--ds-gray-500)' }}
+                  style={{ color: 'var(--ds-gray-700)' }}
                 >
                   {attribute}
                 </span>

--- a/packages/web-shared/src/sidebar/events-list.tsx
+++ b/packages/web-shared/src/sidebar/events-list.tsx
@@ -115,7 +115,7 @@ export function EventsList({
                     >
                       <span
                         className="text-[11px] font-medium"
-                        style={{ color: 'var(--ds-gray-500)' }}
+                        style={{ color: 'var(--ds-gray-700)' }}
                       >
                         {key}
                       </span>


### PR DESCRIPTION
<img width="382" height="208" alt="image" src="https://github.com/user-attachments/assets/fb4fa8bf-b130-4e90-a4cb-ab84f27bf96c" />

<img width="381" height="251" alt="image" src="https://github.com/user-attachments/assets/5313b8d2-ce2b-47dc-8857-8e38b3f55589" />
