### PR TITLE
Structured logger metadata + fold in replay-timeout logging

### DIFF
--- a/.changeset/friendlier-logger-metadata.md
+++ b/.changeset/friendlier-logger-metadata.md
@@ -1,0 +1,12 @@
+---
+'@workflow/core': patch
+---
+
+Improve workflow runtime error logging:
+
+- Structured logger now supports `.child()` and `.forRun(runId, workflowName)` to attach stable run/step context to every log line without repetition.
+- Standardize console prefix to `[workflow-sdk]`.
+- Include error stacks in fatal and user-code errors; use the stack as the primary log message so it surfaces in flattened log drains.
+- Clarify replay-timeout messages (warn while retrying vs. error when giving up), and surface the underlying error when we can't mark a timed-out run as failed.
+- Add comments to silent catches that swallow expected idempotency conflicts.
+- Drop the `[Workflows] "<runId>" - ` prefix from `buildWorkflowSuspensionMessage` — the structured logger attaches run context now.

--- a/.changeset/friendlier-logger-metadata.md
+++ b/.changeset/friendlier-logger-metadata.md
@@ -1,5 +1,5 @@
 ---
-'@workflow/core': patch
+"@workflow/core": patch
 ---
 
 Improve workflow runtime error logging:

--- a/packages/core/src/logger.test.ts
+++ b/packages/core/src/logger.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { runtimeLogger } from './logger.js';
+
+describe('logger', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  test('error logs go to console.error with [workflow-sdk] prefix', () => {
+    runtimeLogger.error('boom', { foo: 'bar' });
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', {
+      foo: 'bar',
+    });
+  });
+
+  test('warn logs go to console.warn with [workflow-sdk] prefix', () => {
+    runtimeLogger.warn('watch out', { foo: 'bar' });
+    expect(warnSpy).toHaveBeenCalledWith('[workflow-sdk] watch out', {
+      foo: 'bar',
+    });
+  });
+
+  test('info and debug do not print to console by default', () => {
+    runtimeLogger.info('quiet');
+    runtimeLogger.debug('quieter');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('child() merges parent metadata into every call', () => {
+    const child = runtimeLogger.child({ workflowRunId: 'run-1' });
+    child.error('boom', { stepId: 'step-1' });
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', {
+      workflowRunId: 'run-1',
+      stepId: 'step-1',
+    });
+  });
+
+  test('call-site metadata wins over child metadata on conflict', () => {
+    const child = runtimeLogger.child({ workflowRunId: 'parent-id' });
+    child.error('boom', { workflowRunId: 'override' });
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', {
+      workflowRunId: 'override',
+    });
+  });
+
+  test('child can be chained', () => {
+    const runLogger = runtimeLogger.child({ workflowRunId: 'run-1' });
+    const stepLogger = runLogger.child({ stepId: 'step-1' });
+    stepLogger.error('boom');
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', {
+      workflowRunId: 'run-1',
+      stepId: 'step-1',
+    });
+  });
+
+  test('forRun attaches workflowRunId and workflowName', () => {
+    const runLogger = runtimeLogger.forRun('run-1', 'myWorkflow');
+    runLogger.error('boom');
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', {
+      workflowRunId: 'run-1',
+      workflowName: 'myWorkflow',
+    });
+  });
+
+  test('forRun without workflowName omits the key', () => {
+    const runLogger = runtimeLogger.forRun('run-1');
+    runLogger.error('boom');
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', {
+      workflowRunId: 'run-1',
+    });
+  });
+
+  test('forRun accepts extra metadata', () => {
+    const runLogger = runtimeLogger.forRun('run-1', 'myWorkflow', {
+      stepId: 'step-1',
+    });
+    runLogger.error('boom');
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', {
+      workflowRunId: 'run-1',
+      workflowName: 'myWorkflow',
+      stepId: 'step-1',
+    });
+  });
+
+  test('no metadata omits the argument object', () => {
+    runtimeLogger.error('boom');
+    expect(errorSpy).toHaveBeenCalledWith('[workflow-sdk] boom', '');
+  });
+});

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,42 +1,90 @@
 import debug from 'debug';
 import { getActiveSpan } from './telemetry.js';
 
