### PR TITLE
Preserve original committer identity in backport cherry-picks

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,16 +29,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Configure Git identity
-        run: |
-          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-
       - name: Cherry-pick to stable
         id: cherry-pick
         run: |
+          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          git config user.name "$(git log -1 --format='%an' "$MERGE_SHA")"
+          git config user.email "$(git log -1 --format='%ae' "$MERGE_SHA")"
           git checkout stable
-          git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} --no-edit
+          git cherry-pick "$MERGE_SHA" --no-edit
           echo "cherry_pick_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           git push origin stable
 


### PR DESCRIPTION
## Summary

- Fix backport cherry-picks attributing the committer to the GitHub App bot instead of the original author
- Before: `git config` was hardcoded to the release bot identity, causing GitHub to show "authored by X and committed by workflow-devkit-release-bot[bot]" on every backported commit
- After: extracts the original commit's author name/email and uses that as the git identity for the cherry-pick, so author and committer match

Push authentication is unaffected since it uses the app token from the checkout step, not the git identity.