### PR TITLE
[backport] [ci] Stop using Release App token + bump pnpm/action-setup

### DIFF
--- a/.changeset/backport-release-app-token-removal.md
+++ b/.changeset/backport-release-app-token-removal.md
@@ -1,0 +1,4 @@
+---
+---
+
+Backport CI changes from `main` to unblock releases on `stable`. Removes the dependency on the temporarily-removed Release App by switching to `secrets.GITHUB_TOKEN` with `commitMode: github-api` for GPG-signed commits, and bumps `pnpm/action-setup` to `v5` so the version is read from `package.json#packageManager`. Backports #1785, #1866, and #1867.

--- a/.github/actions/setup-workflow-dev/action.yml
+++ b/.github/actions/setup-workflow-dev/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '22.x'
-  pnpm-version:
-    description: 'pnpm version to use'
-    required: false
-    default: '10.14.0'
   setup-rust:
     description: 'Whether to setup Rust toolchain'
     required: false
@@ -37,9 +33,7 @@ runs:
         toolchain: stable
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3
-      with:
-        version: ${{ inputs.pnpm-version }}
+      uses: pnpm/action-setup@v5
 
     - name: Setup Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4

--- a/.github/workflows/debug-windows.yml
+++ b/.github/workflows/debug-windows.yml
@@ -27,9 +27,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10.14.0
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4

--- a/.github/workflows/dispatch-front-workflow-release-pr.yml
+++ b/.github/workflows/dispatch-front-workflow-release-pr.yml
@@ -1,5 +1,11 @@
 name: Dispatch Front Workflow Release PR
 
+# DISABLED: This workflow dispatches to vercel/front (cross-repo) which
+# requires a GitHub App token. The Release App has been temporarily
+# removed, so this workflow is disabled (all jobs gated on `if: false`)
+# until the App is restored. See .github/workflows/release.yml and
+# .github/workflows/backport.yml, which have also been updated to no
+# longer rely on the Release App.
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
@@ -15,6 +21,7 @@ jobs:
   dispatch-front-sync:
     name: Dispatch Front Sync
     if: >
+      false &&
       startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
       github.event.action != 'closed'
     runs-on: ubuntu-latest
@@ -68,6 +75,7 @@ jobs:
   dispatch-front-close:
     name: Dispatch Front Close
     if: >
+      false &&
       startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
       github.event.action == 'closed'
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-front-workflow-release-pr.yml
+++ b/.github/workflows/dispatch-front-workflow-release-pr.yml
@@ -3,9 +3,8 @@ name: Dispatch Front Workflow Release PR
 # DISABLED: This workflow dispatches to vercel/front (cross-repo) which
 # requires a GitHub App token. The Release App has been temporarily
 # removed, so this workflow is disabled (all jobs gated on `if: false`)
-# until the App is restored. See .github/workflows/release.yml and
-# .github/workflows/backport.yml, which have also been updated to no
-# longer rely on the Release App.
+# until the App is restored. See .github/workflows/release.yml, which
+# has also been updated to no longer rely on the Release App.
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - stable
+  # Allow manual triggering from the Actions tab. Useful for re-running the
+  # release flow when a push from the default GITHUB_TOKEN (e.g. a clean
+  # cherry-pick from the backport workflow, or a merged "Version Packages"
+  # PR) does not automatically trigger this workflow.
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -23,23 +28,15 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git identity
         run: |
-          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -63,12 +60,12 @@ jobs:
           createGithubReleases: false
           setupGitUser: false
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           # Generate release notes (PUBLISHED_PACKAGES filters to only include packages from this release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
           publish: pnpm ci:publish
           createGithubReleases: false
           setupGitUser: false
+          # Use GitHub API for GPG-signed commits (required by branch rules).
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,7 @@ jobs:
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10.14.0
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js 24.x
         uses: actions/setup-node@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,9 +161,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10.14.0
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
@@ -622,9 +620,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10.14.0
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

The Release job on `stable` is failing at the `Generate GitHub App Token` step because the Release App was temporarily removed:

```
Failed to create token for "workflow" (attempt 4): Integration not found
GET https://api.github.com/repos/vercel/workflow/installation -> 404
```

This was already addressed on `main` in #1866 + #1867 (and #1785 for the related pnpm/action-setup upgrade), but the changes were never backported to `stable`. This PR cherry-picks all three.

Example failing run: https://github.com/vercel/workflow/actions/runs/25303132457/job/74173639841

## Cherry-picked commits

In order:

1. **#1785 — `ci: upgrade pnpm/action-setup to v5 and read version from package.json`**
   - Replaces `pnpm/action-setup@v3` + explicit `version: 10.14.0` with `@v5` (reads `packageManager` field from `package.json`, currently pinned at `10.20.0`).
   - Conflicts resolved:
     - `.github/workflows/backport.yml`: doesn't exist on stable (main-only file) → `git rm`.
     - `.github/workflows/docs-checks.yml` and `.github/workflows/lint.yml`: stable's versions are intentionally stripped to no-op stubs (`if: false` + `- run: true`). Kept stable's stub bodies; nothing to upgrade since neither uses `pnpm/action-setup` in those stubs.

2. **#1866 — `ci: stop using Release App token in release workflows`**
   - `.github/workflows/release.yml`: removes the `Generate GitHub App Token` step, switches `GITHUB_TOKEN` to `secrets.GITHUB_TOKEN` everywhere, hardcodes git identity to `github-actions[bot]`, adds `workflow_dispatch` trigger for manual re-runs.
   - `.github/workflows/dispatch-front-workflow-release-pr.yml`: gates both jobs on `if: false &&` since the cross-repo dispatch to `vercel/front` requires the App token. (Backport-only file `backport.yml` skipped — doesn't exist on stable.)

3. **#1867 — `ci: use GitHub API commit mode for changesets action`**
   - Adds `commitMode: github-api` to the `changesets/action@v1` invocation so commits are GPG-signed via the API (required by org-level branch rulesets that mandate verified signatures on all branches).

## Verification

After cherry-pick, `release.yml` is byte-identical to `main`:

```sh
diff <(git show HEAD:.github/workflows/release.yml) <(gh api 'repos/vercel/workflow/contents/.github/workflows/release.yml?ref=main' -H 'Accept: application/vnd.github.raw+json')
# (no output)
```

Other touched files (`debug-windows.yml`, `tests.yml`, `setup-workflow-dev/action.yml`) have remaining diffs vs main but those are pre-existing stable-vs-main divergences (e.g., stable's `tests.yml` triggers on both `main` and `stable` branches; main's `setup-workflow-dev` has a newer `cache-pnpm` input added by an unrelated PR). None of those are in scope for the App token fix.

`dispatch-front-workflow-release-pr.yml` has a separate divergence in the `wait-for-vercel-project` action API shape (stable uses the older `team-id`/`project-id`/`vercel-token` form, main uses the newer `project-slug` form) — but both versions are now fully disabled via `if: false`, so the inner divergence doesn't matter until the App is restored.

## Caveats (carried over from #1866's PR description)

GitHub Actions' default `GITHUB_TOKEN` does not trigger downstream workflow runs:

1. The "Version Packages" PR created by changesets won't auto-trigger required CI checks. Push an empty commit, or close/reopen the PR, to kick off CI before merging.
2. After merging a "Version Packages" PR, the `Release` workflow won't auto-run. Use the `workflow_dispatch` trigger from the Actions tab to publish.