### PR TITLE
Make `wf build --manifest-file` include steps / classes metadata

### DIFF
--- a/.changeset/few-drinks-return.md
+++ b/.changeset/few-drinks-return.md
@@ -1,0 +1,5 @@
+---
+"@workflow/builders": patch
+---
+
+Make `wf build --manifest-file` include steps / classes metadata

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -627,7 +627,7 @@ export abstract class BaseBuilder {
       await mkdir(dirname(resolvedPath), { recursive: true });
       await writeFile(
         resolvedPath,
-        prefix + JSON.stringify(workflowManifest.workflows, null, 2)
+        prefix + JSON.stringify(workflowManifest, null, 2)
       );
     }
 

--- a/workbench/example/api/trigger.ts
+++ b/workbench/example/api/trigger.ts
@@ -36,7 +36,9 @@ export async function POST(req: Request) {
 
   try {
     const workflowFileItems =
-      workflowManifest[workflowFile as keyof typeof workflowManifest];
+      workflowManifest.workflows[
+        workflowFile as keyof typeof workflowManifest.workflows
+      ];
     const run = await start(
       workflowFileItems[workflowFn as keyof typeof workflowFileItems],
       args


### PR DESCRIPTION
Updated the manifest file output to include complete workflow metadata instead of just the workflows object.

### What changed?

- Modified `base-builder.ts` to write the entire workflow manifest to the manifest file, not just the `workflows` property
- Updated the workbench example trigger API to access workflows through the new structure (`workflowManifest.workflows` instead of directly from `workflowManifest`)

### How to test?

1. Run `wf build --manifest-file=path/to/manifest.js`
2. Verify that the generated manifest file contains the complete workflow metadata including steps and classes
3. Test the workbench example to ensure it correctly accesses workflows through the updated structure

### Why make this change?

Including the complete workflow metadata (steps and classes) in the manifest file provides more comprehensive information for tools and services that consume this data. This enables better workflow visualization, debugging, and integration capabilities.