### PR TITLE
feat: Add VS Code extension for Workflow DevKit TypeScript plugin

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "workflow-vscode",
+  "displayName": "Workflow DevKit",
+  "description": "TypeScript language support for Workflow DevKit — diagnostics, completions, hover info, and code fixes for workflow and step functions.",
+  "version": "4.2.0-beta.67",
+  "publisher": "vercel",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/workflow.git",
+    "directory": "packages/vscode"
+  },
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Linters"
+  ],
+  "keywords": [
+    "workflow",
+    "vercel",
+    "typescript",
+    "durable functions"
+  ],
+  "activationEvents": [],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "typescriptServerPlugins": [
+      {
+        "name": "workflow",
+        "enableForWorkspaceTypeScriptVersions": true
+      }
+    ]
+  },
+  "extensionDependencies": [],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "tsc --build --clean && rm -r dist ||:",
+    "typecheck": "tsc --noEmit",
+    "package": "vsce package --no-dependencies"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.75.0",
+    "@workflow/tsconfig": "workspace:*"
+  }
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,0 +1,23 @@
+import type * as vscode from 'vscode';
+
+/**
+ * VS Code extension for Workflow DevKit.
+ *
+ * This extension is intentionally minimal — its primary purpose is to
+ * activate the "workflow" TypeScript Language Service Plugin via the
+ * `typescriptServerPlugins` contribution in package.json. This ensures
+ * the plugin loads automatically in VS Code without requiring the user
+ * to configure `tsserver.useLocalTsdk` or any other manual setup.
+ *
+ * The actual diagnostics, completions, hover info, and code fixes are
+ * implemented in `@workflow/typescript-plugin`.
+ */
+
+export function activate(_context: vscode.ExtensionContext): void {
+  // The TypeScript plugin is contributed declaratively via package.json.
+  // No programmatic activation is needed.
+}
+
+export function deactivate(): void {
+  // Nothing to clean up.
+}

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@workflow/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -987,6 +987,15 @@ importers:
         specifier: 7.1.12
         version: 7.1.12(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
+  packages/vscode:
+    devDependencies:
+      '@types/vscode':
+        specifier: ^1.75.0
+        version: 1.110.0
+      '@workflow/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+
   packages/web:
     dependencies:
       '@react-router/node':
@@ -8470,6 +8479,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/vscode@1.110.0':
+    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
 
   '@types/watchpack@2.4.4':
     resolution: {integrity: sha512-SbuSavsPxfOPZwVHBgQUVuzYBe6+8KL7dwiJLXaj5rmv3DxktOMwX5WP1J6UontwUbewjVoc7pCgZvqy6rPn+A==}
@@ -23585,6 +23597,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/vscode@1.110.0': {}
 
   '@types/watchpack@2.4.4':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a minimal VS Code extension (`packages/vscode/`) that declaratively activates the `workflow` TypeScript Language Service Plugin
- Uses the `typescriptServerPlugins` contribution point with `enableForWorkspaceTypeScriptVersions: true`, so the plugin loads automatically without any user configuration
- Eliminates the need for users to manually select "Use Workspace Version" or configure `typescript.tsdk`

## Background

The `workflow` TypeScript plugin (`compilerOptions.plugins`) provides diagnostics, completions, hover info, and code fixes for workflow/step functions. However, VS Code uses its own bundled TypeScript by default, which silently ignores workspace `compilerOptions.plugins`. This means users get no errors, no completions, and no indication that anything is wrong.

This extension fixes that by telling VS Code to load the plugin regardless of which TypeScript version is active — zero configuration required from the user.

## Changes

- `packages/vscode/package.json` — Extension manifest with `typescriptServerPlugins` contribution
- `packages/vscode/src/extension.ts` — Minimal activate/deactivate (all work is declarative)
- `packages/vscode/tsconfig.json` — CJS build config