### PR TITLE
[ci] Skip community world E2E tests on main

### DIFF
--- a/.changeset/skip-community-worlds-main.md
+++ b/.changeset/skip-community-worlds-main.md
@@ -1,0 +1,4 @@
+---
+---
+
+Disable community world E2E jobs on `main` CI and drop them from the required checks. Community worlds target an older spec version and don't yet support the CBOR queue transport; they continue to run on `stable`.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -671,10 +671,15 @@ jobs:
           if-no-files-found: ignore
 
   # Community World E2E Tests (dynamically generated from worlds-manifest.json)
+  # Disabled on main: community worlds target spec v2 and do not yet support the
+  # CBOR queue transport used by world-vercel (see #1627 / #1658). They continue
+  # to run on `stable`, where spec v2 is still the primary compat target. Once
+  # the community worlds (mizzle-dev/workflow-worlds) ship CBOR support we can
+  # re-enable these jobs here.
   getCommunityWorldsMatrix:
     name: Get Community Worlds Matrix
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: false
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -693,7 +698,7 @@ jobs:
 
   e2e-community:
     name: E2E Community World (${{ matrix.world.name }})
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: false
     needs: getCommunityWorldsMatrix
     strategy:
       fail-fast: false
@@ -712,7 +717,7 @@ jobs:
   summary:
     name: E2E Summary
     runs-on: ubuntu-latest
-    needs: [e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows, e2e-community]
+    needs: [e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows]
     if: always() && !cancelled()
     timeout-minutes: 10
 
@@ -744,26 +749,17 @@ jobs:
           LOCAL_PROD_STATUS="${{ needs.e2e-local-prod.result }}"
           POSTGRES_STATUS="${{ needs.e2e-local-postgres.result }}"
           WINDOWS_STATUS="${{ needs.e2e-windows.result }}"
-          COMMUNITY_STATUS="${{ needs.e2e-community.result }}"
 
           echo "vercel=$VERCEL_STATUS" >> $GITHUB_OUTPUT
           echo "local-dev=$LOCAL_DEV_STATUS" >> $GITHUB_OUTPUT
           echo "local-prod=$LOCAL_PROD_STATUS" >> $GITHUB_OUTPUT
           echo "postgres=$POSTGRES_STATUS" >> $GITHUB_OUTPUT
           echo "windows=$WINDOWS_STATUS" >> $GITHUB_OUTPUT
-          echo "community=$COMMUNITY_STATUS" >> $GITHUB_OUTPUT
 
-          # Community world failures are warnings, not errors
           if [[ "$VERCEL_STATUS" == "failure" || "$LOCAL_DEV_STATUS" == "failure" || "$LOCAL_PROD_STATUS" == "failure" || "$POSTGRES_STATUS" == "failure" || "$WINDOWS_STATUS" == "failure" ]]; then
             echo "has_failures=true" >> $GITHUB_OUTPUT
           else
             echo "has_failures=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "$COMMUNITY_STATUS" == "failure" ]]; then
-            echo "has_warnings=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_warnings=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Update PR comment with results
@@ -791,25 +787,12 @@ jobs:
 
             Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
-      - name: Append community warning to PR comment
-        if: github.event_name == 'pull_request' && steps.check-status.outputs.has_warnings == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: e2e-test-results
-          append: true
-          message: |
-
-            ---
-            ⚠️ **Community world tests failed** (non-blocking):
-            - Community Worlds: ${{ needs.e2e-community.result }}
-
-            Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
-
-  # Final required check: passes only when unit + all E2E jobs succeed
+  # Final required check: passes only when unit + all E2E jobs succeed.
+  # Community worlds are intentionally excluded — they are disabled on main.
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows, e2e-community]
+    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows]
     if: always()
     timeout-minutes: 5
 
@@ -822,7 +805,6 @@ jobs:
           LOCAL_PROD_STATUS: ${{ needs.e2e-local-prod.result }}
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
           WINDOWS_STATUS: ${{ needs.e2e-windows.result }}
-          COMMUNITY_STATUS: ${{ needs.e2e-community.result }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
         run: |
           FAILED_JOBS=()
@@ -839,7 +821,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "skipped" ]] || echo "Warning: e2e-local-prod was not skipped ($LOCAL_PROD_STATUS)"
             [[ "$POSTGRES_STATUS" == "skipped" ]] || echo "Warning: e2e-local-postgres was not skipped ($POSTGRES_STATUS)"
             [[ "$WINDOWS_STATUS" == "skipped" ]] || echo "Warning: e2e-windows was not skipped ($WINDOWS_STATUS)"
-            [[ "$COMMUNITY_STATUS" == "skipped" ]] || echo "Warning: e2e-community was not skipped ($COMMUNITY_STATUS)"
           else
             echo "Standard PR - checking all jobs"
             [[ "$UNIT_STATUS" == "success" ]] || FAILED_JOBS+=("unit ($UNIT_STATUS)")
@@ -848,7 +829,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")
             [[ "$WINDOWS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-windows ($WINDOWS_STATUS)")
-            [[ "$COMMUNITY_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-community ($COMMUNITY_STATUS)")
           fi
 
           if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then


### PR DESCRIPTION
Until community worlds support the new stream interface, AND we have a way of detecting that support somehow, community worlds won't run on v5, so we shouldn't require the checks to pass (or run them)