### PR TITLE
ci: use PR head SHA for tests workflow checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
@@ -146,6 +148,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -219,6 +223,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
@@ -277,6 +283,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
@@ -303,6 +311,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
@@ -367,6 +377,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
@@ -451,6 +463,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
@@ -516,6 +530,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -601,6 +617,8 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
@@ -637,6 +655,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download all E2E artifacts
         uses: actions/download-artifact@v4
@@ -736,6 +756,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download all E2E artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Why
Our `pull_request` CI currently checks out GitHub's merge ref (`refs/pull/<id>/merge`) by default. In this repo, E2E jobs depend on Vercel preview deployments built from the PR branch head SHA, which can drift from the merge ref when `main` moves.

That mismatch causes false-negative failures (tests from merge ref targeting a deployment built from a different commit).

## What this changes
- In `.github/workflows/tests.yml`, set `actions/checkout@v4` to:
  - `ref: ${{ github.event.pull_request.head.sha || github.sha }}`

This makes PR CI run against the same SHA that Vercel preview deployments are built from, while keeping push workflows on `github.sha`.
