### PR TITLE
[backport] tarballs: redesign preview tarballs index page (#1911)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,7 +630,7 @@ importers:
         version: link:../tsconfig
       nuxt:
         specifier: 4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
 
   packages/rollup:
     dependencies:
@@ -1369,6 +1369,22 @@ importers:
       workflow:
         specifier: workspace:*
         version: link:../packages/workflow
+    devDependencies:
+      '@preact/preset-vite':
+        specifier: ^2.10.1
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.0)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.0
+      preact:
+        specifier: ^10.25.0
+        version: 10.29.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.2
+        version: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
   workbench/astro:
     dependencies:
@@ -1952,7 +1968,7 @@ importers:
         version: 4.2.0
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
       openai:
         specifier: ^6.6.0
         version: 6.6.0(ws@8.20.0)(zod@4.3.6)
@@ -2040,7 +2056,7 @@ importers:
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@vercel/analytics':
         specifier: latest
-        version: 2.0.1(e5ea39116c6ce31f035ae7060cebb9e1)
+        version: 2.0.1(e0479ec49d48dc99ee489bceddd4c4ff)
       '@workflow/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -2574,6 +2590,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-syntax-typescript@7.28.6':
     resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
     engines: {node: '>=6.9.0'}
@@ -2586,6 +2608,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1':
+    resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -2594,6 +2622,12 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.28.6':
+    resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -5054,6 +5088,29 @@ packages:
   '@poppinss/exception@1.2.2':
     resolution: {integrity: sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==}
 
+  '@preact/preset-vite@2.10.5':
+    resolution: {integrity: sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==}
+    peerDependencies:
+      '@babel/core': 7.x
+      vite: 2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x
+
+  '@prefresh/babel-plugin@0.5.3':
+    resolution: {integrity: sha512-57LX2SHs4BX2s1IwCjNzTE2OJeEepRCNf1VTEpbNcUyHfMO68eeOWGDIt4ob9aYlW6PEWZ1SuwNikuoIXANDtQ==}
+
+  '@prefresh/core@1.5.9':
+    resolution: {integrity: sha512-IKBKCPaz34OFVC+adiQ2qaTF5qdztO2/4ZPf4KsRTgjKosWqxVXmEbxCiUydYZRY8GVie+DQlKzQr9gt6HQ+EQ==}
+    peerDependencies:
+      preact: ^10.0.0 || ^11.0.0-0
+
+  '@prefresh/utils@1.2.1':
+    resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
+
+  '@prefresh/vite@2.4.12':
+    resolution: {integrity: sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==}
+    peerDependencies:
+      preact: ^10.4.0 || ^11.0.0-0
+      vite: '>=2.0.0'
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -6302,6 +6359,10 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@rollup/pluginutils@4.2.1':
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -8308,6 +8369,11 @@ packages:
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
+  babel-plugin-transform-hook-names@1.0.2:
+    resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
+    peerDependencies:
+      '@babel/core': ^7.12.10
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -10150,6 +10216,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   hono@4.12.3:
     resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
     engines: {node: '>=16.9.0'}
@@ -11572,6 +11642,9 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
   node-mock-http@1.0.3:
     resolution: {integrity: sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==}
 
@@ -12326,6 +12399,9 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -13016,6 +13092,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-code-frame@1.3.0:
+    resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -13123,6 +13202,10 @@ packages:
   ssh2@1.17.0:
     resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
     engines: {node: '>=10.16.0'}
+
+  stack-trace@1.0.0:
+    resolution: {integrity: sha512-H6D7134xi6qONvh7ZHKgviXf+rd3vhGBSvebPZCaUkd8zvQ+7PtDw6CljPTe4cXWNf2IKZGNqw6VJXSb9IgBpA==}
+    engines: {node: '>=20.0.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -14137,6 +14220,11 @@ packages:
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0
       vue: ^3.5.0
+
+  vite-prerender-plugin@0.5.13:
+    resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
+    peerDependencies:
+      vite: 5.x || 6.x || 7.x || 8.x
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -15369,6 +15457,11 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
@@ -15387,6 +15480,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -15396,6 +15496,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.28.4)':
     dependencies:
@@ -16989,7 +17100,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.4.2(17efd5df4f64de2214937e330355b781)':
+  '@nuxt/nitro-server@4.4.2(e737931cc3e86145a79ae40ee1451a03)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -17008,7 +17119,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.2(@netlify/blobs@9.1.2)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -17078,7 +17189,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.4.2(499185fad7ea9aa80e6b898e01f6be1b)':
+  '@nuxt/vite-builder@4.4.2(fe529e49f53c98c087eb1e6bb70d354a)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.0)
@@ -17096,7 +17207,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -17111,7 +17222,7 @@ snapshots:
       vue: 3.5.30(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       rollup-plugin-visualizer: 7.0.1(rollup@4.60.0)
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -17643,6 +17754,45 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.2': {}
+
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.0)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
+      '@prefresh/vite': 2.4.12(preact@10.29.1)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      magic-string: 0.30.21
+      picocolors: 1.1.1
+      vite: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite-prerender-plugin: 0.5.13(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - preact
+      - rollup
+      - supports-color
+
+  '@prefresh/babel-plugin@0.5.3': {}
+
+  '@prefresh/core@1.5.9(preact@10.29.1)':
+    dependencies:
+      preact: 10.29.1
+
+  '@prefresh/utils@1.2.1': {}
+
+  '@prefresh/vite@2.4.12(preact@10.29.1)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@prefresh/babel-plugin': 0.5.3
+      '@prefresh/core': 1.5.9(preact@10.29.1)
+      '@prefresh/utils': 1.2.1
+      '@rollup/pluginutils': 4.2.1
+      preact: 10.29.1
+      vite: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -19227,6 +19377,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.0
 
+  '@rollup/pluginutils@4.2.1':
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+
   '@rollup/pluginutils@5.3.0(rollup@4.60.0)':
     dependencies:
       '@types/estree': 1.0.8
@@ -20789,11 +20944,11 @@ snapshots:
       vue: 3.5.30(typescript@5.9.3)
       vue-router: 4.6.3(vue@3.5.30(typescript@5.9.3))
 
-  '@vercel/analytics@2.0.1(e5ea39116c6ce31f035ae7060cebb9e1)':
+  '@vercel/analytics@2.0.1(e0479ec49d48dc99ee489bceddd4c4ff)':
     optionalDependencies:
       '@sveltejs/kit': 2.55.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.55.0)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
       next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
       react: 19.2.4
       svelte: 5.55.0
       vue: 3.5.30(typescript@5.9.3)
