### PR TITLE
fix: globalThis singleton for step context storage (#839)

### DIFF
--- a/packages/core/src/step/context-storage.ts
+++ b/packages/core/src/step/context-storage.ts
@@ -3,10 +3,24 @@ import type { CryptoKey } from '../encryption.js';
 import type { WorkflowMetadata } from '../workflow/get-workflow-metadata.js';
 import type { StepMetadata } from './get-step-metadata.js';
 
-export const contextStorage = /* @__PURE__ */ new AsyncLocalStorage<{
+// Use a globalThis singleton so the context storage survives esbuild's
+// module scope duplication (same pattern as the step registry in private.ts).
+const CONTEXT_STORAGE = Symbol.for('@workflow/core//step-context-storage');
+
+type StepContext = {
   stepMetadata: StepMetadata;
   workflowMetadata: WorkflowMetadata;
   ops: Promise<void>[];
   closureVars?: Record<string, any>;
   encryptionKey?: CryptoKey;
-}>();
+};
+
+const _global: typeof globalThis & {
+  [CONTEXT_STORAGE]?: AsyncLocalStorage<StepContext>;
+} = globalThis;
+
+if (!_global[CONTEXT_STORAGE]) {
+  _global[CONTEXT_STORAGE] = new AsyncLocalStorage<StepContext>();
+}
+
+export const contextStorage = _global[CONTEXT_STORAGE];

--- a/packages/world-testing/src/util.mts
+++ b/packages/world-testing/src/util.mts
@@ -33,6 +33,12 @@ export async function startServer(opts: { world: string }) {
       ...process.env,
       WORKFLOW_TARGET_WORLD: opts.world,
       CONTROL_FD: '3',
+      // Serialize queue processing to prevent concurrent replays from
+      // seeing each other's in-flight events (unconsumed event errors).
+      // In production, each function invocation is isolated — this
+      // simulates that isolation in the local world.
+      WORKFLOW_LOCAL_QUEUE_CONCURRENCY:
+        process.env.WORKFLOW_LOCAL_QUEUE_CONCURRENCY ?? '1',
     },
   });
   onTestFinished(() => {


### PR DESCRIPTION
Closes #839

Convert contextStorage AsyncLocalStorage from module-scoped to a globalThis singleton using Symbol.for(). This prevents esbuild's module scope duplication from creating separate ALS instances, which caused AsyncLocalStorage.getStore() to return undefined inside tool execute() callbacks.

Also in https://github.com/vercel/workflow/pull/1338 out of necessity, but duplicated out to land earlier and test separately.