### PR TITLE
Add namespaced streams documentation to workflow skill

### DIFF
--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -3,7 +3,7 @@ name: workflow
 description: Creates durable, resumable workflows using Vercel's Workflow DevKit. Use when building workflows that need to survive restarts, pause for external events, retry on failure, or coordinate multi-step operations over time. Triggers on mentions of "workflow", "durable functions", "resumable", "workflow devkit", "queue", "event", "push", "subscribe", or step-based orchestration.
 metadata:
   author: Vercel Inc.
-  version: '1.3'
+  version: '1.4'
 ---
 
 ## *CRITICAL*: Always Use Correct `workflow` Documentation
@@ -332,6 +332,106 @@ async function streamData(chunk: string) {
   }
 }
 ```
+
+### Namespaced Streams
+
+Use `getWritable({ namespace: 'name' })` to create multiple independent streams for different types of data. This is useful for separating logs from primary output, different log levels, agent outputs, metrics, or any distinct data channels. Long-running workflows benefit from namespaced streams because you can replay only the important events (e.g., final results) while keeping verbose logs in a separate stream.
+
+**Example: Log levels and agent output separation:**
+```typescript
+import { getWritable } from "workflow";
+
+type LogEntry = { level: "debug" | "info" | "warn" | "error"; message: string; timestamp: number };
+type AgentOutput = { type: "thought" | "action" | "result"; content: string };
+
+async function logDebug(message: string) {
+  "use step";
+  const writer = getWritable<LogEntry>({ namespace: "logs:debug" }).getWriter();
+  try {
+    await writer.write({ level: "debug", message, timestamp: Date.now() });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+async function logInfo(message: string) {
+  "use step";
+  const writer = getWritable<LogEntry>({ namespace: "logs:info" }).getWriter();
+  try {
+    await writer.write({ level: "info", message, timestamp: Date.now() });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+async function emitAgentThought(thought: string) {
+  "use step";
+  const writer = getWritable<AgentOutput>({ namespace: "agent:thoughts" }).getWriter();
+  try {
+    await writer.write({ type: "thought", content: thought });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+async function emitAgentResult(result: string) {
+  "use step";
+  // Important results go to the default stream for easy replay
+  const writer = getWritable<AgentOutput>().getWriter();
+  try {
+    await writer.write({ type: "result", content: result });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+export async function agentWorkflow(task: string) {
+  "use workflow";
+  
+  await logInfo(`Starting task: ${task}`);
+  await logDebug("Initializing agent context");
+  await emitAgentThought("Analyzing the task requirements...");
+  
+  // ... agent processing ...
+  
+  await emitAgentResult("Task completed successfully");
+  await logInfo("Workflow finished");
+}
+```
+
+**Consuming namespaced streams:**
+```typescript
+import { start, getRun } from "workflow/api";
+import { agentWorkflow } from "./workflows/agent";
+
+export async function POST(request: Request) {
+  const run = await start(agentWorkflow, ["process data"]);
+
+  // Access specific streams by namespace
+  const results = run.getReadable({ namespace: undefined }); // Default stream (important results)
+  const infoLogs = run.getReadable({ namespace: "logs:info" });
+  const debugLogs = run.getReadable({ namespace: "logs:debug" });
+  const thoughts = run.getReadable({ namespace: "agent:thoughts" });
+
+  // Return only important results for most clients
+  return new Response(results, { headers: { "Content-Type": "application/json" } });
+}
+
+// Resume from a specific point (useful for long sessions)
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const runId = searchParams.get("runId")!;
+  const startIndex = parseInt(searchParams.get("startIndex") || "0", 10);
+  
+  const run = getRun(runId);
+  // Resume only the important stream, skip verbose debug logs
+  const stream = run.getReadable({ startIndex });
+  
+  return new Response(stream);
+}
+```
+
+**Pro tip:** For very long-running sessions (50+ minutes), namespaced streams help manage replay performance. Put verbose/debug output in separate namespaces so you can replay just the important events quickly.
 
 ## Debugging
 


### PR DESCRIPTION
The workflow skill (v1.3) mentioned streaming and `getWritable()` but didn't cover namespaced streams (`getWritable({ namespace: "..." })`).

### What changed
- Bumped skill version to 1.4
- Added a dedicated "Namespaced Streams" section explaining the feature and its benefits for long-running workflows
- Added a practical example showing log levels (`logs:debug`, `logs:info`) and agent output separation (`agent:thoughts` vs default stream for results)
- Added consumer-side code showing how to access specific namespaces and resume from a specific index
- Included pro tip about replay performance for 50+ minute sessions

<a href="https://vercel.slack.com/archives/C0AMN8UE0TX/p1773987642556359?thread_ts=1773987642.556359&cid=C0AMN8UE0TX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>