### PR TITLE
Remove @workflow-init tag from agent skill command

### DIFF
--- a/docs/app/[lang]/(home)/components/hero.tsx
+++ b/docs/app/[lang]/(home)/components/hero.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/command-prompt';
 
 const COMMAND_FOR_HUMANS = 'npm install workflow';
-const COMMAND_FOR_AGENTS = 'npx skills add vercel/workflow@workflow-init';
+const COMMAND_FOR_AGENTS = 'npx skills add vercel/workflow';
 
 type HeroProps = {
   title: string;


### PR DESCRIPTION
Updates the `COMMAND_FOR_AGENTS` constant in the hero component to use `npx skills add vercel/workflow` instead of `npx skills add vercel/workflow@workflow-init`.

This removes the `@workflow-init` tag suffix from the "For agents" command displayed on the homepage.