### PR TITLE
Use fixed versioning strategy for workflow and @workflow/core

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
     { "repo": "vercel/workflow" }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [["workflow", "@workflow/core"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary
- Updates changesets config to use "fixed" versioning strategy for `workflow` and `@workflow/core` packages
- This ensures both packages always have the same version number when released

## Changes
Added `["workflow", "@workflow/core"]` to the `fixed` array in `.changeset/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)