### PR TITLE
[builders] Fix .ts extension rewrite regression for non-vitest frameworks

### DIFF
--- a/.changeset/fix-ts-extension-rewrite-scope.md
+++ b/.changeset/fix-ts-extension-rewrite-scope.md
@@ -1,0 +1,5 @@
+---
+"@workflow/builders": patch
+---
+
+Only rewrite .ts extensions to .js in externalized step imports when targeting Node's native ESM loader (vitest), preserving original extensions for framework bundlers (Next.js, SvelteKit, etc.)

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -337,6 +337,7 @@ export abstract class BaseBuilder {
     format = 'cjs',
     outfile,
     externalizeNonSteps,
+    rewriteTsExtensions,
     tsconfigPath,
     discoveredEntries,
   }: {
@@ -345,6 +346,7 @@ export abstract class BaseBuilder {
     outfile: string;
     format?: 'cjs' | 'esm';
     externalizeNonSteps?: boolean;
+    rewriteTsExtensions?: boolean;
     discoveredEntries?: DiscoveredEntries;
   }): Promise<{
     context: esbuild.BuildContext | undefined;
@@ -519,6 +521,7 @@ export abstract class BaseBuilder {
           outdir: outfile ? dirname(outfile) : undefined,
           projectRoot: this.transformProjectRoot,
           workflowManifest,
+          rewriteTsExtensions,
         }),
       ],
       // Plugin should catch most things, but this lets users hard override

--- a/packages/builders/src/swc-esbuild-plugin.test.ts
+++ b/packages/builders/src/swc-esbuild-plugin.test.ts
@@ -50,10 +50,47 @@ describe('createSwcPlugin externalizeNonSteps', () => {
     { inputExt: '.tsx', outputExt: '.js' },
     { inputExt: '.mts', outputExt: '.mjs' },
     { inputExt: '.cts', outputExt: '.cjs' },
-  ])('rewrites externalized $inputExt imports to $outputExt', async ({
+  ])('rewrites externalized $inputExt imports to $outputExt when rewriteTsExtensions is enabled', async ({
     inputExt,
     outputExt,
   }) => {
+    const outdir = join(testRoot, 'out');
+    const srcDir = join(testRoot, 'src');
+    const stepFile = join(srcDir, 'step.ts');
+
+    writeFile(join(srcDir, `dep${inputExt}`), 'export const dep = {};');
+    writeFile(stepFile, `import { dep } from './dep';\nconsole.log(dep);`);
+
+    const result = await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      outdir,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          entriesToBundle: [stepFile],
+          outdir,
+          rewriteTsExtensions: true,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const output = result.outputFiles[0].text;
+    expect(output).toContain(`/dep${outputExt}`);
+    expect(output).not.toContain(`/dep${inputExt}`);
+  });
+
+  it.each([
+    '.ts',
+    '.tsx',
+    '.mts',
+    '.cts',
+  ])('preserves externalized %s extensions by default', async (inputExt) => {
     const outdir = join(testRoot, 'out');
     const srcDir = join(testRoot, 'src');
     const stepFile = join(srcDir, 'step.ts');
@@ -80,8 +117,7 @@ describe('createSwcPlugin externalizeNonSteps', () => {
 
     expect(result.errors).toHaveLength(0);
     const output = result.outputFiles[0].text;
-    expect(output).toContain(`/dep${outputExt}`);
-    expect(output).not.toContain(`/dep${inputExt}`);
+    expect(output).toContain(`/dep${inputExt}`);
   });
 });
 

--- a/packages/builders/src/swc-esbuild-plugin.ts
+++ b/packages/builders/src/swc-esbuild-plugin.ts
@@ -19,6 +19,18 @@ export interface SwcPluginOptions {
   outdir?: string;
   projectRoot?: string;
   workflowManifest?: WorkflowManifest;
+  /**
+   * Rewrite TypeScript extensions (.ts, .tsx, .mts, .cts) to their JS
+   * equivalents (.js, .mjs, .cjs) in externalized import paths.
+   *
+   * Enable this when the output bundle is consumed directly by Node's native
+   * ESM loader (e.g. vitest), which cannot resolve .ts extensions.
+   *
+   * Leave disabled (default) when a downstream bundler (webpack, Vite, etc.)
+   * handles resolution — those tools resolve .ts natively and rewriting
+   * breaks them because the .js file doesn't exist on disk.
+   */
+  rewriteTsExtensions?: boolean;
 }
 
 const NODE_RESOLVE_OPTIONS = {
@@ -131,12 +143,14 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
               resolvedPath
             ).replace(/\\/g, '/');
 
-            // Rewrite TypeScript extensions to their JS equivalents so the
-            // externalized import is loadable by Node's native ESM loader.
-            externalPath = externalPath
-              .replace(/\.tsx?$/, '.js')
-              .replace(/\.mts$/, '.mjs')
-              .replace(/\.cts$/, '.cjs');
+            if (options.rewriteTsExtensions) {
+              // Rewrite TypeScript extensions to their JS equivalents so the
+              // externalized import is loadable by Node's native ESM loader.
+              externalPath = externalPath
+                .replace(/\.tsx?$/, '.js')
+                .replace(/\.mts$/, '.mjs')
+                .replace(/\.cts$/, '.cjs');
+            }
           } else {
             externalPath = args.path;
           }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -50,6 +50,7 @@ class VitestBuilder extends BaseBuilder {
     await this.createStepsBundle({
       outfile: join(this.#outDir, 'steps.mjs'),
       externalizeNonSteps: true,
+      rewriteTsExtensions: true,
       format: 'esm',
       inputFiles,
     });


### PR DESCRIPTION
## Summary

Closes #1555

- The `.ts → .js` extension rewrite for externalized step imports (introduced in #1524) was applied unconditionally to all framework builders
- This broke Next.js (and potentially SvelteKit, Astro, Nitro) production builds because their downstream bundlers (webpack, Vite) resolve `.ts` natively — the rewritten `.js` file doesn't exist on disk
- Added `rewriteTsExtensions` option to `SwcPluginOptions`, only enabled in the vitest builder where Node's native ESM loader requires `.js` extensions

## Test plan

- [x] Existing `rewriteTsExtensions: true` tests pass (vitest behavior preserved)
- [x] New tests verify `.ts` extensions are preserved by default (Next.js behavior)
- [x] Vitest workbench tests pass (9/9)
- [x] Next.js turbopack workbench build succeeds
- [x] CI checks pass (88/88 non-benchmark checks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)