### PR TITLE
[world-local] Reject run_failed on non-existent run

### DIFF
--- a/.changeset/world-local-run-failed-not-found.md
+++ b/.changeset/world-local-run-failed-not-found.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-local": patch
+---
+
+Throw `WorkflowRunNotFoundError` when `run_failed` is recorded against a run that doesn't exist, matching the behaviour of `world-postgres` and `world-vercel`.

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -276,6 +276,14 @@ describe('Storage', () => {
         expect(updated.error?.message).toBe('Something went wrong');
         expect(updated.completedAt).toBeInstanceOf(Date);
       });
+
+      it('should reject run_failed on non-existent run', async () => {
+        await expect(
+          updateRun(storage, 'wrun_nonexistent', 'run_failed', {
+            error: 'Something went wrong',
+          })
+        ).rejects.toMatchObject({ name: 'WorkflowRunNotFoundError' });
+      });
     });
 
     describe('list', () => {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -6,6 +6,7 @@ import {
   RunExpiredError,
   RunNotSupportedError,
   TooEarlyError,
+  WorkflowRunNotFoundError,
   WorkflowWorldError,
 } from '@workflow/errors';
 import type {
@@ -224,6 +225,14 @@ export function createEventsStorage(
             }
           }
         }
+      }
+
+      // run_failed on a non-existent run is rejected to match the
+      // postgres and vercel worlds, which both surface this as a
+      // WorkflowRunNotFoundError rather than silently persisting an
+      // event for a run that was never created.
+      if (data.eventType === 'run_failed' && !currentRun) {
+        throw new WorkflowRunNotFoundError(effectiveRunId);
       }
 
       // ============================================================


### PR DESCRIPTION
## Summary

- `world-local` previously silently persisted a `run_failed` event when the target run did not exist. `world-postgres` and `world-vercel` (via `workflow-server`) both throw `WorkflowRunNotFoundError` in this case.
- Adds the same check in `world-local` for parity, plus a test covering it.

## Test plan

- [x] `pnpm test` in `packages/world-local` (336 passed)
- [x] `pnpm typecheck` in `packages/world-local`
- [x] New test: `should reject run_failed on non-existent run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)