### PR TITLE
Enforce unique Postgres hook tokens

### DIFF
--- a/packages/world-postgres/src/drizzle/migrations/0013_add_hooks_token_unique_index.sql
+++ b/packages/world-postgres/src/drizzle/migrations/0013_add_hooks_token_unique_index.sql
@@ -1,0 +1,20 @@
+DROP INDEX IF EXISTS "workflow"."workflow_hooks_token_index";
+--> statement-breakpoint
+WITH "ranked_workflow_hooks" AS (
+	SELECT
+		ctid,
+		ROW_NUMBER() OVER (
+			PARTITION BY "token"
+			ORDER BY "created_at", ctid
+		) AS "row_num"
+	FROM "workflow"."workflow_hooks"
+)
+DELETE FROM "workflow"."workflow_hooks"
+WHERE ctid IN (
+	SELECT ctid
+	FROM "ranked_workflow_hooks"
+	WHERE "row_num" > 1
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "workflow_hooks_token_unique"
+	ON "workflow"."workflow_hooks" ("token");

--- a/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
+++ b/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1775600000000,
       "tag": "0012_add_is_system",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1776100000000,
+      "tag": "0013_add_hooks_token_unique_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -204,7 +204,10 @@ export const hooks = schema.table(
     isWebhook: boolean('is_webhook').default(true),
     isSystem: boolean('is_system').default(false),
   } satisfies DrizzlishOfType<Cborized<Hook, 'metadata'>>,
-  (tb) => [index().on(tb.runId), index().on(tb.token)]
+  (tb) => [
+    index().on(tb.runId),
+    uniqueIndex('workflow_hooks_token_unique').on(tb.token),
+  ]
 );
 
 export const waits = schema.table(

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -1029,13 +1029,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
           isSystem?: boolean;
         };
 
-        // Check for duplicate token using prepared statement
-        const [existingHook] = await getHookByToken.execute({
-          token: eventData.token,
-        });
-        if (existingHook) {
-          // Create hook_conflict event instead of throwing 409
-          // This allows the workflow to continue and fail gracefully when the hook is awaited
+        const createHookConflictEvent = async () => {
           const conflictEventData = {
             token: eventData.token,
           };
@@ -1074,6 +1068,16 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             step,
             hook: undefined,
           };
+        };
+
+        // Check for duplicate token using prepared statement
+        const [existingHook] = await getHookByToken.execute({
+          token: eventData.token,
+        });
+        if (existingHook) {
+          // Create hook_conflict event instead of throwing 409
+          // This allows the workflow to continue and fail gracefully when the hook is awaited
+          return createHookConflictEvent();
         }
 
         const [hookValue] = await drizzle
@@ -1096,6 +1100,16 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         if (hookValue) {
           hookValue.metadata ||= hookValue.metadataJson;
           hook = HookSchema.parse(compact(hookValue));
+        } else {
+          const [conflictingHook] = await getHookByToken.execute({
+            token: eventData.token,
+          });
+          if (conflictingHook) {
+            return createHookConflictEvent();
+          }
+          throw new EntityConflictError(
+            `Hook "${data.correlationId}" already exists`
+          );
         }
       }
 

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -1225,6 +1225,38 @@ describe('Storage (Postgres integration)', () => {
       );
       expect(waitCreated).toHaveLength(1);
     });
+
+    it('should serialize concurrent hook_created attempts for the same token', async () => {
+      const token = 'concurrent-token-test';
+      const run2 = await createRun(events, {
+        deploymentId: 'deployment-456',
+        workflowName: 'test-workflow-2',
+        input: new Uint8Array(),
+      });
+      await updateRun(events, run2.runId, 'run_started');
+
+      const results = await Promise.all([
+        events.create(testRunId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_concurrent_1',
+          eventData: { token },
+        }),
+        events.create(run2.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_concurrent_2',
+          eventData: { token },
+        }),
+      ]);
+
+      const eventTypes = results.map((result) => result.event.eventType).sort();
+      expect(eventTypes).toEqual(['hook_conflict', 'hook_created']);
+
+      const { rows } = await pool.query(
+        'SELECT COUNT(*)::int AS count FROM workflow.workflow_hooks WHERE token = $1',
+        [token]
+      );
+      expect(rows[0].count).toBe(1);
+    });
   });
 
   describe('step terminal state validation', () => {


### PR DESCRIPTION
### What

This adds a database-level unique index for `workflow_hooks.token` in `@workflow/world-postgres` and preserves the existing `hook_conflict` behavior when a concurrent insert loses the token race.

### Why

Hook tokens are treated as unique by the storage API. The Postgres implementation checked for duplicates before insert, but the schema only had a non-unique token index. Two concurrent `hook_created` events with the same token could both pass the pre-insert check and create duplicate hook rows.

Adding the unique index moves that invariant into the database and keeps concurrent callers on the existing conflict path.

### Tests

- `git diff --check`
- Migration journal JSON parse
- `npx -y pnpm@10.20.0 --filter @workflow/world --filter @workflow/errors --filter @workflow/utils --filter @workflow/world-local build`
- `npx -y pnpm@10.20.0 --filter @workflow/world-postgres typecheck`

Notes:

- The local shell used Node `v25.2.1`, while the repo declares support through Node 24, so pnpm emitted an engine warning.
- The Docker-backed Postgres integration test was not run because Docker is unavailable in this environment.
