### PR TITLE
Add "classes" object to `manifest.json` file

### DIFF
--- a/.changeset/major-mails-act.md
+++ b/.changeset/major-mails-act.md
@@ -1,0 +1,6 @@
+---
+"@workflow/swc-plugin": patch
+"@workflow/builders": patch
+---
+
+Add "classes" object to `manifest.json` file

--- a/packages/builders/src/apply-swc-transform.ts
+++ b/packages/builders/src/apply-swc-transform.ts
@@ -37,6 +37,13 @@ export type WorkflowManifest = {
       };
     };
   };
+  classes?: {
+    [relativeFileName: string]: {
+      [className: string]: {
+        classId: string;
+      };
+    };
+  };
 };
 
 export async function applySwcTransform(

--- a/packages/builders/src/swc-esbuild-plugin.ts
+++ b/packages/builders/src/swc-esbuild-plugin.ts
@@ -218,6 +218,10 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
             options.workflowManifest.steps || {},
             workflowManifest.steps
           );
+          options.workflowManifest.classes = Object.assign(
+            options.workflowManifest.classes || {},
+            workflowManifest.classes
+          );
 
           return {
             contents: transformedCode,

--- a/packages/swc-plugin-workflow/spec.md
+++ b/packages/swc-plugin-workflow/spec.md
@@ -17,13 +17,18 @@ Directives must:
 
 ## JSON Manifest
 
-All modes emit a JSON manifest comment at the top of the file containing metadata about discovered workflows and steps:
+All modes emit a JSON manifest comment at the top of the file containing metadata about discovered workflows, steps, and classes with custom serialization:
 
 ```javascript
-/**__internal_workflows{"workflows":{"path/file.ts":{"myWorkflow":{"workflowId":"workflow//path/file.ts//myWorkflow"}}},"steps":{"path/file.ts":{"myStep":{"stepId":"step//path/file.ts//myStep"}}}}*/
+/**__internal_workflows{"workflows":{"path/file.ts":{"myWorkflow":{"workflowId":"workflow//path/file.ts//myWorkflow"}}},"steps":{"path/file.ts":{"myStep":{"stepId":"step//path/file.ts//myStep"}}},"classes":{"path/file.ts":{"Point":{"classId":"class//path/file.ts//Point"}}}}*/
 ```
 
-This manifest is used by bundlers and the runtime to discover and register workflows and steps.
+The manifest includes:
+- **`workflows`**: Map of workflow function names to their `workflowId`
+- **`steps`**: Map of step function names to their `stepId`
+- **`classes`**: Map of class names with custom serialization to their `classId`
+
+This manifest is used by bundlers and the runtime to discover and register workflows, steps, and serializable classes.
 
 ## ID Generation
 
@@ -340,6 +345,7 @@ export class Point {
 Output (Client Mode):
 ```javascript
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Point":{"classId":"class//input.js//Point"}}}}*/;
 export class Point {
     constructor(x, y) {
         this.x = x;
@@ -377,7 +383,7 @@ Output (Step Mode):
 ```javascript
 import { registerStepFunction } from "workflow/internal/private";
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"}}},"classes":{"input.js":{"MyService":{"classId":"class//input.js//MyService"}}}}*/;
 export class MyService {
     static async process(data) {
         return data.value * 2;
@@ -390,7 +396,7 @@ registerSerializationClass("class//input.js//MyService", MyService);
 Output (Workflow Mode):
 ```javascript
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"}}},"classes":{"input.js":{"MyService":{"classId":"class//input.js//MyService"}}}}*/;
 export class MyService {
 }
 MyService.process = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//input.js//MyService.process");
@@ -448,6 +454,7 @@ export class Point {
 Output:
 ```javascript
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Point":{"classId":"class//input.js//Point"}}}}*/;
 export class Point {
     constructor(x, y) {
         this.x = x;

--- a/packages/swc-plugin-workflow/transform/tests/errors/instance-methods/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/instance-methods/output-client.js
@@ -1,5 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"TestClass.staticMethod":{"stepId":"step//input.js//TestClass.staticMethod"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"TestClass.staticMethod":{"stepId":"step//input.js//TestClass.staticMethod"}}},"classes":{"input.js":{"TestClass":{"classId":"class//input.js//TestClass"}}}}*/;
 export class TestClass {
     // Error: instance methods can't have directives
     async instanceMethod() {

--- a/packages/swc-plugin-workflow/transform/tests/errors/instance-methods/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/instance-methods/output-step.js
@@ -1,6 +1,6 @@
 import { registerStepFunction } from "workflow/internal/private";
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"TestClass.staticMethod":{"stepId":"step//input.js//TestClass.staticMethod"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"TestClass.staticMethod":{"stepId":"step//input.js//TestClass.staticMethod"}}},"classes":{"input.js":{"TestClass":{"classId":"class//input.js//TestClass"}}}}*/;
 export class TestClass {
     // Error: instance methods can't have directives
     async instanceMethod() {

--- a/packages/swc-plugin-workflow/transform/tests/errors/instance-methods/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/instance-methods/output-workflow.js
@@ -1,5 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"TestClass.staticMethod":{"stepId":"step//input.js//TestClass.staticMethod"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"TestClass.staticMethod":{"stepId":"step//input.js//TestClass.staticMethod"}}},"classes":{"input.js":{"TestClass":{"classId":"class//input.js//TestClass"}}}}*/;
 export class TestClass {
     // Error: instance methods can't have directives
     async instanceMethod() {

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-imported/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-imported/output-client.js
@@ -1,6 +1,7 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
 // Test custom serialization with imported symbols from '@workflow/serde'
 import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde';
+/**__internal_workflows{"classes":{"input.js":{"Color":{"classId":"class//input.js//Color"},"Vector":{"classId":"class//input.js//Vector"}}}}*/;
 // Class using imported symbols
 export class Vector {
     constructor(x, y, z){

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-imported/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-imported/output-step.js
@@ -1,6 +1,7 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
 // Test custom serialization with imported symbols from '@workflow/serde'
 import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde';
+/**__internal_workflows{"classes":{"input.js":{"Color":{"classId":"class//input.js//Color"},"Vector":{"classId":"class//input.js//Vector"}}}}*/;
 // Class using imported symbols
 export class Vector {
     constructor(x, y, z){

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-imported/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-imported/output-workflow.js
@@ -1,6 +1,7 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
 // Test custom serialization with imported symbols from '@workflow/serde'
 import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde';
+/**__internal_workflows{"classes":{"input.js":{"Color":{"classId":"class//input.js//Color"},"Vector":{"classId":"class//input.js//Vector"}}}}*/;
 // Class using imported symbols
 export class Vector {
     constructor(x, y, z){

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-local-const/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-local-const/output-client.js
@@ -1,4 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Circle":{"classId":"class//input.js//Circle"},"Rectangle":{"classId":"class//input.js//Rectangle"},"Triangle":{"classId":"class//input.js//Triangle"}}}}*/;
 // Test custom serialization with locally defined symbols using Symbol.for()
 const WORKFLOW_SERIALIZE = Symbol.for('workflow-serialize');
 const WORKFLOW_DESERIALIZE = Symbol.for('workflow-deserialize');

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-local-const/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-local-const/output-step.js
@@ -1,4 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Circle":{"classId":"class//input.js//Circle"},"Rectangle":{"classId":"class//input.js//Rectangle"},"Triangle":{"classId":"class//input.js//Triangle"}}}}*/;
 // Test custom serialization with locally defined symbols using Symbol.for()
 const WORKFLOW_SERIALIZE = Symbol.for('workflow-serialize');
 const WORKFLOW_DESERIALIZE = Symbol.for('workflow-deserialize');

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-local-const/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization-local-const/output-workflow.js
@@ -1,4 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Circle":{"classId":"class//input.js//Circle"},"Rectangle":{"classId":"class//input.js//Rectangle"},"Triangle":{"classId":"class//input.js//Triangle"}}}}*/;
 // Test custom serialization with locally defined symbols using Symbol.for()
 const WORKFLOW_SERIALIZE = Symbol.for('workflow-serialize');
 const WORKFLOW_DESERIALIZE = Symbol.for('workflow-deserialize');

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization/output-client.js
@@ -1,4 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Point":{"classId":"class//input.js//Point"}}}}*/;
 // Class with custom serialization methods using symbols
 export class Point {
     constructor(x, y){

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization/output-step.js
@@ -1,4 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Point":{"classId":"class//input.js//Point"}}}}*/;
 // Class with custom serialization methods using symbols
 export class Point {
     constructor(x, y){

--- a/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/custom-serialization/output-workflow.js
@@ -1,4 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
+/**__internal_workflows{"classes":{"input.js":{"Point":{"classId":"class//input.js//Point"}}}}*/;
 // Class with custom serialization methods using symbols
 export class Point {
     constructor(x, y){

--- a/packages/swc-plugin-workflow/transform/tests/fixture/static-method-step/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/static-method-step/output-client.js
@@ -1,5 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"},"MyService.transform":{"stepId":"step//input.js//MyService.transform"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"},"MyService.transform":{"stepId":"step//input.js//MyService.transform"}}},"classes":{"input.js":{"MyService":{"classId":"class//input.js//MyService"}}}}*/;
 export class MyService {
     static async process(data) {
         return data.value * 2;

--- a/packages/swc-plugin-workflow/transform/tests/fixture/static-method-step/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/static-method-step/output-step.js
@@ -1,6 +1,6 @@
 import { registerStepFunction } from "workflow/internal/private";
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"},"MyService.transform":{"stepId":"step//input.js//MyService.transform"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"},"MyService.transform":{"stepId":"step//input.js//MyService.transform"}}},"classes":{"input.js":{"MyService":{"classId":"class//input.js//MyService"}}}}*/;
 export class MyService {
     static async process(data) {
         return data.value * 2;

--- a/packages/swc-plugin-workflow/transform/tests/fixture/static-method-step/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/static-method-step/output-workflow.js
@@ -1,5 +1,5 @@
 import { registerSerializationClass } from "workflow/internal/class-serialization";
-/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"},"MyService.transform":{"stepId":"step//input.js//MyService.transform"}}}}*/;
+/**__internal_workflows{"steps":{"input.js":{"MyService.process":{"stepId":"step//input.js//MyService.process"},"MyService.transform":{"stepId":"step//input.js//MyService.transform"}}},"classes":{"input.js":{"MyService":{"classId":"class//input.js//MyService"}}}}*/;
 export class MyService {
     // Regular static method (no directive)
     static regularMethod() {


### PR DESCRIPTION
Added a "classes" object to the `manifest.json` file to track classes with custom serialization. This isn't strictly needed during runtime, but it could be useful for o11y and debugging.