### PR TITLE
[docs] Fix header image 404

### DIFF
--- a/.changeset/fix-readme-header-svg-404.md
+++ b/.changeset/fix-readme-header-svg-404.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(docs): restore SVG and ZIP file exclusion in middleware to fix 404 errors on public static assets

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -40,9 +40,9 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
 };
 
 export const config = {
-  // Matcher ignoring `/_next/`, `/api/`, static assets, favicon, tarballs, etc.
+  // Matcher ignoring `/_next/`, `/api/`, static assets, favicon, tarballs, SVGs, zips, etc.
   matcher: [
-    '/((?!sitemap.xml|api|_next/static|_next/image|favicon.ico|.*\\.tgz$).*)',
+    '/((?!sitemap.xml|api|_next/static|_next/image|favicon.ico|.*\\.tgz$|.*\\.svg$|.*\\.zip$).*)',
   ],
 };
 


### PR DESCRIPTION
### Description

Fixes 404 errors for SVG images and ZIP files in the `docs` header and other public locations. The `docs/proxy.ts` middleware matcher was updated during a recent refactor, inadvertently removing exclusions for `.svg` and `.zip` files, causing them to be processed by the i18n middleware. This PR re-adds `.*\\.svg$` and `.*\\.zip$` to the middleware matcher to ensure these files are served directly.

### How did you test your changes?

The issue was identified by tracing the `docs/proxy.ts` middleware and comparing its matcher configuration with previous versions. The fix involves a direct update to the regex pattern. Manual verification would include navigating to the `docs` site and confirming that the header images (e.g., `workflow-circle-symbol-light.svg`) load correctly.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - During beta, we only use "patch" mode for changes. Don't tag minor/major versions.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)

---
[Slack Thread](https://vercel.slack.com/archives/C09125LC4AX/p1769798519694629?thread_ts=1769798519.694629&cid=C09125LC4AX)

<a href="https://cursor.com/background-agent?bcId=bc-ceac6e30-3378-4a2c-a856-c0921f6b6d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ceac6e30-3378-4a2c-a856-c0921f6b6d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

