### PR TITLE
Friendlier context-violation errors + Ansi renderer

### DIFF
--- a/.changeset/friendlier-context-errors.md
+++ b/.changeset/friendlier-context-errors.md
@@ -1,24 +1,6 @@
 ---
-'@workflow/core': patch
-'@workflow/errors': patch
+"@workflow/core": patch
+"@workflow/errors": patch
 ---
 
-Introduce structured, actionable error messages for context-violation errors.
-
-Adds a new `Ansi` rendering helper on `@workflow/errors` (`Ansi.frame`, `Ansi.hint`, `Ansi.note`, `Ansi.help`, `Ansi.code`, `Ansi.inline`) for composing terminal-friendly, box-drawn error messages.
-
-Adds four new error classes on `@workflow/core`:
-
-- `NotInWorkflowContextError` — thrown when an API must run inside a workflow (e.g. `createHook()`, `sleep()`).
-- `NotInStepContextError` — thrown when an API must run inside a step (e.g. `getStepMetadata()`).
-- `NotInWorkflowOrStepContextError` — thrown when an API must run inside either (e.g. `getWorkflowMetadata()`, `getWritable()`).
-- `UnavailableInWorkflowContextError` — thrown when an API MUST NOT run inside a workflow (e.g. `resumeHook()`, `defineHook().resume()`), and names the active workflow for context.
-
-Each error now includes a docs link and a human-readable framing:
-
-```
-`createHook()` can only be called inside a workflow function
-╰▶ note: Read more about createHook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-hook
-```
-
-Applied to all twelve context-violation sites in `@workflow/core`: `createHook`, `createWebhook`, `defineHook().create`, `defineHook().resume`, `sleep`, `getStepMetadata`, `getWorkflowMetadata` (both overloads), `getWritable`, `resumeHook`, and the workflow-VM stubs.
+Add structured context-violation error classes (`NotInWorkflowContextError`, `NotInStepContextError`, `NotInWorkflowOrStepContextError`, `UnavailableInWorkflowContextError`) with docs links and terminal-friendly framing, plus `Ansi` rendering helpers on `@workflow/errors`. Applied to all twelve user-facing context-violation sites in `@workflow/core`.

--- a/.changeset/friendlier-context-errors.md
+++ b/.changeset/friendlier-context-errors.md
@@ -1,0 +1,24 @@
+---
+'@workflow/core': patch
+'@workflow/errors': patch
+---
+
+Introduce structured, actionable error messages for context-violation errors.
+
+Adds a new `Ansi` rendering helper on `@workflow/errors` (`Ansi.frame`, `Ansi.hint`, `Ansi.note`, `Ansi.help`, `Ansi.code`, `Ansi.inline`) for composing terminal-friendly, box-drawn error messages.
+
+Adds four new error classes on `@workflow/core`:
+
+- `NotInWorkflowContextError` — thrown when an API must run inside a workflow (e.g. `createHook()`, `sleep()`).
+- `NotInStepContextError` — thrown when an API must run inside a step (e.g. `getStepMetadata()`).
+- `NotInWorkflowOrStepContextError` — thrown when an API must run inside either (e.g. `getWorkflowMetadata()`, `getWritable()`).
+- `UnavailableInWorkflowContextError` — thrown when an API MUST NOT run inside a workflow (e.g. `resumeHook()`, `defineHook().resume()`), and names the active workflow for context.
+
+Each error now includes a docs link and a human-readable framing:
+
+```
+`createHook()` can only be called inside a workflow function
+╰▶ note: Read more about createHook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-hook
+```
+
+Applied to all twelve context-violation sites in `@workflow/core`: `createHook`, `createWebhook`, `defineHook().create`, `defineHook().resume`, `sleep`, `getStepMetadata`, `getWorkflowMetadata` (both overloads), `getWritable`, `resumeHook`, and the workflow-VM stubs.

--- a/packages/core/src/context-errors.test.ts
+++ b/packages/core/src/context-errors.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  NotInStepContextError,
+  NotInWorkflowContextError,
+  NotInWorkflowOrStepContextError,
+  UnavailableInWorkflowContextError,
+} from './context-errors.js';
+import {
+  WORKFLOW_CONTEXT_SYMBOL,
+  type WorkflowMetadata,
+} from './workflow/get-workflow-metadata.js';
+
+// These tests assert on the plain-text form of the messages. In a TTY chalk
+// would add color, but vitest runs without a TTY so chalk is level=0 and
+// the styling helpers are pass-throughs. Snapshots therefore match the raw
+// structure we care about (╰▶ / ├▶ tree + labels + docs URL).
+
+describe('NotInWorkflowContextError', () => {
+  it('frames the function name and docs link', () => {
+    const err = new NotInWorkflowContextError(
+      'createHook()',
+      'createHook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-hook'
+    );
+    expect(err.name).toBe('NotInWorkflowContextError');
+    expect(err.message).toMatchInlineSnapshot(`
+      "\`createHook()\` can only be called inside a workflow function
+      ╰▶ note: Read more about createHook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-hook"
+    `);
+  });
+});
+
+describe('NotInStepContextError', () => {
+  it('uses "step function" phrasing', () => {
+    const err = new NotInStepContextError(
+      'getStepMetadata()',
+      'getStepMetadata(): https://workflow-sdk.dev/docs/api-reference/workflow/get-step-metadata'
+    );
+    expect(err.message).toContain('can only be called inside a step function');
+    expect(err.message).toContain('getStepMetadata(): https://');
+  });
+});
+
+describe('NotInWorkflowOrStepContextError', () => {
+  it('uses "workflow or step function" phrasing', () => {
+    const err = new NotInWorkflowOrStepContextError(
+      'getWorkflowMetadata()',
+      'getWorkflowMetadata(): https://workflow-sdk.dev/docs/api-reference/workflow/get-workflow-metadata'
+    );
+    expect(err.message).toContain(
+      'can only be called inside a workflow or step function'
+    );
+  });
+});
+
+describe('UnavailableInWorkflowContextError', () => {
+  afterEach(() => {
+    delete (globalThis as any)[WORKFLOW_CONTEXT_SYMBOL];
+  });
+
+  it('names the workflow when a context is active', () => {
+    (globalThis as any)[WORKFLOW_CONTEXT_SYMBOL] = {
+      workflowName: 'workflow//./src/workflows/example.ts//myWorkflow',
+    } as WorkflowMetadata;
+
+    const err = new UnavailableInWorkflowContextError(
+      'resumeHook()',
+      'resuming hooks: https://workflow-sdk.dev/docs/api-reference/workflow-api/resume-hook'
+    );
+    expect(err.message).toContain('cannot be called from a workflow context');
+    expect(err.message).toContain(
+      'workflow//./src/workflows/example.ts//myWorkflow'
+    );
+  });
+
+  it('falls back to a generic phrasing when no context is present', () => {
+    const err = new UnavailableInWorkflowContextError(
+      'resumeHook()',
+      'resuming hooks: https://workflow-sdk.dev/docs/api-reference/workflow-api/resume-hook'
+    );
+    expect(err.message).toContain('from a workflow context');
+  });
+});

