### PR TITLE
[world] Bump specVersion to 4, disable incompatible community worlds

### DIFF
--- a/.changeset/spec-version-4.md
+++ b/.changeset/spec-version-4.md
@@ -1,0 +1,6 @@
+---
+"@workflow/world": minor
+"@workflow/world-vercel": minor
+---
+
+Bump specVersion to 4 for restructured world interface; disable incompatible community worlds in CI

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -429,6 +429,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has-worlds: ${{ steps.set-matrix.outputs.has-worlds }}
     steps:
       - uses: actions/checkout@v4
 
@@ -439,11 +440,15 @@ jobs:
           build-packages: 'false'
 
       - id: set-matrix
-        run: echo "matrix=$(node ./scripts/create-community-worlds-matrix.mjs)" >> $GITHUB_OUTPUT
+        run: |
+          MATRIX=$(node ./scripts/create-community-worlds-matrix.mjs)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          WORLD_COUNT=$(echo "$MATRIX" | jq '.world | length')
+          echo "has-worlds=$([[ $WORLD_COUNT -gt 0 ]] && echo true || echo false)" >> $GITHUB_OUTPUT
 
   benchmark-community:
     name: Benchmark Community World (${{ matrix.world.name }})
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') && needs.getCommunityWorldsMatrix.outputs.has-worlds == 'true' }}
     needs: [build, getCommunityWorldsMatrix]
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -677,6 +677,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has-worlds: ${{ steps.set-matrix.outputs.has-worlds }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -689,11 +690,15 @@ jobs:
           build-packages: 'false'
 
       - id: set-matrix
-        run: echo "matrix=$(node ./scripts/create-community-worlds-matrix.mjs)" >> $GITHUB_OUTPUT
+        run: |
+          MATRIX=$(node ./scripts/create-community-worlds-matrix.mjs)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          WORLD_COUNT=$(echo "$MATRIX" | jq '.world | length')
+          echo "has-worlds=$([[ $WORLD_COUNT -gt 0 ]] && echo true || echo false)" >> $GITHUB_OUTPUT
 
   e2e-community:
     name: E2E Community World (${{ matrix.world.name }})
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') && needs.getCommunityWorldsMatrix.outputs.has-worlds == 'true' }}
     needs: getCommunityWorldsMatrix
     strategy:
       fail-fast: false
@@ -809,7 +814,7 @@ jobs:
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows, e2e-community]
+    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows, e2e-community, getCommunityWorldsMatrix]
     if: always()
     timeout-minutes: 5
 
@@ -823,6 +828,7 @@ jobs:
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
           WINDOWS_STATUS: ${{ needs.e2e-windows.result }}
           COMMUNITY_STATUS: ${{ needs.e2e-community.result }}
