### PR TITLE
Fix web/web-shared version drift by marking them as fixed in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,10 @@
     [
       "workflow",
       "@workflow/core"
+    ],
+    [
+      "@workflow/web",
+      "@workflow/web-shared"
     ]
   ],
   "linked": [],


### PR DESCRIPTION
## Summary

- Adds `@workflow/web` and `@workflow/web-shared` to a "fixed" group in `.changeset/config.json` so they always receive the same version bump.

## Problem

`@workflow/web-shared` is a `devDependency` of `@workflow/web` because it is bundled into web's build output (it does not need to be installed in the end-user's `node_modules`). However, this means changesets does not bump `@workflow/web`'s version when only `@workflow/web-shared` has changes, causing version drift between the two packages.

This is a known unresolved issue with changesets: https://github.com/changesets/changesets/issues/944

This is exactly what happened in b833e7f3 ("Version Packages (#1724)") — only `@workflow/web-shared` was bumped while `@workflow/web` was left at its previous version.

## Fix

By marking both packages as "fixed", changesets will force-bump both packages even if only one of them has changes — the same strategy already used for `workflow` and `@workflow/core`.

Supersedes #1727.