### PR TITLE
[core] V2: skip inline step execution when suspension also has a wait

### DIFF
--- a/.changeset/fix-step-vs-wait-race.md
+++ b/.changeset/fix-step-vs-wait-race.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Fix `Promise.race(step, sleep)` semantics in V2 mixed suspensions: when a workflow suspension contains both pending steps and at least one wait (sleep), the runtime now queues every step instead of executing one inline. Inline `await executeStep(...)` blocks the handler for the full step duration, so the wait timer never fires on time — a 1s sleep racing a 10s step would silently resolve to the step. Queueing the step in this case lets the wait timeout drive a continuation in parallel, restoring V1's race semantics.

--- a/.changeset/fix-step-vs-wait-race.md
+++ b/.changeset/fix-step-vs-wait-race.md
@@ -2,4 +2,4 @@
 "@workflow/core": patch
 ---
 
-Fix `Promise.race(step, sleep)` semantics in V2 mixed suspensions: when a workflow suspension contains both pending steps and at least one wait (sleep), the runtime now queues every step instead of executing one inline. Inline `await executeStep(...)` blocks the handler for the full step duration, so the wait timer never fires on time — a 1s sleep racing a 10s step would silently resolve to the step. Queueing the step in this case lets the wait timeout drive a continuation in parallel, restoring V1's race semantics.
+Fix `Promise.race(step, sleep)` always blocking until step completed

--- a/docs/content/docs/changelog/eager-processing.mdx
+++ b/docs/content/docs/changelog/eager-processing.mdx
@@ -230,7 +230,15 @@ When an inline step fails with retries remaining:
 
 ### Mixed Suspensions
 
-A suspension may contain steps, hooks, and waits simultaneously. The handler creates events for all, executes any pending step inline, and returns with the wait timeout if applicable. The workflow will re-suspend on next replay for the still-pending hooks/waits.
+A suspension may contain steps, hooks, and waits simultaneously. The handler creates events for all, then chooses between inline execution and queue dispatch:
+
+- **Steps only** (no waits): one owned step is executed inline; the rest are queued. The loop continues after the inline step completes.
+- **Steps + at least one wait**: every step is queued (no inline execution). The handler returns with the wait timeout. Whichever lands first — a step's continuation or the wait timer — drives the next replay.
+- **Hooks / waits only**: handler returns with the wait timeout (or no timeout, for hook-only suspensions). The next continuation is driven by external resume or the wait timer.
+
+The "no inline when there's a wait" carve-out is necessary to preserve `Promise.race(step, sleep)` semantics. Inline `await executeStep(...)` blocks the handler for the full step duration, and `wait_completed` events are only created on the *next* loop iteration's "complete elapsed waits" pass — so a longer-running step would always swallow the shorter sleep and `Promise.race` would resolve incorrectly. Queueing the step in this case lets the wait timer drive a continuation in parallel, matching V1's behavior where each step ran in a separate function invocation.
+
+Pure step suspensions (without waits) still benefit from inline execution; the carve-out only costs an extra queue roundtrip when a step and a sleep coexist.
 
 ### Hook Conflicts
 

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -581,6 +581,22 @@ describe('e2e', () => {
     expect(elapsed).toBeLessThan(25_000);
   });
 
