### PR TITLE
Pipe opencode prompts via stdin instead of argv

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -349,7 +349,7 @@ jobs:
           # code alone — but with `set -e` above, any non-zero exit will also
           # fail the job. The real signal is whether the decision file was
           # produced.
-          opencode run --model "vercel/${AI_MODEL}" "$(cat .backport-decision-prompt.txt)"
+          opencode run --model "vercel/${AI_MODEL}" < .backport-decision-prompt.txt
 
           if [ ! -f "$DECISION_FILE" ]; then
             echo "::error::AI did not produce a decision file at ${DECISION_FILE}. This usually indicates an opencode/AI Gateway infrastructure failure (e.g. expired API key, gateway down, or rejected tool call) — check the step output above. To force a backport regardless of the AI decision, add the \`backport-stable\` label to the source PR."
@@ -561,7 +561,7 @@ jobs:
           # rejected tool calls). The outcome-file presence + `set -e` on
           # this step's exit are what we rely on to distinguish infra vs.
           # AI-said-no.
-          opencode run --model "vercel/${AI_MODEL}" "$(cat .backport-conflict-prompt.txt)"
+          opencode run --model "vercel/${AI_MODEL}" < .backport-conflict-prompt.txt
 
           if [ ! -f "$OUTCOME_FILE" ]; then
             echo "::error::AI conflict resolution did not produce ${OUTCOME_FILE}. This usually indicates an opencode/AI Gateway infrastructure failure (e.g. expired API key, rejected tool call, opencode crash) — check the step output above. To resolve manually, see the source PR for instructions."


### PR DESCRIPTION
## Summary

The backport workflow on the v4/v5 docs split commit ([run 25418088947](https://github.com/vercel/workflow/actions/runs/25418088947/job/74553697353)) failed with:

```
/opt/hostedtoolcache/node/22.22.2/x64/bin/opencode: Argument list too long
##[error]Process completed with exit code 126.
```

The large diff (capped at 200KB) plus the prompt prologue / commit metadata / PR body was big enough that the constructed argv blew past Linux's `ARG_MAX` (~128KB), causing `execve` to fail.

Redirecting the prompt files into `opencode run`'s stdin instead of passing them on the command line avoids the limit. Verified locally that `opencode run` reads the prompt from stdin when no positional message argument is given.