### PR TITLE
Support step function serialization in "client" mode

### DIFF
--- a/.changeset/clean-doodles-learn.md
+++ b/.changeset/clean-doodles-learn.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Set `stepId` property on function in `registerStepFunction` for serialization support

--- a/.changeset/tasty-rules-stick.md
+++ b/.changeset/tasty-rules-stick.md
@@ -1,0 +1,5 @@
+---
+"@workflow/swc-plugin": patch
+---
+
+Set `stepId` property on step functions in "client" mode for serialization support

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -11,15 +11,18 @@ export type StepFunction<
   Result extends Serializable | unknown = unknown,
 > = ((...args: Args) => Promise<Result>) & {
   maxRetries?: number;
+  stepId?: string;
 };
 
 const registeredSteps = new Map<string, StepFunction>();
 
 /**
- * Register a step function to be served in the server bundle
+ * Register a step function to be served in the server bundle.
+ * Also sets the stepId property on the function for serialization support.
  */
 export function registerStepFunction(stepId: string, stepFn: StepFunction) {
   registeredSteps.set(stepId, stepFn);
+  stepFn.stepId = stepId;
 }
 
 /**

--- a/packages/swc-plugin-workflow/transform/tests/errors/invalid-exports/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/invalid-exports/output-client.js
@@ -12,3 +12,4 @@ export * from './other';
 export async function validStep() {
     return 'allowed';
 }
+validStep.stepId = "step//./input//validStep";

--- a/packages/swc-plugin-workflow/transform/tests/errors/misplaced-function-directive/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/misplaced-function-directive/output-client.js
@@ -5,6 +5,7 @@ export async function badStep() {
     'use step';
     return x;
 }
+badStep.stepId = "step//./input//badStep";
 export const badWorkflow = async ()=>{
     console.log('hello');
     // Error: directive must be at the top of function

--- a/packages/swc-plugin-workflow/transform/tests/errors/non-async-functions/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/errors/non-async-functions/output-client.js
@@ -13,6 +13,7 @@ export const syncWorkflow = ()=>{
 export async function validStep() {
     return 42;
 }
+validStep.stepId = "step//./input//validStep";
 export const validWorkflow = async ()=>{
     throw new Error("You attempted to execute workflow validWorkflow function directly. To start a workflow, use start(validWorkflow) from workflow/api");
 };

--- a/packages/swc-plugin-workflow/transform/tests/fixture/agent-with-tool-step-shorthand-method/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/agent-with-tool-step-shorthand-method/output-client.js
@@ -1,10 +1,13 @@
 import { agent } from "experimental-agent";
+/**__internal_workflows{"steps":{"input.js":{"vade/tools/VercelRequest/execute":{"stepId":"step//./input//vade/tools/VercelRequest/execute"}}}}*/;
+var vade$tools$VercelRequest$execute = async function(input, { experimental_context }) {
+    return 1 + 1;
+};
 export const vade = agent({
     tools: {
         VercelRequest: {
-            async execute (input, { experimental_context }) {
-                return 1 + 1;
-            }
+            execute: vade$tools$VercelRequest$execute
         }
     }
 });
+vade$tools$VercelRequest$execute.stepId = "step//./input//vade/tools/VercelRequest/execute";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/agent-with-tool-step/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/agent-with-tool-step/output-client.js
@@ -1,10 +1,13 @@
 import { agent } from "experimental-agent";
+/**__internal_workflows{"steps":{"input.js":{"vade/tools/VercelRequest/execute":{"stepId":"step//./input//vade/tools/VercelRequest/execute"}}}}*/;
+var vade$tools$VercelRequest$execute = async function(input, { experimental_context }) {
+    return 1 + 1;
+};
 export const vade = agent({
     tools: {
         VercelRequest: {
-            execute: async (input, { experimental_context })=>{
-                return 1 + 1;
-            }
+            execute: vade$tools$VercelRequest$execute
         }
     }
 });
