### PR TITLE
Generate `runId` client-side in `start()` and simplify streaming types

### DIFF
--- a/.changeset/client-side-runid.md
+++ b/.changeset/client-side-runid.md
@@ -1,0 +1,8 @@
+---
+"@workflow/core": patch
+"@workflow/world": patch
+---
+
+Generate runId client-side in start() and simplify runId types
+
+The `runId` is now generated client-side using ULID before serialization, rather than waiting for the server response. This simplifies the `Streamer` interface and `WorkflowServerWritableStream` to accept `string` instead of `string | Promise<string>` for `runId`.

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -81,8 +81,10 @@ describe('start', () => {
     let mockQueue: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
-      mockEventsCreate = vi.fn().mockResolvedValue({
-        run: { runId: 'wrun_test123', status: 'pending' },
+      mockEventsCreate = vi.fn().mockImplementation((runId) => {
+        return Promise.resolve({
+          run: { runId: runId ?? 'wrun_test123', status: 'pending' },
+        });
       });
       mockQueue = vi.fn().mockResolvedValue(undefined);
 
@@ -105,7 +107,7 @@ describe('start', () => {
       await start(validWorkflow, []);
 
       expect(mockEventsCreate).toHaveBeenCalledWith(
-        null,
+        expect.stringMatching(/^wrun_/),
         expect.objectContaining({
           eventType: 'run_created',
           specVersion: SPEC_VERSION_CURRENT,
@@ -124,7 +126,7 @@ describe('start', () => {
       await start(validWorkflow, [], { specVersion: SPEC_VERSION_LEGACY });
 
       expect(mockEventsCreate).toHaveBeenCalledWith(
-        null,
+        expect.stringMatching(/^wrun_/),
         expect.objectContaining({
           eventType: 'run_created',
           specVersion: SPEC_VERSION_LEGACY,
@@ -143,7 +145,7 @@ describe('start', () => {
       await start(validWorkflow, [], { specVersion: 1 });
 
       expect(mockEventsCreate).toHaveBeenCalledWith(
-        null,
+        expect.stringMatching(/^wrun_/),
         expect.objectContaining({
           eventType: 'run_created',
           specVersion: 1,

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -1,9 +1,8 @@
 import { waitUntil } from '@vercel/functions';
 import { WorkflowRuntimeError } from '@workflow/errors';
-import { withResolvers } from '@workflow/utils';
 import type { WorkflowInvokePayload, World } from '@workflow/world';
 import { isLegacySpecVersion, SPEC_VERSION_CURRENT } from '@workflow/world';
-import { Run } from './run.js';
+import { monotonicFactory } from 'ulid';
 import type { Serializable } from '../schemas.js';
 import { dehydrateWorkflowArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
@@ -11,7 +10,11 @@ import { serializeTraceCarrier, trace } from '../telemetry.js';
 import { waitedUntil } from '../util.js';
 import { version as workflowCoreVersion } from '../version.js';
 import { getWorkflowQueueName } from './helpers.js';
+import { Run } from './run.js';
 import { getWorld } from './world.js';
+
+/** ULID generator for client-side runId generation */
+const ulid = monotonicFactory();
 
 export interface StartOptions {
   /**
@@ -103,8 +106,10 @@ export async function start<TArgs extends unknown[], TResult>(
       const world = opts?.world ?? getWorld();
       const deploymentId = opts.deploymentId ?? (await world.getDeploymentId());
       const ops: Promise<void>[] = [];
-      const { promise: runIdPromise, resolve: resolveRunId } =
-        withResolvers<string>();
+
+      // Generate runId client-side so we have it before serialization
+      // (required for future E2E encryption where runId is part of the encryption context)
+      const runId = `wrun_${ulid()}`;
 
       // Serialize current trace context to propagate across queue boundary
       const traceCarrier = await serializeTraceCarrier();
@@ -113,16 +118,16 @@ export async function start<TArgs extends unknown[], TResult>(
       const v1Compat = isLegacySpecVersion(specVersion);
 
       // Create run via run_created event (event-sourced architecture)
-      // Pass null for runId - the server generates it and returns it in the response
+      // Pass client-generated runId - server will accept and use it
       const workflowArguments = dehydrateWorkflowArguments(
         args,
         ops,
-        runIdPromise,
+        runId,
         globalThis,
         v1Compat
       );
       const result = await world.events.create(
-        null,
+        runId,
         {
           eventType: 'run_created',
           specVersion,
@@ -143,8 +148,12 @@ export async function start<TArgs extends unknown[], TResult>(
         );
       }
 
-      const runId = result.run.runId;
-      resolveRunId(runId);
+      // Verify server accepted our runId
+      if (result.run.runId !== runId) {
+        throw new WorkflowRuntimeError(
+          `Server returned different runId than requested: expected ${runId}, got ${result.run.runId}`
+        );
+      }
 
       waitUntil(
         Promise.all(ops).catch((err) => {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -41,7 +41,7 @@ export function createEventsStorage(basedir: string): Storage['events'] {
       const eventId = `evnt_${monotonicUlid()}`;
       const now = new Date();
 
-      // For run_created events, generate runId server-side if null or empty
+      // For run_created events, use client-provided runId or generate one server-side
       let effectiveRunId: string;
       if (data.eventType === 'run_created' && (!runId || runId === '')) {
         effectiveRunId = `wrun_${monotonicUlid()}`;

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -287,7 +287,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
     async create(runId, data, params): Promise<EventResult> {
       const eventId = `wevt_${ulid()}`;
 
-      // For run_created events, generate runId server-side if null or empty
+      // For run_created events, use client-provided runId or generate one server-side
       let effectiveRunId: string;
       if (data.eventType === 'run_created' && (!runId || runId === '')) {
         effectiveRunId = `wrun_${ulid()}`;

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -138,7 +138,7 @@ export async function createWorkflowRunEvent(
     return { event: wireResult };
   }
 
-  // For run_created events, runId is null - use "null" string in the URL path
+  // For run_created events, runId may be client-provided or null
   const runIdPath = id === null ? 'null' : id;
 
   const remoteRefBehavior = eventsNeedingResolve.has(data.eventType)

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -282,7 +282,7 @@ export type AnyEventRequest = z.infer<typeof CreateEventSchema>;
 
 /**
  * Event request for creating a new workflow run.
- * Must be used with runId: null since the server generates the runId.
+ * Can be used with a client-generated runId or null for server-generated.
  */
 export type RunCreatedEventRequest = z.infer<typeof RunCreatedEventSchema>;
 

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -26,7 +26,7 @@ import type {
 export interface Streamer {
   writeToStream(
     name: string,
-    runId: string | Promise<string>,
+    runId: string,
     chunk: string | Uint8Array
   ): Promise<void>;
 
@@ -38,16 +38,16 @@ export interface Streamer {
    * If not implemented, the caller should fall back to sequential writeToStream() calls.
    *
    * @param name - The stream name
-   * @param runId - The run ID (can be a promise)
+   * @param runId - The run ID
    * @param chunks - Array of chunks to write, in order
    */
   writeToStreamMulti?(
     name: string,
-    runId: string | Promise<string>,
+    runId: string,
     chunks: (string | Uint8Array)[]
   ): Promise<void>;
 
-  closeStream(name: string, runId: string | Promise<string>): Promise<void>;
+  closeStream(name: string, runId: string): Promise<void>;
   readFromStream(
     name: string,
     startIndex?: number
@@ -127,15 +127,15 @@ export interface Storage {
   events: {
     /**
      * Create a run_created event to start a new workflow run.
-     * The runId parameter must be null - the server generates and returns the runId.
+     * The runId may be provided by the client or left as null for the server to generate.
      *
-     * @param runId - Must be null for run_created events
+     * @param runId - Client-generated runId, or null for server-generated
      * @param data - The run_created event data
      * @param params - Optional parameters for event creation
      * @returns Promise resolving to the created event and run entity
      */
     create(
-      runId: null,
+      runId: string | null,
       data: RunCreatedEventRequest,
       params?: CreateEventParams
     ): Promise<EventResult>;


### PR DESCRIPTION
## Summary

- Generates `runId` client-side in `start()` using ULID (`wrun_${ulid()}`), instead of deferring to the server
- Passes client-generated `runId` to `events.create()` and verifies the server accepted it
- Simplifies `runId` types from `string | Promise<string>` to `string` throughout the serialization layer
- Removes the `withResolvers<string>()` / deferred runId pattern that was needed when `runId` was server-generated
- Updates `Streamer` interface and `WorkflowServerWritableStream` to use plain `string` runId
- Updates `Storage.events.create()` first overload to accept `string | null` instead of just `null`

This is a prerequisite for E2E encryption, where we need the `runId` before serialization so it can be used as part of the encryption context.

## Test plan

All existing tests pass. Updated `start.test.ts` to expect client-generated runId, removed `writable-stream.test.ts` promise runId test (no longer applicable).