### PR TITLE
Don't enforce client-side generated runId in `start()` for `v1Compat`

### DIFF
--- a/.changeset/gentle-friends-arrive.md
+++ b/.changeset/gentle-friends-arrive.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Don't enforce client-side generated runId in `start()` for `v1Compat`

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -160,7 +160,7 @@ export async function start<TArgs extends unknown[], TResult>(
       }
 
       // Verify server accepted our runId
-      if (result.run.runId !== runId) {
+      if (!v1Compat && result.run.runId !== runId) {
         throw new WorkflowRuntimeError(
           `Server returned different runId than requested: expected ${runId}, got ${result.run.runId}`
         );


### PR DESCRIPTION
Removed client-side runId enforcement in the `start()` function when `v1Compat` mode is enabled.

### What changed?

Modified the runId validation logic in `packages/core/src/runtime/start.ts` to skip the server-client runId comparison check when `v1Compat` is true. The validation now only throws a `WorkflowRuntimeError` for runId mismatches when not in v1 compatibility mode.

### How to test?

1. Test workflow startup with `v1Compat` enabled and verify that different runIds between client and server don't cause errors
2. Test workflow startup with `v1Compat` disabled and confirm that runId mismatches still throw the expected `WorkflowRuntimeError`
3. Verify that workflows continue to function normally in both compatibility modes

### Why make this change?

This change maintains backward compatibility with v1 workflows that may not strictly enforce client-generated runIds, while preserving the validation behavior for newer workflow versions that expect consistent runId handling between client and server.