### PR TITLE
Add queue, event, push, subscribe keywords to workflow skill

### DIFF
--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -3,7 +3,7 @@ name: workflow
 description: Creates durable, resumable workflows using Vercel's Workflow DevKit. Use when building workflows that need to survive restarts, pause for external events, retry on failure, or coordinate multi-step operations over time. Triggers on mentions of "workflow", "durable functions", "resumable", "workflow devkit", "queue", "event", "push", "subscribe", or step-based orchestration.
 metadata:
   author: Vercel Inc.
-  version: '1.2'
+  version: '1.3'
 ---
 
 ## *CRITICAL*: Always Use Correct `workflow` Documentation


### PR DESCRIPTION
[@Gaspar Garcia](https://vercel.slack.com/team/U02KBE9L7QX) suggested adding these keywords to improve v0's ability to match the workflow skill when users ask about queuing, events, push patterns, or subscription-based flows.

### What changed
- Added "queue", "event", "push", "subscribe" to the workflow skill description's trigger keywords
- Bumped skill version from 1.2 to 1.3

<a href="https://vercel.slack.com/archives/C0ACY4D798Q/p1772785994953489?thread_ts=1772785994.953489&cid=C0ACY4D798Q"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>