### PR TITLE
skills: bundle skills when publishing to npm

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "build": "tsc && chmod +x bin/run.js",
-    "clean": "tsc --build --clean && rm -rf dist docs ||:",
+    "clean": "tsc --build --clean && rm -rf dist docs skills ||:",
     "dev": "tsc --watch",
     "test": "vitest run src",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
to pin local workflow skills to the version and package installed