### PR TITLE
fix(docs): missing closing ] in code highlight annotation

### DIFF
--- a/docs/content/docs/ai/resumable-streams.mdx
+++ b/docs/content/docs/ai/resumable-streams.mdx
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
 
   return createUIMessageStreamResponse({
     stream: run.readable,
-    headers: { // [!code highlight
+    headers: { // [!code highlight]
       "x-workflow-run-id": run.runId, // [!code highlight]
     }, // [!code highlight]
   });


### PR DESCRIPTION
Fixes a missing closing `]` in the `[!code highlight]` annotation on the `headers: {` line of the first code sample in `/docs/ai/resumable-streams`.

**Before:**
```
headers: { // [!code highlight
```
**After:**
```
headers: { // [!code highlight]
```