### PR TITLE
[world-vercel] Propagate cancel from getReadable() to upstream fetch

### DIFF
--- a/.changeset/stream-cancel-propagation.md
+++ b/.changeset/stream-cancel-propagation.md
@@ -2,4 +2,4 @@
 '@workflow/world-vercel': patch
 ---
 
-Propagate consumer cancellation to upstream fetch in `readFromStream`. Previously, cancelling a stream (e.g. a client disconnecting from an API endpoint returning `run.getReadable()`) could leave the pull loop reconnecting in the background.
+Propagate consumer cancellation to upstream fetch in `readFromStream`

--- a/.changeset/stream-cancel-propagation.md
+++ b/.changeset/stream-cancel-propagation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Propagate consumer cancellation to upstream fetch in `readFromStream`. Previously, cancelling a stream (e.g. a client disconnecting from an API endpoint returning `run.getReadable()`) could leave the pull loop reconnecting in the background.

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -512,4 +512,109 @@ describe('readFromStream reconnection', () => {
 
     await reader.cancel();
   });
+
+  // Regression tests for consumer-cancel propagation.
+  //
+  // Before the fix, cancelling the ReadableStream returned by
+  // readFromStream() only called reader.cancel() on the currently-captured
+  // fetch body reader. The pull loop kept running, and if the upstream had
+  // emitted a timeout control frame, pull would happily call connect()
+  // again and keep reading — so a consumer disconnect (e.g. an HTTP client
+  // hanging up on `run.getReadable()`) would leave the server still fetching
+  // in the background.
+  describe('consumer cancel', () => {
+    it('aborts the in-flight upstream fetch via AbortSignal', async () => {
+      const capturedSignals: (AbortSignal | null | undefined)[] = [];
+      let resolveFirstFetch: (r: Response) => void;
+      const firstFetchPromise = new Promise<Response>((resolve) => {
+        resolveFirstFetch = resolve;
+      });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+        capturedSignals.push(init?.signal);
+        return firstFetchPromise;
+      });
+
+      const streamer = await getStreamer();
+      // readFromStream kicks off the fetch synchronously via connect().
+      const streamPromise = streamer.readFromStream('strm_test');
+      // Give connect() a tick to start the fetch.
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Resolve the fetch so the ReadableStream construction can complete.
+      resolveFirstFetch!(streamResponse(new Uint8Array(0)));
+      const stream = await streamPromise;
+
+      await stream.cancel();
+
+      expect(capturedSignals.length).toBeGreaterThan(0);
+      const signal = capturedSignals[0];
+      expect(signal).toBeDefined();
+      expect(signal?.aborted).toBe(true);
+    });
+
+    it('does not reconnect after the consumer cancels mid-timeout', async () => {
+      const chunk1 = new TextEncoder().encode('hello, world');
+      const timeout = buildControlFrame(false, 1);
+
+      let fetchCount = 0;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          return streamResponse(chunk1, timeout);
+        }
+        // A reconnect should never happen after cancel. If it does, hang
+        // indefinitely so the test can assert fetchCount === 1.
+        return new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('aborted', 'AbortError'))
+          );
+        });
+      });
+
+      const streamer = await getStreamer();
+      const stream = await streamer.readFromStream('strm_test');
+      const reader = stream.getReader();
+
+      // Drain the data bytes — this forces pull to observe the upstream
+      // close and enter the reconnect branch.
+      const first = await reader.read();
+      expect(first.done).toBe(false);
+
+      // Cancel while (or right after) pull is attempting to reconnect.
+      await reader.cancel();
+
+      // Give any lingering pull work a chance to misbehave.
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Only the initial connection should ever have been made.
+      expect(fetchCount).toBe(1);
+    });
+
+    it('cancels the active reader when cancel is called during a read', async () => {
+      // Upstream body that hangs — so pull is blocked in reader.read() when
+      // cancel arrives. A correct implementation cancels the body reader and
+      // lets pull exit cleanly; the broken one would continue spinning.
+      const hangingBody = new ReadableStream<Uint8Array>({
+        start() {
+          // Never enqueue or close; we want pull to be stuck in read().
+        },
+      });
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(hangingBody, { status: 200 })
+      );
+
+      const streamer = await getStreamer();
+      const stream = await streamer.readFromStream('strm_test');
+      const reader = stream.getReader();
+
+      // Schedule a read so pull starts and gets parked in reader.read().
+      const readPromise = reader.read();
+      await new Promise((r) => setTimeout(r, 10));
+
+      await reader.cancel();
+
+      const result = await readPromise;
+      expect(result.done).toBe(true);
+    });
+  });
 });

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -263,6 +263,14 @@ export function createStreamer(config?: APIConfig): Streamer {
       const MAX_RECONNECTS = 50;
       let reconnectCount = 0;
 
+      // Propagates consumer cancellation all the way to the upstream fetch.
+      // Without this, a client disconnect mid-reconnect would leave the new
+      // fetch untouched and the pull loop happily reading from it, so the
+      // caller (e.g. an API endpoint returning run.getReadable()) would keep
+      // running well after its own client hung up.
+      let cancelled = false;
+      const abortController = new AbortController();
+
       const connect = async (): Promise<
         ReadableStreamDefaultReader<Uint8Array>
       > => {
@@ -274,6 +282,7 @@ export function createStreamer(config?: APIConfig): Streamer {
         url.searchParams.set('startIndex', String(currentStartIndex));
         const response = await fetch(url, {
           headers: httpConfig.headers,
+          signal: abortController.signal,
         });
         if (!response.ok) {
           throw new Error(`Failed to fetch stream: ${response.status}`);
@@ -300,10 +309,15 @@ export function createStreamer(config?: APIConfig): Streamer {
           // yielding, rather than returning and relying on the runtime to
           // re-invoke pull when nothing was enqueued.
           for (;;) {
+            if (cancelled) return;
+
             let result: { done: boolean; value?: Uint8Array };
             try {
               result = await reader.read();
             } catch (err) {
+              // A cancel during an in-flight read can surface here as an
+              // AbortError — swallow it, since the consumer asked for it.
+              if (cancelled) return;
               // Network error — not a clean close. Flush any buffered
               // bytes and surface the error so consumers know the stream
               // was truncated.
@@ -314,6 +328,8 @@ export function createStreamer(config?: APIConfig): Streamer {
               controller.error(err);
               return;
             }
+
+            if (cancelled) return;
 
             if (!result.done) {
               // Append new data and forward everything except the last
@@ -356,7 +372,13 @@ export function createStreamer(config?: APIConfig): Streamer {
                 return;
               }
               currentStartIndex = control.nextIndex;
-              reader = await connect();
+              try {
+                reader = await connect();
+              } catch (err) {
+                if (cancelled) return;
+                controller.error(err);
+                return;
+              }
               continue;
             }
 
@@ -370,7 +392,13 @@ export function createStreamer(config?: APIConfig): Streamer {
           }
         },
         cancel: async () => {
-          await reader.cancel();
+          cancelled = true;
+          abortController.abort();
+          // Best-effort cancel of the current reader. `reader` is a closure
+          // variable, so this sees whichever connection is active right now;
+          // the `cancelled` flag guards against a concurrent reconnect
+          // swapping in a fresh reader after this runs.
+          await reader.cancel().catch(() => {});
         },
       });
     },

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -398,7 +398,9 @@ export function createStreamer(config?: APIConfig): Streamer {
           // variable, so this sees whichever connection is active right now;
           // the `cancelled` flag guards against a concurrent reconnect
           // swapping in a fresh reader after this runs.
-          await reader.cancel().catch(() => {});
+          await reader.cancel().catch((err) => {
+            console.warn('Failed to cancel reader:', err);
+          });
         },
       });
     },

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -393,6 +393,7 @@ export function createStreamer(config?: APIConfig): Streamer {
         },
         cancel: async () => {
           cancelled = true;
+          console.log('Cancelling stream');
           abortController.abort();
           // Best-effort cancel of the current reader. `reader` is a closure
           // variable, so this sees whichever connection is active right now;


### PR DESCRIPTION
## Summary

Fixes a regression from #1790 / #1742: when a consumer cancels the `ReadableStream` returned by `run.getReadable()` (e.g. an HTTP client disconnects from an API route that pipes the stream out), the pull loop in `readFromStream` kept running and could trigger further reconnects in the background. The in-flight upstream fetch was never aborted, so the endpoint kept fetching long after the client had gone away.

## Root cause

Two things combined:

1. No `cancelled` flag — `pull` had no way to know the consumer asked to stop.
2. No `AbortSignal` on the upstream `fetch()` — even if we noticed, there was no way to unblock a pending request.

The `cancel` handler only called `reader.cancel()` on whichever reader was captured at that moment. If `pull` was mid-reconnect (`reader = await connect()`), `cancel` cancelled the stale reader; the new fetch then connected and kept streaming.

## Fix

- Track a `cancelled` flag that `pull` checks before and after each `reader.read()` and before each `connect()`.
- Plumb an `AbortController.signal` into `fetch`, aborted from `cancel`, so the in-flight request (including a pending reconnect) unblocks.
- `connect()` failures triggered by abort are swallowed silently when `cancelled`.

## Tests

Three new tests under \`readFromStream reconnection > consumer cancel\`:

- \`aborts the in-flight upstream fetch via AbortSignal\` — fails on \`stable\` without the fix; asserts \`fetch\` was called with an \`AbortSignal\` and that the signal is aborted after \`stream.cancel()\`.
- \`does not reconnect after the consumer cancels mid-timeout\` — documents that no further fetch is initiated after cancel.
- \`cancels the active reader when cancel is called during a read\` — documents that cancel unblocks a pending \`reader.read()\`.

All 70 world-vercel tests pass.

## Note

The same bug exists on \`main\` (the original #1742 implementation that \`main\` carries). Will open a separate PR for that once this lands.

## Test plan

- [x] \`pnpm vitest run\` — all world-vercel tests pass
- [x] Regression test fails on pre-fix code (\`stable\` HEAD)
- [x] Typecheck clean
- [ ] CI + workflow-server auto e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)