### PR TITLE
Fix webpack workbench workflow discovery on Vercel

### DIFF
--- a/workbench/nextjs-webpack/pages/api/trigger-pages.ts
+++ b/workbench/nextjs-webpack/pages/api/trigger-pages.ts
@@ -4,7 +4,9 @@ import {
   WorkflowRunFailedError,
   WorkflowRunNotCompletedError,
 } from 'workflow/internal/errors';
-import { allWorkflows } from '@/_workflows';
+// Use a relative import instead of @/_workflows path alias because esbuild's
+// discovery build cannot resolve tsconfig path aliases without baseUrl set.
+import { allWorkflows } from '../../_workflows';
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## Summary

The esbuild discovery build in the eager builder was unable to resolve the `@/_workflows` path alias in `pages/api/trigger-pages.ts`, causing workflow files imported only through `_workflows.ts` to be missing from the manifest and bundles on Vercel deployments.

This meant only 5 of 87 workflows were discovered (those directly imported by App Router routes), while all workflows reachable only through `_workflows.ts` — including the `100_durable_agent_e2e.ts` agent workflows — were silently dropped.

## Root Cause

esbuild requires `baseUrl` to be set in `tsconfig.json` for `paths` aliases to work. The webpack workbench's tsconfig has `"paths": { "@/*": ["./*"] }` but no `baseUrl`, so esbuild's discovery build could not resolve `@/_workflows`. The discovery build's catch-all error handler silently marked it as external, preventing the import graph from being traced.

## Fix

Use a relative import (`../../_workflows`) instead of the `@/_workflows` path alias in the webpack workbench's `pages/api/trigger-pages.ts`, so the esbuild discovery can trace through it without relying on tsconfig path alias resolution.