@@ -21122,7 +21277,7 @@ snapshots:
       '@vue/shared': 3.5.22
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.8
+      postcss: 8.5.6
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.30':
@@ -21877,6 +22032,10 @@ snapshots:
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
 
   bail@2.0.2: {}
 
@@ -24000,6 +24159,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  he@1.2.0: {}
+
   hono@4.12.3: {}
 
   hono@4.12.9: {}
@@ -25862,6 +26023,11 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-mock-http@1.0.3: {}
 
   node-mock-http@1.0.4: {}
@@ -25895,16 +26061,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3):
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-sfc@3.5.30)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(17efd5df4f64de2214937e330355b781)
+      '@nuxt/nitro-server': 4.4.2(e737931cc3e86145a79ae40ee1451a03)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(499185fad7ea9aa80e6b898e01f6be1b)
+      '@nuxt/vite-builder': 4.4.2(fe529e49f53c98c087eb1e6bb70d354a)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
       c12: 3.3.3(magicast@0.5.2)
@@ -26867,6 +27033,8 @@ snapshots:
     optional: true
 
   powershell-utils@0.1.0: {}
+
+  preact@10.29.1: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -27851,6 +28019,10 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-code-frame@1.3.0:
+    dependencies:
+      kolorist: 1.8.0
+
   simple-concat@1.0.1:
     optional: true
 
@@ -27951,6 +28123,8 @@ snapshots:
     optionalDependencies:
       cpu-features: 0.0.10
       nan: 2.23.0
+
+  stack-trace@1.0.0: {}
 
   stackback@0.0.2: {}
 
@@ -28984,6 +29158,16 @@ snapshots:
       source-map-js: 1.2.1
       vite: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
       vue: 3.5.30(typescript@5.9.3)
+
+  vite-prerender-plugin@0.5.13(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)):
+    dependencies:
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      node-html-parser: 6.1.13
+      simple-code-frame: 1.3.0
+      source-map: 0.7.6
+      stack-trace: 1.0.0
+      vite: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
   vite@6.4.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:

--- a/tarballs/.gitignore
+++ b/tarballs/.gitignore
@@ -2,6 +2,9 @@ node_modules
 .vercel
 .env*.local
 
