### PR TITLE
fix(docs): correct API usage in cookbook examples

### DIFF
--- a/docs/content/docs/cookbook/advanced/custom-serialization.mdx
+++ b/docs/content/docs/cookbook/advanced/custom-serialization.mdx
@@ -11,7 +11,7 @@ This is an advanced guide. It dives into workflow internals and is not required 
 
 ## The Problem
 
-Workflow functions run inside a sandboxed VM. Every value that crosses a function boundary — step arguments, step return values, workflow inputs — must be serializable. Plain objects, strings, and numbers work automatically, but **class instances** lose their prototype chain and methods during serialization.
+Workflow functions run inside a sandboxed VM. Every value that crosses a function boundary — step arguments, step return values, workflow inputs — must be [serializable](/docs/foundations/serialization). Plain objects, strings, numbers, and many built-in types (`Date`, `Map`, `Set`, `RegExp`, etc.) work automatically, but **class instances** that don't implement the serde protocol will throw a serialization error.
 
 ```typescript lineNumbers
 class StorageClient {
@@ -25,8 +25,8 @@ class StorageClient {
 export async function processFile(client: StorageClient) {
   "use workflow";
 
-  // client is no longer a StorageClient here — it's a plain object
-  // client.upload() throws: "client.upload is not a function"
+  // client fails to serialize — StorageClient doesn't implement the serde protocol
+  // The runtime throws a serialization error
   await uploadStep(client, "output.json", data);
 }
 ```
@@ -73,39 +73,6 @@ This means you only need to implement the two symbol methods. The compiler assig
 <Callout type="info">
 No manual registration is required for classes defined in your workflow files. The SWC plugin detects the serde symbols and generates the registration automatically at build time.
 </Callout>
-
-### Manual Registration for Library Authors
-
-If you're a library author whose classes are defined **outside** the workflow build pipeline (e.g., in a published npm package), the SWC plugin won't process your code. In that case, you need to register classes manually using the same global registry the runtime uses:
-
-```typescript lineNumbers
-const WORKFLOW_CLASS_REGISTRY = Symbol.for("workflow-class-registry");
-
-function registerSerializableClass(classId: string, cls: Function) {
-  const g = globalThis as any;
-  let registry = g[WORKFLOW_CLASS_REGISTRY] as Map<string, Function> | undefined;
-  if (!registry) {
-    registry = new Map();
-    g[WORKFLOW_CLASS_REGISTRY] = registry;
-  }
-  registry.set(classId, cls);
-  Object.defineProperty(cls, "classId", {
-    value: classId,
-    writable: false,
-    enumerable: false,
-    configurable: false,
-  });
-}
-```
-
-Then call it after your class definition:
-
-{/* @skip-typecheck - references variables from prior code block */}
-```typescript lineNumbers
-registerSerializableClass("WorkflowStorageClient", WorkflowStorageClient);
-```
-
-The `classId` is a string identifier stored alongside the serialized data. When the runtime encounters serialized data tagged with that ID, it looks up the registry to find the class and calls `WORKFLOW_DESERIALIZE`.
 
 ## Full Example: A Workflow-Safe Storage Client
 
@@ -168,10 +135,9 @@ export class WorkflowStorageClient {
   }
 
   static [WORKFLOW_DESERIALIZE](
-    this: typeof WorkflowStorageClient,
     data: StorageClientOptions
   ): WorkflowStorageClient {
-    return new this(data);
+    return new WorkflowStorageClient(data);
   }
 }
 ```
@@ -198,9 +164,28 @@ export async function processUpload(
 
 Both patterns solve the same root problem — non-serializable objects can't cross workflow boundaries — but they work differently and suit different situations.
 
+### Custom Serde (Recommended)
+
+Custom serde makes the **object itself** serializable. It can be passed as a workflow input, stored in workflow state, returned from steps, and used across multiple steps. Custom classes also appear with their class names in observability tooling, making debugging easier.
+
+```typescript lineNumbers
+// Serde: the object survives serialization
+class WorkflowStorageClient {
+  static [WORKFLOW_SERIALIZE](instance) { /* ... */ }
+  static [WORKFLOW_DESERIALIZE](data) { /* ... */ }
+}
+```
+
+**Best when:**
+- The object has meaningful state that must survive serialization (credentials, configuration, accumulated data)
+- The object is passed as a workflow input by the caller
+- Multiple steps need the same object instance
+- You're a library author shipping classes that workflow users will pass around
+- You want clear observability — class names appear in the event log and dashboard
+
 ### Step-as-Factory
 
-The [step-as-factory pattern](/docs/cookbook/advanced/serializable-steps) passes a **factory function** instead of an object. The real object is constructed inside a step at execution time.
+The [step-as-factory pattern](/docs/cookbook/advanced/serializable-steps) passes a **factory function** instead of an object. The real object is constructed inside a step at execution time. This is a more indirect pattern that can be harder to follow conceptually.
 
 ```typescript lineNumbers
 // Factory: returns a step function, not an object
