### PR TITLE
Publish "workflow" and "@workflow/core" package versions in sync

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
     { "repo": "vercel/workflow" }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [["workflow", "@workflow/core"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
Configure `workflow` and `@workflow/core` packages to be versioned together.

### What changed?

Updated the Changesets configuration to ensure that the `workflow` and `@workflow/core` packages are always versioned together. This means when one package gets a version bump, the other will receive the same version bump, keeping them in sync.

### How to test?

1. Create a new changeset that affects either `workflow` or `@workflow/core`
2. Run `pnpm changeset version`
3. Verify that both packages receive the same version bump

### Why make this change?

These packages are tightly coupled and should maintain version parity to avoid confusion and potential compatibility issues. This change ensures they will always be released with matching version numbers.