### PR TITLE
Enable lazyDiscovery in workbench

### DIFF
--- a/workbench/nextjs-turbopack/next.config.ts
+++ b/workbench/nextjs-turbopack/next.config.ts
@@ -7,4 +7,4 @@ const nextConfig: NextConfig = {
 };
 
 // export default nextConfig;
-export default withWorkflow(nextConfig);
+export default withWorkflow(nextConfig, { workflows: { lazyDiscovery: true } });

--- a/workbench/nextjs-webpack/next.config.ts
+++ b/workbench/nextjs-webpack/next.config.ts
@@ -11,4 +11,4 @@ const nextConfig: NextConfig = {
 };
 
 // export default nextConfig;
-export default withWorkflow(nextConfig);
+export default withWorkflow(nextConfig, { workflows: { lazyDiscovery: true } });


### PR DESCRIPTION
This enables the lazyDiscovery flag so our canary tests are validating it