### PR TITLE
Support `timeoutSeconds: 0` for immediate re-enqueue

### DIFF
--- a/.changeset/immediate-requeue.md
+++ b/.changeset/immediate-requeue.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/world-local': patch
+'@workflow/world-vercel': patch
+---
+
+Support `timeoutSeconds: 0` for immediate re-enqueue without arbitrary delay

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -339,7 +339,7 @@ export async function handleSuspension({
   // We do this after processing all other operations (steps, waits) to ensure
   // they are recorded in the event log before the re-execution
   if (hasHookConflict) {
-    return { timeoutSeconds: 1 };
+    return { timeoutSeconds: 0 };
   }
 
   if (minTimeoutSeconds !== null) {

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -242,7 +242,7 @@ export function createQueue(config: Partial<Config>): LocalQueue {
           );
         }
 
-        if (timeoutSeconds) {
+        if (timeoutSeconds != null) {
           return Response.json({ timeoutSeconds }, { status: 503 });
         }
 

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -453,6 +453,55 @@ describe('createQueue', () => {
       }
     });
 
+    it('should send new message without delaySeconds when handler returns timeoutSeconds: 0', async () => {
+      mockSend.mockResolvedValue({ messageId: 'new-msg-123' });
+
+      let capturedHandler: (
+        message: unknown,
+        metadata: unknown
+      ) => Promise<void>;
+      mockHandleCallback.mockImplementation((handler) => {
+        capturedHandler = handler;
+        return async () => new Response('ok');
+      });
+
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+
+      try {
+        const queue = createQueue();
+        queue.createQueueHandler('__wkf_workflow_', async () => ({
+          timeoutSeconds: 0,
+        }));
+
+        await capturedHandler!(
+          {
+            payload: { runId: 'run-123' },
+            queueName: '__wkf_workflow_test',
+            deploymentId: 'dpl_original',
+          },
+          {
+            messageId: 'msg-123',
+            deliveryCount: 1,
+            createdAt: new Date(),
+            topicName: '__wkf_workflow_test',
+            consumerGroup: 'test',
+          }
+        );
+
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        // send(topicName, payload, options)
+        const sendOpts = mockSend.mock.calls[0][2];
+        expect(sendOpts.delaySeconds).toBeUndefined();
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+    });
+
     it('should not send new message when handler returns void', async () => {
       let capturedHandler: (
         message: unknown,

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -182,12 +182,15 @@ export function createQueue(config?: APIConfig): Queue {
       });
 
       if (typeof result?.timeoutSeconds === 'number') {
-        // Send new message with delay, then acknowledge the current one.
-        // Clamp to max delay (23h) - for longer sleeps, the workflow will chain
+        // When timeoutSeconds is 0, skip delaySeconds entirely for immediate re-enqueue.
+        // Otherwise, clamp to max delay (23h) - for longer sleeps, the workflow will chain
         // multiple delayed messages until the full sleep duration has elapsed.
-        const delaySeconds = Math.min(result.timeoutSeconds, MAX_DELAY_SECONDS);
+        const delaySeconds =
+          result.timeoutSeconds > 0
+            ? Math.min(result.timeoutSeconds, MAX_DELAY_SECONDS)
+            : undefined;
 
-        // Send new message with delay BEFORE acknowledging current message.
+        // Send new message BEFORE acknowledging current message.
         // This ensures crash safety: if process dies after send but before ack,
         // we may get a duplicate invocation but won't lose the scheduled wakeup.
         await queue(queueName, payload, { deploymentId, delaySeconds });


### PR DESCRIPTION
## Summary

- Adds support for `timeoutSeconds: 0` to signal immediate re-enqueue (no arbitrary delay)
- Fixes truthiness check in `world-local` queue handler so `0` is not treated as "no timeout"
- Omits `delaySeconds` from VQS queue options in `world-vercel` when `timeoutSeconds` is `0`
- Updates hook conflict re-enqueue in `suspension-handler` from `timeoutSeconds: 1` to `timeoutSeconds: 0`

## Test plan

- [x] Existing `world-vercel` queue tests pass (19 tests)
- [x] New test: `timeoutSeconds: 0` sends message without `delaySeconds`
- [x] Core helpers tests pass (26 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)