### PR TITLE
Clamp setTimeout value to 32-bit integer (~25d) for `sleep()`

### DIFF
--- a/.changeset/puny-schools-retire.md
+++ b/.changeset/puny-schools-retire.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-local": patch
+---
+
+Clamp setTimeout value to 32-bit integer (~25d) for `sleep()`


### PR DESCRIPTION
Fix timeout overflow error in world-local queue implementation by clamping `setTimeout` values.

Fixes #823.

### What changed?

- Added a `MAX_SAFE_TIMEOUT_MS` constant (2147483647 ms, ~24.85 days) to prevent Node.js 32-bit integer overflow
- Modified the `setTimeout` call in the queue retry logic to clamp timeout values to this maximum

### How to test?

1. Create a workflow with a very long sleep duration (> 25 days)
2. Run it in local mode
3. Verify no "TimeoutOverflowWarning" appears in the logs
4. Confirm the sleep functionality still works correctly with the clamped values

### Why make this change?

Node.js `setTimeout` uses a 32-bit signed integer internally, which means values larger than ~25 days cause overflow warnings. This change prevents those warnings while maintaining the correct behavior by allowing the handler to recalculate remaining time from persistent state when the clamped timeout fires. This is fine (using a value less than what the user requested) because the workflow handler logic will issue another queue call with `timeoutSeconds` if the desired date has not elapsed when the workflow is re-run.