### PR TITLE
Add Platformatic World to worlds-manifest.json

### DIFF
--- a/.changeset/add-platformatic-world.md
+++ b/.changeset/add-platformatic-world.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Add Platformatic to `worlds-manifest.json` as a community world, and add a generic `docker` service type to the community-world CI so worlds can declare arbitrary Docker containers in their manifest `services` array. Platformatic's CI job is gated by the existing `if: false` on `e2e-community` until community worlds ship CBOR queue transport support.
+Add Platformatic to `worlds-manifest.json` as a community world, and add a generic `docker` service type to the community-world CI (both the E2E and benchmark reusable workflows) so worlds can declare arbitrary Docker containers in their manifest `services` array. Platformatic's E2E job is gated by the existing `if: false` on `e2e-community` until community worlds ship CBOR queue transport support.

--- a/.changeset/add-platformatic-world.md
+++ b/.changeset/add-platformatic-world.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Platformatic to `worlds-manifest.json` as a community world, and add a generic `docker` service type to the community-world CI so worlds can declare arbitrary Docker containers in their manifest `services` array. Platformatic's CI job is gated by the existing `if: false` on `e2e-community` until community worlds ship CBOR queue transport support.

--- a/.github/workflows/benchmark-community-world.yml
+++ b/.github/workflows/benchmark-community-world.yml
@@ -19,6 +19,11 @@ on:
         description: 'NPM package name for the world'
         required: true
         type: string
+      package-version:
+        description: 'Optional npm version/dist-tag to pin the world package to (empty = latest)'
+        required: false
+        type: string
+        default: ''
       app-name:
         description: 'App to test (default: nextjs-turbopack)'
         required: false
@@ -30,10 +35,15 @@ on:
         type: string
         default: '{}'
       service-type:
-        description: 'Service container to run (none, mongodb, redis)'
+        description: 'Service container to run (none, mongodb, redis, docker)'
         required: false
         type: string
         default: 'none'
+      services:
+        description: 'JSON array of service definitions from the manifest (used when service-type is docker)'
+        required: false
+        type: string
+        default: '[]'
       full-suite:
         description: 'Run full benchmark suite including long-running tests'
         required: false
@@ -81,6 +91,58 @@ jobs:
             sleep 2
           done
 
+      - name: Start Docker services
+        if: ${{ inputs.service-type == 'docker' }}
+        # Services start serially in manifest order. Each service's health check
+        # must pass before the next one starts, so any service that depends on
+        # another (e.g. a workflow service that needs postgres) must be listed
+        # AFTER its dependency in the manifest's `services` array.
+        #
+        # `healthCheck.cmd` is executed via `sh -c` below, which means the
+        # manifest is a shell-execution surface. Safe here because
+        # `worlds-manifest.json` is in-repo and PR-reviewed.
+        run: |
+          set -euo pipefail
+          SERVICES='${{ inputs.services }}'
+          count=$(echo "$SERVICES" | jq '. | length')
+          for idx in $(seq 0 $((count - 1))); do
+            svc=$(echo "$SERVICES" | jq -c ".[$idx]")
+            name=$(echo "$svc" | jq -r '.name')
+            image=$(echo "$svc" | jq -r '.image')
+            health_cmd=$(echo "$svc" | jq -r '.healthCheck.cmd // empty')
+            retries=$(echo "$svc" | jq -r '.healthCheck.retries // 10')
+
+            # Build docker run as an array so env values with spaces/quotes
+            # survive intact (no shell re-interpretation via eval).
+            args=(docker run -d --name "$name" --network host)
+            env_lines=$(echo "$svc" | jq -r '.env // {} | to_entries[] | "\(.key)=\(.value)"')
+            if [ -n "$env_lines" ]; then
+              while IFS= read -r line; do
+                args+=(-e "$line")
+              done <<< "$env_lines"
+            fi
+            args+=("$image")
+
+            echo "Starting $name ($image)..."
+            "${args[@]}"
+
+            # Health check runs on the host (--network host shares the network).
+            if [ -n "$health_cmd" ]; then
+              echo "Waiting for $name to be ready..."
+              for i in $(seq 1 "$retries"); do
+                if sh -c "$health_cmd" &>/dev/null; then
+                  echo "$name is ready"
+                  break
+                fi
+                if [ "$i" -eq "$retries" ]; then
+                  echo "ERROR: $name health check did not pass after $retries retries"
+                  exit 1
+                fi
+                sleep 2
+              done
+            fi
+          done
+
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
         with:
