### PR TITLE
feat: re-export parseName + hydrators for observability DX

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,9 @@
 export { pluralize } from './pluralize.js';
+export {
+  parseClassName,
+  parseStepName,
+  parseWorkflowName,
+} from './parse-name.js';
 export { once, type PromiseWithResolvers, withResolvers } from './promise.js';
 export { parseDurationToDate } from './time.js';
 export {

--- a/packages/utils/src/re-exports.test.ts
+++ b/packages/utils/src/re-exports.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { parseClassName, parseStepName, parseWorkflowName } from './index';
+
+describe('re-exports from main index', () => {
+  test('parseStepName is re-exported', () => {
+    expect(typeof parseStepName).toBe('function');
+    const result = parseStepName('step//./src/workflows/order//processOrder');
+    expect(result?.shortName).toBe('processOrder');
+  });
+
+  test('parseWorkflowName is re-exported', () => {
+    expect(typeof parseWorkflowName).toBe('function');
+    const result = parseWorkflowName(
+      'workflow//./src/workflows/pulse//pulseRemoteWorkflow'
+    );
+    expect(result?.shortName).toBe('pulseRemoteWorkflow');
+  });
+
+  test('parseClassName is re-exported', () => {
+    expect(typeof parseClassName).toBe('function');
+    const result = parseClassName('class//./src/models/point//Point');
+    expect(result?.shortName).toBe('Point');
+  });
+});

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -48,7 +48,11 @@
     "./astro": "./dist/astro.js",
     "./vite": "./dist/vite.js",
     "./nest": "./dist/nest.js",
-    "./runtime": "./dist/runtime.js"
+    "./runtime": "./dist/runtime.js",
+    "./observability": {
+      "types": "./dist/observability.d.ts",
+      "default": "./dist/observability.js"
+    }
   },
   "scripts": {
     "build": "tsc && chmod +x bin/run.js",
@@ -65,6 +69,7 @@
     "@workflow/core": "workspace:*",
     "@workflow/errors": "workspace:*",
     "@workflow/typescript-plugin": "workspace:*",
+    "@workflow/utils": "workspace:*",
     "ms": "2.1.3",
     "@workflow/next": "workspace:*",
     "@workflow/nest": "workspace:*",

--- a/packages/workflow/src/observability.test.ts
+++ b/packages/workflow/src/observability.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import {
+  hydrateData,
+  hydrateResourceIO,
+  observabilityRevivers,
+  parseClassName,
+  parseStepName,
+  parseWorkflowName,
+} from './observability';
+
+describe('workflow/observability re-exports', () => {
+  test('parseStepName is exported and works', () => {
+    const result = parseStepName('step//./src/workflows/pulse//queryKBStep');
+    expect(result?.shortName).toBe('queryKBStep');
+  });
+
+  test('parseWorkflowName is exported and works', () => {
+    const result = parseWorkflowName(
+      'workflow//./src/workflows/pulse//pulseRemoteWorkflow'
+    );
+    expect(result?.shortName).toBe('pulseRemoteWorkflow');
+  });
+
+  test('parseClassName is exported and works', () => {
+    const result = parseClassName('class//./src/models//MyModel');
+    expect(result?.shortName).toBe('MyModel');
+  });
+
+  test('observabilityRevivers is exported', () => {
+    expect(typeof observabilityRevivers).toBe('object');
+    expect(observabilityRevivers).toHaveProperty('ReadableStream');
+    expect(observabilityRevivers).toHaveProperty('WritableStream');
+    expect(observabilityRevivers).toHaveProperty('StepFunction');
+  });
+
+  test('hydrateResourceIO is exported and handles plain values', () => {
+    const step = { stepId: 'test', input: 'hello', output: 42 };
+    const result = hydrateResourceIO(step, observabilityRevivers);
+    expect(result.input).toBe('hello');
+    expect(result.output).toBe(42);
+  });
+
+  test('hydrateData is exported and passes through plain values', () => {
+    expect(hydrateData('hello', observabilityRevivers)).toBe('hello');
+    expect(hydrateData(42, observabilityRevivers)).toBe(42);
+    expect(hydrateData(null, observabilityRevivers)).toBe(null);
+  });
+});

--- a/packages/workflow/src/observability.ts
+++ b/packages/workflow/src/observability.ts
@@ -1,0 +1,29 @@
+/**
+ * Observability utilities for hydrating serialized workflow data.
+ *
+ * Use these when inspecting workflow step I/O, run inputs/outputs,
+ * or event data from the Workflow SDK's world APIs.
+ *
+ * @example
+ * ```ts
+ * import { getWorld } from 'workflow/api';
+ * import { hydrateResourceIO, observabilityRevivers } from 'workflow/observability';
+ *
+ * const world = getWorld();
+ * const step = await world.steps.get(runId, stepId, { resolveData: 'all' });
+ * const hydrated = hydrateResourceIO(step, observabilityRevivers);
+ * // hydrated.input and hydrated.output are now plain JS objects
+ * ```
+ */
+export {
+  hydrateData,
+  hydrateResourceIO,
+  observabilityRevivers,
+  type Revivers,
+} from '@workflow/core/serialization-format';
+
+export {
+  parseClassName,
+  parseStepName,
+  parseWorkflowName,
+} from '@workflow/utils';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1258,6 +1258,9 @@ importers:
       '@workflow/typescript-plugin':
         specifier: workspace:*
         version: link:../typescript-plugin
+      '@workflow/utils':
+        specifier: workspace:*
+        version: link:../utils
       ms:
         specifier: 2.1.3
         version: 2.1.3
@@ -23456,14 +23459,6 @@ snapshots:
     optionalDependencies:
       vite: 7.1.12(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@vitest/mocker@4.0.18(vite@7.1.12(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.1.12(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
-
   '@vitest/mocker@4.0.18(vite@7.1.12(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -32855,7 +32850,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.1.12(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(vite@7.1.12(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
## Summary

- **Re-export `parseStepName`, `parseWorkflowName`, `parseClassName`** from `@workflow/utils` main index (previously only available via hidden sub-path `@workflow/utils/parse-name`)
- **Add `workflow/observability` sub-export** that bundles hydration utilities (`hydrateResourceIO`, `observabilityRevivers`, `hydrateData`) alongside parseName functions for one-stop observability imports

## Context

From [this Slack thread](https://vercel.slack.com/archives/C09125LC4AX/p1773936163539109) — heavy WDK dogfooding in #project-dse-hypercare surfaced DX gaps. We wrote a custom ~50-line devalue decoder + custom `parseStepName`/`parseWorkflowName` in our CLI ([dsebr-vc#195](https://github.com/vercel/dsebr-vc/pull/195)) because these weren't discoverable from public import paths.

Pranay + Peter aligned that re-exports are the quick win (world-level auto-hydration is harder due to node vs browser env concerns + async hydration conflicting with runtime stream wrapping).

## What this enables

### Before (hidden internal paths)
```ts
import { parseStepName } from '@workflow/utils/parse-name';
import { hydrateResourceIO, observabilityRevivers } from '@workflow/core/serialization-format';
```

### After — option 1: from @workflow/utils main index
```ts
import { parseStepName, parseWorkflowName } from '@workflow/utils';
```

### After — option 2: one-stop import from workflow/observability
```ts
import {
  parseStepName,
  parseWorkflowName,
  hydrateResourceIO,
  observabilityRevivers,
} from 'workflow/observability';
```

### Real-world usage example (from our CLI)
```ts
import { hydrateResourceIO, observabilityRevivers, parseStepName } from 'workflow/observability';

// Hydrate step I/O from Uint8Array/devalue format to plain JS objects
const step = await world.steps.get(runId, stepId, { resolveData: 'all' });
const hydrated = hydrateResourceIO(step, observabilityRevivers);

// Parse verbose step names into short display names
const displayName = parseStepName(step.name)?.shortName ?? step.name;
// "step//./src/workflows/pulse//queryKBStep" → "queryKBStep"
```

## Changes

| File | Change |
|------|--------|
| `packages/utils/src/index.ts` | Re-export `parseClassName`, `parseStepName`, `parseWorkflowName` from main index |
| `packages/utils/src/re-exports.test.ts` | 3 tests verifying re-exports work from main index |
| `packages/workflow/src/observability.ts` | New `workflow/observability` sub-export with JSDoc + usage example |
| `packages/workflow/src/observability.test.ts` | 6 tests verifying all exports + hydration behavior |
| `packages/workflow/package.json` | Add `./observability` export map + `@workflow/utils` dependency |
| `pnpm-lock.yaml` | Lock file update |

## Testing

### Automated (all pass)
```bash
pnpm --filter @workflow/utils test   # 89 tests (86 existing + 3 new re-export tests)
pnpm --filter workflow test          # 7 tests (1 existing + 6 new observability tests)
```

### What the tests verify
- `parseStepName`, `parseWorkflowName`, `parseClassName` importable from `@workflow/utils` main index
- `hydrateResourceIO` correctly hydrates step resources with plain value inputs
- `hydrateData` passes through plain JS values (string, number, null)
- `observabilityRevivers` contains expected reviver keys (`ReadableStream`, `WritableStream`, `StepFunction`)
- Zero type errors on `observability.ts` compilation

### Manual verification
- `tsc --noEmit` confirms zero type errors for our new files
- Built `@workflow/utils`, `@workflow/core`, and `workflow` packages — `observability.js` + `observability.d.ts` generated correctly
- Pre-existing framework adapter build errors (astro, nest, nuxt — needs Rust for SWC plugin) are unrelated to this change

## Related

- Slack thread: https://vercel.slack.com/archives/C09125LC4AX/p1773936163539109
- PR #1451 (stepName TSDoc, already merged): https://github.com/vercel/workflow/pull/1451
- Our CLI PR (shows what we want to delete upstream): https://github.com/vercel/dsebr-vc/pull/195
- Linear: DSE-2322

🤖 Generated with [Claude Code](https://claude.com/claude-code)