### PR TITLE
Add missing `workflow/errors` card to API Reference index

### DIFF
--- a/docs/content/docs/api-reference/index.mdx
+++ b/docs/content/docs/api-reference/index.mdx
@@ -17,6 +17,9 @@ All the functions and primitives that come with Workflow DevKit by package.
     <Card title="workflow/next" href="/docs/api-reference/workflow-next">
         Next.js integration for Workflow DevKit that automatically configures bundling and runtime support.
     </Card>
+    <Card title="workflow/errors" href="/docs/api-reference/workflow-errors">
+        Semantic error types for handling workflow storage backend failures.
+    </Card>
     <Card title="@workflow/serde" href="/docs/api-reference/workflow-serde">
         Serialization symbols for custom class serialization in workflows.
     </Card>


### PR DESCRIPTION
## Summary

- Adds the missing `workflow/errors` card to the API Reference index page