-function createLogger(namespace: string) {
+type LogMetadata = Record<string, unknown>;
+
+type LogFn = (message: string, metadata?: LogMetadata) => void;
+
+export interface Logger {
+  debug: LogFn;
+  info: LogFn;
+  warn: LogFn;
+  error: LogFn;
+  /**
+   * Returns a child logger that merges the given metadata into every call.
+   * Useful for attaching stable context (e.g. `workflowRunId`, `workflowName`,
+   * `stepId`) so callers don't have to repeat it on every log.
+   *
+   * Call-site metadata wins on conflict, so children can still override.
+   */
+  child: (metadata: LogMetadata) => Logger;
+  /**
+   * Convenience child logger for a workflow run. Equivalent to
+   * `logger.child({ workflowRunId, workflowName })`, but centralized so all
+   * runtime code structures run metadata consistently.
+   */
+  forRun: (
+    workflowRunId: string,
+    workflowName?: string,
+    extra?: LogMetadata
+  ) => Logger;
+}
+
+function createLogger(namespace: string): Logger {
   const baseDebug = debug(`workflow:${namespace}`);
 
-  const logger = (level: string) => {
-    const levelDebug = baseDebug.extend(level);
+  const build = (parentMetadata: LogMetadata): Logger => {
+    const logger = (level: string): LogFn => {
+      const levelDebug = baseDebug.extend(level);
 
-    return (message: string, metadata?: Record<string, any>) => {
-      // Always output error/warn to console so users see critical issues
-      // debug/info only output when DEBUG env var is set
-      if (level === 'error') {
-        console.error(`[Workflow] ${message}`, metadata ?? '');
-      } else if (level === 'warn') {
-        console.warn(`[Workflow] ${message}`, metadata ?? '');
-      }
+      return (message, metadata) => {
+        const hasParent = Object.keys(parentMetadata).length > 0;
+        const hasCallSite = metadata && Object.keys(metadata).length > 0;
+        const merged =
+          hasParent || hasCallSite
+            ? { ...parentMetadata, ...(metadata ?? {}) }
+            : undefined;
 
-      // Also log to debug library for verbose output when DEBUG is enabled
-      levelDebug(message, metadata);
+        // Always output error/warn to console so users see critical issues.
+        // debug/info only output when DEBUG env var is set.
+        if (level === 'error') {
+          console.error(`[workflow-sdk] ${message}`, merged ?? '');
+        } else if (level === 'warn') {
+          console.warn(`[workflow-sdk] ${message}`, merged ?? '');
+        }
 
-      if (levelDebug.enabled) {
-        getActiveSpan()
-          .then((span) => {
-            span?.addEvent(`${level}.${namespace}`, { message, ...metadata });
-          })
-          .catch(() => {
-            // Silently ignore telemetry errors
-          });
-      }
+        // Also log to debug library for verbose output when DEBUG is enabled
+        levelDebug(message, merged);
+
+        if (levelDebug.enabled) {
+          getActiveSpan()
+            .then((span) => {
+              span?.addEvent(`${level}.${namespace}`, { message, ...merged });
+            })
+            .catch(() => {
+              // Silently ignore telemetry errors
+            });
+        }
+      };
+    };
+
+    return {
+      debug: logger('debug'),
+      info: logger('info'),
+      warn: logger('warn'),
+      error: logger('error'),
+      child: (metadata) => build({ ...parentMetadata, ...metadata }),
+      forRun: (workflowRunId, workflowName, extra) =>
+        build({
+          ...parentMetadata,
+          workflowRunId,
+          ...(workflowName !== undefined ? { workflowName } : {}),
+          ...(extra ?? {}),
+        }),
     };
   };
 
-  return {
-    debug: logger('debug'),
-    info: logger('info'),
-    warn: logger('warn'),
-    error: logger('error'),
-  };
+  return build({});
 }
 
 export const stepLogger = createLogger('step');

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -137,10 +137,14 @@ export function workflowEntrypoint(
         // of the workflow events, etc. We simply attempt to mark the run as failed
         // and if that fails, the message is still consumed but with adequate logging
         // that an error occurred preventing us from failing the run.
+        // Scoped logger for this run — attaches runId/workflowName to every
+        // log line and child loggers below, so callers don't repeat it.
+        const runLogger = runtimeLogger.forRun(runId, workflowName);
+
         if (metadata.attempt > MAX_QUEUE_DELIVERIES) {
-          runtimeLogger.error(
+          runLogger.error(
             `Workflow handler exceeded max deliveries (${metadata.attempt}/${MAX_QUEUE_DELIVERIES})`,
-            { workflowRunId: runId, workflowName, attempt: metadata.attempt }
+            { attempt: metadata.attempt }
           );
           try {
             const world = await getWorld();
@@ -163,16 +167,17 @@ export function workflowEntrypoint(
               // Run already finished, consume the message silently
               return;
             }
-            runtimeLogger.error(
+            runLogger.error(
               `Failed to mark run as failed after ${metadata.attempt} delivery attempts. ` +
                 `A persistent error is preventing the run from being terminated. ` +
                 `The run will remain in its current state until manually resolved. ` +
                 `This is most likely due to a persistent outage of the workflow backend ` +
                 `or a bug in the workflow runtime and should be reported to the Workflow team.`,
               {
-                workflowRunId: runId,
-                error: err instanceof Error ? err.message : String(err),
                 attempt: metadata.attempt,
+                errorName: err instanceof Error ? err.name : 'UnknownError',
+                errorMessage: err instanceof Error ? err.message : String(err),
+                errorStack: err instanceof Error ? err.stack : undefined,
               }
             );
           }
@@ -188,18 +193,28 @@ export function workflowEntrypoint(
         let replayTimeout: NodeJS.Timeout | undefined;
         if (process.env.VERCEL_URL !== undefined) {
           replayTimeout = setTimeout(async () => {
-            runtimeLogger.error('Workflow replay exceeded timeout', {
-              workflowRunId: runId,
-              timeoutMs: REPLAY_TIMEOUT_MS,
-              attempt: metadata.attempt,
-              maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
-            });
-
             // Allow a few retries before permanently failing the run.
             // On early attempts, just exit so the queue retries the message.
             if (metadata.attempt <= REPLAY_TIMEOUT_MAX_RETRIES) {
+              runLogger.warn(
+                'Workflow replay exceeded timeout but will be re-attempted (attempt < maxRetries)',
+                {
+                  timeoutMs: REPLAY_TIMEOUT_MS,
+                  attempt: metadata.attempt,
+                  maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
+                }
+              );
               process.exit(1);
             }
+
+            runLogger.error(
+              'Workflow replay exceeded timeout and max retries exceeded. Failing the run',
+              {
+                timeoutMs: REPLAY_TIMEOUT_MS,
+                attempt: metadata.attempt,
+                maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
+              }
+            );
 
             try {
               const world = await getWorld();
@@ -217,8 +232,19 @@ export function workflowEntrypoint(
                 },
                 { requestId }
               );
-            } catch {
-              // Best effort — process exits regardless
+            } catch (err) {
+              // Best effort — process exits regardless. Surface why so
+              // operators can diagnose repeat timeouts against the backend.
+              runLogger.warn(
+                'Unable to mark run as failed. The queue will continue to retry',
+                {
+                  attempt: metadata.attempt,
+                  errorName: err instanceof Error ? err.name : 'UnknownError',
+                  errorMessage:
+                    err instanceof Error ? err.message : String(err),
+                  errorStack: err instanceof Error ? err.stack : undefined,
+                }
+              );
             }
             // Note that this also prevents the runtime from acking the queue message,
             // so the queue will call back once, after which a 410 will get it to exit early.
@@ -327,15 +353,22 @@ export function workflowEntrypoint(
                       // completed/failed/cancelled during setup.
                       // RunExpiredError: run already in terminal state.
                       // In both cases, skip processing this message.
-                      runtimeLogger.info(
+                      runLogger.info(
                         'Run already finished during setup, skipping',
-                        { workflowRunId: runId, message: err.message }
+                        { errorName: err.name, errorMessage: err.message }
                       );
                       return;
                     } else if (err instanceof WorkflowRuntimeError) {
-                      runtimeLogger.error(
-                        'Fatal runtime error during workflow setup',
-                        { workflowRunId: runId, error: err.message }
+                      // Include the stack directly in the message so it
+                      // surfaces in stdout even when structured logging is
+                      // being flattened (e.g. Vercel log drain).
+                      runLogger.error(
+                        `Fatal runtime error during workflow setup\n${err.stack}`,
+                        {
+                          errorName: err.name,
+                          errorMessage: err.message,
+                          errorStack: err.stack,
+                        }
                       );
                       try {
                         await world.events.create(
@@ -377,10 +410,9 @@ export function workflowEntrypoint(
 
                   if (workflowRun.status !== 'running') {
                     // Workflow has already completed or failed, so we can skip it
-                    runtimeLogger.info(
+                    runLogger.info(
                       'Workflow already completed or failed, skipping',
                       {
-                        workflowRunId: runId,
                         status: workflowRun.status,
                       }
                     );
@@ -440,8 +472,9 @@ export function workflowEntrypoint(
                       events.push(result.event!);
                     } catch (err) {
                       if (EntityConflictError.is(err)) {
-                        runtimeLogger.info('Wait already completed, skipping', {
-                          workflowRunId: runId,
+                        // Another replay/worker already recorded wait_completed
+                        // for the same correlationId — idempotent, ignore.
+                        runLogger.info('Wait already completed, skipping', {
                           correlationId: waitEvent.correlationId,
                         });
                         continue;
@@ -482,13 +515,12 @@ export function workflowEntrypoint(
                     // WorkflowSuspension is normal control flow — not an error
                     if (WorkflowSuspension.is(err)) {
                       const suspensionMessage = buildWorkflowSuspensionMessage(
-                        runId,
                         err.stepCount,
                         err.hookCount,
                         err.waitCount
                       );
                       if (suspensionMessage) {
-                        runtimeLogger.debug(suspensionMessage);
+                        runLogger.debug(suspensionMessage);
                       }
 
                       const result = await handleSuspension({
@@ -538,12 +570,16 @@ export function workflowEntrypoint(
                     // everything else is a user code error.
                     const errorCode = classifyRunError(err);
 
-                    runtimeLogger.error('Error while running workflow', {
-                      workflowRunId: runId,
-                      errorCode,
-                      errorName,
-                      errorStack,
-                    });
+                    // Use the stack as the primary message so it shows up
+                    // in flattened logs without structured metadata.
+                    runLogger.error(
+                      errorStack || 'Unknown error encountered in workflow',
+                      {
+                        errorCode,
+                        errorName,
+                        errorMessage,
+                      }
+                    );
 
                     // Fail the workflow run via event (event-sourced architecture)
                     try {
@@ -567,11 +603,14 @@ export function workflowEntrypoint(
                         EntityConflictError.is(failErr) ||
                         RunExpiredError.is(failErr)
                       ) {
-                        runtimeLogger.info(
+                        // Run already transitioned to a terminal state via
+                        // another path (duplicate delivery, cancellation).
+                        // Nothing to do — just drop the failure event.
+                        runLogger.info(
                           'Tried failing workflow run, but run has already finished.',
                           {
-                            workflowRunId: runId,
-                            message: failErr.message,
+                            errorName: failErr.name,
+                            errorMessage: failErr.message,
                           }
                         );
                         span?.setAttributes({
@@ -616,11 +655,13 @@ export function workflowEntrypoint(
                       EntityConflictError.is(err) ||
                       RunExpiredError.is(err)
                     ) {
-                      runtimeLogger.info(
+                      // Run already completed/failed elsewhere — idempotent,
+                      // drop the completion event.
+                      runLogger.info(
                         'Tried completing workflow run, but run has already finished.',
                         {
-                          workflowRunId: runId,
-                          message: err.message,
+                          errorName: err.name,
+                          errorMessage: err.message,
                         }
                       );
                       return;

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -82,13 +82,19 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
       // of the step details, etc. We simply attempt to mark the step as failed
       // and enqueue the workflow once, and if either of those fails, the message
       // is still consumed but with adequate logging that an error occurred.
+      // Scoped logger for this step invocation — attaches run/step context to
+      // every log line below so callers don't repeat it.
+      const stepNameFromQueue = metadata.queueName.slice('__wkf_step_'.length);
+      const stepRuntimeLogger = runtimeLogger.forRun(
+        workflowRunId,
+        workflowName,
+        { stepId, stepName: stepNameFromQueue }
+      );
+
       if (metadata.attempt > MAX_QUEUE_DELIVERIES) {
-        runtimeLogger.error(
+        stepRuntimeLogger.error(
           `Step handler exceeded max deliveries (${metadata.attempt}/${MAX_QUEUE_DELIVERIES})`,
           {
-            workflowRunId,
-            stepId,
-            stepName: metadata.queueName.slice('__wkf_step_'.length),
             attempt: metadata.attempt,
           }
         );
@@ -118,17 +124,17 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
           }
           // Can't even mark the step as failed. Consume the message to stop
           // further retries. The run will remain in its current state.
-          runtimeLogger.error(
+          stepRuntimeLogger.error(
             `Failed to mark step as failed after ${metadata.attempt} delivery attempts. ` +
               `A persistent error is preventing the step from being terminated. ` +
               `The run will remain in its current state until manually resolved. ` +
               `This is most likely due to a persistent outage of the workflow backend ` +
               `or a bug in the workflow runtime and should be reported to the Workflow team.`,
             {
-              workflowRunId,
-              stepId,
               attempt: metadata.attempt,
-              error: err instanceof Error ? err.message : String(err),
+              errorName: err instanceof Error ? err.name : 'UnknownError',
+              errorMessage: err instanceof Error ? err.message : String(err),
+              errorStack: err instanceof Error ? err.stack : undefined,
             }
           );
         }
@@ -205,7 +211,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   1,
                   typeof err.retryAfter === 'number' ? err.retryAfter : 1
                 );
-                runtimeLogger.info(
+                stepRuntimeLogger.info(
                   'Throttled again on retry, deferring to queue',
                   {
                     retryAfterSeconds: retryRetryAfter,
@@ -214,19 +220,22 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                 return { timeoutSeconds: retryRetryAfter };
               }
               if (RunExpiredError.is(err)) {
-                runtimeLogger.info(
-                  `Workflow run "${workflowRunId}" has already completed, skipping step "${stepId}": ${err.message}`
+                // Expected when a run is cancelled while a step is in-flight.
+                stepRuntimeLogger.info(
+                  'Workflow run has already completed, skipping step',
+                  { errorName: err.name, errorMessage: err.message }
                 );
                 return;
               }
               if (EntityConflictError.is(err)) {
-                runtimeLogger.debug(
+                // Step already in a terminal state — another worker finished
+                // it or it was retried to completion. Re-enqueue the parent
+                // workflow so it can observe the outcome.
+                stepRuntimeLogger.debug(
                   'Step in terminal state, re-enqueuing workflow',
                   {
-                    stepName,
-                    stepId,
-                    workflowRunId,
-                    error: err.message,
+                    errorName: err.name,
+                    errorMessage: err.message,
                   }
                 );
                 span?.setAttributes({
@@ -258,11 +267,9 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   'delay.reason': 'retry_after_not_reached',
                   'delay.timeout_seconds': timeoutSeconds,
                 });
-                runtimeLogger.debug(
+                stepRuntimeLogger.debug(
                   'Step retryAfter timestamp not yet reached',
                   {
-                    stepName,
-                    stepId,
                     retryAfterSeconds: err.retryAfter,
                     timeoutSeconds,
                   }
@@ -273,9 +280,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
               throw err;
             }
 
-            runtimeLogger.debug('Step execution details', {
-              stepName,
-              stepId: step.stepId,
+            stepRuntimeLogger.debug('Step execution details', {
               status: step.status,
               attempt: step.attempt,
             });
@@ -291,13 +296,12 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
             if (!stepFn || typeof stepFn !== 'function') {
               const err = new StepNotRegisteredError(stepName);
 
-              runtimeLogger.error(
+              stepRuntimeLogger.error(
                 'Step function not registered, failing step (not run)',
                 {
-                  workflowRunId,
-                  stepName,
-                  stepId,
-                  error: err.message,
+                  errorName: err.name,
+                  errorMessage: err.message,
+                  errorStack: err.stack,
                 }
               );
 
@@ -319,13 +323,13 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                 );
               } catch (stepFailErr) {
                 if (EntityConflictError.is(stepFailErr)) {
-                  runtimeLogger.info(
+                  // Step already transitioned to a terminal state — duplicate
+                  // delivery or concurrent cancellation. Drop silently.
+                  stepRuntimeLogger.info(
                     'Tried failing step for missing function, but step has already finished.',
                     {
-                      workflowRunId,
-                      stepId,
-                      stepName,
-                      message: stepFailErr.message,
+                      errorName: stepFailErr.name,
+                      errorMessage: stepFailErr.message,
                     }
                   );
                   return;
@@ -365,6 +369,8 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
               const errorMessage = `Step "${stepName}" exceeded max retries (${retryCount} ${pluralize('retry', 'retries', retryCount)})`;
               stepLogger.error('Step exceeded max retries', {
                 workflowRunId,
+                workflowName,
+                stepId,
                 stepName,
                 retryCount,
               });
@@ -385,13 +391,13 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                 );
               } catch (err) {
                 if (EntityConflictError.is(err)) {
-                  runtimeLogger.info(
+                  // Step already transitioned to a terminal state — duplicate
+                  // delivery or concurrent completion. Drop silently.
+                  stepRuntimeLogger.info(
                     'Tried failing step, but step has already finished.',
                     {
-                      workflowRunId,
-                      stepId,
-                      stepName,
-                      message: err.message,
+                      errorName: err.name,
+                      errorMessage: err.message,
                     }
                   );
                   return;
@@ -425,10 +431,8 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
 
             if (!step.startedAt) {
               const errorMessage = `Step "${stepId}" has no "startedAt" timestamp`;
-              runtimeLogger.error('Fatal runtime error during step setup', {
-                workflowRunId,
-                stepId,
-                error: errorMessage,
+              stepRuntimeLogger.error('Fatal runtime error during step setup', {
+                errorMessage,
               });
               try {
                 await world.events.create(
@@ -614,13 +618,12 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   );
                 } catch (stepFailErr) {
                   if (EntityConflictError.is(stepFailErr)) {
-                    runtimeLogger.info(
+                    // Step already in terminal state — idempotent.
+                    stepRuntimeLogger.info(
                       'Tried failing step, but step has already finished.',
                       {
-                        workflowRunId,
-                        stepId,
-                        stepName,
-                        message: stepFailErr.message,
+                        errorName: stepFailErr.name,
+                        errorMessage: stepFailErr.message,
                       }
                     );
                     return;
@@ -651,9 +654,13 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                     'Max retries reached, bubbling error to parent workflow',
                     {
                       workflowRunId,
+                      workflowName,
+                      stepId,
                       stepName,
                       attempt: step.attempt,
                       retryCount,
+                      errorName: normalizedError.name,
+                      errorMessage: normalizedError.message,
                       errorStack: normalizedStack,
                     }
                   );
@@ -675,13 +682,12 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                     );
                   } catch (stepFailErr) {
                     if (EntityConflictError.is(stepFailErr)) {
-                      runtimeLogger.info(
+                      // Step already in terminal state — idempotent.
+                      stepRuntimeLogger.info(
                         'Tried failing step, but step has already finished.',
                         {
-                          workflowRunId,
-                          stepId,
-                          stepName,
-                          message: stepFailErr.message,
+                          errorName: stepFailErr.name,
+                          errorMessage: stepFailErr.message,
                         }
                       );
                       return;
@@ -700,16 +706,24 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                       'Encountered RetryableError, step will be retried',
                       {
                         workflowRunId,
+                        workflowName,
+                        stepId,
                         stepName,
                         attempt: currentAttempt,
-                        message: err.message,
+                        errorName: err.name,
+                        errorMessage: err.message,
+                        errorStack: normalizedStack,
                       }
                     );
                   } else {
                     stepLogger.info('Encountered Error, step will be retried', {
                       workflowRunId,
+                      workflowName,
+                      stepId,
                       stepName,
                       attempt: currentAttempt,
+                      errorName: normalizedError.name,
+                      errorMessage: normalizedError.message,
                       errorStack: normalizedStack,
                     });
                   }
@@ -734,13 +748,12 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                     );
                   } catch (stepRetryErr) {
                     if (EntityConflictError.is(stepRetryErr)) {
-                      runtimeLogger.info(
+                      // Step already in terminal state — idempotent.
+                      stepRuntimeLogger.info(
                         'Tried retrying step, but step has already finished.',
                         {
-                          workflowRunId,
-                          stepId,
-                          stepName,
-                          message: stepRetryErr.message,
+                          errorName: stepRetryErr.name,
+                          errorMessage: stepRetryErr.message,
                         }
                       );
                       return;
@@ -839,13 +852,12 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                 )
                 .catch((err: unknown) => {
                   if (EntityConflictError.is(err)) {
-                    runtimeLogger.info(
+                    // Step already in terminal state — idempotent.
+                    stepRuntimeLogger.info(
                       'Tried completing step, but step has already finished.',
                       {
-                        workflowRunId,
-                        stepId,
-                        stepName,
-                        message: err.message,
+                        errorName: err.name,
+                        errorMessage: err.message,
                       }
                     );
                     stepCompleted409 = true;

--- a/packages/core/src/util.test.ts
+++ b/packages/core/src/util.test.ts
@@ -3,115 +3,113 @@ import { describe, expect, it } from 'vitest';
 import { buildWorkflowSuspensionMessage, getWorkflowRunStreamId } from './util';
 
 describe('buildWorkflowSuspensionMessage', () => {
-  const runId = 'test-run-123';
-
   it('should return null when both counts are zero', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 0, 0, 0);
+    const result = buildWorkflowSuspensionMessage(0, 0, 0);
     expect(result).toBeNull();
   });
 
   it('should handle single step', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 1, 0, 0);
+    const result = buildWorkflowSuspensionMessage(1, 0, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 step to be enqueued\n  Workflow will suspend and resume when steps are completed`
+      `1 step to be enqueued\n  Workflow will suspend and resume when steps are completed`
     );
   });
 
   it('should handle multiple steps', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 3, 0, 0);
+    const result = buildWorkflowSuspensionMessage(3, 0, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 3 steps to be enqueued\n  Workflow will suspend and resume when steps are completed`
+      `3 steps to be enqueued\n  Workflow will suspend and resume when steps are completed`
     );
   });
 
   it('should handle single hook', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 0, 1, 0);
+    const result = buildWorkflowSuspensionMessage(0, 1, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 hook to be enqueued\n  Workflow will suspend and resume when hooks are received`
+      `1 hook to be enqueued\n  Workflow will suspend and resume when hooks are received`
     );
   });
 
   it('should handle multiple hooks', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 0, 2, 0);
+    const result = buildWorkflowSuspensionMessage(0, 2, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 2 hooks to be enqueued\n  Workflow will suspend and resume when hooks are received`
+      `2 hooks to be enqueued\n  Workflow will suspend and resume when hooks are received`
     );
   });
 
   it('should handle single step and single hook', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 1, 1, 0);
+    const result = buildWorkflowSuspensionMessage(1, 1, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 step and 1 hook to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
+      `1 step and 1 hook to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
     );
   });
 
   it('should handle multiple steps and single hook', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 5, 1, 0);
+    const result = buildWorkflowSuspensionMessage(5, 1, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 5 steps and 1 hook to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
+      `5 steps and 1 hook to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
     );
   });
 
   it('should handle single step and multiple hooks', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 1, 3, 0);
+    const result = buildWorkflowSuspensionMessage(1, 3, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 step and 3 hooks to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
+      `1 step and 3 hooks to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
     );
   });
 
   it('should handle multiple steps and multiple hooks', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 4, 2, 0);
+    const result = buildWorkflowSuspensionMessage(4, 2, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 4 steps and 2 hooks to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
+      `4 steps and 2 hooks to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
     );
   });
 
   it('should handle large numbers correctly', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 100, 50, 0);
+    const result = buildWorkflowSuspensionMessage(100, 50, 0);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 100 steps and 50 hooks to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
+      `100 steps and 50 hooks to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received`
     );
   });
 
   it('should handle single wait without steps or hooks', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 0, 0, 1);
+    const result = buildWorkflowSuspensionMessage(0, 0, 1);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 timer to be enqueued\n  Workflow will suspend and resume when timers have elapsed`
+      `1 timer to be enqueued\n  Workflow will suspend and resume when timers have elapsed`
     );
   });
 
   it('should handle multiple waits without steps or hooks', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 0, 0, 2);
+    const result = buildWorkflowSuspensionMessage(0, 0, 2);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 2 timers to be enqueued\n  Workflow will suspend and resume when timers have elapsed`
+      `2 timers to be enqueued\n  Workflow will suspend and resume when timers have elapsed`
     );
   });
 
   it('should handle hooks and waits without steps', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 0, 1, 1);
+    const result = buildWorkflowSuspensionMessage(0, 1, 1);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 hook and 1 timer to be enqueued\n  Workflow will suspend and resume when hooks are received and timers have elapsed`
+      `1 hook and 1 timer to be enqueued\n  Workflow will suspend and resume when hooks are received and timers have elapsed`
     );
   });
 
   it('should handle steps and waits without hooks', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 1, 0, 1);
+    const result = buildWorkflowSuspensionMessage(1, 0, 1);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 step and 1 timer to be enqueued\n  Workflow will suspend and resume when steps are completed and timers have elapsed`
+      `1 step and 1 timer to be enqueued\n  Workflow will suspend and resume when steps are completed and timers have elapsed`
     );
   });
 
   it('should handle steps, hooks, and waits', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 1, 1, 1);
+    const result = buildWorkflowSuspensionMessage(1, 1, 1);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 1 step and 1 hook and 1 timer to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received and timers have elapsed`
+      `1 step and 1 hook and 1 timer to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received and timers have elapsed`
     );
   });
 
   it('should handle multiple waits with steps and hooks', () => {
-    const result = buildWorkflowSuspensionMessage(runId, 2, 1, 3);
+    const result = buildWorkflowSuspensionMessage(2, 1, 3);
     expect(result).toBe(
-      `[Workflows] "${runId}" - 2 steps and 1 hook and 3 timers to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received and timers have elapsed`
+      `2 steps and 1 hook and 3 timers to be enqueued\n  Workflow will suspend and resume when steps are completed and hooks are received and timers have elapsed`
     );
   });
 });

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -2,15 +2,15 @@ import { waitUntil } from '@vercel/functions';
 import { pluralize } from '@workflow/utils';
 
 /**
- * Builds a workflow suspension log message based on the counts of steps, hooks, and waits.
- * @param runId - The workflow run ID
+ * Builds a workflow suspension log message based on the counts of steps,
+ * hooks, and waits. The structured logger attaches the run context, so the
+ * message itself only describes what's being enqueued.
  * @param stepCount - Number of steps to be enqueued
  * @param hookCount - Number of hooks to be enqueued
  * @param waitCount - Number of waits to be enqueued
  * @returns The formatted log message or null if all counts are 0
  */
 export function buildWorkflowSuspensionMessage(
-  runId: string,
   stepCount: number,
   hookCount: number,
   waitCount: number
@@ -42,7 +42,7 @@ export function buildWorkflowSuspensionMessage(
   }
   const resumeMsg = resumeMsgParts.join(' and ');
 
-  return `[Workflows] "${runId}" - ${parts.join(' and ')} to be enqueued\n  Workflow will suspend and resume when ${resumeMsg}`;
+  return `${parts.join(' and ')} to be enqueued\n  Workflow will suspend and resume when ${resumeMsg}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Phase 3** of the friendlier-errors stack. Also folds in [#1812](https://github.com/vercel/workflow/pull/1812) so that PR can close as superseded.

- **Structured logger child API.** `runtimeLogger` / `stepLogger` / `webhookLogger` etc. now expose `.child(metadata)` and `.forRun(runId, workflowName, extra?)`, so runtime and step handlers don't have to repeat `workflowRunId` / `workflowName` / `stepId` on every log call.
- **Normalized error metadata.** Ad-hoc `error: err.message` strings are replaced with structured `errorName` / `errorMessage` / `errorStack` fields so log drains can render and group them properly.
- **Comments on silent catches.** The `EntityConflictError` / `RunExpiredError` paths that swallow expected idempotency conflicts now explain _why_ it's safe to drop the error.

### Folded in from [#1812](https://github.com/vercel/workflow/pull/1812) (supersedes it)

- Standardize the console prefix to `[workflow-sdk]`.
- Split replay-timeout into warn-while-retrying vs. error-when-giving-up, and surface the underlying error when we can't mark a timed-out run as failed.
- Include error stacks in the "Fatal runtime error during workflow setup" log and the top-level user-code workflow error log so the stack surfaces in flattened drains.
- Drop the `[Workflows] "<runId>" -` prefix from `buildWorkflowSuspensionMessage` — the structured logger attaches run context now.

**Closes / supersedes:** #1812

## Manual test plan

All tests below use `workbench/nextjs-turbopack`. Start with `cd workbench/nextjs-turbopack && pnpm dev` and watch the terminal.

- [ ] **Console prefix** — trigger any workflow. Every log line should begin with `[workflow-sdk]`. Search logs for `\[Workflows\]` — should be zero hits (the old prefix is gone).
- [ ] **Structured run/step context** — inspect any step log line. It should carry `runId`, `workflowName`, `stepId` as **structured metadata** (the object after the message), not interpolated into the message string.
- [ ] **Error stacks in logs** — deliberately throw from a step:
  ```ts
  async function brokenStep() { 'use step'; throw new Error('boom'); }
  ```
  Run the workflow. Confirm the full stack is the **log message** (survives flattened drains like Axiom/Datadog), not relegated to a structured field.
- [ ] **Structured error fields** — at step-failure / run-failure, confirm `errorName`, `errorMessage`, and `errorStack` appear as structured metadata fields (in addition to the stack in the message).
- [ ] **Replay-timeout warn vs. error** — set `WORKFLOW_REPLAY_TIMEOUT_MS=50` in env and run a workflow with any non-trivial work. On early replay attempts expect a `warn`-level line ("replay timed out, retrying"); after retries exhaust expect an `error`-level line with the underlying failure cause visible.
- [ ] **Fatal setup error includes stack** — if you can induce a fatal-at-setup (e.g. by crashing a worker init path), the "Fatal runtime error during workflow setup" log should include the full stack.
- [ ] **Suspension message has no legacy prefix** — trigger a workflow that awaits a hook and suspends. The suspension log line should NOT start with `[Workflows] "<runId>" -` — only `[workflow-sdk]`, with run context in structured metadata.
- [ ] **Idempotency conflicts are silently dropped** — hard to induce deliberately; verify by reading the commented catches (`EntityConflictError` / `RunExpiredError`) around idempotent step-completion paths. No user-visible test.

## Unit tests

- [x] New `src/logger.test.ts` covers `.child`, `.forRun`, metadata merging, and conflict precedence (10 tests).
- [x] Existing `src/util.test.ts` updated for new suspension-message format (23 tests pass).
- [x] `pnpm typecheck` reports no new errors.

---

## 📚 Friendlier errors stack

Multi-PR initiative inspired by @schniz's stalled [#706](https://github.com/vercel/workflow/pull/706):

| # | PR | Phase | Summary |
|---|-----|-------|---------|
| 1 | [#1831](https://github.com/vercel/workflow/pull/1831) | Phase 1 + 2 | `Ansi` rendering primitives + context-violation errors |
| 2 | **→ this PR (#1832)** | Phase 3 | Structured logger metadata; folds in [#1812](https://github.com/vercel/workflow/pull/1812) |
| 3 | [#1836](https://github.com/vercel/workflow/pull/1836) | Phase 4 | `SerializationError` at serialization / stream / encryption boundaries |
| 4 | [#1837](https://github.com/vercel/workflow/pull/1837) | Phase 5 | Presentation-only user vs SDK attribution (`describeError`) |
| 5 | [#1838](https://github.com/vercel/workflow/pull/1838) | Phase 6 | Consistency pass on remaining bare `throw new Error(...)` sites |
| 6 | [#1839](https://github.com/vercel/workflow/pull/1839) | Phase 7 foundation | Data-driven `describeRunError` + public subpath |
| 7 | [#1840](https://github.com/vercel/workflow/pull/1840) | Phase 8 | `WorkflowBuildError` + applications in `@workflow/builders` |
| 8 | [#1849](https://github.com/vercel/workflow/pull/1849) | Followups | Drop `functionName` leak, simplify docs framing, redirect stack to user code |

Each PR is stacked on the previous one; merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
