### PR TITLE
Fix infinite queue retry loop for cancelled workflow runs

### DIFF
--- a/.changeset/fix-409-cancelled-step-retry.md
+++ b/.changeset/fix-409-cancelled-step-retry.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Handle 409 Conflict in step execution catch block for cancelled workflow runs, preventing infinite queue retries

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -435,13 +435,15 @@ const stepHandler = getWorldHandlers().createQueueHandler(
             });
 
             if (WorkflowAPIError.is(err)) {
-              if (err.status === 410) {
-                // Workflow has already completed, so no-op
+              if (err.status === 410 || err.status === 409) {
+                // 410 Gone: Workflow has already completed
+                // 409 Conflict: Workflow has been cancelled or step in terminal state
                 stepLogger.info(
-                  'Workflow run already completed, skipping step',
+                  'Workflow run already finished, skipping step',
                   {
                     workflowRunId,
                     stepId,
+                    status: err.status,
                     message: err.message,
                   }
                 );


### PR DESCRIPTION
## Summary
- The step execution catch block (step-handler.ts) only handled `410 Gone` (completed runs) but not `409 Conflict` (cancelled/terminal runs)
- When a step failed on a cancelled run, the `step_retrying` event also returned 409, which was uncaught — causing the queue to retry the message indefinitely
- Fix: handle 409 the same way 410 is already handled — log and return early

## Context
Observed in production: a cancelled workflow run (`wrun_01KH4WFCWWHVRK9331EX49EMQH`) triggered 99+ queue retries in ~18 hours with no sign of stopping.

```
Queue callback error: Error [WorkflowAPIError]: Cannot step_retrying workflow run wrun_01KH4WFCWWHVRK9331EX49EMQH because it has already finished with status 'cancelled'
    at async default (.next/server/chunks/_381bce51._.js:180:8345)
    at async db.processMessage (.next/server/chunks/_381bce51._.js:173:15814)
    at async db.consume (.next/server/chunks/_381bce51._.js:173:16538) {
  cause: undefined,
  status: 409,
  code: undefined,
  url: 'https://vercel-workflow.com/api/v2/runs/wrun_01KH4WFCWWHVRK9331EX49EMQH/events'
}
```