### PR TITLE
feat(core): add serialization support for workflow function references

### DIFF
--- a/.changeset/workflow-function-serialization.md
+++ b/.changeset/workflow-function-serialization.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": minor
+---
+
+Add serialization support for workflow function references

--- a/packages/core/src/serialization-format.test.ts
+++ b/packages/core/src/serialization-format.test.ts
@@ -710,3 +710,12 @@ describe('encrypted data handling', () => {
     });
   });
 });
+
+describe('observabilityRevivers', () => {
+  it('should render WorkflowFunction as <workflow:workflowId>', () => {
+    const result = observabilityRevivers.WorkflowFunction({
+      workflowId: 'workflow//./workflows/example//myWorkflow',
+    });
+    expect(result).toBe('<workflow:workflow//./workflows/example//myWorkflow>');
+  });
+});

--- a/packages/core/src/serialization-format.ts
+++ b/packages/core/src/serialization-format.ts
@@ -373,6 +373,8 @@ export const observabilityRevivers: Revivers = {
   WritableStream: streamToStreamRef,
   TransformStream: streamToStreamRef,
   StepFunction: serializedStepFunctionToString,
+  WorkflowFunction: (value: { workflowId: string }) =>
+    `<workflow:${value.workflowId}>`,
   Instance: serializedInstanceToRef,
   Class: serializedClassToString,
 };

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -4533,6 +4533,6 @@ describe('WorkflowFunction serialization', () => {
     );
     await expect(
       dehydrateStepReturnValue(plainFn, 'wrun_test', undefined)
-    ).rejects.toThrow('serialization');
+    ).rejects.toThrow('Failed to serialize');
   });
 });

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -4422,3 +4422,117 @@ describe('isEncrypted', () => {
     expect(isEncrypted(new Uint8Array(2))).toBe(false);
   });
 });
+
+describe('WorkflowFunction serialization', () => {
+  it('should serialize a function with workflowId and hydrate as a function with workflowId', async () => {
+    const workflowFn = Object.assign(
+      async () => {
+        /* workflow body */
+      },
+      { workflowId: 'wf_myWorkflow' }
+    );
+    const dehydrated = await dehydrateStepReturnValue(
+      workflowFn,
+      'wrun_test',
+      undefined
+    );
+    const hydrated = await hydrateStepReturnValue(
+      dehydrated,
+      'wrun_test',
+      undefined
+    );
+    // Deserialized as a function with .workflowId that throws on direct call
+    expect(typeof hydrated).toBe('function');
+    expect((hydrated as any).workflowId).toBe('wf_myWorkflow');
+    expect(() => (hydrated as any)()).toThrow(
+      'Workflow functions cannot be called directly'
+    );
+  });
+
+  it('should roundtrip through step arguments as a function with workflowId', async () => {
+    const workflowFn = Object.assign(
+      async () => {
+        /* workflow body */
+      },
+      { workflowId: 'wf_argTest' }
+    );
+    const dehydrated = await dehydrateStepArguments(
+      [workflowFn],
+      'wrun_test',
+      undefined
+    );
+    const hydrated = await hydrateStepArguments(
+      dehydrated,
+      'wrun_test',
+      undefined
+    );
+    expect(typeof hydrated[0]).toBe('function');
+    expect((hydrated[0] as any).workflowId).toBe('wf_argTest');
+    expect(() => (hydrated[0] as any)()).toThrow(
+      'Workflow functions cannot be called directly'
+    );
+  });
+
+  it('should not match plain objects with workflowId (only functions)', async () => {
+    const workflowMeta = { workflowId: 'wf_otherWorkflow' };
+    const dehydrated = await dehydrateStepReturnValue(
+      workflowMeta,
+      'wrun_test',
+      undefined
+    );
+    const hydrated = await hydrateStepReturnValue(
+      dehydrated,
+      'wrun_test',
+      undefined
+    );
+    expect(hydrated).toEqual({ workflowId: 'wf_otherWorkflow' });
+  });
+
+  it('should roundtrip workflow function reference through step arguments', async () => {
+    const workflowFn = Object.assign(
+      async () => {
+        /* workflow body */
+      },
+      { workflowId: 'wf_childWorkflow' }
+    );
+    const dehydrated = await dehydrateStepArguments(
+      [workflowFn, [42]],
+      'wrun_test',
+      undefined
+    );
+    const hydrated = await hydrateStepArguments(
+      dehydrated,
+      'wrun_test',
+      undefined
+    );
+    expect(hydrated[0]).toHaveProperty('workflowId', 'wf_childWorkflow');
+    expect(hydrated[1]).toEqual([42]);
+  });
+
+  it('should not match objects without workflowId', async () => {
+    const plainObj = { name: 'test', value: 42 };
+    const dehydrated = await dehydrateStepReturnValue(
+      plainObj,
+      'wrun_test',
+      undefined
+    );
+    const hydrated = await hydrateStepReturnValue(
+      dehydrated,
+      'wrun_test',
+      undefined
+    );
+    expect(hydrated).toEqual({ name: 'test', value: 42 });
+  });
+
+  it('should not match functions without workflowId', async () => {
+    const plainFn = Object.assign(
+      async () => {
+        /* some function */
+      },
+      { someOtherProp: 'test' }
+    );
+    await expect(
+      dehydrateStepReturnValue(plainFn, 'wrun_test', undefined)
+    ).rejects.toThrow('serialization');
+  });
+});

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -653,6 +653,9 @@ export interface SerializableSpecial {
     closureVars?: Record<string, any>;
   };
   URL: string;
