### PR TITLE
fix(web-shared): ensure arrow container is square in event list view

### DIFF
--- a/packages/web-shared/src/components/event-list-view.tsx
+++ b/packages/web-shared/src/components/event-list-view.tsx
@@ -643,8 +643,11 @@ function RowsSkeleton() {
             />
           </div>
           {/* Chevron placeholder */}
-          <div className="w-5 flex-shrink-0 flex items-center justify-center">
-            <Skeleton className="w-5 h-5" style={{ borderRadius: 4 }} />
+          <div
+            className="flex-shrink-0 flex items-center justify-center"
+            style={{ width: 20, height: 20 }}
+          >
+            <Skeleton style={{ width: 20, height: 20, borderRadius: 4 }} />
           </div>
           {/* Time */}
           <div className="min-w-0 px-4" style={{ flex: '2 1 0%' }}>
@@ -933,8 +936,10 @@ function EventRow({
         >
           {/* Expand chevron indicator */}
           <div
-            className="flex items-center justify-center w-5 h-5 flex-shrink-0 rounded"
+            className="flex items-center justify-center flex-shrink-0 rounded"
             style={{
+              width: 20,
+              height: 20,
               border: '1px solid var(--ds-gray-400)',
             }}
           >
@@ -1039,7 +1044,7 @@ function EventRow({
             continuationOnly
           />
           {/* Spacer for chevron column */}
-          <div className="w-5 flex-shrink-0" />
+          <div className="flex-shrink-0" style={{ width: 20 }} />
           <div
             className="flex-1 my-1.5 mr-3 ml-2 py-2 rounded-md border overflow-hidden"
             style={{
@@ -1353,7 +1358,7 @@ export function EventListView({
           style={{ borderColor: 'var(--ds-gray-alpha-200)' }}
         >
           <div className="flex-shrink-0" style={{ width: GUTTER_WIDTH }} />
-          <div className="w-5 flex-shrink-0" />
+          <div className="flex-shrink-0" style={{ width: 20 }} />
           <div className="min-w-0 px-4" style={{ flex: '2 1 0%' }}>
             <Skeleton className="h-3" style={{ width: 40 }} />
           </div>
@@ -1487,7 +1492,7 @@ export function EventListView({
         }}
       >
         <div className="flex-shrink-0" style={{ width: GUTTER_WIDTH }} />
-        <div className="w-5 flex-shrink-0" />
+        <div className="flex-shrink-0" style={{ width: 20 }} />
         <div className="min-w-0 px-4" style={{ flex: '2 1 0%' }}>
           Time
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixed the arrow container in the event list view to be a perfect square instead of a rectangle.

The expand chevron indicator containers were using Tailwind's `w-5 h-5` utility classes, but the actual rendered dimensions were not perfectly square (appearing wider than tall as shown in the reported screenshot).

Changed to explicit inline styles (`width: 20, height: 20`) to ensure the containers maintain a 20×20 pixel square aspect ratio consistently, regardless of any CSS class conflicts or flexbox layout effects.

**Changes:**
- Updated the main expand chevron indicator container to use explicit width/height
- Updated the skeleton placeholder to match
- Updated related spacer elements for consistency

### How did you test your changes?

This is a styling-only change for the event list view component in `@workflow/web-shared`. The change replaces Tailwind utility classes with equivalent inline styles to ensure consistent square dimensions.

Verified that:
- TypeScript syntax is valid
- The explicit pixel values (20px × 20px) match the original Tailwind `w-5 h-5` values (1.25rem = 20px)
- All related spacer elements use consistent widths for proper alignment

### PR Checklist - Required to merge

- [ ] 📦 `pnpm changeset` was run to create a changelog for this PR
  - During beta, we only use "patch" mode for changes. Don't tag minor/major versions.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0AFKL7AT9N/p1773700482413499?thread_ts=1773700482.413499&cid=C0AFKL7AT9N)

<div><a href="https://cursor.com/agents/bc-ac247aee-e473-5d12-9f64-31233f7d03b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac247aee-e473-5d12-9f64-31233f7d03b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

