### PR TITLE
Add distributed abort controller support and documentation

### DIFF
--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -1,0 +1,389 @@
+---
+title: Distributed Abort Controller
+description: Create an AbortSignal that can be triggered across distributed systems using workflow streams and hooks.
+type: guide
+summary: Encapsulate a durable workflow that provides a standard AbortSignal interface for distributed cancellation, using hooks for abort triggering and streams for signal propagation.
+---
+
+Use this pattern when you need to coordinate cancellation across distributed systems using a familiar AbortSignal/AbortController interface. The distributed abort controller wraps a workflow that uses hooks to trigger abortion and streams to propagate the signal to listeners.
+
+## When to use this
+
+- Cancelling long-running operations across multiple services
+- Providing a standard AbortSignal to code that expects one, backed by distributed infrastructure
+- Coordinating graceful shutdown across distributed workers
+- Implementing timeout patterns that span multiple processes
+
+## Pattern: Distributed Abort Controller
+
+The pattern consists of:
+
+1. A **workflow** that waits for an abort hook and writes a cancellation message to a stream
+2. A **class wrapper** that provides the standard AbortController-like interface
+3. Consumers receive a standard `AbortSignal` that listens to the workflow's readable stream
+
+### Core Workflow
+
+```typescript
+import { defineHook, getWritable } from "workflow";
+import { z } from "zod";
+
+export const abortHook = defineHook({
+  schema: z.object({
+    reason: z.string().optional(),
+  }),
+});
+
+// Chunk written to the stream when abort is triggered
+export type AbortChunk = {
+  type: "abort";
+  reason?: string;
+  timestamp: number;
+};
+
+async function writeAbortSignal(reason?: string) {
+  "use step";
+
+  const writable = getWritable<AbortChunk>();
+  const writer = writable.getWriter();
+
+  try {
+    await writer.write({
+      type: "abort",
+      reason,
+      timestamp: Date.now(),
+    });
+  } finally {
+    writer.releaseLock();
+  }
+
+  await writable.close();
+}
+
+export async function distributedAbortWorkflow(token: string) {
+  "use workflow";
+
+  // Wait for the abort hook to be triggered
+  const { reason } = await abortHook.create({ token }); // [!code highlight]
+
+  // Write the abort signal to the stream
+  await writeAbortSignal(reason); // [!code highlight]
+
+  return { aborted: true, reason };
+}
+```
+
+### The DistributedAbortController Class
+
+```typescript
+import { start, getRun } from "workflow/api";
+import { abortHook, distributedAbortWorkflow, type AbortChunk } from "./workflow";
+
+export class DistributedAbortController {
+  private runId: string;
+  private token: string;
+  private _signal: AbortSignal | null = null;
+  private abortController: AbortController | null = null;
+
+  private constructor(runId: string, token: string) {
+    this.runId = runId;
+    this.token = token;
+  }
+
+  // Factory method to create and start the controller
+  static async create(): Promise<DistributedAbortController> { // [!code highlight]
+    const token = `abort:${crypto.randomUUID()}`;
+    const run = await start(distributedAbortWorkflow, [token]);
+    return new DistributedAbortController(run.runId, token);
+  }
+
+  // Trigger the distributed abort
+  async abort(reason?: string): Promise<void> { // [!code highlight]
+    await abortHook.resume(this.token, { reason });
+  }
+
+  // Get the AbortSignal that listens to the distributed stream
+  get signal(): AbortSignal { // [!code highlight]
+    if (this._signal) return this._signal;
+
+    // Create a local AbortController to produce the signal
+    this.abortController = new AbortController();
+    this._signal = this.abortController.signal;
+
+    // Start listening to the stream in the background
+    this.listenToStream();
+
+    return this._signal;
+  }
+
+  private async listenToStream(): Promise<void> {
+    const run = getRun(this.runId);
+    const readable = run.getReadable<AbortChunk>();
+
+    try {
+      for await (const chunk of readable) { // [!code highlight]
+        if (chunk.type === "abort") {
+          this.abortController?.abort(chunk.reason); // [!code highlight]
+          break;
+        }
+      }
+    } catch {
+      // Stream closed or errored - abort if not already aborted
+      if (!this.abortController?.signal.aborted) {
+        this.abortController?.abort("Stream closed unexpectedly");
+      }
+    }
+  }
+
+  // Expose the run ID for debugging or persistence
+  get runId_(): string {
+    return this.runId;
+  }
+}
+```
+
+### Full Implementation
+
+```typescript lineNumbers
+// lib/distributed-abort-controller.ts
+import { defineHook, getWritable } from "workflow";
+import { start, getRun } from "workflow/api";
+import { z } from "zod";
+
+// --- Workflow Definition ---
+
+export const abortHook = defineHook({
+  schema: z.object({
+    reason: z.string().optional(),
+  }),
+});
+
+export type AbortChunk = {
+  type: "abort";
+  reason?: string;
+  timestamp: number;
+};
+
+async function writeAbortSignal(reason?: string) {
+  "use step";
+
+  const writable = getWritable<AbortChunk>();
+  const writer = writable.getWriter();
+
+  try {
+    await writer.write({
+      type: "abort",
+      reason,
+      timestamp: Date.now(),
+    });
+  } finally {
+    writer.releaseLock();
+  }
+
+  await writable.close();
+}
+
+export async function distributedAbortWorkflow(token: string) {
+  "use workflow";
+
+  const { reason } = await abortHook.create({ token });
+  await writeAbortSignal(reason);
+
+  return { aborted: true, reason };
+}
+
+// --- Class Wrapper ---
+
+export class DistributedAbortController {
+  private runId: string;
+  private token: string;
+  private _signal: AbortSignal | null = null;
+  private abortController: AbortController | null = null;
+
+  private constructor(runId: string, token: string) {
+    this.runId = runId;
+    this.token = token;
+  }
+
+  /**
+   * Creates a new DistributedAbortController.
+   * Starts a workflow that waits for an abort signal.
+   */
+  static async create(): Promise<DistributedAbortController> {
+    const token = `abort:${crypto.randomUUID()}`;
+    const run = await start(distributedAbortWorkflow, [token]);
+    return new DistributedAbortController(run.runId, token);
+  }
+
+  /**
+   * Reconnect to an existing DistributedAbortController by run ID and token.
+   * Useful for resuming after a process restart.
+   */
+  static reconnect(runId: string, token: string): DistributedAbortController {
+    return new DistributedAbortController(runId, token);
+  }
+
+  /**
+   * Triggers the distributed abort signal.
+   * All listeners will receive the abort event.
+   */
+  async abort(reason?: string): Promise<void> {
+    await abortHook.resume(this.token, { reason });
+  }
+
+  /**
+   * Returns an AbortSignal that will be aborted when the distributed
+   * abort is triggered. The signal listens to the workflow's stream.
+   */
+  get signal(): AbortSignal {
+    if (this._signal) return this._signal;
+
+    this.abortController = new AbortController();
+    this._signal = this.abortController.signal;
+
+    this.listenToStream();
+
+    return this._signal;
+  }
+
+  private async listenToStream(): Promise<void> {
+    const run = getRun(this.runId);
+    const readable = run.getReadable<AbortChunk>();
+
+    try {
+      for await (const chunk of readable) {
+        if (chunk.type === "abort") {
+          this.abortController?.abort(chunk.reason);
+          break;
+        }
+      }
+    } catch {
+      if (!this.abortController?.signal.aborted) {
+        this.abortController?.abort("Stream closed unexpectedly");
+      }
+    }
+  }
+
+  /**
+   * Get the workflow run ID for persistence or debugging.
+   */
+  get workflowRunId(): string {
+    return this.runId;
+  }
+
+  /**
+   * Get the hook token for persistence or debugging.
+   */
+  get hookToken(): string {
+    return this.token;
+  }
+}
+```
+
+### Usage Example
+
+```typescript lineNumbers
+import { DistributedAbortController } from "./lib/distributed-abort-controller";
+
+async function longRunningOperation(signal: AbortSignal) {
+  // Standard AbortSignal usage
+  signal.addEventListener("abort", () => {
+    console.log("Abort received:", signal.reason);
+  });
+
+  // Use with fetch
+  const response = await fetch("https://api.example.com/data", { signal });
+
+  // Or check manually
+  if (signal.aborted) {
+    throw new Error("Operation was aborted");
+  }
+
+  return response.json();
+}
+
+// API route to start work
+export async function POST(request: Request) {
+  // Create a distributed abort controller
+  const controller = await DistributedAbortController.create(); // [!code highlight]
+
+  // Store the run ID and token for later cancellation
+  await saveToDatabase({
+    operationId: "op-123",
+    runId: controller.workflowRunId,
+    token: controller.hookToken,
+  });
+
+  // Pass the signal to your operation
+  const result = await longRunningOperation(controller.signal); // [!code highlight]
+
+  return Response.json(result);
+}
+
+// API route to cancel work
+export async function DELETE(request: Request) {
+  const { operationId } = await request.json();
+
+  // Retrieve the stored controller info
+  const { runId, token } = await getFromDatabase(operationId);
+
+  // Reconnect and abort
+  const controller = DistributedAbortController.reconnect(runId, token); // [!code highlight]
+  await controller.abort("User cancelled the operation"); // [!code highlight]
+
+  return Response.json({ cancelled: true });
+}
+```
+
+### Multiple Listeners
+
+Multiple processes can listen to the same abort signal by reconnecting to the same workflow:
+
+```typescript lineNumbers
+// Worker 1
+async function worker1() {
+  const controller = DistributedAbortController.reconnect(runId, token);
+  const signal = controller.signal;
+
+  while (!signal.aborted) {
+    await doWork();
+  }
+  console.log("Worker 1 shutting down");
+}
+
+// Worker 2 (different process)
+async function worker2() {
+  const controller = DistributedAbortController.reconnect(runId, token);
+  const signal = controller.signal;
+
+  while (!signal.aborted) {
+    await doOtherWork();
+  }
+  console.log("Worker 2 shutting down");
+}
+
+// Coordinator (yet another process)
+async function coordinator() {
+  const controller = DistributedAbortController.reconnect(runId, token);
+
+  // Abort all workers at once
+  await controller.abort("Graceful shutdown requested");
+}
+```
+
+## Tips
+
+- **Store `runId` and `token` for persistence.** If your process restarts, use `reconnect()` to reattach to the existing workflow.
+- **The signal is lazy.** The stream listener only starts when you first access `.signal`. This avoids unnecessary connections.
+- **Multiple readers are supported.** The workflow's stream can have multiple readers, so multiple processes can listen to the same abort signal.
+- **Use with timeouts.** Combine with `AbortSignal.timeout()` for local timeouts that complement the distributed abort.
+- **Clean up on completion.** The workflow completes after writing the abort chunk. No manual cleanup is needed.
+
+## Key APIs
+
+- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) -- declares the orchestrator function
+- [`"use step"`](/docs/api-reference/workflow/use-step) -- declares step functions with retries
+- [`defineHook()`](/docs/api-reference/workflow/define-hook) -- creates the typed abort hook
+- [`getWritable()`](/docs/api-reference/workflow/get-writable) -- writes the abort signal to the stream
+- [`start()`](/docs/api-reference/workflow-api/start) -- spawns the abort controller workflow
+- [`getRun()`](/docs/api-reference/workflow-api/get-run) -- retrieves the run to read the stream

