### PR TITLE
ci: stop using Release App token in release workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,20 +13,14 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'backport-stable')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -165,7 +159,7 @@ jobs:
         if: steps.cherry-pick.outputs.status == 'conflict' && steps.ai-resolve.outputs.resolved == 'true'
         id: backport-pr
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -195,7 +189,7 @@ jobs:
         if: steps.cherry-pick.outputs.status == 'clean'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const originalSha = '${{ github.event.pull_request.merge_commit_sha }}'.slice(0, 7);
             const cherryPickSha = '${{ steps.cherry-pick.outputs.cherry_pick_sha }}'.slice(0, 7);
@@ -210,7 +204,7 @@ jobs:
         if: steps.cherry-pick.outputs.status == 'conflict' && steps.ai-resolve.outputs.resolved == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -223,7 +217,7 @@ jobs:
         if: always() && steps.cherry-pick.outputs.status == 'conflict' && steps.ai-resolve.outputs.resolved != 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const sha = '${{ github.event.pull_request.merge_commit_sha }}';
             await github.rest.issues.createComment({
@@ -249,7 +243,7 @@ jobs:
         if: always() && steps.cherry-pick.outputs.status != 'clean' && steps.cherry-pick.outputs.status != 'conflict'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.createComment({

--- a/.github/workflows/dispatch-front-workflow-release-pr.yml
+++ b/.github/workflows/dispatch-front-workflow-release-pr.yml
@@ -1,5 +1,11 @@
 name: Dispatch Front Workflow Release PR
 
+# DISABLED: This workflow dispatches to vercel/front (cross-repo) which
+# requires a GitHub App token. The Release App has been temporarily
+# removed, so this workflow is disabled (all jobs gated on `if: false`)
+# until the App is restored. See .github/workflows/release.yml and
+# .github/workflows/backport.yml, which have also been updated to no
+# longer rely on the Release App.
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
@@ -15,6 +21,7 @@ jobs:
   dispatch-front-sync:
     name: Dispatch Front Sync
     if: >
+      false &&
       startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
       github.event.action != 'closed'
     runs-on: ubuntu-latest
@@ -71,6 +78,7 @@ jobs:
   dispatch-front-close:
     name: Dispatch Front Close
     if: >
+      false &&
       startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
       github.event.action == 'closed'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - stable
+  # Allow manual triggering from the Actions tab. Useful for re-running the
+  # release flow when a push from the default GITHUB_TOKEN (e.g. a clean
+  # cherry-pick from the backport workflow, or a merged "Version Packages"
+  # PR) does not automatically trigger this workflow.
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -23,23 +28,15 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git identity
         run: |
-          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -63,12 +60,12 @@ jobs:
           createGithubReleases: false
           setupGitUser: false
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           # Generate release notes (PUBLISHED_PACKAGES filters to only include packages from this release)


### PR DESCRIPTION
## Summary

The Release App has been temporarily removed, which currently blocks publishing new releases of the Workflow packages. This PR removes our reliance on the App token in the CI workflows so that releases can resume.

## Changes

- **`release.yml`**: Removed the `Generate GitHub App Token` step. Checkout, changesets, and `gh release` calls now use the default `GITHUB_TOKEN`. Git identity is hardcoded to `github-actions[bot]`. Added a `workflow_dispatch` trigger so the Version Packages PR can be created/updated manually.
- **`backport.yml`**: Removed the App token step. Bumped job permissions from `contents: read` to `contents: write` / `pull-requests: write` / `issues: write` (needed for pushing to `stable`, opening backport PRs, and commenting). All `github-token` references switched to `${{ secrets.GITHUB_TOKEN }}`.
- **`dispatch-front-workflow-release-pr.yml`**: Disabled both jobs (`if: false &&` ...) since cross-repo dispatch to `vercel/front` requires an App token. Re-enable when the App is restored.

## Caveats (pre-existing GitHub Actions behavior with `GITHUB_TOKEN`)

Pushes/PRs created by `GITHUB_TOKEN` do **not** trigger downstream workflow runs. Implications:

1. The "Version Packages" PR created by changesets won't auto-trigger required CI checks. Push an empty commit, or close/reopen the PR, to kick off CI before merging.
2. After merging a "Version Packages" PR (or after a clean cherry-pick from `backport.yml` lands on `stable`), the `Release` workflow won't auto-run. Use the new `workflow_dispatch` trigger from the Actions tab to publish.
3. If `stable` has branch protection that disallows pushes from `GITHUB_TOKEN`, the backport's clean-cherry-pick `git push origin stable` step will fail. The AI-resolved-conflict path opens a PR instead, so that path should still work.