@@ -109,7 +171,10 @@ jobs:
         env:
           APP_NAME: ${{ inputs.app-name }}
           WORLD_PACKAGE: ${{ inputs.world-package }}
-        run: pnpm --filter "$APP_NAME" add "$WORLD_PACKAGE"
+          WORLD_PACKAGE_VERSION: ${{ inputs.package-version }}
+        run: |
+          SPEC="${WORLD_PACKAGE}${WORLD_PACKAGE_VERSION:+@$WORLD_PACKAGE_VERSION}"
+          pnpm --filter "$APP_NAME" add "$SPEC"
 
       # Per-world setup. Hardcoded (not taken from the matrix) so a malicious
       # fork PR cannot smuggle arbitrary shell through matrix.world.setup-command.
@@ -175,3 +240,8 @@ jobs:
         run: |
           docker stop mongodb 2>/dev/null || true
           docker stop redis 2>/dev/null || true
+          if [ '${{ inputs.service-type }}' = 'docker' ]; then
+            echo '${{ inputs.services }}' | jq -r '.[].name' 2>/dev/null | while read -r name; do
+              docker stop "$name" 2>/dev/null || true
+            done
+          fi

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -513,8 +513,10 @@ jobs:
       world-id: ${{ matrix.world.id }}
       world-name: ${{ matrix.world.name }}
       world-package: ${{ matrix.world.package }}
+      package-version: ${{ matrix.world.version }}
       service-type: ${{ matrix.world.service-type }}
       env-vars: ${{ matrix.world.env-vars }}
+      services: ${{ matrix.world.services }}
       # Run full suite only when manually triggered with full_suite=true
       full-suite: ${{ (github.event_name == 'workflow_dispatch' && inputs.full_suite) || contains(github.event.pull_request.labels.*.name, 'stress-test') }}
     secrets: inherit

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -23,6 +23,11 @@ on:
         description: 'NPM package name for the world'
         required: true
         type: string
+      package-version:
+        description: 'Optional npm version/dist-tag to pin the world package to (empty = latest)'
+        required: false
+        type: string
+        default: ''
       app-name:
         description: 'App to test (default: nextjs-turbopack)'
         required: false
@@ -168,7 +173,10 @@ jobs:
         env:
           APP_NAME: ${{ inputs.app-name }}
           WORLD_PACKAGE: ${{ inputs.world-package }}
-        run: pnpm --filter "$APP_NAME" add "$WORLD_PACKAGE"
+          WORLD_PACKAGE_VERSION: ${{ inputs.package-version }}
+        run: |
+          SPEC="${WORLD_PACKAGE}${WORLD_PACKAGE_VERSION:+@$WORLD_PACKAGE_VERSION}"
+          pnpm --filter "$APP_NAME" add "$SPEC"
 
       # Per-world setup. Hardcoded (not taken from the matrix) so a malicious
       # fork PR cannot smuggle arbitrary shell through matrix.world.setup-command.

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -219,7 +219,7 @@ jobs:
         run: |
           docker stop mongodb 2>/dev/null || true
           docker stop redis 2>/dev/null || true
-          if [ '${{ inputs.service-type }}' = 'custom' ]; then
+          if [ '${{ inputs.service-type }}' = 'docker' ]; then
             echo '${{ inputs.services }}' | jq -r '.[].name' 2>/dev/null | while read -r name; do
               docker stop "$name" 2>/dev/null || true
             done

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -34,10 +34,15 @@ on:
         type: string
         default: '{}'
       service-type:
