### PR TITLE
Skip OIDC call in fetchRunKey when token already available

### DIFF
--- a/.changeset/fair-owls-tap.md
+++ b/.changeset/fair-owls-tap.md
@@ -2,4 +2,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Skip OIDC call in `fetchRunKey` when token is already available
+Reorder token resolution in `fetchRunKey` and `resolveLatestDeploymentId` to prefer `options.token` / `VERCEL_TOKEN` before calling OIDC, skipping the OIDC network call when a token is already available

--- a/packages/world-vercel/src/encryption.ts
+++ b/packages/world-vercel/src/encryption.ts
@@ -99,9 +99,10 @@ export async function fetchRunKey(
     teamId?: string;
   }
 ): Promise<Uint8Array | undefined> {
-  // Authenticate via provided token (CLI/config), OIDC token (runtime),
-  // or VERCEL_TOKEN env var (external tooling).
-  // Skip the OIDC network call when a token is already available.
+  // Authenticate via provided token (CLI/config), VERCEL_TOKEN env var
+  // (external tooling), or OIDC token (runtime) — in that order.
+  // OIDC is last to avoid an unnecessary network call when a token is
+  // already available (e.g. CLI or CI contexts).
   const token =
     options?.token ??
     process.env.VERCEL_TOKEN ??

--- a/packages/world-vercel/src/resolve-latest-deployment.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.ts
@@ -35,9 +35,10 @@ export function createResolveLatestDeploymentId(
       );
     }
 
-    // Authenticate via provided token (CLI/config), OIDC token (runtime),
-    // or VERCEL_TOKEN env var (external tooling).
-    // Skip the OIDC network call when a token is already available.
+    // Authenticate via provided token (CLI/config), VERCEL_TOKEN env var
+    // (external tooling), or OIDC token (runtime) — in that order.
+    // OIDC is last to avoid an unnecessary network call when a token is
+    // already available (e.g. CLI or CI contexts).
     const token =
       config?.token ??
       process.env.VERCEL_TOKEN ??


### PR DESCRIPTION
## Summary

- Extracted from #1360: reorders the token fallback chain in `@workflow/world-vercel` so that `options.token` and `VERCEL_TOKEN` are checked before calling `getVercelOidcToken()`
- Avoids an unnecessary (and potentially hanging) OIDC call in CLI/e2e contexts where a token is always provided