### PR TITLE
Handle ECONNRESET and transient network errors in world-vercel fetch calls

### DIFF
--- a/.changeset/handle-econnreset-errors.md
+++ b/.changeset/handle-econnreset-errors.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": patch
+---
+
+Handle ECONNRESET and other transient network errors in fetch calls by wrapping them as WorkflowAPIError with status 500, enabling automatic retry via withServerErrorRetry

--- a/packages/world-vercel/src/encryption.ts
+++ b/packages/world-vercel/src/encryption.ts
@@ -14,6 +14,7 @@ import { webcrypto } from 'node:crypto';
 import { getVercelOidcToken } from '@vercel/oidc';
 import type { WorkflowRun, World } from '@workflow/world';
 import * as z from 'zod';
+import { fetchWithNetworkErrorHandling } from './utils.js';
 
 const KEY_BYTES = 32; // 256 bits = 32 bytes (AES-256)
 
@@ -112,7 +113,7 @@ export async function fetchRunKey(
   if (options?.teamId) {
     params.set('teamId', options.teamId);
   }
-  const response = await fetch(
+  const response = await fetchWithNetworkErrorHandling(
     `https://api.vercel.com/v1/workflow/run-key/${deploymentId}?${params}`,
     {
       headers: {

--- a/packages/world-vercel/src/refs.ts
+++ b/packages/world-vercel/src/refs.ts
@@ -9,7 +9,11 @@ import {
   trace,
   UrlFull,
 } from './telemetry.js';
-import { type APIConfig, getHttpConfig } from './utils.js';
+import {
+  type APIConfig,
+  fetchWithNetworkErrorHandling,
+  getHttpConfig,
+} from './utils.js';
 
 /**
  * A ref descriptor as returned by workflow-server when `remoteRefBehavior=lazy`.
@@ -105,7 +109,7 @@ export async function resolveRefDescriptor(
         ...PeerService('workflow-server'),
       });
 
-      const response = await fetch(
+      const response = await fetchWithNetworkErrorHandling(
         new Request(url, { method: 'GET', headers })
       );
 

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -1,5 +1,10 @@
 import type { Streamer } from '@workflow/world';
-import { type APIConfig, getHttpConfig, type HttpConfig } from './utils.js';
+import {
+  type APIConfig,
+  fetchWithNetworkErrorHandling,
+  getHttpConfig,
+  type HttpConfig,
+} from './utils.js';
 
 function getStreamUrl(
   name: string,
@@ -62,12 +67,15 @@ export function createStreamer(config?: APIConfig): Streamer {
       const resolvedRunId = await runId;
 
       const httpConfig = await getHttpConfig(config);
-      await fetch(getStreamUrl(name, resolvedRunId, httpConfig), {
-        method: 'PUT',
-        body: chunk,
-        headers: httpConfig.headers,
-        duplex: 'half',
-      });
+      await fetchWithNetworkErrorHandling(
+        getStreamUrl(name, resolvedRunId, httpConfig),
+        {
+          method: 'PUT',
+          body: chunk,
+          headers: httpConfig.headers,
+          duplex: 'half',
+        }
+      );
     },
 
     async writeToStreamMulti(
@@ -86,12 +94,15 @@ export function createStreamer(config?: APIConfig): Streamer {
       httpConfig.headers.set('X-Stream-Multi', 'true');
 
       const body = encodeMultiChunks(chunks);
-      await fetch(getStreamUrl(name, resolvedRunId, httpConfig), {
-        method: 'PUT',
-        body,
-        headers: httpConfig.headers,
-        duplex: 'half',
-      });
+      await fetchWithNetworkErrorHandling(
+        getStreamUrl(name, resolvedRunId, httpConfig),
+        {
+          method: 'PUT',
+          body,
+          headers: httpConfig.headers,
+          duplex: 'half',
+        }
+      );
     },
 
     async closeStream(name: string, runId: string | Promise<string>) {
@@ -100,10 +111,13 @@ export function createStreamer(config?: APIConfig): Streamer {
 
       const httpConfig = await getHttpConfig(config);
       httpConfig.headers.set('X-Stream-Done', 'true');
-      await fetch(getStreamUrl(name, resolvedRunId, httpConfig), {
-        method: 'PUT',
-        headers: httpConfig.headers,
-      });
+      await fetchWithNetworkErrorHandling(
+        getStreamUrl(name, resolvedRunId, httpConfig),
+        {
+          method: 'PUT',
+          headers: httpConfig.headers,
+        }
+      );
     },
 
     async readFromStream(name: string, startIndex?: number) {
@@ -112,7 +126,9 @@ export function createStreamer(config?: APIConfig): Streamer {
       if (typeof startIndex === 'number') {
         url.searchParams.set('startIndex', String(startIndex));
       }
-      const res = await fetch(url, { headers: httpConfig.headers });
+      const res = await fetchWithNetworkErrorHandling(url, {
+        headers: httpConfig.headers,
+      });
       if (!res.ok) throw new Error(`Failed to fetch stream: ${res.status}`);
       return res.body as ReadableStream<Uint8Array>;
     },
@@ -120,7 +136,9 @@ export function createStreamer(config?: APIConfig): Streamer {
     async listStreamsByRunId(runId: string) {
       const httpConfig = await getHttpConfig(config);
       const url = new URL(`${httpConfig.baseUrl}/v2/runs/${runId}/streams`);
-      const res = await fetch(url, { headers: httpConfig.headers });
+      const res = await fetchWithNetworkErrorHandling(url, {
+        headers: httpConfig.headers,
+      });
       if (!res.ok) throw new Error(`Failed to list streams: ${res.status}`);
       return (await res.json()) as string[];
     },

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -138,6 +138,70 @@ export function deserializeError<T extends Record<string, any>>(obj: any): T {
   return obj as T;
 }
 
+/**
+ * Transient network error codes that indicate connection-level failures.
+ * These are not HTTP status codes — they come from the OS/Node.js networking
+ * layer and surface as `cause.code` on the TypeError thrown by `fetch()`.
+ */
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'EAI_AGAIN',
+  'UND_ERR_SOCKET', // undici socket error
+  'UND_ERR_CONNECT_TIMEOUT', // undici connect timeout
+]);
+
+/**
+ * Check whether an error thrown by `fetch()` is a transient network error
+ * (e.g. ECONNRESET). Node's `fetch` (undici) throws a `TypeError` whose
+ * `.cause` carries the underlying OS error code.
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof TypeError)) return false;
+  const cause = (err as any).cause;
+  if (!cause) return false;
+  const code: unknown = cause.code ?? cause.cause?.code;
+  if (typeof code === 'string' && TRANSIENT_NETWORK_ERROR_CODES.has(code)) {
+    return true;
+  }
+  // Also match by message as a fallback (e.g. "fetch failed")
+  const msg: string = cause.message ?? '';
+  return msg.includes('ECONNRESET') || msg.includes('fetch failed');
+}
+
+/**
+ * Wraps a `fetch()` call so that transient network errors (ECONNRESET, etc.)
+ * are re-thrown as `WorkflowAPIError` with status 500. This lets the existing
+ * `withServerErrorRetry` retry logic handle them transparently.
+ */
+export async function fetchWithNetworkErrorHandling(
+  input: string | URL | Request,
+  init?: RequestInit
+): Promise<Response> {
+  try {
+    return await fetch(input, init);
+  } catch (err) {
+    if (isTransientNetworkError(err)) {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      throw new WorkflowAPIError(
+        `Network error (${(err as any).cause?.code ?? 'unknown'}): ${(err as Error).message}`,
+        { url, status: 500, cause: err }
+      );
+    }
+    throw err;
+  }
+}
+
 const getUserAgent = () => {
   const deploymentId = process.env.VERCEL_DEPLOYMENT_ID;
   if (deploymentId) {
@@ -276,7 +340,7 @@ export async function makeRequest<T>({
         body,
         headers,
       });
-      const response = await fetch(request);
+      const response = await fetchWithNetworkErrorHandling(request);
 
       span?.setAttributes({
         ...HttpResponseStatusCode(response.status),


### PR DESCRIPTION
Transient network errors like ECONNRESET from Node's `fetch()` (undici) were not being caught, causing workflow runs to fail without retry. These errors surface as `TypeError` with a nested `.cause.code` rather than HTTP error responses.

### What changed
- Added `isTransientNetworkError()` helper that detects OS/undici-level connection failures (ECONNRESET, ECONNREFUSED, ETIMEDOUT, EPIPE, UND_ERR_SOCKET, etc.)
- Added `fetchWithNetworkErrorHandling()` wrapper that catches these errors and re-throws them as `WorkflowAPIError` with status 500
- Replaced all `fetch()` calls in `world-vercel` (utils.ts, refs.ts, streamer.ts, encryption.ts) with the new wrapper
- Network errors now flow through the existing `withServerErrorRetry` retry logic (3 retries with exponential backoff: 500ms, 1s, 2s), same as any 5xx server error

<a href="https://vercel.slack.com/archives/C09G3EQAL84/p1772149856058409?thread_ts=1772149856.058409&cid=C09G3EQAL84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>