### PR TITLE
docs: use markdown image syntax in observability page

### DIFF
--- a/docs/content/docs/observability/index.mdx
+++ b/docs/content/docs/observability/index.mdx
@@ -33,7 +33,7 @@ will locally serve the Web UI when using the `--web` flag.
 npx workflow inspect runs --web
 ```
 
-<img src="/o11y-ui.png" alt="Workflow DevKit Web UI" />
+![Workflow DevKit Web UI](/o11y-ui.png)
 
 ## Backends
 


### PR DESCRIPTION
Replace HTML `<img>` tag with standard markdown image syntax (`![alt](src)`) in the observability docs page, to avoid  404 on https://useworkflow.dev/o11y-ui.png (using Markdown syntax uses Next.js `<Image>` component which uses a different URL).