### PR TITLE
[o11y] Polish display when run data has expired

### DIFF
--- a/.changeset/rotten-bats-smell.md
+++ b/.changeset/rotten-bats-smell.md
@@ -1,0 +1,7 @@
+---
+"@workflow/web-shared": patch
+"@workflow/core": patch
+"@workflow/cli": patch
+---
+
+Improve display when run data has expired

--- a/packages/cli/src/lib/inspect/hydration.ts
+++ b/packages/cli/src/lib/inspect/hydration.ts
@@ -12,6 +12,7 @@ import {
   extractClassName,
   hydrateResourceIO as hydrateResourceIOGeneric,
   isEncryptedData,
+  isExpiredStub,
   observabilityRevivers,
   type Revivers,
 } from '@workflow/core/serialization-format';
@@ -98,6 +99,39 @@ const ENCRYPTED_REF = new EncryptedDataRef();
 /** Check if a value is an EncryptedDataRef (for custom table formatting in CLI) */
 export function isEncryptedRef(value: unknown): value is EncryptedDataRef {
   return value instanceof EncryptedDataRef;
+}
+
+// ---------------------------------------------------------------------------
+// CLI expired data placeholder with custom inspect
+// ---------------------------------------------------------------------------
+
+/**
+ * Placeholder object for expired data fields in CLI output.
+ *
+ * Uses `util.inspect.custom` to render as a styled, unquoted string
+ * (e.g., dim gray "<data expired>") instead of a raw stub object.
+ * Also provides `toJSON()` for `--json` output.
+ */
+class ExpiredDataRef {
+  [inspect.custom](): string {
+    return chalk.gray('<data expired>');
+  }
+
+  toJSON(): string {
+    return '<data expired>';
+  }
+
+  toString(): string {
+    return '<data expired>';
+  }
+}
+
+/** Singleton expired data placeholder for CLI display */
+const EXPIRED_REF = new ExpiredDataRef();
+
+/** Check if a value is an ExpiredDataRef (for custom table formatting in CLI) */
+export function isExpiredRef(value: unknown): value is ExpiredDataRef {
+  return value instanceof ExpiredDataRef;
 }
 
 // ---------------------------------------------------------------------------
@@ -251,27 +285,30 @@ async function maybeDecryptFields<
 // Public API
 // ---------------------------------------------------------------------------
 
+/** Replace a single field value with a display ref if it's encrypted or expired. */
+function toDisplayRef(value: unknown): unknown {
+  if (isEncryptedData(value)) return ENCRYPTED_REF;
+  if (isExpiredStub(value)) return EXPIRED_REF;
+  return value;
+}
+
 /**
- * Replace encrypted Uint8Array values with EncryptedDataRef objects
- * in known data fields so they render with custom inspect styling.
+ * Replace encrypted Uint8Array values and expired stubs with styled
+ * ref objects in known data fields for custom inspect rendering.
  */
