### PR TITLE
fix(ai): avoid crashing on malformed streamed tool-call input

### DIFF
--- a/.changeset/fix-malformed-tool-call-input.md
+++ b/.changeset/fix-malformed-tool-call-input.md
@@ -1,0 +1,5 @@
+---
+'@workflow/ai': patch
+---
+
+fix(ai): preserve malformed streamed tool-call input instead of crashing before repair hooks can run

--- a/.changeset/fix-malformed-tool-call-input.md
+++ b/.changeset/fix-malformed-tool-call-input.md
@@ -2,4 +2,4 @@
 '@workflow/ai': patch
 ---
 
-fix(ai): preserve malformed streamed tool-call input instead of crashing before repair hooks can run
+Preserve malformed streamed tool-call input until repair hooks can run

--- a/packages/ai/src/agent/do-stream-step.test.ts
+++ b/packages/ai/src/agent/do-stream-step.test.ts
@@ -1,5 +1,10 @@
+import type { UIMessageChunk } from 'ai';
 import { describe, expect, it } from 'vitest';
-import { normalizeFinishReason } from './do-stream-step.js';
+import {
+  doStreamStep,
+  normalizeFinishReason,
+  safeParseToolCallInput,
+} from './do-stream-step.js';
 
 describe('normalizeFinishReason', () => {
   describe('string finish reasons', () => {
@@ -120,5 +125,80 @@ describe('normalizeFinishReason', () => {
       expect(normalized).toBe('tool-calls');
       expect(typeof normalized).toBe('string');
     });
+  });
+});
+
+describe('safeParseToolCallInput', () => {
+  it('should parse valid JSON input', () => {
+    expect(safeParseToolCallInput('{"city":"San Francisco"}')).toEqual({
+      city: 'San Francisco',
+    });
+  });
+
+  it('should return empty object for undefined input', () => {
+    expect(safeParseToolCallInput(undefined)).toEqual({});
+  });
+
+  it('should preserve malformed input as a string', () => {
+    expect(safeParseToolCallInput('{"city":"San Francisco"')).toBe(
+      '{"city":"San Francisco"'
+    );
+  });
+});
+
+describe('doStreamStep', () => {
+  it('should not throw when streamed tool-call input is malformed JSON', async () => {
+    const writtenChunks: UIMessageChunk[] = [];
+    const writable = new WritableStream<UIMessageChunk>({
+      write: async (chunk) => {
+        writtenChunks.push(chunk);
+      },
+    });
+
+    const model = {
+      provider: 'mock-provider',
+      modelId: 'mock-model',
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              input: '{"city":"San Francisco"',
+            });
+            controller.enqueue({
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: {
+                inputTokens: { total: 10, noCache: 10 },
+                outputTokens: { total: 5, text: 0, reasoning: 5 },
+              },
+            });
+            controller.close();
+          },
+        }),
+      }),
+    };
+
+    const result = await doStreamStep(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      async () => model as any,
+      writable,
+      undefined,
+      { sendStart: false }
+    );
+
+    expect(result.step.toolCalls).toHaveLength(1);
+    expect(result.step.toolCalls[0]?.input).toBe('{"city":"San Francisco"');
+    expect(writtenChunks).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-input-available',
+        toolCallId: 'call-1',
+        toolName: 'getWeather',
+        input: '{"city":"San Francisco"',
+      })
+    );
   });
 });

--- a/packages/ai/src/agent/do-stream-step.test.ts
+++ b/packages/ai/src/agent/do-stream-step.test.ts
@@ -1,10 +1,7 @@
 import type { UIMessageChunk } from 'ai';
 import { describe, expect, it } from 'vitest';
