### PR TITLE
Fix compatibility with Zod 4.4.x

### DIFF
--- a/packages/world/src/runs.ts
+++ b/packages/world/src/runs.ts
@@ -66,28 +66,28 @@ export const WorkflowRunSchema = z.discriminatedUnion('status', [
   // Non-final states
   WorkflowRunBaseSchema.extend({
     status: z.enum(['pending', 'running']),
-    output: z.undefined(),
-    error: z.undefined(),
-    completedAt: z.undefined(),
+    output: z.undefined().optional(),
+    error: z.undefined().optional(),
+    completedAt: z.undefined().optional(),
   }),
   // Cancelled state
   WorkflowRunBaseSchema.extend({
     status: z.literal('cancelled'),
-    output: z.undefined(),
-    error: z.undefined(),
+    output: z.undefined().optional(),
+    error: z.undefined().optional(),
     completedAt: z.coerce.date(),
   }),
   // Completed state - output can be v1 or v2 format
   WorkflowRunBaseSchema.extend({
     status: z.literal('completed'),
     output: SerializedDataSchema,
-    error: z.undefined(),
+    error: z.undefined().optional(),
     completedAt: z.coerce.date(),
   }),
   // Failed state
   WorkflowRunBaseSchema.extend({
     status: z.literal('failed'),
-    output: z.undefined(),
+    output: z.undefined().optional(),
     error: StructuredErrorSchema,
     completedAt: z.coerce.date(),
   }),


### PR DESCRIPTION
I have mentioned this issue here -> https://github.com/vercel/workflow/issues/1901

Turns out from release 4.4.0, Zod now treats a property whose schema is z.undefined() as required.

To fix this I have explicitly made them optional.

Ref -> `Required object properties with z.undefined()` in -> https://github.com/vercel/workflow/issues/1901