### PR TITLE
Add missing changeset for #1872 (trace viewer polish)

### DIFF
--- a/.changeset/trace-viewer-polish.md
+++ b/.changeset/trace-viewer-polish.md
@@ -1,0 +1,6 @@
+---
+"@workflow/web-shared": patch
+"@workflow/web": patch
+---
+
+Polish the new trace viewer: add detail pane, middle-truncate component, timeline tweaks, and various UI cleanups.


### PR DESCRIPTION
## Summary

- The PR #1872 ([trace viewer] Polish items) was merged to `main` in commit aeb495bcc without a changeset.
- This adds a `patch` changeset for `@workflow/web-shared` and `@workflow/web` to cover those changes.

Force-pushing the changeset onto the original commit was attempted but blocked by branch protection rules on `main`, so this follow-up PR is the alternative.