### PR TITLE
fix(core): suppress stale WORKFLOW_VERCEL_* env var warning outside serverless runtime

### DIFF
--- a/.changeset/funny-doors-allow.md
+++ b/.changeset/funny-doors-allow.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Suppress stale `WORKFLOW_VERCEL_*` env var warning when running outside Vercel serverless (e.g. CLI, web observability app)

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -34,16 +34,18 @@ export const createWorld = (): World => {
   const targetWorld = resolveWorkflowTargetWorld();
 
   if (isVercelWorldTarget(targetWorld)) {
-    // Warn if WORKFLOW_VERCEL_* env vars are set — they have no effect at
-    // runtime and likely indicate a misconfiguration (user manually added
-    // them as Vercel project env vars, which is not needed).
+    // Warn if WORKFLOW_VERCEL_* env vars are set inside a Vercel serverless
+    // function (VERCEL=1) — they have no effect at runtime and likely indicate
+    // a misconfiguration (user manually added them as Vercel project env vars,
+    // which is not needed). We gate on VERCEL=1 so the warning does not fire
+    // when the CLI or web observability app sets these env vars intentionally.
     const staleEnvVars = [
       'WORKFLOW_VERCEL_PROJECT',
       'WORKFLOW_VERCEL_TEAM',
       'WORKFLOW_VERCEL_AUTH_TOKEN',
       'WORKFLOW_VERCEL_ENV',
     ].filter((key) => process.env[key]);
-    if (staleEnvVars.length > 0) {
+    if (staleEnvVars.length > 0 && process.env.VERCEL === '1') {
       console.warn(
         `[workflow] Warning: ${staleEnvVars.join(', ')} env var(s) ` +
           'are set but have no effect at runtime. These are only used by the Workflow CLI. ' +


### PR DESCRIPTION
## Summary

- Gate the `WORKFLOW_VERCEL_*` stale env var warning on `VERCEL=1` so it only fires inside Vercel serverless functions
- The warning was incorrectly shown when the Workflow CLI or web observability app was running, where those env vars are intentionally set
- `VERCEL=1` is already used elsewhere in the codebase (e.g. `packages/world-vercel/src/encryption.ts`) to distinguish serverless runtime from external tooling