### PR TITLE
[backport] [tarballs] Build workspace deps before packing (#1908)

### DIFF
--- a/.changeset/fix-tarballs-build.md
+++ b/.changeset/fix-tarballs-build.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the `tarballs` Vercel project so workspace dependencies are built before packing — without this, every preview tarball ships with an empty `dist/` directory and downstream installs fail to resolve `dist/*` entry points.

--- a/tarballs/vercel.json
+++ b/tarballs/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm --filter tarballs build",
+  "buildCommand": "pnpm turbo build --filter=tarballs",
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": "public",
   "framework": null


### PR DESCRIPTION
Backport of #1908 to `stable`.

## Summary

The `tarballs` Vercel project's `vercel.json` sets `"buildCommand": "pnpm --filter tarballs build"`, which only runs the `tarballs` package's `build` script (`node scripts/pack.ts`) and does **not** trigger turbo's `dependsOn: ["^build"]` chain. As a result every preview tarball gets packed with an empty `dist/` directory — only `bin/`, `package.json`, `README.md`, and `docs/` make it in. Downstream installs then fail with errors like:

```
Cannot find module '/.../node_modules/workflow/dist/next.cjs'
```

The fix flips the build command to `pnpm turbo build --filter=tarballs` so turbo fans out via `^build` to compile every workspace dependency first, and only then runs `tarballs#build` (`pack.ts`) against the populated `dist/` directories.

This applies to `stable` for the same reason as on `main`: PR #1899 backported the tarballs split (#1893) onto `stable`, so stable's preview tarballs are broken in the same way.

## Test plan

- [ ] Preview deployment for this branch produces tarballs that resolve `workflow/next` correctly when installed in a downstream Next.js app.
- [ ] CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)