### PR TITLE
[backport] [vitest] [world-local] Fix local-world data recovery isolation (#1895)

### DIFF
--- a/.changeset/moody-rivers-play.md
+++ b/.changeset/moody-rivers-play.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tighten cleanup in `dev.test.ts` `should include steps discovered from workflow imports` so the deferred builder drops the discovered step from the manifest before the next test file runs. Avoids a Windows-only race where the generated step route retains an import to a deleted source file and breaks every subsequent step request.

--- a/.changeset/swift-cobras-repair.md
+++ b/.changeset/swift-cobras-repair.md
@@ -1,0 +1,6 @@
+---
+"@workflow/vitest": patch
+"@workflow/world-local": patch
+---
+
+Fix local-world recovery isolation in Vitest and support custom test directories

--- a/docs/content/docs/api-reference/vitest/index.mdx
+++ b/docs/content/docs/api-reference/vitest/index.mdx
@@ -22,6 +22,30 @@ export default defineConfig({
 });
 ```
 
+Pass a [`WorkflowTestOptions`](#workflowtestoptions) object when your project uses a non-standard layout — for example, a monorepo where `workflows/` does not live at the Vitest config's directory, or when the default `.workflow-data` / `.workflow-vitest` output locations need to move. The plugin forwards these paths to `buildWorkflowTests()` and `setupWorkflowTests()` through Vitest's per-project provided context, so each Vitest workspace project stays isolated.
+
+{/* @skip-typecheck - @workflow/vitest not available in docs-typecheck */}
+
+```typescript
+import { defineConfig } from "vitest/config";
+import { workflow } from "@workflow/vitest";
+
+export default defineConfig({
+  plugins: [
+    workflow({
+      cwd: "./apps/api",
+      rootDir: "./apps/api/test-artifacts",
+    }),
+  ],
+});
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `options?` | `WorkflowTestOptions` | Optional configuration |
+
 **Returns:** `Plugin[]`
 
 ## Setup Functions
@@ -83,7 +107,10 @@ Tears down the workflow test world. Clears the global world and closes the Local
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `cwd` | `string` | `process.cwd()` | The working directory of the project (where `workflows/` lives) |
+| `cwd` | `string` | `process.cwd()` | The working directory of the project (where `workflows/` lives). Relative paths resolve against `process.cwd()`. |
+| `rootDir` | `string` | same as `cwd` | Root directory used for default test artifacts. When set, `dataDir` and `outDir` default to `<rootDir>/.workflow-data` and `<rootDir>/.workflow-vitest`. Relative paths resolve against `cwd`. |
+| `dataDir` | `string` | `<rootDir>/.workflow-data` | Directory for workflow runtime data written by the test world. Relative paths resolve against `cwd`. |
+| `outDir` | `string` | `<rootDir>/.workflow-vitest` | Directory for generated workflow and step bundles. Relative paths resolve against `cwd`. |
 
 ## Test Helpers
 

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -137,15 +137,20 @@ export function createDevTests(config?: DevTestConfig) {
     });
 
     afterEach(async () => {
+      // Restore file contents before deleting any files. If a deletion races
+      // ahead of an api-file restore, the dev server briefly sees an import
+      // pointing at a missing module and fails compilation. On Windows that
+      // failure can stick — Turbopack leaves stale imports in the generated
+      // step route bundle — and every subsequent step request returns 500.
+      const toRestore = restoreFiles.filter((item) => item.content !== '');
+      const toDelete = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
-        restoreFiles.map(async (item) => {
-          if (item.content === '') {
-            await fs.unlink(item.path);
-          } else {
-            await fs.writeFile(item.path, item.content);
-          }
-        })
+        toRestore.map((item) => fs.writeFile(item.path, item.content))
       );
+      if (toDelete.length > 0) {
+        await prewarm();
+      }
+      await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
       await prewarm();
       restoreFiles.length = 0;
     });
@@ -250,6 +255,8 @@ export async function ${marker}() {
         );
         restoreFiles.push({ path: importedStepFile, content });
 