-import {
-  doStreamStep,
-  normalizeFinishReason,
-  safeParseToolCallInput,
-} from './do-stream-step.js';
+import { doStreamStep, normalizeFinishReason } from './do-stream-step.js';
+import { safeParseToolCallInput } from './safe-parse-tool-call-input.js';
 
 describe('normalizeFinishReason', () => {
   describe('string finish reasons', () => {

--- a/packages/ai/src/agent/do-stream-step.ts
+++ b/packages/ai/src/agent/do-stream-step.ts
@@ -52,6 +52,22 @@ function uint8ArrayToBase64(data: Uint8Array): string {
 }
 
 /**
+ * Parse streamed tool-call input without crashing the workflow step when a
+ * provider emits malformed or truncated JSON.
+ */
+export function safeParseToolCallInput(input: string | undefined): unknown {
+  if (input == null || input === '') {
+    return {};
+  }
+
+  try {
+    return JSON.parse(input);
+  } catch {
+    return input;
+  }
+}
+
+/**
  * Options for the doStreamStep function.
  */
 export interface DoStreamStepOptions {
@@ -454,7 +470,7 @@ export async function doStreamStep(
                     type: 'tool-input-available',
                     toolCallId: part.toolCallId,
                     toolName: part.toolName,
-                    input: JSON.parse(part.input || '{}'),
+                    input: safeParseToolCallInput(part.input),
                     ...(part.providerExecuted != null
                       ? { providerExecuted: part.providerExecuted }
                       : {}),
@@ -779,6 +795,14 @@ function chunksToStep(
         ? v3FinishReason
         : undefined;
 
+  const mapToolCall = (toolCall: LanguageModelV3ToolCall) => ({
+    type: 'tool-call' as const,
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    input: safeParseToolCallInput(toolCall.input),
+    dynamic: true as const,
+  });
+
   const stepResult: StepResult<any> = {
     stepNumber: 0, // Will be overridden by the caller
     model: {
@@ -790,13 +814,7 @@ function chunksToStep(
     experimental_context: undefined,
     content: [
       ...(text ? [{ type: 'text' as const, text }] : []),
-      ...toolCalls.map((toolCall) => ({
-        type: 'tool-call' as const,
-        toolCallId: toolCall.toolCallId,
-        toolName: toolCall.toolName,
-        input: JSON.parse(toolCall.input),
-        dynamic: true as const,
-      })),
+      ...toolCalls.map(mapToolCall),
     ],
     text,
     reasoning: reasoning.map((r) => ({
@@ -809,21 +827,9 @@ function chunksToStep(
     reasoningText: reasoningText || undefined,
     files,
     sources,
-    toolCalls: toolCalls.map((toolCall) => ({
-      type: 'tool-call' as const,
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      input: JSON.parse(toolCall.input),
-      dynamic: true as const,
-    })),
+    toolCalls: toolCalls.map(mapToolCall),
     staticToolCalls: [],
-    dynamicToolCalls: toolCalls.map((toolCall) => ({
-      type: 'tool-call' as const,
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      input: JSON.parse(toolCall.input),
-      dynamic: true as const,
-    })),
+    dynamicToolCalls: toolCalls.map(mapToolCall),
     toolResults: [],
     staticToolResults: [],
     dynamicToolResults: [],
@@ -864,13 +870,7 @@ function chunksToStep(
     request: {
       body: JSON.stringify({
         prompt: conversationPrompt,
-        tools: toolCalls.map((toolCall) => ({
-          type: 'tool-call' as const,
-          toolCallId: toolCall.toolCallId,
-          toolName: toolCall.toolName,
-          input: JSON.parse(toolCall.input),
-          dynamic: true as const,
-        })),
+        tools: toolCalls.map(mapToolCall),
       }),
     },
     response: {

--- a/packages/ai/src/agent/do-stream-step.ts
+++ b/packages/ai/src/agent/do-stream-step.ts
@@ -22,6 +22,7 @@ import type {
   TelemetrySettings,
 } from './durable-agent.js';
 import { getErrorMessage } from '../get-error-message.js';
+import { safeParseToolCallInput } from './safe-parse-tool-call-input.js';
 import { recordSpan } from './telemetry.js';
 import type { CompatibleLanguageModel } from './types.js';
 
@@ -49,22 +50,6 @@ function uint8ArrayToBase64(data: Uint8Array): string {
     binary += String.fromCharCode(data[i]);
   }
   return btoa(binary);
-}
-
-/**
- * Parse streamed tool-call input without crashing the workflow step when a
- * provider emits malformed or truncated JSON.
- */
-export function safeParseToolCallInput(input: string | undefined): unknown {
-  if (input == null || input === '') {
-    return {};
-  }
-
-  try {
-    return JSON.parse(input);
-  } catch {
-    return input;
-  }
 }
 
 /**

--- a/packages/ai/src/agent/durable-agent.test.ts
+++ b/packages/ai/src/agent/durable-agent.test.ts
@@ -2446,6 +2446,92 @@ describe('DurableAgent', () => {
         })
       );
     });
+
+    it('should patch repaired tool-call input back into the conversation prompt', async () => {
+      const repairFn: ToolCallRepairFunction<ToolSet> = vi
+        .fn()
+        .mockReturnValue({
+          toolCallId: 'test-call-id',
+          toolName: 'testTool',
+          input: '{"name":"repaired"}',
+        });
+
+      const tools: ToolSet = {
+        testTool: {
+          description: 'A test tool',
+          inputSchema: z.object({ name: z.string() }),
+          execute: async () => ({ result: 'success' }),
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new DurableAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const mockMessages: LanguageModelV3Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'test-call-id',
+              toolName: 'testTool',
+              input: 'invalid json',
+            },
+          ],
+        },
+      ];
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              toolCalls: [
+                {
+                  toolCallId: 'test-call-id',
+                  toolName: 'testTool',
+                  input: 'invalid json',
+                } as LanguageModelV3ToolCall,
+              ],
+              messages: mockMessages,
+            },
+          })
+          .mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+        experimental_repairToolCall: repairFn,
+      });
+
+      expect(mockMessages[1]).toMatchObject({
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'test-call-id',
+            toolName: 'testTool',
+            input: { name: 'repaired' },
+          },
+        ],
+      });
+    });
   });
 
   describe('includeRawChunks', () => {

--- a/packages/ai/src/agent/durable-agent.ts
+++ b/packages/ai/src/agent/durable-agent.ts
@@ -27,6 +27,7 @@ import {
 } from 'ai';
 import { convertToLanguageModelPrompt, standardizePrompt } from 'ai/internal';
 import { getErrorMessage } from '../get-error-message.js';
+import { safeParseToolCallInput } from './safe-parse-tool-call-input.js';
 import { streamTextIterator } from './stream-text-iterator.js';
 import { recordSpan, runInContext } from './telemetry.js';
 import type { CompatibleLanguageModel } from './types.js';
@@ -1133,7 +1134,7 @@ export class DurableAgent<TBaseTools extends ToolSet = ToolSet> {
               type: 'tool-call' as const,
               toolCallId: tc.toolCallId,
               toolName: tc.toolName,
-              input: safeParseInput(tc.input),
+              input: safeParseToolCallInput(tc.input),
             }));
 
             // Build toolResults only for tools that were executed
@@ -1141,7 +1142,7 @@ export class DurableAgent<TBaseTools extends ToolSet = ToolSet> {
               type: 'tool-result' as const,
               toolCallId: r.toolCallId,
               toolName: r.toolName,
-              input: safeParseInput(
+              input: safeParseToolCallInput(
                 toolCalls.find((tc) => tc.toolCallId === r.toolCallId)?.input
               ),
               output: 'value' in r.output ? r.output.value : undefined,
@@ -1244,13 +1245,13 @@ export class DurableAgent<TBaseTools extends ToolSet = ToolSet> {
             type: 'tool-call' as const,
             toolCallId: tc.toolCallId,
             toolName: tc.toolName,
-            input: safeParseInput(tc.input),
+            input: safeParseToolCallInput(tc.input),
           }));
           lastStepToolResults = toolResults.map((r) => ({
             type: 'tool-result' as const,
             toolCallId: r.toolCallId,
             toolName: r.toolName,
-            input: safeParseInput(
+            input: safeParseToolCallInput(
               toolCalls.find((tc) => tc.toolCallId === r.toolCallId)?.input
             ),
             output: 'value' in r.output ? r.output.value : undefined,
@@ -1479,10 +1480,6 @@ async function convertChunksToUIMessages(
 }
 
 /**
- * Safely parse tool call input JSON. Returns the parsed value or the raw string
- * if parsing fails (e.g., for tool calls that were repaired).
- */
-/**
  * Valid `type` values for LanguageModelV3ToolResultOutput.
  * When a tool returns an object whose `type` matches one of these,
  * it is passed through as-is instead of being wrapped in json/text.
@@ -1503,11 +1500,35 @@ function isToolResultOutput(
   return TOOL_RESULT_OUTPUT_TYPES.has((result as { type?: string }).type ?? '');
 }
 
-function safeParseInput(input: string | undefined): unknown {
-  try {
-    return JSON.parse(input || '{}');
-  } catch {
-    return input;
+function patchToolCallInMessages(
+  messages: LanguageModelV3Prompt,
+  toolCall: LanguageModelV3ToolCall
+): void {
+  const repairedInput = safeParseToolCallInput(toolCall.input);
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+      continue;
+    }
+
+    const toolCallPart = message.content.find(
+      (
+        part
+      ): part is {
+        type: 'tool-call';
+        toolCallId: string;
+        toolName: string;
+        input: unknown;
+      } => part.type === 'tool-call' && part.toolCallId === toolCall.toolCallId
+    );
+
+    if (toolCallPart) {
+      toolCallPart.toolName = toolCall.toolName;
+      toolCallPart.input = repairedInput;
+      return;
+    }
   }
 }
 
@@ -1589,6 +1610,9 @@ async function executeTool(
           messages,
         });
         if (repairedToolCall) {
+          toolCall.toolName = repairedToolCall.toolName;
+          toolCall.input = repairedToolCall.input;
+          patchToolCallInMessages(messages, repairedToolCall);
           // Retry with repaired tool call
           return executeTool(
             repairedToolCall,
@@ -1614,6 +1638,9 @@ async function executeTool(
         messages,
       });
       if (repairedToolCall) {
+        toolCall.toolName = repairedToolCall.toolName;
+        toolCall.input = repairedToolCall.input;
+        patchToolCallInMessages(messages, repairedToolCall);
         // Retry with repaired tool call
         return executeTool(
           repairedToolCall,

--- a/packages/ai/src/agent/safe-parse-tool-call-input.ts
+++ b/packages/ai/src/agent/safe-parse-tool-call-input.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse streamed tool-call input without crashing the workflow step when a
+ * provider emits malformed or truncated JSON.
+ */
+export function safeParseToolCallInput(input: string | undefined): unknown {
+  if (input == null || input === '') {
+    return {};
+  }
+
+  try {
+    return JSON.parse(input);
+  } catch {
+    return input;
+  }
+}

--- a/packages/ai/src/agent/stream-text-iterator.test.ts
+++ b/packages/ai/src/agent/stream-text-iterator.test.ts
@@ -18,6 +18,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Mock doStreamStep
 vi.mock('./do-stream-step.js', () => ({
   doStreamStep: vi.fn(),
+  safeParseToolCallInput: (input: string | undefined) => {
+    if (input == null || input === '') {
+      return {};
+    }
+
+    try {
+      return JSON.parse(input);
+    } catch {
+      return input;
+    }
+  },
 }));
 
 // Import after mocking
@@ -1093,6 +1104,94 @@ describe('streamTextIterator', () => {
         role: 'system',
         content: 'System prompt v1',
       });
+    });
+  });
+
+  describe('malformed tool-call input handling', () => {
+    it('should preserve malformed tool-call input instead of throwing', async () => {
+      const mockWritable = createMockWritable();
+      const mockModel = vi.fn();
+
+      let capturedPrompt: LanguageModelV3Prompt | undefined;
+
+      const malformedToolCall: LanguageModelV3ToolCall = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'testTool',
+        input: '{"query":"test"',
+      };
+
+      vi.mocked(doStreamStep)
+        .mockResolvedValueOnce({
+          toolCalls: [malformedToolCall],
+          finish: { finishReason: 'tool-calls' },
+          step: createMockStepResult({
+            finishReason: 'tool-calls',
+            toolCalls: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'testTool',
+                input: '{"query":"test"',
+                dynamic: true as const,
+              },
+            ],
+            dynamicToolCalls: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'testTool',
+                input: '{"query":"test"',
+                dynamic: true as const,
+              },
+            ],
+          }),
+        })
+        .mockImplementationOnce(async (prompt) => {
+          capturedPrompt = prompt;
+          return {
+            toolCalls: [],
+            finish: { finishReason: 'stop' },
+            step: createMockStepResult({ finishReason: 'stop' }),
+          };
+        });
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {
+          testTool: {
+            description: 'A test tool',
+            execute: async () => ({ result: 'success' }),
+          },
+        } as ToolSet,
+        writable: mockWritable,
+        model: mockModel as any,
+      });
+
+      const firstResult = await iterator.next();
+      expect(firstResult.done).toBe(false);
+      expect(firstResult.value.toolCalls).toHaveLength(1);
+
+      const toolResults: LanguageModelV3ToolResult[] = [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'testTool',
+          output: { type: 'text', value: '{"result":"success"}' },
+        },
+      ];
+
+      await iterator.next(toolResults);
+
+      const assistantMessage = capturedPrompt?.find(
+        (msg) => msg.role === 'assistant'
+      );
+      const toolCallPart = (assistantMessage?.content as any[])?.find(
+        (part) => part.type === 'tool-call'
+      );
+
+      expect(toolCallPart).toBeDefined();
+      expect(toolCallPart.input).toBe('{"query":"test"');
     });
   });
 });

--- a/packages/ai/src/agent/stream-text-iterator.test.ts
+++ b/packages/ai/src/agent/stream-text-iterator.test.ts
@@ -18,17 +18,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Mock doStreamStep
 vi.mock('./do-stream-step.js', () => ({
   doStreamStep: vi.fn(),
-  safeParseToolCallInput: (input: string | undefined) => {
-    if (input == null || input === '') {
-      return {};
-    }
-
-    try {
-      return JSON.parse(input);
-    } catch {
-      return input;
-    }
-  },
 }));
 
 // Import after mocking

--- a/packages/ai/src/agent/stream-text-iterator.ts
+++ b/packages/ai/src/agent/stream-text-iterator.ts
@@ -16,6 +16,7 @@ import {
   doStreamStep,
   type ModelStopCondition,
   type ProviderExecutedToolResult,
+  safeParseToolCallInput,
 } from './do-stream-step.js';
 import type {
   GenerationSettings,
@@ -358,7 +359,7 @@ export async function* streamTextIterator({
                   type: 'tool-call' as const,
                   toolCallId: toolCall.toolCallId,
                   toolName: toolCall.toolName,
-                  input: JSON.parse(toolCall.input),
+                  input: safeParseToolCallInput(toolCall.input),
                   ...(meta != null ? { providerOptions: meta } : {}),
                 };
               }),

--- a/packages/ai/src/agent/stream-text-iterator.ts
+++ b/packages/ai/src/agent/stream-text-iterator.ts
@@ -16,7 +16,6 @@ import {
   doStreamStep,
   type ModelStopCondition,
   type ProviderExecutedToolResult,
-  safeParseToolCallInput,
 } from './do-stream-step.js';
 import type {
   GenerationSettings,
@@ -31,6 +30,7 @@ import {
   runInContext,
   type SpanHandle,
 } from './telemetry.js';
+import { safeParseToolCallInput } from './safe-parse-tool-call-input.js';
 import { toolsToModelTools } from './tools-to-model-tools.js';
 import type { CompatibleLanguageModel } from './types.js';
 


### PR DESCRIPTION
### Description

Closes #1706

- add a small safe parser for streamed `tool-call.input`
- replace eager `JSON.parse(...)` calls in `do-stream-step.ts` and `stream-text-iterator.ts` that could crash the workflow step before `experimental_repairToolCall` was reached
- preserve malformed input as the raw string instead of throwing so existing repair and error-handling paths remain reachable

This keeps the fix narrowly scoped to internal DurableAgent reconstruction paths. It does not change the public API or introduce provider-specific behavior.

### How did you test your changes?

- added unit coverage for the new safe parser in `packages/ai/src/agent/do-stream-step.test.ts`
- added a regression test that exercises `doStreamStep` with a mock streamed tool call whose input is malformed JSON and verifies the step no longer throws
- added a regression test in `packages/ai/src/agent/stream-text-iterator.test.ts` that verifies malformed tool-call input is preserved into the reconstructed assistant message instead of crashing during prompt rebuild
- ran the focused `@workflow/ai` test suite for the touched agent paths:

```bash
pnpm --filter @workflow/ai test -- \
  src/agent/do-stream-step.test.ts \
  src/agent/stream-text-iterator.test.ts \
  src/agent/durable-agent.test.ts \
  src/agent/telemetry.test.ts
```

- ran the package build:

```bash
pnpm --filter @workflow/ai build
```

Recommended commands to rerun in a fresh fork before marking ready:

```bash
pnpm --filter @workflow/ai test -- \
  src/agent/do-stream-step.test.ts \
  src/agent/stream-text-iterator.test.ts \
  src/agent/durable-agent.test.ts \
  src/agent/telemetry.test.ts
pnpm --filter @workflow/ai build
```

### Notes

- This intentionally preserves the raw malformed input string on parse failure rather than coercing to `{}` so repair hooks and debugging still have access to the original provider output.
- This does not attempt to repair malformed input itself; it only prevents internal reconstruction from crashing before repair/error handling can occur.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [x] 🔒 DCO sign-off passes
- [x] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete