### PR TITLE
Add SurrealDB as a community world

### DIFF
--- a/.changeset/add-surrealdb-world.md
+++ b/.changeset/add-surrealdb-world.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add SurrealDB to `worlds-manifest.json` as a community world, and add optional `args` support to the community-world CI's generic `docker` service runner so a manifest service can pass command arguments to its container image (SurrealDB's image entrypoint needs the `start` subcommand). The E2E job remains gated by the existing `if: false` on `e2e-community`.

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -124,6 +124,14 @@ jobs:
               done <<< "$env_lines"
             fi
             args+=("$image")
+            # Optional command args passed to the image entrypoint (e.g. a
+            # `start` subcommand for images whose entrypoint is the bare binary).
+            cmd_args=$(echo "$svc" | jq -r '.args // [] | .[]')
+            if [ -n "$cmd_args" ]; then
+              while IFS= read -r line; do
+                args+=("$line")
+              done <<< "$cmd_args"
+            fi
 
             echo "Starting $name ($image)..."
             "${args[@]}"

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -130,6 +130,48 @@
       ]
     },
     {
+      "id": "surrealdb",
+      "type": "community",
+      "package": "workflow-world-surrealdb",
+      "name": "SurrealDB",
+      "description": "SurrealDB world using LIVE SELECT for queueing and real-time streaming",
+      "repository": "https://github.com/sepcnt/workflow-world-surrealdb",
+      "docs": "https://github.com/sepcnt/workflow-world-surrealdb",
+      "features": [],
+      "env": {
+        "WORKFLOW_TARGET_WORLD": "workflow-world-surrealdb",
+        "WORKFLOW_SURREAL_URL": "ws://127.0.0.1:8000/rpc",
+        "WORKFLOW_SURREAL_NAMESPACE": "workflow",
+        "WORKFLOW_SURREAL_DATABASE": "workflow",
+        "WORKFLOW_SURREAL_USERNAME": "root",
+        "WORKFLOW_SURREAL_PASSWORD": "root"
+      },
+      "services": [
+        {
+          "name": "surrealdb",
+          "image": "surrealdb/surrealdb:v3",
+          "args": [
+            "start",
+            "--user",
+            "root",
+            "--pass",
+            "root",
+            "--bind",
+            "0.0.0.0:8000",
+            "memory"
+          ],
+          "ports": ["8000:8000"],
+          "healthCheck": {
+            "cmd": "curl -sf http://localhost:8000/health || exit 1",
+            "interval": "5s",
+            "timeout": "3s",
+            "retries": 10
+          }
+        }
+      ],
+      "setup": "pnpm exec workflow-surreal-setup"
+    },
+    {
       "id": "jazz",
       "type": "community",
       "package": "workflow-world-jazz",


### PR DESCRIPTION
## Summary

Adds [workflow-world-surrealdb](https://github.com/sepcnt/workflow-world-surrealdb) as a community world — a SurrealDB-backed World implementation that uses `LIVE SELECT` for queueing and real-time streaming.

- **Published on npm**: [`workflow-world-surrealdb@0.1.0`](https://www.npmjs.com/package/workflow-world-surrealdb)
- **Repository**: [sepcnt/workflow-world-surrealdb](https://github.com/sepcnt/workflow-world-surrealdb)
- **Benchmark**: All 6 `@workflow/world-testing` spec tests pass (addition, idempotency, hooks, null bytes, retriable and fatal errors)

Closes #1566 

## Test plan

- [x] All 6 `@workflow/world-testing` spec tests pass locally
- [ ] CI community world E2E tests pass with SurrealDB service container
- [ ] CI community world benchmarks run successfully
