### PR TITLE
fix(world-local, world-postgres): default hooks.list() sort order to ascending

### DIFF
--- a/.changeset/fix-hooks-list-sort-order.md
+++ b/.changeset/fix-hooks-list-sort-order.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-local': patch
+'@workflow/world-postgres': patch
+---
+
+Fix `hooks.list()` default sort order to ascending (creation order) in world-local and world-postgres, matching world-vercel behavior. Also fix world-postgres `hooks.list()` to respect the `sortOrder` pagination parameter instead of hardcoding descending order.

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -1396,10 +1396,10 @@ describe('Storage', () => {
         const result = await storage.hooks.list({});
 
         expect(result.data).toHaveLength(2);
-        // Should be in descending order (most recent first)
-        expect(result.data[0].hookId).toBe(hook2.hookId);
-        expect(result.data[1].hookId).toBe(hook1.hookId);
-        expect(result.data[0].createdAt.getTime()).toBeGreaterThanOrEqual(
+        // Should be in ascending order (oldest first) by default
+        expect(result.data[0].hookId).toBe(hook1.hookId);
+        expect(result.data[1].hookId).toBe(hook2.hookId);
+        expect(result.data[0].createdAt.getTime()).toBeLessThanOrEqual(
           result.data[1].createdAt.getTime()
         );
       });

--- a/packages/world-local/src/storage/hooks-storage.ts
+++ b/packages/world-local/src/storage/hooks-storage.ts
@@ -1,5 +1,5 @@
-import { HookNotFoundError } from '@workflow/errors';
 import path from 'node:path';
+import { HookNotFoundError } from '@workflow/errors';
 import type {
   GetHookParams,
   Hook,
@@ -68,7 +68,7 @@ export function createHooksStorage(basedir: string): Storage['hooks'] {
     const result = await paginatedFileSystemQuery({
       directory: hooksDir,
       schema: HookSchema,
-      sortOrder: params.pagination?.sortOrder,
+      sortOrder: params.pagination?.sortOrder ?? 'asc',
       limit: params.pagination?.limit,
       cursor: params.pagination?.cursor,
       filePrefix: undefined, // Hooks don't have ULIDs, so we can't optimize by filename
@@ -80,11 +80,10 @@ export function createHooksStorage(basedir: string): Storage['hooks'] {
         return true;
       },
       getCreatedAt: () => {
-        // Hook files don't have ULID timestamps in filename
-        // We need to read the file to get createdAt, but that's inefficient
-        // So we return the hook's createdAt directly (item.createdAt will be used for sorting)
-        // Return a dummy date to pass the null check, actual sorting uses item.createdAt
-        return new Date(0);
+        // Hook files don't have ULID timestamps in filename, so return null
+        // to skip the filename-based optimization and defer to JSON-based
+        // cursor filtering which uses the actual createdAt from the file.
+        return null;
       },
       getId: (hook) => hook.hookId,
     });

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -28,7 +28,7 @@ import {
   StepSchema,
   WorkflowRunSchema,
 } from '@workflow/world';
-import { and, desc, eq, gt, lt, notInArray, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, lt, notInArray, sql } from 'drizzle-orm';
 import { monotonicFactory } from 'ulid';
 import { type Drizzle, Schema } from './drizzle/index.js';
 import type { SerializedContent } from './drizzle/schema.js';
@@ -1159,16 +1159,19 @@ export function createHooksStorage(drizzle: Drizzle): Storage['hooks'] {
     async list(params: ListHooksParams) {
       const limit = params?.pagination?.limit ?? 100;
       const fromCursor = params?.pagination?.cursor;
+      const sortOrder = params?.pagination?.sortOrder ?? 'asc';
+      const orderFn = sortOrder === 'asc' ? asc : desc;
+      const cursorFn = sortOrder === 'asc' ? gt : lt;
       const all = await drizzle
         .select()
         .from(hooks)
         .where(
           and(
             map(params.runId, (id) => eq(hooks.runId, id)),
-            map(fromCursor, (c) => lt(hooks.hookId, c))
+            map(fromCursor, (c) => cursorFn(hooks.hookId, c))
           )
         )
-        .orderBy(desc(hooks.hookId))
+        .orderBy(orderFn(hooks.hookId))
         .limit(limit + 1);
       const values = all.slice(0, limit);
       const hasMore = all.length > limit;


### PR DESCRIPTION
## Summary

- Fix `hooks.list()` default sort order in world-local and world-postgres to ascending (creation order), matching world-vercel behavior
- Fix world-postgres `hooks.list()` to actually respect the `sortOrder` pagination parameter (was hardcoded to `desc` and silently ignored the param)
- Fix world-local `hooks.list()` cursor pagination bug where `getCreatedAt` returned `new Date(0)` instead of `null`, causing the filename-based optimization to incorrectly filter out all files when paginating in ascending order

## Root Cause

The `webhookWorkflow` e2e test was failing on both world-local and world-postgres because `hooks.list()` returned hooks in descending order (newest first) by default, while the test assumes creation order (ascending). This caused the test to send the first webhook request to the manual-response hook instead of the default-response hook, creating a deadlock that timed out after 60 seconds.

## Test Plan

- Verified `webhookWorkflow` e2e test passes against nextjs-turbopack with world-local
- Verified world-local hooks storage unit tests pass (19/19)
- Verified world-postgres builds successfully