### PR TITLE
Trace Vercel workflow function dependencies

### DIFF
--- a/.changeset/trace-vercel-function-files.md
+++ b/.changeset/trace-vercel-function-files.md
@@ -1,0 +1,5 @@
+---
+"@workflow/builders": patch
+---
+
+Trace and copy runtime files into Vercel Build Output API workflow functions so native and dynamically loaded dependencies are available at runtime.

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@swc/core": "catalog:",
+    "@vercel/nft": "1.5.0",
     "@workflow/core": "workspace:*",
     "@workflow/errors": "workspace:*",
     "@workflow/utils": "workspace:*",

--- a/packages/builders/src/vercel-build-output-api.test.ts
+++ b/packages/builders/src/vercel-build-output-api.test.ts
@@ -1,0 +1,94 @@
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { VercelBuildOutputAPIBuilder } from './vercel-build-output-api.js';
+
+class TestVercelBuildOutputAPIBuilder extends VercelBuildOutputAPIBuilder {
+  constructor(workingDir: string) {
+    super({
+      buildTarget: 'vercel-build-output-api',
+      dirs: ['src'],
+      workingDir,
+      stepsBundlePath: '',
+      workflowsBundlePath: '',
+      webhookBundlePath: '',
+    });
+  }
+
+  trace(functionDir: string, entrypoints: string[]): Promise<void> {
+    return this.traceFunctionDependencies(functionDir, entrypoints);
+  }
+}
+
+describe('VercelBuildOutputAPIBuilder', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+  });
+
+  it('copies traced runtime files into function directories', async () => {
+    const tempDir = await mkdtemp(
+      join(await realpath(tmpdir()), 'workflow-vercel-boa-')
+    );
+    tempDirs.push(tempDir);
+
+    await mkdir(join(tempDir, 'src'), { recursive: true });
+    await mkdir(join(tempDir, 'node_modules/native-package/prebuilds'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'test-project', type: 'module' })
+    );
+    await writeFile(
+      join(tempDir, 'src/step.ts'),
+      'import nativePackage from "native-package";\nexport const value = nativePackage;\n'
+    );
+    await writeFile(
+      join(tempDir, 'node_modules/native-package/package.json'),
+      JSON.stringify({ name: 'native-package', main: 'index.js' })
+    );
+    await writeFile(
+      join(tempDir, 'node_modules/native-package/index.js'),
+      'module.exports = require("./prebuilds/native.node");\n'
+    );
+    await writeFile(
+      join(tempDir, 'node_modules/native-package/prebuilds/native.node'),
+      ''
+    );
+
+    const functionDir = join(
+      tempDir,
+      '.vercel/output/functions/.well-known/workflow/v1/step.func'
+    );
+    await mkdir(functionDir, { recursive: true });
+    await writeFile(
+      join(functionDir, 'package.json'),
+      JSON.stringify({ type: 'module' })
+    );
+
+    const builder = new TestVercelBuildOutputAPIBuilder(tempDir);
+    await builder.trace(functionDir, [join(tempDir, 'src/step.ts')]);
+
+    await expect(
+      access(
+        join(functionDir, 'node_modules/native-package/prebuilds/native.node')
+      )
+    ).resolves.toBeUndefined();
+    await expect(
+      readFile(join(functionDir, 'package.json'), 'utf-8')
+    ).resolves.toBe(JSON.stringify({ type: 'module' }));
+  });
+});

--- a/packages/builders/src/vercel-build-output-api.ts
+++ b/packages/builders/src/vercel-build-output-api.ts
@@ -1,7 +1,11 @@
-import { copyFile, mkdir, writeFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { copyFile, cp, mkdir, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { nodeFileTrace } from '@vercel/nft';
 import { BaseBuilder } from './base-builder.js';
 import { STEP_QUEUE_TRIGGER, WORKFLOW_QUEUE_TRIGGER } from './constants.js';
+
+type DiscoveredEntries = Awaited<ReturnType<BaseBuilder['discoverEntries']>>;
 
 export class VercelBuildOutputAPIBuilder extends BaseBuilder {
   async build(): Promise<void> {
@@ -14,10 +18,16 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
 
     const inputFiles = await this.getInputFiles();
     const tsconfigPath = await this.findTsConfigPath();
+    const discoveredEntries = await this.discoverEntries(
+      inputFiles,
+      workflowGeneratedDir,
+      tsconfigPath
+    );
     const options = {
       inputFiles,
       workflowGeneratedDir,
       tsconfigPath,
+      discoveredEntries,
     };
     const stepsManifest = await this.buildStepsFunction(options);
     const workflowsManifest = await this.buildWorkflowsFunction(options);
@@ -63,10 +73,12 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
     inputFiles,
     workflowGeneratedDir,
     tsconfigPath,
+    discoveredEntries,
   }: {
     inputFiles: string[];
     workflowGeneratedDir: string;
     tsconfigPath?: string;
+    discoveredEntries: DiscoveredEntries;
   }) {
     console.log('Creating Vercel Build Output API steps function');
     const stepsFuncDir = join(workflowGeneratedDir, 'step.func');
@@ -77,6 +89,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       inputFiles,
       outfile: join(stepsFuncDir, 'index.mjs'),
       tsconfigPath,
+      discoveredEntries,
     });
 
     // Create package.json and .vc-config.json for steps function
@@ -88,6 +101,11 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       experimentalTriggers: [STEP_QUEUE_TRIGGER],
       runtime: this.config.runtime,
     });
