### PR TITLE
Enable public manifest in e2e community world workflow

### DIFF
--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -50,6 +50,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      WORKFLOW_PUBLIC_MANIFEST: '1'
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
## Summary
This change enables the public manifest feature in the e2e-community-world GitHub Actions workflow by setting the `WORKFLOW_PUBLIC_MANIFEST` environment variable.

## Changes
- Added `WORKFLOW_PUBLIC_MANIFEST: '1'` environment variable to the e2e-community-world workflow job
- This environment variable is now available to all steps in the workflow, alongside existing Turbo configuration variables

## Details
The `WORKFLOW_PUBLIC_MANIFEST` environment variable is set to `'1'` to enable public manifest functionality during the e2e community world tests. This allows the workflow to generate or utilize public manifest data as part of the testing process.

https://claude.ai/code/session_01GezavpthQcEpyYVisScncM