### PR TITLE
fix(web): correct hooks empty state docs link

### DIFF
--- a/packages/web/app/components/hooks-table.tsx
+++ b/packages/web/app/components/hooks-table.tsx
@@ -3,7 +3,7 @@ import {
   ResolveHookDropdownItem,
   useHookActions,
 } from '@workflow/web-shared';
-import type { Event, Hook } from '@workflow/world';
+import type { Hook } from '@workflow/world';
 import {
   AlertCircle,
   ChevronLeft,
@@ -35,16 +35,16 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '~/components/ui/tooltip';
-import { CopyableText } from './display-utils/copyable-text';
-import { RelativeTime } from './display-utils/relative-time';
-import { TableSkeleton } from './display-utils/table-skeleton';
+import { fetchEvents } from '~/lib/rpc-client';
+import type { EnvMap } from '~/lib/types';
 import {
   getErrorMessage,
   resumeHook,
   useWorkflowHooks,
 } from '~/lib/workflow-api-client';
-import type { EnvMap } from '~/lib/types';
-import { fetchEvents } from '~/lib/rpc-client';
+import { CopyableText } from './display-utils/copyable-text';
+import { RelativeTime } from './display-utils/relative-time';
+import { TableSkeleton } from './display-utils/table-skeleton';
 
 interface HooksTableProps {
   runId?: string;
@@ -142,7 +142,11 @@ export function HooksTable({
           setInvocationData((prev) => {
             const updated = new Map(prev);
             for (const hook of hooks) {
-              updated.set(hook.hookId, { count: 0, hasMore: false, loading: false });
+              updated.set(hook.hookId, {
+                count: 0,
+                hasMore: false,
+                loading: false,
+              });
             }
             return updated;
           });
@@ -182,7 +186,11 @@ export function HooksTable({
         setInvocationData((prev) => {
           const updated = new Map(prev);
           for (const hook of hooks) {
-            updated.set(hook.hookId, { count: 0, hasMore: false, loading: false });
+            updated.set(hook.hookId, {
+              count: 0,
+              hasMore: false,
+              loading: false,
+            });
           }
           return updated;
         });
@@ -270,7 +278,7 @@ export function HooksTable({
       ) : !loading && (!hooks || hooks.length === 0) ? (
         <div className="text-center py-8 text-muted-foreground">
           No active hooks found. <br />
-          <DocsLink href="https://useworkflow.dev/docs/api-reference/workflow/create-hook">
+          <DocsLink href="https://useworkflow.dev/docs/foundations/hooks">
             Learn how to create a hook
           </DocsLink>
         </div>

--- a/packages/web/app/components/ui/docs-link.test.tsx
+++ b/packages/web/app/components/ui/docs-link.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('~/lib/utils', () => ({
+  cn: (...inputs: Array<string | undefined>) =>
+    inputs.filter(Boolean).join(' '),
+}));
+
+import { DocsLink } from './docs-link';
+
+describe('DocsLink', () => {
+  it('renders an external anchor for absolute docs URLs', () => {
+    render(
+      <DocsLink href="https://useworkflow.dev/docs/foundations/hooks">
+        Learn how to create a hook
+      </DocsLink>
+    );
+
+    const link = screen.getByRole('link', {
+      name: 'Learn how to create a hook',
+    });
+
+    expect(link.getAttribute('href')).toBe(
+      'https://useworkflow.dev/docs/foundations/hooks'
+    );
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+});

--- a/packages/web/app/components/ui/docs-link.tsx
+++ b/packages/web/app/components/ui/docs-link.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router';
 import * as React from 'react';
 
 import { cn } from '~/lib/utils';
@@ -20,7 +19,7 @@ const DocsLink = React.forwardRef<HTMLAnchorElement, DocsLinkProps>(
       : `https://useworkflow.dev/docs/${href.replace(/^\//, '')}`;
 
     return (
-      <Link
+      <a
         href={fullHref}
         className={cn(
           'font-medium underline underline-offset-4 transition-colors',
@@ -35,7 +34,7 @@ const DocsLink = React.forwardRef<HTMLAnchorElement, DocsLinkProps>(
         {...props}
       >
         {children}
-      </Link>
+      </a>
     );
   }
 );


### PR DESCRIPTION
## Summary
- fix the hooks empty-state CTA to point to the hooks guide
- render docs links as external anchors instead of router links
- add a regression test for the docs link component

## Why
This is a bug: the hooks empty-state link can resolve to the local app instead of the public docs.