+    await this.traceFunctionDependencies(stepsFuncDir, [
+      ...discoveredEntries.discoveredSteps,
+      ...discoveredEntries.discoveredSerdeFiles,
+      ...this.resolveTraceEntryPoints(['workflow/runtime']),
+    ]);
 
     return manifest;
   }
@@ -96,10 +114,12 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
     inputFiles,
     workflowGeneratedDir,
     tsconfigPath,
+    discoveredEntries,
   }: {
     inputFiles: string[];
     workflowGeneratedDir: string;
     tsconfigPath?: string;
+    discoveredEntries: DiscoveredEntries;
   }) {
     console.log('Creating Vercel Build Output API workflows function');
     const workflowsFuncDir = join(workflowGeneratedDir, 'flow.func');
@@ -109,6 +129,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       outfile: join(workflowsFuncDir, 'index.mjs'),
       inputFiles,
       tsconfigPath,
+      discoveredEntries,
     });
 
     // Create package.json and .vc-config.json for workflows function
@@ -119,6 +140,11 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
       runtime: this.config.runtime,
     });
+    await this.traceFunctionDependencies(workflowsFuncDir, [
+      ...discoveredEntries.discoveredWorkflows,
+      ...discoveredEntries.discoveredSerdeFiles,
+      ...this.resolveTraceEntryPoints(['workflow/runtime']),
+    ]);
 
     return manifest;
   }
@@ -146,6 +172,74 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       shouldAddHelpers: false,
       runtime: this.config.runtime,
     });
+    await this.traceFunctionDependencies(
+      webhookFuncDir,
+      this.resolveTraceEntryPoints(['workflow/api'])
+    );
+  }
+
+  protected async traceFunctionDependencies(
+    functionDir: string,
+    entrypoints: string[]
+  ): Promise<void> {
+    const uniqueEntryPoints = Array.from(new Set(entrypoints)).filter(Boolean);
+
+    if (uniqueEntryPoints.length === 0) {
+      return;
+    }
+
+    const { fileList } = await nodeFileTrace(uniqueEntryPoints, {
+      base: this.config.workingDir,
+      processCwd: this.config.workingDir,
+    });
+
+    await Promise.all(
+      Array.from(fileList, async (file) => {
+        const normalizedFile = file.replace(/\\/g, '/');
+
+        if (
+          normalizedFile === 'index.mjs' ||
+          normalizedFile === 'package.json' ||
+          normalizedFile === '.vc-config.json' ||
+          normalizedFile === '..' ||
+          normalizedFile.startsWith('../') ||
+          normalizedFile.startsWith('/')
+        ) {
+          return;
+        }
+
+        const source = resolve(this.config.workingDir, file);
+        const target = join(functionDir, file);
+
+        if (source === target) {
+          return;
+        }
+
+        await mkdir(dirname(target), { recursive: true });
+        await cp(source, target, {
+          recursive: true,
+          force: true,
+          dereference: false,
+        });
+      })
+    );
+  }
+
+  private resolveTraceEntryPoints(specifiers: string[]): string[] {
+    const require = createRequire(join(this.config.workingDir, 'package.json'));
+    const resolved: string[] = [];
+
+    for (const specifier of specifiers) {
+      try {
+        resolved.push(require.resolve(specifier));
+      } catch {
+        // The normal bundle step reports missing Workflow entry points. This
+        // trace pass should not mask that error with a duplicate resolution
+        // failure.
+      }
+    }
+
+    return resolved;
   }
 
   private async createBuildOutputConfig(outputDir: string): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,9 @@ importers:
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.3
+      '@vercel/nft':
+        specifier: 1.5.0
+        version: 1.5.0(rollup@4.60.0)
       '@workflow/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary
- run node-file-trace over Vercel Build Output API workflow, step, and webhook entry points
- copy traced runtime files into each generated `.func` directory so native/dynamic dependencies such as `sharp` and `cbor-extract` are available at runtime
- preserve generated function control files like `package.json`, `index.mjs`, and `.vc-config.json` during the copy

## Testing
- `pnpm --filter @workflow/builders typecheck`
- `pnpm --filter @workflow/builders test`
- local trace smoke test against a TanStack Start + Workflow repro using `sharp`, verifying `@img/sharp-linux-arm64` is copied and the function package.json remains `{ "type": "module" }`

Fixes a runtime failure where Workflow Build Output API functions could bundle `sharp` JavaScript but omit its optional native packages from the isolated `.func` directory.