### PR TITLE
fix(world-vercel): include runId in streams.get() request URL

### DIFF
--- a/.changeset/fix-stream-get-runid.md
+++ b/.changeset/fix-stream-get-runid.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Fix `streams.get()` to include `runId` in the request URL instead of always omitting it.

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -180,6 +180,47 @@ vi.mock('./utils.js', () => ({
   }),
 }));
 
+describe('streams.get', () => {
+  async function getStreamer() {
+    const { createStreamer } = await import('./streamer.js');
+    return createStreamer();
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes runId in the fetch URL', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(
+        async () => new Response(new ReadableStream(), { status: 200 })
+      );
+
+    const streamer = await getStreamer();
+    await streamer.streams.get('run-123', 'my-stream');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/v2/runs/run-123/stream/my-stream');
+  });
+
+  it('passes startIndex as a query parameter', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(
+        async () => new Response(new ReadableStream(), { status: 200 })
+      );
+
+    const streamer = await getStreamer();
+    await streamer.streams.get('run-123', 'my-stream', 5);
+
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/v2/runs/run-123/stream/my-stream');
+    expect(url.searchParams.get('startIndex')).toBe('5');
+  });
+});
+
 describe('writeMulti pagination', () => {
   /**
    * Decode length-prefixed multi-chunk body to count chunks per request.

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -23,17 +23,10 @@ export const MAX_CHUNKS_PER_REQUEST = 1000;
 // (partial writes, long-lived reads), and duplex streams are incompatible
 // with undici's experimental H2 support.
 
-function getStreamUrl(
-  name: string,
-  runId: string | undefined,
-  httpConfig: HttpConfig
-) {
-  if (runId) {
-    return new URL(
-      `${httpConfig.baseUrl}/v2/runs/${encodeURIComponent(runId)}/stream/${encodeURIComponent(name)}`
-    );
-  }
-  return new URL(`${httpConfig.baseUrl}/v2/stream/${encodeURIComponent(name)}`);
+function getStreamUrl(name: string, runId: string, httpConfig: HttpConfig) {
+  return new URL(
+    `${httpConfig.baseUrl}/v2/runs/${encodeURIComponent(runId)}/stream/${encodeURIComponent(name)}`
+  );
 }
 
 /**
@@ -188,9 +181,9 @@ export function createStreamer(config?: APIConfig): Streamer {
         }
       },
 
-      async get(_runId: string, name: string, startIndex?: number) {
+      async get(runId: string, name: string, startIndex?: number) {
         const httpConfig = await getHttpConfig(config);
-        const url = getStreamUrl(name, undefined, httpConfig);
+        const url = getStreamUrl(name, runId, httpConfig);
         if (typeof startIndex === 'number') {
           url.searchParams.set('startIndex', String(startIndex));
         }


### PR DESCRIPTION
## Summary

- Fix `streams.get()` in `@workflow/world-vercel` to pass `runId` through to `getStreamUrl()` instead of hardcoding `undefined`, which was causing all stream read requests to hit `/api/v2/stream/:streamId` instead of `/api/v2/runs/:runId/stream/:streamId`
- Remove the fallback code path in `getStreamUrl()` that allowed omitting `runId` — the parameter is now required as `string` (was `string | undefined`)

The health check case is unaffected since it already generates a synthetic runId via `generateHealthCheckRunId()` — the bug was just that `get()` was discarding it.