### PR TITLE
Throw an error if no deployment ID was specified

### DIFF
--- a/.changeset/hot-fans-check.md
+++ b/.changeset/hot-fans-check.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": patch
+---
+
+Throw an error if no deployment ID was specified

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -34,14 +34,89 @@ describe('createQueue', () => {
     it('should send message with payload and queueName', async () => {
       mockSend.mockResolvedValue({ messageId: 'msg-123' });
 
-      const queue = createQueue();
-      await queue.queue('__wkf_workflow_test', { runId: 'run-123' });
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
 
-      expect(mockSend).toHaveBeenCalledTimes(1);
-      const sentPayload = mockSend.mock.calls[0][1];
+      try {
+        const queue = createQueue();
+        await queue.queue('__wkf_workflow_test', { runId: 'run-123' });
 
-      expect(sentPayload.payload).toEqual({ runId: 'run-123' });
-      expect(sentPayload.queueName).toBe('__wkf_workflow_test');
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        const sentPayload = mockSend.mock.calls[0][1];
+
+        expect(sentPayload.payload).toEqual({ runId: 'run-123' });
+        expect(sentPayload.queueName).toBe('__wkf_workflow_test');
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+    });
+
+    it('should throw when no deploymentId and VERCEL_DEPLOYMENT_ID is not set', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+
+      // Ensure VERCEL_DEPLOYMENT_ID is not set
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      delete process.env.VERCEL_DEPLOYMENT_ID;
+
+      try {
+        const queue = createQueue();
+        await expect(
+          queue.queue('__wkf_workflow_test', { runId: 'run-123' })
+        ).rejects.toThrow(
+          'No deploymentId provided and VERCEL_DEPLOYMENT_ID environment variable is not set'
+        );
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        }
+      }
+    });
+
+    it('should not throw when deploymentId is provided in options', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+
+      // Ensure VERCEL_DEPLOYMENT_ID is not set
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      delete process.env.VERCEL_DEPLOYMENT_ID;
+
+      try {
+        const queue = createQueue();
+        await expect(
+          queue.queue(
+            '__wkf_workflow_test',
+            { runId: 'run-123' },
+            { deploymentId: 'dpl_123' }
+          )
+        ).resolves.toEqual({ messageId: 'msg-123' });
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        }
+      }
+    });
+
+    it('should not throw when VERCEL_DEPLOYMENT_ID is set', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_env_123';
+
+      try {
+        const queue = createQueue();
+        await expect(
+          queue.queue('__wkf_workflow_test', { runId: 'run-123' })
+        ).resolves.toEqual({ messageId: 'msg-123' });
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
     });
   });
 
@@ -118,6 +193,7 @@ describe('createQueue', () => {
         {
           payload: { runId: 'run-123' },
           queueName: '__wkf_workflow_test',
+          deploymentId: 'dpl_original', // Include deploymentId for re-enqueueing
         },
         { messageId: 'msg-123', deliveryCount: 1, createdAt: oldMessageTime }
       );
@@ -184,6 +260,7 @@ describe('createQueue', () => {
         {
           payload: stepPayload,
           queueName: '__wkf_step_myStep',
+          deploymentId: 'dpl_original', // Include deploymentId for re-enqueueing
         },
         { messageId: 'msg-123', deliveryCount: 1, createdAt: oldMessageTime }
       );

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -65,6 +65,16 @@ export function createQueue(config?: APIConfig): Queue {
   });
 
   const queue: Queue['queue'] = async (queueName, payload, opts) => {
+    // Check if we have a deployment ID either from options or environment
+    const deploymentId = opts?.deploymentId ?? process.env.VERCEL_DEPLOYMENT_ID;
+    if (!deploymentId) {
+      throw new Error(
+        'No deploymentId provided and VERCEL_DEPLOYMENT_ID environment variable is not set. ' +
+          'Queue messages require a deployment ID to route correctly. ' +
+          'Either set VERCEL_DEPLOYMENT_ID or provide deploymentId in options.'
+      );
+    }
+
     // zod v3 doesn't have the `encode` method. We only support zod v4 officially,
     // but codebases that pin zod v3 are still common.
     const hasEncoder = typeof MessageWrapper.encode === 'function';


### PR DESCRIPTION
Added validation to ensure a deployment ID is available when queuing messages in the Vercel world package. This could happen for example when running the queue-based health check locally, against the Vercel backend. In that case `VERCEL_DEPLOYMENT_ID` env var needs to be set.

### Why make this change?

Queue messages require a deployment ID to route correctly in Vercel's infrastructure. Without proper validation, messages could be sent without this critical information, leading to routing failures. This change ensures that developers are immediately notified if they're missing this required configuration rather than experiencing silent failures.