### PR TITLE
fix(cli): remove `-e` short flag collision in health command

### DIFF
--- a/.changeset/clever-maps-hop.md
+++ b/.changeset/clever-maps-hop.md
@@ -1,0 +1,5 @@
+---
+"@workflow/cli": patch
+---
+
+Fix `-e` short flag collision between `--endpoint` and `--env` in health command

--- a/packages/cli/src/commands/health.ts
+++ b/packages/cli/src/commands/health.ts
@@ -223,12 +223,11 @@ export default class Health extends BaseCommand {
 
   static flags = {
     endpoint: Flags.string({
-      char: 'e',
       description: 'Which endpoint(s) to check',
       options: ['workflow', 'step', 'both'],
       default: 'both',
       helpGroup: 'Health Check',
-      helpLabel: '-e, --endpoint',
+      helpLabel: '--endpoint',
       helpValue: ['workflow', 'step', 'both'],
     }),
     timeout: Flags.integer({


### PR DESCRIPTION
## Summary

- The health command's `endpoint` flag and the shared `env` flag both declared `char: 'e'`, causing ambiguity when using `-e` as a short flag
- Removed the `-e` short flag from `endpoint` so it unambiguously maps to `--env` (used for selecting `production`/`preview` Vercel environments)
- `--endpoint` must now be used in its long form; `-e` correctly maps to `--env` across all commands