+          HAS_COMMUNITY_WORLDS: ${{ needs.getCommunityWorldsMatrix.outputs.has-worlds }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
         run: |
           FAILED_JOBS=()
@@ -848,7 +854,12 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")
             [[ "$WINDOWS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-windows ($WINDOWS_STATUS)")
-            [[ "$COMMUNITY_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-community ($COMMUNITY_STATUS)")
+            # Community worlds are skipped when no worlds match the current specVersion
+            if [[ "$HAS_COMMUNITY_WORLDS" == "true" ]]; then
+              [[ "$COMMUNITY_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-community ($COMMUNITY_STATUS)")
+            else
+              echo "No compatible community worlds — skipping community check"
+            fi
           fi
 
           if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1594,8 +1594,8 @@ describe('e2e', () => {
       expect(flowBody).toEqual({
         healthy: true,
         endpoint: '/.well-known/workflow/v1/flow',
-        // specVersion comes from the World's declared specVersion (e.g. 3
-        // for world-vercel) or falls back to SPEC_VERSION_CURRENT (2).
+        // specVersion comes from the World's declared specVersion
+        // or falls back to SPEC_VERSION_SUPPORTS_EVENT_SOURCING (2).
         specVersion: expect.any(Number),
         workflowCoreVersion: expect.any(String),
       });

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -135,7 +135,7 @@ describe('start', () => {
 
       vi.clearAllMocks();
 
-      // Mock world with specVersion 3 → uses it
+      // Mock world with specVersion set → uses it
       vi.mocked(getWorld).mockReturnValue({
         specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -1,5 +1,5 @@
 import type { World } from '@workflow/world';
-import { SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT } from '@workflow/world';
+import { SPEC_VERSION_SUPPORTS_RESTRUCTURED_WORLD } from '@workflow/world';
 import { createGetEncryptionKeyForRun } from './encryption.js';
 import { instrumentObject } from './instrumentObject.js';
 import { createQueue } from './queue.js';
@@ -25,7 +25,7 @@ export function createVercelWorld(config?: APIConfig): World {
     config?.projectConfig?.projectId || process.env.VERCEL_PROJECT_ID;
 
   return {
-    specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+    specVersion: SPEC_VERSION_SUPPORTS_RESTRUCTURED_WORLD,
     ...createQueue(config),
     ...createStorage(config),
     ...instrumentObject('world.streams', createStreamer(config)),

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -52,6 +52,7 @@ export {
   SPEC_VERSION_LEGACY,
   SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
   SPEC_VERSION_SUPPORTS_EVENT_SOURCING,
+  SPEC_VERSION_SUPPORTS_RESTRUCTURED_WORLD,
 } from './spec-version.js';
 export type * from './steps.js';
 export { StepSchema, StepStatusSchema } from './steps.js';

--- a/packages/world/src/spec-version.ts
+++ b/packages/world/src/spec-version.ts
@@ -23,10 +23,11 @@ export const SPEC_VERSION_LEGACY = 1 as SpecVersion;
 
 export const SPEC_VERSION_SUPPORTS_EVENT_SOURCING = 2 as SpecVersion;
 export const SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT = 3 as SpecVersion;
+export const SPEC_VERSION_SUPPORTS_RESTRUCTURED_WORLD = 4 as SpecVersion;
 
-/** Current spec version (event-sourced architecture with CBOR queue transport). */
+/** Current spec version (restructured world interface with run-scoped streams and async getWorld). */
 export const SPEC_VERSION_CURRENT =
-  SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT as SpecVersion;
+  SPEC_VERSION_SUPPORTS_RESTRUCTURED_WORLD as SpecVersion;
 
 /**
  * Check if a spec version is legacy (<= SPEC_VERSION_LEGACY or undefined).

--- a/scripts/create-community-worlds-matrix.mjs
+++ b/scripts/create-community-worlds-matrix.mjs
@@ -2,7 +2,8 @@
 
 /**
  * Generates a GitHub Actions matrix for community world testing.
- * Reads from worlds-manifest.json and filters to testable community worlds.
+ * Reads from worlds-manifest.json and filters to testable community worlds
+ * whose specVersion matches the current SDK spec version.
  *
  * Usage: node scripts/create-community-worlds-matrix.mjs
  *
@@ -21,12 +22,51 @@
  * }
  */
 
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.join(__dirname, '..');
+
+// Read SPEC_VERSION_CURRENT from spec-version.ts
+const specVersionPath = path.join(
+  rootDir,
+  'packages/world/src/spec-version.ts'
+);
+const specVersionSrc = fs.readFileSync(specVersionPath, 'utf-8');
+const currentVersionMatch = specVersionSrc.match(
+  /SPEC_VERSION_CURRENT\s*=\s*\n?\s*(\w+)\s+as\s+SpecVersion/
+);
+if (!currentVersionMatch) {
+  // Fallback: try to resolve the numeric alias
+  const aliasMatch = specVersionSrc.match(
+    /SPEC_VERSION_CURRENT\s*=\s*(\d+)\s+as\s+SpecVersion/
+  );
+  if (!aliasMatch) {
+    throw new Error(
+      'Could not parse SPEC_VERSION_CURRENT from spec-version.ts'
+    );
+  }
+}
+// Resolve the constant that SPEC_VERSION_CURRENT points to
+let currentSpecVersion;
+if (currentVersionMatch) {
+  const alias = currentVersionMatch[1];
+  const aliasValueMatch = specVersionSrc.match(
+    new RegExp(`${alias}\\s*=\\s*(\\d+)\\s+as\\s+SpecVersion`)
+  );
+  if (!aliasValueMatch) {
+    throw new Error(`Could not resolve value of ${alias} from spec-version.ts`);
+  }
+  currentSpecVersion = Number(aliasValueMatch[1]);
+} else {
+  currentSpecVersion = Number(
+    specVersionSrc.match(
+      /SPEC_VERSION_CURRENT\s*=\s*(\d+)\s+as\s+SpecVersion/
+    )[1]
+  );
+}
 
 // Read the manifest
 const manifestPath = path.join(rootDir, 'worlds-manifest.json');
@@ -39,6 +79,19 @@ const testableWorlds = manifest.worlds.filter((world) => {
 
   // Skip worlds that require external credentials (e.g., Jazz needs API keys)
   if (world.requiresCredentials) return false;
+
+  // Skip worlds whose specVersion doesn't match the current SDK version.
+  // Community worlds built against an older @workflow/world will fail e2e tests
+  // because the world interface has changed in breaking ways.
+  if (
+    world.specVersion !== undefined &&
+    world.specVersion !== currentSpecVersion
+  ) {
+    console.error(
+      `Skipping ${world.id}: specVersion ${world.specVersion} !== current ${currentSpecVersion}`
+    );
+    return false;
+  }
 
   return true;
 });

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -66,6 +66,7 @@
       "description": "Turso/libSQL World for embedded or remote SQLite databases",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/turso",
+      "specVersion": 3,
       "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/turso",
@@ -82,6 +83,7 @@
       "description": "MongoDB World using native driver",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/mongodb",
+      "specVersion": 3,
       "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/mongodb",
@@ -110,6 +112,7 @@
       "description": "Redis World using BullMQ for queues, Redis Streams for output",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/redis",
+      "specVersion": 3,
       "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/redis",
@@ -137,6 +140,7 @@
       "description": "Jazz Cloud world for local-first sync and real-time collaboration",
       "repository": "https://github.com/garden-co/workflow-world-jazz",
       "docs": "https://github.com/garden-co/workflow-world-jazz",
+      "specVersion": 3,
       "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "workflow-world-jazz"


### PR DESCRIPTION
## Summary

- Adds `SPEC_VERSION_SUPPORTS_RESTRUCTURED_WORLD = 4` and bumps `SPEC_VERSION_CURRENT` to 4
- Updates `world-vercel` to declare the new spec version
- Adds `specVersion` field to community world entries in `worlds-manifest.json` (set to 3)
- Filters community worlds in CI matrix generation when their `specVersion` doesn't match `SPEC_VERSION_CURRENT`
- Handles empty matrix gracefully in both `tests.yml` and `benchmarks.yml`

Recent interface changes (restructured streams requiring run IDs, async `getWorld`) break community worlds built against the v3 interface. Rather than letting them fail in CI, this skips them until they're updated to implement the v4 interface.

## Test plan

- [x] `pnpm typecheck` passes (41/41 tasks)
- [x] `start.test.ts` passes (20/20 tests)
- [x] Matrix script correctly filters out specVersion 3 worlds
- [x] Verify CI skips community world jobs when matrix is empty
- [ ] Verify `e2e-required-check` passes with skipped community worlds

🤖 Generated with [Claude Code](https://claude.com/claude-code)