### PR TITLE
[vitest] Isolate test data and improve cleanup

### DIFF
--- a/.changeset/moody-rivers-play.md
+++ b/.changeset/moody-rivers-play.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tighten cleanup in `dev.test.ts` `should include steps discovered from workflow imports` so the deferred builder drops the discovered step from the manifest before the next test file runs. Avoids a Windows-only race where the generated step route retains an import to a deleted source file and breaks every subsequent step request.

--- a/.changeset/swift-cobras-repair.md
+++ b/.changeset/swift-cobras-repair.md
@@ -1,0 +1,6 @@
+---
+"@workflow/vitest": patch
+"@workflow/world-local": patch
+---
+
+Fix local-world recovery isolation in Vitest and support custom test directories

--- a/docs/content/docs/api-reference/vitest/index.mdx
+++ b/docs/content/docs/api-reference/vitest/index.mdx
@@ -22,6 +22,30 @@ export default defineConfig({
 });
 ```
 
+Pass a [`WorkflowTestOptions`](#workflowtestoptions) object when your project uses a non-standard layout — for example, a monorepo where `workflows/` does not live at the Vitest config's directory, or when the default `.workflow-data` / `.workflow-vitest` output locations need to move. The plugin forwards these paths to `buildWorkflowTests()` and `setupWorkflowTests()` through Vitest's per-project provided context, so each Vitest workspace project stays isolated.
+
+{/* @skip-typecheck - @workflow/vitest not available in docs-typecheck */}
+
+```typescript
+import { defineConfig } from "vitest/config";
+import { workflow } from "@workflow/vitest";
+
+export default defineConfig({
+  plugins: [
+    workflow({
+      cwd: "./apps/api",
+      rootDir: "./apps/api/test-artifacts",
+    }),
+  ],
+});
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `options?` | `WorkflowTestOptions` | Optional configuration |
+
 **Returns:** `Plugin[]`
 
 ## Setup Functions
@@ -83,7 +107,10 @@ Tears down the workflow test world. Clears the global world and closes the Local
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `cwd` | `string` | `process.cwd()` | The working directory of the project (where `workflows/` lives) |
+| `cwd` | `string` | `process.cwd()` | The working directory of the project (where `workflows/` lives). Relative paths resolve against `process.cwd()`. |
+| `rootDir` | `string` | same as `cwd` | Root directory used for default test artifacts. When set, `dataDir` and `outDir` default to `<rootDir>/.workflow-data` and `<rootDir>/.workflow-vitest`. Relative paths resolve against `cwd`. |
+| `dataDir` | `string` | `<rootDir>/.workflow-data` | Directory for workflow runtime data written by the test world. Relative paths resolve against `cwd`. |
+| `outDir` | `string` | `<rootDir>/.workflow-vitest` | Directory for generated workflow and step bundles. Relative paths resolve against `cwd`. |
 
 ## Test Helpers
 

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -150,15 +150,20 @@ export function createDevTests(config?: DevTestConfig) {
     });
 
     afterEach(async () => {
+      // Restore file contents before deleting any files. If a deletion races
+      // ahead of an api-file restore, the dev server briefly sees an import
+      // pointing at a missing module and fails compilation. On Windows that
+      // failure can stick — Turbopack leaves stale imports in the generated
+      // step route bundle — and every subsequent step request returns 500.
+      const toRestore = restoreFiles.filter((item) => item.content !== '');
+      const toDelete = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
-        restoreFiles.map(async (item) => {
-          if (item.content === '') {
-            await fs.unlink(item.path);
-          } else {
-            await fs.writeFile(item.path, item.content);
-          }
-        })
+        toRestore.map((item) => fs.writeFile(item.path, item.content))
       );
+      if (toDelete.length > 0) {
+        await prewarm();
+      }
+      await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
       await prewarm();
       restoreFiles.length = 0;
     });
@@ -251,12 +256,27 @@ export async function ${marker}() {
         );
         restoreFiles.push({ path: importedStepFile, content });
 
