### PR TITLE
fix(cli): read orgId from project entry in repo.json, not root

### DIFF
--- a/.changeset/fix-cli-team-id-repo-link.md
+++ b/.changeset/fix-cli-team-id-repo-link.md
@@ -1,0 +1,5 @@
+---
+"@workflow/cli": patch
+---
+
+Fix CLI 401 errors by reading orgId from per-project entry in repo.json for newer Vercel CLI versions

--- a/packages/cli/src/lib/inspect/vercel-link.ts
+++ b/packages/cli/src/lib/inspect/vercel-link.ts
@@ -23,10 +23,13 @@ interface RepoProjectConfig {
   id: string;
   name: string;
   directory: string;
+  /** Per-project orgId — added in vercel/vercel#14967. Prefer this over root-level orgId. */
+  orgId?: string;
 }
 
 interface RepoProjectsConfig {
-  orgId: string;
+  /** Legacy root-level orgId — older Vercel CLI versions put orgId here. */
+  orgId?: string;
   remoteName: string;
   projects: RepoProjectConfig[];
 }
@@ -195,9 +198,16 @@ async function getProjectLinkFromRepoLink(
   logger.debug(`Found matching repo projects: ${JSON.stringify(projects)}`);
   if (projects.length === 1) {
     const project = projects[0];
+    // Prefer per-project orgId (vercel/vercel#14967), fall back to
+    // root-level orgId for older Vercel CLI versions.
+    const orgId = project.orgId ?? repoLink.repoConfig?.orgId;
+    if (!orgId) {
+      logger.debug('No orgId found in repo link project or root config');
+      return null;
+    }
     return {
       repoRoot: repoLink.rootPath,
-      orgId: repoLink.repoConfig.orgId,
+      orgId,
       projectId: project.id,
       projectName: project.name,
       projectRootDirectory: project.directory,


### PR DESCRIPTION
## Summary

Fixes CLI 401 errors when using `--backend=vercel` with projects linked via `vc link` in a monorepo.

## Problem

The Vercel CLI recently moved `orgId` from the root level of `.vercel/repo.json` to each project entry (see [vercel/vercel#14967](https://github.com/vercel/vercel/pull/14967)):

```json
// New format (vercel/vercel#14967):
{
  "remoteName": "origin",
  "projects": [
    {
      "id": "prj_xxx",
      "name": "my-app",
      "directory": "workbench/nextjs-turbopack",
      "orgId": "team_xxx"  ← moved here
    }
  ]
}

// Old format:
{
  "orgId": "team_xxx",  ← was here
  "remoteName": "origin",
  "projects": [...]
}
```

The workflow CLI was only reading `repoConfig.orgId` (root level), which is now `undefined` with the new format. Without `teamId`, `world-vercel` uses the direct `vercel-workflow.com` URL instead of the `api.vercel.com` proxy, causing 401 because `vercel-workflow.com` only accepts OIDC tokens.

## Fix

- Prefer `project.orgId` (new per-project format), fall back to `repoConfig.orgId` (legacy root format) for backwards compatibility
- Update `RepoProjectConfig` type to include optional `orgId`
- Keep `RepoProjectsConfig.orgId` as optional for legacy support
- Return `null` if neither location has `orgId`