### PR TITLE
Update @sveltejs/adapter-node version to 5.5.1

### DIFF
--- a/workbench/sveltekit/package.json
+++ b/workbench/sveltekit/package.json
@@ -29,7 +29,7 @@
     "@ai-sdk/react": "2.0.76",
     "@node-rs/xxhash": "1.7.6",
     "@opentelemetry/api": "^1.9.0",
-    "@sveltejs/adapter-node": "^5.4.0",
+    "@sveltejs/adapter-node": "^5.5.1",
     "@sveltejs/adapter-vercel": "^6.1.1",
     "@swc/core": "catalog:",
     "@vercel/otel": "^1.13.0",


### PR DESCRIPTION
SvelteKit is a framework for rapidly developing robust, performant web applications using Svelte. Prior to 2.49.5, SvelteKit is vulnerable to a server side request forgery (SSRF) and denial of service (DoS) under certain conditions. From 2.44.0 through 2.49.4, the vulnerability results in a DoS when your app has at least one prerendered route (export const prerender = true). From 2.19.0 through 2.49.4, the vulnerability results in a DoS when your app has at least one prerendered route and you are using adapter-node without a configured ORIGIN environment variable, and you are not using a reverse proxy that implements Host header validation. This vulnerability is fixed in 2.49.5.