### PR TITLE
Skip CLI update check in CI e2e tests

### DIFF
--- a/.changeset/skip-update-check-env.md
+++ b/.changeset/skip-update-check-env.md
@@ -1,0 +1,5 @@
+---
+"@workflow/cli": patch
+---
+
+Support `WORKFLOW_NO_UPDATE_CHECK=1` env var to skip the npm registry version check on startup

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -246,10 +246,17 @@ async function isCacheValid(
 /**
  * Check for updates with filesystem caching
  * Cache is valid unless the local version changes
+ *
+ * Set WORKFLOW_NO_UPDATE_CHECK=1 to skip the update check entirely.
  */
 export async function checkForUpdateCached(
   currentVersion: string
 ): Promise<VersionCheckResult> {
+  if (process.env.WORKFLOW_NO_UPDATE_CHECK === '1') {
+    logger.debug('Skipping update check (WORKFLOW_NO_UPDATE_CHECK=1)');
+    return { currentVersion, needsUpdate: false };
+  }
+
   const cacheFile = getVersionCheckCacheFile();
 
   // Check if cache is valid

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -137,6 +137,7 @@ const awaitCommand = async (
         env: {
           ...process.env,
           DEBUG: '1',
+          WORKFLOW_NO_UPDATE_CHECK: '1',
           ...envOverrides,
         },
       });


### PR DESCRIPTION
## Summary

- The Vercel prod e2e tests have become very flaky, with random tests failing due to CLI subprocess SIGTERM across all 11+ matrix variants (see [example run](https://github.com/vercel/workflow/actions/runs/23015794852/job/66838588262?pr=1347))
- Root cause: every `cliInspectJson` call spawns a full CLI subprocess with a 20s timeout. The CLI performs an npm registry version check on startup (`fetch('https://registry.npmjs.org/@workflow/cli')`) which can hang under load, consuming the entire timeout budget before the actual API call even begins
- Adds `WORKFLOW_NO_UPDATE_CHECK=1` env var to `@workflow/cli` to skip the version check, and sets it in the e2e test harness