### PR TITLE
[docs] Build packages before packing preview tarballs on stable

### DIFF
--- a/.changeset/rude-places-tap.md
+++ b/.changeset/rude-places-tap.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix empty `dist/` in preview tarballs from `stable` docs deployments by building packages before packing.

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "next build",
-    "prebuild": "node scripts/pack.ts"
+    "prebuild": "pnpm -w run build && node scripts/pack.ts"
   },
   "dependencies": {
     "next": "16.2.1",


### PR DESCRIPTION
## Summary

The `stable` docs app packs per-deployment SDK tarballs during `prebuild` (see `docs/scripts/pack.ts`), but nothing was building the workspace packages first. Because each package's `files` array includes `dist`, the resulting `.tgz` files shipped without any compiled output — e.g. `workflow-core.tgz` contained only `package.json`, `runtime.js`, `README.md`, and the docs copy, with no `dist/**`.

Fix: chain `pnpm -w run build` (i.e. `turbo build --filter='./packages/*'`) before `scripts/pack.ts` so the tarballs include the built output.

## Test plan

- [x] Delete `packages/*/dist` and run `pnpm run prebuild` in `docs/`
- [x] Confirm `workflow-core.tgz` now contains `package/dist/**` files (150+ dist entries)
- [ ] Verify on the preview deployment that the tarball URL serves a real `dist/`