### PR TITLE
Add logging to world-vercel to diagnose proxy routing

### DIFF
--- a/packages/world-vercel/src/encryption.ts
+++ b/packages/world-vercel/src/encryption.ts
@@ -113,6 +113,14 @@ export async function fetchRunKey(
   if (options?.teamId) {
     params.set('teamId', options.teamId);
   }
+
+  if (process.env.DEBUG === '1') {
+    console.debug(
+      `[workflow] fetchRunKey: cross-deployment key fetch for deployment=${deploymentId}, ` +
+        `runId=${runId} -> api.vercel.com`
+    );
+  }
+
   const response = await fetch(
     `https://api.vercel.com/v1/workflow/run-key/${deploymentId}?${params}`,
     {

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -21,6 +21,14 @@ export function createVercelWorld(config?: APIConfig): World {
   const projectId =
     config?.projectConfig?.projectId || process.env.VERCEL_PROJECT_ID;
 
+  console.log(
+    `[workflow] Creating Vercel world: ` +
+      `projectId=${config?.projectConfig?.projectId ? 'set' : 'unset'}, ` +
+      `teamId=${config?.projectConfig?.teamId ? 'set' : 'unset'}, ` +
+      `token=${config?.token ? 'set' : 'unset'}, ` +
+      `VERCEL_DEPLOYMENT_ID=${process.env.VERCEL_DEPLOYMENT_ID ? 'set' : 'unset'}`
+  );
+
   return {
     ...createQueue(config),
     ...createStorage(config),

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -1,4 +1,4 @@
-import { QueueClient, DuplicateMessageError } from '@vercel/queue';
+import { DuplicateMessageError, QueueClient } from '@vercel/queue';
 import {
   MessageId,
   type Queue,
@@ -81,6 +81,11 @@ export function createQueue(config?: APIConfig): Queue {
   const headers = getHeaders(config, { usingProxy });
 
   const region = 'iad1';
+
+  console.log(
+    `[workflow] Queue routing: usingProxy=${usingProxy}, ` +
+      `target=${usingProxy ? `${baseUrl}/queues-proxy` : `default (${region}.vercel-queue.com)`}`
+  );
 
   const clientOptions = {
     region,

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -153,6 +153,8 @@ export interface HttpConfig {
   usingProxy: boolean;
 }
 
+let httpUrlLogged = false;
+
 export const getHttpUrl = (
   config?: APIConfig
 ): { baseUrl: string; usingProxy: boolean } => {
@@ -168,6 +170,16 @@ export const getHttpUrl = (
   const baseUrl = usingProxy
     ? customProxyUrl || defaultProxyUrl
     : `${defaultHost}/api`;
+
+  if (!httpUrlLogged) {
+    httpUrlLogged = true;
+    console.log(
+      `[workflow] HTTP routing: usingProxy=${usingProxy}, baseUrl=${baseUrl}, ` +
+        `projectId=${projectConfig?.projectId ? 'set' : 'unset'}, ` +
+        `teamId=${projectConfig?.teamId ? 'set' : 'unset'}`
+    );
+  }
+
   return { baseUrl, usingProxy };
 };
 
@@ -229,6 +241,10 @@ export async function makeRequest<T>({
   const method = options.method || 'GET';
   const { baseUrl, headers } = await getHttpConfig(config);
   const url = `${baseUrl}${endpoint}`;
+
+  if (process.env.DEBUG === '1') {
+    console.debug(`[workflow] makeRequest: ${method} ${url}`);
+  }
 
   // Parse server address and port from URL for OTEL attributes
   let serverAddress: string | undefined;

--- a/workbench/astro/vercel.json
+++ b/workbench/astro/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/example/vercel.json
+++ b/workbench/example/vercel.json
@@ -10,6 +10,7 @@
     }
   ],
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/express/vercel.json
+++ b/workbench/express/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/fastify/vercel.json
+++ b/workbench/fastify/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/hono/vercel.json
+++ b/workbench/hono/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/nest/vercel.json
+++ b/workbench/nest/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/nextjs-turbopack/vercel.json
+++ b/workbench/nextjs-turbopack/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/nextjs-webpack/vercel.json
+++ b/workbench/nextjs-webpack/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/nitro-v2/vercel.json
+++ b/workbench/nitro-v2/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/nitro-v3/vercel.json
+++ b/workbench/nitro-v3/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/nuxt/vercel.json
+++ b/workbench/nuxt/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/sveltekit/vercel.json
+++ b/workbench/sveltekit/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/swc-playground/vercel.json
+++ b/workbench/swc-playground/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }

--- a/workbench/vite/vercel.json
+++ b/workbench/vite/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "DEBUG": "1"
   }
 }


### PR DESCRIPTION
## Summary

- Adds startup and debug-level logs to `@workflow/world-vercel` to validate whether the Vercel API proxy (`api.vercel.com`) is being used during normal workflow execution (where it should **not** be)
- Helps diagnose an unexpected traffic spike through the proxy observed in production
- Enables `DEBUG=1` in all workbench app `vercel.json` files to activate per-request logging

## Changes

### `packages/world-vercel/src/`

| File | Log type | Gated? | What it logs |
|------|----------|--------|--------------|
| `utils.ts` | One-time startup | Always | `usingProxy`, `baseUrl`, `projectId`/`teamId` presence |
| `utils.ts` | Per-request | `DEBUG=1` | HTTP method + full URL for every `makeRequest()` call |
| `queue.ts` | Startup | Always | Whether queue routes through proxy or default VQS URL |
| `encryption.ts` | Per-request | `DEBUG=1` | Cross-deployment key fetches hitting `api.vercel.com` |
| `index.ts` | Startup | Always | World config summary (projectId, teamId, token, deploymentId) |

### `workbench/*/vercel.json` (14 files)

Added `"DEBUG": "1"` to the `env` block in all workbench apps.

## Expected output

Normal (non-proxy) execution:
```
[workflow] Creating Vercel world: projectId=unset, teamId=unset, token=unset, VERCEL_DEPLOYMENT_ID=set
[workflow] HTTP routing: usingProxy=false, baseUrl=https://vercel-workflow.com/api, projectId=unset, teamId=unset
[workflow] Queue routing: usingProxy=false, target=default (iad1.vercel-queue.com)
```

If proxy is unexpectedly active:
```
[workflow] HTTP routing: usingProxy=true, baseUrl=https://api.vercel.com/v1/workflow, projectId=set, teamId=set
[workflow] Queue routing: usingProxy=true, target=https://api.vercel.com/v1/workflow/queues-proxy
```