+  test('sleepWinsRaceWorkflow', { timeout: 60_000 }, async () => {
+    const run = await start(await e2e('sleepWinsRaceWorkflow'), []);
+    const returnValue = await run.returnValue;
+    expect(returnValue.winner).toBe('sleep');
+    // Sleep is 1s; step would take 10s. Should resolve in ~1s, well under 5s.
+    expect(returnValue.durationMs).toBeLessThan(5_000);
+  });
+
+  test('stepWinsRaceWorkflow', { timeout: 60_000 }, async () => {
+    const run = await start(await e2e('stepWinsRaceWorkflow'), []);
+    const returnValue = await run.returnValue;
+    expect(returnValue.winner).toBe('step');
+    // Step is 1s; sleep would take 10s. Should resolve in ~1s, well under 5s.
+    expect(returnValue.durationMs).toBeLessThan(5_000);
+  });
+
   test('nullByteWorkflow', { timeout: 60_000 }, async () => {
     const run = await start(await e2e('nullByteWorkflow'), []);
     const returnValue = await run.returnValue;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -882,9 +882,26 @@ export function workflowEntrypoint(
 
                         // Pick one owned step to execute inline (if any).
                         // The rest of the pending steps are queued below.
+                        //
+                        // Skip inline execution entirely when the suspension
+                        // also has a pending wait (sleep): an inline `await
+                        // executeStep(...)` blocks the handler for the full
+                        // step duration, so the wait timer never has a chance
+                        // to fire on time. That defeats `Promise.race(step,
+                        // sleep)` semantics — if the sleep is shorter than
+                        // the step, replay still picks the step because
+                        // wait_completed is only created on the *next* loop
+                        // iteration, which doesn't run until the step
+                        // finishes. Queueing every step in this case lets
+                        // the wait timeout drive a continuation in parallel,
+                        // matching V1's behavior where each step ran in a
+                        // separate function invocation.
                         const inlineStep:
                           | (typeof pendingSteps)[number]
-                          | undefined = ownedPendingSteps[0];
+                          | undefined =
+                          suspensionResult.timeoutSeconds === undefined
+                            ? ownedPendingSteps[0]
+                            : undefined;
 
                         // Queue every pending step except the one we're
                         // executing inline. This mirrors V1's unconditional

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -215,6 +215,36 @@ export async function parallelSleepWorkflow() {
 
 //////////////////////////////////////////////////////////
 
+async function delayMsStep(ms: number, label: string) {
+  'use step';
+  await new Promise((resolve) => setTimeout(resolve, ms));
+  return label;
+}
+
+export async function sleepWinsRaceWorkflow() {
+  'use workflow';
+  const startTime = Date.now();
+  const winner = await Promise.race([
+    delayMsStep(10_000, 'step'),
+    sleep('1s').then(() => 'sleep'),
+  ]);
+  const endTime = Date.now();
+  return { winner, durationMs: endTime - startTime };
+}
+
+export async function stepWinsRaceWorkflow() {
+  'use workflow';
+  const startTime = Date.now();
+  const winner = await Promise.race([
+    delayMsStep(1_000, 'step'),
+    sleep('10s').then(() => 'sleep'),
+  ]);
+  const endTime = Date.now();
+  return { winner, durationMs: endTime - startTime };
+}
+
+//////////////////////////////////////////////////////////
+
 async function nullByteStep() {
   'use step';
   return 'null byte \0';


### PR DESCRIPTION
## Summary

Fix `Promise.race(step, sleep)` semantics in V2 mixed suspensions: when a workflow suspension contains both pending steps and at least one wait (sleep), the runtime now queues every step instead of executing one inline.

Inline \`await executeStep(...)\` blocks the V2 handler for the full step duration, but \`wait_completed\` events are only created on the *next* loop iteration's "complete elapsed waits" pass. So if the sleep is shorter than the step, the wait timer never fires on time — replay just sees \`step_completed\` first and \`Promise.race\` resolves with the step. A 1s sleep racing a 10s step would silently resolve to the step.

This restores V1's behavior, where each step ran in a separate function invocation and the wait timer drove a parallel queue continuation.

## Reproducer (failing test from #1916)

\`sleepWinsRaceWorkflow\`: a 1s sleep raced against a 10s step. Expected \`'sleep'\` to win.

Event log on the failing run, before the fix:

| t (s) | Event | |
|---|---|---|
| 0.000 | \`run_created\` | |
| 1.738 | \`step_created\` + \`wait_created\` | resumeAt = t+1s |
| 1.742 | \`step_started\` | inline execution begins |
| **11.825** | \`step_completed\` | step body finishes after ~10s |
| **11.861** | \`wait_completed\` | created right after step_completed, not on time |
| 11.959 | \`run_completed\` | replay picked \`'step'\` |

After the fix, \`wait_completed\` lands at t≈1s after \`wait_created\` and the run completes with \`'sleep'\` in ~1s.

## Change

One-liner in \`packages/core/src/runtime.ts\`:

\`\`\`ts
const inlineStep =
  suspensionResult.timeoutSeconds === undefined
    ? ownedPendingSteps[0]
    : undefined;
\`\`\`

The existing \"queue every pending step except the inline one\" loop and the \`if (!inlineStep)\` early-return already handle the \`undefined\` case correctly.

## What about hooks?

Audited every flavor of suspension. Step + wait is the only fully-broken combination.

| Suspension contains | Behavior in V2 | Race-correct? |
|---|---|---|
| steps only | one inline, rest queued | ✅ |
| wait only | returns with timeoutSeconds | ✅ |
| hook only | returns; external resumeHook drives continuation | ✅ |
| wait + hook | no steps → returns with timeoutSeconds | ✅ |
| **step + wait** | step inline-blocks, wait timer never fires | ❌ — fixed here |
| step + hook | step inline-blocks, but hook continuation runs concurrently via queueConcurrency (≥1000 on world-local, 50 on world-postgres, auto on Vercel) | ⚠️ correct via concurrency, but step keeps running uselessly until termination |

Step + hook works on all first-party worlds today. A consistent follow-up would extend the same carve-out to \`hasPendingHooks\`, but it would require a new field in \`SuspensionHandlerResult\` and isn't strictly necessary — happy to do that as a follow-up if desired.

## Test plan

- [x] New e2e tests \`sleepWinsRaceWorkflow\` and \`stepWinsRaceWorkflow\` (the failing tests from #1916, plus the symmetric stepWins case).
- [x] \`pnpm vitest run packages/core/e2e/e2e.test.ts -t WinsRaceWorkflow\` against the \`nextjs-turbopack\` workbench locally — both pass.
- [x] Event log inspection confirms \`wait_completed\` is now created at t≈1s.
- [x] All 842 \`@workflow/core\` unit tests pass.

## Docs

\`docs/content/docs/changelog/eager-processing.mdx\` "Mixed Suspensions" section rewritten to describe the carve-out and explicitly call out the \`Promise.race(step, sleep)\` race-semantics motivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)