### PR TITLE
feat: add manifest access to World interface

### DIFF
--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -2,6 +2,7 @@ import type { World } from '@workflow/world';
 import type { Config } from './config.js';
 import { config } from './config.js';
 import { initDataDir } from './init.js';
+import { createManifestStore } from './manifest.js';
 import { createQueue } from './queue.js';
 import { createStorage } from './storage.js';
 import { createStreamer } from './streamer.js';
@@ -37,6 +38,7 @@ export function createLocalWorld(args?: Partial<Config>): World {
     ...createQueue(mergedConfig),
     ...createStorage(mergedConfig.dataDir),
     ...createStreamer(mergedConfig.dataDir),
+    manifest: createManifestStore(mergedConfig.dataDir),
     async start() {
       await initDataDir(mergedConfig.dataDir);
     },

--- a/packages/world-local/src/manifest.ts
+++ b/packages/world-local/src/manifest.ts
@@ -1,0 +1,104 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import type { WorkflowManifestData } from '@workflow/world';
+
+const MANIFEST_FILENAME = 'manifest.json';
+
+/**
+ * Known paths where the manifest JSON file may be located, relative to the
+ * project root. These match the locations used by framework-specific builders.
+ */
+const KNOWN_MANIFEST_PATHS = [
+  'app/.well-known/workflow/v1/manifest.json',
+  'src/app/.well-known/workflow/v1/manifest.json',
+  '.well-known/workflow/v1/manifest.json',
+  'src/routes/.well-known/workflow/v1/manifest.json',
+  'node_modules/.nitro/workflow/manifest.json',
+  '.nuxt/workflow/manifest.json',
+  '.nestjs/workflow/manifest.json',
+];
+
+/**
+ * Attempts to read a JSON file. Returns null if the file doesn't exist.
+ */
+async function tryReadJson(filePath: string): Promise<unknown | null> {
+  try {
+    const content = await readFile(filePath, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Creates a manifest store backed by the local filesystem.
+ *
+ * The `get()` method looks for the manifest in two locations:
+ * 1. The data directory itself (where `set()` writes it)
+ * 2. Known framework-specific manifest locations relative to the project root
+ *    (auto-discovered by walking up from the data directory)
+ *
+ * The `set()` method stores the manifest as a JSON file in the data directory.
+ */
+export function createManifestStore(dataDir: string) {
+  const storedManifestPath = join(dataDir, MANIFEST_FILENAME);
+
+  return {
+    async get(): Promise<WorkflowManifestData | null> {
+      // First, check the data directory for a manifest stored via set()
+      const stored = await tryReadJson(storedManifestPath);
+      if (stored) {
+        return stored as WorkflowManifestData;
+      }
+
+      // Otherwise, search for the manifest in known framework locations
+      // Walk up from the data directory to find the project root
+      const projectRoot = resolveProjectRoot(dataDir);
+      if (projectRoot) {
+        for (const manifestPath of KNOWN_MANIFEST_PATHS) {
+          const fullPath = join(projectRoot, manifestPath);
+          const data = await tryReadJson(fullPath);
+          if (data) {
+            return data as WorkflowManifestData;
+          }
+        }
+      }
+
+      return null;
+    },
+
+    async set(manifest: WorkflowManifestData): Promise<void> {
+      await writeFile(
+        storedManifestPath,
+        JSON.stringify(manifest, null, 2),
+        'utf-8'
+      );
+    },
+  };
+}
+
+/**
+ * Resolves the project root directory from a data directory path.
+ * The data directory is typically inside the project root:
+ * - .workflow-data/ -> parent is project root
+ * - .next/workflow-data/ -> grandparent is project root
+ */
+function resolveProjectRoot(dataDir: string): string {
+  const absDataDir = resolve(dataDir);
+
+  // Check common data dir patterns to determine the project root
+  if (absDataDir.endsWith('.workflow-data')) {
+    return dirname(absDataDir);
+  }
+  if (absDataDir.endsWith('workflow-data')) {
+    // Could be .next/workflow-data or just workflow-data
+    const parent = dirname(absDataDir);
+    if (parent.endsWith('.next') || parent.endsWith('.nestjs')) {
+      return dirname(parent);
+    }
+    return parent;
+  }
+
+  // Default: assume data dir is inside the project root
+  return dirname(absDataDir);
+}

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -8,6 +8,7 @@ export {
 export type * from './hooks.js';
 export { HookSchema } from './hooks.js';
 export type * from './interfaces.js';
+export type * from './manifest.js';
 export type * from './queue.js';
 export {
   HealthCheckPayloadSchema,

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -8,6 +8,7 @@ import type {
   RunCreatedEventRequest,
 } from './events.js';
 import type { GetHookParams, Hook, ListHooksParams } from './hooks.js';
+import type { WorkflowManifestData } from './manifest.js';
 import type { Queue } from './queue.js';
 import type {
   GetWorkflowRunParams,
@@ -177,4 +178,24 @@ export interface World extends Queue, Storage, Streamer {
    * For example, in the case of a queue backed World, this would start the queue processing.
    */
   start?(): Promise<void>;
+
+  /**
+   * Optional manifest access. Provides the workflow manifest which contains
+   * metadata about all workflows, steps, and classes discovered during the build.
+   *
+   * Not all World implementations may support manifest storage.
+   * When not supported, this property is undefined.
+   */
+  manifest?: {
+    /**
+     * Retrieve the stored workflow manifest.
+     * Returns null if no manifest has been stored.
+     */
+    get(): Promise<WorkflowManifestData | null>;
+
+    /**
+     * Store a workflow manifest. Called during the build process.
+     */
+    set(manifest: WorkflowManifestData): Promise<void>;
+  };
 }

--- a/packages/world/src/manifest.ts
+++ b/packages/world/src/manifest.ts
@@ -1,0 +1,56 @@
+/**
+ * The workflow manifest contains metadata about all workflows, steps, and classes
+ * discovered during the build process. It includes workflow IDs, step IDs,
+ * class IDs, and optionally workflow graph data for visualization.
+ *
+ * The manifest is created during the build process and can be retrieved
+ * via the World interface's `manifest.get()` method.
+ */
+export interface WorkflowManifestData {
+  version: string;
+  steps: Record<
+    string,
+    Record<
+      string,
+      {
+        stepId: string;
+      }
+    >
+  >;
+  workflows: Record<
+    string,
+    Record<
+      string,
+      {
+        workflowId: string;
+        graph?: {
+          nodes: Array<{
+            id: string;
+            type: string;
+            data: {
+              label: string;
+              nodeKind: string;
+              stepId?: string;
+            };
+            metadata?: Record<string, unknown>;
+          }>;
+          edges: Array<{
+            id: string;
+            source: string;
+            target: string;
+            type?: string;
+          }>;
+        };
+      }
+    >
+  >;
+  classes?: Record<
+    string,
+    Record<
+      string,
+      {
+        classId: string;
+      }
+    >
+  >;
+}


### PR DESCRIPTION
## Summary

- Adds an optional `manifest` property to the `World` interface with `get()` and `set()` methods for retrieving/storing the workflow manifest
- Defines `WorkflowManifestData` type in `@workflow/world` package for the manifest schema
- Implements manifest access for `world-local` which discovers manifests from known framework-specific filesystem locations (auto-detected by walking up from the data directory)
- The `manifest` property is optional, so existing world implementations (`world-vercel`, `world-postgres`) are unaffected

This enables programmatic access to the workflow manifest (containing workflow IDs, step IDs, and graph data) through the World interface, which is needed for simplifying E2E test setup (PR #958).