### PR TITLE
fix(ai): remove itemId from providerOptions for openai models

### DIFF
--- a/packages/ai/src/agent/stream-text-iterator.ts
+++ b/packages/ai/src/agent/stream-text-iterator.ts
@@ -102,6 +102,7 @@ export async function* streamTextIterator({
   let currentToolChoice = toolChoice;
   let currentContext = experimental_context;
   let currentActiveTools: string[] | undefined;
+  let previousResponseId: string | undefined; // Track OpenAI response ID (for openai responses api)
 
   const steps: StepResult<any>[] = [];
   let done = false;
@@ -255,6 +256,15 @@ export async function* streamTextIterator({
           ? filterToolSet(tools, currentActiveTools)
           : tools;
 
+      // Set previousResponseId in providerOptions for OpenAI conversation continuity
+      if (
+        previousResponseId &&
+        currentGenerationSettings?.providerOptions?.openai
+      ) {
+        currentGenerationSettings.providerOptions.openai.previousResponseId =
+          previousResponseId;
+      }
+
       const {
         toolCalls,
         finish,
@@ -277,6 +287,15 @@ export async function* streamTextIterator({
           collectUIChunks,
         }
       );
+
+      // Extract response ID from finish chunk for next iteration
+      // OpenAI provides this in providerMetadata.openai.responseId
+      const openaiResponseId = (finish as any)?.providerMetadata?.openai
+        ?.responseId;
+      if (openaiResponseId && typeof openaiResponseId === 'string') {
+        previousResponseId = openaiResponseId;
+      }
+
       isFirstIteration = false;
       stepNumber++;
       steps.push(step);
@@ -309,7 +328,26 @@ export async function* streamTextIterator({
             toolName: toolCall.toolName,
             input: JSON.parse(toolCall.input),
             ...(toolCall.providerMetadata != null
-              ? { providerOptions: toolCall.providerMetadata }
+              ? {
+                  providerOptions: (() => {
+                    if (
+                      toolCall.providerMetadata.openai &&
+                      typeof toolCall.providerMetadata.openai === 'object'
+                    ) {
+                      const { itemId: _itemId, ...rest } =
+                        toolCall.providerMetadata.openai;
+                      // Remove itemId here — it requires a paired reasoningId.
+                      // Passing previousResponseId is sufficient. (we already pass this above)
+                      // Passing previousResponseId + itemId throws a duplicate item error
+
+                      return {
+                        ...toolCall.providerMetadata,
+                        openai: rest,
+                      };
+                    }
+                    return toolCall.providerMetadata;
+                  })(),
+                }
               : {}),
           })),
         });


### PR DESCRIPTION
Fix DurableAgent + OpenAI Responses API failing on tool calls due to missing required reasoning item. The issue occurred because tool calls were forwarding itemId in providerMetadata, which requires a paired reasoning item that DurableAgent doesn't provide.

Changes:
- Remove itemId from tool call providerMetadata
- Add previousResponseId tracking for proper conversation continuity
- Extract responseId from finish chunk and pass it in subsequent requests

The previousResponseId approach is sufficient for conversation continuity and avoids the duplicate item error that occurs when both previousResponseId and itemId are present.

Fixes #880