### PR TITLE
Friendlier build-time errors: WorkflowBuildError + builders sites

### DIFF
--- a/.changeset/friendlier-build-errors.md
+++ b/.changeset/friendlier-build-errors.md
@@ -1,0 +1,10 @@
+---
+"@workflow/errors": patch
+"@workflow/builders": patch
+---
+
+Add `WorkflowBuildError` class (with optional `hint` for an actionable next
+step) and apply it to user-facing build sites in `@workflow/builders`:
+failed esbuild phases, unresolved built-in steps, and empty esbuild output
+now throw `WorkflowBuildError` with a hint pointing at the fix. Runtime
+invariants remain plain `Error`.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, realpath, rename, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
+import { WorkflowBuildError } from '@workflow/errors';
 import { pluralize, usesVercelWorld } from '@workflow/utils';
 import chalk from 'chalk';
 import enhancedResolveOriginal from 'enhanced-resolve';
@@ -343,8 +344,11 @@ export abstract class BaseBuilder {
       }
 
       if (throwOnError) {
-        throw new Error(
-          `Build failed during ${phase}:\n${errorMessages.join('\n')}`
+        throw new WorkflowBuildError(
+          `Build failed during ${phase}:\n${errorMessages.join('\n')}`,
+          {
+            hint: `Review the esbuild errors above — they come from the ${phase} bundle. Fix the offending source files and re-run the build.`,
+          }
         );
       }
     }
@@ -421,13 +425,12 @@ export abstract class BaseBuilder {
       dirname(outfile),
       'workflow/internal/builtins'
     ).catch((err) => {
-      throw new Error(
-        [
-          chalk.red('Failed to resolve built-in steps sources.'),
-          `${chalk.yellow.bold('hint:')} run \`${chalk.cyan.italic('npm install workflow')}\` to resolve this issue.`,
-          '',
-          `Caused by: ${chalk.red(String(err))}`,
-        ].join('\n')
+      throw new WorkflowBuildError(
+        `Failed to resolve built-in steps sources.\n\nCaused by: ${String(err)}`,
+        {
+          hint: 'run `pnpm install workflow` to resolve this issue.',
+          cause: err,
+        }
       );
     });
 
@@ -856,7 +859,9 @@ export abstract class BaseBuilder {
         !interimBundle.outputFiles ||
         interimBundle.outputFiles.length === 0
       ) {
-        throw new Error('No output files generated from esbuild');
+        throw new WorkflowBuildError('No output files generated from esbuild', {
+          hint: 'This usually indicates a misconfigured entry point or an empty workflow directory. Check that your workflow files contain a `"use workflow"` or `"use step"` directive.',
+        });
       }
 
       // Serde compliance warnings: check if workflow bundle has Node.js imports

--- a/packages/errors/src/build-error.test.ts
+++ b/packages/errors/src/build-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { WorkflowBuildError, WorkflowError } from './index.js';
+
+describe('WorkflowBuildError', () => {
+  test('sets the name and extends WorkflowError', () => {
+    const err = new WorkflowBuildError('boom');
+    expect(err.name).toBe('WorkflowBuildError');
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowBuildError);
+  });
+
+  test('appends hint with a blank line separator', () => {
+    const err = new WorkflowBuildError('Build failed during steps', {
+      hint: 'run `pnpm install workflow` and try again',
+    });
+    expect(err.hint).toBe('run `pnpm install workflow` and try again');
+    expect(err.message).toMatchInlineSnapshot(`
+      "Build failed during steps
+
+      run \`pnpm install workflow\` and try again"
+    `);
+  });
+
+  test('preserves cause for debugging', () => {
+    const cause = new TypeError('underlying esbuild failure');
+    const err = new WorkflowBuildError('boom', { cause });
+    expect(err.cause).toBe(cause);
+  });
+
+  test('WorkflowBuildError.is discriminates by name', () => {
+    const err = new WorkflowBuildError('boom');
+    const other = new Error('boom');
+    expect(WorkflowBuildError.is(err)).toBe(true);
+    expect(WorkflowBuildError.is(other)).toBe(false);
+    expect(WorkflowBuildError.is(null)).toBe(false);
+  });
+});

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -219,6 +219,42 @@ export class WorkflowRuntimeError extends WorkflowError {
   }
 }
 
