### PR TITLE
[backport] ci: switch Vercel deployment-protection bypass to OIDC Trusted Sources (#1882)

### DIFF
--- a/.changeset/world-vercel-trusted-sources.md
+++ b/.changeset/world-vercel-trusted-sources.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": minor
+---
+
+Switch the workflow-server Deployment Protection bypass to OIDC Trusted Sources. The `VERCEL_WORKFLOW_SERVER_PROTECTION_BYPASS` env var is no longer used; the `x-vercel-trusted-oidc-idp-token` header is now sourced from `getVercelOidcToken()`.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -335,6 +335,10 @@ jobs:
     needs: build
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
     timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: read
+      deployments: read
     strategy:
       fail-fast: false
       matrix:
@@ -400,7 +404,13 @@ jobs:
           WORKFLOW_VERCEL_TEAM: "team_nO2mCG4W8IxPIeKoSsqwAxxB"
           WORKFLOW_VERCEL_PROJECT: ${{ matrix.app.project-id }}
           WORKFLOW_VERCEL_PROJECT_SLUG: ${{ matrix.app.project-slug }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          # Trusted-sources OIDC token is minted on demand by
+          # scripts/trusted-sources-headers.mjs via the runner's
+          # ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN env vars (auto-set when
+          # `permissions: id-token: write` is on the job) and re-minted
+          # before its 5-minute expiry, so long benchmark runs keep a
+          # fresh token throughout.
+          # See: https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/trusted-sources
           # Run full suite on nextjs-turbopack only (stress tests are too slow to run on all apps)
           BENCHMARK_FULL_SUITE: ${{ matrix.app.name == 'nextjs-turbopack' && ((github.event_name == 'workflow_dispatch' && inputs.full_suite) || contains(github.event.pull_request.labels.*.name, 'stress-test')) }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,6 +213,10 @@ jobs:
     name: E2E Vercel Prod Tests (${{ matrix.app.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+      deployments: read
     strategy:
       fail-fast: false
       matrix:
@@ -291,7 +295,17 @@ jobs:
           WORKFLOW_VERCEL_TEAM: "team_nO2mCG4W8IxPIeKoSsqwAxxB"
           WORKFLOW_VERCEL_PROJECT: ${{ matrix.app.project-id }}
           WORKFLOW_VERCEL_PROJECT_SLUG: ${{ matrix.app.project-slug }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          # The trusted-sources OIDC token (x-vercel-trusted-oidc-idp-token)
+          # is minted on demand inside `scripts/trusted-sources-headers.mjs`
+          # via the runner's ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN env vars
+          # (exposed when `permissions: id-token: write` is set on the job),
+          # and re-minted before its 5-minute expiry. This lets long e2e
+          # suites keep a fresh token throughout the run instead of using
+          # a single pre-minted token that would expire mid-suite.
+          # See: https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/trusted-sources
+          # Point PRs at the protected workflow-server preview; unset on main
+          # so production runs hit the public vercel-workflow.com URL.
+          VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
 
       - name: Generate E2E summary
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,14 +87,43 @@ pkill -f "pnpm dev"
 # To run specific tests, use the -t flag:
 DEPLOYMENT_URL="http://localhost:3000" APP_NAME="nextjs-turbopack" pnpm vitest run packages/core/e2e/e2e.test.ts -t "sleeping"
 
-# For production testing against deployed Vercel app:
-# See .github/workflows/tests.yml for required environment variables:
-# - DEPLOYMENT_URL: URL of deployed app
-# - APP_NAME: App name (example, nextjs-turbopack, nextjs-webpack, nitro)
-# - WORKFLOW_VERCEL_ENV: Environment (production or preview)
-# - WORKFLOW_VERCEL_AUTH_TOKEN: Vercel auth token
-# - WORKFLOW_VERCEL_TEAM: Vercel team ID
-# - WORKFLOW_VERCEL_PROJECT: Vercel project ID
+# For running E2E locally against a deployed Vercel preview/production app:
+# The test matrix in .github/workflows/tests.yml is the source of truth —
+# each app entry defines the project-id / project-slug needed below.
+#
+# Required environment variables (matches the CI `e2e-vercel-prod` job):
+# - DEPLOYMENT_URL: Full URL of the deployed app (e.g. a preview deployment URL)
+# - VERCEL_DEPLOYMENT_ID: The dpl_... ID of the deployment (get via `vercel inspect <url>`)
+# - APP_NAME: App name (example, nextjs-turbopack, nextjs-webpack, nitro, vite,
+#             nuxt, sveltekit, hono, express, fastify, astro)
+# - WORKFLOW_VERCEL_ENV: "preview" or "production"
+# - WORKFLOW_VERCEL_AUTH_TOKEN: Vercel auth token with access to the team
+# - WORKFLOW_VERCEL_TEAM: Vercel team ID (CI uses team_nO2mCG4W8IxPIeKoSsqwAxxB for labs)
+# - WORKFLOW_VERCEL_PROJECT: Vercel project ID (prj_...) — see test matrix
+# - WORKFLOW_VERCEL_PROJECT_SLUG: Vercel project slug — see test matrix
+# - VERCEL_OIDC_TOKEN:         Short-lived OIDC token used to bypass
+#                              deployment protection via Trusted Sources.
+#                              In CI this is auto-minted from the GitHub
+#                              Actions runner. Locally, run
+#                              `vercel env pull` from any workbench app's
+#                              directory and the resulting `.env.local`
+#                              will contain a `VERCEL_OIDC_TOKEN` value
+#                              that all workbench projects accept (they
+#                              are configured to trust each other under
+#                              `trustedSources.projects`).
+#
+# Example (nextjs-turbopack preview deployment):
+NODE_OPTIONS="--enable-source-maps" \
+DEPLOYMENT_URL="https://example-nextjs-workflow-turbopack-<hash>.labs.vercel.dev" \
+VERCEL_DEPLOYMENT_ID="dpl_..." \
+APP_NAME="nextjs-turbopack" \
+WORKFLOW_VERCEL_ENV="preview" \
+WORKFLOW_VERCEL_AUTH_TOKEN="<vercel_labs_token>" \
+WORKFLOW_VERCEL_TEAM="team_nO2mCG4W8IxPIeKoSsqwAxxB" \
+WORKFLOW_VERCEL_PROJECT="prj_yjkM7UdHliv8bfxZ1sMJQf1pMpdi" \
+WORKFLOW_VERCEL_PROJECT_SLUG="example-nextjs-workflow-turbopack" \
+VERCEL_OIDC_TOKEN="$(grep VERCEL_OIDC_TOKEN workbench/nextjs-turbopack/.env.local | cut -d= -f2-)" \
+pnpm run test:e2e
 ```
 
 ### Example App Development

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -2,13 +2,10 @@ import { createVercelWorld } from '@workflow/world-vercel';
 import fs from 'fs';
 import path from 'path';
 import { bench, describe } from 'vitest';
+import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
 import { setWorld, start } from '../src/runtime';
-import {
-  getProtectionBypassHeaders,
-  getWorkbenchAppPath,
-  isLocalDeployment,
-} from './utils';
+import { getWorkbenchAppPath, isLocalDeployment } from './utils';
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
 if (!deploymentUrl) {
@@ -59,7 +56,7 @@ async function fetchManifest(): Promise<WorkflowManifest> {
   if (cachedManifest) return cachedManifest;
   const url = new URL('/.well-known/workflow/v1/manifest.json', deploymentUrl);
   const res = await fetch(url, {
-    headers: getProtectionBypassHeaders(),
+    headers: await getTrustedSourcesHeaders(),
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) {

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -16,6 +16,7 @@ import {
   expect,
   test,
 } from 'vitest';
+import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
 import {
   getHookByToken,
@@ -31,7 +32,6 @@ import {
   cliInspectJson,
   fetchManifest,
   getCollectedRunIds,
-  getProtectionBypassHeaders,
   getWorkflowMetadata,
   hasStepSourceMaps,
   hasWorkflowSourceMaps,
@@ -117,7 +117,7 @@ async function startWorkflowViaHttp(
   const res = await fetch(url, {
     method: 'POST',
     headers: {
-      ...getProtectionBypassHeaders(),
+      ...(await getTrustedSourcesHeaders()),
     },
   });
   if (!res.ok) {
@@ -379,7 +379,7 @@ describe('e2e', () => {
         ),
         {
           method: 'POST',
-          headers: getProtectionBypassHeaders(),
+          headers: await getTrustedSourcesHeaders(),
           body: JSON.stringify({ message: 'should-be-rejected' }),
         }
       );
@@ -434,7 +434,7 @@ describe('e2e', () => {
       ),
       {
         method: 'POST',
-        headers: getProtectionBypassHeaders(),
+        headers: await getTrustedSourcesHeaders(),
         body: JSON.stringify({ message: 'one' }),
       }
     );
@@ -450,7 +450,7 @@ describe('e2e', () => {
       ),
       {
         method: 'POST',
-        headers: getProtectionBypassHeaders(),
+        headers: await getTrustedSourcesHeaders(),
         body: JSON.stringify({ message: 'two' }),
       }
     );
@@ -466,7 +466,7 @@ describe('e2e', () => {
       ),
       {
         method: 'POST',
-        headers: getProtectionBypassHeaders(),
+        headers: await getTrustedSourcesHeaders(),
         body: JSON.stringify({ message: 'three' }),
       }
     );
@@ -511,7 +511,7 @@ describe('e2e', () => {
     );
     const res = await fetch(invalidWebhookUrl, {
       method: 'POST',
-      headers: getProtectionBypassHeaders(),
+      headers: await getTrustedSourcesHeaders(),
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(404);
@@ -1174,7 +1174,7 @@ describe('e2e', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...getProtectionBypassHeaders(),
+          ...(await getTrustedSourcesHeaders()),
         },
         body: JSON.stringify({ x: 3, y: 5 }),
       });
@@ -1531,7 +1531,7 @@ describe('e2e', () => {
       );
       const flowRes = await fetch(flowHealthUrl, {
         method: 'POST',
-        headers: getProtectionBypassHeaders(),
+        headers: await getTrustedSourcesHeaders(),
       });
       expect(flowRes.status).toBe(200);
       expect(flowRes.headers.get('Content-Type')).toBe('application/json');
@@ -1553,7 +1553,7 @@ describe('e2e', () => {
       );
       const stepRes = await fetch(stepHealthUrl, {
         method: 'POST',
-        headers: getProtectionBypassHeaders(),
+        headers: await getTrustedSourcesHeaders(),
       });
       expect(stepRes.status).toBe(200);
       expect(stepRes.headers.get('Content-Type')).toBe('application/json');

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -5,6 +5,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import { createVercelWorld } from '@workflow/world-vercel';
 import { onTestFailed } from 'vitest';
+import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
 import { getWorld, setWorld } from '../src/runtime';
 
@@ -191,20 +192,6 @@ const awaitCommand = async (
   );
 };
 
-/**
- * Returns headers needed to bypass Vercel Deployment Protection.
- * When VERCEL_AUTOMATION_BYPASS_SECRET is set, includes the x-vercel-protection-bypass header.
- */
-export function getProtectionBypassHeaders(): HeadersInit {
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    return {
-      'x-vercel-protection-bypass': bypassSecret,
-    };
-  }
-  return {};
-}
-
 export const cliInspectJson = async (args: string) => {
   const cliAppPath = getWorkbenchAppPath();
   const cliArgs = splitArgs(getCliArgs());
@@ -297,7 +284,7 @@ export async function fetchManifest(
 
   const url = new URL('/.well-known/workflow/v1/manifest.json', deploymentUrl);
   const res = await fetch(url, {
-    headers: getProtectionBypassHeaders(),
+    headers: await getTrustedSourcesHeaders(),
   });
   if (!res.ok) {
     throw new Error(

--- a/packages/world-vercel/src/encryption.ts
+++ b/packages/world-vercel/src/encryption.ts
@@ -123,7 +123,7 @@ export async function fetchRunKey(
     {
       method: 'GET',
       headers: {
-        authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       },
       // @ts-expect-error -- undici dispatcher is accepted by Node.js fetch but not in @types/node's RequestInit
       dispatcher: getDispatcher(),

--- a/packages/world-vercel/src/resolve-latest-deployment.test.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.test.ts
@@ -56,7 +56,7 @@ describe('createResolveLatestDeploymentId', () => {
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({
-          authorization: 'Bearer test-token',
+          Authorization: 'Bearer test-token',
         }),
       })
     );
@@ -114,7 +114,7 @@ describe('createResolveLatestDeploymentId', () => {
       expect.any(String),
       expect.objectContaining({
         headers: expect.objectContaining({
-          authorization: 'Bearer env-token-123',
+          Authorization: 'Bearer env-token-123',
         }),
       })
     );
@@ -152,7 +152,7 @@ describe('createResolveLatestDeploymentId', () => {
       expect.any(String),
       expect.objectContaining({
         headers: expect.objectContaining({
-          authorization: 'Bearer oidc-token-456',
+          Authorization: 'Bearer oidc-token-456',
         }),
       })
     );

--- a/packages/world-vercel/src/resolve-latest-deployment.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.ts
@@ -55,7 +55,7 @@ export function createResolveLatestDeploymentId(
     const response = await fetch(url, {
       method: 'GET',
       headers: {
-        authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       },
       // @ts-expect-error -- undici dispatcher is accepted by Node.js fetch but not in @types/node's RequestInit
       dispatcher: getDispatcher(),

--- a/packages/world-vercel/src/utils.test.ts
+++ b/packages/world-vercel/src/utils.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getHeaders, getHttpConfig, getHttpUrl } from './utils.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn().mockRejectedValue(new Error('no OIDC')),
+}));
+
+describe('getHttpUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.VERCEL_WORKFLOW_SERVER_URL;
+    delete process.env.WORKFLOW_VERCEL_BACKEND_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses default workflow-server URL when no config and no env override', () => {
+    expect(getHttpUrl()).toEqual({
+      baseUrl: 'https://vercel-workflow.com/api',
+      usingProxy: false,
+    });
+  });
+
+  it('respects VERCEL_WORKFLOW_SERVER_URL when set (no proxy)', () => {
+    process.env.VERCEL_WORKFLOW_SERVER_URL = 'https://custom-host.example.com';
+    expect(getHttpUrl()).toEqual({
+      baseUrl: 'https://custom-host.example.com/api',
+      usingProxy: false,
+    });
+  });
+
+  it('uses proxy when projectId + teamId are provided', () => {
+    expect(
+      getHttpUrl({
+        projectConfig: { projectId: 'prj_123', teamId: 'team_456' },
+      })
+    ).toEqual({
+      baseUrl: 'https://api.vercel.com/v1/workflow',
+      usingProxy: true,
+    });
+  });
+
+  it('respects WORKFLOW_VERCEL_BACKEND_URL for custom proxy URL', () => {
+    process.env.WORKFLOW_VERCEL_BACKEND_URL = 'https://proxy.example.com/v1';
+    expect(
+      getHttpUrl({
+        projectConfig: { projectId: 'prj_123', teamId: 'team_456' },
+      })
+    ).toEqual({
+      baseUrl: 'https://proxy.example.com/v1',
+      usingProxy: true,
+    });
+  });
+});
+
+describe('getHeaders', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.VERCEL_WORKFLOW_SERVER_URL;
+    delete process.env.VERCEL_OIDC_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('does not attach x-vercel-trusted-oidc-idp-token (set by getHttpConfig)', () => {
+    process.env.VERCEL_OIDC_TOKEN = 'my-oidc-token';
+    const headers = getHeaders(undefined, { usingProxy: false });
+    expect(headers.get('x-vercel-trusted-oidc-idp-token')).toBeNull();
+  });
+
+  it('omits x-vercel-workflow-api-url when override is unset', () => {
+    const headers = getHeaders(undefined, { usingProxy: true });
+    expect(headers.get('x-vercel-workflow-api-url')).toBeNull();
+  });
+
+  it('sets x-vercel-workflow-api-url when VERCEL_WORKFLOW_SERVER_URL is set and using proxy', () => {
+    process.env.VERCEL_WORKFLOW_SERVER_URL = 'https://custom.example.com';
+    const headers = getHeaders(undefined, { usingProxy: true });
+    expect(headers.get('x-vercel-workflow-api-url')).toBe(
+      'https://custom.example.com'
+    );
+  });
+
+  it('omits x-vercel-workflow-api-url when override is set but not using proxy', () => {
+    // Direct-to-workflow-server mode uses baseUrl, so the header is redundant.
+    process.env.VERCEL_WORKFLOW_SERVER_URL = 'https://custom.example.com';
+    const headers = getHeaders(undefined, { usingProxy: false });
+    expect(headers.get('x-vercel-workflow-api-url')).toBeNull();
+  });
+
+  it('sets project config headers when provided', () => {
+    const headers = getHeaders(
+      {
+        projectConfig: {
+          projectId: 'prj_123',
+          teamId: 'team_456',
+          environment: 'preview',
+        },
+      },
+      { usingProxy: true }
+    );
+    expect(headers.get('x-vercel-project-id')).toBe('prj_123');
+    expect(headers.get('x-vercel-team-id')).toBe('team_456');
+    expect(headers.get('x-vercel-environment')).toBe('preview');
+  });
+});
+
+describe('getHttpConfig (proxied path)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.VERCEL_WORKFLOW_SERVER_URL;
+    delete process.env.VERCEL_OIDC_TOKEN;
+    delete process.env.WORKFLOW_VERCEL_BACKEND_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('throws when usingProxy and no config.token is provided', async () => {
+    await expect(
+      getHttpConfig({
+        projectConfig: { projectId: 'prj_123', teamId: 'team_456' },
+      })
+    ).rejects.toThrow(/no Vercel auth token was provided/);
+  });
+
+  it('attaches Authorization bearer when usingProxy and config.token is provided', async () => {
+    const { headers } = await getHttpConfig({
+      projectConfig: { projectId: 'prj_123', teamId: 'team_456' },
+      token: 'my-vercel-auth-token',
+    });
+    expect(headers.get('Authorization')).toBe('Bearer my-vercel-auth-token');
+    // The trusted-sources bypass header is meaningless on the proxied
+    // path (api.vercel.com is public) and must NOT be attached.
+    expect(headers.get('x-vercel-trusted-oidc-idp-token')).toBeNull();
+  });
+});

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -63,6 +63,15 @@ function httpLog(
  */
 const WORKFLOW_SERVER_URL_OVERRIDE = '';
 
+/**
+ * Resolves the effective workflow-server URL override at call time. The hard-coded
+ * `WORKFLOW_SERVER_URL_OVERRIDE` constant takes precedence so it is always honored
+ * when set; otherwise we fall back to the `VERCEL_WORKFLOW_SERVER_URL` env var
+ * (used by CI to point preview runs at a protected workflow-server preview).
+ */
+const getWorkflowServerUrlOverride = (): string =>
+  WORKFLOW_SERVER_URL_OVERRIDE || process.env.VERCEL_WORKFLOW_SERVER_URL || '';
+
 export interface APIConfig {
   token?: string;
   headers?: RequestInit['headers'];
@@ -195,7 +204,7 @@ export const getHttpUrl = (
 ): { baseUrl: string; usingProxy: boolean } => {
   const projectConfig = config?.projectConfig;
   const defaultHost =
-    WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
+    getWorkflowServerUrlOverride() || 'https://vercel-workflow.com';
   const customProxyUrl = process.env.WORKFLOW_VERCEL_BACKEND_URL;
   const defaultProxyUrl = 'https://api.vercel.com/v1/workflow';
   // Use proxy when we have project config (for authentication via Vercel API)
@@ -230,8 +239,9 @@ export const getHeaders = (
   // Only set workflow-api-url header when using the proxy, since the proxy
   // forwards it to the workflow-server. When not using proxy, requests go
   // directly to the workflow-server so this header has no effect.
-  if (WORKFLOW_SERVER_URL_OVERRIDE && options.usingProxy) {
-    headers.set('x-vercel-workflow-api-url', WORKFLOW_SERVER_URL_OVERRIDE);
+  const workflowServerUrlOverride = getWorkflowServerUrlOverride();
+  if (workflowServerUrlOverride && options.usingProxy) {
+    headers.set('x-vercel-workflow-api-url', workflowServerUrlOverride);
   }
   return headers;
 };
@@ -239,10 +249,40 @@ export const getHeaders = (
 export async function getHttpConfig(config?: APIConfig): Promise<HttpConfig> {
   const { baseUrl, usingProxy } = getHttpUrl(config);
   const headers = getHeaders(config, { usingProxy });
-  const token = config?.token ?? (await getVercelOidcToken());
-  if (token) {
-    headers.set('Authorization', `Bearer ${token}`);
+
+  if (usingProxy) {
+    // The api-workflow proxy authenticates the caller with a regular Vercel
+    // auth token; it does not accept OIDC. Fail loudly instead of letting
+    // an opaque 401 bubble up at request time.
+    if (!config?.token) {
+      throw new Error(
+        'world-vercel: api-workflow proxy requested ' +
+          `(${baseUrl}) but no Vercel auth token was provided. ` +
+          'Pass one as `config.token` (the SDK reads it from ' +
+          '`WORKFLOW_VERCEL_AUTH_TOKEN`).'
+      );
+    }
+    headers.set('Authorization', `Bearer ${config.token}`);
+  } else {
+    // Direct workflow-server path. The bearer prefers an explicit
+    // config.token (CLI / GitHub Actions runner / local dev) and falls
+    // back to the per-request Vercel OIDC token. The trusted-sources
+    // bypass header always uses the per-request OIDC token.
+    let oidcToken: string | undefined;
+    try {
+      oidcToken = await getVercelOidcToken();
+    } catch {
+      // No OIDC available outside a Vercel function context.
+    }
+    const authToken = config?.token ?? oidcToken;
+    if (authToken) {
+      headers.set('Authorization', `Bearer ${authToken}`);
+    }
+    if (oidcToken) {
+      headers.set('x-vercel-trusted-oidc-idp-token', oidcToken);
+    }
   }
+
   return { baseUrl, headers, usingProxy };
 }
 

--- a/scripts/trusted-sources-headers.mjs
+++ b/scripts/trusted-sources-headers.mjs
@@ -1,0 +1,145 @@
+/**
+ * Returns headers needed to bypass Vercel Deployment Protection via OIDC
+ * Trusted Sources.
+ *
+ * Source preference, in order:
+ *   1. **GitHub Actions runner** — when running inside a job with
+ *      `permissions: id-token: write`, the runner exposes
+ *      `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`,
+ *      and we mint short-lived OIDC tokens on demand. The runner-issued
+ *      tokens have a hard 5-minute lifetime; we cache the active token
+ *      and re-mint shortly before expiry so a long-running test suite
+ *      keeps working past the 5-minute mark (otherwise tests that run
+ *      late in the suite would 401 against trusted-sources rules).
+ *   2. **`VERCEL_OIDC_TOKEN` env var** — used inside Vercel functions
+ *      (the runtime injects the per-request token) and as a manual
+ *      override for local development.
+ *
+ * Returns an empty object when neither source is available, so callers
+ * can safely spread the result into request headers regardless of
+ * environment. When the target deployment doesn't have Deployment
+ * Protection enabled, the header is silently ignored by Vercel's edge.
+ *
+ * See: https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/trusted-sources
+ *
+ * @returns {Promise<Record<string, string>>}
+ */
+export async function getTrustedSourcesHeaders() {
+  const token = await getOidcToken();
+  if (token) {
+    return { 'x-vercel-trusted-oidc-idp-token': token };
+  }
+  return {};
+}
+
+/**
+ * Cached OIDC token state. The runner-issued JWT carries an `exp` claim
+ * (5 minutes from issuance); we eagerly refresh `EARLY_REFRESH_MS` before
+ * it actually expires so an in-flight request never carries an
+ * about-to-expire token.
+ */
+let cachedToken = null;
+/** @type {number} */
+let cachedExpiresAtMs = 0;
+/** @type {Promise<string | null> | null} */
+let inflight = null;
+const EARLY_REFRESH_MS = 60_000; // refresh 1 min before expiry
+
+/**
+ * @returns {Promise<string | null>}
+ */
+async function getOidcToken() {
+  // Fast path: cached token is still safely fresh.
+  const now = Date.now();
+  if (cachedToken && now < cachedExpiresAtMs - EARLY_REFRESH_MS) {
+    return cachedToken;
+  }
+  // Coalesce concurrent calls during a refresh.
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const minted = await mintFromGitHubActionsRunner();
+      if (minted) {
+        cachedToken = minted.token;
+        cachedExpiresAtMs = minted.expiresAtMs;
+        return minted.token;
+      }
+      // Fall back to the env var (Vercel runtime / local dev).
+      const envToken = process.env.VERCEL_OIDC_TOKEN;
+      if (envToken) {
+        cachedToken = envToken;
+        // We can't trust the runner refresh path on env-var tokens, but
+        // we also can't introspect their lifetime safely; treat them as
+        // long-lived. Setting a far-future expiry effectively pins the
+        // value for the lifetime of the process.
+        cachedExpiresAtMs = Number.POSITIVE_INFINITY;
+        return envToken;
+      }
+      return null;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+/**
+ * Mints a fresh OIDC token from the GitHub Actions runner if the
+ * required env vars are set; returns `null` otherwise.
+ *
+ * @returns {Promise<{ token: string, expiresAtMs: number } | null>}
+ */
+async function mintFromGitHubActionsRunner() {
+  const url = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  if (!url || !requestToken) return null;
+  // Audience defaults to `https://github.com/<owner>`; matches the
+  // trusted-source rules configured on each Vercel project.
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${requestToken}`,
+      Accept: 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to mint GitHub Actions OIDC token: ${res.status} ${res.statusText}`
+    );
+  }
+  /** @type {{ value?: string }} */
+  const body = await res.json();
+  const token = body.value;
+  if (!token || typeof token !== 'string') {
+    throw new Error(
+      'Failed to mint GitHub Actions OIDC token: empty/invalid response body'
+    );
+  }
+  // Decode the unsigned `exp` claim so we know when to refresh.
+  const expiresAtMs = readJwtExpMs(token);
+  return { token, expiresAtMs };
+}
+
+/**
+ * Reads the `exp` claim (in seconds since epoch) from the JWT payload
+ * and returns it in milliseconds. Falls back to "5 minutes from now"
+ * (GitHub Actions's documented OIDC token lifetime) if the claim is
+ * missing or unparseable.
+ *
+ * @param {string} jwt
+ * @returns {number}
+ */
+function readJwtExpMs(jwt) {
+  const fallback = Date.now() + 5 * 60 * 1000;
+  const parts = jwt.split('.');
+  if (parts.length !== 3) return fallback;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], 'base64url').toString('utf8')
+    );
+    if (typeof payload?.exp === 'number') return payload.exp * 1000;
+  } catch {
+    // ignore — return fallback
+  }
+  return fallback;
+}


### PR DESCRIPTION
Backports #1882 onto `stable`.

Cherry-pick of `cd50618d1f` with conflict resolution for stable's diverged state:

- **`docs/scripts/check-docs-smoke.mjs`**: Dropped — file does not exist on stable (docs app is a placeholder).
- **`.github/workflows/docs-checks.yml`**: Kept stable's no-op stub (`if: false`); the OIDC-equipped smoke job from main is not applicable.
- **`.github/workflows/tests.yml`**: Took the OIDC version of the env block.
- **`packages/world-vercel/src/utils.ts`**: Added the missing `getWorkflowServerUrlOverride()` helper (referenced by the cherry-picked changes but only defined on main as part of an earlier PR), so `WORKFLOW_SERVER_URL_OVERRIDE` and `VERCEL_WORKFLOW_SERVER_URL` are honored consistently across `getHttpUrl` and `getHeaders`.
- **`AGENTS.md`**, **`packages/world-vercel/src/encryption.ts`**, **`packages/world-vercel/src/resolve-latest-deployment.ts`**: Trivial whitespace / casing conflicts resolved in favor of the cherry-pick.
- **`packages/world-vercel/src/utils.test.ts`**: Added (new on main, didn't exist on stable). All 11 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)