### PR TITLE
Pass runtime option to Vercel Build Output API functions

### DIFF
--- a/.changeset/fix-runtime-option.md
+++ b/.changeset/fix-runtime-option.md
@@ -1,0 +1,7 @@
+---
+"@workflow/builders": patch
+"@workflow/nitro": patch
+"@workflow/astro": patch
+---
+
+Pass runtime option to Vercel Build Output API functions

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -194,6 +194,7 @@ export class VercelBuilder extends VercelBuildOutputAPIBuilder {
       ...createBaseBuilderConfig({
         workingDir,
         dirs: ['src/pages', 'src/workflows'],
+        runtime: config?.runtime,
       }),
       buildTarget: 'vercel-build-output-api',
       debugFilePrefix: '_',

--- a/packages/builders/src/config-helpers.ts
+++ b/packages/builders/src/config-helpers.ts
@@ -77,6 +77,7 @@ export function createBaseBuilderConfig(options: {
   dirs?: string[];
   watch?: boolean;
   externalPackages?: string[];
+  runtime?: string;
 }): Omit<WorkflowConfig, 'buildTarget'> {
   return {
     dirs: options.dirs ?? ['workflows'],
@@ -86,5 +87,6 @@ export function createBaseBuilderConfig(options: {
     workflowsBundlePath: '', // Not used by base builder methods
     webhookBundlePath: '', // Not used by base builder methods
     externalPackages: options.externalPackages,
+    runtime: options.runtime,
   };
 }

--- a/packages/builders/src/types.ts
+++ b/packages/builders/src/types.ts
@@ -26,6 +26,9 @@ interface BaseWorkflowConfig {
 
   // Optional prefix for debug files (e.g., "_" for Astro to ignore them)
   debugFilePrefix?: string;
+
+  // Node.js runtime version for Vercel Functions (e.g., "nodejs22.x", "nodejs24.x")
+  runtime?: string;
 }
 
 /**

--- a/packages/builders/src/vercel-build-output-api.ts
+++ b/packages/builders/src/vercel-build-output-api.ts
@@ -60,6 +60,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
     await this.createVcConfig(stepsFuncDir, {
       shouldAddSourcemapSupport: true,
       experimentalTriggers: [STEP_QUEUE_TRIGGER],
+      runtime: this.config.runtime,
     });
 
     return manifest;
@@ -88,6 +89,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
     await this.createPackageJson(workflowsFuncDir, 'commonjs');
     await this.createVcConfig(workflowsFuncDir, {
       experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
+      runtime: this.config.runtime,
     });
   }
 
@@ -111,6 +113,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
     await this.createPackageJson(webhookFuncDir, 'commonjs');
     await this.createVcConfig(webhookFuncDir, {
       shouldAddHelpers: false,
+      runtime: this.config.runtime,
     });
   }
 

--- a/packages/nitro/src/builders.ts
+++ b/packages/nitro/src/builders.ts
@@ -13,6 +13,7 @@ export class VercelBuilder extends VercelBuildOutputAPIBuilder {
       ...createBaseBuilderConfig({
         workingDir: nitro.options.rootDir,
         dirs: ['.'], // Different apps that use nitro have different directories
+        runtime: nitro.options.workflow?.runtime,
       }),
       buildTarget: 'vercel-build-output-api',
     });

--- a/packages/nitro/src/types.ts
+++ b/packages/nitro/src/types.ts
@@ -14,6 +14,13 @@ export interface ModuleOptions {
    * @default false
    */
   typescriptPlugin?: boolean;
+
+  /**
+   * Node.js runtime version for Vercel Functions.
+   * @example "nodejs22.x"
+   * @example "nodejs24.x"
+   */
+  runtime?: string;
 }
 
 declare module 'nitro/types' {


### PR DESCRIPTION
The `runtime` configuration option (e.g., "nodejs24.x") was not being passed to the generated .vc-config.json files, causing workflow functions to always deploy with the default nodejs22.x runtime on Vercel.

This fix:
- Adds `runtime` field to BaseWorkflowConfig type
- Adds `runtime` to createBaseBuilderConfig helper
- Passes runtime to all three createVcConfig calls in vercel-build-output-api.ts
- Adds `runtime` option to Nitro ModuleOptions
- Passes runtime through Nitro and Astro builders

Fixes #798