### PR TITLE
[backport] [builders] Fix transitive local TS dep externalization in step bundles (#1609)

### DIFF
--- a/.changeset/fix-transitive-local-dep-bundling.md
+++ b/.changeset/fix-transitive-local-dep-bundling.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Fix transitive local TS dependencies being externalized in step bundles instead of bundled

--- a/packages/builders/src/discover-entries-esbuild-plugin.test.ts
+++ b/packages/builders/src/discover-entries-esbuild-plugin.test.ts
@@ -134,9 +134,9 @@ describe('createDiscoverEntriesPlugin projectRoot', () => {
     );
 
     const state = {
-      discoveredSteps: new Set<string>(),
-      discoveredWorkflows: new Set<string>(),
-      discoveredSerdeFiles: new Set<string>(),
+      discoveredSteps: [] as string[],
+      discoveredWorkflows: [] as string[],
+      discoveredSerdeFiles: [] as string[],
     };
 
     await esbuild.build({

--- a/packages/builders/src/discover-entries-esbuild-plugin.test.ts
+++ b/packages/builders/src/discover-entries-esbuild-plugin.test.ts
@@ -113,6 +113,58 @@ describe('createDiscoverEntriesPlugin projectRoot', () => {
     );
   });
 
+  it('tracks extensionless relative imports in the import graph', async () => {
+    const workflowFile = join(
+      testRoot,
+      'server',
+      'workflows',
+      'my-workflow.ts'
+    );
+    const constantsFile = join(testRoot, 'shared', 'constants.ts');
+    const helpersFile = join(testRoot, 'shared', 'helpers.ts');
+
+    writeFile(helpersFile, `export const HELLO = "world";`);
+    writeFile(
+      constantsFile,
+      `import { HELLO } from './helpers';\nexport const MSG = HELLO;`
+    );
+    writeFile(
+      workflowFile,
+      `import { MSG } from '../../shared/constants';\nexport function myWorkflow() {\n  "use workflow";\n  return MSG;\n}`
+    );
+
+    const state = {
+      discoveredSteps: new Set<string>(),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+    };
+
+    await esbuild.build({
+      entryPoints: [workflowFile],
+      absWorkingDir: testRoot,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+      plugins: [createDiscoverEntriesPlugin(state, testRoot)],
+    });
+
+    const normalizedWorkflow = normalizeSlashes(workflowFile);
+    const normalizedConstants = normalizeSlashes(constantsFile);
+    const normalizedHelpers = normalizeSlashes(helpersFile);
+
+    // my-workflow.ts -> shared/constants.ts (extensionless import)
+    const workflowChildren = importParents.get(normalizedWorkflow);
+    expect(workflowChildren).toBeDefined();
+    expect(workflowChildren!.has(normalizedConstants)).toBe(true);
+
+    // shared/constants.ts -> shared/helpers.ts (extensionless import)
+    const constantsChildren = importParents.get(normalizedConstants);
+    expect(constantsChildren).toBeDefined();
+    expect(constantsChildren!.has(normalizedHelpers)).toBe(true);
+  });
+
   it('defaults discovery transforms to absWorkingDir when projectRoot is omitted', async () => {
     const fixture = setupFixture();
     const normalizedWorkflowFile = normalizeSlashes(fixture.workflowFile);

--- a/packages/builders/src/discover-entries-esbuild-plugin.ts
+++ b/packages/builders/src/discover-entries-esbuild-plugin.ts
@@ -90,7 +90,12 @@ export function createDiscoverEntriesPlugin(
   return {
     name: 'discover-entries-esbuild-plugin',
     setup(build) {
-      build.onResolve({ filter: jsTsRegex }, async (args) => {
+      // Track parent→child import relationships for ALL imports (not just
+      // those with file extensions) so that `parentHasChild()` can correctly
+      // identify transitive parents of serde/step files even when the
+      // dependency chain passes through bare specifier or extensionless
+      // relative imports.
+      build.onResolve({ filter: /.*/ }, async (args) => {
         try {
           const resolved = await enhancedResolve(args.resolveDir, args.path);
 

--- a/packages/builders/src/discover-entries-esbuild-plugin.ts
+++ b/packages/builders/src/discover-entries-esbuild-plugin.ts
@@ -9,7 +9,28 @@ import {
   isWorkflowSdkFile,
 } from './transform-utils.js';
 
-const enhancedResolve = promisify(enhancedResolveOriginal);
+const enhancedResolve = promisify(
+  enhancedResolveOriginal.create({
+    extensions: [
+      '.ts',
+      '.tsx',
+      '.mts',
+      '.cts',
+      '.cjs',
+      '.mjs',
+      '.js',
+      '.jsx',
+      '.json',
+      '.node',
+    ],
+    mainFields: ['main'],
+    mainFiles: ['index'],
+    conditionNames: ['node', 'import'],
+    // Match swc-esbuild-plugin's resolver so both plugins resolve the same
+    // paths — important for parentHasChild() graph lookups.
+    symlinks: true,
+  })
+);
 
 export const jsTsRegex = /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts)$/;
 

--- a/packages/builders/src/swc-esbuild-plugin.test.ts
+++ b/packages/builders/src/swc-esbuild-plugin.test.ts
@@ -250,9 +250,9 @@ describe('createSwcPlugin externalizeNonSteps', () => {
     // Run discovery first to populate importParents
     importParents.clear();
     const state = {
-      discoveredSteps: new Set<string>(),
-      discoveredWorkflows: new Set<string>(),
-      discoveredSerdeFiles: new Set<string>(),
+      discoveredSteps: [] as string[],
+      discoveredWorkflows: [] as string[],
+      discoveredSerdeFiles: [] as string[],
     };
     await esbuild.build({
       entryPoints: [stepFile],

--- a/packages/builders/src/swc-esbuild-plugin.test.ts
+++ b/packages/builders/src/swc-esbuild-plugin.test.ts
@@ -19,6 +19,10 @@ vi.mock('./apply-swc-transform.js', () => ({
 }));
 
 import { createSwcPlugin } from './swc-esbuild-plugin.js';
+import {
+  importParents,
+  createDiscoverEntriesPlugin,
+} from './discover-entries-esbuild-plugin.js';
 
 const realTmpdir = realpathSync(tmpdir());
 
@@ -225,6 +229,69 @@ describe('createSwcPlugin externalizeNonSteps', () => {
     expect(result.errors).toHaveLength(0);
     const output = result.outputFiles[0].text;
     expect(output).toContain(`/dep${inputExt}`);
+  });
+
+  it('bundles transitive local dependencies of entries instead of externalizing them', async () => {
+    const outdir = join(testRoot, 'out');
+    const stepFile = join(testRoot, 'server', 'workflows', 'my-step.ts');
+    const constantsFile = join(testRoot, 'shared', 'constants.ts');
+    const helpersFile = join(testRoot, 'shared', 'helpers.ts');
+
+    writeFile(helpersFile, `export const HELLO = "world";`);
+    writeFile(
+      constantsFile,
+      `import { HELLO } from './helpers';\nexport const MSG = HELLO;`
+    );
+    writeFile(
+      stepFile,
+      `import { MSG } from '../../shared/constants';\nconsole.log(MSG);`
+    );
+
+    // Run discovery first to populate importParents
+    importParents.clear();
+    const state = {
+      discoveredSteps: new Set<string>(),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+    };
+    await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+      plugins: [createDiscoverEntriesPlugin(state, testRoot)],
+    });
+
+    // Now build with swc plugin — transitive deps should be bundled
+    const result = await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      outdir,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          entriesToBundle: [stepFile],
+          outdir,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const output = result.outputFiles[0].text;
+    // Both constants.ts and helpers.ts should be inlined, not externalized
+    expect(output).toContain('world');
+    expect(output).not.toContain('../shared/constants');
+    expect(output).not.toContain('./helpers');
+
+    importParents.clear();
   });
 });
 

--- a/packages/builders/src/swc-esbuild-plugin.ts
+++ b/packages/builders/src/swc-esbuild-plugin.ts
@@ -188,10 +188,17 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
                 break;
               }
 
-              // if the current entry imports a child that needs
+              // if the current file imports a child that needs
               // to be bundled then it needs to also be bundled so
               // that the child can have our transform applied
               if (parentHasChild(normalizedResolvedPath, normalizedEntry)) {
+                shouldBundle = true;
+                break;
+              }
+
+              // if an entry transitively imports this file, bundle it
+              // so the step bundle is self-contained for local deps
+              if (parentHasChild(normalizedEntry, normalizedResolvedPath)) {
                 shouldBundle = true;
                 break;
               }


### PR DESCRIPTION
Backports #1609 onto \`stable\`. Closes #1179.

Cherry-pick of \`eef34a391e\` plus a follow-up adapter commit because the PR was authored on top of #1669 (\`fix(builders): improve step bundle discovery and externalization for SDK serde classes\`), which is on \`main\` but not on \`stable\`.

Adapter changes (second commit):

- Broaden \`discover-entries\` \`onResolve\` filter from \`jsTsRegex\` to \`/.*/\` (carried over from #1669) so the import graph captures bare-specifier and extensionless imports — the resolver fix in #1609 only helps if \`onResolve\` actually fires for those imports.
- Switch the new test fixtures from \`Set<string>\` back to \`string[]\` to match stable's still-array-based state interface in \`createDiscoverEntriesPlugin\` (the Set conversion is also part of #1669).

Verified locally:
- \`pnpm --filter @workflow/builders test\`: 129/129 passing, including the two new regression tests added by #1609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)