### PR TITLE
test(core): add closure comment in sleep test helper

### DIFF
--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -19,6 +19,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
   const workflowStartedAt = context.globalThis.Date.now();
   const ctx: WorkflowOrchestratorContext = {
     globalThis: context.globalThis,
+    // ctx.onWorkflowError is accessed via closure — it's defined below on the same object
     eventsConsumer: new EventsConsumer(events, {
       onUnconsumedEvent: (event) => {
         ctx.onWorkflowError(


### PR DESCRIPTION
## Summary
- Adds a clarifying comment in `sleep.test.ts`'s `setupWorkflowContext` about the `ctx.onWorkflowError` closure reference (per TooTallNate's [review feedback](https://github.com/vercel/workflow/pull/1055#issuecomment-3901435650) on #1055)

## Test plan
- Comment-only change, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)