### PR TITLE
ci: fix git identity for changesets Version Packages commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
           version: pnpm ci:version
           publish: pnpm ci:publish
           createGithubReleases: false
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary

- Set `setupGitUser: false` on `changesets/action` to prevent it from overwriting our git config with the hardcoded `github-actions[bot]` identity
- The git identity is already configured in a prior step using the `app-slug` output from `actions/create-github-app-token`, but `changesets/action` was silently overwriting it via its `setupGitUser` default (`true`)

This ensures the "Version Packages" commit on the release PR is attributed to the GitHub App bot account.

Follow-up to #1351 and #1356.