+  WorkflowFunction: {
+    workflowId: string;
+  };
   URLSearchParams: string;
   Uint8Array: string; // base64 string
   Uint8ClampedArray: string; // base64 string
@@ -834,6 +837,16 @@ function getCommonReducers(global: Record<string, any> = globalThis) {
       return { stepId };
     },
     URL: (value) => value instanceof global.URL && value.href,
+    WorkflowFunction: (value) => {
+      // Only match function references with a workflowId property (set by
+      // the SWC compiler on workflow functions). Plain { workflowId } objects
+      // are NOT matched — this prevents infinite recursion since the reduced
+      // form { workflowId } is a plain object, not a function.
+      if (typeof value !== 'function') return false;
+      const workflowId = (value as any).workflowId;
+      if (typeof workflowId !== 'string') return false;
+      return { workflowId };
+    },
     URLSearchParams: (value) => {
       if (!(value instanceof global.URLSearchParams)) return false;
 
@@ -1190,6 +1203,16 @@ export function getExternalRevivers(
       );
     },
 
+    WorkflowFunction: (value) =>
+      Object.assign(
+        () => {
+          throw new Error(
+            'Workflow functions cannot be called directly. Use start() to invoke them.'
+          );
+        },
+        { workflowId: value.workflowId }
+      ),
+
     Request: (value) => {
       return new global.Request(value.url, {
         method: value.method,
@@ -1342,6 +1365,17 @@ export function getWorkflowRevivers(
       }
       return value;
     },
+    // Workflow function reviver for workflow context — returns a function-like
+    // object with .workflowId that mimics what the SWC compiler produces,
+    WorkflowFunction: (value) =>
+      Object.assign(
+        () => {
+          throw new Error(
+            'Workflow functions cannot be called directly. Use start() to invoke them.'
+          );
+        },
+        { workflowId: value.workflowId }
+      ),
     Response: (value) => {
       Object.setPrototypeOf(value, global.Response.prototype);
       return value;
@@ -1454,6 +1488,16 @@ function getStepRevivers(
 
       return stepFn;
     },
+
+    WorkflowFunction: (value) =>
+      Object.assign(
+        () => {
+          throw new Error(
+            'Workflow functions cannot be called directly. Use start() to invoke them.'
+          );
+        },
+        { workflowId: value.workflowId }
+      ),
 
     Request: (value) => {
       const responseWritable = value.responseWritable;


### PR DESCRIPTION
## Summary
Add a `WorkflowFunction` reducer/reviver pair to the serialization system so that workflow function references (functions with a `.workflowId` property, as produced by the SWC compiler) can cross the step serialization boundary.

This is a prerequisite for allowing `start()` to be called directly from workflow functions with `"use step"` — the workflow function reference passed as the first argument needs to be serializable.

## How it works

**Reducer:** Detects functions with a `.workflowId` string property, serializes as `{ workflowId }`. Only matches functions (not plain objects) to prevent infinite recursion since the reduced form is a plain object.

**Revivers:** All contexts (step, workflow, external) deserialize as a function with `.workflowId` that throws "Workflow functions cannot be called directly. Use start() to invoke them." on direct invocation. This is sufficient because `start()` only reads `.workflowId` from the reference.

**Observability:** Renders as `<workflow:workflowId>` in the o11y UI.

## Note on workflow context hydration
It is recognized that the workflow context reviver should ideally return the proper registered function reference (since the SWC compiler registers workflow functions in the VM). However, since this PR is primarily for the `start()` as a step use-case — where the deserialized reference is only passed to `start()` which reads `.workflowId` — returning a throwing wrapper is sufficient. Full workflow function registry hydration can be revisited in the future when there is a concrete use case requiring the actual function reference in workflow context.

## Example
```ts
// In user code (workflow context):
const childRun = await start(myChildWorkflow, [42]);
//                           ^^^^^^^^^^^^^^^^
// This is a function with .workflowId attached by SWC.
// The WorkflowFunction reducer serializes it as { workflowId: "..." }
// so it can cross the step boundary as an argument to start().
```