### PR TITLE
Fix published package sourcemaps for npm consumers

### DIFF
--- a/.changeset/few-cups-share.md
+++ b/.changeset/few-cups-share.md
@@ -1,0 +1,25 @@
+---
+"@workflow/ai": patch
+"@workflow/astro": patch
+"@workflow/builders": patch
+"@workflow/cli": patch
+"@workflow/core": patch
+"@workflow/errors": patch
+"@workflow/next": patch
+"@workflow/nitro": patch
+"@workflow/nuxt": patch
+"@workflow/rollup": patch
+"@workflow/serde": patch
+"@workflow/sveltekit": patch
+"@workflow/typescript-plugin": patch
+"@workflow/utils": patch
+"@workflow/vite": patch
+"@workflow/vitest": patch
+"@workflow/world-local": patch
+"@workflow/world-postgres": patch
+"@workflow/world-testing": patch
+"@workflow/world-vercel": patch
+"workflow": patch
+---
+
+Embed source content in published sourcemaps.

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
-    "inlineSources": false,
+    "inlineSources": true,
     "isolatedModules": true,
     "moduleResolution": "node16",
     "noUnusedLocals": true,


### PR DESCRIPTION
# Fix published package sourcemaps for npm consumers

## Summary
Downstream Vite and Vitest users can currently hit warnings like `Sourcemap for ".../dist/*.js" points to missing source files` when `@workflow/*` packages are inlined during tests. The published packages were shipping sourcemaps that pointed at `../src/*.ts`, but the matching source files were not present in the npm tarball and the maps did not embed `sourcesContent`.

This left `workflow` in an unusable middle state for consumers: sourcemaps were published, but they were not self-contained and the referenced sources were absent.

## Root cause
The shared package TypeScript base config enabled `sourceMap`, but it set `inlineSources` to `false`. Packages that publish `dist/` without publishing `src/` therefore emitted `.js.map` files that referenced `../src/*.ts` paths with no embedded source content. Vite eagerly reads those maps, so it warns once per affected file.

## What changed
- Enabled `inlineSources` in `packages/tsconfig/base.json`.
- Kept the fix at the shared build layer so it applies consistently across the published packages that inherit this config.
- Left package `files` entries unchanged. The fix comes from making the published JavaScript sourcemaps self-contained rather than suppressing warnings in consumers or expanding npm tarballs to include every `src/` tree.
- Added a patch changeset for the published packages whose tarballs pick up this shared sourcemap change:
  `workflow`, `@workflow/ai`, `@workflow/astro`, `@workflow/builders`, `@workflow/cli`, `@workflow/core`, `@workflow/errors`, `@workflow/next`, `@workflow/nitro`, `@workflow/nuxt`, `@workflow/rollup`, `@workflow/serde`, `@workflow/sveltekit`, `@workflow/typescript-plugin`, `@workflow/utils`, `@workflow/vite`, `@workflow/vitest`, `@workflow/world-local`, `@workflow/world-postgres`, `@workflow/world-testing`, and `@workflow/world-vercel`.

Packages with existing inline JS sourcemaps such as `@workflow/core` and `workflow` keep that shape, but their embedded maps now also carry source content. Packages that ship external `.js.map` files such as `@workflow/builders`, `@workflow/rollup`, and `@workflow/vitest` now publish those maps with `sourcesContent`.

This follows the internal `vercel/ai` precedent of shipping usable sourcemaps to npm consumers instead of asking consumers to suppress warnings. Other Vercel OSS packages like `swr`, `serve`, and `@vercel/ncc` avoid this class of problem by not publishing sourcemaps at all. Since `workflow` already publishes sourcemaps, embedding source content is the narrowest fix that makes those published maps usable.

## Validation
Commands run:
- `pnpm --filter @workflow/core --filter @workflow/builders --filter @workflow/rollup --filter @workflow/vitest build`
- `pnpm --filter @workflow/utils --filter @workflow/errors --filter @workflow/world-local --filter @workflow/world-vercel --filter @workflow/serde build`
- `pnpm pack --pack-destination /tmp/workflow-pack` in `packages/core`, `packages/builders`, `packages/rollup`, and `packages/vitest`
- direct inspection of emitted `.map` files in `dist/` and packaged tarball contents under `/tmp/workflow-pack`
