### PR TITLE
fix: extract actual output value from tool results in writeToolOutputToUI

### DIFF
--- a/.changeset/fix-tool-output-double-stringify.md
+++ b/.changeset/fix-tool-output-double-stringify.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+Fix double-serialization of tool output in writeToolOutputToUI. The function was JSON.stringify-ing the entire LanguageModelV2ToolResultPart object instead of extracting the actual tool output value.

--- a/docs/content/docs/ai/human-in-the-loop.mdx
+++ b/docs/content/docs/ai/human-in-the-loop.mdx
@@ -170,24 +170,13 @@ export function BookingApproval({ toolCallId, input, output }: BookingApprovalPr
   const [comment, setComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-    // If we have output, the approval has been processed
+  // If we have output, the approval has been processed
   if (output) {
-    try {
-      const json = JSON.parse(output) as { output: { value: string } };
-      return (
-        <div className="border rounded-lg p-4">
-          <p className="text-sm text-muted-foreground">{json.output.value}</p>
-        </div>
-      );
-    } catch (error) {
-      return (
-        <div className="border rounded-lg p-4">
-          <p className="text-sm text-muted-foreground">
-            Error parsing approval result: {(error as Error).message}
-          </p>
-        </div>
-      );
-    }
+    return (
+      <div className="border rounded-lg p-4">
+        <p className="text-sm text-muted-foreground">{output}</p>
+      </div>
+    );
   }
 
   const handleSubmit = async (approved: boolean) => {

--- a/packages/ai/src/agent/stream-text-iterator.ts
+++ b/packages/ai/src/agent/stream-text-iterator.ts
@@ -434,7 +434,7 @@ async function writeToolOutputToUI(
       const chunk: UIMessageChunk = {
         type: 'tool-output-available' as const,
         toolCallId: result.toolCallId,
-        output: JSON.stringify(result) ?? '',
+        output: result.output.value,
       };
       if (collectUIChunks) {
         chunks.push(chunk);


### PR DESCRIPTION
Fix double-serialization of tool output in writeToolOutputToUI. The function was JSON.stringify-ing the entire LanguageModelV2ToolResultPart object instead of extracting the actual tool output value.