### PR TITLE
feat(cli, builders): support WORKFLOW_EXTERNAL_PACKAGES env var

### DIFF
--- a/.changeset/add-external-packages-env.md
+++ b/.changeset/add-external-packages-env.md
@@ -1,0 +1,6 @@
+---
+"@workflow/cli": patch
+"@workflow/builders": patch
+---
+
+Support `WORKFLOW_EXTERNAL_PACKAGES` env var for externalizing packages from workflow bundles

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -809,7 +809,10 @@ export const POST = workflowEntrypoint(workflowCode);`;
         write: true,
         keepNames: true,
         minify: false,
-        external: ['@aws-sdk/credential-provider-web-identity'],
+        external: [
+          '@aws-sdk/credential-provider-web-identity',
+          ...(this.config.externalPackages || []),
+        ],
       });
 
       this.logEsbuildMessages(

--- a/packages/cli/src/lib/config/workflow-config.ts
+++ b/packages/cli/src/lib/config/workflow-config.ts
@@ -11,6 +11,18 @@ function resolveObservabilityCwd(): string {
   return resolve(process.cwd(), raw);
 }
 
+function parseExternalPackages(): string[] | undefined {
+  const raw = process.env.WORKFLOW_EXTERNAL_PACKAGES;
+  if (!raw) {
+    return undefined;
+  }
+  const parts = raw
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return parts.length ? parts : undefined;
+}
+
 export const getWorkflowConfig = (
   {
     buildTarget,
@@ -30,6 +42,7 @@ export const getWorkflowConfig = (
     workflowsBundlePath: './.well-known/workflow/v1/flow.js',
     webhookBundlePath: './.well-known/workflow/v1/webhook.js',
     workflowManifestPath: workflowManifest,
+    externalPackages: parseExternalPackages(),
 
     // WIP: generate a client library to easily execute workflows/steps
     // clientBundlePath: './lib/generated/workflows.js',


### PR DESCRIPTION
## Summary

- Parse `WORKFLOW_EXTERNAL_PACKAGES` env var (comma-separated package names) in the CLI config and wire it to `externalPackages` on the `WorkflowConfig` object.
- Add the `externalPackages` spread to the final workflow bundle's esbuild `external` array, completing coverage across all three bundle phases (discovery, steps, and workflow bundles).

## Motivation

The `externalPackages` field already exists on the `WorkflowConfig` type and is respected during discovery and steps bundling, but:

1. The CLI's `getWorkflowConfig()` never sets it — there's no way to populate it from the environment.
2. The final workflow bundle in `base-builder.ts` doesn't include it in its `external` array.

This means users with native binary dependencies (e.g., `pg`, `pg-native`, `better-sqlite3`) that can't be bundled by esbuild have no built-in way to externalize them from workflow bundles when using the CLI. The only workaround is patching `node_modules` after install.

## Changes

**`packages/cli/src/lib/config/workflow-config.ts`**
- Add `parseExternalPackages()` that reads `WORKFLOW_EXTERNAL_PACKAGES`, splits on commas, trims whitespace, and returns `string[] | undefined`.
- Wire the result into `getWorkflowConfig()` via the existing `externalPackages` config field.

**`packages/builders/src/base-builder.ts`**
- Spread `this.config.externalPackages` into the final workflow bundle's `external` array (lines ~809-813), matching the pattern already used in the discovery and steps bundles.

## Usage

```bash
WORKFLOW_EXTERNAL_PACKAGES=pg,pg-native,better-sqlite3 npx workflow build
```

## Test plan

- [ ] `workflow build` without the env var produces identical output (no regression)
- [ ] `workflow build` with `WORKFLOW_EXTERNAL_PACKAGES=pg,pg-native` excludes those packages from the final `flow.js` bundle
- [ ] Comma-separated values with whitespace are handled: `" pg , pg-native "` → `["pg", "pg-native"]`
- [ ] Empty string or whitespace-only value is treated as no external packages


Made with [Cursor](https://cursor.com)