### PR TITLE
Content negation for cookbook route

### DIFF
--- a/docs/lib/md-tracking.ts
+++ b/docs/lib/md-tracking.ts
@@ -7,8 +7,10 @@ type TrackMdRequestParams = {
   userAgent: string | null;
   referer: string | null;
   acceptHeader: string | null;
-  /** How the markdown was requested: 'md-url' for direct .md URLs, 'header-negotiated' for Accept header */
-  requestType?: 'md-url' | 'header-negotiated';
+  /** How the markdown was requested. */
+  requestType?: 'md-url' | 'header-negotiated' | 'agent-rewrite';
+  /** Which AI-agent detection signal triggered the rewrite. */
+  detectionMethod?: 'ua-match' | 'signature-agent' | 'heuristic' | null;
 };
 
 /**

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -48,7 +48,7 @@ function getMarkdownRewrite(pathname: string): string | null {
     return `/${i18n.defaultLanguage}/llms.mdx/cookbook`;
   }
 
-  return rewriteDocsLLM(pathname) ?? rewriteCookbookLLM(pathname);
+  return rewriteDocsLLM(pathname) || rewriteCookbookLLM(pathname) || null;
 }
 
 const internationalizer = createI18nMiddleware(i18n);

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -5,14 +5,51 @@ import {
   type NextRequest,
   NextResponse,
 } from 'next/server';
+import { isAIAgent } from '@/lib/ai-agent-detection';
 import { i18n } from '@/lib/geistdocs/i18n';
 import { trackMdRequest } from '@/lib/md-tracking';
-import { isAIAgent } from '@/lib/ai-agent-detection';
 
-const { rewrite: rewriteLLM } = rewritePath(
+const { rewrite: rewriteDocsLLM } = rewritePath(
   '/docs/*path',
   `/${i18n.defaultLanguage}/llms.mdx/*path`
 );
+const { rewrite: rewriteCookbookLLM } = rewritePath(
+  '/cookbook/*path',
+  `/${i18n.defaultLanguage}/llms.mdx/cookbook/*path`
+);
+
+function isDocsOrCookbookPath(pathname: string): boolean {
+  return (
+    pathname === '/docs' ||
+    pathname.startsWith('/docs/') ||
+    pathname === '/cookbook' ||
+    pathname.startsWith('/cookbook/')
+  );
+}
+
+function isDocsOrCookbookMarkdownPath(pathname: string): boolean {
+  return (
+    (pathname === '/docs.md' ||
+      pathname === '/docs.mdx' ||
+      pathname.startsWith('/docs/') ||
+      pathname === '/cookbook.md' ||
+      pathname === '/cookbook.mdx' ||
+      pathname.startsWith('/cookbook/')) &&
+    (pathname.endsWith('.md') || pathname.endsWith('.mdx'))
+  );
+}
+
+function getMarkdownRewrite(pathname: string): string | null {
+  if (pathname === '/docs') {
+    return `/${i18n.defaultLanguage}/llms.mdx`;
+  }
+
+  if (pathname === '/cookbook') {
+    return `/${i18n.defaultLanguage}/llms.mdx/cookbook`;
+  }
+
+  return rewriteDocsLLM(pathname) ?? rewriteCookbookLLM(pathname);
+}
 
 const internationalizer = createI18nMiddleware(i18n);
 
@@ -31,18 +68,11 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
     );
   }
 
-  // Handle .md/.mdx URL requests before i18n runs
-  if (
-    (pathname === '/docs.md' ||
-      pathname === '/docs.mdx' ||
-      pathname.startsWith('/docs/')) &&
-    (pathname.endsWith('.md') || pathname.endsWith('.mdx'))
-  ) {
+  // Handle .md/.mdx URL requests before i18n runs.
+  if (isDocsOrCookbookMarkdownPath(pathname)) {
     const stripped = pathname.replace(/\.mdx?$/, '');
-    const result =
-      stripped === '/docs'
-        ? `/${i18n.defaultLanguage}/llms.mdx`
-        : rewriteLLM(stripped);
+    const result = getMarkdownRewrite(stripped);
+
     if (result) {
       context.waitUntil(
         trackMdRequest({
@@ -56,18 +86,14 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
     }
   }
 
-  // AI agent detection — rewrite docs pages to markdown for agents
+  const markdownRewrite = getMarkdownRewrite(pathname);
+
+  // AI agent detection — rewrite docs and cookbook pages to markdown for agents
   // so they always get structured content without needing .md URLs or Accept headers
-  if (
-    (pathname === '/docs' || pathname.startsWith('/docs/')) &&
-    !pathname.includes('/llms.mdx/')
-  ) {
+  if (isDocsOrCookbookPath(pathname) && !pathname.includes('/llms.mdx/')) {
     const agentResult = isAIAgent(request);
     if (agentResult.detected && !isMarkdownPreferred(request)) {
-      const result =
-        pathname === '/docs'
-          ? `/${i18n.defaultLanguage}/llms.mdx`
-          : rewriteLLM(pathname);
+      const result = markdownRewrite;
 
       if (result) {
         context.waitUntil(
@@ -86,20 +112,17 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
   }
 
   // Handle Accept header content negotiation and track the request
-  if (isMarkdownPreferred(request)) {
-    const result = rewriteLLM(pathname);
-    if (result) {
-      context.waitUntil(
-        trackMdRequest({
-          path: pathname,
-          userAgent: request.headers.get('user-agent'),
-          referer: request.headers.get('referer'),
-          acceptHeader: request.headers.get('accept'),
-          requestType: 'header-negotiated',
-        })
-      );
-      return NextResponse.rewrite(new URL(result, request.nextUrl));
-    }
+  if (isMarkdownPreferred(request) && markdownRewrite) {
+    context.waitUntil(
+      trackMdRequest({
+        path: pathname,
+        userAgent: request.headers.get('user-agent'),
+        referer: request.headers.get('referer'),
+        acceptHeader: request.headers.get('accept'),
+        requestType: 'header-negotiated',
+      })
+    );
+    return NextResponse.rewrite(new URL(markdownRewrite, request.nextUrl));
   }
 
   // Fallback to i18n middleware


### PR DESCRIPTION
We didn't handle markdown pages for the `/cookbook` route. 

Test by visiting: 

[https://workflow-docs-git-ms-cookbook-md-page.vercel.sh/cookbook](https://workflow-docs-git-ms-cookbook-md-page.vercel.sh/cookbook) and adding `.md` to a route 

or by asking Claude to fetch the route and confirm if it received markdown and not HTML.