### PR TITLE
Ignore all `@workflow/example-*` apps from changesets publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,14 +14,6 @@
     "docs",
     "nextjs-turbopack",
     "nextjs-webpack",
-    "@workflow/example-app",
-    "@workflow/example-hono",
-    "@workflow/example-express",
-    "@workflow/example-nitro-v3",
-    "@workflow/example-nitro-v2",
-    "@workflow/example-nuxt",
-    "@workflow/example-vite",
-    "@workflow/example-sveltekit",
-    "@workflow/example-astro"
+    "@workflow/example-*"
   ]
 }


### PR DESCRIPTION
Updated the changeset configuration to use a wildcard pattern for workflow examples.

### What changed?

Replaced the explicit list of workflow example packages in the `.changeset/config.json` file with a wildcard pattern `@workflow/example-*`. This simplifies the configuration and automatically includes all current and future workflow example packages.

### How to test?

1. Verify that running changeset commands still ignores all workflow example packages
2. Add a new workflow example package and confirm it's automatically excluded without needing to update the config

### Why make this change?

This change reduces maintenance overhead by eliminating the need to manually update the changeset configuration every time a new workflow example package is added. The wildcard pattern ensures all workflow example packages are automatically excluded from the changeset process.