### PR TITLE
ci: fix VERCEL_WORKFLOW_SERVER_* env var ternary on main

### DIFF
--- a/.github/actions/setup-workflow-dev/action.yml
+++ b/.github/actions/setup-workflow-dev/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Whether to build packages (excludes workbenches)'
     required: false
     default: 'true'
+  cache-pnpm:
+    description: 'Whether to enable the pnpm store cache. Disable for jobs that never run pnpm install (the post-job cache save fails with "Path Validation Error" when the store path was never created).'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -39,7 +43,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'pnpm'
+        cache: ${{ inputs.cache-pnpm == 'true' && 'pnpm' || '' }}
 
     - name: Install Dependencies
       if: ${{ inputs.install-dependencies == 'true' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -331,6 +331,7 @@ jobs:
         with:
           install-dependencies: 'false'
           build-packages: 'false'
+          cache-pnpm: 'false'
 
       - id: set-matrix
         run: |
@@ -711,6 +712,7 @@ jobs:
         with:
           install-dependencies: 'false'
           build-packages: 'false'
+          cache-pnpm: 'false'
 
       - id: set-matrix
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -291,8 +291,8 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           # Point PRs at the protected workflow-server preview; unset on main
           # so production runs hit the public vercel-workflow.com URL.
-          VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref == 'refs/heads/main' && '' || secrets.VERCEL_WORKFLOW_SERVER_URL }}
-          VERCEL_WORKFLOW_SERVER_PROTECTION_BYPASS: ${{ github.ref == 'refs/heads/main' && '' || secrets.VERCEL_WORKFLOW_SERVER_PROTECTION_BYPASS }}
+          VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
+          VERCEL_WORKFLOW_SERVER_PROTECTION_BYPASS: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_PROTECTION_BYPASS || '' }}
 
       - name: Generate E2E summary
         if: always()


### PR DESCRIPTION
## Summary

Fixes broken e2e CI on `main` introduced by #1824.

In GitHub Actions expressions, empty string `''` is falsy. The previous expression

```yaml
${{ github.ref == 'refs/heads/main' && '' || secrets.VERCEL_WORKFLOW_SERVER_URL }}
```

always fell through to the secret on both branches: on main, `true && '' → ''`, then `'' || secrets.X → secrets.X`. So pushes to `main` were sending the preview workflow-server URL/bypass values into production e2e runs, which caused `world-vercel` to set `x-vercel-workflow-api-url: <preview-url>` on calls to `api.vercel.com`. The API rejected those with `invalid_url`, cascading into ~all e2e tests failing on every push to `main` since #1824 merged.

## Fix

Flip the condition so the secret sits in the truthy branch — `||` then correctly selects `''` on `main`:

```yaml
${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
```

## Notes

- CI-only change; no changeset needed (`pnpm changeset status` confirms).
- Example failing run: https://github.com/vercel/workflow/actions/runs/24802651700