### PR TITLE
Add configurable `moduleSpecifier` value for SWC Playground

### DIFF
--- a/workbench/swc-playground/.gitignore
+++ b/workbench/swc-playground/.gitignore
@@ -3,3 +3,4 @@
 .vercel
 next-env.d.ts
 node_modules
+tsconfig.tsbuildinfo

--- a/workbench/swc-playground/lib/transform-action.ts
+++ b/workbench/swc-playground/lib/transform-action.ts
@@ -27,7 +27,8 @@ export interface TransformResult {
 }
 
 export async function transformCode(
-  sourceCode: string
+  sourceCode: string,
+  moduleSpecifier?: string
 ): Promise<TransformResult> {
   const modes = ['workflow', 'step', 'client'] as const;
   const results: TransformResult = {
@@ -49,7 +50,7 @@ export async function transformCode(
             },
             target: 'es2022',
             experimental: {
-              plugins: [[wasmPath, { mode }]],
+              plugins: [[wasmPath, { mode, moduleSpecifier }]],
             },
           },
           module: {


### PR DESCRIPTION
Added the ability to specify a module name/version in the SWC Playground that gets passed to the compiler.

### What changed?

- Added a new input field in the playground header for specifying a module name/version
- Created storage functionality to persist the module specifier in localStorage
- Updated the transform code function to pass the module specifier to the SWC plugin
- Added `tsconfig.tsbuildinfo` to the gitignore file

### How to test?

1. Open the SWC Playground
2. Enter a module specifier (e.g., "my-package@1.0.0") in the new input field
3. Write some code in the editor and verify that the module specifier is passed to the compiler
4. Refresh the page and confirm that the module specifier persists

### Why make this change?

This enhancement allows developers to test how their code would compile with specific module versions, providing more accurate and contextual transformations in the playground environment. The module specifier information helps the compiler make better decisions about how to transform imports and exports.