### PR TITLE
Add testing documentation to workflow skill

### DIFF
--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -3,7 +3,7 @@ name: workflow
 description: Creates durable, resumable workflows using Vercel's Workflow DevKit. Use when building workflows that need to survive restarts, pause for external events, retry on failure, or coordinate multi-step operations over time. Triggers on mentions of "workflow", "durable functions", "resumable", "workflow devkit", "queue", "event", "push", "subscribe", or step-based orchestration.
 metadata:
   author: Vercel Inc.
-  version: '1.3'
+  version: '1.4'
 ---
 
 ## *CRITICAL*: Always Use Correct `workflow` Documentation
@@ -367,3 +367,89 @@ npx workflow cancel <run_id> --backend vercel --project <project-name> --team <t
 - Use `--web` to open the Vercel Observability dashboard in your browser
 - Use `--help` on any command for full usage details
 - Only import workflow APIs you actually use. Unused imports can cause 500 errors.
+
+## Testing Workflows
+
+Workflow DevKit provides a Vitest plugin for testing workflows in-process — no running server required.
+
+**Unit testing steps:** Steps are just functions; without the compiler, `"use step"` is a no-op. Test them directly:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { createUser } from "./user-signup";
+
+describe("createUser step", () => {
+  it("should create a user", async () => {
+    const user = await createUser("test@example.com");
+    expect(user.email).toBe("test@example.com");
+  });
+});
+```
+
+**Integration testing:** Use `@workflow/vitest` for workflows using `sleep()`, hooks, webhooks, or retries:
+
+```typescript
+// vitest.integration.config.ts
+import { defineConfig } from "vitest/config";
+import { workflow } from "@workflow/vitest";
+
+export default defineConfig({
+  plugins: [workflow()],
+  test: {
+    include: ["**/*.integration.test.ts"],
+    testTimeout: 60_000,
+  },
+});
+```
+
+```typescript
+// approval.integration.test.ts
+import { describe, it, expect } from "vitest";
+import { start, getRun, resumeHook } from "workflow/api";
+import { waitForHook, waitForSleep } from "@workflow/vitest";
+import { approvalWorkflow } from "./approval";
+
+describe("approvalWorkflow", () => {
+  it("should publish when approved", async () => {
+    const run = await start(approvalWorkflow, ["doc-123"]);
+
+    // Wait for the hook, then resume it
+    await waitForHook(run, { token: "approval:doc-123" });
+    await resumeHook("approval:doc-123", { approved: true, reviewer: "alice" });
+
+    // Wait for sleep, then wake it up
+    const sleepId = await waitForSleep(run);
+    await getRun(run.runId).wakeUp({ correlationIds: [sleepId] });
+
+    const result = await run.returnValue;
+    expect(result).toEqual({ status: "published", reviewer: "alice" });
+  });
+});
+```
+
+**Testing webhooks:** Use `resumeWebhook()` with a `Request` object — no HTTP server needed:
+
+```typescript
+import { start, resumeWebhook } from "workflow/api";
+import { waitForHook } from "@workflow/vitest";
+
+const run = await start(ingestWorkflow, ["ep-1"]);
+const hook = await waitForHook(run);  // Discovers the random webhook token
+await resumeWebhook(hook.token, new Request("https://example.com/webhook", {
+  method: "POST",
+  body: JSON.stringify({ event: "order.created" }),
+}));
+```
+
+**Key APIs:**
+- `start()` — trigger a workflow
+- `run.returnValue` — await workflow completion
+- `waitForHook(run, { token? })` / `waitForSleep(run)` — wait for workflow to reach a pause point
+- `resumeHook(token, data)` / `resumeWebhook(token, request)` — resume paused workflows
+- `getRun(runId).wakeUp({ correlationIds })` — skip `sleep()` calls
+
+**Best practices:**
+- Keep unit tests (no plugin) and integration tests (`workflow()` plugin) in separate configs
+- Use deterministic hook tokens based on test data for easier resumption
+- Set generous `testTimeout` — workflows may run longer than typical unit tests
+- `vi.mock()` does **not** work in integration tests — step dependencies are bundled by esbuild


### PR DESCRIPTION
Added comprehensive testing section to the workflow skill (v1.3 → v1.4) covering:

### What changed
- Unit testing steps as plain functions (no plugin needed)
- Integration testing with `@workflow/vitest` plugin for hooks, sleeps, webhooks
- Example Vitest config and test file showing `waitForHook`, `waitForSleep`, `resumeHook`, and `wakeUp` usage
- Webhook testing with `resumeWebhook()` and `Request` objects
- Key APIs summary and best practices

Based on the official testing guide at https://useworkflow.dev/docs/testing

<a href="https://vercel.slack.com/archives/C0AMN8UE0TX/p1773987642556359?thread_ts=1773987642.556359&cid=C0AMN8UE0TX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>