### PR TITLE
Add workflow runtime detection example to getWorkflowMetadata docs

### DIFF
--- a/docs/content/docs/api-reference/workflow/get-workflow-metadata.mdx
+++ b/docs/content/docs/api-reference/workflow/get-workflow-metadata.mdx
@@ -19,11 +19,22 @@ You may want to use this function when you need to:
 If you need to access step context, take a look at [`getStepMetadata`](/docs/api-reference/workflow/get-step-metadata).
 </Callout>
 
+```typescript lineNumbers
+import { getWorkflowMetadata } from "workflow"
+
+async function testWorkflow() {
+    "use workflow"
+
+    const ctx = getWorkflowMetadata() // [!code highlight]
+    console.log(ctx.workflowRunId)
+}
+```
+
 ### Detecting Workflow Runtime
 
-You can use `getWorkflowMetadata` to detect whether your code is running inside a workflow context. This is useful when building libraries or utilities that need to behave differently inside and outside of workflows.
+You can use `getWorkflowMetadata` to detect whether your code is running inside a workflow context. This is useful when building shared utilities that need to behave differently inside and outside of workflows.
 
-Since `getWorkflowMetadata` throws an error when called outside a workflow, you can use a try-catch pattern:
+Since `getWorkflowMetadata` throws when called outside a workflow, you can wrap it in a try-catch:
 
 ```typescript lineNumbers
 import { getWorkflowMetadata } from "workflow"
@@ -36,27 +47,20 @@ function isInWorkflow(): boolean {
         return false
     }
 }
-
-// Example: Warn when a function that requires special handling is called inside a workflow
-function getServerSession() {
-    if (isInWorkflow()) {
-        console.warn(
-            "getServerSession called inside a workflow. " +
-            "Make sure you're using an async local storage provider."
-        )
-    }
-    // ... rest of implementation
-}
 ```
+
+For example, a logging utility could include the workflow run ID when available:
 
 ```typescript lineNumbers
 import { getWorkflowMetadata } from "workflow"
 
-async function testWorkflow() {
-    "use workflow"
-
-    const ctx = getWorkflowMetadata() // [!code highlight]
-    console.log(ctx.workflowRunId)
+function log(message: string) {
+    try {
+        const { workflowRunId } = getWorkflowMetadata()
+        console.log(`[workflow:${workflowRunId}] ${message}`)
+    } catch {
+        console.log(message)
+    }
 }
 ```
 

--- a/docs/content/docs/api-reference/workflow/get-workflow-metadata.mdx
+++ b/docs/content/docs/api-reference/workflow/get-workflow-metadata.mdx
@@ -19,6 +19,36 @@ You may want to use this function when you need to:
 If you need to access step context, take a look at [`getStepMetadata`](/docs/api-reference/workflow/get-step-metadata).
 </Callout>
 
+### Detecting Workflow Runtime
+
+You can use `getWorkflowMetadata` to detect whether your code is running inside a workflow context. This is useful when building libraries or utilities that need to behave differently inside and outside of workflows.
+
+Since `getWorkflowMetadata` throws an error when called outside a workflow, you can use a try-catch pattern:
+
+```typescript lineNumbers
+import { getWorkflowMetadata } from "workflow"
+
+function isInWorkflow(): boolean {
+    try {
+        getWorkflowMetadata()
+        return true
+    } catch {
+        return false
+    }
+}
+
+// Example: Warn when a function that requires special handling is called inside a workflow
+function getServerSession() {
+    if (isInWorkflow()) {
+        console.warn(
+            "getServerSession called inside a workflow. " +
+            "Make sure you're using an async local storage provider."
+        )
+    }
+    // ... rest of implementation
+}
+```
+
 ```typescript lineNumbers
 import { getWorkflowMetadata } from "workflow"
 


### PR DESCRIPTION
Adds a new "Detecting Workflow Runtime" section to the `getWorkflowMetadata` API reference showing how to use try-catch to detect if code is running inside a workflow context.

### What changed
- Added code example showing `isInWorkflow()` helper pattern
- Included practical use case for warning when session functions are called without proper providers

This addresses the common question of "how can I tell if I'm in a workflow?" and makes it discoverable via search terms like "detecting workflow runtime" or "isInWorkflow".

<a href="https://vercel.slack.com/archives/C09125LC4AX/p1776192260095189?thread_ts=1776192260.095189&cid=C09125LC4AX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>