### PR TITLE
Add Cloudflare Workers community world to worlds manifest [CI mirror for #1477]

### DIFF
--- a/docs/content/docs/deploying/world/cloudflare-world.mdx
+++ b/docs/content/docs/deploying/world/cloudflare-world.mdx
@@ -1,0 +1,121 @@
+---
+title: Cloudflare Workers World
+description: Community world using Durable Objects, D1, and Cloudflare Queues.
+type: integration
+summary: Deploy workflows to Cloudflare Workers using Durable Objects for state, D1 for indexing, and Queues for dispatch.
+prerequisites:
+  - /docs/deploying
+related:
+  - /docs/deploying/world/local-world
+  - /docs/deploying/world/vercel-world
+  - /docs/deploying/world/postgres-world
+---
+
+The Cloudflare Workers World is a community-maintained backend that runs workflows on [Cloudflare's edge network](https://workers.cloudflare.com). It uses three Cloudflare primitives for a fully serverless architecture:
+
+- **Durable Objects** for per-run state (events, steps, hooks, waits, streams)
+- **D1 (SQLite)** for cross-run index queries
+- **Cloudflare Queues** for reliable message dispatch
+
+<Callout type="info">
+This is a community World maintained at [`@ataylorme/workflow-world-cloudflare`](https://github.com/ataylorme/workflow-world-cloudflare). For issues and contributions, visit the [GitHub repository](https://github.com/ataylorme/workflow-world-cloudflare).
+</Callout>
+
+## Installation
+
+Install the package:
+
+```package-install
+@ataylorme/workflow-world-cloudflare
+```
+
+## Cloudflare Bindings
+
+Configure your `wrangler.toml` with the required bindings:
+
+```toml title="wrangler.toml"
+name = "my-workflow-worker"
+main = "src/worker.ts"
+compatibility_date = "2024-12-01"
+
+[durable_objects]
+bindings = [
+  { name = "WORKFLOW_RUNS", class_name = "WorkflowRunDO" }
+]
+
+[[d1_databases]]
+binding = "WORKFLOW_DB"
+database_name = "workflow"
+database_id = "<your-d1-database-id>"
+
+[[queues.producers]]
+binding = "WORKFLOW_QUEUE"
+queue = "workflow-jobs"
+
+[[queues.consumers]]
+queue = "workflow-jobs"
+max_batch_size = 10
+max_retries = 3
+
+[[migrations]]
+tag = "v1"
+new_classes = ["WorkflowRunDO"]
+```
+
+## Database Migration
+
+Run the D1 migration to create index tables. This is idempotent and safe to run multiple times:
+
+```ts
+import { migrate } from '@ataylorme/workflow-world-cloudflare/d1';
+
+await migrate(env.WORKFLOW_DB);
+```
+
+## Usage
+
+Create the world in your Worker and re-export the Durable Object class:
+
+```ts title="src/worker.ts" lineNumbers
+import { createWorld, WorkflowRunDO } from '@ataylorme/workflow-world-cloudflare';
+
+// Re-export the DO class so Cloudflare can instantiate it
+export { WorkflowRunDO };
+
+export default {
+  async fetch(request, env) {
+    const world = createWorld({
+      db: env.WORKFLOW_DB,
+      runs: env.WORKFLOW_RUNS,
+      queue: env.WORKFLOW_QUEUE,
+    });
+    // Use world with your workflow runtime...
+  },
+
+  async queue(batch, env) {
+    const world = createWorld({
+      db: env.WORKFLOW_DB,
+      runs: env.WORKFLOW_RUNS,
+      queue: env.WORKFLOW_QUEUE,
+    });
+    await world.handleQueueBatch(batch);
+  },
+};
+```
+
+## How It Works
+
+Each workflow run maps 1:1 to a Durable Object instance. All per-run state lives in the DO's transactional storage, which provides strong consistency without external databases.
+
+D1 maintains a lightweight global index so that cross-run queries (`runs.list`, `hooks.getByToken`) work without needing to fan out to every DO. The DO writes index updates to D1 fire-and-forget after each mutation.
+
+Workflow and step invocations are dispatched through Cloudflare Queues for reliable, at-least-once delivery.
+
+## Limitations
+
+- **`events.listByCorrelationId()`** — Requires `runId` context; the DO-per-run architecture cannot query across runs without knowing which DO to target
+- **`steps.get()`** — Requires `runId` for the same routing reason
+- **`readFromStream()`** — Expects stream names in `runId:streamName` format because the Streamer interface does not pass `runId` for reads
+- **Cloudflare platform** — Requires Cloudflare Workers with Durable Objects, D1, and Queues enabled
+
+For local development, use the [Local World](/worlds/local) which requires no external services.

--- a/docs/content/docs/deploying/world/meta.json
+++ b/docs/content/docs/deploying/world/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "World",
-  "pages": ["local-world", "vercel-world", "postgres-world"]
+  "pages": ["local-world", "vercel-world", "postgres-world", "cloudflare-world"]
 }

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -66,6 +66,7 @@
       "description": "Turso/libSQL World for embedded or remote SQLite databases",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/turso",
+      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/turso",
         "WORKFLOW_TURSO_DATABASE_URL": "file:workflow.db"
@@ -81,6 +82,7 @@
       "description": "MongoDB World using native driver",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/mongodb",
+      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/mongodb",
         "WORKFLOW_MONGODB_URI": "mongodb://localhost:27017",
@@ -108,6 +110,7 @@
       "description": "Redis World using BullMQ for queues, Redis Streams for output",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/redis",
+      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/redis",
         "WORKFLOW_REDIS_URI": "redis://localhost:6379"
@@ -134,6 +137,7 @@
       "description": "Jazz Cloud world for local-first sync and real-time collaboration",
       "repository": "https://github.com/garden-co/workflow-world-jazz",
       "docs": "https://github.com/garden-co/workflow-world-jazz",
+      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "workflow-world-jazz"
       },
@@ -149,6 +153,7 @@
       "description": "Cloudflare Workers world using Durable Objects for per-run state, D1 for cross-run queries, and Cloudflare Queues for message dispatch",
       "repository": "https://github.com/ataylorme/workflow-world-cloudflare",
       "docs": "https://github.com/ataylorme/workflow-world-cloudflare",
+      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@ataylorme/workflow-world-cloudflare"
       },

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -152,7 +152,7 @@
       "name": "Cloudflare Workers",
       "description": "Cloudflare Workers world using Durable Objects for per-run state, D1 for cross-run queries, and Cloudflare Queues for message dispatch",
       "repository": "https://github.com/ataylorme/workflow-world-cloudflare",
