### PR TITLE
Show git commit sha in swc-playground

### DIFF
--- a/workbench/swc-playground/app/page.tsx
+++ b/workbench/swc-playground/app/page.tsx
@@ -22,5 +22,8 @@ function getPluginVersion(): string {
 
 export default function Page() {
   const pluginVersion = getPluginVersion();
-  return <SwcPlayground pluginVersion={pluginVersion} />;
+  const gitCommitSha = process.env.VERCEL_GIT_COMMIT_SHA;
+  return (
+    <SwcPlayground pluginVersion={pluginVersion} gitCommitSha={gitCommitSha} />
+  );
 }

--- a/workbench/swc-playground/components/swc-playground.tsx
+++ b/workbench/swc-playground/components/swc-playground.tsx
@@ -37,9 +37,13 @@ interface CompilationResult {
 
 interface SwcPlaygroundProps {
   pluginVersion?: string;
+  gitCommitSha?: string;
 }
 
-export function SwcPlayground({ pluginVersion }: SwcPlaygroundProps) {
+export function SwcPlayground({
+  pluginVersion,
+  gitCommitSha,
+}: SwcPlaygroundProps) {
   const [code, setCode] = useState(DEFAULT_CODE);
   const [isHydrated, setIsHydrated] = useState(false);
   const [results, setResults] = useState<Record<ViewMode, CompilationResult>>({
@@ -103,6 +107,16 @@ export function SwcPlayground({ pluginVersion }: SwcPlaygroundProps) {
           <span className="text-xs px-2 py-1 bg-muted rounded text-muted-foreground">
             @workflow/swc-plugin{pluginVersion ? `@${pluginVersion}` : ''}
           </span>
+          {gitCommitSha && (
+            <a
+              href={`https://github.com/vercel/workflow/commit/${gitCommitSha}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs px-2 py-1 bg-muted rounded text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {gitCommitSha.slice(0, 7)}
+            </a>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
Added Git commit SHA display to the SWC Playground UI.

### What changed?

- Added `gitCommitSha` prop to the `SwcPlayground` component
- Passed the Vercel Git commit SHA from environment variables to the component
- Added a clickable link in the header that displays the short commit SHA (first 7 characters)
- The link directs users to the specific GitHub commit

### How to test?

1. Deploy the application to Vercel
2. Verify that the commit SHA appears in the header of the SWC Playground
3. Click on the SHA link to confirm it navigates to the correct GitHub commit page
4. Check that the link opens in a new tab with proper security attributes

### Why make this change?

This change improves traceability by making it easy to identify which version of the code is running in the deployed playground. It helps developers and users reference the exact code state when reporting issues or discussing features, creating a direct link between the deployed application and its source code.