### PR TITLE
[swc-plugin-workflow] Detect duplicate serialization class names

### DIFF
--- a/packages/swc-plugin-workflow/spec.md
+++ b/packages/swc-plugin-workflow/spec.md
@@ -434,6 +434,39 @@ export class Vector {
 }
 ```
 
+### Duplicate Class Name Error
+
+Classes with serialization methods must have unique names within a file. The plugin emits an error if multiple classes with the same name define serialization methods, since they would produce the same `classId` and conflict at runtime:
+
+```javascript
+// ERROR: Multiple classes named "A" have serialization methods
+export const a = function() {
+  return class A {  // First "A" - classId would be "class//input.js//A"
+    static [Symbol.for('workflow-serialize')](instance) { ... }
+    static [Symbol.for('workflow-deserialize')](data) { ... }
+  }
+}
+
+export const b = function() {
+  return class A {  // Second "A" - same classId collision!
+    static [Symbol.for('workflow-serialize')](instance) { ... }
+    static [Symbol.for('workflow-deserialize')](data) { ... }
+  }
+}
+```
+
+To fix this, give each class a unique name:
+
+```javascript
+export const a = function() {
+  return class PointA { ... }  // Unique name
+}
+
+export const b = function() {
+  return class PointB { ... }  // Unique name
+}
+```
+
 ---
 
 ## Default Exports
@@ -473,6 +506,7 @@ The plugin emits errors for invalid usage:
 | Conflicting directives | Cannot have both `"use step"` and `"use workflow"` at module level |
 | Invalid exports | Module-level directive files can only export async functions |
 | Misspelled directive | Detects typos like `"use steps"` or `"use workflows"` |
+| Duplicate serialization class | Multiple classes with the same name have serialization methods within the same file |
 
 ---
 

--- a/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/input.js
@@ -1,0 +1,24 @@
+// Two classes with the same name but in different scopes
+// This should produce an error because they would have the same classId
+
+export const a = function() {
+  return class A {
+    static [Symbol.for('workflow-serialize')](instance) {
+      return { x: instance.x };
+    }
+    static [Symbol.for('workflow-deserialize')](data) {
+      return new A(data);
+    }
+  }
+}
+
+export const b = function() {
+  return class A {
+    static [Symbol.for('workflow-serialize')](instance) {
+      return { y: instance.y };
+    }
+    static [Symbol.for('workflow-deserialize')](data) {
+      return new A(data);
+    }
+  }
+}

--- a/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-client.js
@@ -1,0 +1,26 @@
+// Two classes with the same name but in different scopes
+// This should produce an error because they would have the same classId
+export const a = function() {
+    return class A {
+        static [Symbol.for('workflow-serialize')](instance) {
+            return {
+                x: instance.x
+            };
+        }
+        static [Symbol.for('workflow-deserialize')](data) {
+            return new A(data);
+        }
+    };
+};
+export const b = function() {
+    return class A {
+        static [Symbol.for('workflow-serialize')](instance) {
+            return {
+                y: instance.y
+            };
+        }
+        static [Symbol.for('workflow-deserialize')](data) {
+            return new A(data);
+        }
+    };
+};

--- a/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-client.stderr
+++ b/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-client.stderr
@@ -1,0 +1,28 @@
+  x Multiple classes named "A" have serialization methods. Each class with workflow-serialize/workflow-deserialize must have a unique name within the file.
+    ,-[input.js:16:1]
+ 15 |     export const b = function() {
+ 16 | ,->   return class A {
+ 17 | |       static [Symbol.for('workflow-serialize')](instance) {
+ 18 | |         return { y: instance.y };
+ 19 | |       }
+ 20 | |       static [Symbol.for('workflow-deserialize')](data) {
+ 21 | |         return new A(data);
+ 22 | |       }
+ 23 | `->   }
+ 24 |     }
+    `----
+
+Advice: 
+  > first class "A" defined here
+    ,-[input.js:5:1]
+  4 |     export const a = function() {
+  5 | ,->   return class A {
+  6 | |       static [Symbol.for('workflow-serialize')](instance) {
+  7 | |         return { x: instance.x };
+  8 | |       }
+  9 | |       static [Symbol.for('workflow-deserialize')](data) {
+ 10 | |         return new A(data);
+ 11 | |       }
+ 12 | `->   }
+ 13 |     }
+    `----

--- a/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-step.js
@@ -1,0 +1,28 @@
+import { registerSerializationClass } from "workflow/internal/class-serialization";
+// Two classes with the same name but in different scopes
+// This should produce an error because they would have the same classId
+export const a = function() {
+    return class A {
+        static [Symbol.for('workflow-serialize')](instance) {
+            return {
+                x: instance.x
+            };
+        }
+        static [Symbol.for('workflow-deserialize')](data) {
+            return new A(data);
+        }
+    };
+};
+export const b = function() {
+    return class A {
+        static [Symbol.for('workflow-serialize')](instance) {
+            return {
+                y: instance.y
+            };
+        }
+        static [Symbol.for('workflow-deserialize')](data) {
+            return new A(data);
+        }
+    };
+};
+registerSerializationClass("class//input.js//A", A);

--- a/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-step.stderr
+++ b/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-step.stderr
@@ -1,0 +1,28 @@
+  x Multiple classes named "A" have serialization methods. Each class with workflow-serialize/workflow-deserialize must have a unique name within the file.
+    ,-[input.js:16:1]
+ 15 |     export const b = function() {
+ 16 | ,->   return class A {
+ 17 | |       static [Symbol.for('workflow-serialize')](instance) {
+ 18 | |         return { y: instance.y };
+ 19 | |       }
+ 20 | |       static [Symbol.for('workflow-deserialize')](data) {
+ 21 | |         return new A(data);
+ 22 | |       }
+ 23 | `->   }
+ 24 |     }
+    `----
+
+Advice: 
+  > first class "A" defined here
+    ,-[input.js:5:1]
+  4 |     export const a = function() {
+  5 | ,->   return class A {
+  6 | |       static [Symbol.for('workflow-serialize')](instance) {
+  7 | |         return { x: instance.x };
+  8 | |       }
+  9 | |       static [Symbol.for('workflow-deserialize')](data) {
+ 10 | |         return new A(data);
+ 11 | |       }
+ 12 | `->   }
+ 13 |     }
+    `----

--- a/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-workflow.js
@@ -1,0 +1,28 @@
+import { registerSerializationClass } from "workflow/internal/class-serialization";
+// Two classes with the same name but in different scopes
+// This should produce an error because they would have the same classId
+export const a = function() {
+    return class A {
+        static [Symbol.for('workflow-serialize')](instance) {
+            return {
+                x: instance.x
+            };
+        }
+        static [Symbol.for('workflow-deserialize')](data) {
+            return new A(data);
+        }
+    };
+};
+export const b = function() {
+    return class A {
+        static [Symbol.for('workflow-serialize')](instance) {
+            return {
+                y: instance.y
+            };
+        }
+        static [Symbol.for('workflow-deserialize')](data) {
+            return new A(data);
+        }
+    };
+};
+registerSerializationClass("class//input.js//A", A);

--- a/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-workflow.stderr
+++ b/packages/swc-plugin-workflow/transform/tests/errors/duplicate-serialization-class/output-workflow.stderr
@@ -1,0 +1,28 @@
+  x Multiple classes named "A" have serialization methods. Each class with workflow-serialize/workflow-deserialize must have a unique name within the file.
+    ,-[input.js:16:1]
+ 15 |     export const b = function() {
+ 16 | ,->   return class A {
+ 17 | |       static [Symbol.for('workflow-serialize')](instance) {
+ 18 | |         return { y: instance.y };
+ 19 | |       }
+ 20 | |       static [Symbol.for('workflow-deserialize')](data) {
+ 21 | |         return new A(data);
+ 22 | |       }
+ 23 | `->   }
+ 24 |     }
+    `----
+
+Advice: 
+  > first class "A" defined here
+    ,-[input.js:5:1]
+  4 |     export const a = function() {
+  5 | ,->   return class A {
+  6 | |       static [Symbol.for('workflow-serialize')](instance) {
+  7 | |         return { x: instance.x };
+  8 | |       }
+  9 | |       static [Symbol.for('workflow-deserialize')](data) {
+ 10 | |         return new A(data);
+ 11 | |       }
+ 12 | `->   }
+ 13 |     }
+    `----


### PR DESCRIPTION

### Description

Classes with serialization methods (workflow-serialize/workflow-deserialize)
generate a classId based on filename and class name. When two classes in
the same file share the same name (e.g., in different scopes), they would
produce identical classIds, causing one to silently overwrite the other
in the runtime registry.

This change emits a compile-time error when duplicate class names are
detected, showing both the duplicate and the original location. This
prevents potential serialization conflicts and makes the issue visible
during development rather than causing subtle runtime bugs.

### How did you test your changes?

Using our parser test infra, with the following case:

```ts
export const a = () => {
  return class A { /* ... */ }
}

export const b = () => {
  return class A { /* ... */ }
}
```

### PR Checklist - Required to merge

- [ ] 📦 `pnpm changeset` was run to create a changelog for this PR
  - During beta, we only use "patch" mode for changes. Don't tag minor/major versions.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