--- a/packages/core/src/context-errors.ts
+++ b/packages/core/src/context-errors.ts
@@ -1,6 +1,5 @@
 import { Ansi } from '@workflow/errors';
 import {
-  getWorkflowMetadata,
   WORKFLOW_CONTEXT_SYMBOL,
   type WorkflowMetadata,
 } from './workflow/get-workflow-metadata.js';
@@ -12,9 +11,11 @@ import {
  */
 type DocLink = `${string}: https://${string}`;
 
-/** Apply dim styling to the `workflow//` / `step//` separators in a name. */
+/** Apply dim styling to the `workflow/` / `step/` prefixes in a qualified name. */
 function ansifyName(name: string): string {
-  return name;
+  return name
+    .replace(/^workflow\//, `${Ansi.dim('workflow/')}`)
+    .replace(/^step\//, `${Ansi.dim('step/')}`);
 }
 
 /**
@@ -119,7 +120,3 @@ export class UnavailableInWorkflowContextError extends Error {
     );
   }
 }
-
-// Keep `getWorkflowMetadata` import live for future use (the error message
-// currently reads the symbol directly to avoid a circular throw).
-void getWorkflowMetadata;

--- a/packages/core/src/context-errors.ts
+++ b/packages/core/src/context-errors.ts
@@ -1,0 +1,125 @@
+import { Ansi } from '@workflow/errors';
+import {
+  getWorkflowMetadata,
+  WORKFLOW_CONTEXT_SYMBOL,
+  type WorkflowMetadata,
+} from './workflow/get-workflow-metadata.js';
+
+/**
+ * URL strings shaped as `"<topic>: https://<path>"` so the error surface always
+ * shows a human-readable topic alongside the link. The `https://` prefix is
+ * enforced by the type to prevent accidental protocol-less URLs.
+ */
+type DocLink = `${string}: https://${string}`;
+
+/** Apply dim styling to the `workflow//` / `step//` separators in a name. */
+function ansifyName(name: string): string {
+  return name;
+}
+
+/**
+ * Thrown when an API that must run inside a workflow function is called
+ * from outside a workflow context (e.g. from a step function or from
+ * regular application code).
+ *
+ * @example
+ * ```
+ * `createHook()` can only be called inside a workflow function
+ * ╰▶ note: Read more about creating hooks: https://...
+ * ```
+ */
+export class NotInWorkflowContextError extends Error {
+  name = 'NotInWorkflowContextError';
+
+  constructor(
+    readonly functionName: string,
+    docLink: DocLink
+  ) {
+    super(
+      Ansi.frame(
+        `${Ansi.code(functionName)} can only be called inside a workflow function`,
+        [Ansi.note(`Read more about ${docLink}`)]
+      )
+    );
+  }
+}
+
+/**
+ * Thrown when an API that must run inside a step function is called from
+ * outside a step context.
+ */
+export class NotInStepContextError extends Error {
+  name = 'NotInStepContextError';
+
+  constructor(
+    readonly functionName: string,
+    docLink: DocLink
+  ) {
+    super(
+      Ansi.frame(
+        `${Ansi.code(functionName)} can only be called inside a step function`,
+        [Ansi.note(`Read more about ${docLink}`)]
+      )
+    );
+  }
+}
+
+/**
+ * Thrown when an API that must run inside either a workflow or step function
+ * is called from regular application code.
+ */
+export class NotInWorkflowOrStepContextError extends Error {
+  name = 'NotInWorkflowOrStepContextError';
+
+  constructor(
+    readonly functionName: string,
+    docLink: DocLink
+  ) {
+    super(
+      Ansi.frame(
+        `${Ansi.code(functionName)} can only be called inside a workflow or step function`,
+        [Ansi.note(`Read more about ${docLink}`)]
+      )
+    );
+  }
+}
+
+/**
+ * Thrown when an API that MUST NOT run inside a workflow function is called
+ * from one (e.g. `resumeHook()`, which would cause determinism issues).
+ * The message names the specific workflow that made the offending call.
+ */
+export class UnavailableInWorkflowContextError extends Error {
+  name = 'UnavailableInWorkflowContextError';
+
+  constructor(
+    readonly functionName: string,
+    docLink: DocLink
+  ) {
+    const ctx = (globalThis as any)[WORKFLOW_CONTEXT_SYMBOL] as
+      | WorkflowMetadata
+      | undefined;
+    const workflowName = ctx?.workflowName;
+
+    const noteLines = [
+      workflowName
+        ? `this call was made from the ${ansifyName(workflowName)} workflow context.`
+        : 'this call was made from a workflow context.',
+      `Read more about ${docLink}`,
+    ];
+
+    super(
+      Ansi.frame(
+        `${Ansi.code(functionName)} cannot be called from a workflow context.`,
+        [
+          'calling this in a workflow context can cause determinism issues.',
+          Ansi.note(noteLines),
+        ]
+      )
+    );
+  }
+}
+
+// Keep `getWorkflowMetadata` import live for future use (the error message
+// currently reads the symbol directly to avoid a circular throw).
+void getWorkflowMetadata;

--- a/packages/core/src/create-hook.ts
+++ b/packages/core/src/create-hook.ts
@@ -1,3 +1,4 @@
+import { NotInWorkflowContextError } from './context-errors.js';
 import type { Serializable } from './schemas.js';
 
 /**
@@ -177,8 +178,9 @@ export interface WebhookOptions
  */
 // @ts-expect-error `options` is here for types/docs
 export function createHook<T = any>(options?: HookOptions): Hook<T> {
-  throw new Error(
-    '`createHook()` can only be called inside a workflow function'
+  throw new NotInWorkflowContextError(
+    'createHook()',
+    'createHook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-hook'
   );
 }
 
@@ -197,7 +199,8 @@ export function createWebhook(
   // @ts-expect-error `options` is here for types/docs
   options?: WebhookOptions
 ): Webhook<Request> | Webhook<RequestWithResponse> {
-  throw new Error(
-    '`createWebhook()` can only be called inside a workflow function'
+  throw new NotInWorkflowContextError(
+    'createWebhook()',
+    'createWebhook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-webhook'
   );
 }

--- a/packages/core/src/define-hook.ts
+++ b/packages/core/src/define-hook.ts
@@ -1,5 +1,6 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { Hook as HookEntity } from '@workflow/world';
+import { NotInWorkflowContextError } from './context-errors.js';
 import type { Hook, HookOptions } from './create-hook.js';
 import { resumeHook } from './runtime/resume-hook.js';
 
@@ -74,8 +75,9 @@ export function defineHook<TInput, TOutput = TInput>({
 } = {}): TypedHook<TInput, TOutput> {
   return {
     create(_options?: HookOptions): Hook<TOutput> {
-      throw new Error(
-        '`defineHook().create()` can only be called inside a workflow function.'
+      throw new NotInWorkflowContextError(
+        'defineHook().create()',
+        'defineHook(): https://workflow-sdk.dev/docs/api-reference/workflow/define-hook'
       );
     },
     async resume(token: string, payload: TInput): Promise<HookEntity> {

--- a/packages/core/src/sleep.ts
+++ b/packages/core/src/sleep.ts
@@ -1,4 +1,5 @@
 import type { StringValue } from 'ms';
+import { NotInWorkflowContextError } from './context-errors.js';
 import { WORKFLOW_SLEEP } from './symbols.js';
 
 /**
@@ -39,7 +40,10 @@ export async function sleep(param: StringValue | Date | number): Promise<void> {
   // Inside the workflow VM, the sleep function is stored in the globalThis object behind a symbol
   const sleepFn = (globalThis as any)[WORKFLOW_SLEEP];
   if (!sleepFn) {
-    throw new Error('`sleep()` can only be called inside a workflow function');
+    throw new NotInWorkflowContextError(
+      'sleep()',
+      'sleep(): https://workflow-sdk.dev/docs/api-reference/workflow/sleep'
+    );
   }
   return sleepFn(param);
 }

--- a/packages/core/src/step/get-step-metadata.ts
+++ b/packages/core/src/step/get-step-metadata.ts
@@ -1,3 +1,4 @@
+import { NotInStepContextError } from '../context-errors.js';
 import { contextStorage } from './context-storage.js';
 
 export interface StepMetadata {
@@ -47,8 +48,9 @@ export interface StepMetadata {
 export function getStepMetadata(): StepMetadata {
   const ctx = contextStorage.getStore();
   if (!ctx) {
-    throw new Error(
-      '`getStepMetadata()` can only be called inside a step function'
+    throw new NotInStepContextError(
+      'getStepMetadata()',
+      'getStepMetadata(): https://workflow-sdk.dev/docs/api-reference/workflow/get-step-metadata'
     );
   }
   return ctx.stepMetadata;

--- a/packages/core/src/step/get-workflow-metadata.ts
+++ b/packages/core/src/step/get-workflow-metadata.ts
@@ -1,3 +1,4 @@
+import { NotInWorkflowOrStepContextError } from '../context-errors.js';
 import type { WorkflowMetadata } from '../workflow/get-workflow-metadata.js';
 import { contextStorage } from './context-storage.js';
 
@@ -9,8 +10,9 @@ export type { WorkflowMetadata };
 export function getWorkflowMetadata(): WorkflowMetadata {
   const ctx = contextStorage.getStore();
   if (!ctx) {
-    throw new Error(
-      '`getWorkflowMetadata()` can only be called inside a workflow or step function'
+    throw new NotInWorkflowOrStepContextError(
+      'getWorkflowMetadata()',
+      'getWorkflowMetadata(): https://workflow-sdk.dev/docs/api-reference/workflow/get-workflow-metadata'
     );
   }
   return ctx.workflowMetadata;

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -1,3 +1,4 @@
+import { NotInWorkflowOrStepContextError } from '../context-errors.js';
 import {
   createFlushableState,
   flushablePipe,
@@ -37,8 +38,9 @@ export function getWritable<W = any>(
 ): WritableStream<W> {
   const ctx = contextStorage.getStore();
   if (!ctx) {
-    throw new Error(
-      '`getWritable()` can only be called inside a workflow or step function'
+    throw new NotInWorkflowOrStepContextError(
+      'getWritable()',
+      'getWritable(): https://workflow-sdk.dev/docs/api-reference/workflow/get-writable'
     );
   }
 

--- a/packages/core/src/workflow/create-hook.ts
+++ b/packages/core/src/workflow/create-hook.ts
@@ -1,3 +1,4 @@
+import { NotInWorkflowContextError } from '../context-errors.js';
 import type {
   Hook,
   HookOptions,
@@ -14,8 +15,9 @@ export function createHook<T = any>(options?: HookOptions): Hook<T> {
     WORKFLOW_CREATE_HOOK
   ] as typeof createHook<T>;
   if (!createHookFn) {
-    throw new Error(
-      '`createHook()` can only be called inside a workflow function'
+    throw new NotInWorkflowContextError(
+      'createHook()',
+      'createHook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-hook'
     );
   }
   return createHookFn(options);

--- a/packages/core/src/workflow/define-hook.ts
+++ b/packages/core/src/workflow/define-hook.ts
@@ -1,4 +1,5 @@
 import type { Hook as HookEntity } from '@workflow/world';
+import { UnavailableInWorkflowContextError } from '../context-errors.js';
 import type { Hook, HookOptions } from '../create-hook.js';
 import { createHook } from './create-hook.js';
 
@@ -12,8 +13,9 @@ export function defineHook<TInput, TOutput = TInput>() {
     },
 
     resume(_token: string, _payload: TInput): Promise<HookEntity | null> {
-      throw new Error(
-        '`defineHook().resume()` can only be called from external contexts (e.g. API routes).'
+      throw new UnavailableInWorkflowContextError(
+        'defineHook().resume()',
+        'resuming hooks: https://workflow-sdk.dev/docs/api-reference/workflow-api/resume-hook'
       );
     },
   };

--- a/packages/core/src/workflow/get-workflow-metadata.ts
+++ b/packages/core/src/workflow/get-workflow-metadata.ts
@@ -39,6 +39,10 @@ export function getWorkflowMetadata(): WorkflowMetadata {
   // Inside the workflow VM, the context is stored in the globalThis object behind a symbol
   const ctx = (globalThis as any)[WORKFLOW_CONTEXT_SYMBOL] as WorkflowMetadata;
   if (!ctx) {
+    // Avoid importing NotInWorkflowOrStepContextError here — that module
+    // imports from this file, so bringing it in eagerly would create a
+    // module-init cycle. The companion step/get-workflow-metadata.ts uses
+    // the structured class.
     throw new Error(
       '`getWorkflowMetadata()` can only be called inside a workflow or step function'
     );

--- a/packages/core/src/workflow/get-workflow-metadata.ts
+++ b/packages/core/src/workflow/get-workflow-metadata.ts
@@ -1,3 +1,5 @@
+import { Ansi } from '@workflow/errors';
+
 export interface WorkflowMetadata {
   /**
    * The name of the workflow.
@@ -41,10 +43,18 @@ export function getWorkflowMetadata(): WorkflowMetadata {
   if (!ctx) {
     // Avoid importing NotInWorkflowOrStepContextError here — that module
     // imports from this file, so bringing it in eagerly would create a
-    // module-init cycle. The companion step/get-workflow-metadata.ts uses
-    // the structured class.
+    // module-init cycle. Render the same Ansi framing inline to match the
+    // sibling `step/get-workflow-metadata.ts` path which uses the structured
+    // class.
     throw new Error(
-      '`getWorkflowMetadata()` can only be called inside a workflow or step function'
+      Ansi.frame(
+        `${Ansi.code('getWorkflowMetadata()')} can only be called inside a workflow or step function`,
+        [
+          Ansi.note(
+            'Read more about getWorkflowMetadata(): https://workflow-sdk.dev/docs/api-reference/workflow/get-workflow-metadata'
+          ),
+        ]
+      )
     );
   }
   return ctx;

--- a/packages/core/src/workflow/index.ts
+++ b/packages/core/src/workflow/index.ts
@@ -1,3 +1,7 @@
+import {
+  NotInStepContextError,
+  UnavailableInWorkflowContextError,
+} from '../context-errors.js';
 import type { StepMetadata } from '../step/get-step-metadata.js';
 
 export {
@@ -15,12 +19,14 @@ export { getWritable } from './writable-stream.js';
 // workflows can't use these functions, but we still need to provide
 // the export so bundling doesn't fail when step and workflow are in same file
 export function getStepMetadata(): StepMetadata {
-  throw new Error(
-    '`getStepMetadata()` can only be called inside a step function'
+  throw new NotInStepContextError(
+    'getStepMetadata()',
+    'getStepMetadata(): https://workflow-sdk.dev/docs/api-reference/workflow/get-step-metadata'
   );
 }
 export function resumeHook() {
-  throw new Error(
-    '`resumeHook()` can only be called from outside a workflow function'
+  throw new UnavailableInWorkflowContextError(
+    'resumeHook()',
+    'resuming hooks: https://workflow-sdk.dev/docs/api-reference/workflow-api/resume-hook'
   );
 }

--- a/packages/errors/__mocks__/chalk.ts
+++ b/packages/errors/__mocks__/chalk.ts
@@ -1,0 +1,26 @@
+// Mock implementation of the 'chalk' library for testing purposes.
+// This mock wraps text in HTML-like tags to indicate styles because
+// terminal styling is unreadable in test snapshots.
+
+import type { ChalkInstance } from 'chalk';
+
+const short = new Map([
+  ['italic', 'i'],
+  ['bold', 'b'],
+]);
+
+function createChalkMock(currentModifiers: string[] = []): ChalkInstance {
+  return new Proxy(() => {}, {
+    get(_, prop: string) {
+      return createChalkMock([...currentModifiers, short.get(prop) || prop]);
+    },
+    apply(_target, _thisArg, [text]) {
+      return currentModifiers.reduceRight((acc, mod) => {
+        const tag = String(mod);
+        return `<${tag}>${acc}</${tag}>`;
+      }, text as string);
+    },
+  }) as ChalkInstance;
+}
+
+export default createChalkMock();

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -26,16 +26,19 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "tsc --build --clean && rm -rf dist",
+    "test": "vitest run src",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/ms": "2.1.0",
     "@types/node": "catalog:",
     "@workflow/tsconfig": "workspace:*",
-    "@workflow/world": "workspace:*"
+    "@workflow/world": "workspace:*",
+    "vitest": "catalog:"
   },
   "dependencies": {
     "@workflow/utils": "workspace:*",
+    "chalk": "5.6.2",
     "ms": "2.1.3"
   }
 }

--- a/packages/errors/src/ansi.test.ts
+++ b/packages/errors/src/ansi.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as Ansi from './ansi.js';
+
+// Render ANSI styles as HTML-like tags in snapshots so they're readable.
+vi.mock('chalk');
+
+describe('Ansi.frame', () => {
+  it('renders a single-line title with no contents', () => {
+    expect(Ansi.frame('something went wrong', [])).toMatchInlineSnapshot(
+      `"something went wrong"`
+    );
+  });
+
+  it('renders a single content line with ╰▶', () => {
+    expect(
+      Ansi.frame('something went wrong', ['here is why'])
+    ).toMatchInlineSnapshot(`
+      "something went wrong
+      ╰▶ here is why"
+    `);
+  });
+
+  it('renders multiple contents with ├▶ and ╰▶', () => {
+    expect(
+      Ansi.frame('something went wrong', ['first reason', 'second reason'])
+    ).toMatchInlineSnapshot(`
+      "something went wrong
+      ├▶ first reason
+      ╰▶ second reason"
+    `);
+  });
+
+  it('indents continuation lines under their branch', () => {
+    expect(
+      Ansi.frame('title', ['first\nwith two lines', 'last\nalso two lines'])
+    ).toMatchInlineSnapshot(`
+      "title
+      ├▶ first
+      │  with two lines
+      ╰▶ last
+         also two lines"
+    `);
+  });
+});
+
+describe('Ansi.code', () => {
+  it('wraps a token in dim backticks and italics', () => {
+    expect(Ansi.code('fn()')).toMatchInlineSnapshot(
+      `"<i><dim>\`</dim>fn()<dim>\`</dim></i>"`
+    );
+  });
+});
+
+describe('Ansi.hint / note / help', () => {
+  it('renders a hint line', () => {
+    expect(Ansi.hint('try reloading')).toMatchInlineSnapshot(
+      `"<blue><b>hint:</b> try reloading</blue>"`
+    );
+  });
+
+  it('renders a note line', () => {
+    expect(
+      Ansi.note(['read more:', 'https://example.com'])
+    ).toMatchInlineSnapshot(
+      `"<blue><b>note:</b> read more:\nhttps://example.com</blue>"`
+    );
+  });
+
+  it('renders a help line', () => {
+    expect(Ansi.help('run `wf inspect run run_123`')).toMatchInlineSnapshot(
+      `"<cyan><b>help:</b> run \`wf inspect run run_123\`</cyan>"`
+    );
+  });
+});
+
+describe('Ansi.inline', () => {
+  it('underlines a single token on a single line', () => {
+    const out = Ansi.inline`function ${{ text: 'hello', explain: 'name not allowed' }}()`;
+    expect(out).toMatchInlineSnapshot(`
+      "function hello()
+               ──┬──
+                 ╰▶ name not allowed"
+    `);
+  });
+
+  it('preserves subsequent lines unchanged', () => {
+    const out = Ansi.inline`const ${{ text: 'x', explain: 'unused' }} = 1
+const y = 2`;
+    expect(out).toMatchInlineSnapshot(`
+      "const x = 1
+            ┬
+            ╰▶ unused
+      const y = 2"
+    `);
+  });
+});

--- a/packages/errors/src/ansi.ts
+++ b/packages/errors/src/ansi.ts
@@ -1,0 +1,247 @@
+import chalk from 'chalk';
+
+/**
+ * Helpers for composing structured, human-friendly error messages.
+ *
+ * The goal is to make errors *actionable*: say what happened, explain why,
+ * and give the user a way out. Rendering uses ANSI colors when the terminal
+ * supports them (chalk auto-detects) and falls back to plain text elsewhere.
+ *
+ * Typical usage:
+ *
+ * ```ts
+ * throw new Error(
+ *   Ansi.frame(
+ *     `${Ansi.code(fnName)} can only be called inside a workflow function`,
+ *     [Ansi.note(`Read more about creating hooks: https://...`)]
+ *   )
+ * );
+ * ```
+ *
+ * Renders as:
+ *
+ * ```
+ * `createHook()` can only be called inside a workflow function
+ * ╰▶ note: Read more about creating hooks: https://...
+ * ```
+ */
+
+const styles = {
+  info: chalk.blue,
+  help: chalk.cyan,
+  warn: chalk.yellow,
+  error: chalk.red,
+};
+
+/** A "help:" line — use for the primary suggested fix. */
+export function help(messages: string | string[]): string {
+  const message = Array.isArray(messages) ? messages.join('\n') : messages;
+  return styles.help(`${chalk.bold('help:')} ${message}`);
+}
+
+/** A "hint:" line — use for supplementary context or suggestions. */
+export function hint(messages: string | string[]): string {
+  const message = Array.isArray(messages) ? messages.join('\n') : messages;
+  return styles.info(`${chalk.bold('hint:')} ${message}`);
+}
+
+/** A "note:" line — use for informational context (docs links, etc). */
+export function note(messages: string | string[]): string {
+  const message = Array.isArray(messages) ? messages.join('\n') : messages;
+  return styles.info(`${chalk.bold('note:')} ${message}`);
+}
+
+/** Render an inline code token (italicized, dim backticks). */
+export function code(str: string): string {
+  return chalk.italic(`${chalk.dim('`')}${str}${chalk.dim('`')}`);
+}
+
+/**
+ * Frame a title with one or more continuation lines, drawn with
+ * box-drawing characters. The last content uses `╰▶`, others use `├▶`.
+ * Multi-line contents are indented under their branch.
+ *
+ * @example
+ * frame('Something went wrong', ['why it happened', hint('how to fix it')])
+ * // Something went wrong
+ * // ├▶ why it happened
+ * // ╰▶ hint: how to fix it
+ */
+export function frame(title: string, contents: string[]): string {
+  const result = [title];
+
+  contents.forEach((content, index) => {
+    const lines = content.split('\n');
+    const isLastContent = index === contents.length - 1;
+
+    const firstLinePrefix = isLastContent ? '╰▶ ' : '├▶ ';
+    const continuationPrefix = isLastContent ? '   ' : '│  ';
+
+    const framedLines = lines.map((line, lineIndex) => {
+      const prefix = lineIndex === 0 ? firstLinePrefix : continuationPrefix;
+      return `${prefix}${line}`;
+    });
+
+    result.push(...framedLines);
+  });
+
+  return result.join('\n');
+}
+
+interface Explain {
+  text: string;
+  explain: string;
+  /** adds ansi coloring */
+  color?: (s: string) => string;
+}
+
+type Explainish =
+  | Explain
+  | [text: string, explain: string, opts?: { color: Explain['color'] }];
+
+type Marker = {
+  startCol: number;
+  endCol: number;
+  explain: string;
+  color?: (s: string) => string;
+};
+
+const identity = (s: string) => s;
+
+function getMarkerMidpoint(marker: Marker): number {
+  const textLen = marker.endCol - marker.startCol;
+  return marker.startCol + Math.floor(textLen / 2);
+}
+
+function buildUnderline(markers: Marker[]): string {
+  const parts: string[] = [];
+  let pos = 0;
+  for (const marker of markers) {
+    const textLen = marker.endCol - marker.startCol;
+    const midPoint = Math.floor(textLen / 2);
+
+    if (marker.startCol > pos) {
+      parts.push(' '.repeat(marker.startCol - pos));
+      pos = marker.startCol;
+    }
+    const segment = `${'─'.repeat(midPoint)}┬${'─'.repeat(textLen - midPoint - 1)}`;
+    const colorFn = marker.color ?? identity;
+    parts.push(colorFn(segment));
+    pos += textLen;
+  }
+  return parts.join('');
+}
+
+function buildExplanationLine(
+  marker: Marker,
+  midCol: number,
+  remainingMids: number[],
+  isOnlyMarker: boolean
+): string {
+  let line = '╰';
+  let pos = midCol + 1;
+
+  for (const nextMid of remainingMids) {
+    while (pos < nextMid) {
+      line += '─';
+      pos++;
+    }
+    line += '┼';
+    pos++;
+  }
+
+  const arrow = isOnlyMarker ? '▶ ' : '─▶ ';
+  line += arrow + marker.explain;
+
+  const colorFn = marker.color ?? identity;
+  return ' '.repeat(midCol) + colorFn(line);
+}
+
+/**
+ * Tagged template for underlining tokens in a source string and annotating
+ * them with explanations. Useful for pointing out offending tokens in
+ * user-authored code.
+ *
+ * @example
+ * inline`function ${{ text: 'hello', explain: 'name not allowed' }}() {
+ *   return 666
+ * }`
+ * // function hello() {
+ * //          ──┬──
+ * //            ╰▶ name not allowed
+ * //   return 666
+ * // }
+ */
+export function inline(
+  text: TemplateStringsArray,
+  ...values: Explainish[]
+): string {
+  const resultLines: string[] = [];
+  let currentLine = '';
+  let currentLineVisualLen = 0;
+  let pendingMarkers: Marker[] = [];
+
+  const flushLine = () => {
+    resultLines.push(currentLine);
+    if (pendingMarkers.length === 0) {
+      currentLine = '';
+      currentLineVisualLen = 0;
+      return;
+    }
+
+    const markerMids = pendingMarkers.map(getMarkerMidpoint);
+
+    resultLines.push(buildUnderline(pendingMarkers));
+
+    for (let i = 0; i < pendingMarkers.length; i++) {
+      const line = buildExplanationLine(
+        pendingMarkers[i],
+        markerMids[i],
+        markerMids.slice(i + 1),
+        pendingMarkers.length === 1
+      );
+      resultLines.push(line);
+    }
+
+    pendingMarkers = [];
+    currentLine = '';
+    currentLineVisualLen = 0;
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const segment = text[i];
+    const lines = segment.split('\n');
+
+    for (let j = 0; j < lines.length; j++) {
+      if (j > 0) {
+        flushLine();
+      }
+      currentLine += lines[j];
+      currentLineVisualLen += lines[j].length;
+    }
+
+    if (i < values.length) {
+      const val = values[i];
+      const value: Explain = !Array.isArray(val)
+        ? val
+        : { text: val[0], explain: val[1], ...val[2] };
+      const startCol = currentLineVisualLen;
+      const colorFn = value.color ?? ((s: string) => s);
+      currentLine += colorFn(value.text);
+      currentLineVisualLen += value.text.length;
+      const endCol = currentLineVisualLen;
+      pendingMarkers.push({
+        startCol,
+        endCol,
+        explain: value.explain,
+        color: value.color,
+      });
+    }
+  }
+
+  if (currentLine || pendingMarkers.length > 0) {
+    flushLine();
+  }
+
+  return resultLines.join('\n');
+}

--- a/packages/errors/src/ansi.ts
+++ b/packages/errors/src/ansi.ts
@@ -56,6 +56,11 @@ export function code(str: string): string {
   return chalk.italic(`${chalk.dim('`')}${str}${chalk.dim('`')}`);
 }
 
+/** Apply dim styling to a string (used for de-emphasizing separators). */
+export function dim(str: string): string {
+  return chalk.dim(str);
+}
+
 /**
  * Frame a title with one or more continuation lines, drawn with
  * box-drawing characters. The last content uses `╰▶`, others use `├▶`.
@@ -117,14 +122,18 @@ function buildUnderline(markers: Marker[]): string {
   const parts: string[] = [];
   let pos = 0;
   for (const marker of markers) {
-    const textLen = marker.endCol - marker.startCol;
+    // Treat zero-length markers as length 1 so we always emit a `┬` anchor
+    // for the explanation line and avoid a negative `String.repeat` count.
+    const textLen = Math.max(1, marker.endCol - marker.startCol);
     const midPoint = Math.floor(textLen / 2);
 
     if (marker.startCol > pos) {
       parts.push(' '.repeat(marker.startCol - pos));
       pos = marker.startCol;
     }
-    const segment = `${'─'.repeat(midPoint)}┬${'─'.repeat(textLen - midPoint - 1)}`;
+    const leftFill = '─'.repeat(midPoint);
+    const rightFill = '─'.repeat(Math.max(0, textLen - midPoint - 1));
+    const segment = `${leftFill}┬${rightFill}`;
     const colorFn = marker.color ?? identity;
     parts.push(colorFn(segment));
     pos += textLen;

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -2,6 +2,8 @@ import { parseDurationToDate } from '@workflow/utils';
 import type { StructuredError } from '@workflow/world';
 import type { StringValue } from 'ms';
 
+export * as Ansi from './ansi.js';
+
 const BASE_URL = 'https://workflow-sdk.dev/err';
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
       '@workflow/utils':
         specifier: workspace:*
         version: link:../utils
+      chalk:
+        specifier: 5.6.2
+        version: 5.6.2
       ms:
         specifier: 2.1.3
         version: 2.1.3
@@ -696,6 +699,9 @@ importers:
       '@workflow/world':
         specifier: workspace:*
         version: link:../world
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
   packages/nest:
     dependencies:
@@ -825,7 +831,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: 1.0.2
-        version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
       '@nuxt/schema':
         specifier: 4.4.2
         version: 4.4.2
@@ -1536,7 +1542,7 @@ importers:
         version: 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13)
       '@vercel/otel':
         specifier: ^1.13.0
-        version: 1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
+        version: 1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
       '@workflow/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -18231,7 +18237,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       citty: 0.1.6
@@ -18239,14 +18245,14 @@ snapshots:
       defu: 6.1.4
       jiti: 2.6.1
       magic-regexp: 0.10.0
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
       tsconfck: 3.1.6(typescript@5.9.3)
       typescript: 5.9.3
-      unbuild: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3))
+      unbuild: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - esbuild
@@ -18430,7 +18436,7 @@ snapshots:
 
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
-      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api': 1.9.0
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -18441,9 +18447,26 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.28.0
 
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
   '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
@@ -18459,6 +18482,12 @@ snapshots:
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
 
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
   '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -18466,17 +18495,37 @@ snapshots:
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
@@ -22721,6 +22770,16 @@ snapshots:
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
 
+  '@vercel/otel@1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@vercel/queue@0.1.4':
     dependencies:
       '@vercel/oidc': 3.2.0
@@ -22819,6 +22878,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
+
+  '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
@@ -27587,7 +27654,7 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -27605,7 +27672,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       vue: 3.5.30(typescript@5.9.3)
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3))
 
   mlly@1.8.0:
     dependencies:
@@ -31116,7 +31183,7 @@ snapshots:
 
   ultrahtml@1.6.0: {}
 
-  unbuild@3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  unbuild@3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.60.0)
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.60.0)
@@ -31132,7 +31199,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -31781,7 +31848,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -31820,7 +31887,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -31949,11 +32016,11 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.30
 
-  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)):
+  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.7)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@babel/parser': 7.28.5
       '@vue/compiler-core': 3.5.30
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       vue: 3.5.30(typescript@5.9.3)
 
   vue@3.5.30(typescript@5.9.3):


### PR DESCRIPTION
## Summary

**Phase 1 + 2** of the friendlier-errors stack. Picks up where [#706](https://github.com/vercel/workflow/pull/706) (@schniz, stalled) left off.

- **`@workflow/errors`** — new `Ansi` rendering helpers (`frame`, `hint`, `note`, `help`, `code`, `inline`) for composing terminal-friendly, box-drawn error messages. Chalk auto-detects TTY and falls back to plain text (CI, Datadog).
- **`@workflow/core`** — four context-violation error classes applied to all 12 user-facing throw sites:
  - `NotInWorkflowContextError` (e.g. `createHook()`, `sleep()`)
  - `NotInStepContextError` (e.g. `getStepMetadata()`)
  - `NotInWorkflowOrStepContextError` (e.g. `getWorkflowMetadata()`, `getWritable()`)
  - `UnavailableInWorkflowContextError` (e.g. `resumeHook()`, `defineHook().resume()`) — names the active workflow.

Example rendering:

```
`createHook()` can only be called inside a workflow function
╰▶ note: Read more about createHook(): https://workflow-sdk.dev/docs/api-reference/workflow/create-hook
```

> [!NOTE]
> The rendered framing in this PR is later polished in PR #1849 (drop `functionName` leak, simplify `note: Read more about…` → `docs:`, and redirect the stack trace to user code). Verify the phase-1 behavior here; the polished form lands in the followups PR.

## Manual test plan

All tests below use `workbench/nextjs-turbopack` — start with `cd workbench/nextjs-turbopack && pnpm dev` and visit `http://localhost:3000`. Watch the **terminal** running `pnpm dev` for rendered errors.

A convenient smoke route that exercises most throw sites — drop this at `workbench/nextjs-turbopack/app/api/friendlier-errors-smoke/route.ts`:

```ts
import { NextResponse } from 'next/server';
import { createHook, sleep, getStepMetadata, getWorkflowMetadata } from 'workflow';

export async function GET(req: Request) {
  const which = new URL(req.url).searchParams.get('which');
  try {
    if (which === 'createHook') createHook();
    if (which === 'sleep') await sleep('1s');
    if (which === 'getStepMetadata') getStepMetadata();
    if (which === 'getWorkflowMetadata') getWorkflowMetadata();
    return NextResponse.json({ ok: true });
  } catch (err) {
    console.error(err);
    return NextResponse.json(
      { name: (err as Error).name, message: (err as Error).message, stack: (err as Error).stack },
      { status: 500 }
    );
  }
}
```

- [ ] **`createHook()` outside workflow** — hit `?which=createHook`. Expect a box-drawn frame (`╭─ … ╰─`) with title `` `createHook()` can only be called inside a workflow function `` and a `note: Read more about createHook(): https://…/workflow/create-hook` inside.
- [ ] **`sleep()` outside workflow** — hit `?which=sleep`. Same framing, docs URL ends in `.../workflow/sleep`.
- [ ] **`getStepMetadata()` in a workflow function (not a step)** — add to a `"use workflow"` file:
  ```ts
  export async function broken() {
    'use workflow';
    const meta = getStepMetadata(); // should throw
  }
  ```
  Expect title: "can only be called inside a **step function**".
- [ ] **`getWorkflowMetadata()` in application code** — hit `?which=getWorkflowMetadata`. Expect "workflow **or step** function".
- [ ] **`resumeHook()` inside a workflow** — call `resumeHook(token, payload)` from inside a `"use workflow"` function. Expect:
  - Title: `` `resumeHook()` cannot be called from a workflow context. ``
  - Three body lines: the determinism explanation; `this call was made from the workflow//./src/workflows/example.ts//myWorkflow workflow context.` (with the `workflow/` prefix dimmed); and the docs URL.
- [ ] **TTY detection** — run the rendered error in a real terminal and confirm the blue docs URL / bold code backticks show; pipe through `| cat` and confirm ANSI escape bytes are stripped (chalk auto-detect).

## Unit tests

- [x] `pnpm --filter @workflow/errors test` (10 new Ansi tests)
- [x] `pnpm --filter @workflow/core test` (5 new context-error tests)

---

## 📚 Friendlier errors stack

Multi-PR initiative inspired by @schniz's stalled [#706](https://github.com/vercel/workflow/pull/706):

| # | PR | Phase | Summary |
|---|-----|-------|---------|
| 1 | **→ this PR (#1831)** | Phase 1 + 2 | `Ansi` rendering primitives + context-violation errors |
| 2 | [#1832](https://github.com/vercel/workflow/pull/1832) | Phase 3 | Structured logger metadata; folds in [#1812](https://github.com/vercel/workflow/pull/1812) |
| 3 | [#1836](https://github.com/vercel/workflow/pull/1836) | Phase 4 | `SerializationError` at serialization / stream / encryption boundaries |
| 4 | [#1837](https://github.com/vercel/workflow/pull/1837) | Phase 5 | Presentation-only user vs SDK attribution (`describeError`) |
| 5 | [#1838](https://github.com/vercel/workflow/pull/1838) | Phase 6 | Consistency pass on remaining bare `throw new Error(...)` sites |
| 6 | [#1839](https://github.com/vercel/workflow/pull/1839) | Phase 7 foundation | Data-driven `describeRunError` + public subpath |
| 7 | [#1840](https://github.com/vercel/workflow/pull/1840) | Phase 8 | `WorkflowBuildError` + applications in `@workflow/builders` |
| 8 | [#1849](https://github.com/vercel/workflow/pull/1849) | Followups | Drop `functionName` leak, simplify docs framing, redirect stack to user code |

Each PR is stacked on the previous one; merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
