### PR TITLE
fix(world): make run.input and step.input optional on snapshot schemas

### DIFF
--- a/.changeset/optional-input-on-snapshots.md
+++ b/.changeset/optional-input-on-snapshots.md
@@ -1,0 +1,6 @@
+---
+"@workflow/world": patch
+"workflow": patch
+---
+
+Make `run.input` and `step.input` `.optional()` on the World snapshot schemas so consumers no longer fail validation when the service externalizes payloads as `RemoteRef` blobs.

--- a/packages/world/src/runs.ts
+++ b/packages/world/src/runs.ts
@@ -47,7 +47,7 @@ export const WorkflowRunBaseSchema = z.object({
   // Optional in database for backwards compatibility, defaults to 1 (legacy) when reading
   specVersion: z.number().optional(),
   executionContext: z.record(z.string(), z.any()).optional(),
-  input: SerializedDataSchema,
+  input: SerializedDataSchema.optional(),
   output: SerializedDataSchema.optional(),
   /**
    * The thrown value from a run_failed event, serialized via the workflow

--- a/packages/world/src/steps.ts
+++ b/packages/world/src/steps.ts
@@ -44,7 +44,7 @@ export const StepSchema = z.object({
    */
   stepName: z.string(),
   status: StepStatusSchema,
-  input: SerializedDataSchema,
+  input: SerializedDataSchema.optional(),
   output: SerializedDataSchema.optional(),
   /**
    * The thrown value from a step_retrying or step_failed event, serialized


### PR DESCRIPTION
The World service omits input fields from run/step snapshot responses when payloads are externalized as `RemoteRef` blobs. Mirrors existing `WorkflowRunWithoutData` / `StepWithoutData` types and extends #1939 's treatment of output/error/completedAt to input.

Fixes #1977