### PR TITLE
fix(core): remove redundant hc_ prefix from health check correlationId

### DIFF
--- a/.changeset/fix-health-check-correlation-id.md
+++ b/.changeset/fix-health-check-correlation-id.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Remove redundant `hc_` prefix from health check correlationId that caused doubled `hc_hc_` in the derived runId and stream name.

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -229,7 +229,7 @@ export async function healthCheck(
   options?: HealthCheckOptions
 ): Promise<HealthCheckResult> {
   const timeout = options?.timeout ?? DEFAULT_HEALTH_CHECK_TIMEOUT;
-  const correlationId = `hc_${generateId()}`;
+  const correlationId = generateId();
   const streamName = getHealthCheckStreamName(correlationId);
 
   const queueName: ValidQueueName =


### PR DESCRIPTION
## Summary

- Remove the `hc_` prefix from the health check `correlationId` generation, which was redundant since `generateHealthCheckRunId()` and `getHealthCheckStreamName()` already add their own prefixes
- Before: `wrun_hc_hc_01KNT...` / `__health_check__hc_01KNT...`
- After: `wrun_hc_01KNT...` / `__health_check__01KNT...`