### PR TITLE
Add distributed abort controller guide and implementation

### DIFF
--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -5,41 +5,40 @@ type: guide
 summary: Build a distributed abort controller that uses workflow streams and hooks to propagate cancellation signals across process boundaries.
 ---
 
-Use this pattern when you need an `AbortController`-like interface that works across distributed systems. The controller uses a durable workflow to coordinate cancellation — calling `.abort()` on one machine triggers the signal on any other machine listening to `.signal`.
+Use this pattern when you need an `AbortController`-like interface that works across distributed systems. The controller uses a durable workflow to coordinate cancellation — calling `.abort()` on one machine triggers the `.signal` on any other machine.
 
 ## When to use this
 
 - **Cross-process cancellation** — Cancel a long-running operation from a different server, worker, or edge function
 - **Durable cancellation** — The abort signal persists even if the process that created it crashes
 - **UI stop buttons** — Let users cancel operations running on the server from the browser
-- **Timeout coordination** — Combine with `sleep()` for distributed timeout handling
+- **Timeout coordination** — The built-in TTL auto-expires stale controllers
 
 ## Pattern
 
 The `DistributedAbortController` class encapsulates a workflow that:
-1. Accepts a user-provided unique ID (like a chat ID or task ID) for the hook token
-2. Waits for a hook signal when `.abort()` is called
-3. Writes a cancellation message to the run's stream
-4. Returns a local `AbortSignal` that listens to the stream
+1. Accepts a user-provided unique ID (like a chat ID or task ID)
+2. Creates or reconnects to an existing workflow using that ID
+3. Waits for a hook signal OR TTL expiration
+4. Writes a cancellation message to the run's stream when triggered
 
 ### Core Implementation
 
 ```typescript lineNumbers
-import { defineHook, getWritable } from "workflow";
+import { defineHook, getWritable, sleep } from "workflow";
 import { start, getRun, getHookByToken } from "workflow/api";
-import { z } from "zod";
 
-// Hook to trigger the abort signal — token is derived from user-provided ID
-export const abortHook = defineHook({
-  schema: z.object({
-    reason: z.string().optional(),
-  }),
-});
+// Default TTL: 24 hours
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+// Hook to trigger the abort signal
+export const abortHook = defineHook<{ reason?: string }>();
 
 // The abort message written to the stream
 export type AbortMessage = {
   type: "abort";
   reason?: string;
+  expired?: boolean;
 };
 
 // Helper to create a consistent hook token from the user ID
@@ -48,78 +47,97 @@ function getAbortToken(id: string): string {
 }
 
 // Step function that writes the abort message to the stream
-async function writeAbortSignal(reason?: string) {
+async function writeAbortSignal(reason?: string, expired?: boolean) {
   "use step";
 
   const writable = getWritable<AbortMessage>();
   const writer = writable.getWriter();
   try {
-    await writer.write({ type: "abort", reason });
+    await writer.write({ type: "abort", reason, expired });
   } finally {
     writer.releaseLock();
   }
   await writable.close();
 }
 
-// Workflow that waits for the abort signal and writes to the stream
-export async function abortControllerWorkflow(id: string) { // [!code highlight]
+// Workflow that waits for abort or TTL expiration
+export async function abortControllerWorkflow(id: string, ttlMs: number) {
   "use workflow";
 
-  // Use the user-provided ID for the hook token
-  const hook = abortHook.create({ token: getAbortToken(id) }); // [!code highlight]
-  const { reason } = await hook;
+  const hook = abortHook.create({ token: getAbortToken(id) });
 
-  // Write the abort message inside a step
-  await writeAbortSignal(reason);
+  // Race: manual abort OR TTL expiration // [!code highlight]
+  const result = await Promise.race([
+    hook.then((payload) => ({
+      reason: payload.reason,
+      expired: false,
+    })),
+    sleep(`${ttlMs}ms`).then(() => ({
+      reason: "Controller expired",
+      expired: true,
+    })),
+  ]);
 
-  return { aborted: true, reason };
+  await writeAbortSignal(result.reason, result.expired);
+
+  return { aborted: true, reason: result.reason, expired: result.expired };
 }
 
 /**
  * A distributed abort controller that works across process boundaries.
  * Uses a semantically meaningful ID (like a chat ID or task ID) to coordinate.
- *
- * @example
- * ```typescript
- * // Process A: Create the controller with a meaningful ID
- * const controller = await DistributedAbortController.create("chat:123");
- *
- * // Process B: Abort using the same ID (no run ID needed!)
- * await DistributedAbortController.abort("chat:123", "User cancelled");
- *
- * // Process C: Get a signal using the same ID
- * const signal = await DistributedAbortController.getSignal("chat:123");
- * signal.addEventListener("abort", () => {
- *   console.log("Aborted:", signal.reason);
- * });
- * ```
  */
 export class DistributedAbortController {
-  /**
-   * Creates a new distributed abort controller by starting a workflow.
-   * The ID should be semantically meaningful (e.g., "chat:123", "task:abc").
-   */
-  static async create(id: string): Promise<void> { // [!code highlight]
-    await start(abortControllerWorkflow, { args: [id] });
+  private id: string;
+  private runId: string;
+
+  private constructor(id: string, runId: string) {
+    this.id = id;
+    this.runId = runId;
   }
 
   /**
-   * Triggers the abort signal for the given ID.
-   * Can be called from any process — finds the run via the hook token.
+   * Creates or reconnects to a distributed abort controller.
+   * If a controller with this ID already exists, reconnects to it.
+   * Otherwise, starts a new workflow.
+   *
+   * @param id - A unique, semantically meaningful ID (e.g., "chat:123")
+   * @param options.ttlMs - Time-to-live in ms (default: 24 hours)
    */
-  static async abort(id: string, reason?: string): Promise<void> { // [!code highlight]
-    await abortHook.resume(getAbortToken(id), { reason });
+  static async create( // [!code highlight]
+    id: string,
+    options: { ttlMs?: number } = {}
+  ): Promise<DistributedAbortController> {
+    const { ttlMs = DEFAULT_TTL_MS } = options;
+    const token = getAbortToken(id);
+
+    // Try to find an existing run with this hook token
+    const existingHook = await getHookByToken(token).catch(() => null); // [!code highlight]
+
+    if (existingHook) {
+      // Reconnect to existing controller
+      return new DistributedAbortController(id, existingHook.runId);
+    }
+
+    // Create a new workflow
+    const run = await start(abortControllerWorkflow, { args: [id, ttlMs] }); // [!code highlight]
+    return new DistributedAbortController(id, run.id);
   }
 
   /**
-   * Returns an AbortSignal for the given ID.
-   * Finds the run via the hook token and listens to its stream.
+   * Triggers the abort signal.
+   * Can be called from any process with this controller instance.
    */
-  static async getSignal(id: string): Promise<AbortSignal> { // [!code highlight]
-    // Find the run by looking up the hook token
-    const hook = await getHookByToken(getAbortToken(id)); // [!code highlight]
-    const run = getRun<{ aborted: boolean; reason?: string }>(hook.runId);
+  async abort(reason?: string): Promise<void> { // [!code highlight]
+    await abortHook.resume(getAbortToken(this.id), { reason });
+  }
 
+  /**
+   * Returns an AbortSignal that fires when abort() is called or TTL expires.
+   * The signal fires with a reason indicating what triggered it.
+   */
+  get signal(): AbortSignal { // [!code highlight]
+    const run = getRun<{ aborted: boolean; reason?: string; expired?: boolean }>(this.runId);
     const controller = new AbortController();
     const readable = run.getReadable<AbortMessage>();
 
@@ -131,7 +149,10 @@ export class DistributedAbortController {
           const { done, value } = await reader.read();
           if (done) break;
           if (value.type === "abort") {
-            controller.abort(value.reason);
+            const reason = value.expired
+              ? `${value.reason} (expired)`
+              : value.reason;
+            controller.abort(reason);
             break;
           }
         }
@@ -145,41 +166,64 @@ export class DistributedAbortController {
 }
 ```
 
-### Usage: Creating and Using the Controller
+### Usage: Single Process
 
 ```typescript lineNumbers
 import { DistributedAbortController } from "./distributed-abort-controller";
 
-// Create a new controller with a meaningful ID
-await DistributedAbortController.create("chat:user-123");
+// Create a controller with a meaningful ID
+const controller = await DistributedAbortController.create("chat:user-123");
 
-// Get the signal (can be passed to fetch, etc.)
-const signal = await DistributedAbortController.getSignal("chat:user-123");
-
-// Use with fetch
+// Get the signal and use it with fetch
+const signal = controller.signal;
 const response = await fetch("https://api.example.com/long-operation", {
   signal,
 });
 
-// Or listen for the abort event
-signal.addEventListener("abort", () => {
-  console.log("Operation was cancelled:", signal.reason);
-});
+// Later: abort the operation
+await controller.abort("User cancelled");
 ```
 
-### Usage: Aborting from a Different Process
+### Usage: Cross-Process Coordination
 
 ```typescript lineNumbers
 import { DistributedAbortController } from "./distributed-abort-controller";
 
-// In Process A: Create with a task ID
-await DistributedAbortController.create("task:build-123");
+// Process A: Create the controller
+const controller = await DistributedAbortController.create("task:build-123");
+// start long operation using controller.signal...
 
-// In Process B: Abort using the same task ID — no need to share run IDs!
-await DistributedAbortController.abort("task:build-123", "Cancelled by admin");
+// Process B: Reconnect and abort (no run ID sharing needed!)
+const sameController = await DistributedAbortController.create("task:build-123"); // [!code highlight]
+await sameController.abort("Cancelled by admin");
 
-// In Process C: Listen using the same task ID
-const signal = await DistributedAbortController.getSignal("task:build-123");
+// Process C: Reconnect and listen
+const anotherRef = await DistributedAbortController.create("task:build-123");
+anotherRef.signal.addEventListener("abort", (e) => {
+  console.log("Task was cancelled:", (e.target as AbortSignal).reason);
+});
+```
+
+### Custom TTL
+
+```typescript lineNumbers
+// Short-lived controller for a quick operation (5 minutes)
+const shortLived = await DistributedAbortController.create("quick-task", {
+  ttlMs: 5 * 60 * 1000,
+});
+
+// Long-lived controller for batch jobs (7 days)
+const longLived = await DistributedAbortController.create("batch-job", {
+  ttlMs: 7 * 24 * 60 * 60 * 1000,
+});
+
+// When TTL expires, the signal fires with expired reason
+shortLived.signal.addEventListener("abort", (e) => {
+  const reason = (e.target as AbortSignal).reason;
+  if (reason?.includes("expired")) {
+    console.log("Controller expired, cleaning up...");
+  }
+});
 ```
 
 ### API Route for Remote Abort
