### PR TITLE
fix: use types.isNativeError() for cross-VM Error serialization

### DIFF
--- a/.changeset/small-houses-walk.md
+++ b/.changeset/small-houses-walk.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Fix `FatalError` instance serialization

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -1817,6 +1817,118 @@ describe('step arguments', () => {
   });
 });
 
+describe('cross-VM Error serialization', () => {
+  // Create a VM context that mimics the real workflow VM setup (with
+  // Request/Response/ReadableStream/WritableStream from the host context)
+  const { context, globalThis: vmGlobalThis } = createContext({
+    seed: 'test-error',
+    fixedTimestamp: 1714857600000,
+  });
+  // The real workflow VM (workflow.ts) sets these on vmGlobalThis.
+  // Without them, other reducers would throw on `instanceof` checks.
+  vmGlobalThis.Request = globalThis.Request;
+  vmGlobalThis.Response = globalThis.Response;
+  vmGlobalThis.ReadableStream = globalThis.ReadableStream;
+  vmGlobalThis.WritableStream = globalThis.WritableStream;
+
+  it('should serialize a host-context Error when using VM globalThis', async () => {
+    // This simulates the scenario where a FatalError (created in the host
+    // context) is passed as an argument to a step function. The serialization
+    // uses VM's globalThis, so `instanceof vmGlobal.Error` would fail for
+    // host-context errors. Using types.isNativeError() fixes this.
+    const hostError = new Error('host error');
+    hostError.name = 'FatalError';
+
+    const serialized = await dehydrateStepArguments(
+      [hostError],
+      mockRunId,
+      noEncryptionKey,
+      vmGlobalThis
+    );
+
+    const ops: Promise<void>[] = [];
+    const hydrated = await hydrateStepArguments(
+      serialized,
+      mockRunId,
+      noEncryptionKey,
+      ops,
+      vmGlobalThis
+    );
+
+    // The reviver creates errors with `new global.Error()` (VM's Error),
+    // so `instanceof` against the host Error fails. Check duck-type instead.
+    expect((hydrated[0] as Error).name).toBe('FatalError');
+    expect((hydrated[0] as Error).message).toBe('host error');
+    // Verify it's an instance of the VM's Error
+    vmGlobalThis.__testVal = hydrated[0];
+    expect(runInContext('__testVal instanceof Error', context)).toBe(true);
+  });
+
+  it('should serialize a VM-context Error when using VM globalThis', async () => {
+    const vmError = runInContext(
+      '(() => { const e = new Error("vm error"); e.name = "FatalError"; return e; })()',
+      context
+    );
+
+    const serialized = await dehydrateStepArguments(
+      [vmError],
+      mockRunId,
+      noEncryptionKey,
+      vmGlobalThis
+    );
+
+    const ops: Promise<void>[] = [];
+    const hydrated = await hydrateStepArguments(
+      serialized,
+      mockRunId,
+      noEncryptionKey,
+      ops,
+      vmGlobalThis
+    );
+
+    // The reviver creates errors with `new global.Error()` (VM's Error),
+    // so `instanceof` against the host Error fails. Check duck-type instead.
+    expect((hydrated[0] as Error).name).toBe('FatalError');
+    expect((hydrated[0] as Error).message).toBe('vm error');
+    // Verify it's an instance of the VM's Error
+    vmGlobalThis.__testVal = hydrated[0];
+    expect(runInContext('__testVal instanceof Error', context)).toBe(true);
+  });
+
+  it('should serialize Error subclass from host context through workflow reducers', async () => {
+    class FatalError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'FatalError';
+      }
+    }
+    const error = new FatalError('step failed');
+
+    const serialized = await dehydrateStepArguments(
+      { error },
+      mockRunId,
+      noEncryptionKey,
+      vmGlobalThis
+    );
+
+    const ops: Promise<void>[] = [];
+    const hydrated = (await hydrateStepArguments(
+      serialized,
+      mockRunId,
+      noEncryptionKey,
+      ops,
+      vmGlobalThis
+    )) as { error: Error };
+
+    // The reviver creates errors with `new global.Error()` (VM's Error)
+    expect(hydrated.error.name).toBe('FatalError');
+    expect(hydrated.error.message).toBe('step failed');
+    // Verify it's an instance of the VM's Error
+    vmGlobalThis.__testVal = hydrated.error;
+    expect(runInContext('__testVal instanceof Error', context)).toBe(true);
+  });
+});
+
 describe('step return value', () => {
   it('should throw error for an unsupported type', async () => {
     class Foo {}

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1,3 +1,4 @@
+import { types } from 'node:util';
 import { WorkflowRuntimeError } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { DevalueError, parse, stringify, unflatten } from 'devalue';
@@ -553,7 +554,13 @@ function getCommonReducers(global: Record<string, any> = globalThis) {
       return valid ? value.toISOString() : '.';
     },
     Error: (value) => {
-      if (!(value instanceof global.Error)) return false;
+      // Use types.isNativeError() instead of `instanceof global.Error`
+      // because errors may originate from a different VM context (e.g.
+      // FatalError from the host context passed into a VM-context workflow).
+      // `instanceof` checks fail across VM boundaries since each context
+      // has its own Error constructor, but isNativeError() uses V8's
+      // internal type tag which works across all contexts.
+      if (!types.isNativeError(value)) return false;
       return {
         name: value.name,
         message: value.message,


### PR DESCRIPTION
FatalError was not properly serialized when passed from workflow code into a step function because the Error reducer checked `value instanceof global.Error` where `global` is the VM's globalThis. Errors created in the host context (like FatalError from @workflow/errors) have a different Error prototype than the VM context, so the instanceof check returned false and the error was silently dropped.

Replaced with `types.isNativeError()` from `node:util` which uses V8's internal type tag and works across VM context boundaries.