### PR TITLE
fix: allow square brackets and parentheses in workflow names

### DIFF
--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -63,6 +63,26 @@ describe('getWorkflowQueueName', () => {
     );
   });
 
+  it('should allow square brackets for Next.js dynamic route segments', () => {
+    expect(
+      getWorkflowQueueName(
+        'workflow//./src/app/api/[[...rest]]/workflow//agentWorkflow'
+      )
+    ).toBe(
+      '__wkf_workflow_workflow//./src/app/api/[[...rest]]/workflow//agentWorkflow'
+    );
+  });
+
+  it('should allow parentheses for Next.js route groups', () => {
+    expect(
+      getWorkflowQueueName(
+        'workflow//./src/app/(dashboard)/api/workflow//myWorkflow'
+      )
+    ).toBe(
+      '__wkf_workflow_workflow//./src/app/(dashboard)/api/workflow//myWorkflow'
+    );
+  });
+
   it('should throw for names containing spaces', () => {
     expect(() => getWorkflowQueueName('my workflow')).toThrow(
       'Invalid workflow name'

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -18,9 +18,11 @@ const DEFAULT_HEALTH_CHECK_TIMEOUT = 30_000;
 /**
  * Pattern for safe workflow names. Only allows alphanumeric characters,
  * underscores, hyphens, dots, forward slashes (for namespaced workflows),
- * and at signs (for scoped packages).
+ * at signs (for scoped packages), square brackets (for Next.js dynamic
+ * route segments like `[id]` and `[[...rest]]`), and parentheses
+ * (for Next.js route groups like `(dashboard)`).
  */
-const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@]+$/;
+const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@[\]()]+$/;
 
 /**
  * Validates a workflow name and returns the corresponding queue name.
@@ -30,7 +32,7 @@ const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@]+$/;
 export function getWorkflowQueueName(workflowName: string): ValidQueueName {
   if (!SAFE_WORKFLOW_NAME_PATTERN.test(workflowName)) {
     throw new Error(
-      `Invalid workflow name "${workflowName}": must only contain alphanumeric characters, underscores, hyphens, dots, forward slashes, or at signs`
+      `Invalid workflow name "${workflowName}": must only contain alphanumeric characters, underscores, hyphens, dots, forward slashes, at signs, square brackets, or parentheses`
     );
   }
   return `__wkf_workflow_${workflowName}` as ValidQueueName;


### PR DESCRIPTION
Workflow names are generated from file paths by the SWC plugin. Next.js dynamic route segments (`[[...rest]]`, `[id]`) and route groups (`(dashboard)`) produce square bracket and parenthesis characters in the name, which the validation regex in `getWorkflowQueueName` rejected.

Adds `[]` and `()` to the allowed character set and adds test coverage for both cases.

Made with [Cursor](https://cursor.com)