### PR TITLE
Presentation-only user vs SDK error attribution

### DIFF
--- a/.changeset/friendlier-error-attribution.md
+++ b/.changeset/friendlier-error-attribution.md
@@ -1,5 +1,5 @@
 ---
-'@workflow/core': patch
+"@workflow/core": patch
 ---
 
 Add presentation-only `describeError` helper that computes user vs SDK error

--- a/.changeset/friendlier-error-attribution.md
+++ b/.changeset/friendlier-error-attribution.md
@@ -1,0 +1,11 @@
+---
+'@workflow/core': patch
+---
+
+Add presentation-only `describeError` helper that computes user vs SDK error
+attribution from existing error classes and `RUN_ERROR_CODES`. Terminal logs
+for step failures, max-delivery exhaustion, run failures, and fatal workflow
+setup errors now include `errorAttribution` metadata and class-aware hints
+for well-known error types (`SerializationError`, context-violation errors,
+`WorkflowRuntimeError`, replay timeouts, max-delivery exhaustion). No event
+data or persisted error classification is affected.

--- a/packages/core/src/describe-error.test.ts
+++ b/packages/core/src/describe-error.test.ts
@@ -1,0 +1,71 @@
+import {
+  RUN_ERROR_CODES,
+  SerializationError,
+  StepNotRegisteredError,
+  WorkflowRuntimeError,
+} from '@workflow/errors';
+import { describe, expect, test } from 'vitest';
+import {
+  NotInStepContextError,
+  NotInWorkflowContextError,
+} from './context-errors.js';
+import { describeError } from './describe-error.js';
+
+describe('describeError', () => {
+  test('plain user errors are attributed to the user with no hint', () => {
+    const result = describeError(new Error('something user code did'));
+    expect(result.attribution).toBe('user');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.USER_ERROR);
+    expect(result.hint).toBeUndefined();
+  });
+
+  test('non-Error throws are attributed to the user', () => {
+    expect(describeError('string').attribution).toBe('user');
+    expect(describeError(undefined).attribution).toBe('user');
+    expect(describeError(null).attribution).toBe('user');
+    expect(describeError({ oops: true }).attribution).toBe('user');
+  });
+
+  test('SerializationError is attributed to the user with a hint', () => {
+    const result = describeError(
+      new SerializationError('Failed to serialize step arguments')
+    );
+    expect(result.attribution).toBe('user');
+    expect(result.hint).toContain('serialized');
+  });
+
+  test('context-violation errors are attributed to the user', () => {
+    const workflowOnly = describeError(
+      new NotInWorkflowContextError(
+        'createHook',
+        'hooks: https://example.com/hooks'
+      )
+    );
+    expect(workflowOnly.attribution).toBe('user');
+    expect(workflowOnly.hint).toContain('wrong context');
+
+    const stepOnly = describeError(
+      new NotInStepContextError(
+        'respondWith',
+        'webhook responses: https://example.com/webhook'
+      )
+    );
+    expect(stepOnly.attribution).toBe('user');
+    expect(stepOnly.hint).toContain('wrong context');
+  });
+
+  test('WorkflowRuntimeError is attributed to the SDK', () => {
+    const result = describeError(
+      new WorkflowRuntimeError('corrupted event log')
+    );
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.RUNTIME_ERROR);
+    expect(result.hint).toContain('internal workflow SDK error');
+  });
+
+  test('StepNotRegisteredError (subclass of WorkflowRuntimeError) is attributed to the SDK', () => {
+    const result = describeError(new StepNotRegisteredError('missingStep'));
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.RUNTIME_ERROR);
+  });
+});

--- a/packages/core/src/describe-error.test.ts
+++ b/packages/core/src/describe-error.test.ts
@@ -68,4 +68,33 @@ describe('describeError', () => {
     expect(result.attribution).toBe('sdk');
     expect(result.errorCode).toBe(RUN_ERROR_CODES.RUNTIME_ERROR);
   });
