### PR TITLE
Fix Nitro dev loading of local step dependencies

### DIFF
--- a/.changeset/narrow-step-bundling.md
+++ b/.changeset/narrow-step-bundling.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Bundle transitive local step dependencies while keeping ordinary package dependencies external unless they contain workflow entries.

--- a/.changeset/narrow-step-bundling.md
+++ b/.changeset/narrow-step-bundling.md
@@ -2,4 +2,4 @@
 '@workflow/builders': patch
 ---
 
-Bundle transitive local step dependencies while keeping ordinary package dependencies external unless they contain workflow entries.
+Bundle transitive local step dependencies for direct Nitro dev loading while keeping ordinary package dependencies external unless they contain workflow entries.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -556,6 +556,7 @@ export abstract class BaseBuilder {
    * Steps have full Node.js runtime access and handle side effects, API calls, etc.
    *
    * @param externalizeNonSteps - If true, only bundles step entry points and externalizes other code
+   * @param bundleTransitiveLocalStepDependencies - If true, also bundles project-local files imported by step entries for direct runtime loading
    * @returns Build context (for watch mode) and the collected workflow manifest
    */
   protected async createStepsBundle({
@@ -563,6 +564,7 @@ export abstract class BaseBuilder {
     format = 'esm',
     outfile,
     externalizeNonSteps,
+    bundleTransitiveLocalStepDependencies,
     rewriteTsExtensions,
     tsconfigPath,
     discoveredEntries,
@@ -573,6 +575,7 @@ export abstract class BaseBuilder {
     outfile: string;
     format?: 'cjs' | 'esm';
     externalizeNonSteps?: boolean;
+    bundleTransitiveLocalStepDependencies?: boolean;
     rewriteTsExtensions?: boolean;
     discoveredEntries?: DiscoveredEntries;
     /**
@@ -784,6 +787,7 @@ export abstract class BaseBuilder {
           outdir: outfile ? dirname(outfile) : undefined,
           projectRoot: this.transformProjectRoot,
           workflowManifest,
+          bundleTransitiveLocalStepDependencies,
           rewriteTsExtensions,
           sideEffectEntries: normalizedSideEffectEntries,
         }),
@@ -1225,6 +1229,7 @@ export const POST = workflowEntrypoint(workflowCode);`;
     bundleFinalOutput = true,
     tsconfigPath,
     externalizeNonSteps,
+    bundleTransitiveLocalStepDependencies,
     discoveredEntries,
   }: {
     inputFiles: string[];
@@ -1236,6 +1241,7 @@ export const POST = workflowEntrypoint(workflowCode);`;
     bundleFinalOutput?: boolean;
     tsconfigPath?: string;
     externalizeNonSteps?: boolean;
+    bundleTransitiveLocalStepDependencies?: boolean;
     discoveredEntries?: DiscoveredEntries;
   }): Promise<{
     manifest: WorkflowManifest;
@@ -1257,6 +1263,7 @@ export const POST = workflowEntrypoint(workflowCode);`;
         // when esbuild inlines the steps without a __commonJS wrapper.
         format: bundleFinalOutput ? 'esm' : format,
         externalizeNonSteps,
+        bundleTransitiveLocalStepDependencies,
         tsconfigPath,
         discoveredEntries,
         // Skip the createRequire banner here — when bundleFinalOutput is true

--- a/packages/builders/src/discover-entries-esbuild-plugin.ts
+++ b/packages/builders/src/discover-entries-esbuild-plugin.ts
@@ -9,7 +9,24 @@ import {
   isGeneratedWorkflowFile,
 } from './transform-utils.js';
 
-const enhancedResolve = promisify(enhancedResolveOriginal);
+const enhancedResolve = promisify(
+  enhancedResolveOriginal.create({
+    extensions: [
+      '.ts',
+      '.tsx',
+      '.mts',
+      '.cts',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.json',
+      '.node',
+    ],
+    fullySpecified: false,
+    conditionNames: ['node', 'import', 'require'],
+  })
+);
 
 export const jsTsRegex = /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts)$/;
 

--- a/packages/builders/src/swc-esbuild-plugin.test.ts
+++ b/packages/builders/src/swc-esbuild-plugin.test.ts
@@ -18,6 +18,10 @@ vi.mock('./apply-swc-transform.js', () => ({
   applySwcTransform: applySwcTransformMock,
 }));
 
+import {
+  createDiscoverEntriesPlugin,
+  importParents,
+} from './discover-entries-esbuild-plugin.js';
 import { createSwcPlugin } from './swc-esbuild-plugin.js';
 
 const realTmpdir = realpathSync(tmpdir());
@@ -32,6 +36,7 @@ describe('createSwcPlugin externalizeNonSteps', () => {
 
   beforeEach(() => {
     testRoot = mkdtempSync(join(realTmpdir, 'workflow-swc-plugin-'));
+    importParents.clear();
     applySwcTransformMock.mockReset();
     applySwcTransformMock.mockImplementation(
       async (_filename: string, source: string) => ({
@@ -42,6 +47,7 @@ describe('createSwcPlugin externalizeNonSteps', () => {
   });
 
   afterEach(() => {
+    importParents.clear();
     rmSync(testRoot, { recursive: true, force: true });
   });
 
@@ -348,6 +354,173 @@ export const client = { provider: providerName };`
     expect(result.errors).toHaveLength(0);
     const output = result.outputFiles[0].text;
     expect(output).toContain(`/dep${inputExt}`);
+  });
+
+  it('bundles transitive local TypeScript dependencies with extensionless imports', async () => {
+    const outdir = join(testRoot, 'out');
+    const stepFile = join(testRoot, 'server', 'workflows', 'my-workflow.ts');
+    const constantsFile = join(testRoot, 'shared', 'constants.ts');
+    const helpersFile = join(testRoot, 'shared', 'helpers.ts');
+
+    writeFile(helpersFile, `export const HELPER_VALUE = "from-helper";`);
+    writeFile(
+      constantsFile,
+      `import { HELPER_VALUE } from './helpers';\nexport const CATEGORIES = [HELPER_VALUE];`
+    );
+    writeFile(
+      stepFile,
+      `import { CATEGORIES } from '../../shared/constants';\nexport async function myStep() {\n  'use step';\n  return CATEGORIES[0];\n}`
+    );
+
+    const state = {
+      discoveredSteps: new Set<string>(),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+    };
+    await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+      plugins: [createDiscoverEntriesPlugin(state, testRoot)],
+    });
+
+    const result = await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      outdir,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          entriesToBundle: [stepFile],
+          outdir,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const output = result.outputFiles[0].text;
+    expect(output).toContain('from-helper');
+    expect(output).not.toMatch(/from\s+["'][^"']*shared\/constants/);
+    expect(output).not.toMatch(/from\s+["'][^"']*shared\/helpers/);
+  });
+
+  it('keeps ordinary package dependencies external when reachable from a bundled step', async () => {
+    const outdir = join(testRoot, 'out');
+    const stepFile = join(testRoot, 'server', 'workflows', 'my-workflow.ts');
+    const pkgDir = join(testRoot, 'node_modules', 'plain-pkg');
+    const pkgIndex = join(pkgDir, 'index.js');
+
+    writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'plain-pkg', main: 'index.js' })
+    );
+    writeFile(pkgIndex, `export const value = "from-package";`);
+    writeFile(
+      stepFile,
+      `import { value } from 'plain-pkg';\nexport async function myStep() {\n  'use step';\n  return value;\n}`
+    );
+
+    const state = {
+      discoveredSteps: new Set<string>(),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+    };
+    await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      plugins: [createDiscoverEntriesPlugin(state, testRoot)],
+    });
+
+    const result = await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      outdir,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          entriesToBundle: [stepFile],
+          outdir,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const output = result.outputFiles[0].text;
+    expect(output).toMatch(/from\s+["']plain-pkg["']/);
+    expect(output).not.toContain('from-package');
+  });
+
+  it('bundles package parents when they lead to discovered workflow-related entries', async () => {
+    const outdir = join(testRoot, 'out');
+    const stepFile = join(testRoot, 'server', 'workflows', 'my-workflow.ts');
+    const pkgDir = join(testRoot, 'node_modules', 'workflow-pkg');
+    const pkgIndex = join(pkgDir, 'index.js');
+    const pkgSerde = join(pkgDir, 'serde.js');
+
+    writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'workflow-pkg', main: 'index.js' })
+    );
+    writeFile(pkgSerde, `export const value = "from-serde";`);
+    writeFile(pkgIndex, `export { value } from './serde.js';`);
+    writeFile(
+      stepFile,
+      `import { value } from 'workflow-pkg';\nexport async function myStep() {\n  'use step';\n  return value;\n}`
+    );
+
+    const state = {
+      discoveredSteps: new Set<string>(),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+    };
+    await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      plugins: [createDiscoverEntriesPlugin(state, testRoot)],
+    });
+
+    const result = await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      outdir,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          entriesToBundle: [stepFile, pkgSerde],
+          outdir,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const output = result.outputFiles[0].text;
+    expect(output).toContain('from-serde');
+    expect(output).not.toMatch(/from\s+["']workflow-pkg["']/);
   });
 });
 

--- a/packages/builders/src/swc-esbuild-plugin.test.ts
+++ b/packages/builders/src/swc-esbuild-plugin.test.ts
@@ -402,6 +402,7 @@ export const client = { provider: providerName };`
           mode: 'step',
           entriesToBundle: [stepFile],
           outdir,
+          bundleTransitiveLocalStepDependencies: true,
         }),
       ],
     });
@@ -411,6 +412,62 @@ export const client = { provider: providerName };`
     expect(output).toContain('from-helper');
     expect(output).not.toMatch(/from\s+["'][^"']*shared\/constants/);
     expect(output).not.toMatch(/from\s+["'][^"']*shared\/helpers/);
+  });
+
+  it('externalizes transitive local TypeScript dependencies by default', async () => {
+    const outdir = join(testRoot, 'out');
+    const stepFile = join(testRoot, 'server', 'workflows', 'my-workflow.ts');
+    const constantsFile = join(testRoot, 'shared', 'constants.ts');
+    const helpersFile = join(testRoot, 'shared', 'helpers.ts');
+
+    writeFile(helpersFile, `export const HELPER_VALUE = "from-helper";`);
+    writeFile(
+      constantsFile,
+      `import { HELPER_VALUE } from './helpers';\nexport const CATEGORIES = [HELPER_VALUE];`
+    );
+    writeFile(
+      stepFile,
+      `import { CATEGORIES } from '../../shared/constants';\nexport async function myStep() {\n  'use step';\n  return CATEGORIES[0];\n}`
+    );
+
+    const state = {
+      discoveredSteps: new Set<string>(),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+    };
+    await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+      plugins: [createDiscoverEntriesPlugin(state, testRoot)],
+    });
+
+    const result = await esbuild.build({
+      entryPoints: [stepFile],
+      absWorkingDir: testRoot,
+      outdir,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          entriesToBundle: [stepFile],
+          outdir,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const output = result.outputFiles[0].text;
+    expect(output).not.toContain('from-helper');
+    expect(output).toMatch(/from\s+["'][^"']*shared\/constants\.ts["']/);
   });
 
   it('keeps ordinary package dependencies external when reachable from a bundled step', async () => {
@@ -457,6 +514,7 @@ export const client = { provider: providerName };`
           mode: 'step',
           entriesToBundle: [stepFile],
           outdir,
+          bundleTransitiveLocalStepDependencies: true,
         }),
       ],
     });

--- a/packages/builders/src/swc-esbuild-plugin.ts
+++ b/packages/builders/src/swc-esbuild-plugin.ts
@@ -11,6 +11,7 @@ import {
   jsTsRegex,
   parentHasChild,
 } from './discover-entries-esbuild-plugin.js';
+import { resolveModuleSpecifier } from './module-specifier.js';
 import { resolveWorkflowAliasRelativePath } from './workflow-alias.js';
 
 export interface SwcPluginOptions {
@@ -78,6 +79,10 @@ const NODE_ESM_RESOLVE_OPTIONS = {
   dependencyType: 'esm',
   conditionNames: ['node', 'import'],
 };
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/');
+}
 
 export function createSwcPlugin(options: SwcPluginOptions): Plugin {
   return {
@@ -194,7 +199,10 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
           if (!resolvedPath) return null;
 
           // Normalize to forward slashes for cross-platform comparison
-          const normalizedResolvedPath = resolvedPath.replace(/\\/g, '/');
+          const normalizedResolvedPath = normalizePath(resolvedPath);
+          const workingDir =
+            build.initialOptions.absWorkingDir || process.cwd();
+          const projectRoot = options.projectRoot || workingDir;
 
           if (
             options.entriesToBundle &&
@@ -228,6 +236,19 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
               // to be bundled then it needs to also be bundled so
               // that the child can have our transform applied
               if (parentHasChild(normalizedResolvedPath, normalizedEntry)) {
+                shouldBundle = true;
+                break;
+              }
+
+              // Bundle project-local source files that are imported by a
+              // step/serde entry so direct runtime loaders do not see raw TS
+              // extensionless imports. Keep package dependencies external
+              // unless they are themselves in entriesToBundle or are parents
+              // of a discovered workflow/step/serde file via the check above.
+              if (
+                isProjectLocalFile(normalizedResolvedPath, projectRoot) &&
+                parentHasChild(normalizedEntry, normalizedResolvedPath)
+              ) {
                 shouldBundle = true;
                 break;
               }
@@ -419,4 +440,14 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
       });
     },
   };
+}
+
+function isProjectLocalFile(filePath: string, projectRoot: string): boolean {
+  if (normalizePath(filePath).includes('/node_modules/')) {
+    return false;
+  }
+
+  return (
+    resolveModuleSpecifier(filePath, projectRoot).moduleSpecifier === undefined
+  );
 }

--- a/packages/builders/src/swc-esbuild-plugin.ts
+++ b/packages/builders/src/swc-esbuild-plugin.ts
@@ -33,6 +33,15 @@ export interface SwcPluginOptions {
    */
   rewriteTsExtensions?: boolean;
   /**
+   * Bundle project-local files that are transitively imported by step entries.
+   *
+   * Keep this disabled when a downstream bundler consumes the generated step
+   * bundle because that bundler can resolve the externalized local imports.
+   * Enable it for direct runtime loading, where Node imports the generated step
+   * bundle from disk without a later bundling pass.
+   */
+  bundleTransitiveLocalStepDependencies?: boolean;
+  /**
    * Absolute file paths of discovered workflow/step/serde entries whose
    * imports must be treated as side-effectful.
    *
@@ -246,6 +255,7 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
               // unless they are themselves in entriesToBundle or are parents
               // of a discovered workflow/step/serde file via the check above.
               if (
+                options.bundleTransitiveLocalStepDependencies &&
                 isProjectLocalFile(normalizedResolvedPath, projectRoot) &&
                 parentHasChild(normalizedEntry, normalizedResolvedPath)
               ) {

--- a/packages/nitro/src/builders.ts
+++ b/packages/nitro/src/builders.ts
@@ -97,6 +97,10 @@ export class LocalBuilder extends BaseBuilder {
       // because esbuild wraps CJS require() calls in ESM output.
       bundleFinalOutput: false,
       externalizeNonSteps: true,
+      // In dev, Nitro dynamically imports the generated workflow files from
+      // disk, so there is no later Rollup pass to resolve externalized local
+      // TypeScript imports. In prod, Nitro/Rollup handles those imports.
+      bundleTransitiveLocalStepDependencies: this.config.watch,
     });
 
     await this.createWebhookBundle({


### PR DESCRIPTION
## Summary

- keep `externalizeNonSteps` externalizing local deps for downstream bundlers like Nitro/Rollup
- add an explicit opt-in for bundling transitive project-local step deps when generated files are loaded directly
- enable that opt-in only for Nitro dev, where workflow bundles are imported from disk outside Nitro's bundle graph

This is a narrower alternative to #1609: instead of broadening the `externalizeNonSteps` graph for all downstream bundler paths, it only bundles transitive local step dependencies for Nitro dev's direct-from-disk loading path.

Closes #1609
Closes #1179