@@ -194,7 +238,8 @@ export async function POST(
   const { id } = await params;
   const { reason } = await request.json();
 
-  await DistributedAbortController.abort(id, reason || "Cancelled via API");
+  const controller = await DistributedAbortController.create(id);
+  await controller.abort(reason || "Cancelled via API");
 
   return Response.json({ success: true });
 }
@@ -222,75 +267,19 @@ export function CancelButton({ taskId }: { taskId: string }) {
 }
 ```
 
-## Advanced: With Timeout
-
-Combine the abort controller with `sleep()` for automatic timeout:
-
-```typescript lineNumbers
-import { defineHook, getWritable, sleep } from "workflow";
-import { z } from "zod";
-
-export const abortHook = defineHook({
-  schema: z.object({ reason: z.string().optional() }),
-});
-
-export type AbortMessage = { type: "abort"; reason?: string };
-
-function getAbortToken(id: string): string {
-  return `abort:${id}`;
-}
-
-async function writeAbortSignal(reason?: string) {
-  "use step";
-
-  const writable = getWritable<AbortMessage>();
-  const writer = writable.getWriter();
-  try {
-    await writer.write({ type: "abort", reason });
-  } finally {
-    writer.releaseLock();
-  }
-  await writable.close();
-}
-
-export async function timedAbortWorkflow(id: string, timeoutMs: number) {
-  "use workflow";
-
-  const hook = abortHook.create({ token: getAbortToken(id) });
-
-  // Race: manual abort OR timeout
-  const result = await Promise.race([ // [!code highlight]
-    hook.then((payload) => ({ type: "manual" as const, ...payload })),
-    sleep(`${timeoutMs}ms`).then(() => ({
-      type: "timeout" as const,
-      reason: "Operation timed out",
-    })),
-  ]);
-
-  await writeAbortSignal(result.reason);
-
-  return {
-    aborted: true,
-    reason: result.reason,
-    timedOut: result.type === "timeout",
-  };
-}
-```
-
 ## Tips
 
 - **Use semantic IDs** — Use meaningful IDs like `chat:123` or `task:abc` instead of random UUIDs
-- **No run ID sharing needed** — The hook token lookup means you only need to share the semantic ID
-- **Signal is lazy** — The `getSignal()` method only starts listening when called
-- **One-shot** — Once aborted, the workflow completes; create a new controller for new operations
-- **Combine with operations** — Use the signal with `fetch`, database queries, or any API that accepts `AbortSignal`
-- **Memory cleanup** — The signal listener runs until abort or workflow completion; the stream closes automatically
+- **Create is idempotent** — Calling `create()` with the same ID reconnects to the existing controller
+- **TTL auto-cleanup** — Workflows self-terminate after TTL expires; no manual cleanup needed
+- **Signal is a getter** — Each access to `.signal` creates a new listener; cache it if needed
+- **One-shot** — Once aborted or expired, the workflow completes; create a new controller for new operations
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
-- [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook for the abort signal
+- [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook for the abort trigger
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) — write abort messages to the stream
+- [`sleep()`](/docs/api-reference/workflow/sleep) — TTL timer for auto-expiration
 - [`start()`](/docs/api-reference/workflow-api/start) — start the abort controller workflow
-- [`getHookByToken()`](/docs/api-reference/workflow-api/get-hook-by-token) — find a run by its hook token
+- [`getHookByToken()`](/docs/api-reference/workflow-api/get-hook-by-token) — find existing run by hook token
 - [`getRun()`](/docs/api-reference/workflow-api/get-run) — reconnect to the workflow's readable stream

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -135,10 +135,8 @@ export class DistributedAbortController {
     }
 
     // Create a new workflow
-    const run = await start(abortControllerWorkflow, { // [!code highlight]
-      args: [id, ttlMs, graceMs],
-    });
-    return new DistributedAbortController(id, run.id);
+    const run = await start(abortControllerWorkflow, [id, ttlMs, graceMs]); // [!code highlight]
+    return new DistributedAbortController(id, run.runId);
   }
 
   /**

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -1,0 +1,289 @@
+---
+title: Distributed Abort Controller
+description: A distributed AbortController that uses durable workflows for cross-process cancellation signaling.
+type: guide
+summary: Build a distributed abort controller that uses workflow streams and hooks to propagate cancellation signals across process boundaries.
+---
+
+Use this pattern when you need an `AbortController`-like interface that works across distributed systems. The controller uses a durable workflow to coordinate cancellation — calling `.abort()` on one machine triggers the signal on any other machine listening to `.signal`.
+
+## When to use this
+
+- **Cross-process cancellation** — Cancel a long-running operation from a different server, worker, or edge function
+- **Durable cancellation** — The abort signal persists even if the process that created it crashes
+- **UI stop buttons** — Let users cancel operations running on the server from the browser
+- **Timeout coordination** — Combine with `sleep()` for distributed timeout handling
+
+## Pattern
+
+The `DistributedAbortController` class encapsulates a workflow that:
+1. Creates a unique run when instantiated
+2. Waits for a hook signal when `.abort()` is called
+3. Writes a cancellation message to the run's stream
+4. Returns a local `AbortSignal` that listens to the stream
+
+### Core Implementation
+
+```typescript lineNumbers
+import { defineHook, getWritable, getWorkflowMetadata } from "workflow";
+import { start, getRun } from "workflow/api";
+import { z } from "zod";
+
+// Hook to trigger the abort signal
+export const abortHook = defineHook({
+  schema: z.object({
+    reason: z.string().optional(),
+  }),
+});
+
+// The abort message written to the stream
+export type AbortMessage = {
+  type: "abort";
+  reason?: string;
+};
+
+// Workflow that waits for the abort signal and writes to the stream
+export async function abortControllerWorkflow() {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+  const writable = getWritable<AbortMessage>();
+
+  // Wait for the abort hook to be triggered
+  const hook = abortHook.create({ token: `abort:${workflowRunId}` }); // [!code highlight]
+  const { reason } = await hook; // [!code highlight]
+
+  // Write the abort message to the stream
+  const writer = writable.getWriter();
+  try {
+    await writer.write({ type: "abort", reason }); // [!code highlight]
+  } finally {
+    writer.releaseLock();
+  }
+  await writable.close();
+
+  return { aborted: true, reason };
+}
+
+/**
+ * A distributed abort controller that works across process boundaries.
+ *
+ * @example
+ * ```typescript
+ * // Process A: Create the controller
+ * const controller = await DistributedAbortController.create();
+ * const runId = controller.runId; // Share this with Process B
+ *
+ * // Process B: Abort from anywhere
+ * const controller = DistributedAbortController.fromRunId(runId);
+ * await controller.abort("User cancelled");
+ *
+ * // Process A: Listen for the signal
+ * const signal = await controller.signal;
+ * signal.addEventListener("abort", () => {
+ *   console.log("Aborted:", signal.reason);
+ * });
+ * ```
+ */
+export class DistributedAbortController {
+  readonly runId: string;
+  #signalPromise: Promise<AbortSignal> | null = null;
+
+  private constructor(runId: string) {
+    this.runId = runId;
+  }
+
+  /**
+   * Creates a new distributed abort controller by starting a workflow.
+   */
+  static async create(): Promise<DistributedAbortController> {
+    const run = await start(abortControllerWorkflow); // [!code highlight]
+    return new DistributedAbortController(run.runId);
+  }
+
+  /**
+   * Reconnects to an existing abort controller by run ID.
+   * Use this to abort from a different process.
+   */
+  static fromRunId(runId: string): DistributedAbortController {
+    return new DistributedAbortController(runId);
+  }
+
+  /**
+   * Triggers the abort signal across all listeners.
+   */
+  async abort(reason?: string): Promise<void> {
+    await abortHook.resume(`abort:${this.runId}`, { reason }); // [!code highlight]
+  }
+
+  /**
+   * Returns an AbortSignal that triggers when the workflow receives
+   * the abort hook. The signal listens to the workflow's readable stream.
+   */
+  get signal(): Promise<AbortSignal> {
+    if (!this.#signalPromise) {
+      this.#signalPromise = this.#createSignal();
+    }
+    return this.#signalPromise;
+  }
+
+  async #createSignal(): Promise<AbortSignal> {
+    const controller = new AbortController();
+    const run = getRun<{ aborted: boolean; reason?: string }>(this.runId);
+    const readable = run.getReadable<AbortMessage>(); // [!code highlight]
+
+    // Read from the stream in the background
+    (async () => {
+      const reader = readable.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value.type === "abort") {
+            controller.abort(value.reason); // [!code highlight]
+            break;
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    })();
+
+    return controller.signal;
+  }
+}
+```
+
+### Usage: Creating and Using the Controller
+
+```typescript lineNumbers
+import { DistributedAbortController } from "./distributed-abort-controller";
+
+// Create a new controller
+const controller = await DistributedAbortController.create();
+
+// Get the signal (can be passed to fetch, etc.)
+const signal = await controller.signal;
+
+// Use with fetch
+const response = await fetch("https://api.example.com/long-operation", {
+  signal,
+});
+
+// Or listen for the abort event
+signal.addEventListener("abort", () => {
+  console.log("Operation was cancelled:", signal.reason);
+});
+```
+
+### Usage: Aborting from a Different Process
+
+```typescript lineNumbers
+import { DistributedAbortController } from "./distributed-abort-controller";
+
+// In Process A: Share the runId
+const controller = await DistributedAbortController.create();
+console.log("Share this ID:", controller.runId);
+
+// In Process B: Abort using the shared runId
+const remoteController = DistributedAbortController.fromRunId(runId);
+await remoteController.abort("Cancelled by admin");
+```
+
+### API Route for Remote Abort
+
+```typescript lineNumbers
+import { DistributedAbortController } from "@/lib/distributed-abort-controller";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const { runId } = await params;
+  const { reason } = await request.json();
+
+  const controller = DistributedAbortController.fromRunId(runId);
+  await controller.abort(reason || "Cancelled via API");
+
+  return Response.json({ success: true });
+}
+```
+
+### Client Cancel Button
+
+```tsx lineNumbers
+"use client";
+
+export function CancelButton({ runId }: { runId: string }) {
+  const handleCancel = async () => {
+    await fetch(`/api/abort/${runId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: "User clicked cancel" }),
+    });
+  };
+
+  return (
+    <button type="button" onClick={handleCancel}>
+      Cancel Operation
+    </button>
+  );
+}
+```
+
+## Advanced: With Timeout
+
+Combine the abort controller with `sleep()` for automatic timeout:
+
+```typescript lineNumbers
+import { defineHook, getWritable, getWorkflowMetadata, sleep } from "workflow";
+import { z } from "zod";
+
+export const abortHook = defineHook({
+  schema: z.object({ reason: z.string().optional() }),
+});
+
+export type AbortMessage = { type: "abort"; reason?: string };
+
+export async function timedAbortWorkflow(timeoutMs: number) {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+  const writable = getWritable<AbortMessage>();
+
+  const hook = abortHook.create({ token: `abort:${workflowRunId}` });
+
+  // Race: manual abort OR timeout
+  const result = await Promise.race([ // [!code highlight]
+    hook.then((payload) => ({ type: "manual" as const, ...payload })),
+    sleep(`${timeoutMs}ms`).then(() => ({ type: "timeout" as const, reason: "Operation timed out" })),
+  ]);
+
+  const writer = writable.getWriter();
+  try {
+    await writer.write({ type: "abort", reason: result.reason });
+  } finally {
+    writer.releaseLock();
+  }
+  await writable.close();
+
+  return { aborted: true, reason: result.reason, timedOut: result.type === "timeout" };
+}
+```
+
+## Tips
+
+- **Run ID is the coordination key** — Share the `runId` to allow abort from any process
+- **Signal is lazy** — The `.signal` property only starts listening when accessed
+- **One-shot** — Once aborted, the workflow completes; create a new controller for new operations
+- **Combine with operations** — Use the signal with `fetch`, database queries, or any API that accepts `AbortSignal`
+- **Memory cleanup** — The signal listener runs until abort or workflow completion; the stream closes automatically
+
+## Key APIs
+
+- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
+- [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook for the abort signal
+- [`getWorkflowMetadata()`](/docs/api-reference/workflow/get-workflow-metadata) — access the run ID for deterministic hook tokens
+- [`getWritable()`](/docs/api-reference/workflow/get-writable) — write abort messages to the stream
+- [`start()`](/docs/api-reference/workflow-api/start) — start the abort controller workflow
+- [`getRun()`](/docs/api-reference/workflow-api/get-run) — reconnect to the workflow's readable stream

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -17,7 +17,7 @@ Use this pattern when you need an `AbortController`-like interface that works ac
 ## Pattern
 
 The `DistributedAbortController` class encapsulates a workflow that:
-1. Creates a unique run when instantiated
+1. Accepts a user-provided unique ID (like a chat ID or task ID) for the hook token
 2. Waits for a hook signal when `.abort()` is called
 3. Writes a cancellation message to the run's stream
 4. Returns a local `AbortSignal` that listens to the stream
@@ -25,11 +25,11 @@ The `DistributedAbortController` class encapsulates a workflow that:
 ### Core Implementation
 
 ```typescript lineNumbers
-import { defineHook, getWritable, getWorkflowMetadata } from "workflow";
-import { start, getRun } from "workflow/api";
+import { defineHook, getWritable } from "workflow";
+import { start, getRun, getHookByToken } from "workflow/api";
 import { z } from "zod";
 
-// Hook to trigger the abort signal
+// Hook to trigger the abort signal — token is derived from user-provided ID
 export const abortHook = defineHook({
   schema: z.object({
     reason: z.string().optional(),
@@ -42,9 +42,14 @@ export type AbortMessage = {
   reason?: string;
 };
 
+// Helper to create a consistent hook token from the user ID
+function getAbortToken(id: string): string {
+  return `abort:${id}`;
+}
+
 // Step function that writes the abort message to the stream
-async function writeAbortSignal(reason?: string) { // [!code highlight]
-  "use step"; // [!code highlight]
+async function writeAbortSignal(reason?: string) {
+  "use step";
 
   const writable = getWritable<AbortMessage>();
   const writer = writable.getWriter();
@@ -57,87 +62,66 @@ async function writeAbortSignal(reason?: string) { // [!code highlight]
 }
 
 // Workflow that waits for the abort signal and writes to the stream
-export async function abortControllerWorkflow() {
+export async function abortControllerWorkflow(id: string) { // [!code highlight]
   "use workflow";
 
-  const { workflowRunId } = getWorkflowMetadata();
-
-  // Wait for the abort hook to be triggered
-  const hook = abortHook.create({ token: `abort:${workflowRunId}` }); // [!code highlight]
-  const { reason } = await hook; // [!code highlight]
+  // Use the user-provided ID for the hook token
+  const hook = abortHook.create({ token: getAbortToken(id) }); // [!code highlight]
+  const { reason } = await hook;
 
   // Write the abort message inside a step
-  await writeAbortSignal(reason); // [!code highlight]
+  await writeAbortSignal(reason);
 
   return { aborted: true, reason };
 }
 
 /**
  * A distributed abort controller that works across process boundaries.
+ * Uses a semantically meaningful ID (like a chat ID or task ID) to coordinate.
  *
  * @example
  * ```typescript
- * // Process A: Create the controller
- * const controller = await DistributedAbortController.create();
- * const runId = controller.runId; // Share this with Process B
+ * // Process A: Create the controller with a meaningful ID
+ * const controller = await DistributedAbortController.create("chat:123");
  *
- * // Process B: Abort from anywhere
- * const controller = DistributedAbortController.fromRunId(runId);
- * await controller.abort("User cancelled");
+ * // Process B: Abort using the same ID (no run ID needed!)
+ * await DistributedAbortController.abort("chat:123", "User cancelled");
  *
- * // Process A: Listen for the signal
- * const signal = await controller.signal;
+ * // Process C: Get a signal using the same ID
+ * const signal = await DistributedAbortController.getSignal("chat:123");
  * signal.addEventListener("abort", () => {
  *   console.log("Aborted:", signal.reason);
  * });
  * ```
  */
 export class DistributedAbortController {
-  readonly runId: string;
-  #signalPromise: Promise<AbortSignal> | null = null;
-
-  private constructor(runId: string) {
-    this.runId = runId;
-  }
-
   /**
    * Creates a new distributed abort controller by starting a workflow.
+   * The ID should be semantically meaningful (e.g., "chat:123", "task:abc").
    */
-  static async create(): Promise<DistributedAbortController> {
-    const run = await start(abortControllerWorkflow); // [!code highlight]
-    return new DistributedAbortController(run.runId);
+  static async create(id: string): Promise<void> { // [!code highlight]
+    await start(abortControllerWorkflow, { args: [id] });
   }
 
   /**
-   * Reconnects to an existing abort controller by run ID.
-   * Use this to abort from a different process.
+   * Triggers the abort signal for the given ID.
+   * Can be called from any process — finds the run via the hook token.
    */
-  static fromRunId(runId: string): DistributedAbortController {
-    return new DistributedAbortController(runId);
+  static async abort(id: string, reason?: string): Promise<void> { // [!code highlight]
+    await abortHook.resume(getAbortToken(id), { reason });
   }
 
   /**
-   * Triggers the abort signal across all listeners.
+   * Returns an AbortSignal for the given ID.
+   * Finds the run via the hook token and listens to its stream.
    */
-  async abort(reason?: string): Promise<void> {
-    await abortHook.resume(`abort:${this.runId}`, { reason }); // [!code highlight]
-  }
+  static async getSignal(id: string): Promise<AbortSignal> { // [!code highlight]
+    // Find the run by looking up the hook token
+    const hook = await getHookByToken(getAbortToken(id)); // [!code highlight]
+    const run = getRun<{ aborted: boolean; reason?: string }>(hook.runId);
 
-  /**
-   * Returns an AbortSignal that triggers when the workflow receives
-   * the abort hook. The signal listens to the workflow's readable stream.
-   */
-  get signal(): Promise<AbortSignal> {
-    if (!this.#signalPromise) {
-      this.#signalPromise = this.#createSignal();
-    }
-    return this.#signalPromise;
-  }
-
-  async #createSignal(): Promise<AbortSignal> {
     const controller = new AbortController();
-    const run = getRun<{ aborted: boolean; reason?: string }>(this.runId);
-    const readable = run.getReadable<AbortMessage>(); // [!code highlight]
+    const readable = run.getReadable<AbortMessage>();
 
     // Read from the stream in the background
     (async () => {
@@ -147,7 +131,7 @@ export class DistributedAbortController {
           const { done, value } = await reader.read();
           if (done) break;
           if (value.type === "abort") {
-            controller.abort(value.reason); // [!code highlight]
+            controller.abort(value.reason);
             break;
           }
         }
@@ -166,11 +150,11 @@ export class DistributedAbortController {
 ```typescript lineNumbers
 import { DistributedAbortController } from "./distributed-abort-controller";
 
-// Create a new controller
-const controller = await DistributedAbortController.create();
+// Create a new controller with a meaningful ID
+await DistributedAbortController.create("chat:user-123");
 
 // Get the signal (can be passed to fetch, etc.)
-const signal = await controller.signal;
+const signal = await DistributedAbortController.getSignal("chat:user-123");
 
 // Use with fetch
 const response = await fetch("https://api.example.com/long-operation", {
@@ -188,13 +172,14 @@ signal.addEventListener("abort", () => {
 ```typescript lineNumbers
 import { DistributedAbortController } from "./distributed-abort-controller";
 
-// In Process A: Share the runId
-const controller = await DistributedAbortController.create();
-console.log("Share this ID:", controller.runId);
+// In Process A: Create with a task ID
+await DistributedAbortController.create("task:build-123");
 
-// In Process B: Abort using the shared runId
-const remoteController = DistributedAbortController.fromRunId(runId);
-await remoteController.abort("Cancelled by admin");
+// In Process B: Abort using the same task ID — no need to share run IDs!
+await DistributedAbortController.abort("task:build-123", "Cancelled by admin");
+
+// In Process C: Listen using the same task ID
+const signal = await DistributedAbortController.getSignal("task:build-123");
 ```
 
 ### API Route for Remote Abort
@@ -204,13 +189,12 @@ import { DistributedAbortController } from "@/lib/distributed-abort-controller";
 
 export async function POST(
   request: Request,
-  { params }: { params: Promise<{ runId: string }> }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const { runId } = await params;
+  const { id } = await params;
   const { reason } = await request.json();
 
-  const controller = DistributedAbortController.fromRunId(runId);
-  await controller.abort(reason || "Cancelled via API");
+  await DistributedAbortController.abort(id, reason || "Cancelled via API");
 
   return Response.json({ success: true });
 }
@@ -221,9 +205,9 @@ export async function POST(
 ```tsx lineNumbers
 "use client";
 
-export function CancelButton({ runId }: { runId: string }) {
+export function CancelButton({ taskId }: { taskId: string }) {
   const handleCancel = async () => {
-    await fetch(`/api/abort/${runId}`, {
+    await fetch(`/api/abort/${taskId}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ reason: "User clicked cancel" }),
@@ -243,7 +227,7 @@ export function CancelButton({ runId }: { runId: string }) {
 Combine the abort controller with `sleep()` for automatic timeout:
 
 ```typescript lineNumbers
-import { defineHook, getWritable, getWorkflowMetadata, sleep } from "workflow";
+import { defineHook, getWritable, sleep } from "workflow";
 import { z } from "zod";
 
 export const abortHook = defineHook({
@@ -252,7 +236,10 @@ export const abortHook = defineHook({
 
 export type AbortMessage = { type: "abort"; reason?: string };
 
-// Step function that writes the abort message
+function getAbortToken(id: string): string {
+  return `abort:${id}`;
+}
+
 async function writeAbortSignal(reason?: string) {
   "use step";
 
@@ -266,30 +253,35 @@ async function writeAbortSignal(reason?: string) {
   await writable.close();
 }
 
-export async function timedAbortWorkflow(timeoutMs: number) {
+export async function timedAbortWorkflow(id: string, timeoutMs: number) {
   "use workflow";
 
-  const { workflowRunId } = getWorkflowMetadata();
-
-  const hook = abortHook.create({ token: `abort:${workflowRunId}` });
+  const hook = abortHook.create({ token: getAbortToken(id) });
 
   // Race: manual abort OR timeout
   const result = await Promise.race([ // [!code highlight]
     hook.then((payload) => ({ type: "manual" as const, ...payload })),
-    sleep(`${timeoutMs}ms`).then(() => ({ type: "timeout" as const, reason: "Operation timed out" })),
+    sleep(`${timeoutMs}ms`).then(() => ({
+      type: "timeout" as const,
+      reason: "Operation timed out",
+    })),
   ]);
 
-  // Write the abort message inside a step
-  await writeAbortSignal(result.reason); // [!code highlight]
+  await writeAbortSignal(result.reason);
 
-  return { aborted: true, reason: result.reason, timedOut: result.type === "timeout" };
+  return {
+    aborted: true,
+    reason: result.reason,
+    timedOut: result.type === "timeout",
+  };
 }
 ```
 
 ## Tips
 
-- **Run ID is the coordination key** — Share the `runId` to allow abort from any process
-- **Signal is lazy** — The `.signal` property only starts listening when accessed
+- **Use semantic IDs** — Use meaningful IDs like `chat:123` or `task:abc` instead of random UUIDs
+- **No run ID sharing needed** — The hook token lookup means you only need to share the semantic ID
+- **Signal is lazy** — The `getSignal()` method only starts listening when called
 - **One-shot** — Once aborted, the workflow completes; create a new controller for new operations
 - **Combine with operations** — Use the signal with `fetch`, database queries, or any API that accepts `AbortSignal`
 - **Memory cleanup** — The signal listener runs until abort or workflow completion; the stream closes automatically
@@ -298,7 +290,7 @@ export async function timedAbortWorkflow(timeoutMs: number) {
 
 - [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
 - [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook for the abort signal
-- [`getWorkflowMetadata()`](/docs/api-reference/workflow/get-workflow-metadata) — access the run ID for deterministic hook tokens
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) — write abort messages to the stream
 - [`start()`](/docs/api-reference/workflow-api/start) — start the abort controller workflow
+- [`getHookByToken()`](/docs/api-reference/workflow-api/get-hook-by-token) — find a run by its hook token
 - [`getRun()`](/docs/api-reference/workflow-api/get-run) — reconnect to the workflow's readable stream

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -30,6 +30,8 @@ import { start, getRun, getHookByToken } from "workflow/api";
 
 // Default TTL: 24 hours
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+// Default grace period: 1 hour (keeps hook alive after abort for late subscribers)
+const DEFAULT_GRACE_MS = 60 * 60 * 1000;
 
 // Hook to trigger the abort signal
 export const abortHook = defineHook<{ reason?: string }>();
@@ -61,9 +63,14 @@ async function writeAbortSignal(reason?: string, expired?: boolean) {
 }
 
 // Workflow that waits for abort or TTL expiration
-export async function abortControllerWorkflow(id: string, ttlMs: number) {
+export async function abortControllerWorkflow(
+  id: string,
+  ttlMs: number,
+  graceMs: number
+) {
   "use workflow";
 
+  const startTime = Date.now();
   const hook = abortHook.create({ token: getAbortToken(id) });
 
   // Race: manual abort OR TTL expiration // [!code highlight]
@@ -79,6 +86,13 @@ export async function abortControllerWorkflow(id: string, ttlMs: number) {
   ]);
 
   await writeAbortSignal(result.reason, result.expired);
+
+  // Sleep until TTL + grace period to keep hook alive for late subscribers // [!code highlight]
+  const elapsed = Date.now() - startTime;
+  const remainingTime = ttlMs + graceMs - elapsed;
+  if (remainingTime > 0) {
+    await sleep(`${remainingTime}ms`); // [!code highlight]
+  }
 
   return { aborted: true, reason: result.reason, expired: result.expired };
 }
@@ -103,12 +117,13 @@ export class DistributedAbortController {
    *
    * @param id - A unique, semantically meaningful ID (e.g., "chat:123")
    * @param options.ttlMs - Time-to-live in ms (default: 24 hours)
+   * @param options.graceMs - Grace period after abort (default: 1 hour)
    */
   static async create( // [!code highlight]
     id: string,
-    options: { ttlMs?: number } = {}
+    options: { ttlMs?: number; graceMs?: number } = {}
   ): Promise<DistributedAbortController> {
-    const { ttlMs = DEFAULT_TTL_MS } = options;
+    const { ttlMs = DEFAULT_TTL_MS, graceMs = DEFAULT_GRACE_MS } = options;
     const token = getAbortToken(id);
 
     // Try to find an existing run with this hook token
@@ -120,7 +135,9 @@ export class DistributedAbortController {
     }
 
     // Create a new workflow
-    const run = await start(abortControllerWorkflow, { args: [id, ttlMs] }); // [!code highlight]
+    const run = await start(abortControllerWorkflow, { // [!code highlight]
+      args: [id, ttlMs, graceMs],
+    });
     return new DistributedAbortController(id, run.id);
   }
 

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -235,6 +235,8 @@ anotherRef.signal.addEventListener("abort", (e) => {
 ### Custom TTL
 
 ```typescript lineNumbers
+import { DistributedAbortController } from "./distributed-abort-controller";
+
 // Short-lived controller for a quick operation (5 minutes)
 const shortLived = await DistributedAbortController.create("quick-task", {
   ttlMs: 5 * 60 * 1000,

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -106,7 +106,7 @@ export async function abortControllerWorkflow(
  */
 export class DistributedAbortController {
   private id: string;
-  private runId: string;
+  readonly runId: string;
 
   private constructor(id: string, runId: string) {
     this.id = id;

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -42,25 +42,32 @@ export type AbortMessage = {
   reason?: string;
 };
 
+// Step function that writes the abort message to the stream
+async function writeAbortSignal(reason?: string) { // [!code highlight]
+  "use step"; // [!code highlight]
+
+  const writable = getWritable<AbortMessage>();
+  const writer = writable.getWriter();
+  try {
+    await writer.write({ type: "abort", reason });
+  } finally {
+    writer.releaseLock();
+  }
+  await writable.close();
+}
+
 // Workflow that waits for the abort signal and writes to the stream
 export async function abortControllerWorkflow() {
   "use workflow";
 
   const { workflowRunId } = getWorkflowMetadata();
-  const writable = getWritable<AbortMessage>();
 
   // Wait for the abort hook to be triggered
   const hook = abortHook.create({ token: `abort:${workflowRunId}` }); // [!code highlight]
   const { reason } = await hook; // [!code highlight]
 
-  // Write the abort message to the stream
-  const writer = writable.getWriter();
-  try {
-    await writer.write({ type: "abort", reason }); // [!code highlight]
-  } finally {
-    writer.releaseLock();
-  }
-  await writable.close();
+  // Write the abort message inside a step
+  await writeAbortSignal(reason); // [!code highlight]
 
   return { aborted: true, reason };
 }
@@ -245,11 +252,24 @@ export const abortHook = defineHook({
 
 export type AbortMessage = { type: "abort"; reason?: string };
 
+// Step function that writes the abort message
+async function writeAbortSignal(reason?: string) {
+  "use step";
+
+  const writable = getWritable<AbortMessage>();
+  const writer = writable.getWriter();
+  try {
+    await writer.write({ type: "abort", reason });
+  } finally {
+    writer.releaseLock();
+  }
+  await writable.close();
+}
+
 export async function timedAbortWorkflow(timeoutMs: number) {
   "use workflow";
 
   const { workflowRunId } = getWorkflowMetadata();
-  const writable = getWritable<AbortMessage>();
 
   const hook = abortHook.create({ token: `abort:${workflowRunId}` });
 
@@ -259,13 +279,8 @@ export async function timedAbortWorkflow(timeoutMs: number) {
     sleep(`${timeoutMs}ms`).then(() => ({ type: "timeout" as const, reason: "Operation timed out" })),
   ]);
 
-  const writer = writable.getWriter();
-  try {
-    await writer.write({ type: "abort", reason: result.reason });
-  } finally {
-    writer.releaseLock();
-  }
-  await writable.close();
+  // Write the abort message inside a step
+  await writeAbortSignal(result.reason); // [!code highlight]
 
   return { aborted: true, reason: result.reason, timedOut: result.type === "timeout" };
 }

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -87,11 +87,14 @@ export async function abortControllerWorkflow(
 
   await writeAbortSignal(result.reason, result.expired);
 
-  // Sleep until TTL + grace period to keep hook alive for late subscribers // [!code highlight]
-  const elapsed = Date.now() - startTime;
-  const remainingTime = ttlMs + graceMs - elapsed;
-  if (remainingTime > 0) {
-    await sleep(`${remainingTime}ms`); // [!code highlight]
+  // Only sleep through grace period on TTL expiration (keeps hook alive for late subscribers). // [!code highlight]
+  // Manual aborts complete immediately.
+  if (result.expired) {
+    const elapsed = Date.now() - startTime;
+    const remainingTime = graceMs - (elapsed - ttlMs);
+    if (remainingTime > 0) {
+      await sleep(`${remainingTime}ms`); // [!code highlight]
+    }
   }
 
   return { aborted: true, reason: result.reason, expired: result.expired };

--- a/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
+++ b/docs/content/docs/cookbook/common-patterns/distributed-abort-controller.mdx
@@ -141,10 +141,18 @@ export class DistributedAbortController {
 
   /**
    * Triggers the abort signal.
-   * Can be called from any process with this controller instance.
+   * Idempotent: safe to call multiple times or after the workflow has completed.
    */
   async abort(reason?: string): Promise<void> { // [!code highlight]
-    await abortHook.resume(getAbortToken(this.id), { reason });
+    try {
+      await abortHook.resume(getAbortToken(this.id), { reason });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message.toLowerCase() : '';
+      if (msg.includes('not found') || msg.includes('expired')) {
+        return;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -156,7 +164,6 @@ export class DistributedAbortController {
     const controller = new AbortController();
     const readable = run.getReadable<AbortMessage>();
 
-    // Read from the stream in the background
     (async () => {
       const reader = readable.getReader();
       try {
@@ -170,6 +177,12 @@ export class DistributedAbortController {
             controller.abort(reason);
             break;
           }
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          controller.abort(
+            error instanceof Error ? error.message : "Stream read failed"
+          );
         }
       } finally {
         reader.releaseLock();

--- a/docs/content/docs/cookbook/common-patterns/meta.json
+++ b/docs/content/docs/cookbook/common-patterns/meta.json
@@ -10,6 +10,7 @@
     "idempotency",
     "webhooks",
     "content-router",
-    "child-workflows"
+    "child-workflows",
+    "distributed-abort-controller"
   ]
 }

--- a/docs/content/docs/cookbook/index.mdx
+++ b/docs/content/docs/cookbook/index.mdx
@@ -17,6 +17,7 @@ A curated collection of workflow patterns with clean, copy-paste code examples f
 - [**Webhooks**](/cookbook/common-patterns/webhooks) — Receive HTTP callbacks from external services and process them durably
 - [**Conditional Routing**](/cookbook/common-patterns/content-router) — Route payloads to different step handlers based on content
 - [**Child Workflows**](/cookbook/common-patterns/child-workflows) — Spawn and orchestrate child workflows from a parent
+- [**Distributed Abort Controller**](/cookbook/common-patterns/distributed-abort-controller) — Build a cross-process abort controller using workflow streams and hooks
 
 ## Agent Patterns
 

--- a/docs/lib/cookbook-tree.ts
+++ b/docs/lib/cookbook-tree.ts
@@ -37,6 +37,7 @@ export const slugToCategory: Record<string, string> = {
   webhooks: 'common-patterns',
   'content-router': 'common-patterns',
   'child-workflows': 'common-patterns',
+  'distributed-abort-controller': 'common-patterns',
 
   // Agent Patterns
   'durable-agent': 'agent-patterns',
@@ -122,6 +123,13 @@ export const recipes: Record<string, Recipe> = {
     title: 'Child Workflows',
     description:
       'Spawn and orchestrate child workflows from a parent, polling for completion and handling partial failures.',
+    category: 'common-patterns',
+  },
+  'distributed-abort-controller': {
+    slug: 'distributed-abort-controller',
+    title: 'Distributed Abort Controller',
+    description:
+      'Build a cross-process abort controller using workflow streams and hooks to coordinate cancellation by semantic ID.',
     category: 'common-patterns',
   },
 

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2331,4 +2331,109 @@ describe('e2e', () => {
       });
     }
   );
+
+  // ============================================================
+  // Distributed Abort Controller
+  // ============================================================
+  test(
+    'distributedAbortController - manual abort triggers signal',
+    { timeout: 60_000 },
+    async () => {
+      const controllerId = `test-abort-${Math.random().toString(36).slice(2)}`;
+
+      // Start the abort controller workflow with short TTL for testing
+      const run = await start(
+        await e2e('distributedAbortControllerWorkflow'),
+        [controllerId, 60_000, 10_000] // 60s TTL, 10s grace
+      );
+
+      // Wait for the hook to be registered
+      await sleep(3_000);
+
+      // Get the abort signal (reads from stream)
+      const readable = await run.getReadable();
+      const reader = readable.getReader();
+
+      // Trigger abort via hook
+      const token = `distributed-abort:${controllerId}`;
+      const hook = await getHookByToken(token);
+      expect(hook.runId).toBe(run.runId);
+      await resumeHook(token, { reason: 'User cancelled' });
+
+      // Read the abort message from the stream
+      const { value } = await reader.read();
+      reader.releaseLock();
+
+      expect(value).toEqual({
+        type: 'abort',
+        reason: 'User cancelled',
+        expired: false,
+      });
+    }
+  );
+
+  test(
+    'distributedAbortController - TTL expiration triggers signal',
+    { timeout: 30_000 },
+    async () => {
+      const controllerId = `test-expire-${Math.random().toString(36).slice(2)}`;
+
+      // Start with very short TTL (3 seconds)
+      const run = await start(
+        await e2e('distributedAbortControllerWorkflow'),
+        [controllerId, 3_000, 1_000] // 3s TTL, 1s grace
+      );
+
+      // Get the abort signal stream
+      const readable = await run.getReadable();
+      const reader = readable.getReader();
+
+      // Wait for TTL to expire and read the abort message
+      const { value } = await reader.read();
+      reader.releaseLock();
+
+      expect(value).toEqual({
+        type: 'abort',
+        reason: 'Controller expired',
+        expired: true,
+      });
+    }
+  );
+
+  test(
+    'distributedAbortController - reconnect to existing controller',
+    { timeout: 60_000 },
+    async () => {
+      const controllerId = `test-reconnect-${Math.random().toString(36).slice(2)}`;
+      const token = `distributed-abort:${controllerId}`;
+
+      // Start first controller
+      const run1 = await start(
+        await e2e('distributedAbortControllerWorkflow'),
+        [controllerId, 60_000, 10_000]
+      );
+
+      // Wait for hook to be registered
+      await sleep(3_000);
+
+      // Look up the hook - should find the same run
+      const hook = await getHookByToken(token);
+      expect(hook.runId).toBe(run1.runId);
+
+      // A second lookup should still find the same run (hook persists)
+      const hook2 = await getHookByToken(token);
+      expect(hook2.runId).toBe(run1.runId);
+
+      // Abort the controller
+      await resumeHook(token, { reason: 'Test complete' });
+
+      // Workflow should still be running (grace period), so hook should still be findable
+      await sleep(1_000);
+      const hookAfterAbort = await getHookByToken(token).catch(() => null);
+      // Hook may or may not be disposed depending on timing, but run should complete
+      const returnValue = await run1.returnValue;
+      expect(returnValue.aborted).toBe(true);
+      expect(returnValue.reason).toBe('Test complete');
+    }
+  );
 });

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -1780,11 +1780,14 @@ export async function distributedAbortControllerWorkflow(
   // Write the abort signal to the stream
   await writeAbortSignal(result.reason, result.expired);
 
-  // Sleep until TTL + grace period to keep hook alive for late subscribers
-  const elapsed = Date.now() - startTime;
-  const remainingTime = ttlMs + graceMs - elapsed;
-  if (remainingTime > 0) {
-    await sleep(remainingTime);
+  // Only sleep through grace period on TTL expiration (keeps hook alive for late subscribers).
+  // Manual aborts complete immediately.
+  if (result.expired) {
+    const elapsed = Date.now() - startTime;
+    const remainingTime = graceMs - (elapsed - ttlMs);
+    if (remainingTime > 0) {
+      await sleep(remainingTime);
+    }
   }
 
   return { aborted: true, reason: result.reason, expired: result.expired };

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -13,7 +13,7 @@ import {
   RetryableError,
   sleep,
 } from 'workflow';
-import { getRun, Run, resumeHook, start } from 'workflow/api';
+import { getHookByToken, getRun, resumeHook, Run, start } from 'workflow/api';
 import { importedStepOnly } from './_imported_step_only';
 import { callThrower, stepThatThrowsFromHelper } from './helpers';
 
@@ -1715,4 +1715,163 @@ export async function fibonacciWorkflow(n: number): Promise<number> {
 
   const [a, b] = await Promise.all([runA.returnValue, runB.returnValue]);
   return a + b;
+}
+
+//////////////////////////////////////////////////////////
+// Distributed Abort Controller
+//////////////////////////////////////////////////////////
+
+// Message type written to the stream when abort fires
+export type AbortMessage = {
+  type: 'abort';
+  reason?: string;
+  expired: boolean;
+};
+
+// Helper to derive abort hook token from user-provided ID
+function getAbortToken(id: string): string {
+  return `distributed-abort:${id}`;
+}
+
+// Step function that writes the abort message to the stream
+async function writeAbortSignal(reason?: string, expired = false) {
+  'use step';
+  const writable = getWritable<AbortMessage>();
+  const writer = writable.getWriter();
+  try {
+    await writer.write({ type: 'abort', reason, expired });
+  } finally {
+    writer.releaseLock();
+  }
+  await writable.close();
+}
+
+/**
+ * Workflow that backs the DistributedAbortController.
+ * Waits for either:
+ * 1. Manual abort via hook trigger
+ * 2. TTL expiration
+ *
+ * After abort, sleeps until TTL + grace period to keep hook alive
+ * for late subscribers.
+ */
+export async function distributedAbortControllerWorkflow(
+  id: string,
+  ttlMs: number,
+  graceMs: number
+) {
+  'use workflow';
+
+  const startTime = Date.now();
+  const hook = createHook<{ reason?: string }>({ token: getAbortToken(id) });
+
+  // Race: manual abort OR TTL expiration
+  const result = await Promise.race([
+    hook.then((payload) => ({
+      reason: payload.reason,
+      expired: false,
+    })),
+    sleep(ttlMs).then(() => ({
+      reason: 'Controller expired',
+      expired: true,
+    })),
+  ]);
+
+  // Write the abort signal to the stream
+  await writeAbortSignal(result.reason, result.expired);
+
+  // Sleep until TTL + grace period to keep hook alive for late subscribers
+  const elapsed = Date.now() - startTime;
+  const remainingTime = ttlMs + graceMs - elapsed;
+  if (remainingTime > 0) {
+    await sleep(remainingTime);
+  }
+
+  return { aborted: true, reason: result.reason, expired: result.expired };
+}
+
+/**
+ * DistributedAbortController - a cross-process abort controller backed by a durable workflow.
+ *
+ * Usage:
+ *   const controller = await DistributedAbortController.create('my-task-123');
+ *   // In any process:
+ *   controller.abort('User cancelled');
+ *   // In any other process:
+ *   const signal = await controller.signal;
+ *   signal.addEventListener('abort', () => console.log('Aborted!'));
+ */
+export class DistributedAbortController {
+  private constructor(
+    public readonly id: string,
+    public readonly runId: string
+  ) {}
+
+  /**
+   * Creates or reconnects to a distributed abort controller.
+   * If a controller with this ID already exists, reconnects to it.
+   * Otherwise, starts a new workflow.
+   */
+  static async create(
+    id: string,
+    options: { ttlMs?: number; graceMs?: number } = {}
+  ): Promise<DistributedAbortController> {
+    const { ttlMs = 24 * 60 * 60 * 1000, graceMs = 60 * 60 * 1000 } = options;
+    const token = getAbortToken(id);
+
+    // Try to find an existing run with this hook token
+    const existingHook = await getHookByToken(token).catch(() => null);
+
+    if (existingHook) {
+      // Reconnect to existing controller
+      return new DistributedAbortController(id, existingHook.runId);
+    }
+
+    // Create a new workflow
+    const run = await start(distributedAbortControllerWorkflow, [
+      id,
+      ttlMs,
+      graceMs,
+    ]);
+    return new DistributedAbortController(id, run.runId);
+  }
+
+  /**
+   * Triggers the abort signal across all processes.
+   */
+  async abort(reason?: string): Promise<void> {
+    const token = getAbortToken(this.id);
+    await resumeHook(token, { reason });
+  }
+
+  /**
+   * Returns an AbortSignal that fires when the controller is aborted.
+   * Listens to the workflow's output stream.
+   */
+  get signal(): Promise<AbortSignal> {
+    return (async () => {
+      const controller = new AbortController();
+      const run = getRun<AbortMessage>(this.runId);
+      const readable = await run.getReadable();
+      const reader = readable.getReader();
+
+      // Read from stream in background
+      (async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value && value.type === 'abort') {
+              controller.abort(value.reason);
+              break;
+            }
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      })();
+
+      return controller.signal;
+    })();
+  }
 }

--- a/workbench/vitest/test/cookbook-common.test.ts
+++ b/workbench/vitest/test/cookbook-common.test.ts
@@ -147,71 +147,79 @@ describe('child-workflows', () => {
 });
 
 describe('distributed-abort-controller', () => {
+  const TTL_MS = 5 * 60 * 1000;
+  const GRACE_MS = 60 * 1000;
+
   it('should abort via hook and emit message on stream', async () => {
     const testId = `test-${Date.now()}`;
 
-    // Start the abort controller workflow directly
-    const run = await start(abortControllerWorkflow, [testId]);
+    const run = await start(abortControllerWorkflow, [
+      testId,
+      TTL_MS,
+      GRACE_MS,
+    ]);
 
-    // Wait for the hook to be registered
     const hook = await waitForHook(run);
     expect(hook.token).toBe(`abort:${testId}`);
 
-    // Trigger the abort via the hook
     await abortHook.resume(`abort:${testId}`, { reason: 'User cancelled' });
 
-    // Verify the workflow completes with the expected result
     const result = await run.returnValue;
-    expect(result).toEqual({ aborted: true, reason: 'User cancelled' });
+    expect(result).toEqual({
+      aborted: true,
+      reason: 'User cancelled',
+      expired: false,
+    });
   });
 
   it('should emit abort message on the readable stream', async () => {
     const testId = `stream-test-${Date.now()}`;
 
-    // Start the workflow
-    const run = await start(abortControllerWorkflow, [testId]);
+    const run = await start(abortControllerWorkflow, [
+      testId,
+      TTL_MS,
+      GRACE_MS,
+    ]);
 
-    // Get the readable stream before triggering abort
     const readable = run.getReadable<{ type: string; reason?: string }>();
     const reader = readable.getReader();
 
-    // Wait for hook and trigger abort
     await waitForHook(run);
     await abortHook.resume(`abort:${testId}`, { reason: 'Stream test' });
 
-    // Read the abort message from the stream
     const { value, done } = await reader.read();
     expect(done).toBe(false);
-    expect(value).toEqual({ type: 'abort', reason: 'Stream test' });
+    expect(value).toEqual({
+      type: 'abort',
+      reason: 'Stream test',
+      expired: false,
+    });
 
     reader.releaseLock();
 
-    // Verify workflow completes
     const result = await run.returnValue;
     expect(result.aborted).toBe(true);
   });
 
-  it('should work with DistributedAbortController.getSignal', async () => {
+  it('should work with DistributedAbortController instance', async () => {
     const testId = `signal-test-${Date.now()}`;
 
-    // Create the controller
-    await DistributedAbortController.create(testId);
+    const controller = await DistributedAbortController.create(testId, {
+      ttlMs: TTL_MS,
+      graceMs: GRACE_MS,
+    });
 
-    // Get the signal
-    const signal = await DistributedAbortController.getSignal(testId);
+    const signal = controller.signal;
     expect(signal.aborted).toBe(false);
 
-    // Set up a promise that resolves when aborted
     const abortPromise = new Promise<string | undefined>((resolve) => {
       signal.addEventListener('abort', () => {
         resolve(signal.reason as string | undefined);
       });
     });
 
-    // Trigger the abort
-    await DistributedAbortController.abort(testId, 'Signal test reason');
+    await controller.abort('Signal test reason');
 
-    // Verify the signal was triggered
     const reason = await abortPromise;
     expect(reason).toBe('Signal test reason');
     expect(signal.aborted).toBe(true);

--- a/workbench/vitest/test/cookbook-common.test.ts
+++ b/workbench/vitest/test/cookbook-common.test.ts
@@ -218,6 +218,9 @@ describe('distributed-abort-controller', () => {
       });
     });
 
+    // Wait for the workflow to register the hook before resuming it
+    await waitForHook(getRun(controller.runId));
+
     await controller.abort('Signal test reason');
 
     const reason = await abortPromise;

--- a/workbench/vitest/test/cookbook-common.test.ts
+++ b/workbench/vitest/test/cookbook-common.test.ts
@@ -13,6 +13,11 @@ import {
   parentWorkflow,
   childWorkflow,
 } from '../workflows/cookbook/child-workflows.js';
+import {
+  DistributedAbortController,
+  abortControllerWorkflow,
+  abortHook,
+} from '../workflows/cookbook/distributed-abort-controller.js';
 
 describe('saga', () => {
   it('should run compensations in reverse on FatalError', async () => {
@@ -138,5 +143,77 @@ describe('child-workflows', () => {
     const result = await run.returnValue;
     expect(result.childRunId).toMatch(/^wrun_/);
     expect(result.result).toEqual({ item: 'x', result: 'processed-x' });
+  });
+});
+
+describe('distributed-abort-controller', () => {
+  it('should abort via hook and emit message on stream', async () => {
+    const testId = `test-${Date.now()}`;
+
+    // Start the abort controller workflow directly
+    const run = await start(abortControllerWorkflow, [testId]);
+
+    // Wait for the hook to be registered
+    const hook = await waitForHook(run);
+    expect(hook.token).toBe(`abort:${testId}`);
+
+    // Trigger the abort via the hook
+    await abortHook.resume(`abort:${testId}`, { reason: 'User cancelled' });
+
+    // Verify the workflow completes with the expected result
+    const result = await run.returnValue;
+    expect(result).toEqual({ aborted: true, reason: 'User cancelled' });
+  });
+
+  it('should emit abort message on the readable stream', async () => {
+    const testId = `stream-test-${Date.now()}`;
+
+    // Start the workflow
+    const run = await start(abortControllerWorkflow, [testId]);
+
+    // Get the readable stream before triggering abort
+    const readable = run.getReadable<{ type: string; reason?: string }>();
+    const reader = readable.getReader();
+
+    // Wait for hook and trigger abort
+    await waitForHook(run);
+    await abortHook.resume(`abort:${testId}`, { reason: 'Stream test' });
+
+    // Read the abort message from the stream
+    const { value, done } = await reader.read();
+    expect(done).toBe(false);
+    expect(value).toEqual({ type: 'abort', reason: 'Stream test' });
+
+    reader.releaseLock();
+
+    // Verify workflow completes
+    const result = await run.returnValue;
+    expect(result.aborted).toBe(true);
+  });
+
+  it('should work with DistributedAbortController.getSignal', async () => {
+    const testId = `signal-test-${Date.now()}`;
+
+    // Create the controller
+    await DistributedAbortController.create(testId);
+
+    // Get the signal
+    const signal = await DistributedAbortController.getSignal(testId);
+    expect(signal.aborted).toBe(false);
+
+    // Set up a promise that resolves when aborted
+    const abortPromise = new Promise<string | undefined>((resolve) => {
+      signal.addEventListener('abort', () => {
+        resolve(signal.reason as string | undefined);
+      });
+    });
+
+    // Trigger the abort
+    await DistributedAbortController.abort(testId, 'Signal test reason');
+
+    // Verify the signal was triggered
+    const reason = await abortPromise;
+    expect(reason).toBe('Signal test reason');
+    expect(signal.aborted).toBe(true);
   });
 });

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -4,13 +4,16 @@
  * Demonstrates a distributed AbortController that uses a durable workflow
  * to coordinate cancellation signals across process boundaries.
  *
- * Uses a semantically meaningful ID (like a chat ID or task ID) to coordinate:
- * 1. `create(id)` — Starts a workflow that registers a hook using the provided ID
- * 2. `getSignal(id)` — Finds the run via the hook token and returns a signal listening to its stream
- * 3. `abort(id)` — Triggers the hook which writes a cancellation message to the stream
+ * Usage:
+ *   const controller = await DistributedAbortController.create("chat:123");
+ *   controller.signal.addEventListener("abort", () => console.log("Aborted!"));
+ *   await controller.abort("User cancelled");
  */
-import { defineHook, getWritable } from 'workflow';
+import { defineHook, getWritable, sleep } from 'workflow';
 import { getHookByToken, getRun, start } from 'workflow/api';
+
+// Default TTL: 24 hours in milliseconds
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
 // Hook to trigger the abort signal
 export const abortHook = defineHook<{ reason?: string }>();
@@ -19,6 +22,7 @@ export const abortHook = defineHook<{ reason?: string }>();
 export type AbortMessage = {
   type: 'abort';
   reason?: string;
+  expired?: boolean;
 };
 
 // Helper to create a consistent hook token from the user ID
@@ -30,13 +34,13 @@ function getAbortToken(id: string): string {
  * Step function that writes the abort message to the stream.
  * Writing must happen inside a step, not directly in the workflow.
  */
-async function writeAbortSignal(reason?: string) {
+async function writeAbortSignal(reason?: string, expired?: boolean) {
   'use step';
 
   const writable = getWritable<AbortMessage>();
   const writer = writable.getWriter();
   try {
-    await writer.write({ type: 'abort', reason });
+    await writer.write({ type: 'abort', reason, expired });
   } finally {
     writer.releaseLock();
   }
@@ -44,20 +48,30 @@ async function writeAbortSignal(reason?: string) {
 }
 
 /**
- * Workflow that waits for the abort hook and writes to the stream.
+ * Workflow that waits for the abort hook or TTL expiration.
  * Accepts a user-provided ID to use as the hook token.
  */
-export async function abortControllerWorkflow(id: string) {
+export async function abortControllerWorkflow(id: string, ttlMs: number) {
   'use workflow';
 
-  // Use the user-provided ID for the hook token
   const hook = abortHook.create({ token: getAbortToken(id) });
-  const { reason } = await hook;
+
+  // Race: manual abort OR TTL expiration
+  const result = await Promise.race([
+    hook.then((payload) => ({
+      reason: payload.reason,
+      expired: false,
+    })),
+    sleep(`${ttlMs}ms`).then(() => ({
+      reason: 'Controller expired',
+      expired: true,
+    })),
+  ]);
 
   // Write the abort message inside a step
-  await writeAbortSignal(reason);
+  await writeAbortSignal(result.reason, result.expired);
 
-  return { aborted: true, reason };
+  return { aborted: true, reason: result.reason, expired: result.expired };
 }
 
 /**
@@ -66,41 +80,65 @@ export async function abortControllerWorkflow(id: string) {
  *
  * Unlike the standard AbortController which only works in a single process,
  * this version uses a durable workflow to coordinate the abort signal.
- * Any process with the same ID can create, abort, or listen to the signal.
+ * Any process with the same ID can create/reconnect, abort, or listen.
  */
 export class DistributedAbortController {
-  /**
-   * Creates a new distributed abort controller by starting a workflow.
-   * The ID should be semantically meaningful (e.g., "chat:123", "task:abc").
-   *
-   * @param id - A unique, semantically meaningful ID
-   */
-  static async create(id: string): Promise<void> {
-    await start(abortControllerWorkflow, { args: [id] });
+  private id: string;
+  private runId: string;
+
+  private constructor(id: string, runId: string) {
+    this.id = id;
+    this.runId = runId;
   }
 
   /**
-   * Triggers the abort signal for the given ID.
-   * Can be called from any process — resumes the hook registered with this ID.
+   * Creates or reconnects to a distributed abort controller.
+   * If a controller with this ID already exists, reconnects to it.
+   * Otherwise, starts a new workflow.
    *
-   * @param id - The same ID used when creating the controller
+   * @param id - A unique, semantically meaningful ID (e.g., "chat:123")
+   * @param options.ttlMs - Time-to-live in ms (default: 24 hours)
+   */
+  static async create(
+    id: string,
+    options: { ttlMs?: number } = {}
+  ): Promise<DistributedAbortController> {
+    const { ttlMs = DEFAULT_TTL_MS } = options;
+    const token = getAbortToken(id);
+
+    // Try to find an existing run with this hook token
+    const existingHook = await getHookByToken(token).catch(() => null);
+
+    if (existingHook) {
+      // Reconnect to existing controller
+      return new DistributedAbortController(id, existingHook.runId);
+    }
+
+    // Create a new workflow
+    const run = await start(abortControllerWorkflow, { args: [id, ttlMs] });
+    return new DistributedAbortController(id, run.id);
+  }
+
+  /**
+   * Triggers the abort signal.
+   * Can be called from any process with this controller instance.
+   *
    * @param reason - Optional reason for the cancellation
    */
-  static async abort(id: string, reason?: string): Promise<void> {
-    await abortHook.resume(getAbortToken(id), { reason });
+  async abort(reason?: string): Promise<void> {
+    await abortHook.resume(getAbortToken(this.id), { reason });
   }
 
   /**
-   * Returns an AbortSignal for the given ID.
-   * Finds the run via the hook token and listens to its stream.
-   *
-   * @param id - The same ID used when creating the controller
+   * Returns an AbortSignal that fires when abort() is called or TTL expires.
+   * The signal fires with a reason indicating what triggered it.
    */
-  static async getSignal(id: string): Promise<AbortSignal> {
-    // Find the run by looking up the hook token
-    const hook = await getHookByToken(getAbortToken(id));
-    const run = getRun<{ aborted: boolean; reason?: string }>(hook.runId);
-
+  get signal(): AbortSignal {
+    const run = getRun<{
+      aborted: boolean;
+      reason?: string;
+      expired?: boolean;
+    }>(this.runId);
     const controller = new AbortController();
     const readable = run.getReadable<AbortMessage>();
 
@@ -113,7 +151,10 @@ export class DistributedAbortController {
           const { done, value } = await reader.read();
           if (done) break;
           if (value.type === 'abort') {
-            controller.abort(value.reason);
+            const reason = value.expired
+              ? `${value.reason} (expired)`
+              : value.reason;
+            controller.abort(reason);
             break;
           }
         }

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -132,10 +132,8 @@ export class DistributedAbortController {
     }
 
     // Create a new workflow
-    const run = await start(abortControllerWorkflow, {
-      args: [id, ttlMs, graceMs],
-    });
-    return new DistributedAbortController(id, run.id);
+    const run = await start(abortControllerWorkflow, [id, ttlMs, graceMs]);
+    return new DistributedAbortController(id, run.runId);
   }
 
   /**

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -1,0 +1,162 @@
+/**
+ * Cookbook: distributed-abort-controller pattern
+ *
+ * Demonstrates a distributed AbortController that uses a durable workflow
+ * to coordinate cancellation signals across process boundaries.
+ *
+ * The controller:
+ * 1. Starts a workflow with a unique run ID
+ * 2. Waits for a hook signal to trigger abortion
+ * 3. Writes a cancellation message to the run's stream
+ * 4. Returns a local AbortSignal that listens to the stream
+ */
+import { defineHook, getWritable, getWorkflowMetadata } from 'workflow';
+import { getRun, start } from 'workflow/api';
+
+// Hook to trigger the abort signal
+export const abortHook = defineHook<{ reason?: string }>();
+
+// The abort message written to the stream
+export type AbortMessage = {
+  type: 'abort';
+  reason?: string;
+};
+
+/**
+ * Workflow that waits for the abort hook and writes to the stream.
+ * This workflow is the "coordinator" - it holds the abort state durably.
+ */
+export async function abortControllerWorkflow() {
+  'use workflow';
+
+  const { workflowRunId } = getWorkflowMetadata();
+  const writable = getWritable<AbortMessage>();
+
+  // Wait for the abort hook to be triggered
+  const hook = abortHook.create({ token: `abort:${workflowRunId}` });
+  const { reason } = await hook;
+
+  // Write the abort message to the stream
+  const writer = writable.getWriter();
+  try {
+    await writer.write({ type: 'abort', reason });
+  } finally {
+    writer.releaseLock();
+  }
+  await writable.close();
+
+  return { aborted: true, reason };
+}
+
+/**
+ * A distributed abort controller that works across process boundaries.
+ *
+ * Unlike the standard AbortController which only works in a single process,
+ * this version uses a durable workflow to coordinate the abort signal.
+ * The runId can be shared with any other process to allow remote cancellation.
+ */
+export class DistributedAbortController {
+  readonly runId: string;
+  #signalPromise: Promise<AbortSignal> | null = null;
+
+  private constructor(runId: string) {
+    this.runId = runId;
+  }
+
+  /**
+   * Creates a new distributed abort controller by starting a workflow.
+   * The workflow will wait indefinitely for an abort signal.
+   */
+  static async create(): Promise<DistributedAbortController> {
+    const run = await start(abortControllerWorkflow);
+    return new DistributedAbortController(run.runId);
+  }
+
+  /**
+   * Reconnects to an existing abort controller by run ID.
+   * Use this to abort or listen from a different process.
+   */
+  static fromRunId(runId: string): DistributedAbortController {
+    return new DistributedAbortController(runId);
+  }
+
+  /**
+   * Triggers the abort signal across all listeners.
+   * This resumes the hook in the workflow, which writes to the stream.
+   */
+  async abort(reason?: string): Promise<void> {
+    await abortHook.resume(`abort:${this.runId}`, { reason });
+  }
+
+  /**
+   * Returns an AbortSignal that triggers when the workflow receives
+   * the abort hook. The signal listens to the workflow's readable stream.
+   *
+   * This is lazy - the stream connection is only established when
+   * this property is first accessed.
+   */
+  get signal(): Promise<AbortSignal> {
+    if (!this.#signalPromise) {
+      this.#signalPromise = this.#createSignal();
+    }
+    return this.#signalPromise;
+  }
+
+  /**
+   * Creates a local AbortSignal that listens to the workflow's stream.
+   * When an abort message arrives, the local AbortController is aborted.
+   */
+  async #createSignal(): Promise<AbortSignal> {
+    const controller = new AbortController();
+    const run = getRun<{ aborted: boolean; reason?: string }>(this.runId);
+    const readable = run.getReadable<AbortMessage>();
+
+    // Read from the stream in the background
+    // When an abort message arrives, trigger the local controller
+    (async () => {
+      const reader = readable.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value.type === 'abort') {
+            controller.abort(value.reason);
+            break;
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    })();
+
+    return controller.signal;
+  }
+}
+
+/**
+ * Example usage workflow that demonstrates using the distributed abort controller
+ * to cancel a long-running operation.
+ */
+export async function longRunningOperationDemo(controllerRunId: string) {
+  'use workflow';
+
+  // Reconnect to the abort controller from a different "process"
+  const controller = DistributedAbortController.fromRunId(controllerRunId);
+  const signal = await controller.signal;
+
+  // Simulate checking the signal during a long operation
+  const results: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    if (signal.aborted) {
+      return {
+        completed: false,
+        reason: signal.reason,
+        progress: results,
+      };
+    }
+    results.push(`step-${i}`);
+    // In real code, you'd do actual work here
+  }
+
+  return { completed: true, progress: results };
+}

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -4,14 +4,13 @@
  * Demonstrates a distributed AbortController that uses a durable workflow
  * to coordinate cancellation signals across process boundaries.
  *
- * The controller:
- * 1. Starts a workflow with a unique run ID
- * 2. Waits for a hook signal to trigger abortion
- * 3. Writes a cancellation message to the run's stream
- * 4. Returns a local AbortSignal that listens to the stream
+ * Uses a semantically meaningful ID (like a chat ID or task ID) to coordinate:
+ * 1. `create(id)` — Starts a workflow that registers a hook using the provided ID
+ * 2. `getSignal(id)` — Finds the run via the hook token and returns a signal listening to its stream
+ * 3. `abort(id)` — Triggers the hook which writes a cancellation message to the stream
  */
-import { defineHook, getWritable, getWorkflowMetadata } from 'workflow';
-import { getRun, start } from 'workflow/api';
+import { defineHook, getWritable } from 'workflow';
+import { getHookByToken, getRun, start } from 'workflow/api';
 
 // Hook to trigger the abort signal
 export const abortHook = defineHook<{ reason?: string }>();
@@ -21,6 +20,11 @@ export type AbortMessage = {
   type: 'abort';
   reason?: string;
 };
+
+// Helper to create a consistent hook token from the user ID
+function getAbortToken(id: string): string {
+  return `abort:${id}`;
+}
 
 /**
  * Step function that writes the abort message to the stream.
@@ -41,15 +45,13 @@ async function writeAbortSignal(reason?: string) {
 
 /**
  * Workflow that waits for the abort hook and writes to the stream.
- * This workflow is the "coordinator" - it holds the abort state durably.
+ * Accepts a user-provided ID to use as the hook token.
  */
-export async function abortControllerWorkflow() {
+export async function abortControllerWorkflow(id: string) {
   'use workflow';
 
-  const { workflowRunId } = getWorkflowMetadata();
-
-  // Wait for the abort hook to be triggered
-  const hook = abortHook.create({ token: `abort:${workflowRunId}` });
+  // Use the user-provided ID for the hook token
+  const hook = abortHook.create({ token: getAbortToken(id) });
   const { reason } = await hook;
 
   // Write the abort message inside a step
@@ -60,65 +62,46 @@ export async function abortControllerWorkflow() {
 
 /**
  * A distributed abort controller that works across process boundaries.
+ * Uses a semantically meaningful ID (like a chat ID or task ID) to coordinate.
  *
  * Unlike the standard AbortController which only works in a single process,
  * this version uses a durable workflow to coordinate the abort signal.
- * The runId can be shared with any other process to allow remote cancellation.
+ * Any process with the same ID can create, abort, or listen to the signal.
  */
 export class DistributedAbortController {
-  readonly runId: string;
-  #signalPromise: Promise<AbortSignal> | null = null;
-
-  private constructor(runId: string) {
-    this.runId = runId;
-  }
-
   /**
    * Creates a new distributed abort controller by starting a workflow.
-   * The workflow will wait indefinitely for an abort signal.
-   */
-  static async create(): Promise<DistributedAbortController> {
-    const run = await start(abortControllerWorkflow);
-    return new DistributedAbortController(run.runId);
-  }
-
-  /**
-   * Reconnects to an existing abort controller by run ID.
-   * Use this to abort or listen from a different process.
-   */
-  static fromRunId(runId: string): DistributedAbortController {
-    return new DistributedAbortController(runId);
-  }
-
-  /**
-   * Triggers the abort signal across all listeners.
-   * This resumes the hook in the workflow, which writes to the stream.
-   */
-  async abort(reason?: string): Promise<void> {
-    await abortHook.resume(`abort:${this.runId}`, { reason });
-  }
-
-  /**
-   * Returns an AbortSignal that triggers when the workflow receives
-   * the abort hook. The signal listens to the workflow's readable stream.
+   * The ID should be semantically meaningful (e.g., "chat:123", "task:abc").
    *
-   * This is lazy - the stream connection is only established when
-   * this property is first accessed.
+   * @param id - A unique, semantically meaningful ID
    */
-  get signal(): Promise<AbortSignal> {
-    if (!this.#signalPromise) {
-      this.#signalPromise = this.#createSignal();
-    }
-    return this.#signalPromise;
+  static async create(id: string): Promise<void> {
+    await start(abortControllerWorkflow, { args: [id] });
   }
 
   /**
-   * Creates a local AbortSignal that listens to the workflow's stream.
-   * When an abort message arrives, the local AbortController is aborted.
+   * Triggers the abort signal for the given ID.
+   * Can be called from any process — resumes the hook registered with this ID.
+   *
+   * @param id - The same ID used when creating the controller
+   * @param reason - Optional reason for the cancellation
    */
-  async #createSignal(): Promise<AbortSignal> {
+  static async abort(id: string, reason?: string): Promise<void> {
+    await abortHook.resume(getAbortToken(id), { reason });
+  }
+
+  /**
+   * Returns an AbortSignal for the given ID.
+   * Finds the run via the hook token and listens to its stream.
+   *
+   * @param id - The same ID used when creating the controller
+   */
+  static async getSignal(id: string): Promise<AbortSignal> {
+    // Find the run by looking up the hook token
+    const hook = await getHookByToken(getAbortToken(id));
+    const run = getRun<{ aborted: boolean; reason?: string }>(hook.runId);
+
     const controller = new AbortController();
-    const run = getRun<{ aborted: boolean; reason?: string }>(this.runId);
     const readable = run.getReadable<AbortMessage>();
 
     // Read from the stream in the background
@@ -141,32 +124,4 @@ export class DistributedAbortController {
 
     return controller.signal;
   }
-}
-
-/**
- * Example usage workflow that demonstrates using the distributed abort controller
- * to cancel a long-running operation.
- */
-export async function longRunningOperationDemo(controllerRunId: string) {
-  'use workflow';
-
-  // Reconnect to the abort controller from a different "process"
-  const controller = DistributedAbortController.fromRunId(controllerRunId);
-  const signal = await controller.signal;
-
-  // Simulate checking the signal during a long operation
-  const results: string[] = [];
-  for (let i = 0; i < 10; i++) {
-    if (signal.aborted) {
-      return {
-        completed: false,
-        reason: signal.reason,
-        progress: results,
-      };
-    }
-    results.push(`step-${i}`);
-    // In real code, you'd do actual work here
-  }
-
-  return { completed: true, progress: results };
 }

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -139,11 +139,20 @@ export class DistributedAbortController {
   /**
    * Triggers the abort signal.
    * Can be called from any process with this controller instance.
+   * Idempotent: safe to call multiple times or after the workflow has completed.
    *
    * @param reason - Optional reason for the cancellation
    */
   async abort(reason?: string): Promise<void> {
-    await abortHook.resume(getAbortToken(this.id), { reason });
+    try {
+      await abortHook.resume(getAbortToken(this.id), { reason });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message.toLowerCase() : '';
+      if (msg.includes('not found') || msg.includes('expired')) {
+        return;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -159,8 +168,6 @@ export class DistributedAbortController {
     const controller = new AbortController();
     const readable = run.getReadable<AbortMessage>();
 
-    // Read from the stream in the background
-    // When an abort message arrives, trigger the local controller
     (async () => {
       const reader = readable.getReader();
       try {
@@ -174,6 +181,12 @@ export class DistributedAbortController {
             controller.abort(reason);
             break;
           }
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          controller.abort(
+            error instanceof Error ? error.message : 'Stream read failed'
+          );
         }
       } finally {
         reader.releaseLock();

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -14,6 +14,8 @@ import { getHookByToken, getRun, start } from 'workflow/api';
 
 // Default TTL: 24 hours in milliseconds
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+// Default grace period: 1 hour (keeps hook alive after abort for late subscribers)
+const DEFAULT_GRACE_MS = 60 * 60 * 1000;
 
 // Hook to trigger the abort signal
 export const abortHook = defineHook<{ reason?: string }>();
@@ -50,10 +52,17 @@ async function writeAbortSignal(reason?: string, expired?: boolean) {
 /**
  * Workflow that waits for the abort hook or TTL expiration.
  * Accepts a user-provided ID to use as the hook token.
+ * After abort/expiration, sleeps until TTL + grace period to keep hook
+ * alive for late subscribers.
  */
-export async function abortControllerWorkflow(id: string, ttlMs: number) {
+export async function abortControllerWorkflow(
+  id: string,
+  ttlMs: number,
+  graceMs: number
+) {
   'use workflow';
 
+  const startTime = Date.now();
   const hook = abortHook.create({ token: getAbortToken(id) });
 
   // Race: manual abort OR TTL expiration
@@ -70,6 +79,13 @@ export async function abortControllerWorkflow(id: string, ttlMs: number) {
 
   // Write the abort message inside a step
   await writeAbortSignal(result.reason, result.expired);
+
+  // Sleep until TTL + grace period to keep hook alive for late subscribers
+  const elapsed = Date.now() - startTime;
+  const remainingTime = ttlMs + graceMs - elapsed;
+  if (remainingTime > 0) {
+    await sleep(`${remainingTime}ms`);
+  }
 
   return { aborted: true, reason: result.reason, expired: result.expired };
 }
@@ -98,12 +114,13 @@ export class DistributedAbortController {
    *
    * @param id - A unique, semantically meaningful ID (e.g., "chat:123")
    * @param options.ttlMs - Time-to-live in ms (default: 24 hours)
+   * @param options.graceMs - Grace period after abort to keep hook alive (default: 1 hour)
    */
   static async create(
     id: string,
-    options: { ttlMs?: number } = {}
+    options: { ttlMs?: number; graceMs?: number } = {}
   ): Promise<DistributedAbortController> {
-    const { ttlMs = DEFAULT_TTL_MS } = options;
+    const { ttlMs = DEFAULT_TTL_MS, graceMs = DEFAULT_GRACE_MS } = options;
     const token = getAbortToken(id);
 
     // Try to find an existing run with this hook token
@@ -115,7 +132,9 @@ export class DistributedAbortController {
     }
 
     // Create a new workflow
-    const run = await start(abortControllerWorkflow, { args: [id, ttlMs] });
+    const run = await start(abortControllerWorkflow, {
+      args: [id, ttlMs, graceMs],
+    });
     return new DistributedAbortController(id, run.id);
   }
 

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -80,11 +80,14 @@ export async function abortControllerWorkflow(
   // Write the abort message inside a step
   await writeAbortSignal(result.reason, result.expired);
 
-  // Sleep until TTL + grace period to keep hook alive for late subscribers
-  const elapsed = Date.now() - startTime;
-  const remainingTime = ttlMs + graceMs - elapsed;
-  if (remainingTime > 0) {
-    await sleep(`${remainingTime}ms`);
+  // Only sleep through grace period on TTL expiration (keeps hook alive for late subscribers).
+  // Manual aborts complete immediately — no need to keep the workflow running.
+  if (result.expired) {
+    const elapsed = Date.now() - startTime;
+    const remainingTime = graceMs - (elapsed - ttlMs);
+    if (remainingTime > 0) {
+      await sleep(`${remainingTime}ms`);
+    }
   }
 
   return { aborted: true, reason: result.reason, expired: result.expired };

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -103,7 +103,7 @@ export async function abortControllerWorkflow(
  */
 export class DistributedAbortController {
   private id: string;
-  private runId: string;
+  readonly runId: string;
 
   private constructor(id: string, runId: string) {
     this.id = id;

--- a/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
+++ b/workbench/vitest/workflows/cookbook/distributed-abort-controller.ts
@@ -23,20 +23,13 @@ export type AbortMessage = {
 };
 
 /**
- * Workflow that waits for the abort hook and writes to the stream.
- * This workflow is the "coordinator" - it holds the abort state durably.
+ * Step function that writes the abort message to the stream.
+ * Writing must happen inside a step, not directly in the workflow.
  */
-export async function abortControllerWorkflow() {
-  'use workflow';
+async function writeAbortSignal(reason?: string) {
+  'use step';
 
-  const { workflowRunId } = getWorkflowMetadata();
   const writable = getWritable<AbortMessage>();
-
-  // Wait for the abort hook to be triggered
-  const hook = abortHook.create({ token: `abort:${workflowRunId}` });
-  const { reason } = await hook;
-
-  // Write the abort message to the stream
   const writer = writable.getWriter();
   try {
     await writer.write({ type: 'abort', reason });
@@ -44,6 +37,23 @@ export async function abortControllerWorkflow() {
     writer.releaseLock();
   }
   await writable.close();
+}
+
+/**
+ * Workflow that waits for the abort hook and writes to the stream.
+ * This workflow is the "coordinator" - it holds the abort state durably.
+ */
+export async function abortControllerWorkflow() {
+  'use workflow';
+
+  const { workflowRunId } = getWorkflowMetadata();
+
+  // Wait for the abort hook to be triggered
+  const hook = abortHook.create({ token: `abort:${workflowRunId}` });
+  const { reason } = await hook;
+
+  // Write the abort message inside a step
+  await writeAbortSignal(reason);
 
   return { aborted: true, reason };
 }


### PR DESCRIPTION
- Added a comprehensive guide and technical implementation for a distributed abort controller.
- Provided documentation and code examples for managing request cancellation across distributed systems.

[v0 Session](https://v0.app/chat/WadATMggPkk)