-      "docs": "https://github.com/ataylorme/workflow-world-cloudflare",
+      "docs": "/docs/deploying/world/cloudflare-world",
       "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@ataylorme/workflow-world-cloudflare"

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -66,7 +66,6 @@
       "description": "Turso/libSQL World for embedded or remote SQLite databases",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/turso",
-      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/turso",
         "WORKFLOW_TURSO_DATABASE_URL": "file:workflow.db"
@@ -82,7 +81,6 @@
       "description": "MongoDB World using native driver",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/mongodb",
-      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/mongodb",
         "WORKFLOW_MONGODB_URI": "mongodb://localhost:27017",
@@ -110,7 +108,6 @@
       "description": "Redis World using BullMQ for queues, Redis Streams for output",
       "repository": "https://github.com/mizzle-dev/workflow-worlds",
       "docs": "https://github.com/mizzle-dev/workflow-worlds/tree/main/packages/redis",
-      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "@workflow-worlds/redis",
         "WORKFLOW_REDIS_URI": "redis://localhost:6379"
@@ -137,13 +134,25 @@
       "description": "Jazz Cloud world for local-first sync and real-time collaboration",
       "repository": "https://github.com/garden-co/workflow-world-jazz",
       "docs": "https://github.com/garden-co/workflow-world-jazz",
-      "features": [],
       "env": {
         "WORKFLOW_TARGET_WORLD": "workflow-world-jazz"
       },
       "services": [],
       "requiresCredentials": true,
       "credentialsNote": "Requires JAZZ_API_KEY, JAZZ_WORKER_ACCOUNT, and JAZZ_WORKER_SECRET from Jazz Cloud"
+    },
+    {
+      "id": "cloudflare",
+      "type": "community",
+      "package": "@ataylorme/workflow-world-cloudflare",
+      "name": "Cloudflare Workers",
+      "description": "Cloudflare Workers world using Durable Objects for per-run state, D1 for cross-run queries, and Cloudflare Queues for message dispatch",
+      "repository": "https://github.com/ataylorme/workflow-world-cloudflare",
+      "docs": "https://github.com/ataylorme/workflow-world-cloudflare",
+      "env": {
+        "WORKFLOW_TARGET_WORLD": "@ataylorme/workflow-world-cloudflare"
+      },
+      "services": []
     }
   ]
 }


### PR DESCRIPTION
This draft PR mirrors the changes from external PR #1477 so GitHub Actions can run in the upstream repository context.

Original PR: #1477

Plan:
- Let CI run here
- If checks pass, merge the original PR instead of this mirror

Author of original contribution: @ataylorme