+        const apiFile = path.join(appPath, finalConfig.apiFilePath);
+        const apiFileContent = await fs.readFile(apiFile, 'utf8');
         const copiedStepDir = path.join(
           path.dirname(generatedStep),
           '__workflow_step_files__'
@@ -260,7 +267,19 @@ export async function ${marker}() {
             'copied deferred step files to include imported step hot-reload marker',
           timeoutMs: 50_000,
           check: async () => {
-            await triggerWorkflowRun('importedStepOnlyWorkflow');
+            try {
+              await triggerWorkflowRun('importedStepOnlyWorkflow');
+            } catch (error) {
+              // Turbopack on Windows occasionally caches a stale resolver
+              // failure (e.g. `Could not parse module
+              // '@workflow/core/dist/runtime/start.js'`) after an HMR
+              // cascade and returns 500 to every request until something
+              // invalidates its cache. Rewriting the api file is enough to
+              // force a fresh resolve on the next request, so we treat the
+              // 500 as transient and keep polling instead of bailing out.
+              await fs.writeFile(apiFile, apiFileContent);
+              throw error;
+            }
             const copiedStepFileNames = await fs.readdir(copiedStepDir);
             const copiedStepContents = await Promise.all(
               copiedStepFileNames.map(async (copiedStepFileName) => {
@@ -332,7 +351,7 @@ ${apiFileContent}`
 
     test.skipIf(!supportsDeferredStepCopies)(
       'should include steps discovered from workflow imports',
-      { timeout: 30_000 },
+      { timeout: 60_000 },
       async () => {
         const workflowFile = path.join(
           appPath,

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "build": "tsc",
     "clean": "tsc --build --clean && rm -rf dist ||:",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run src"
   },
   "dependencies": {
     "@workflow/builders": "workspace:*",
@@ -38,7 +39,8 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@workflow/tsconfig": "workspace:*",
-    "vite": "7.1.12"
+    "vite": "7.1.12",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "vite": ">=6.0.0",

--- a/packages/vitest/src/global-setup.ts
+++ b/packages/vitest/src/global-setup.ts
@@ -1,5 +1,14 @@
+import type { TestProject } from 'vitest/node';
 import { buildWorkflowTests } from './index.js';
+import {
+  readProvidedWorkflowTestOptions,
+  WORKFLOW_VITEST_OPTIONS_KEY,
+} from './options.js';
 
-export async function setup() {
-  await buildWorkflowTests();
+export async function setup(project: TestProject) {
+  await buildWorkflowTests(
+    readProvidedWorkflowTestOptions(
+      project.config.provide?.[WORKFLOW_VITEST_OPTIONS_KEY]
+    )
+  );
 }

--- a/packages/vitest/src/index.test.ts
+++ b/packages/vitest/src/index.test.ts
@@ -1,0 +1,286 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createLocalWorld = vi.fn();
+const initDataDir = vi.fn();
+const setWorld = vi.fn();
+const workflowTransformPlugin = vi.fn((options) => ({
+  name: 'workflow:transform',
+  options,
+}));
+const createBaseBuilderConfig = vi.fn((config) => config);
+const getInputFiles = vi.fn(async () => ['workflows/example.ts']);
+const createWorkflowsBundle = vi.fn(async () => {});
+const createStepsBundle = vi.fn(async () => {});
+const baseBuilderConfigs: unknown[] = [];
+
+vi.mock('@workflow/builders', () => {
+  class BaseBuilder {
+    constructor(config: unknown) {
+      baseBuilderConfigs.push(config);
+    }
+
+    async getInputFiles() {
+      return getInputFiles();
+    }
+
+    async createWorkflowsBundle(args: unknown) {
+      return createWorkflowsBundle(args);
+    }
+
+    async createStepsBundle(args: unknown) {
+      return createStepsBundle(args);
+    }
+  }
+
+  return {
+    BaseBuilder,
+    createBaseBuilderConfig,
+  };
+});
+
+vi.mock('@workflow/core/runtime', () => ({
+  setWorld,
+}));
+
+vi.mock('@workflow/rollup', () => ({
+  workflowTransformPlugin,
+}));
+
+vi.mock('@workflow/world-local', () => ({
+  createLocalWorld,
+  initDataDir,
+}));
+
+type WorkflowVitestModule = typeof import('./index.js');
+
+let loadedModule: WorkflowVitestModule | undefined;
+const tempDirs: string[] = [];
+
+async function loadModule(): Promise<WorkflowVitestModule> {
+  loadedModule ??= await import('./index.js');
+  return loadedModule;
+}
+
+function createMockWorld() {
+  const handlers = new Map<string, (req: Request) => Promise<Response>>();
+  return {
+    handlers,
+    clear: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    registerHandler: vi.fn(
+      (prefix: string, handler: (req: Request) => Promise<Response>) => {
+        handlers.set(prefix, handler);
+      }
+    ),
+    start: vi.fn(async () => {}),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  loadedModule = undefined;
+  baseBuilderConfigs.length = 0;
+  tempDirs.length = 0;
+  delete process.env.VITEST_POOL_ID;
+});
+
+afterEach(async () => {
+  if (loadedModule) {
+    await loadedModule.teardownWorkflowTests();
+  }
+  await Promise.all(
+    tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+describe('@workflow/vitest', () => {
+  it('builds bundles and initializes data in custom directories', async () => {
+    const { buildWorkflowTests } = await loadModule();
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), 'workflow-vitest-build-')
+    );
+    tempDirs.push(rootDir);
+    const cwd = path.resolve('/repo/app');
+
+    await buildWorkflowTests({ cwd, rootDir });
+
+    expect(createBaseBuilderConfig).toHaveBeenCalledWith({
+      workingDir: cwd,
+      dirs: ['.'],
+    });
+    expect(baseBuilderConfigs).toHaveLength(1);
+    expect(createWorkflowsBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outfile: path.join(rootDir, '.workflow-vitest', 'workflows.mjs'),
+      })
+    );
+    expect(createStepsBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outfile: path.join(rootDir, '.workflow-vitest', 'steps.mjs'),
+      })
+    );
+    expect(initDataDir).toHaveBeenCalledWith(
+      path.join(rootDir, '.workflow-data')
+    );
+  });
+
+  it('sets up a local world with custom directories and recovery disabled', async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'workflow-vitest-'));
+    tempDirs.push(tmpDir);
+    const outDir = path.join(tmpDir, 'bundles');
+    const dataDir = path.join(tmpDir, 'data');
+    await mkdir(outDir, { recursive: true });
+    await writeFile(
+      path.join(outDir, 'workflows.mjs'),
+      `export async function POST() { return Response.json({ bundle: 'workflow' }); }`
+    );
+    await writeFile(
+      path.join(outDir, 'steps.mjs'),
+      `export async function POST() { return Response.json({ bundle: 'step' }); }`
+    );
+
+    process.env.VITEST_POOL_ID = '7';
+    const mockWorld = createMockWorld();
+    createLocalWorld.mockReturnValue(mockWorld);
+
+    const { setupWorkflowTests } = await loadModule();
+    await setupWorkflowTests({
+      dataDir,
+      outDir,
+    });
+
+    expect(createLocalWorld).toHaveBeenCalledWith({
+      dataDir,
+      recoverActiveRuns: false,
+      tag: 'vitest-7',
+    });
+    expect(mockWorld.clear).toHaveBeenCalledTimes(1);
+    expect(mockWorld.registerHandler).toHaveBeenCalledTimes(2);
+    expect(mockWorld.start).toHaveBeenCalledTimes(1);
+    expect(mockWorld.registerHandler.mock.invocationCallOrder[1]).toBeLessThan(
+      mockWorld.start.mock.invocationCallOrder[0]
+    );
+    expect(setWorld).toHaveBeenCalledWith(mockWorld);
+
+    const workflowHandler = mockWorld.handlers.get('__wkf_workflow_');
+    const stepHandler = mockWorld.handlers.get('__wkf_step_');
+    expect(workflowHandler).toBeDefined();
+    expect(stepHandler).toBeDefined();
+
+    const workflowResponse = await workflowHandler!(new Request('http://test'));
+    expect(await workflowResponse.json()).toEqual({ bundle: 'workflow' });
+
+    const stepResponse = await stepHandler!(new Request('http://test'));
+    expect(await stepResponse.json()).toEqual({ bundle: 'step' });
+  });
+
+  it('provides project-scoped directory options without mutating process env', async () => {
+    const rootDir = path.resolve('/tmp/workflow-vitest-root');
+    const dataDir = path.resolve('/tmp/workflow-vitest-data');
+    const outDir = path.resolve('/tmp/workflow-vitest-out');
+    const cwd = path.resolve('/repo/app');
+
+    const { workflow } = await loadModule();
+    const plugins = workflow({ cwd, rootDir, dataDir, outDir });
+
+    expect(workflowTransformPlugin).toHaveBeenCalledWith({
+      exclude: [outDir + '/'],
+    });
+
+    const vitestPlugin = plugins[1];
+    expect(vitestPlugin.name).toBe('workflow:vitest');
+    const config = vitestPlugin.config?.() as {
+      test: {
+        provide: Record<string, unknown>;
+      };
+    };
+
+    expect(process.env.WORKFLOW_VITEST_CWD).toBeUndefined();
+    expect(process.env.WORKFLOW_VITEST_ROOT_DIR).toBeUndefined();
+    expect(process.env.WORKFLOW_VITEST_DATA_DIR).toBeUndefined();
+    expect(process.env.WORKFLOW_VITEST_OUT_DIR).toBeUndefined();
+    expect(config.test.provide.__workflowVitestOptions).toEqual({
+      cwd,
+      rootDir,
+      dataDir,
+      outDir,
+    });
+  });
+
+  it('builds from project-scoped options in global setup', async () => {
+    const buildWorkflowTests = vi.fn(async () => {});
+    vi.doMock('./index.js', () => ({
+      buildWorkflowTests,
+    }));
+
+    const cwd = path.resolve('/repo/app');
+    const rootDir = path.join(cwd, 'test-root');
+    const dataDir = path.join(rootDir, '.workflow-data');
+    const outDir = path.join(rootDir, '.workflow-vitest');
+
+    const { setup } = await import('./global-setup.js');
+    await setup({
+      config: {
+        provide: {
+          __workflowVitestOptions: {
+            cwd,
+            rootDir,
+            dataDir,
+            outDir,
+          },
+        },
+      },
+    } as any);
+
+    expect(buildWorkflowTests).toHaveBeenCalledWith({
+      cwd,
+      rootDir,
+      dataDir,
+      outDir,
+    });
+  });
+
+  it('sets up and tears down from project-scoped injected options', async () => {
+    const afterAll = vi.fn();
+    const setupWorkflowTests = vi.fn(async () => {});
+    const teardownWorkflowTests = vi.fn(async () => {});
+
+    const cwd = path.resolve('/repo/app');
+    const rootDir = path.join(cwd, 'test-root');
+    const dataDir = path.join(rootDir, '.workflow-data');
+    const outDir = path.join(rootDir, '.workflow-vitest');
+
+    vi.doMock('vitest', () => ({
+      afterAll,
+      inject: vi.fn(() => ({
+        cwd,
+        rootDir,
+        dataDir,
+        outDir,
+      })),
+    }));
+    vi.doMock('./index.js', () => ({
+      setupWorkflowTests,
+      teardownWorkflowTests,
+    }));
+
+    await import('./setup-file.js');
+
+    expect(setupWorkflowTests).toHaveBeenCalledWith({
+      cwd,
+      rootDir,
+      dataDir,
+      outDir,
+    });
+    expect(afterAll).toHaveBeenCalledTimes(1);
+
+    const teardown = afterAll.mock.calls[0]?.[0];
+    expect(teardown).toBeTypeOf('function');
+    await teardown();
+    expect(teardownWorkflowTests).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -12,6 +12,10 @@ import {
   type LocalWorld,
 } from '@workflow/world-local';
 import type { Plugin } from 'vite';
+import {
+  resolveWorkflowTestOptions,
+  WORKFLOW_VITEST_OPTIONS_KEY,
+} from './options.js';
 
 class VitestBuilder extends BaseBuilder {
   #outDir: string;
@@ -63,10 +67,22 @@ export interface WorkflowTestOptions {
    * Defaults to process.cwd().
    */
   cwd?: string;
-}
-
-function getOutDir(cwd: string): string {
-  return join(cwd, '.workflow-vitest');
+  /**
+   * Root directory used for default test artifacts.
+   * When set, `.workflow-data` and `.workflow-vitest` are created here unless
+   * overridden explicitly with `dataDir` or `outDir`.
+   */
+  rootDir?: string;
+  /**
+   * Directory for workflow runtime data written by the test world.
+   * Defaults to `<rootDir>/.workflow-data`.
+   */
+  dataDir?: string;
+  /**
+   * Directory for generated workflow and step bundles.
+   * Defaults to `<rootDir>/.workflow-vitest`.
+   */
+  outDir?: string;
 }
 
 /**
@@ -84,11 +100,13 @@ function getOutDir(cwd: string): string {
  * });
  * ```
  */
-export function workflow(): Plugin[] {
+export function workflow(options?: WorkflowTestOptions): Plugin[] {
+  const resolvedOptions = resolveWorkflowTestOptions(options);
+  const { outDir } = resolvedOptions;
   const dir = fileURLToPath(new URL('.', import.meta.url));
   return [
     workflowTransformPlugin({
-      exclude: [join(process.cwd(), '.workflow-vitest') + '/'],
+      exclude: [outDir + '/'],
     }),
     {
       name: 'workflow:vitest',
@@ -97,6 +115,9 @@ export function workflow(): Plugin[] {
           test: {
             globalSetup: [join(dir, 'global-setup.js')],
             setupFiles: [join(dir, 'setup-file.js')],
+            provide: {
+              [WORKFLOW_VITEST_OPTIONS_KEY]: resolvedOptions,
+            },
           },
         } as Record<string, unknown>;
       },
@@ -112,12 +133,11 @@ export function workflow(): Plugin[] {
 export async function buildWorkflowTests(
   options?: WorkflowTestOptions
 ): Promise<void> {
-  const cwd = options?.cwd ?? process.cwd();
-  const outDir = getOutDir(cwd);
+  const { cwd, dataDir, outDir } = resolveWorkflowTestOptions(options);
   const builder = new VitestBuilder(cwd, outDir);
   await builder.build();
   // Pre-create the shared data directory so workers don't race on mkdir
-  await initDataDir(join(cwd, '.workflow-data'));
+  await initDataDir(dataDir);
 }
 
 let world: LocalWorld | undefined;
@@ -139,8 +159,7 @@ export async function setupWorkflowTests(
     world = undefined;
   }
 
-  const cwd = options?.cwd ?? process.cwd();
-  const outDir = getOutDir(cwd);
+  const { dataDir, outDir } = resolveWorkflowTestOptions(options);
 
   // Lazy-load bundles on first dispatch instead of eagerly at setup time.
   // Eager native import() during setupFiles loads step dependencies into
@@ -168,13 +187,14 @@ export async function setupWorkflowTests(
   // Each vitest worker uses a unique tag to isolate its test data.
   // All workers write to the shared .workflow-data directory so runs
   // are visible to the observability dashboard, but clear() only
-  // deletes files matching the worker's tag.
+  // deletes files matching the worker's tag. Recovery stays disabled because
+  // tests expect a clean world and register direct handlers after setup begins.
   const poolId = process.env.VITEST_POOL_ID ?? '0';
   world = createLocalWorld({
-    dataDir: join(cwd, '.workflow-data'),
+    dataDir,
+    recoverActiveRuns: false,
     tag: `vitest-${poolId}`,
   });
-  await world.start?.();
   await world.clear();
 
   world.registerHandler(
@@ -186,6 +206,11 @@ export async function setupWorkflowTests(
     createLazyHandler(join(outDir, 'steps.mjs'))
   );
 
+  // Handlers must be registered before start(): if recoverActiveRuns is ever
+  // re-enabled here (or plumbed through from a caller), start() re-enqueues
+  // pending runs and the queue begins dispatching. Registering after start
+  // would race handler installation against that dispatch.
+  await world.start?.();
   setWorld(world);
 }
 

--- a/packages/vitest/src/options.ts
+++ b/packages/vitest/src/options.ts
@@ -1,0 +1,50 @@
+import { join, resolve } from 'node:path';
+import type { WorkflowTestOptions } from './index.js';
+
+export const WORKFLOW_VITEST_OPTIONS_KEY = '__workflowVitestOptions';
+
+export type ResolvedWorkflowTestOptions = {
+  cwd: string;
+  rootDir: string;
+  dataDir: string;
+  outDir: string;
+};
+
+function getDefinedOptions(
+  options?: WorkflowTestOptions
+): Partial<WorkflowTestOptions> {
+  if (!options) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(options).filter(([, value]) => value !== undefined)
+  );
+}
+
+export function resolveWorkflowTestOptions(
+  options?: WorkflowTestOptions
+): ResolvedWorkflowTestOptions {
+  const mergedOptions = getDefinedOptions(options);
+  const cwd = resolve(mergedOptions.cwd ?? process.cwd());
+  const rootDir = mergedOptions.rootDir
+    ? resolve(cwd, mergedOptions.rootDir)
+    : cwd;
+
+  return {
+    cwd,
+    rootDir,
+    dataDir: mergedOptions.dataDir
+      ? resolve(cwd, mergedOptions.dataDir)
+      : join(rootDir, '.workflow-data'),
+    outDir: mergedOptions.outDir
+      ? resolve(cwd, mergedOptions.outDir)
+      : join(rootDir, '.workflow-vitest'),
+  };
+}
+
+export function readProvidedWorkflowTestOptions(
+  value: unknown
+): ResolvedWorkflowTestOptions {
+  return resolveWorkflowTestOptions(value as WorkflowTestOptions | undefined);
+}

--- a/packages/vitest/src/setup-file.ts
+++ b/packages/vitest/src/setup-file.ts
@@ -1,7 +1,13 @@
-import { afterAll } from 'vitest';
+import { afterAll, inject } from 'vitest';
 import { setupWorkflowTests, teardownWorkflowTests } from './index.js';
+import {
+  readProvidedWorkflowTestOptions,
+  WORKFLOW_VITEST_OPTIONS_KEY,
+} from './options.js';
 
-await setupWorkflowTests();
+await setupWorkflowTests(
+  readProvidedWorkflowTestOptions(inject(WORKFLOW_VITEST_OPTIONS_KEY))
+);
 
 afterAll(async () => {
   await teardownWorkflowTests();

--- a/packages/vitest/src/vitest-context.d.ts
+++ b/packages/vitest/src/vitest-context.d.ts
@@ -1,0 +1,10 @@
+import 'vitest';
+import type { ResolvedWorkflowTestOptions } from './options.js';
+
+declare module 'vitest' {
+  interface ProvidedContext {
+    __workflowVitestOptions: ResolvedWorkflowTestOptions;
+  }
+}
+
+export {};

--- a/packages/world-local/src/config.ts
+++ b/packages/world-local/src/config.ts
@@ -16,6 +16,12 @@ export type Config = {
   port?: number;
   baseUrl?: string;
   /**
+   * Whether start() should re-enqueue pending/running runs from storage.
+   * Defaults to true. Test harnesses that always start from a clean slate can
+   * disable recovery to avoid replaying stale runs.
+   */
+  recoverActiveRuns?: boolean;
+  /**
    * Optional tag to scope filesystem operations.
    * When set, files are written as `{id}.{tag}.json` and `clear()` only deletes
    * files matching this tag. Used by vitest to isolate test data in the shared

--- a/packages/world-local/src/fs.test.ts
+++ b/packages/world-local/src/fs.test.ts
@@ -580,6 +580,71 @@ describe('fs utilities', () => {
         assert(result.data[0], 'expected first result to be defined');
         expect(result.data[0].name).toBe('prefixed-1');
       });
+
+      it('keeps fileIdFilter applied on later cursor pages', async () => {
+        const pageDir = await fs.mkdtemp(
+          path.join(os.tmpdir(), 'fileid-filter-pagination-')
+        );
+        const baseTime = new Date('2024-01-01T00:00:00.000Z').getTime();
+        const ulidAfter = createUlidAfter(baseTime);
+
+        try {
+          const files: Record<string, object> = {};
+          for (let i = 0; i < 5; i++) {
+            const fileId = `match_${ulidAfter(`${i}m`)}`;
+            files[fileId] = {
+              id: fileId,
+              name: `match-${i}`,
+              createdAt: new Date(baseTime + ms(`${i}m`)),
+            };
+          }
+
+          for (let i = 5; i < 8; i++) {
+            const fileId = `other_${ulidAfter(`${i}m`)}`;
+            files[fileId] = {
+              id: fileId,
+              name: `other-${i}`,
+              createdAt: new Date(baseTime + ms(`${i}m`)),
+            };
+          }
+
+          await createFilesystem(pageDir, files);
+
+          const firstPage = await paginatedFileSystemQuery({
+            directory: pageDir,
+            schema: TestItemSchema,
+            fileIdFilter: (fileId) => fileId.startsWith('match_'),
+            getCreatedAt: getPrefixCreatedAt,
+            getId: (item) => item.id,
+            limit: 2,
+            sortOrder: 'desc',
+          });
+
+          expect(firstPage.data).toHaveLength(2);
+          expect(
+            firstPage.data.every((item) => item.id.startsWith('match_'))
+          ).toBe(true);
+          assert(firstPage.cursor, 'expected first page cursor to be defined');
+
+          const secondPage = await paginatedFileSystemQuery({
+            directory: pageDir,
+            schema: TestItemSchema,
+            fileIdFilter: (fileId) => fileId.startsWith('match_'),
+            getCreatedAt: getPrefixCreatedAt,
+            getId: (item) => item.id,
+            limit: 2,
+            cursor: firstPage.cursor,
+            sortOrder: 'desc',
+          });
+
+          expect(secondPage.data).toHaveLength(2);
+          expect(
+            secondPage.data.every((item) => item.id.startsWith('match_'))
+          ).toBe(true);
+        } finally {
+          await fs.rm(pageDir, { recursive: true, force: true });
+        }
+      });
     });
 
     describe('error handling', () => {

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -72,6 +72,15 @@ export function stripTag(fileId: string): string {
 }
 
 /**
+ * Check whether a fileId belongs to a specific tag.
+ * `wrun_ABC.vitest-0` belongs to `vitest-0`.
+ * Untagged fileIds never match a tag-scoped lookup.
+ */
+export function hasTag(fileId: string, tag: string): boolean {
+  return fileId.endsWith(`.${tag}`);
+}
+
+/**
  * Build the file path for an entity, with optional tag embedded in the filename.
  * `taggedPath('runs', 'wrun_ABC', 'vitest-0')` → `runs/wrun_ABC.vitest-0.json`
  * `taggedPath('runs', 'wrun_ABC')` → `runs/wrun_ABC.json`
@@ -321,6 +330,7 @@ interface PaginatedFileSystemQueryConfig<T> {
   directory: string;
   schema: z.ZodType<T>;
   filePrefix?: string;
+  fileIdFilter?: (fileId: string) => boolean;
   filter?: (item: T) => boolean;
   sortOrder?: 'asc' | 'desc';
   limit?: number;
@@ -355,6 +365,7 @@ export async function paginatedFileSystemQuery<T extends { createdAt: Date }>(
     directory,
     schema,
     filePrefix,
+    fileIdFilter,
     filter,
     sortOrder = 'desc',
     limit = 20,
@@ -370,13 +381,16 @@ export async function paginatedFileSystemQuery<T extends { createdAt: Date }>(
   const relevantFileIds = filePrefix
     ? fileIds.filter((fileId) => fileId.startsWith(filePrefix))
     : fileIds;
+  const filteredFileIds = fileIdFilter
+    ? relevantFileIds.filter(fileIdFilter)
+    : relevantFileIds;
 
   // 3. ULID Optimization: Filter by cursor using filename timestamps before loading JSON
   const parsedCursor = parseCursor(cursor);
-  let candidateFileIds = relevantFileIds;
+  let candidateFileIds = filteredFileIds;
 
   if (parsedCursor) {
-    candidateFileIds = relevantFileIds.filter((fileId) => {
+    candidateFileIds = filteredFileIds.filter((fileId) => {
       const filenameDate = getCreatedAt(`${fileId}.json`);
       if (filenameDate) {
         // Use filename timestamp for cursor filtering

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -8,6 +8,7 @@ import { config } from './config.js';
 import {
   clearCreatedFilesCache,
   deleteJSON,
+  hasTag,
   listTaggedFiles,
   listTaggedFilesByExtension,
   readJSON,
@@ -48,6 +49,7 @@ export type LocalWorld = World & {
  * @param args.dataDir - Directory for storing workflow data (default: `.workflow-data/`)
  * @param args.port - Port override for queue transport (default: auto-detected)
  * @param args.baseUrl - Full base URL override for queue transport (default: `http://localhost:{port}`)
+ * @param args.recoverActiveRuns - Whether `start()` should re-enqueue pending/running runs from storage (default: `true`)
  * @param args.tag - Optional tag to scope files (e.g., `vitest-0`). When set, files are written
  *   as `{id}.{tag}.json` and `clear()` only deletes files matching this tag.
  * @throws {DataDirAccessError} If the data directory cannot be created or accessed
@@ -63,10 +65,11 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
   const tag = mergedConfig.tag;
   const queue = createQueue(mergedConfig);
   const storage = createStorage(mergedConfig.dataDir, tag);
+  const recoverActiveRuns = mergedConfig.recoverActiveRuns ?? true;
   return {
     specVersion: SPEC_VERSION_CURRENT,
     ...queue,
-    ...createStorage(mergedConfig.dataDir, tag),
+    ...storage,
     ...instrumentObject('world.streams', {
       ...createStreamer(mergedConfig.dataDir, tag),
       ...(mergedConfig.streamFlushIntervalMs !== undefined && {
@@ -75,7 +78,20 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
     }),
     async start() {
       await initDataDir(mergedConfig.dataDir);
-      await reenqueueActiveRuns(storage.runs, queue.queue, 'world-local');
+      if (!recoverActiveRuns) {
+        return;
+      }
+      const recoveryRuns = tag
+        ? {
+            ...storage.runs,
+            list: ((params) =>
+              storage.runs.list({
+                ...params,
+                fileIdFilter: (fileId) => hasTag(fileId, tag),
+              })) as typeof storage.runs.list,
+          }
+        : storage.runs;
+      await reenqueueActiveRuns(recoveryRuns, queue.queue, 'world-local');
     },
     async close() {
       await queue.close();

--- a/packages/world-local/src/reenqueue.test.ts
+++ b/packages/world-local/src/reenqueue.test.ts
@@ -121,6 +121,139 @@ describe('re-enqueue active runs on start', () => {
     await world2.close();
   });
 
+  it('only re-enqueues runs for the matching tag', async () => {
+    const world0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    await world0.start();
+
+    const run0 = await createRun(world0, {
+      deploymentId: 'dpl_1',
+      workflowName: 'taggedWorkflow0',
+      input: new Uint8Array([1]),
+    });
+
+    const world1 = createLocalWorld({ dataDir, tag: 'vitest-1' });
+    const run1 = await createRun(world1, {
+      deploymentId: 'dpl_1',
+      workflowName: 'taggedWorkflow1',
+      input: new Uint8Array([2]),
+    });
+
+    await world0.close();
+    await world1.close();
+
+    const restartedWorld0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    const receivedRunIds: string[] = [];
+    restartedWorld0.registerHandler('__wkf_workflow_', async (req) => {
+      const body = await req.json();
+      receivedRunIds.push(body.runId);
+      return Response.json({ ok: true });
+    });
+
+    await restartedWorld0.start();
+
+    await vi.waitFor(() => {
+      expect(receivedRunIds).toEqual([run0.runId]);
+    });
+
+    expect(receivedRunIds).not.toContain(run1.runId);
+
+    await restartedWorld0.close();
+  });
+
+  it('keeps tag filtering when recovery paginates across multiple pages', async () => {
+    const world0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    const world1 = createLocalWorld({ dataDir, tag: 'vitest-1' });
+    const untaggedWorld = createLocalWorld({ dataDir });
+
+    await world0.start();
+    await world1.start();
+    await untaggedWorld.start();
+
+    const taggedRunIds: string[] = [];
+    const otherRunIds: string[] = [];
+
+    for (let i = 0; i < 25; i++) {
+      const run = await createRun(world0, {
+        deploymentId: 'dpl_1',
+        workflowName: `taggedWorkflow${i}`,
+        input: new Uint8Array([i]),
+      });
+      taggedRunIds.push(run.runId);
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const run = await createRun(world1, {
+        deploymentId: 'dpl_1',
+        workflowName: `otherTaggedWorkflow${i}`,
+        input: new Uint8Array([i]),
+      });
+      otherRunIds.push(run.runId);
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const run = await createRun(untaggedWorld, {
+        deploymentId: 'dpl_1',
+        workflowName: `untaggedWorkflow${i}`,
+        input: new Uint8Array([i]),
+      });
+      otherRunIds.push(run.runId);
+    }
+
+    await world0.close();
+    await world1.close();
+    await untaggedWorld.close();
+
+    const restartedWorld0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    const receivedRunIds: string[] = [];
+    restartedWorld0.registerHandler('__wkf_workflow_', async (req) => {
+      const body = await req.json();
+      receivedRunIds.push(body.runId);
+      return Response.json({ ok: true });
+    });
+
+    await restartedWorld0.start();
+
+    await vi.waitFor(() => {
+      expect(receivedRunIds).toHaveLength(taggedRunIds.length);
+    });
+
+    expect(new Set(receivedRunIds)).toEqual(new Set(taggedRunIds));
+    for (const runId of otherRunIds) {
+      expect(receivedRunIds).not.toContain(runId);
+    }
+
+    await restartedWorld0.close();
+  });
+
+  it('skips startup recovery when recoverActiveRuns is false', async () => {
+    const world1 = createLocalWorld({ dataDir });
+    await world1.start();
+
+    const run = await createRun(world1, {
+      deploymentId: 'dpl_1',
+      workflowName: 'myWorkflow',
+      input: new Uint8Array([1]),
+    });
+
+    await world1.close();
+
+    const world2 = createLocalWorld({ dataDir, recoverActiveRuns: false });
+    const receivedRunIds: string[] = [];
+    world2.registerHandler('__wkf_workflow_', async (req) => {
+      const body = await req.json();
+      receivedRunIds.push(body.runId);
+      return Response.json({ ok: true });
+    });
+
+    await world2.start();
+
+    await new Promise((r) => globalThis.setTimeout(r, 50));
+    expect(receivedRunIds).toHaveLength(0);
+    expect(receivedRunIds).not.toContain(run.runId);
+
+    await world2.close();
+  });
+
   it('does nothing on first start with empty data dir', async () => {
     const world = createLocalWorld({ dataDir });
     const receivedRunIds: string[] = [];

--- a/packages/world-local/src/storage/index.ts
+++ b/packages/world-local/src/storage/index.ts
@@ -2,8 +2,15 @@ import type { Storage } from '@workflow/world';
 import { instrumentObject } from '../instrumentObject.js';
 import { createEventsStorage } from './events-storage.js';
 import { createHooksStorage } from './hooks-storage.js';
-import { createRunsStorage } from './runs-storage.js';
+import { createRunsStorage, type LocalRunsStorage } from './runs-storage.js';
 import { createStepsStorage } from './steps-storage.js';
+
+/**
+ * Storage shape used inside world-local: identical to `Storage`, but `runs`
+ * exposes the internal `fileIdFilter` option on `list()`. Structurally
+ * assignable to `Storage` at public boundaries (e.g., `reenqueueActiveRuns`).
+ */
+export type LocalStorage = Omit<Storage, 'runs'> & { runs: LocalRunsStorage };
 
 /**
  * Creates a complete storage implementation using the filesystem.
@@ -14,21 +21,19 @@ import { createStepsStorage } from './steps-storage.js';
  * @param basedir - The base directory for storing workflow data
  * @returns A complete Storage implementation with tracing
  */
-export function createStorage(basedir: string, tag?: string): Storage {
+export function createStorage(basedir: string, tag?: string): LocalStorage {
   // Create raw storage implementations
-  const storage: Storage = {
-    runs: createRunsStorage(basedir, tag),
-    steps: createStepsStorage(basedir, tag),
-    events: createEventsStorage(basedir, tag),
-    hooks: createHooksStorage(basedir, tag),
-  };
+  const runs = createRunsStorage(basedir, tag);
+  const steps = createStepsStorage(basedir, tag);
+  const events = createEventsStorage(basedir, tag);
+  const hooks = createHooksStorage(basedir, tag);
 
   // Instrument all storage methods with tracing
   // NOTE: Span names are lowercase per OTEL semantic conventions
   return {
-    runs: instrumentObject('world.runs', storage.runs),
-    steps: instrumentObject('world.steps', storage.steps),
-    events: instrumentObject('world.events', storage.events),
-    hooks: instrumentObject('world.hooks', storage.hooks),
+    runs: instrumentObject('world.runs', runs),
+    steps: instrumentObject('world.steps', steps),
+    events: instrumentObject('world.events', events),
+    hooks: instrumentObject('world.hooks', hooks),
   };
 }

--- a/packages/world-local/src/storage/runs-storage.ts
+++ b/packages/world-local/src/storage/runs-storage.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
 import { WorkflowRunNotFoundError } from '@workflow/errors';
-import type { Storage, WorkflowRunWithoutData } from '@workflow/world';
+import type {
+  ListWorkflowRunsParams,
+  PaginatedResponse,
+  Storage,
+  WorkflowRun,
+  WorkflowRunWithoutData,
+} from '@workflow/world';
 import { WorkflowRunSchema } from '@workflow/world';
 import { DEFAULT_RESOLVE_DATA_OPTION } from '../config.js';
 import { paginatedFileSystemQuery, readJSONWithFallback } from '../fs.js';
@@ -8,13 +14,39 @@ import { filterRunData } from './filters.js';
 import { getObjectCreatedAt } from './helpers.js';
 
 /**
+ * Internal extension of `ListWorkflowRunsParams` that adds a `fileIdFilter`
+ * for scoping queries by raw filename (e.g., by tag suffix). Kept out of the
+ * public `Storage['runs']['list']` surface — consumers of `@workflow/world`
+ * must not see this option.
+ */
+export interface LocalListWorkflowRunsParams extends ListWorkflowRunsParams {
+  fileIdFilter?: (fileId: string) => boolean;
+}
+
+export interface LocalRunsStorage {
+  get: Storage['runs']['get'];
+  list: {
+    (
+      params: LocalListWorkflowRunsParams & { resolveData: 'none' }
+    ): Promise<PaginatedResponse<WorkflowRunWithoutData>>;
+    (
+      params?: LocalListWorkflowRunsParams & { resolveData?: 'all' }
+    ): Promise<PaginatedResponse<WorkflowRun>>;
+    (
+      params?: LocalListWorkflowRunsParams
+    ): Promise<PaginatedResponse<WorkflowRun | WorkflowRunWithoutData>>;
+  };
+}
+
+/**
  * Creates the runs storage implementation using the filesystem.
- * Implements the Storage['runs'] interface with get and list operations.
+ * Implements the Storage['runs'] interface with get and list operations,
+ * plus an internal `fileIdFilter` on `list` for tag-scoped recovery queries.
  */
 export function createRunsStorage(
   basedir: string,
   tag?: string
-): Storage['runs'] {
+): LocalRunsStorage {
   return {
     get: (async (id: string, params?: any) => {
       const run = await readJSONWithFallback(
@@ -31,11 +63,12 @@ export function createRunsStorage(
       return filterRunData(run, resolveData);
     }) as Storage['runs']['get'],
 
-    list: (async (params?: any) => {
+    list: (async (params?: LocalListWorkflowRunsParams) => {
       const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
       const result = await paginatedFileSystemQuery({
         directory: path.join(basedir, 'runs'),
         schema: WorkflowRunSchema,
+        fileIdFilter: params?.fileIdFilter,
         filter: (run) => {
           if (
             params?.workflowName &&
@@ -68,6 +101,6 @@ export function createRunsStorage(
       }
 
       return result;
-    }) as Storage['runs']['list'],
+    }) as LocalRunsStorage['list'],
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,7 +618,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: 1.0.2
-        version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
       '@nuxt/schema':
         specifier: 4.4.2
         version: 4.4.2
@@ -787,9 +787,6 @@ importers:
       '@workflow/world-local':
         specifier: workspace:*
         version: link:../world-local
-      vitest:
-        specifier: '>=3.0.0'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -800,6 +797,9 @@ importers:
       vite:
         specifier: 7.1.12
         version: 7.1.12(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
   packages/web:
     dependencies:
@@ -2511,24 +2511,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.4':
     resolution: {integrity: sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.4':
     resolution: {integrity: sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.4':
     resolution: {integrity: sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.4':
     resolution: {integrity: sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==}
@@ -3480,166 +3484,196 @@ packages:
     resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.3':
     resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.3':
     resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.3':
     resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.3':
     resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
     resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.3':
     resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.4':
     resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.4':
     resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.4':
     resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.4':
     resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.4':
     resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.4':
     resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.4':
     resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.4':
     resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
@@ -3949,42 +3983,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -4114,24 +4155,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.1':
     resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.1':
     resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.1':
     resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.1':
     resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
@@ -4186,24 +4231,28 @@ packages:
     engines: {node: '>= 12'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/xxhash-linux-arm64-musl@1.7.6':
     resolution: {integrity: sha512-AB5m6crGYSllM9F/xZNOQSPImotR5lOa9e4arW99Bv82S+gcpphI8fGMDOVTTCXY/RLRhvvhwzLDxmLB2O8VDg==}
     engines: {node: '>= 12'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/xxhash-linux-x64-gnu@1.7.6':
     resolution: {integrity: sha512-a2A6M+5tc0PVlJlE/nl0XsLEzMpKkwg7Y1lR5urFUbW9uVQnKjJYQDrUojhlXk0Uv3VnYQPa6ThmwlacZA5mvQ==}
     engines: {node: '>= 12'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/xxhash-linux-x64-musl@1.7.6':
     resolution: {integrity: sha512-WioGJSC1GoxQpmdQrG5l/uddSBAS4XCWczHNwXe895J5xadGQzyvmr0r17BNfihvbBUDH1H9jwouNYzDDeA6+A==}
     engines: {node: '>= 12'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/xxhash-wasm32-wasi@1.7.6':
     resolution: {integrity: sha512-WDXXKMMFMrez+esm2DzMPHFNPFYf+wQUtaXrXwtxXeQMFEzleOLwEaqV0+bbXGJTwhPouL3zY1Qo2xmIH4kkTg==}
@@ -4479,84 +4528,98 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-gnu@0.96.0':
     resolution: {integrity: sha512-Yl+KcTldsEJNcaYxxonwAXZ2q3gxIzn3kXYQWgKWdaGIpNhOCWqF+KE5WLsldoh5Ro5SHtomvb8GM6cXrIBMog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.117.0':
     resolution: {integrity: sha512-C3zapJconWpl2Y7LR3GkRkH6jxpuV2iVUfkFcHT5Ffn4Zu7l88mZa2dhcfdULZDybN1Phka/P34YUzuskUUrXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-arm64-musl@0.96.0':
     resolution: {integrity: sha512-rNqoFWOWaxwMmUY5fspd/h5HfvgUlA3sv9CUdA2MpnHFiyoJNovR7WU8tGh+Yn0qOAs0SNH0a05gIthHig14IA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-2T/Bm+3/qTfuNS4gKSzL8qbiYk+ErHW2122CtDx+ilZAzvWcJ8IbqdZIbEWOlwwe03lESTxPwTBLFqVgQU2OeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-MKLjpldYkeoB4T+yAi4aIAb0waifxUjLcKkCUDmYAY3RqBJTvWK34KtfaKZL0IBMIXfD92CbKkcxQirDUS9Xcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.96.0':
     resolution: {integrity: sha512-3paajIuzGnukHwSI3YBjYVqbd72pZd8NJxaayaNFR0AByIm8rmIT5RqFXbq8j2uhtpmNdZRXiu0em1zOmIScWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-UFVcbPvKUStry6JffriobBp8BHtjmLLPl4bCY+JMxIn/Q3pykCpZzRwFTcDurG/kY8tm+uSNfKKdRNa5Nh9A7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-B9GyPQ1NKbvpETVAMyJMfRlD3c6UJ7kiuFUAlx9LTYiQL+YIyT6vpuRlq1zgsXxavZluVrfeJv6x0owV4KDx4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.96.0':
     resolution: {integrity: sha512-9ESrpkB2XG0lQ89JlsxlZa86iQCOs+jkDZLl6O+u5wb7ynUy21bpJJ1joauCOSYIOUlSy3+LbtJLiqi7oSQt5Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-fXfhtr+WWBGNy4M5GjAF5vu/lpulR4Me34FjTyaK9nDrTZs7LM595UDsP1wliksqp4hD/KdoqHGmbCrC+6d4vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.96.0':
     resolution: {integrity: sha512-UMM1jkns+p+WwwmdjC5giI3SfR2BCTga18x3C0cAu6vDVf4W37uTZeTtSIGmwatTBbgiq++Te24/DE0oCdm1iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.117.0':
     resolution: {integrity: sha512-jFBgGbx1oLadb83ntJmy1dWlAHSQanXTS21G4PgkxyONmxZdZ/UMKr7KsADzMuoPsd2YhJHxzRpwJd9U+4BFBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-x64-musl@0.96.0':
     resolution: {integrity: sha512-8b1naiC7MdP7xeMi7cQ5tb9W1rZAP9Qz/jBRqp1Y5EOZ1yhSGnf1QWuZ/0pCc+XiB9vEHXEY3Aki/H+86m2eOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-nxPd9vx1vYz8IlIMdl9HFdOK/ood1H5hzbSFsyO8JU55tkcJoBL8TLCbuFf9pHpOy27l2gcPyV6z3p4eAcTH5Q==}
@@ -4651,48 +4714,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.117.0':
     resolution: {integrity: sha512-QagKTDF4lrz8bCXbUi39Uq5xs7C7itAseKm51f33U+Dyar9eJY/zGKqfME9mKLOiahX7Fc1J3xMWVS0AdDXLPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-RPddpcE/0xxWaommWy0c5i/JdrXcXAkxBS2GOrAUh5LKmyCh03hpJedOAWszG4ADsKQwoUQQ1/tZVGRhZIWtKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-ur/WVZF9FSOiZGxyP+nfxZzuv6r5OJDYoVxJnUR7fM/hhXLh4V/be6rjbzm9KLCDBRwYCEKJtt+XXNccwd06IA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-ujGcAx8xAMvhy7X5sBFi3GXML1EtyORuJZ5z2T6UV3U416WgDX/4OCi3GnoteeenvxIf6JgP45B+YTHpt71vpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-hbsfKjUwRjcMZZvvmpZSc+qS0bHcHRu8aV/I3Ikn9BzOA0ZAgUE7ctPtce5zCU7bM8dnTLi4sJ1Pi9YHdx6Urw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-1QrTrf8rige7UPJrYuDKJLQOuJlgkt+nRSJLBMHWNm9TdivzP48HaK3f4q18EjNlglKtn03lgjMu4fryDm8X4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.117.0':
     resolution: {integrity: sha512-gRvK6HPzF5ITRL68fqb2WYYs/hGviPIbkV84HWCgiJX+LkaOpp+HIHQl3zVZdyKHwopXToTbXbtx/oFjDjl8pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-QPJvFbnnDZZY7xc+xpbIBWLThcGBakwaYA9vKV8b3+oS5MGfAZUoTFJcix5+Zg2Ri46sOfrUim6Y6jsKNcssAQ==}
@@ -4809,84 +4880,98 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-gnu@0.96.0':
     resolution: {integrity: sha512-kaqvUzNu8LL4aBSXqcqGVLFG13GmJEplRI2+yqzkgAItxoP/LfFMdEIErlTWLGyBwd0OLiNMHrOvkcCQRWadVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.117.0':
     resolution: {integrity: sha512-ykxpPQp0eAcSmhy0Y3qKvdanHY4d8THPonDfmCoktUXb6r0X6qnjpJB3V+taN1wevW55bOEZd97kxtjTKjqhmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-arm64-musl@0.96.0':
     resolution: {integrity: sha512-EiG/L3wEkPgTm4p906ufptyblBgtiQWTubGg/JEw82f8uLRroayr5zhbUqx40EgH037a3SfJthIyLZi7XPRFJw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-Rvspti4Kr7eq6zSrURK5WjscfWQPvmy/KjJZV45neRKW8RLonE3r9+NgrwSLGoHvQ3F24fbqlkplox1RtlhH5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-Dr2ZW9ZZ4l1eQ5JUEUY3smBh4JFPCPuybWaDZTLn3ADZjyd8ZtNXEjeMT8rQbbhbgSL9hEgbwaqraole3FNThQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.96.0':
     resolution: {integrity: sha512-r01CY6OxKGtVeYnvH4mGmtkQMlLkXdPWWNXwo5o7fE2s/fgZPMpqh8bAuXEhuMXipZRJrjxTk1+ZQ4KCHpMn3Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-oD1Bnes1bIC3LVBSrWEoSUBj6fvatESPwAVWfJVGVQlqWuOs/ZBn1e4Nmbipo3KGPHK7DJY75r/j7CQCxhrOFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-qT//IAPLvse844t99Kff5j055qEbXfwzWgvCMb0FyjisnB8foy25iHZxZIocNBe6qwrCYWUP1M8rNrB/WyfS1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.96.0':
     resolution: {integrity: sha512-4djg2vYLGbVeS8YiA2K4RPPpZE4fxTGCX5g/bOMbCYyirDbmBAIop4eOAj8vOA9i1CcWbDtmp+PVJ1dSw7f3IQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-2YEO5X+KgNzFqRVO5dAkhjcI5gwxus4NSWVl/+cs2sI6P0MNPjqE3VWPawl4RTC11LvetiiZdHcujUCPM8aaUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.96.0':
     resolution: {integrity: sha512-f6pcWVz57Y8jXa2OS7cz3aRNuks34Q3j61+3nQ4xTE8H1KbalcEvHNmM92OEddaJ8QLs9YcE0kUC6eDTbY34+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.117.0':
     resolution: {integrity: sha512-3wqWbTSaIFZvDr1aqmTul4cg8PRWYh6VC52E8bLI7ytgS/BwJLW+sDUU2YaGIds4sAf/1yKeJRmudRCDPW9INg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-x64-musl@0.96.0':
     resolution: {integrity: sha512-NSiRtFvR7Pbhv3mWyPMkTK38czIjcnK0+K5STo3CuzZRVbX1TM17zGdHzKBUHZu7v6IQ6/XsQ3ELa1BlEHPGWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-Ebxx6NPqhzlrjvx4+PdSqbOq+li0f7X59XtJljDghkbJsbnkHvhLmPR09ifHt5X32UlZN63ekjwcg/nbmHLLlA==}
@@ -4963,36 +5048,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.1':
     resolution: {integrity: sha512-RJxlQQLkaMMIuWRozy+z2vEqbaQlCuaCgVZIUCzQLYggY22LZbP5Y1+ia+FD724Ids9e+XIyOLXLrLgQSHIthw==}
@@ -6357,121 +6448,145 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -6899,24 +7014,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.3':
     resolution: {integrity: sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.3':
     resolution: {integrity: sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.3':
     resolution: {integrity: sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.3':
     resolution: {integrity: sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA==}
@@ -7029,48 +7148,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
     resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
     resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
     resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.13':
     resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.13':
     resolution: {integrity: sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==}
@@ -10499,48 +10626,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -13715,6 +13850,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -16677,7 +16813,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       citty: 0.1.6
@@ -16685,14 +16821,14 @@ snapshots:
       defu: 6.1.4
       jiti: 2.6.1
       magic-regexp: 0.10.0
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
       tsconfck: 3.1.6(typescript@5.9.3)
       typescript: 5.9.3
-      unbuild: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3))
+      unbuild: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - esbuild
@@ -24766,7 +24902,7 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -24784,7 +24920,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       vue: 3.5.30(typescript@5.9.3)
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3))
 
   mlly@1.8.0:
     dependencies:
@@ -28101,7 +28237,7 @@ snapshots:
 
   ultrahtml@1.6.0: {}
 
-  unbuild@3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
+  unbuild@3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.53.2)
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.53.2)
@@ -28117,7 +28253,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -28856,11 +28992,11 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.30
 
-  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.4)(vue@3.5.30(typescript@5.9.3)):
+  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@babel/parser': 7.28.5
       '@vue/compiler-core': 3.5.30
-      esbuild: 0.27.4
+      esbuild: 0.27.3
       vue: 3.5.30(typescript@5.9.3)
 
   vue@3.5.30(typescript@5.9.3):


### PR DESCRIPTION
Backports #1895 onto \`stable\`.

Cherry-pick of \`2f52d14f38\` with conflict resolution for stable's diverged state:

- **\`packages/vitest/package.json\`**: Kept stable's \`vite\` version (\`7.1.12\`) but added the new \`vitest\` devDep so the new \`packages/vitest/src/index.test.ts\` can run.
- **\`packages/core/e2e/dev.test.ts\`**: Stable still uses the copied-step-files mechanism (the \`step file copy\` removal in #1796 is on main only), so the test bodies were kept verbatim from stable. Adopted the new \`apiFile\` retry-on-500 try/catch from the cherry-pick where it composes cleanly with the copied-files check. Did not adopt the manifest-based assertion or the in-test teardown (manifest.json is not produced by stable's deferred builder).
- **\`pnpm-lock.yaml\`**: Regenerated via \`pnpm install --lockfile-only\`.

Verified locally:
- \`pnpm --filter @workflow/vitest test\`: 5/5 passing
- \`pnpm --filter @workflow/world-local test\`: 270/270 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)