### PR TITLE
fix(core): lazy-load built-in worlds in runtime

### DIFF
--- a/.changeset/witty-mails-smile.md
+++ b/.changeset/witty-mails-smile.md
@@ -1,0 +1,5 @@
+---
+"@workflow/next": patch
+---
+
+Allow `WORKFLOW_NEXT_LAZY_DISCOVERY=0` to explicitly disable deferred Next.js discovery

--- a/.github/scripts/generate-docs-data.js
+++ b/.github/scripts/generate-docs-data.js
@@ -144,7 +144,7 @@ function parseE2EResults(files) {
       // Extract framework from filename for detailed breakdown
       const basename = path.basename(file, '.json');
       const frameworkMatch = basename.match(
-        /-(nextjs-turbopack|nextjs-webpack|nitro|nuxt|sveltekit|vite|hono|express|fastify|astro)(?:-(canary|stable))?$/
+        /-(nextjs-turbopack|nextjs-webpack|nitro|nuxt|sveltekit|vite|hono|express|fastify|astro)(?:-(?:canary|stable(?:-lazy-discovery-(?:enabled|disabled))?))?$/
       );
       if (frameworkMatch) {
         const framework = frameworkMatch[1];

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,6 +253,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       WORKFLOW_PUBLIC_MANIFEST: '1'
+      WORKFLOW_NEXT_LAZY_DISCOVERY: ${{ matrix.app.canary != true && (matrix.app.name == 'nextjs-turbopack' || matrix.app.name == 'nextjs-webpack') && '0' || '' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -332,7 +333,7 @@ jobs:
         run: echo "matrix=$(node ./scripts/create-test-matrix.mjs)" >> $GITHUB_OUTPUT
 
   e2e-local-dev:
-    name: E2E Local Dev Tests (${{ matrix.app.name }} - ${{ matrix.app.canary && 'canary' || 'stable' }})
+    name: E2E Local Dev Tests (${{ matrix.app.name }} - ${{ matrix.app.runLabel }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
@@ -345,6 +346,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       WORKFLOW_PUBLIC_MANIFEST: '1'
+      WORKFLOW_NEXT_LAZY_DISCOVERY: ${{ matrix.app.lazyDiscovery == false && '0' || matrix.app.lazyDiscovery == true && '1' || '' }}
 
     steps:
       - name: Checkout Repo
@@ -382,7 +384,7 @@ jobs:
           cd "${{ steps.prepare-workbench.outputs.workbench_app_path }}" && pnpm dev &
           echo "starting tests in 10 seconds" && sleep 10
           pnpm vitest run packages/core/e2e/dev.test.ts; sleep 10
-          pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}.json
+          pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
         env:
           NODE_OPTIONS: "--enable-source-maps"
           APP_NAME: ${{ matrix.app.name }}
@@ -393,19 +395,19 @@ jobs:
 
       - name: Generate E2E summary
         if: always()
-        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Local Dev (${{ matrix.app.name }})" >> $GITHUB_STEP_SUMMARY || true
+        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Local Dev (${{ matrix.app.name }} - ${{ matrix.app.runLabel }})" >> $GITHUB_STEP_SUMMARY || true
 
       - name: Upload E2E results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-results-local-dev-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}
-          path: e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}.json
+          name: e2e-results-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}
+          path: e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
           retention-days: 7
           if-no-files-found: ignore
 
   e2e-local-prod:
-    name: E2E Local Prod Tests (${{ matrix.app.name }} - ${{ matrix.app.canary && 'canary' || 'stable' }})
+    name: E2E Local Prod Tests (${{ matrix.app.name }} - ${{ matrix.app.runLabel }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
@@ -418,6 +420,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       WORKFLOW_PUBLIC_MANIFEST: '1'
+      WORKFLOW_NEXT_LAZY_DISCOVERY: ${{ matrix.app.lazyDiscovery == false && '0' || matrix.app.lazyDiscovery == true && '1' || '' }}
 
     steps:
       - name: Checkout Repo
@@ -460,7 +463,7 @@ jobs:
         run: |
           cd "${{ steps.prepare-workbench.outputs.workbench_app_path }}" && pnpm start &
           echo "starting tests in 10 seconds" && sleep 10
-          pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}.json
+          pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
         env:
           NODE_OPTIONS: "--enable-source-maps"
           APP_NAME: ${{ matrix.app.name }}
@@ -470,19 +473,19 @@ jobs:
 
       - name: Generate E2E summary
         if: always()
-        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Local Prod (${{ matrix.app.name }})" >> $GITHUB_STEP_SUMMARY || true
+        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Local Prod (${{ matrix.app.name }} - ${{ matrix.app.runLabel }})" >> $GITHUB_STEP_SUMMARY || true
 
       - name: Upload E2E results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-results-local-prod-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}
-          path: e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}.json
+          name: e2e-results-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}
+          path: e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
           retention-days: 7
           if-no-files-found: ignore
 
   e2e-local-postgres:
-    name: E2E Local Postgres Tests (${{ matrix.app.name }} - ${{ matrix.app.canary && 'canary' || 'stable' }})
+    name: E2E Local Postgres Tests (${{ matrix.app.name }} - ${{ matrix.app.runLabel }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
@@ -512,6 +515,7 @@ jobs:
       WORKFLOW_PUBLIC_MANIFEST: '1'
       WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
       WORKFLOW_POSTGRES_URL: "postgres://world:world@localhost:5432/world"
+      WORKFLOW_NEXT_LAZY_DISCOVERY: ${{ matrix.app.lazyDiscovery == false && '0' || matrix.app.lazyDiscovery == true && '1' || '' }}
 
     steps:
       - name: Checkout Repo
@@ -557,7 +561,7 @@ jobs:
         run: |
           cd "${{ steps.prepare-workbench.outputs.workbench_app_path }}" && pnpm start &
           echo "starting tests in 10 seconds" && sleep 10
-          pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}.json
+          pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
         env:
           NODE_OPTIONS: "--enable-source-maps"
           APP_NAME: ${{ matrix.app.name }}
@@ -567,14 +571,14 @@ jobs:
 
       - name: Generate E2E summary
         if: always()
-        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Local Postgres (${{ matrix.app.name }})" >> $GITHUB_STEP_SUMMARY || true
+        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Local Postgres (${{ matrix.app.name }} - ${{ matrix.app.runLabel }})" >> $GITHUB_STEP_SUMMARY || true
 
       - name: Upload E2E results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-results-local-postgres-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}
-          path: e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.canary && 'canary' || 'stable' }}.json
+          name: e2e-results-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}
+          path: e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
           retention-days: 7
           if-no-files-found: ignore
 

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -124,6 +124,18 @@ export abstract class BaseBuilder {
     };
   }
 
