### PR TITLE
Show precise (non-rounded) durations in the new trace viewer

### DIFF
--- a/.changeset/trace-viewer-precise-duration.md
+++ b/.changeset/trace-viewer-precise-duration.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Show precise, non-rounded durations in the new trace viewer hover labels, event list, and detail pane (e.g. `1.5s` instead of `2s`).

--- a/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
@@ -1,7 +1,7 @@
 import { Circle } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import type { Span } from '../../trace-viewer/types';
-import { formatDurationPrecise } from '../../trace-viewer/util/timing';
+import { formatDuration } from '../../trace-viewer/util/timing';
 import {
   WorkflowIcon,
   WebhookIcon,
@@ -79,7 +79,7 @@ const EventRow = ({
           </div>
           <div className="ml-2 shrink-0">
             <span className="text-label-14 text-gray-900 tabular-nums">
-              {formatDurationPrecise(durationMs)}
+              {formatDuration(durationMs, { precise: true })}
             </span>
           </div>
         </div>

--- a/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
@@ -1,7 +1,7 @@
 import { Circle } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import type { Span } from '../../trace-viewer/types';
-import { formatDuration } from '../../trace-viewer/util/timing';
+import { formatDurationPrecise } from '../../trace-viewer/util/timing';
 import {
   WorkflowIcon,
   WebhookIcon,
@@ -79,7 +79,7 @@ const EventRow = ({
           </div>
           <div className="ml-2 shrink-0">
             <span className="text-label-14 text-gray-900 tabular-nums">
-              {formatDuration(durationMs)}
+              {formatDurationPrecise(durationMs)}
             </span>
           </div>
         </div>

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -5,10 +5,7 @@ import type { ReactNode } from 'react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../../../lib/utils';
 import type { Span } from '../../trace-viewer/types';
-import {
-  formatDurationPrecise,
-  getHighResInMs,
-} from '../../trace-viewer/util/timing';
+import { formatDuration, getHighResInMs } from '../../trace-viewer/util/timing';
 import type { SegmentStatus, TimeMarker } from '../utils';
 import {
   computeSpanGaps,
@@ -133,7 +130,7 @@ const TimelineBar = memo(function TimelineBar({
   );
   const getMinDurationLabelWidthPx = (label: string) =>
     Math.max(40, label.length * 6 + 12);
-  const totalDurationLabel = formatDurationPrecise(totalDurationMs);
+  const totalDurationLabel = formatDuration(totalDurationMs, { precise: true });
   const showBarDurationLabel =
     isRowHovered &&
     pixelWidth >= getMinDurationLabelWidthPx(totalDurationLabel);
@@ -154,8 +151,9 @@ const TimelineBar = memo(function TimelineBar({
       {segments.map((seg, i) => {
         const segPixelWidth =
           (seg.endFraction - seg.startFraction) * pixelWidth;
-        const segDurationLabel = formatDurationPrecise(
-          (seg.endFraction - seg.startFraction) * totalDurationMs
+        const segDurationLabel = formatDuration(
+          (seg.endFraction - seg.startFraction) * totalDurationMs,
+          { precise: true }
         );
         const showSegmentDurationLabel =
           isRowHovered &&
@@ -374,7 +372,7 @@ export function Timeline({
               key={gap.rowIndex}
               leftFrac={gap.leftFrac}
               rightFrac={gap.rightFrac}
-              label={formatDurationPrecise(gap.gapMs)}
+              label={formatDuration(gap.gapMs, { precise: true })}
               rowIndex={gap.rowIndex}
             />
           ))}

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -5,7 +5,10 @@ import type { ReactNode } from 'react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../../../lib/utils';
 import type { Span } from '../../trace-viewer/types';
-import { formatDuration, getHighResInMs } from '../../trace-viewer/util/timing';
+import {
+  formatDurationPrecise,
+  getHighResInMs,
+} from '../../trace-viewer/util/timing';
 import type { SegmentStatus, TimeMarker } from '../utils';
 import {
   computeSpanGaps,
@@ -130,7 +133,7 @@ const TimelineBar = memo(function TimelineBar({
   );
   const getMinDurationLabelWidthPx = (label: string) =>
     Math.max(40, label.length * 6 + 12);
-  const totalDurationLabel = formatDuration(totalDurationMs);
+  const totalDurationLabel = formatDurationPrecise(totalDurationMs);
   const showBarDurationLabel =
     isRowHovered &&
     pixelWidth >= getMinDurationLabelWidthPx(totalDurationLabel);
@@ -151,7 +154,7 @@ const TimelineBar = memo(function TimelineBar({
       {segments.map((seg, i) => {
         const segPixelWidth =
           (seg.endFraction - seg.startFraction) * pixelWidth;
-        const segDurationLabel = formatDuration(
+        const segDurationLabel = formatDurationPrecise(
           (seg.endFraction - seg.startFraction) * totalDurationMs
         );
         const showSegmentDurationLabel =
@@ -371,7 +374,7 @@ export function Timeline({
               key={gap.rowIndex}
               leftFrac={gap.leftFrac}
               rightFrac={gap.rightFrac}
-              label={formatDuration(gap.gapMs, true)}
+              label={formatDurationPrecise(gap.gapMs)}
               rowIndex={gap.rowIndex}
             />
           ))}

--- a/packages/web-shared/src/components/new-trace-viewer/detail-panel.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/detail-panel.tsx
@@ -3,7 +3,10 @@
 import { X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import type { Span } from '../trace-viewer/types';
-import { formatDuration, getHighResInMs } from '../trace-viewer/util/timing';
+import {
+  formatDurationPrecise,
+  getHighResInMs,
+} from '../trace-viewer/util/timing';
 import { getSpanDurationMs } from './utils';
 
 interface DetailPanelProps {
@@ -41,11 +44,11 @@ export function DetailPanel({
           <dd className="text-gray-1000 font-mono">{span.resource}</dd>
           <dt className="text-gray-900">Duration</dt>
           <dd className="text-gray-1000 tabular-nums font-mono">
-            {formatDuration(durationMs)}
+            {formatDurationPrecise(durationMs)}
           </dd>
           <dt className="text-gray-900">Offset</dt>
           <dd className="text-gray-1000 tabular-nums font-mono">
-            +{formatDuration(offsetMs)}
+            +{formatDurationPrecise(offsetMs)}
           </dd>
           <dt className="text-gray-900">Status</dt>
           <dd className="text-gray-1000 font-mono">

--- a/packages/web-shared/src/components/new-trace-viewer/detail-panel.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/detail-panel.tsx
@@ -3,10 +3,7 @@
 import { X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import type { Span } from '../trace-viewer/types';
-import {
-  formatDurationPrecise,
-  getHighResInMs,
-} from '../trace-viewer/util/timing';
+import { formatDuration, getHighResInMs } from '../trace-viewer/util/timing';
 import { getSpanDurationMs } from './utils';
 
 interface DetailPanelProps {
@@ -44,11 +41,11 @@ export function DetailPanel({
           <dd className="text-gray-1000 font-mono">{span.resource}</dd>
           <dt className="text-gray-900">Duration</dt>
           <dd className="text-gray-1000 tabular-nums font-mono">
-            {formatDurationPrecise(durationMs)}
+            {formatDuration(durationMs, { precise: true })}
           </dd>
           <dt className="text-gray-900">Offset</dt>
           <dd className="text-gray-1000 tabular-nums font-mono">
-            +{formatDurationPrecise(offsetMs)}
+            +{formatDuration(offsetMs, { precise: true })}
           </dd>
           <dt className="text-gray-900">Status</dt>
           <dd className="text-gray-1000 font-mono">

--- a/packages/web-shared/src/components/trace-viewer/util/timing.ts
+++ b/packages/web-shared/src/components/trace-viewer/util/timing.ts
@@ -1,6 +1,6 @@
-import { formatDuration } from '../../../lib/utils';
+import { formatDuration, formatDurationPrecise } from '../../../lib/utils';
 
-export { formatDuration };
+export { formatDuration, formatDurationPrecise };
 
 export function getHighResInMs([seconds, nanoseconds]: [
   number,

--- a/packages/web-shared/src/components/trace-viewer/util/timing.ts
+++ b/packages/web-shared/src/components/trace-viewer/util/timing.ts
@@ -1,6 +1,6 @@
-import { formatDuration, formatDurationPrecise } from '../../../lib/utils';
+import { formatDuration } from '../../../lib/utils';
 
-export { formatDuration, formatDurationPrecise };
+export { formatDuration };
 
 export function getHighResInMs([seconds, nanoseconds]: [
   number,

--- a/packages/web-shared/src/index.ts
+++ b/packages/web-shared/src/index.ts
@@ -57,6 +57,7 @@ export type { StreamStep } from './lib/utils';
 export {
   extractConversation,
   formatDuration,
+  formatDurationPrecise,
   identifyStreamSteps,
   isDoStreamStep,
 } from './lib/utils';

--- a/packages/web-shared/src/index.ts
+++ b/packages/web-shared/src/index.ts
@@ -54,10 +54,10 @@ export type { DecodedStreamChunkSource } from './lib/stream-display';
 export type { ToastAdapter } from './lib/toast';
 export { ToastProvider, useToast } from './lib/toast';
 export type { StreamStep } from './lib/utils';
+export type { FormatDurationOptions } from './lib/utils';
 export {
   extractConversation,
   formatDuration,
-  formatDurationPrecise,
   identifyStreamSteps,
   isDoStreamStep,
 } from './lib/utils';

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -81,6 +81,64 @@ export function formatDuration(ms: number, compact = false): string {
 }
 
 /**
+ * Formats a duration in milliseconds with as much precision as can fit in
+ * a compact label, without rounding up to the next-larger unit.
+ *
+ * Unlike `formatDuration`, this preserves sub-second / sub-minute detail so
+ * the displayed value never overstates the underlying duration (e.g. 1500ms
+ * renders as `1.5s` rather than `2s`). Use for hover labels, detail panes,
+ * and other places where the value is meant to be read as an exact figure.
+ *
+ * Format:
+ * - < 1s: integer milliseconds (e.g. `380ms`)
+ * - < 1m: seconds with up to 2 decimal places, trailing zeros trimmed
+ *   (e.g. `1.5s`, `12.34s`, `59.99s`)
+ * - < 1h: `Xm Y.Zs` with one decimal of seconds (e.g. `1m 5.2s`)
+ * - >= 1h / >= 1d: same decomposition as `formatDuration`, but seconds are
+ *   floored rather than rounded so the label can't exceed the true value.
+ */
+export function formatDurationPrecise(ms: number): string {
+  if (ms === 0) {
+    return '0s';
+  }
+
+  if (ms < MS_IN_SECOND) {
+    return `${Math.round(ms)}ms`;
+  }
+
+  if (ms < MS_IN_MINUTE) {
+    const s = ms / MS_IN_SECOND;
+    return `${trimTrailingZeros(s.toFixed(2))}s`;
+  }
+
+  if (ms < MS_IN_HOUR) {
+    const m = Math.floor(ms / MS_IN_MINUTE);
+    const s = (ms % MS_IN_MINUTE) / MS_IN_SECOND;
+    if (s === 0) {
+      return `${m}m`;
+    }
+    return `${m}m ${trimTrailingZeros(s.toFixed(1))}s`;
+  }
+
+  const days = Math.floor(ms / MS_IN_DAY);
+  const hours = Math.floor((ms % MS_IN_DAY) / MS_IN_HOUR);
+  const minutes = Math.floor((ms % MS_IN_HOUR) / MS_IN_MINUTE);
+  const seconds = Math.floor((ms % MS_IN_MINUTE) / MS_IN_SECOND);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+function trimTrailingZeros(value: string): string {
+  if (!value.includes('.')) return value;
+  return value.replace(/\.?0+$/, '');
+}
+
+/**
  * Returns a formatted pagination display string
  * @param currentPage - The current page number
  * @param totalPages - The total number of pages visited so far

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -12,27 +12,84 @@ const MS_IN_MINUTE = 60 * MS_IN_SECOND;
 const MS_IN_HOUR = 60 * MS_IN_MINUTE;
 const MS_IN_DAY = 24 * MS_IN_HOUR;
 
+export interface FormatDurationOptions {
+  /**
+   * Compact multi-unit format that drops the smallest unit at the
+   * hour/minute boundary (e.g. `2h 30m` instead of `2h 30m 15s`).
+   */
+  compact?: boolean;
+  /**
+   * Preserve sub-second / sub-minute precision instead of rounding to
+   * whole seconds. Use for labels where the value is meant to be read
+   * as an exact figure — a 1500ms duration renders as `1.5s` rather
+   * than `2s`. Values are truncated (floored) rather than rounded so
+   * the label can never overstate the underlying duration or roll over
+   * into the next-larger unit at the boundary.
+   */
+  precise?: boolean;
+}
+
 /**
  * Formats a duration in milliseconds to a human-readable string.
  *
  * @param ms - Duration in milliseconds
- * @param compact - If true, returns a compact format (e.g., "380ms", "2m 30s").
- *                  If false (default), returns multi-part format (e.g., "1m 13s", "2d 5h 3m 12s").
+ * @param options - Either an options object, or a boolean shorthand
+ *                  equivalent to `{ compact: true }` for backwards
+ *                  compatibility with the original two-arg signature.
  *
- * Compact format (timeline markers):
- * - < 1s: shows milliseconds (e.g., "380ms")
- * - < 1m: shows seconds (e.g., "45s")
- * - < 1h: shows minutes and seconds (e.g., "2m 30s")
- * - >= 1h: shows hours and minutes (e.g., "2h 30m")
+ * Default format (no options):
+ * - < 1s: milliseconds (e.g. `380ms`)
+ * - < 1m: whole seconds, rounded (e.g. `45s`)
+ * - >= 1m: decomposed into days/hours/minutes/seconds (e.g. `1m 13s`,
+ *   `2d 5h 3m 12s`)
  *
- * Full format:
- * - < 1s: shows milliseconds (e.g., "380ms")
- * - < 1m: shows seconds (e.g., "45s")
- * - >= 1m: shows decomposed format with whole seconds (e.g., "1m 13s", "2m 13s")
+ * Compact format (`{ compact: true }`, used for timeline tick labels):
+ * - < 1s: milliseconds (e.g. `380ms`)
+ * - < 1m: whole seconds (e.g. `45s`)
+ * - < 1h: minutes + seconds (e.g. `2m 30s`)
+ * - >= 1h: hours + minutes (e.g. `2h 30m`)
+ *
+ * Precise format (`{ precise: true }`, used for hover labels and detail
+ * panes — never rounds up into the next-larger unit):
+ * - < 1s: truncated milliseconds (e.g. `380ms`, `999ms`)
+ * - < 1m: seconds truncated to up to two decimal places, trailing
+ *   zeros trimmed (e.g. `1.5s`, `12.34s`, `59.99s`)
+ * - < 1h: `Xm Y.Zs` with one decimal of seconds, truncated
+ *   (e.g. `1m 5.2s`, `1m 59.9s`)
+ * - >= 1h / >= 1d: same decomposition as the default format, but
+ *   seconds are floored so the label can't exceed the true value
+ *
+ * `precise` takes precedence over `compact` when both are set.
  */
-export function formatDuration(ms: number, compact = false): string {
+export function formatDuration(
+  ms: number,
+  options: boolean | FormatDurationOptions = false
+): string {
+  const { compact = false, precise = false } =
+    typeof options === 'boolean' ? { compact: options } : options;
+
   if (ms === 0) {
     return '0s';
+  }
+
+  if (precise) {
+    if (ms < MS_IN_SECOND) {
+      return `${Math.floor(ms)}ms`;
+    }
+
+    if (ms < MS_IN_MINUTE) {
+      return `${trimTrailingZeros(truncateToFixed(ms / MS_IN_SECOND, 2))}s`;
+    }
+
+    if (ms < MS_IN_HOUR) {
+      const m = Math.floor(ms / MS_IN_MINUTE);
+      const s = (ms % MS_IN_MINUTE) / MS_IN_SECOND;
+      return s === 0
+        ? `${m}m`
+        : `${m}m ${trimTrailingZeros(truncateToFixed(s, 1))}s`;
+    }
+
+    return decomposeLargeUnits(ms, { dropZeroSeconds: true });
   }
 
   if (ms < MS_IN_SECOND) {
@@ -58,68 +115,13 @@ export function formatDuration(ms: number, compact = false): string {
     return m > 0 ? `${h}h ${m}m` : `${h}h`;
   }
 
-  // Full format: decompose into larger units + whole seconds.
-  const days = Math.floor(roundedMs / MS_IN_DAY);
-  const hours = Math.floor((roundedMs % MS_IN_DAY) / MS_IN_HOUR);
-  const minutes = Math.floor((roundedMs % MS_IN_HOUR) / MS_IN_MINUTE);
-  const seconds = Math.floor((roundedMs % MS_IN_MINUTE) / MS_IN_SECOND);
-
-  const parts: string[] = [];
-
-  if (days > 0) {
-    parts.push(`${days}d`);
-  }
-  if (hours > 0) {
-    parts.push(`${hours}h`);
-  }
-  if (minutes > 0) {
-    parts.push(`${minutes}m`);
-  }
-  parts.push(`${seconds}s`);
-
-  return parts.join(' ');
+  return decomposeLargeUnits(roundedMs, { dropZeroSeconds: false });
 }
 
-/**
- * Formats a duration in milliseconds with as much precision as can fit in
- * a compact label, without rounding up to the next-larger unit.
- *
- * Unlike `formatDuration`, this preserves sub-second / sub-minute detail so
- * the displayed value never overstates the underlying duration (e.g. 1500ms
- * renders as `1.5s` rather than `2s`). Use for hover labels, detail panes,
- * and other places where the value is meant to be read as an exact figure.
- *
- * Format:
- * - < 1s: integer milliseconds (e.g. `380ms`)
- * - < 1m: seconds with up to 2 decimal places, trailing zeros trimmed
- *   (e.g. `1.5s`, `12.34s`, `59.99s`)
- * - < 1h: `Xm Y.Zs` with one decimal of seconds (e.g. `1m 5.2s`)
- * - >= 1h / >= 1d: same decomposition as `formatDuration`, but seconds are
- *   floored rather than rounded so the label can't exceed the true value.
- */
-export function formatDurationPrecise(ms: number): string {
-  if (ms === 0) {
-    return '0s';
-  }
-
-  if (ms < MS_IN_SECOND) {
-    return `${Math.floor(ms)}ms`;
-  }
-
-  if (ms < MS_IN_MINUTE) {
-    const s = ms / MS_IN_SECOND;
-    return `${trimTrailingZeros(truncateToFixed(s, 2))}s`;
-  }
-
-  if (ms < MS_IN_HOUR) {
-    const m = Math.floor(ms / MS_IN_MINUTE);
-    const s = (ms % MS_IN_MINUTE) / MS_IN_SECOND;
-    if (s === 0) {
-      return `${m}m`;
-    }
-    return `${m}m ${trimTrailingZeros(truncateToFixed(s, 1))}s`;
-  }
-
+function decomposeLargeUnits(
+  ms: number,
+  { dropZeroSeconds }: { dropZeroSeconds: boolean }
+): string {
   const days = Math.floor(ms / MS_IN_DAY);
   const hours = Math.floor((ms % MS_IN_DAY) / MS_IN_HOUR);
   const minutes = Math.floor((ms % MS_IN_HOUR) / MS_IN_MINUTE);
@@ -129,7 +131,9 @@ export function formatDurationPrecise(ms: number): string {
   if (days > 0) parts.push(`${days}d`);
   if (hours > 0) parts.push(`${hours}h`);
   if (minutes > 0) parts.push(`${minutes}m`);
-  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+  if (!dropZeroSeconds || seconds > 0 || parts.length === 0) {
+    parts.push(`${seconds}s`);
+  }
   return parts.join(' ');
 }
 
@@ -140,7 +144,7 @@ function trimTrailingZeros(value: string): string {
 
 /** Truncate (floor) a number to a fixed number of decimal places, without rounding up. */
 function truncateToFixed(value: number, decimals: number): string {
-  const factor = Math.pow(10, decimals);
+  const factor = 10 ** decimals;
   return (Math.floor(value * factor) / factor).toFixed(decimals);
 }
 

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -103,12 +103,12 @@ export function formatDurationPrecise(ms: number): string {
   }
 
   if (ms < MS_IN_SECOND) {
-    return `${Math.round(ms)}ms`;
+    return `${Math.floor(ms)}ms`;
   }
 
   if (ms < MS_IN_MINUTE) {
     const s = ms / MS_IN_SECOND;
-    return `${trimTrailingZeros(s.toFixed(2))}s`;
+    return `${trimTrailingZeros(truncateToFixed(s, 2))}s`;
   }
 
   if (ms < MS_IN_HOUR) {
@@ -117,7 +117,7 @@ export function formatDurationPrecise(ms: number): string {
     if (s === 0) {
       return `${m}m`;
     }
-    return `${m}m ${trimTrailingZeros(s.toFixed(1))}s`;
+    return `${m}m ${trimTrailingZeros(truncateToFixed(s, 1))}s`;
   }
 
   const days = Math.floor(ms / MS_IN_DAY);
@@ -136,6 +136,12 @@ export function formatDurationPrecise(ms: number): string {
 function trimTrailingZeros(value: string): string {
   if (!value.includes('.')) return value;
   return value.replace(/\.?0+$/, '');
+}
+
+/** Truncate (floor) a number to a fixed number of decimal places, without rounding up. */
+function truncateToFixed(value: number, decimals: number): string {
+  const factor = Math.pow(10, decimals);
+  return (Math.floor(value * factor) / factor).toFixed(decimals);
 }
 
 /**

--- a/packages/web-shared/test/format-duration.test.ts
+++ b/packages/web-shared/test/format-duration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { formatDurationPrecise } from '../src/lib/utils.js';
+
+/**
+ * `formatDurationPrecise` is used in the new trace viewer for span durations,
+ * timeline hover labels, and detail-pane offsets. Unlike `formatDuration`, it
+ * must never round up to the next-larger unit — a 1500ms span should never
+ * render as `2s`.
+ */
+describe('formatDurationPrecise', () => {
+  it('renders zero', () => {
+    expect(formatDurationPrecise(0)).toBe('0s');
+  });
+
+  it('renders sub-second values as integer milliseconds', () => {
+    expect(formatDurationPrecise(1)).toBe('1ms');
+    expect(formatDurationPrecise(380)).toBe('380ms');
+    expect(formatDurationPrecise(999)).toBe('999ms');
+    expect(formatDurationPrecise(999.4)).toBe('999ms');
+  });
+
+  it('renders sub-minute values with up to two decimals of seconds', () => {
+    expect(formatDurationPrecise(1000)).toBe('1s');
+    expect(formatDurationPrecise(1500)).toBe('1.5s');
+    expect(formatDurationPrecise(1530)).toBe('1.53s');
+    expect(formatDurationPrecise(8500)).toBe('8.5s');
+    expect(formatDurationPrecise(12340)).toBe('12.34s');
+    expect(formatDurationPrecise(59990)).toBe('59.99s');
+  });
+
+  it('never rounds up to the next-larger unit', () => {
+    expect(formatDurationPrecise(1500)).not.toBe('2s');
+    expect(formatDurationPrecise(8500)).not.toBe('9s');
+    expect(formatDurationPrecise(59999)).not.toBe('1m');
+  });
+
+  it('renders sub-hour values as minutes + decimal seconds', () => {
+    expect(formatDurationPrecise(60_000)).toBe('1m');
+    expect(formatDurationPrecise(65_000)).toBe('1m 5s');
+    expect(formatDurationPrecise(65_200)).toBe('1m 5.2s');
+    expect(formatDurationPrecise(125_500)).toBe('2m 5.5s');
+  });
+
+  it('renders longer durations as hour/day decomposition', () => {
+    expect(formatDurationPrecise(3_600_000)).toBe('1h');
+    expect(formatDurationPrecise(3_660_000)).toBe('1h 1m');
+    expect(formatDurationPrecise(3_665_000)).toBe('1h 1m 5s');
+    expect(formatDurationPrecise(90_061_000)).toBe('1d 1h 1m 1s');
+  });
+});

--- a/packages/web-shared/test/format-duration.test.ts
+++ b/packages/web-shared/test/format-duration.test.ts
@@ -1,50 +1,84 @@
 import { describe, expect, it } from 'vitest';
-import { formatDurationPrecise } from '../src/lib/utils.js';
+import { formatDuration } from '../src/lib/utils.js';
 
 /**
- * `formatDurationPrecise` is used in the new trace viewer for span durations,
- * timeline hover labels, and detail-pane offsets. Unlike `formatDuration`, it
+ * The `precise` option on `formatDuration` is used in the new trace viewer
+ * for span durations, timeline hover labels, and detail-pane offsets. It
  * must never round up to the next-larger unit — a 1500ms span should never
  * render as `2s`.
  */
-describe('formatDurationPrecise', () => {
+describe('formatDuration with { precise: true }', () => {
+  const precise = (ms: number) => formatDuration(ms, { precise: true });
+
   it('renders zero', () => {
-    expect(formatDurationPrecise(0)).toBe('0s');
+    expect(precise(0)).toBe('0s');
   });
 
   it('renders sub-second values as integer milliseconds', () => {
-    expect(formatDurationPrecise(1)).toBe('1ms');
-    expect(formatDurationPrecise(380)).toBe('380ms');
-    expect(formatDurationPrecise(999)).toBe('999ms');
-    expect(formatDurationPrecise(999.4)).toBe('999ms');
+    expect(precise(1)).toBe('1ms');
+    expect(precise(380)).toBe('380ms');
+    expect(precise(999)).toBe('999ms');
+    expect(precise(999.4)).toBe('999ms');
   });
 
   it('renders sub-minute values with up to two decimals of seconds', () => {
-    expect(formatDurationPrecise(1000)).toBe('1s');
-    expect(formatDurationPrecise(1500)).toBe('1.5s');
-    expect(formatDurationPrecise(1530)).toBe('1.53s');
-    expect(formatDurationPrecise(8500)).toBe('8.5s');
-    expect(formatDurationPrecise(12340)).toBe('12.34s');
-    expect(formatDurationPrecise(59990)).toBe('59.99s');
+    expect(precise(1000)).toBe('1s');
+    expect(precise(1500)).toBe('1.5s');
+    expect(precise(1530)).toBe('1.53s');
+    expect(precise(8500)).toBe('8.5s');
+    expect(precise(12340)).toBe('12.34s');
+    expect(precise(59990)).toBe('59.99s');
   });
 
   it('never rounds up to the next-larger unit', () => {
-    expect(formatDurationPrecise(1500)).not.toBe('2s');
-    expect(formatDurationPrecise(8500)).not.toBe('9s');
-    expect(formatDurationPrecise(59999)).not.toBe('1m');
+    expect(precise(1500)).not.toBe('2s');
+    expect(precise(8500)).not.toBe('9s');
+    expect(precise(59999)).not.toBe('1m');
+  });
+
+  it('truncates at unit boundaries instead of overflowing', () => {
+    // 999.5ms must stay in the ms bucket — `Math.round` would emit "1000ms".
+    expect(precise(999.5)).toBe('999ms');
+    // 59.999s must stay in the seconds bucket — `toFixed(2)` would emit "60s".
+    expect(precise(59_999)).toBe('59.99s');
+    // 1m 59.95s must not roll over to "1m 60s" via `toFixed(1)`.
+    expect(precise(119_950)).toBe('1m 59.9s');
   });
 
   it('renders sub-hour values as minutes + decimal seconds', () => {
-    expect(formatDurationPrecise(60_000)).toBe('1m');
-    expect(formatDurationPrecise(65_000)).toBe('1m 5s');
-    expect(formatDurationPrecise(65_200)).toBe('1m 5.2s');
-    expect(formatDurationPrecise(125_500)).toBe('2m 5.5s');
+    expect(precise(60_000)).toBe('1m');
+    expect(precise(65_000)).toBe('1m 5s');
+    expect(precise(65_200)).toBe('1m 5.2s');
+    expect(precise(125_500)).toBe('2m 5.5s');
   });
 
   it('renders longer durations as hour/day decomposition', () => {
-    expect(formatDurationPrecise(3_600_000)).toBe('1h');
-    expect(formatDurationPrecise(3_660_000)).toBe('1h 1m');
-    expect(formatDurationPrecise(3_665_000)).toBe('1h 1m 5s');
-    expect(formatDurationPrecise(90_061_000)).toBe('1d 1h 1m 1s');
+    expect(precise(3_600_000)).toBe('1h');
+    expect(precise(3_660_000)).toBe('1h 1m');
+    expect(precise(3_665_000)).toBe('1h 1m 5s');
+    expect(precise(90_061_000)).toBe('1d 1h 1m 1s');
+  });
+});
+
+/**
+ * Guard the pre-existing default and compact behaviors of `formatDuration`
+ * — the precise refactor must not change them, and the legacy two-arg
+ * `formatDuration(ms, true)` form is still in use across the codebase.
+ */
+describe('formatDuration default + compact (unchanged behavior)', () => {
+  it('preserves the legacy boolean compact shorthand', () => {
+    expect(formatDuration(125_000, true)).toBe('2m 5s');
+    expect(formatDuration(125_000, { compact: true })).toBe('2m 5s');
+  });
+
+  it('still rounds seconds in the default and compact modes', () => {
+    expect(formatDuration(1500)).toBe('2s');
+    expect(formatDuration(1500, true)).toBe('2s');
+  });
+
+  it('renders the long form when no options are passed', () => {
+    expect(formatDuration(0)).toBe('0s');
+    expect(formatDuration(380)).toBe('380ms');
+    expect(formatDuration(73_000)).toBe('1m 13s');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The new trace viewer was formatting span durations with `formatDuration()`, which rounds to whole seconds once the value crosses `1s`. That means a 1.5s span renders as `2s` on hover — overstating the real duration and being confusing when the bar visually shows ~1.5 grid units.

This PR adds a new `precise` option to `formatDuration` (no separate function — the second arg now accepts either an options object `{ compact?, precise? }` or the original boolean for backwards compatibility) and switches the new trace viewer to `{ precise: true }` everywhere a duration / offset is shown to the user as an exact figure:

- Timeline bar + segment hover labels
- Gap delta indicators (Alt-held)
- Event list row durations
- Detail pane `Duration` and `Offset` fields

The precise branch keeps up to two decimals of seconds (e.g. `1.5s`, `12.34s`), one decimal inside `Xm Y.Zs` form, and **truncates** rather than rounds — so 999.5ms / 59.999s / 1m 59.95s never roll over into the next-larger unit at the boundary. Default and compact (`true` / `{ compact: true }`) behavior is unchanged, so all existing call sites — the old trace viewer, the workflow graph execution viewer, the status badge, and the new viewer's own timeline tick / ruler labels — keep working without changes.

### How did you test your changes?

- Added `packages/web-shared/test/format-duration.test.ts` covering sub-second / sub-minute / sub-hour / multi-day cases for the precise mode, an explicit "never rounds up" guard, the three boundary cases identified by the upstream fix (999.5ms → `999ms`, 59 999ms → `59.99s`, 119 950ms → `1m 59.9s`), and the unchanged default / compact behavior including the legacy two-arg `formatDuration(ms, true)` form.
- `pnpm --filter @workflow/web-shared run test` (46 / 46 pass)
- `pnpm --filter @workflow/web-shared run build` and `pnpm --filter @workflow/web run build` both succeed.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0AFKL7AT9N/p1778772216504459?thread_ts=1778772216.504459&cid=C0AFKL7AT9N)

<div><a href="https://cursor.com/agents/bc-dd31b8e8-ef84-5c44-a25c-b752921d1fa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd31b8e8-ef84-5c44-a25c-b752921d1fa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

