### PR TITLE
Add Python SDK beta documentation page

### DIFF
--- a/docs/app/[lang]/(home)/components/frameworks.tsx
+++ b/docs/app/[lang]/(home)/components/frameworks.tsx
@@ -1,11 +1,11 @@
-"use client";
+'use client';
 
-import { track } from "@vercel/analytics";
-import Link from "next/link";
-import type { ComponentProps } from "react";
-import { toast } from "sonner";
+import { track } from '@vercel/analytics';
+import Link from 'next/link';
+import type { ComponentProps } from 'react';
+import { toast } from 'sonner';
 
-export const Express = (props: ComponentProps<"svg">) => (
+export const Express = (props: ComponentProps<'svg'>) => (
   <svg
     width="999"
     height="223"
@@ -22,7 +22,7 @@ export const Express = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const Fastify = (props: ComponentProps<"svg">) => (
+export const Fastify = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 1000 1000"
     fill="none"
@@ -37,7 +37,7 @@ export const Fastify = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const AstroDark = (props: ComponentProps<"svg">) => (
+export const AstroDark = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 85 107"
     fill="none"
@@ -78,7 +78,7 @@ export const AstroDark = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const AstroLight = (props: ComponentProps<"svg">) => (
+export const AstroLight = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 85 107"
     fill="none"
@@ -104,7 +104,7 @@ export const AstroLight = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const AstroGray = (props: ComponentProps<"svg">) => (
+export const AstroGray = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 85 107"
     fill="none"
@@ -130,7 +130,7 @@ export const AstroGray = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const TanStack = (props: ComponentProps<"svg">) => (
+export const TanStack = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 410 413"
     fill="none"
@@ -152,7 +152,7 @@ export const TanStack = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const TanStackGray = (props: ComponentProps<"svg">) => (
+export const TanStackGray = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 409 413"
     fill="none"
@@ -167,7 +167,7 @@ export const TanStackGray = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const Vite = (props: ComponentProps<"svg">) => (
+export const Vite = (props: ComponentProps<'svg'>) => (
   <svg
     width="410"
     height="404"
@@ -213,7 +213,7 @@ export const Vite = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const Nitro = (props: ComponentProps<"svg">) => (
+export const Nitro = (props: ComponentProps<'svg'>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
@@ -230,7 +230,7 @@ export const Nitro = (props: ComponentProps<"svg">) => (
       />
       <mask
         id="mask0_115_108"
-        style={{ maskType: "alpha" }}
+        style={{ maskType: 'alpha' }}
         maskUnits="userSpaceOnUse"
         x="0"
         y="0"
@@ -302,7 +302,7 @@ export const Nitro = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const SvelteKit = (props: ComponentProps<"svg">) => (
+export const SvelteKit = (props: ComponentProps<'svg'>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     xmlnsXlink="http://www.w3.org/1999/xlink"
@@ -325,7 +325,7 @@ export const SvelteKit = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const SvelteKitGray = (props: ComponentProps<"svg">) => (
+export const SvelteKitGray = (props: ComponentProps<'svg'>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     xmlnsXlink="http://www.w3.org/1999/xlink"
@@ -348,7 +348,7 @@ export const SvelteKitGray = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const Nuxt = (props: ComponentProps<"svg">) => (
+export const Nuxt = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 424 283"
     fill="none"
@@ -363,7 +363,7 @@ export const Nuxt = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const NuxtGray = (props: ComponentProps<"svg">) => (
+export const NuxtGray = (props: ComponentProps<'svg'>) => (
   <svg
     viewBox="0 0 424 283"
     fill="none"
@@ -378,7 +378,7 @@ export const NuxtGray = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const Hono = (props: ComponentProps<"svg">) => (
+export const Hono = (props: ComponentProps<'svg'>) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76 98" {...props}>
     <title>Hono</title>
     <path
@@ -395,7 +395,7 @@ export const Hono = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const HonoGray = (props: ComponentProps<"svg">) => (
+export const HonoGray = (props: ComponentProps<'svg'>) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76 98" {...props}>
     <title>Hono</title>
     <path
@@ -415,7 +415,7 @@ export const HonoGray = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const Bun = (props: ComponentProps<"svg">) => (
+export const Bun = (props: ComponentProps<'svg'>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     id="Bun"
@@ -449,7 +449,7 @@ export const Bun = (props: ComponentProps<"svg">) => (
         id="Top"
         d="M35.12,5.53A16.41,16.41,0,0,1,29.49,18c-.28.25-.06.73.3.59,3.37-1.31,7.92-5.23,6-13.14C35.71,5,35.12,5.12,35.12,5.53Zm2.27,0A16.24,16.24,0,0,1,39,19c-.12.35.31.65.55.36C41.74,16.56,43.65,11,37.93,5,37.64,4.74,37.19,5.14,37.39,5.49Zm2.76-.17A16.42,16.42,0,0,1,47,17.12a.33.33,0,0,0,.65.11c.92-3.49.4-9.44-7.17-12.53C40.08,4.54,39.82,5.08,40.15,5.32ZM21.69,15.76a16.94,16.94,0,0,0,10.47-9c.18-.36.75-.22.66.18-1.73,8-7.52,9.67-11.12,9.45C21.32,16.4,21.33,15.87,21.69,15.76Z"
         fill="#ccbea7"
-        style={{ fillRule: "evenodd" }}
+        style={{ fillRule: 'evenodd' }}
       />
       <path
         id="Outline"
@@ -504,19 +504,19 @@ export const Bun = (props: ComponentProps<"svg">) => (
       <path
         id="Eyes"
         d="M25.7,38.8a5.51,5.51,0,1,0-5.5-5.51A5.51,5.51,0,0,0,25.7,38.8Zm24.77,0A5.51,5.51,0,1,0,45,33.29,5.5,5.5,0,0,0,50.47,38.8Z"
-        style={{ fillRule: "evenodd" }}
+        style={{ fillRule: 'evenodd' }}
       />
       <path
         id="Iris"
         d="M24,33.64a2.07,2.07,0,1,0-2.06-2.07A2.07,2.07,0,0,0,24,33.64Zm24.77,0a2.07,2.07,0,1,0-2.06-2.07A2.07,2.07,0,0,0,48.75,33.64Z"
-        style={{ fillRule: "evenodd" }}
+        style={{ fillRule: 'evenodd' }}
         fill="#fff"
       />
     </g>
   </svg>
 );
 
-export const BunGray = (props: ComponentProps<"svg">) => (
+export const BunGray = (props: ComponentProps<'svg'>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     id="Bun"
@@ -553,7 +553,7 @@ export const BunGray = (props: ComponentProps<"svg">) => (
         id="Top"
         d="M35.12,5.53A16.41,16.41,0,0,1,29.49,18c-.28.25-.06.73.3.59,3.37-1.31,7.92-5.23,6-13.14C35.71,5,35.12,5.12,35.12,5.53Zm2.27,0A16.24,16.24,0,0,1,39,19c-.12.35.31.65.55.36C41.74,16.56,43.65,11,37.93,5,37.64,4.74,37.19,5.14,37.39,5.49Zm2.76-.17A16.42,16.42,0,0,1,47,17.12a.33.33,0,0,0,.65.11c.92-3.49.4-9.44-7.17-12.53C40.08,4.54,39.82,5.08,40.15,5.32ZM21.69,15.76a16.94,16.94,0,0,0,10.47-9c.18-.36.75-.22.66.18-1.73,8-7.52,9.67-11.12,9.45C21.32,16.4,21.33,15.87,21.69,15.76Z"
         fill="var(--color-background)"
-        style={{ fillRule: "evenodd" }}
+        style={{ fillRule: 'evenodd' }}
       />
       <path
         id="Outline"
@@ -615,20 +615,20 @@ export const BunGray = (props: ComponentProps<"svg">) => (
       <path
         id="Eyes"
         d="M25.7,38.8a5.51,5.51,0,1,0-5.5-5.51A5.51,5.51,0,0,0,25.7,38.8Zm24.77,0A5.51,5.51,0,1,0,45,33.29,5.5,5.5,0,0,0,50.47,38.8Z"
-        style={{ fillRule: "evenodd" }}
+        style={{ fillRule: 'evenodd' }}
         fill="var(--color-muted-foreground)"
       />
       <path
         id="Iris"
         d="M24,33.64a2.07,2.07,0,1,0-2.06-2.07A2.07,2.07,0,0,0,24,33.64Zm24.77,0a2.07,2.07,0,1,0-2.06-2.07A2.07,2.07,0,0,0,48.75,33.64Z"
-        style={{ fillRule: "evenodd" }}
+        style={{ fillRule: 'evenodd' }}
         fill="var(--color-background)"
       />
     </g>
   </svg>
 );
 
-export const Nest = (props: ComponentProps<"svg">) => (
+export const Nest = (props: ComponentProps<'svg'>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     id="NestJS"
@@ -644,7 +644,7 @@ export const Nest = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const NestGray = (props: ComponentProps<"svg">) => (
+export const NestGray = (props: ComponentProps<'svg'>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     id="NestJS"
@@ -660,7 +660,43 @@ export const NestGray = (props: ComponentProps<"svg">) => (
   </svg>
 );
 
-export const Next = (props: ComponentProps<"svg">) => (
+export const Python = (props: ComponentProps<'svg'>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 255" {...props}>
+    <title>Python</title>
+    <defs>
+      <linearGradient
+        id="pythonLogoA"
+        x1="12.959%"
+        x2="79.639%"
+        y1="12.039%"
+        y2="78.201%"
+      >
+        <stop offset="0%" stopColor="#387EB8" />
+        <stop offset="100%" stopColor="#366994" />
+      </linearGradient>
+      <linearGradient
+        id="pythonLogoB"
+        x1="19.128%"
+        x2="90.742%"
+        y1="20.579%"
+        y2="88.429%"
+      >
+        <stop offset="0%" stopColor="#FFE052" />
+        <stop offset="100%" stopColor="#FFC331" />
+      </linearGradient>
+    </defs>
+    <path
+      fill="url(#pythonLogoA)"
+      d="M126.916.072c-64.832 0-60.784 28.115-60.784 28.115l.072 29.128h61.868v8.745H41.631S.145 61.355.145 126.77c0 65.417 36.21 63.097 36.21 63.097h21.61v-30.356s-1.165-36.21 35.632-36.21h61.362s34.475.557 34.475-33.319V33.97S194.67.072 126.916.072zM92.802 19.66a11.12 11.12 0 0 1 11.13 11.13 11.12 11.12 0 0 1-11.13 11.13 11.12 11.12 0 0 1-11.13-11.13 11.12 11.12 0 0 1 11.13-11.13z"
+    />
+    <path
+      fill="url(#pythonLogoB)"
+      d="M128.757 254.126c64.832 0 60.784-28.115 60.784-28.115l-.072-29.127H127.6v-8.745h86.441s41.486 4.705 41.486-60.712c0-65.416-36.21-63.096-36.21-63.096h-21.61v30.355s1.165 36.21-35.632 36.21h-61.362s-34.475-.557-34.475 33.32v56.013s-5.235 33.897 62.518 33.897zm34.114-19.586a11.12 11.12 0 0 1-11.13-11.13 11.12 11.12 0 0 1 11.13-11.131 11.12 11.12 0 0 1 11.13 11.13 11.12 11.12 0 0 1-11.13 11.13z"
+    />
+  </svg>
+);
+
+export const Next = (props: ComponentProps<'svg'>) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" {...props}>
     <title>Next.js</title>
     <circle cx="64" cy="64" r="62" strokeWidth="4" className="stroke-border" />
@@ -700,10 +736,10 @@ export const Next = (props: ComponentProps<"svg">) => (
 
 export const Frameworks = () => {
   const handleRequest = () => {
-    track("Framework requested", { framework: "tanstack" });
-    toast.success("Request received", {
+    track('Framework requested', { framework: 'tanstack' });
+    toast.success('Request received', {
       description:
-        "Thanks for expressing interest in TanStack. We will be adding support for it soon.",
+        'Thanks for expressing interest in TanStack. We will be adding support for it soon.',
     });
   };
 

--- a/docs/components/geistdocs/sidebar.tsx
+++ b/docs/components/geistdocs/sidebar.tsx
@@ -115,16 +115,28 @@ export const Folder: SidebarPageTreeComponents['Folder'] = ({
   );
 };
 
-export const Item: SidebarPageTreeComponents['Item'] = ({ item }) => (
-  <SidebarItem
-    className="block w-full truncate text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground"
-    external={item.external}
-    href={item.url}
-    icon={item.icon}
-  >
-    {item.name}
-  </SidebarItem>
-);
+export const Item: SidebarPageTreeComponents['Item'] = ({ item }) => {
+  const badgeLabel = SIDEBAR_ITEM_BADGES[item.url];
+
+  return (
+    <SidebarItem
+      className="flex w-full items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground"
+      external={item.external}
+      href={item.url}
+      icon={item.icon}
+    >
+      <span className="truncate">{item.name}</span>
+      {badgeLabel ? (
+        <Badge
+          variant="secondary"
+          className="shrink-0 px-1.5 py-0 text-[10px] leading-4"
+        >
+          {badgeLabel}
+        </Badge>
+      ) : null}
+    </SidebarItem>
+  );
+};
 
 export const Separator: SidebarPageTreeComponents['Separator'] = ({ item }) => (
   <SidebarSeparator className="mt-4 mb-2 flex items-center gap-2 px-0 font-medium text-sm first-child:mt-0">

--- a/docs/components/geistdocs/sidebar.tsx
+++ b/docs/components/geistdocs/sidebar.tsx
@@ -24,10 +24,14 @@ import { Badge } from '@/components/ui/badge';
 import { useSidebarContext } from '@/hooks/geistdocs/use-sidebar';
 import { SearchButton } from './search';
 
-// Map of URLs to badges shown inline next to the sidebar item name.
-const SIDEBAR_ITEM_BADGES: Record<string, string> = {
-  '/docs/getting-started/python': 'Beta',
-};
+// Map of URL suffixes to badges shown inline next to the sidebar item name.
+const SIDEBAR_ITEM_BADGES: Array<{ suffix: string; label: string }> = [
+  { suffix: '/docs/getting-started/python', label: 'Beta' },
+];
+
+function getSidebarBadge(url: string): string | undefined {
+  return SIDEBAR_ITEM_BADGES.find((b) => url.endsWith(b.suffix))?.label;
+}
 
 export const Sidebar = () => {
   const { root } = useTreeContext();
@@ -116,7 +120,7 @@ export const Folder: SidebarPageTreeComponents['Folder'] = ({
 };
 
 export const Item: SidebarPageTreeComponents['Item'] = ({ item }) => {
-  const badgeLabel = SIDEBAR_ITEM_BADGES[item.url];
+  const badgeLabel = getSidebarBadge(item.url);
 
   return (
     <SidebarItem

--- a/docs/components/geistdocs/sidebar.tsx
+++ b/docs/components/geistdocs/sidebar.tsx
@@ -20,8 +20,14 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import { Badge } from '@/components/ui/badge';
 import { useSidebarContext } from '@/hooks/geistdocs/use-sidebar';
 import { SearchButton } from './search';
+
+// Map of URLs to badges shown inline next to the sidebar item name.
+const SIDEBAR_ITEM_BADGES: Record<string, string> = {
+  '/docs/getting-started/python': 'Beta',
+};
 
 export const Sidebar = () => {
   const { root } = useTreeContext();

--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -80,7 +80,7 @@ import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStac
     <Card href="/docs/getting-started/python">
       <div className="flex flex-col items-center justify-center gap-2">
         <Python className="size-16" />
-        <span className="font-medium">Python SDK</span>
+        <span className="font-medium">Python</span>
         <Badge variant="secondary">Beta</Badge>
       </div>
     </Card>

--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -63,6 +63,13 @@ import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStac
         <span className="font-medium">SvelteKit</span>
      </div>
     </Card>
+    <Card href="/docs/getting-started/python">
+      <div className="flex flex-col items-center justify-center gap-2">
+        <Python className="size-16" />
+        <span className="font-medium">Python</span>
+        <Badge variant="secondary">Beta</Badge>
+      </div>
+    </Card>
     <Card className="opacity-50">
       <div className="flex flex-col items-center justify-center gap-2">
         <Nest className="size-16 dark:invert grayscale" />
@@ -75,13 +82,6 @@ import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStac
         <TanStack className="size-16 dark:invert grayscale" />
         <span className="font-medium">TanStack Start</span>
         <Badge variant="secondary">Coming soon</Badge>
-      </div>
-    </Card>
-    <Card href="/docs/getting-started/python">
-      <div className="flex flex-col items-center justify-center gap-2">
-        <Python className="size-16" />
-        <span className="font-medium">Python</span>
-        <Badge variant="secondary">Beta</Badge>
       </div>
     </Card>
 </Cards>

--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -11,13 +11,6 @@ related:
 import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStack, Vite, Express, Nest, Fastify, Python } from "@/app/[lang]/(home)/components/frameworks";
 
 <Cards>
-    <Card href="/docs/getting-started/python">
-      <div className="flex flex-col items-center justify-center gap-2">
-        <Python className="size-16" />
-        <span className="font-medium">Python SDK</span>
-        <Badge variant="secondary">Beta</Badge>
-      </div>
-    </Card>
     <Card href="/docs/getting-started/next">
       <div  className="flex flex-col items-center justify-center gap-2"> <Next className="size-16" /> <span className="font-medium">Next.js</span> </div>
     </Card>
@@ -82,6 +75,13 @@ import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStac
         <TanStack className="size-16 dark:invert grayscale" />
         <span className="font-medium">TanStack Start</span>
         <Badge variant="secondary">Coming soon</Badge>
+      </div>
+    </Card>
+    <Card href="/docs/getting-started/python">
+      <div className="flex flex-col items-center justify-center gap-2">
+        <Python className="size-16" />
+        <span className="font-medium">Python SDK</span>
+        <Badge variant="secondary">Beta</Badge>
       </div>
     </Card>
 </Cards>

--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -8,9 +8,16 @@ related:
   - /docs/foundations/workflows-and-steps
 ---
 
-import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStack, Vite, Express, Nest, Fastify } from "@/app/[lang]/(home)/components/frameworks";
+import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStack, Vite, Express, Nest, Fastify, Python } from "@/app/[lang]/(home)/components/frameworks";
 
 <Cards>
+    <Card href="/docs/getting-started/python">
+      <div className="flex flex-col items-center justify-center gap-2">
+        <Python className="size-16" />
+        <span className="font-medium">Python SDK</span>
+        <Badge variant="secondary">Beta</Badge>
+      </div>
+    </Card>
     <Card href="/docs/getting-started/next">
       <div  className="flex flex-col items-center justify-center gap-2"> <Next className="size-16" /> <span className="font-medium">Next.js</span> </div>
     </Card>

--- a/docs/content/docs/getting-started/meta.json
+++ b/docs/content/docs/getting-started/meta.json
@@ -9,7 +9,8 @@
     "nitro",
     "nuxt",
     "sveltekit",
-    "vite"
+    "vite",
+    "python"
   ],
   "defaultOpen": true
 }

--- a/docs/content/docs/getting-started/python.mdx
+++ b/docs/content/docs/getting-started/python.mdx
@@ -11,7 +11,7 @@ related:
 ---
 
 <Callout type="warn">
-The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python).
+The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python?language=py).
 </Callout>
 
 You can build durable workflows in Python using the [`vercel` Python SDK](https://pypi.org/project/vercel/). Your workflow code can pause, resume, and maintain state, just like the JavaScript and TypeScript Workflow SDK.

--- a/docs/content/docs/getting-started/python.mdx
+++ b/docs/content/docs/getting-started/python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python
-description: Get started with the Vercel Workflow Python SDK for building durable, long-running workflows.
+description: Get started with the Workflow Python SDK for building durable, long-running workflows.
 type: guide
 summary: Set up the Workflow Python SDK in your Python application.
 prerequisites:
@@ -14,7 +14,7 @@ related:
 The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/concepts?language=py).
 </Callout>
 
-The Vercel Workflow Python SDK brings durable, long-running workflows to Python applications. Using `@wf.workflow` and `@wf.step` decorators, you can build workflows that survive restarts, pause for external events, and coordinate multi-step logic over time.
+The Workflow Python SDK brings durable, long-running workflows to Python applications. Using `@wf.workflow` and `@wf.step` decorators, you can build workflows that survive restarts, pause for external events, and coordinate multi-step logic over time.
 
 ## Core Concepts
 

--- a/docs/content/docs/getting-started/python.mdx
+++ b/docs/content/docs/getting-started/python.mdx
@@ -1,0 +1,156 @@
+---
+title: Python SDK
+description: Get started with the Vercel Workflow Python SDK for building durable, long-running workflows.
+type: guide
+summary: Set up the Workflow Python SDK in your Python application.
+prerequisites:
+  - /docs/getting-started
+related:
+  - /docs/foundations
+  - /docs/foundations/workflows-and-steps
+---
+
+<Callout type="warn">
+The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/concepts?language=py).
+</Callout>
+
+The Vercel Workflow Python SDK brings durable, long-running workflows to Python applications. Using `@wf.workflow` and `@wf.step` decorators, you can build workflows that survive restarts, pause for external events, and coordinate multi-step logic over time.
+
+## Core Concepts
+
+### Workflow
+
+A workflow is a stateful function that coordinates multi-step logic over time. In Python, the `@wf.workflow` decorator marks a function as durable.
+
+Use a workflow when your logic needs to pause, resume, or span minutes to months:
+
+```python
+from vercel import workflow
+
+wf = workflow.Workflows()
+
+@wf.workflow
+async def ai_content_workflow(*, topic: str):
+    draft = await generate_draft(topic=topic)
+    summary = await summarize_draft(draft=draft)
+
+    return {
+        "draft": draft,
+        "summary": summary,
+    }
+```
+
+Under the hood, the workflow compiles into a route that orchestrates execution. All inputs and outputs are recorded in an event log. If a deploy or crash happens, the system replays execution deterministically from where it stopped.
+
+### Step
+
+A step is a stateless function that runs a unit of durable work inside a workflow. In Python, the `@wf.step` decorator marks a function as a step.
+
+Use a step when calling external APIs or performing isolated operations:
+
+```python
+import random
+from app.workflow import wf
+
+@wf.step
+async def generate_draft(*, topic: str):
+    return await ai_generate(prompt=f"Write a blog post about {topic}")
+
+@wf.step
+async def summarize_draft(*, draft: str):
+    summary = await ai_summarize(text=draft)
+
+    # Simulate a transient error. The step automatically retries.
+    if random.random() < 0.3:
+        raise Exception("Transient AI provider error")
+
+    return summary
+```
+
+Each step compiles into an isolated route. While the step executes, the workflow suspends without consuming resources. When the step completes, the workflow resumes automatically where it left off.
+
+### Sleep
+
+Sleep pauses a workflow for a specified duration without consuming compute resources. Use it when you need to wait for hours or days before continuing, such as sending a follow-up email or delaying a reward.
+
+```python
+from vercel import workflow
+from app.workflow import wf
+
+@wf.workflow
+async def ai_refine_workflow(*, draft_id: str):
+    draft = await fetch_draft(draft_id)
+
+    await workflow.sleep("7 days")  # Wait 7 days to gather more signals.
+
+    refined = await refine_draft(draft)
+
+    return {
+        "draft_id": draft_id,
+        "refined": refined,
+    }
+```
+
+The sleep call pauses the workflow and consumes no resources. The workflow resumes automatically when the time expires.
+
+### Hook
+
+A hook lets a workflow wait for external events such as user actions, webhooks, or third-party API responses. This is useful for human-in-the-loop workflows where you need to pause until someone approves, confirms, or provides input.
+
+```python
+import typing
+from pydantic import BaseModel
+from vercel import workflow
+from app.workflow import wf
+
+class Approval(BaseModel, workflow.BaseHook):
+    """Human approval for AI-generated drafts"""
+
+    decision: typing.Literal["approved", "changes"]
+    notes: str | None = None
+
+@wf.workflow
+async def ai_approval_workflow(*, topic: str):
+    draft = await generate_draft(topic=topic)
+
+    # Wait for human approval events
+    async for event in Approval.wait(token="draft-123"):
+        if event.decision == "approved":
+            await publish_draft(draft)
+            break
+
+        revised = await refine_draft(draft, event.notes)
+        await publish_draft(revised)
+```
+
+Resume the workflow when data arrives:
+
+```python
+from fastapi import FastAPI
+from app.workflows.approval import Approval
+
+app = FastAPI()
+
+@app.post("/api/resume")
+async def resume(approval: Approval):
+    """Resume the workflow when an approval is received"""
+
+    await approval.resume("draft-123")
+    return {"ok": True}
+```
+
+When a hook receives data, the workflow resumes automatically. You don&apos;t need polling, message queues, or manual state management.
+
+### Skew Protection
+
+Skew protection keeps a workflow run pinned to the deployment where it started. That means you can ship newer versions of your workflow code without changing the logic for runs that are already in progress.
+
+## Learn More
+
+For comprehensive documentation, examples, and the latest updates, visit the [official Vercel Workflow documentation](https://vercel.com/docs/workflow/concepts?language=py).
+
+## Next Steps
+
+- Learn more about the [Foundations](/docs/foundations).
+- Check [Errors](/docs/errors) if you encounter issues.
+- Explore the [API Reference](/docs/api-reference).

--- a/docs/content/docs/getting-started/python.mdx
+++ b/docs/content/docs/getting-started/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Python SDK
+title: Python
 description: Get started with the Vercel Workflow Python SDK for building durable, long-running workflows.
 type: guide
 summary: Set up the Workflow Python SDK in your Python application.

--- a/docs/content/docs/getting-started/python.mdx
+++ b/docs/content/docs/getting-started/python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python
-description: Get started with the Workflow Python SDK for building durable, long-running workflows.
+description: Build durable workflows and AI agents in Python with the Vercel SDK.
 type: guide
 summary: Set up the Workflow Python SDK in your Python application.
 prerequisites:
@@ -11,23 +11,45 @@ related:
 ---
 
 <Callout type="warn">
-The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/concepts?language=py).
+The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python).
 </Callout>
 
-The Workflow Python SDK brings durable, long-running workflows to Python applications. Using `@wf.workflow` and `@wf.step` decorators, you can build workflows that survive restarts, pause for external events, and coordinate multi-step logic over time.
+You can build durable workflows in Python using the [`vercel` Python SDK](https://pypi.org/project/vercel/). Your workflow code can pause, resume, and maintain state, just like the JavaScript and TypeScript Workflow SDK.
 
-## Core Concepts
+## Getting Started
 
-### Workflow
+Install the `vercel` package:
 
-A workflow is a stateful function that coordinates multi-step logic over time. In Python, the `@wf.workflow` decorator marks a function as durable.
+```bash filename="Terminal"
+pip install vercel
+```
 
-Use a workflow when your logic needs to pause, resume, or span minutes to months:
+Configure `experimentalServices` in your `vercel.json`:
 
-```python
+```json filename="vercel.json"
+{
+  "experimentalServices": {
+    "ai_content_workflow": {
+      "type": "worker",
+      "entrypoint": "app/workflows/ai_content_workflow.py",
+      "topics": ["__wkf_*"]
+    }
+  }
+}
+```
+
+## Workflows
+
+A workflow is a stateful function that coordinates multi-step logic over time. Create a `Workflows` instance and use the `@wf.workflow` decorator to mark a function as durable:
+
+```python filename="app/workflow.py" {3}
 from vercel import workflow
 
 wf = workflow.Workflows()
+```
+
+```python filename="app/workflows/ai_content_workflow.py" {3}
+from app.workflow import wf
 
 @wf.workflow
 async def ai_content_workflow(*, topic: str):
@@ -42,13 +64,11 @@ async def ai_content_workflow(*, topic: str):
 
 Under the hood, the workflow compiles into a route that orchestrates execution. All inputs and outputs are recorded in an event log. If a deploy or crash happens, the system replays execution deterministically from where it stopped.
 
-### Step
+## Steps
 
-A step is a stateless function that runs a unit of durable work inside a workflow. In Python, the `@wf.step` decorator marks a function as a step.
+A step is a stateless function that runs a unit of durable work inside a workflow. Use `@wf.step` to mark a function as a step:
 
-Use a step when calling external APIs or performing isolated operations:
-
-```python
+```python filename="app/steps/generate_draft.py" {4,8}
 import random
 from app.workflow import wf
 
@@ -69,13 +89,12 @@ async def summarize_draft(*, draft: str):
 
 Each step compiles into an isolated route. While the step executes, the workflow suspends without consuming resources. When the step completes, the workflow resumes automatically where it left off.
 
-### Sleep
+## Sleep
 
-Sleep pauses a workflow for a specified duration without consuming compute resources. Use it when you need to wait for hours or days before continuing, such as sending a follow-up email or delaying a reward.
+Sleep pauses a workflow for a specified duration without consuming compute resources:
 
-```python
+```python filename="app/workflows/ai_refine.py" {7}
 from vercel import workflow
-from app.workflow import wf
 
 @wf.workflow
 async def ai_refine_workflow(*, draft_id: str):
@@ -93,20 +112,19 @@ async def ai_refine_workflow(*, draft_id: str):
 
 The sleep call pauses the workflow and consumes no resources. The workflow resumes automatically when the time expires.
 
-### Hook
+## Hooks
 
-A hook lets a workflow wait for external events such as user actions, webhooks, or third-party API responses. This is useful for human-in-the-loop workflows where you need to pause until someone approves, confirms, or provides input.
+A hook lets a workflow wait for external events such as user actions, webhooks, or third-party API responses.
 
-```python
-import typing
-from pydantic import BaseModel
+Define a hook model with Pydantic and `workflow.BaseHook`:
+
+```python filename="app/workflows/approval.py" {3,14}
 from vercel import workflow
-from app.workflow import wf
 
 class Approval(BaseModel, workflow.BaseHook):
     """Human approval for AI-generated drafts"""
 
-    decision: typing.Literal["approved", "changes"]
+    decision: Literal["approved", "changes"]
     notes: str | None = None
 
 @wf.workflow
@@ -125,12 +143,7 @@ async def ai_approval_workflow(*, topic: str):
 
 Resume the workflow when data arrives:
 
-```python
-from fastapi import FastAPI
-from app.workflows.approval import Approval
-
-app = FastAPI()
-
+```python filename="app/api/resume.py" {5}
 @app.post("/api/resume")
 async def resume(approval: Approval):
     """Resume the workflow when an approval is received"""
@@ -141,13 +154,9 @@ async def resume(approval: Approval):
 
 When a hook receives data, the workflow resumes automatically. You don&apos;t need polling, message queues, or manual state management.
 
-### Skew Protection
-
-Skew protection keeps a workflow run pinned to the deployment where it started. That means you can ship newer versions of your workflow code without changing the logic for runs that are already in progress.
-
 ## Learn More
 
-For comprehensive documentation, examples, and the latest updates, visit the [official Vercel Workflow documentation](https://vercel.com/docs/workflow/concepts?language=py).
+For comprehensive documentation, examples, and the latest updates, visit the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python).
 
 ## Next Steps
 


### PR DESCRIPTION
Adds a dedicated Python SDK page to the Getting Started section of the docs, as discussed for the launch.

### What changed
- Created `/docs/getting-started/python.mdx` with content sourced from [vercel.com/docs/workflow/concepts](https://vercel.com/docs/workflow/concepts?language=py)
- Added a prominent beta warning callout at the top of the page
- Added a "Beta" badge pill to the Python SDK card in the Getting Started index
- Created a Python logo SVG icon and exported it from the frameworks component
- Positioned the Python SDK card first in the Getting Started grid to highlight it

The page covers core concepts (Workflow, Step, Sleep, Hook, Skew Protection) with Python code samples and links back to the official Vercel docs.

<a href="https://vercel.slack.com/archives/C0AG7R4PU22/p1776354109663229?thread_ts=1776354109.663229&cid=C0AG7R4PU22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>