### PR TITLE
fix(core,next): fix Turbopack e2e build failures

### DIFF
--- a/.changeset/thirty-memes-fail.md
+++ b/.changeset/thirty-memes-fail.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": patch
+"@workflow/next": patch
+---
+
+Fix Turbopack builds by lazy-loading world implementations and resolving step file imports to built dist/ paths

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -6,12 +6,8 @@ import {
   resolveWorkflowTargetWorld,
 } from '@workflow/utils';
 import type { World } from '@workflow/world';
-import { createLocalWorld } from '@workflow/world-local';
-import { createVercelWorld } from '@workflow/world-vercel';
 
-const require = createRequire(
-  pathToFileURL(process.cwd() + '/package.json').href
-);
+const require = createRequire(import.meta.url);
 
 const WorldCache = Symbol.for('@workflow/world//cache');
 const StubbedWorldCache = Symbol.for('@workflow/world//stubbedCache');
@@ -93,10 +89,12 @@ export const createWorld = async (): Promise<World> => {
       );
     }
 
+    const { createVercelWorld } = await import('@workflow/world-vercel');
     return createVercelWorld();
   }
 
   if (targetWorld === 'local') {
+    const { createLocalWorld } = await import('@workflow/world-local');
     return createLocalWorld({
       dataDir: process.env.WORKFLOW_LOCAL_DATA_DIR,
     });

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -1452,6 +1452,15 @@ export async function getNextBuilderDeferred() {
         return targetPath;
       }
 
+      // When a relative import like ../encryption.js resolves to a src/
+      // path that doesn't exist, try the built dist/ equivalent first.
+      // Turbopack can't follow .js extension imports inside .ts source
+      // files, but it handles built dist/ JS fine.
+      const distPath = targetPath.replace(/\/src\//, '/dist/');
+      if (distPath !== targetPath && existsSync(distPath)) {
+        return distPath;
+      }
+
       const extensionMatch = targetPath.match(/(\.[^./\\]+)$/);
       const extension = extensionMatch?.[1]?.toLowerCase();
       if (!extension) {


### PR DESCRIPTION
## Summary

- **world.ts**: Replace `process.cwd()`-based `createRequire()` with `import.meta.url` and lazy-load world implementations via dynamic `import()` instead of static top-level imports. This prevents Turbopack from tracing a dynamic dependency on the project root and from eagerly bundling both `@workflow/world-local` and `@workflow/world-vercel`.
- **builder-deferred.ts**: When the deferred builder copies step files and rewrites relative imports (e.g. `../encryption.js`), prefer the built `dist/` equivalent over falling back to `src/*.ts`. Turbopack can't follow `.js` extension imports inside `.ts` source files.

The world.ts fix mirrors commit ed713075a from `peter/v2-flow`. The builder fix addresses a separate pre-existing issue where Turbopack builds fail with "Module not found" errors for transitive imports from copied step files.

## Test plan

- [x] `APP_NAME=nextjs-turbopack pnpm vitest run packages/core/e2e/local-build.test.ts` — 12/12 pass
- [x] `APP_NAME=nextjs-webpack pnpm vitest run packages/core/e2e/local-build.test.ts` — 12/12 pass (no regression)
- [x] `pnpm vitest run packages/core/src` — 583/583 pass
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)