### PR TITLE
[ci] Remove community world E2E from required checks on stable

### DIFF
--- a/.changeset/unrequire-community-worlds-stable.md
+++ b/.changeset/unrequire-community-worlds-stable.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove `e2e-community` from the list of required CI checks. The job still runs and posts a warning on failure, but no longer blocks merges on `stable` — community worlds are maintained externally, so cross-repo breakage shouldn't gate the release branch.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -806,11 +806,14 @@ jobs:
 
             Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
-  # Final required check: passes only when unit + all E2E jobs succeed
+  # Final required check: passes only when unit + all E2E jobs succeed.
+  # Community world E2E still runs (see summary job above) but is reported as a
+  # warning rather than required — those worlds are maintained externally and
+  # we don't want cross-repo breakage to block merges here.
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows, e2e-community]
+    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows]
     if: always()
     timeout-minutes: 5
 
@@ -823,7 +826,6 @@ jobs:
           LOCAL_PROD_STATUS: ${{ needs.e2e-local-prod.result }}
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
           WINDOWS_STATUS: ${{ needs.e2e-windows.result }}
-          COMMUNITY_STATUS: ${{ needs.e2e-community.result }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
         run: |
           FAILED_JOBS=()
@@ -840,7 +842,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "skipped" ]] || echo "Warning: e2e-local-prod was not skipped ($LOCAL_PROD_STATUS)"
             [[ "$POSTGRES_STATUS" == "skipped" ]] || echo "Warning: e2e-local-postgres was not skipped ($POSTGRES_STATUS)"
             [[ "$WINDOWS_STATUS" == "skipped" ]] || echo "Warning: e2e-windows was not skipped ($WINDOWS_STATUS)"
-            [[ "$COMMUNITY_STATUS" == "skipped" ]] || echo "Warning: e2e-community was not skipped ($COMMUNITY_STATUS)"
           else
             echo "Standard PR - checking all jobs"
             [[ "$UNIT_STATUS" == "success" ]] || FAILED_JOBS+=("unit ($UNIT_STATUS)")
@@ -849,7 +850,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")
             [[ "$WINDOWS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-windows ($WINDOWS_STATUS)")
-            [[ "$COMMUNITY_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-community ($COMMUNITY_STATUS)")
           fi
 
           if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Community world E2E (turso, mongodb, redis) still runs on \`stable\` and is reported in the PR comment, but it is no longer blocking the \`e2e-required-check\` job.

- Keeps the \`e2e-community\` job and the \"Community world tests failed (non-blocking)\" warning in the summary comment.
- Drops \`e2e-community\` from \`e2e-required-check\`'s \`needs:\` list and from its status script.
- Matches the direction in the companion \`main\` PR, where community worlds are disabled entirely on that branch pending upstream CBOR support in [mizzle-dev/workflow-worlds](https://github.com/mizzle-dev/workflow-worlds).

## Test plan

- [ ] CI on this PR: community world job runs to completion, its result doesn't gate \`E2E Required Check\`.
- [ ] After merge, branch protection on \`stable\` will need the \`e2e-community (…)\` entries removed from the required checks list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)