### PR TITLE
fix(next): resolve next/package.json from working directory first

### DIFF
--- a/.changeset/fix-next-version-resolution.md
+++ b/.changeset/fix-next-version-resolution.md
@@ -1,0 +1,5 @@
+---
+"@workflow/next": patch
+---
+
+Fix `next/package.json` resolution failure in npm workspaces monorepos

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -7,6 +7,8 @@ import {
 } from './builder.js';
 
 function resolveNextVersion(workingDir: string): string {
+  const errors: unknown[] = [];
+
   // Try resolving from the consuming project's working directory first.
   // This handles monorepo setups where `next` may not be hoisted to the
   // same location as `@workflow/next`.
@@ -20,8 +22,8 @@ function resolveNextVersion(workingDir: string): string {
     if (typeof resolvedPackageJson.version === 'string') {
       return resolvedPackageJson.version;
     }
-  } catch {
-    // next/package.json not resolvable from working directory
+  } catch (e) {
+    errors.push(e);
   }
 
   // Fall back to resolving relative to this package's location.
@@ -31,12 +33,13 @@ function resolveNextVersion(workingDir: string): string {
     if (typeof version === 'string') {
       return version;
     }
-  } catch {
-    // next/package.json not resolvable from this package's location either
+  } catch (e) {
+    errors.push(e);
   }
 
-  throw new Error(
-    'Could not resolve Next.js version. Ensure `next` is installed in your project.'
+  throw new AggregateError(
+    errors,
+    `Could not resolve Next.js version. Ensure \`next\` is installed in your project (working directory: ${workingDir}).`
   );
 }
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -7,8 +7,9 @@ import {
 } from './builder.js';
 
 function resolveNextVersion(workingDir: string): string {
-  const fallbackVersion = require('next/package.json').version as string;
-
+  // Try resolving from the consuming project's working directory first.
+  // This handles monorepo setups where `next` may not be hoisted to the
+  // same location as `@workflow/next`.
   try {
     const packageJsonPath = require.resolve('next/package.json', {
       paths: [workingDir],
@@ -16,12 +17,27 @@ function resolveNextVersion(workingDir: string): string {
     const resolvedPackageJson = require(packageJsonPath) as {
       version?: unknown;
     };
-    return typeof resolvedPackageJson.version === 'string'
-      ? resolvedPackageJson.version
-      : fallbackVersion;
+    if (typeof resolvedPackageJson.version === 'string') {
+      return resolvedPackageJson.version;
+    }
   } catch {
-    return fallbackVersion;
+    // next/package.json not resolvable from working directory
   }
+
+  // Fall back to resolving relative to this package's location.
+  try {
+    const version = (require('next/package.json') as { version?: unknown })
+      .version;
+    if (typeof version === 'string') {
+      return version;
+    }
+  } catch {
+    // next/package.json not resolvable from this package's location either
+  }
+
+  throw new Error(
+    'Could not resolve Next.js version. Ensure `next` is installed in your project.'
+  );
 }
 
 export function withWorkflow(


### PR DESCRIPTION
## Summary

- Fixes `@workflow/next` failing to resolve `next/package.json` in npm workspaces monorepos where `next` is not hoisted to the root `node_modules/`
- Restructures `resolveNextVersion()` to try the working-directory-relative resolution first (preferred), then fall back to the package-relative resolution, with both paths wrapped in separate try/catch blocks
- Throws a clear error message if neither resolution succeeds

Closes #1680