### PR TITLE
Ignore Astro on local dev tests for source map e2e tests

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -605,12 +605,9 @@ describe('e2e', () => {
             expect(result.name).toBe('WorkflowRunFailedError');
             expect(result.cause.message).toContain('Nested workflow error');
 
-            // TODO: Known issue - workflow error stack traces are muddled when
-            //       running sveltekit in dev mode
-            if (
-              !process.env.DEV_TEST_CONFIG ||
-              process.env.APP_NAME !== 'sveltekit'
-            ) {
+            // Workflow source maps are not properly supported everywhere. Check the definition
+            // of hasWorkflowSourceMaps() to see where they are supported
+            if (hasWorkflowSourceMaps()) {
               // Stack shows call chain: errorNested1 -> errorNested2 -> errorNested3
               expect(result.cause.stack).toContain('errorNested1');
               expect(result.cause.stack).toContain('errorNested2');
@@ -637,24 +634,14 @@ describe('e2e', () => {
               'Error from imported helper module'
             );
 
-            // TODO: Known issue - workflow error stack traces are muddled when
-            //       running sveltekit in dev mode
-            if (
-              !process.env.DEV_TEST_CONFIG ||
-              process.env.APP_NAME !== 'sveltekit'
-            ) {
+            // Workflow source maps are not properly supported everywhere. Check the definition
+            // of hasWorkflowSourceMaps() to see where they are supported
+            if (hasWorkflowSourceMaps()) {
               expect(result.cause.stack).toContain('throwError');
               expect(result.cause.stack).toContain('callThrower');
               expect(result.cause.stack).toContain('errorWorkflowCrossFile');
+              expect(result.cause.stack).toContain('helpers.ts');
               expect(result.cause.stack).not.toContain('evalmachine');
-
-              // Workflow source maps are not properly supported everyhwere. Check the definition
-              // of hasWorkflowSourceMaps() to see where they are supported
-              if (hasWorkflowSourceMaps()) {
-                expect(result.cause.stack).toContain('helpers.ts');
-              } else {
-                expect(result.cause.stack).not.toContain('helpers.ts');
-              }
             }
 
             const { json: runData } = await cliInspectJson(`runs ${run.runId}`);

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -78,7 +78,10 @@ export function hasWorkflowSourceMaps(): boolean {
 
   // These frameworks currently don't handle sourcemaps correctly in local dev
   // TODO: figure out how to get sourcemaps working in these frameworks too
-  if (process.env.DEV_TEST_CONFIG && ['vite', 'astro'].includes(appName)) {
+  if (
+    process.env.DEV_TEST_CONFIG &&
+    ['vite', 'astro', 'sveltekit'].includes(appName)
+  ) {
     return false;
   }
 


### PR DESCRIPTION
Add Astro to the list of dev tests to skip the source map handling E2E test because it is very flaky.