### PR TITLE
ci: bump opencode model to claude-opus-4.7 in backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -137,7 +137,7 @@ jobs:
           Do NOT run git cherry-pick --continue or git commit.
           PROMPT
 
-          opencode run --model vercel/anthropic/claude-opus-4.6 "$(cat /tmp/backport-prompt.txt)"
+          opencode run --model vercel/anthropic/claude-opus-4.7 "$(cat /tmp/backport-prompt.txt)"
 
           # Verify all conflicts are resolved
           REMAINING=$(git diff --name-only --diff-filter=U || true)


### PR DESCRIPTION
## Summary
- Bumps the opencode model used for AI-powered conflict resolution in the backport workflow from `claude-opus-4.6` to `claude-opus-4.7`.