### PR TITLE
ci: fail fast when Next.js dev server is wedged on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -642,9 +642,61 @@ jobs:
           $job = Start-Job -ScriptBlock { Set-Location $using:PWD; pnpm dev *>&1 | Tee-Object -FilePath $using:logFile }
           Start-Sleep -Seconds 15
           cd ../..
+
+          # Fail-fast guards: if the Next.js dev server gets into a corrupted
+          # state during HMR (a recurring Turbopack-on-Windows issue where
+          # `packages/core/dist/*.js` becomes "MODULE_UNPARSABLE" and every
+          # subsequent request returns 500), the e2e suite would otherwise burn
+          # the full 30-minute job window polling stuck workflow runs before
+          # finally being cancelled. Below we (1) bail out if `dev.test.ts`
+          # fails, since that's the first thing to start hitting 500s, and
+          # (2) probe the server before the long e2e run to catch any other
+          # silent breakage.
+          #
+          # Get-DevServerStatus returns the HTTP status code of GET /api/chat,
+          # or 0 if the request never produced a response. /api/chat is a
+          # POST-only endpoint, so a healthy dev server responds with 405
+          # Method Not Allowed; we only treat 5xx (and no-response) as
+          # unhealthy.
+          function Get-DevServerStatus {
+            try {
+              $resp = Invoke-WebRequest -Uri "http://localhost:3000/api/chat" -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
+              return [int]$resp.StatusCode
+            } catch {
+              if ($_.Exception.Response) {
+                try { return [int]$_.Exception.Response.StatusCode } catch { return 0 }
+              }
+              return 0
+            }
+          }
+
+          $devExit = 0
           pnpm vitest run packages/core/e2e/dev.test.ts
+          $devExit = $LASTEXITCODE
+          if ($devExit -ne 0) {
+            Write-Host "::warning title=dev.test.ts failed::dev.test.ts exited with code $devExit. Skipping the remainder of the e2e suite to avoid waiting for the 30-minute job timeout."
+            Stop-Job $job -ErrorAction SilentlyContinue
+            exit $devExit
+          }
+
+          # Sanity-check the server before kicking off the long e2e suite. This
+          # catches the case where Turbopack quietly went sideways (e.g. lost
+          # track of files in `packages/core/dist` after HMR on Windows) and is
+          # returning 500 for every request. Without this check the e2e suite
+          # would burn the full 30-minute job window polling stuck workflow
+          # runs before getting cancelled.
+          $status = Get-DevServerStatus
+          Write-Host "[health-check:pre-e2e] GET /api/chat -> $status"
+          if ($status -eq 0 -or $status -ge 500) {
+            Write-Host "::error title=Next.js dev server unhealthy::Dev server returned $status before e2e tests. Aborting to avoid the 30-minute job timeout. See the 'Print Next.js server logs' step for the underlying Turbopack error."
+            Stop-Job $job -ErrorAction SilentlyContinue
+            exit 1
+          }
+
           pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-windows-nextjs-turbopack.json
-          Stop-Job $job
+          $e2eExit = $LASTEXITCODE
+          Stop-Job $job -ErrorAction SilentlyContinue
+          exit $e2eExit
         shell: powershell
         env:
           NODE_OPTIONS: "--enable-source-maps"


### PR DESCRIPTION
## Summary

- Bail out of the Windows e2e job as soon as `dev.test.ts` fails, instead of letting `test:e2e` run for ~25 more minutes against a broken server.
- Add a `Get-DevServerStatus` health check (probes `GET /api/chat`, expecting `405` from the POST-only endpoint) right before the heavy `test:e2e` run, so any other silent breakage is surfaced quickly with a clear `::error` annotation rather than a `cancelled` status at the 30-minute timeout.
- Forward the actual exit codes (`$devExit`, `$e2eExit`) so the job correctly reports failure rather than relying on PowerShell's default behavior.

## Why

A recurring Turbopack-on-Windows bug causes the Next.js dev server to enter a corrupted state during the HMR test in `dev.test.ts` (the one that modifies `_imported_step_only.ts`). Turbopack starts emitting:

```
ERROR  failed to read input source map: failed to find input source map file "index.js.map"
       in "packages/serde/dist/index.js" file as either ".../index.js.map" or with appended .map
Error: Could not parse module '[project]/packages/core/dist/serialization.js', file not found
  code: 'MODULE_UNPARSABLE'
```

After that, every request returns 500 for the rest of the run. The exact wedged file varies between runs (`serialization.js`, `runtime/start.js`, etc.), but the symptom is identical.

The job was hanging for the full 30 minutes because:

1. PowerShell doesn't bail on a non-zero exit by default, so `pnpm run test:e2e` would still execute after `pnpm vitest run dev.test.ts` failed.
2. Each subsequent test polls a stuck workflow run for 60s before reporting `Test failed`. With ~30 tests × 60s, the suite slowly burns through the entire job window.

Looking at recent `main` runs, ~50% of `E2E Windows Tests` jobs were getting cancelled at the 30-minute timeout this way (e.g. https://github.com/vercel/workflow/actions/runs/25129905724/job/73653019647).

## What this does *not* do

This doesn't fix the underlying Turbopack-on-Windows bug — it just converts a 30-minute hang-and-cancel into a fast, clearly-attributed failure that points at the existing `Print Next.js server logs` step for the actual root cause.