### PR TITLE
Add DOMException to VM context and first-class serialization support

### DIFF
--- a/.changeset/domexception-serialization.md
+++ b/.changeset/domexception-serialization.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Add `DOMException` to the workflow VM context and add first-class serialization support, preserving `message`, `name`, and derived `code` across serialization boundaries

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -25,6 +25,7 @@ export type Serializable =
   | BigInt64Array
   | BigUint64Array
   | Date
+  | DOMException
   | Float32Array
   | Float64Array
   | Headers

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -3180,6 +3180,131 @@ describe('custom Error subclass serialization', () => {
   });
 });
 
+describe('DOMException serialization', () => {
+  const { context, globalThis: vmGlobalThis } = createContext({
+    seed: 'test-domexception',
+    fixedTimestamp: 1714857600000,
+  });
+  vmGlobalThis.Request = globalThis.Request;
+  vmGlobalThis.Response = globalThis.Response;
+  vmGlobalThis.ReadableStream = globalThis.ReadableStream;
+  vmGlobalThis.WritableStream = globalThis.WritableStream;
+
+  async function roundTrip(value: unknown) {
+    const serialized = await dehydrateStepReturnValue(
+      value,
+      mockRunId,
+      noEncryptionKey
+    );
+    return hydrateStepReturnValue(
+      serialized,
+      mockRunId,
+      noEncryptionKey,
+      globalThis
+    );
+  }
+
+  it('should round-trip DOMException with AbortError name', async () => {
+    const error = new DOMException('operation aborted', 'AbortError');
+    const hydrated = (await roundTrip(error)) as DOMException;
+    expect(hydrated).toBeInstanceOf(DOMException);
+    expect(hydrated.message).toBe('operation aborted');
+    expect(hydrated.name).toBe('AbortError');
+    // code is derived from name automatically
+    expect(hydrated.code).toBe(20);
+  });
+
+  it('should round-trip DOMException with NotFoundError name', async () => {
+    const error = new DOMException('resource not found', 'NotFoundError');
+    const hydrated = (await roundTrip(error)) as DOMException;
+    expect(hydrated).toBeInstanceOf(DOMException);
+    expect(hydrated.message).toBe('resource not found');
+    expect(hydrated.name).toBe('NotFoundError');
+    expect(hydrated.code).toBe(8);
+  });
+
+  it('should round-trip DOMException with default name', async () => {
+    // When no name is provided, DOMException defaults to "Error"
+    const error = new DOMException('something failed');
+    const hydrated = (await roundTrip(error)) as DOMException;
+    expect(hydrated).toBeInstanceOf(DOMException);
+    expect(hydrated.message).toBe('something failed');
+    expect(hydrated.name).toBe('Error');
+    expect(hydrated.code).toBe(0);
+  });
+
+  it('should preserve cause on DOMException when manually set', async () => {
+    const error = new DOMException('aborted', 'AbortError');
+    (error as any).cause = new TypeError('underlying cause');
+    const hydrated = (await roundTrip(error)) as DOMException;
+    expect(hydrated).toBeInstanceOf(DOMException);
+    expect(hydrated.message).toBe('aborted');
+    expect(hydrated.name).toBe('AbortError');
+    expect((hydrated.cause as Error).message).toBe('underlying cause');
+  });
+
+  it('should not set cause on DOMException when original had none', async () => {
+    const error = new DOMException('no cause', 'AbortError');
+    expect('cause' in error).toBe(false);
+    const hydrated = (await roundTrip(error)) as DOMException;
+    expect(hydrated.message).toBe('no cause');
+    expect('cause' in hydrated).toBe(false);
+  });
+
+  it('should use DOMException serialization key (not generic Error)', async () => {
+    const error = new DOMException('test', 'AbortError');
+    const serialized = await dehydrateStepReturnValue(
+      error,
+      mockRunId,
+      noEncryptionKey
+    );
+    const str = new TextDecoder().decode(
+      (serialized as Uint8Array).subarray(4)
+    );
+    expect(str).toContain('DOMException');
+    expect(str).not.toMatch(/"Error"/);
+  });
+
+  it('should round-trip DOMException across VM boundaries', async () => {
+    const hostError = new DOMException('host abort', 'AbortError');
+    const serialized = await dehydrateStepReturnValue(
+      hostError,
+      mockRunId,
+      noEncryptionKey
+    );
+    const hydrated = await hydrateStepReturnValue(
+      serialized,
+      mockRunId,
+      noEncryptionKey,
+      vmGlobalThis
+    );
+    runInContext('var __testVal = null', context);
+    (vmGlobalThis as any).__testVal = hydrated;
+    expect(runInContext('__testVal instanceof DOMException', context)).toBe(
+      true
+    );
+    expect(runInContext('__testVal.message', context)).toBe('host abort');
+    expect(runInContext('__testVal.name', context)).toBe('AbortError');
+  });
+
+  it('should have DOMException available in VM context by default', () => {
+    // DOMException is a standard Web API that is passed through to the VM
+    // context by createContext(), so it should always be available.
+    const { context: freshContext } = createContext({
+      seed: 'test-dom-available',
+      fixedTimestamp: 1714857600000,
+    });
+    expect(runInContext('typeof DOMException', freshContext)).toBe('function');
+    const result = runInContext(
+      'new DOMException("test", "AbortError")',
+      freshContext
+    );
+    expect(result).toBeInstanceOf(DOMException);
+    expect(result.name).toBe('AbortError');
+    expect(result.message).toBe('test');
+  });
+});
+
 describe('format prefix system', () => {
   const { globalThis: vmGlobalThis } = createContext({
     seed: 'test',

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -585,6 +585,12 @@ export interface SerializableSpecial {
   BigInt64Array: string; // base64 string
   BigUint64Array: string; // base64 string
   Date: string; // ISO string
+  DOMException: {
+    message: string;
+    name: string;
+    stack?: string;
+    cause?: unknown;
+  };
   Float32Array: string; // base64 string
   Float64Array: string; // base64 string
   Error: Record<string, any>;
@@ -722,6 +728,21 @@ function getCommonReducers(global: Record<string, any> = globalThis) {
       const valid = !Number.isNaN(value.getDate());
       // Note: "." is to avoid returning a falsy value when the date is invalid
       return valid ? value.toISOString() : '.';
+    },
+    // DOMException is a special case: in Node.js it passes isNativeError()
+    // and instanceof Error, but has a unique constructor signature
+    // (message, name) and a read-only numeric `code` property derived from
+    // `name`. It must be checked before the generic Error reducer.
+    DOMException: (value) => {
+      if (!types.isNativeError(value)) return false;
+      if (value.constructor?.name !== 'DOMException') return false;
+      const reduced: SerializableSpecial['DOMException'] = {
+        message: value.message,
+        name: value.name,
+        stack: value.stack,
+      };
+      if ('cause' in value) reduced.cause = value.cause;
+      return reduced;
     },
     Error: (value) => {
       // Use types.isNativeError() instead of `instanceof global.Error`
@@ -1033,6 +1054,14 @@ export function getCommonRevivers(global: Record<string, any> = globalThis) {
       return new global.BigUint64Array(ab);
     },
     Date: (value) => new global.Date(value),
+    DOMException: (value) => {
+      const error = new global.DOMException(value.message, value.name);
+      if (value.stack !== undefined) error.stack = value.stack;
+      // DOMException's constructor doesn't accept a cause option, so
+      // we set it manually when present in the serialized data.
+      if ('cause' in value) error.cause = value.cause;
+      return error;
+    },
     Error: (value) => {
       const error = new global.Error(value.message);
       error.name = value.name;

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -91,6 +91,7 @@ export function createContext(options: CreateContextOptions) {
   };
 
   // Stateless + synchronous Web APIs that are made available inside the sandbox
+  g.DOMException = globalThis.DOMException;
   g.Headers = globalThis.Headers;
   g.TextEncoder = globalThis.TextEncoder;
   g.TextDecoder = globalThis.TextDecoder;


### PR DESCRIPTION
## Summary

- Pass `DOMException` through to the workflow VM context alongside other Web APIs (`Headers`, `URL`, `TextEncoder`, etc.)
- Add `DOMException` reducer/reviver to the devalue serialization pipeline, preserving `message`, `name`, and derived `code`
- Add `DOMException` to the `Serializable` type union
- 6 new tests: round-trip for AbortError, NotFoundError, default name, serialization key verification, cross-VM boundaries, and VM context availability

## Context

This is **PR 2 of 5** in a series to improve error handling in Workflow DevKit. Stacked on top of #1511.

1. #1511 — First-class serde for built-in Error subclasses
2. **This PR** — `DOMException` VM context + serde support
3. `WORKFLOW_SERIALIZE`/`WORKFLOW_DESERIALIZE` for `FatalError` and `RetryableError`
4. Serialize thrown step errors through the devalue pipeline (event log format change)
5. Serialize thrown workflow errors through the devalue pipeline

## Design notes

`DOMException` is a standard Web API available in Node.js since v17. It was previously missing from the workflow VM context, which meant deserialization would have needed a fallback. This PR adds it to `createContext()` alongside the other Web API passthroughs, so the reviver can always construct a proper `DOMException`.

Key differences from regular Error subclasses:
- Constructor signature is `new DOMException(message, name)` — no options bag
- The `code` property is read-only and automatically derived from the `name` (e.g. `AbortError` → `20`, `NotFoundError` → `8`)
- In Node.js, `types.isNativeError()` returns `true` and `instanceof Error` is `true`

## Test plan

- 6 new tests added to the existing `built-in Error subclass serialization` describe block
- All 519 core package tests pass (22 test files)
- Core package builds cleanly with `tsc`