### PR TITLE
ci: use GitHub API commit mode for changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
           publish: pnpm ci:publish
           createGithubReleases: false
           setupGitUser: false
+          # Use GitHub API for GPG-signed commits (required by branch rules).
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Follow-up to #1866. The Release workflow [failed](https://github.com/vercel/workflow/actions/runs/25123713969/job/73630993090) when trying to push the "Version Packages" PR commit to `changeset-release/main`:

```
remote: error: GH013: Repository rule violations found for refs/heads/changeset-release/main.
remote: - Commits must have verified signatures.
```

Org/enterprise-level rulesets require verified signatures on all branches in the repo. Commits pushed via the Git CLI using `GITHUB_TOKEN` are not signed.

This PR switches `changesets/action` to `commitMode: github-api`, which creates commits via the GitHub REST API. Commits made through the API are automatically GPG-signed by GitHub and therefore satisfy the signature requirement.

## Note on backport workflow

`backport.yml` still pushes cherry-picks to `stable` via `git push`, which will likely also fail the signature rule. That can be addressed in a follow-up PR if/when the backport flow is exercised — the manual fallback documented in the workflow's failure comment still works.