### PR TITLE
[web] Probe deployment specVersion before replaying run

### DIFF
--- a/.changeset/replay-specversion-probe.md
+++ b/.changeset/replay-specversion-probe.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Replay/Re-run probes the target deployment's specVersion via health check before recreating the run, so the correct queue transport (JSON for old deployments, CBOR for new) is used. Falls back to the original run's specVersion if the probe fails.

--- a/packages/web/app/server/workflow-server-actions.server.ts
+++ b/packages/web/app/server/workflow-server-actions.server.ts
@@ -815,11 +815,35 @@ export async function recreateRun(
 ): Promise<ServerActionResult<string>> {
   try {
     const world = await getWorldFromEnv({ ...worldEnv });
+
+    // Probe the target deployment's specVersion via health check so we use
+    // the correct queue transport (JSON for old deployments, CBOR for new).
+    // Falls back to the run's specVersion inside recreateRunFromExisting
+    // if the probe fails (e.g. old deployment without health check support).
+    let specVersion: number | undefined;
+    try {
+      let targetDeploymentId = deploymentId;
+      if (!targetDeploymentId) {
+        const run = await world.runs.get(runId, { resolveData: 'none' });
+        targetDeploymentId = run.deploymentId;
+      }
+      const hc = await healthCheck(world, 'workflow', {
+        deploymentId: targetDeploymentId,
+        timeout: 10_000,
+      });
+      if (hc.healthy && hc.specVersion != null) {
+        specVersion = hc.specVersion;
+      }
+    } catch {
+      // Health check failed — fall back to run's specVersion.
+    }
+
     const newRunId = await workflowRunHelpers.recreateRunFromExisting(
       world,
       runId,
       {
         deploymentId,
+        specVersion,
       }
     );
     return createResponse(newRunId);


### PR DESCRIPTION
## Summary

Follows #1629 and #1627. The web dashboard's Replay / Re-run flow now probes the target deployment's specVersion via health check before calling `recreateRunFromExisting`, so the correct queue transport (JSON for old deployments, CBOR for new) is used.

Without this, the transport was chosen based on the **original run's** specVersion, which mismatches the target deployment when the deployment has been upgraded past that spec.

- Resolves the deployment ID (override, or the run's current deployment) and sends a `healthCheck(world, 'workflow', { deploymentId, timeout: 10_000 })`
- On healthy response with `specVersion`, passes it to `recreateRunFromExisting`
- On probe failure (e.g. old deployment without health check support), falls back to the run's `specVersion` inside `recreateRunFromExisting`

## Test plan

- [ ] e2e: replay a specVersion 2 run → probe reports specVersion 2 → JSON transport used
- [ ] e2e: replay against a deployment upgraded to specVersion 3 → probe reports 3 → CBOR transport used
- [ ] e2e: probe timeout / old deployment without health check → falls back to run's specVersion

🤖 Generated with [Claude Code](https://claude.com/claude-code)