### PR TITLE
Add missing env for tests on deploy

### DIFF
--- a/workbench/astro/vercel.json
+++ b/workbench/astro/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/example/vercel.json
+++ b/workbench/example/vercel.json
@@ -8,5 +8,8 @@
       "source": "/api/:provider/webhook",
       "destination": "/api/webhook"
     }
-  ]
+  ],
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
 }

--- a/workbench/express/vercel.json
+++ b/workbench/express/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/fastify/vercel.json
+++ b/workbench/fastify/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/hono/vercel.json
+++ b/workbench/hono/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/nest/vercel.json
+++ b/workbench/nest/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/nextjs-turbopack/vercel.json
+++ b/workbench/nextjs-turbopack/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/nextjs-webpack/vercel.json
+++ b/workbench/nextjs-webpack/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/nitro-v2/vercel.json
+++ b/workbench/nitro-v2/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/nitro-v3/vercel.json
+++ b/workbench/nitro-v3/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/nuxt/vercel.json
+++ b/workbench/nuxt/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/sveltekit/vercel.json
+++ b/workbench/sveltekit/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/swc-playground/vercel.json
+++ b/workbench/swc-playground/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}

--- a/workbench/vite/vercel.json
+++ b/workbench/vite/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
+  }
+}


### PR DESCRIPTION
Follow-up to https://github.com/vercel/workflow/pull/958 this fixes tests failing for deploy since they weren't exposing the manifest needed now. 