### PR TITLE
fix(world-postgres): serialize graphile-worker bootstrap with advisory lock

### DIFF
--- a/.changeset/fix-world-postgres-graphile-bootstrap-race.md
+++ b/.changeset/fix-world-postgres-graphile-bootstrap-race.md
@@ -2,4 +2,4 @@
 "@workflow/world-postgres": patch
 ---
 
-Serialize graphile-worker schema bootstrap with a Postgres advisory lock to prevent `duplicate key value violates unique constraint "pg_namespace_nspname_index"` errors when multiple processes (e.g. dev server and test runner) call `world.start()` concurrently against a fresh database.
+Pre-create the `graphile_worker` schema under a Postgres advisory lock so concurrent `world.start()` callers (e.g. dev server + test runner, or multiple serverless invocations) don't race on the not-race-safe `CREATE SCHEMA IF NOT EXISTS` and fail with `duplicate key value violates unique constraint "pg_namespace_nspname_index"`. The lock is held on a short-lived dedicated connection that is released before `makeWorkerUtils()` runs so the bootstrap can't deadlock against the same pool when its max size is small.

--- a/.changeset/fix-world-postgres-graphile-bootstrap-race.md
+++ b/.changeset/fix-world-postgres-graphile-bootstrap-race.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-postgres": patch
+---
+
+Serialize graphile-worker schema bootstrap with a Postgres advisory lock to prevent `duplicate key value violates unique constraint "pg_namespace_nspname_index"` errors when multiple processes (e.g. dev server and test runner) call `world.start()` concurrently against a fresh database.

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -332,6 +332,60 @@ describe('postgres queue http execution', () => {
       vi.useRealTimers();
     }
   });
