### PR TITLE
Cosmetic consistency pass on remaining bare throws

### DIFF
--- a/.changeset/friendlier-errors-consistency.md
+++ b/.changeset/friendlier-errors-consistency.md
@@ -1,0 +1,10 @@
+---
+'@workflow/core': patch
+---
+
+Cosmetic consistency pass on remaining `throw new Error(...)` call sites.
+Internal invariants (missing `startedAt`, VM `crypto.subtle.generateKey`,
+closure-vars outside step context, `ENOTSUP`) now throw `WorkflowRuntimeError`
+so they are attributed to the SDK by `describeError`. `defineHook().resume()`
+now formats schema validation failures as a readable list instead of a raw
+JSON dump.

--- a/.changeset/friendlier-errors-consistency.md
+++ b/.changeset/friendlier-errors-consistency.md
@@ -1,5 +1,5 @@
 ---
-'@workflow/core': patch
+"@workflow/core": patch
 ---
 
 Cosmetic consistency pass on remaining `throw new Error(...)` call sites.

--- a/packages/core/src/define-hook.test.ts
+++ b/packages/core/src/define-hook.test.ts
@@ -102,14 +102,9 @@ describe('defineHook', () => {
         comment: string;
       })
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      [Error: [
-        {
-          "message": "Invalid input: expected boolean at \\"approved\\""
-        },
-        {
-          "message": "Invalid input: expected string at \\"comment\\""
-        }
-      ]]
+      [Error: Hook payload did not match the defined schema:
+        Invalid input: expected boolean at "approved"
+        Invalid input: expected string at "comment"]
     `);
   });
 });

--- a/packages/core/src/define-hook.ts
+++ b/packages/core/src/define-hook.ts
@@ -92,7 +92,21 @@ export function defineHook<TInput, TOutput = TInput>({
 
       // if the `issues` field exists, the validation failed
       if (result.issues) {
-        throw new Error(JSON.stringify(result.issues, null, 2));
+        const lines = result.issues.map((issue) => {
+          const path = issue.path
+            ?.map((segment) =>
+              typeof segment === 'object' && segment !== null
+                ? String((segment as { key: PropertyKey }).key)
+                : String(segment)
+            )
+            .join('.');
+          return path
+            ? `  at "${path}": ${issue.message}`
+            : `  ${issue.message}`;
+        });
+        throw new Error(
+          `Hook payload did not match the defined schema:\n${lines.join('\n')}`
+        );
       }
 
       return await resumeHook<TOutput>(token, result.value);

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -1,3 +1,4 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
 import { pluralize } from '@workflow/utils';
 import type { Serializable } from './schemas.js';
 
@@ -125,5 +126,7 @@ export class WorkflowSuspension extends Error {
 }
 
 export function ENOTSUP(): never {
-  throw new Error('Not supported in workflow functions');
+  throw new WorkflowRuntimeError(
+    'This API is not available inside a workflow function. Workflow functions run in a deterministic VM; move the call to a step function for full Node.js access.'
+  );
 }

--- a/packages/core/src/step/get-closure-vars.ts
+++ b/packages/core/src/step/get-closure-vars.ts
@@ -1,3 +1,4 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
 import { contextStorage } from './context-storage.js';
 
 /**
@@ -10,7 +11,7 @@ import { contextStorage } from './context-storage.js';
 export function __private_getClosureVars(): Record<string, any> {
   const ctx = contextStorage.getStore();
   if (!ctx) {
-    throw new Error(
+    throw new WorkflowRuntimeError(
       'Closure variables can only be accessed inside a step function'
     );
   }

--- a/packages/core/src/vm/index.test.ts
+++ b/packages/core/src/vm/index.test.ts
@@ -167,7 +167,8 @@ describe('createContext', () => {
     }
     expect(err).toBeDefined();
     expect(err).toBeInstanceOf(Error);
-    expect(err?.message).toEqual('Not implemented');
+    expect(err?.message).toContain('crypto.subtle.generateKey()');
+    expect(err?.message).toContain('not available inside a workflow function');
   });
 
   it('should call `onWorkflowError` when a workflow error occurs', async () => {

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -1,4 +1,5 @@
 import { runInContext, createContext as vmCreateContext } from 'node:vm';
+import { WorkflowRuntimeError } from '@workflow/errors';
 import seedrandom from 'seedrandom';
 import { installUint8ArrayBase64 } from './uint8array-base64.js';
 import { createRandomUUID } from './uuid.js';
@@ -72,7 +73,9 @@ export function createContext(options: CreateContextOptions) {
           get(target, prop) {
             if (prop === 'generateKey') {
               return () => {
-                throw new Error('Not implemented');
+                throw new WorkflowRuntimeError(
+                  '`crypto.subtle.generateKey()` is not available inside a workflow function. Move key generation to a step function where full Node.js crypto is available.'
+                );
               };
             } else if (prop === 'digest') {
               return boundDigest;

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -92,7 +92,7 @@ export async function runWorkflow(
 
     const startedAt = workflowRun.startedAt;
     if (!startedAt) {
-      throw new Error(
+      throw new WorkflowRuntimeError(
         `Workflow run "${workflowRun.runId}" has no "startedAt" timestamp (should not happen)`
       );
     }


### PR DESCRIPTION
## Summary

**Phase 6** of the friendlier-errors stack. A small consistency pass converting the last ergonomically-important bare `throw new Error(...)` sites in `@workflow/core` to structured error classes and friendlier messages.

- Internal invariants now throw `WorkflowRuntimeError` so `describeError` attributes them to the SDK, not the user:
  - `workflow.ts`: missing `startedAt` timestamp (should not happen)
  - `vm/index.ts`: `crypto.subtle.generateKey()` disabled inside the workflow VM — now explains _why_ and points to step functions
  - `step/get-closure-vars.ts`: closure-vars accessed outside a step context
  - `global.ts` (`ENOTSUP`): explains the workflow-VM constraint and suggests moving the call to a step function
- `defineHook().resume()`: schema validation failures are rendered as a readable list (`at "field": <message>`) instead of a raw JSON dump.
- Test + snapshot updated for the two changed messages.

## Manual test plan

Using `workbench/nextjs-turbopack` — `pnpm dev` and watch the terminal.

- [ ] **Zod schema failure on `defineHook().resume()`** — the headline user-visible change:
  ```ts
  import { z } from 'zod';
  import { defineHook } from 'workflow';

  export const paymentHook = defineHook<{ amount: number }>({
    schema: z.object({ amount: z.number().positive() }),
  });
  ```
  Call `paymentHook.resume(token, { amount: -5 })` from a server route. Expect a **readable bulleted list** of validation issues — one line per issue with the field path and message (`at "amount": Number must be greater than 0`) — NOT a raw JSON dump of `ZodError.issues`.

- [ ] **`crypto.subtle.generateKey()` inside workflow VM** — call it from a `"use workflow"` function:
  ```ts
  export async function broken() {
    'use workflow';
    await crypto.subtle.generateKey({name: 'AES-GCM', length: 256}, true, ['encrypt']);
  }
  ```
  Expect a clear message explaining _why_ it's disabled in the VM and pointing at "move this into a step function".

- [ ] **`WorkflowRuntimeError` → `'sdk'` attribution** — reusing Phase 5 behavior: confirm the log for the above test includes `errorAttribution: 'sdk'` (not `'user'`). Internal invariants should be framed as "this is us, not you."

- [ ] **Non-Zod schema** (e.g. valibot) — if you use a non-Zod schema validator, confirm the list rendering still works via the shared error-shaping path.

- [ ] **Rare internal invariants** — these only trip on severe bugs; not generally testable by hand. Covered by unit tests.

## Unit tests

- [x] `pnpm --filter @workflow/core exec vitest run src/define-hook.test.ts src/vm/index.test.ts src/describe-error.test.ts`
- [x] Pre-existing `DOMException` / `world.streams` failures still match baseline

---

## 📚 Friendlier errors stack

Multi-PR initiative inspired by @schniz's stalled [#706](https://github.com/vercel/workflow/pull/706):

| # | PR | Phase | Summary |
|---|-----|-------|---------|
| 1 | [#1831](https://github.com/vercel/workflow/pull/1831) | Phase 1 + 2 | `Ansi` rendering primitives + context-violation errors |
| 2 | [#1832](https://github.com/vercel/workflow/pull/1832) | Phase 3 | Structured logger metadata; folds in [#1812](https://github.com/vercel/workflow/pull/1812) |
| 3 | [#1836](https://github.com/vercel/workflow/pull/1836) | Phase 4 | `SerializationError` at serialization / stream / encryption boundaries |
| 4 | [#1837](https://github.com/vercel/workflow/pull/1837) | Phase 5 | Presentation-only user vs SDK attribution (`describeError`) |
| 5 | **→ this PR (#1838)** | Phase 6 | Consistency pass on remaining bare `throw new Error(...)` sites |
| 6 | [#1839](https://github.com/vercel/workflow/pull/1839) | Phase 7 foundation | Data-driven `describeRunError` + public subpath |
| 7 | [#1840](https://github.com/vercel/workflow/pull/1840) | Phase 8 | `WorkflowBuildError` + applications in `@workflow/builders` |
| 8 | [#1849](https://github.com/vercel/workflow/pull/1849) | Followups | Drop `functionName` leak, simplify docs framing, redirect stack to user code |

Each PR is stacked on the previous one; merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
