### PR TITLE
Fix flaky streamer test ENOENT when chunks directory does not exist yet

### DIFF
--- a/packages/world-local/src/streamer.test.ts
+++ b/packages/world-local/src/streamer.test.ts
@@ -507,8 +507,11 @@ describe('streamer', () => {
       });
 
       it('should not lose or duplicate chunks written during stream initialization (race condition test)', async () => {
-        // Run multiple iterations to increase probability of catching race conditions
-        for (let iteration = 0; iteration < 10; iteration++) {
+        // Run multiple iterations to increase probability of catching race conditions.
+        // Keep the count low — each iteration creates a fresh streamer with its own
+        // temp directory, and per-chunk I/O on Windows CI can be ~100-200ms which
+        // easily blows the timeout at higher counts.
+        for (let iteration = 0; iteration < 3; iteration++) {
           const { streamer } = await setupStreamer();
           const streamName = `race-${iteration}`;
 


### PR DESCRIPTION
## Summary

Fixes two issues causing the streamer race condition test to fail on Windows CI ([run](https://github.com/vercel/workflow/actions/runs/22967896166/job/66682234368)):

- **ENOENT in `onTestFinished` debug callback**: When the test fails before any chunks are written, the `streams/chunks` directory doesn't exist yet. The `readdir` call in the debug dump now catches `ENOENT` and falls back to an empty array instead of throwing a secondary error that masks the real failure.

- **Test timeout (20s) on slow Windows CI**: The race condition test ran 10 iterations, each creating a fresh temp directory and streamer. With per-chunk I/O latency of ~100-200ms on Windows CI runners, 10 iterations took ~22s, exceeding the 20s timeout. Reduced to 3 iterations which still provides race condition coverage while fitting comfortably within the timeout.