### PR TITLE
fix(core): pass resolved deploymentId to getEncryptionKeyForRun in start()

### DIFF
--- a/.changeset/fix-start-encryption-deploymentid.md
+++ b/.changeset/fix-start-encryption-deploymentid.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Fix `start()` not encrypting initial workflow input in external contexts (e2e tests, CLI). The resolved `deploymentId` was not being passed to `getEncryptionKeyForRun`, causing it to silently skip encryption when `deploymentId` was inferred from the environment rather than explicitly provided in options.

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -156,4 +156,64 @@ describe('start', () => {
       );
     });
   });
+
+  describe('encryption', () => {
+    let mockEventsCreate: ReturnType<typeof vi.fn>;
+    let mockQueue: ReturnType<typeof vi.fn>;
+    let mockGetEncryptionKeyForRun: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockEventsCreate = vi.fn().mockImplementation((runId) => {
+        return Promise.resolve({
+          run: { runId: runId ?? 'wrun_test123', status: 'pending' },
+        });
+      });
+      mockQueue = vi.fn().mockResolvedValue(undefined);
+      mockGetEncryptionKeyForRun = vi.fn().mockResolvedValue(undefined);
+
+      vi.mocked(getWorld).mockReturnValue({
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_resolved'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+        getEncryptionKeyForRun: mockGetEncryptionKeyForRun,
+      } as any);
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should pass resolved deploymentId to getEncryptionKeyForRun even when not in opts', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+
+      // Call start() without explicit deploymentId in options — it should
+      // be resolved from world.getDeploymentId() and forwarded to
+      // getEncryptionKeyForRun so the key can be fetched.
+      await start(validWorkflow, []);
+
+      expect(mockGetEncryptionKeyForRun).toHaveBeenCalledWith(
+        expect.stringMatching(/^wrun_/),
+        expect.objectContaining({
+          deploymentId: 'deploy_resolved',
+        })
+      );
+    });
+
+    it('should pass explicit deploymentId from opts to getEncryptionKeyForRun', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+
+      await start(validWorkflow, [], { deploymentId: 'deploy_explicit' });
+
+      expect(mockGetEncryptionKeyForRun).toHaveBeenCalledWith(
+        expect.stringMatching(/^wrun_/),
+        expect.objectContaining({
+          deploymentId: 'deploy_explicit',
+        })
+      );
+    });
+  });
 });

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -121,10 +121,14 @@ export async function start<TArgs extends unknown[], TResult>(
       // Resolve encryption key for the new run. The runId has already been
       // generated above (client-generated ULID) and will be used for both
       // key derivation and the run_created event. The World implementation
-      // uses the runId for per-run HKDF key derivation. The opts object is
-      // passed as opaque context so the World can read world-specific fields
-      // (e.g., deploymentId for world-vercel) needed for key resolution.
-      const rawKey = await world.getEncryptionKeyForRun?.(runId, { ...opts });
+      // uses the runId for per-run HKDF key derivation. We pass the resolved
+      // deploymentId (not just the raw opts) so the World can use it for
+      // key resolution even when deploymentId was inferred from the environment
+      // rather than explicitly provided in opts (e.g., in e2e test runners).
+      const rawKey = await world.getEncryptionKeyForRun?.(runId, {
+        ...opts,
+        deploymentId,
+      });
       const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
 
       // Create run via run_created event (event-sourced architecture)


### PR DESCRIPTION
## Summary

- **Fix**: `start()` was not encrypting the initial workflow input when called from external contexts (e2e test runners, CLI) because it passed the raw user-provided `opts` to `getEncryptionKeyForRun` instead of including the resolved `deploymentId`.
- The `deploymentId` was correctly resolved from `world.getDeploymentId()` on line 108, but never forwarded into the context object on line 127, so `getEncryptionKeyForRun` received `undefined` and silently skipped encryption.
- Step inputs/outputs were encrypted correctly because they execute inside the Vercel Function where the local HKDF path (`VERCEL=1` + `VERCEL_DEPLOYMENT_KEY`) is used instead.

## Changes

- **`packages/core/src/runtime/start.ts`**: Include the resolved `deploymentId` in the context passed to `getEncryptionKeyForRun`
- **`packages/core/src/runtime/start.test.ts`**: Add test cases verifying `getEncryptionKeyForRun` receives the resolved `deploymentId` both when inferred from the environment and when explicitly provided
- **Changeset**: `@workflow/core` patch