### PR TITLE
Make `resumeHook()` accept a `Hook` object or string

### DIFF
--- a/.changeset/new-crabs-hope.md
+++ b/.changeset/new-crabs-hope.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Make `resumeHook()` accept a `Hook` object or string


### PR DESCRIPTION
```typescript
// Using with a token string (existing behavior)
await resumeHook("some-token-string", payload);

// Using with a Hook object (new behavior)
const hook = await getHookByToken("some-token");
await resumeHook(hook, payload);
```

### Why make this change?

Optimization for `resumeWebhook()`.

This change improves efficiency in cases where the caller already has the `Hook` object, eliminating the need to perform an additional database lookup by token. It maintains backward compatibility while providing a more flexible API.