+vade$tools$VercelRequest$execute.stepId = "step//./input//vade/tools/VercelRequest/execute";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/deeply-nested-step/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/deeply-nested-step/output-client.js
@@ -1,13 +1,16 @@
 import { createConfig } from "some-library";
+/**__internal_workflows{"steps":{"input.js":{"config/level1/level2/level3/myStep":{"stepId":"step//./input//config/level1/level2/level3/myStep"}}}}*/;
+var config$level1$level2$level3$myStep = async function(input) {
+    return input * 2;
+};
 // Test deeply nested step functions (4 levels deep)
 export const config = createConfig({
     level1: {
         level2: {
             level3: {
-                myStep: async (input)=>{
-                    return input * 2;
-                }
+                myStep: config$level1$level2$level3$myStep
             }
         }
     }
 });
+config$level1$level2$level3$myStep.stepId = "step//./input//config/level1/level2/level3/myStep";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/destructuring/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/destructuring/output-client.js
@@ -2,15 +2,19 @@
 export async function destructure({ a, b }) {
     return a + b;
 }
+destructure.stepId = "step//./input//destructure";
 export async function process_array([first, second]) {
     return first + second;
 }
+process_array.stepId = "step//./input//process_array";
 export async function nested_destructure({ user: { name, age } }) {
     return `${name} is ${age} years old`;
 }
+nested_destructure.stepId = "step//./input//nested_destructure";
 export async function with_defaults({ x = 10, y = 20 }) {
     return x + y;
 }
