### PR TITLE
Encryption: derive unique key per operation for key binding

### DIFF
--- a/.changeset/early-dolls-fix.md
+++ b/.changeset/early-dolls-fix.md
@@ -1,0 +1,7 @@
+---
+"@workflow/core": patch
+"@workflow/cli": patch
+"@workflow/web-shared": patch
+---
+
+Add `enc2` encryption for serialized workflow data, which includes key binding for each operation, also reducing the likelihood of nonce reuse for long-running workflows.

--- a/packages/cli/src/lib/inspect/hydration.ts
+++ b/packages/cli/src/lib/inspect/hydration.ts
@@ -237,8 +237,8 @@ async function maybeDecryptFields<
 
   try {
     const rawKey = await resolver(runId);
-    const { importKey } = await import('@workflow/core/encryption');
-    const k = rawKey ? await importKey(rawKey) : undefined;
+    const { importEncryptionKeys } = await import('@workflow/core/encryption');
+    const k = rawKey ? await importEncryptionKeys(rawKey) : undefined;
 
     // Decrypt input/output/error fields (WorkflowRun, Step)
     result.input = await maybeDecrypt(result.input, k);

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -1,4 +1,4 @@
-import { importKey } from '@workflow/core/encryption';
+import { importEncryptionKeys } from '@workflow/core/encryption';
 import {
   type EncryptionKeyParam,
   getDeserializeStream,
@@ -859,7 +859,7 @@ export const showStream = async (
     encryptionKey = (async () => {
       const run = await world.runs.get(opts.runId!);
       const rawKey = await world.getEncryptionKeyForRun?.(run);
-      return rawKey ? await importKey(rawKey) : undefined;
+      return rawKey ? await importEncryptionKeys(rawKey) : undefined;
     })();
   } else if (opts.decrypt && !opts.runId) {
     logger.warn(

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -1,19 +1,18 @@
 /**
- * Browser-compatible AES-256-GCM encryption module.
+ * Browser-compatible encryption helpers.
  *
  * Uses the Web Crypto API (`globalThis.crypto.subtle`) which works in
  * both modern browsers and Node.js 20+. This module is intentionally
  * free of Node.js-specific imports so it can be bundled for the browser.
  *
  * The World interface (`getEncryptionKeyForRun`) returns a raw 32-byte
- * AES-256 key. Callers should use `importKey()` once to convert it to a
- * `CryptoKey`, then pass that to `encrypt()`/`decrypt()` for all
- * operations within the same run. This avoids repeated `importKey()`
- * calls on every encrypt/decrypt invocation.
+ * per-run key. Core imports that key twice:
+ * - as `AES-GCM` for legacy `encr` payloads
+ * - as `HKDF` for derived-key `enc2` payloads
  *
- * Wire format: `[nonce (12 bytes)][ciphertext + auth tag]`
- * The `encr` format prefix is NOT part of this module — it's added/stripped
- * by the serialization layer in `maybeEncrypt`/`maybeDecrypt`.
+ * Wire format for AES-GCM blobs: `[nonce (12 bytes)][ciphertext + auth tag]`
+ * The `encr` / `enc2` serialization prefixes are NOT part of this module —
+ * they're added/stripped by the serialization layer.
  */
 
 // CryptoKey is a global type in browsers and Node.js 20+, but TypeScript's
@@ -24,22 +23,71 @@ export type CryptoKey = import('node:crypto').webcrypto.CryptoKey;
 const NONCE_LENGTH = 12;
 const TAG_LENGTH = 128; // bits
 const KEY_LENGTH = 32; // bytes (AES-256)
+const HKDF_SALT = new Uint8Array(KEY_LENGTH);
+const V2_HEADER_LENGTH_SIZE = 4;
+const MAX_V2_HEADER_LENGTH = 16 * 1024;
 
-/**
- * Import a raw AES-256 key as a `CryptoKey` for use with `encrypt()`/`decrypt()`.
- *
- * Callers should call this once per run (after `getEncryptionKeyForRun()`)
- * and pass the resulting `CryptoKey` to all subsequent encrypt/decrypt calls.
- *
- * @param raw - Raw 32-byte AES-256 key (from World.getEncryptionKeyForRun)
- * @returns CryptoKey ready for AES-GCM operations
- */
-export async function importKey(raw: Uint8Array) {
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export interface EncryptionKeyBundle {
+  legacyKey: CryptoKey;
+  derivationKey: CryptoKey;
+}
+
+export type EncryptionKeyLike = CryptoKey | EncryptionKeyBundle;
+
+export interface EncryptedV2Header {
+  purpose: string;
+  runId: string;
+  activityId?: string;
+  counter?: number;
+}
+
+function validateRawKey(raw: Uint8Array): void {
   if (raw.byteLength !== KEY_LENGTH) {
     throw new Error(
       `Encryption key must be exactly ${KEY_LENGTH} bytes, got ${raw.byteLength}`
     );
   }
+}
+
+export function isEncryptionKeyBundle(
+  key: EncryptionKeyLike | undefined
+): key is EncryptionKeyBundle {
+  return (
+    typeof key === 'object' &&
+    key !== null &&
+    'legacyKey' in key &&
+    'derivationKey' in key
+  );
+}
+
+export function getLegacyKey(
+  key: EncryptionKeyLike | undefined
+): CryptoKey | undefined {
+  if (!key) return undefined;
+  return isEncryptionKeyBundle(key) ? key.legacyKey : key;
+}
+
+export function getDerivationKey(
+  key: EncryptionKeyLike | undefined
+): CryptoKey | undefined {
+  if (!isEncryptionKeyBundle(key)) return undefined;
+  return key.derivationKey;
+}
+
+/**
+ * Import a raw AES-256 key as a legacy `AES-GCM` `CryptoKey`.
+ *
+ * This is kept for backwards compatibility with callers that still
+ * explicitly work with the legacy `encr` path.
+ *
+ * @param raw - Raw 32-byte AES-256 key (from World.getEncryptionKeyForRun)
+ * @returns CryptoKey ready for AES-GCM operations
+ */
+export async function importLegacyKey(raw: Uint8Array) {
+  validateRawKey(raw);
   return globalThis.crypto.subtle.importKey('raw', raw, 'AES-GCM', false, [
     'encrypt',
     'decrypt',
@@ -47,19 +95,186 @@ export async function importKey(raw: Uint8Array) {
 }
 
 /**
+ * Import a raw per-run key as an `HKDF` base key for derived `enc2` keys.
+ *
+ * @param raw - Raw 32-byte per-run key
+ * @returns CryptoKey ready for HKDF deriveKey operations
+ */
+export async function importDerivationKey(raw: Uint8Array) {
+  validateRawKey(raw);
+  return globalThis.crypto.subtle.importKey('raw', raw, 'HKDF', false, [
+    'deriveKey',
+  ]);
+}
+
+/**
+ * Import a raw per-run key into the pair of keys needed by core.
+ */
+export async function importEncryptionKeys(
+  raw: Uint8Array
+): Promise<EncryptionKeyBundle> {
+  const [legacyKey, derivationKey] = await Promise.all([
+    importLegacyKey(raw),
+    importDerivationKey(raw),
+  ]);
+  return { legacyKey, derivationKey };
+}
+
+/**
+ * Derive an activity-specific AES-256-GCM key from the per-run HKDF key.
+ *
+ * The `info` bytes should encode the full activity context. For `enc2`
+ * payloads we reuse the exact serialized header bytes as both the HKDF
+ * `info` parameter and the AES-GCM AAD.
+ */
+export async function deriveActivityKey(
+  derivationKey: CryptoKey,
+  info: Uint8Array
+): Promise<CryptoKey> {
+  const derived = await globalThis.crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: HKDF_SALT,
+      info,
+    },
+    derivationKey,
+    { name: 'AES-GCM', length: KEY_LENGTH * 8 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+  return derived as CryptoKey;
+}
+
+function isValidEncryptedV2Header(value: unknown): value is EncryptedV2Header {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const header = value as Record<string, unknown>;
+  return (
+    typeof header.purpose === 'string' &&
+    header.purpose.length > 0 &&
+    typeof header.runId === 'string' &&
+    header.runId.length > 0 &&
+    (header.activityId === undefined ||
+      typeof header.activityId === 'string') &&
+    (header.counter === undefined ||
+      (typeof header.counter === 'number' &&
+        Number.isInteger(header.counter) &&
+        header.counter >= 0))
+  );
+}
+
+export function encodeEncryptedV2Header(header: EncryptedV2Header): Uint8Array {
+  if (!isValidEncryptedV2Header(header)) {
+    throw new Error('Invalid enc2 header');
+  }
+
+  const normalized: EncryptedV2Header = {
+    purpose: header.purpose,
+    runId: header.runId,
+  };
+  if (header.activityId !== undefined) {
+    normalized.activityId = header.activityId;
+  }
+  if (header.counter !== undefined) {
+    normalized.counter = header.counter;
+  }
+
+  return encoder.encode(JSON.stringify(normalized));
+}
+
+export function decodeEncryptedV2Header(
+  headerBytes: Uint8Array
+): EncryptedV2Header {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoder.decode(headerBytes));
+  } catch (error) {
+    throw new Error('Invalid enc2 header JSON', { cause: error });
+  }
+
+  if (!isValidEncryptedV2Header(parsed)) {
+    throw new Error('Invalid enc2 header fields');
+  }
+
+  return parsed;
+}
+
+/**
+ * Encode the inner `enc2` payload body:
+ * `[4-byte header length][header bytes][nonce + ciphertext + auth tag]`
+ */
+export function encodeEncryptedV2Body(
+  headerBytes: Uint8Array,
+  ciphertext: Uint8Array
+): Uint8Array {
+  const result = new Uint8Array(
+    V2_HEADER_LENGTH_SIZE + headerBytes.byteLength + ciphertext.byteLength
+  );
+  new DataView(result.buffer).setUint32(0, headerBytes.byteLength, false);
+  result.set(headerBytes, V2_HEADER_LENGTH_SIZE);
+  result.set(ciphertext, V2_HEADER_LENGTH_SIZE + headerBytes.byteLength);
+  return result;
+}
+
+export function decodeEncryptedV2Body(data: Uint8Array): {
+  headerBytes: Uint8Array;
+  ciphertext: Uint8Array;
+} {
+  if (data.byteLength < V2_HEADER_LENGTH_SIZE) {
+    throw new Error('enc2 payload too short to contain header length');
+  }
+
+  const headerLength = new DataView(
+    data.buffer,
+    data.byteOffset,
+    data.byteLength
+  ).getUint32(0, false);
+
+  if (headerLength === 0 || headerLength > MAX_V2_HEADER_LENGTH) {
+    throw new Error(`Invalid enc2 header length: ${headerLength}`);
+  }
+
+  const headerStart = V2_HEADER_LENGTH_SIZE;
+  const headerEnd = headerStart + headerLength;
+  if (data.byteLength < headerEnd) {
+    throw new Error('enc2 payload truncated before header completed');
+  }
+
+  const ciphertext = data.subarray(headerEnd);
+  if (ciphertext.byteLength === 0) {
+    throw new Error('enc2 payload missing ciphertext');
+  }
+
+  return {
+    headerBytes: data.subarray(headerStart, headerEnd),
+    ciphertext,
+  };
+}
+
+/**
  * Encrypt data using AES-256-GCM.
  *
- * @param key - CryptoKey from `importKey()`
+ * @param key - CryptoKey from `importLegacyKey()`
  * @param data - Plaintext to encrypt
+ * @param aad - Optional AES-GCM additional authenticated data
  * @returns `[nonce (12 bytes)][ciphertext + GCM auth tag]`
  */
 export async function encrypt(
   key: CryptoKey,
-  data: Uint8Array
+  data: Uint8Array,
+  aad?: Uint8Array
 ): Promise<Uint8Array> {
   const nonce = globalThis.crypto.getRandomValues(new Uint8Array(NONCE_LENGTH));
   const ciphertext = await globalThis.crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
+    {
+      name: 'AES-GCM',
+      iv: nonce,
+      tagLength: TAG_LENGTH,
+      ...(aad ? { additionalData: aad } : {}),
+    },
     key,
     data
   );
@@ -72,13 +287,15 @@ export async function encrypt(
 /**
  * Decrypt data using AES-256-GCM.
  *
- * @param key - CryptoKey from `importKey()`
+ * @param key - CryptoKey from `importLegacyKey()`
  * @param data - `[nonce (12 bytes)][ciphertext + GCM auth tag]`
+ * @param aad - Optional AES-GCM additional authenticated data
  * @returns Decrypted plaintext
  */
 export async function decrypt(
   key: CryptoKey,
-  data: Uint8Array
+  data: Uint8Array,
+  aad?: Uint8Array
 ): Promise<Uint8Array> {
   const minLength = NONCE_LENGTH + TAG_LENGTH / 8; // nonce + auth tag
   if (data.byteLength < minLength) {
@@ -89,7 +306,12 @@ export async function decrypt(
   const nonce = data.subarray(0, NONCE_LENGTH);
   const ciphertext = data.subarray(NONCE_LENGTH);
   const plaintext = await globalThis.crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
+    {
+      name: 'AES-GCM',
+      iv: nonce,
+      tagLength: TAG_LENGTH,
+      ...(aad ? { additionalData: aad } : {}),
+    },
     key,
     ciphertext
   );

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -2,7 +2,7 @@
  * Utils used by the bundler when transforming code
  */
 
-import type { CryptoKey } from './encryption.js';
+import type { EncryptionKeyLike } from './encryption.js';
 import type { EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
 import type { Serializable } from './schemas.js';
@@ -114,7 +114,7 @@ export { __private_getClosureVars } from './step/get-closure-vars.js';
 
 export interface WorkflowOrchestratorContext {
   runId: string;
-  encryptionKey: CryptoKey | undefined;
+  encryptionKey: EncryptionKeyLike | undefined;
   globalThis: typeof globalThis;
   eventsConsumer: EventsConsumer;
   /**

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -13,7 +13,7 @@ import {
   WorkflowInvokePayloadSchema,
   type WorkflowRun,
 } from '@workflow/world';
-import { importKey } from './encryption.js';
+import { importEncryptionKeys } from './encryption.js';
 import { WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
 import {
@@ -346,7 +346,7 @@ export function workflowEntrypoint(
                 const rawKey =
                   await world.getEncryptionKeyForRun?.(workflowRun);
                 const encryptionKey = rawKey
-                  ? await importKey(rawKey)
+                  ? await importEncryptionKeys(rawKey)
                   : undefined;
 
                 // --- User code execution ---

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -11,7 +11,7 @@ import {
   type WorkflowInvokePayload,
   type WorkflowRun,
 } from '@workflow/world';
-import { type CryptoKey, importKey } from '../encryption.js';
+import { type EncryptionKeyLike, importEncryptionKeys } from '../encryption.js';
 import {
   dehydrateStepReturnValue,
   hydrateStepArguments,
@@ -30,13 +30,13 @@ import { getWorld } from './world.js';
 async function getHookByTokenWithKey(token: string): Promise<{
   hook: Hook;
   run: WorkflowRun;
-  encryptionKey: CryptoKey | undefined;
+  encryptionKey: EncryptionKeyLike | undefined;
 }> {
   const world = getWorld();
   const hook = await world.hooks.getByToken(token);
   const run = await world.runs.get(hook.runId);
   const rawKey = await world.getEncryptionKeyForRun?.(run);
-  const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+  const encryptionKey = rawKey ? await importEncryptionKeys(rawKey) : undefined;
   if (typeof hook.metadata !== 'undefined') {
     hook.metadata = await hydrateStepArguments(
       hook.metadata as any,
@@ -91,7 +91,7 @@ export async function getHookByToken(token: string): Promise<Hook> {
 export async function resumeHook<T = any>(
   tokenOrHook: string | Hook,
   payload: T,
-  encryptionKeyOverride?: CryptoKey
+  encryptionKeyOverride?: EncryptionKeyLike
 ): Promise<Hook> {
   return await waitedUntil(() => {
     return trace('hook.resume', async (span) => {
@@ -100,7 +100,7 @@ export async function resumeHook<T = any>(
       try {
         let hook: Hook;
         let workflowRun: WorkflowRun;
-        let encryptionKey: CryptoKey | undefined;
+        let encryptionKey: EncryptionKeyLike | undefined;
         if (typeof tokenOrHook === 'string') {
           const result = await getHookByTokenWithKey(tokenOrHook);
           hook = result.hook;
@@ -113,7 +113,9 @@ export async function resumeHook<T = any>(
             encryptionKey = encryptionKeyOverride;
           } else {
             const rawKey = await world.getEncryptionKeyForRun?.(workflowRun);
-            encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+            encryptionKey = rawKey
+              ? await importEncryptionKeys(rawKey)
+              : undefined;
           }
         }
 
@@ -132,7 +134,8 @@ export async function resumeHook<T = any>(
           encryptionKey,
           ops,
           globalThis,
-          v1Compat
+          v1Compat,
+          hook.hookId
         );
         // NOTE: Workaround instead of injecting catching undefined unhandled rejections in webhook bundle
         waitUntil(

--- a/packages/core/src/runtime/run.ts
+++ b/packages/core/src/runtime/run.ts
@@ -9,7 +9,7 @@ import {
   type WorkflowRunStatus,
   type World,
 } from '@workflow/world';
-import { type CryptoKey, importKey } from '../encryption.js';
+import { type EncryptionKeyLike, importEncryptionKeys } from '../encryption.js';
 import {
   getExternalRevivers,
   hydrateWorkflowReturnValue,
@@ -85,7 +85,8 @@ export class Run<TResult> {
    * reused for returnValue, getReadable(), etc.
    * @internal
    */
-  private encryptionKeyPromise: Promise<CryptoKey | undefined> | null = null;
+  private encryptionKeyPromise: Promise<EncryptionKeyLike | undefined> | null =
+    null;
 
   constructor(runId: string) {
     this.runId = runId;
@@ -98,12 +99,12 @@ export class Run<TResult> {
    * to be resolved once.
    * @internal
    */
-  private getEncryptionKey(): Promise<CryptoKey | undefined> {
+  private getEncryptionKey(): Promise<EncryptionKeyLike | undefined> {
     if (!this.encryptionKeyPromise) {
       this.encryptionKeyPromise = (async () => {
         const run = await this.world.runs.get(this.runId);
         const rawKey = await this.world.getEncryptionKeyForRun?.(run);
-        return rawKey ? await importKey(rawKey) : undefined;
+        return rawKey ? await importEncryptionKeys(rawKey) : undefined;
       })();
     }
     return this.encryptionKeyPromise;

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -5,7 +5,7 @@ import {
   SPEC_VERSION_LEGACY,
   type World,
 } from '@workflow/world';
-import { importKey } from '../encryption.js';
+import { importEncryptionKeys } from '../encryption.js';
 import { hydrateWorkflowArguments } from '../serialization.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { start } from './start.js';
@@ -52,7 +52,9 @@ export async function recreateRunFromExisting(
   try {
     const run = await world.runs.get(runId, { resolveData: 'all' });
     const rawKey = await world.getEncryptionKeyForRun?.(run);
-    const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+    const encryptionKey = rawKey
+      ? await importEncryptionKeys(rawKey)
+      : undefined;
     const workflowArgs = normalizeWorkflowArgs(
       await hydrateWorkflowArguments(
         run.input,

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -3,7 +3,7 @@ import { WorkflowRuntimeError } from '@workflow/errors';
 import type { WorkflowInvokePayload, World } from '@workflow/world';
 import { isLegacySpecVersion, SPEC_VERSION_CURRENT } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
-import { importKey } from '../encryption.js';
+import { importEncryptionKeys } from '../encryption.js';
 import type { Serializable } from '../schemas.js';
 import { dehydrateWorkflowArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
@@ -145,7 +145,9 @@ export async function start<TArgs extends unknown[], TResult>(
         ...opts,
         deploymentId,
       });
-      const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+      const encryptionKey = rawKey
+        ? await importEncryptionKeys(rawKey)
+        : undefined;
 
       // Create run via run_created event (event-sourced architecture)
       // Pass client-generated runId - server will accept and use it

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -13,7 +13,7 @@ import {
 import { pluralize } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
 import { SPEC_VERSION_CURRENT, StepInvokePayloadSchema } from '@workflow/world';
-import { importKey } from '../encryption.js';
+import { importEncryptionKeys } from '../encryption.js';
 import { runtimeLogger, stepLogger } from '../logger.js';
 import { getStepFunction } from '../private.js';
 import {
@@ -459,7 +459,9 @@ const stepHandler = getWorldHandlers().createQueueHandler(
           // via Promise.all(ops) - their timing is not included in this measurement.
           const ops: Promise<void>[] = [];
           const rawKey = await world.getEncryptionKeyForRun?.(workflowRunId);
-          const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+          const encryptionKey = rawKey
+            ? await importEncryptionKeys(rawKey)
+            : undefined;
           const hydratedInput = await trace(
             'step.hydrate',
             {},
@@ -782,7 +784,10 @@ const stepHandler = getWorldHandlers().createQueueHandler(
               result,
               workflowRunId,
               encryptionKey,
-              ops
+              ops,
+              globalThis,
+              false,
+              stepId
             );
             const durationMs = Date.now() - startTime;
             dehydrateSpan?.setAttributes({

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -12,7 +12,7 @@ import {
   type WorkflowRun,
   type World,
 } from '@workflow/world';
-import { importKey } from '../encryption.js';
+import { importEncryptionKeys } from '../encryption.js';
 import type {
   HookInvocationQueueItem,
   StepInvocationQueueItem,
@@ -94,7 +94,7 @@ export async function handleSuspension({
 
   // Resolve encryption key for this run
   const rawKey = await world.getEncryptionKeyForRun?.(run);
-  const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+  const encryptionKey = rawKey ? await importEncryptionKeys(rawKey) : undefined;
 
   // Build hook_created events (World will atomically create hook entities)
   const hookEvents: CreateEventRequest[] = await Promise.all(
@@ -106,7 +106,9 @@ export async function handleSuspension({
               queueItem.metadata,
               runId,
               encryptionKey,
-              suspension.globalThis
+              suspension.globalThis,
+              false,
+              queueItem.correlationId
             )) as SerializedData);
       return {
         eventType: 'hook_created' as const,
@@ -229,7 +231,9 @@ export async function handleSuspension({
             },
             runId,
             encryptionKey,
-            suspension.globalThis
+            suspension.globalThis,
+            false,
+            queueItem.correlationId
           );
           const stepEvent: CreateEventRequest = {
             eventType: 'step_created' as const,

--- a/packages/core/src/serialization-format.test.ts
+++ b/packages/core/src/serialization-format.test.ts
@@ -1,6 +1,14 @@
 import { stringify } from 'devalue';
 import { describe, expect, it } from 'vitest';
 import {
+  deriveActivityKey,
+  encodeEncryptedV2Body,
+  encodeEncryptedV2Header,
+  encrypt,
+  importEncryptionKeys,
+  importLegacyKey,
+} from './encryption.js';
+import {
   ClassInstanceRef,
   decodeFormatPrefix,
   encodeWithFormatPrefix,
@@ -488,9 +496,24 @@ describe('encrypted data handling', () => {
     return result;
   }
 
+  function makeEncryptedV2Payload(): Uint8Array {
+    const headerBytes = encodeEncryptedV2Header({
+      purpose: 'workflow-arguments',
+      runId: 'wrun_test',
+    });
+    return encodeWithFormatPrefix(
+      SerializationFormat.ENCRYPTED_V2,
+      encodeEncryptedV2Body(headerBytes, new Uint8Array([1, 2, 3, 4]))
+    ) as Uint8Array;
+  }
+
   describe('isEncryptedData', () => {
     it('should detect encr-prefixed Uint8Array', () => {
       expect(isEncryptedData(makeEncryptedPayload())).toBe(true);
+    });
+
+    it('should detect enc2-prefixed Uint8Array', () => {
+      expect(isEncryptedData(makeEncryptedV2Payload())).toBe(true);
     });
 
     it('should not detect devl-prefixed Uint8Array', () => {
@@ -514,6 +537,14 @@ describe('encrypted data handling', () => {
   describe('hydrateData with encrypted values', () => {
     it('should pass through encr-prefixed data as Uint8Array', () => {
       const encrypted = makeEncryptedPayload();
+      const result = hydrateData(encrypted, {});
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result).toBe(encrypted);
+      expect(isEncryptedData(result)).toBe(true);
+    });
+
+    it('should pass through enc2-prefixed data as Uint8Array', () => {
+      const encrypted = makeEncryptedV2Payload();
       const result = hydrateData(encrypted, {});
       expect(result).toBeInstanceOf(Uint8Array);
       expect(result).toBe(encrypted);
@@ -571,18 +602,38 @@ describe('encrypted data handling', () => {
     ]);
 
     async function getTestKey() {
-      const { importKey } = await import('./encryption.js');
-      return importKey(testKeyRaw);
+      return importLegacyKey(testKeyRaw);
+    }
+
+    async function getTestKeys() {
+      return importEncryptionKeys(testKeyRaw);
     }
 
     async function encryptPayload(value: unknown) {
-      const { encrypt, importKey } = await import('./encryption.js');
-      const key = await importKey(testKeyRaw);
+      const key = await importLegacyKey(testKeyRaw);
       const inner = makeDevlPayload(value);
       const encrypted = await encrypt(key, inner);
       return encodeWithFormatPrefix(
         SerializationFormat.ENCRYPTED,
         encrypted
+      ) as Uint8Array;
+    }
+
+    async function encryptPayloadV2(value: unknown) {
+      const keys = await importEncryptionKeys(testKeyRaw);
+      const inner = makeDevlPayload(value);
+      const headerBytes = encodeEncryptedV2Header({
+        purpose: 'workflow-arguments',
+        runId: 'wrun_test',
+      });
+      const activityKey = await deriveActivityKey(
+        keys.derivationKey,
+        headerBytes
+      );
+      const encrypted = await encrypt(activityKey, inner, headerBytes);
+      return encodeWithFormatPrefix(
+        SerializationFormat.ENCRYPTED_V2,
+        encodeEncryptedV2Body(headerBytes, encrypted)
       ) as Uint8Array;
     }
 
@@ -611,6 +662,29 @@ describe('encrypted data handling', () => {
       // Without a key, encrypted data is returned as-is
       expect(result).toBeInstanceOf(Uint8Array);
       expect(isEncryptedData(result)).toBe(true);
+    });
+
+    it('should decrypt and hydrate enc2 payload with key bundle', async () => {
+      const original = { message: 'derived', count: 7 };
+      const encrypted = await encryptPayloadV2(original);
+      const keys = await getTestKeys();
+
+      const result = await hydrateDataWithKey(
+        encrypted,
+        observabilityRevivers,
+        keys
+      );
+      expect(result).toEqual(original);
+    });
+
+    it('should fail to decrypt enc2 payload with only legacy AES key', async () => {
+      const original = { message: 'derived' };
+      const encrypted = await encryptPayloadV2(original);
+      const legacyKey = await getTestKey();
+
+      await expect(
+        hydrateDataWithKey(encrypted, observabilityRevivers, legacyKey)
+      ).rejects.toThrow('Encrypted V2 data encountered');
     });
 
     it('should hydrate non-encrypted payloads normally', async () => {

--- a/packages/core/src/serialization-format.ts
+++ b/packages/core/src/serialization-format.ts
@@ -7,6 +7,15 @@
  */
 
 import { parse, unflatten } from 'devalue';
+import {
+  decodeEncryptedV2Body,
+  decodeEncryptedV2Header,
+  decrypt as aesGcmDecrypt,
+  deriveActivityKey,
+  getDerivationKey,
+  getLegacyKey,
+  type EncryptionKeyLike,
+} from './encryption.js';
 
 // ---------------------------------------------------------------------------
 // Format prefix constants and encoding/decoding
@@ -17,6 +26,8 @@ export const SerializationFormat = {
   DEVALUE_V1: 'devl',
   /** Encrypted payload (inner payload has its own format prefix after decryption) */
   ENCRYPTED: 'encr',
+  /** Derived-key encrypted payload with authenticated cleartext header */
+  ENCRYPTED_V2: 'enc2',
 } as const;
 
 export type SerializationFormatType =
@@ -143,7 +154,10 @@ export function isEncryptedData(data: unknown): boolean {
     return false;
   }
   const prefix = formatDecoder.decode(data.subarray(0, FORMAT_PREFIX_LENGTH));
-  return prefix === SerializationFormat.ENCRYPTED;
+  return (
+    prefix === SerializationFormat.ENCRYPTED ||
+    prefix === SerializationFormat.ENCRYPTED_V2
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -214,13 +228,35 @@ export function hydrateData(value: unknown, revivers: Revivers): unknown {
 export async function hydrateDataWithKey(
   value: unknown,
   revivers: Revivers,
-  key: import('./encryption.js').CryptoKey | undefined
+  key: EncryptionKeyLike | undefined
 ): Promise<unknown> {
   if (value instanceof Uint8Array && isEncryptedData(value) && key) {
-    // Decrypt: strip 'encr' prefix, AES-GCM decrypt, then hydrate the result
-    const { decrypt } = await import('./encryption.js');
-    const { payload } = decodeFormatPrefix(value);
-    const decrypted = await decrypt(key, payload);
+    const { format, payload } = decodeFormatPrefix(value);
+    let decrypted: Uint8Array;
+
+    if (format === SerializationFormat.ENCRYPTED) {
+      const legacyKey = getLegacyKey(key);
+      if (!legacyKey) {
+        throw new Error(
+          'Encrypted legacy data encountered but no AES-GCM key is available'
+        );
+      }
+      decrypted = await aesGcmDecrypt(legacyKey, payload);
+    } else if (format === SerializationFormat.ENCRYPTED_V2) {
+      const derivationKey = getDerivationKey(key);
+      if (!derivationKey) {
+        throw new Error(
+          'Encrypted V2 data encountered but no derivation key is available'
+        );
+      }
+      const { headerBytes, ciphertext } = decodeEncryptedV2Body(payload);
+      decodeEncryptedV2Header(headerBytes);
+      const activityKey = await deriveActivityKey(derivationKey, headerBytes);
+      decrypted = await aesGcmDecrypt(activityKey, ciphertext, headerBytes);
+    } else {
+      throw new Error(`Unsupported encrypted format: ${format}`);
+    }
+
     // The decrypted bytes have their own format prefix (e.g., 'devl')
     return hydrateData(decrypted, revivers);
   }

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -3,7 +3,16 @@ import type { WorkflowRuntimeError } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { registerSerializationClass } from './class-serialization.js';
-import { decrypt, encrypt, importKey } from './encryption.js';
+import {
+  decodeEncryptedV2Body,
+  decodeEncryptedV2Header,
+  decrypt,
+  deriveActivityKey,
+  encodeEncryptedV2Header,
+  encrypt,
+  importEncryptionKeys,
+  importLegacyKey,
+} from './encryption.js';
 import { getStepFunction, registerStepFunction } from './private.js';
 import {
   decodeFormatPrefix,
@@ -3576,7 +3585,7 @@ describe('stream encryption round-trip', () => {
   ]);
   let cryptoKey: CryptoKey;
   beforeAll(async () => {
-    cryptoKey = await importKey(testKeyRaw);
+    cryptoKey = await importLegacyKey(testKeyRaw);
   });
 
   const reducers = {} as any;
@@ -3769,8 +3778,208 @@ describe('stream encryption round-trip', () => {
   });
 });
 
+describe('stream derived-key encryption round-trip', () => {
+  const testKeyRaw = new Uint8Array([
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+    0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+  ]);
+  const runId = 'wrun_stream_enc2';
+  const activityId = 'step_stream_enc2';
+  let encryptionKeys: Awaited<ReturnType<typeof importEncryptionKeys>>;
+
+  beforeAll(async () => {
+    encryptionKeys = await importEncryptionKeys(testKeyRaw);
+  });
+
+  const reducers = {} as any;
+  const revivers = getCommonRevivers(globalThis) as any;
+
+  async function serializeValues(values: unknown[]): Promise<Uint8Array[]> {
+    const serialize = getSerializeStream(reducers, encryptionKeys, {
+      runId,
+      activityId,
+    });
+    const results: Uint8Array[] = [];
+
+    const readPromise = (async () => {
+      const reader = serialize.readable.getReader();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        results.push(value);
+      }
+    })();
+
+    const writer = serialize.writable.getWriter();
+    for (const value of values) {
+      await writer.write(value);
+    }
+    await writer.close();
+    await readPromise;
+    return results;
+  }
+
+  async function deserializeValues(chunks: Uint8Array[]): Promise<unknown[]> {
+    const deserialize = getDeserializeStream(revivers, encryptionKeys);
+    const results: unknown[] = [];
+
+    const readPromise = (async () => {
+      const reader = deserialize.readable.getReader();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        results.push(value);
+      }
+    })();
+
+    const writer = deserialize.writable.getWriter();
+    for (const chunk of chunks) {
+      await writer.write(chunk);
+    }
+    await writer.close();
+    await readPromise;
+    return results;
+  }
+
+  it('should produce enc2-prefixed frames with authenticated header metadata', async () => {
+    const chunks = await serializeValues([{ hello: 'world' }, { again: true }]);
+    expect(chunks).toHaveLength(2);
+
+    for (const [index, chunk] of chunks.entries()) {
+      const frame = chunk.subarray(4);
+      const { format, payload } = decodeFormatPrefix(frame);
+      expect(format).toBe(SerializationFormat.ENCRYPTED_V2);
+
+      const { headerBytes } = decodeEncryptedV2Body(payload);
+      expect(decodeEncryptedV2Header(headerBytes)).toEqual({
+        purpose: 'serialize-stream',
+        runId,
+        activityId,
+        counter: index,
+      });
+    }
+  });
+
+  it('should round-trip enc2 stream frames with the key bundle', async () => {
+    const original = [{ secret: 1 }, 'hello', [1, 2, 3]];
+    const encrypted = await serializeValues(original);
+    const results = await deserializeValues(encrypted);
+    expect(results).toEqual(original);
+  });
+});
+
+describe('derived-key encryption integration', () => {
+  const testKeyRaw = new Uint8Array([
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+    0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+  ]);
+  let encryptionKeys: Awaited<ReturnType<typeof importEncryptionKeys>>;
+
+  beforeAll(async () => {
+    encryptionKeys = await importEncryptionKeys(testKeyRaw);
+  });
+
+  it('should encrypt workflow arguments with enc2 when a key bundle is provided', async () => {
+    const runId = 'wrun_enc2_args';
+    const value = { secret: 'data', count: 42 };
+
+    const encrypted = await dehydrateWorkflowArguments(
+      value,
+      runId,
+      encryptionKeys,
+      [],
+      globalThis,
+      false
+    );
+
+    expect(encrypted).toBeInstanceOf(Uint8Array);
+    const { format, payload } = decodeFormatPrefix(encrypted);
+    expect(format).toBe(SerializationFormat.ENCRYPTED_V2);
+    const { headerBytes } = decodeEncryptedV2Body(payload);
+    expect(decodeEncryptedV2Header(headerBytes)).toEqual({
+      purpose: 'workflow-arguments',
+      runId,
+    });
+
+    const decrypted = await hydrateWorkflowArguments(
+      encrypted,
+      runId,
+      encryptionKeys,
+      globalThis,
+      {}
+    );
+    expect(decrypted).toEqual(value);
+  });
+
+  it('should encrypt step payloads with activity-specific enc2 headers', async () => {
+    const runId = 'wrun_enc2_step';
+    const stepId = 'step_enc2_123';
+    const value = { ok: true, nested: ['a', 'b'] };
+
+    const encrypted = await dehydrateStepReturnValue(
+      value,
+      runId,
+      encryptionKeys,
+      [],
+      globalThis,
+      false,
+      stepId
+    );
+
+    const { format, payload } = decodeFormatPrefix(encrypted);
+    expect(format).toBe(SerializationFormat.ENCRYPTED_V2);
+    const { headerBytes } = decodeEncryptedV2Body(payload);
+    expect(decodeEncryptedV2Header(headerBytes)).toEqual({
+      purpose: 'return-value',
+      runId,
+      activityId: stepId,
+    });
+
+    const decrypted = await hydrateStepReturnValue(
+      encrypted,
+      runId,
+      encryptionKeys,
+      globalThis
+    );
+    expect(decrypted).toEqual(value);
+  });
+
+  it('should derive deterministic keys for the same header and different keys for different headers', async () => {
+    const sharedHeader = encodeEncryptedV2Header({
+      purpose: 'return-value',
+      runId: 'wrun_deterministic',
+      activityId: 'step_a',
+    });
+    const differentHeader = encodeEncryptedV2Header({
+      purpose: 'return-value',
+      runId: 'wrun_deterministic',
+      activityId: 'step_b',
+    });
+    const plaintext = new TextEncoder().encode('deterministic secret');
+
+    const keyA1 = await deriveActivityKey(
+      encryptionKeys.derivationKey,
+      sharedHeader
+    );
+    const keyA2 = await deriveActivityKey(
+      encryptionKeys.derivationKey,
+      sharedHeader
+    );
+    const keyB = await deriveActivityKey(
+      encryptionKeys.derivationKey,
+      differentHeader
+    );
+
+    const encrypted = await encrypt(keyA1, plaintext, sharedHeader);
+    expect(await decrypt(keyA2, encrypted, sharedHeader)).toEqual(plaintext);
+    await expect(decrypt(keyB, encrypted, sharedHeader)).rejects.toThrow();
+  });
+});
+
 describe('encryption integration', () => {
-  // Real 32-byte AES-256 test key (raw bytes for importKey)
+  // Real 32-byte AES-256 test key (raw bytes for importLegacyKey)
   const testKeyRaw = new Uint8Array([
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
     0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
@@ -3783,8 +3992,8 @@ describe('encryption integration', () => {
   let testKey: CryptoKey;
   let wrongKey: CryptoKey;
   beforeAll(async () => {
-    testKey = await importKey(testKeyRaw);
-    wrongKey = await importKey(wrongKeyRaw);
+    testKey = await importLegacyKey(testKeyRaw);
+    wrongKey = await importLegacyKey(wrongKeyRaw);
   });
 
   it('should encrypt workflow arguments when key is provided', async () => {
@@ -4144,7 +4353,7 @@ describe('encrypt/decrypt primitives', () => {
   ]);
   let testKey: CryptoKey;
   beforeAll(async () => {
-    testKey = await importKey(testKeyRaw);
+    testKey = await importLegacyKey(testKeyRaw);
   });
 
   it('should round-trip arbitrary data', async () => {
@@ -4179,9 +4388,9 @@ describe('encrypt/decrypt primitives', () => {
     expect(await decrypt(testKey, enc2)).toEqual(data);
   });
 
-  it('should reject keys that are not 32 bytes via importKey', async () => {
+  it('should reject keys that are not 32 bytes via importLegacyKey', async () => {
     const shortKey = new Uint8Array(16);
-    await expect(importKey(shortKey)).rejects.toThrow(
+    await expect(importLegacyKey(shortKey)).rejects.toThrow(
       'Encryption key must be exactly 32 bytes'
     );
   });
@@ -4196,7 +4405,7 @@ describe('encrypt/decrypt primitives', () => {
   it('should fail with wrong key (auth tag mismatch)', async () => {
     const data = new TextEncoder().encode('secret');
     const encrypted = await encrypt(testKey, data);
-    const wrongKey = await importKey(new Uint8Array(32).fill(0xff));
+    const wrongKey = await importLegacyKey(new Uint8Array(32).fill(0xff));
     await expect(decrypt(wrongKey, encrypted)).rejects.toThrow();
   });
 
@@ -4217,7 +4426,7 @@ describe('maybeEncrypt / maybeDecrypt', () => {
   ]);
   let testKey: CryptoKey;
   beforeAll(async () => {
-    testKey = await importKey(testKeyRaw);
+    testKey = await importLegacyKey(testKeyRaw);
   });
 
   it('should pass through data unchanged when key is undefined', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -5,9 +5,17 @@ import { DevalueError, parse, stringify, unflatten } from 'devalue';
 import { monotonicFactory } from 'ulid';
 import { getSerializationClass } from './class-serialization.js';
 import {
+  decodeEncryptedV2Body,
+  decodeEncryptedV2Header,
   decrypt as aesGcmDecrypt,
+  deriveActivityKey,
+  encodeEncryptedV2Body,
+  encodeEncryptedV2Header,
   encrypt as aesGcmEncrypt,
-  type CryptoKey,
+  getDerivationKey,
+  getLegacyKey,
+  type EncryptedV2Header,
+  type EncryptionKeyLike,
 } from './encryption.js';
 
 /**
@@ -17,9 +25,9 @@ import {
  * is resolved lazily inside the first async transform() call.
  */
 export type EncryptionKeyParam =
-  | CryptoKey
+  | EncryptionKeyLike
   | undefined
-  | Promise<CryptoKey | undefined>;
+  | Promise<EncryptionKeyLike | undefined>;
 
 import {
   createFlushableState,
@@ -58,6 +66,7 @@ import {
 // Current formats:
 // - "devl" - devalue stringify/parse with TextEncoder/TextDecoder (current default)
 // - "encr" - Encrypted payload (inner payload has its own format prefix)
+// - "enc2" - Derived-key encrypted payload with authenticated cleartext header
 //
 // Future formats (reserved):
 // - "cbor" - CBOR binary serialization
@@ -72,6 +81,8 @@ export const SerializationFormat = {
   DEVALUE_V1: 'devl',
   /** Encrypted payload (inner payload has its own format prefix) */
   ENCRYPTED: 'encr',
+  /** Derived-key encrypted payload with authenticated cleartext header */
+  ENCRYPTED_V2: 'enc2',
 } as const;
 
 export type SerializationFormatType =
@@ -143,7 +154,11 @@ export function peekFormatPrefix(
  * @returns true if data has the encrypted format prefix
  */
 export function isEncrypted(data: Uint8Array | unknown): boolean {
-  return peekFormatPrefix(data) === SerializationFormat.ENCRYPTED;
+  const format = peekFormatPrefix(data);
+  return (
+    format === SerializationFormat.ENCRYPTED ||
+    format === SerializationFormat.ENCRYPTED_V2
+  );
 }
 
 /**
@@ -235,6 +250,10 @@ export function getStreamType(stream: ReadableStream): 'bytes' | undefined {
   } catch {}
 }
 
+function getCurrentStreamActivityId(fallbackName: string): string {
+  return contextStorage.getStore()?.stepMetadata.stepId ?? fallbackName;
+}
+
 /**
  * Frame format for stream chunks:
  *   [4-byte big-endian length][format-prefixed payload]
@@ -245,16 +264,78 @@ export function getStreamType(stream: ReadableStream): 'bytes' | undefined {
  */
 const FRAME_HEADER_SIZE = 4;
 
+interface DerivedEncryptionContext {
+  purpose: EncryptedV2Header['purpose'];
+  runId: string;
+  activityId?: string;
+  counter?: number;
+}
+
+interface StreamEncryptionContext {
+  runId: string;
+  activityId?: string;
+}
+
+function buildEncryptedV2Header(context: DerivedEncryptionContext): Uint8Array {
+  return encodeEncryptedV2Header({
+    purpose: context.purpose,
+    runId: context.runId,
+    ...(context.activityId !== undefined
+      ? { activityId: context.activityId }
+      : {}),
+    ...(context.counter !== undefined ? { counter: context.counter } : {}),
+  });
+}
+
+async function decryptEncryptedPayload(
+  format: SerializationFormatType,
+  payload: Uint8Array,
+  key: EncryptionKeyLike | undefined
+): Promise<Uint8Array> {
+  if (format === SerializationFormat.ENCRYPTED) {
+    const legacyKey = getLegacyKey(key);
+    if (!legacyKey) {
+      throw new WorkflowRuntimeError(
+        'Encrypted data encountered but no encryption key is available. ' +
+          'Encryption is not configured or no key was provided for this run.'
+      );
+    }
+    return aesGcmDecrypt(legacyKey, payload);
+  }
+
+  if (format === SerializationFormat.ENCRYPTED_V2) {
+    const derivationKey = getDerivationKey(key);
+    if (!derivationKey) {
+      throw new WorkflowRuntimeError(
+        'Encrypted V2 data encountered but no derivation key is available. ' +
+          'Use importEncryptionKeys() or pass a run key bundle for this run.'
+      );
+    }
+
+    const { headerBytes, ciphertext } = decodeEncryptedV2Body(payload);
+    decodeEncryptedV2Header(headerBytes);
+    const activityKey = await deriveActivityKey(derivationKey, headerBytes);
+    return aesGcmDecrypt(activityKey, ciphertext, headerBytes);
+  }
+
+  throw new WorkflowRuntimeError(`Unsupported encrypted format: ${format}`);
+}
+
 export function getSerializeStream(
   reducers: Reducers,
-  cryptoKey: EncryptionKeyParam
+  cryptoKey: EncryptionKeyParam,
+  encryptionContext?: StreamEncryptionContext
 ): TransformStream<any, Uint8Array> {
   const encoder = new TextEncoder();
   // Resolve the key promise once on first use and cache the result.
   // Note: if the cryptoKey promise rejects (e.g., network error fetching
   // the derived key), the rejection won't surface until the first chunk
   // is processed — not at stream construction time.
-  const keyState = { resolved: false, key: undefined as CryptoKey | undefined };
+  const keyState = {
+    resolved: false,
+    key: undefined as EncryptionKeyLike | undefined,
+  };
+  let frameCounter = 0;
   const stream = new TransformStream<any, Uint8Array>({
     async transform(chunk, controller) {
       try {
@@ -273,11 +354,21 @@ export function getSerializeStream(
         // The length header remains in the clear so the deserializer can
         // find frame boundaries regardless of transport chunking.
         if (keyState.key) {
-          const encrypted = await aesGcmEncrypt(keyState.key, prefixed);
-          prefixed = encodeWithFormatPrefix(
-            SerializationFormat.ENCRYPTED,
-            encrypted
-          ) as Uint8Array;
+          const streamContext =
+            encryptionContext &&
+            getDerivationKey(keyState.key) &&
+            encryptionContext.runId
+              ? {
+                  purpose: 'serialize-stream' as const,
+                  runId: encryptionContext.runId,
+                  ...(encryptionContext.activityId !== undefined
+                    ? { activityId: encryptionContext.activityId }
+                    : {}),
+                  counter: frameCounter++,
+                }
+              : undefined;
+
+          prefixed = await maybeEncrypt(prefixed, keyState.key, streamContext);
         }
 
         // Write length-prefixed frame: [4-byte length][prefixed data]
@@ -305,7 +396,10 @@ export function getDeserializeStream(
   const decoder = new TextDecoder();
   let buffer = new Uint8Array(0);
   // Resolve the key promise once on first use and cache the result.
-  const keyState = { resolved: false, key: undefined as CryptoKey | undefined };
+  const keyState = {
+    resolved: false,
+    key: undefined as EncryptionKeyLike | undefined,
+  };
 
   function appendToBuffer(data: Uint8Array) {
     const newBuffer = new Uint8Array(buffer.length + data.length);
@@ -346,7 +440,10 @@ export function getDeserializeStream(
       // If the frame payload is encrypted, decrypt it first to reveal
       // the inner format-prefixed data (e.g., 'devl' + serialized text),
       // then fall through to the normal deserialization path.
-      if (format === SerializationFormat.ENCRYPTED) {
+      if (
+        format === SerializationFormat.ENCRYPTED ||
+        format === SerializationFormat.ENCRYPTED_V2
+      ) {
         if (!keyState.key) {
           controller.error(
             new WorkflowRuntimeError(
@@ -356,7 +453,11 @@ export function getDeserializeStream(
           );
           return;
         }
-        const decrypted = await aesGcmDecrypt(keyState.key, payload);
+        const decrypted = await decryptEncryptedPayload(
+          format,
+          payload,
+          keyState.key
+        );
         ({ format, payload } = decodeFormatPrefix(decrypted));
       }
 
@@ -570,8 +671,7 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
         // unsettled promise because the cleared timer will never fire.
         const waiters = flushWaiters;
         flushWaiters = [];
-        const abortError =
-          reason ?? new Error("Stream aborted");
+        const abortError = reason ?? new Error('Stream aborted');
         for (const w of waiters) w.reject(abortError);
       },
     });
@@ -857,7 +957,8 @@ export function getExternalReducers(
             .pipeThrough(
               getSerializeStream(
                 getExternalReducers(global, ops, runId, cryptoKey),
-                cryptoKey
+                cryptoKey,
+                { runId, activityId: name }
               )
             )
             .pipeTo(writable)
@@ -965,6 +1066,7 @@ function getStepReducers(
         const streamId = ((global as any)[STABLE_ULID] || defaultUlid)();
         name = `strm_${streamId}`;
         type = getStreamType(value);
+        const activityId = getCurrentStreamActivityId(name);
 
         const writable = new WorkflowServerWritableStream(name, runId);
         if (type === 'bytes') {
@@ -975,7 +1077,8 @@ function getStepReducers(
               .pipeThrough(
                 getSerializeStream(
                   getStepReducers(global, ops, runId, cryptoKey),
-                  cryptoKey
+                  cryptoKey,
+                  { runId, activityId }
                 )
               )
               .pipeTo(writable)
@@ -1219,7 +1322,8 @@ export function getExternalRevivers(
     WritableStream: (value) => {
       const serialize = getSerializeStream(
         getExternalReducers(global, ops, runId, cryptoKey),
-        cryptoKey
+        cryptoKey,
+        { runId, activityId: value.name }
       );
       const serverWritable = new WorkflowServerWritableStream(
         value.name,
@@ -1489,7 +1593,8 @@ function getStepRevivers(
     WritableStream: (value) => {
       const serialize = getSerializeStream(
         getStepReducers(global, ops, runId, cryptoKey),
-        cryptoKey
+        cryptoKey,
+        { runId, activityId: getCurrentStreamActivityId(value.name) }
       );
       const serverWritable = new WorkflowServerWritableStream(
         value.name,
@@ -1528,10 +1633,26 @@ function getStepRevivers(
  */
 export async function maybeEncrypt(
   data: Uint8Array,
-  key: CryptoKey | undefined
+  key: EncryptionKeyLike | undefined,
+  context?: DerivedEncryptionContext
 ): Promise<Uint8Array> {
   if (!key) return data;
-  const encrypted = await aesGcmEncrypt(key, data);
+
+  const derivationKey = getDerivationKey(key);
+  if (derivationKey && context) {
+    const headerBytes = buildEncryptedV2Header(context);
+    const activityKey = await deriveActivityKey(derivationKey, headerBytes);
+    const encrypted = await aesGcmEncrypt(activityKey, data, headerBytes);
+    return encodeWithFormatPrefix(
+      SerializationFormat.ENCRYPTED_V2,
+      encodeEncryptedV2Body(headerBytes, encrypted)
+    ) as Uint8Array;
+  }
+
+  const legacyKey = getLegacyKey(key);
+  if (!legacyKey) return data;
+
+  const encrypted = await aesGcmEncrypt(legacyKey, data);
   return encodeWithFormatPrefix(
     SerializationFormat.ENCRYPTED,
     encrypted
@@ -1551,7 +1672,7 @@ export async function maybeEncrypt(
  */
 export async function maybeDecrypt(
   data: Uint8Array | unknown,
-  key: CryptoKey | undefined
+  key: EncryptionKeyLike | undefined
 ): Promise<Uint8Array | unknown> {
   // Legacy specVersion 1 runs stored event data as plain JSON arrays
   // (not binary Uint8Array). Pass through as-is for backwards compat.
@@ -1560,15 +1681,8 @@ export async function maybeDecrypt(
   }
 
   if (isEncrypted(data)) {
-    if (!key) {
-      throw new WorkflowRuntimeError(
-        'Encrypted data encountered but no encryption key is available. ' +
-          'Encryption is not configured or no key was provided for this run.'
-      );
-    }
-    // Strip the 'encr' format prefix — the prefix is a core framing concern
-    const { payload } = decodeFormatPrefix(data);
-    return aesGcmDecrypt(key, payload);
+    const { format, payload } = decodeFormatPrefix(data);
+    return decryptEncryptedPayload(format, payload, key);
   }
 
   return data;
@@ -1594,7 +1708,7 @@ export async function maybeDecrypt(
 export async function dehydrateWorkflowArguments(
   value: unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: EncryptionKeyLike | undefined,
   ops: Promise<void>[] = [],
   global: Record<string, any> = globalThis,
   v1Compat = false
@@ -1611,7 +1725,10 @@ export async function dehydrateWorkflowArguments(
     ) as Uint8Array;
 
     // Encrypt if world supports encryption
-    return maybeEncrypt(serialized, key);
+    return maybeEncrypt(serialized, key, {
+      purpose: 'workflow-arguments',
+      runId,
+    });
   } catch (error) {
     throw new WorkflowRuntimeError(
       formatSerializationError('workflow arguments', error),
@@ -1634,7 +1751,7 @@ export async function dehydrateWorkflowArguments(
 export async function hydrateWorkflowArguments(
   value: Uint8Array | unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: EncryptionKeyLike | undefined,
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {}
 ) {
@@ -1676,8 +1793,8 @@ export async function hydrateWorkflowArguments(
  */
 export async function dehydrateWorkflowReturnValue(
   value: unknown,
-  _runId: string,
-  key: CryptoKey | undefined,
+  runId: string,
+  key: EncryptionKeyLike | undefined,
   global: Record<string, any> = globalThis,
   v1Compat = false
 ): Promise<Uint8Array | unknown> {
@@ -1693,7 +1810,10 @@ export async function dehydrateWorkflowReturnValue(
     ) as Uint8Array;
 
     // Encrypt if world supports encryption
-    return maybeEncrypt(serialized, key);
+    return maybeEncrypt(serialized, key, {
+      purpose: 'workflow-return-value',
+      runId,
+    });
   } catch (error) {
     throw new WorkflowRuntimeError(
       formatSerializationError('workflow return value', error),
@@ -1718,7 +1838,7 @@ export async function dehydrateWorkflowReturnValue(
 export async function hydrateWorkflowReturnValue(
   value: Uint8Array | unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: EncryptionKeyLike | undefined,
   ops: Promise<void>[] = [],
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {}
@@ -1764,10 +1884,11 @@ export async function hydrateWorkflowReturnValue(
  */
 export async function dehydrateStepArguments(
   value: unknown,
-  _runId: string,
-  key: CryptoKey | undefined,
+  runId: string,
+  key: EncryptionKeyLike | undefined,
   global: Record<string, any> = globalThis,
-  v1Compat = false
+  v1Compat = false,
+  activityId?: string
 ): Promise<Uint8Array | unknown> {
   try {
     const str = stringify(value, getWorkflowReducers(global));
@@ -1781,7 +1902,11 @@ export async function dehydrateStepArguments(
     ) as Uint8Array;
 
     // Encrypt if world supports encryption
-    return maybeEncrypt(serialized, key);
+    return maybeEncrypt(serialized, key, {
+      purpose: 'step-arguments',
+      runId,
+      ...(activityId !== undefined ? { activityId } : {}),
+    });
   } catch (error) {
     throw new WorkflowRuntimeError(
       formatSerializationError('step arguments', error),
@@ -1805,7 +1930,7 @@ export async function dehydrateStepArguments(
 export async function hydrateStepArguments(
   value: Uint8Array | unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: EncryptionKeyLike | undefined,
   ops: Promise<any>[] = [],
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {}
@@ -1853,10 +1978,11 @@ export async function hydrateStepArguments(
 export async function dehydrateStepReturnValue(
   value: unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: EncryptionKeyLike | undefined,
   ops: Promise<any>[] = [],
   global: Record<string, any> = globalThis,
-  v1Compat = false
+  v1Compat = false,
+  activityId?: string
 ): Promise<Uint8Array | unknown> {
   try {
     const str = stringify(value, getStepReducers(global, ops, runId, key));
@@ -1870,7 +1996,11 @@ export async function dehydrateStepReturnValue(
     ) as Uint8Array;
 
     // Encrypt if world supports encryption
-    return maybeEncrypt(serialized, key);
+    return maybeEncrypt(serialized, key, {
+      purpose: 'return-value',
+      runId,
+      ...(activityId !== undefined ? { activityId } : {}),
+    });
   } catch (error) {
     throw new WorkflowRuntimeError(
       formatSerializationError('step return value', error),
@@ -1893,7 +2023,7 @@ export async function dehydrateStepReturnValue(
 export async function hydrateStepReturnValue(
   value: Uint8Array | unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: EncryptionKeyLike | undefined,
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {}
 ) {

--- a/packages/core/src/step/context-storage.ts
+++ b/packages/core/src/step/context-storage.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type { CryptoKey } from '../encryption.js';
+import type { EncryptionKeyLike } from '../encryption.js';
 import type { WorkflowMetadata } from '../workflow/get-workflow-metadata.js';
 import type { StepMetadata } from './get-step-metadata.js';
 
@@ -8,5 +8,5 @@ export const contextStorage = /* @__PURE__ */ new AsyncLocalStorage<{
   workflowMetadata: WorkflowMetadata;
   ops: Promise<void>[];
   closureVars?: Record<string, any>;
-  encryptionKey?: CryptoKey;
+  encryptionKey?: EncryptionKeyLike;
 }>();

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -49,7 +49,8 @@ export function getWritable<W = any>(
   // Create a transform stream that serializes chunks and pipes to the workflow server
   const serialize = getSerializeStream(
     getExternalReducers(globalThis, ctx.ops, runId, ctx.encryptionKey),
-    ctx.encryptionKey
+    ctx.encryptionKey,
+    { runId, activityId: ctx.stepMetadata.stepId ?? name }
   );
 
   // Use flushable pipe so the ops promise resolves when the user releases

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -10,7 +10,7 @@ import { parseWorkflowName } from '@workflow/utils/parse-name';
 import type { Event, WorkflowRun } from '@workflow/world';
 import * as nanoid from 'nanoid';
 import { monotonicFactory } from 'ulid';
-import type { CryptoKey } from './encryption.js';
+import type { EncryptionKeyLike } from './encryption.js';
 import { EventConsumerResult, EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
 import { ENOTSUP, WorkflowSuspension } from './global.js';
@@ -80,7 +80,7 @@ export async function runWorkflow(
   workflowCode: string,
   workflowRun: WorkflowRun,
   events: Event[],
-  encryptionKey: CryptoKey | undefined
+  encryptionKey: EncryptionKeyLike | undefined
 ): Promise<Uint8Array | unknown> {
   return trace(`workflow.run ${workflowRun.workflowName}`, async (span) => {
     span?.setAttributes({

--- a/packages/web-shared/src/lib/hydration.ts
+++ b/packages/web-shared/src/lib/hydration.ts
@@ -278,15 +278,15 @@ export async function hydrateResourceIOWithKey<T>(
   const { hydrateDataWithKey } = await import(
     '@workflow/core/serialization-format'
   );
-  const { importKey } = await import('@workflow/core/encryption');
-  const cryptoKey = await importKey(key);
+  const { importEncryptionKeys } = await import('@workflow/core/encryption');
+  const cryptoKey = await importEncryptionKeys(key);
   const revivers = getRevivers();
 
   /** Extract original encrypted bytes from a marker or raw Uint8Array, then decrypt + hydrate */
   async function decryptField(
     value: unknown,
     rev: Revivers,
-    k: Awaited<ReturnType<typeof importKey>>
+    k: Awaited<ReturnType<typeof importEncryptionKeys>>
   ): Promise<unknown> {
     // Already-hydrated: encrypted marker with stored bytes
     if (isEncryptedMarker(value)) {

--- a/packages/web/app/lib/hooks/use-stream-reader.ts
+++ b/packages/web/app/lib/hooks/use-stream-reader.ts
@@ -1,7 +1,8 @@
-import { decrypt as aesGcmDecrypt, importKey } from '@workflow/core/encryption';
+import { importEncryptionKeys } from '@workflow/core/encryption';
 import {
   decodeFormatPrefix,
   hydrateData,
+  hydrateDataWithKey,
   SerializationFormat,
 } from '@workflow/core/serialization-format';
 import { getWebRevivers } from '@workflow/web-shared';
@@ -153,7 +154,7 @@ export function useStreamReader(
         );
 
         const cryptoKey = encryptionKey
-          ? await importKey(encryptionKey)
+          ? await importEncryptionKeys(encryptionKey)
           : undefined;
 
         const reader = (rawStream as ReadableStream<Uint8Array>).getReader();
@@ -250,10 +251,12 @@ export function useStreamReader(
             offset += FRAME_HEADER_SIZE + frameLength;
 
             try {
-              const { format, payload } = decodeFormatPrefix(frameData);
-              let dataToHydrate: Uint8Array;
+              const { format } = decodeFormatPrefix(frameData);
 
-              if (format === SerializationFormat.ENCRYPTED) {
+              if (
+                format === SerializationFormat.ENCRYPTED ||
+                format === SerializationFormat.ENCRYPTED_V2
+              ) {
                 if (!cryptoKey) {
                   if (mounted) {
                     setError(
@@ -264,12 +267,11 @@ export function useStreamReader(
                   reader.cancel().catch(() => {});
                   return;
                 }
-                dataToHydrate = await aesGcmDecrypt(cryptoKey, payload);
-              } else {
-                dataToHydrate = frameData;
               }
 
-              const hydrated = hydrateData(dataToHydrate, revivers);
+              const hydrated = cryptoKey
+                ? await hydrateDataWithKey(frameData, revivers, cryptoKey)
+                : hydrateData(frameData, revivers);
               if (mounted && hydrated !== undefined && hydrated !== null) {
                 const chunkId = chunkIdRef.current++;
                 let text: string;


### PR DESCRIPTION
This PR tweaks the way workflow data is encrypted by ensuring that each operation uses a unique encryption key, achieving key binding.

Currently, the encryption serialization format `encr` uses a different key for each workflow run ID. However, the same key is used for all encryption operations performed within the same workflow run, including workflow arguments & return values, step arguments & return values, and each frame in the serialized stream.

The downsides of reusing the same key are:

1. While there's key binding for each specific workflow run (so, attackers cannot swap data from "workflow run 1" with "workflow run 2"), there's no binding within the same run, so for example the input of step 1 and 2 could be swapped undetected.
2. Encryption uses AES-GCM with a random nonce of "just" 96 bits. Due to the nature of GCM, re-using the same (key, nonce) pair has catastrophic effects (causes the plaintext key to be leaked). While the risk is very small (it's considered safe to re-use the same key up to ~4 billion times with random nonces), a different key removes the likelihood of nonce reuse entirely.