-        description: 'Service container to run (none, mongodb, redis)'
+        description: 'Service container to run (none, mongodb, redis, docker)'
         required: false
         type: string
         default: 'none'
+      services:
+        description: 'JSON array of service definitions from the manifest (used when service-type is docker)'
+        required: false
+        type: string
+        default: '[]'
 
 jobs:
   e2e:
@@ -81,6 +86,45 @@ jobs:
               break
             fi
             sleep 2
+          done
+
+      - name: Start Docker services
+        if: ${{ inputs.service-type == 'docker' }}
+        run: |
+          SERVICES='${{ inputs.services }}'
+          count=$(echo "$SERVICES" | jq '. | length')
+          for idx in $(seq 0 $((count - 1))); do
+            svc=$(echo "$SERVICES" | jq -c ".[$idx]")
+            name=$(echo "$svc" | jq -r '.name')
+            image=$(echo "$svc" | jq -r '.image')
+            health_cmd=$(echo "$svc" | jq -r '.healthCheck.cmd // empty')
+            retries=$(echo "$svc" | jq -r '.healthCheck.retries // 10')
+
+            # Build docker run command with env flags
+            cmd="docker run -d --name $name --network host"
+            for key in $(echo "$svc" | jq -r '.env // {} | keys[]'); do
+              val=$(echo "$svc" | jq -r ".env[\"$key\"]")
+              cmd="$cmd -e $key=$val"
+            done
+            cmd="$cmd $image"
+
+            echo "Starting $name ($image)..."
+            eval "$cmd"
+
+            # Health check runs on the host (--network host shares the network)
+            if [ -n "$health_cmd" ]; then
+              echo "Waiting for $name to be ready..."
+              for i in $(seq 1 "$retries"); do
+                if sh -c "$health_cmd" &>/dev/null; then
+                  echo "$name is ready"
+                  break
+                fi
+                if [ "$i" -eq "$retries" ]; then
+                  echo "WARNING: $name health check did not pass after $retries retries"
+                fi
+                sleep 2
+              done
+            fi
           done
 
       - name: Setup environment
@@ -175,3 +219,8 @@ jobs:
         run: |
           docker stop mongodb 2>/dev/null || true
           docker stop redis 2>/dev/null || true
+          if [ '${{ inputs.service-type }}' = 'custom' ]; then
+            echo '${{ inputs.services }}' | jq -r '.[].name' 2>/dev/null | while read -r name; do
+              docker stop "$name" 2>/dev/null || true
+            done
+          fi

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -90,7 +90,16 @@ jobs:
 
       - name: Start Docker services
         if: ${{ inputs.service-type == 'docker' }}
+        # Services start serially in manifest order. Each service's health check
+        # must pass before the next one starts, so any service that depends on
+        # another (e.g. a workflow service that needs postgres) must be listed
+        # AFTER its dependency in the manifest's `services` array.
+        #
+        # `healthCheck.cmd` is executed via `sh -c` below, which means the
+        # manifest is a shell-execution surface. Safe here because
+        # `worlds-manifest.json` is in-repo and PR-reviewed.
         run: |
+          set -euo pipefail
           SERVICES='${{ inputs.services }}'
           count=$(echo "$SERVICES" | jq '. | length')
           for idx in $(seq 0 $((count - 1))); do
@@ -100,18 +109,21 @@ jobs:
             health_cmd=$(echo "$svc" | jq -r '.healthCheck.cmd // empty')
             retries=$(echo "$svc" | jq -r '.healthCheck.retries // 10')
 
