### PR TITLE
fix(docs): correct retry instructions in corrupted-event-log error page

### DIFF
--- a/docs/content/docs/errors/corrupted-event-log.mdx
+++ b/docs/content/docs/errors/corrupted-event-log.mdx
@@ -45,12 +45,7 @@ npm install workflow@latest
 
 ### 2. Retry the failed run
 
-Since this is a fatal error, the run is automatically marked as `failed`. You can start a new run using the Workflow Dashboard or the CLI:
-
-```bash
-# Using the CLI
-npx workflow runs start <workflow-name> [input]
-```
+Since this is a fatal error, the run is automatically marked as `failed`. You can re-run it using the **Re-run** button in the Workflow Dashboard.
 
 ### 3. Report the issue
 


### PR DESCRIPTION
## Summary

- Removes reference to non-existent `npx workflow runs start` CLI command from the `corrupted-event-log` error docs page
- The correct way to retry a failed run is via the **Re-run** button in the Workflow Dashboard