### PR TITLE
Keep debug-windows tmate session open after disconnect

### DIFF
--- a/.github/workflows/debug-windows.yml
+++ b/.github/workflows/debug-windows.yml
@@ -48,3 +48,13 @@ jobs:
         timeout-minutes: ${{ fromJSON(github.event.inputs.timeout_minutes) }}
         with:
           limit-access-to-actor: true
+          detached: true
+
+      - name: Keep session alive
+        run: |
+          echo "Session is running in detached mode."
+          echo "You can reconnect multiple times until the timeout expires."
+          echo "To end early, create a file: touch C:\continue"
+          while (!(Test-Path "C:\continue")) { Start-Sleep -Seconds 10 }
+        shell: powershell
+        timeout-minutes: ${{ fromJSON(github.event.inputs.timeout_minutes) }}


### PR DESCRIPTION
## Summary

Fixes the debug-windows workflow so the SSH session stays open after disconnecting.

- Uses `detached: true` mode so the tmate session persists
- Adds a keep-alive step that waits until the timeout or until `C:\continue` file is created
- Allows reconnecting multiple times during the session timeout

To end the session early, run `touch C:\continue` in the SSH session.