### PR TITLE
Update hero to "React for the backend"

### DIFF
--- a/docs/app/[lang]/(home)/page.tsx
+++ b/docs/app/[lang]/(home)/page.tsx
@@ -12,12 +12,12 @@ import { UseCases } from './components/use-cases-server';
 import { FeatureGridExtended } from './components/vercel-com-visuals/feature-grid';
 import { VercelSection } from './components/vercel-com-visuals/vercel-section';
 
-const title = 'Make any TypeScript Function Durable';
+const title = 'React for the backend';
 const description =
-  '"use workflow" brings durability, reliability, and observability to async JavaScript. Build apps and AI Agents that can suspend, resume, and maintain state with ease.';
+  'Workflow SDK lets you build and distribute long-running, durable, reliable and observable workflows and AI agents that can suspend, resume and maintain state.';
 
 export const metadata: Metadata = {
-  title: 'Workflow SDK - Make any TypeScript Function Durable',
+  title: 'Workflow SDK - React for the backend',
   description,
   alternates: {
     canonical: '/',


### PR DESCRIPTION
Updates the homepage hero title and byline as requested by [@Pranay Prakash](https://vercel.slack.com/team/U090115MM7D).

### What changed
- Hero title: "Make any TypeScript Function Durable" → "React for the backend"
- Byline: Updated to emphasize building and distributing long-running, durable, reliable and observable workflows and AI agents
- Page metadata title updated to match

<a href="https://vercel.slack.com/archives/C09R2J37F6K/p1776797760051119?thread_ts=1776797760.051119&cid=C09R2J37F6K"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>