@@ -218,34 +203,16 @@ export function createS3Client(region: string) {
 - You don't need to pass the object back out of a step
 - The object is only used inside a single step
 
-### Custom Serde
-
-Custom serde makes the **object itself** serializable. It can be passed as a workflow input, stored in workflow state, returned from steps, and used across multiple steps.
-
-```typescript lineNumbers
-// Serde: the object survives serialization
-class WorkflowStorageClient {
-  static [WORKFLOW_SERIALIZE](instance) { /* ... */ }
-  static [WORKFLOW_DESERIALIZE](data) { /* ... */ }
-}
-```
-
-**Best when:**
-- The object has meaningful state that must survive serialization (credentials, configuration, accumulated data)
-- The object is passed as a workflow input by the caller
-- Multiple steps need the same object instance
-- You're a library author shipping classes that workflow users will pass around
-
 ### Decision Guide
 
 | Scenario | Recommended pattern |
 |---|---|
-| AI SDK model provider (`openai("gpt-4o")`) | Step-as-factory |
-| Database/HTTP client with no config state | Step-as-factory |
 | Storage client with region + credentials | Custom serde |
 | Domain object passed as workflow input | Custom serde |
 | Object returned from one step, used in another | Custom serde |
 | Library class that users instantiate and pass to `start()` | Custom serde |
+| AI SDK model provider (`openai("gpt-4o")`) | Step-as-factory |
+| Stateless client used in a single step | Step-as-factory |
 
 ## Key APIs
 

--- a/docs/content/docs/cookbook/advanced/custom-serialization.mdx
+++ b/docs/content/docs/cookbook/advanced/custom-serialization.mdx
@@ -2,7 +2,7 @@
 title: Custom Serialization
 description: Make class instances serializable across workflow boundaries using the WORKFLOW_SERIALIZE and WORKFLOW_DESERIALIZE symbol protocol.
 type: guide
-summary: Implement the serde symbol protocol on classes so instances survive serialization when passed between workflow and step functions, and register them in the global class registry.
+summary: Implement the WORKFLOW_SERIALIZE and WORKFLOW_DESERIALIZE symbol protocol on classes so instances survive serialization when passed between workflow and step functions.
 ---
 
 <Callout>
@@ -11,7 +11,7 @@ This is an advanced guide. It dives into workflow internals and is not required 
 
 ## The Problem
 
-Workflow functions run inside a sandboxed VM. Every value that crosses a function boundary — step arguments, step return values, workflow inputs — must be [serializable](/docs/foundations/serialization). Plain objects, strings, numbers, and many built-in types (`Date`, `Map`, `Set`, `RegExp`, etc.) work automatically, but **class instances** that don't implement the serde protocol will throw a serialization error.
+Workflow functions run inside a sandboxed VM. Every value that crosses a function boundary — step arguments, step return values, workflow inputs — must be [serializable](/docs/foundations/serialization). Plain objects, strings, numbers, and many built-in types (`Date`, `Map`, `Set`, `RegExp`, etc.) work automatically, but **class instances** that don't implement the custom class serialization protocol will throw a serialization error.
 
 ```typescript lineNumbers
 class StorageClient {
@@ -25,17 +25,17 @@ class StorageClient {
 export async function processFile(client: StorageClient) {
   "use workflow";
 
-  // client fails to serialize — StorageClient doesn't implement the serde protocol
+  // client fails to serialize — StorageClient doesn't implement custom class serialization
   // The runtime throws a serialization error
   await uploadStep(client, "output.json", data);
 }
 ```
 
-The [step-as-factory pattern](/docs/cookbook/advanced/serializable-steps) solves this by deferring object construction into steps. But sometimes you need the object itself to cross boundaries — for example, when a class instance is passed as a workflow input, returned from a step, or stored in workflow state. That's where custom serialization comes in.
+Custom class serialization solves this by teaching the runtime how to convert your class instances to plain data and back.
 
 ## The WORKFLOW_SERIALIZE / WORKFLOW_DESERIALIZE Protocol
 
-The `@workflow/serde` package exports two symbols that act as a serialization protocol. When the workflow runtime encounters a class instance with these symbols, it knows how to convert it to plain data and back.
+The `@workflow/serde` package exports two symbols that act as a custom class serialization protocol. When the workflow runtime encounters a class instance with these symbols, it knows how to convert it to plain data and back.
 
 {/* @skip-typecheck - @workflow/serde is not mapped in the type-checker */}
 ```typescript lineNumbers
@@ -48,11 +48,11 @@ class Point {
     return Math.sqrt((this.x - other.x) ** 2 + (this.y - other.y) ** 2);
   }
 
-  static [WORKFLOW_SERIALIZE](instance: Point) {
+  static [WORKFLOW_SERIALIZE](instance: Point) { // [!code highlight]
     return { x: instance.x, y: instance.y };
   }
 
-  static [WORKFLOW_DESERIALIZE](data: { x: number; y: number }) {
+  static [WORKFLOW_DESERIALIZE](data: { x: number; y: number }) { // [!code highlight]
     return new Point(data.x, data.y);
   }
 }
@@ -61,7 +61,7 @@ class Point {
 Both methods must be **static**. `WORKFLOW_SERIALIZE` receives an instance and returns plain serializable data. `WORKFLOW_DESERIALIZE` receives that same data and reconstructs a new instance.
 
 <Callout type="warn">
-Both serde methods run inside the workflow VM. They must not use Node.js APIs, non-deterministic operations, or network calls. Keep them focused on extracting and reconstructing data.
+Both serialization methods run inside the workflow VM. They must not use Node.js APIs, non-deterministic operations, or network calls. Keep them focused on extracting and reconstructing data.
 </Callout>
 
 ## Automatic Class Registration
@@ -71,7 +71,7 @@ For the runtime to deserialize a class, the class must be registered in a global
 This means you only need to implement the two symbol methods. The compiler assigns a deterministic `classId` based on the file path and class name, and registers it in the global `Symbol.for("workflow-class-registry")` registry.
 
 <Callout type="info">
-No manual registration is required for classes defined in your workflow files. The SWC plugin detects the serde symbols and generates the registration automatically at build time.
+No manual registration is required for classes defined in your workflow files. The SWC plugin detects the serialization symbols and generates the registration automatically at build time.
 </Callout>
 
 ## Full Example: A Workflow-Safe Storage Client
@@ -123,9 +123,9 @@ export class WorkflowStorageClient {
     return getSignedUrl(client, new GetObjectCommand({ Bucket: this.bucket, Key: key }));
   }
 
-  // --- Serde protocol ---
+  // --- Serialization protocol ---
 
-  static [WORKFLOW_SERIALIZE](instance: WorkflowStorageClient): StorageClientOptions {
+  static [WORKFLOW_SERIALIZE](instance: WorkflowStorageClient): StorageClientOptions { // [!code highlight]
     return {
       region: instance.region,
       bucket: instance.bucket,
@@ -134,7 +134,7 @@ export class WorkflowStorageClient {
     };
   }
 
-  static [WORKFLOW_DESERIALIZE](
+  static [WORKFLOW_DESERIALIZE]( // [!code highlight]
     data: StorageClientOptions
   ): WorkflowStorageClient {
     return new WorkflowStorageClient(data);
@@ -154,65 +154,11 @@ export async function processUpload(
   "use workflow";
 
   // client is a real WorkflowStorageClient with working methods
-  await client.upload("output/result.json", data);
-  const url = await client.getSignedUrl("output/result.json");
+  await client.upload("output/result.json", data); // [!code highlight]
+  const url = await client.getSignedUrl("output/result.json"); // [!code highlight]
   return { url };
 }
 ```
-
-## When to Use Custom Serde vs Step-as-Factory
-
-Both patterns solve the same root problem — non-serializable objects can't cross workflow boundaries — but they work differently and suit different situations.
-
-### Custom Serde (Recommended)
-
-Custom serde makes the **object itself** serializable. It can be passed as a workflow input, stored in workflow state, returned from steps, and used across multiple steps. Custom classes also appear with their class names in observability tooling, making debugging easier.
-
-```typescript lineNumbers
-// Serde: the object survives serialization
-class WorkflowStorageClient {
-  static [WORKFLOW_SERIALIZE](instance) { /* ... */ }
-  static [WORKFLOW_DESERIALIZE](data) { /* ... */ }
-}
-```
-
-**Best when:**
-- The object has meaningful state that must survive serialization (credentials, configuration, accumulated data)
-- The object is passed as a workflow input by the caller
-- Multiple steps need the same object instance
-- You're a library author shipping classes that workflow users will pass around
-- You want clear observability — class names appear in the event log and dashboard
-
-### Step-as-Factory
-
-The [step-as-factory pattern](/docs/cookbook/advanced/serializable-steps) passes a **factory function** instead of an object. The real object is constructed inside a step at execution time. This is a more indirect pattern that can be harder to follow conceptually.
-
-```typescript lineNumbers
-// Factory: returns a step function, not an object
-export function createS3Client(region: string) {
-  return async () => {
-    "use step";
-    const { S3Client } = await import("@aws-sdk/client-s3");
-    return new S3Client({ region });
-  };
-}
-```
-
-**Best when:**
-- The object has no serializable state (e.g., AI SDK model providers that are pure configuration)
-- You don't need to pass the object back out of a step
-- The object is only used inside a single step
-
-### Decision Guide
-
-| Scenario | Recommended pattern |
-|---|---|
-| Storage client with region + credentials | Custom serde |
-| Domain object passed as workflow input | Custom serde |
-| Object returned from one step, used in another | Custom serde |
-| Library class that users instantiate and pass to `start()` | Custom serde |
-| AI SDK model provider (`openai("gpt-4o")`) | Step-as-factory |
-| Stateless client used in a single step | Step-as-factory |
 
 ## Key APIs
 

--- a/docs/content/docs/cookbook/advanced/durable-objects.mdx
+++ b/docs/content/docs/cookbook/advanced/durable-objects.mdx
@@ -90,7 +90,7 @@ A chat session where conversation history is the durable state. Each user messag
 ```typescript lineNumbers
 import { defineHook, getWritable, getWorkflowMetadata } from "workflow";
 import { DurableAgent } from "@workflow/ai/agent";
-import { anthropic } from "@workflow/ai/providers/anthropic";
+import { anthropic } from "@workflow/ai/anthropic";
 import { z } from "zod";
 import type { UIMessageChunk, ModelMessage } from "ai";
 

--- a/docs/content/docs/cookbook/advanced/durable-objects.mdx
+++ b/docs/content/docs/cookbook/advanced/durable-objects.mdx
@@ -23,7 +23,7 @@ A counter that persists its value without a database. Each increment/decrement i
 import { defineHook, getWorkflowMetadata } from "workflow";
 import { z } from "zod";
 
-const counterAction = defineHook({
+const counterAction = defineHook({ // [!code highlight]
   schema: z.object({
     type: z.enum(["increment", "decrement", "get"]),
     amount: z.number().default(1),
@@ -38,7 +38,7 @@ export async function durableCounter() {
 
   while (true) {
     const hook = counterAction.create({ token: `counter:${workflowRunId}` });
-    const action = await hook;
+    const action = await hook; // [!code highlight]
 
     switch (action.type) {
       case "increment":
@@ -78,7 +78,7 @@ import { resumeHook } from "workflow/api";
 
 export async function POST(request: Request) {
   const { runId, type, amount } = await request.json();
-  await resumeHook(`counter:${runId}`, { type, amount });
+  await resumeHook(`counter:${runId}`, { type, amount }); // [!code highlight]
   return Response.json({ ok: true });
 }
 ```
@@ -94,7 +94,7 @@ import { anthropic } from "@workflow/ai/anthropic";
 import { z } from "zod";
 import type { UIMessageChunk, ModelMessage } from "ai";
 
-const messageHook = defineHook({
+const messageHook = defineHook({ // [!code highlight]
   schema: z.object({
     role: z.literal("user"),
     content: z.string(),
@@ -115,7 +115,7 @@ export async function durableSession() {
 
   while (true) {
     const hook = messageHook.create({ token: `session:${runId}` });
-    const userMessage = await hook;
+    const userMessage = await hook; // [!code highlight]
 
     messages.push({
       role: userMessage.role,

--- a/docs/content/docs/cookbook/advanced/durable-objects.mdx
+++ b/docs/content/docs/cookbook/advanced/durable-objects.mdx
@@ -77,8 +77,6 @@ From an API route, resume the hook to "invoke a method" on the durable object:
 import { resumeHook } from "workflow/api";
 
 export async function POST(request: Request) {
-  "use step";
-
   const { runId, type, amount } = await request.json();
   await resumeHook(`counter:${runId}`, { type, amount });
   return Response.json({ ok: true });

--- a/docs/content/docs/cookbook/advanced/isomorphic-packages.mdx
+++ b/docs/content/docs/cookbook/advanced/isomorphic-packages.mdx
@@ -30,7 +30,7 @@ export async function processPayment(amount: number, currency: string) {
 
   let runId: string | undefined;
   try {
-    const metadata = getWorkflowMetadata();
+    const metadata = getWorkflowMetadata(); // [!code highlight]
     runId = metadata.workflowRunId;
   } catch {
     // Not running inside a workflow — proceed without durability
@@ -39,7 +39,7 @@ export async function processPayment(amount: number, currency: string) {
 
   if (runId) {
     // Inside a workflow: use the run ID as an idempotency key
-    return await chargeWithIdempotency(amount, currency, runId);
+    return await chargeWithIdempotency(amount, currency, runId); // [!code highlight]
   } else {
     // Outside a workflow: standard charge
     return await chargeStandard(amount, currency);
@@ -69,7 +69,7 @@ export async function createDurableTask(name: string, payload: unknown) {
   let sleep: ((duration: string) => Promise<void>) | undefined;
 
   try {
-    const wf = await import("workflow");
+    const wf = await import("workflow"); // [!code highlight]
     sleep = wf.sleep;
   } catch {
     // workflow not installed — use setTimeout fallback
@@ -80,7 +80,7 @@ export async function createDurableTask(name: string, payload: unknown) {
 
   if (sleep) {
     // Inside workflow: durable sleep that survives restarts
-    await sleep("5m");
+    await sleep("5m"); // [!code highlight]
   } else {
     // Outside workflow: plain timer (not durable)
     await new Promise((resolve) => setTimeout(resolve, 5 * 60 * 1000));

--- a/docs/content/docs/cookbook/advanced/publishing-libraries.mdx
+++ b/docs/content/docs/cookbook/advanced/publishing-libraries.mdx
@@ -126,14 +126,12 @@ When you publish a workflow library, every step function's inputs and outputs ar
 
 ### 1. Everything Must Be Serializable
 
-Step inputs and outputs must be JSON-serializable. Do not pass or return:
+Step inputs and outputs must be serializable. The workflow runtime supports a rich set of types beyond plain JSON — including `Date`, `RegExp`, `Map`, `Set`, `BigInt`, `Uint8Array`, `URL`, `Error`, and class instances that implement the [custom serde protocol](/docs/cookbook/advanced/custom-serialization). See the [serialization reference](/docs/foundations/serialization) for the full list of supported types. Do not pass or return:
 
-- Class instances (unless they implement custom serialization)
 - Functions or closures
-- `Map`, `Set`, `WeakRef`, or other non-JSON types
-- Circular references
+- `WeakRef`, `WeakMap`, or `WeakSet`
 
-If your library works with complex objects, pass serializable configuration into steps and reconstruct the objects inside the step body.
+If your library works with complex objects that don't implement serde, pass serializable configuration into steps and reconstruct the objects inside the step body.
 
 {/* @skip-typecheck - good/bad comparison with duplicate function names */}
 ```typescript lineNumbers
@@ -154,43 +152,24 @@ async function callExternalApi(client: ApiClient, params: Record<string, string>
 
 See [Serializable Steps](/docs/cookbook/advanced/serializable-steps) for the step-as-factory pattern.
 
-### 2. Secrets Must Not Appear in Step I/O
+### 2. Resolve Credentials Inside Steps
 
-Step inputs and outputs are persisted in the event log and may be visible in observability tools. **Never pass secrets as step arguments or return them from steps.**
+While workflow encryption protects the event log at rest, it's still best practice to resolve credentials from environment variables inside step functions rather than passing them as step arguments. This avoids secrets appearing in observability tooling and keeps your library's API clean.
 
 {/* @skip-typecheck - good/bad comparison with duplicate function names */}
 ```typescript lineNumbers
-// Bad: API key appears in the event log
-async function fetchData(apiKey: string, query: string) {
-  "use step";
-  const client = createClient(apiKey);
-  return await client.fetch(query);
-}
-
-// Good: resolve credentials inside the step from environment
+// Preferred: resolve credentials inside the step from environment
 async function fetchData(query: string) {
   "use step";
   const client = createClient(process.env.API_KEY!);
   return await client.fetch(query);
 }
-```
 
-Similarly, helper functions that create API clients using credentials should **not** be marked as steps. If a function's return value would contain sensitive data, keep it as a plain function called inside a step body:
-
-{/* @skip-typecheck - references undefined ServiceClient */}
-```typescript lineNumbers
-// This is NOT a step — intentionally, to avoid credentials in step I/O
-function createAuthenticatedClient(credentials: { token: string }) {
-  return new ServiceClient({ auth: credentials.token });
-}
-
-async function processItem(itemId: string) {
+// Works but unnecessary: credentials in step arguments
+async function fetchData(apiKey: string, query: string) {
   "use step";
-  // Resolve credentials and create client inside the step
-  const client = createAuthenticatedClient({
-    token: process.env.SERVICE_TOKEN!,
-  });
-  return await client.process(itemId);
+  const client = createClient(apiKey);
+  return await client.fetch(query);
 }
 ```
 
@@ -285,8 +264,8 @@ Before publishing a workflow library:
 - [ ] Separate `./workflows` export in `package.json` for the raw workflow functions
 - [ ] `workflow` is marked as **external** in your bundler config
 - [ ] Documentation tells consumers to re-export from `@your-lib/workflows`
-- [ ] No secrets in step inputs or outputs — credentials are resolved at runtime inside steps
-- [ ] All step I/O is JSON-serializable
+- [ ] Credentials are resolved from environment variables inside steps
+- [ ] All step I/O uses [supported serializable types](/docs/foundations/serialization)
 - [ ] Integration tests use a test server with re-exported workflows
 - [ ] Both with-workflow and without-workflow code paths are tested
 

--- a/docs/content/docs/cookbook/advanced/publishing-libraries.mdx
+++ b/docs/content/docs/cookbook/advanced/publishing-libraries.mdx
@@ -90,7 +90,7 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  external: ["workflow"],
+  external: ["workflow"], // [!code highlight]
 });
 ```
 
@@ -105,7 +105,7 @@ The fix is a **re-export file**. The consumer creates a file in their `workflows
 ```typescript lineNumbers
 // workflows/media.ts (in the consumer's project)
 // Re-export library workflows so the build system assigns stable IDs
-export * from "@acme/media/workflows";
+export * from "@acme/media/workflows"; // [!code highlight]
 ```
 
 This one-line file is all that's needed. The workflow compiler transforms this file, discovers the workflow and step functions from the library, and assigns IDs that are stable across deployments.
@@ -126,12 +126,12 @@ When you publish a workflow library, every step function's inputs and outputs ar
 
 ### 1. Everything Must Be Serializable
 
-Step inputs and outputs must be serializable. The workflow runtime supports a rich set of types beyond plain JSON — including `Date`, `RegExp`, `Map`, `Set`, `BigInt`, `Uint8Array`, `URL`, `Error`, and class instances that implement the [custom serde protocol](/docs/cookbook/advanced/custom-serialization). See the [serialization reference](/docs/foundations/serialization) for the full list of supported types. Do not pass or return:
+Step inputs and outputs must be serializable. The workflow runtime supports a rich set of types beyond plain JSON — including `Date`, `RegExp`, `Map`, `Set`, `BigInt`, `Uint8Array`, `URL`, `Error`, and class instances that implement [custom class serialization](/docs/cookbook/advanced/custom-serialization). See the [serialization reference](/docs/foundations/serialization) for the full list of supported types. Do not pass or return:
 
 - Functions or closures
 - `WeakRef`, `WeakMap`, or `WeakSet`
 
-If your library works with complex objects that don't implement serde, pass serializable configuration into steps and reconstruct the objects inside the step body.
+If your library works with complex objects that don't implement custom class serialization, pass serializable configuration into steps and reconstruct the objects inside the step body.
 
 {/* @skip-typecheck - good/bad comparison with duplicate function names */}
 ```typescript lineNumbers
@@ -152,26 +152,28 @@ async function callExternalApi(client: ApiClient, params: Record<string, string>
 
 See [Serializable Steps](/docs/cookbook/advanced/serializable-steps) for the step-as-factory pattern.
 
-### 2. Resolve Credentials Inside Steps
+### 2. Credentials
 
-While workflow encryption protects the event log at rest, it's still best practice to resolve credentials from environment variables inside step functions rather than passing them as step arguments. This avoids secrets appearing in observability tooling and keeps your library's API clean.
+With workflow encryption enabled, credentials passed as step arguments are encrypted in the event log, so either approach is valid:
 
 {/* @skip-typecheck - good/bad comparison with duplicate function names */}
 ```typescript lineNumbers
-// Preferred: resolve credentials inside the step from environment
+// Option A: resolve credentials from environment inside the step
 async function fetchData(query: string) {
   "use step";
   const client = createClient(process.env.API_KEY!);
   return await client.fetch(query);
 }
 
-// Works but unnecessary: credentials in step arguments
+// Option B: pass credentials as step arguments (encrypted in the event log)
 async function fetchData(apiKey: string, query: string) {
   "use step";
   const client = createClient(apiKey);
   return await client.fetch(query);
 }
 ```
+
+The choice is a matter of library API design preference. Resolving from environment variables keeps the step signature simpler, while passing credentials explicitly makes dependencies visible and can be easier to test.
 
 ## Testing Workflow Libraries
 
@@ -183,7 +185,7 @@ Create a minimal test server that re-exports your library's workflows, just like
 
 ```typescript lineNumbers
 // test-server/workflows.ts
-export * from "@acme/media/workflows";
+export * from "@acme/media/workflows"; // [!code highlight]
 ```
 
 This test server acts as a stand-in consumer app. Point your test runner at it to exercise the full workflow lifecycle: start, replay, and completion.
@@ -246,7 +248,7 @@ async function isWorkflowRuntime(): Promise<boolean> {
   try {
     const wf = await import("workflow");
     if (typeof wf.getWorkflowMetadata !== "function") return false;
-    wf.getWorkflowMetadata();
+    wf.getWorkflowMetadata(); // [!code highlight]
     return true;
   } catch {
     return false;
@@ -264,7 +266,7 @@ Before publishing a workflow library:
 - [ ] Separate `./workflows` export in `package.json` for the raw workflow functions
 - [ ] `workflow` is marked as **external** in your bundler config
 - [ ] Documentation tells consumers to re-export from `@your-lib/workflows`
-- [ ] Credentials are resolved from environment variables inside steps
+- [ ] Credentials are either resolved from environment variables or passed explicitly (both are safe with encryption enabled)
 - [ ] All step I/O uses [supported serializable types](/docs/foundations/serialization)
 - [ ] Integration tests use a test server with re-exported workflows
 - [ ] Both with-workflow and without-workflow code paths are tested

--- a/docs/content/docs/cookbook/advanced/serializable-steps.mdx
+++ b/docs/content/docs/cookbook/advanced/serializable-steps.mdx
@@ -69,7 +69,7 @@ export function anthropic(...args: Parameters<typeof anthropicProvider>) {
 This means you import from `@workflow/ai` instead of `@ai-sdk/*` directly:
 
 ```typescript lineNumbers
-import { anthropic } from "@workflow/ai/providers/anthropic";
+import { anthropic } from "@workflow/ai/anthropic";
 import { DurableAgent } from "@workflow/ai/agent";
 import { getWritable } from "workflow";
 import type { UIMessageChunk } from "ai";
@@ -127,20 +127,6 @@ async function uploadFile(
 1. **Compiler transformation**: `"use step"` tells the SWC plugin to extract the function into a separate bundle. The workflow VM only sees a serializable reference (function ID + captured arguments).
 2. **Closure tracking**: The compiler tracks which variables the step function closes over. Only serializable values (strings, numbers, plain objects) can be captured.
 3. **Deferred construction**: The actual provider/client is only constructed when the step executes in the Node.js runtime — never in the sandboxed workflow VM.
-
-## Bundle optimization with dynamic imports
-
-Step functions run in full Node.js, so they can use `await import()` to load heavy dependencies on demand. This keeps the workflow bundle light -- the sandboxed workflow VM never needs to parse or load these libraries.
-
-```typescript
-async function processWithHeavyLib(data: string) {
-  "use step";
-  const { parse } = await import("heavy-parser-lib");
-  return parse(data);
-}
-```
-
-This is especially useful for large SDKs (AWS, Google Cloud, parser libraries) that would bloat the workflow bundle unnecessarily. The `createS3Client` example [above](#writing-your-own-serializable-wrapper) already uses this pattern with `await import("@aws-sdk/client-s3")`.
 
 ## Key APIs
 

--- a/docs/content/docs/cookbook/advanced/serializable-steps.mdx
+++ b/docs/content/docs/cookbook/advanced/serializable-steps.mdx
@@ -43,7 +43,7 @@ import { openai as openaiProvider } from "@ai-sdk/openai";
 export function openai(...args: Parameters<typeof openaiProvider>) {
   return async () => {
     "use step";
-    return openaiProvider(...args);
+    return openaiProvider(...args); // [!code highlight]
   };
 }
 ```
@@ -61,7 +61,7 @@ import { anthropic as anthropicProvider } from "@ai-sdk/anthropic";
 export function anthropic(...args: Parameters<typeof anthropicProvider>) {
   return async () => {
     "use step";
-    return anthropicProvider(...args);
+    return anthropicProvider(...args); // [!code highlight]
   };
 }
 ```
@@ -79,7 +79,7 @@ export async function chatAgent(prompt: string) {
 
   const writable = getWritable<UIMessageChunk>();
   const agent = new DurableAgent({
-    model: anthropic("claude-sonnet-4-20250514"),
+    model: anthropic("claude-sonnet-4-20250514"), // [!code highlight]
   });
 
   await agent.stream({ messages: [{ role: "user", content: prompt }], writable });
@@ -106,7 +106,7 @@ export function createS3Client(region: string) {
 export async function processUpload(region: string, key: string) {
   "use workflow";
 
-  const getClient = createS3Client(region);
+  const getClient = createS3Client(region); // [!code highlight]
   // getClient is a serializable step reference, not an S3Client
   await uploadFile(getClient, key);
 }
@@ -116,7 +116,7 @@ async function uploadFile(
   key: string
 ) {
   "use step";
-  const client = await getClient();
+  const client = await getClient(); // [!code highlight]
   // Now you have a real S3Client with full Node.js access
   await client.send(/* ... */);
 }

--- a/docs/content/docs/cookbook/agent-patterns/durable-agent.mdx
+++ b/docs/content/docs/cookbook/agent-patterns/durable-agent.mdx
@@ -25,7 +25,7 @@ declare function bookFlight(args: { flightId: string; passenger: string }): Prom
 export async function flightAgent(messages: ModelMessage[]) {
   "use workflow";
 
-  const agent = new DurableAgent({
+  const agent = new DurableAgent({ // [!code highlight]
     model: "anthropic/claude-haiku-4.5",
     instructions: "You are a helpful flight booking assistant.",
     tools: {
@@ -49,7 +49,7 @@ export async function flightAgent(messages: ModelMessage[]) {
     },
   });
 
-  await agent.stream({
+  await agent.stream({ // [!code highlight]
     messages,
     writable: getWritable<UIMessageChunk>(),
   });
@@ -115,9 +115,9 @@ async function checkStatus({ flightId }: { flightId: string }) {
 export async function flightAgent(messages: ModelMessage[]) {
   "use workflow";
 
-  const writable = getWritable<UIMessageChunk>();
+  const writable = getWritable<UIMessageChunk>(); // [!code highlight]
 
-  const agent = new DurableAgent({
+  const agent = new DurableAgent({ // [!code highlight]
     model: "anthropic/claude-haiku-4.5",
     instructions: "You are a helpful flight booking assistant.",
     tools: {
@@ -148,7 +148,7 @@ export async function flightAgent(messages: ModelMessage[]) {
     },
   });
 
-  const result = await agent.stream({
+  const result = await agent.stream({ // [!code highlight]
     messages,
     writable,
     maxSteps: 10,
@@ -171,7 +171,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
   const modelMessages = await convertToModelMessages(messages);
 
-  const run = await start(flightAgent, [modelMessages]);
+  const run = await start(flightAgent, [modelMessages]); // [!code highlight]
 
   return createUIMessageStreamResponse({
     stream: run.readable,

--- a/docs/content/docs/cookbook/agent-patterns/human-in-the-loop.mdx
+++ b/docs/content/docs/cookbook/agent-patterns/human-in-the-loop.mdx
@@ -33,9 +33,9 @@ async function requestBookingApproval(
   { flightId, passenger, price }: { flightId: string; passenger: string; price: number },
   { toolCallId }: { toolCallId: string }
 ) {
-  const hook = bookingApprovalHook.create({ token: toolCallId });
+  const hook = bookingApprovalHook.create({ token: toolCallId }); // [!code highlight]
 
-  const result = await Promise.race([
+  const result = await Promise.race([ // [!code highlight]
     hook.then((payload) => ({ type: "decision" as const, ...payload })),
     sleep("24h").then(() => ({ type: "timeout" as const, approved: false })),
   ]);
@@ -66,7 +66,7 @@ export async function bookingAgent(messages: ModelMessage[]) {
     },
   });
 
-  await agent.stream({
+  await agent.stream({ // [!code highlight]
     messages,
     writable: getWritable<UIMessageChunk>(),
   });
@@ -136,10 +136,10 @@ async function requestBookingApproval(
 ) {
   // No "use step" — hooks are workflow-level primitives
 
-  const hook = bookingApprovalHook.create({ token: toolCallId });
+  const hook = bookingApprovalHook.create({ token: toolCallId }); // [!code highlight]
 
   // Race: human approval vs. 24-hour timeout
-  const result = await Promise.race([
+  const result = await Promise.race([ // [!code highlight]
     hook.then((payload) => ({ type: "decision" as const, ...payload })),
     sleep("24h").then(() => ({ type: "timeout" as const, approved: false })),
   ]);
@@ -188,7 +188,7 @@ export async function bookingAgent(messages: ModelMessage[]) {
     },
   });
 
-  await agent.stream({ messages, writable });
+  await agent.stream({ messages, writable }); // [!code highlight]
 }
 ```
 
@@ -201,7 +201,7 @@ export async function POST(request: Request) {
   const { toolCallId, approved, comment } = await request.json();
 
   // Schema validation happens automatically via defineHook
-  await bookingApprovalHook.resume(toolCallId, { approved, comment });
+  await bookingApprovalHook.resume(toolCallId, { approved, comment }); // [!code highlight]
 
   return Response.json({ success: true });
 }

--- a/docs/content/docs/cookbook/agent-patterns/stop-workflow.mdx
+++ b/docs/content/docs/cookbook/agent-patterns/stop-workflow.mdx
@@ -31,8 +31,8 @@ export async function stoppableAgent(messages: ModelMessage[]) {
   const { workflowRunId } = getWorkflowMetadata();
   let stopRequested = false;
 
-  const hook = stopHook.create({ token: `stop:${workflowRunId}` });
-  hook.then(() => { stopRequested = true; });
+  const hook = stopHook.create({ token: `stop:${workflowRunId}` }); // [!code highlight]
+  hook.then(() => { stopRequested = true; }); // [!code highlight]
 
   const agent = new DurableAgent({
     model: "anthropic/claude-haiku-4.5",
@@ -48,8 +48,8 @@ export async function stoppableAgent(messages: ModelMessage[]) {
   const result = await agent.stream({
     messages,
     writable: getWritable<UIMessageChunk>(),
-    prepareStep: () => {
-      if (stopRequested) return { toolChoice: "none" };
+    prepareStep: () => { // [!code highlight]
+      if (stopRequested) return { toolChoice: "none" }; // [!code highlight]
       return {};
     },
   });
@@ -113,8 +113,8 @@ export async function stoppableAgent(messages: ModelMessage[]) {
   let stopRequested = false;
   let stopReason: string | undefined;
 
-  const hook = stopHook.create({ token: `stop:${workflowRunId}` });
-  hook.then(({ reason }) => {
+  const hook = stopHook.create({ token: `stop:${workflowRunId}` }); // [!code highlight]
+  hook.then(({ reason }) => { // [!code highlight]
     stopRequested = true;
     stopReason = reason;
   });
@@ -141,12 +141,12 @@ export async function stoppableAgent(messages: ModelMessage[]) {
     writable,
     preventClose: true,
     maxSteps: 20,
-    prepareStep: ({ stepNumber }) => {
+    prepareStep: ({ stepNumber }) => { // [!code highlight]
       // Check stop flag before each agent step.
       // Setting toolChoice to "none" prevents tool calls,
       // causing the agent to generate a final response and exit.
       if (stopRequested) {
-        return { toolChoice: "none" };
+        return { toolChoice: "none" }; // [!code highlight]
       }
       return {};
     },
@@ -176,7 +176,7 @@ export async function POST(
   const { runId } = await params;
   const { reason } = await request.json();
 
-  await stopHook.resume(`stop:${runId}`, {
+  await stopHook.resume(`stop:${runId}`, { // [!code highlight]
     reason: reason || "User requested stop",
   });
 

--- a/docs/content/docs/cookbook/agent-patterns/stop-workflow.mdx
+++ b/docs/content/docs/cookbook/agent-patterns/stop-workflow.mdx
@@ -9,11 +9,10 @@ Use this pattern when you need to gracefully stop a running agent from the outsi
 
 ## Pattern
 
-Create a hook with a known token (the run ID). Listen for a stop signal in a non-blocking `.then()`. Check the flag before each agent turn and break if signaled. Close the stream cleanly on exit.
+Create a hook with a known token (the run ID). Listen for a stop signal in a non-blocking `.then()`. In the `prepareStep` callback, check the flag and return `{ toolChoice: "none" }` to prevent further tool calls, causing the agent to generate a final response and exit the loop cleanly.
 
 ### Simplified
 
-{/* @skip-typecheck - prepareStep stop pattern is conceptual */}
 ```typescript lineNumbers
 import { DurableAgent } from "@workflow/ai/agent";
 import { defineHook, getWritable, getWorkflowMetadata } from "workflow";
@@ -50,7 +49,7 @@ export async function stoppableAgent(messages: ModelMessage[]) {
     messages,
     writable: getWritable<UIMessageChunk>(),
     prepareStep: () => {
-      if (stopRequested) return { stop: true };
+      if (stopRequested) return { toolChoice: "none" };
       return {};
     },
   });
@@ -61,7 +60,6 @@ export async function stoppableAgent(messages: ModelMessage[]) {
 
 ### Full Implementation
 
-{/* @skip-typecheck - prepareStep stop pattern is conceptual */}
 ```typescript lineNumbers
 import { DurableAgent } from "@workflow/ai/agent";
 import { defineHook, getWritable, getWorkflowMetadata } from "workflow";
@@ -136,17 +134,19 @@ export async function stoppableAgent(messages: ModelMessage[]) {
         execute: analyzeData,
       },
     },
-    maxSteps: 20,
   });
 
   const result = await agent.stream({
     messages,
     writable,
     preventClose: true,
+    maxSteps: 20,
     prepareStep: ({ stepNumber }) => {
-      // Check stop flag before each agent step
+      // Check stop flag before each agent step.
+      // Setting toolChoice to "none" prevents tool calls,
+      // causing the agent to generate a final response and exit.
       if (stopRequested) {
-        return { stop: true };
+        return { toolChoice: "none" };
       }
       return {};
     },

--- a/docs/content/docs/cookbook/agent-patterns/tool-orchestration.mdx
+++ b/docs/content/docs/cookbook/agent-patterns/tool-orchestration.mdx
@@ -15,7 +15,7 @@ Tools marked with `"use step"` get automatic retries and full Node.js access but
 
 | Capability | Step (`"use step"`) | Workflow Level |
 |------------|---------------------|----------------|
-| `getWritable()` | Yes | No |
+| `getWritable()` | Yes | Yes |
 | Automatic retries | Yes | No |
 | Side effects (fetch, DB) | Yes | No |
 | `sleep()` | No | Yes |
@@ -147,7 +147,7 @@ async function pollEndpoint(endpoint: string) {
 
 async function waitForCallback({ description }: { description: string }) {
   // No "use step" — webhooks are workflow primitives
-  const webhook = createWebhook<{ status: string }>();
+  const webhook = createWebhook();
   // Log the URL so external systems can call it
   console.log(`Waiting for callback at: ${webhook.url}`);
 

--- a/docs/content/docs/cookbook/agent-patterns/tool-orchestration.mdx
+++ b/docs/content/docs/cookbook/agent-patterns/tool-orchestration.mdx
@@ -39,14 +39,14 @@ async function fetchWeather({ city }: { city: string }) {
 // Workflow-level tool: uses sleep()
 async function scheduleReminder({ delayMs }: { delayMs: number }) {
   // No "use step" — sleep() requires workflow context
-  await sleep(delayMs);
+  await sleep(delayMs); // [!code highlight]
   return { message: `Reminder fired after ${delayMs}ms` };
 }
 
 // Combined: workflow-level orchestration calling into steps
 async function fetchWithDelay({ url, delayMs }: { url: string; delayMs: number }) {
-  const result = await doFetch(url);   // Step handles I/O
-  await sleep(delayMs);                // Workflow handles sleep
+  const result = await doFetch(url);   // Step handles I/O // [!code highlight]
+  await sleep(delayMs);                // Workflow handles sleep // [!code highlight]
   return result;
 }
 
@@ -80,7 +80,7 @@ export async function assistantAgent(userMessage: string) {
     },
   });
 
-  await agent.stream({
+  await agent.stream({ // [!code highlight]
     messages: [{ role: "user", content: userMessage }],
     writable: getWritable<UIMessageChunk>(),
   });
@@ -132,7 +132,7 @@ async function waitThenCheck({
   endpoint: string;
 }) {
   // No "use step" — workflow context needed for sleep()
-  await sleep(delayMs);
+  await sleep(delayMs); // [!code highlight]
   // Delegate I/O to a step
   return pollEndpoint(endpoint);
 }
@@ -147,11 +147,11 @@ async function pollEndpoint(endpoint: string) {
 
 async function waitForCallback({ description }: { description: string }) {
   // No "use step" — webhooks are workflow primitives
-  const webhook = createWebhook();
+  const webhook = createWebhook(); // [!code highlight]
   // Log the URL so external systems can call it
   console.log(`Waiting for callback at: ${webhook.url}`);
 
-  const result = await Promise.race([
+  const result = await Promise.race([ // [!code highlight]
     webhook.then((req) => req.json()),
     sleep("1h").then(() => ({ status: "timeout" })),
   ]);
@@ -172,7 +172,7 @@ async function retryWithCooldown({
     const result = await attemptFetch(url);
     if (result.success) return result;
     if (i < maxAttempts - 1) {
-      await sleep(`${(i + 1) * 5}s`); // Increasing cooldown between attempts
+      await sleep(`${(i + 1) * 5}s`); // Increasing cooldown between attempts // [!code highlight]
     }
   }
   return { success: false, error: "All attempts failed" };
@@ -238,7 +238,7 @@ export async function orchestrationAgent(userMessage: string) {
     },
   });
 
-  await agent.stream({
+  await agent.stream({ // [!code highlight]
     messages: [{ role: "user", content: userMessage }],
     writable,
   });

--- a/docs/content/docs/cookbook/agent-patterns/tool-streaming.mdx
+++ b/docs/content/docs/cookbook/agent-patterns/tool-streaming.mdx
@@ -36,7 +36,7 @@ export async function searchAgent(userMessage: string) {
     },
   });
 
-  await agent.stream({
+  await agent.stream({ // [!code highlight]
     messages: [{ role: "user", content: userMessage }],
     writable: getWritable<UIMessageChunk>(),
   });
@@ -68,7 +68,7 @@ async function searchWithProgress(
 ) {
   "use step";
 
-  const writable = getWritable<UIMessageChunk>();
+  const writable = getWritable<UIMessageChunk>(); // [!code highlight]
   const writer = writable.getWriter();
 
   try {
@@ -84,7 +84,7 @@ async function searchWithProgress(
       await new Promise((resolve) => setTimeout(resolve, 800));
 
       // Stream each result to the UI as it's found
-      await writer.write({
+      await writer.write({ // [!code highlight]
         type: "data-found-item",
         id: `${toolCallId}-${item.title}`,
         data: item,
@@ -109,7 +109,7 @@ async function getItemDetails({ itemId }: { itemId: string }) {
 
   try {
     // Emit a transient progress message
-    await writer.write({
+    await writer.write({ // [!code highlight]
       type: "data-progress",
       data: { message: `Loading details for ${itemId}...` },
       transient: true,
@@ -149,7 +149,7 @@ export async function searchAgent(userMessage: string) {
     },
   });
 
-  await agent.stream({
+  await agent.stream({ // [!code highlight]
     messages: [{ role: "user", content: userMessage }],
     writable,
   });

--- a/docs/content/docs/cookbook/common-patterns/batching.mdx
+++ b/docs/content/docs/cookbook/common-patterns/batching.mdx
@@ -31,7 +31,7 @@ export async function processBatch(items: string[], batchSize: number = 5) {
     const batch = items.slice(i, i + batchSize);
 
     // Run batch in parallel -- failures are isolated
-    const outcomes = await Promise.allSettled(
+    const outcomes = await Promise.allSettled( // [!code highlight]
       batch.map((item) => processItem(item))
     );
 
@@ -46,7 +46,7 @@ export async function processBatch(items: string[], batchSize: number = 5) {
 
     // Pace between batches to avoid overload
     if (i + batchSize < items.length) {
-      await sleep("1s");
+      await sleep("1s"); // [!code highlight]
     }
   }
 
@@ -81,7 +81,7 @@ When you need results from multiple independent sources before continuing, fan o
 export async function scatterGather(query: string) {
   "use workflow";
 
-  const [web, database, cache] = await Promise.allSettled([
+  const [web, database, cache] = await Promise.allSettled([ // [!code highlight]
     searchWeb(query),
     searchDatabase(query),
     searchCache(query),
@@ -128,7 +128,7 @@ async function processConcurrently<T>(
 
   for (let i = 0; i < items.length; i += maxConcurrent) {
     const batch = items.slice(i, i + maxConcurrent);
-    const batchResults = await Promise.all(batch.map(processor));
+    const batchResults = await Promise.all(batch.map(processor)); // [!code highlight]
     results.push(...batchResults);
   }
 

--- a/docs/content/docs/cookbook/common-patterns/child-workflows.mdx
+++ b/docs/content/docs/cookbook/common-patterns/child-workflows.mdx
@@ -140,7 +140,7 @@ async function checkStatuses(
 
     if (status === "completed") completed += 1;
     else if (status === "failed" || status === "cancelled") failed += 1;
-    else running += 1; // queued, starting, running
+    else running += 1; // pending, running
   }
 
   return { running, completed, failed };

--- a/docs/content/docs/cookbook/common-patterns/content-router.mdx
+++ b/docs/content/docs/cookbook/common-patterns/content-router.mdx
@@ -28,9 +28,9 @@ declare function handleFeedback(ticketId: string): Promise<void>; // @setup
 export async function routeTicket(ticketId: string, subject: string) {
   "use workflow";
 
-  const { ticketType } = await classifyTicket(ticketId, subject);
+  const { ticketType } = await classifyTicket(ticketId, subject); // [!code highlight]
 
-  if (ticketType === "billing") {
+  if (ticketType === "billing") { // [!code highlight]
     await handleBilling(ticketId);
   } else if (ticketType === "technical") {
     await handleTechnical(ticketId);
@@ -103,7 +103,7 @@ export async function enrichAndRoute(email: string) {
   const contact = await lookupContact(email);
 
   // Step 2: Enrich from multiple sources in parallel
-  const [crm, social] = await Promise.allSettled([
+  const [crm, social] = await Promise.allSettled([ // [!code highlight]
     fetchCrmData(contact),
     fetchSocialData(contact),
   ]);
@@ -115,7 +115,7 @@ export async function enrichAndRoute(email: string) {
   };
 
   // Step 3: Route based on enriched data
-  if (enriched.crm?.segment === "enterprise") {
+  if (enriched.crm?.segment === "enterprise") { // [!code highlight]
     await routeToEnterpriseSales(enriched);
   } else {
     await routeToSelfServe(enriched);
@@ -167,12 +167,12 @@ export async function waitForAllSignals(orderId: string) {
   "use workflow";
 
   const hooks = SIGNALS.map((kind) =>
-    orderSignal.create({ token: `${kind}:${orderId}` })
+    orderSignal.create({ token: `${kind}:${orderId}` }) // [!code highlight]
   );
 
-  const outcome = await Promise.race([
-    Promise.all(hooks).then(() => ({ type: "ready" as const })),
-    sleep("5m").then(() => ({ type: "timeout" as const })),
+  const outcome = await Promise.race([ // [!code highlight]
+    Promise.all(hooks).then(() => ({ type: "ready" as const })), // [!code highlight]
+    sleep("5m").then(() => ({ type: "timeout" as const })), // [!code highlight]
   ]);
 
   if (outcome.type === "timeout") {

--- a/docs/content/docs/cookbook/common-patterns/fan-out.mdx
+++ b/docs/content/docs/cookbook/common-patterns/fan-out.mdx
@@ -26,12 +26,12 @@ declare function sendPagerDutyAlert(incidentId: string, message: string): Promis
 export async function incidentFanOut(incidentId: string, message: string) {
   "use workflow";
 
-  const settled = await Promise.allSettled([
+  const settled = await Promise.allSettled([ // [!code highlight]
     sendSlackAlert(incidentId, message),
     sendEmailAlert(incidentId, message),
     sendSmsAlert(incidentId, message),
     sendPagerDutyAlert(incidentId, message),
-  ]);
+  ]); // [!code highlight]
 
   const ok = settled.filter((r) => r.status === "fulfilled").length;
   return { incidentId, delivered: ok, failed: settled.length - ok };
@@ -101,9 +101,9 @@ export async function alertByRecipientList(
 
   const matched = RULES.filter((r) => r.match(severity)).map((r) => r.channel);
 
-  const settled = await Promise.allSettled(
+  const settled = await Promise.allSettled( // [!code highlight]
     matched.map((channel) => deliverToChannel(channel, alertId, message))
-  );
+  ); // [!code highlight]
 
   const delivered = settled.filter((r) => r.status === "fulfilled").length;
   return { alertId, severity, matched, delivered, failed: matched.length - delivered };
@@ -136,9 +136,9 @@ export async function publishEvent(topic: string, payload: string) {
   const subscribers = await loadSubscribers();
   const matched = subscribers.filter((sub) => sub.topics.includes(topic));
 
-  await Promise.allSettled(
+  await Promise.allSettled( // [!code highlight]
     matched.map((sub) => deliverToSubscriber(sub.id, topic, payload))
-  );
+  ); // [!code highlight]
 
   return { topic, delivered: matched.length, total: subscribers.length };
 }
@@ -179,14 +179,14 @@ export async function onboardUser(userId: string, data: Record<string, string>) 
   "use workflow";
 
   // Start report generation in the background
-  const reportPromise = generateReport(data);
+  const reportPromise = generateReport(data); // [!code highlight]
 
   // Do other work while the report generates
   await sendNotification(userId, "Processing started");
   await updateDashboard(userId);
 
   // Now await the report when we actually need it
-  const report = await reportPromise;
+  const report = await reportPromise; // [!code highlight]
   return { userId, report };
 }
 ```

--- a/docs/content/docs/cookbook/common-patterns/idempotency.mdx
+++ b/docs/content/docs/cookbook/common-patterns/idempotency.mdx
@@ -45,7 +45,7 @@ async function createCharge(
 ): Promise<{ id: string }> {
   "use step";
 
-  const { stepId } = getStepMetadata();
+  const { stepId } = getStepMetadata(); // [!code highlight]
 
   // Stripe uses the idempotency key to deduplicate requests.
   // If this step is retried, Stripe returns the same charge.
@@ -53,7 +53,7 @@ async function createCharge(
     method: "POST",
     headers: {
       Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY}`,
-      "Idempotency-Key": stepId,
+      "Idempotency-Key": stepId, // [!code highlight]
     },
     body: new URLSearchParams({
       amount: String(amount),

--- a/docs/content/docs/cookbook/common-patterns/rate-limiting.mdx
+++ b/docs/content/docs/cookbook/common-patterns/rate-limiting.mdx
@@ -43,9 +43,9 @@ async function fetchFromCrm(contactId: string) {
 
   const res = await fetch(`https://crm.example.com/contacts/${contactId}`);
 
-  if (res.status === 429) {
+  if (res.status === 429) { // [!code highlight]
     const retryAfter = res.headers.get("Retry-After");
-    throw new RetryableError("Rate limited by CRM", {
+    throw new RetryableError("Rate limited by CRM", { // [!code highlight]
       retryAfter: retryAfter ? parseInt(retryAfter) * 1000 : "1m",
     });
   }
@@ -73,12 +73,12 @@ import { RetryableError, getStepMetadata } from "workflow";
 async function callFlakeyApi(endpoint: string) {
   "use step";
 
-  const { attempt } = getStepMetadata();
+  const { attempt } = getStepMetadata(); // [!code highlight]
   const res = await fetch(endpoint);
 
   if (res.status === 429 || res.status >= 500) {
-    throw new RetryableError(`Request failed (${res.status})`, {
-      retryAfter: (attempt ** 2) * 1000, // 1s, 4s, 9s...
+    throw new RetryableError(`Request failed (${res.status})`, { // [!code highlight]
+      retryAfter: (attempt ** 2) * 1000, // 1s, 4s, 9s... // [!code highlight]
     });
   }
 
@@ -102,7 +102,7 @@ export async function circuitBreaker(maxRequests: number = 10) {
 
   for (let i = 1; i <= maxRequests; i++) {
     if (state === "open") {
-      await sleep("30s"); // Durable cooldown
+      await sleep("30s"); // Durable cooldown // [!code highlight]
       state = "half-open";
     }
 
@@ -147,7 +147,7 @@ async function fetchWithRetries(url: string) {
 }
 
 // Allow up to 10 retry attempts
-fetchWithRetries.maxRetries = 10;
+fetchWithRetries.maxRetries = 10; // [!code highlight]
 ```
 
 ## Application-level retry
@@ -197,7 +197,7 @@ declare function downloadFile(url: string): Promise<any>; // @setup
 export async function downloadWithRetry(url: string) {
   "use workflow";
 
-  const result = await withRetry(() => downloadFile(url), {
+  const result = await withRetry(() => downloadFile(url), { // [!code highlight]
     maxRetries: 5,
     shouldRetry: (error) => error.message.includes("Timeout"),
   });

--- a/docs/content/docs/cookbook/common-patterns/saga.mdx
+++ b/docs/content/docs/cookbook/common-patterns/saga.mdx
@@ -36,23 +36,23 @@ export async function subscriptionUpgradeSaga(accountId: string, seats: number) 
   try {
     // Step 1: Reserve seats
     const reservationId = await reserveSeats(accountId, seats);
-    compensations.push(() => releaseSeats(accountId, reservationId));
+    compensations.push(() => releaseSeats(accountId, reservationId)); // [!code highlight]
 
     // Step 2: Capture payment
     const invoiceId = await captureInvoice(accountId, seats);
-    compensations.push(() => refundInvoice(accountId, invoiceId));
+    compensations.push(() => refundInvoice(accountId, invoiceId)); // [!code highlight]
 
     // Step 3: Provision access
     const entitlementId = await provisionSeats(accountId, seats);
-    compensations.push(() => deprovisionSeats(accountId, entitlementId));
+    compensations.push(() => deprovisionSeats(accountId, entitlementId)); // [!code highlight]
 
     // Step 4: Notify
     await sendConfirmation(accountId, invoiceId, entitlementId);
     return { status: "completed" };
   } catch (error) {
     // Unwind compensations in reverse order
-    for (const compensate of compensations.reverse()) {
-      await compensate();
+    for (const compensate of compensations.reverse()) { // [!code highlight]
+      await compensate(); // [!code highlight]
     }
 
     return { status: "rolled_back" };
@@ -73,7 +73,7 @@ async function reserveSeats(accountId: string, seats: number): Promise<string> {
     method: "POST",
     body: JSON.stringify({ accountId, seats }),
   });
-  if (!res.ok) throw new FatalError("Seat reservation failed");
+  if (!res.ok) throw new FatalError("Seat reservation failed"); // [!code highlight]
   const { reservationId } = await res.json();
   return reservationId;
 }
@@ -93,7 +93,7 @@ async function captureInvoice(accountId: string, seats: number): Promise<string>
     method: "POST",
     body: JSON.stringify({ accountId, seats }),
   });
-  if (!res.ok) throw new FatalError("Invoice capture failed");
+  if (!res.ok) throw new FatalError("Invoice capture failed"); // [!code highlight]
   const { invoiceId } = await res.json();
   return invoiceId;
 }
@@ -112,7 +112,7 @@ async function provisionSeats(accountId: string, seats: number): Promise<string>
     method: "POST",
     body: JSON.stringify({ accountId, seats }),
   });
-  if (!res.ok) throw new FatalError("Provisioning failed");
+  if (!res.ok) throw new FatalError("Provisioning failed"); // [!code highlight]
   const { entitlementId } = await res.json();
   return entitlementId;
 }

--- a/docs/content/docs/cookbook/common-patterns/scheduling.mdx
+++ b/docs/content/docs/cookbook/common-patterns/scheduling.mdx
@@ -25,13 +25,13 @@ export async function onboardingDrip(email: string) {
 
   await sendEmail(email, "welcome");
 
-  await sleep("1d");
+  await sleep("1d"); // [!code highlight]
   await sendEmail(email, "getting-started-tips");
 
-  await sleep("2d");
+  await sleep("2d"); // [!code highlight]
   await sendEmail(email, "feature-highlights");
 
-  await sleep("4d");
+  await sleep("4d"); // [!code highlight]
   await sendEmail(email, "follow-up");
 
   return { email, status: "completed", totalDays: 7 };
@@ -70,9 +70,9 @@ export async function scheduleReminder(userId: string, delayMs: number) {
   let sendAt = new Date(Date.now() + delayMs);
   const action = reminderActionHook.create({ token: `reminder:${userId}` });
 
-  const outcome = await Promise.race([
-    sleep(sendAt).then(() => ({ kind: "time" as const })),
-    action.then((payload) => ({ kind: "action" as const, payload })),
+  const outcome = await Promise.race([ // [!code highlight]
+    sleep(sendAt).then(() => ({ kind: "time" as const })), // [!code highlight]
+    action.then((payload) => ({ kind: "action" as const, payload })), // [!code highlight]
   ]);
 
   if (outcome.kind === "action") {
@@ -107,7 +107,7 @@ import { resumeHook } from "workflow/api";
 // POST /api/reminder/cancel
 export async function POST(request: Request) {
   const { userId } = await request.json();
-  await resumeHook(`reminder:${userId}`, { type: "cancel" });
+  await resumeHook(`reminder:${userId}`, { type: "cancel" }); // [!code highlight]
   return Response.json({ ok: true });
 }
 ```
@@ -137,12 +137,12 @@ export async function collectAndSendDigest(
   const events: EventPayload[] = [];
 
   while (true) {
-    const outcome = await Promise.race([
+    const outcome = await Promise.race([ // [!code highlight]
       hook.then((payload) => ({ kind: "event" as const, payload })),
       windowClosed,
     ]);
 
-    if (outcome.kind === "window_closed") break;
+    if (outcome.kind === "window_closed") break; // [!code highlight]
     events.push(outcome.payload);
   }
 
@@ -172,9 +172,9 @@ import { sleep, FatalError } from "workflow";
 export async function processWithTimeout(jobId: string) {
   "use workflow";
 
-  const result = await Promise.race([
+  const result = await Promise.race([ // [!code highlight]
     processData(jobId),
-    sleep("30s").then(() => "timeout" as const),
+    sleep("30s").then(() => "timeout" as const), // [!code highlight]
   ]);
 
   if (result === "timeout") {
@@ -209,9 +209,9 @@ export async function waitForTranscription(jobId: string) {
   const maxAttempts = 36; // ~3 minutes at 5s intervals
 
   while (status === "processing" && attempts < maxAttempts) {
-    await sleep(5000);
+    await sleep(5000); // [!code highlight]
     attempts++;
-    const result = await checkJobStatus(jobId);
+    const result = await checkJobStatus(jobId); // [!code highlight]
     status = result.status;
   }
 

--- a/docs/content/docs/cookbook/common-patterns/webhooks.mdx
+++ b/docs/content/docs/cookbook/common-patterns/webhooks.mdx
@@ -25,12 +25,12 @@ declare function processEvent(request: RequestWithResponse): Promise<{ type: str
 export async function paymentWebhook(orderId: string) {
   "use workflow";
 
-  const webhook = createWebhook({ respondWith: "manual" });
+  const webhook = createWebhook({ respondWith: "manual" }); // [!code highlight]
   // webhook.url is the URL to give to the external service
 
   const ledger: { type: string }[] = [];
 
-  for await (const request of webhook) {
+  for await (const request of webhook) { // [!code highlight]
     const entry = await processEvent(request);
     ledger.push(entry);
 
@@ -62,7 +62,7 @@ async function processEvent(
   // Validate, process, and respond inline
   if (type === "payment.succeeded") {
     // Record the payment in your database
-    await request.respondWith(Response.json({ ack: true, action: "captured" }));
+    await request.respondWith(Response.json({ ack: true, action: "captured" })); // [!code highlight]
   } else if (type === "payment.failed") {
     await request.respondWith(Response.json({ ack: true, action: "flagged" }));
   } else {
@@ -89,7 +89,7 @@ export async function asyncVerification(documentId: string) {
   await submitToVendor(documentId, webhook.url);
 
   // Race: wait for callback OR timeout after 30 seconds
-  const result = await Promise.race([
+  const result = await Promise.race([ // [!code highlight]
     (async () => {
       for await (const request of webhook) {
         const body = await processCallback(request);
@@ -97,7 +97,7 @@ export async function asyncVerification(documentId: string) {
       }
       throw new FatalError("Webhook closed without callback");
     })(),
-    sleep("30s").then(() => ({ status: "timed_out" as const })),
+    sleep("30s").then(() => ({ status: "timed_out" as const })), // [!code highlight]
   ]);
 
   return { documentId, ...result };
@@ -131,13 +131,13 @@ When payloads are too large to serialize into the event log, pass a lightweight 
 ```typescript
 import { defineHook } from "workflow";
 
-export const blobReady = defineHook<{ blobToken: string }>();
+export const blobReady = defineHook<{ blobToken: string }>(); // [!code highlight]
 
 export async function importLargeFile(importId: string) {
   "use workflow";
 
   // Suspend until the external system signals the blob is uploaded
-  const { blobToken } = await blobReady.create({ token: `upload:${importId}` });
+  const { blobToken } = await blobReady.create({ token: `upload:${importId}` }); // [!code highlight]
 
   // Process by reference -- the full payload never enters the event log
   await processBlob(blobToken);
@@ -162,7 +162,7 @@ import { resumeHook } from "workflow/api";
 // POST /api/upload-complete
 export async function POST(request: Request) {
   const { importId, blobToken } = await request.json();
-  await resumeHook(`upload:${importId}`, { blobToken });
+  await resumeHook(`upload:${importId}`, { blobToken }); // [!code highlight]
   return Response.json({ ok: true });
 }
 ```

--- a/docs/content/docs/cookbook/integrations/ai-sdk.mdx
+++ b/docs/content/docs/cookbook/integrations/ai-sdk.mdx
@@ -162,12 +162,18 @@ async function bookFlight(input: {
 Use `WorkflowChatTransport` on the client to automatically reconnect to a workflow's stream if the connection drops.
 
 ```typescript title="app/api/chat/route.ts" lineNumbers
+import { createUIMessageStreamResponse } from "ai";
 import { start } from "workflow/api";
 import { researchAgent } from "@/workflows/research";
 
 export async function POST(request: Request) {
   const { messages } = await request.json();
-  return start(researchAgent, [messages]);
+  const run = await start(researchAgent, [messages]);
+
+  return createUIMessageStreamResponse({
+    stream: run.readable,
+    headers: { "x-workflow-run-id": run.runId },
+  });
 }
 ```
 

--- a/docs/content/docs/cookbook/integrations/ai-sdk.mdx
+++ b/docs/content/docs/cookbook/integrations/ai-sdk.mdx
@@ -61,7 +61,7 @@ async function summarize(input: { text: string }): Promise<{ summary: string }> 
 export async function researchAgent(messages: UIMessage[]) {
   "use workflow";
 
-  const agent = new DurableAgent({
+  const agent = new DurableAgent({ // [!code highlight]
     model: "anthropic/claude-sonnet-4-20250514",
     instructions: "You are a research assistant. Search the web and summarize findings.",
     tools: {
@@ -82,7 +82,7 @@ export async function researchAgent(messages: UIMessage[]) {
     },
   });
 
-  const result = await agent.stream({
+  const result = await agent.stream({ // [!code highlight]
     messages: await convertToModelMessages(messages),
     writable: getWritable<UIMessageChunk>(),
   });
@@ -168,10 +168,10 @@ import { researchAgent } from "@/workflows/research";
 
 export async function POST(request: Request) {
   const { messages } = await request.json();
-  const run = await start(researchAgent, [messages]);
+  const run = await start(researchAgent, [messages]); // [!code highlight]
 
   return createUIMessageStreamResponse({
-    stream: run.readable,
+    stream: run.readable, // [!code highlight]
     headers: { "x-workflow-run-id": run.runId },
   });
 }
@@ -185,7 +185,7 @@ import { WorkflowChatTransport } from "@workflow/ai";
 
 export function Chat() {
   const chat = useChat({
-    transport: new WorkflowChatTransport({
+    transport: new WorkflowChatTransport({ // [!code highlight]
       api: "/api/chat",
     }),
   });

--- a/docs/content/docs/cookbook/integrations/chat-sdk.mdx
+++ b/docs/content/docs/cookbook/integrations/chat-sdk.mdx
@@ -57,12 +57,18 @@ export async function chat(messages: UIMessage[]) {
 ```
 
 ```typescript title="app/api/chat/route.ts" lineNumbers
+import { createUIMessageStreamResponse } from "ai";
 import { start } from "workflow/api";
 import { chat } from "@/workflows/chat";
 
 export async function POST(request: Request) {
   const { messages } = await request.json();
-  return start(chat, [messages]);
+  const run = await start(chat, [messages]);
+
+  return createUIMessageStreamResponse({
+    stream: run.readable,
+    headers: { "x-workflow-run-id": run.runId },
+  });
 }
 ```
 
@@ -157,12 +163,18 @@ export async function durableChat(initialMessages: UIMessage[]) {
 You need two routes: one to start the session, another to send follow-up messages.
 
 ```typescript title="app/api/chat/route.ts" lineNumbers
+import { createUIMessageStreamResponse } from "ai";
 import { start } from "workflow/api";
 import { durableChat } from "@/workflows/durable-chat";
 
 export async function POST(request: Request) {
   const { messages } = await request.json();
-  return start(durableChat, [messages]);
+  const run = await start(durableChat, [messages]);
+
+  return createUIMessageStreamResponse({
+    stream: run.readable,
+    headers: { "x-workflow-run-id": run.runId },
+  });
 }
 ```
 

--- a/docs/content/docs/cookbook/integrations/chat-sdk.mdx
+++ b/docs/content/docs/cookbook/integrations/chat-sdk.mdx
@@ -47,7 +47,7 @@ export async function chat(messages: UIMessage[]) {
     tools: { /* your tools here */ },
   });
 
-  const result = await agent.stream({
+  const result = await agent.stream({ // [!code highlight]
     messages: await convertToModelMessages(messages),
     writable: getWritable<UIMessageChunk>(),
   });
@@ -63,7 +63,7 @@ import { chat } from "@/workflows/chat";
 
 export async function POST(request: Request) {
   const { messages } = await request.json();
-  const run = await start(chat, [messages]);
+  const run = await start(chat, [messages]); // [!code highlight]
 
   return createUIMessageStreamResponse({
     stream: run.readable,
@@ -82,7 +82,7 @@ import { WorkflowChatTransport } from "@workflow/ai";
 
 export function Chat() {
   const chat = useChat({
-    transport: new WorkflowChatTransport({ api: "/api/chat" }),
+    transport: new WorkflowChatTransport({ api: "/api/chat" }), // [!code highlight]
   });
 
   return (
@@ -112,7 +112,7 @@ import {
 import { defineHook, getWritable, getWorkflowMetadata } from "workflow";
 import { z } from "zod";
 
-const chatMessageHook = defineHook({
+const chatMessageHook = defineHook({ // [!code highlight]
   schema: z.object({
     messages: z.array(z.any()),
   }),
@@ -141,7 +141,7 @@ export async function durableChat(initialMessages: UIMessage[]) {
   // Subsequent turns -- wait for new messages via hook
   while (true) {
     const hook = chatMessageHook.create({ token: workflowRunId });
-    const { messages: newMessages } = await hook;
+    const { messages: newMessages } = await hook; // [!code highlight]
 
     allMessages = [
       ...allMessages,
@@ -169,7 +169,7 @@ import { durableChat } from "@/workflows/durable-chat";
 
 export async function POST(request: Request) {
   const { messages } = await request.json();
-  const run = await start(durableChat, [messages]);
+  const run = await start(durableChat, [messages]); // [!code highlight]
 
   return createUIMessageStreamResponse({
     stream: run.readable,
@@ -183,7 +183,7 @@ import { resumeHook } from "workflow/api";
 
 export async function POST(request: Request) {
   const { runId, messages } = await request.json();
-  await resumeHook(runId, { messages });
+  await resumeHook(runId, { messages }); // [!code highlight]
   return new Response("OK");
 }
 ```

--- a/docs/content/docs/cookbook/integrations/sandbox.mdx
+++ b/docs/content/docs/cookbook/integrations/sandbox.mdx
@@ -40,17 +40,17 @@ export async function sandboxPipeline(input: {
 }) {
   "use workflow";
 
-  const sandbox = await Sandbox.create({ template: input.template });
+  const sandbox = await Sandbox.create({ template: input.template }); // [!code highlight]
 
   try {
     const results = [];
     for (const command of input.commands) {
-      const result = await sandbox.runCommand(command);
+      const result = await sandbox.runCommand(command); // [!code highlight]
       results.push(result);
     }
     return { status: "completed", results };
   } catch (error) {
-    await sandbox.destroy();
+    await sandbox.destroy(); // [!code highlight]
     throw error;
   }
 }
@@ -85,7 +85,7 @@ export async function codeAgent(messages: UIMessage[]) {
           template: z.string().describe("The sandbox template (e.g., 'node', 'python')"),
         }),
         execute: async ({ template }) => {
-          activeSandbox = await Sandbox.create({ template });
+          activeSandbox = await Sandbox.create({ template }); // [!code highlight]
           return { sandboxId: activeSandbox.id };
         },
       },
@@ -96,7 +96,7 @@ export async function codeAgent(messages: UIMessage[]) {
         }),
         execute: async ({ command }) => {
           if (!activeSandbox) throw new Error("No active sandbox");
-          return activeSandbox.runCommand(command);
+          return activeSandbox.runCommand(command); // [!code highlight]
         },
       },
       cleanupSandbox: {
@@ -104,7 +104,7 @@ export async function codeAgent(messages: UIMessage[]) {
         inputSchema: z.object({}),
         execute: async () => {
           if (!activeSandbox) throw new Error("No active sandbox");
-          await activeSandbox.destroy();
+          await activeSandbox.destroy(); // [!code highlight]
           activeSandbox = null;
           return { cleaned: true };
         },


### PR DESCRIPTION
## Summary

Audited all 23 cookbook documentation files against the real SDK API surface. Fixed incorrect APIs, removed aspirational/non-existent patterns, corrected inaccurate claims, and added `[!code highlight]` markers throughout.

### API correctness fixes

- **ai-sdk.mdx, chat-sdk.mdx** (3 instances): `return start()` returned `Run` not `Response` — use `createUIMessageStreamResponse({ stream: run.readable })` instead
- **tool-orchestration.mdx**: Table incorrectly stated `getWritable()` is unavailable at workflow level; removed invalid generic on `createWebhook()`
- **stop-workflow.mdx**: Replaced non-existent `{ stop: true }` prepareStep return with `{ toolChoice: "none" }`; moved `maxSteps` from DurableAgent constructor to `stream()` options; removed `@skip-typecheck` comments
- **durable-objects.mdx**: Removed erroneous `"use step"` directive from API route handler
- **child-workflows.mdx**: Fixed comment referencing non-existent `"queued"` / `"starting"` statuses
- **serializable-steps.mdx, durable-objects.mdx**: Fixed `@workflow/ai/providers/anthropic` → `@workflow/ai/anthropic`

### Content corrections

- **publishing-libraries.mdx**: Fixed "must be JSON-serializable" — workflow supports `Date`, `Map`, `Set`, `RegExp`, `BigInt`, `Uint8Array`, `URL`, `Error`, and custom classes. Added link to [serialization reference](/docs/foundations/serialization). Rewrote credential guidance to present env vars and explicit passing as equally valid (both safe with encryption enabled).
- **custom-serialization.mdx**: Fixed "class instances lose their prototype chain" — they throw a serialization error. Removed incorrect "Manual Registration for Library Authors" section (build process discovers classes in node_modules). Removed step-as-factory comparison section (page should focus on custom class serialization). Fixed `return new this` → `return new WorkflowStorageClient`. Replaced "serde" shorthand with explicit "custom class serialization" throughout.
- **serializable-steps.mdx**: Removed "Bundle optimization with dynamic imports" section (SWC plugin dead-code-eliminates unused imports automatically).

### Code highlights

Added `[!code highlight]` markers to key lines across all 23 cookbook files to draw attention to the important API calls and patterns in each example.