### PR TITLE
[release] Fix workflow/ai peer dependendency causing a major bump in changeset

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "ai": "^5 || ^6",
-    "workflow": "^4.0.1-beta.50"
+    "workflow": "^4.0.0"
   },
   "dependencies": {
     "@ai-sdk/provider": "^2.0.0 || ^3.0.0",


### PR DESCRIPTION
```
When workflow gets bumped to 4.1.0 (minor), changesets treats this as a breaking change for @workflow/ai because the pinned peer dependency 4.0.1-beta.50 won't satisfy 4.1.0. Changesets
   automatically bumps packages to major when their peer dependencies have breaking version changes.

  Solutions:

  1. Use a range for the peer dependency (recommended):
  "peerDependencies": {
    "workflow": "^4.0.0"
  }
  2. Or use >= if you want to be more permissive:
  "peerDependencies": {
    "workflow": ">=4.0.0"
  }

  This way, when workflow bumps to 4.1.0, the peer dependency is still satisfied and changesets won't force a major bump on @workflow/ai.
```