### PR TITLE
changeset for projectRoot api

### DIFF
--- a/.changeset/twenty-heads-jam.md
+++ b/.changeset/twenty-heads-jam.md
@@ -1,0 +1,6 @@
+---
+"@workflow/builders": patch
+"@workflow/next": patch
+---
+
+Add optional projectRoot to builder config to allow explicit resolution of workflow module specifiers without relying on process.cwd(). Threads the root through discovery, SWC transforms, and the Next.js deferred builder while preserving existing behavior when omitted.


### PR DESCRIPTION
This pull request introduces an optional `projectRoot` configuration to the builder setup, allowing explicit resolution of workflow module specifiers instead of relying on `process.cwd()`. The change is threaded through module discovery, SWC transforms, and the Next.js deferred builder, while maintaining backward compatibility when the option is not provided.

Configuration and resolution improvements:

* Added an optional `projectRoot` property to the builder config, enabling explicit module resolution and reducing reliance on `process.cwd()`.
* Updated module discovery, SWC transforms, and the Next.js deferred builder to utilize the new `projectRoot` option, while preserving existing behavior if it is omitted.