### PR TITLE
fix(next): externalize workflow world packages to avoid bundling native modules

### DIFF
--- a/.changeset/fix-next-server-externals-native-modules.md
+++ b/.changeset/fix-next-server-externals-native-modules.md
@@ -1,0 +1,5 @@
+---
+"@workflow/next": patch
+---
+
+Add workflow world packages to Next.js `serverExternalPackages` so webpack/turbopack do not follow transitive `require()` calls into native modules (e.g. `@napi-rs/keyring` reached via `@vercel/queue` → `@vercel/oidc` → `@vercel/cli-auth`) when bundling route handlers

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -260,7 +260,7 @@ export function withWorkflow(
     // configure the loader for webpack
     const existingWebpackModify = nextConfig.webpack;
     nextConfig.webpack = (...args) => {
-      const [webpackConfig] = args;
+      const [webpackConfig, options] = args;
       if (!webpackConfig.module) {
         webpackConfig.module = {};
       }
@@ -273,6 +273,40 @@ export function withWorkflow(
         test: /.*\.(mjs|cjs|cts|ts|tsx|js|jsx)$/,
         loader: loaderPath,
       });
+
+      // For server builds, mark workflow world packages as commonjs externals
+      // so webpack does not follow transitive `require()` calls into native
+      // modules (e.g. `@napi-rs/keyring` reached via `@vercel/queue` →
+      // `@vercel/oidc` → `@vercel/cli-auth`). `serverExternalPackages` is
+      // not always honored for these auto-generated workflow route handlers,
+      // so we also push direct externals here as a belt-and-suspenders.
+      if (options?.isServer) {
+        const externalPackages = [
+          '@workflow/world-vercel',
+          '@workflow/world-local',
+          '@workflow/world-postgres',
+          '@vercel/queue',
+          '@vercel/oidc',
+          '@napi-rs/keyring',
+        ];
+        const existingExternals = webpackConfig.externals;
+        const externalEntry = (
+          { request }: { request?: string },
+          callback: (err?: unknown, result?: string) => void
+        ) => {
+          if (request && externalPackages.includes(request)) {
+            return callback(null, `commonjs ${request}`);
+          }
+          return callback();
+        };
+        if (Array.isArray(existingExternals)) {
+          webpackConfig.externals = [externalEntry, ...existingExternals];
+        } else if (existingExternals) {
+          webpackConfig.externals = [externalEntry, existingExternals];
+        } else {
+          webpackConfig.externals = [externalEntry];
+        }
+      }
 
       return existingWebpackModify
         ? existingWebpackModify(...args)

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -97,6 +97,32 @@ export function withWorkflow(
     // shallow clone to avoid read-only on top-level
     nextConfig = Object.assign({}, nextConfig);
 
+    // Mark workflow world packages as server-only externals so Next.js does
+    // not try to bundle them into route handlers. Bundling these would force
+    // webpack/turbopack to follow transitive `require()` calls into native
+    // modules (e.g. `@napi-rs/keyring` reached via `@vercel/queue` →
+    // `@vercel/oidc` → `@vercel/cli-auth`) that cannot be parsed by the JS
+    // bundler. Leaving them as runtime requires resolves to the installed
+    // `node_modules` copy on the server.
+    const existingServerExternalPackages = Array.isArray(
+      nextConfig.serverExternalPackages
+    )
+      ? nextConfig.serverExternalPackages
+      : [];
+    nextConfig.serverExternalPackages = Array.from(
+      new Set([
+        ...existingServerExternalPackages,
+        '@workflow/world-vercel',
+        '@workflow/world-local',
+        '@workflow/world-postgres',
+        // Externalize the underlying SDKs reached transitively from
+        // `@workflow/world-vercel` so Next.js does not follow them into
+        // optional native modules during bundling.
+        '@vercel/queue',
+        '@vercel/oidc',
+      ])
+    );
+
     // configure the loader if turbopack is being used
     if (!nextConfig.turbopack) {
       nextConfig.turbopack = {};


### PR DESCRIPTION
## Summary

- Add `@workflow/world-vercel`, `@workflow/world-local`, `@workflow/world-postgres`, `@vercel/queue`, and `@vercel/oidc` to Next.js `serverExternalPackages` so webpack/turbopack don't follow transitive `require()` calls into native modules.

## Why

`@vercel/oidc@3.3.0` was published earlier today (2026-04-29) and added `@vercel/cli-auth` as a runtime dependency, which transitively pulls in `@napi-rs/keyring` (a native `.node` binary). When Next.js webpack/turbopack bundle `@workflow/world-vercel` into route handlers, they follow:

```
@workflow/world-vercel → @vercel/queue → @vercel/oidc → @vercel/cli-auth → @napi-rs/keyring
```

…and choke on the `.node` binary file (`Module parse failed: Unexpected character '\xef'`).

The CI staging script (`scripts/stage-workbench-with-tarballs.mjs`) installs with `--no-frozen-lockfile`, so it freshly resolves to `@vercel/oidc@3.3.0` and breaks all Next.js workbench e2e tests. End users with fresh installs of workflow apps would also hit this.

## Fix

Server-side workflow world packages have no business being bundled into route handlers — they should stay as runtime requires. Adding them to `serverExternalPackages` is the architectural fix and also protects against future native deps showing up transitively.

Failing CI: https://github.com/vercel/workflow/actions/runs/25138307140