-            # Build docker run command with env flags
-            cmd="docker run -d --name $name --network host"
-            for key in $(echo "$svc" | jq -r '.env // {} | keys[]'); do
-              val=$(echo "$svc" | jq -r ".env[\"$key\"]")
-              cmd="$cmd -e $key=$val"
-            done
-            cmd="$cmd $image"
+            # Build docker run as an array so env values with spaces/quotes
+            # survive intact (no shell re-interpretation via eval).
+            args=(docker run -d --name "$name" --network host)
+            env_lines=$(echo "$svc" | jq -r '.env // {} | to_entries[] | "\(.key)=\(.value)"')
+            if [ -n "$env_lines" ]; then
+              while IFS= read -r line; do
+                args+=(-e "$line")
+              done <<< "$env_lines"
+            fi
+            args+=("$image")
 
             echo "Starting $name ($image)..."
-            eval "$cmd"
+            "${args[@]}"
 
-            # Health check runs on the host (--network host shares the network)
+            # Health check runs on the host (--network host shares the network).
             if [ -n "$health_cmd" ]; then
               echo "Waiting for $name to be ready..."
               for i in $(seq 1 "$retries"); do
@@ -120,7 +132,8 @@ jobs:
                   break
                 fi
                 if [ "$i" -eq "$retries" ]; then
-                  echo "WARNING: $name health check did not pass after $retries retries"
+                  echo "ERROR: $name health check did not pass after $retries retries"
+                  exit 1
                 fi
                 sleep 2
               done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -929,6 +929,7 @@ jobs:
       world-package: ${{ matrix.world.package }}
       service-type: ${{ matrix.world.service-type }}
       env-vars: ${{ matrix.world.env-vars }}
+      services: ${{ matrix.world.services }}
     secrets: inherit
 
   # Final job: Aggregate all E2E results and update PR comment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -927,6 +927,7 @@ jobs:
       world-id: ${{ matrix.world.id }}
       world-name: ${{ matrix.world.name }}
       world-package: ${{ matrix.world.package }}
+      package-version: ${{ matrix.world.version }}
       service-type: ${{ matrix.world.service-type }}
       env-vars: ${{ matrix.world.env-vars }}
       services: ${{ matrix.world.services }}

--- a/scripts/create-community-worlds-matrix.mjs
+++ b/scripts/create-community-worlds-matrix.mjs
@@ -50,10 +50,13 @@ const matrix = {
     let serviceType = 'none';
     if (world.services && world.services.length > 0) {
       // Use the first service's name as the service type
-      // Currently supports: mongodb, redis
+      // mongodb and redis have dedicated CI steps; everything else
+      // is started generically via the manifest services definition
       const serviceName = world.services[0].name;
       if (['mongodb', 'redis'].includes(serviceName)) {
         serviceType = serviceName;
+      } else {
+        serviceType = 'docker';
       }
     }
 
@@ -63,6 +66,7 @@ const matrix = {
       package: world.package,
       'service-type': serviceType,
       'env-vars': JSON.stringify(world.env || {}),
+      services: JSON.stringify(world.services || []),
     };
   }),
 };

