### PR TITLE
Fix "Edit this page on GitHub" link path

### DIFF
--- a/docs/components/geistdocs/edit-source.tsx
+++ b/docs/components/geistdocs/edit-source.tsx
@@ -9,7 +9,7 @@ export const EditSource = ({ path }: EditSourceProps) => {
   let url: string | undefined;
 
   if (github.owner && github.repo && path) {
-    url = `https://github.com/${github.owner}/${github.repo}/edit/main/content/docs/${path}`;
+    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/content/${path}`;
   }
 
   if (!url) {

--- a/docs/components/geistdocs/edit-source.tsx
+++ b/docs/components/geistdocs/edit-source.tsx
@@ -9,7 +9,7 @@ export const EditSource = ({ path }: EditSourceProps) => {
   let url: string | undefined;
 
   if (github.owner && github.repo && path) {
-    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/content/${path}`;
+    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/content/docs/${path}`;
   }
 
   if (!url) {

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -66,12 +66,6 @@ const config: NextConfig = {
 
   async redirects() {
     return [
-      // Strip .md extension from any route
-      {
-        source: '/:path*.md',
-        destination: '/:path*',
-        permanent: true,
-      },
       {
         source: '/docs',
         destination: '/docs/getting-started',

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -66,6 +66,12 @@ const config: NextConfig = {
 
   async redirects() {
     return [
+      // Strip .md extension from any route
+      {
+        source: '/:path*.md',
+        destination: '/:path*',
+        permanent: true,
+      },
       {
         source: '/docs',
         destination: '/docs/getting-started',


### PR DESCRIPTION
The "Edit this page on GitHub" link was pointing to `/main/content/docs/` but the actual content files live at `/main/docs/content/docs/`.

### What changed
- Fixed the edit URL path in `docs/components/geistdocs/edit-source.tsx` to use the correct directory structure

<a href="https://vercel.slack.com/archives/C09125LC4AX/p1776281595825439?thread_ts=1776281595.825439&cid=C09125LC4AX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>