### PR TITLE
[docs] Fix image link in NestJS getting started guide

### DIFF
--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -62,6 +62,7 @@ import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStac
       <div className="flex flex-col items-center justify-center gap-2">
         <Nest className="size-16" />
         <span className="font-medium">NestJS</span>
+        <Badge variant="secondary">Experimental</Badge>
       </div>
     </Card>
     <Card className="opacity-50">

--- a/docs/content/docs/getting-started/nestjs.mdx
+++ b/docs/content/docs/getting-started/nestjs.mdx
@@ -242,7 +242,8 @@ Taking a look at this code:
 
 To invoke your new workflow, update your controller with a new endpoint:
 
-{/* @skip-typecheck - NestJS decorators require special TypeScript config */}
+{/*@skip-typecheck - NestJS decorators require special TypeScript config*/}
+
 ```typescript title="src/app.controller.ts" lineNumbers
 import { Body, Controller, Post } from '@nestjs/common';
 import { start } from 'workflow/api';
@@ -289,7 +290,7 @@ npx workflow web
 npx workflow inspect runs
 ```
 
-<img src="/o11y-ui.png" alt="Workflow DevKit Web UI" />
+![Workflow DevKit Web UI](/o11y-ui.png)
 
 </Step>
 
@@ -301,7 +302,8 @@ npx workflow inspect runs
 
 The `WorkflowModule.forRoot()` method accepts optional configuration:
 
-{/* @skip-typecheck - Configuration snippet, WorkflowModule not imported */}
+{/*@skip-typecheck - Configuration snippet, WorkflowModule not imported*/}
+
 ```typescript
 WorkflowModule.forRoot({
   // Directory to scan for workflow files (default: ['src'])


### PR DESCRIPTION
also adds an "Experimental" badge to the NestJS card in the framework list