### PR TITLE
Use pull_request_target for backport workflow to support fork PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: Backport to stable
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed, labeled]
     branches: [main]
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,8 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'backport-stable')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
## Summary

- Fix backport workflow failing on PRs from external contributors (forks), e.g. https://github.com/vercel/workflow/actions/runs/24410087349/job/71304128891
- The `pull_request` event doesn't expose repository secrets for fork PRs, causing the `Generate GitHub App Token` step to fail with `Input required and not supplied: app-id`
- Switch to `pull_request_target` which runs in the context of the base repository and has access to secrets

This is safe because:
- We only trigger on `closed` (merged) and `labeled` events, meaning the PR was already approved by maintainers
- We cherry-pick the merge commit from `main`, never checking out or executing fork code