### PR TITLE
fix: await convertToModelMessages in docs chat API

### DIFF
--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -81,10 +81,10 @@ User question: ${userQuestion}`,
 
     const stream = createUIMessageStream({
       originalMessages: messages,
-      execute: ({ writer }) => {
+      execute: async ({ writer }) => {
         const result = streamText({
           model: 'openai/gpt-4.1-mini',
-          messages: convertToModelMessages(processedMessages),
+          messages: await convertToModelMessages(processedMessages),
           stopWhen: stepCountIs(10),
           tools: createTools(writer),
           system: createSystemPrompt(currentRoute),


### PR DESCRIPTION
## Summary
- `convertToModelMessages` is async but was called without `await` in the docs chat route
- The raw Promise was passed to `streamText`, which validated it against `z.array(modelMessageSchema)` — a Promise isn't an array, so every chat request failed with "Invalid prompt: The messages do not match the ModelMessage[] schema."

## Test plan
- [ ] Open the docs site and use the AI chat (Cmd+I)
- [ ] Send any message and confirm it streams a response without error
- [ ] Clear chat history and send a new message — should also work