### PR TITLE
fix(builders): bundle aliased project-local helpers instead of externalizing

### DIFF
--- a/.changeset/bundle-aliased-project-local-helpers.md
+++ b/.changeset/bundle-aliased-project-local-helpers.md
@@ -1,0 +1,7 @@
+---
+"@workflow/builders": patch
+---
+
+Fix `Package subpath ... is not defined by "exports"` runtime errors when step files reach project-local helpers via tsconfig `paths` / esbuild aliases / self-referencing package names.
+
+Such helpers are now bundled inline rather than externalized as relative paths. Externalization was unsafe because the helper's source on disk could contain further alias imports, and Node's ESM loader at runtime doesn't know about build-time path mappings — leading to errors like `Package subpath './lib/foo' is not defined by "exports"` (or `ERR_MODULE_NOT_FOUND`) once the helper was loaded.

--- a/packages/builders/src/swc-esbuild-plugin.test.ts
+++ b/packages/builders/src/swc-esbuild-plugin.test.ts
@@ -85,13 +85,20 @@ describe('createSwcPlugin externalizeNonSteps', () => {
     expect(output).not.toContain(`/dep${inputExt}`);
   });
 
-  it('rewrites path-aliased imports to relative paths', async () => {
+  it('bundles path-aliased project-local imports inline', async () => {
+    // Aliased project-local files must be bundled inline (not externalized
+    // as relative paths) because their source on disk may contain further
+    // alias imports that Node's ESM loader cannot resolve at runtime.
+    // See packages/builders/src/swc-esbuild-plugin.ts for full reasoning.
     const outdir = join(testRoot, 'out');
     const srcDir = join(testRoot, 'src');
     const libDir = join(srcDir, 'lib');
     const stepFile = join(srcDir, 'step.ts');
 
-    writeFile(join(libDir, 'config.ts'), 'export const config = {};');
+    writeFile(
+      join(libDir, 'config.ts'),
+      'export const config = { value: "hello-from-config" };'
+    );
     writeFile(
       stepFile,
       `import { config } from '@/lib/config';\nconsole.log(config);`
@@ -118,8 +125,75 @@ describe('createSwcPlugin externalizeNonSteps', () => {
 
     expect(result.errors).toHaveLength(0);
     const output = result.outputFiles[0].text;
-    expect(output).toContain('/lib/config.js');
+    // The aliased helper should be bundled inline (its content is in the
+    // output), not externalized as a relative path or left as a bare alias.
+    expect(output).toContain('hello-from-config');
     expect(output).not.toContain('@/lib/config');
+    expect(output).not.toMatch(/from\s+["'][^"']*\/lib\/config\.(js|ts)["']/);
+  });
+
+  it('bundles transitive aliased imports inside aliased helpers (Mux self-referencing package regression)', async () => {
+    // Regression test for https://github.com/muxinc/ai/pull/193.
+    //
+    // A package self-references its own subpath via tsconfig `paths` (e.g.
+    // `@my-pkg/lib/foo` → `src/lib/foo.ts`). A step file imports a helper
+    // via the alias, and that helper imports another helper via the alias.
+    //
+    // Previously the helpers were externalized as relative paths, but their
+    // source on disk still contained `import "@my-pkg/lib/..."`. At runtime,
+    // Node's ESM loader didn't know about tsconfig paths, fell through to
+    // the package's `exports` map, and threw `Package subpath ... is not
+    // defined by "exports"`.
+    //
+    // With the fix, aliased project-local files are bundled inline, so
+    // their alias imports are resolved at build time.
+    const outdir = join(testRoot, 'out');
+    const srcDir = join(testRoot, 'src');
+    const libDir = join(srcDir, 'lib');
+    const stepFile = join(srcDir, 'step.ts');
+
+    writeFile(
+      join(libDir, 'providers.ts'),
+      'export const providerName = "anthropic";'
+    );
+    writeFile(
+      join(libDir, 'client-factory.ts'),
+      // Helper uses the same alias to reach a sibling — this is the case
+      // that broke the Mux build with workflow >= 4.2.0-beta.78.
+      `import { providerName } from '@my-pkg/lib/providers';
+export const client = { provider: providerName };`
+    );
+    writeFile(
+      stepFile,
+      `import { client } from '@my-pkg/lib/client-factory';\nconsole.log(client);`
+    );
+
+    const result = await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      outdir,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      alias: { '@my-pkg': srcDir },
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          entriesToBundle: [stepFile],
+          outdir,
+          rewriteTsExtensions: true,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const output = result.outputFiles[0].text;
+    // Both helpers should be bundled inline — no aliased specifiers should
+    // leak into the output, where Node's ESM loader would choke on them.
+    expect(output).toContain('anthropic');
+    expect(output).not.toContain('@my-pkg/lib/providers');
+    expect(output).not.toContain('@my-pkg/lib/client-factory');
   });
 
   it('does not relativize Node.js builtin imports', async () => {

--- a/packages/builders/src/swc-esbuild-plugin.ts
+++ b/packages/builders/src/swc-esbuild-plugin.ts
@@ -129,9 +129,10 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
             specifier.startsWith('.') || specifier.startsWith('/');
 
           let resolvedPath: string | false | undefined;
-          // Determines whether the external path should be relativized
-          // (project-local file) or kept as a bare specifier (npm package).
-          let shouldMakeRelative = specifierIsPath;
+          // Path-style specifiers (./foo, ../foo, /abs/path) externalize as
+          // relative paths from `outdir`. Bare specifiers (npm packages)
+          // externalize as-is so Node can resolve them at runtime.
+          const shouldMakeRelative = specifierIsPath;
 
           if (specifierIsPath) {
             resolvedPath = await enhancedResolve(args.resolveDir, specifier);
@@ -142,8 +143,23 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
               specifier
             ).catch(() => undefined); // swallow so esbuild fallback below can try
 
-            // Fall back to esbuild for aliases/tsconfig paths,
-            // but only accept project-local results
+            // Fall back to esbuild for aliases/tsconfig paths.
+            //
+            // If the specifier resolves to a project-local file via an
+            // alias/path mapping (e.g. tsconfig `paths`, esbuild `alias`,
+            // self-referencing package names like `@my-pkg/lib/foo`), we
+            // bundle it inline rather than externalizing.
+            //
+            // Externalizing such files is unsafe: we'd emit a relative
+            // import to the original source on disk, but that source can
+            // contain further alias imports. At runtime, Node's ESM loader
+            // doesn't know about tsconfig paths or build-time aliases, so
+            // those transitive imports throw `ERR_MODULE_NOT_FOUND` /
+            // `Package subpath ... is not defined by "exports"`.
+            //
+            // Bundling inline ensures alias-based imports are resolved at
+            // build time (where the alias map is known) and the runtime
+            // never sees an unresolvable specifier.
             if (!resolvedPath) {
               const esbuildResult = await build.resolve(specifier, {
                 resolveDir: args.resolveDir,
@@ -159,8 +175,10 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
                   .replace(/\\/g, '/')
                   .includes('/node_modules/');
               if (isProjectLocalFile) {
-                resolvedPath = esbuildResult.path;
-                shouldMakeRelative = true;
+                // Let esbuild bundle this aliased project-local file inline
+                // (return null to defer to esbuild's normal pipeline). The
+                // SWC `onLoad` handler will still process it.
+                return null;
               }
             }
           }


### PR DESCRIPTION
## Summary

Fixes a regression where step files reaching project-local helpers via tsconfig `paths` / esbuild aliases / self-referencing package names crash at runtime in non-vite-node environments (Nitro, plain Node ESM, etc.) with:

- `Package subpath './lib/foo' is not defined by "exports"`
- `ERR_MODULE_NOT_FOUND`

Reported by Mux: [muxinc/ai#193](https://github.com/muxinc/ai/pull/193).

## Root cause

[#1613](https://github.com/vercel/workflow/pull/1613) added an esbuild fallback resolver so aliased imports resolve via tsconfig `paths`. When the resolved file is project-local, it gets externalized as a relative path. But the externalized file's **source on disk** can contain further alias imports (`import "@my-pkg/lib/providers"` etc.). Node's ESM loader doesn't know about build-time aliases and falls through to the package's `exports` map — where the subpath isn't defined — and throws.

[#1644](https://github.com/vercel/workflow/pull/1644) fixed this for Node builtins (because esbuild marks builtins external). Genuinely project-local files aren't external, so the `!esbuildResult.external` guard doesn't help them.

## Fix

When the esbuild fallback resolves a bare specifier to a project-local file, bundle it inline instead of externalizing it as a relative path. Bundling resolves all alias imports at build time, so the runtime never sees an unresolvable specifier. Relative-path imports are unaffected and continue to externalize as before — they don't have this problem because Node can resolve relative paths fine.

### Relationship to #1613

For the aliased-project-local-helper case specifically, this fix produces the **same end behavior as pre-#1613**: such helpers get bundled inline. The mechanism is different (we still run the esbuild fallback resolver, but use its result to choose "let esbuild bundle this" rather than "externalize"), so this is not a literal revert:

- **Aliased imports resolving into `node_modules`** are still detected by the fallback and bundled inline (test at `swc-esbuild-plugin.test.ts:161` covers this). Pre-#1613, these were also bundled but only because `enhanced-resolve` happened to fail on them; the new path is more deliberate.
- **Node builtins** are still handled correctly by #1644's `!esbuildResult.external` guard, which this fix preserves.
- **The `pluginData?.skipSwcPlugin` re-entry guard** added by #1613 is preserved.

#1613's stated vitest motivation (externalize aliased imports so `vi.mock()` can intercept them) appears to have been illusory — per `workbench/vitest/MOCKING.md`, `vi.mock()` cannot intercept step dependencies regardless of externalization, due to three independent architectural layers (bundle bypasses Vitest's module system, setup runs before mocks, etc.). So we lose nothing user-visible by reverting to inline bundling here.

## Tests

- Updated existing `'rewrites path-aliased imports to relative paths'` → renamed to `'bundles path-aliased project-local imports inline'`, asserts inlined bundling.
- Added regression test `'bundles transitive aliased imports inside aliased helpers (Mux self-referencing package regression)'` reproducing the exact Mux scenario: step → aliased helper → transitive aliased helper.

All 133 builder tests pass; typecheck clean.

## Trade-off

Aliased helpers now contribute to step bundle size (inlined into each step bundle that imports them). This restores pre-#1613 behavior for that path. Relative-path imports continue to externalize as before, so this only affects projects using path aliases for project-local helpers.