-function replaceEncryptedWithRef<T>(resource: T): T {
+function replaceEncryptedAndExpiredWithRef<T>(resource: T): T {
   if (!resource || typeof resource !== 'object') return resource;
   const r = resource as Record<string, unknown>;
   const result = { ...r };
 
   for (const key of ['input', 'output', 'metadata', 'error']) {
-    if (isEncryptedData(result[key])) {
-      result[key] = ENCRYPTED_REF;
-    }
+    result[key] = toDisplayRef(result[key]);
   }
 
   if (result.eventData && typeof result.eventData === 'object') {
     const ed = { ...(result.eventData as Record<string, unknown>) };
     for (const key of ['result', 'input', 'output', 'metadata', 'payload']) {
-      if (isEncryptedData(ed[key])) {
-        ed[key] = ENCRYPTED_REF;
-      }
+      ed[key] = toDisplayRef(ed[key]);
     }
     result.eventData = ed;
   }
@@ -298,6 +335,6 @@ export async function hydrateResourceIO<T>(
     keyResolver ?? null
   );
   const hydrated = hydrateResourceIOGeneric(preprocessed, getRevivers()) as T;
-  // Post-process: swap encrypted Uint8Arrays for CLI-styled objects
-  return replaceEncryptedWithRef(hydrated);
+  // Post-process: swap encrypted Uint8Arrays and expired stubs for CLI-styled objects
+  return replaceEncryptedAndExpiredWithRef(hydrated);
 }

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -27,6 +27,7 @@ import {
   type EncryptionKeyResolver,
   hydrateResourceIO,
   isEncryptedRef,
+  isExpiredRef,
 } from './hydration.js';
 
 /**
@@ -489,10 +490,21 @@ const showInspectInfoBox = (resource: string) => {
 const EXPIRED_DATA_MESSAGE = chalk.gray('<data expired>');
 
 /**
- * Checks if a run has expired data storage
+ * Checks if a run has expired data storage (run-level expiredAt field)
  */
 const hasExpiredData = (run: WorkflowRun): boolean => {
   return 'expiredAt' in run && run.expiredAt != null;
+};
+
+/**
+ * Checks if any data field in a hydrated resource has been replaced with an
+ * expired placeholder. Works for runs, steps, hooks, and events — unlike
+ * `hasExpiredData` which only checks the run-level `expiredAt` field.
+ */
+const hasExpiredFields = (resource: Record<string, unknown>): boolean => {
+  return ['input', 'output', 'error', 'metadata'].some((key) =>
+    isExpiredRef(resource[key])
+  );
 };
 
 /**
@@ -507,6 +519,8 @@ const inlineFormatIO = <T>(io: T, topLevel: boolean = true): string => {
     value = '<null>';
   } else if (isEncryptedRef(io)) {
     value = chalk.dim.yellow('\u{1F512} Encrypted');
+  } else if (isExpiredRef(io)) {
+    value = chalk.gray('<data expired>');
   } else if (io && Array.isArray(io)) {
     if (io.length === 0) {
       value = '<empty>';
@@ -801,6 +815,15 @@ export const showStep = async (
       showJson(stepWithHydratedIO);
       return;
     } else {
+      if (
+        hasExpiredFields(
+          stepWithHydratedIO as unknown as Record<string, unknown>
+        )
+      ) {
+        logger.warn(
+          "This step's data (input/output/error) has expired and is no longer available."
+        );
+      }
       logger.log(stepWithHydratedIO);
     }
   } catch (error) {
@@ -1115,6 +1138,13 @@ export const showHook = async (
       showJson(hydratedHook);
       return;
     } else {
+      if (
+        hasExpiredFields(hydratedHook as unknown as Record<string, unknown>)
+      ) {
+        logger.warn(
+          "This hook's data (metadata) has expired and is no longer available."
+        );
+      }
       logger.log(hydratedHook);
     }
   } catch (error) {

--- a/packages/core/src/serialization-format.test.ts
+++ b/packages/core/src/serialization-format.test.ts
@@ -10,6 +10,7 @@ import {
   hydrateResourceIO,
   isClassInstanceRef,
   isEncryptedData,
+  isExpiredStub,
   isStreamId,
   isStreamRef,
   observabilityRevivers,
@@ -636,6 +637,76 @@ describe('encrypted data handling', () => {
         undefined
       );
       expect(result).toBe(legacyValue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isExpiredStub
+  // ---------------------------------------------------------------------------
+
+  describe('isExpiredStub', () => {
+    it('should detect unwrapped expired stub', () => {
+      expect(isExpiredStub({ expiredAt: '2025-03-18T00:00:00.000Z' })).toBe(
+        true
+      );
+    });
+
+    it('should detect array-wrapped expired stub (devalue unflatten format)', () => {
+      expect(isExpiredStub([{ expiredAt: '2025-03-18T00:00:00.000Z' }])).toBe(
+        true
+      );
+    });
+
+    it('should return false for objects with extra keys', () => {
+      expect(
+        isExpiredStub({ expiredAt: '2025-03-18T00:00:00.000Z', other: 'data' })
+      ).toBe(false);
+    });
+
+    it('should return false for non-string expiredAt', () => {
+      expect(isExpiredStub({ expiredAt: 12345 })).toBe(false);
+      expect(isExpiredStub({ expiredAt: null })).toBe(false);
+      expect(isExpiredStub({ expiredAt: new Date() })).toBe(false);
+    });
+
+    it('should return false for non-object values', () => {
+      expect(isExpiredStub(null)).toBe(false);
+      expect(isExpiredStub(undefined)).toBe(false);
+      expect(isExpiredStub('hello')).toBe(false);
+      expect(isExpiredStub(42)).toBe(false);
+      expect(isExpiredStub([])).toBe(false);
+    });
+
+    it('should return false for empty objects', () => {
+      expect(isExpiredStub({})).toBe(false);
+    });
+
+    it('should return false for objects with different single key', () => {
+      expect(isExpiredStub({ input: 'hello' })).toBe(false);
+    });
+
+    it('should return false for array with non-expired object', () => {
+      expect(isExpiredStub([{ input: 'hello' }])).toBe(false);
+    });
+
+    it('should return false for array with multiple elements', () => {
+      expect(
+        isExpiredStub([
+          { expiredAt: '2025-03-18T00:00:00.000Z' },
+          { expiredAt: '2025-03-18T00:00:00.000Z' },
+        ])
+      ).toBe(false);
+    });
+  });
+
+  describe('hydrateData with expired stubs', () => {
+    it('should unflatten server expired stub into array-wrapped form', () => {
+      // Server format: makeExpiredStub produces [[1], { expiredAt: 2 }, isoString]
+      // After unflatten: [{ expiredAt: "..." }] (array-wrapped due to devalue encoding)
+      const serverStub = [[1], { expiredAt: 2 }, '2025-03-18T00:00:00.000Z'];
+      const result = hydrateData(serverStub, observabilityRevivers);
+      expect(isExpiredStub(result)).toBe(true);
+      expect(result).toEqual([{ expiredAt: '2025-03-18T00:00:00.000Z' }]);
     });
   });
 });

--- a/packages/core/src/serialization-format.ts
+++ b/packages/core/src/serialization-format.ts
@@ -96,6 +96,44 @@ export function decodeFormatPrefix(data: Uint8Array | unknown): {
  */
 export const ENCRYPTED_PLACEHOLDER = '\u{1F512} Encrypted';
 
+// ---------------------------------------------------------------------------
+// Expired data detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a plain object is `{ expiredAt: "<ISO date>" }` — a single-key
+ * object with a string `expiredAt` value.
+ */
+function isExpiredObject(data: unknown): data is { expiredAt: string } {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return false;
+  }
+  const keys = Object.keys(data);
+  return (
+    keys.length === 1 &&
+    keys[0] === 'expiredAt' &&
+    typeof (data as Record<string, unknown>).expiredAt === 'string'
+  );
+}
+
+/**
+ * Check if a hydrated value is an expired data stub from the server.
+ *
+ * The server replaces expired ref fields with a devalue-encoded stub
+ * (`makeExpiredStub`) that deserializes to `[{ expiredAt: "<ISO date>" }]`
+ * after `unflatten` (array-wrapped due to backwards-compatible encoding).
+ * Also matches the unwrapped `{ expiredAt: "..." }` form for robustness.
+ */
+export function isExpiredStub(data: unknown): boolean {
+  // Direct object form: { expiredAt: "..." }
+  if (isExpiredObject(data)) return true;
+  // Array-wrapped form from devalue unflatten: [{ expiredAt: "..." }]
+  if (Array.isArray(data) && data.length === 1 && isExpiredObject(data[0])) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Check if a binary value has the 'encr' format prefix indicating encryption.
  * Browser-safe — does not depend on the full serialization module.

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -6,17 +6,17 @@ import type { ModelMessage } from 'ai';
 import { Lock } from 'lucide-react';
 import type { KeyboardEvent, ReactNode } from 'react';
 import { useCallback, useMemo, useState } from 'react';
+import { isEncryptedMarker, isExpiredMarker } from '../../lib/hydration';
 import { useToast } from '../../lib/toast';
-import { isEncryptedMarker } from '../../lib/hydration';
 import { extractConversation, isDoStreamStep } from '../../lib/utils';
 import { StreamClickContext } from '../ui/data-inspector';
-import { TimestampTooltip } from '../ui/timestamp-tooltip';
 import { ErrorCard } from '../ui/error-card';
 import {
   ErrorStackBlock,
   isStructuredErrorWithStack,
 } from '../ui/error-stack-block';
 import { Skeleton } from '../ui/skeleton';
+import { TimestampTooltip } from '../ui/timestamp-tooltip';
 import { ConversationView } from './conversation-view';
 import { CopyableDataBlock } from './copyable-data-block';
 import { DetailCard } from './detail-card';
@@ -191,6 +191,24 @@ function EncryptedFieldBlock() {
     >
       <Lock className="h-3 w-3" />
       <span className="font-medium">Encrypted</span>
+    </div>
+  );
+}
+
+/**
+ * Inline display for an expired field — flat label indicating data is no longer available.
+ */
+function ExpiredFieldBlock() {
+  return (
+    <div
+      className="flex items-center gap-1.5 rounded-md border px-3 py-2 text-xs"
+      style={{
+        borderColor: 'var(--ds-gray-300)',
+        backgroundColor: 'var(--ds-gray-100)',
+        color: 'var(--ds-gray-700)',
+      }}
+    >
+      <span className="font-medium">Data expired</span>
     </div>
   );
 }
