### PR TITLE
[web-shared] Fix resolve hook modal theming and token fetching

### DIFF
--- a/.changeset/slow-suits-juggle.md
+++ b/.changeset/slow-suits-juggle.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Style the resolve hook modal for theme tokens and align the cancel action with secondary button styling.

--- a/packages/web-shared/src/sidebar/resolve-hook-modal.tsx
+++ b/packages/web-shared/src/sidebar/resolve-hook-modal.tsx
@@ -54,28 +54,32 @@ export function ResolveHookModal({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, isSubmitting, onClose]);
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      setParseError(null);
+  const submitPayload = useCallback(async () => {
+    setParseError(null);
 
-      // Parse the JSON input
-      let payload: unknown;
-      try {
-        // Allow empty string as null payload
-        if (jsonInput.trim() === '') {
-          payload = null;
-        } else {
-          payload = JSON.parse(jsonInput);
-        }
-      } catch {
-        setParseError('Invalid JSON. Please check your input.');
-        return;
+    // Parse the JSON input
+    let payload: unknown;
+    try {
+      // Allow empty string as null payload
+      if (jsonInput.trim() === '') {
+        payload = null;
+      } else {
+        payload = JSON.parse(jsonInput);
       }
+    } catch {
+      setParseError('Invalid JSON. Please check your input.');
+      return;
+    }
 
-      await onSubmit(payload);
+    await onSubmit(payload);
+  }, [jsonInput, onSubmit]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      void submitPayload();
     },
-    [jsonInput, onSubmit]
+    [submitPayload]
   );
 
   // Handle Cmd/Ctrl + Enter to submit
@@ -110,15 +114,15 @@ export function ResolveHookModal({
       <div
         className={clsx(
           'relative z-10 w-full max-w-lg mx-4',
-          'bg-white dark:bg-gray-900 rounded-lg shadow-xl',
-          'border border-gray-200 dark:border-gray-700'
+          'bg-background text-foreground rounded-lg shadow-xl',
+          'border border-border'
         )}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <h2
             id="resolve-hook-modal-title"
-            className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+            className="text-lg font-semibold text-foreground"
           >
             Resolve Hook
           </h2>
@@ -128,8 +132,8 @@ export function ResolveHookModal({
             disabled={isSubmitting}
             className={clsx(
               'p-1 rounded-md transition-colors',
-              'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
-              'hover:bg-gray-100 dark:hover:bg-gray-800',
+              'text-muted-foreground hover:text-foreground',
+              'hover:bg-muted',
               'disabled:opacity-50 disabled:cursor-not-allowed'
             )}
             aria-label="Close modal"
@@ -143,15 +147,13 @@ export function ResolveHookModal({
           <div className="px-4 py-4">
             <label
               htmlFor="json-payload"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+              className="block text-sm font-medium text-foreground mb-2"
             >
               JSON Payload
             </label>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            <p className="text-xs text-muted-foreground mb-3">
               Enter a JSON value to send to the hook. Leave empty to send{' '}
-              <code className="px-1 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-xs">
-                null
-              </code>
+              <code className="px-1 py-0.5 bg-muted rounded text-xs">null</code>
               .
             </p>
             <textarea
@@ -167,57 +169,42 @@ export function ResolveHookModal({
               placeholder='{"key": "value"}'
               className={clsx(
                 'w-full h-40 px-3 py-2 font-mono text-sm',
-                'bg-gray-50 dark:bg-gray-800',
+                'text-foreground',
+                'bg-background',
                 'border rounded-md',
-                'focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400',
+                'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
-                'placeholder:text-gray-400 dark:placeholder:text-gray-500',
-                parseError
-                  ? 'border-red-500 dark:border-red-400'
-                  : 'border-gray-300 dark:border-gray-600'
+                'placeholder:text-muted-foreground',
+                parseError ? 'border-destructive' : 'border-input'
               )}
             />
             {parseError && (
-              <p className="mt-2 text-sm text-red-600 dark:text-red-400">
-                {parseError}
-              </p>
+              <p className="mt-2 text-sm text-destructive">{parseError}</p>
             )}
-            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-              Press{' '}
-              <kbd className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                ⌘
-              </kbd>{' '}
-              +{' '}
-              <kbd className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                Enter
-              </kbd>{' '}
-              to submit
-            </p>
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border">
             <button
               type="button"
               onClick={onClose}
               disabled={isSubmitting}
               className={clsx(
                 'px-4 py-2 text-sm font-medium rounded-md transition-colors',
-                'text-gray-700 dark:text-gray-300',
-                'bg-gray-100 dark:bg-gray-800',
-                'hover:bg-gray-200 dark:hover:bg-gray-700',
+                'bg-secondary text-secondary-foreground',
+                'hover:bg-secondary/80',
                 'disabled:opacity-50 disabled:cursor-not-allowed'
               )}
             >
               Cancel
             </button>
             <button
-              type="submit"
+              type="button"
+              onClick={() => void submitPayload()}
               disabled={isSubmitting}
               className={clsx(
-                'flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors',
-                'text-white bg-blue-600 hover:bg-blue-700',
-                'dark:bg-blue-500 dark:hover:bg-blue-600',
+                'flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+                'bg-primary text-primary-foreground hover:bg-primary/90',
                 'disabled:opacity-50 disabled:cursor-not-allowed'
               )}
             >


### PR DESCRIPTION
## Summary
- Align resolve hook modal styling with theme tokens and secondary cancel button.
- Improve hook resolution by fetching and preferring the latest hook token.
- Keep the send payload flow stable while updating modal visuals.

## Test plan
- Open a run with a hook, open Resolve Hook modal in light and dark mode.
- Verify Cancel uses secondary styling and modal colors adapt correctly.
- Send a payload and confirm the hook resolves successfully.

## Before
- In Dark mode - the text inside the text area is also white and hence it's visible only when highlighted. 
- The "Send Payload" button click handler was blocked due to the form submission.
- The dialog has the same theme for both light and dark themes.

<img width="1534" height="1290" alt="image" src="https://github.com/user-attachments/assets/b7a67cfd-1aa6-4076-99e4-090b7f200114" />

The "Resolve Hook" button theme is off.

<img width="792" height="982" alt="image" src="https://github.com/user-attachments/assets/d7b0ab5c-3c2a-4281-9cc3-ce4b3b86fe2b" />

## After

<img width="1044" height="1276" alt="image" src="https://github.com/user-attachments/assets/dbfd3666-0fc1-4703-83b3-75acad10b2b5" />

<img width="1204" height="990" alt="image" src="https://github.com/user-attachments/assets/24ffb6a9-7724-4ccf-8165-0b9f3a94067f" />