+  private getConfiguredWorldDefine(): Record<string, string> {
+    if (!this.config.configuredWorldPackage) {
+      return {};
+    }
+
+    return {
+      'process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE': JSON.stringify(
+        this.config.configuredWorldPackage
+      ),
+    };
+  }
+
   /**
    * When outputting fully-bundled ESM, CJS dependencies that call require()
    * for Node.js builtins (e.g. debug → require('tty')) break because esbuild's
@@ -495,16 +507,6 @@ export abstract class BaseBuilder {
     // Include serde-only files for class registration side effects
     const serdeImports = serdeOnlyFiles.map(createImport).join('\n');
 
-    const entryContent = `
-    // Built in steps
-    import '${builtInSteps}';
-    // User steps
-    ${stepImports}
-    // Serde files for cross-context class registration
-    ${serdeImports}
-    // API entrypoint
-    export { stepEntrypoint as POST } from 'workflow/runtime';`;
-
     // Bundle with esbuild and our custom SWC plugin
     const entriesToBundle = externalizeNonSteps
       ? [
@@ -526,6 +528,16 @@ export abstract class BaseBuilder {
     const { banner: importMetaBanner, define: importMetaDefine } =
       this.getCjsImportMetaPolyfill(format);
     const esmRequireBanner = this.getEsmRequireBanner(format);
+
+    const entryContent = `
+    // Built in steps
+    import '${builtInSteps}';
+    // User steps
+    ${stepImports}
+    // Serde files for cross-context class registration
+    ${serdeImports}
+    // API entrypoint
+    export { stepEntrypoint as POST } from 'workflow/runtime';`;
 
     const esbuildCtx = await esbuild.context({
       banner: {
@@ -553,7 +565,10 @@ export abstract class BaseBuilder {
       // Use tsconfig for path alias resolution.
       // For symlinked configs this uses tsconfigRaw to preserve cwd-relative aliases.
       ...esbuildTsconfigOptions,
-      define: importMetaDefine,
+      define: {
+        ...importMetaDefine,
+        ...this.getConfiguredWorldDefine(),
+      },
       resolveExtensions: [
         '.ts',
         '.tsx',
@@ -953,6 +968,7 @@ export const POST = workflowEntrypoint(workflowCode);`;
           write: true,
           keepNames: true,
           minify: false,
+          define: this.getConfiguredWorldDefine(),
           external: ['@aws-sdk/credential-provider-web-identity'],
         });
 
@@ -1203,6 +1219,7 @@ export const OPTIONS = handler;`;
       treeShaking: true,
       keepNames: true,
       minify: false,
+      define: this.getConfiguredWorldDefine(),
       resolveExtensions: [
         '.ts',
         '.tsx',

--- a/packages/builders/src/config-helpers.ts
+++ b/packages/builders/src/config-helpers.ts
@@ -95,6 +95,7 @@ export function createBaseBuilderConfig(options: {
   dirs?: string[];
   watch?: boolean;
   externalPackages?: string[];
+  configuredWorldPackage?: string;
   runtime?: string;
 }): Omit<WorkflowConfig, 'buildTarget'> {
   return {
@@ -106,6 +107,7 @@ export function createBaseBuilderConfig(options: {
     workflowsBundlePath: '', // Not used by base builder methods
     webhookBundlePath: '', // Not used by base builder methods
     externalPackages: options.externalPackages,
+    configuredWorldPackage: options.configuredWorldPackage,
     runtime: options.runtime,
   };
 }

--- a/packages/builders/src/types.ts
+++ b/packages/builders/src/types.ts
@@ -27,6 +27,7 @@ interface BaseWorkflowConfig {
   clientBundlePath?: string;
 
   externalPackages?: string[];
+  configuredWorldPackage?: string;
 
   workflowManifestPath?: string;
 

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -1,7 +1,10 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
-import { getWorkbenchAppPath } from './utils';
+import {
+  getWorkbenchAppPath,
+  isNextLazyDiscoveryEnabledForTest,
+} from './utils';
 
 export interface DevTestConfig {
   generatedStepPath: string;
@@ -44,9 +47,11 @@ export function createDevTests(config?: DevTestConfig) {
     );
     const testWorkflowFile = finalConfig.testWorkflowFile ?? '3_streams.ts';
     const workflowsDir = finalConfig.workflowsDir ?? 'workflows';
-    const supportsDeferredStepCopies = generatedStep.includes(
-      path.join('.well-known', 'workflow', 'v1', 'step', 'route.js')
-    );
+    const supportsDeferredStepCopies =
+      isNextLazyDiscoveryEnabledForTest() &&
+      generatedStep.includes(
+        path.join('.well-known', 'workflow', 'v1', 'step', 'route.js')
+      );
     const restoreFiles: Array<{ path: string; content: string }> = [];
 
     const fetchWithTimeout = (pathname: string) => {

--- a/packages/core/e2e/local-build.test.ts
+++ b/packages/core/e2e/local-build.test.ts
@@ -3,7 +3,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { usesVercelWorld } from '../../utils/src/world-target';
-import { getWorkbenchAppPath } from './utils';
+import {
+  getWorkbenchAppPath,
+  isNextLazyDiscoveryEnabledForTest,
+} from './utils';
 
 interface CommandResult {
   stdout: string;
@@ -119,7 +122,10 @@ describe.each([
 
     expect(result.output).not.toContain('Error:');
 
-    if (DEFERRED_BUILD_MODE_PROJECTS.has(project)) {
+    if (
+      DEFERRED_BUILD_MODE_PROJECTS.has(project) &&
+      isNextLazyDiscoveryEnabledForTest()
+    ) {
       const deferredBuildSupported = !result.output.includes(
         DEFERRED_BUILD_UNSUPPORTED_WARNING
       );

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -19,6 +19,25 @@ function splitArgs(raw: string): string[] {
   return value.split(/\s+/);
 }
 
+function parseBooleanEnvFlag(
+  rawValue: string | undefined
+): boolean | undefined {
+  const normalizedValue = rawValue?.trim().toLowerCase();
+  if (!normalizedValue) {
+    return undefined;
+  }
+
+  if (normalizedValue === '0' || normalizedValue === 'false') {
+    return false;
+  }
+
+  return true;
+}
+
+export function isNextLazyDiscoveryEnabledForTest(): boolean {
+  return parseBooleanEnvFlag(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY) ?? true;
+}
+
 export function getWorkbenchAppPath(overrideAppName?: string): string {
   const explicitWorkbenchPath = process.env.WORKBENCH_APP_PATH;
   const appName = process.env.APP_NAME ?? overrideAppName;

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -5,6 +5,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import { createVercelWorld } from '@workflow/world-vercel';
 import { onTestFailed } from 'vitest';
+import { parseEnvironmentFlag } from '../../next/src/environment-flag.js';
 import type { Run } from '../src/runtime';
 import { getWorld, setWorld } from '../src/runtime';
 
@@ -19,23 +20,8 @@ function splitArgs(raw: string): string[] {
   return value.split(/\s+/);
 }
 
-function parseBooleanEnvFlag(
-  rawValue: string | undefined
-): boolean | undefined {
-  const normalizedValue = rawValue?.trim().toLowerCase();
-  if (!normalizedValue) {
-    return undefined;
-  }
-
-  if (normalizedValue === '0' || normalizedValue === 'false') {
-    return false;
-  }
-
-  return true;
-}
-
 export function isNextLazyDiscoveryEnabledForTest(): boolean {
-  return parseBooleanEnvFlag(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY) ?? true;
+  return parseEnvironmentFlag(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY) ?? true;
 }
 
 export function getWorkbenchAppPath(overrideAppName?: string): string {

--- a/packages/core/src/base-url.ts
+++ b/packages/core/src/base-url.ts
@@ -1,0 +1,39 @@
+import { getCoreRuntimeRequire } from './package-require.js';
+
+function parsePort(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 65535) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+async function getLocalPort(): Promise<number | undefined> {
+  const envPort = parsePort(process.env.PORT);
+  if (envPort !== undefined) {
+    return envPort;
+  }
+
+  try {
+    const loadedModule = getCoreRuntimeRequire()(
+      ['@workflow', 'utils', 'get-port'].join('/')
+    ) as { getPort?: () => Promise<number | undefined> };
+    return await loadedModule.getPort?.();
+  } catch {
+    return undefined;
+  }
+}
+
+export async function getBaseUrl(): Promise<string> {
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  const port = await getLocalPort();
+  return `http://localhost:${port ?? 3000}`;
+}

--- a/packages/core/src/logger.test.ts
+++ b/packages/core/src/logger.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalDebug = process.env.DEBUG;
+const originalRequire = (globalThis as Record<string, unknown>).require;
+
+describe('logger', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.DEBUG = originalDebug;
+
+    if (originalRequire === undefined) {
+      delete (globalThis as Record<string, unknown>).require;
+    } else {
+      (globalThis as Record<string, unknown>).require = originalRequire;
+    }
+
+    vi.restoreAllMocks();
+  });
+
+  it('loads debug lazily from the runtime require when DEBUG is enabled', async () => {
+    const extendedLogger = vi.fn() as unknown as ((
+      ...args: unknown[]
+    ) => void) & {
+      enabled?: boolean;
+    };
+    extendedLogger.enabled = true;
+
+    const baseLogger = Object.assign(vi.fn(), {
+      extend: vi.fn(() => extendedLogger),
+    });
+    const debugFactory = vi.fn(() => baseLogger);
+    const runtimeRequire = vi.fn(() => ({ default: debugFactory }));
+    (globalThis as Record<string, unknown>).require = runtimeRequire;
+    process.env.DEBUG = 'workflow:';
+
+    const { runtimeLogger } = await import('./logger.js');
+
+    runtimeLogger.debug('hello');
+
+    expect(runtimeRequire).toHaveBeenCalledWith('debug');
+    expect(debugFactory).toHaveBeenCalledWith('workflow:runtime');
+    expect(baseLogger.extend).toHaveBeenCalledWith('debug');
+    expect(extendedLogger).toHaveBeenCalledWith('hello', undefined);
+  });
+
+  it('does not throw when runtime require is unavailable', async () => {
+    delete (globalThis as Record<string, unknown>).require;
+    process.env.DEBUG = 'workflow:';
+
+    const { runtimeLogger } = await import('./logger.js');
+
+    expect(() => runtimeLogger.debug('hello')).not.toThrow();
+  });
+});

--- a/packages/core/src/logger.test.ts
+++ b/packages/core/src/logger.test.ts
@@ -1,21 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const originalDebug = process.env.DEBUG;
-const originalRequire = (globalThis as Record<string, unknown>).require;
 
 describe('logger', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.doUnmock('./package-require.js');
   });
 
   afterEach(() => {
     process.env.DEBUG = originalDebug;
-
-    if (originalRequire === undefined) {
-      delete (globalThis as Record<string, unknown>).require;
-    } else {
-      (globalThis as Record<string, unknown>).require = originalRequire;
-    }
 
     vi.restoreAllMocks();
   });
@@ -33,7 +27,9 @@ describe('logger', () => {
     });
     const debugFactory = vi.fn(() => baseLogger);
     const runtimeRequire = vi.fn(() => ({ default: debugFactory }));
-    (globalThis as Record<string, unknown>).require = runtimeRequire;
+    vi.doMock('./package-require.js', () => ({
+      getCoreRuntimeRequire: () => runtimeRequire,
+    }));
     process.env.DEBUG = 'workflow:';
 
     const { runtimeLogger } = await import('./logger.js');
@@ -47,7 +43,11 @@ describe('logger', () => {
   });
 
   it('does not throw when runtime require is unavailable', async () => {
-    delete (globalThis as Record<string, unknown>).require;
+    vi.doMock('./package-require.js', () => ({
+      getCoreRuntimeRequire: () => {
+        throw new Error('runtime require unavailable');
+      },
+    }));
     process.env.DEBUG = 'workflow:';
 
     const { runtimeLogger } = await import('./logger.js');

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,11 +1,65 @@
-import debug from 'debug';
 import { getActiveSpan } from './telemetry.js';
 
+type DebugLogger = ((
+  message: string,
+  metadata?: Record<string, unknown>
+) => void) & {
+  enabled?: boolean;
+  extend(suffix: string): DebugLogger;
+};
+
+type DebugFactory =
+  | ((namespace: string) => DebugLogger)
+  | {
+      default?: (namespace: string) => DebugLogger;
+    };
+
+let cachedDebugEnv: string | undefined;
+let cachedDebugFactory: ((namespace: string) => DebugLogger) | null = null;
+
+function loadDebugFactory(): ((namespace: string) => DebugLogger) | null {
+  const currentDebugEnv = process.env.DEBUG;
+  if (!currentDebugEnv) {
+    cachedDebugEnv = undefined;
+    cachedDebugFactory = null;
+    return null;
+  }
+
+  if (cachedDebugEnv === currentDebugEnv) {
+    return cachedDebugFactory;
+  }
+
+  cachedDebugEnv = currentDebugEnv;
+
+  try {
+    const getRuntimeRequire = new Function(
+      'return typeof require !== "undefined" ? require : undefined;'
+    ) as () => ((specifier: string) => unknown) | undefined;
+    const runtimeRequire = getRuntimeRequire();
+
+    if (!runtimeRequire) {
+      cachedDebugFactory = null;
+      return null;
+    }
+
+    const loadedModule = runtimeRequire('debug') as DebugFactory;
+    const debugFactory =
+      typeof loadedModule === 'function' ? loadedModule : loadedModule.default;
+
+    cachedDebugFactory =
+      typeof debugFactory === 'function' ? debugFactory : null;
+  } catch {
+    cachedDebugFactory = null;
+  }
+
+  return cachedDebugFactory;
+}
+
 function createLogger(namespace: string) {
-  const baseDebug = debug(`workflow:${namespace}`);
+  const baseDebug = loadDebugFactory()?.(`workflow:${namespace}`);
 
   const logger = (level: string) => {
-    const levelDebug = baseDebug.extend(level);
+    const levelDebug = baseDebug?.extend(level);
 
     return (message: string, metadata?: Record<string, any>) => {
       // Always output error/warn to console so users see critical issues
@@ -17,9 +71,9 @@ function createLogger(namespace: string) {
       }
 
       // Also log to debug library for verbose output when DEBUG is enabled
-      levelDebug(message, metadata);
+      levelDebug?.(message, metadata);
 
-      if (levelDebug.enabled) {
+      if (levelDebug?.enabled) {
         getActiveSpan()
           .then((span) => {
             span?.addEvent(`${level}.${namespace}`, { message, ...metadata });

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,3 +1,4 @@
+import { getCoreRuntimeRequire } from './package-require.js';
 import { getActiveSpan } from './telemetry.js';
 
 type DebugLogger = ((
@@ -8,55 +9,28 @@ type DebugLogger = ((
   extend(suffix: string): DebugLogger;
 };
 
-type DebugFactory =
-  | ((namespace: string) => DebugLogger)
-  | {
-      default?: (namespace: string) => DebugLogger;
-    };
+type DebugFactory = (namespace: string) => DebugLogger;
 
-let cachedDebugEnv: string | undefined;
-let cachedDebugFactory: ((namespace: string) => DebugLogger) | null = null;
-
-function loadDebugFactory(): ((namespace: string) => DebugLogger) | null {
-  const currentDebugEnv = process.env.DEBUG;
-  if (!currentDebugEnv) {
-    cachedDebugEnv = undefined;
-    cachedDebugFactory = null;
-    return null;
+function loadDebugLogger(namespace: string): DebugLogger | undefined {
+  if (!process.env.DEBUG) {
+    return undefined;
   }
-
-  if (cachedDebugEnv === currentDebugEnv) {
-    return cachedDebugFactory;
-  }
-
-  cachedDebugEnv = currentDebugEnv;
 
   try {
-    const getRuntimeRequire = new Function(
-      'return typeof require !== "undefined" ? require : undefined;'
-    ) as () => ((specifier: string) => unknown) | undefined;
-    const runtimeRequire = getRuntimeRequire();
-
-    if (!runtimeRequire) {
-      cachedDebugFactory = null;
-      return null;
-    }
-
-    const loadedModule = runtimeRequire('debug') as DebugFactory;
-    const debugFactory =
+    const loadedModule = getCoreRuntimeRequire()(['de', 'bug'].join('')) as
+      | DebugFactory
+      | { default?: DebugFactory };
+    const createDebug =
       typeof loadedModule === 'function' ? loadedModule : loadedModule.default;
 
-    cachedDebugFactory =
-      typeof debugFactory === 'function' ? debugFactory : null;
+    return createDebug?.(`workflow:${namespace}`);
   } catch {
-    cachedDebugFactory = null;
+    return undefined;
   }
-
-  return cachedDebugFactory;
 }
 
 function createLogger(namespace: string) {
-  const baseDebug = loadDebugFactory()?.(`workflow:${namespace}`);
+  const baseDebug = loadDebugLogger(namespace);
 
   const logger = (level: string) => {
     const levelDebug = baseDebug?.extend(level);

--- a/packages/core/src/package-require.ts
+++ b/packages/core/src/package-require.ts
@@ -1,0 +1,37 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const localRequire = createRequire(import.meta.url);
+
+export type RuntimeRequire = typeof localRequire;
+
+export function getProjectRequire(): RuntimeRequire {
+  try {
+    return createRequire(
+      pathToFileURL(
+        resolve(/* turbopackIgnore: true */ process.cwd(), 'package.json')
+      ).href
+    );
+  } catch {
+    return localRequire;
+  }
+}
+
+export function getCoreRuntimeRequire(): RuntimeRequire {
+  const projectRequire = getProjectRequire();
+
+  try {
+    const workflowRuntimePath = projectRequire.resolve('workflow/runtime');
+    const workflowRuntimeRequire = createRequire(
+      pathToFileURL(workflowRuntimePath).href
+    );
+    const coreRuntimePath = workflowRuntimeRequire.resolve(
+      '@workflow/core/runtime'
+    );
+
+    return createRequire(pathToFileURL(coreRuntimePath).href);
+  } catch {
+    return localRequire;
+  }
+}

--- a/packages/core/src/package-require.ts
+++ b/packages/core/src/package-require.ts
@@ -3,6 +3,8 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const localRequire = createRequire(import.meta.url);
+const WORKFLOW_RUNTIME_SPECIFIER = ['workflow', 'runtime'].join('/');
+const CORE_RUNTIME_SPECIFIER = ['@workflow', 'core', 'runtime'].join('/');
 
 export type RuntimeRequire = typeof localRequire;
 
