### PR TITLE
Fix stale SvelteKit workflow queue triggers

### DIFF
--- a/.changeset/stale-sveltekit-triggers.md
+++ b/.changeset/stale-sveltekit-triggers.md
@@ -2,4 +2,4 @@
 '@workflow/sveltekit': patch
 ---
 
-Remove stale workflow queue triggers from shared SvelteKit Vercel function configs.
+Fix duplicate Workflow queue consumers in SvelteKit deployments by removing stale workflow queue triggers from shared Vercel function configs.

--- a/.changeset/stale-sveltekit-triggers.md
+++ b/.changeset/stale-sveltekit-triggers.md
@@ -1,0 +1,5 @@
+---
+'@workflow/sveltekit': patch
+---
+
+Remove stale workflow queue triggers from shared SvelteKit Vercel function configs.

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -3,12 +3,42 @@ import fs from 'fs-extra';
 
 import { SvelteKitBuilder } from './builder.js';
 
+const WORKFLOW_QUEUE_TOPICS = new Set(['__wkf_workflow_*', '__wkf_step_*']);
+
 const builder = new SvelteKitBuilder();
 
 // This needs to be in the top-level as we need to create these
 // entries before svelte plugin is started or the entries are
 // a race to be created before svelte discovers entries
 await builder.build();
+
+function stripWorkflowQueueTriggers(file: string) {
+  if (!fs.existsSync(file)) {
+    return;
+  }
+
+  const existingConfig = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const experimentalTriggers = existingConfig.experimentalTriggers;
+  if (!Array.isArray(experimentalTriggers)) {
+    return;
+  }
+
+  const filteredTriggers = experimentalTriggers.filter(
+    (trigger) => !WORKFLOW_QUEUE_TOPICS.has(trigger?.topic)
+  );
+  if (filteredTriggers.length === experimentalTriggers.length) {
+    return;
+  }
+
+  const nextConfig = { ...existingConfig };
+  if (filteredTriggers.length > 0) {
+    nextConfig.experimentalTriggers = filteredTriggers;
+  } else {
+    delete nextConfig.experimentalTriggers;
+  }
+
+  fs.writeFileSync(file, JSON.stringify(nextConfig));
+}
 
 process.on('beforeExit', () => {
   // Don't patch functions output if not in Vercel adapter
@@ -47,21 +77,24 @@ process.on('beforeExit', () => {
       },
     },
   ]) {
+    const funcDir = path.dirname(file);
+    if (!fs.existsSync(funcDir)) {
+      continue;
+    }
+
+    const sourceFuncDir = path.join(
+      funcDir.replace(/\.func$/, ''),
+      '__data.json.func'
+    );
+
     // Un-symlink these as they can't be shared due to different
     // experimental triggers config
-    const toCopy = fs.readdirSync(path.dirname(file));
-    fs.removeSync(path.dirname(file));
-    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const toCopy = fs.readdirSync(funcDir);
+    fs.removeSync(funcDir);
+    fs.mkdirSync(funcDir, { recursive: true });
 
     for (const item of toCopy) {
-      fs.copySync(
-        path.join(
-          path.dirname(file).replace(/\.func$/, ''),
-          '__data.json.func',
-          item
-        ),
-        path.join(path.dirname(file), item)
-      );
+      fs.copySync(path.join(sourceFuncDir, item), path.join(funcDir, item));
     }
 
     // Update .vc-config.json with the new experimental triggers config
@@ -73,6 +106,10 @@ process.on('beforeExit', () => {
         ...config,
       })
     );
+
+    // The source function may be a shared catchall. It must not keep stale
+    // workflow queue triggers after the dedicated function is copied out.
+    stripWorkflowQueueTriggers(path.join(sourceFuncDir, '.vc-config.json'));
   }
 });
 

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -2,8 +2,7 @@ import path from 'node:path';
 import fs from 'fs-extra';
 
 import { SvelteKitBuilder } from './builder.js';
-
-const WORKFLOW_QUEUE_TOPICS = new Set(['__wkf_workflow_*', '__wkf_step_*']);
+import { stripWorkflowQueueTriggers } from './vc-config.js';
 
 const builder = new SvelteKitBuilder();
 
@@ -11,34 +10,6 @@ const builder = new SvelteKitBuilder();
 // entries before svelte plugin is started or the entries are
 // a race to be created before svelte discovers entries
 await builder.build();
