### PR TITLE
[docs] Restore minimal Next.js placeholder on stable

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,7 @@
   "baseBranch": "stable",
   "updateInternalDependencies": "patch",
   "ignore": [
+    "docs",
     "nextjs-turbopack",
     "nextjs-webpack",
     "workflow-sdk-compiler-playground",

--- a/.changeset/evil-taxes-bathe.md
+++ b/.changeset/evil-taxes-bathe.md
@@ -1,0 +1,4 @@
+---
+---
+
+Restore a minimal `docs/` Next.js placeholder on `stable` so the Vercel docs deploy check passes and per-deployment SDK tarballs (used for pre-release testing on backport PRs) are published.

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -1,7 +1,8 @@
-# The docs/ directory does not exist on the stable branch.
-# Docs are deployed only from main. This workflow is kept as a
-# no-op on stable so that any branch protection rules referencing
-# these job names still pass.
+# On stable, docs/ is a minimal placeholder that only builds a
+# blank Next.js app and packs per-deployment SDK tarballs. The real
+# docs site is deployed from main. This workflow is kept as a no-op
+# on stable so that any branch protection rules referencing these
+# job names still pass.
 name: Docs Checks
 
 on:

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+.next
+next-env.d.ts
+public
+.turbo

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# docs (stable branch)
+
+This is a minimal placeholder Next.js app that lives on the `stable` branch
+only. The real docs site is maintained on `main` and deployed from there.
+
+The purpose of the stub is twofold:
+
+1. Keep the `Vercel – workflow-docs` deploy check green on PRs targeting
+   `stable` (the Vercel project has `docs/` as its root directory).
+2. Keep the `prebuild` pack script (`scripts/pack.ts`), which publishes
+   per-deployment package tarballs under the preview URL so that pre-release
+   builds of the SDK can be installed against backport PRs for testing.
+
+`docs/content/` is the canonical markdown bundled into npm packages via their
+`prepack` scripts — do not remove it.
+
+Do not grow this stub into a real app. The backport workflow auto-resolves any
+cherry-pick conflict under `docs/` (outside `docs/content/`) by deleting the
+conflicting file, so files here are disposable by design.

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1,0 +1,17 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>Workflow SDK</h1>
+      <p>
+        The docs site is built from the <code>main</code> branch. This page
+        exists on the <code>stable</code> branch only so that Vercel preview
+        builds succeed and pre-release package tarballs are published alongside
+        the deployment.
+      </p>
+      <p>
+        Visit <a href="https://workflow-sdk.dev">workflow-sdk.dev</a> for
+        documentation.
+      </p>
+    </main>
+  );
+}

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const config = {
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+};
+
+export default config;

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,13 +9,13 @@
   },
   "dependencies": {
     "next": "16.2.1",
-    "react": "^19.2.1",
-    "react-dom": "^19.2.1"
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@types/react": "^19.2.7",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "19.1.13",
+    "@types/react-dom": "19.1.9",
     "typescript": "catalog:"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "docs",
+  "version": "4.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "next build",
+    "prebuild": "node scripts/pack.ts"
+  },
+  "dependencies": {
+    "next": "16.2.1",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "catalog:"
+  }
+}

