### PR TITLE
fix(core): ensure worlds are started before queue publish

### DIFF
--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -10,7 +10,7 @@ import { monotonicFactory } from 'ulid';
 import { runtimeLogger } from '../logger.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanKind, trace } from '../telemetry.js';
-import { getWorld } from './world.js';
+import { ensureWorldStarted, getWorld } from './world.js';
 
 /** Default timeout for health checks in milliseconds */
 const DEFAULT_HEALTH_CHECK_TIMEOUT = 30_000;
@@ -214,6 +214,8 @@ export async function healthCheck(
   const startTime = Date.now();
 
   try {
+    await ensureWorldStarted(world);
+
     await world.queue(queueName, {
       __healthCheck: true,
       correlationId,
@@ -364,6 +366,7 @@ export async function queueMessage(
   ...args: Parameters<typeof world.queue>
 ) {
   const queueName = args[0];
+  await ensureWorldStarted(world);
   await trace(
     'queue.publish',
     {

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -14,7 +14,7 @@ import { WEBHOOK_RESPONSE_WRITABLE } from '../symbols.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanContextForTraceCarrier, trace } from '../telemetry.js';
 import { waitedUntil } from '../util.js';
-import { getWorkflowQueueName } from './helpers.js';
+import { getWorkflowQueueName, queueMessage } from './helpers.js';
 import { getWorld } from './world.js';
 
 /**
@@ -130,7 +130,8 @@ export async function resumeHook<T = any>(
 
         // Re-trigger the workflow against the deployment ID associated
         // with the workflow run that the hook belongs to
-        await world.queue(
+        await queueMessage(
+          world,
           getWorkflowQueueName(workflowRun.workflowName),
           {
             runId: hook.runId,

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -5,7 +5,7 @@ import {
   SPEC_VERSION_LEGACY,
   type World,
 } from '@workflow/world';
-import { getWorkflowQueueName } from './helpers.js';
+import { getWorkflowQueueName, queueMessage } from './helpers.js';
 import { start } from './start.js';
 
 export interface RecreateRunOptions {
@@ -100,7 +100,8 @@ export async function cancelRun(world: World, runId: string): Promise<void> {
 export async function reenqueueRun(world: World, runId: string): Promise<void> {
   try {
     const run = await world.runs.get(runId, { resolveData: 'none' });
-    await world.queue(
+    await queueMessage(
+      world,
       getWorkflowQueueName(run.workflowName),
       {
         runId,
@@ -188,7 +189,8 @@ export async function wakeUpRun(
     }
 
     if (stoppedCount > 0) {
-      await world.queue(
+      await queueMessage(
+        world,
         getWorkflowQueueName(run.workflowName),
         {
           runId,

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -2,7 +2,7 @@ import { WorkflowRuntimeError } from '@workflow/errors';
 import { SPEC_VERSION_CURRENT, SPEC_VERSION_LEGACY } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { start } from './start.js';
-import { getWorld } from './world.js';
+import { ensureWorldStarted, getWorld } from './world.js';
 
 // Mock @vercel/functions
 vi.mock('@vercel/functions', () => ({
@@ -15,12 +15,17 @@ vi.mock('./world.js', () => ({
   getWorldHandlers: vi.fn(() => ({
     createQueueHandler: vi.fn(() => vi.fn()),
   })),
+  ensureWorldStarted: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock telemetry
 vi.mock('../telemetry.js', () => ({
   serializeTraceCarrier: vi.fn().mockResolvedValue({}),
-  trace: vi.fn((_name, fn) => fn(undefined)),
+  trace: vi.fn((...args: any[]) => {
+    const fn = args[args.length - 1];
+    return fn(undefined);
+  }),
+  getSpanKind: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('start', () => {
@@ -86,7 +91,7 @@ describe('start', () => {
           run: { runId: runId ?? 'wrun_test123', status: 'pending' },
         });
       });
-      mockQueue = vi.fn().mockResolvedValue(undefined);
+      mockQueue = vi.fn().mockResolvedValue({ messageId: 'msg_test123' });
 
       vi.mocked(getWorld).mockReturnValue({
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
@@ -154,6 +159,18 @@ describe('start', () => {
           v1Compat: true,
         })
       );
+    });
+
+    it('should ensure the world is started before queueing', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+
+      await start(validWorkflow, []);
+      await start(validWorkflow, []);
+
+      expect(vi.mocked(ensureWorldStarted)).toHaveBeenCalledTimes(2);
+      expect(mockQueue).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -9,7 +9,7 @@ import * as Attribute from '../telemetry/semantic-conventions.js';
 import { serializeTraceCarrier, trace } from '../telemetry.js';
 import { waitedUntil } from '../util.js';
 import { version as workflowCoreVersion } from '../version.js';
-import { getWorkflowQueueName } from './helpers.js';
+import { getWorkflowQueueName, queueMessage } from './helpers.js';
 import { Run } from './run.js';
 import { getWorld } from './world.js';
 
@@ -170,7 +170,8 @@ export async function start<TArgs extends unknown[], TResult>(
         ...Attribute.DeploymentId(deploymentId),
       });
 
-      await world.queue(
+      await queueMessage(
+        world,
         getWorkflowQueueName(workflowName),
         {
           runId,

--- a/packages/core/src/runtime/world.test.ts
+++ b/packages/core/src/runtime/world.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureWorldStarted } from './world.js';
+
+describe('ensureWorldStarted', () => {
+  it('should start worlds that expose start() only once per instance', async () => {
+    const start = vi.fn().mockResolvedValue(undefined);
+    const world = { start } as any;
+
+    await ensureWorldStarted(world);
+    await ensureWorldStarted(world);
+
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be a no-op for worlds without start()', async () => {
+    const world = {} as any;
+
+    await expect(ensureWorldStarted(world)).resolves.toBeUndefined();
+  });
+
+  it('should start different world instances independently', async () => {
+    const startA = vi.fn().mockResolvedValue(undefined);
+    const startB = vi.fn().mockResolvedValue(undefined);
+    const worldA = { start: startA } as any;
+    const worldB = { start: startB } as any;
+
+    await ensureWorldStarted(worldA);
+    await ensureWorldStarted(worldB);
+
+    expect(startA).toHaveBeenCalledTimes(1);
+    expect(startB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -14,6 +14,8 @@ const globalSymbols: typeof globalThis & {
   [StubbedWorldCache]?: World;
 } = globalThis;
 
+const worldStartPromises = new WeakMap<World, Promise<void>>();
+
 function defaultWorld(): 'vercel' | 'local' {
   if (process.env.VERCEL_DEPLOYMENT_ID) {
     return 'vercel';
@@ -87,6 +89,23 @@ export const getWorld = (): World => {
   }
   globalSymbols[WorldCache] = createWorld();
   return globalSymbols[WorldCache];
+};
+
+/**
+ * Ensure a world that exposes `start()` is started exactly once per process.
+ */
+export const ensureWorldStarted = async (world: World): Promise<void> => {
+  if (typeof world.start !== 'function') {
+    return;
+  }
+
+  let startPromise = worldStartPromises.get(world);
+  if (!startPromise) {
+    startPromise = Promise.resolve().then(() => world.start?.());
+    worldStartPromises.set(world, startPromise);
+  }
+
+  await startPromise;
 };
 
 /**


### PR DESCRIPTION
## Summary
- add an idempotent `ensureWorldStarted(world)` helper in runtime world management
- call it before queue publishing so worlds that require `start()` (like starter world) are initialized in every process path
- route direct queue usage in `start`, `runs`, and `resume-hook` through `queueMessage` so startup guard is consistently applied
- add runtime tests for one-time startup behavior and updated start path coverage

## Validation
- `pnpm --filter @workflow/core test -- src/runtime/start.test.ts src/runtime/world.test.ts`
- `pnpm --filter @workflow/core typecheck`

## Root cause addressed
`@workflow-worlds/starter@0.2.1` progressed past the previous runId guard and exposed that some queue publish paths assumed the world was already started. In CLI/test-runner processes this caused queue buffering with no consumer, leading to health-check timeouts and job timeout cancellations.
