### PR TITLE
fix(builders): restore discovery WeakMap cache for dev rebuilds

### DIFF
--- a/.changeset/fix-discovery-weakmap-cache.md
+++ b/.changeset/fix-discovery-weakmap-cache.md
@@ -1,0 +1,5 @@
+---
+"@workflow/builders": patch
+---
+
+Fix discovery WeakMap cache miss causing duplicate esbuild passes during dev rebuilds

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -218,6 +218,23 @@ export abstract class BaseBuilder {
     };
 
     const discoverStart = Date.now();
+
+    // Resolve the SDK runtime entry point so that the discovery pass
+    // traces through it and discovers serde classes (like `Run`) that
+    // live inside SDK packages. Without this, files like `run.js` are
+    // only discovered when user code happens to import them.
+    // This is resolved here (rather than in callers) so that the original
+    // `inputs` array reference is preserved for WeakMap caching — callers
+    // like createWorkflowsBundle and createStepsBundle can share the same
+    // cache entry when they pass the same inputFiles array.
+    const resolvedWorkflowRuntime = await enhancedResolve(
+      outdir,
+      'workflow/runtime'
+    ).catch(() => undefined);
+    const entryPoints = resolvedWorkflowRuntime
+      ? [...inputs, resolvedWorkflowRuntime]
+      : inputs;
+
     const effectiveTsconfigPath =
       tsconfigPath ?? (await this.findTsConfigPath());
     const esbuildTsconfigOptions = await getEsbuildTsconfigOptions(
@@ -226,7 +243,7 @@ export abstract class BaseBuilder {
     try {
       await esbuild.build({
         treeShaking: true,
-        entryPoints: inputs,
+        entryPoints,
         plugins: [
           createDiscoverEntriesPlugin(state, this.transformProjectRoot),
         ],
@@ -414,29 +431,13 @@ export abstract class BaseBuilder {
       );
     });
 
-    // Resolve the SDK runtime entry point so that the discovery pass
-    // traces through it and discovers serde classes (like `Run`) that
-    // live inside SDK packages. Without this, files like `run.js` are
-    // only discovered when user code happens to import them.
-    const resolvedWorkflowRuntime = await enhancedResolve(
-      dirname(outfile),
-      'workflow/runtime'
-    ).catch(() => undefined);
-
-    // These need to handle watching for dev to scan for
-    // new entries and changes to existing ones.
-    // Pass inputFiles directly when no extra entries are needed to
-    // preserve the array reference for discoverEntries() WeakMap caching.
-    const discoveryInputs = resolvedWorkflowRuntime
-      ? [...inputFiles, resolvedWorkflowRuntime]
-      : inputFiles;
+    // Discovery of workflow/step/serde entries. The SDK runtime entry point
+    // (workflow/runtime) is resolved inside discoverEntries() itself so that
+    // callers can pass the original inputFiles reference and benefit from
+    // WeakMap caching across createWorkflowsBundle / createStepsBundle calls.
     const discovered =
       discoveredEntries ??
-      (await this.discoverEntries(
-        discoveryInputs,
-        dirname(outfile),
-        tsconfigPath
-      ));
+      (await this.discoverEntries(inputFiles, dirname(outfile), tsconfigPath));
     const stepFiles = [...discovered.discoveredSteps].sort();
     const workflowFiles = [...discovered.discoveredWorkflows].sort();
     const serdeFiles = [...discovered.discoveredSerdeFiles].sort();


### PR DESCRIPTION
## Summary

Fixes flaky E2E Local Dev Tests that started failing after #1669.

- Moves `workflow/runtime` resolution from `createStepsBundle()` into `discoverEntries()` so callers pass the original `inputFiles` array reference
- Restores the `WeakMap<string[], DiscoveredEntries>` cache hit when `createWorkflowsBundle()` and `createStepsBundle()` are called sequentially with the same `inputFiles`
- Eliminates the redundant second esbuild discovery pass per build that was pushing dev rebuild times past the 50s polling timeout on CI

### Root Cause

PR #1669 added `workflow/runtime` to the discovery inputs inside `createStepsBundle`:

```ts
const discoveryInputs = resolvedWorkflowRuntime
  ? [...inputFiles, resolvedWorkflowRuntime]  // new array reference every time
  : inputFiles;
```

Since `resolvedWorkflowRuntime` is almost always truthy, this always created a **new array**, causing the WeakMap cache (keyed on array reference) to never hit. Each `build()` call ran **two full esbuild discovery passes** instead of one. Combined with the broader `/.*/` onResolve filter (also from #1669), this roughly doubled an already-slower build, pushing total rebuild time past the 50-second polling timeout on CI.

### Fix

The `workflow/runtime` resolution now lives inside `discoverEntries()` itself. The expanded entry points list is used internally for the esbuild build, but the original `inputs` array is preserved as the WeakMap key. Both `createWorkflowsBundle` and `createStepsBundle` pass the same `inputFiles` reference and share the cache.