+        const apiFile = path.join(appPath, finalConfig.apiFilePath);
+        const apiFileContent = await fs.readFile(apiFile, 'utf8');
+
         await pollUntil({
           description:
             'manifest.json to include imported step hot-reload marker',
           timeoutMs: 50_000,
           check: async () => {
-            await triggerWorkflowRun('importedStepOnlyWorkflow');
+            try {
+              await triggerWorkflowRun('importedStepOnlyWorkflow');
+            } catch (error) {
+              // Turbopack on Windows occasionally caches a stale resolver
+              // failure (e.g. `Could not parse module
+              // '@workflow/core/dist/runtime/start.js'`) after an HMR
+              // cascade and returns 500 to every request until something
+              // invalidates its cache. Rewriting the api file is enough to
+              // force a fresh resolve on the next request, so we treat the
+              // 500 as transient and keep polling instead of bailing out.
+              await fs.writeFile(apiFile, apiFileContent);
+              throw error;
+            }
             const manifestFunctionNames = await readManifestStepFunctionNames();
             expect(manifestFunctionNames).toContain(marker);
           },
@@ -311,7 +331,7 @@ ${apiFileContent}`
 
     test.skipIf(!usesDeferredBuilder)(
       'should include steps discovered from workflow imports',
-      { timeout: 30_000 },
+      { timeout: 60_000 },
       async () => {
         const workflowFile = path.join(
           appPath,
@@ -365,6 +385,39 @@ ${apiFileContent}`
             await fetchWithTimeout('/api/chat');
             const manifestFunctionNames = await readManifestStepFunctionNames();
             expect(manifestFunctionNames).toContain(
+              'discoveredViaWorkflowStep'
+            );
+          },
+        });
+
+        // Tear down in-test (rather than relying on afterEach) so we can wait
+        // for the deferred builder to drop the discovered step from the
+        // manifest before the next test file runs. The generated step route
+        // bundle holds a literal `import '../workflows/discovered-via-workflow-step.ts'`
+        // that is only pruned when the deferred builder rebuilds and
+        // `filterExistingFiles` excludes the now-missing source. On Windows
+        // the rebuild can lag behind the deletion, leaving the bundle
+        // unable to compile and breaking every step request in subsequent
+        // tests (which all share the same dev server).
+        await fs.writeFile(apiFile, apiFileContent);
+        await fs.unlink(workflowFile);
+        await fs.unlink(stepFile);
+        for (const trackedPath of [apiFile, workflowFile, stepFile]) {
+          const idx = restoreFiles.findIndex(
+            (item) => item.path === trackedPath
+          );
+          if (idx !== -1) {
+            restoreFiles.splice(idx, 1);
+          }
+        }
+        await pollUntil({
+          description:
+            'manifest.json to drop discoveredViaWorkflowStep after cleanup',
+          timeoutMs: 25_000,
+          check: async () => {
+            await fetchWithTimeout('/api/chat');
+            const manifestFunctionNames = await readManifestStepFunctionNames();
+            expect(manifestFunctionNames).not.toContain(
               'discoveredViaWorkflowStep'
             );
           },

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "build": "tsc",
     "clean": "tsc --build --clean && rm -rf dist ||:",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run src"
   },
   "dependencies": {
     "@workflow/builders": "workspace:*",
@@ -38,7 +39,8 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@workflow/tsconfig": "workspace:*",
-    "vite": "7.3.2"
+    "vite": "7.3.2",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "vite": ">=6.0.0",

--- a/packages/vitest/src/global-setup.ts
+++ b/packages/vitest/src/global-setup.ts
@@ -1,5 +1,14 @@
+import type { TestProject } from 'vitest/node';
 import { buildWorkflowTests } from './index.js';
+import {
+  readProvidedWorkflowTestOptions,
+  WORKFLOW_VITEST_OPTIONS_KEY,
+} from './options.js';
 
-export async function setup() {
-  await buildWorkflowTests();
+export async function setup(project: TestProject) {
+  await buildWorkflowTests(
+    readProvidedWorkflowTestOptions(
+      project.config.provide?.[WORKFLOW_VITEST_OPTIONS_KEY]
+    )
+  );
 }

--- a/packages/vitest/src/index.test.ts
+++ b/packages/vitest/src/index.test.ts
@@ -1,0 +1,286 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createLocalWorld = vi.fn();
+const initDataDir = vi.fn();
+const setWorld = vi.fn();
+const workflowTransformPlugin = vi.fn((options) => ({
+  name: 'workflow:transform',
+  options,
+}));
+const createBaseBuilderConfig = vi.fn((config) => config);
+const getInputFiles = vi.fn(async () => ['workflows/example.ts']);
+const createWorkflowsBundle = vi.fn(async () => {});
+const createStepsBundle = vi.fn(async () => {});
+const baseBuilderConfigs: unknown[] = [];
+
+vi.mock('@workflow/builders', () => {
+  class BaseBuilder {
+    constructor(config: unknown) {
+      baseBuilderConfigs.push(config);
+    }
+
+    async getInputFiles() {
+      return getInputFiles();
+    }
+
+    async createWorkflowsBundle(args: unknown) {
+      return createWorkflowsBundle(args);
+    }
+
+    async createStepsBundle(args: unknown) {
+      return createStepsBundle(args);
+    }
+  }
+
+  return {
+    BaseBuilder,
+    createBaseBuilderConfig,
+  };
+});
+
+vi.mock('@workflow/core/runtime', () => ({
+  setWorld,
+}));
+
+vi.mock('@workflow/rollup', () => ({
+  workflowTransformPlugin,
+}));
+
+vi.mock('@workflow/world-local', () => ({
+  createLocalWorld,
+  initDataDir,
+}));
+
+type WorkflowVitestModule = typeof import('./index.js');
+
+let loadedModule: WorkflowVitestModule | undefined;
+const tempDirs: string[] = [];
+
+async function loadModule(): Promise<WorkflowVitestModule> {
+  loadedModule ??= await import('./index.js');
+  return loadedModule;
+}
+
+function createMockWorld() {
+  const handlers = new Map<string, (req: Request) => Promise<Response>>();
+  return {
+    handlers,
+    clear: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    registerHandler: vi.fn(
+      (prefix: string, handler: (req: Request) => Promise<Response>) => {
+        handlers.set(prefix, handler);
+      }
+    ),
+    start: vi.fn(async () => {}),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  loadedModule = undefined;
+  baseBuilderConfigs.length = 0;
+  tempDirs.length = 0;
+  delete process.env.VITEST_POOL_ID;
+});
+
+afterEach(async () => {
+  if (loadedModule) {
+    await loadedModule.teardownWorkflowTests();
+  }
+  await Promise.all(
+    tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+describe('@workflow/vitest', () => {
+  it('builds bundles and initializes data in custom directories', async () => {
+    const { buildWorkflowTests } = await loadModule();
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), 'workflow-vitest-build-')
+    );
+    tempDirs.push(rootDir);
+    const cwd = path.resolve('/repo/app');
+
+    await buildWorkflowTests({ cwd, rootDir });
+
+    expect(createBaseBuilderConfig).toHaveBeenCalledWith({
+      workingDir: cwd,
+      dirs: ['.'],
+    });
+    expect(baseBuilderConfigs).toHaveLength(1);
+    expect(createWorkflowsBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outfile: path.join(rootDir, '.workflow-vitest', 'workflows.mjs'),
+      })
+    );
+    expect(createStepsBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outfile: path.join(rootDir, '.workflow-vitest', 'steps.mjs'),
+      })
+    );
+    expect(initDataDir).toHaveBeenCalledWith(
+      path.join(rootDir, '.workflow-data')
+    );
+  });
+
+  it('sets up a local world with custom directories and recovery disabled', async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'workflow-vitest-'));
+    tempDirs.push(tmpDir);
+    const outDir = path.join(tmpDir, 'bundles');
+    const dataDir = path.join(tmpDir, 'data');
+    await mkdir(outDir, { recursive: true });
+    await writeFile(
+      path.join(outDir, 'workflows.mjs'),
+      `export async function POST() { return Response.json({ bundle: 'workflow' }); }`
+    );
+    await writeFile(
+      path.join(outDir, 'steps.mjs'),
+      `export async function POST() { return Response.json({ bundle: 'step' }); }`
+    );
+
+    process.env.VITEST_POOL_ID = '7';
+    const mockWorld = createMockWorld();
+    createLocalWorld.mockReturnValue(mockWorld);
+
+    const { setupWorkflowTests } = await loadModule();
+    await setupWorkflowTests({
+      dataDir,
+      outDir,
+    });
+
+    expect(createLocalWorld).toHaveBeenCalledWith({
+      dataDir,
+      recoverActiveRuns: false,
+      tag: 'vitest-7',
+    });
+    expect(mockWorld.clear).toHaveBeenCalledTimes(1);
+    expect(mockWorld.registerHandler).toHaveBeenCalledTimes(2);
+    expect(mockWorld.start).toHaveBeenCalledTimes(1);
+    expect(mockWorld.registerHandler.mock.invocationCallOrder[1]).toBeLessThan(
+      mockWorld.start.mock.invocationCallOrder[0]
+    );
+    expect(setWorld).toHaveBeenCalledWith(mockWorld);
+
+    const workflowHandler = mockWorld.handlers.get('__wkf_workflow_');
+    const stepHandler = mockWorld.handlers.get('__wkf_step_');
+    expect(workflowHandler).toBeDefined();
+    expect(stepHandler).toBeDefined();
+
+    const workflowResponse = await workflowHandler!(new Request('http://test'));
+    expect(await workflowResponse.json()).toEqual({ bundle: 'workflow' });
+
+    const stepResponse = await stepHandler!(new Request('http://test'));
+    expect(await stepResponse.json()).toEqual({ bundle: 'step' });
+  });
+
+  it('provides project-scoped directory options without mutating process env', async () => {
+    const rootDir = path.resolve('/tmp/workflow-vitest-root');
+    const dataDir = path.resolve('/tmp/workflow-vitest-data');
+    const outDir = path.resolve('/tmp/workflow-vitest-out');
+    const cwd = path.resolve('/repo/app');
+
+    const { workflow } = await loadModule();
+    const plugins = workflow({ cwd, rootDir, dataDir, outDir });
+
+    expect(workflowTransformPlugin).toHaveBeenCalledWith({
+      exclude: [outDir + '/'],
+    });
+
+    const vitestPlugin = plugins[1];
+    expect(vitestPlugin.name).toBe('workflow:vitest');
+    const config = vitestPlugin.config?.() as {
+      test: {
+        provide: Record<string, unknown>;
+      };
+    };
+
+    expect(process.env.WORKFLOW_VITEST_CWD).toBeUndefined();
+    expect(process.env.WORKFLOW_VITEST_ROOT_DIR).toBeUndefined();
+    expect(process.env.WORKFLOW_VITEST_DATA_DIR).toBeUndefined();
+    expect(process.env.WORKFLOW_VITEST_OUT_DIR).toBeUndefined();
+    expect(config.test.provide.__workflowVitestOptions).toEqual({
+      cwd,
+      rootDir,
+      dataDir,
+      outDir,
+    });
+  });
+
+  it('builds from project-scoped options in global setup', async () => {
+    const buildWorkflowTests = vi.fn(async () => {});
+    vi.doMock('./index.js', () => ({
+      buildWorkflowTests,
+    }));
+
+    const cwd = path.resolve('/repo/app');
+    const rootDir = path.join(cwd, 'test-root');
+    const dataDir = path.join(rootDir, '.workflow-data');
+    const outDir = path.join(rootDir, '.workflow-vitest');
+
+    const { setup } = await import('./global-setup.js');
+    await setup({
+      config: {
+        provide: {
+          __workflowVitestOptions: {
+            cwd,
+            rootDir,
+            dataDir,
+            outDir,
+          },
+        },
+      },
+    } as any);
+
+    expect(buildWorkflowTests).toHaveBeenCalledWith({
+      cwd,
+      rootDir,
+      dataDir,
+      outDir,
+    });
+  });
+
+  it('sets up and tears down from project-scoped injected options', async () => {
+    const afterAll = vi.fn();
+    const setupWorkflowTests = vi.fn(async () => {});
+    const teardownWorkflowTests = vi.fn(async () => {});
+
+    const cwd = path.resolve('/repo/app');
+    const rootDir = path.join(cwd, 'test-root');
+    const dataDir = path.join(rootDir, '.workflow-data');
+    const outDir = path.join(rootDir, '.workflow-vitest');
+
+    vi.doMock('vitest', () => ({
+      afterAll,
+      inject: vi.fn(() => ({
+        cwd,
+        rootDir,
+        dataDir,
+        outDir,
+      })),
+    }));
+    vi.doMock('./index.js', () => ({
+      setupWorkflowTests,
+      teardownWorkflowTests,
+    }));
+
+    await import('./setup-file.js');
+
+    expect(setupWorkflowTests).toHaveBeenCalledWith({
+      cwd,
+      rootDir,
+      dataDir,
+      outDir,
+    });
+    expect(afterAll).toHaveBeenCalledTimes(1);
+
+    const teardown = afterAll.mock.calls[0]?.[0];
+    expect(teardown).toBeTypeOf('function');
+    await teardown();
+    expect(teardownWorkflowTests).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -12,6 +12,10 @@ import {
   type LocalWorld,
 } from '@workflow/world-local';
 import type { Plugin } from 'vite';
+import {
+  resolveWorkflowTestOptions,
+  WORKFLOW_VITEST_OPTIONS_KEY,
+} from './options.js';
 
 class VitestBuilder extends BaseBuilder {
   #outDir: string;
@@ -63,10 +67,22 @@ export interface WorkflowTestOptions {
    * Defaults to process.cwd().
    */
   cwd?: string;
-}
-
-function getOutDir(cwd: string): string {
-  return join(cwd, '.workflow-vitest');
+  /**
+   * Root directory used for default test artifacts.
+   * When set, `.workflow-data` and `.workflow-vitest` are created here unless
+   * overridden explicitly with `dataDir` or `outDir`.
+   */
+  rootDir?: string;
+  /**
+   * Directory for workflow runtime data written by the test world.
+   * Defaults to `<rootDir>/.workflow-data`.
+   */
+  dataDir?: string;
+  /**
+   * Directory for generated workflow and step bundles.
+   * Defaults to `<rootDir>/.workflow-vitest`.
+   */
+  outDir?: string;
 }
 
 /**
@@ -84,11 +100,13 @@ function getOutDir(cwd: string): string {
  * });
  * ```
  */
-export function workflow(): Plugin[] {
+export function workflow(options?: WorkflowTestOptions): Plugin[] {
+  const resolvedOptions = resolveWorkflowTestOptions(options);
+  const { outDir } = resolvedOptions;
   const dir = fileURLToPath(new URL('.', import.meta.url));
   return [
     workflowTransformPlugin({
-      exclude: [join(process.cwd(), '.workflow-vitest') + '/'],
+      exclude: [outDir + '/'],
     }),
     {
       name: 'workflow:vitest',
@@ -97,6 +115,9 @@ export function workflow(): Plugin[] {
           test: {
             globalSetup: [join(dir, 'global-setup.js')],
             setupFiles: [join(dir, 'setup-file.js')],
+            provide: {
+              [WORKFLOW_VITEST_OPTIONS_KEY]: resolvedOptions,
+            },
           },
         } as Record<string, unknown>;
       },
@@ -112,12 +133,11 @@ export function workflow(): Plugin[] {
 export async function buildWorkflowTests(
   options?: WorkflowTestOptions
 ): Promise<void> {
-  const cwd = options?.cwd ?? process.cwd();
-  const outDir = getOutDir(cwd);
+  const { cwd, dataDir, outDir } = resolveWorkflowTestOptions(options);
   const builder = new VitestBuilder(cwd, outDir);
   await builder.build();
   // Pre-create the shared data directory so workers don't race on mkdir
-  await initDataDir(join(cwd, '.workflow-data'));
+  await initDataDir(dataDir);
 }
 
 let world: LocalWorld | undefined;
@@ -139,8 +159,7 @@ export async function setupWorkflowTests(
     world = undefined;
   }
 
-  const cwd = options?.cwd ?? process.cwd();
-  const outDir = getOutDir(cwd);
+  const { dataDir, outDir } = resolveWorkflowTestOptions(options);
 
   // Lazy-load bundles on first dispatch instead of eagerly at setup time.
   // Eager native import() during setupFiles loads step dependencies into
@@ -168,13 +187,14 @@ export async function setupWorkflowTests(
   // Each vitest worker uses a unique tag to isolate its test data.
   // All workers write to the shared .workflow-data directory so runs
   // are visible to the observability dashboard, but clear() only
-  // deletes files matching the worker's tag.
+  // deletes files matching the worker's tag. Recovery stays disabled because
+  // tests expect a clean world and register direct handlers after setup begins.
   const poolId = process.env.VITEST_POOL_ID ?? '0';
   world = createLocalWorld({
-    dataDir: join(cwd, '.workflow-data'),
+    dataDir,
+    recoverActiveRuns: false,
     tag: `vitest-${poolId}`,
   });
-  await world.start?.();
   await world.clear();
 
   world.registerHandler(
@@ -186,6 +206,11 @@ export async function setupWorkflowTests(
     createLazyHandler(join(outDir, 'steps.mjs'))
   );
 
+  // Handlers must be registered before start(): if recoverActiveRuns is ever
+  // re-enabled here (or plumbed through from a caller), start() re-enqueues
+  // pending runs and the queue begins dispatching. Registering after start
+  // would race handler installation against that dispatch.
+  await world.start?.();
   setWorld(world);
 }
 

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -1,0 +1,50 @@
+import { join, resolve } from 'node:path';
+import type { WorkflowTestOptions } from './index.js';
+
+export const WORKFLOW_VITEST_OPTIONS_KEY = '__workflowVitestOptions';
+
+export type ResolvedWorkflowTestOptions = {
+  cwd: string;
+  rootDir: string;
+  dataDir: string;
+  outDir: string;
+};
+
+function getDefinedOptions(
+  options?: WorkflowTestOptions
+): Partial<WorkflowTestOptions> {
+  if (!options) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(options).filter(([, value]) => value !== undefined)
+  );
+}
+
+export function resolveWorkflowTestOptions(
+  options?: WorkflowTestOptions
+): ResolvedWorkflowTestOptions {
+  const mergedOptions = getDefinedOptions(options);
+  const cwd = resolve(mergedOptions.cwd ?? process.cwd());
+  const rootDir = mergedOptions.rootDir
+    ? resolve(cwd, mergedOptions.rootDir)
+    : cwd;
+
+  return {
+    cwd,
+    rootDir,
+    dataDir: mergedOptions.dataDir
+      ? resolve(cwd, mergedOptions.dataDir)
+      : join(rootDir, '.workflow-data'),
+    outDir: mergedOptions.outDir
+      ? resolve(cwd, mergedOptions.outDir)
+      : join(rootDir, '.workflow-vitest'),
+  };
+}
+
+export function readProvidedWorkflowTestOptions(
+  value: unknown
+): ResolvedWorkflowTestOptions {
+  return resolveWorkflowTestOptions(value as WorkflowTestOptions | undefined);
+}

--- a/packages/vitest/src/setup-file.ts
+++ b/packages/vitest/src/setup-file.ts
@@ -1,7 +1,13 @@
-import { afterAll } from 'vitest';
+import { afterAll, inject } from 'vitest';
 import { setupWorkflowTests, teardownWorkflowTests } from './index.js';
+import {
+  readProvidedWorkflowTestOptions,
+  WORKFLOW_VITEST_OPTIONS_KEY,
+} from './options.js';
 
-await setupWorkflowTests();
+await setupWorkflowTests(
+  readProvidedWorkflowTestOptions(inject(WORKFLOW_VITEST_OPTIONS_KEY))
+);
 
 afterAll(async () => {
   await teardownWorkflowTests();

--- a/packages/vitest/src/vitest-context.d.ts
+++ b/packages/vitest/src/vitest-context.d.ts
@@ -1,0 +1,10 @@
+import 'vitest';
+import type { ResolvedWorkflowTestOptions } from './options.js';
+
+declare module 'vitest' {
+  interface ProvidedContext {
+    __workflowVitestOptions: ResolvedWorkflowTestOptions;
+  }
+}
+
+export {};

--- a/packages/world-local/src/config.ts
+++ b/packages/world-local/src/config.ts
@@ -16,6 +16,12 @@ export type Config = {
   port?: number;
   baseUrl?: string;
   /**
+   * Whether start() should re-enqueue pending/running runs from storage.
+   * Defaults to true. Test harnesses that always start from a clean slate can
+   * disable recovery to avoid replaying stale runs.
+   */
+  recoverActiveRuns?: boolean;
+  /**
    * Optional tag to scope filesystem operations.
    * When set, files are written as `{id}.{tag}.json` and `clear()` only deletes
    * files matching this tag. Used by vitest to isolate test data in the shared

--- a/packages/world-local/src/fs.test.ts
+++ b/packages/world-local/src/fs.test.ts
@@ -590,6 +590,71 @@ describe('fs utilities', () => {
         assert(result.data[0], 'expected first result to be defined');
         expect(result.data[0].name).toBe('prefixed-1');
       });
+
+      it('keeps fileIdFilter applied on later cursor pages', async () => {
+        const pageDir = await fs.mkdtemp(
+          path.join(os.tmpdir(), 'fileid-filter-pagination-')
+        );
+        const baseTime = new Date('2024-01-01T00:00:00.000Z').getTime();
+        const ulidAfter = createUlidAfter(baseTime);
+
+        try {
+          const files: Record<string, object> = {};
+          for (let i = 0; i < 5; i++) {
+            const fileId = `match_${ulidAfter(`${i}m`)}`;
+            files[fileId] = {
+              id: fileId,
+              name: `match-${i}`,
+              createdAt: new Date(baseTime + ms(`${i}m`)),
+            };
+          }
+
+          for (let i = 5; i < 8; i++) {
+            const fileId = `other_${ulidAfter(`${i}m`)}`;
+            files[fileId] = {
+              id: fileId,
+              name: `other-${i}`,
+              createdAt: new Date(baseTime + ms(`${i}m`)),
+            };
+          }
+
+          await createFilesystem(pageDir, files);
+
+          const firstPage = await paginatedFileSystemQuery({
+            directory: pageDir,
+            schema: TestItemSchema,
+            fileIdFilter: (fileId) => fileId.startsWith('match_'),
+            getCreatedAt: getPrefixCreatedAt,
+            getId: (item) => item.id,
+            limit: 2,
+            sortOrder: 'desc',
+          });
+
+          expect(firstPage.data).toHaveLength(2);
+          expect(
+            firstPage.data.every((item) => item.id.startsWith('match_'))
+          ).toBe(true);
+          assert(firstPage.cursor, 'expected first page cursor to be defined');
+
+          const secondPage = await paginatedFileSystemQuery({
+            directory: pageDir,
+            schema: TestItemSchema,
+            fileIdFilter: (fileId) => fileId.startsWith('match_'),
+            getCreatedAt: getPrefixCreatedAt,
+            getId: (item) => item.id,
+            limit: 2,
+            cursor: firstPage.cursor,
+            sortOrder: 'desc',
+          });
+
+          expect(secondPage.data).toHaveLength(2);
+          expect(
+            secondPage.data.every((item) => item.id.startsWith('match_'))
+          ).toBe(true);
+        } finally {
+          await fs.rm(pageDir, { recursive: true, force: true });
+        }
+      });
     });
 
     describe('error handling', () => {

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -153,6 +153,15 @@ export function stripTag(fileId: string): string {
 }
 
 /**
+ * Check whether a fileId belongs to a specific tag.
+ * `wrun_ABC.vitest-0` belongs to `vitest-0`.
+ * Untagged fileIds never match a tag-scoped lookup.
+ */
+export function hasTag(fileId: string, tag: string): boolean {
+  return fileId.endsWith(`.${tag}`);
+}
+
+/**
  * Build the file path for an entity, with optional tag embedded in the filename.
  * `taggedPath('/data', 'runs', 'wrun_ABC', 'vitest-0')` → `/data/runs/wrun_ABC.vitest-0.json`
  * `taggedPath('/data', 'runs', 'wrun_ABC')` → `/data/runs/wrun_ABC.json`
@@ -414,6 +423,7 @@ interface PaginatedFileSystemQueryConfig<T> {
   directory: string;
   schema: z.ZodType<T>;
   filePrefix?: string;
+  fileIdFilter?: (fileId: string) => boolean;
   filter?: (item: T) => boolean;
   sortOrder?: 'asc' | 'desc';
   limit?: number;
@@ -448,6 +458,7 @@ export async function paginatedFileSystemQuery<T extends { createdAt: Date }>(
     directory,
     schema,
     filePrefix,
+    fileIdFilter,
     filter,
     sortOrder = 'desc',
     limit = 20,
@@ -472,13 +483,16 @@ export async function paginatedFileSystemQuery<T extends { createdAt: Date }>(
   const relevantFileIds = filePrefix
     ? fileIds.filter((fileId) => fileId.startsWith(filePrefix))
     : fileIds;
+  const filteredFileIds = fileIdFilter
+    ? relevantFileIds.filter(fileIdFilter)
+    : relevantFileIds;
 
   // 3. ULID Optimization: Filter by cursor using filename timestamps before loading JSON
   const parsedCursor = parseCursor(cursor);
-  let candidateFileIds = relevantFileIds;
+  let candidateFileIds = filteredFileIds;
 
   if (parsedCursor) {
-    candidateFileIds = relevantFileIds.filter((fileId) => {
+    candidateFileIds = filteredFileIds.filter((fileId) => {
       const filenameDate = getCreatedAt(`${fileId}.json`);
       if (filenameDate) {
         // Use filename timestamp for cursor filtering

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -8,6 +8,7 @@ import { config } from './config.js';
 import {
   clearCreatedFilesCache,
   deleteJSON,
+  hasTag,
   listTaggedFiles,
   listTaggedFilesByExtension,
   readJSON,
@@ -48,6 +49,7 @@ export type LocalWorld = World & {
  * @param args.dataDir - Directory for storing workflow data (default: `.workflow-data/`)
  * @param args.port - Port override for queue transport (default: auto-detected)
  * @param args.baseUrl - Full base URL override for queue transport (default: `http://localhost:{port}`)
+ * @param args.recoverActiveRuns - Whether `start()` should re-enqueue pending/running runs from storage (default: `true`)
  * @param args.tag - Optional tag to scope files (e.g., `vitest-0`). When set, files are written
  *   as `{id}.{tag}.json` and `clear()` only deletes files matching this tag.
  * @throws {DataDirAccessError} If the data directory cannot be created or accessed
@@ -63,10 +65,11 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
   const tag = mergedConfig.tag;
   const queue = createQueue(mergedConfig);
   const storage = createStorage(mergedConfig.dataDir, tag);
+  const recoverActiveRuns = mergedConfig.recoverActiveRuns ?? true;
   return {
     specVersion: SPEC_VERSION_CURRENT,
     ...queue,
-    ...createStorage(mergedConfig.dataDir, tag),
+    ...storage,
     ...instrumentObject('world.streams', {
       ...createStreamer(mergedConfig.dataDir, tag),
       ...(mergedConfig.streamFlushIntervalMs !== undefined && {
@@ -75,7 +78,20 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
     }),
     async start() {
       await initDataDir(mergedConfig.dataDir);
-      await reenqueueActiveRuns(storage.runs, queue.queue, 'world-local');
+      if (!recoverActiveRuns) {
+        return;
+      }
+      const recoveryRuns = tag
+        ? {
+            ...storage.runs,
+            list: ((params) =>
+              storage.runs.list({
+                ...params,
+                fileIdFilter: (fileId) => hasTag(fileId, tag),
+              })) as typeof storage.runs.list,
+          }
+        : storage.runs;
+      await reenqueueActiveRuns(recoveryRuns, queue.queue, 'world-local');
     },
     async close() {
       await queue.close();

--- a/packages/world-local/src/reenqueue.test.ts
+++ b/packages/world-local/src/reenqueue.test.ts
@@ -121,6 +121,139 @@ describe('re-enqueue active runs on start', () => {
     await world2.close();
   });
 
+  it('only re-enqueues runs for the matching tag', async () => {
+    const world0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    await world0.start();
+
+    const run0 = await createRun(world0, {
+      deploymentId: 'dpl_1',
+      workflowName: 'taggedWorkflow0',
+      input: new Uint8Array([1]),
+    });
+
+    const world1 = createLocalWorld({ dataDir, tag: 'vitest-1' });
+    const run1 = await createRun(world1, {
+      deploymentId: 'dpl_1',
+      workflowName: 'taggedWorkflow1',
+      input: new Uint8Array([2]),
+    });
+
+    await world0.close();
+    await world1.close();
+
+    const restartedWorld0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    const receivedRunIds: string[] = [];
+    restartedWorld0.registerHandler('__wkf_workflow_', async (req) => {
+      const body = await req.json();
+      receivedRunIds.push(body.runId);
+      return Response.json({ ok: true });
+    });
+
+    await restartedWorld0.start();
+
+    await vi.waitFor(() => {
+      expect(receivedRunIds).toEqual([run0.runId]);
+    });
+
+    expect(receivedRunIds).not.toContain(run1.runId);
+
+    await restartedWorld0.close();
+  });
+
+  it('keeps tag filtering when recovery paginates across multiple pages', async () => {
+    const world0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    const world1 = createLocalWorld({ dataDir, tag: 'vitest-1' });
+    const untaggedWorld = createLocalWorld({ dataDir });
+
+    await world0.start();
+    await world1.start();
+    await untaggedWorld.start();
+
+    const taggedRunIds: string[] = [];
+    const otherRunIds: string[] = [];
+
+    for (let i = 0; i < 25; i++) {
+      const run = await createRun(world0, {
+        deploymentId: 'dpl_1',
+        workflowName: `taggedWorkflow${i}`,
+        input: new Uint8Array([i]),
+      });
+      taggedRunIds.push(run.runId);
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const run = await createRun(world1, {
+        deploymentId: 'dpl_1',
+        workflowName: `otherTaggedWorkflow${i}`,
+        input: new Uint8Array([i]),
+      });
+      otherRunIds.push(run.runId);
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const run = await createRun(untaggedWorld, {
+        deploymentId: 'dpl_1',
+        workflowName: `untaggedWorkflow${i}`,
+        input: new Uint8Array([i]),
+      });
+      otherRunIds.push(run.runId);
+    }
+
+    await world0.close();
+    await world1.close();
+    await untaggedWorld.close();
+
+    const restartedWorld0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    const receivedRunIds: string[] = [];
+    restartedWorld0.registerHandler('__wkf_workflow_', async (req) => {
+      const body = await req.json();
+      receivedRunIds.push(body.runId);
+      return Response.json({ ok: true });
+    });
+
+    await restartedWorld0.start();
+
+    await vi.waitFor(() => {
+      expect(receivedRunIds).toHaveLength(taggedRunIds.length);
+    });
+
+    expect(new Set(receivedRunIds)).toEqual(new Set(taggedRunIds));
+    for (const runId of otherRunIds) {
+      expect(receivedRunIds).not.toContain(runId);
+    }
+
+    await restartedWorld0.close();
+  });
+
+  it('skips startup recovery when recoverActiveRuns is false', async () => {
+    const world1 = createLocalWorld({ dataDir });
+    await world1.start();
+
+    const run = await createRun(world1, {
+      deploymentId: 'dpl_1',
+      workflowName: 'myWorkflow',
+      input: new Uint8Array([1]),
+    });
+
+    await world1.close();
+
+    const world2 = createLocalWorld({ dataDir, recoverActiveRuns: false });
+    const receivedRunIds: string[] = [];
+    world2.registerHandler('__wkf_workflow_', async (req) => {
+      const body = await req.json();
+      receivedRunIds.push(body.runId);
+      return Response.json({ ok: true });
+    });
+
+    await world2.start();
+
+    await new Promise((r) => globalThis.setTimeout(r, 50));
+    expect(receivedRunIds).toHaveLength(0);
+    expect(receivedRunIds).not.toContain(run.runId);
+
+    await world2.close();
+  });
+
   it('does nothing on first start with empty data dir', async () => {
     const world = createLocalWorld({ dataDir });
     const receivedRunIds: string[] = [];

--- a/packages/world-local/src/storage/index.ts
+++ b/packages/world-local/src/storage/index.ts
@@ -2,8 +2,15 @@ import type { Storage } from '@workflow/world';
 import { instrumentObject } from '../instrumentObject.js';
 import { createEventsStorage } from './events-storage.js';
 import { createHooksStorage } from './hooks-storage.js';
-import { createRunsStorage } from './runs-storage.js';
+import { createRunsStorage, type LocalRunsStorage } from './runs-storage.js';
 import { createStepsStorage } from './steps-storage.js';
+
+/**
+ * Storage shape used inside world-local: identical to `Storage`, but `runs`
+ * exposes the internal `fileIdFilter` option on `list()`. Structurally
+ * assignable to `Storage` at public boundaries (e.g., `reenqueueActiveRuns`).
+ */
+export type LocalStorage = Omit<Storage, 'runs'> & { runs: LocalRunsStorage };
 
 /**
  * Creates a complete storage implementation using the filesystem.
@@ -14,21 +21,19 @@ import { createStepsStorage } from './steps-storage.js';
  * @param basedir - The base directory for storing workflow data
  * @returns A complete Storage implementation with tracing
  */
-export function createStorage(basedir: string, tag?: string): Storage {
+export function createStorage(basedir: string, tag?: string): LocalStorage {
   // Create raw storage implementations
-  const storage: Storage = {
-    runs: createRunsStorage(basedir, tag),
-    steps: createStepsStorage(basedir, tag),
-    events: createEventsStorage(basedir, tag),
-    hooks: createHooksStorage(basedir, tag),
-  };
+  const runs = createRunsStorage(basedir, tag);
+  const steps = createStepsStorage(basedir, tag);
+  const events = createEventsStorage(basedir, tag);
+  const hooks = createHooksStorage(basedir, tag);
 
   // Instrument all storage methods with tracing
   // NOTE: Span names are lowercase per OTEL semantic conventions
   return {
-    runs: instrumentObject('world.runs', storage.runs),
-    steps: instrumentObject('world.steps', storage.steps),
-    events: instrumentObject('world.events', storage.events),
-    hooks: instrumentObject('world.hooks', storage.hooks),
+    runs: instrumentObject('world.runs', runs),
+    steps: instrumentObject('world.steps', steps),
+    events: instrumentObject('world.events', events),
+    hooks: instrumentObject('world.hooks', hooks),
   };
 }

--- a/packages/world-local/src/storage/runs-storage.ts
+++ b/packages/world-local/src/storage/runs-storage.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
 import { WorkflowRunNotFoundError } from '@workflow/errors';
-import type { Storage, WorkflowRunWithoutData } from '@workflow/world';
+import type {
+  ListWorkflowRunsParams,
+  PaginatedResponse,
+  Storage,
+  WorkflowRun,
+  WorkflowRunWithoutData,
+} from '@workflow/world';
 import { WorkflowRunSchema } from '@workflow/world';
 import { DEFAULT_RESOLVE_DATA_OPTION } from '../config.js';
 import {
@@ -12,13 +18,39 @@ import { filterRunData } from './filters.js';
 import { getObjectCreatedAt } from './helpers.js';
 
 /**
+ * Internal extension of `ListWorkflowRunsParams` that adds a `fileIdFilter`
+ * for scoping queries by raw filename (e.g., by tag suffix). Kept out of the
+ * public `Storage['runs']['list']` surface — consumers of `@workflow/world`
+ * must not see this option.
+ */
+export interface LocalListWorkflowRunsParams extends ListWorkflowRunsParams {
+  fileIdFilter?: (fileId: string) => boolean;
+}
+
+export interface LocalRunsStorage {
+  get: Storage['runs']['get'];
+  list: {
+    (
+      params: LocalListWorkflowRunsParams & { resolveData: 'none' }
+    ): Promise<PaginatedResponse<WorkflowRunWithoutData>>;
+    (
+      params?: LocalListWorkflowRunsParams & { resolveData?: 'all' }
+    ): Promise<PaginatedResponse<WorkflowRun>>;
+    (
+      params?: LocalListWorkflowRunsParams
+    ): Promise<PaginatedResponse<WorkflowRun | WorkflowRunWithoutData>>;
+  };
+}
+
+/**
  * Creates the runs storage implementation using the filesystem.
- * Implements the Storage['runs'] interface with get and list operations.
+ * Implements the Storage['runs'] interface with get and list operations,
+ * plus an internal `fileIdFilter` on `list` for tag-scoped recovery queries.
  */
 export function createRunsStorage(
   basedir: string,
   tag?: string
-): Storage['runs'] {
+): LocalRunsStorage {
   return {
     get: (async (id: string, params?: any) => {
       assertSafeEntityId('runId', id);
@@ -36,11 +68,12 @@ export function createRunsStorage(
       return filterRunData(run, resolveData);
     }) as Storage['runs']['get'],
 
-    list: (async (params?: any) => {
+    list: (async (params?: LocalListWorkflowRunsParams) => {
       const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
       const result = await paginatedFileSystemQuery({
         directory: path.join(basedir, 'runs'),
         schema: WorkflowRunSchema,
+        fileIdFilter: params?.fileIdFilter,
         filter: (run) => {
           if (
             params?.workflowName &&
@@ -73,6 +106,6 @@ export function createRunsStorage(
       }
 
       return result;
-    }) as Storage['runs']['list'],
+    }) as LocalRunsStorage['list'],
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -991,9 +991,6 @@ importers:
       '@workflow/world-local':
         specifier: workspace:*
         version: link:../world-local
-      vitest:
-        specifier: '>=3.0.0'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1004,6 +1001,9 @@ importers:
       vite:
         specifier: 7.3.2
         version: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
   packages/web:
     dependencies:


### PR DESCRIPTION
## Summary

Closes https://github.com/vercel/workflow/pull/1818

Squashes the contents of #1818 (vitest project-context isolation + world-local recovery scoping by Tom Dale) together with two follow-up fixes for the e2e dev tests that surfaced once the vitest changes restored test isolation:

- **`@workflow/vitest` project-scoped context.** `workflow()` resolves `cwd`, `rootDir`, `dataDir`, and `outDir` once and passes them through Vitest's per-project provided context. `global-setup` and `setup-file` consume that resolved state instead of reading process-wide env vars, so workspace projects and config reloads no longer leak paths into one another. Adds a unit test suite for the harness.
- **`world-local` recovery scoped by tag.** `paginatedFileSystemQuery` now keeps `fileIdFilter` applied across cursor pages (previously dropped after page one). `start()` gains a `recoverActiveRuns` opt-out, used by the Vitest harness so worker startup does not re-enqueue stale runs before direct handlers are registered.
- **Dev test cleanup hardening.** `should include steps discovered from workflow imports` now tears down in-test and waits for the deferred builder to drop the discovered step from the manifest before the next test file runs, instead of relying on `afterEach`. `should rebuild on imported step dependency change` swallows the Turbopack-on-Windows `MODULE_UNPARSABLE` flake by rewriting the api file to invalidate Turbopack's bad cache and retrying. Both addressed cases where the Windows E2E job would burn its full 30-minute timeout polling stuck workflow runs.

## Test plan

- [ ] All Tests CI checks pass on Windows (the Turbopack flake is the focus)
- [ ] `pnpm exec vitest run packages/vitest/src/index.test.ts packages/world-local/src/fs.test.ts packages/world-local/src/reenqueue.test.ts`
- [ ] `pnpm exec tsc -p packages/vitest/tsconfig.json --noEmit`
- [ ] `pnpm exec tsc -p packages/world-local/tsconfig.json --noEmit`
- [ ] Manual e2e against nextjs-turbopack workbench: dev tests + `e2e.test.ts` succeed against the same dev server (verified locally on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)