### PR TITLE
Fix workflow discovery for steps inside dot-prefixed directories like .well-known/agent

### DIFF
--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -105,6 +105,11 @@ export abstract class BaseBuilder {
     });
 
     const result = await glob(patterns, {
+      // Enable dot-file matching so directories like `.well-known/agent/`
+      // are traversed. Without this, tinyglobby skips dot-prefixed directories
+      // by default, causing "use step" / "use workflow" files inside paths
+      // like `app/.well-known/agent/…` to be silently ignored.
+      dot: true,
       ignore: [
         '**/node_modules/**',
         '**/.git/**',

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -263,6 +263,28 @@ describe('e2e', () => {
     );
   });
 
+  // Test that "use step" / "use workflow" functions inside dot-prefixed
+  // directories like `.well-known/agent/` are discovered and executed correctly.
+  // Only runs on Next.js workbenches where the test file is placed.
+  const isNextApp = process.env.APP_NAME?.includes('nextjs');
+  test.skipIf(!isNextApp)(
+    'wellKnownAgentWorkflow (.well-known/agent)',
+    { timeout: 60_000 },
+    async () => {
+      const run = await start(
+        await getWorkflowMetadata(
+          'app/.well-known/agent/v1/steps.ts',
+          'wellKnownAgentWorkflow'
+        ),
+        [5]
+      );
+
+      const returnValue = await run.returnValue;
+      // wellKnownAgentStep(5) => 5 * 2 = 10, then workflow adds 1 => 11
+      expect(returnValue).toBe(11);
+    }
+  );
+
   const isNext = process.env.APP_NAME?.includes('nextjs');
   const isLocal = deploymentUrl.includes('localhost');
   // only works with framework that transpiles react and

--- a/packages/core/e2e/manifest.test.ts
+++ b/packages/core/e2e/manifest.test.ts
@@ -183,6 +183,76 @@ function getStepNodes(graph: ManifestWorkflow['graph']): ManifestNode[] {
 }
 
 /**
+ * Tests that steps and workflows inside dot-prefixed directories like
+ * `.well-known/agent/` are correctly discovered and included in the manifest.
+ * This verifies the fix for tinyglobby's `dot: true` option.
+ */
+describe.each(['nextjs-webpack', 'nextjs-turbopack'])(
+  'dot-directory discovery (.well-known/agent)',
+  (project) => {
+    test(
+      `${project}: discovers steps inside .well-known/agent directory`,
+      { timeout: 30_000 },
+      async () => {
+        if (process.env.APP_NAME && project !== process.env.APP_NAME) {
+          return;
+        }
+
+        const manifest = await tryReadManifest(project);
+        if (!manifest) return;
+
+        // Find the step from .well-known/agent/v1/steps.ts
+        const stepFiles = Object.keys(manifest.steps);
+        const wellKnownStepFile = stepFiles.find(
+          (f) =>
+            f.includes('.well-known/agent') ||
+            f.includes('well-known/agent')
+        );
+        expect(
+          wellKnownStepFile,
+          `Expected a step file matching ".well-known/agent" in manifest steps. Available: ${stepFiles.join(', ')}`
+        ).toBeDefined();
+
+        const fileSteps = manifest.steps[wellKnownStepFile!];
+        expect(fileSteps.wellKnownAgentStep).toBeDefined();
+        expect(fileSteps.wellKnownAgentStep.stepId).toContain('wellKnownAgentStep');
+      }
+    );
+
+    test(
+      `${project}: discovers workflows inside .well-known/agent directory`,
+      { timeout: 30_000 },
+      async () => {
+        if (process.env.APP_NAME && project !== process.env.APP_NAME) {
+          return;
+        }
+
+        const manifest = await tryReadManifest(project);
+        if (!manifest) return;
+
+        // Find the workflow from .well-known/agent/v1/steps.ts
+        const workflowFiles = Object.keys(manifest.workflows);
+        const wellKnownWorkflowFile = workflowFiles.find(
+          (f) =>
+            f.includes('.well-known/agent') ||
+            f.includes('well-known/agent')
+        );
+        expect(
+          wellKnownWorkflowFile,
+          `Expected a workflow file matching ".well-known/agent" in manifest workflows. Available: ${workflowFiles.join(', ')}`
+        ).toBeDefined();
+
+        const fileWorkflows = manifest.workflows[wellKnownWorkflowFile!];
+        expect(fileWorkflows.wellKnownAgentWorkflow).toBeDefined();
+        expect(
+          fileWorkflows.wellKnownAgentWorkflow.workflowId
+        ).toContain('wellKnownAgentWorkflow');
+      }
+    );
+  }
+);
+
+/**
  * Tests for single-statement control flow extraction.
  * These verify that steps inside if/while/for without braces are extracted.
  * Tests are skipped if manifest doesn't exist or workflow isn't found.

--- a/workbench/nextjs-turbopack/app/.well-known/agent/v1/steps.ts
+++ b/workbench/nextjs-turbopack/app/.well-known/agent/v1/steps.ts
@@ -1,0 +1,18 @@
+/**
+ * Test file for verifying that workflow discovers step/workflow functions
+ * inside dot-prefixed directories like `.well-known/agent/`.
+ *
+ * This simulates the pattern used by agent frameworks that place generated
+ * step functions inside `app/.well-known/agent/v1/steps.ts`.
+ */
+
+export async function wellKnownAgentStep(input: number) {
+  'use step';
+  return input * 2;
+}
+
+export async function wellKnownAgentWorkflow(value: number) {
+  'use workflow';
+  const result = await wellKnownAgentStep(value);
+  return result + 1;
+}

--- a/workbench/nextjs-turbopack/app/api/chat/route.ts
+++ b/workbench/nextjs-turbopack/app/api/chat/route.ts
@@ -1,8 +1,10 @@
 // THIS FILE IS JUST FOR TESTING HMR AS AN ENTRY NEEDS
 // TO IMPORT THE WORKFLOWS TO DISCOVER THEM AND WATCH
 import * as workflows from '@/workflows/3_streams';
+// Test that steps inside dot-prefixed directories are discovered
+import * as wellKnownAgentSteps from '@/app/.well-known/agent/v1/steps';
 
 export async function POST(_req: Request) {
-  console.log(workflows);
+  console.log(workflows, wellKnownAgentSteps);
   return Response.json('hello world');
 }

--- a/workbench/nextjs-webpack/app/.well-known/agent/v1/steps.ts
+++ b/workbench/nextjs-webpack/app/.well-known/agent/v1/steps.ts
@@ -1,0 +1,18 @@
+/**
+ * Test file for verifying that workflow discovers step/workflow functions
+ * inside dot-prefixed directories like `.well-known/agent/`.
+ *
+ * This simulates the pattern used by agent frameworks that place generated
+ * step functions inside `app/.well-known/agent/v1/steps.ts`.
+ */
+
+export async function wellKnownAgentStep(input: number) {
+  'use step';
+  return input * 2;
+}
+
+export async function wellKnownAgentWorkflow(value: number) {
+  'use workflow';
+  const result = await wellKnownAgentStep(value);
+  return result + 1;
+}

--- a/workbench/nextjs-webpack/app/api/chat/route.ts
+++ b/workbench/nextjs-webpack/app/api/chat/route.ts
@@ -1,8 +1,10 @@
 // THIS FILE IS JUST FOR TESTING HMR AS AN ENTRY NEEDS
 // TO IMPORT THE WORKFLOWS TO DISCOVER THEM AND WATCH
 import * as workflows from '@/workflows/3_streams';
+// Test that steps inside dot-prefixed directories are discovered
+import * as wellKnownAgentSteps from '@/app/.well-known/agent/v1/steps';
 
 export async function POST(_req: Request) {
-  console.log(workflows);
+  console.log(workflows, wellKnownAgentSteps);
   return Response.json('hello world');
 }


### PR DESCRIPTION
Steps and workflows defined inside dot-prefixed directories (e.g. `app/.well-known/agent/v1/steps.ts`) were silently ignored because `tinyglobby`'s `glob()` defaults to `dot: false`, which skips directories starting with `.`. This broke the pattern used by agent frameworks like `withAgent` that generate step functions inside `.well-known/agent/`.

### What changed
- Added `dot: true` to the `glob()` call in `BaseBuilder.getInputFiles()` so dot-prefixed directories like `.well-known/agent/` are traversed — the explicit `ignore` patterns already filter out directories that should remain excluded (`.git`, `.next`, `.vercel`, `.well-known/workflow/`, etc.)
- Added test step/workflow files in `app/.well-known/agent/v1/steps.ts` for both `nextjs-turbopack` and `nextjs-webpack` workbenches, with corresponding imports in their chat routes so the eager builder discovers them
- Added manifest tests verifying the `.well-known/agent` steps and workflows appear in the build manifest
- Added an e2e test that runs the `wellKnownAgentWorkflow` end-to-end on Next.js workbenches

<a href="https://vercel.slack.com/archives/C09125LC4AX/p1770673876646159?thread_ts=1770673876.646159&cid=C09125LC4AX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>