### PR TITLE
fix(docs): remove scroll-smooth to fix navigation scroll position

### DIFF
--- a/docs/app/[lang]/layout.tsx
+++ b/docs/app/[lang]/layout.tsx
@@ -28,7 +28,7 @@ const Layout = async ({ children, params }: LayoutProps<'/[lang]'>) => {
 
   return (
     <html
-      className={cn(sans.variable, mono.variable, 'scroll-smooth antialiased')}
+      className={cn(sans.variable, mono.variable, 'antialiased')}
       lang={lang}
       suppressHydrationWarning
     >


### PR DESCRIPTION
## Summary
- Removes the `scroll-smooth` CSS class from the `<html>` element in the docs root layout
- The global smooth scroll was causing Next.js navigation scroll-to-top to animate instead of jumping instantly, making cross-page links (e.g. "World Interface Docs" on /worlds) appear stuck at the previous scroll position
- Components that need smooth scrolling (e.g. the "Scroll to top" button) already use `behavior: 'smooth'` explicitly and are unaffected