+interface WorkflowBuildErrorOptions extends ErrorOptions {
+  /**
+   * An optional actionable hint appended to the main message, explaining how
+   * the user can resolve the failure. Shown after a blank line.
+   */
+  hint?: string;
+}
+
+/**
+ * Thrown when the workflow build pipeline (esbuild, SWC transform, file
+ * discovery, bundler integration) fails in a way the user can act on.
+ *
+ * This is distinct from `WorkflowRuntimeError` (which is raised at runtime
+ * by the workflow engine) — `WorkflowBuildError` fires during `pnpm build`,
+ * `next build`, or equivalent, before any workflow has started executing.
+ *
+ * Prefer attaching a short, actionable `hint` (e.g. `run \`pnpm install workflow\``)
+ * as plain text — the rendering layer is responsible for any styling or
+ * "hint:" label. Keeping `hint` plain keeps it useful in non-TTY contexts
+ * (CI logs, structured error serialization) where ANSI escapes are noise.
+ */
+export class WorkflowBuildError extends WorkflowError {
+  readonly hint?: string;
+
+  constructor(message: string, options?: WorkflowBuildErrorOptions) {
+    const body = options?.hint ? `${message}\n\n${options.hint}` : message;
+    super(body, { cause: options?.cause });
+    this.name = 'WorkflowBuildError';
+    this.hint = options?.hint;
+  }
+
+  static is(value: unknown): value is WorkflowBuildError {
+    return isError(value) && value.name === 'WorkflowBuildError';
+  }
+}
+
 interface SerializationErrorOptions extends ErrorOptions {
   /**
    * An optional actionable hint appended to the main message, explaining how


### PR DESCRIPTION
## Summary

**Phase 8** (final) of the friendlier-errors stack — extends the error-quality work from runtime into build-time.

- Adds `WorkflowBuildError` in `@workflow/errors` with an optional `hint` field (appended after a blank line) and a `.is()` discriminator.
- Applies it at user-facing sites in `@workflow/builders/base-builder.ts`:
  - Failed esbuild phases → hint at the likely fix for the phase
  - Unresolved built-in steps → hint at `pnpm install workflow`
  - Empty esbuild output → hint that workflow files need `"use workflow"` / `"use step"` directives
- Internal runtime invariants remain plain `Error`.

**Scope note**: deliberately kept to `@workflow/builders` (ESM). Extending `WorkflowBuildError` into `@workflow/next` (CJS) needs a dynamic-import bridge similar to the existing `eval('import("@workflow/builders")')` pattern — can follow up in a separate PR.

## Manual test plan

All tests here exercise the **build pipeline**, not the runtime. Use `workbench/nextjs-turbopack` and run `pnpm build` (not `pnpm dev`).

- [ ] **Syntax error in a workflow file** → failed esbuild phase:
  ```ts
  // workbench/nextjs-turbopack/app/_workflows/broken.ts
  'use workflow';
  export async function broken(
    this is not valid ts
  ```
  Run `pnpm build`. Expect in build output:
  - `WorkflowBuildError` with title mentioning the phase (e.g. "Build failed during workflows bundle").
  - A blank line, then `hint: Review the esbuild errors above — they come from the workflows bundle. Fix the offending source files and re-run the build.`
  - The original esbuild error messages printed **before** the WorkflowBuildError, not suppressed.

- [ ] **Unresolved built-in steps** — temporarily rename `node_modules/workflow` to `node_modules/workflow-bak`:
  ```bash
  mv node_modules/workflow node_modules/workflow-bak
  cd workbench/nextjs-turbopack && pnpm build
  mv ../../node_modules/workflow-bak ../../node_modules/workflow  # restore
  ```
  Expect:
  - `WorkflowBuildError`: "Failed to resolve built-in steps sources."
  - `hint: run \`pnpm install workflow\` to resolve this issue.`
  - `cause:` preserves the underlying resolution error.

- [ ] **Empty workflow directory** — move all your workflow files aside (or create a fresh workspace with none):
  ```bash
  mkdir /tmp/wf-empty && cd /tmp/wf-empty
  # set up minimal package + workflow config with an empty workflows/ dir
  pnpm workflow build
  ```
  Or: delete all `"use workflow"` / `"use step"` directives from your files. Expect:
  - `WorkflowBuildError`: "No output files generated from esbuild"
  - `hint` mentions `"use workflow"` / `"use step"` directives.

- [ ] **`.is()` discriminator** — in a scratch script:
  ```ts
  import { WorkflowBuildError } from '@workflow/errors';
  const e = new WorkflowBuildError('x', { hint: 'y' });
  console.log(WorkflowBuildError.is(e));   // true
  console.log(WorkflowBuildError.is(new Error('x'))); // false
  ```

- [ ] **Hint renders below a blank line** — verify the `hint` output appears after a blank line, not jammed onto the title line (visual formatting check).

- [ ] **Runtime paths unaffected** — run a normal workflow at runtime (`pnpm dev` and trigger a workflow). Confirm no `WorkflowBuildError` shows up at runtime; this class should only appear in build output.

## Unit tests

- [x] `pnpm --filter @workflow/errors test` — 19 total (4 new `WorkflowBuildError` tests)
- [x] `pnpm --filter @workflow/builders typecheck` + test (129 pass)

---

## 📚 Friendlier errors stack

Multi-PR initiative inspired by @schniz's stalled [#706](https://github.com/vercel/workflow/pull/706):

| # | PR | Phase | Summary |
|---|-----|-------|---------|
| 1 | [#1831](https://github.com/vercel/workflow/pull/1831) | Phase 1 + 2 | `Ansi` rendering primitives + context-violation errors |
| 2 | [#1832](https://github.com/vercel/workflow/pull/1832) | Phase 3 | Structured logger metadata; folds in [#1812](https://github.com/vercel/workflow/pull/1812) |
| 3 | [#1836](https://github.com/vercel/workflow/pull/1836) | Phase 4 | `SerializationError` at serialization / stream / encryption boundaries |
| 4 | [#1837](https://github.com/vercel/workflow/pull/1837) | Phase 5 | Presentation-only user vs SDK attribution (`describeError`) |
| 5 | [#1838](https://github.com/vercel/workflow/pull/1838) | Phase 6 | Consistency pass on remaining bare `throw new Error(...)` sites |
| 6 | [#1839](https://github.com/vercel/workflow/pull/1839) | Phase 7 foundation | Data-driven `describeRunError` + public subpath |
| 7 | **→ this PR (#1840)** | Phase 8 | `WorkflowBuildError` + applications in `@workflow/builders` |
| 8 | [#1849](https://github.com/vercel/workflow/pull/1849) | Followups | Drop `functionName` leak, simplify docs framing, redirect stack to user code |

Each PR is stacked on the previous one; merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
