### PR TITLE
Update turbo inputs to include shared config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,9 +6,9 @@
       "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
-        "../../packages/tsconfig/base.json",
-        "../../pnpm-workspace.yaml",
-        "../../.node-version"
+        "$TURBO_ROOT$/packages/tsconfig/base.json",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/.node-version"
       ],
       "outputs": [
         "dist/**",


### PR DESCRIPTION
We've occasionally had cache hits in CI when we shouldn't have so this updates our inputs to try to address this https://github.com/vercel/workflow/pull/745/commits/7c6beadda8c11e350d71390192ec68a873ee4eef