+with_defaults.stepId = "step//./input//with_defaults";
 export async function with_rest({ a, b, ...rest }) {
     return {
         a,
@@ -18,6 +22,7 @@ export async function with_rest({ a, b, ...rest }) {
         rest
     };
 }
+with_rest.stepId = "step//./input//with_rest";
 export async function multiple({ a, b }, { c, d }) {
     return {
         a,
@@ -26,6 +31,7 @@ export async function multiple({ a, b }, { c, d }) {
         d
     };
 }
+multiple.stepId = "step//./input//multiple";
 export async function rest_top_level(a, b, ...rest) {
     return {
         a,
@@ -33,3 +39,4 @@ export async function rest_top_level(a, b, ...rest) {
         rest
     };
 }
+rest_top_level.stepId = "step//./input//rest_top_level";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/factory-with-step-method/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/factory-with-step-method/output-client.js
@@ -1,7 +1,9 @@
-import fs from 'fs/promises';
+/**__internal_workflows{"steps":{"input.js":{"myFactory/myStep":{"stepId":"step//./input//myFactory/myStep"}}}}*/;
+var myFactory$myStep = async function() {
+    await fs.mkdir('test');
+};
 const myFactory = ()=>({
-        myStep: async ()=>{
-            await fs.mkdir('test');
-        }
+        myStep: myFactory$myStep
     });
 export default myFactory;
+myFactory$myStep.stepId = "step//./input//myFactory/myStep";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/let-arrow-step-function/output-client.js
@@ -2,9 +2,12 @@
 let stepArrow = async ()=>{
     return 1;
 };
+stepArrow.stepId = "step//./input//stepArrow";
 export let exportedStepArrow = async ()=>{
     return 2;
 };
+exportedStepArrow.stepId = "step//./input//exportedStepArrow";
 export async function normalStep() {
     return 3;
 }
+normalStep.stepId = "step//./input//normalStep";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/mixed-functions/output-client.js
@@ -2,9 +2,11 @@
 export async function stepFunction(a, b) {
     return a + b;
 }
+stepFunction.stepId = "step//./input//stepFunction";
 async function stepFunctionWithoutExport(a, b) {
     return a - b;
 }
+stepFunctionWithoutExport.stepId = "step//./input//stepFunctionWithoutExport";
 export async function workflowFunction(a, b) {
     throw new Error("You attempted to execute workflow workflowFunction function directly. To start a workflow, use start(workflowFunction) from workflow/api");
 }

--- a/packages/swc-plugin-workflow/transform/tests/fixture/module-level-step/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/module-level-step/output-client.js
@@ -2,6 +2,8 @@
 export async function step(input) {
     return input.foo;
 }
+step.stepId = "step//./input//step";
 export const stepArrow = async (input)=>{
     return input.bar;
 };
+stepArrow.stepId = "step//./input//stepArrow";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/module-level-workflow/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/module-level-workflow/output-client.js
@@ -1,6 +1,6 @@
 /**__internal_workflows{"workflows":{"input.js":{"arrowWorkflow":{"workflowId":"workflow//./input//arrowWorkflow"},"workflow":{"workflowId":"workflow//./input//workflow"}}}}*/;
 export async function workflow(input) {
-    return input.foo;
+    throw new Error("You attempted to execute workflow workflow function directly. To start a workflow, use start(workflow) from workflow/api");
 }
 workflow.workflowId = "workflow//./input//workflow";
 export const arrowWorkflow = async (input)=>{

--- a/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/multiple-const-step-functions/output-client.js
@@ -4,19 +4,25 @@ const fn1 = async ()=>{
 }, fn2 = async ()=>{
     return 2;
 };
+fn2.stepId = "step//./input//fn2";
+fn1.stepId = "step//./input//fn1";
 export const fn3 = async ()=>{
     return 3;
 }, fn4 = async ()=>{
     return 4;
 };
+fn4.stepId = "step//./input//fn4";
+fn3.stepId = "step//./input//fn3";
 // Test case: regular function BEFORE step function in same declaration
 // This verifies that processing doesn't skip the step function
 const regularArrow = ()=>1, stepAfterRegular = async ()=>{
     return 5;
 };
+stepAfterRegular.stepId = "step//./input//stepAfterRegular";
 // Test case: regular function expression BEFORE step function
 const regularFn = function() {
     return 2;
 }, stepAfterRegularFn = async function() {
     return 6;
 };
+stepAfterRegularFn.stepId = "step//./input//stepAfterRegularFn";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/object-property-step/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/object-property-step/output-client.js
@@ -1,34 +1,41 @@
 import * as z from 'zod';
 import { tool } from 'ai';
+/**__internal_workflows{"steps":{"input.js":{"timeTool/execute":{"stepId":"step//./input//timeTool/execute"},"weatherTool/execute":{"stepId":"step//./input//weatherTool/execute"},"weatherTool2/execute":{"stepId":"step//./input//weatherTool2/execute"}}}}*/;
+var weatherTool$execute = async function({ location }) {
+    return {
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10
+    };
+};
+var timeTool$execute = async function timeToolImpl() {
+    return {
+        time: new Date().toISOString()
+    };
+};
+var weatherTool2$execute = async function({ location }) {
+    return {
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10
+    };
+};
 export const weatherTool = tool({
     description: 'Get the weather in a location',
     inputSchema: z.object({
         location: z.string().describe('The location to get the weather for')
     }),
-    execute: async ({ location })=>{
-        return {
-            location,
-            temperature: 72 + Math.floor(Math.random() * 21) - 10
-        };
-    }
+    execute: weatherTool$execute
 });
 export const timeTool = tool({
     description: 'Get the current time',
-    execute: async function timeToolImpl() {
-        return {
-            time: new Date().toISOString()
-        };
-    }
+    execute: timeTool$execute
 });
 export const weatherTool2 = tool({
     description: 'Get the weather in a location',
     inputSchema: z.object({
         location: z.string().describe('The location to get the weather for')
     }),
-    async execute ({ location }) {
-        return {
-            location,
-            temperature: 72 + Math.floor(Math.random() * 21) - 10
-        };
-    }
+    execute: weatherTool2$execute
 });
+weatherTool$execute.stepId = "step//./input//weatherTool/execute";
+timeTool$execute.stepId = "step//./input//timeTool/execute";
+weatherTool2$execute.stepId = "step//./input//weatherTool2/execute";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/separate-export-statement/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/separate-export-statement/output-client.js
@@ -2,6 +2,7 @@
 async function stepFunction(a, b) {
     return a + b;
 }
+stepFunction.stepId = "step//./input//stepFunction";
 async function workflowFunction(a, b) {
     throw new Error("You attempted to execute workflow workflowFunction function directly. To start a workflow, use start(workflowFunction) from workflow/api");
 }

--- a/packages/swc-plugin-workflow/transform/tests/fixture/single-step/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/single-step/output-client.js
@@ -2,3 +2,4 @@
 export async function add(a, b) {
     return a + b;
 }
+add.stepId = "step//./input//add";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-arrow-function/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-arrow-function/output-client.js
@@ -2,3 +2,4 @@
 export const multiply = async (a, b)=>{
     return a * b;
 };
+multiply.stepId = "step//./input//multiply";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-with-imports/output-client.js
@@ -8,6 +8,7 @@ export async function processData(data) {
     localFunction();
     return defaultExport(transformed);
 }
+processData.stepId = "step//./input//processData";
 export function normalFunction() {
     // since this function is exported we can't remove it
     useful.doSomething();

--- a/packages/swc-plugin-workflow/transform/tests/fixture/step-with-this-arguments-super/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/step-with-this-arguments-super/output-client.js
@@ -4,10 +4,12 @@ export async function stepWithThis() {
     // `this` is allowed in step functions
     return this.value;
 }
+stepWithThis.stepId = "step//./input//stepWithThis";
 export async function stepWithArguments() {
     // `arguments` is allowed in step functions
     return arguments[0];
 }
+stepWithArguments.stepId = "step//./input//stepWithArguments";
 class TestClass extends BaseClass {
     async stepMethod() {
         // `super` is allowed in step functions

--- a/packages/swc-plugin-workflow/transform/tests/fixture/unused-exports/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/unused-exports/output-client.js
@@ -13,6 +13,7 @@ export function formatData(data) {
 export async function processData(input) {
     return helper(input);
 }
+processData.stepId = "step//./input//processData";
 // This is used internally
 function internalHelper(value) {
     return value * 2;

--- a/packages/swc-plugin-workflow/transform/tests/fixture/unused-variables-and-types/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/unused-variables-and-types/output-client.js
@@ -12,6 +12,7 @@ export const sendRecipientEmail = async ({ recipientEmail, cardImage, cardText, 
         html
     });
 };
+sendRecipientEmail.stepId = "step//./input//sendRecipientEmail";
 export function normalFunction() {
     return 'this stays because it is exported';
 }

--- a/packages/swc-plugin-workflow/transform/tests/fixture/using-declaration-step/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/using-declaration-step/output-client.js
@@ -23,3 +23,4 @@ export async function testStep() {
         env.stack.pop();
     }
 }
+testStep.stepId = "step//./input//testStep";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-client.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/var-named-step-function/output-client.js
@@ -2,6 +2,8 @@
 async function namedStep() {
     return 1;
 }
+namedStep.stepId = "step//./input//namedStep";
 export async function exportedNamedStep() {
     return 2;
 }
+exportedNamedStep.stepId = "step//./input//exportedNamedStep";


### PR DESCRIPTION
Added support for step function serialization in client mode by setting the `stepId` property and registering step functions.

### What changed?

- Added a `stepId` property to step functions in `registerStepFunction` to support serialization
- Modified the SWC plugin to call `registerStepFunction()` on step functions in client mode
- Updated the client mode transformation to preserve step function bodies while also registering them
- Updated the plugin specification documentation to reflect these changes
- Added appropriate imports for `registerStepFunction` in client mode output

### How to test?

1. Create a workflow that passes step functions as arguments to other step functions
2. Run the workflow in client mode
3. Verify that step functions are properly serialized and can be passed between boundaries
4. Check that step functions maintain their identity when passed as arguments or returned from other functions

### Why make this change?

This change enables proper serialization of step functions in client mode. Previously, step functions in client mode weren't registered, which meant they couldn't be properly serialized when passed as arguments to `start()` or returned from other step functions. By setting the `stepId` property and registering step functions in client mode, we ensure consistent behavior between client and server modes when step functions are passed across boundaries.