### PR TITLE
fix(next,builders): resolve `next build` failures from stale socket and dynamic imports

### DIFF
--- a/.changeset/fix-next-build-stale-socket.md
+++ b/.changeset/fix-next-build-stale-socket.md
@@ -1,0 +1,7 @@
+---
+"@workflow/next": patch
+---
+
+fix(next): guard socket-info filesystem fallback behind lazy discovery flag
+
+Prevents `ECONNREFUSED` during `next build` when a stale `workflow-socket.json` file exists from a previous `next dev` session.

--- a/.changeset/fix-step-bundle-dynamic-imports.md
+++ b/.changeset/fix-step-bundle-dynamic-imports.md
@@ -1,0 +1,7 @@
+---
+"@workflow/builders": patch
+---
+
+fix(builders): add `webpackIgnore` comments to dynamic imports in generated step bundle
+
+Prevents Turbopack/webpack "Module not found" errors for runtime-resolved dynamic `import()` calls (e.g. from `@vercel/queue`) that are inlined into the step route bundle.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -589,6 +589,22 @@ export abstract class BaseBuilder {
 
     const stepsResult = await esbuildCtx.rebuild();
 
+    // Post-process the generated step bundle to add bundler-ignore comments
+    // to dynamic `import()` calls with non-literal arguments (e.g. variables,
+    // expressions).  These dynamic imports are resolved at runtime and should
+    // not be traced by downstream bundlers like Turbopack/webpack, which would
+    // otherwise emit "Module not found" errors for unresolvable paths.
+    if (outfile) {
+      const bundleContent = await readFile(outfile, 'utf8');
+      const processed = bundleContent.replace(
+        /\bimport\((?!\s*["'`])/g,
+        'import(/* webpackIgnore: true */ '
+      );
+      if (processed !== bundleContent) {
+        await writeFile(outfile, processed);
+      }
+    }
+
     this.logEsbuildMessages(stepsResult, 'steps bundle creation');
     this.logBaseBuilderInfo(
       'Created steps bundle',

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -178,6 +178,14 @@ function getSocketInfoFilePath(): string | null {
     return configuredPath;
   }
 
+  // Only fall back to filesystem discovery when deferred (lazy) discovery is
+  // active.  Without this guard, a stale socket-info file left behind by a
+  // previous `next dev` session causes ECONNREFUSED during eager builds
+  // (i.e. `next build` without `lazyDiscovery`).
+  if (process.env.WORKFLOW_NEXT_LAZY_DISCOVERY !== '1') {
+    return null;
+  }
+
   // Fallback for worker processes that don't inherit dynamic env updates
   // from the process that created the socket server.
   const distDir = process.env.WORKFLOW_NEXT_DIST_DIR || '.next';


### PR DESCRIPTION
## Summary

Fixes `next build` failures introduced in `5.0.0-beta.1` caused by two separate regressions:

- **ECONNREFUSED during build** (`@workflow/next`): The loader's `getSocketInfoFilePath()` filesystem fallback (added in #1646) unconditionally reads `.next/cache/workflow-socket.json`, which may contain stale credentials from a previous `next dev` session. When the eager builder is active (no socket server), this causes `connect ECONNREFUSED`. Fixed by gating the fallback behind `WORKFLOW_NEXT_LAZY_DISCOVERY=1`.

- **`Module not found: Can't resolve './ROOT'`** (`@workflow/builders`): `@vercel/queue`'s `import(absolutePath)` pattern gets inlined into the generated step route bundle by esbuild. Turbopack traces the dynamic import at build time and fails because `path.resolve(process.cwd(), ...)` produces an unresolvable path. Fixed by post-processing the step bundle to add `/* webpackIgnore: true */` comments to dynamic `import()` calls with non-literal arguments.

## Test plan

- Verified `next build` succeeds on a reproduction project that previously failed with 5 build errors (3 ECONNREFUSED + 2 module-not-found), now produces 0 errors
- All 590 core unit tests pass
- All 12 local-build e2e tests pass
- All 256 builders tests pass (2 pre-existing failures in `node-module-esbuild-plugin.test.ts`)