### PR TITLE
Improve workflow runtime error logging

### DIFF
--- a/.changeset/improve-workflow-error-logging.md
+++ b/.changeset/improve-workflow-error-logging.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Improve workflow runtime error logging: include error stacks in fatal and user-code errors, clarify replay-timeout messages (warn when retrying vs. error when giving up), include `workflowRunId` in suspension debug logs, and standardize the console prefix to `[workflow-sdk]`.

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -11,9 +11,9 @@ function createLogger(namespace: string) {
       // Always output error/warn to console so users see critical issues
       // debug/info only output when DEBUG env var is set
       if (level === 'error') {
-        console.error(`[Workflow] ${message}`, metadata ?? '');
+        console.error(`[workflow-sdk] ${message}`, metadata ?? '');
       } else if (level === 'warn') {
-        console.warn(`[Workflow] ${message}`, metadata ?? '');
+        console.warn(`[workflow-sdk] ${message}`, metadata ?? '');
       }
 
       // Also log to debug library for verbose output when DEBUG is enabled

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -188,18 +188,30 @@ export function workflowEntrypoint(
         let replayTimeout: NodeJS.Timeout | undefined;
         if (process.env.VERCEL_URL !== undefined) {
           replayTimeout = setTimeout(async () => {
-            runtimeLogger.error('Workflow replay exceeded timeout', {
-              workflowRunId: runId,
-              timeoutMs: REPLAY_TIMEOUT_MS,
-              attempt: metadata.attempt,
-              maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
-            });
-
             // Allow a few retries before permanently failing the run.
             // On early attempts, just exit so the queue retries the message.
             if (metadata.attempt <= REPLAY_TIMEOUT_MAX_RETRIES) {
+              runtimeLogger.warn(
+                'Workflow replay exceeded timeout but will be re-attempted (attempt < maxRetries)',
+                {
+                  workflowRunId: runId,
+                  timeoutMs: REPLAY_TIMEOUT_MS,
+                  attempt: metadata.attempt,
+                  maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
+                }
+              );
               process.exit(1);
             }
+
+            runtimeLogger.error(
+              'Workflow replay exceeded timeout and max retries exceeded. Failing the run',
+              {
+                workflowRunId: runId,
+                timeoutMs: REPLAY_TIMEOUT_MS,
+                attempt: metadata.attempt,
+                maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
+              }
+            );
 
             try {
               const world = await getWorld();
@@ -217,8 +229,16 @@ export function workflowEntrypoint(
                 },
                 { requestId }
               );
-            } catch {
+            } catch (err) {
               // Best effort — process exits regardless
+              runtimeLogger.warn(
+                'Unable to mark run as failed. The queue will continue to retry',
+                {
+                  workflowRunId: runId,
+                  error: err instanceof Error ? err.message : String(err),
+                  attempt: metadata.attempt,
+                }
+              );
             }
             // Note that this also prevents the runtime from acking the queue message,
             // so the queue will call back once, after which a 410 will get it to exit early.
@@ -538,11 +558,10 @@ export function workflowEntrypoint(
                     // everything else is a user code error.
                     const errorCode = classifyRunError(err);
 
-                    runtimeLogger.error('Error while running workflow', {
+                    runtimeLogger.error(errorStack, {
                       workflowRunId: runId,
                       errorCode,
                       errorName,
-                      errorStack,
                     });
 
                     // Fail the workflow run via event (event-sourced architecture)

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -354,7 +354,7 @@ export function workflowEntrypoint(
                       return;
                     } else if (err instanceof WorkflowRuntimeError) {
                       runtimeLogger.error(
-                        'Fatal runtime error during workflow setup',
+                        `Fatal runtime error during workflow setup\n${err.stack}`,
                         { workflowRunId: runId, error: err.message }
                       );
                       try {
@@ -508,7 +508,9 @@ export function workflowEntrypoint(
                         err.waitCount
                       );
                       if (suspensionMessage) {
-                        runtimeLogger.debug(suspensionMessage);
+                        runtimeLogger.debug(suspensionMessage, {
+                          workflowRunId: runId,
+                        });
                       }
 
                       const result = await handleSuspension({
@@ -558,11 +560,14 @@ export function workflowEntrypoint(
                     // everything else is a user code error.
                     const errorCode = classifyRunError(err);
 
-                    runtimeLogger.error(errorStack, {
-                      workflowRunId: runId,
-                      errorCode,
-                      errorName,
-                    });
+                    runtimeLogger.error(
+                      errorStack || 'Unknown error encountered in workflow',
+                      {
+                        workflowRunId: runId,
+                        errorCode,
+                        errorName,
+                      }
+                    );
 
                     // Fail the workflow run via event (event-sourced architecture)
                     try {

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -42,7 +42,7 @@ export function buildWorkflowSuspensionMessage(
   }
   const resumeMsg = resumeMsgParts.join(' and ');
 
-  return `[Workflows] "${runId}" - ${parts.join(' and ')} to be enqueued\n  Workflow will suspend and resume when ${resumeMsg}`;
+  return `${parts.join(' and ')} to be enqueued\n  Workflow will suspend and resume when ${resumeMsg}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Log the error stack as the message for user-code errors and `WorkflowRuntimeError` during setup, so stacks actually appear in logs
- Replay-timeout path: `warn` when the queue will retry, `error` only when max retries is exhausted; log the reason when we fail to mark the run as failed
- Include `workflowRunId` in the suspension `debug` log, and drop the now-redundant `[Workflows] "<runId>" - ` prefix from the suspension message
- Standardize the console prefix in `logger.ts` to `[workflow-sdk]`

## Test plan
- [ ] `pnpm test` in `packages/core`
- [ ] Trigger a failing workflow locally and confirm the stack is visible in the runtime error log
- [ ] Trigger a replay timeout and confirm retry attempts log as `warn` and the final attempt logs as `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)