### PR TITLE
[web-shared][web] Move decrypt button inside the Trace viewer entity panel

### DIFF
--- a/.changeset/wide-ants-smash.md
+++ b/.changeset/wide-ants-smash.md
@@ -1,0 +1,6 @@
+---
+"@workflow/web-shared": patch
+"@workflow/web": patch
+---
+
+Move decrypt operation to the entity panel inside web-shared and wire it up to web via component callback.

--- a/packages/web-shared/src/components/sidebar/detail-card.tsx
+++ b/packages/web-shared/src/components/sidebar/detail-card.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 export function DetailCard({
@@ -42,14 +43,21 @@ export function DetailCard({
       onToggle={(e) => onToggle?.((e.target as HTMLDetailsElement).open)}
     >
       <summary
-        className={`cursor-pointer rounded-md border px-2.5 py-1.5 text-xs hover:brightness-95 ${summaryClassName ?? ''}`}
+        className={`cursor-pointer rounded-md border px-2.5 py-1.5 text-xs hover:brightness-95 [&::-webkit-details-marker]:hidden ${summaryClassName ?? ''}`}
         style={{
           borderColor: 'var(--ds-gray-300)',
           backgroundColor: 'var(--ds-gray-100)',
           color: 'var(--ds-gray-900)',
+          listStyle: 'none',
         }}
       >
-        {summary}
+        <span className="flex items-center gap-1.5">
+          <ChevronRight
+            size={14}
+            className="shrink-0 transition-transform group-open:rotate-90"
+          />
+          {summary}
+        </span>
       </summary>
       {/* Expanded content with connecting line */}
       <div className={`relative pl-6 mt-3 ${contentClassName ?? ''}`}>

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -2,12 +2,13 @@
 
 import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
 import clsx from 'clsx';
-import { Send, Zap } from 'lucide-react';
+import { Lock, Send, Unlock, Zap } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { AttributePanel } from './attribute-panel';
 import { EventsList } from './events-list';
 import { ResolveHookModal } from './resolve-hook-modal';
+import { isEncryptedMarker } from '../../lib/hydration';
 
 // Type guards for runtime validation of span attribute data
 function isStep(data: unknown): data is Step {
@@ -63,6 +64,7 @@ export function EntityDetailPanel({
   onLoadEventData,
   onResolveHook,
   encryptionKey,
+  onDecrypt,
   selectedSpan,
 }: {
   run: WorkflowRun;
@@ -96,6 +98,8 @@ export function EntityDetailPanel({
   ) => Promise<void>;
   /** Encryption key (available after Decrypt is clicked), used to re-load event data */
   encryptionKey?: Uint8Array;
+  /** Callback to initiate decryption of encrypted run data */
+  onDecrypt?: () => void;
   /** Info about the currently selected span from the trace viewer */
   selectedSpan: SelectedSpanInfo | null;
 }): React.JSX.Element | null {
@@ -195,6 +199,17 @@ export function EntityDetailPanel({
 
   const error = spanDetailError ?? undefined;
   const loading = spanDetailLoading ?? false;
+
+  const hasEncryptedFields = useMemo(() => {
+    if (!spanDetailData) return false;
+    const d = spanDetailData as Record<string, unknown>;
+    return (
+      isEncryptedMarker(d.input) ||
+      isEncryptedMarker(d.output) ||
+      isEncryptedMarker(d.error) ||
+      isEncryptedMarker(d.metadata)
+    );
+  }, [spanDetailData]);
 
   // Get the hook token for resolving (prefer fetched data, then hooks array fallback)
   const hookToken = useMemo(() => {
@@ -371,6 +386,33 @@ export function EntityDetailPanel({
               {resourceId}
             </p>
           </div>
+          {(hasEncryptedFields || encryptionKey) && onDecrypt && (
+            <button
+              type="button"
+              onClick={onDecrypt}
+              disabled={!!encryptionKey}
+              className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium transition-colors flex-shrink-0"
+              style={{
+                borderColor: encryptionKey
+                  ? 'var(--ds-green-400)'
+                  : 'var(--ds-gray-300)',
+                color: encryptionKey
+                  ? 'var(--ds-green-900)'
+                  : 'var(--ds-gray-900)',
+                backgroundColor: encryptionKey
+                  ? 'var(--ds-green-100)'
+                  : 'var(--ds-background-100)',
+                cursor: encryptionKey ? 'default' : 'pointer',
+              }}
+            >
+              {encryptionKey ? (
+                <Unlock className="h-3 w-3" />
+              ) : (
+                <Lock className="h-3 w-3" />
+              )}
+              {encryptionKey ? 'Decrypted' : 'Decrypt'}
+            </button>
+          )}
         </div>
       </div>
 

--- a/packages/web-shared/src/components/workflow-trace-view.tsx
+++ b/packages/web-shared/src/components/workflow-trace-view.tsx
@@ -894,6 +894,7 @@ export const WorkflowTraceViewer = ({
   hasMoreSpans = false,
   isLoadingMoreSpans = false,
   encryptionKey,
+  onDecrypt,
 }: {
   run: WorkflowRun;
   steps: Step[];
@@ -932,6 +933,8 @@ export const WorkflowTraceViewer = ({
   isLoadingMoreSpans?: boolean;
   /** Encryption key (available after Decrypt), threaded to event list for re-loading */
   encryptionKey?: Uint8Array;
+  /** Callback to initiate decryption of encrypted run data */
+  onDecrypt?: () => void;
 }) => {
   const [selectedSpan, setSelectedSpan] = useState<SelectedSpanInfo | null>(
     null
@@ -1256,6 +1259,7 @@ export const WorkflowTraceViewer = ({
                 onLoadEventData={onLoadEventData}
                 onResolveHook={onResolveHook}
                 encryptionKey={encryptionKey}
+                onDecrypt={onDecrypt}
                 selectedSpan={selectedSpan}
               />
             </ErrorBoundary>

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -5,7 +5,6 @@ import {
   EventListView,
   hydrateResourceIO,
   hydrateResourceIOWithKey,
-  isEncryptedMarker,
   StreamViewer,
   WorkflowTraceViewer,
 } from '@workflow/web-shared';
@@ -16,8 +15,6 @@ import {
   HelpCircle,
   List,
   Loader2,
-  Lock,
-  Unlock,
 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
@@ -541,49 +538,6 @@ export function RunDetailView({
 
               <div className="flex items-center justify-between gap-2">
                 <LiveStatus hasError={hasError} errorMessage={errorMessage} />
-                {/* Decrypt button — shown when any run/step data is encrypted */}
-                {(isEncryptedMarker(run.input) ||
-                  isEncryptedMarker(run.output) ||
-                  isEncryptedMarker(run.error) ||
-                  allSteps.some(
-                    (s) =>
-                      isEncryptedMarker(s.input) || isEncryptedMarker(s.output)
-                  )) && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={handleDecrypt}
-                          disabled={!!encryptionKey}
-                        >
-                          {encryptionKey ? (
-                            <Unlock className="h-4 w-4" />
-                          ) : (
-                            <Lock className="h-4 w-4" />
-                          )}
-                          {encryptionKey ? 'Decrypted' : 'Decrypt'}
-                        </Button>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {encryptionKey ? (
-                        <p>
-                          Data has been decrypted for this workflow run. All
-                          encrypted input, output, and event data is now visible
-                          across all tabs.
-                        </p>
-                      ) : (
-                        <p>
-                          This run&apos;s data is end-to-end encrypted. Decrypt
-                          to reveal input, output, and event data across all
-                          tabs for this workflow run.
-                        </p>
-                      )}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
                 <RunActionsButtons
                   env={env}
                   runId={runId}
@@ -763,6 +717,7 @@ export function RunDetailView({
                     hasMoreSpans={hasMoreTraceData}
                     isLoadingMoreSpans={isLoadingMoreTraceData}
                     encryptionKey={encryptionKey ?? undefined}
+                    onDecrypt={handleDecrypt}
                   />
                 </div>
               </ErrorBoundary>


### PR DESCRIPTION
### Changes

- Moved the Decrypt button from the run detail header to the entity detail side panel, shown when selecting a span with encrypted data
- The header button no longer worked because run data is now fetched with `resolveData: 'none'`, so `input`/`output` fields are never populated at the header level — the encrypted marker check always returned false
- The side panel fetches data with `resolveData: 'all'` via `useWorkflowResourceData`, making it the correct place to detect and act on encrypted fields
- Once the key is fetched from the side panel, it propagates to all tabs (trace, events, streams) via shared state

### Changed files

- `web-shared`: Added `onDecrypt` prop to `EntityDetailPanel` and `WorkflowTraceViewer`, detect encrypted fields in `spanDetailData`
- `web`: Removed header decrypt button and unused imports, wired `handleDecrypt` through `onDecrypt` prop

<img width="1158" height="1418" alt="CleanShot 2026-03-09 at 15 39 42@2x" src="https://github.com/user-attachments/assets/dfa90560-a315-43e4-8a80-faf34e877649" />
