### PR TITLE
ci: configure git identity for GitHub App bot account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Configure Git identity
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:


### PR DESCRIPTION
## Summary

- Configure `git user.name` and `git user.email` in the release workflow so that the "Version Packages" commit created by `changesets/action` is attributed to `workflow-devkit-release-bot[bot]` instead of the default `github-actions[bot]`

Follow-up to #1351.