### PR TITLE
Avoid attempting to serialize the "tool" during tool call execution

### DIFF
--- a/.changeset/rude-suits-wonder.md
+++ b/.changeset/rude-suits-wonder.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+Avoid attempting to serialize the "tool" during tool call execution

--- a/packages/ai/src/agent/durable-agent.ts
+++ b/packages/ai/src/agent/durable-agent.ts
@@ -1023,7 +1023,13 @@ async function executeTool(
   }
 
   try {
-    const toolResult = await tool.execute(parsedInput, {
+    // Extract execute function to avoid binding `this` to the tool object.
+    // If we called `tool.execute(...)` directly, JavaScript would bind `this`
+    // to `tool`, which contains non-serializable properties like `inputSchema`.
+    // When the execute function is a workflow step (marked with 'use step'),
+    // the step system captures `this` for serialization, causing failures.
+    const { execute } = tool;
+    const toolResult = await execute(parsedInput, {
       toolCallId: toolCall.toolCallId,
       // Pass the conversation messages to the tool so it has context about the conversation
       messages,


### PR DESCRIPTION
Fixed serialization issue when executing tool calls in `DurableAgent`.

### What changed?

Modified the `executeTool` function in `durable-agent.ts` to extract the `execute` method from the tool object before calling it, rather than invoking it directly on the tool object. This prevents JavaScript from binding `this` to the tool object, which contains non-serializable properties like `inputSchema`.

### How to test?

Test tool execution in workflows where tools have complex properties that can't be serialized. Verify that tool calls complete successfully without serialization errors.

### Why make this change?

When a tool's execute function is used as a workflow step (marked with 'use step'), the step system attempts to capture and serialize `this`. Since the tool object contains non-serializable properties, this was causing failures. By extracting the execute function before calling it, we avoid the serialization of the entire tool object.