### PR TITLE
Phase 4: SerializationError + user-facing serialization hints

### DIFF
--- a/.changeset/friendlier-serialization-errors.md
+++ b/.changeset/friendlier-serialization-errors.md
@@ -1,0 +1,11 @@
+---
+'@workflow/core': patch
+'@workflow/errors': patch
+---
+
+Add `SerializationError` (with optional `hint` and docs link) and apply it to
+user-facing serialization boundaries: stream locking, unregistered classes,
+missing `WORKFLOW_DESERIALIZE`, step-function / workflow-function misuse, and
+dehydrate/hydrate failures for workflow args, step args, and return values.
+Bare `throw new Error(…)` internal invariants now throw `WorkflowRuntimeError`
+for consistent classification.

--- a/.changeset/friendlier-serialization-errors.md
+++ b/.changeset/friendlier-serialization-errors.md
@@ -1,6 +1,6 @@
 ---
-'@workflow/core': patch
-'@workflow/errors': patch
+"@workflow/core": patch
+"@workflow/errors": patch
 ---
 
 Add `SerializationError` (with optional `hint` and docs link) and apply it to

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -1,3 +1,5 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
+
 /**
  * Browser-compatible AES-256-GCM encryption module.
  *
@@ -36,7 +38,7 @@ const KEY_LENGTH = 32; // bytes (AES-256)
  */
 export async function importKey(raw: Uint8Array) {
   if (raw.byteLength !== KEY_LENGTH) {
-    throw new Error(
+    throw new WorkflowRuntimeError(
       `Encryption key must be exactly ${KEY_LENGTH} bytes, got ${raw.byteLength}`
     );
   }
@@ -82,7 +84,7 @@ export async function decrypt(
 ): Promise<Uint8Array> {
   const minLength = NONCE_LENGTH + TAG_LENGTH / 8; // nonce + auth tag
   if (data.byteLength < minLength) {
-    throw new Error(
+    throw new WorkflowRuntimeError(
       `Encrypted data too short: expected at least ${minLength} bytes, got ${data.byteLength}`
     );
   }

--- a/packages/core/src/flushable-stream.ts
+++ b/packages/core/src/flushable-stream.ts
@@ -1,3 +1,4 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
 import { type PromiseWithResolvers, withResolvers } from '@workflow/utils';
 
 /**
@@ -223,7 +224,7 @@ export async function flushablePipe(
       const readResult = await Promise.race([
         reader.read(),
         writer.closed.then(() => {
-          throw new Error('Writable stream closed prematurely');
+          throw new WorkflowRuntimeError('Writable stream closed prematurely');
         }),
       ]);
 

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -2144,7 +2144,9 @@ describe('step function serialization', () => {
 
     expect(err).toBeDefined();
     expect(err?.message).toContain('Step function "nonExistentStep" not found');
-    expect(err?.message).toContain('Make sure the step function is registered');
+    expect(err?.message).toContain(
+      'Make sure the step file is included in your build'
+    );
   });
 
   it('should dehydrate step function passed as argument to a step', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1,5 +1,5 @@
 import { types } from 'node:util';
-import { WorkflowRuntimeError } from '@workflow/errors';
+import { SerializationError, WorkflowRuntimeError } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { DevalueError, parse, stringify, unflatten } from 'devalue';
 import { monotonicFactory } from 'ulid';
@@ -103,7 +103,7 @@ export function encodeWithFormatPrefix(
 
   const prefixBytes = formatEncoder.encode(format);
   if (prefixBytes.length !== FORMAT_PREFIX_LENGTH) {
-    throw new Error(
+    throw new WorkflowRuntimeError(
       `Format identifier must be exactly ${FORMAT_PREFIX_LENGTH} ASCII characters, got "${format}" (${prefixBytes.length} bytes)`
     );
   }
@@ -167,7 +167,7 @@ export function decodeFormatPrefix(data: Uint8Array | unknown): {
   }
 
   if (data.length < FORMAT_PREFIX_LENGTH) {
-    throw new Error(
+    throw new WorkflowRuntimeError(
       `Data too short to contain format prefix: expected at least ${FORMAT_PREFIX_LENGTH} bytes, got ${data.length}`
     );
   }
@@ -199,7 +199,10 @@ const defaultUlid = monotonicFactory();
  * Extracts path, value, and reason from devalue's DevalueError when available.
  * Logs the problematic value to the console for better debugging.
  */
-function formatSerializationError(context: string, error: unknown): string {
+function formatSerializationError(
+  context: string,
+  error: unknown
+): { message: string; hint: string } {
   // Use "returning" for return values, "passing" for arguments/inputs
   const verb = context.includes('return value') ? 'returning' : 'passing';
 
@@ -208,7 +211,7 @@ function formatSerializationError(context: string, error: unknown): string {
   if (error instanceof DevalueError && error.path) {
     message += ` at path "${error.path}"`;
   }
-  message += `. Ensure you're ${verb} serializable types (plain objects, arrays, primitives, Date, RegExp, Map, Set).`;
+  const hint = `Ensure you're ${verb} serializable types (plain objects, arrays, primitives, Date, RegExp, Map, Set).`;
 
   // Log the problematic value for debugging
   if (error instanceof DevalueError && error.value !== undefined) {
@@ -218,7 +221,7 @@ function formatSerializationError(context: string, error: unknown): string {
     });
   }
 
-  return message;
+  return { message, hint };
 }
 
 /**
@@ -286,11 +289,12 @@ export function getSerializeStream(
         frame.set(prefixed, FRAME_HEADER_SIZE);
         controller.enqueue(frame);
       } catch (error) {
+        const { message, hint } = formatSerializationError(
+          'stream chunk',
+          error
+        );
         controller.error(
-          new WorkflowRuntimeError(
-            formatSerializationError('stream chunk', error),
-            { slug: 'serialization-failed', cause: error }
-          )
+          new SerializationError(message, { hint, cause: error })
         );
       }
     },
@@ -417,7 +421,7 @@ export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
 
   constructor(runId: string, name: string, startIndex?: number) {
     if (typeof name !== 'string' || name.length === 0) {
-      throw new Error(`"name" is required, got "${name}"`);
+      throw new WorkflowRuntimeError(`"name" is required, got "${name}"`);
     }
     super({
       // @ts-expect-error Not sure why TypeScript is complaining about this
@@ -431,7 +435,7 @@ export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
           reader = this.#reader = stream.getReader();
         }
         if (!reader) {
-          controller.error(new Error('Failed to get reader'));
+          controller.error(new WorkflowRuntimeError('Failed to get reader'));
           return;
         }
 
@@ -464,10 +468,12 @@ const STREAM_FLUSH_INTERVAL_MS = 10;
 export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
   constructor(runId: string, name: string) {
     if (typeof runId !== 'string') {
-      throw new Error(`"runId" must be a string, got "${typeof runId}"`);
+      throw new WorkflowRuntimeError(
+        `"runId" must be a string, got "${typeof runId}"`
+      );
     }
     if (typeof name !== 'string' || name.length === 0) {
-      throw new Error(`"name" is required, got "${name}"`);
+      throw new WorkflowRuntimeError(`"name" is required, got "${name}"`);
     }
     const worldPromise = getWorld();
 
@@ -584,7 +590,7 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
         // unsettled promise because the cleared timer will never fire.
         const waiters = flushWaiters;
         flushWaiters = [];
-        const abortError = reason ?? new Error('Stream aborted');
+        const abortError = reason ?? new WorkflowRuntimeError('Stream aborted');
         for (const w of waiters) w.reject(abortError);
       },
     });
@@ -731,8 +737,11 @@ function getCommonReducers(global: Record<string, any> = globalThis) {
       // Get the classId from the static class property (set by SWC plugin)
       const classId = cls.classId;
       if (typeof classId !== 'string') {
-        throw new Error(
-          `Class "${cls.name}" with ${String(WORKFLOW_SERIALIZE)} must have a static "classId" property.`
+        throw new SerializationError(
+          `Class "${cls.name}" with ${String(WORKFLOW_SERIALIZE)} must have a static "classId" property.`,
+          {
+            hint: `Add a unique string "classId" to the class so the SDK can look it up on deserialization. The SWC plugin usually injects this — check your compiler setup if it's missing.`,
+          }
         );
       }
 
@@ -888,7 +897,12 @@ export function getExternalReducers(
 
       // Stream must not be locked when passing across execution boundary
       if (value.locked) {
-        throw new Error('ReadableStream is locked');
+        throw new SerializationError(
+          'ReadableStream is locked and cannot be passed across a workflow boundary.',
+          {
+            hint: 'Pass the stream before calling .getReader() / .pipeThrough() / .pipeTo(), or tee it with .tee() and pass one of the branches.',
+          }
+        );
       }
 
       const streamId = ((global as any)[STABLE_ULID] || defaultUlid)();
@@ -958,7 +972,7 @@ export function getWorkflowReducers(
 
       const name = value[STREAM_NAME_SYMBOL];
       if (!name) {
-        throw new Error('ReadableStream `name` is not set');
+        throw new WorkflowRuntimeError('ReadableStream `name` is not set');
       }
       const s: SerializableSpecial['ReadableStream'] = { name };
       const type = value[STREAM_TYPE_SYMBOL];
@@ -969,7 +983,7 @@ export function getWorkflowReducers(
       if (!(value instanceof global.WritableStream)) return false;
       const name = value[STREAM_NAME_SYMBOL];
       if (!name) {
-        throw new Error('WritableStream `name` is not set');
+        throw new WorkflowRuntimeError('WritableStream `name` is not set');
       }
       return { name };
     },
@@ -999,7 +1013,12 @@ function getStepReducers(
 
       // Stream must not be locked when passing across execution boundary
       if (value.locked) {
-        throw new Error('ReadableStream is locked');
+        throw new SerializationError(
+          'ReadableStream is locked and cannot be passed across a workflow boundary.',
+          {
+            hint: 'Pass the stream before calling .getReader() / .pipeThrough() / .pipeTo(), or tee it with .tee() and pass one of the branches.',
+          }
+        );
       }
 
       // Check if the stream already has the name symbol set, in which case
@@ -1124,9 +1143,9 @@ export function getCommonRevivers(global: Record<string, any> = globalThis) {
       // on the VM's global rather than the host's globalThis
       const cls = getSerializationClass(classId, global);
       if (!cls) {
-        throw new Error(
-          `Class "${classId}" not found. Make sure the class is registered with registerSerializationClass.`
-        );
+        throw new SerializationError(`Class "${classId}" not found.`, {
+          hint: `Register the class with registerSerializationClass(classId, Class) before a value of this type flows across a workflow boundary.`,
+        });
       }
       return cls;
     },
@@ -1140,16 +1159,19 @@ export function getCommonRevivers(global: Record<string, any> = globalThis) {
       const cls = getSerializationClass(classId, global);
 
       if (!cls) {
-        throw new Error(
-          `Class "${classId}" not found. Make sure the class is registered with registerSerializationClass.`
-        );
+        throw new SerializationError(`Class "${classId}" not found.`, {
+          hint: `Register the class with registerSerializationClass(classId, Class) before a value of this type flows across a workflow boundary.`,
+        });
       }
 
       // Get the deserializer from the class
       const deserialize = (cls as any)[WORKFLOW_DESERIALIZE];
       if (typeof deserialize !== 'function') {
-        throw new Error(
-          `Class "${classId}" does not have a static ${String(WORKFLOW_DESERIALIZE)} method.`
+        throw new SerializationError(
+          `Class "${classId}" does not have a static ${String(WORKFLOW_DESERIALIZE)} method.`,
+          {
+            hint: `Implement a static ${String(WORKFLOW_DESERIALIZE)}(data) method on the class that rebuilds an instance from the data returned by ${String(WORKFLOW_SERIALIZE)}.`,
+          }
         );
       }
 
@@ -1198,16 +1220,22 @@ export function getExternalRevivers(
 
     // StepFunction should not be returned from workflows to clients
     StepFunction: () => {
-      throw new Error(
-        'Step functions cannot be deserialized in client context. Step functions should not be returned from workflows.'
+      throw new SerializationError(
+        'Step functions cannot be deserialized in client context. Step functions should not be returned from workflows.',
+        {
+          hint: `Return the step's result — a plain, serializable value — from your workflow instead of the step function itself.`,
+        }
       );
     },
 
     WorkflowFunction: (value) =>
       Object.assign(
         () => {
-          throw new Error(
-            'Workflow functions cannot be called directly. Use start() to invoke them.'
+          throw new SerializationError(
+            'Workflow functions cannot be called directly. Use start() to invoke them.',
+            {
+              hint: `Import start() from @workflow/core and call start(workflowFn, args) to kick off a workflow run.`,
+            }
           );
         },
         { workflowId: value.workflowId }
@@ -1340,7 +1368,7 @@ export function getWorkflowRevivers(
       const closureVars = value.closureVars;
 
       if (!useStep) {
-        throw new Error(
+        throw new WorkflowRuntimeError(
           'WORKFLOW_USE_STEP not found on global object. Step functions cannot be deserialized outside workflow context.'
         );
       }
@@ -1358,8 +1386,11 @@ export function getWorkflowRevivers(
         (value as any)[WEBHOOK_RESPONSE_WRITABLE] = responseWritable;
         delete value.responseWritable;
         (value as any).respondWith = () => {
-          throw new Error(
-            '`respondWith()` must be called from within a step function'
+          throw new SerializationError(
+            '`respondWith()` must be called from within a step function.',
+            {
+              hint: `Move the respondWith() call into a step (a function with "use step") — webhook responses can only be written from the step handler.`,
+            }
           );
         };
       }
@@ -1370,8 +1401,11 @@ export function getWorkflowRevivers(
     WorkflowFunction: (value) =>
       Object.assign(
         () => {
-          throw new Error(
-            'Workflow functions cannot be called directly. Use start() to invoke them.'
+          throw new SerializationError(
+            'Workflow functions cannot be called directly. Use start() to invoke them.',
+            {
+              hint: `Import start() from @workflow/core and call start(workflowFn, args) to kick off a workflow run.`,
+            }
           );
         },
         { workflowId: value.workflowId }
@@ -1441,9 +1475,9 @@ function getStepRevivers(
 
       const stepFn = getStepFunction(stepId);
       if (!stepFn) {
-        throw new Error(
-          `Step function "${stepId}" not found. Make sure the step function is registered.`
-        );
+        throw new SerializationError(`Step function "${stepId}" not found.`, {
+          hint: `Make sure the step file is included in your build and that every step function declaration is marked with "use step".`,
+        });
       }
 
       // If closure variables were serialized, return a wrapper function
@@ -1454,7 +1488,7 @@ function getStepRevivers(
           const currentContext = contextStorage.getStore();
 
           if (!currentContext) {
-            throw new Error(
+            throw new WorkflowRuntimeError(
               'Cannot call step function with closure variables outside step context'
             );
           }
@@ -1492,8 +1526,11 @@ function getStepRevivers(
     WorkflowFunction: (value) =>
       Object.assign(
         () => {
-          throw new Error(
-            'Workflow functions cannot be called directly. Use start() to invoke them.'
+          throw new SerializationError(
+            'Workflow functions cannot be called directly. Use start() to invoke them.',
+            {
+              hint: `Import start() from @workflow/core and call start(workflowFn, args) to kick off a workflow run.`,
+            }
           );
         },
         { workflowId: value.workflowId }
@@ -1700,10 +1737,11 @@ export async function dehydrateWorkflowArguments(
     // Encrypt if world supports encryption
     return maybeEncrypt(serialized, key);
   } catch (error) {
-    throw new WorkflowRuntimeError(
-      formatSerializationError('workflow arguments', error),
-      { slug: 'serialization-failed', cause: error }
+    const { message, hint } = formatSerializationError(
+      'workflow arguments',
+      error
     );
+    throw new SerializationError(message, { hint, cause: error });
   }
 }
 
@@ -1749,7 +1787,7 @@ export async function hydrateWorkflowArguments(
     return obj;
   }
 
-  throw new Error(`Unsupported serialization format: ${format}`);
+  throw new WorkflowRuntimeError(`Unsupported serialization format: ${format}`);
 }
 
 /**
@@ -1782,10 +1820,11 @@ export async function dehydrateWorkflowReturnValue(
     // Encrypt if world supports encryption
     return maybeEncrypt(serialized, key);
   } catch (error) {
-    throw new WorkflowRuntimeError(
-      formatSerializationError('workflow return value', error),
-      { slug: 'serialization-failed', cause: error }
+    const { message, hint } = formatSerializationError(
+      'workflow return value',
+      error
     );
+    throw new SerializationError(message, { hint, cause: error });
   }
 }
 
@@ -1834,7 +1873,7 @@ export async function hydrateWorkflowReturnValue(
     return obj;
   }
 
-  throw new Error(`Unsupported serialization format: ${format}`);
+  throw new WorkflowRuntimeError(`Unsupported serialization format: ${format}`);
 }
 
 /**
@@ -1870,10 +1909,8 @@ export async function dehydrateStepArguments(
     // Encrypt if world supports encryption
     return maybeEncrypt(serialized, key);
   } catch (error) {
-    throw new WorkflowRuntimeError(
-      formatSerializationError('step arguments', error),
-      { slug: 'serialization-failed', cause: error }
-    );
+    const { message, hint } = formatSerializationError('step arguments', error);
+    throw new SerializationError(message, { hint, cause: error });
   }
 }
 
@@ -1921,7 +1958,7 @@ export async function hydrateStepArguments(
     return obj;
   }
 
-  throw new Error(`Unsupported serialization format: ${format}`);
+  throw new WorkflowRuntimeError(`Unsupported serialization format: ${format}`);
 }
 
 /**
@@ -1959,10 +1996,11 @@ export async function dehydrateStepReturnValue(
     // Encrypt if world supports encryption
     return maybeEncrypt(serialized, key);
   } catch (error) {
-    throw new WorkflowRuntimeError(
-      formatSerializationError('step return value', error),
-      { slug: 'serialization-failed', cause: error }
+    const { message, hint } = formatSerializationError(
+      'step return value',
+      error
     );
+    throw new SerializationError(message, { hint, cause: error });
   }
 }
 
@@ -2007,5 +2045,5 @@ export async function hydrateStepReturnValue(
     });
   }
 
-  throw new Error(`Unsupported serialization format: ${format}`);
+  throw new WorkflowRuntimeError(`Unsupported serialization format: ${format}`);
 }

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -219,6 +219,46 @@ export class WorkflowRuntimeError extends WorkflowError {
   }
 }
 
+interface SerializationErrorOptions extends ErrorOptions {
+  /**
+   * An optional actionable hint appended to the main message, explaining how
+   * the user can resolve the failure (e.g. "register the class with…" or
+   * "move this call inside a step").
+   */
+  hint?: string;
+}
+
+/**
+ * Thrown when a value cannot be serialized into or deserialized out of the
+ * workflow event log.
+ *
+ * This usually indicates a user-facing mistake: passing a non-serializable
+ * value (class without `WORKFLOW_SERIALIZE`, locked stream, direct workflow
+ * function reference) into a step boundary, or an unregistered class
+ * returning from a step.
+ *
+ * Internal invariants (corrupted buffers, unknown format bytes) should use
+ * `WorkflowRuntimeError` instead — this class is scoped to things the user
+ * can fix in their own code.
+ */
+export class SerializationError extends WorkflowError {
+  readonly hint?: string;
+
+  constructor(message: string, options?: SerializationErrorOptions) {
+    const body = options?.hint ? `${message}\n\n${options.hint}` : message;
+    super(body, {
+      slug: ERROR_SLUGS.SERIALIZATION_FAILED,
+      cause: options?.cause,
+    });
+    this.name = 'SerializationError';
+    this.hint = options?.hint;
+  }
+
+  static is(value: unknown): value is SerializationError {
+    return isError(value) && value.name === 'SerializationError';
+  }
+}
+
 /**
  * Thrown when a step function is not registered in the current deployment.
  *

--- a/packages/errors/src/serialization-error.test.ts
+++ b/packages/errors/src/serialization-error.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import { SerializationError, WorkflowError } from './index.js';
+
+describe('SerializationError', () => {
+  test('sets the name and extends WorkflowError', () => {
+    const err = new SerializationError('boom');
+    expect(err.name).toBe('SerializationError');
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err).toBeInstanceOf(SerializationError);
+  });
+
+  test('includes the serialization-failed docs link', () => {
+    const err = new SerializationError('boom');
+    expect(err.message).toContain('boom');
+    expect(err.message).toContain(
+      'https://workflow-sdk.dev/err/serialization-failed'
+    );
+  });
+
+  test('appends hint before the docs link', () => {
+    const err = new SerializationError('boom', {
+      hint: 'Register the class with WORKFLOW_SERIALIZE.',
+    });
+    expect(err.hint).toBe('Register the class with WORKFLOW_SERIALIZE.');
+    expect(err.message).toMatchInlineSnapshot(`
+      "boom
+
+      Register the class with WORKFLOW_SERIALIZE.
+
+      Learn more: https://workflow-sdk.dev/err/serialization-failed"
+    `);
+  });
+
+  test('preserves cause for debugging', () => {
+    const cause = new TypeError('underlying');
+    const err = new SerializationError('boom', { cause });
+    expect(err.cause).toBe(cause);
+  });
+
+  test('SerializationError.is discriminates by name', () => {
+    const err = new SerializationError('boom');
+    const other = new Error('boom');
+    expect(SerializationError.is(err)).toBe(true);
+    expect(SerializationError.is(other)).toBe(false);
+    expect(SerializationError.is(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 4** of the friendlier-errors stack. Introduces `SerializationError` and adopts it at every user-facing serialization boundary in `@workflow/core`, while normalizing bare `throw new Error(...)` internal invariants to `WorkflowRuntimeError`.

### What changes

- **New class `SerializationError`** in `@workflow/errors`:
  - Extends `WorkflowError` with `slug: 'serialization-failed'` so the docs link (`https://workflow-sdk.dev/err/serialization-failed`) appears in every message.
  - Optional `hint` option — an actionable "how to fix" line rendered above the docs link.
  - `SerializationError.is(value)` for runtime discrimination.

- **User-facing sites throw `SerializationError` with a hint**:
  - Locked `ReadableStream` passed across a workflow boundary
  - Class without `classId` / unregistered `classId` / missing `WORKFLOW_DESERIALIZE`
  - `StepFunction` returned to client / `WorkflowFunction` called directly / `respondWith()` outside a step
  - All four `dehydrate*` paths (`workflow arguments`, `workflow return value`, `step arguments`, `step return value`) and stream-chunk transform errors
  - `formatSerializationError` now returns `{ message, hint }` so the hint renders through the standard framing instead of being baked into the message string.

- **Internal invariants converted to `WorkflowRuntimeError`**: format prefix length checks, unknown serialization format bytes, missing `STREAM_NAME_SYMBOL`, encryption key / ciphertext size guards, `Stream aborted` default reason, `Writable stream closed prematurely`, `Failed to get reader`, and the `WORKFLOW_USE_STEP` / closure-var context checks.

## Manual test plan

Using `workbench/nextjs-turbopack` — `pnpm dev` and watch the terminal. Each test should produce a `SerializationError` with a `hint:` line and the docs URL `https://workflow-sdk.dev/err/serialization-failed`.

- [ ] **Unregistered class across step boundary**:
  ```ts
  class MyThing { constructor(public x: number) {} }

  async function myStep(thing: MyThing) { 'use step'; return thing.x; }

  export async function wf() {
    'use workflow';
    await myStep(new MyThing(1));
  }
  ```
  Expect `SerializationError` naming `"MyThing"` and a `hint:` explaining how to register via `registerClass` / serde.

- [ ] **Non-serializable value (function)**:
  ```ts
  async function echo<T>(v: T) { 'use step'; return v; }

  export async function wf() {
    'use workflow';
    await echo(() => 123); // function is not serializable
  }
  ```
  Expect `SerializationError` with `hint:` naming the offending value path (e.g. `at .args[0]`).

- [ ] **Non-serializable value (symbol)** — same shape as above but pass `Symbol('x')`.

- [ ] **Locked `ReadableStream`** — deliberately lock a `ReadableStream` (call `.getReader()`) before passing it across a step boundary. Expect `SerializationError: locked ReadableStream` with a hint describing the stream-lock constraint.

- [ ] **`StepFunction` returned to client** — have a workflow return a bare step reference directly (not a result). Expect a clear message that you can't surface step functions to the caller.

- [ ] **`WorkflowFunction` called directly** — call a `"use workflow"`-tagged function from regular app code (not through `start()`). Expect a clear message pointing at `start()`.

- [ ] **`respondWith()` outside a step** — call `respondWith(new Response())` from workflow or application code. Expect a `SerializationError` explaining that `respondWith` only works inside step functions.

- [ ] **Stream chunk transform error** — pipe a non-serializable value through `getWritable()`. Expect a `SerializationError` identifying the offending chunk.

- [ ] **Internal invariant now attributed to SDK** — harder to induce, but if you can corrupt a serialization prefix byte or strip `STREAM_NAME_SYMBOL`, confirm the thrown error is `WorkflowRuntimeError` (not bare `Error`) so Phase 5's `describeError` attributes it to `sdk`.

- [ ] **Attribution in step-failed log** — confirm the `[workflow-sdk]` log at step-failure time carries `errorAttribution: 'user'` for all the above, plus `hint: 'A value passed across a workflow/step boundary…'` (Phase 5 wiring).

## Unit tests

- [x] `pnpm --filter @workflow/errors test` — 15 pass (10 Ansi + 5 new `SerializationError`)
- [x] `pnpm --filter @workflow/core exec vitest run src/serialization.test.ts` — 116 pass; 7 pre-existing `DOMException` failures unrelated (confirmed on stash baseline)
- [x] Updated `"should throw error when reviver cannot find registered step function"` for the new hint text
- [x] Typecheck clean for Phase 4 changes

---

## 📚 Friendlier errors stack

Multi-PR initiative inspired by @schniz's stalled [#706](https://github.com/vercel/workflow/pull/706):

| # | PR | Phase | Summary |
|---|-----|-------|---------|
| 1 | [#1831](https://github.com/vercel/workflow/pull/1831) | Phase 1 + 2 | `Ansi` rendering primitives + context-violation errors |
| 2 | [#1832](https://github.com/vercel/workflow/pull/1832) | Phase 3 | Structured logger metadata; folds in [#1812](https://github.com/vercel/workflow/pull/1812) |
| 3 | **→ this PR (#1836)** | Phase 4 | `SerializationError` at serialization / stream / encryption boundaries |
| 4 | [#1837](https://github.com/vercel/workflow/pull/1837) | Phase 5 | Presentation-only user vs SDK attribution (`describeError`) |
| 5 | [#1838](https://github.com/vercel/workflow/pull/1838) | Phase 6 | Consistency pass on remaining bare `throw new Error(...)` sites |
| 6 | [#1839](https://github.com/vercel/workflow/pull/1839) | Phase 7 foundation | Data-driven `describeRunError` + public subpath |
| 7 | [#1840](https://github.com/vercel/workflow/pull/1840) | Phase 8 | `WorkflowBuildError` + applications in `@workflow/builders` |
| 8 | [#1849](https://github.com/vercel/workflow/pull/1849) | Followups | Drop `functionName` leak, simplify docs framing, redirect stack to user code |

Each PR is stacked on the previous one; merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
