### PR TITLE
Backport #1740: [core] Re-try runtime replays that exceed deadline up to three times

### DIFF
--- a/.changeset/curvy-dingos-cry.md
+++ b/.changeset/curvy-dingos-cry.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+When runtime replays exceed 240s, re-try them up to three times, instead of failing immediately

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -17,6 +17,7 @@ import { WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
 import {
   MAX_QUEUE_DELIVERIES,
+  REPLAY_TIMEOUT_MAX_RETRIES,
   REPLAY_TIMEOUT_MS,
 } from './runtime/constants.js';
 import {
@@ -181,9 +182,18 @@ export function workflowEntrypoint(
           runtimeLogger.error('Workflow replay exceeded timeout', {
             workflowRunId: runId,
             timeoutMs: REPLAY_TIMEOUT_MS,
+            attempt: metadata.attempt,
+            maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
           });
+
+          // Allow a few retries before permanently failing the run.
+          // On early attempts, just exit so the queue retries the message.
+          if (metadata.attempt <= REPLAY_TIMEOUT_MAX_RETRIES) {
+            process.exit(1);
+          }
+
           try {
-            const world = getWorld();
+            const world = await getWorld();
             await world.events.create(
               runId,
               {
@@ -191,7 +201,7 @@ export function workflowEntrypoint(
                 specVersion: SPEC_VERSION_CURRENT,
                 eventData: {
                   error: {
-                    message: `Workflow replay exceeded maximum duration (${REPLAY_TIMEOUT_MS / 1000}s)`,
+                    message: `Workflow replay exceeded maximum duration (${REPLAY_TIMEOUT_MS / 1000}s) after ${metadata.attempt} attempts`,
                   },
                   errorCode: RUN_ERROR_CODES.REPLAY_TIMEOUT,
                 },
@@ -201,7 +211,7 @@ export function workflowEntrypoint(
           } catch {
             // Best effort — process exits regardless
           }
-          // Note that this also prevents the runtime to acking the queue message,
+          // Note that this also prevents the runtime from acking the queue message,
           // so the queue will call back once, after which a 410 will get it to exit early.
           process.exit(1);
         }, REPLAY_TIMEOUT_MS);

--- a/packages/core/src/runtime/constants.ts
+++ b/packages/core/src/runtime/constants.ts
@@ -13,10 +13,16 @@
 export const MAX_QUEUE_DELIVERIES = 48;
 
 // Maximum time allowed for a single workflow replay execution (in ms).
-// If a replay exceeds this duration, the run is failed and the process exits.
+// If a replay exceeds this duration, the process exits so the queue can retry.
 // This must be lower than the function's maxDuration to ensure the
 // timeout handler has time to post the run_failed event before the platform
 // kills the function.
 // Note that on hobby plan, the maxDuration is 60s, so this barrier will not be hit,
 // and the queue will re-try until the visibility window expires.
 export const REPLAY_TIMEOUT_MS = 240_000;
+
+// Number of queue delivery attempts to allow before permanently failing a run
+// due to a replay timeout. On attempts 1 through this value, the timeout
+// handler exits without writing run_failed so the queue retries the message.
+// On the next attempt the run is marked as failed.
+export const REPLAY_TIMEOUT_MAX_RETRIES = 3;


### PR DESCRIPTION
## Summary

Backport of #1740 to `stable`.

When runtime replays exceed the 240s deadline, re-try them up to three times instead of failing immediately. On early attempts the timeout handler exits without writing `run_failed`, so the queue retries the message. After exhausting retries, the run is marked as failed with an error message indicating the attempt count.

## Test plan

- [x] Unit tests pass (581/581)
- [x] E2E tests pass locally against `nextjs-turbopack` dev server (61/61)