### PR TITLE
[core] Don't fail to queue on 409 responses

### DIFF
--- a/.changeset/twelve-poets-grow.md
+++ b/.changeset/twelve-poets-grow.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Don't fail to queue on 409 responses

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -162,6 +162,18 @@ export function workflowEntrypoint(
                     );
                   }
                 } catch (err) {
+                  // 409/410: run was concurrently completed/failed/cancelled
+                  // between the GET and the run_started event creation
+                  if (
+                    WorkflowAPIError.is(err) &&
+                    (err.status === 409 || err.status === 410)
+                  ) {
+                    runtimeLogger.info(
+                      'Run already finished during setup, skipping',
+                      { workflowRunId: runId, message: err.message }
+                    );
+                    return;
+                  }
                   if (err instanceof WorkflowRuntimeError) {
                     runtimeLogger.error(
                       'Fatal runtime error during workflow setup',

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -134,7 +134,7 @@ export async function handleSuspension({
           }
         } catch (err) {
           if (WorkflowAPIError.is(err)) {
-            if (err.status === 410) {
+            if (err.status === 409 || err.status === 410) {
               runtimeLogger.info(
                 'Workflow run already completed, skipping hook',
                 {
@@ -166,7 +166,7 @@ export async function handleSuspension({
           await world.events.create(runId, hookDisposedEvent);
         } catch (err) {
           if (WorkflowAPIError.is(err)) {
-            if (err.status === 410) {
+            if (err.status === 409 || err.status === 410) {
               runtimeLogger.info(
                 'Workflow run already completed, skipping hook disposal',
                 {


### PR DESCRIPTION
Noticed error logs from 409s falling through the queue, which are confusing for users. Log example:

```
Queue callback error: Error [WorkflowAPIError]: Cannot update workflow run wrun_01KKVYQ2TNA4PCEH9MA0SHN7DV with status 'completed'. Operation requires status 'running' or 'pending'.
    at cP (.next/server/chunks/[root-of-the-server]__fd848f42._.js:63:41)
    at async gA (.next/server/chunks/[root-of-the-server]__fd848f42._.js:67:3954)
    at async (.next/server/chunks/[root-of-the-server]__fd848f42._.js:86:8)
    at async (.next/server/chunks/[root-of-the-server]__fd848f42._.js:60:148157)
    at async (.next/server/chunks/[root-of-the-server]__fd848f42._.js:60:146659)
    at async (.next/server/chunks/[root-of-the-server]__fd848f42._.js:83:2206)
    at async default (.next/server/chunks/[root-of-the-server]__fd848f42._.js:67:7813)
    at async u7.processMessage (.next/server/chunks/[root-of-the-server]__fd848f42._.js:62:13992)
    at async u7.consume (.next/server/chunks/[root-of-the-server]__fd848f42._.js:62:15197) {
  cause: undefined,
  status: 409,
  code: undefined,
  url: 'https://vercel-workflow.com/api/v1/runs/wrun_01KKVYQ2TNA4PCEH9MA0SHN7DV'
}
```

so I ensures we catch and gracefully return for these cases. I had Claude run an eval on whether this blocks any real use cases. Eval below:

---

## Concurrent scenarios and why skipping is safe

### Scenario 1: Two handlers race on `run_started`

Two queue messages for the same run arrive while it's still `pending`. Both handlers call `world.runs.get()`, see `pending`, and try to create a `run_started` event.

```
Handler A: runs.get() → pending → events.create(run_started) → ✅ succeeds → continues replay loop
Handler B: runs.get() → pending → events.create(run_started) → ❌ 409 → returns early
```

**Why it's safe:** Handler A transitions the run to `running` and enters the replay loop. The replay loop either completes the workflow or suspends it with queued continuations. Handler B's early exit is a no-op — Handler A guarantees progress.

**Location:** `runtime.ts` catch block after `run_started` event creation.

### Scenario 2: Two handlers race on `run_completed`

Two concurrent replay loops both reach the end of the workflow and try to create `run_completed`.

```
Handler A: events.create(run_completed) → ✅ succeeds → returns
Handler B: events.create(run_completed) → ❌ 409 → logs info → returns
```

**Why it's safe:** The run is completed. Both handlers return. No continuation is needed.

**Location:** `runtime.ts` catch block after `run_completed` event creation.

### Scenario 3: Two handlers race on `run_failed`

Same as Scenario 2 but for failure. Both handlers detect an error in user code and try to fail the run.

```
Handler A: events.create(run_failed) → ✅ succeeds → returns
Handler B: events.create(run_failed) → ❌ 409 → logs info → returns
```

**Why it's safe:** The run is failed. Both handlers return. No continuation is needed.

**Location:** `runtime.ts` catch block after `run_failed` event creation.

### Scenario 4: Run completes while another handler creates hooks

Handler A completes the workflow. Handler B (from an earlier queue message) is still in the suspension handler creating hook events.

```
Handler A: events.create(run_completed) → ✅ run is now terminal
Handler B: events.create(hook_created)  → ❌ 409 (run terminal) → logs info, continues
         → returns from handleSuspension with pendingSteps
         → tries to execute inline step
         → events.create(step_started)  → ❌ 410 (run gone) → returns { type: 'gone' }
         → caller returns
```

**Why it's safe:** Handler A already completed the workflow. Handler B's hook creation fails, and if any steps were queued, the step executor receives 410 on `step_started` and exits gracefully. The 410 on `step_started` is the safety net — even if the suspension handler returns pending steps after a 409, the step executor won't make progress on a finished run.

**Location:** `suspension-handler.ts` catch blocks for `hook_created` and `hook_disposed`; `step-executor.ts` 410 handling on `step_started`.

### Scenario 5: Two handlers race on `wait_completed`

During the replay loop, both handlers see an elapsed wait and try to complete it.

```
Handler A: events.create(wait_completed) → ✅ succeeds → adds event to cache → continues replay
Handler B: events.create(wait_completed) → ❌ 409 → continue (skip this wait) → continues replay
```

**Why it's safe:** Both handlers continue their replay loops. The event log is the same for both (the winning handler's `wait_completed` is visible to future reads). Subsequent replay from either handler converges to the same state because replay is deterministic and event-sourced.

**Location:** `runtime.ts` wait completion loop with `continue` on 409.

### Scenario 6: Two handlers race on `step_completed`

Two handlers execute the same step concurrently (e.g., both received the step's queue message). Both finish execution and try to create `step_completed`.

```
Handler A: events.create(step_completed) → ✅ succeeds → queues workflow continuation → returns
Handler B: events.create(step_completed) → ❌ 409 → returns WITHOUT queuing continuation
```

**Why it's safe:** Handler A queues the workflow continuation. Handler B does not — this is correct because only one continuation should be queued per step completion. If both queued, there would be redundant replay (which is safe but wasteful).

**Location:** `step-executor.ts` catch on `step_completed` event creation.

### Scenario 7: Two handlers race on `step_started`

Two handlers try to start the same step. Handler A wins; Handler B gets 409 because the step transitioned to a terminal state.

```
Handler A: events.create(step_started) → ✅ succeeds → executes step → queues continuation
Handler B: events.create(step_started) → ❌ 409 (step terminal) → returns { type: 'skipped' }
         → caller queues workflow continuation (runtime.ts replay loop)
```

**Why it's safe:** Both handlers ensure workflow continuation — Handler A via step completion, Handler B via the replay loop re-queuing the workflow. The redundant replay is safe because event-sourced replay is convergent.

**Location:** `step-executor.ts` 409 handling on `step_started`.

### Scenario 8: `step_created`/`wait_created` duplicate

During suspension handling, two concurrent replays both try to create the same step or wait event.

```
Handler A: events.create(step_created) → ✅ succeeds
Handler B: events.create(step_created) → ❌ 409 → logs info → continues
```

**Why it's safe:** The step/wait entity already exists. The suspension handler continues processing other items. The step will be executed by whichever handler picks it up from the queue.

**Location:** `suspension-handler.ts` catch blocks for `step_created` and `wait_created`.