### PR TITLE
Fix release PR updates not dispatching front sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
**Problem**

The `changesets/action` push to `changeset-release/main` was authenticating with the default `GITHUB_TOKEN` (via `actions/checkout`'s `extraheader`), which doesn't generate `pull_request.synchronize` events. 

This meant the front sync dispatch only fired on initial release PR creation (`opened`), not on subsequent updates.

**Changes**

Passes `GH_TOKEN_PULL_REQUESTS` to `actions/checkout` so the git extraheader uses the PAT, ensuring pushes trigger `synchronize` events on the release PR.