--- a/docs/scripts/pack.ts
+++ b/docs/scripts/pack.ts
@@ -1,0 +1,120 @@
+import cp from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const exec = promisify(cp.exec);
+
+interface PackageJson {
+  name: string;
+  version: string;
+  private?: boolean;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+const rootDir = fileURLToPath(new URL('../../', import.meta.url));
+const packagesDir = path.join(rootDir, 'packages');
+const outDir = fileURLToPath(new URL('../public', import.meta.url));
+
+async function main() {
+  const sha = await getSha();
+
+  // Ensure output directory exists
+  await fs.mkdir(outDir, { recursive: true });
+
+  // Scan the packages directory for all packages
+  const packageDirs = await fs.readdir(packagesDir);
+  const packages: Array<{
+    name: string;
+    dir: string;
+    packageJson: PackageJson;
+  }> = [];
+
+  for (const packageDir of packageDirs) {
+    const dir = path.join(packagesDir, packageDir);
+    const packageJsonPath = path.join(dir, 'package.json');
+
+    try {
+      const stat = await fs.stat(packageJsonPath);
+      if (!stat.isFile()) continue;
+    } catch {
+      continue; // Skip directories without package.json
+    }
+
+    const packageJsonContent = await fs.readFile(packageJsonPath, 'utf8');
+    const packageJson: PackageJson = JSON.parse(packageJsonContent);
+
+    // Skip private packages
+    if (packageJson.private) continue;
+
+    packages.push({ name: packageJson.name, dir, packageJson });
+  }
+
+  // Create a set of all package names for dependency resolution
+  const packageNames = new Set(packages.map((p) => p.name));
+
+  for (const { name, dir, packageJson } of packages) {
+    const packageJsonPath = path.join(dir, 'package.json');
+    const originalPackageJson = JSON.stringify(packageJson, null, 2);
+
+    // Create modified package.json with preview version
+    const modifiedPackageJson: PackageJson = JSON.parse(originalPackageJson);
+    modifiedPackageJson.version += `-${sha}`;
+
+    // Update workspace dependencies to use preview tarball URLs
+    const updateDeps = (deps: Record<string, string> | undefined) => {
+      if (!deps) return;
+      for (const depName of Object.keys(deps)) {
+        if (packageNames.has(depName)) {
+          const escapedName = depName.replace(/^@(.+)\//, '$1-');
+          deps[depName] =
+            `https://${process.env.VERCEL_URL}/${escapedName}.tgz`;
+        }
+      }
+    };
+
+    updateDeps(modifiedPackageJson.dependencies);
+    updateDeps(modifiedPackageJson.devDependencies);
+    updateDeps(modifiedPackageJson.peerDependencies);
+
+    // Write modified package.json
+    await fs.writeFile(
+      packageJsonPath,
+      JSON.stringify(modifiedPackageJson, null, 2)
+    );
+
+    try {
+      // Pack the package
+      await exec(`pnpm pack --out="${outDir}/%s.tgz"`, { cwd: dir });
+      console.log(`Packed ${name}`);
+    } finally {
+      // Always restore original package.json
+      await fs.writeFile(packageJsonPath, originalPackageJson);
+    }
+  }
+
+  console.log(
+    `\nSuccessfully packed ${packages.length} preview packages to ${outDir}`
+  );
+}
+
+async function getSha(): Promise<string> {
+  try {
+    const { stdout } = await exec('git rev-parse --short HEAD', {
+      cwd: rootDir,
+    });
+    return stdout.trim();
+  } catch (error) {
+    console.error('Failed to get git SHA:', error);
+    console.log('Using "local" as the SHA.');
+    return 'local';
+  }
+}
+
+main().catch((err) => {
+  console.error('Error running pack:', err);
+  process.exit(1);
+});

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,21 +100,21 @@ importers:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.2.1
+        specifier: 19.2.4
         version: 19.2.4
       react-dom:
-        specifier: ^19.2.1
+        specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.0
       '@types/react':
-        specifier: ^19.2.7
-        version: 19.2.14
+        specifier: 19.1.13
+        version: 19.1.13
       '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
+        specifier: 19.1.9
+        version: 19.1.9(@types/react@19.1.13)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -7393,16 +7393,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
-    peerDependencies:
-      '@types/react': ^19.2.0
-
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
-
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -8772,9 +8764,6 @@ packages:
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -20312,15 +20301,7 @@ snapshots:
     dependencies:
       '@types/react': 19.1.13
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
-
   '@types/react@19.1.13':
-    dependencies:
-      csstype: 3.1.3
-
-  '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
 
@@ -22151,8 +22132,6 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
-
-  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,31 @@ importers:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.6.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
+  docs:
+    dependencies:
+      next:
+        specifier: 16.2.1
+        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/ai:
     dependencies:
       '@ai-sdk/provider':
@@ -7368,8 +7393,16 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -20279,9 +20312,17 @@ snapshots:
     dependencies:
       '@types/react': 19.1.13
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react@19.1.13':
     dependencies:
       csstype: 3.1.3
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
 
@@ -20660,7 +20701,7 @@ snapshots:
       '@vue/shared': 3.5.22
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.8
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.30':
@@ -21574,7 +21615,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001766
+      caniuse-lite: 1.0.30001781
       electron-to-chromium: 1.5.279
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -21663,7 +21704,7 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001766
+      caniuse-lite: 1.0.30001781
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
@@ -24873,7 +24914,7 @@ snapshots:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001766
+      caniuse-lite: 1.0.30001781
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -24898,7 +24939,7 @@ snapshots:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001766
+      caniuse-lite: 1.0.30001781
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -24923,7 +24964,7 @@ snapshots:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001766
+      caniuse-lite: 1.0.30001781
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - workbench/*
   - "!workbench/nitro"
   - packages/*
+  - docs
 
 catalog:
   "@biomejs/biome": ^2.4.4


### PR DESCRIPTION
## Summary

- Restore a minimal `docs/` Next.js app on `stable` so the `Vercel – workflow-docs` deploy check on PRs succeeds. Since #1771 the check has been failing with "No Next.js version detected" because the Vercel project has `docs/` configured as its root directory.
- Keep the `prebuild` tarball pack script, so preview deployments continue to publish per-SDK package tarballs at `/<pkg>.tgz`, which is what we instruct users to install for pre-release testing on backport PRs.

## Scope

The placeholder is as minimal as possible:
- `docs/package.json` with only `next`, `react`, `react-dom` and their types. No fumadocs, no AI chat, no OG images, no home-page components, no docs content.
- A single trivial home page (`app/page.tsx`) with a pointer to workflow-sdk.dev.
- `docs/scripts/pack.ts` copied verbatim from `main`.
- `docs` re-added to `pnpm-workspace.yaml` and the `.changeset/config.json` ignore list.

## Interaction with the backport workflow

#1770's rule to auto-delete any cherry-pick conflict under `docs/` (outside `docs/content/`) is unchanged and still the intended behavior. The files introduced here are treated as disposable on `stable` — if a future backport deletes them, we can restore this placeholder in a follow-up. They're small and self-contained, so conflicts from `main` should be rare.

## Verification

Locally:
- `pnpm install` succeeds.
- `pnpm --filter docs build` succeeds, producing 26 `*.tgz` tarballs in `docs/public/`.

The `Vercel – workflow-docs` check should now return `success` on this PR — holding as draft until confirmed.