-# Generated tarballs and index page
+# Generated tarballs and catalog written by scripts/pack.ts
 public/*.tgz
-public/index.html
+public/catalog.json
+
+# Vite build output served by Vercel
+dist

--- a/tarballs/index.html
+++ b/tarballs/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Workflow SDK preview tarballs</title>
+    <meta
+      name="description"
+      content="Preview tarballs for the Workflow SDK, built straight from a commit."
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='black'/%3E%3Cpath d='M16 8 L24 24 L8 24 Z' fill='white'/%3E%3C/svg%3E"
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/tarballs/package.json
+++ b/tarballs/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "node scripts/pack.ts",
+    "build": "node scripts/pack.ts && vite build",
+    "dev": "node scripts/pack.ts && vite",
     "test:smoke": "node ./scripts/check-tarballs-smoke.mjs"
   },
   "dependencies": {
@@ -35,5 +36,12 @@
     "@workflow/world-testing": "workspace:*",
     "@workflow/world-vercel": "workspace:*",
     "workflow": "workspace:*"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.10.1",
+    "@types/node": "^22.10.0",
+    "preact": "^10.25.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.3.2"
   }
 }

--- a/tarballs/scripts/check-tarballs-smoke.mjs
+++ b/tarballs/scripts/check-tarballs-smoke.mjs
@@ -60,6 +60,26 @@ const assertHtmlResponse = async (path) => {
   }
 };
 
+const assertCatalogJson = async (path) => {
+  const res = await fetch(`${BASE_URL}${path}`);
+  if (!res.ok) {
+    throw new Error(`${path} returned ${res.status}`);
+  }
+  const data = await res.json();
+  if (!data || !Array.isArray(data.packages) || data.packages.length === 0) {
+    throw new Error(`${path} did not return a catalog with packages`);
+  }
+  const workflow = data.packages.find((p) => p.name === 'workflow');
+  if (!workflow) {
+    throw new Error(`${path} catalog is missing the 'workflow' package`);
+  }
+  if (!workflow.fileCount || workflow.fileCount < 5) {
+    throw new Error(
+      `'workflow' tarball only has ${workflow.fileCount} files — packages probably weren't built before pack`
+    );
+  }
+};
+
 const checks = [
   {
     name: 'Deployment protection',
@@ -68,6 +88,10 @@ const checks = [
   {
     name: 'Index page',
     run: () => assertHtmlResponse('/'),
+  },
+  {
+    name: 'Catalog JSON',
+    run: () => assertCatalogJson('/catalog.json'),
   },
   {
     name: 'Tarball - workflow',

--- a/tarballs/scripts/pack.ts
+++ b/tarballs/scripts/pack.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import zlib from 'node:zlib';
 
 const exec = promisify(cp.exec);
 
@@ -10,9 +11,44 @@ interface PackageJson {
   name: string;
   version: string;
   private?: boolean;
+  description?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+}
+
+export interface TarballFile {
+  path: string;
+  size: number;
+}
+
+export interface PackedPackage {
+  name: string;
+  escapedName: string;
+  version: string;
+  description?: string;
+  tarballSizeBytes: number;
+  unpackedSizeBytes: number;
+  fileCount: number;
+  files: TarballFile[];
+  url: string;
+}
+
+export interface BuildContext {
+  fullSha: string;
+  shortSha: string;
+  branch?: string;
+  pr?: string;
+  repoUrl?: string;
+  commitUrl?: string;
+  branchUrl?: string;
+  prUrl?: string;
+  builtAt: string;
+}
+
+export interface Catalog {
+  build: BuildContext;
+  packages: PackedPackage[];
 }
 
 const rootDir = fileURLToPath(new URL('../../', import.meta.url));
@@ -21,11 +57,10 @@ const outDir = fileURLToPath(new URL('../public', import.meta.url));
 
 async function main() {
   const sha = await getSha();
+  const localBranch = await getLocalBranch();
 
-  // Ensure output directory exists
   await fs.mkdir(outDir, { recursive: true });
 
-  // Scan the packages directory for all packages
   const packageDirs = await fs.readdir(packagesDir);
   const packages: Array<{
     name: string;
@@ -42,13 +77,12 @@ async function main() {
       const stat = await fs.stat(packageJsonPath);
       if (!stat.isFile()) continue;
     } catch {
-      continue; // Skip directories without package.json
+      continue;
     }
 
     const originalContent = await fs.readFile(packageJsonPath, 'utf8');
     const packageJson: PackageJson = JSON.parse(originalContent);
 
-    // Skip private packages
     if (packageJson.private) continue;
 
     packages.push({
@@ -59,19 +93,21 @@ async function main() {
     });
   }
 
-  // Create a set of all package names for dependency resolution
   const packageNames = new Set(packages.map((p) => p.name));
+  const baseUrl = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : '';
+  const packed: PackedPackage[] = [];
 
   for (const { name, dir, packageJson, originalContent } of packages) {
     const packageJsonPath = path.join(dir, 'package.json');
 
-    // Create modified package.json with preview version
     const modifiedPackageJson: PackageJson = JSON.parse(
       JSON.stringify(packageJson)
     );
-    modifiedPackageJson.version += `-${sha}`;
+    const previewVersion = `${packageJson.version}-${sha}`;
+    modifiedPackageJson.version = previewVersion;
 
-    // Update workspace dependencies to use preview tarball URLs
     const updateDeps = (deps: Record<string, string> | undefined) => {
       if (!deps) return;
       for (const depName of Object.keys(deps)) {
@@ -87,119 +123,179 @@ async function main() {
     updateDeps(modifiedPackageJson.devDependencies);
     updateDeps(modifiedPackageJson.peerDependencies);
 
-    // Write modified package.json
     await fs.writeFile(
       packageJsonPath,
       JSON.stringify(modifiedPackageJson, null, 2)
     );
 
     try {
-      // Pack the package
       await exec(`pnpm pack --out="${outDir}/%s.tgz"`, { cwd: dir });
-      console.log(`Packed ${name}`);
+
+      const escapedName = name.replace(/^@(.+)\//, '$1-');
+      const tgzPath = path.join(outDir, `${escapedName}.tgz`);
+      const stat = await fs.stat(tgzPath);
+      const files = await listTarballFiles(tgzPath);
+      const unpackedSizeBytes = files.reduce((sum, f) => sum + f.size, 0);
+
+      packed.push({
+        name,
+        escapedName,
+        version: previewVersion,
+        description: packageJson.description,
+        tarballSizeBytes: stat.size,
+        unpackedSizeBytes,
+        fileCount: files.length,
+        files,
+        url: `${baseUrl}/${escapedName}.tgz`,
+      });
+      console.log(
+        `Packed ${name} (${formatBytes(stat.size)} → ${formatBytes(unpackedSizeBytes)} unpacked, ${files.length} files)`
+      );
     } finally {
-      // Always restore original package.json (preserves trailing newline /
-      // exact byte content of the source file)
       await fs.writeFile(packageJsonPath, originalContent);
     }
   }
 
-  await writeIndexHtml(packages.map((p) => p.name).sort(), sha);
+  const catalog: Catalog = {
+    build: getBuildContext(sha, localBranch),
+    packages: packed,
+  };
+
+  await fs.writeFile(
+    path.join(outDir, 'catalog.json'),
+    JSON.stringify(catalog, null, 2)
+  );
 
   console.log(
-    `\nSuccessfully packed ${packages.length} preview packages to ${outDir}`
+    `\nPacked ${packed.length} packages into ${outDir} and wrote catalog.json`
   );
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
 }
 
-async function writeIndexHtml(
-  packageNames: string[],
-  sha: string
-): Promise<void> {
-  // Use the actual deployment URL when running on Vercel, otherwise build
-  // commands relative to the page so they remain useful when the file is
-  // viewed via a non-Vercel host or directly from disk.
-  const baseUrlExpr = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : '';
+/**
+ * List regular files inside a `.tgz` tarball, returning `{path, size}` for
+ * each entry. Implemented as an in-process tar reader so the result is
+ * identical on macOS (BSD tar) and Linux (GNU tar) — `tar -tvzf` formats
+ * its verbose output differently on each, and parsing it is fragile.
+ *
+ * We unzip the whole tarball into memory (npm pack outputs are small) and
+ * walk 512-byte blocks. Each entry is one 512-byte ustar header followed
+ * by the file content rounded up to 512 bytes. We only emit regular files
+ * (typeflag `0` or NUL); directories, symlinks, and pax/long-name
+ * extension entries are consumed but not emitted.
+ */
+async function listTarballFiles(tgzPath: string): Promise<TarballFile[]> {
+  const compressed = await fs.readFile(tgzPath);
+  const buf = zlib.gunzipSync(compressed);
+  const files: TarballFile[] = [];
+  let offset = 0;
+  let pendingLongName: string | undefined;
 
-  const rows = packageNames
-    .map((name) => {
-      const escapedName = name.replace(/^@(.+)\//, '$1-');
-      const installCmd = `pnpm i ${baseUrlExpr}/${escapedName}.tgz`;
-      return `        <tr>
-          <td><code>${escapeHtml(name)}</code></td>
-          <td>
-            <code id="cmd-${escapeHtml(escapedName)}">${escapeHtml(installCmd)}</code>
-            <button class="copy" data-target="cmd-${escapeHtml(escapedName)}" type="button">copy</button>
-          </td>
-        </tr>`;
-    })
-    .join('\n');
+  while (offset + 512 <= buf.length) {
+    const header = buf.subarray(offset, offset + 512);
+    // The end of an archive is marked by two consecutive zero blocks.
+    if (header.every((b) => b === 0)) break;
 
-  const html = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Workflow SDK preview tarballs</title>
-    <style>
-      :root { color-scheme: light dark; }
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        max-width: 960px;
-        margin: 2rem auto;
-        padding: 0 1rem;
-        line-height: 1.5;
-      }
-      h1 { margin-bottom: 0.25rem; }
-      .meta { color: #666; font-size: 0.9rem; margin-bottom: 1.5rem; }
-      table { border-collapse: collapse; width: 100%; }
-      th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd; vertical-align: top; }
-      th { font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: #555; }
-      code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9rem; }
-      button.copy {
-        margin-left: 0.5rem; padding: 0.1rem 0.5rem; font-size: 0.75rem;
-        border: 1px solid #888; background: transparent; cursor: pointer; border-radius: 3px;
-      }
-      button.copy:hover { background: rgba(0,0,0,0.05); }
-    </style>
-  </head>
-  <body>
-    <h1>Workflow SDK preview tarballs</h1>
-    <p class="meta">Built from <code>${escapeHtml(sha)}</code>. Drop one of these install commands into a project to test pre-release builds.</p>
-    <table>
-      <thead><tr><th>Package</th><th>Install</th></tr></thead>
-      <tbody>
-${rows}
-      </tbody>
-    </table>
-    <script>
-      for (const button of document.querySelectorAll('button.copy')) {
-        button.addEventListener('click', () => {
-          const target = document.getElementById(button.dataset.target);
-          if (!target) return;
-          navigator.clipboard.writeText(target.textContent || '').then(() => {
-            const original = button.textContent;
-            button.textContent = 'copied';
-            setTimeout(() => { button.textContent = original; }, 1500);
-          });
-        });
-      }
-    </script>
-  </body>
-</html>
-`;
+    const name = readNullTerminatedString(header, 0, 100);
+    const sizeOctal = readNullTerminatedString(header, 124, 12).trim();
+    const size = sizeOctal ? Number.parseInt(sizeOctal, 8) : 0;
+    const typeflag = String.fromCharCode(header[156] ?? 0);
+    const prefix = readNullTerminatedString(header, 345, 155);
+    const contentBlocks = Math.ceil(size / 512);
 
-  await fs.writeFile(path.join(outDir, 'index.html'), html);
+    offset += 512;
+
+    if (typeflag === 'L') {
+      // GNU long-name entry: the next `size` bytes are the path of the
+      // following entry. Read it and stash for the next iteration.
+      pendingLongName = buf
+        .subarray(offset, offset + size)
+        .toString('utf8')
+        .replace(/\0+$/, '');
+      offset += contentBlocks * 512;
+      continue;
+    }
+
+    if (typeflag === 'x' || typeflag === 'g') {
+      // pax extended / global headers — skip.
+      offset += contentBlocks * 512;
+      continue;
+    }
+
+    const fullName = pendingLongName ?? (prefix ? `${prefix}/${name}` : name);
+    pendingLongName = undefined;
+
+    // typeflag '0' or NUL = regular file.
+    if (typeflag === '0' || typeflag === '\0') {
+      if (fullName) files.push({ path: fullName, size });
+    }
+
+    offset += contentBlocks * 512;
+  }
+
+  files.sort((a, b) => b.size - a.size);
+  return files;
+}
+
+function readNullTerminatedString(
+  buf: Buffer,
+  offset: number,
+  len: number
+): string {
+  const slice = buf.subarray(offset, offset + len);
+  const end = slice.indexOf(0);
+  return slice.subarray(0, end === -1 ? len : end).toString('utf8');
+}
+
+function getBuildContext(sha: string, localBranch?: string): BuildContext {
+  const fullSha = process.env.VERCEL_GIT_COMMIT_SHA || sha;
+  const shortSha = fullSha.slice(0, 7);
+  const branch = process.env.VERCEL_GIT_COMMIT_REF || localBranch;
+  const pr = process.env.VERCEL_GIT_PULL_REQUEST_ID;
+  const owner = process.env.VERCEL_GIT_REPO_OWNER;
+  const slug = process.env.VERCEL_GIT_REPO_SLUG;
+  const provider = process.env.VERCEL_GIT_PROVIDER;
+
+  let repoUrl: string | undefined;
+  let commitUrl: string | undefined;
+  let prUrl: string | undefined;
+  let branchUrl: string | undefined;
+
+  if (owner && slug && (!provider || provider === 'github')) {
+    repoUrl = `https://github.com/${owner}/${slug}`;
+    commitUrl = `${repoUrl}/commit/${fullSha}`;
+    if (branch) branchUrl = `${repoUrl}/tree/${branch}`;
+    if (pr) prUrl = `${repoUrl}/pull/${pr}`;
+  }
+
+  return {
+    fullSha,
+    shortSha,
+    branch,
+    pr,
+    repoUrl,
+    commitUrl,
+    branchUrl,
+    prUrl,
+    builtAt: new Date().toISOString(),
+  };
+}
+
+async function getLocalBranch(): Promise<string | undefined> {
+  try {
+    const { stdout } = await exec('git rev-parse --abbrev-ref HEAD', {
+      cwd: rootDir,
+    });
+    const branch = stdout.trim();
+    return branch && branch !== 'HEAD' ? branch : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function getSha(): Promise<string> {

--- a/tarballs/src/app.tsx
+++ b/tarballs/src/app.tsx
@@ -1,0 +1,550 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import {
+  type Catalog,
+  type PackageManager,
+  type PackedPackage,
+  buildInstallCommand,
+  formatBytes,
+} from './catalog';
+import {
+  BranchIcon,
+  CheckIcon,
+  ChevronIcon,
+  CommitIcon,
+  CopyIcon,
+  DownloadIcon,
+  PrIcon,
+  SearchIcon,
+} from './icons';
+
+const FEATURED_PACKAGE = 'workflow';
+
+export function App({ catalog }: { catalog: Catalog }) {
+  const featured = catalog.packages.find((p) => p.name === FEATURED_PACKAGE);
+  const others = useMemo(
+    () =>
+      catalog.packages
+        .filter((p) => p.name !== FEATURED_PACKAGE)
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [catalog.packages]
+  );
+
+  const [pm, setPm] = useState<PackageManager>('pnpm');
+  const [filter, setFilter] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // `/` focuses the filter input.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === '/' && document.activeElement !== searchRef.current) {
+        e.preventDefault();
+        searchRef.current?.focus();
+        searchRef.current?.select();
+      }
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return others;
+    return others.filter((p) => p.name.toLowerCase().includes(q));
+  }, [others, filter]);
+
+  const totalSize = catalog.packages.reduce(
+    (sum, p) => sum + p.tarballSizeBytes,
+    0
+  );
+
+  return (
+    <div class="container">
+      <Header catalog={catalog} totalSize={totalSize} />
+
+      {featured && <FeaturedCard pkg={featured} pm={pm} />}
+
+      <h2 class="section-title">Other packages</h2>
+      <div class="controls">
+        <PmTabs value={pm} onChange={setPm} />
+        <label class="search">
+          <SearchIcon />
+          <input
+            ref={searchRef}
+            type="search"
+            placeholder="Filter packages…"
+            aria-label="Filter packages"
+            autoComplete="off"
+            value={filter}
+            onInput={(e) => setFilter((e.target as HTMLInputElement).value)}
+          />
+        </label>
+      </div>
+
+      <div class="pkg-list">
+        {filtered.length === 0 ? (
+          <div class="empty">No packages match that filter.</div>
+        ) : (
+          filtered.map((p) => <PackageRow key={p.name} pkg={p} pm={pm} />)
+        )}
+      </div>
+
+      <Footer catalog={catalog} totalSize={totalSize} />
+    </div>
+  );
+}
+
+function Header({
+  catalog,
+  totalSize,
+}: {
+  catalog: Catalog;
+  totalSize: number;
+}) {
+  const { build } = catalog;
+  return (
+    <header class="page">
+      <h1>Workflow SDK preview tarballs</h1>
+      <p class="lede">
+        Pre-release builds of every public package, packed straight from the
+        latest commit. Drop one into a project to test before publish.
+      </p>
+      <div class="meta-chips">
+        {build.commitUrl ? (
+          <a class="chip" href={build.commitUrl} target="_blank" rel="noopener">
+            <CommitIcon />
+            <code>{build.shortSha}</code>
+          </a>
+        ) : (
+          <span class="chip">
+            <CommitIcon />
+            <code>{build.shortSha}</code>
+          </span>
+        )}
+        {build.branch &&
+          (build.branchUrl ? (
+            <a
+              class="chip"
+              href={build.branchUrl}
+              target="_blank"
+              rel="noopener"
+            >
+              <BranchIcon /> {build.branch}
+            </a>
+          ) : (
+            <span class="chip">
+              <BranchIcon /> {build.branch}
+            </span>
+          ))}
+        {build.pr && build.prUrl && (
+          <a class="chip" href={build.prUrl} target="_blank" rel="noopener">
+            <PrIcon /> PR #{build.pr}
+          </a>
+        )}
+        <span class="chip">
+          <time dateTime={build.builtAt}>{build.builtAt}</time>
+        </span>
+        <span class="chip">
+          {catalog.packages.length} packages · {formatBytes(totalSize)}
+        </span>
+      </div>
+      <details class="about">
+        <summary>What is this?</summary>
+        <p>
+          Each commit on the <code>workflow</code> repo produces a deployment
+          that builds and serves a tarball for every public package under{' '}
+          <code>packages/*</code>. Versions are rewritten to{' '}
+          <code>&lt;version&gt;-&lt;sha&gt;</code> and workspace dependencies
+          are rewritten to point at sibling tarballs on this same deployment, so
+          installing a single tarball pulls in the rest transitively.
+        </p>
+        <p>
+          Use these to verify a fix in a downstream project before publishing to
+          npm. Every tarball URL is a stable, immutable artifact tied to a
+          specific commit.
+        </p>
+      </details>
+    </header>
+  );
+}
+
+function PmTabs({
+  value,
+  onChange,
+}: {
+  value: PackageManager;
+  onChange: (pm: PackageManager) => void;
+}) {
+  const options: PackageManager[] = ['pnpm', 'npm', 'yarn', 'bun'];
+  return (
+    <div class="pm-tabs">
+      {options.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          class="pm-tab"
+          aria-label={`Show install commands for ${opt}`}
+          aria-pressed={value === opt}
+          onClick={() => onChange(opt)}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function FeaturedCard({ pkg, pm }: { pkg: PackedPackage; pm: PackageManager }) {
+  const cmd = buildInstallCommand(pm, pkg.url);
+  return (
+    <section class="featured">
+      <div class="featured-header">
+        <span class="featured-badge">Main package</span>
+        <span class="featured-name">{pkg.name}</span>
+        <span class="featured-version">v{pkg.version}</span>
+        <span class="featured-size">
+          · {formatBytes(pkg.tarballSizeBytes)} ·{' '}
+          {formatBytes(pkg.unpackedSizeBytes)} unpacked · {pkg.fileCount} files
+        </span>
+      </div>
+      {pkg.description && <p class="featured-desc">{pkg.description}</p>}
+      <div class="install-block">
+        <code class="install-cmd">{cmd}</code>
+        <CopyButton
+          text={cmd}
+          variant="primary"
+          accessibleName={`Copy install command for ${pkg.name}`}
+        />
+        <a
+          class="download-btn"
+          href={pkg.url}
+          download
+          aria-label={`Download ${pkg.name} tarball`}
+        >
+          <DownloadIcon />
+          <span>Download</span>
+        </a>
+      </div>
+      <PackageContents pkg={pkg} variant="featured" />
+    </section>
+  );
+}
+
+function PackageRow({ pkg, pm }: { pkg: PackedPackage; pm: PackageManager }) {
+  const cmd = buildInstallCommand(pm, pkg.url);
+  return (
+    <div class="pkg-row" data-name={pkg.name}>
+      <div class="pkg-info">
+        <div class="pkg-name">{pkg.name}</div>
+        <div class="pkg-meta">
+          v{pkg.version} · {formatBytes(pkg.tarballSizeBytes)} ·{' '}
+          {formatBytes(pkg.unpackedSizeBytes)} unpacked · {pkg.fileCount} files
+        </div>
+      </div>
+      <code class="pkg-cmd">{cmd}</code>
+      <div class="pkg-actions">
+        <CopyButton
+          text={cmd}
+          variant="icon"
+          accessibleName={`Copy install command for ${pkg.name}`}
+        />
+        <a
+          class="icon-btn"
+          href={pkg.url}
+          download
+          aria-label={`Download ${pkg.name} tarball`}
+        >
+          <DownloadIcon />
+        </a>
+      </div>
+      <PackageContents pkg={pkg} variant="row" />
+    </div>
+  );
+}
+
+function PackageContents({
+  pkg,
+  variant,
+}: {
+  pkg: PackedPackage;
+  variant: 'featured' | 'row';
+}) {
+  if (pkg.files.length === 0) return null;
+
+  return (
+    <details class={`contents contents-${variant}`}>
+      <summary>
+        <ChevronIcon />
+        <span>What's inside?</span>
+        <span class="contents-summary-meta">
+          {pkg.fileCount} files · {formatBytes(pkg.unpackedSizeBytes)} unpacked
+        </span>
+      </summary>
+      <div class="contents-body">
+        <SizeStats pkg={pkg} />
+        <FileTable files={pkg.files} />
+      </div>
+    </details>
+  );
+}
+
+/**
+ * Two large prominent metric tiles, modeled after packagephobia's `Stats`
+ * widget — value + unit on top, uppercase label beneath. The headline
+ * numbers a viewer is most likely to want.
+ */
+function SizeStats({ pkg }: { pkg: PackedPackage }) {
+  return (
+    <div class="size-stats">
+      <SizeStat bytes={pkg.tarballSizeBytes} label="Publish size" />
+      <SizeStat bytes={pkg.unpackedSizeBytes} label="Unpacked size" />
+    </div>
+  );
+}
+
+function SizeStat({ bytes, label }: { bytes: number; label: string }) {
+  const { value, unit } = splitSize(bytes);
+  return (
+    <div class="size-stat">
+      <div class="size-stat-row">
+        <span class="size-stat-value">{value}</span>
+        <span class="size-stat-unit">{unit}</span>
+      </div>
+      <div class="size-stat-label">{label}</div>
+    </div>
+  );
+}
+
+function splitSize(bytes: number): { value: string; unit: string } {
+  if (bytes < 1024) return { value: String(bytes), unit: 'B' };
+  if (bytes < 1024 * 1024)
+    return { value: (bytes / 1024).toFixed(1), unit: 'KiB' };
+  return { value: (bytes / 1024 / 1024).toFixed(2), unit: 'MiB' };
+}
+
+type SortKey = 'size' | 'path';
+type SortDir = 'asc' | 'desc';
+
+interface DisplayFile {
+  path: string;
+  size: number;
+}
+
+function FileTable({ files }: { files: DisplayFile[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>('size');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const stripped = useMemo<DisplayFile[]>(
+    () =>
+      files.map((f) => ({
+        path: f.path.startsWith('package/')
+          ? f.path.slice('package/'.length)
+          : f.path,
+        size: f.size,
+      })),
+    [files]
+  );
+
+  const sorted = useMemo(() => {
+    const arr = [...stripped];
+    arr.sort((a, b) => {
+      const cmp =
+        sortKey === 'size' ? a.size - b.size : a.path.localeCompare(b.path);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return arr;
+  }, [stripped, sortKey, sortDir]);
+
+  function toggleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'size' ? 'desc' : 'asc');
+    }
+  }
+
+  const ariaSortFor = (key: SortKey) =>
+    sortKey === key ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none';
+
+  return (
+    <div class="file-table-wrap">
+      <table class="file-table">
+        <thead>
+          <tr>
+            <th aria-sort={ariaSortFor('path')}>
+              <button
+                type="button"
+                class="sort-btn"
+                onClick={() => toggleSort('path')}
+              >
+                File
+                <SortIndicator
+                  active={sortKey === 'path'}
+                  direction={sortDir}
+                />
+              </button>
+            </th>
+            <th class="file-table-size" aria-sort={ariaSortFor('size')}>
+              <button
+                type="button"
+                class="sort-btn"
+                onClick={() => toggleSort('size')}
+              >
+                Size
+                <SortIndicator
+                  active={sortKey === 'size'}
+                  direction={sortDir}
+                />
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((f) => (
+            <tr key={f.path}>
+              <td class="file-path">{f.path}</td>
+              <td class="file-size">{formatBytes(f.size)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SortIndicator({
+  active,
+  direction,
+}: {
+  active: boolean;
+  direction: SortDir;
+}) {
+  if (!active) return <span class="sort-indicator" aria-hidden="true" />;
+  return (
+    <span class="sort-indicator sort-indicator-active" aria-hidden="true">
+      {direction === 'asc' ? '↑' : '↓'}
+    </span>
+  );
+}
+
+function CopyButton({
+  text,
+  variant,
+  accessibleName = 'Copy install command',
+}: {
+  text: string;
+  variant: 'primary' | 'icon';
+  accessibleName?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  async function handleClick() {
+    const success = await writeToClipboard(text);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    if (success) {
+      setFailed(false);
+      setCopied(true);
+      timeoutRef.current = setTimeout(() => setCopied(false), 1500);
+    } else {
+      setCopied(false);
+      setFailed(true);
+      timeoutRef.current = setTimeout(() => setFailed(false), 2000);
+    }
+  }
+
+  const label = copied ? 'Copied' : failed ? 'Copy failed' : accessibleName;
+
+  if (variant === 'icon') {
+    return (
+      <button
+        type="button"
+        class="icon-btn"
+        data-copied={copied}
+        data-failed={failed}
+        onClick={handleClick}
+        aria-label={label}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      class="copy-btn"
+      data-copied={copied}
+      data-failed={failed}
+      onClick={handleClick}
+      aria-label={label}
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+      <span class="copy-label">
+        {copied ? 'Copied' : failed ? 'Failed' : 'Copy'}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Try to write `text` to the clipboard. Returns whether the write actually
+ * succeeded — both the modern `navigator.clipboard` path and the
+ * `execCommand('copy')` fallback can fail (insecure context, denied
+ * permission, headless test runner, etc.) and in that case the caller
+ * should *not* show a "Copied" success state.
+ */
+async function writeToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to execCommand fallback
+    }
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    ta.remove();
+  }
+}
+
+function Footer({
+  catalog,
+  totalSize,
+}: {
+  catalog: Catalog;
+  totalSize: number;
+}) {
+  const { build } = catalog;
+  return (
+    <footer class="page">
+      Built from{' '}
+      {build.commitUrl ? (
+        <a href={build.commitUrl} target="_blank" rel="noopener">
+          {build.shortSha}
+        </a>
+      ) : (
+        <code>{build.shortSha}</code>
+      )}{' '}
+      · {catalog.packages.length} packages totaling {formatBytes(totalSize)}
+    </footer>
+  );
+}

--- a/tarballs/src/catalog.ts
+++ b/tarballs/src/catalog.ts
@@ -1,0 +1,52 @@
+export interface TarballFile {
+  path: string;
+  size: number;
+}
+
+export interface PackedPackage {
+  name: string;
+  escapedName: string;
+  version: string;
+  description?: string;
+  tarballSizeBytes: number;
+  unpackedSizeBytes: number;
+  fileCount: number;
+  files: TarballFile[];
+  url: string;
+}
+
+export interface BuildContext {
+  fullSha: string;
+  shortSha: string;
+  branch?: string;
+  pr?: string;
+  repoUrl?: string;
+  commitUrl?: string;
+  branchUrl?: string;
+  prUrl?: string;
+  builtAt: string;
+}
+
+export interface Catalog {
+  build: BuildContext;
+  packages: PackedPackage[];
+}
+
+export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun';
+
+const INSTALL_PREFIX: Record<PackageManager, string> = {
+  pnpm: 'pnpm i',
+  npm: 'npm i',
+  yarn: 'yarn add',
+  bun: 'bun add',
+};
+
+export function buildInstallCommand(pm: PackageManager, url: string): string {
+  return `${INSTALL_PREFIX[pm]} ${url}`;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}

--- a/tarballs/src/icons.tsx
+++ b/tarballs/src/icons.tsx
@@ -1,0 +1,98 @@
+// Inline SVG icons. Each is a self-contained 16×16 glyph with `currentColor`
+// fill so they pick up the surrounding text color.
+
+export function CommitIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M11.93 8.5a4 4 0 0 1-7.86 0H.75a.75.75 0 0 1 0-1.5h3.32a4 4 0 0 1 7.86 0h3.32a.75.75 0 0 1 0 1.5Zm-1.43-.75a2.5 2.5 0 1 0-5 0 2.5 2.5 0 0 0 5 0Z"
+      />
+    </svg>
+  );
+}
+
+export function BranchIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v.628a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v2.146A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z"
+      />
+    </svg>
+  );
+}
+
+export function PrIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854v1.523h.5A2.5 2.5 0 0 1 13 4.877v5.252a2.251 2.251 0 1 1-1.5 0V4.877a1 1 0 0 0-1-1H10v1.522a.25.25 0 0 1-.427.177L7.177 3.18a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"
+      />
+    </svg>
+  );
+}
+
+export function CopyIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"
+      />
+      <path
+        fill="currentColor"
+        d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"
+      />
+    </svg>
+  );
+}
+
+export function DownloadIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"
+      />
+      <path
+        fill="currentColor"
+        d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 6.78a.75.75 0 0 1 1.06-1.06l1.97 1.969Z"
+      />
+    </svg>
+  );
+}
+
+export function SearchIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M11.5 7a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Zm-.82 4.74a6 6 0 1 1 1.06-1.06l3.04 3.04a.75.75 0 1 1-1.06 1.06l-3.04-3.04Z"
+      />
+    </svg>
+  );
+}
+
+export function CheckIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"
+      />
+    </svg>
+  );
+}
+
+export function ChevronIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M5.22 6.22a.75.75 0 0 1 1.06 0L8 7.94l1.72-1.72a.75.75 0 1 1 1.06 1.06l-2.25 2.25a.75.75 0 0 1-1.06 0L5.22 7.28a.75.75 0 0 1 0-1.06Z"
+      />
+    </svg>
+  );
+}

