### PR TITLE
Replace breadcrumb "Runs" text with truncated run ID

### DIFF
--- a/.changeset/truncated-breadcrumb-runid.md
+++ b/.changeset/truncated-breadcrumb-runid.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web": patch
+---
+
+Replace "Runs" breadcrumb text with truncated run ID on run detail page

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -39,8 +39,6 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
 } from '~/components/ui/breadcrumb';
 import { Button } from '~/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
@@ -552,14 +550,10 @@ export function RunDetailView({
             <BreadcrumbList>
               <BreadcrumbItem>
                 <BreadcrumbLink asChild>
-                  <Link to="/">Runs</Link>
+                  <Link to="/" className="font-mono text-xs">
+                    {runId.length > 8 ? `${runId.slice(0, 8)}...` : runId}
+                  </Link>
                 </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbPage className="font-mono text-xs">
-                  {runId}
-                </BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

On the run detail page (`/run/:runId`), replaces the "Runs" breadcrumb text with a truncated version of the run ID (first 8 characters + "...").

Before: `Runs / abc123def456...`
After: `abc123de...` (single breadcrumb with truncated ID linking to home)

### How did you test your changes?

This is a simple UI text change in the breadcrumb component. The change:
- Removes the "Runs" literal text
- Displays the first 8 characters of the run ID followed by "..."
- Keeps the same font styling (`font-mono text-xs`) as the previous run ID display
- Maintains the link to home (`/`)

The typecheck passes for the `@workflow/web` package.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - Use the correct semver bump type: `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0AFKL7AT9N/p1776109543181379?thread_ts=1776109543.181379&cid=C0AFKL7AT9N)

<div><a href="https://cursor.com/agents/bc-8cf2c1fb-11a8-5681-afae-7dd08fea3e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cf2c1fb-11a8-5681-afae-7dd08fea3e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

