### PR TITLE
docs: remove experimental labeling from @workflow/ai API references

### DIFF
--- a/docs/content/docs/api-reference/workflow-ai/durable-agent.mdx
+++ b/docs/content/docs/api-reference/workflow-ai/durable-agent.mdx
@@ -9,10 +9,6 @@ related:
   - /docs/ai/defining-tools
 ---
 
-<Callout type="warn">
-The `@workflow/ai` package is currently in active development and should be considered experimental.
-</Callout>
-
 The `DurableAgent` class enables you to create AI-powered agents that can maintain state across workflow steps, call tools, and gracefully handle interruptions and resumptions.
 
 Tool calls can be implemented as workflow steps for automatic retries, or as regular workflow-level logic utilizing core library features such as [`sleep()`](/docs/api-reference/workflow/sleep) and [Hooks](/docs/foundations/hooks).

--- a/docs/content/docs/api-reference/workflow-ai/index.mdx
+++ b/docs/content/docs/api-reference/workflow-ai/index.mdx
@@ -1,16 +1,11 @@
 ---
 title: "@workflow/ai"
-icon: FlaskConical
 description: Helpers for building AI-powered workflows with the AI SDK.
 type: overview
 summary: Explore helpers for integrating AI SDK to build durable AI-powered workflows.
 related:
   - /docs/ai
 ---
-
-<Callout type="warn">
-The `@workflow/ai` package is currently in active development and should be considered experimental.
-</Callout>
 
 Helpers for integrating AI SDK for building AI-powered workflows.
 

--- a/docs/content/docs/api-reference/workflow-ai/workflow-chat-transport.mdx
+++ b/docs/content/docs/api-reference/workflow-ai/workflow-chat-transport.mdx
@@ -9,10 +9,6 @@ related:
   - /docs/ai/resumable-streams
 ---
 
-<Callout type="warn">
-The `@workflow/ai` package is currently in active development and should be considered experimental.
-</Callout>
-
 A chat transport implementation for the AI SDK that provides reliable message streaming with automatic reconnection to interrupted streams. This transport is a drop-in replacement for the default AI SDK transport, enabling seamless recovery from network issues, page refreshes, or Vercel Function timeouts.
 
 <Callout>


### PR DESCRIPTION
## Summary
- remove the experimental warning callouts from the `@workflow/ai` API reference pages
- remove the beaker icon from the `@workflow/ai` API reference overview
- keep the actual `experimental_*` API names untouched where they are part of the public surface

## Testing
- not run (docs-only change)