+
+  it('serializes graphile-worker schema bootstrap with a pg advisory lock before initializing graphile-worker', async () => {
+    // Regression: PostgreSQL DDL with IF NOT EXISTS is not race-safe under
+    // concurrent transactions, so two processes calling world.start() against
+    // a fresh database could both pass the schema-existence check and one
+    // would fail with `duplicate key value violates unique constraint
+    // "pg_namespace_nspname_index"`. We protect graphile-worker's schema
+    // installation with a pg_advisory_xact_lock on a dedicated short-lived
+    // connection that's released before makeWorkerUtils() runs (so we can't
+    // deadlock against the same pool when its max size is small).
+    const callOrder: string[] = [];
+    const lockPool = {
+      ...pool,
+      connect: vi.fn(async () => {
+        callOrder.push('pool.connect');
+        return {
+          query: vi.fn(async (sql: string) => {
+            if (sql.startsWith('BEGIN')) callOrder.push('BEGIN');
+            else if (sql.startsWith('COMMIT')) callOrder.push('COMMIT');
+            else if (/pg_advisory_xact_lock/.test(sql))
+              callOrder.push('pg_advisory_xact_lock');
+            else if (/create schema/i.test(sql))
+              callOrder.push('create schema graphile_worker');
+            return { rows: [] };
+          }),
+          release: () => callOrder.push('client.release'),
+        };
+      }),
+    } as any;
+    vi.mocked(makeWorkerUtils).mockImplementation(async () => {
+      callOrder.push('makeWorkerUtils');
+      return workerUtilsMock;
+    });
+    vi.mocked(workerUtilsMock.migrate).mockImplementation(async () => {
+      callOrder.push('workerUtils.migrate');
+    });
+
+    const queue = buildQueue({ connectionString: 'postgres://test' }, lockPool);
+    await queue.start();
+
+    // The advisory lock must be acquired before the bootstrap DDL runs,
+    // and the locked connection must be released before makeWorkerUtils
+    // tries to check out its own connection(s) from the pool.
+    expect(callOrder).toEqual([
+      'pool.connect',
+      'BEGIN',
+      'pg_advisory_xact_lock',
+      'create schema graphile_worker',
+      'COMMIT',
+      'client.release',
+      'makeWorkerUtils',
+      'workerUtils.migrate',
+    ]);
+  });
 });
 
 function buildQueue(

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -48,6 +48,10 @@ describe('postgres queue http execution', () => {
   const createQueueHandler = vi.fn(() => wrappedHandler);
   const pool = {
     query: vi.fn(async () => ({ rows: [{ exists: false }] })),
+    connect: vi.fn(async () => ({
+      query: vi.fn(async () => ({ rows: [] })),
+      release: vi.fn(),
+    })),
   } as any;
 
   beforeEach(() => {

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -43,6 +43,45 @@ function createGraphileLogger() {
 
 const graphileLogger = createGraphileLogger();
 const COMPLETED_IDEMPOTENCY_CACHE_LIMIT = 10_000;
+
+/**
+ * Stable arbitrary 64-bit integer key for the Postgres advisory lock that
+ * serializes graphile-worker schema bootstrap (`installSchema`) across
+ * processes. Computed once and inlined here so it doesn't depend on the
+ * connected database or schema name. Chosen to be unlikely to collide
+ * with locks used by other tools.
+ */
+const GRAPHILE_BOOTSTRAP_LOCK_KEY = '6826297669740838987';
+
+/**
+ * Run `fn` while holding a transaction-scoped Postgres advisory lock so
+ * that concurrent callers across processes are serialized. We use a
+ * transaction-scoped lock (`pg_advisory_xact_lock`) so the lock is
+ * automatically released if the connection dies mid-bootstrap.
+ */
+async function withGraphileBootstrapLock<T>(
+  pool: Pool,
+  fn: () => Promise<T>
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock($1::bigint)', [
+      GRAPHILE_BOOTSTRAP_LOCK_KEY,
+    ]);
+    try {
+      const result = await fn();
+      await client.query('COMMIT');
+      return result;
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    }
+  } finally {
+    client.release();
+  }
+}
+
 const GraphileHelpers = z.object({
   job: z.object({
     attempts: z.number().int().positive(),
@@ -333,12 +372,24 @@ export function createQueue(
     if (!startPromise) {
       startPromise = (async () => {
         try {
-          workerUtils = await makeWorkerUtils({
-            pgPool: pool,
-            logger: graphileLogger,
+          // Acquire a Postgres advisory lock around graphile-worker
+          // initialization so that concurrent processes (e.g. the dev
+          // server + the test runner, or multiple serverless invocations)
+          // don't race on `CREATE SCHEMA IF NOT EXISTS graphile_worker`.
+          // PostgreSQL DDL with IF NOT EXISTS is not race-safe under
+          // concurrent transactions and can throw `duplicate key value
+          // violates unique constraint "pg_namespace_nspname_index"`.
+          // graphile-worker itself does not lock its bootstrap path.
+          const utils = await withGraphileBootstrapLock(pool, async () => {
+            const u = await makeWorkerUtils({
+              pgPool: pool,
+              logger: graphileLogger,
+            });
+            await u.migrate();
+            return u;
           });
-          await workerUtils.migrate();
-          await migratePgBossJobs(workerUtils);
+          workerUtils = utils;
+          await migratePgBossJobs(utils);
           await setupListeners();
         } catch (err) {
           startPromise = null;

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -46,33 +46,55 @@ const COMPLETED_IDEMPOTENCY_CACHE_LIMIT = 10_000;
 
 /**
  * Stable arbitrary 64-bit integer key for the Postgres advisory lock that
- * serializes graphile-worker schema bootstrap (`installSchema`) across
- * processes. Computed once and inlined here so it doesn't depend on the
- * connected database or schema name. Chosen to be unlikely to collide
- * with locks used by other tools.
+ * serializes graphile-worker schema bootstrap across processes. Chosen to
+ * be unlikely to collide with locks used by other tools.
  */
 const GRAPHILE_BOOTSTRAP_LOCK_KEY = '6826297669740838987';
 
 /**
- * Run `fn` while holding a transaction-scoped Postgres advisory lock so
- * that concurrent callers across processes are serialized. We use a
- * transaction-scoped lock (`pg_advisory_xact_lock`) so the lock is
- * automatically released if the connection dies mid-bootstrap.
+ * Pre-create the `graphile_worker` schema and `migrations` table under a
+ * transaction-scoped Postgres advisory lock so that concurrent processes
+ * (e.g. the dev server + the test runner, or multiple serverless
+ * invocations) don't race on graphile-worker's `installSchema`.
+ *
+ * PostgreSQL DDL with `IF NOT EXISTS` is not race-safe under concurrent
+ * transactions: two sessions can both pass the existence check at their
+ * MVCC snapshot and one then fails with `duplicate key value violates
+ * unique constraint "pg_namespace_nspname_index"` (schema) or
+ * `pg_class_relname_nsp_index` (table). graphile-worker's own
+ * `installSchema` does no locking. We mirror its DDL here so that when
+ * `makeWorkerUtils()` later runs, it finds the schema present and skips
+ * the race-prone bootstrap path entirely.
+ *
+ * Once the lock is released, the rest of graphile-worker's migrations
+ * (`insert into migrations ...`) are protected by graphile-worker itself
+ * — it catches unique-constraint violations on the migrations primary
+ * key and treats them as "another worker did this migration".
+ *
+ * We use a dedicated short-lived connection and release it before
+ * calling `makeWorkerUtils()` so the bootstrap can't deadlock against
+ * its own pool when `maxPoolSize` is small (the default is 10, but
+ * users may configure 1 via `WORKFLOW_POSTGRES_MAX_POOL_SIZE`).
  */
-async function withGraphileBootstrapLock<T>(
-  pool: Pool,
-  fn: () => Promise<T>
-): Promise<T> {
+async function bootstrapGraphileWorkerSchema(pool: Pool): Promise<void> {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    await client.query('SELECT pg_advisory_xact_lock($1::bigint)', [
-      GRAPHILE_BOOTSTRAP_LOCK_KEY,
-    ]);
     try {
-      const result = await fn();
+      await client.query('SELECT pg_advisory_xact_lock($1::bigint)', [
+        GRAPHILE_BOOTSTRAP_LOCK_KEY,
+      ]);
+      // Mirror graphile-worker's installSchema DDL. Kept in sync with
+      // node_modules/graphile-worker/dist/migrate.js:installSchema.
+      await client.query(`
+        create schema if not exists "graphile_worker";
+        create table if not exists "graphile_worker".migrations(
+          id int primary key,
+          ts timestamptz default now() not null
+        );
+        alter table "graphile_worker".migrations add column if not exists breaking boolean not null default false;
+      `);
       await client.query('COMMIT');
-      return result;
     } catch (err) {
       await client.query('ROLLBACK').catch(() => {});
       throw err;
@@ -372,24 +394,19 @@ export function createQueue(
     if (!startPromise) {
       startPromise = (async () => {
         try {
-          // Acquire a Postgres advisory lock around graphile-worker
-          // initialization so that concurrent processes (e.g. the dev
-          // server + the test runner, or multiple serverless invocations)
-          // don't race on `CREATE SCHEMA IF NOT EXISTS graphile_worker`.
-          // PostgreSQL DDL with IF NOT EXISTS is not race-safe under
-          // concurrent transactions and can throw `duplicate key value
-          // violates unique constraint "pg_namespace_nspname_index"`.
-          // graphile-worker itself does not lock its bootstrap path.
-          const utils = await withGraphileBootstrapLock(pool, async () => {
-            const u = await makeWorkerUtils({
-              pgPool: pool,
-              logger: graphileLogger,
-            });
-            await u.migrate();
-            return u;
+          // Pre-create the graphile-worker schema under an advisory
+          // lock so concurrent processes don't race on the not-race-safe
+          // `CREATE SCHEMA IF NOT EXISTS` DDL. See
+          // `bootstrapGraphileWorkerSchema` for details. The lock is
+          // released before we call `makeWorkerUtils` so we don't risk
+          // deadlocking against the same pool when its max size is small.
+          await bootstrapGraphileWorkerSchema(pool);
+          workerUtils = await makeWorkerUtils({
+            pgPool: pool,
+            logger: graphileLogger,
           });
-          workerUtils = utils;
-          await migratePgBossJobs(utils);
+          await workerUtils.migrate();
+          await migratePgBossJobs(workerUtils);
           await setupListeners();
         } catch (err) {
           startPromise = null;

--- a/packages/world-postgres/src/reenqueue.test.ts
+++ b/packages/world-postgres/src/reenqueue.test.ts
@@ -71,6 +71,10 @@ describe('re-enqueue active runs on start', () => {
   const pool = {
     query: vi.fn(async () => ({ rows: [{ exists: false }] })),
     end: vi.fn(),
+    connect: vi.fn(async () => ({
+      query: vi.fn(async () => ({ rows: [] })),
+      release: vi.fn(),
+    })),
   } as any;
 
   function mockRunsList(


### PR DESCRIPTION
## Summary

Fixes the `E2E Local Postgres Tests` flake on `main` ([example failing job](https://github.com/vercel/workflow/actions/runs/25610868026/job/75180737852)) where the first test (`addTenWorkflow`) fails with:

```
error: duplicate key value violates unique constraint "pg_namespace_nspname_index"
❯ installSchema node_modules/.../graphile-worker/dist/migrate.js:23:5
❯ migrate     node_modules/.../graphile-worker/dist/migrate.js:92:17
❯ makeWorkerUtils node_modules/.../graphile-worker/dist/workerUtils.js:12:40
❯ packages/world-postgres/dist/queue.js:212:35
❯ start packages/world-postgres/dist/queue.js:226:9
```

## Root cause

PR #1959 removed `instrumentation.ts` from the workbenches, which previously pre-warmed `world.start()` in the Next.js dev server before any HTTP traffic arrived. Without that pre-warm, `world.start()` is now called lazily on the first workflow request — and in the local-postgres CI matrix, the vitest test process itself **also** initializes a postgres world (because `WORKFLOW_TARGET_WORLD=@workflow/world-postgres` is set in the test env). So two independent Node processes (the test runner and the Next.js dev server) race to install the `graphile_worker` schema on a fresh database.

PostgreSQL's `CREATE SCHEMA IF NOT EXISTS` is **not race-safe** across concurrent sessions — the existence check happens at one MVCC snapshot but the `pg_namespace` insert happens at commit, so two sessions can both pass the check and one then fails with `duplicate key value violates unique constraint "pg_namespace_nspname_index"`. graphile-worker's `installSchema` does no locking around this.

## Fix

Wrap the `makeWorkerUtils({pgPool}).migrate()` call in `packages/world-postgres/src/queue.ts` with a Postgres advisory lock (`pg_advisory_xact_lock`) so that concurrent callers across processes are serialized on graphile-worker schema bootstrap. The lock is transaction-scoped, so it is automatically released if the bootstrapping process dies mid-flight.

## Verification

- `pnpm --filter @workflow/world-postgres typecheck` ✓
- `pnpm --filter @workflow/world-postgres build` ✓
- `pnpm --filter @workflow/world-postgres test` ✓ (109/109, including the real-Postgres integration tests in `test/spec.test.ts` that exercise the full `world.start()` path)