--- a/scripts/create-community-worlds-matrix.mjs
+++ b/scripts/create-community-worlds-matrix.mjs
@@ -46,15 +46,17 @@ const testableWorlds = manifest.worlds.filter((world) => {
 // Build the matrix
 const matrix = {
   world: testableWorlds.map((world) => {
-    // Determine service type based on services array
+    // Determine service type based on services array.
+    // `mongodb` and `redis` have dedicated single-service CI steps; anything
+    // else (or any multi-service world) goes through the generic `docker`
+    // path driven by the manifest's `services` array.
     let serviceType = 'none';
     if (world.services && world.services.length > 0) {
-      // Use the first service's name as the service type
-      // mongodb and redis have dedicated CI steps; everything else
-      // is started generically via the manifest services definition
-      const serviceName = world.services[0].name;
-      if (['mongodb', 'redis'].includes(serviceName)) {
-        serviceType = serviceName;
+      if (world.services.length === 1) {
+        const serviceName = world.services[0].name;
+        serviceType = ['mongodb', 'redis'].includes(serviceName)
+          ? serviceName
+          : 'docker';
       } else {
         serviceType = 'docker';
       }

--- a/scripts/create-community-worlds-matrix.mjs
+++ b/scripts/create-community-worlds-matrix.mjs
@@ -66,6 +66,7 @@ const matrix = {
       id: world.id,
       name: world.name,
       package: world.package,
+      version: world.version || '',
       'service-type': serviceType,
       'env-vars': JSON.stringify(world.env || {}),
       services: JSON.stringify(world.services || []),

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -309,14 +309,12 @@
           },
           "healthCheck": {
             "cmd": "pg_isready -h localhost",
-            "interval": "10s",
-            "timeout": "5s",
             "retries": 5
           }
         },
         {
           "name": "platformatic-workflow",
-          "image": "platformatic/workflow:latest",
+          "image": "platformatic/workflow:0.8.1",
           "ports": ["3042:3042"],
           "env": {
             "DATABASE_URL": "postgres://wf:wf@localhost:5432/workflow",
@@ -324,8 +322,6 @@
           },
           "healthCheck": {
             "cmd": "curl -sf http://localhost:3042/status",
-            "interval": "10s",
-            "timeout": "5s",
             "retries": 10
           }
         }

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -286,6 +286,7 @@
       "id": "platformatic",
       "type": "community",
       "package": "@platformatic/world",
+      "version": "0.8.1",
       "name": "Platformatic",
       "description": "Platformatic World backed by a centralized workflow service with PostgreSQL for version-safe orchestration on Kubernetes",
       "repository": "https://github.com/platformatic/platformatic-world",

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -281,6 +281,55 @@
       "services": [],
       "requiresCredentials": true,
       "credentialsNote": "Requires Upstash Redis and QStash credentials from Upstash console (https://console.upstash.com)"
+    },
+    {
+      "id": "platformatic",
+      "type": "community",
+      "package": "@platformatic/world",
+      "name": "Platformatic",
+      "description": "Platformatic World backed by a centralized workflow service with PostgreSQL for version-safe orchestration on Kubernetes",
+      "repository": "https://github.com/platformatic/platformatic-world",
+      "docs": "https://github.com/platformatic/platformatic-world",
+      "features": [],
+      "env": {
+        "WORKFLOW_TARGET_WORLD": "@platformatic/world",
+        "PLT_WORLD_SERVICE_URL": "http://localhost:3042",
+        "PLT_WORLD_APP_ID": "default",
+        "PLT_WORLD_DEPLOYMENT_VERSION": "local"
+      },
+      "services": [
+        {
+          "name": "postgres",
+          "image": "postgres:18-alpine",
+          "ports": ["5432:5432"],
+          "env": {
+            "POSTGRES_USER": "wf",
+            "POSTGRES_PASSWORD": "wf",
+            "POSTGRES_DB": "workflow"
+          },
+          "healthCheck": {
+            "cmd": "pg_isready -h localhost",
+            "interval": "10s",
+            "timeout": "5s",
+            "retries": 5
+          }
+        },
+        {
+          "name": "platformatic-workflow",
+          "image": "platformatic/workflow:latest",
+          "ports": ["3042:3042"],
+          "env": {
+            "DATABASE_URL": "postgres://wf:wf@localhost:5432/workflow",
+            "PORT": "3042"
+          },
+          "healthCheck": {
+            "cmd": "curl -sf http://localhost:3042/status",
+            "interval": "10s",
+            "timeout": "5s",
+            "retries": 10
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `@platformatic/world` as a community world backed by a centralized workflow service (`@platformatic/workflow`) with PostgreSQL
- Introduce a generic `docker` service type in the CI so worlds can declare arbitrary Docker containers in their manifest `services` array
- Services are started with `--network host` and health-checked from the runner

## How it works

Platformatic World is a thin HTTP client that talks to an external workflow service. The CI needs two containers:

1. **postgres** — database for the workflow service
2. **platformatic-workflow** — the workflow service (`platformatic/workflow:latest` from Docker Hub)

Both run with `--network host` so they share localhost with the test runner. The matrix script sets `service-type: "docker"` for any world whose services aren't the built-in mongodb/redis, and passes the full `services` JSON to the reusable workflow.