@@ -398,10 +416,12 @@ const attributeToDisplayFn: Record<
   metadata: (value: unknown) => {
     if (!hasDisplayContent(value)) return null;
     if (isEncryptedMarker(value)) return <EncryptedFieldBlock />;
+    if (isExpiredMarker(value)) return <ExpiredFieldBlock />;
     return JsonBlock(value);
   },
   input: (value: unknown, context?: DisplayContext) => {
     if (isEncryptedMarker(value)) return <EncryptedFieldBlock />;
+    if (isExpiredMarker(value)) return <ExpiredFieldBlock />;
     // Check if input has args + closure vars structure
     if (value && typeof value === 'object' && 'args' in value) {
       const { args, closureVars, thisVal } = value as {
@@ -506,6 +526,7 @@ const attributeToDisplayFn: Record<
   output: (value: unknown) => {
     if (!hasDisplayContent(value)) return null;
     if (isEncryptedMarker(value)) return <EncryptedFieldBlock />;
+    if (isExpiredMarker(value)) return <ExpiredFieldBlock />;
     return (
       <DetailCard
         summary="Output"
@@ -518,6 +539,7 @@ const attributeToDisplayFn: Record<
   },
   error: (value: unknown) => {
     if (isEncryptedMarker(value)) return <EncryptedFieldBlock />;
+    if (isExpiredMarker(value)) return <ExpiredFieldBlock />;
     if (!hasDisplayContent(value)) return null;
 
     // If the error object has a `stack` field, render it as readable
@@ -546,6 +568,7 @@ const attributeToDisplayFn: Record<
   },
   eventData: (value: unknown) => {
     if (isEncryptedMarker(value)) return <EncryptedFieldBlock />;
+    if (isExpiredMarker(value)) return <ExpiredFieldBlock />;
     if (!hasDisplayContent(value)) return null;
     return <DetailCard summary="Event Data">{JsonBlock(value)}</DetailCard>;
   },

--- a/packages/web-shared/src/components/sidebar/events-list.tsx
+++ b/packages/web-shared/src/components/sidebar/events-list.tsx
@@ -2,6 +2,7 @@
 
 import type { Event } from '@workflow/world';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { isExpiredMarker } from '../../lib/hydration';
 import { ErrorCard } from '../ui/error-card';
 import {
   ErrorStackBlock,
@@ -198,6 +199,24 @@ function EventItem({
 }
 
 /**
+ * Check if an eventData object has only expired marker values in its serialized
+ * sub-fields (result, input, output, metadata, payload). Non-serialized fields
+ * like `resumeAt` or `reason` are ignored.
+ */
+function hasOnlyExpiredFields(data: unknown): boolean {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return false;
+  }
+  const record = data as Record<string, unknown>;
+  const serializedKeys = ['result', 'input', 'output', 'metadata', 'payload'];
+  const presentKeys = serializedKeys.filter((k) => k in record);
+  return (
+    presentKeys.length > 0 &&
+    presentKeys.every((k) => isExpiredMarker(record[k]))
+  );
+}
+
+/**
  * Renders event data, using ErrorStackBlock for error events that contain
  * a structured error with a stack trace, and CopyableDataBlock otherwise.
  */
@@ -208,6 +227,24 @@ function EventDataBlock({
   eventType: string;
   data: unknown;
 }) {
+  // Expired data — show a simple message instead of the raw stub.
+  // Check both the top-level eventData and nested sub-fields (result, input, etc.)
+  // since the server stubs each ref field independently.
+  if (isExpiredMarker(data) || hasOnlyExpiredFields(data)) {
+    return (
+      <div
+        className="flex items-center gap-1.5 rounded-md border px-3 py-2 text-xs"
+        style={{
+          borderColor: 'var(--ds-gray-300)',
+          backgroundColor: 'var(--ds-gray-100)',
+          color: 'var(--ds-gray-700)',
+        }}
+      >
+        <span className="font-medium">Data expired</span>
+      </div>
+    );
+  }
+
   // For error events (step_failed, step_retrying), the eventData has the shape
   // { error: StructuredError, stack?: string, ... }. Check both the top-level
   // value and the nested `error` field for a stack trace.

--- a/packages/web-shared/src/lib/hydration.ts
+++ b/packages/web-shared/src/lib/hydration.ts
@@ -10,6 +10,7 @@ import {
   extractClassName,
   hydrateResourceIO as hydrateResourceIOGeneric,
   isEncryptedData,
+  isExpiredStub,
   observabilityRevivers,
   type Revivers,
 } from '@workflow/core/serialization-format';
@@ -149,7 +150,7 @@ export function hydrateResourceIO<T>(resource: T): T {
     resource as any,
     getRevivers()
   ) as T;
-  return replaceEncryptedWithMarkers(hydrated);
+  return replaceEncryptedAndExpiredWithMarkers(hydrated);
 }
 
 // ---------------------------------------------------------------------------
@@ -191,27 +192,60 @@ export function isEncryptedMarker(value: unknown): boolean {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Expired data display markers
+// ---------------------------------------------------------------------------
+
+export const EXPIRED_DISPLAY_NAME = 'Expired Data';
+
+/**
+ * Create a display-friendly object for expired data.
+ *
+ * Uses the same named-constructor trick as the encrypted marker so that
+ * ObjectInspector renders the constructor name ("Expired Data") with no
+ * expandable children.
+ */
+function createExpiredMarker(): object {
+  // biome-ignore lint/complexity/useArrowFunction: arrow functions have no .prototype
+  const ctor = { [EXPIRED_DISPLAY_NAME]: function () {} }[
+    EXPIRED_DISPLAY_NAME
+  ]!;
+  return Object.create(ctor.prototype);
+}
+
+/** Check if a value is an expired data display marker */
+export function isExpiredMarker(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    value.constructor?.name === EXPIRED_DISPLAY_NAME
+  );
+}
+
+/** Replace a single field value with a display marker if it's encrypted or expired. */
+function toDisplayMarker(value: unknown): unknown {
+  if (isEncryptedData(value)) return createEncryptedMarker(value as Uint8Array);
+  if (isExpiredStub(value)) return createExpiredMarker();
+  return value;
+}
+
 /**
  * Post-process hydrated resource data: replace encrypted Uint8Array values
- * with display-friendly marker objects in known data fields.
+ * and expired stubs with display-friendly marker objects in known data fields.
  */
-function replaceEncryptedWithMarkers<T>(resource: T): T {
+function replaceEncryptedAndExpiredWithMarkers<T>(resource: T): T {
   if (!resource || typeof resource !== 'object') return resource;
   const r = resource as Record<string, unknown>;
   const result = { ...r };
 
   for (const key of ['input', 'output', 'metadata', 'error']) {
-    if (isEncryptedData(result[key])) {
-      result[key] = createEncryptedMarker(result[key] as Uint8Array);
-    }
+    result[key] = toDisplayMarker(result[key]);
   }
 
   if (result.eventData && typeof result.eventData === 'object') {
     const ed = { ...(result.eventData as Record<string, unknown>) };
     for (const key of EVENT_DATA_SERIALIZED_FIELDS) {
-      if (isEncryptedData(ed[key])) {
-        ed[key] = createEncryptedMarker(ed[key] as Uint8Array);
-      }
+      ed[key] = toDisplayMarker(ed[key]);
     }
     result.eventData = ed;
   }


### PR DESCRIPTION
Idea is that similarly to encrypted data, we first-class the expiry marker and show it differently in the UI and CLI