### PR TITLE
Webhook URL production

### DIFF
--- a/.changeset/webhook-production-url.md
+++ b/.changeset/webhook-production-url.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Use `VERCEL_PROJECT_PRODUCTION_URL` instead of `VERCEL_URL` for webhook URLs to avoid deployment protection issues

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -246,6 +246,12 @@ const stepHandler = getWorldHandlers().createQueueHandler(
               ...Attribute.StepArgumentsCount(args.length),
             });
 
+            // Prefer VERCEL_PROJECT_PRODUCTION_URL for webhook URLs to avoid deployment
+            // protection issues (deployment-specific URLs may be blocked by Vercel's
+            // standard deployment protection).
+            const vercelUrl =
+              process.env.VERCEL_PROJECT_PRODUCTION_URL ??
+              process.env.VERCEL_URL;
             result = await contextStorage.run(
               {
                 stepMetadata: {
@@ -258,8 +264,8 @@ const stepHandler = getWorldHandlers().createQueueHandler(
                   workflowStartedAt: new Date(+workflowStartedAt),
                   // TODO: there should be a getUrl method on the world interface itself. This
                   // solution only works for vercel + local worlds.
-                  url: process.env.VERCEL_URL
-                    ? `https://${process.env.VERCEL_URL}`
+                  url: vercelUrl
+                    ? `https://${vercelUrl}`
                     : `http://localhost:${port ?? 3000}`,
                 },
                 ops,

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -127,8 +127,13 @@ export async function runWorkflow(
 
     // TODO: there should be a getUrl method on the world interface itself. This
     // solution only works for vercel + local worlds.
-    const url = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
+    // Prefer VERCEL_PROJECT_PRODUCTION_URL for webhook URLs to avoid deployment
+    // protection issues (deployment-specific URLs may be blocked by Vercel's
+    // standard deployment protection).
+    const vercelUrl =
+      process.env.VERCEL_PROJECT_PRODUCTION_URL ?? process.env.VERCEL_URL;
+    const url = vercelUrl
+      ? `https://${vercelUrl}`
       : `http://localhost:${port ?? 3000}`;
 
     // For the workflow VM, we store the context in a symbol on the `globalThis` object


### PR DESCRIPTION
### Description

This PR changes how webhook URLs are constructed to prefer the Vercel production URL (`VERCEL_PROJECT_PRODUCTION_URL`) over the deployment-specific URL (`VERCEL_URL`).

Previously, webhooks generated with deployment-specific URLs could be blocked by Vercel's deployment protection. By using the stable production domain, this change ensures webhooks are consistently accessible and avoids these blocking issues. This applies to URLs in both workflow and step contexts.

### How did you test your changes?

Unit tests were run and passed. Typecheck and lint checks also passed. The logic was verified to correctly prioritize `VERCEL_PROJECT_PRODUCTION_URL` when available, falling back to `VERCEL_URL` and then `localhost`.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - During beta, we only use "patch" mode for changes. Don't tag minor/major versions.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)

---
[Slack Thread](https://vercel.slack.com/archives/C09125LC4AX/p1769754238177949?thread_ts=1769754238.177949&cid=C09125LC4AX)

<a href="https://cursor.com/background-agent?bcId=bc-9ec4c34e-840b-474b-a2dc-0badf41bd2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ec4c34e-840b-474b-a2dc-0badf41bd2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