+
+  test('REPLAY_TIMEOUT via precomputed errorCode is attributed to the SDK', () => {
+    const result = describeError(undefined, RUN_ERROR_CODES.REPLAY_TIMEOUT);
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.REPLAY_TIMEOUT);
+    expect(result.hint).toContain('replay took too long');
+  });
+
+  test('MAX_DELIVERIES_EXCEEDED via precomputed errorCode is attributed to the SDK', () => {
+    const result = describeError(
+      undefined,
+      RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED
+    );
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED);
+    expect(result.hint).toContain('max-delivery budget');
+  });
+
+  test('precomputed errorCode wins over classifyRunError when both are provided', () => {
+    // A plain Error would classify as USER_ERROR, but passing REPLAY_TIMEOUT
+    // explicitly overrides that — useful for callers that know the failure
+    // category from the surrounding runtime context.
+    const result = describeError(
+      new Error('something'),
+      RUN_ERROR_CODES.REPLAY_TIMEOUT
+    );
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.REPLAY_TIMEOUT);
+    expect(result.attribution).toBe('sdk');
+  });
 });

--- a/packages/core/src/describe-error.ts
+++ b/packages/core/src/describe-error.ts
@@ -1,0 +1,99 @@
+import {
+  RUN_ERROR_CODES,
+  type RunErrorCode,
+  SerializationError,
+  WorkflowRuntimeError,
+} from '@workflow/errors';
+import { classifyRunError } from './classify-error.js';
+
+/**
+ * Attribution of a workflow/step failure for presentation.
+ *
+ * - `user`: the error came from customer code (a step or workflow function
+ *   threw, or a value they passed across a boundary wasn't serializable).
+ * - `sdk`: the SDK produced the error itself — an internal invariant broke,
+ *   or a runtime guard rejected the call. These should be rare; when they
+ *   happen we want to frame the terminal output as "this is us, not you."
+ */
+export type ErrorAttribution = 'user' | 'sdk';
+
+export interface ErrorDescription {
+  attribution: ErrorAttribution;
+  errorCode: RunErrorCode;
+  /**
+   * Short, class-aware hint to help a user understand what the error means.
+   * Only set for well-known SDK error classes (SerializationError,
+   * WorkflowRuntimeError, context-violation errors); `undefined` for plain
+   * user errors, where the stack is already the most useful thing to show.
+   */
+  hint?: string;
+}
+
+const CONTEXT_ERROR_NAMES = new Set([
+  'NotInWorkflowContextError',
+  'NotInStepContextError',
+  'NotInWorkflowOrStepContextError',
+  'UnavailableInWorkflowContextError',
+]);
+
+/**
+ * Describe an error for user-facing presentation. Purely informational —
+ * does not change any persisted event data or error classification used by
+ * the runtime.
+ *
+ * The attribution here is more nuanced than `classifyRunError`:
+ *
+ * - `SerializationError` is technically raised by the SDK, but it almost
+ *   always points at something the caller did (passed a non-serializable
+ *   value, didn't register a class). We attribute it to the user.
+ * - Context-violation errors (`NotInWorkflowContextError`, etc.) likewise
+ *   describe a user mistake.
+ * - `WorkflowRuntimeError` (and subclasses like `StepNotRegisteredError`)
+ *   indicates an internal SDK invariant broke — surface that as `sdk`.
+ */
+export function describeError(err: unknown): ErrorDescription {
+  const errorCode = classifyRunError(err);
+  const name = err instanceof Error ? err.name : undefined;
+
+  if (SerializationError.is(err)) {
+    return {
+      attribution: 'user',
+      errorCode,
+      hint: 'A value passed across a workflow/step boundary could not be serialized. See the error message for the offending path and the Learn More link for details.',
+    };
+  }
+
+  if (name && CONTEXT_ERROR_NAMES.has(name)) {
+    return {
+      attribution: 'user',
+      errorCode,
+      hint: 'A workflow-only or step-only API was called from the wrong context. The error message includes the exact API and how to move the call.',
+    };
+  }
+
+  if (err instanceof WorkflowRuntimeError) {
+    return {
+      attribution: 'sdk',
+      errorCode,
+      hint: 'This is an internal workflow SDK error, not a bug in your code. If it keeps happening, please report it with the stack trace and the runId.',
+    };
+  }
+
+  if (errorCode === RUN_ERROR_CODES.REPLAY_TIMEOUT) {
+    return {
+      attribution: 'sdk',
+      errorCode,
+      hint: 'The workflow replay took too long. This usually means the event log is unusually large or the workflow function is doing heavy synchronous work between step boundaries.',
+    };
+  }
+
+  if (errorCode === RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED) {
+    return {
+      attribution: 'sdk',
+      errorCode,
+      hint: 'The workflow queue exceeded its max-delivery budget. This usually indicates a persistent runtime failure — check the most recent stack traces for the underlying cause.',
+    };
+  }
+
+  return { attribution: 'user', errorCode };
+}