@@ -22,12 +24,14 @@ export function getCoreRuntimeRequire(): RuntimeRequire {
   const projectRequire = getProjectRequire();
 
   try {
-    const workflowRuntimePath = projectRequire.resolve('workflow/runtime');
+    const workflowRuntimePath = projectRequire.resolve(
+      WORKFLOW_RUNTIME_SPECIFIER
+    );
     const workflowRuntimeRequire = createRequire(
       pathToFileURL(workflowRuntimePath).href
     );
     const coreRuntimePath = workflowRuntimeRequire.resolve(
-      '@workflow/core/runtime'
+      CORE_RUNTIME_SPECIFIER
     );
 
     return createRequire(pathToFileURL(coreRuntimePath).href);

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -11,8 +11,8 @@ import {
   WorkflowWorldError,
 } from '@workflow/errors';
 import { pluralize } from '@workflow/utils';
-import { getPort } from '@workflow/utils/get-port';
 import { SPEC_VERSION_CURRENT, StepInvokePayloadSchema } from '@workflow/world';
+import { getBaseUrl } from '../base-url.js';
 import { importKey } from '../encryption.js';
 import { runtimeLogger, stepLogger } from '../logger.js';
 import { getStepFunction } from '../private.js';
@@ -141,11 +141,10 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
         // Extract the step name from the topic name
         const stepName = metadata.queueName.slice('__wkf_step_'.length);
         const world = await getWorld();
-        const isVercel = process.env.VERCEL_URL !== undefined;
 
         // Resolve local async values concurrently before entering the trace span
-        const [port, spanKind] = await Promise.all([
-          isVercel ? undefined : getPort(),
+        const [baseUrl, spanKind] = await Promise.all([
+          getBaseUrl(),
           getSpanKind('CONSUMER'),
         ]);
 
@@ -513,11 +512,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                       workflowName,
                       workflowRunId,
                       workflowStartedAt: new Date(+workflowStartedAt),
-                      // TODO: there should be a getUrl method on the world interface itself. This
-                      // solution only works for vercel + local worlds.
-                      url: isVercel
-                        ? `https://${process.env.VERCEL_URL}`
-                        : `http://localhost:${port ?? 3000}`,
+                      url: baseUrl,
                       features: { encryption: !!encryptionKey },
                     },
                     ops,

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -49,7 +49,9 @@ function resolveImportPath(
   }
   // Relative path - resolve relative to cwd and convert to file:// URL
   if (specifier.startsWith('./') || specifier.startsWith('../')) {
-    return pathToFileURL(resolve(process.cwd(), specifier)).href;
+    return pathToFileURL(
+      resolve(/* turbopackIgnore: true */ process.cwd(), specifier)
+    ).href;
   }
   // Package specifier - use require.resolve to find the package
   try {
@@ -70,7 +72,7 @@ function resolveRequirePath(
     return specifier;
   }
   if (specifier.startsWith('./') || specifier.startsWith('../')) {
-    return resolve(process.cwd(), specifier);
+    return resolve(/* turbopackIgnore: true */ process.cwd(), specifier);
   }
   try {
     return requireFn.resolve(specifier);
@@ -125,6 +127,33 @@ function resolveWorldSpecifier(targetWorld: string): string {
   }
   return targetWorld;
 }
+
+/**
+ * Resolve the configured world package once at module load so bundlers/NFT can
+ * trace it into server deployments without eagerly loading the module itself.
+ *
+ * Keep the env access inline so Next/BaseBuilder can replace it with a literal
+ * package name in generated bundles.
+ */
+function traceConfiguredWorldPackage(): void {
+  if (!process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE) {
+    return;
+  }
+
+  try {
+    const requireFn =
+      isLocalWorldTarget(process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE) ||
+      isVercelWorldTarget(process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE)
+        ? getCoreRuntimeRequire()
+        : getProjectRequire();
+
+    requireFn.resolve(process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE);
+  } catch {
+    // Actual module loading still happens lazily in createWorld().
+  }
+}
+
+traceConfiguredWorldPackage();
 
 function warnForStaleVercelEnvVars(): void {
   // Warn if WORKFLOW_VERCEL_* env vars are set inside a Vercel serverless

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -89,10 +89,18 @@ function resolveWorldFactory(
 async function loadBundledWorldModule(
   specifier: '@workflow/world-local' | '@workflow/world-vercel'
 ): Promise<any> {
+  if (specifier === '@workflow/world-local') {
+    try {
+      return await import('@workflow/world-local');
+    } catch {
+      return require('@workflow/world-local');
+    }
+  }
+
   try {
-    return await dynamicImport(specifier);
+    return await import('@workflow/world-vercel');
   } catch {
-    return require(specifier);
+    return require('@workflow/world-vercel');
   }
 }
 

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -23,29 +23,9 @@ const globalSymbols: typeof globalThis & {
   [StubbedWorldCachePromise]?: Promise<World>;
 } = globalThis;
 
-/**
- * Hides dynamic imports behind `new Function` so eager step bundles do not
- * statically trace world implementations into generated routes.
- *
- * Custom worlds still need a parameterized form because the specifier comes
- * from user configuration. Built-in worlds use literal specifiers so runtime
- * environments like Turbopack dev can execute a concrete import expression
- * without analyzing package imports at build time.
- */
 const dynamicImport = new Function('specifier', 'return import(specifier)') as (
   specifier: string
 ) => Promise<any>;
-const dynamicImportLocalWorld = new Function(
-  'return import("@workflow/world-local")'
-) as () => Promise<any>;
-const dynamicImportVercelWorld = new Function(
-  'return import("@workflow/world-vercel")'
-) as () => Promise<any>;
-const dynamicRequire = new Function(
-  'requireFn',
-  'specifier',
-  'return requireFn(specifier)'
-) as (requireFn: typeof require, specifier: string) => any;
 
 function getProjectRequire() {
   return createRequire(
@@ -105,16 +85,16 @@ async function loadBundledWorldModule(
 ): Promise<any> {
   if (specifier === '@workflow/world-local') {
     try {
-      return await dynamicImportLocalWorld();
+      return await import('@workflow/world-local');
     } catch {
-      return dynamicRequire(require, '@workflow/world-local');
+      return require('@workflow/world-local');
     }
   }
 
   try {
-    return await dynamicImportVercelWorld();
+    return await import('@workflow/world-vercel');
   } catch {
-    return dynamicRequire(require, '@workflow/world-vercel');
+    return require('@workflow/world-vercel');
   }
 }
 

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -1,13 +1,15 @@
-import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   isVercelWorldTarget,
   resolveWorkflowTargetWorld,
 } from '@workflow/utils';
 import type { World } from '@workflow/world';
-
-const require = createRequire(import.meta.url);
+import {
+  getCoreRuntimeRequire,
+  getProjectRequire,
+  type RuntimeRequire,
+} from '../package-require.js';
 
 const WorldCache = Symbol.for('@workflow/world//cache');
 const StubbedWorldCache = Symbol.for('@workflow/world//stubbedCache');
@@ -23,19 +25,20 @@ const globalSymbols: typeof globalThis & {
   [StubbedWorldCachePromise]?: Promise<World>;
 } = globalThis;
 
+/**
+ * Hides the dynamic import behind `new Function` to prevent bundlers from
+ * trying to resolve it at build time, since the world module may not exist
+ * at build time. Falls back to `require()` in environments where
+ * `new Function`-based `import()` is unavailable (e.g. CJS test runners).
+ */
 const dynamicImport = new Function('specifier', 'return import(specifier)') as (
   specifier: string
 ) => Promise<any>;
 
-function getProjectRequire() {
-  return createRequire(
-    pathToFileURL(
-      resolve(/* turbopackIgnore: true */ process.cwd(), 'package.json')
-    ).href
-  );
-}
-
-function resolveModulePath(specifier: string): string {
+function resolveImportPath(
+  specifier: string,
+  requireFn: RuntimeRequire
+): string {
   // Already a file:// URL
   if (specifier.startsWith('file://')) {
     return specifier;
@@ -46,15 +49,44 @@ function resolveModulePath(specifier: string): string {
   }
   // Relative path - resolve relative to cwd and convert to file:// URL
   if (specifier.startsWith('./') || specifier.startsWith('../')) {
-    return pathToFileURL(
-      resolve(/* turbopackIgnore: true */ process.cwd(), specifier)
-    ).href;
+    return pathToFileURL(resolve(process.cwd(), specifier)).href;
   }
   // Package specifier - use require.resolve to find the package
   try {
-    return pathToFileURL(getProjectRequire().resolve(specifier)).href;
+    return pathToFileURL(requireFn.resolve(specifier)).href;
   } catch {
     return specifier;
+  }
+}
+
+function resolveRequirePath(
+  specifier: string,
+  requireFn: RuntimeRequire
+): string {
+  if (specifier.startsWith('file://')) {
+    return fileURLToPath(specifier);
+  }
+  if (specifier.startsWith('/')) {
+    return specifier;
+  }
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    return resolve(process.cwd(), specifier);
+  }
+  try {
+    return requireFn.resolve(specifier);
+  } catch {
+    return specifier;
+  }
+}
+
+async function loadWorldModule(
+  specifier: string,
+  requireFn: RuntimeRequire
+): Promise<any> {
+  try {
+    return await dynamicImport(resolveImportPath(specifier, requireFn));
+  } catch {
+    return requireFn(resolveRequirePath(specifier, requireFn));
   }
 }
 
@@ -80,35 +112,86 @@ function resolveWorldFactory(
   return undefined;
 }
 
-async function loadBundledWorldModule(
-  specifier: '@workflow/world-local' | '@workflow/world-vercel'
-): Promise<any> {
-  if (specifier === '@workflow/world-local') {
-    try {
-      return await import('@workflow/world-local');
-    } catch {
-      return require('@workflow/world-local');
-    }
-  }
+function isLocalWorldTarget(targetWorld: string): boolean {
+  return targetWorld === 'local' || targetWorld === '@workflow/world-local';
+}
 
-  try {
-    return await import('@workflow/world-vercel');
-  } catch {
-    return require('@workflow/world-vercel');
+function resolveWorldSpecifier(targetWorld: string): string {
+  if (isVercelWorldTarget(targetWorld)) {
+    return '@workflow/world-vercel';
+  }
+  if (isLocalWorldTarget(targetWorld)) {
+    return '@workflow/world-local';
+  }
+  return targetWorld;
+}
+
+function warnForStaleVercelEnvVars(): void {
+  // Warn if WORKFLOW_VERCEL_* env vars are set inside a Vercel serverless
+  // function (VERCEL=1) — they have no effect at runtime and likely indicate
+  // a misconfiguration (user manually added them as Vercel project env vars,
+  // which is not needed). We gate on VERCEL=1 so the warning does not fire
+  // when the CLI or web observability app sets these env vars intentionally.
+  const staleEnvVars = [
+    'WORKFLOW_VERCEL_PROJECT',
+    'WORKFLOW_VERCEL_TEAM',
+    'WORKFLOW_VERCEL_AUTH_TOKEN',
+    'WORKFLOW_VERCEL_ENV',
+  ].filter((key) => process.env[key]);
+  if (staleEnvVars.length > 0 && process.env.VERCEL === '1') {
+    console.warn(
+      `[workflow] Warning: ${staleEnvVars.join(', ')} env var(s) ` +
+        'are set but have no effect at runtime. These are only used by the Workflow CLI. ' +
+        'Remove them from your Vercel project environment variables.'
+    );
   }
 }
 
-async function loadCustomWorldModule(specifier: string): Promise<any> {
-  try {
-    const resolvedPath = resolveModulePath(specifier);
-    return await dynamicImport(resolvedPath);
-  } catch {
-    try {
-      return getProjectRequire()(specifier);
-    } catch {
-      return require(specifier);
-    }
+async function createConfiguredVercelWorld(): Promise<World> {
+  warnForStaleVercelEnvVars();
+
+  const mod = await loadWorldModule(
+    '@workflow/world-vercel',
+    getCoreRuntimeRequire()
+  );
+  const create = resolveWorldFactory(mod, 'createVercelWorld');
+  if (!create) {
+    throw new Error(
+      'Invalid built-in world module "@workflow/world-vercel": expected createVercelWorld/default export.'
+    );
   }
+  return create();
+}
+
+async function createConfiguredLocalWorld(): Promise<World> {
+  const mod = await loadWorldModule(
+    '@workflow/world-local',
+    getCoreRuntimeRequire()
+  );
+  const create = resolveWorldFactory(mod, 'createLocalWorld');
+  if (!create) {
+    throw new Error(
+      'Invalid built-in world module "@workflow/world-local": expected createLocalWorld/default export.'
+    );
+  }
+  return create({
+    dataDir: process.env.WORKFLOW_LOCAL_DATA_DIR,
+  });
+}
+
+async function createConfiguredCustomWorld(
+  specifier: string,
+  targetWorldForErrors: string
+): Promise<World> {
+  const mod = await loadWorldModule(specifier, getProjectRequire());
+  const create = resolveWorldFactory(mod);
+  if (create) {
+    return create();
+  }
+
+  throw new Error(
+    `Invalid target world module: ${targetWorldForErrors}, must export a default function or createWorld function that returns a World instance.`
+  );
 }
 
 /**
@@ -124,63 +207,35 @@ async function loadCustomWorldModule(specifier: string): Promise<any> {
  * use setWorld() to inject the instance.
  */
 export const createWorld = async (): Promise<World> => {
+  const configuredWorldPackage = process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE;
+
+  if (configuredWorldPackage === '@workflow/world-vercel') {
+    return createConfiguredVercelWorld();
+  }
+
+  if (configuredWorldPackage === '@workflow/world-local') {
+    return createConfiguredLocalWorld();
+  }
+
+  if (configuredWorldPackage) {
+    return createConfiguredCustomWorld(
+      configuredWorldPackage,
+      configuredWorldPackage
+    );
+  }
+
   const targetWorld = resolveWorkflowTargetWorld();
+  const worldSpecifier = resolveWorldSpecifier(targetWorld);
 
-  if (isVercelWorldTarget(targetWorld)) {
-    // Warn if WORKFLOW_VERCEL_* env vars are set inside a Vercel serverless
-    // function (VERCEL=1) — they have no effect at runtime and likely indicate
-    // a misconfiguration (user manually added them as Vercel project env vars,
-    // which is not needed). We gate on VERCEL=1 so the warning does not fire
-    // when the CLI or web observability app sets these env vars intentionally.
-    const staleEnvVars = [
-      'WORKFLOW_VERCEL_PROJECT',
-      'WORKFLOW_VERCEL_TEAM',
-      'WORKFLOW_VERCEL_AUTH_TOKEN',
-      'WORKFLOW_VERCEL_ENV',
-    ].filter((key) => process.env[key]);
-    if (staleEnvVars.length > 0 && process.env.VERCEL === '1') {
-      console.warn(
-        `[workflow] Warning: ${staleEnvVars.join(', ')} env var(s) ` +
-          'are set but have no effect at runtime. These are only used by the Workflow CLI. ' +
-          'Remove them from your Vercel project environment variables.'
-      );
-    }
-
-    const mod = await loadBundledWorldModule('@workflow/world-vercel');
-    const create = resolveWorldFactory(mod, 'createVercelWorld');
-    if (!create) {
-      throw new Error(
-        'Invalid built-in world module "@workflow/world-vercel": expected createVercelWorld/default export.'
-      );
-    }
-    return create();
+  if (worldSpecifier === '@workflow/world-vercel') {
+    return createConfiguredVercelWorld();
   }
 
-  if (targetWorld === 'local') {
-    const mod = await loadBundledWorldModule('@workflow/world-local');
-    const create = resolveWorldFactory(mod, 'createLocalWorld');
-    if (!create) {
-      throw new Error(
-        'Invalid built-in world module "@workflow/world-local": expected createLocalWorld/default export.'
-      );
-    }
-    return create({
-      dataDir: process.env.WORKFLOW_LOCAL_DATA_DIR,
-    });
+  if (worldSpecifier === '@workflow/world-local') {
+    return createConfiguredLocalWorld();
   }
 
-  // Try dynamic import() first — ESM-first since this PR's purpose is ESM support.
-  // Fall back to require() for environments where `new Function`-based import()
-  // is unavailable (e.g. CJS test runners).
-  const mod = await loadCustomWorldModule(targetWorld);
-  const create = resolveWorldFactory(mod);
-  if (create) {
-    return create();
-  }
-
-  throw new Error(
-    `Invalid target world module: ${targetWorld}, must export a default function or createWorld function that returns a World instance.`
-  );
+  return createConfiguredCustomWorld(worldSpecifier, targetWorld);
 };
 
 export type WorldHandlers = Pick<World, 'createQueueHandler' | 'specVersion'>;

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -24,14 +24,28 @@ const globalSymbols: typeof globalThis & {
 } = globalThis;
 
 /**
- * Hides the dynamic import behind `new Function` to prevent bundlers from
- * trying to resolve it at build time, since the world module may not exist
- * at build time. Falls back to `require()` in environments where
- * `new Function`-based `import()` is unavailable (e.g. CJS test runners).
+ * Hides dynamic imports behind `new Function` so eager step bundles do not
+ * statically trace world implementations into generated routes.
+ *
+ * Custom worlds still need a parameterized form because the specifier comes
+ * from user configuration. Built-in worlds use literal specifiers so runtime
+ * environments like Turbopack dev can execute a concrete import expression
+ * without analyzing package imports at build time.
  */
 const dynamicImport = new Function('specifier', 'return import(specifier)') as (
   specifier: string
 ) => Promise<any>;
+const dynamicImportLocalWorld = new Function(
+  'return import("@workflow/world-local")'
+) as () => Promise<any>;
+const dynamicImportVercelWorld = new Function(
+  'return import("@workflow/world-vercel")'
+) as () => Promise<any>;
+const dynamicRequire = new Function(
+  'requireFn',
+  'specifier',
+  'return requireFn(specifier)'
+) as (requireFn: typeof require, specifier: string) => any;
 
 function getProjectRequire() {
   return createRequire(
@@ -91,16 +105,16 @@ async function loadBundledWorldModule(
 ): Promise<any> {
   if (specifier === '@workflow/world-local') {
     try {
-      return await import('@workflow/world-local');
+      return await dynamicImportLocalWorld();
     } catch {
-      return require('@workflow/world-local');
+      return dynamicRequire(require, '@workflow/world-local');
     }
   }
 
   try {
-    return await import('@workflow/world-vercel');
+    return await dynamicImportVercelWorld();
   } catch {
-    return require('@workflow/world-vercel');
+    return dynamicRequire(require, '@workflow/world-vercel');
   }
 }
 

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -6,12 +6,8 @@ import {
   resolveWorkflowTargetWorld,
 } from '@workflow/utils';
 import type { World } from '@workflow/world';
-import { createLocalWorld } from '@workflow/world-local';
-import { createVercelWorld } from '@workflow/world-vercel';
 
-const require = createRequire(
-  pathToFileURL(process.cwd() + '/package.json').href
-);
+const require = createRequire(import.meta.url);
 
 const WorldCache = Symbol.for('@workflow/world//cache');
 const StubbedWorldCache = Symbol.for('@workflow/world//stubbedCache');
@@ -37,6 +33,14 @@ const dynamicImport = new Function('specifier', 'return import(specifier)') as (
   specifier: string
 ) => Promise<any>;
 
+function getProjectRequire() {
+  return createRequire(
+    pathToFileURL(
+      resolve(/* turbopackIgnore: true */ process.cwd(), 'package.json')
+    ).href
+  );
+}
+
 function resolveModulePath(specifier: string): string {
   // Already a file:// URL
   if (specifier.startsWith('file://')) {
@@ -48,13 +52,60 @@ function resolveModulePath(specifier: string): string {
   }
   // Relative path - resolve relative to cwd and convert to file:// URL
   if (specifier.startsWith('./') || specifier.startsWith('../')) {
-    return pathToFileURL(resolve(process.cwd(), specifier)).href;
+    return pathToFileURL(
+      resolve(/* turbopackIgnore: true */ process.cwd(), specifier)
+    ).href;
   }
   // Package specifier - use require.resolve to find the package
   try {
-    return pathToFileURL(require.resolve(specifier)).href;
+    return pathToFileURL(getProjectRequire().resolve(specifier)).href;
   } catch {
     return specifier;
+  }
+}
+
+function resolveWorldFactory(
+  mod: any,
+  preferredNamedExport?: string
+): ((...args: any[]) => World) | undefined {
+  if (
+    preferredNamedExport &&
+    typeof mod?.[preferredNamedExport] === 'function'
+  ) {
+    return mod[preferredNamedExport] as (...args: any[]) => World;
+  }
+  if (typeof mod === 'function') {
+    return mod as (...args: any[]) => World;
+  }
+  if (typeof mod?.default === 'function') {
+    return mod.default as (...args: any[]) => World;
+  }
+  if (typeof mod?.createWorld === 'function') {
+    return mod.createWorld as (...args: any[]) => World;
+  }
+  return undefined;
+}
+
+async function loadBundledWorldModule(
+  specifier: '@workflow/world-local' | '@workflow/world-vercel'
+): Promise<any> {
+  try {
+    return await dynamicImport(specifier);
+  } catch {
+    return require(specifier);
+  }
+}
+
+async function loadCustomWorldModule(specifier: string): Promise<any> {
+  try {
+    const resolvedPath = resolveModulePath(specifier);
+    return await dynamicImport(resolvedPath);
+  } catch {
+    try {
+      return getProjectRequire()(specifier);
+    } catch {
+      return require(specifier);
+    }
   }
 }
 
@@ -93,11 +144,25 @@ export const createWorld = async (): Promise<World> => {
       );
     }
 
-    return createVercelWorld();
+    const mod = await loadBundledWorldModule('@workflow/world-vercel');
+    const create = resolveWorldFactory(mod, 'createVercelWorld');
+    if (!create) {
+      throw new Error(
+        'Invalid built-in world module "@workflow/world-vercel": expected createVercelWorld/default export.'
+      );
+    }
+    return create();
   }
 
   if (targetWorld === 'local') {
-    return createLocalWorld({
+    const mod = await loadBundledWorldModule('@workflow/world-local');
+    const create = resolveWorldFactory(mod, 'createLocalWorld');
+    if (!create) {
+      throw new Error(
+        'Invalid built-in world module "@workflow/world-local": expected createLocalWorld/default export.'
+      );
+    }
+    return create({
       dataDir: process.env.WORKFLOW_LOCAL_DATA_DIR,
     });
   }
@@ -105,19 +170,10 @@ export const createWorld = async (): Promise<World> => {
   // Try dynamic import() first — ESM-first since this PR's purpose is ESM support.
   // Fall back to require() for environments where `new Function`-based import()
   // is unavailable (e.g. CJS test runners).
-  let mod: any;
-  try {
-    const resolvedPath = resolveModulePath(targetWorld);
-    mod = await dynamicImport(resolvedPath);
-  } catch {
-    mod = require(targetWorld);
-  }
-  if (typeof mod === 'function') {
-    return mod() as World;
-  } else if (typeof mod.default === 'function') {
-    return mod.default() as World;
-  } else if (typeof mod.createWorld === 'function') {
-    return mod.createWorld() as World;
+  const mod = await loadCustomWorldModule(targetWorld);
+  const create = resolveWorldFactory(mod);
+  if (create) {
+    return create();
   }
 
   throw new Error(

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -5,11 +5,11 @@ import {
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
-import { getPort } from '@workflow/utils/get-port';
 import { parseWorkflowName } from '@workflow/utils/parse-name';
 import type { Event, WorkflowRun } from '@workflow/world';
 import * as nanoid from 'nanoid';
 import { monotonicFactory } from 'ulid';
+import { getBaseUrl } from './base-url.js';
 import type { CryptoKey } from './encryption.js';
 import { EventConsumerResult, EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
@@ -97,10 +97,9 @@ export async function runWorkflow(
       );
     }
 
-    // Get the port before creating VM context to avoid async operations
-    // affecting the deterministic timestamp
-    const isVercel = process.env.VERCEL_URL !== undefined;
-    const port = isVercel ? undefined : await getPort();
+    // Resolve the runtime base URL before creating the VM context so async
+    // work does not affect the deterministic timestamp.
+    const url = await getBaseUrl();
 
     const {
       context,
@@ -199,12 +198,6 @@ export async function runWorkflow(
     // @ts-expect-error - `@types/node` says symbol is not valid, but it does work
     vmGlobalThis[WORKFLOW_GET_STREAM_ID] = (namespace?: string) =>
       getWorkflowRunStreamId(workflowRun.runId, namespace);
-
-    // TODO: there should be a getUrl method on the world interface itself. This
-    // solution only works for vercel + local worlds.
-    const url = isVercel
-      ? `https://${process.env.VERCEL_URL}`
-      : `http://localhost:${port ?? 3000}`;
 
     // For the workflow VM, we store the context in a symbol on the `globalThis` object
     const ctx: WorkflowMetadata = {

--- a/packages/next/src/builder.test.ts
+++ b/packages/next/src/builder.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { shouldUseDeferredBuilder } from './builder.js';
+import { parseEnvironmentFlag } from './environment-flag.js';
 
 const originalLazyDiscoveryEnv = process.env.WORKFLOW_NEXT_LAZY_DISCOVERY;
 
@@ -21,6 +22,15 @@ describe('shouldUseDeferredBuilder', () => {
   it('treats WORKFLOW_NEXT_LAZY_DISCOVERY=false as disabled', () => {
     process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = 'false';
 
+    expect(shouldUseDeferredBuilder('16.2.1')).toBe(false);
+  });
+
+  it('treats WORKFLOW_NEXT_LAZY_DISCOVERY=off as disabled', () => {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = 'off';
+
+    expect(parseEnvironmentFlag(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY)).toBe(
+      false
+    );
     expect(shouldUseDeferredBuilder('16.2.1')).toBe(false);
   });
 

--- a/packages/next/src/builder.test.ts
+++ b/packages/next/src/builder.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { shouldUseDeferredBuilder } from './builder.js';
+
+const originalLazyDiscoveryEnv = process.env.WORKFLOW_NEXT_LAZY_DISCOVERY;
+
+afterEach(() => {
+  if (originalLazyDiscoveryEnv === undefined) {
+    delete process.env.WORKFLOW_NEXT_LAZY_DISCOVERY;
+  } else {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = originalLazyDiscoveryEnv;
+  }
+});
+
+describe('shouldUseDeferredBuilder', () => {
+  it('treats WORKFLOW_NEXT_LAZY_DISCOVERY=0 as disabled', () => {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = '0';
+
+    expect(shouldUseDeferredBuilder('16.2.1')).toBe(false);
+  });
+
+  it('treats WORKFLOW_NEXT_LAZY_DISCOVERY=false as disabled', () => {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = 'false';
+
+    expect(shouldUseDeferredBuilder('16.2.1')).toBe(false);
+  });
+
+  it('enables deferred mode for compatible versions when the env is enabled', () => {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = '1';
+
+    expect(shouldUseDeferredBuilder('16.2.1')).toBe(true);
+  });
+});

--- a/packages/next/src/builder.ts
+++ b/packages/next/src/builder.ts
@@ -12,8 +12,24 @@ export const WORKFLOW_DEFERRED_ENTRIES = [
 
 let warnedAboutFlagAndVersion = false;
 
+export function parseEnvironmentFlag(
+  rawValue: string | undefined
+): boolean | undefined {
+  const normalizedValue = rawValue?.trim().toLowerCase();
+  if (!normalizedValue) {
+    return undefined;
+  }
+
+  if (normalizedValue === '0' || normalizedValue === 'false') {
+    return false;
+  }
+
+  return true;
+}
+
 export function shouldUseDeferredBuilder(nextVersion: string): boolean {
-  const flagEnabled = Boolean(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY);
+  const flagEnabled =
+    parseEnvironmentFlag(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY) ?? false;
   const versionCompatible = semver.gte(
     nextVersion,
     DEFERRED_BUILDER_MIN_VERSION

--- a/packages/next/src/builder.ts
+++ b/packages/next/src/builder.ts
@@ -1,6 +1,7 @@
 import semver from 'semver';
 import { getNextBuilderDeferred } from './builder-deferred.js';
 import { getNextBuilderEager } from './builder-eager.js';
+import { parseEnvironmentFlag } from './environment-flag.js';
 
 export const DEFERRED_BUILDER_MIN_VERSION = '16.2.0-canary.48';
 
@@ -11,21 +12,6 @@ export const WORKFLOW_DEFERRED_ENTRIES = [
 ] as const;
 
 let warnedAboutFlagAndVersion = false;
-
-export function parseEnvironmentFlag(
-  rawValue: string | undefined
-): boolean | undefined {
-  const normalizedValue = rawValue?.trim().toLowerCase();
-  if (!normalizedValue) {
-    return undefined;
-  }
-
-  if (normalizedValue === '0' || normalizedValue === 'false') {
-    return false;
-  }
-
-  return true;
-}
 
 export function shouldUseDeferredBuilder(nextVersion: string): boolean {
   const flagEnabled =

--- a/packages/next/src/environment-flag.ts
+++ b/packages/next/src/environment-flag.ts
@@ -1,0 +1,16 @@
+const FALSE_ENV_VALUES = new Set(['0', 'false', 'no', 'off']);
+
+export function parseEnvironmentFlag(
+  rawValue: string | undefined
+): boolean | undefined {
+  const normalizedValue = rawValue?.trim().toLowerCase();
+  if (!normalizedValue) {
+    return undefined;
+  }
+
+  if (FALSE_ENV_VALUES.has(normalizedValue)) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -31,18 +31,6 @@ const {
 
 vi.mock('./builder.js', () => ({
   getNextBuilder: getNextBuilderMock,
-  parseEnvironmentFlag: (rawValue: string | undefined) => {
-    const normalizedValue = rawValue?.trim().toLowerCase();
-    if (!normalizedValue) {
-      return undefined;
-    }
-
-    if (normalizedValue === '0' || normalizedValue === 'false') {
-      return false;
-    }
-
-    return true;
-  },
   shouldUseDeferredBuilder: shouldUseDeferredBuilderMock,
   WORKFLOW_DEFERRED_ENTRIES: [
     '/.well-known/workflow/v1/flow',

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -31,6 +31,18 @@ const {
 
 vi.mock('./builder.js', () => ({
   getNextBuilder: getNextBuilderMock,
+  parseEnvironmentFlag: (rawValue: string | undefined) => {
+    const normalizedValue = rawValue?.trim().toLowerCase();
+    if (!normalizedValue) {
+      return undefined;
+    }
+
+    if (normalizedValue === '0' || normalizedValue === 'false') {
+      return false;
+    }
+
+    return true;
+  },
   shouldUseDeferredBuilder: shouldUseDeferredBuilderMock,
   WORKFLOW_DEFERRED_ENTRIES: [
     '/.well-known/workflow/v1/flow',
@@ -108,5 +120,35 @@ describe('withWorkflow outputFileTracingRoot', () => {
       projectRoot: '/repo',
       workingDir: process.cwd(),
     });
+  });
+
+  it('preserves an explicit lazyDiscovery disable override', () => {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = '0';
+
+    withWorkflow(
+      {},
+      {
+        workflows: {
+          lazyDiscovery: true,
+        },
+      }
+    );
+
+    expect(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY).toBe('0');
+  });
+
+  it('treats an empty lazyDiscovery env override as unset', () => {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = '';
+
+    withWorkflow(
+      {},
+      {
+        workflows: {
+          lazyDiscovery: true,
+        },
+      }
+    );
+
+    expect(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY).toBe('1');
   });
 });

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -57,6 +57,8 @@ describe('withWorkflow outputFileTracingRoot', () => {
     WORKFLOW_LOCAL_DATA_DIR: process.env.WORKFLOW_LOCAL_DATA_DIR,
     WORKFLOW_NEXT_LAZY_DISCOVERY: process.env.WORKFLOW_NEXT_LAZY_DISCOVERY,
     WORKFLOW_NEXT_PRIVATE_BUILT: process.env.WORKFLOW_NEXT_PRIVATE_BUILT,
+    WORKFLOW_CONFIGURED_WORLD_PACKAGE:
+      process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE,
     WORKFLOW_TARGET_WORLD: process.env.WORKFLOW_TARGET_WORLD,
   };
 
@@ -75,6 +77,7 @@ describe('withWorkflow outputFileTracingRoot', () => {
     delete process.env.WORKFLOW_LOCAL_DATA_DIR;
     delete process.env.WORKFLOW_NEXT_LAZY_DISCOVERY;
     delete process.env.WORKFLOW_NEXT_PRIVATE_BUILT;
+    delete process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE;
     delete process.env.WORKFLOW_TARGET_WORLD;
   });
 
@@ -138,5 +141,82 @@ describe('withWorkflow outputFileTracingRoot', () => {
     );
 
     expect(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY).toBe('1');
+  });
+
+  it('externalizes only the configured local world package by default', async () => {
+    const config = withWorkflow({});
+
+    const nextConfig = await config('phase-production-build', {
+      defaultConfig: {},
+    });
+
+    expect(nextConfig.serverExternalPackages).toEqual([
+      '@workflow/world-local',
+    ]);
+    expect(nextConfig.outputFileTracingIncludes).toMatchObject({
+      '/.well-known/workflow/v1/**': ['./packages/world-local/**/*'],
+    });
+    expect(nextConfig.env?.WORKFLOW_CONFIGURED_WORLD_PACKAGE).toBe(
+      '@workflow/world-local'
+    );
+    expect(process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE).toBe(
+      '@workflow/world-local'
+    );
+    expect(builderConfigs).toHaveLength(1);
+    expect(builderConfigs[0]).toMatchObject({
+      configuredWorldPackage: '@workflow/world-local',
+      externalPackages: ['server-only', 'client-only', '@workflow/world-local'],
+    });
+    expect(nextConfig.serverExternalPackages).not.toContain('workflow');
+    expect(nextConfig.serverExternalPackages).not.toContain('@workflow/core');
+  });
+
+  it('externalizes the configured world package root alongside existing externals', async () => {
+    process.env.WORKFLOW_TARGET_WORLD = '@workflow/world-postgres/subpath';
+
+    const config = withWorkflow({
+      serverExternalPackages: ['sharp'],
+    });
+
+    const nextConfig = await config('phase-production-build', {
+      defaultConfig: {},
+    });
+
+    expect(nextConfig.serverExternalPackages).toEqual([
+      'sharp',
+      '@workflow/world-postgres',
+    ]);
+    expect(nextConfig.env?.WORKFLOW_CONFIGURED_WORLD_PACKAGE).toBe(
+      '@workflow/world-postgres'
+    );
+    expect(builderConfigs).toHaveLength(1);
+    expect(builderConfigs[0]).toMatchObject({
+      configuredWorldPackage: '@workflow/world-postgres',
+      externalPackages: [
+        'server-only',
+        'client-only',
+        'sharp',
+        '@workflow/world-postgres',
+      ],
+    });
+  });
+
+  it('does not add path-based custom worlds to serverExternalPackages', async () => {
+    process.env.WORKFLOW_TARGET_WORLD = './src/world.ts';
+
+    const config = withWorkflow({});
+
+    const nextConfig = await config('phase-production-build', {
+      defaultConfig: {},
+    });
+
+    expect(nextConfig.serverExternalPackages).toBeUndefined();
+    expect(nextConfig.env?.WORKFLOW_CONFIGURED_WORLD_PACKAGE).toBeUndefined();
+    expect(process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE).toBeUndefined();
+    expect(builderConfigs).toHaveLength(1);
+    expect(builderConfigs[0]).toMatchObject({
+      configuredWorldPackage: undefined,
+      externalPackages: ['server-only', 'client-only'],
+    });
   });
 });

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 import semver from 'semver';
 import {
   getNextBuilder,
+  parseEnvironmentFlag,
   shouldUseDeferredBuilder,
   WORKFLOW_DEFERRED_ENTRIES,
 } from './builder.js';
@@ -61,8 +62,17 @@ export function withWorkflow(
     };
   } = {}
 ) {
-  if (workflows?.lazyDiscovery) {
-    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = '1';
+  const lazyDiscoveryOverride = parseEnvironmentFlag(
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY
+  );
+  if (lazyDiscoveryOverride === undefined) {
+    if (workflows?.lazyDiscovery) {
+      process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = '1';
+    }
+  } else {
+    process.env.WORKFLOW_NEXT_LAZY_DISCOVERY = lazyDiscoveryOverride
+      ? '1'
+      : '0';
   }
 
   if (!process.env.VERCEL_DEPLOYMENT_ID) {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,8 +1,8 @@
 import type { NextConfig } from 'next';
 import semver from 'semver';
+import { parseEnvironmentFlag } from './environment-flag.js';
 import {
   getNextBuilder,
-  parseEnvironmentFlag,
   shouldUseDeferredBuilder,
   WORKFLOW_DEFERRED_ENTRIES,
 } from './builder.js';

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,3 +1,6 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, relative } from 'node:path';
 import type { NextConfig } from 'next';
 import semver from 'semver';
 import { parseEnvironmentFlag } from './environment-flag.js';
@@ -7,12 +10,139 @@ import {
   WORKFLOW_DEFERRED_ENTRIES,
 } from './builder.js';
 
-const WORKFLOW_SERVER_EXTERNAL_PACKAGES = [
-  'workflow',
-  '@workflow/core',
-  '@workflow/world-local',
-  '@workflow/world-vercel',
-] as const;
+function isPathLikeWorldTarget(targetWorld: string): boolean {
+  return (
+    targetWorld.startsWith('./') ||
+    targetWorld.startsWith('../') ||
+    targetWorld.startsWith('/') ||
+    targetWorld.startsWith('file:') ||
+    /^[A-Za-z]:[\\/]/.test(targetWorld) ||
+    targetWorld.startsWith('\\\\')
+  );
+}
+
+function resolvePackageName(specifier: string): string | undefined {
+  if (!specifier || isPathLikeWorldTarget(specifier)) {
+    return undefined;
+  }
+
+  if (specifier.startsWith('@')) {
+    const [scope, name] = specifier.split('/');
+    return scope && name ? `${scope}/${name}` : undefined;
+  }
+
+  const [name] = specifier.split('/');
+  return name || undefined;
+}
+
+function resolveConfiguredWorldExternalPackage(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const targetWorld =
+    env.WORKFLOW_TARGET_WORLD ??
+    (env.VERCEL_DEPLOYMENT_ID ? 'vercel' : 'local');
+
+  if (targetWorld === 'vercel') {
+    return '@workflow/world-vercel';
+  }
+
+  if (targetWorld === 'local' || targetWorld === '@workflow/world-local') {
+    return '@workflow/world-local';
+  }
+
+  return resolvePackageName(targetWorld);
+}
+
+function toTracingGlob(rootDir: string, targetDir: string): string {
+  let relativePath = relative(rootDir, targetDir).replace(/\\/g, '/');
+
+  if (!relativePath) {
+    return './**/*';
+  }
+
+  if (!relativePath.startsWith('./') && !relativePath.startsWith('../')) {
+    relativePath = `./${relativePath}`;
+  }
+
+  return `${relativePath}/**/*`;
+}
+
+function findPackageRoot(startPath: string): string | undefined {
+  let currentPath = startPath;
+
+  while (true) {
+    if (existsSync(join(currentPath, 'package.json'))) {
+      return currentPath;
+    }
+
+    const parentPath = dirname(currentPath);
+    if (parentPath === currentPath) {
+      return undefined;
+    }
+    currentPath = parentPath;
+  }
+}
+
+function resolveConfiguredWorldTraceIncludes(
+  configuredWorldPackage: string | undefined,
+  workingDir: string,
+  outputFileTracingRoot?: string
+): string[] | undefined {
+  if (!configuredWorldPackage) {
+    return undefined;
+  }
+
+  try {
+    const resolvedWorkingDir = realpathSync(workingDir);
+    const tracingRoot = realpathSync(
+      outputFileTracingRoot ?? resolvedWorkingDir
+    );
+    const appRequire = createRequire(join(resolvedWorkingDir, 'package.json'));
+
+    try {
+      const worldEntryPath = realpathSync(
+        appRequire.resolve(configuredWorldPackage)
+      );
+      const worldPackageRoot = findPackageRoot(dirname(worldEntryPath));
+      return worldPackageRoot
+        ? [toTracingGlob(tracingRoot, worldPackageRoot)]
+        : undefined;
+    } catch {
+      const workflowRuntimePath = realpathSync(
+        appRequire.resolve('workflow/runtime')
+      );
+      const workflowRequire = createRequire(workflowRuntimePath);
+      const coreRuntimePath = realpathSync(
+        workflowRequire.resolve('@workflow/core/runtime')
+      );
+      const coreRequire = createRequire(coreRuntimePath);
+      const worldEntryPath = realpathSync(
+        coreRequire.resolve(configuredWorldPackage)
+      );
+      const worldPackageRoot = findPackageRoot(dirname(worldEntryPath));
+      return worldPackageRoot
+        ? [toTracingGlob(tracingRoot, worldPackageRoot)]
+        : undefined;
+    }
+  } catch {
+    try {
+      const tracingRoot = realpathSync(outputFileTracingRoot ?? workingDir);
+      const coreRuntimePath = realpathSync(
+        require.resolve('@workflow/core/runtime')
+      );
+      const coreRequire = createRequire(coreRuntimePath);
+      const worldEntryPath = realpathSync(
+        coreRequire.resolve(configuredWorldPackage)
+      );
+      const worldPackageRoot = findPackageRoot(dirname(worldEntryPath));
+      return worldPackageRoot
+        ? [toTracingGlob(tracingRoot, worldPackageRoot)]
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
 
 function resolveNextVersion(workingDir: string): string {
   const errors: unknown[] = [];
@@ -97,6 +227,16 @@ export function withWorkflow(
     }
   }
 
+  const configuredWorldExternalPackage = resolveConfiguredWorldExternalPackage(
+    process.env
+  );
+  if (configuredWorldExternalPackage) {
+    process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE =
+      configuredWorldExternalPackage;
+  } else {
+    delete process.env.WORKFLOW_CONFIGURED_WORLD_PACKAGE;
+  }
+
   return async function buildConfig(
     phase: string,
     ctx: { defaultConfig: NextConfig }
@@ -113,13 +253,54 @@ export function withWorkflow(
     }
     // shallow clone to avoid read-only on top-level
     nextConfig = Object.assign({}, nextConfig);
-    const serverExternalPackages = [
-      ...new Set([
-        ...WORKFLOW_SERVER_EXTERNAL_PACKAGES,
-        ...(nextConfig.serverExternalPackages || []),
-      ]),
-    ];
-    nextConfig.serverExternalPackages = serverExternalPackages;
+
+    const serverExternalPackages = new Set(
+      Array.isArray(nextConfig.serverExternalPackages)
+        ? nextConfig.serverExternalPackages
+        : []
+    );
+    if (configuredWorldExternalPackage) {
+      serverExternalPackages.add(configuredWorldExternalPackage);
+    }
+    if (serverExternalPackages.size > 0) {
+      nextConfig.serverExternalPackages = [...serverExternalPackages];
+    }
+
+    const configuredWorldTraceIncludes = resolveConfiguredWorldTraceIncludes(
+      configuredWorldExternalPackage,
+      process.cwd(),
+      nextConfig.outputFileTracingRoot
+    );
+    if (configuredWorldTraceIncludes?.length) {
+      const routePattern = '/.well-known/workflow/v1/**';
+      const outputFileTracingIncludes = {
+        ...(nextConfig.outputFileTracingIncludes as
+          | Record<string, string[]>
+          | undefined),
+      };
+      outputFileTracingIncludes[routePattern] = [
+        ...new Set([
+          ...(outputFileTracingIncludes[routePattern] || []),
+          ...configuredWorldTraceIncludes,
+        ]),
+      ];
+      nextConfig.outputFileTracingIncludes = outputFileTracingIncludes;
+    }
+
+    const nextEnv = {
+      ...nextConfig.env,
+    } as Record<string, string>;
+    if (configuredWorldExternalPackage) {
+      nextEnv.WORKFLOW_CONFIGURED_WORLD_PACKAGE =
+        configuredWorldExternalPackage;
+    } else {
+      delete nextEnv.WORKFLOW_CONFIGURED_WORLD_PACKAGE;
+    }
+    if (Object.keys(nextEnv).length > 0) {
+      nextConfig.env = nextEnv;
+    } else {
+      delete nextConfig.env;
+    }
 
     // configure the loader if turbopack is being used
     if (!nextConfig.turbopack) {
@@ -159,6 +340,7 @@ export function withWorkflow(
             suppressCreateWorkflowsBundleWarnings: useDeferredBuilder,
             suppressCreateWebhookBundleLogs: useDeferredBuilder,
             suppressCreateManifestLogs: useDeferredBuilder,
+            configuredWorldPackage: configuredWorldExternalPackage,
             externalPackages: [
               // server-only and client-only are pseudo-packages handled by Next.js
               // during its build process. We mark them as external to prevent esbuild
@@ -166,7 +348,7 @@ export function withWorkflow(
               // See: https://nextjs.org/docs/app/getting-started/server-and-client-components
               'server-only',
               'client-only',
-              ...serverExternalPackages,
+              ...(nextConfig.serverExternalPackages || []),
             ],
           });
         })();

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -53,6 +53,10 @@ function resolveConfiguredWorldExternalPackage(
   return resolvePackageName(targetWorld);
 }
 
+function isBuiltInWorldPackage(pkg: string | undefined): boolean {
+  return pkg === '@workflow/world-local' || pkg === '@workflow/world-vercel';
+}
+
 function toTracingGlob(rootDir: string, targetDir: string): string {
   let relativePath = relative(rootDir, targetDir).replace(/\\/g, '/');
 
@@ -266,11 +270,15 @@ export function withWorkflow(
       nextConfig.serverExternalPackages = [...serverExternalPackages];
     }
 
-    const configuredWorldTraceIncludes = resolveConfiguredWorldTraceIncludes(
-      configuredWorldExternalPackage,
-      process.cwd(),
-      nextConfig.outputFileTracingRoot
-    );
+    const configuredWorldTraceIncludes = isBuiltInWorldPackage(
+      configuredWorldExternalPackage
+    )
+      ? undefined
+      : resolveConfiguredWorldTraceIncludes(
+          configuredWorldExternalPackage,
+          process.cwd(),
+          nextConfig.outputFileTracingRoot
+        );
     if (configuredWorldTraceIncludes?.length) {
       const routePattern = '/.well-known/workflow/v1/**';
       const outputFileTracingIncludes = {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -7,6 +7,13 @@ import {
   WORKFLOW_DEFERRED_ENTRIES,
 } from './builder.js';
 
+const WORKFLOW_SERVER_EXTERNAL_PACKAGES = [
+  'workflow',
+  '@workflow/core',
+  '@workflow/world-local',
+  '@workflow/world-vercel',
+] as const;
+
 function resolveNextVersion(workingDir: string): string {
   const errors: unknown[] = [];
 
@@ -106,6 +113,13 @@ export function withWorkflow(
     }
     // shallow clone to avoid read-only on top-level
     nextConfig = Object.assign({}, nextConfig);
+    const serverExternalPackages = [
+      ...new Set([
+        ...WORKFLOW_SERVER_EXTERNAL_PACKAGES,
+        ...(nextConfig.serverExternalPackages || []),
+      ]),
+    ];
+    nextConfig.serverExternalPackages = serverExternalPackages;
 
     // configure the loader if turbopack is being used
     if (!nextConfig.turbopack) {
@@ -152,7 +166,7 @@ export function withWorkflow(
               // See: https://nextjs.org/docs/app/getting-started/server-and-client-components
               'server-only',
               'client-only',
-              ...(nextConfig.serverExternalPackages || []),
+              ...serverExternalPackages,
             ],
           });
         })();

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { dirname, join, relative } from 'node:path';
 import { transform } from '@swc/core';
+import { parseEnvironmentFlag } from './environment-flag.js';
 import {
   parseMessage,
   type SocketMessage,
@@ -688,7 +689,7 @@ export default function workflowLoader(
     // Detect workflow patterns in the source code.
     const patterns = await detectPatterns(sourceForTransform);
     const shouldTrackDeferredDiscovery =
-      process.env.WORKFLOW_NEXT_LAZY_DISCOVERY === '1';
+      parseEnvironmentFlag(process.env.WORKFLOW_NEXT_LAZY_DISCOVERY) ?? false;
 
     // Discovery tracking is only needed for deferred builds. Eager builds
     // discover inputs up front and should ignore any stale socket metadata.

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -687,11 +687,15 @@ export default function workflowLoader(
 
     // Detect workflow patterns in the source code.
     const patterns = await detectPatterns(sourceForTransform);
-    // Always notify discovery tracking, even for `false/false`, so files that
-    // previously had workflow/step usage are removed from the tracked sets.
-    // Deferred step copy files must report using their original source path so
-    // deferred rebuilds can react to source edits outside generated artifacts.
-    if (!isDeferredStepCopyFile || deferredStepSourceMetadata?.absolutePath) {
+    const shouldTrackDeferredDiscovery =
+      process.env.WORKFLOW_NEXT_LAZY_DISCOVERY === '1';
+
+    // Discovery tracking is only needed for deferred builds. Eager builds
+    // discover inputs up front and should ignore any stale socket metadata.
+    if (
+      shouldTrackDeferredDiscovery &&
+      (!isDeferredStepCopyFile || deferredStepSourceMetadata?.absolutePath)
+    ) {
       const hasSerde = patterns.hasSerde;
       const nextPatternState: DiscoveredPatternState = {
         hasWorkflow: patterns.hasUseWorkflow,

--- a/scripts/create-test-matrix.mjs
+++ b/scripts/create-test-matrix.mjs
@@ -71,81 +71,93 @@ const DEV_TEST_CONFIGS = {
   },
 };
 
+function createMatrixEntry(name, project, config, overrides = {}) {
+  const canary = overrides.canary === true;
+
+  return {
+    name,
+    project,
+    ...config,
+    runLabel: canary ? 'canary' : 'stable',
+    artifactSuffix: canary ? 'canary' : 'stable',
+    ...overrides,
+  };
+}
+
 const matrix = {
-  app: [
-    {
-      name: 'nextjs-turbopack',
-      project: 'example-nextjs-workflow-turbopack',
-      ...DEV_TEST_CONFIGS['nextjs-turbopack'],
-    },
-    {
-      name: 'nextjs-webpack',
-      project: 'example-nextjs-workflow-webpack',
-      ...DEV_TEST_CONFIGS['nextjs-webpack'],
-    },
-  ],
+  app: [],
 };
 
-const newItems = [];
-
-for (const item of matrix.app) {
-  newItems.push({ ...item, canary: true });
+for (const app of [
+  {
+    name: 'nextjs-turbopack',
+    project: 'example-nextjs-workflow-turbopack',
+  },
+  {
+    name: 'nextjs-webpack',
+    project: 'example-nextjs-workflow-webpack',
+  },
+]) {
+  matrix.app.push(
+    createMatrixEntry(app.name, app.project, DEV_TEST_CONFIGS[app.name], {
+      lazyDiscovery: true,
+      runLabel: 'stable lazyDiscovery enabled',
+      artifactSuffix: 'stable-lazy-discovery-enabled',
+    })
+  );
+  matrix.app.push(
+    createMatrixEntry(app.name, app.project, DEV_TEST_CONFIGS[app.name], {
+      lazyDiscovery: false,
+      runLabel: 'stable lazyDiscovery disabled',
+      artifactSuffix: 'stable-lazy-discovery-disabled',
+    })
+  );
+  matrix.app.push(
+    createMatrixEntry(app.name, app.project, DEV_TEST_CONFIGS[app.name], {
+      canary: true,
+      lazyDiscovery: true,
+    })
+  );
 }
-matrix.app.push(...newItems);
 
-// Manually add nitro
-matrix.app.push({
-  name: 'nitro',
-  project: 'workbench-nitro-workflow',
-  ...DEV_TEST_CONFIGS.nitro,
-});
-
-matrix.app.push({
-  name: 'sveltekit',
-  project: 'workbench-sveltekit-workflow',
-  ...DEV_TEST_CONFIGS.sveltekit,
-});
-
-matrix.app.push({
-  name: 'nuxt',
-  project: 'workbench-nuxt-workflow',
-  ...DEV_TEST_CONFIGS.nuxt,
-});
-
-matrix.app.push({
-  name: 'hono',
-  project: 'workbench-hono-workflow',
-  ...DEV_TEST_CONFIGS.hono,
-});
-
-matrix.app.push({
-  name: 'vite',
-  project: 'workbench-vite-workflow',
-  ...DEV_TEST_CONFIGS.vite,
-});
-
-matrix.app.push({
-  name: 'express',
-  project: 'workbench-express-workflow',
-  ...DEV_TEST_CONFIGS.express,
-});
-
-matrix.app.push({
-  name: 'fastify',
-  project: 'workbench-fastify-workflow',
-  ...DEV_TEST_CONFIGS.fastify,
-});
-
-matrix.app.push({
-  name: 'nest',
-  project: 'workbench-nest-workflow',
-  ...DEV_TEST_CONFIGS.nest,
-});
-
-matrix.app.push({
-  name: 'astro',
-  project: 'workbench-astro-workflow',
-  ...DEV_TEST_CONFIGS.astro,
-});
+matrix.app.push(
+  createMatrixEntry('nitro', 'workbench-nitro-workflow', DEV_TEST_CONFIGS.nitro)
+);
+matrix.app.push(
+  createMatrixEntry(
+    'sveltekit',
+    'workbench-sveltekit-workflow',
+    DEV_TEST_CONFIGS.sveltekit
+  )
+);
+matrix.app.push(
+  createMatrixEntry('nuxt', 'workbench-nuxt-workflow', DEV_TEST_CONFIGS.nuxt)
+);
+matrix.app.push(
+  createMatrixEntry('hono', 'workbench-hono-workflow', DEV_TEST_CONFIGS.hono)
+);
+matrix.app.push(
+  createMatrixEntry('vite', 'workbench-vite-workflow', DEV_TEST_CONFIGS.vite)
+);
+matrix.app.push(
+  createMatrixEntry(
+    'express',
+    'workbench-express-workflow',
+    DEV_TEST_CONFIGS.express
+  )
+);
+matrix.app.push(
+  createMatrixEntry(
+    'fastify',
+    'workbench-fastify-workflow',
+    DEV_TEST_CONFIGS.fastify
+  )
+);
+matrix.app.push(
+  createMatrixEntry('nest', 'workbench-nest-workflow', DEV_TEST_CONFIGS.nest)
+);
+matrix.app.push(
+  createMatrixEntry('astro', 'workbench-astro-workflow', DEV_TEST_CONFIGS.astro)
+);
 
 console.log(JSON.stringify(matrix));

--- a/workbench/nextjs-turbopack/app/api/chat/route.ts
+++ b/workbench/nextjs-turbopack/app/api/chat/route.ts
@@ -1,12 +1,12 @@
 // Keep existing imports so HMR discovery still works
 import * as wellKnownAgentSteps from '@/app/.well-known/agent/v1/steps';
-import * as _workflows from '@/workflows/3_streams';
+import * as _workflows from 'workflow-workbench/3_streams';
 void wellKnownAgentSteps;
 void _workflows;
 
 import { createUIMessageStreamResponse, type UIMessage } from 'ai';
 import { start } from 'workflow/api';
-import { chat } from '@/workflows/agent_chat';
+import { chat } from 'workflow-workbench/agent_chat';
 
 export async function POST(req: Request) {
   const { messages, model }: { messages: UIMessage[]; model?: string } =

--- a/workbench/nextjs-turbopack/app/api/test-direct-step-call/route.ts
+++ b/workbench/nextjs-turbopack/app/api/test-direct-step-call/route.ts
@@ -2,7 +2,7 @@
 // After the SWC compiler changes, step functions in client mode have their directive removed
 // and keep their original implementation, allowing them to be called as regular async functions
 
-import { add } from '@/workflows/99_e2e';
+import { add } from 'workflow-workbench/99_e2e';
 
 export async function POST(req: Request) {
   const body = await req.json();

--- a/workbench/nextjs-turbopack/app/api/workflows/start/route.ts
+++ b/workbench/nextjs-turbopack/app/api/workflows/start/route.ts
@@ -8,49 +8,116 @@ import type { WorkflowName } from '@/app/workflows/types';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { workflowName, args } = body as {
-      workflowName: WorkflowName;
-      args?: unknown[];
-    };
+    const { workflowName, workflowFile, workflowFn, args, responseMode } =
+      body as {
+        workflowName?: WorkflowName;
+        workflowFile?: string;
+        workflowFn?: string;
+        args?: unknown[];
+        responseMode?: 'run';
+      };
 
-    // Find workflow definition
-    const definition = WORKFLOW_DEFINITIONS.find(
-      (w) => w.name === workflowName
-    );
-    if (!definition) {
+    let resolvedWorkflowFn: (() => Promise<unknown>) | undefined;
+    let resolvedWorkflowName: string | undefined;
+    if (workflowFile && workflowFn) {
+      const workflows = allWorkflows[workflowFile as keyof typeof allWorkflows];
+      if (!workflows) {
+        return NextResponse.json(
+          { error: `Workflow file "${workflowFile}" not found` },
+          { status: 404 }
+        );
+      }
+
+      if (workflowFn.includes('.')) {
+        const [className, methodName] = workflowFn.split('.');
+        const cls = workflows[className as keyof typeof workflows];
+        if (cls && typeof cls === 'function') {
+          resolvedWorkflowFn = (cls as Record<string, unknown>)[methodName] as
+            | (() => Promise<unknown>)
+            | undefined;
+        }
+      } else {
+        resolvedWorkflowFn = workflows[workflowFn as keyof typeof workflows] as
+          | (() => Promise<unknown>)
+          | undefined;
+      }
+
+      if (typeof resolvedWorkflowFn !== 'function') {
+        return NextResponse.json(
+          { error: `Workflow "${workflowFn}" is not a function` },
+          { status: 400 }
+        );
+      }
+
+      resolvedWorkflowName = workflowFn;
+    } else {
+      const typedWorkflowName = workflowName;
+      if (!typedWorkflowName) {
+        return NextResponse.json(
+          { error: 'workflowName or workflowFile/workflowFn is required' },
+          { status: 400 }
+        );
+      }
+
+      resolvedWorkflowName = typedWorkflowName;
+
+      // Find workflow definition
+      const definition = WORKFLOW_DEFINITIONS.find(
+        (w) => w.name === typedWorkflowName
+      );
+      if (!definition) {
+        return NextResponse.json(
+          { error: `Workflow "${typedWorkflowName}" not found` },
+          { status: 404 }
+        );
+      }
+
+      // Get the workflow file
+      const workflows =
+        allWorkflows[definition.workflowFile as keyof typeof allWorkflows];
+      if (!workflows) {
+        return NextResponse.json(
+          { error: `Workflow file "${definition.workflowFile}" not found` },
+          { status: 404 }
+        );
+      }
+
+      // Get the workflow function
+      resolvedWorkflowFn = workflows[
+        typedWorkflowName as keyof typeof workflows
+      ] as () => Promise<unknown>;
+      if (typeof resolvedWorkflowFn !== 'function') {
+        return NextResponse.json(
+          { error: `Workflow "${typedWorkflowName}" is not a function` },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (!resolvedWorkflowFn || !resolvedWorkflowName) {
       return NextResponse.json(
-        { error: `Workflow "${workflowName}" not found` },
-        { status: 404 }
+        { error: 'Failed to resolve workflow function' },
+        { status: 500 }
       );
     }
 
-    // Get the workflow file
-    const workflows =
-      allWorkflows[definition.workflowFile as keyof typeof allWorkflows];
-    if (!workflows) {
-      return NextResponse.json(
-        { error: `Workflow file "${definition.workflowFile}" not found` },
-        { status: 404 }
-      );
+    let workflowArgs = args ?? [];
+    if (workflowArgs === undefined) {
+      workflowArgs = [];
     }
 
-    // Get the workflow function
-    const workflowFn = workflows[
-      workflowName as keyof typeof workflows
-    ] as () => Promise<unknown>;
-    if (typeof workflowFn !== 'function') {
-      return NextResponse.json(
-        { error: `Workflow "${workflowName}" is not a function` },
-        { status: 400 }
+    if (workflowArgs.length === 0 && workflowName) {
+      const definition = WORKFLOW_DEFINITIONS.find(
+        (w) => w.name === workflowName
       );
+      if (definition) {
+        workflowArgs = definition.defaultArgs;
+      }
     }
-
-    // Use provided args or default args
-    const workflowArgs = args !== undefined ? args : definition.defaultArgs;
 
     // Start the workflow
     // @ts-expect-error - we're doing arbitrary calls to unknown functions
-    const run = await start(workflowFn, workflowArgs);
+    const run = await start(resolvedWorkflowFn, workflowArgs);
 
     if (!run) {
       return NextResponse.json(
@@ -59,7 +126,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Create a stream that properly closes when workflow completes
+    if (responseMode === 'run') {
+      return NextResponse.json({ runId: run.runId });
+    }
 
     const stream = new ReadableStream({
       async start(controller) {

--- a/workbench/nextjs-turbopack/app/api/workflows/stream/route.ts
+++ b/workbench/nextjs-turbopack/app/api/workflows/stream/route.ts
@@ -5,7 +5,10 @@ import { getRun } from 'workflow/api';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { runId } = body as { runId: string };
+    const { runId, namespace } = body as {
+      runId: string;
+      namespace?: string;
+    };
 
     if (!runId) {
       return NextResponse.json({ error: 'runId is required' }, { status: 400 });
@@ -21,7 +24,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const readable = run.getReadable();
+    const readable = run.getReadable({ namespace });
     return new Response(readable, {
       headers: {
         'Content-Type': 'text/event-stream',

--- a/workbench/nextjs-turbopack/app/test-direct-step-call-server-action/actions.ts
+++ b/workbench/nextjs-turbopack/app/test-direct-step-call-server-action/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { getFormattedStepResult } from '@/workflows/server_action_step_imports';
+import { getFormattedStepResult } from 'workflow-workbench/server_action_step_imports';
 
 export type DirectImportedStepActionState = {
   error: string | null;

--- a/workbench/nextjs-turbopack/next.config.ts
+++ b/workbench/nextjs-turbopack/next.config.ts
@@ -13,6 +13,11 @@ const nextConfig: NextConfig = {
   /* config options here */
   outputFileTracingRoot: turbopackRoot,
   serverExternalPackages: ['@node-rs/xxhash'],
+  experimental: {
+    // Deferred step routes rely on runtime stack traces in prod E2E. Turbopack
+    // minification currently strips original function names from those stacks.
+    turbopackMinify: false,
+  },
   turbopack: {
     // Keep Turbopack root aligned with repo root so @repo/* path aliases can
     // resolve files outside the app directory in both monorepo and staged temp layouts.

--- a/workbench/nextjs-turbopack/next.config.ts
+++ b/workbench/nextjs-turbopack/next.config.ts
@@ -3,14 +3,36 @@ import path from 'node:path';
 import { withWorkflow } from 'workflow/next';
 
 const turbopackRoot = path.resolve(process.cwd(), '../..');
+const generatedWorkflowsRoot = path.resolve(
+  process.cwd(),
+  '.generated/workflows'
+);
+const useGeneratedWorkflows = process.env.NODE_ENV === 'production';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  outputFileTracingRoot: turbopackRoot,
   serverExternalPackages: ['@node-rs/xxhash'],
   turbopack: {
     // Keep Turbopack root aligned with repo root so @repo/* path aliases can
     // resolve files outside the app directory in both monorepo and staged temp layouts.
     root: turbopackRoot,
+    ...(useGeneratedWorkflows
+      ? {
+          resolveAlias: {
+            'workflow-workbench': generatedWorkflowsRoot,
+          },
+        }
+      : {}),
+  },
+  webpack: (config) => {
+    if (useGeneratedWorkflows) {
+      config.resolve ??= {};
+      config.resolve.alias ??= {};
+      config.resolve.alias['workflow-workbench'] = generatedWorkflowsRoot;
+    }
+
+    return config;
   },
 };
 

--- a/workbench/nextjs-turbopack/package.json
+++ b/workbench/nextjs-turbopack/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "generate:workflows": "node ../scripts/generate-workflows-registry.js",
-    "predev": "pnpm generate:workflows",
-    "prebuild": "pnpm generate:workflows",
+    "sync:workflows": "node ../scripts/sync-workflows.js ./workflows ./.generated/workflows",
+    "generate:workflows": "node ../scripts/generate-workflows-registry.js ./workflows ./_workflows.ts --alias-prefix workflow-workbench",
+    "predev": "pnpm sync:workflows && pnpm generate:workflows",
+    "prebuild": "pnpm sync:workflows && pnpm generate:workflows",
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
-    "clean": "rm -rf .next .swc app/.well-known/workflow _workflows.ts",
+    "clean": "rm -rf .next .swc .generated app/.well-known/workflow _workflows.ts",
     "start": "next start",
     "lint": "next lint"
   },

--- a/workbench/nextjs-turbopack/pages/api/trigger-pages.ts
+++ b/workbench/nextjs-turbopack/pages/api/trigger-pages.ts
@@ -1,10 +1,28 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getRun, start } from 'workflow/api';
-import {
-  WorkflowRunFailedError,
-  WorkflowRunNotCompletedError,
-} from 'workflow/internal/errors';
-import { allWorkflows } from '@/_workflows';
+
+function getBaseUrl(req: NextApiRequest): string {
+  const protoHeader = req.headers['x-forwarded-proto'];
+  const proto = Array.isArray(protoHeader)
+    ? protoHeader[0]
+    : protoHeader || 'http';
+  const host = req.headers.host;
+  if (!host) {
+    throw new Error('Missing host header');
+  }
+  return `${proto}://${host}`;
+}
+
+async function proxyJson(
+  req: NextApiRequest,
+  path: string,
+  body: unknown
+): Promise<Response> {
+  return fetch(new URL(path, getBaseUrl(req)), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
 
 export default async function handler(
   req: NextApiRequest,
@@ -26,29 +44,9 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   if (!workflowFile) {
     return res.status(400).send('No workflowFile query parameter provided');
   }
-  const workflows = allWorkflows[workflowFile as keyof typeof allWorkflows];
-  if (!workflows) {
-    return res.status(400).send(`Workflow file "${workflowFile}" not found`);
-  }
-
   const workflowFn = (req.query.workflowFn as string) || 'simple';
   if (!workflowFn) {
     return res.status(400).send('No workflow query parameter provided');
-  }
-
-  // Handle static method lookups (e.g., "Calculator.calculate")
-  let workflow: unknown;
-  if (workflowFn.includes('.')) {
-    const [className, methodName] = workflowFn.split('.');
-    const cls = workflows[className as keyof typeof workflows];
-    if (cls && typeof cls === 'function') {
-      workflow = (cls as Record<string, unknown>)[methodName];
-    }
-  } else {
-    workflow = workflows[workflowFn as keyof typeof workflows];
-  }
-  if (!workflow) {
-    return res.status(400).send(`Workflow "${workflowFn}" not found`);
   }
 
   let args: any[] = [];
@@ -69,9 +67,17 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   console.log(`Starting "${workflowFn}" workflow with args: ${args}`);
 
   try {
-    const run = await start(workflow as any, args as any);
-    console.log('Run', run.runId);
-    return res.status(200).json(run);
+    const response = await proxyJson(req, '/api/workflows/start', {
+      workflowFile,
+      workflowFn,
+      args,
+      responseMode: 'run',
+    });
+    const text = await response.text();
+    return res
+      .status(response.status)
+      .setHeader('Content-Type', 'application/json')
+      .send(text);
   } catch (err) {
     console.error(`Failed to start!!`, err);
     throw err;
@@ -87,23 +93,27 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
   const outputStreamParam = req.query['output-stream'] as string | undefined;
   if (outputStreamParam) {
     const namespace = outputStreamParam === '1' ? undefined : outputStreamParam;
-    const run = getRun(runId);
-    const stream = run.getReadable({
+    const response = await proxyJson(req, '/api/workflows/stream', {
+      runId,
       namespace,
     });
+    if (!response.ok || !response.body) {
+      return res.status(response.status).send(await response.text());
+    }
 
-    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader(
+      'Content-Type',
+      response.headers.get('Content-Type') || 'application/octet-stream'
+    );
 
-    const reader = stream.getReader();
+    const reader = response.body.getReader();
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-        const data =
-          value instanceof Uint8Array
-            ? { data: Buffer.from(value).toString('base64') }
-            : value;
-        res.write(`${JSON.stringify(data)}\n`);
+        if (value) {
+          res.write(value);
+        }
       }
     } finally {
       reader.releaseLock();
@@ -112,65 +122,13 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const run = getRun(runId);
-    const returnValue = await run.returnValue;
-    console.log('Return value:', returnValue);
-
-    // Include run metadata in headers
-    const [createdAt, startedAt, completedAt] = await Promise.all([
-      run.createdAt,
-      run.startedAt,
-      run.completedAt,
-    ]);
-
-    res.setHeader('X-Workflow-Run-Created-At', createdAt?.toISOString() || '');
-    res.setHeader('X-Workflow-Run-Started-At', startedAt?.toISOString() || '');
-    res.setHeader(
-      'X-Workflow-Run-Completed-At',
-      completedAt?.toISOString() || ''
-    );
-
-    if (returnValue instanceof ReadableStream) {
-      res.setHeader('Content-Type', 'application/octet-stream');
-      const reader = returnValue.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          res.write(value);
-        }
-      } finally {
-        reader.releaseLock();
-      }
-      return res.end();
+    const response = await proxyJson(req, '/api/workflows/await', { runId });
+    const result = await response.json();
+    if (!response.ok) {
+      return res.status(response.status).json(result);
     }
-
-    return res.status(200).json(returnValue);
+    return res.status(200).json(result.result);
   } catch (error) {
-    if (error instanceof Error) {
-      if (WorkflowRunNotCompletedError.is(error)) {
-        return res.status(202).json({
-          ...error,
-          name: error.name,
-          message: error.message,
-        });
-      }
-
-      if (WorkflowRunFailedError.is(error)) {
-        const cause = error.cause;
-        return res.status(400).json({
-          ...error,
-          name: error.name,
-          message: error.message,
-          cause: {
-            message: cause.message,
-            stack: cause.stack,
-            code: cause.code,
-          },
-        });
-      }
-    }
-
     console.error(
       'Unexpected error while getting workflow return value:',
       error

--- a/workbench/nextjs-turbopack/tsconfig.json
+++ b/workbench/nextjs-turbopack/tsconfig.json
@@ -22,6 +22,7 @@
       }
     ],
     "paths": {
+      "workflow-workbench/*": ["./.generated/workflows/*", "./workflows/*"],
       "@/*": ["./*"],
       "@repo/*": ["../../*"]
     }

--- a/workbench/nextjs-turbopack/tsconfig.json
+++ b/workbench/nextjs-turbopack/tsconfig.json
@@ -22,7 +22,7 @@
       }
     ],
     "paths": {
-      "workflow-workbench/*": ["./.generated/workflows/*", "./workflows/*"],
+      "workflow-workbench/*": ["./workflows/*"],
       "@/*": ["./*"],
       "@repo/*": ["../../*"]
     }

--- a/workbench/nextjs-turbopack/workflows/8_react_render.tsx
+++ b/workbench/nextjs-turbopack/workflows/8_react_render.tsx
@@ -1,9 +1,8 @@
 async function render(a: number, b: number): Promise<string> {
   'use step';
 
-  // biome-ignore lint/security/noGlobalEval: need to avoid next.js rule about using react-dom directly
-  const ReactDOM = eval('require("react-dom/server")');
-  return ReactDOM.renderToString(<div>hello world {a + b}</div>);
+  const { renderToString } = await import('react-dom/server');
+  return renderToString(<div>hello world {a + b}</div>);
 }
 
 export async function reactWorkflow() {

--- a/workbench/nextjs-webpack/app/api/duplicate-case/route.ts
+++ b/workbench/nextjs-webpack/app/api/duplicate-case/route.ts
@@ -2,7 +2,7 @@
 //       using it because webpack relies on esbuild's tree shaking
 
 import { start } from 'workflow/api';
-import { addTenWorkflow } from '@/workflows/98_duplicate_case';
+import { addTenWorkflow } from 'workflow-workbench/98_duplicate_case';
 
 export async function GET(_: Request) {
   const run = await start(addTenWorkflow, [10]);

--- a/workbench/nextjs-webpack/app/api/test-direct-step-call/route.ts
+++ b/workbench/nextjs-webpack/app/api/test-direct-step-call/route.ts
@@ -2,7 +2,7 @@
 // After the SWC compiler changes, step functions in client mode have their directive removed
 // and keep their original implementation, allowing them to be called as regular async functions
 
-import { add } from '@/workflows/99_e2e';
+import { add } from 'workflow-workbench/99_e2e';
 
 export async function POST(req: Request) {
   const body = await req.json();

--- a/workbench/nextjs-webpack/next.config.ts
+++ b/workbench/nextjs-webpack/next.config.ts
@@ -1,13 +1,31 @@
 import type { NextConfig } from 'next';
+import path from 'node:path';
 import { withWorkflow } from 'workflow/next';
+
+const tracingRoot = path.resolve(process.cwd(), '../..');
+const generatedWorkflowsRoot = path.resolve(
+  process.cwd(),
+  '.generated/workflows'
+);
+const useGeneratedWorkflows = process.env.NODE_ENV === 'production';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  outputFileTracingRoot: tracingRoot,
   // for easier debugging
   experimental: {
     serverMinification: false,
   },
   serverExternalPackages: ['@node-rs/xxhash'],
+  webpack: (config) => {
+    if (useGeneratedWorkflows) {
+      config.resolve ??= {};
+      config.resolve.alias ??= {};
+      config.resolve.alias['workflow-workbench'] = generatedWorkflowsRoot;
+    }
+
+    return config;
+  },
 };
 
 // export default nextConfig;

--- a/workbench/nextjs-webpack/package.json
+++ b/workbench/nextjs-webpack/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "generate:workflows": "node ../scripts/generate-workflows-registry.js",
-    "predev": "pnpm generate:workflows",
-    "prebuild": "pnpm generate:workflows",
+    "sync:workflows": "node ../scripts/sync-workflows.js ./workflows ./.generated/workflows",
+    "generate:workflows": "node ../scripts/generate-workflows-registry.js ./workflows ./_workflows.ts --alias-prefix workflow-workbench",
+    "predev": "pnpm sync:workflows && pnpm generate:workflows",
+    "prebuild": "pnpm sync:workflows && pnpm generate:workflows",
     "dev": "next dev --webpack",
     "build": "next build --webpack",
-    "clean": "rm -rf .next .swc app/.well-known/workflow _workflows.ts",
+    "clean": "rm -rf .next .swc .generated app/.well-known/workflow _workflows.ts",
     "start": "next start",
     "lint": "next lint"
   },

--- a/workbench/nextjs-webpack/workflows/8_react_render.tsx
+++ b/workbench/nextjs-webpack/workflows/8_react_render.tsx
@@ -1,9 +1,8 @@
 async function render(a: number, b: number): Promise<string> {
   'use step';
 
-  // biome-ignore lint/security/noGlobalEval: need to avoid next.js rule about using react-dom directly
-  const ReactDOM = eval('require("react-dom/server")');
-  return ReactDOM.renderToString(<div>hello world {a + b}</div>);
+  const { renderToString } = await import('react-dom/server');
+  return renderToString(<div>hello world {a + b}</div>);
 }
 
 export async function reactWorkflow() {

--- a/workbench/scripts/generate-workflows-registry.js
+++ b/workbench/scripts/generate-workflows-registry.js
@@ -25,7 +25,9 @@ const aliasPrefix =
   aliasPrefixFlagIndex === -1 ? undefined : args[aliasPrefixFlagIndex + 1];
 const nonFlagArgs = args.filter((arg, index) => {
   if (arg === '--alias-prefix') return false;
-  if (index === aliasPrefixFlagIndex + 1) return false;
+  if (aliasPrefixFlagIndex !== -1 && index === aliasPrefixFlagIndex + 1) {
+    return false;
+  }
   return !arg.startsWith('--');
 });
 

--- a/workbench/scripts/generate-workflows-registry.js
+++ b/workbench/scripts/generate-workflows-registry.js
@@ -3,7 +3,7 @@
 /**
  * Auto-generates _workflows.ts registry file for workbenches
  *
- * Usage: node generate-workflows-registry.js [workflowsDir] [outputPath] [--esm]
+ * Usage: node generate-workflows-registry.js [workflowsDir] [outputPath] [--esm] [--alias-prefix <prefix>]
  *
  * Defaults:
  *   workflowsDir: ./workflows
@@ -11,6 +11,7 @@
  *
  * Options:
  *   --esm: Add .js extension to imports (required for ESM with NodeNext moduleResolution)
+ *   --alias-prefix: Use an import prefix instead of relative file paths
  */
 
 const fs = require('node:fs');
@@ -19,7 +20,14 @@ const path = require('node:path');
 // Parse arguments
 const args = process.argv.slice(2);
 const esmMode = args.includes('--esm');
-const nonFlagArgs = args.filter((arg) => !arg.startsWith('--'));
+const aliasPrefixFlagIndex = args.indexOf('--alias-prefix');
+const aliasPrefix =
+  aliasPrefixFlagIndex === -1 ? undefined : args[aliasPrefixFlagIndex + 1];
+const nonFlagArgs = args.filter((arg, index) => {
+  if (arg === '--alias-prefix') return false;
+  if (index === aliasPrefixFlagIndex + 1) return false;
+  return !arg.startsWith('--');
+});
 
 // Get arguments or use defaults
 const workflowsDir = nonFlagArgs[0] || './workflows';
@@ -77,7 +85,12 @@ function generateRegistry() {
       // Use relative path from output directory to workflows directory
       let importPath;
       const baseName = file.replace(/\.tsx?$/, '');
-      if (relativeWorkflowsPath && relativeWorkflowsPath !== 'workflows') {
+      if (aliasPrefix) {
+        importPath = `${aliasPrefix}/${baseName}${importExtension}`;
+      } else if (
+        relativeWorkflowsPath &&
+        relativeWorkflowsPath !== 'workflows'
+      ) {
         importPath = `${relativeWorkflowsPath}/${baseName}${importExtension}`;
       } else {
         importPath = `./workflows/${baseName}${importExtension}`;

--- a/workbench/scripts/sync-workflows.js
+++ b/workbench/scripts/sync-workflows.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function copyDirContents(sourceDir, targetDir) {
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirContents(sourcePath, targetPath);
+      continue;
+    }
+
+    if (entry.isSymbolicLink()) {
+      const realSourcePath = fs.realpathSync(sourcePath);
+      const realStats = fs.statSync(realSourcePath);
+
+      if (realStats.isDirectory()) {
+        copyDirContents(realSourcePath, targetPath);
+      } else {
+        fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+        fs.copyFileSync(realSourcePath, targetPath);
+      }
+      continue;
+    }
+
+    if (entry.isFile()) {
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
+function removeDir(targetDir) {
+  fs.rmSync(targetDir, { recursive: true, force: true });
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const sourceDir = args[0] || './workflows';
+  const targetDir = args[1] || './.generated/workflows';
+
+  if (!fs.existsSync(sourceDir)) {
+    console.error(`Error: Workflows directory not found: ${sourceDir}`);
+    process.exit(1);
+  }
+
+  removeDir(targetDir);
+  copyDirContents(sourceDir, targetDir);
+
+  console.log(`✓ Synced workflows to ${targetDir}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error('Error syncing workflows:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- lazy-load the built-in local and vercel world modules instead of statically importing them
- stop using a top-level project-root createRequire in core runtime world loading
- preserve custom world fallback resolution while keeping eager Next.js step routes out of world implementation graphs

## Validation
- WORKFLOW_NEXT_LAZY_DISCOVERY=0 APP_NAME=nextjs-turbopack pnpm vitest run packages/core/e2e/local-build.test.ts
- WORKFLOW_NEXT_LAZY_DISCOVERY=0 APP_NAME=nextjs-webpack pnpm vitest run packages/core/e2e/local-build.test.ts

Stacked on #1747.