### PR TITLE
[tarballs] Build workspace deps before packing

### DIFF
--- a/.changeset/fix-tarballs-build.md
+++ b/.changeset/fix-tarballs-build.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the `tarballs` Vercel project so workspace dependencies are built before packing — without this, every preview tarball ships with an empty `dist/` directory and downstream installs fail to resolve `dist/*` entry points.

--- a/tarballs/vercel.json
+++ b/tarballs/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm --filter tarballs build",
+  "buildCommand": "pnpm turbo build --filter=tarballs",
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": "public",
   "framework": null


### PR DESCRIPTION
## Summary

The `tarballs` Vercel project's `vercel.json` sets

```json
"buildCommand": "pnpm --filter tarballs build"
```

which only runs the `tarballs` package's `build` script (`node scripts/pack.ts`) and does **not** trigger turbo's `dependsOn: ["^build"]` chain. As a result every preview tarball gets packed with an empty `dist/` directory — only `bin/`, `package.json`, `README.md`, and `docs/` make it in. Downstream installs then fail with errors like:

```
Cannot find module '/.../node_modules/workflow/dist/next.cjs'
```

The old docs-based pipeline did not hit this because Vercel detected `docs` as a Next.js framework, ran turbo for it (which fans out via `^build`), and `pack.ts` was wired as a `prebuild` step that ran after workspace deps were already built. Splitting tarballs out of docs in #1893 dropped that side-effect.

The fix is one line: switch the build command to

```json
"buildCommand": "pnpm turbo build --filter=tarballs"
```

so turbo evaluates the build task for `tarballs`, fans out via `^build` to compile every workspace dependency first, and only then runs `tarballs#build` (`pack.ts`) against the populated `dist/` directories.

## Test plan

- [x] `pnpm turbo build --filter=tarballs` locally — output tarballs contain the full `dist/` tree (verified `package/dist/next.cjs` is present in `tarballs/public/workflow.tgz`).
- [ ] Preview deployment for this branch produces tarballs that resolve `workflow/next` correctly when installed in a downstream Next.js app.
- [ ] CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)