--- a/packages/core/src/describe-error.ts
+++ b/packages/core/src/describe-error.ts
@@ -5,6 +5,12 @@ import {
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import { classifyRunError } from './classify-error.js';
+import {
+  NotInStepContextError,
+  NotInWorkflowContextError,
+  NotInWorkflowOrStepContextError,
+  UnavailableInWorkflowContextError,
+} from './context-errors.js';
 
 /**
  * Attribution of a workflow/step failure for presentation.
@@ -29,12 +35,14 @@ export interface ErrorDescription {
   hint?: string;
 }
 
-const CONTEXT_ERROR_NAMES = new Set([
-  'NotInWorkflowContextError',
-  'NotInStepContextError',
-  'NotInWorkflowOrStepContextError',
-  'UnavailableInWorkflowContextError',
-]);
+function isContextViolationError(err: unknown): boolean {
+  return (
+    err instanceof NotInWorkflowContextError ||
+    err instanceof NotInStepContextError ||
+    err instanceof NotInWorkflowOrStepContextError ||
+    err instanceof UnavailableInWorkflowContextError
+  );
+}
 
 /**
  * Describe an error for user-facing presentation. Purely informational —
@@ -50,23 +58,31 @@ const CONTEXT_ERROR_NAMES = new Set([
  *   describe a user mistake.
  * - `WorkflowRuntimeError` (and subclasses like `StepNotRegisteredError`)
  *   indicates an internal SDK invariant broke — surface that as `sdk`.
+ *
+ * @param err The error value thrown by the workflow / step.
+ * @param errorCode Optional precomputed error code. Callers that already
+ *   know the code (e.g. `REPLAY_TIMEOUT` or `MAX_DELIVERIES_EXCEEDED`, which
+ *   `classifyRunError` can't derive from the error alone) should pass it so
+ *   the attribution and hint reflect the actual failure category.
  */
-export function describeError(err: unknown): ErrorDescription {
-  const errorCode = classifyRunError(err);
-  const name = err instanceof Error ? err.name : undefined;
+export function describeError(
+  err: unknown,
+  errorCode?: RunErrorCode
+): ErrorDescription {
+  const effectiveCode = errorCode ?? classifyRunError(err);
 
   if (SerializationError.is(err)) {
     return {
       attribution: 'user',
-      errorCode,
+      errorCode: effectiveCode,
       hint: 'A value passed across a workflow/step boundary could not be serialized. See the error message for the offending path and the Learn More link for details.',
     };
   }
 
-  if (name && CONTEXT_ERROR_NAMES.has(name)) {
+  if (isContextViolationError(err)) {
     return {
       attribution: 'user',
-      errorCode,
+      errorCode: effectiveCode,
       hint: 'A workflow-only or step-only API was called from the wrong context. The error message includes the exact API and how to move the call.',
     };
   }
@@ -74,26 +90,26 @@ export function describeError(err: unknown): ErrorDescription {
   if (err instanceof WorkflowRuntimeError) {
     return {
       attribution: 'sdk',
-      errorCode,
+      errorCode: effectiveCode,
       hint: 'This is an internal workflow SDK error, not a bug in your code. If it keeps happening, please report it with the stack trace and the runId.',
     };
   }
 
-  if (errorCode === RUN_ERROR_CODES.REPLAY_TIMEOUT) {
+  if (effectiveCode === RUN_ERROR_CODES.REPLAY_TIMEOUT) {
     return {
       attribution: 'sdk',
-      errorCode,
+      errorCode: effectiveCode,
       hint: 'The workflow replay took too long. This usually means the event log is unusually large or the workflow function is doing heavy synchronous work between step boundaries.',
     };
   }
 
-  if (errorCode === RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED) {
+  if (effectiveCode === RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED) {
     return {
       attribution: 'sdk',
-      errorCode,
+      errorCode: effectiveCode,
       hint: 'The workflow queue exceeded its max-delivery budget. This usually indicates a persistent runtime failure — check the most recent stack traces for the underlying cause.',
     };
   }
 
-  return { attribution: 'user', errorCode };
+  return { attribution: 'user', errorCode: effectiveCode };
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -12,6 +12,7 @@ import {
   type WorkflowRun,
 } from '@workflow/world';
 import { classifyRunError } from './classify-error.js';
+import { describeError } from './describe-error.js';
 import { importKey } from './encryption.js';
 import { WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
@@ -362,12 +363,18 @@ export function workflowEntrypoint(
                       // Include the stack directly in the message so it
                       // surfaces in stdout even when structured logging is
                       // being flattened (e.g. Vercel log drain).
+                      const description = describeError(err);
                       runLogger.error(
                         `Fatal runtime error during workflow setup\n${err.stack}`,
                         {
+                          errorCode: description.errorCode,
+                          errorAttribution: description.attribution,
                           errorName: err.name,
                           errorMessage: err.message,
                           errorStack: err.stack,
+                          ...(description.hint
+                            ? { hint: description.hint }
+                            : {}),
                         }
                       );
                       try {
@@ -569,15 +576,22 @@ export function workflowEntrypoint(
                     // internal issue (corrupted event log, missing data);
                     // everything else is a user code error.
                     const errorCode = classifyRunError(err);
+                    const description = describeError(err);
+                    const framing =
+                      description.attribution === 'sdk'
+                        ? `Workflow "${workflowName}" failed due to an SDK runtime error`
+                        : `Workflow "${workflowName}" threw`;
 
                     // Use the stack as the primary message so it shows up
                     // in flattened logs without structured metadata.
                     runLogger.error(
-                      errorStack || 'Unknown error encountered in workflow',
+                      `${framing}\n${errorStack || 'Unknown error encountered in workflow'}`,
                       {
                         errorCode,
+                        errorAttribution: description.attribution,
                         errorName,
                         errorMessage,
+                        ...(description.hint ? { hint: description.hint } : {}),
                       }
                     );
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -143,9 +143,20 @@ export function workflowEntrypoint(
         const runLogger = runtimeLogger.forRun(runId, workflowName);
 
         if (metadata.attempt > MAX_QUEUE_DELIVERIES) {
+          const maxDeliveriesDescription = describeError(
+            undefined,
+            RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED
+          );
           runLogger.error(
             `Workflow handler exceeded max deliveries (${metadata.attempt}/${MAX_QUEUE_DELIVERIES})`,
-            { attempt: metadata.attempt }
+            {
+              attempt: metadata.attempt,
+              errorCode: maxDeliveriesDescription.errorCode,
+              errorAttribution: maxDeliveriesDescription.attribution,
+              ...(maxDeliveriesDescription.hint
+                ? { hint: maxDeliveriesDescription.hint }
+                : {}),
+            }
           );
           try {
             const world = await getWorld();
@@ -208,12 +219,21 @@ export function workflowEntrypoint(
               process.exit(1);
             }
 
+            const replayTimeoutDescription = describeError(
+              undefined,
+              RUN_ERROR_CODES.REPLAY_TIMEOUT
+            );
             runLogger.error(
               'Workflow replay exceeded timeout and max retries exceeded. Failing the run',
               {
                 timeoutMs: REPLAY_TIMEOUT_MS,
                 attempt: metadata.attempt,
                 maxRetries: REPLAY_TIMEOUT_MAX_RETRIES,
+                errorCode: replayTimeoutDescription.errorCode,
+                errorAttribution: replayTimeoutDescription.attribution,
+                ...(replayTimeoutDescription.hint
+                  ? { hint: replayTimeoutDescription.hint }
+                  : {}),
               }
             );
 
@@ -576,7 +596,7 @@ export function workflowEntrypoint(
                     // internal issue (corrupted event log, missing data);
                     // everything else is a user code error.
                     const errorCode = classifyRunError(err);
-                    const description = describeError(err);
+                    const description = describeError(err, errorCode);
                     const framing =
                       description.attribution === 'sdk'
                         ? `Workflow "${workflowName}" failed due to an SDK runtime error`

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -13,6 +13,7 @@ import {
 import { pluralize } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
 import { SPEC_VERSION_CURRENT, StepInvokePayloadSchema } from '@workflow/world';
+import { describeError } from '../describe-error.js';
 import { importKey } from '../encryption.js';
 import { runtimeLogger, stepLogger } from '../logger.js';
 import { getStepFunction } from '../private.js';
@@ -593,12 +594,19 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
               });
 
               if (isFatal) {
+                const description = describeError(err);
                 stepLogger.error(
-                  'Encountered FatalError while executing step, bubbling up to parent workflow',
+                  description.attribution === 'sdk'
+                    ? `Step "${stepName}" failed with a FatalError from the SDK runtime — bubbling up to parent workflow`
+                    : `Step "${stepName}" threw a FatalError — bubbling up to parent workflow`,
                   {
                     workflowRunId,
                     stepName,
+                    errorAttribution: description.attribution,
+                    errorName: normalizedError.name,
+                    errorMessage: normalizedError.message,
                     errorStack: normalizedStack,
+                    ...(description.hint ? { hint: description.hint } : {}),
                   }
                 );
                 // Fail the step via event (event-sourced architecture)
@@ -650,8 +658,11 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                 if (currentAttempt >= maxRetries + 1) {
                   // Max retries reached
                   const retryCount = step.attempt - 1;
+                  const description = describeError(err);
                   stepLogger.error(
-                    'Max retries reached, bubbling error to parent workflow',
+                    description.attribution === 'sdk'
+                      ? `Step "${stepName}" hit max retries on an SDK runtime error — bubbling to parent workflow`
+                      : `Step "${stepName}" hit max retries — bubbling error thrown by your step to the parent workflow`,
                     {
                       workflowRunId,
                       workflowName,
@@ -659,9 +670,11 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                       stepName,
                       attempt: step.attempt,
                       retryCount,
+                      errorAttribution: description.attribution,
                       errorName: normalizedError.name,
                       errorMessage: normalizedError.message,
                       errorStack: normalizedStack,
+                      ...(description.hint ? { hint: description.hint } : {}),
                     }
                   );
                   const errorMessage = `Step "${stepName}" failed after ${maxRetries} ${pluralize('retry', 'retries', maxRetries)}: ${normalizedError.message}`;


### PR DESCRIPTION
## Summary

**Phase 5** of the friendlier-errors stack. Adds a presentation-only helper `describeError()` that computes user vs SDK attribution and class-aware hints from existing error classes and `RUN_ERROR_CODES`. No event data or persisted error classification is affected.

- New `packages/core/src/describe-error.ts` returning `{ attribution, errorCode, hint? }`
  - `user` for plain errors, `SerializationError`, and context-violation errors (`NotInWorkflowContextError`, etc.)
  - `sdk` for `WorkflowRuntimeError` (and subclasses like `StepNotRegisteredError`), replay timeouts, and max-delivery exhaustion
- Terminal logs at step-failure, max-retries, run-failure, and fatal-setup sites now include `errorAttribution` metadata and a `hint` field for known error types.
- 6 unit tests cover the attribution matrix.

Motivated by a real customer case where a vendor's 503 looked like an SDK failure.

## Manual test plan

Using `workbench/nextjs-turbopack` — `pnpm dev` and watch the terminal. Each test checks the structured metadata in the `[workflow-sdk]` log at step/run-failure time.

- [ ] **User error → `attribution: 'user'`, no hint** — throw plain `Error('boom')` from a step. Confirm the log metadata includes `errorAttribution: 'user'` and **no** `hint` field (plain user errors get no hint — stack is already useful).

- [ ] **`SerializationError` → `'user'` + serialization hint** — reuse the "unregistered class" test from Phase 4. Log metadata should include `errorAttribution: 'user'` and `hint: 'A value passed across a workflow/step boundary could not be serialized. See the error message for the offending path and the Learn More link for details.'`

- [ ] **Context-violation → `'user'` + context hint** — call `createHook()` from a route. Log metadata should include `errorAttribution: 'user'` and `hint: 'A workflow-only or step-only API was called from the wrong context. The error message includes the exact API and how to move the call.'`

- [ ] **`WorkflowRuntimeError` → `'sdk'` + runtime hint** — hard to trigger accidentally; throw one directly:
  ```ts
  import { WorkflowRuntimeError } from '@workflow/errors';
  async function s() { 'use step'; throw new WorkflowRuntimeError('invariant broken'); }
  ```
  Expect `errorAttribution: 'sdk'` and `hint: 'This is an internal workflow SDK error, not a bug in your code. If it keeps happening, please report it with the stack trace and the runId.'`

- [ ] **Replay timeout → `'sdk'` + replay hint** — set `WORKFLOW_REPLAY_TIMEOUT_MS=50`, run a non-trivial workflow. After retries exhaust, expect `errorAttribution: 'sdk'` and `hint: 'The workflow replay took too long…'`.

- [ ] **Max-delivery exhaustion → `'sdk'` + max-delivery hint** — write a step that always throws. After the queue's max-delivery budget exhausts, expect `errorAttribution: 'sdk'` and `hint: 'The workflow queue exceeded its max-delivery budget…'`.

- [ ] **Attribution applies at all four log sites** — confirm the log contains `errorAttribution` + optional `hint` at:
  - step failure (non-terminal)
  - step max-retries (terminal)
  - run failure
  - fatal workflow setup

## Unit tests

- [x] `pnpm --filter @workflow/core exec vitest run src/describe-error.test.ts` (6 tests)
- [x] Step-handler / runtime log-site changes don't affect `classify-error.test.ts`

---

## 📚 Friendlier errors stack

Multi-PR initiative inspired by @schniz's stalled [#706](https://github.com/vercel/workflow/pull/706):

| # | PR | Phase | Summary |
|---|-----|-------|---------|
| 1 | [#1831](https://github.com/vercel/workflow/pull/1831) | Phase 1 + 2 | `Ansi` rendering primitives + context-violation errors |
| 2 | [#1832](https://github.com/vercel/workflow/pull/1832) | Phase 3 | Structured logger metadata; folds in [#1812](https://github.com/vercel/workflow/pull/1812) |
| 3 | [#1836](https://github.com/vercel/workflow/pull/1836) | Phase 4 | `SerializationError` at serialization / stream / encryption boundaries |
| 4 | **→ this PR (#1837)** | Phase 5 | Presentation-only user vs SDK attribution (`describeError`) |
| 5 | [#1838](https://github.com/vercel/workflow/pull/1838) | Phase 6 | Consistency pass on remaining bare `throw new Error(...)` sites |
| 6 | [#1839](https://github.com/vercel/workflow/pull/1839) | Phase 7 foundation | Data-driven `describeRunError` + public subpath |
| 7 | [#1840](https://github.com/vercel/workflow/pull/1840) | Phase 8 | `WorkflowBuildError` + applications in `@workflow/builders` |
| 8 | [#1849](https://github.com/vercel/workflow/pull/1849) | Followups | Drop `functionName` leak, simplify docs framing, redirect stack to user code |

Each PR is stacked on the previous one; merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
