### PR TITLE
[workbench] disable lazyDiscovery in Next.js workbench apps

### DIFF
--- a/workbench/nextjs-turbopack/next.config.ts
+++ b/workbench/nextjs-turbopack/next.config.ts
@@ -14,5 +14,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-// export default nextConfig;
 export default withWorkflow(nextConfig);

--- a/workbench/nextjs-turbopack/next.config.ts
+++ b/workbench/nextjs-turbopack/next.config.ts
@@ -1,5 +1,5 @@
-import type { NextConfig } from 'next';
 import path from 'node:path';
+import type { NextConfig } from 'next';
 import { withWorkflow } from 'workflow/next';
 
 const turbopackRoot = path.resolve(process.cwd(), '../..');
@@ -15,6 +15,4 @@ const nextConfig: NextConfig = {
 };
 
 // export default nextConfig;
-export default withWorkflow(nextConfig, {
-  workflows: { lazyDiscovery: true },
-});
+export default withWorkflow(nextConfig);

--- a/workbench/nextjs-webpack/next.config.ts
+++ b/workbench/nextjs-webpack/next.config.ts
@@ -10,5 +10,4 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['@node-rs/xxhash'],
 };
 
-// export default nextConfig;
 export default withWorkflow(nextConfig);

--- a/workbench/nextjs-webpack/next.config.ts
+++ b/workbench/nextjs-webpack/next.config.ts
@@ -11,4 +11,4 @@ const nextConfig: NextConfig = {
 };
 
 // export default nextConfig;
-export default withWorkflow(nextConfig, { workflows: { lazyDiscovery: true } });
+export default withWorkflow(nextConfig);


### PR DESCRIPTION
## Summary
- Remove `lazyDiscovery: true` from `workbench/nextjs-turbopack/next.config.ts` and `workbench/nextjs-webpack/next.config.ts`
- Ensures e2e tests on the `stable` branch exercise the eager discovery path

No published packages change, so no changeset needed.