### PR TITLE
Auto-inject workflow run/step ID VQS headers from queue payload

### DIFF
--- a/.changeset/auto-vqs-run-id-header.md
+++ b/.changeset/auto-vqs-run-id-header.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-vercel': patch
+'@workflow/core': patch
+---
+
+Auto-inject `x-workflow-run-id` and `x-workflow-step-id` VQS headers from queue payload in `world-vercel`

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -265,18 +265,11 @@ const stepHandler = getWorldHandlers().createQueueHandler(
             });
 
             // Re-invoke the workflow to handle the failed step
-            await queueMessage(
-              world,
-              getWorkflowQueueName(workflowName),
-              {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              },
-              {
-                headers: { 'x-workflow-run-id': workflowRunId },
-              }
-            );
+            await queueMessage(world, getWorkflowQueueName(workflowName), {
+              runId: workflowRunId,
+              traceCarrier: await serializeTraceCarrier(),
+              requestedAt: new Date(),
+            });
             return;
           }
 
@@ -608,18 +601,11 @@ const stepHandler = getWorldHandlers().createQueueHandler(
             }
           }
 
-          await queueMessage(
-            world,
-            getWorkflowQueueName(workflowName),
-            {
-              runId: workflowRunId,
-              traceCarrier: await serializeTraceCarrier(),
-              requestedAt: new Date(),
-            },
-            {
-              headers: { 'x-workflow-run-id': workflowRunId },
-            }
-          );
+          await queueMessage(world, getWorkflowQueueName(workflowName), {
+            runId: workflowRunId,
+            traceCarrier: await serializeTraceCarrier(),
+            requestedAt: new Date(),
+          });
         }
       );
     });

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -204,7 +204,6 @@ export async function handleSuspension({
           {
             idempotencyKey: queueItem.correlationId,
             headers: {
-              'x-workflow-run-id': runId,
               ...extractTraceHeaders(traceCarrier),
             },
           }


### PR DESCRIPTION
## Summary
- Moves `x-workflow-run-id` and `x-workflow-step-id` header injection into `world-vercel` queue implementation (`getHeadersFromPayload`) so headers are automatically derived from the queue payload
- Removes manual `x-workflow-run-id` header passing from all callers in `@workflow/core` (step-handler, suspension-handler)
- Also covers the sleep re-enqueue path inside `createQueueHandler` which was previously missing the header entirely

## Test plan
- [ ] Verify `pnpm typecheck` passes (pre-existing `web-shared` failure is unrelated)
- [ ] Verify `pnpm build` passes for `@workflow/core` and `@workflow/world-vercel`
- [ ] Run e2e tests to confirm VQS messages still carry correct headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)