### PR TITLE
Add missing changeset for #1902 (Zod 4.4.x compat in @workflow/world)

### DIFF
--- a/.changeset/fix-world-zod-44-compat.md
+++ b/.changeset/fix-world-zod-44-compat.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world': patch
+---
+
+Fix compatibility with Zod 4.4.x in `WorkflowRunSchema` by marking `output`, `error`, and `completedAt` as `.optional()` on non-final / cancelled / completed / failed run states.


### PR DESCRIPTION
## Summary

PR #1902 ("Fix compatibility with Zod 4.4.x") landed on `main` without a changeset — this adds the missing patch-level changeset for `@workflow/world`, describing the `WorkflowRunSchema` fix that marks `output` / `error` / `completedAt` as `.optional()` on non-final / cancelled / completed / failed run states.

A companion changeset is also being added directly to the open backport PR #1938 against `stable`, so the fix lands with proper changelog attribution on both branches.