### PR TITLE
test: enable step source-map assertions for vite local dev

### DIFF
--- a/.changeset/fix-vite-step-source-maps-e2e.md
+++ b/.changeset/fix-vite-step-source-maps-e2e.md
@@ -1,4 +1,2 @@
 ---
 ---
-
-Fix vite local-dev e2e error tests by enabling step source-map assertions for vite. After bumping vite to ^7.3.2 (#1827), vite preserves step bundle source maps in dev mode and stack traces now contain original file paths (`99_e2e.ts`, `helpers.ts`), so `hasStepSourceMaps()` should return `true` for vite local dev.

--- a/.changeset/fix-vite-step-source-maps-e2e.md
+++ b/.changeset/fix-vite-step-source-maps-e2e.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix vite local-dev e2e error tests by enabling step source-map assertions for vite. After bumping vite to ^7.3.2 (#1827), vite preserves step bundle source maps in dev mode and stack traces now contain original file paths (`99_e2e.ts`, `helpers.ts`), so `hasStepSourceMaps()` should return `true` for vite local dev.

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -63,13 +63,6 @@ export function hasStepSourceMaps(): boolean {
     return appName !== 'sveltekit';
   }
 
-  // Vite local prod doesn't currently emit source maps for step bundles.
-  // In local dev (vite >=7.3) source maps are preserved, so we only
-  // disable for non-dev (i.e. local prod) here.
-  if (appName === 'vite' && !process.env.DEV_TEST_CONFIG) {
-    return false;
-  }
-
   // NestJS preserves source maps in all builds including prod
   if (appName === 'nest') {
     return true;

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -63,8 +63,10 @@ export function hasStepSourceMaps(): boolean {
     return appName !== 'sveltekit';
   }
 
-  // Vite only works in vercel, not on local prod or dev
-  if (appName === 'vite') {
+  // Vite local prod doesn't currently emit source maps for step bundles.
+  // In local dev (vite >=7.3) source maps are preserved, so we only
+  // disable for non-dev (i.e. local prod) here.
+  if (appName === 'vite' && !process.env.DEV_TEST_CONFIG) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Vite local-dev e2e tests `basic step error preserves message and stack trace` and `cross-file step error preserves message and function names in stack` have been failing consistently since [#1827](https://github.com/vercel/workflow/pull/1827) bumped `workbench/vite` from `vite@^7.1.12` to `vite@^7.3.2`.
- The newer vite preserves step bundle source maps in dev mode, so stack traces now point at original files (`99_e2e.ts`, `helpers.ts`). However, `hasStepSourceMaps()` in `packages/core/e2e/utils.ts` still hard-codes vite as having no step source maps in any local environment, so the assertion `expect(stack).not.toContain('99_e2e.ts')` fails.
- Fix: drop the vite-specific block in `hasStepSourceMaps()` entirely. Vite local dev now falls through to the default `return true`, while vite local prod is still caught by the existing `!DEV_TEST_CONFIG` guard further down — so local-prod behavior is unchanged.

## Why this took 6 days to surface

1. The push for #1827 had Local Dev tests skipped due to matrix selection at the time.
2. The next push (#1860) introduced a CI env-var bug that prevented Local Dev tests from running at all.
3. #1859 (`28dc089e`) fixed the env-var bug, finally letting vite local dev run — and it surfaced this assertion failure.

Reference failing run: https://github.com/vercel/workflow/actions/runs/25067758534/job/73444472541