### PR TITLE
Add retry for filesystem operation errors on Windows

### DIFF
--- a/.changeset/gold-dogs-reply.md
+++ b/.changeset/gold-dogs-reply.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-local": patch
+---
+
+Add retry for filesystem operation errors on Windows


### PR DESCRIPTION
Added retry logic for filesystem operations on Windows to handle transient file locking issues. This is an attempt to fix CI failures like [this one](https://github.com/vercel/workflow/actions/runs/21195179858/job/60969454201).

### What changed?

- Created a new `withWindowsRetry` utility function that implements exponential backoff for filesystem operations on Windows
- Applied this retry mechanism to critical file operations (`fs.rename` and `fs.unlink`)
- Added detection for common Windows-specific error codes: EPERM, EBUSY, and EACCES

### Why make this change?

On Windows, filesystem operations can fail with permission errors when files are temporarily locked by other processes or antivirus software. These errors are often transient and can be resolved by retrying the operation after a short delay. This change improves reliability on Windows by automatically retrying failed operations with exponential backoff, reducing errors in environments where file locking is common.