-
-function stripWorkflowQueueTriggers(file: string) {
-  if (!fs.existsSync(file)) {
-    return;
-  }
-
-  const existingConfig = JSON.parse(fs.readFileSync(file, 'utf8'));
-  const experimentalTriggers = existingConfig.experimentalTriggers;
-  if (!Array.isArray(experimentalTriggers)) {
-    return;
-  }
-
-  const filteredTriggers = experimentalTriggers.filter(
-    (trigger) => !WORKFLOW_QUEUE_TOPICS.has(trigger?.topic)
-  );
-  if (filteredTriggers.length === experimentalTriggers.length) {
-    return;
-  }
-
-  const nextConfig = { ...existingConfig };
-  if (filteredTriggers.length > 0) {
-    nextConfig.experimentalTriggers = filteredTriggers;
-  } else {
-    delete nextConfig.experimentalTriggers;
-  }
-
-  fs.writeFileSync(file, JSON.stringify(nextConfig));
-}
 
 process.on('beforeExit', () => {
   // Don't patch functions output if not in Vercel adapter

--- a/packages/sveltekit/src/vc-config.test.ts
+++ b/packages/sveltekit/src/vc-config.test.ts
@@ -1,0 +1,54 @@
+import { STEP_QUEUE_TRIGGER, WORKFLOW_QUEUE_TRIGGER } from '@workflow/builders';
+import { describe, expect, it } from 'vitest';
+
+import { stripWorkflowQueueTriggersFromConfig } from './vc-config.js';
+
+describe('stripWorkflowQueueTriggersFromConfig', () => {
+  it('removes workflow queue triggers while preserving unrelated triggers', () => {
+    const unrelatedTrigger = {
+      type: 'queue/v2beta',
+      topic: 'user-topic',
+      consumer: 'default',
+    };
+
+    expect(
+      stripWorkflowQueueTriggersFromConfig({
+        runtime: 'nodejs',
+        experimentalTriggers: [
+          WORKFLOW_QUEUE_TRIGGER,
+          unrelatedTrigger,
+          STEP_QUEUE_TRIGGER,
+        ],
+      })
+    ).toEqual({
+      runtime: 'nodejs',
+      experimentalTriggers: [unrelatedTrigger],
+    });
+  });
+
+  it('deletes experimentalTriggers when only workflow triggers remain', () => {
+    expect(
+      stripWorkflowQueueTriggersFromConfig({
+        runtime: 'nodejs',
+        experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER, STEP_QUEUE_TRIGGER],
+      })
+    ).toEqual({
+      runtime: 'nodejs',
+    });
+  });
+
+  it('leaves configs without workflow triggers unchanged', () => {
+    const config = {
+      runtime: 'nodejs',
+      experimentalTriggers: [
+        {
+          type: 'queue/v2beta',
+          topic: 'user-topic',
+          consumer: 'default',
+        },
+      ],
+    };
+
+    expect(stripWorkflowQueueTriggersFromConfig(config)).toBe(config);
+  });
+});

--- a/packages/sveltekit/src/vc-config.ts
+++ b/packages/sveltekit/src/vc-config.ts
@@ -1,0 +1,55 @@
+import { STEP_QUEUE_TRIGGER, WORKFLOW_QUEUE_TRIGGER } from '@workflow/builders';
+import fs from 'fs-extra';
+
+const WORKFLOW_QUEUE_TOPICS = new Set([
+  STEP_QUEUE_TRIGGER.topic,
+  WORKFLOW_QUEUE_TRIGGER.topic,
+]);
+
+function isWorkflowQueueTrigger(trigger: unknown) {
+  if (typeof trigger !== 'object' || trigger === null) {
+    return false;
+  }
+
+  const topic = (trigger as { topic?: unknown }).topic;
+  return typeof topic === 'string' && WORKFLOW_QUEUE_TOPICS.has(topic);
+}
+
+export function stripWorkflowQueueTriggersFromConfig<
+  TConfig extends Record<string, unknown>,
+>(existingConfig: TConfig): TConfig {
+  const experimentalTriggers = existingConfig.experimentalTriggers;
+  if (!Array.isArray(experimentalTriggers)) {
+    return existingConfig;
+  }
+
+  const filteredTriggers = experimentalTriggers.filter(
+    (trigger) => !isWorkflowQueueTrigger(trigger)
+  );
+  if (filteredTriggers.length === experimentalTriggers.length) {
+    return existingConfig;
+  }
+
+  const nextConfig: Record<string, unknown> = { ...existingConfig };
+  if (filteredTriggers.length > 0) {
+    nextConfig.experimentalTriggers = filteredTriggers;
+  } else {
+    delete nextConfig.experimentalTriggers;
+  }
+
+  return nextConfig as TConfig;
+}
+
+export function stripWorkflowQueueTriggers(file: string) {
+  if (!fs.existsSync(file)) {
+    return;
+  }
+
+  const existingConfig = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const nextConfig = stripWorkflowQueueTriggersFromConfig(existingConfig);
+  if (nextConfig === existingConfig) {
+    return;
+  }
+
+  fs.writeFileSync(file, JSON.stringify(nextConfig));
+}


### PR DESCRIPTION
## Summary

- Strip Workflow queue triggers from the shared SvelteKit Vercel source function after copying it into the dedicated `flow.func` and `step.func` outputs.
- Keep the dedicated workflow functions subscribed to their expected queues only.
- Add a patch changeset for `@workflow/sveltekit`.

## Root cause

SvelteKit adapter output can use shared `__data.json.func`/catchall function configs. The Workflow SvelteKit integration copies those shared functions into dedicated workflow functions and patches queue triggers there, but stale queue triggers can remain on the shared source config. That can leave extra Workflow queue consumers in a deployment.

## Validation

- `pnpm --filter @workflow/sveltekit build`
- `pnpm exec biome check packages/sveltekit/src/index.ts`
- Vercel-mode SvelteKit build on Node 24 with injected stale V1 workflow queue triggers. Final output only had queue triggers on:
  - `.well-known/workflow/v1/flow.func` for `__wkf_workflow_*`
  - `.well-known/workflow/v1/step.func` for `__wkf_step_*`
  - shared/catchall source configs had no workflow queue triggers

Note: `pnpm changeset status --since=origin/stable` reported the expected patch bump set after staging the changeset.