--- a/docs/content/docs/cookbook/common-patterns/meta.json
+++ b/docs/content/docs/cookbook/common-patterns/meta.json
@@ -10,6 +10,7 @@
     "idempotency",
     "webhooks",
     "content-router",
-    "child-workflows"
+    "child-workflows",
+    "distributed-abort-controller"
   ]
 }

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -1,0 +1,95 @@
+/**
+ * Cookbook: distributed-abort-controller pattern
+ *
+ * Demonstrates creating an AbortSignal-compatible interface that works
+ * across distributed systems using workflow hooks and streams.
+ */
+import { defineHook, getWritable } from 'workflow';
+
+// Hook to trigger the abort
+export const abortHook = defineHook<{ reason?: string }>();
+
+// Chunk type written to the stream when abort is triggered
+export type AbortChunk = {
+  type: 'abort';
+  reason?: string;
+  timestamp: number;
+};
+
+// Step to write the abort signal to the stream
+async function writeAbortSignal(reason?: string) {
+  'use step';
+
+  const writable = getWritable<AbortChunk>();
+  const writer = writable.getWriter();
+
+  try {
+    await writer.write({
+      type: 'abort',
+      reason,
+      timestamp: Date.now(),
+    });
+  } finally {
+    writer.releaseLock();
+  }
+
+  await writable.close();
+}
+
+/**
+ * The core workflow that backs the distributed abort controller.
+ * It waits for the abort hook to be triggered, then writes an abort
+ * chunk to the stream for all listeners.
+ */
+export async function distributedAbortWorkflow(token: string) {
+  'use workflow';
+
+  // Wait for the abort hook to be triggered
+  const { reason } = await abortHook.create({ token });
+
+  // Write the abort signal to the stream
+  await writeAbortSignal(reason);
+
+  return { aborted: true, reason };
+}
+
+/**
+ * Demo workflow that uses the distributed abort controller pattern
+ * to coordinate cancellation with a worker loop.
+ */
+export async function abortableWorkerDemo(
+  abortToken: string,
+  maxIterations: number
+) {
+  'use workflow';
+
+  let aborted = false;
+  let abortReason: string | undefined;
+
+  // Listen for abort signal
+  const hook = abortHook.create({ token: abortToken });
+  hook.then(({ reason }) => {
+    aborted = true;
+    abortReason = reason;
+  });
+
+  const results: Array<{ iteration: number; result: string }> = [];
+
+  for (let i = 0; i < maxIterations; i++) {
+    if (aborted) break;
+    const work = await doWork(i);
+    results.push(work);
+  }
+
+  return {
+    completed: results.length,
+    aborted,
+    abortReason,
+    results,
+  };
+}
+
+async function doWork(iteration: number) {
+  'use step';
+  return { iteration, result: `work-${iteration}` };
+}


### PR DESCRIPTION
- Implemented a distributed abort controller to enable coordinated request cancellation across distributed systems.
- Added comprehensive documentation detailing the usage and implementation of the distributed abort controller.

[v0 Session](https://v0.app/chat/viQObaY3XS8)