--- a/tarballs/src/main.tsx
+++ b/tarballs/src/main.tsx
@@ -1,0 +1,26 @@
+import { render } from 'preact';
+import { App } from './app';
+import type { Catalog } from './catalog';
+import './styles.css';
+
+async function load() {
+  const root = document.getElementById('app');
+  if (!root) throw new Error('No #app root element');
+
+  try {
+    const res = await fetch('/catalog.json');
+    if (!res.ok) throw new Error(`Failed to load catalog.json: ${res.status}`);
+    const catalog = (await res.json()) as Catalog;
+    render(<App catalog={catalog} />, root);
+  } catch (err) {
+    render(
+      <div class="error">
+        <h1>Failed to load catalog</h1>
+        <pre>{String(err)}</pre>
+      </div>,
+      root
+    );
+  }
+}
+
+void load();

--- a/tarballs/src/styles.css
+++ b/tarballs/src/styles.css
@@ -1,0 +1,794 @@
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --bg-elevated: #fafafa;
+  --bg-hover: #f5f5f5;
+  --fg: #0a0a0a;
+  --fg-muted: #666666;
+  --fg-subtle: #999999;
+  --border: #eaeaea;
+  --border-strong: #d4d4d4;
+  --accent: #0070f3;
+  --accent-fg: #ffffff;
+  --accent-soft: rgba(0, 112, 243, 0.12);
+  --code-bg: #f5f5f5;
+  --success: #16a34a;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0a0a0a;
+    --bg-elevated: #111111;
+    --bg-hover: #1a1a1a;
+    --fg: #ededed;
+    --fg-muted: #a1a1a1;
+    --fg-subtle: #666666;
+    --border: #1f1f1f;
+    --border-strong: #2a2a2a;
+    --accent: #3291ff;
+    --accent-soft: rgba(50, 145, 255, 0.18);
+    --code-bg: #161616;
+    --success: #4ade80;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code,
+pre,
+.mono {
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.container {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 5rem;
+}
+
+header.page {
+  margin-bottom: 2.5rem;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.5rem;
+}
+
+.lede {
+  color: var(--fg-muted);
+  font-size: 1rem;
+  margin: 0 0 1.25rem;
+  max-width: 60ch;
+}
+
+.meta-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+a.chip:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--fg);
+}
+
+.chip code {
+  background: transparent;
+  padding: 0;
+  font-size: 0.8rem;
+}
+
+details.about {
+  margin: 1.5rem 0 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+}
+
+details.about summary {
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.9rem;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--fg);
+}
+
+details.about summary::-webkit-details-marker {
+  display: none;
+}
+
+details.about summary::before {
+  content: '▸';
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  transition: transform 0.15s;
+}
+
+details.about[open] summary::before {
+  transform: rotate(90deg);
+}
+
+details.about p {
+  margin: 0.75rem 0 0;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
+details.about p + p {
+  margin-top: 0.5rem;
+}
+
+details.about code {
+  background: var(--code-bg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin: 0.5rem 0 1rem;
+  flex-wrap: wrap;
+}
+
+.pm-tabs {
+  display: inline-flex;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+}
+
+.pm-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0.4rem 0.85rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--fg-muted);
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.pm-tab:hover {
+  color: var(--fg);
+}
+
+.pm-tab[aria-pressed='true'] {
+  background: var(--bg);
+  color: var(--fg);
+  box-shadow: var(--shadow);
+}
+
+@media (prefers-color-scheme: dark) {
+  .pm-tab[aria-pressed='true'] {
+    background: var(--bg-hover);
+  }
+}
+
+.search {
+  flex: 1;
+  min-width: 200px;
+  position: relative;
+}
+
+.search input {
+  width: 100%;
+  padding: 0.55rem 0.85rem 0.55rem 2.25rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 8px;
+  outline: none;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.search input:focus {
+  border-color: var(--accent);
+  background: var(--bg);
+}
+
+.search svg {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--fg-subtle);
+  pointer-events: none;
+}
+
+/* Featured card */
+.featured {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.featured::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at top right,
+    var(--accent-soft),
+    transparent 60%
+  );
+  pointer-events: none;
+}
+
+.featured > * {
+  position: relative;
+}
+
+.featured-header {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.featured-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: 4px;
+}
+
+.featured-name {
+  font-size: 1.5rem;
+  font-weight: 600;
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: -0.01em;
+}
+
+.featured-version,
+.featured-size {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.featured-desc {
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+  margin: 0 0 1.25rem;
+}
+
+.install-block {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.install-cmd {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9rem;
+  overflow-x: auto;
+  white-space: nowrap;
+  color: var(--fg);
+}
+
+.install-cmd::-webkit-scrollbar {
+  height: 4px;
+}
+
+.install-cmd::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 2px;
+}
+
+.copy-btn,
+.download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0 1rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--fg);
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.copy-btn:hover,
+.download-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.copy-btn[data-copied='true'] {
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.copy-btn[data-failed='true'],
+.icon-btn[data-failed='true'] {
+  color: #dc2626;
+  border-color: #dc2626;
+}
+
+@media (prefers-color-scheme: dark) {
+  .copy-btn[data-failed='true'],
+  .icon-btn[data-failed='true'] {
+    color: #f87171;
+    border-color: #f87171;
+  }
+}
+
+/* Other packages section */
+.section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted);
+  margin: 0 0 0.75rem;
+}
+
+.pkg-list {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--bg-elevated);
+}
+
+.pkg-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 2fr) auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.1s;
+}
+
+.pkg-row:last-child {
+  border-bottom: 0;
+}
+
+.pkg-row:hover {
+  background: var(--bg-hover);
+}
+
+.pkg-info {
+  min-width: 0;
+}
+
+.pkg-name {
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pkg-meta {
+  font-size: 0.75rem;
+  color: var(--fg-subtle);
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin-top: 0.15rem;
+}
+
+.pkg-cmd {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.45rem 0.7rem;
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  white-space: nowrap;
+  color: var(--fg);
+  min-width: 0;
+}
+
+.pkg-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.icon-btn {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+  text-decoration: none;
+}
+
+.icon-btn:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+  border-color: var(--border-strong);
+}
+
+.icon-btn[data-copied='true'] {
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.empty {
+  padding: 2rem 1.25rem;
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
+footer.page {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  color: var(--fg-subtle);
+}
+
+footer.page a {
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+
+footer.page a:hover {
+  color: var(--fg);
+}
+
+/* Package contents (file breakdown) */
+details.contents {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+details.contents-row {
+  grid-column: 1 / -1;
+  margin-top: 0.5rem;
+  background: transparent;
+}
+
+details.contents > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--fg-muted);
+  user-select: none;
+}
+
+details.contents > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.contents > summary svg {
+  transition: transform 0.15s;
+}
+
+details.contents[open] > summary svg {
+  transform: rotate(180deg);
+}
+
+details.contents > summary:hover {
+  color: var(--fg);
+}
+
+.contents-summary-meta {
+  margin-left: auto;
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: var(--fg-subtle);
+}
+
+.contents-body {
+  padding: 0;
+  border-top: 1px solid var(--border);
+}
+
+/* Stats — packagephobia-style headline metrics */
+.size-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+
+.size-stat {
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.size-stat + .size-stat {
+  border-left: 1px solid var(--border);
+}
+
+.size-stat-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  line-height: 1;
+}
+
+.size-stat-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+
+.size-stat-unit {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--fg-muted);
+}
+
+.size-stat-label {
+  margin-top: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--fg-muted);
+}
+
+@media (max-width: 480px) {
+  .size-stat-value {
+    font-size: 1.8rem;
+  }
+  .size-stat-unit {
+    font-size: 1.1rem;
+  }
+}
+
+/* Sortable file table */
+.file-table-wrap {
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.file-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family:
+    'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+}
+
+.file-table thead {
+  position: sticky;
+  top: 0;
+  background: var(--bg-elevated);
+  z-index: 1;
+}
+
+.file-table th {
+  text-align: left;
+  padding: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.file-table th.file-table-size {
+  text-align: right;
+  width: 110px;
+}
+
+.sort-btn {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  width: 100%;
+  padding: 0.55rem 0.85rem;
+  font-family: inherit;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  text-align: inherit;
+}
+
+.file-table th.file-table-size .sort-btn {
+  justify-content: flex-end;
+}
+
+.sort-btn:hover {
+  color: var(--fg);
+}
+
+.sort-indicator {
+  display: inline-block;
+  width: 10px;
+  text-align: center;
+  color: var(--fg-subtle);
+  font-size: 0.85em;
+}
+
+.sort-indicator-active {
+  color: var(--accent);
+}
+
+.file-table tbody tr {
+  border-bottom: 1px solid var(--border);
+}
+
+.file-table tbody tr:last-child {
+  border-bottom: 0;
+}
+
+.file-table tbody tr:hover {
+  background: var(--bg-hover);
+}
+
+.file-table td {
+  padding: 0.4rem 0.85rem;
+  vertical-align: top;
+}
+
+.file-path {
+  color: var(--fg);
+  word-break: break-all;
+}
+
+.file-size {
+  color: var(--fg-muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.error {
+  max-width: 600px;
+  margin: 4rem auto;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.error pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--code-bg);
+  padding: 1rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  .container {
+    padding: 1.5rem 1rem 3rem;
+  }
+  h1 {
+    font-size: 1.5rem;
+  }
+  .featured-name {
+    font-size: 1.2rem;
+  }
+  .install-block {
+    flex-direction: column;
+  }
+  .copy-btn,
+  .download-btn {
+    padding: 0.55rem 1rem;
+    justify-content: center;
+  }
+  .pkg-row {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+  .pkg-actions {
+    justify-content: flex-end;
+  }
+}

--- a/tarballs/tsconfig.json
+++ b/tarballs/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "vite.config.ts", "scripts"]
+}

--- a/tarballs/turbo.json
+++ b/tarballs/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": ["public/*.tgz", "public/index.html"]
+      "outputs": ["public/*.tgz", "public/catalog.json", "dist/**"]
     }
   }
 }

--- a/tarballs/vercel.json
+++ b/tarballs/vercel.json
@@ -2,6 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm turbo build --filter=tarballs",
   "installCommand": "pnpm install --frozen-lockfile",
-  "outputDirectory": "public",
+  "outputDirectory": "dist",
   "framework": null
 }

--- a/tarballs/vite.config.ts
+++ b/tarballs/vite.config.ts
@@ -1,0 +1,16 @@
+import preact from '@preact/preset-vite';
+import { defineConfig } from 'vite';
+
+// Layout:
+// - `public/` holds static assets (tarballs and `catalog.json`) that pack.ts
+//   writes before vite runs. In dev mode, vite serves them at the root of
+//   the dev server. During `vite build`, vite copies them into `dist/`.
+// - `dist/` is the final build output that Vercel serves (set as
+//   `outputDirectory` in vercel.json).
+export default defineConfig({
+  plugins: [preact()],
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+});


### PR DESCRIPTION
Manual backport of #1911 to `stable`.

The auto-backport action ([run](https://github.com/vercel/workflow/actions/runs/25352707833)) cherry-picked cleanly but couldn't push directly because `stable` requires PRs / signed commits / status checks.

## Summary

- Cherry-picked the squashed merge commit `b883ea0d` (#1911) onto `stable`.
- Only conflict was `pnpm-lock.yaml`; resolved by re-running `pnpm install` (same approach the backport action uses).
- No changeset needed — `tarballs` is private (not published).

## Test plan

- [ ] CI green (tarballs build + smoke check)
- [ ] Tarballs preview deploys and renders the new Vite + Preact SPA