### PR TITLE
Guard `fibonacciWorkflow` against non-finite numbers

### DIFF
--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -1706,6 +1706,9 @@ export async function startFromWorkflow(inputValue: number) {
  */
 export async function fibonacciWorkflow(n: number): Promise<number> {
   'use workflow';
+  if (!Number.isFinite(n)) {
+    throw new FatalError(`fibonacciWorkflow requires a finite number for n`);
+  }
   if (n <= 1) return n;
 
   const [runA, runB] = await Promise.all([


### PR DESCRIPTION
## Summary

Throw a `FatalError` at the top of `fibonacciWorkflow` if `n` is not a finite number.

The workflow recurses via `start(fibonacciWorkflow, [n - 1])` / `start(fibonacciWorkflow, [n - 2])` with a base case of `if (n <= 1) return n`. If `n` is ever `undefined` / `NaN`, that base case never fires (`NaN <= 1 === false`), and every descendant does the same — spawning two more children. This is a defensive guard that fails the run immediately instead of amplifying.

## Change

```ts
export async function fibonacciWorkflow(n: number): Promise<number> {
  'use workflow';
  if (!Number.isFinite(n)) {
    throw new FatalError(`fibonacciWorkflow requires a finite number for n`);
  }
  if (n <= 1) return n;
  // …
}
```

Only touches `workbench/example/workflows/99_e2e.ts`. No changeset needed (workbench files aren't published).