### PR TITLE
[docs] Rename workflowdevkit to workflowsdk and useworkflow.dev to workflow-sdk.dev

### DIFF
--- a/.changeset/rename-domain-urls.md
+++ b/.changeset/rename-domain-urls.md
@@ -1,0 +1,21 @@
+---
+"@workflow/core": patch
+"workflow": patch
+"@workflow/errors": patch
+"@workflow/builders": patch
+"@workflow/cli": patch
+"@workflow/nuxt": patch
+"@workflow/typescript-plugin": patch
+"@workflow/web": patch
+"@workflow/ai": patch
+"@workflow/astro": patch
+"@workflow/next": patch
+"@workflow/nitro": patch
+"@workflow/sveltekit": patch
+"@workflow/swc-plugin": patch
+"@workflow/utils": patch
+"@workflow/vite": patch
+"@workflow/web-shared": patch
+---
+
+Rename `useworkflow.dev` URLs to `workflow-sdk.dev`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Workflow SDK Docs
 
-Check out the docs [here](https://useworkflow.dev/)
+Check out the docs [here](https://workflow-sdk.dev/)

--- a/docs/app/[lang]/(home)/components/tweet-wall.tsx
+++ b/docs/app/[lang]/(home)/components/tweet-wall.tsx
@@ -21,7 +21,7 @@ const TWEETS: Tweet[] = [
     tweet: (
       <>
         <span>
-          Resend + <InlineLink>@vercel</InlineLink> Workflow Dev Kit
+          Resend + <InlineLink>@vercel</InlineLink> Workflow SDK
         </span>
         <span>A match made in heaven</span>
       </>
@@ -78,7 +78,7 @@ const TWEETS: Tweet[] = [
         <span>
           Built a complete end-to-end workflow with{' '}
           <InlineLink>@ampcode</InlineLink> using{' '}
-          <InlineLink>@WorkflowDevKit</InlineLink> and{' '}
+          <InlineLink>@WorkflowSDK</InlineLink> and{' '}
           <InlineLink>@vercel</InlineLink> AI Gateway
         </span>
         <span>

--- a/docs/app/[lang]/layout.tsx
+++ b/docs/app/[lang]/layout.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 const getMetadataBase = () => {
   // Use VERCEL_URL for preview deployments, production URL for production
   if (process.env.VERCEL_ENV === 'production') {
-    return new URL('https://useworkflow.dev');
+    return new URL('https://workflow-sdk.dev');
   }
   if (process.env.VERCEL_URL) {
     return new URL(`https://${process.env.VERCEL_URL}`);

--- a/docs/components/geistdocs/x-button.tsx
+++ b/docs/components/geistdocs/x-button.tsx
@@ -4,7 +4,7 @@ import { Button } from '../ui/button';
 export const XButton = () => {
   return (
     <Button asChild size="icon-sm" type="button" variant="ghost">
-      <a href="https://x.com/workflowdevkit" rel="noopener" target="_blank">
+      <a href="https://x.com/workflowsdk" rel="noopener" target="_blank">
         <SiX className="size-4" />
       </a>
     </Button>

--- a/docs/content/docs/cookbook/advanced/publishing-libraries.mdx
+++ b/docs/content/docs/cookbook/advanced/publishing-libraries.mdx
@@ -195,12 +195,12 @@ This test server acts as a stand-in consumer app. Point your test runner at it t
 Use a dedicated Vitest config for integration tests that run against the Workflow SDK runtime:
 
 ```typescript lineNumbers
-// vitest.workflowdevkit.config.ts
+// vitest.workflowsdk.config.ts
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["tests/integration/**/*.workflowdevkit.test.ts"],
+    include: ["tests/integration/**/*.workflowsdk.test.ts"],
     testTimeout: 120_000, // Workflows may take time to complete
     setupFiles: ["./tests/setup.ts"],
   },
@@ -214,7 +214,7 @@ Run these tests separately from your unit tests:
 pnpm vitest run tests/unit
 
 # Integration tests (requires workflow runtime)
-pnpm vitest run --config vitest.workflowdevkit.config.ts
+pnpm vitest run --config vitest.workflowsdk.config.ts
 ```
 
 ### What to Test

--- a/docs/content/docs/errors/start-invalid-workflow-function.mdx
+++ b/docs/content/docs/errors/start-invalid-workflow-function.mdx
@@ -123,7 +123,7 @@ Before calling `start()`:
 1. Confirm the function includes `"use workflow"` as its first statement.
 2. Confirm your framework integration is enabled (for Next.js, wrap `next.config.ts` with [`withWorkflow()`](/docs/api-reference/workflow-next/with-workflow)).
 3. Pass the imported workflow function directly to `start()`, not a wrapper callback.
-4. Keep the function in a file that goes through Workflow DevKit's transform step.
+4. Keep the function in a file that goes through Workflow SDK's transform step.
 
 ## Related
 

--- a/docs/geistdocs.tsx
+++ b/docs/geistdocs.tsx
@@ -39,7 +39,7 @@ export const title = 'Workflow SDK Documentation';
 export const prompt = `
 You are a helpful assistant specializing in answering questions about Workflow, an SDK by Vercel that brings durability, reliability, and observability to async JavaScript. Build apps and AI Agents that can suspend, resume, and maintain state with ease.
 
-Always link to relevant documentation using Markdown with the domain \`useworkflow.dev\`. Ensure the link text is descriptive (e.g. [Deploying](https://useworkflow.dev/docs/deploying)) and not just the URL.
+Always link to relevant documentation using Markdown with the domain \`workflow-sdk.dev\`. Ensure the link text is descriptive (e.g. [Deploying](https://workflow-sdk.dev/docs/deploying)) and not just the URL.
 
 Politely refuse to respond to queries that do not relate to Vercel or Workflow SDK's documentation, guides, or tools.`;
 

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -25,8 +25,7 @@ const config: NextConfig = {
       beforeFiles: [
         {
           source: '/sitemap.xml',
-          destination:
-            'https://crawled-sitemap.vercel.sh/workflow-sdk.dev-.xml',
+          destination: 'https://crawled-sitemap.vercel.sh/useworkflow.dev-.xml',
         },
         {
           source: '/docs/:path*',

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -25,7 +25,8 @@ const config: NextConfig = {
       beforeFiles: [
         {
           source: '/sitemap.xml',
-          destination: 'https://crawled-sitemap.vercel.sh/useworkflow.dev-.xml',
+          destination:
+            'https://crawled-sitemap.vercel.sh/workflow-sdk.dev-.xml',
         },
         {
           source: '/docs/:path*',

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,6 +1,6 @@
 # @workflow/ai
 
-[Workflow SDK](https://useworkflow.dev) compatible helper library for the [AI SDK](https://ai-sdk.dev/).
+[Workflow SDK](https://workflow-sdk.dev) compatible helper library for the [AI SDK](https://ai-sdk.dev/).
 
 ## Installation
 
@@ -43,4 +43,4 @@ npm install ai@5 @ai-sdk/openai@2
 
 ## Documentation
 
-For usage examples and full documentation, see the [API reference](https://useworkflow.dev/docs/api-reference/workflow-ai/).
+For usage examples and full documentation, see the [API reference](https://workflow-sdk.dev/docs/api-reference/workflow-ai/).

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,3 +1,3 @@
 # workflow/astro
 
-The docs have moved! Refer to them [here](https://useworkflow.dev/)
+The docs have moved! Refer to them [here](https://workflow-sdk.dev/)

--- a/packages/builders/src/node-module-esbuild-plugin.ts
+++ b/packages/builders/src/node-module-esbuild-plugin.ts
@@ -440,8 +440,8 @@ export function createNodeModuleErrorPlugin(): esbuild.Plugin {
 
               // Different messages for built-in modules vs npm packages that use them
               const text = isBuiltinModule
-                ? `You are attempting to use "${violation.packageName}" which is a ${moduleType} module. ${moduleType} modules are not available in workflow functions.\n\nLearn more: https://useworkflow.dev/err/${ERROR_SLUGS.NODE_JS_MODULE_IN_WORKFLOW}`
-                : `You are attempting to use "${violation.packageName}" which depends on ${moduleType} modules. Packages that depend on ${moduleType} modules are not available in workflow functions.\n\nLearn more: https://useworkflow.dev/err/${ERROR_SLUGS.NODE_JS_MODULE_IN_WORKFLOW}`;
+                ? `You are attempting to use "${violation.packageName}" which is a ${moduleType} module. ${moduleType} modules are not available in workflow functions.\n\nLearn more: https://workflow-sdk.dev/err/${ERROR_SLUGS.NODE_JS_MODULE_IN_WORKFLOW}`
+                : `You are attempting to use "${violation.packageName}" which depends on ${moduleType} modules. Packages that depend on ${moduleType} modules are not available in workflow functions.\n\nLearn more: https://workflow-sdk.dev/err/${ERROR_SLUGS.NODE_JS_MODULE_IN_WORKFLOW}`;
 
               return {
                 text,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,3 +1,3 @@
 # @workflow/cli
 
-CLI Package bundled in the [Workflow SDK](https://useworkflow.dev).
+CLI Package bundled in the [Workflow SDK](https://workflow-sdk.dev).

--- a/packages/cli/src/lib/inspect/setup.ts
+++ b/packages/cli/src/lib/inspect/setup.ts
@@ -39,8 +39,8 @@ export const setupCliWorld = async (
 
   const withAnsiLinks = flags.json ? false : true;
   const docsUrl = withAnsiLinks
-    ? terminalLink('https://useworkflow.dev/', 'https://useworkflow.dev/')
-    : 'https://useworkflow.dev/';
+    ? terminalLink('https://workflow-sdk.dev/', 'https://workflow-sdk.dev/')
+    : 'https://workflow-sdk.dev/';
 
   // Prepare showBox lines
   const boxLines = [

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,3 +1,3 @@
 # @workflow/core
 
-Core runtime package for [Workflow SDK](https://useworkflow.dev).
+Core runtime package for [Workflow SDK](https://workflow-sdk.dev).

--- a/packages/core/e2e/build-errors.test.ts
+++ b/packages/core/e2e/build-errors.test.ts
@@ -130,7 +130,7 @@ export async function nodeModuleViolationWorkflow() {
 
       // Verify the error doc link is present
       expect(output).toContain(
-        'useworkflow.dev/err/node-js-module-in-workflow'
+        'workflow-sdk.dev/err/node-js-module-in-workflow'
       );
     }
   );
@@ -214,7 +214,7 @@ export async function blobViolationWorkflow() {
 
       // Verify the error doc link is present
       expect(output).toContain(
-        'useworkflow.dev/err/node-js-module-in-workflow'
+        'workflow-sdk.dev/err/node-js-module-in-workflow'
       );
     }
   );

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -1505,7 +1505,7 @@ describe('runWorkflow', () => {
       }
       assert(error);
       expect(error.message).toContain(
-        'https://useworkflow.dev/err/timeout-in-workflow'
+        'https://workflow-sdk.dev/err/timeout-in-workflow'
       );
       expect(error.message).toContain(
         'Use the "sleep" function from "workflow"'

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -224,7 +224,7 @@ export async function runWorkflow(
     //       For now `fetch` must be explicitly imported from `workflow`.
     vmGlobalThis.fetch = () => {
       throw new vmGlobalThis.Error(
-        `Global "fetch" is unavailable in workflow functions. Use the "fetch" step function from "workflow" to make HTTP requests.\n\nLearn more: https://useworkflow.dev/err/${ERROR_SLUGS.FETCH_IN_WORKFLOW_FUNCTION}`
+        `Global "fetch" is unavailable in workflow functions. Use the "fetch" step function from "workflow" to make HTTP requests.\n\nLearn more: https://workflow-sdk.dev/err/${ERROR_SLUGS.FETCH_IN_WORKFLOW_FUNCTION}`
       );
     };
 

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,3 +1,3 @@
 # @workflow/errors
 
-Centralized errors package for [Workflow SDK](https://useworkflow.dev).
+Centralized errors package for [Workflow SDK](https://workflow-sdk.dev).

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -2,7 +2,7 @@ import { parseDurationToDate } from '@workflow/utils';
 import type { StructuredError } from '@workflow/world';
 import type { StringValue } from 'ms';
 
-const BASE_URL = 'https://useworkflow.dev/err';
+const BASE_URL = 'https://workflow-sdk.dev/err';
 
 /**
  * @internal

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,3 +1,3 @@
 # @workflow/next
 
-Next.js plugin for [Workflow SDK](https://useworkflow.dev).
+Next.js plugin for [Workflow SDK](https://workflow-sdk.dev).

--- a/packages/nitro/README.md
+++ b/packages/nitro/README.md
@@ -1,3 +1,3 @@
 # workflow/nitro
 
-The docs have moved! Refer to them [here](https://useworkflow.dev/)
+The docs have moved! Refer to them [here](https://workflow-sdk.dev/)

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -1,4 +1,4 @@
 # @workflow/nuxt
 
-Nuxt module for [Workflow SDK](https://useworkflow.dev).
+Nuxt module for [Workflow SDK](https://workflow-sdk.dev).
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -15,7 +15,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule({
   meta: {
     name: 'workflow',
     configKey: 'workflow',
-    docs: 'https://useworkflow.dev/docs/getting-started/nuxt',
+    docs: 'https://workflow-sdk.dev/docs/getting-started/nuxt',
   },
   // Default configuration options of the Nuxt module
   defaults: {

--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -1,3 +1,3 @@
 # workflow/sveltekit
 
-The docs have moved! Refer to them [here](https://useworkflow.dev/)
+The docs have moved! Refer to them [here](https://workflow-sdk.dev/)

--- a/packages/swc-plugin-workflow/README.md
+++ b/packages/swc-plugin-workflow/README.md
@@ -1,6 +1,6 @@
 # @workflow/swc-plugin
 
-SWC transform plugin to transform the directives for Workflow [Workflow SDK](https://useworkflow.dev).
+SWC transform plugin to transform the directives for Workflow [Workflow SDK](https://workflow-sdk.dev).
 
 ## Development
 

--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -1,3 +1,3 @@
 # @workflow/typescript-plugin
 
-A helpful Language Server Plugin that adds IDE IntelliSense for [Workflow SDK](https://useworkflow.dev).
+A helpful Language Server Plugin that adds IDE IntelliSense for [Workflow SDK](https://workflow-sdk.dev).

--- a/packages/typescript-plugin/src/hover.test.ts
+++ b/packages/typescript-plugin/src/hover.test.ts
@@ -23,7 +23,7 @@ describe('getHoverInfo', () => {
       expect(hoverInfo?.documentation).toBeDefined();
       expect(hoverInfo?.documentation?.[0].text).toContain('use workflow');
       expect(hoverInfo?.documentation?.[0].text).toContain(
-        'https://useworkflow.dev/docs'
+        'https://workflow-sdk.dev/docs'
       );
     });
 
@@ -59,7 +59,7 @@ describe('getHoverInfo', () => {
       const hoverInfo = getHoverInfo('test.ts', directivePos, program, ts);
 
       expect(hoverInfo?.documentation?.[0].text).toContain(
-        'https://useworkflow.dev/docs/foundations/workflows-and-steps#workflow-functions'
+        'https://workflow-sdk.dev/docs/foundations/workflows-and-steps#workflow-functions'
       );
     });
   });

--- a/packages/typescript-plugin/src/hover.ts
+++ b/packages/typescript-plugin/src/hover.ts
@@ -80,8 +80,8 @@ export function getHoverInfo(
 
   const isWorkflow = directive === 'use workflow';
   const docUrl = isWorkflow
-    ? 'https://useworkflow.dev/docs/foundations/workflows-and-steps#workflow-functions'
-    : 'https://useworkflow.dev/docs/foundations/workflows-and-steps#step-functions';
+    ? 'https://workflow-sdk.dev/docs/foundations/workflows-and-steps#workflow-functions'
+    : 'https://workflow-sdk.dev/docs/foundations/workflows-and-steps#step-functions';
   const directiveType = isWorkflow ? 'Workflow' : 'Step';
 
   return {

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,3 +1,3 @@
 # @workflow/utils
 
-Utility functions for [Workflow SDK](https://useworkflow.dev).
+Utility functions for [Workflow SDK](https://workflow-sdk.dev).

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -1,3 +1,3 @@
 # @workflow/vite
 
-Vite plugin for [Workflow SDK](https://useworkflow.dev).
+Vite plugin for [Workflow SDK](https://workflow-sdk.dev).

--- a/packages/web-shared/README.md
+++ b/packages/web-shared/README.md
@@ -1,6 +1,6 @@
 # @workflow/web-shared
 
-Workflow Observability UI primitives. See [Workflow SDK](https://useworkflow.dev/docs/observability) for more information.
+Workflow Observability UI primitives. See [Workflow SDK](https://workflow-sdk.dev/docs/observability) for more information.
 
 ## Usage
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,6 +1,6 @@
 # @workflow/web
 
-Observability Web UI Package bundled in the [Workflow SDK](https://useworkflow.dev/docs/observability).
+Observability Web UI Package bundled in the [Workflow SDK](https://workflow-sdk.dev/docs/observability).
 
 ## Self-hosting
 

--- a/packages/web/app/components/display-utils/connection-status.tsx
+++ b/packages/web/app/components/display-utils/connection-status.tsx
@@ -130,7 +130,7 @@ export function ConnectionStatus() {
                 restart the web UI. See{' '}
                 <a
                   className="underline"
-                  href="https://useworkflow.dev/docs/observability"
+                  href="https://workflow-sdk.dev/docs/observability"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/packages/web/app/components/hooks-table.tsx
+++ b/packages/web/app/components/hooks-table.tsx
@@ -278,7 +278,7 @@ export function HooksTable({
       ) : !loading && (!hooks || hooks.length === 0) ? (
         <div className="text-center py-8 text-muted-foreground">
           No active hooks found. <br />
-          <DocsLink href="https://useworkflow.dev/docs/api-reference/workflow/create-hook">
+          <DocsLink href="https://workflow-sdk.dev/docs/api-reference/workflow/create-hook">
             Learn how to create a hook
           </DocsLink>
         </div>

--- a/packages/web/app/components/top-nav/docs-link.tsx
+++ b/packages/web/app/components/top-nav/docs-link.tsx
@@ -5,7 +5,7 @@ export function DocsLink() {
   return (
     <Button asChild variant="outline" size="sm">
       <a
-        href="https://useworkflow.dev/docs/observability"
+        href="https://workflow-sdk.dev/docs/observability"
         target="_blank"
         rel="noopener noreferrer"
         className="gap-1"

--- a/packages/web/app/components/ui/docs-link.tsx
+++ b/packages/web/app/components/ui/docs-link.tsx
@@ -17,7 +17,7 @@ const DocsLink = React.forwardRef<HTMLAnchorElement, DocsLinkProps>(
     // Convert relative paths to full docs URLs
     const fullHref = href.startsWith('http')
       ? href
-      : `https://useworkflow.dev/docs/${href.replace(/^\//, '')}`;
+      : `https://workflow-sdk.dev/docs/${href.replace(/^\//, '')}`;
 
     return (
       <Link

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-  <a href="https://useworkflow.dev">
+  <a href="https://workflow-sdk.dev">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://useworkflow.dev/workflow-circle-symbol-dark.svg">
-      <img alt="Workflow SDK logo" src="https://useworkflow.dev/workflow-circle-symbol-light.svg" height="128">
+      <source media="(prefers-color-scheme: dark)" srcset="https://workflow-sdk.dev/workflow-circle-symbol-dark.svg">
+      <img alt="Workflow SDK logo" src="https://workflow-sdk.dev/workflow-circle-symbol-light.svg" height="128">
     </picture>
   </a>
   <h1>Workflow SDK</h1>
@@ -18,7 +18,7 @@
 
 The **Workflow SDK** lets you easily add durability, reliability, and observability to async JavaScript. Build apps and AI agents that can suspend, resume, and maintain state with ease.
 
-Visit [https://useworkflow.dev](https://useworkflow.dev) to view the full documentation.
+Visit [https://workflow-sdk.dev](https://workflow-sdk.dev) to view the full documentation.
 
 ## Community
 

--- a/skills/workflow-init/SKILL.md
+++ b/skills/workflow-init/SKILL.md
@@ -3,7 +3,7 @@ name: workflow-init
 description: Install and configure Vercel Workflow SDK before it exists in node_modules. Use when the user asks to "install workflow", "set up workflow", "add durable workflows", "configure workflow sdk", or "init workflow" for Next.js, Express, Hono, Fastify, NestJS, Nitro, Nuxt, Astro, SvelteKit, or Vite.
 metadata:
   author: Vercel Inc.
-  version: '1.1'
+  version: '1.2'
 ---
 
 # workflow-init
@@ -38,16 +38,16 @@ Fetch **exactly one** of these URLs and follow the guide step-by-step:
 
 | Framework | URL |
 |-----------|-----|
-| Next.js | https://useworkflow.dev/docs/getting-started/next |
-| Express | https://useworkflow.dev/docs/getting-started/express |
-| Hono | https://useworkflow.dev/docs/getting-started/hono |
-| Fastify | https://useworkflow.dev/docs/getting-started/fastify |
-| NestJS | https://useworkflow.dev/docs/getting-started/nestjs |
-| Nitro | https://useworkflow.dev/docs/getting-started/nitro |
-| Nuxt | https://useworkflow.dev/docs/getting-started/nuxt |
-| Astro | https://useworkflow.dev/docs/getting-started/astro |
-| SvelteKit | https://useworkflow.dev/docs/getting-started/sveltekit |
-| Vite | https://useworkflow.dev/docs/getting-started/vite |
+| Next.js | https://workflow-sdk.dev/docs/getting-started/next |
+| Express | https://workflow-sdk.dev/docs/getting-started/express |
+| Hono | https://workflow-sdk.dev/docs/getting-started/hono |
+| Fastify | https://workflow-sdk.dev/docs/getting-started/fastify |
+| NestJS | https://workflow-sdk.dev/docs/getting-started/nestjs |
+| Nitro | https://workflow-sdk.dev/docs/getting-started/nitro |
+| Nuxt | https://workflow-sdk.dev/docs/getting-started/nuxt |
+| Astro | https://workflow-sdk.dev/docs/getting-started/astro |
+| SvelteKit | https://workflow-sdk.dev/docs/getting-started/sveltekit |
+| Vite | https://workflow-sdk.dev/docs/getting-started/vite |
 
 Each guide covers: install deps, configure framework, create first workflow, create route handler, run + verify.
 
@@ -67,8 +67,8 @@ Then follow the "Create Your Project" section of the chosen guide.
 
 ## Concept questions (pre-install)
 If the user asks conceptual questions before installing, fetch:
-- https://useworkflow.dev/docs/foundations/workflows-and-steps
-- https://useworkflow.dev/docs/foundations/common-patterns
+- https://workflow-sdk.dev/docs/foundations/workflows-and-steps
+- https://workflow-sdk.dev/docs/foundations/common-patterns
 
 ## Handoff
 When setup is complete, tell the user: **Use `/workflow` for ongoing development** - it reads the versioned docs bundled in `node_modules/workflow/docs/`.

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -3,7 +3,7 @@ name: workflow
 description: Creates durable, resumable workflows using Vercel's Workflow SDK. Use when building workflows that need to survive restarts, pause for external events, retry on failure, or coordinate multi-step operations over time. Triggers on mentions of "workflow", "durable functions", "resumable", "workflow sdk", "queue", "event", "push", "subscribe", or step-based orchestration.
 metadata:
   author: Vercel Inc.
-  version: '1.7'
+  version: '1.8'
 ---
 
 ## *CRITICAL*: Always Use Correct `workflow` Documentation
@@ -38,7 +38,7 @@ Related packages also include bundled docs:
 
 ### Official Resources
 
-- **Website**: https://useworkflow.dev
+- **Website**: https://workflow-sdk.dev
 - **GitHub**: https://github.com/vercel/workflow
 
 ### Quick Reference

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,3 +1,3 @@
 # Workbench
 
-These apps are used for testing internally. Refer to [Workflow SDK Examples](https://useworkflow.dev/examples) to see some use cases and working examples.
+These apps are used for testing internally. Refer to [Workflow SDK Examples](https://workflow-sdk.dev/examples) to see some use cases and working examples.


### PR DESCRIPTION
## Summary

- Updates the X/Twitter social link from `@workflowdevkit` to `@workflowsdk`
- Renames "Workflow DevKit" / "Workflow Dev Kit" to "Workflow SDK" in docs and tweet wall
- Updates example config/test filenames from `workflowdevkit` to `workflowsdk` in the publishing libraries cookbook
- Replaces all 56 references to `useworkflow.dev` with `workflow-sdk.dev` across 36 files (source code, READMEs, skills, docs)
- Bumps skill versions for `workflow` (1.7 → 1.8) and `workflow-init` (1.1 → 1.2)