### PR TITLE
Show hook name on trace viewer + no toast on decrypt

### DIFF
--- a/.changeset/clever-wombats-drop.md
+++ b/.changeset/clever-wombats-drop.md
@@ -1,0 +1,6 @@
+---
+"@workflow/web-shared": patch
+"@workflow/web": patch
+---
+
+Show hook name on trace viewer + no toast on decrypt

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -443,6 +443,10 @@ function NewTraceViewerContent({ trace }: NewTraceViewerProps): ReactNode {
   const selectedSpanName = useMemo(() => {
     if (!selectedSpan?.data) return 'Details';
     const data = selectedSpan.data as Record<string, unknown>;
+    if (selectedSpan.resource === 'hook') {
+      return (data.token as string | undefined) ?? (data.hookId as string);
+    }
+
     const stepName = data.stepName as string | undefined;
     const workflowName = data.workflowName as string | undefined;
     return (
@@ -453,19 +457,23 @@ function NewTraceViewerContent({ trace }: NewTraceViewerProps): ReactNode {
       (data.hookId as string) ??
       'Details'
     );
-  }, [selectedSpan?.data]);
+  }, [selectedSpan?.data, selectedSpan?.resource]);
 
   const selectedResource = selectedSpan?.resource as string | undefined;
   const selectedResourceId = useMemo(() => {
     if (!selectedSpan?.data) return undefined;
     const data = selectedSpan.data as Record<string, unknown>;
+    if (selectedSpan.resource === 'hook') {
+      return (data.hookId as string | undefined) ?? selectedSpan.spanId;
+    }
+
     return (
       (data.stepId as string) ??
       (data.runId as string) ??
       (data.hookId as string) ??
       selectedSpan.spanId
     );
-  }, [selectedSpan?.data, selectedSpan?.spanId]);
+  }, [selectedSpan?.data, selectedSpan?.resource, selectedSpan?.spanId]);
 
   return (
     <div

--- a/packages/web-shared/src/components/workflow-traces/trace-span-construction.ts
+++ b/packages/web-shared/src/components/workflow-traces/trace-span-construction.ts
@@ -314,7 +314,7 @@ export function hookToSpan(hookEvents: Event[], maxEndTime: Date): Span | null {
 
   return {
     spanId: String(hook.hookId),
-    name: String(hook.hookId),
+    name: hook.token ?? String(hook.hookId),
     kind: 1, // INTERNAL span kind
     resource: 'hook',
     library: WORKFLOW_LIBRARY,

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -412,7 +412,6 @@ export function RunDetailView({
         return;
       }
       setEncryptionKey(keyResult);
-      toast.success('Run data decrypted successfully');
     } finally {
       setIsDecrypting(false);
     }


### PR DESCRIPTION
Hooks will show their actual token name on event list and detail panel
<img width="716" height="432" alt="CleanShot 2026-05-06 at 13 55 08@2x" src="https://github.com/user-attachments/assets/96109e4e-700e-4754-86d0-5012410d27b2" />


No more toast if decrypted, the UI already indicates success state.