### PR TITLE
[web-shared] Allow recreateRun to accept an optional deploymentId parameter

### DIFF
--- a/.changeset/nine-falcons-speak.md
+++ b/.changeset/nine-falcons-speak.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Allow recreateRun to accept an optional deploymentId parameter

--- a/packages/web-shared/src/api/workflow-server-actions.ts
+++ b/packages/web-shared/src/api/workflow-server-actions.ts
@@ -831,18 +831,18 @@ export async function cancelRun(
  */
 export async function recreateRun(
   worldEnv: EnvMap,
-  runId: string
+  runId: string,
+  deploymentId?: string
 ): Promise<ServerActionResult<string>> {
   try {
     const world = await getWorldFromEnv({ ...worldEnv });
     const run = await world.runs.get(runId);
     const hydratedRun = hydrate(run as WorkflowRun);
-    const deploymentId = run.deploymentId;
     const newRun = await start(
       { workflowId: run.workflowName },
       hydratedRun.input,
       {
-        deploymentId,
+        deploymentId: deploymentId ?? run.deploymentId,
         world,
       }
     );


### PR DESCRIPTION
This API change is pre-requisite for allowing users to replay an existing run on the latest deployment in addition to the deployment on which it ran originally.

Related: https://vercel.slack.com/archives/C09125LC4AX/p1769462912746749?thread_ts=1769462650.915579&cid=C09125LC4AX