### PR TITLE
ci: use dedicated GitHub App token instead of shared PAT

### DIFF
--- a/.github/workflows/dispatch-front-workflow-release-pr.yml
+++ b/.github/workflows/dispatch-front-workflow-release-pr.yml
@@ -19,6 +19,15 @@ jobs:
       github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: vercel
+          repositories: workflow,front
+
       - name: Checkout workflow repo
         uses: actions/checkout@v4
 
@@ -51,7 +60,7 @@ jobs:
           WORKFLOW_VERSION: ${{ steps.version.outputs.version }}
           DOCS_DEPLOYMENT_URL: ${{ steps.waitForDocsDeployment.outputs.deployment-url }}
         with:
-          github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const trigger = require('./scripts/trigger-front-release-workflow-dispatch.cjs');
             await trigger({ github, context });
@@ -63,6 +72,15 @@ jobs:
       github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: vercel
+          repositories: workflow,front
+
       - name: Checkout workflow repo
         uses: actions/checkout@v4
 
@@ -78,7 +96,7 @@ jobs:
           WORKFLOW_VERSION: ""
           DOCS_DEPLOYMENT_URL: ""
         with:
-          github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const trigger = require('./scripts/trigger-front-release-workflow-dispatch.cjs');
             await trigger({ github, context });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,18 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -54,7 +61,7 @@ jobs:
           publish: pnpm ci:publish
           createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Add latest dist-tag to published packages
         if: steps.changesets.outputs.published == 'true'
@@ -81,7 +88,7 @@ jobs:
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           # Generate release notes (PUBLISHED_PACKAGES filters to only include packages from this release)


### PR DESCRIPTION
## Summary

- Replace the shared `GH_TOKEN_PULL_REQUESTS` PAT with a dedicated GitHub App token generated per-run via `actions/create-github-app-token`
- The shared org PAT was being rate limited by GitHub due to noisy neighbors within the company also using the same token
- The GitHub App gets its own isolated rate limit bucket (5,000 req/hr per installation), uses short-lived auto-rotating tokens, and shows a `[bot]` badge on PRs/commits

## Changes

**`.github/workflows/release.yml`**
- Added `Generate GitHub App Token` step using `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` secrets
- Replaced all 3 `GH_TOKEN_PULL_REQUESTS` references (checkout, changesets action, GitHub release creation)

**`.github/workflows/dispatch-front-workflow-release-pr.yml`**
- Added `Generate GitHub App Token` step to both `dispatch-front-sync` and `dispatch-front-close` jobs with cross-repo access to `vercel/workflow` and `vercel/front`
- Replaced both `GH_TOKEN_PULL_REQUESTS` references

## Prerequisites

The following have already been set up:
- GitHub App created and installed on `vercel/workflow` and `vercel/front`
- `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` repository secrets configured

## Follow-up

- Remove the `GH_TOKEN_PULL_REQUESTS` secret from this repo once verified working