### PR TITLE
Fix Windows ERR_UNSUPPORTED_ESM_URL_SCHEME in dynamic imports

### DIFF
--- a/.changeset/fix-windows-esm-dynamic-import.md
+++ b/.changeset/fix-windows-esm-dynamic-import.md
@@ -1,0 +1,7 @@
+---
+"@workflow/web": patch
+"@workflow/nest": patch
+"@workflow/vitest": patch
+---
+
+Fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows by converting absolute file paths to `file://` URLs before passing them to dynamic `import()`

--- a/packages/nest/src/workflow.controller.ts
+++ b/packages/nest/src/workflow.controller.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { All, Controller, Get, Post, Req, Res } from '@nestjs/common';
 import { join } from 'pathe';
 
@@ -88,7 +89,9 @@ export class WorkflowController {
   @Post('step')
   async handleStep(@Req() req: any, @Res() res: any) {
     const outDir = getOutDir();
-    const { POST } = await import(join(outDir, 'steps.mjs'));
+    const { POST } = await import(
+      pathToFileURL(join(outDir, 'steps.mjs')).href
+    );
     const webRequest = toWebRequest(req);
     const webResponse = await POST(webRequest);
     await sendWebResponse(res, webResponse);
@@ -97,7 +100,9 @@ export class WorkflowController {
   @Post('flow')
   async handleFlow(@Req() req: any, @Res() res: any) {
     const outDir = getOutDir();
-    const { POST } = await import(join(outDir, 'workflows.mjs'));
+    const { POST } = await import(
+      pathToFileURL(join(outDir, 'workflows.mjs')).href
+    );
     const webRequest = toWebRequest(req);
     const webResponse = await POST(webRequest);
     await sendWebResponse(res, webResponse);
@@ -106,7 +111,9 @@ export class WorkflowController {
   @All('webhook/:token')
   async handleWebhook(@Req() req: any, @Res() res: any) {
     const outDir = getOutDir();
-    const { POST } = await import(join(outDir, 'webhook.mjs'));
+    const { POST } = await import(
+      pathToFileURL(join(outDir, 'webhook.mjs')).href
+    );
     const webRequest = toWebRequest(req);
     const webResponse = await POST(webRequest);
     await sendWebResponse(res, webResponse);

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,6 +1,6 @@
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { BaseBuilder, createBaseBuilderConfig } from '@workflow/builders';
 import type { Run } from '@workflow/core/runtime';
 import { setWorld } from '@workflow/core/runtime';
@@ -134,10 +134,10 @@ export async function setupWorkflowTests(
   const outDir = getOutDir(cwd);
 
   const workflowsModule = await import(
-    /* @vite-ignore */ join(outDir, 'workflows.mjs')
+    /* @vite-ignore */ pathToFileURL(join(outDir, 'workflows.mjs')).href
   );
   const stepsModule = await import(
-    /* @vite-ignore */ join(outDir, 'steps.mjs')
+    /* @vite-ignore */ pathToFileURL(join(outDir, 'steps.mjs')).href
   );
 
   const workflowHandler = workflowsModule.POST as (

--- a/packages/web/server.js
+++ b/packages/web/server.js
@@ -9,7 +9,7 @@
  */
 
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import express from 'express';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -18,7 +18,9 @@ const buildDir = path.resolve(__dirname, 'build');
 async function createApp() {
   // Import the compiled server build, which exports { app } (an Express app
   // with the React Router request handler already mounted by server/app.ts)
-  const { app } = await import(path.join(buildDir, 'server/index.js'));
+  const { app } = await import(
+    pathToFileURL(path.join(buildDir, 'server/index.js')).href
+  );
 
   // Add static file serving in front of the React Router handler.
   // We create a wrapper app so static middleware runs first.


### PR DESCRIPTION
## Summary

Closes #1295

On Windows, Node.js ESM `import()` requires `file://` URLs for absolute file paths. When a Windows absolute path like `D:\path\to\file.js` is passed directly to `import()`, the drive letter `D:` is interpreted as a URL scheme, causing `ERR_UNSUPPORTED_ESM_URL_SCHEME`.

This fix wraps all dynamic `import()` calls that use computed absolute file paths with `pathToFileURL()` from `node:url`, converting them to proper `file://` URLs before importing. This is cross-platform safe — on macOS/Linux it produces `file:///path/to/file`, and on Windows it produces `file:///D:/path/to/file`.

## Changes

- **`packages/web/server.js`** — Fix dynamic import of the React Router server build (primary fix for the reported `workflow web` crash)
- **`packages/nest/src/workflow.controller.ts`** — Fix dynamic imports of workflow step/flow/webhook bundles
- **`packages/vitest/src/index.ts`** — Fix dynamic imports of built workflow/step bundles