### PR TITLE
Fix class ID generation when class is bound to a variable

### DIFF
--- a/.changeset/great-clouds-move.md
+++ b/.changeset/great-clouds-move.md
@@ -1,0 +1,5 @@
+---
+"@workflow/swc-plugin": patch
+---
+
+Fix class ID generation when class is bound to a variable

--- a/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/input.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/input.js
@@ -1,0 +1,35 @@
+// Test class expression where binding name differs from internal class name
+// e.g., `var Bash = class _Bash {}` - the registration should use "Bash", not "_Bash"
+import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde';
+
+// Class expression with different binding name
+var Bash = class _Bash {
+  constructor(command) {
+    this.command = command;
+  }
+
+  static [WORKFLOW_SERIALIZE](instance) {
+    return { command: instance.command };
+  }
+
+  static [WORKFLOW_DESERIALIZE](data) {
+    return new Bash(data.command);
+  }
+};
+
+// Also test anonymous class expression (no internal name)
+var Shell = class {
+  constructor(cmd) {
+    this.cmd = cmd;
+  }
+
+  static [WORKFLOW_SERIALIZE](instance) {
+    return { cmd: instance.cmd };
+  }
+
+  static [WORKFLOW_DESERIALIZE](data) {
+    return new Shell(data.cmd);
+  }
+};
+
+export { Bash, Shell };

--- a/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/output-client.js
@@ -1,0 +1,36 @@
+import { registerSerializationClass } from "workflow/internal/class-serialization";
+// Test class expression where binding name differs from internal class name
+// e.g., `var Bash = class _Bash {}` - the registration should use "Bash", not "_Bash"
+import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde';
+/**__internal_workflows{"classes":{"input.js":{"Bash":{"classId":"class//input.js//Bash"},"Shell":{"classId":"class//input.js//Shell"}}}}*/;
+// Class expression with different binding name
+var Bash = class _Bash {
+    constructor(command){
+        this.command = command;
+    }
+    static [WORKFLOW_SERIALIZE](instance) {
+        return {
+            command: instance.command
+        };
+    }
+    static [WORKFLOW_DESERIALIZE](data) {
+        return new Bash(data.command);
+    }
+};
+// Also test anonymous class expression (no internal name)
+var Shell = class {
+    constructor(cmd){
+        this.cmd = cmd;
+    }
+    static [WORKFLOW_SERIALIZE](instance) {
+        return {
+            cmd: instance.cmd
+        };
+    }
+    static [WORKFLOW_DESERIALIZE](data) {
+        return new Shell(data.cmd);
+    }
+};
+export { Bash, Shell };
+registerSerializationClass("class//input.js//Bash", Bash);
+registerSerializationClass("class//input.js//Shell", Shell);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/output-step.js
@@ -1,0 +1,36 @@
+import { registerSerializationClass } from "workflow/internal/class-serialization";
+// Test class expression where binding name differs from internal class name
+// e.g., `var Bash = class _Bash {}` - the registration should use "Bash", not "_Bash"
+import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde';
+/**__internal_workflows{"classes":{"input.js":{"Bash":{"classId":"class//input.js//Bash"},"Shell":{"classId":"class//input.js//Shell"}}}}*/;
+// Class expression with different binding name
+var Bash = class _Bash {
+    constructor(command){
+        this.command = command;
+    }
+    static [WORKFLOW_SERIALIZE](instance) {
+        return {
+            command: instance.command
+        };
+    }
+    static [WORKFLOW_DESERIALIZE](data) {
+        return new Bash(data.command);
+    }
+};
+// Also test anonymous class expression (no internal name)
+var Shell = class {
+    constructor(cmd){
+        this.cmd = cmd;
+    }
+    static [WORKFLOW_SERIALIZE](instance) {
+        return {
+            cmd: instance.cmd
+        };
+    }
+    static [WORKFLOW_DESERIALIZE](data) {
+        return new Shell(data.cmd);
+    }
+};
+export { Bash, Shell };
+registerSerializationClass("class//input.js//Bash", Bash);
+registerSerializationClass("class//input.js//Shell", Shell);

--- a/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/class-expression-binding-name/output-workflow.js
@@ -1,0 +1,36 @@
+import { registerSerializationClass } from "workflow/internal/class-serialization";
+// Test class expression where binding name differs from internal class name
+// e.g., `var Bash = class _Bash {}` - the registration should use "Bash", not "_Bash"
+import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde';
+/**__internal_workflows{"classes":{"input.js":{"Bash":{"classId":"class//input.js//Bash"},"Shell":{"classId":"class//input.js//Shell"}}}}*/;
+// Class expression with different binding name
+var Bash = class _Bash {
+    constructor(command){
+        this.command = command;
+    }
+    static [WORKFLOW_SERIALIZE](instance) {
+        return {
+            command: instance.command
+        };
+    }
+    static [WORKFLOW_DESERIALIZE](data) {
+        return new Bash(data.command);
+    }
+};
+// Also test anonymous class expression (no internal name)
+var Shell = class {
+    constructor(cmd){
+        this.cmd = cmd;
+    }
+    static [WORKFLOW_SERIALIZE](instance) {
+        return {
+            cmd: instance.cmd
+        };
+    }
+    static [WORKFLOW_DESERIALIZE](data) {
+        return new Shell(data.cmd);
+    }
+};
+export { Bash, Shell };
+registerSerializationClass("class//input.js//Bash", Bash);
+registerSerializationClass("class//input.js//Shell", Shell);


### PR DESCRIPTION
Fixed class ID generation for class expressions bound to variables in the SWC plugin.

### What changed?

- Added support for correctly handling class expressions with binding names that differ from internal class names
- Updated the SWC plugin to use the variable name (binding name) for registration instead of the internal class name
- Added test cases for class expressions with different binding names and anonymous class expressions
- Updated documentation to explain how class expressions with binding names are handled

### How to test?

Test with code patterns like:
```javascript
var Bash = class _Bash {
  // Class implementation with serialization methods
};
```

Verify that the generated code correctly uses the binding name "Bash" for registration rather than the internal name "_Bash".

### Why make this change?

When a class expression is assigned to a variable, the internal class name is only accessible inside the class body, not at module level. Using the binding name ensures that the registration call references a symbol that's actually in scope at module level, preventing runtime errors when the code attempts to register the class for serialization.