### PR TITLE
Fix stable CI test harness failures

### DIFF
--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix stable CI test harness failures without releasing package changes.

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -6,7 +6,8 @@
 "@workflow/next": patch
 "@workflow/sveltekit": patch
 "@workflow/utils": patch
+"@workflow/world-vercel": patch
 "workflow": patch
 ---
 
-Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, wait for step return stream serialization before completing the step, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook disposal.
+Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, wait for step return stream serialization before completing the step, bound Vercel stream mutations so stuck writes retry instead of hanging, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook registration/disposal.

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -1,4 +1,11 @@
 ---
+"@workflow/astro": patch
+"@workflow/builders": patch
+"@workflow/core": patch
+"@workflow/next": patch
+"@workflow/sveltekit": patch
+"@workflow/utils": patch
+"workflow": patch
 ---
 
-Fix stable CI test harness failures without releasing package changes.
+Fix local workflow port detection and make generated health endpoints respond to HEAD requests.

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -9,4 +9,4 @@
 "workflow": patch
 ---
 
-Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, and allow remote Vercel e2e CLI inspections enough time to fetch run data.
+Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook disposal.

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -2,6 +2,7 @@
 "@workflow/astro": patch
 "@workflow/builders": patch
 "@workflow/core": patch
+"@workflow/nest": patch
 "@workflow/next": patch
 "@workflow/sveltekit": patch
 "@workflow/utils": patch

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -10,4 +10,4 @@
 "workflow": patch
 ---
 
-Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, wait for step return stream serialization before completing the step, bound Vercel stream mutations so stuck writes retry instead of hanging, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook registration/disposal.
+Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, wait for step return stream serialization before completing the step, bound Vercel stream and health-check operations so stuck writes or queue sends retry or time out instead of hanging, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook registration/disposal.

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -9,4 +9,4 @@
 "workflow": patch
 ---
 
-Fix local workflow port detection, make generated health endpoints respond to HEAD requests, and materialize manual webhook response bodies before returning them.
+Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, and allow remote Vercel e2e CLI inspections enough time to fetch run data.

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -9,4 +9,4 @@
 "workflow": patch
 ---
 
-Fix local workflow port detection and make generated health endpoints respond to HEAD requests.
+Fix local workflow port detection, make generated health endpoints respond to HEAD requests, and materialize manual webhook response bodies before returning them.

--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -9,4 +9,4 @@
 "workflow": patch
 ---
 
-Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook disposal.
+Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, wait for step return stream serialization before completing the step, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook disposal.

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -23,6 +23,24 @@ const WORKFLOW_ROUTES = [
   },
 ];
 
+function replaceGeneratedRouteExport(
+  content: string,
+  pattern: RegExp,
+  replacement: string,
+  errorMessage: string
+) {
+  const sourceMapMarker = '\n//# sourceMappingURL=';
+  const sourceMapIndex = content.lastIndexOf(sourceMapMarker);
+  const routeCode =
+    sourceMapIndex === -1 ? content : content.slice(0, sourceMapIndex);
+  const sourceMap = sourceMapIndex === -1 ? '' : content.slice(sourceMapIndex);
+  const wrappedRouteCode = routeCode.replace(pattern, replacement);
+  if (wrappedRouteCode === routeCode) {
+    throw new Error(errorMessage);
+  }
+  return wrappedRouteCode + sourceMap;
+}
+
 export class LocalBuilder extends BaseBuilder {
   constructor() {
     super({
@@ -119,8 +137,9 @@ export const prerender = false;\n`
     let stepsRouteContent = await readFile(stepsRouteFile, 'utf-8');
 
     // Normalize request, needed for preserving request through astro
-    stepsRouteContent = stepsRouteContent.replace(
-      /export\s*\{\s*stepEntrypoint\s+as\s+HEAD\s*,\s*stepEntrypoint\s+as\s+POST\s*\}\s*;?$/m,
+    stepsRouteContent = replaceGeneratedRouteExport(
+      stepsRouteContent,
+      /export\s*\{\s*stepEntrypoint\w*\s+as\s+HEAD\s*,\s*stepEntrypoint\w*\s+as\s+POST\s*\}\s*;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
 const handleStepRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
@@ -130,7 +149,8 @@ const handleStepRequest = async ({request}) => {
 export const HEAD = handleStepRequest;
 export const POST = handleStepRequest;
 
-export const prerender = false;`
+export const prerender = false;`,
+      'Failed to wrap generated Astro step route'
     );
     await writeFile(stepsRouteFile, stepsRouteContent);
 
@@ -159,8 +179,8 @@ export const prerender = false;`
     let workflowsRouteContent = await readFile(workflowsRouteFile, 'utf-8');
 
     // Normalize request, needed for preserving request through astro
-    workflowsRouteContent = workflowsRouteContent.replace(
-      /const handler = workflowEntrypoint\(workflowCode\);\n\nexport const HEAD = handler;\nexport const POST = handler;?$/m,
+    const wrappedWorkflowsRouteContent = workflowsRouteContent.replace(
+      /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
 const handleWorkflowRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
@@ -172,6 +192,10 @@ export const POST = handleWorkflowRequest;
 
 export const prerender = false;`
     );
+    if (wrappedWorkflowsRouteContent === workflowsRouteContent) {
+      throw new Error('Failed to wrap generated Astro workflow route');
+    }
+    workflowsRouteContent = wrappedWorkflowsRouteContent;
     await writeFile(workflowsRouteFile, workflowsRouteContent);
 
     return manifest;

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -5,6 +5,7 @@ import {
   BaseBuilder,
   createBaseBuilderConfig,
   NORMALIZE_REQUEST_CODE,
+  replaceGeneratedRouteExport,
   VercelBuildOutputAPIBuilder,
 } from '@workflow/builders';
 
@@ -22,24 +23,6 @@ const WORKFLOW_ROUTES = [
     dest: '/.well-known/workflow/v1/webhook/[token]',
   },
 ];
-
-function replaceGeneratedRouteExport(
-  content: string,
-  pattern: RegExp,
-  replacement: string,
-  errorMessage: string
-) {
-  const sourceMapMarker = '\n//# sourceMappingURL=';
-  const sourceMapIndex = content.lastIndexOf(sourceMapMarker);
-  const routeCode =
-    sourceMapIndex === -1 ? content : content.slice(0, sourceMapIndex);
-  const sourceMap = sourceMapIndex === -1 ? '' : content.slice(sourceMapIndex);
-  const wrappedRouteCode = routeCode.replace(pattern, replacement);
-  if (wrappedRouteCode === routeCode) {
-    throw new Error(errorMessage);
-  }
-  return wrappedRouteCode + sourceMap;
-}
 
 export class LocalBuilder extends BaseBuilder {
   constructor() {
@@ -179,7 +162,8 @@ export const prerender = false;`,
     let workflowsRouteContent = await readFile(workflowsRouteFile, 'utf-8');
 
     // Normalize request, needed for preserving request through astro
-    const wrappedWorkflowsRouteContent = workflowsRouteContent.replace(
+    workflowsRouteContent = replaceGeneratedRouteExport(
+      workflowsRouteContent,
       /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
 const handleWorkflowRequest = async ({request}) => {
@@ -190,12 +174,9 @@ const handleWorkflowRequest = async ({request}) => {
 export const HEAD = handleWorkflowRequest;
 export const POST = handleWorkflowRequest;
 
-export const prerender = false;`
+export const prerender = false;`,
+      'Failed to wrap generated Astro workflow route'
     );
-    if (wrappedWorkflowsRouteContent === workflowsRouteContent) {
-      throw new Error('Failed to wrap generated Astro workflow route');
-    }
-    workflowsRouteContent = wrappedWorkflowsRouteContent;
     await writeFile(workflowsRouteFile, workflowsRouteContent);
 
     return manifest;

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -120,12 +120,15 @@ export const prerender = false;\n`
 
     // Normalize request, needed for preserving request through astro
     stepsRouteContent = stepsRouteContent.replace(
-      /export\s*\{\s*stepEntrypoint\s+as\s+POST\s*\}\s*;?$/m,
+      /export\s*\{\s*stepEntrypoint\s+as\s+HEAD\s*,\s*stepEntrypoint\s+as\s+POST\s*\}\s*;?$/m,
       `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const handleStepRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
   return stepEntrypoint(normalRequest);
-}
+};
+
+export const HEAD = handleStepRequest;
+export const POST = handleStepRequest;
 
 export const prerender = false;`
     );
@@ -157,12 +160,15 @@ export const prerender = false;`
 
     // Normalize request, needed for preserving request through astro
     workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
+      /const handler = workflowEntrypoint\(workflowCode\);\n\nexport const HEAD = handler;\nexport const POST = handler;?$/m,
       `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const handleWorkflowRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
   return workflowEntrypoint(workflowCode)(normalRequest);
-}
+};
+
+export const HEAD = handleWorkflowRequest;
+export const POST = handleWorkflowRequest;
 
 export const prerender = false;`
     );

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -603,7 +603,7 @@ export abstract class BaseBuilder {
     // Serde files for cross-context class registration
     ${serdeImports}
     // API entrypoint
-    export { stepEntrypoint as POST } from 'workflow/runtime';`;
+    export { stepEntrypoint as HEAD, stepEntrypoint as POST } from 'workflow/runtime';`;
 
     // Bundle with esbuild and our custom SWC plugin
     const entriesToBundle = externalizeNonSteps
@@ -1006,7 +1006,10 @@ import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${workflowBundleCode.replace(/[\\`$]/g, '\\$&')}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+const handler = workflowEntrypoint(workflowCode);
+
+export const HEAD = handler;
+export const POST = handler;`;
 
         // we skip the final bundling step for Next.js so it can bundle itself
         if (!bundleFinalOutput) {

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -23,7 +23,10 @@ export {
   createPseudoPackagePlugin,
   PSEUDO_PACKAGES,
 } from './pseudo-package-esbuild-plugin.js';
-export { NORMALIZE_REQUEST_CODE } from './request-converter.js';
+export {
+  NORMALIZE_REQUEST_CODE,
+  replaceGeneratedRouteExport,
+} from './request-converter.js';
 export {
   analyzeSerdeCompliance,
   extractClassEntries,

--- a/packages/builders/src/request-converter.test.ts
+++ b/packages/builders/src/request-converter.test.ts
@@ -15,6 +15,31 @@ describe('replaceGeneratedRouteExport', () => {
     );
   });
 
+  it('ignores source map comments embedded before route exports', () => {
+    const result = replaceGeneratedRouteExport(
+      [
+        'const workflowCode = `',
+        '//# sourceMappingURL=data:application/json;base64,inner',
+        '`;',
+        'const handler = workflowEntrypoint(workflowCode);',
+        'export const HEAD = handler;',
+        'export const POST = handler;',
+      ].join('\n'),
+      /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
+      'export const POST = wrappedHandler;',
+      'not found'
+    );
+
+    expect(result).toBe(
+      [
+        'const workflowCode = `',
+        '//# sourceMappingURL=data:application/json;base64,inner',
+        '`;',
+        'export const POST = wrappedHandler;',
+      ].join('\n')
+    );
+  });
+
   it('throws when the route export pattern is not found', () => {
     expect(() =>
       replaceGeneratedRouteExport(

--- a/packages/builders/src/request-converter.test.ts
+++ b/packages/builders/src/request-converter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { replaceGeneratedRouteExport } from './request-converter.js';
+
+describe('replaceGeneratedRouteExport', () => {
+  it('replaces route code before an inline source map', () => {
+    const result = replaceGeneratedRouteExport(
+      'export const POST = handler;\n//# sourceMappingURL=data:application/json;base64,abc',
+      /export const POST = handler;$/,
+      'export const POST = wrappedHandler;',
+      'not found'
+    );
+
+    expect(result).toBe(
+      'export const POST = wrappedHandler;\n//# sourceMappingURL=data:application/json;base64,abc'
+    );
+  });
+
+  it('throws when the route export pattern is not found', () => {
+    expect(() =>
+      replaceGeneratedRouteExport(
+        'export const GET = handler;',
+        /export const POST = handler;$/,
+        'export const POST = wrappedHandler;',
+        'missing route export'
+      )
+    ).toThrow('missing route export');
+  });
+});

--- a/packages/builders/src/request-converter.ts
+++ b/packages/builders/src/request-converter.ts
@@ -17,11 +17,19 @@ function replaceGeneratedRouteExport(
   replacement: string,
   errorMessage: string
 ) {
+  const replacedContent = content.replace(pattern, replacement);
+  if (replacedContent !== content) {
+    return replacedContent;
+  }
+
   const sourceMapMarker = '\n//# sourceMappingURL=';
   const sourceMapIndex = content.lastIndexOf(sourceMapMarker);
-  const routeCode =
-    sourceMapIndex === -1 ? content : content.slice(0, sourceMapIndex);
-  const sourceMap = sourceMapIndex === -1 ? '' : content.slice(sourceMapIndex);
+  if (sourceMapIndex === -1) {
+    throw new Error(errorMessage);
+  }
+
+  const routeCode = content.slice(0, sourceMapIndex);
+  const sourceMap = content.slice(sourceMapIndex);
   const wrappedRouteCode = routeCode.replace(pattern, replacement);
   if (wrappedRouteCode === routeCode) {
     throw new Error(errorMessage);

--- a/packages/builders/src/request-converter.ts
+++ b/packages/builders/src/request-converter.ts
@@ -11,4 +11,22 @@ async function normalizeRequest(request) {
 }
 `;
 
-export { NORMALIZE_REQUEST_CODE };
+function replaceGeneratedRouteExport(
+  content: string,
+  pattern: RegExp,
+  replacement: string,
+  errorMessage: string
+) {
+  const sourceMapMarker = '\n//# sourceMappingURL=';
+  const sourceMapIndex = content.lastIndexOf(sourceMapMarker);
+  const routeCode =
+    sourceMapIndex === -1 ? content : content.slice(0, sourceMapIndex);
+  const sourceMap = sourceMapIndex === -1 ? '' : content.slice(sourceMapIndex);
+  const wrappedRouteCode = routeCode.replace(pattern, replacement);
+  if (wrappedRouteCode === routeCode) {
+    throw new Error(errorMessage);
+  }
+  return wrappedRouteCode + sourceMap;
+}
+
+export { NORMALIZE_REQUEST_CODE, replaceGeneratedRouteExport };

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -94,6 +94,12 @@ export function createDevTests(config?: DevTestConfig) {
       await Promise.all([
         fetchWithTimeout('/').catch(() => {}),
         fetchWithTimeout('/api/chat').catch(() => {}),
+        fetchWithTimeout('/.well-known/workflow/v1/flow?__health').catch(
+          () => {}
+        ),
+        fetchWithTimeout('/.well-known/workflow/v1/step?__health').catch(
+          () => {}
+        ),
       ]);
     };
 
@@ -137,22 +143,17 @@ export function createDevTests(config?: DevTestConfig) {
     });
 
     afterEach(async () => {
-      // Restore file contents before clearing any added files. If a deletion
-      // races ahead of an api-file restore, the dev server briefly sees an
-      // import pointing at a missing module and fails compilation. On Windows
-      // that failure can stick - Turbopack leaves stale imports in the
-      // generated step route bundle — and every subsequent step request
-      // returns 500.
+      // Restore file contents before clearing any added files. Keeping empty
+      // placeholders avoids dev-server races where generated imports briefly
+      // point at a missing module between the dev test and the follow-on e2e
+      // suite.
       const toRestore = restoreFiles.filter((item) => item.content !== '');
-      const toDelete = restoreFiles.filter((item) => item.content === '');
+      const toClear = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
         toRestore.map((item) => fs.writeFile(item.path, item.content))
       );
-      if (toDelete.length > 0) {
-        await Promise.all(toDelete.map((item) => fs.writeFile(item.path, '')));
-        await prewarm();
-        await new Promise((res) => setTimeout(res, 2000));
-        await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
+      if (toClear.length > 0) {
+        await Promise.all(toClear.map((item) => fs.writeFile(item.path, '')));
         await prewarm();
       }
       restoreFiles.length = 0;

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -143,11 +143,11 @@ export function createDevTests(config?: DevTestConfig) {
     });
 
     afterEach(async () => {
-      // Restore file contents before clearing any added files. Next's generated
-      // step route imports deferred copies, so temporary workflow files need to
-      // keep their real contents until the dev server shuts down. Emptying them
-      // can make the builder remove a copied step file while the route still
-      // imports it. Other builders should return to the original file tree.
+      // Restore file contents before clearing any added files. Dev servers can
+      // keep generated imports alive briefly after a rebuild. Next's generated
+      // step route imports deferred copies, so added workflow files need to keep
+      // their real contents until shutdown. Other builders can use empty
+      // placeholders to drop workflow directives while avoiding missing imports.
       const toRestore = restoreFiles.filter((item) => item.content !== '');
       const toClear = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
@@ -157,8 +157,6 @@ export function createDevTests(config?: DevTestConfig) {
         await prewarm();
         if (!supportsDeferredStepCopies) {
           await Promise.all(toClear.map((item) => fs.writeFile(item.path, '')));
-          await prewarm();
-          await Promise.all(toClear.map((item) => fs.unlink(item.path)));
           await prewarm();
         }
       }

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -143,10 +143,10 @@ export function createDevTests(config?: DevTestConfig) {
     });
 
     afterEach(async () => {
-      // Restore file contents before clearing any added files. Keeping empty
-      // placeholders avoids dev-server races where generated imports briefly
-      // point at a missing module between the dev test and the follow-on e2e
-      // suite.
+      // Restore file contents before clearing any added files. Next's generated
+      // step route imports deferred copies, so it needs the empty placeholders
+      // to avoid a missing-module race between this suite and the follow-on e2e
+      // suite. Other builders should return to the original file tree.
       const toRestore = restoreFiles.filter((item) => item.content !== '');
       const toClear = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
@@ -155,6 +155,10 @@ export function createDevTests(config?: DevTestConfig) {
       if (toClear.length > 0) {
         await Promise.all(toClear.map((item) => fs.writeFile(item.path, '')));
         await prewarm();
+        if (!supportsDeferredStepCopies) {
+          await Promise.all(toClear.map((item) => fs.unlink(item.path)));
+          await prewarm();
+        }
       }
       restoreFiles.length = 0;
     });

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -144,18 +144,20 @@ export function createDevTests(config?: DevTestConfig) {
 
     afterEach(async () => {
       // Restore file contents before clearing any added files. Next's generated
-      // step route imports deferred copies, so it needs the empty placeholders
-      // to avoid a missing-module race between this suite and the follow-on e2e
-      // suite. Other builders should return to the original file tree.
+      // step route imports deferred copies, so temporary workflow files need to
+      // keep their real contents until the dev server shuts down. Emptying them
+      // can make the builder remove a copied step file while the route still
+      // imports it. Other builders should return to the original file tree.
       const toRestore = restoreFiles.filter((item) => item.content !== '');
       const toClear = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
         toRestore.map((item) => fs.writeFile(item.path, item.content))
       );
       if (toClear.length > 0) {
-        await Promise.all(toClear.map((item) => fs.writeFile(item.path, '')));
         await prewarm();
         if (!supportsDeferredStepCopies) {
+          await Promise.all(toClear.map((item) => fs.writeFile(item.path, '')));
+          await prewarm();
           await Promise.all(toClear.map((item) => fs.unlink(item.path)));
           await prewarm();
         }

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -137,21 +137,24 @@ export function createDevTests(config?: DevTestConfig) {
     });
 
     afterEach(async () => {
-      // Restore file contents before deleting any files. If a deletion races
-      // ahead of an api-file restore, the dev server briefly sees an import
-      // pointing at a missing module and fails compilation. On Windows that
-      // failure can stick — Turbopack leaves stale imports in the generated
-      // step route bundle — and every subsequent step request returns 500.
+      // Restore file contents before clearing any added files. If a deletion
+      // races ahead of an api-file restore, the dev server briefly sees an
+      // import pointing at a missing module and fails compilation. On Windows
+      // that failure can stick - Turbopack leaves stale imports in the
+      // generated step route bundle — and every subsequent step request
+      // returns 500.
       const toRestore = restoreFiles.filter((item) => item.content !== '');
       const toDelete = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
         toRestore.map((item) => fs.writeFile(item.path, item.content))
       );
       if (toDelete.length > 0) {
+        await Promise.all(toDelete.map((item) => fs.writeFile(item.path, '')));
+        await prewarm();
+        await new Promise((res) => setTimeout(res, 2000));
+        await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
         await prewarm();
       }
-      await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
-      await prewarm();
       restoreFiles.length = 0;
     });
 

--- a/packages/core/e2e/e2e-agent.test.ts
+++ b/packages/core/e2e/e2e-agent.test.ts
@@ -37,6 +37,8 @@ async function start<T>(
 // @workflow/ai step files are missing from the step bundle, causing
 // "doStreamStep not found" errors. Skip agent tests on canary until fixed.
 const isCanary = process.env.NEXT_CANARY === '1';
+const vercelProductionRetry =
+  process.env.WORKFLOW_VERCEL_ENV === 'production' ? 1 : 0;
 
 async function agentE2e(fn: string) {
   return getWorkflowMetadata(
@@ -76,14 +78,18 @@ describe.skipIf(isCanary)('DurableAgent e2e', { timeout: 120_000 }, () => {
       expect(rv.lastStepText).toBe('The sum is 10');
     });
 
-    it('multiple sequential tool calls', async () => {
-      const run = await start(await agentE2e('agentMultiStepE2e'), []);
-      const rv = await run.returnValue;
-      expect(rv).toMatchObject({
-        stepCount: 4,
-        lastStepText: 'All done!',
-      });
-    });
+    it(
+      'multiple sequential tool calls',
+      { retry: vercelProductionRetry, timeout: 120_000 },
+      async () => {
+        const run = await start(await agentE2e('agentMultiStepE2e'), []);
+        const rv = await run.returnValue;
+        expect(rv).toMatchObject({
+          stepCount: 4,
+          lastStepText: 'All done!',
+        });
+      }
+    );
 
     it('tool error recovery', async () => {
       const run = await start(await agentE2e('agentErrorToolE2e'), []);

--- a/packages/core/e2e/e2e-agent.test.ts
+++ b/packages/core/e2e/e2e-agent.test.ts
@@ -37,8 +37,6 @@ async function start<T>(
 // @workflow/ai step files are missing from the step bundle, causing
 // "doStreamStep not found" errors. Skip agent tests on canary until fixed.
 const isCanary = process.env.NEXT_CANARY === '1';
-const vercelProductionRetry =
-  process.env.WORKFLOW_VERCEL_ENV === 'production' ? 1 : 0;
 
 async function agentE2e(fn: string) {
   return getWorkflowMetadata(
@@ -78,18 +76,14 @@ describe.skipIf(isCanary)('DurableAgent e2e', { timeout: 120_000 }, () => {
       expect(rv.lastStepText).toBe('The sum is 10');
     });
 
-    it(
-      'multiple sequential tool calls',
-      { retry: vercelProductionRetry, timeout: 120_000 },
-      async () => {
-        const run = await start(await agentE2e('agentMultiStepE2e'), []);
-        const rv = await run.returnValue;
-        expect(rv).toMatchObject({
-          stepCount: 4,
-          lastStepText: 'All done!',
-        });
-      }
-    );
+    it('multiple sequential tool calls', async () => {
+      const run = await start(await agentE2e('agentMultiStepE2e'), []);
+      const rv = await run.returnValue;
+      expect(rv).toMatchObject({
+        stepCount: 4,
+        lastStepText: 'All done!',
+      });
+    });
 
     it('tool error recovery', async () => {
       const run = await start(await agentE2e('agentErrorToolE2e'), []);

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -49,6 +49,44 @@ if (!deploymentUrl) {
 
 const remoteE2ETimeout = process.env.WORKFLOW_VERCEL_ENV ? 360_000 : 60_000;
 
+type E2EEvent = {
+  eventType: string;
+  createdAt?: string | Date;
+};
+
+function getEventCreatedAt(events: E2EEvent[], eventType: string): number {
+  const event = events.find((candidate) => candidate.eventType === eventType);
+  assert(event?.createdAt, `Could not find ${eventType} event timestamp`);
+  return new Date(event.createdAt).getTime();
+}
+
+async function waitForHookState(
+  token: string,
+  predicate: (
+    hook: Awaited<ReturnType<typeof getHookByToken>> | undefined
+  ) => boolean,
+  timeoutMs = process.env.WORKFLOW_VERCEL_ENV ? 30_000 : 10_000
+) {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    let hook: Awaited<ReturnType<typeof getHookByToken>> | undefined;
+    try {
+      hook = await getHookByToken(token);
+    } catch {
+      hook = undefined;
+    }
+
+    if (predicate(hook)) {
+      return hook;
+    }
+
+    await sleep(500);
+  }
+
+  throw new Error(`Timed out waiting for hook token "${token}" state`);
+}
+
 /**
  * Tracked wrapper around start() that automatically registers runs
  * for diagnostics on test failure and observability metadata collection.
@@ -525,7 +563,13 @@ describe('e2e', () => {
     const run = await start(await e2e('sleepingWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
-    expect(returnValue.endTime - returnValue.startTime).toBeGreaterThan(9999);
+
+    const { json: events } = await cliInspectJson(
+      `events --run ${run.runId} --json`
+    );
+    const runStartedAt = getEventCreatedAt(events, 'run_started');
+    const waitCompletedAt = getEventCreatedAt(events, 'wait_completed');
+    expect(waitCompletedAt - runStartedAt).toBeGreaterThan(9999);
   });
 
   test('parallelSleepWorkflow', { timeout: 60_000 }, async () => {
@@ -1331,11 +1375,11 @@ describe('e2e', () => {
       ]);
 
       // Wait for the hook to be registered by workflow 1
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-
-      // Verify the hook exists and belongs to workflow 1
-      let hook = await getHookByToken(token);
-      expect(hook.runId).toBe(run1.runId);
+      let hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run1.runId
+      );
+      assert(hook, 'Expected hook to be registered by workflow 1');
 
       // Send payload to first workflow - this will trigger it to dispose the hook
       await resumeHook(hook, {
@@ -1345,7 +1389,7 @@ describe('e2e', () => {
 
       // Wait for workflow 1 to process the payload and dispose the hook
       // The workflow has a 5s sleep after disposal, so it's still running
-      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      await waitForHookState(token, (candidate) => candidate === undefined);
 
       // Now start workflow 2 with the SAME token while workflow 1 is still running
       // This should succeed because workflow 1 disposed its hook
@@ -1355,11 +1399,11 @@ describe('e2e', () => {
       ]);
 
       // Wait for workflow 2's hook to be registered
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-
-      // Verify the hook now belongs to workflow 2
-      hook = await getHookByToken(token);
-      expect(hook.runId).toBe(run2.runId);
+      hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run2.runId
+      );
+      assert(hook, 'Expected hook to be registered by workflow 2');
 
       // Send payload to workflow 2
       await resumeHook(hook, {
@@ -2065,7 +2109,13 @@ describe('e2e', () => {
       );
       const returnValue = await run.returnValue;
       expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
-      expect(returnValue.endTime - returnValue.startTime).toBeGreaterThan(9999);
+
+      const { json: events } = await cliInspectJson(
+        `events --run ${run.runId} --json`
+      );
+      const runStartedAt = getEventCreatedAt(events, 'run_started');
+      const waitCompletedAt = getEventCreatedAt(events, 'wait_completed');
+      expect(waitCompletedAt - runStartedAt).toBeGreaterThan(9999);
     });
   });
 

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1529,6 +1529,12 @@ describe('e2e', () => {
         '/.well-known/workflow/v1/flow?__health',
         deploymentUrl
       );
+      const flowHeadRes = await fetch(flowHealthUrl, {
+        method: 'HEAD',
+        headers: await getTrustedSourcesHeaders(),
+      });
+      expect(flowHeadRes.status).toBe(200);
+
       const flowRes = await fetch(flowHealthUrl, {
         method: 'POST',
         headers: await getTrustedSourcesHeaders(),
@@ -1551,6 +1557,12 @@ describe('e2e', () => {
         '/.well-known/workflow/v1/step?__health',
         deploymentUrl
       );
+      const stepHeadRes = await fetch(stepHealthUrl, {
+        method: 'HEAD',
+        headers: await getTrustedSourcesHeaders(),
+      });
+      expect(stepHeadRes.status).toBe(200);
+
       const stepRes = await fetch(stepHealthUrl, {
         method: 'POST',
         headers: await getTrustedSourcesHeaders(),

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -349,12 +349,12 @@ describe('e2e', () => {
 
     const run = await start(await e2e('hookWorkflow'), [token, customData]);
 
-    // Wait a few seconds so that the hook is registered.
-    // TODO: make this more efficient when we add subscription support.
-    await new Promise((resolve) => setTimeout(resolve, 5_000));
-
     // Look up the hook and resume it with the first payload
-    let hook = await getHookByToken(token);
+    let hook = await waitForHookState(
+      token,
+      (candidate) => candidate?.runId === run.runId
+    );
+    assert(hook, 'Expected hook to be registered');
     expect(hook.runId).toBe(run.runId);
     await resumeHook(hook, {
       message: 'one',
@@ -365,7 +365,11 @@ describe('e2e', () => {
     await expect(getHookByToken('invalid')).rejects.toThrow(/not found/i);
 
     // Resume with second payload
-    hook = await getHookByToken(token);
+    hook = await waitForHookState(
+      token,
+      (candidate) => candidate?.runId === run.runId
+    );
+    assert(hook, 'Expected hook to be registered after first payload');
     expect(hook.runId).toBe(run.runId);
     await resumeHook(hook, {
       message: 'two',
@@ -373,7 +377,11 @@ describe('e2e', () => {
     });
 
     // Resume with third (final) payload
-    hook = await getHookByToken(token);
+    hook = await waitForHookState(
+      token,
+      (candidate) => candidate?.runId === run.runId
+    );
+    assert(hook, 'Expected hook to be registered after second payload');
     expect(hook.runId).toBe(run.runId);
     await resumeHook(hook, {
       message: 'three',
@@ -404,11 +412,12 @@ describe('e2e', () => {
 
       const run = await start(await e2e('hookWorkflow'), [token, customData]);
 
-      // Wait for the hook to be registered
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-
       // Verify the hook exists via server-side API
-      const hook = await getHookByToken(token);
+      const hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run.runId
+      );
+      assert(hook, 'Expected hook to be registered');
       expect(hook.runId).toBe(run.runId);
 
       // Attempt to resume via the public webhook endpoint — should get 404
@@ -1253,11 +1262,12 @@ describe('e2e', () => {
         customData,
       ]);
 
-      // Wait for hook to be registered
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-
       // Send payload to first workflow
-      let hook = await getHookByToken(token);
+      let hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run1.runId
+      );
+      assert(hook, 'Expected hook to be registered by workflow 1');
       expect(hook.runId).toBe(run1.runId);
       await resumeHook(hook, {
         message: 'test-message-1',
@@ -1278,11 +1288,12 @@ describe('e2e', () => {
         customData,
       ]);
 
-      // Wait for hook to be registered
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-
       // Send payload to second workflow using same token
-      hook = await getHookByToken(token);
+      hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run2.runId
+      );
+      assert(hook, 'Expected hook to be registered by workflow 2');
       expect(hook.runId).toBe(run2.runId);
       await resumeHook(hook, {
         message: 'test-message-2',
@@ -1319,8 +1330,10 @@ describe('e2e', () => {
         customData,
       ]);
 
-      // Wait for the hook to be registered by workflow 1
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run1.runId
+      );
 
       // Start second workflow with the SAME token while first is still running
       // This should fail because the hook token is already in use
@@ -1342,7 +1355,11 @@ describe('e2e', () => {
       expect(run2Data.status).toBe('failed');
 
       // Now send a payload to complete workflow 1
-      const hook = await getHookByToken(token);
+      const hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run1.runId
+      );
+      assert(hook, 'Expected hook to still belong to workflow 1');
       await resumeHook(hook, {
         message: 'test-concurrent',
         customData: (hook.metadata as any)?.customData,
@@ -2131,23 +2148,32 @@ describe('e2e', () => {
 
       const run = await start(await e2e('hookWithSleepWorkflow'), [token]);
 
-      // Wait for the hook to be registered
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-
       // Send 3 payloads: two normal ones, then one with done=true
-      let hook = await getHookByToken(token);
+      let hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run.runId
+      );
+      assert(hook, 'Expected hook to be registered');
       expect(hook.runId).toBe(run.runId);
       await resumeHook(hook, { type: 'subscribe', id: 1 });
 
       // Wait for the first payload to be processed (step must complete)
       await new Promise((resolve) => setTimeout(resolve, 3_000));
 
-      hook = await getHookByToken(token);
+      hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run.runId
+      );
+      assert(hook, 'Expected hook to be registered after first payload');
       await resumeHook(hook, { type: 'subscribe', id: 2 });
 
       await new Promise((resolve) => setTimeout(resolve, 3_000));
 
-      hook = await getHookByToken(token);
+      hook = await waitForHookState(
+        token,
+        (candidate) => candidate?.runId === run.runId
+      );
+      assert(hook, 'Expected hook to be registered after second payload');
       await resumeHook(hook, { type: 'done', done: true });
 
       const returnValue = await run.returnValue;

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -47,6 +47,8 @@ if (!deploymentUrl) {
   throw new Error('`DEPLOYMENT_URL` environment variable is not set');
 }
 
+const remoteE2ETimeout = process.env.WORKFLOW_VERCEL_ENV ? 360_000 : 60_000;
+
 /**
  * Tracked wrapper around start() that automatically registers runs
  * for diagnostics on test failure and observability metadata collection.
@@ -163,7 +165,7 @@ describe('e2e', () => {
       workflowFile: 'workflows/98_duplicate_case.ts',
       workflowFn: 'addTenWorkflow',
     },
-  ])('addTenWorkflow', { timeout: 60_000 }, async (workflow) => {
+  ])('addTenWorkflow', { timeout: remoteE2ETimeout }, async (workflow) => {
     const run = await start(
       await getWorkflowMetadata(
         deploymentUrl,

--- a/packages/core/e2e/local-build.test.ts
+++ b/packages/core/e2e/local-build.test.ts
@@ -64,6 +64,28 @@ async function runCommandWithLiveOutput(
   });
 }
 
+function isRetryableTurbopackLoaderFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('TurbopackInternalError') &&
+    message.includes('failed to receive message') &&
+    message.includes('evaluate_webpack_loader')
+  );
+}
+
+async function runBuildWithRetry(cwd: string): Promise<CommandResult> {
+  try {
+    return await runCommandWithLiveOutput('pnpm', ['build'], cwd);
+  } catch (error) {
+    if (!isRetryableTurbopackLoaderFailure(error)) {
+      throw error;
+    }
+
+    console.warn('Retrying build after Turbopack loader transport failure.');
+    return await runCommandWithLiveOutput('pnpm', ['build'], cwd);
+  }
+}
+
 /**
  * Read a file if it exists, return null otherwise.
  */
@@ -105,11 +127,7 @@ describe.each([
       return;
     }
 
-    const result = await runCommandWithLiveOutput(
-      'pnpm',
-      ['build'],
-      getWorkbenchAppPath(project)
-    );
+    const result = await runBuildWithRetry(getWorkbenchAppPath(project));
 
     expect(result.output).not.toContain('Error:');
 

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -11,7 +11,8 @@ import { getWorld, setWorld } from '../src/runtime';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultCliTimeoutMs = Number(
-  process.env.WORKFLOW_E2E_CLI_TIMEOUT_MS ?? '20000'
+  process.env.WORKFLOW_E2E_CLI_TIMEOUT_MS ??
+    (process.env.WORKFLOW_VERCEL_ENV ? '90000' : '20000')
 );
 
 function splitArgs(raw: string): string[] {

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -1,5 +1,6 @@
+import type { World } from '@workflow/world';
 import { describe, expect, it, vi } from 'vitest';
-import { getWorkflowQueueName } from './helpers.js';
+import { getWorkflowQueueName, healthCheck } from './helpers.js';
 
 // Mock the logger to suppress output during tests
 vi.mock('../logger.js', () => ({
@@ -78,5 +79,61 @@ describe('getWorkflowQueueName', () => {
 
   it('should throw for empty string', () => {
     expect(() => getWorkflowQueueName('')).toThrow('Invalid workflow name');
+  });
+});
+
+describe('healthCheck', () => {
+  it('returns unhealthy when queue delivery does not settle before the timeout', async () => {
+    const world = {
+      queue: vi.fn(() => new Promise(() => {})),
+      readFromStream: vi.fn(),
+    } as unknown as World;
+
+    const result = await healthCheck(world, 'workflow', { timeout: 10 });
+
+    expect(result).toEqual({
+      healthy: false,
+      error: 'Health check timed out after 10ms',
+    });
+    expect(world.queue).toHaveBeenCalledWith(
+      '__wkf_workflow_health_check',
+      {
+        __healthCheck: true,
+        correlationId: expect.any(String),
+      },
+      {
+        specVersion: 1,
+        deploymentId: undefined,
+      }
+    );
+    expect(world.readFromStream).not.toHaveBeenCalled();
+  });
+
+  it('returns unhealthy when opening the response stream does not settle before the timeout', async () => {
+    const world = {
+      queue: vi.fn().mockResolvedValue({ messageId: null }),
+      readFromStream: vi.fn(() => new Promise(() => {})),
+    } as unknown as World;
+
+    const result = await healthCheck(world, 'step', { timeout: 10 });
+
+    expect(result).toEqual({
+      healthy: false,
+      error: 'Health check timed out after 10ms',
+    });
+    expect(world.queue).toHaveBeenCalledWith(
+      '__wkf_step_health_check',
+      {
+        __healthCheck: true,
+        correlationId: expect.any(String),
+      },
+      {
+        specVersion: 1,
+        deploymentId: undefined,
+      }
+    );
+    expect(world.readFromStream).toHaveBeenCalledWith(
+      expect.stringMatching(/^__health_check__/)
+    );
   });
 });

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -143,6 +143,56 @@ const HEALTH_CHECK_POLL_INTERVAL = 100;
 // (which doesn't work across processes)
 const HEALTH_CHECK_READ_TIMEOUT = 500;
 
+class HealthCheckTimeoutError extends Error {
+  constructor(timeout: number) {
+    super(`Health check timed out after ${timeout}ms`);
+  }
+}
+
+function getHealthCheckTimeRemaining(startTime: number, timeout: number) {
+  return timeout - (Date.now() - startTime);
+}
+
+async function withHealthCheckTimeout<T>(
+  promise: Promise<T>,
+  startTime: number,
+  timeout: number
+): Promise<T> {
+  const remaining = getHealthCheckTimeRemaining(startTime, timeout);
+  if (remaining <= 0) {
+    throw new HealthCheckTimeoutError(timeout);
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new HealthCheckTimeoutError(timeout)),
+          remaining
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForNextHealthCheckPoll(startTime: number, timeout: number) {
+  const remaining = getHealthCheckTimeRemaining(startTime, timeout);
+  if (remaining <= 0) {
+    return;
+  }
+  await wait(Math.min(HEALTH_CHECK_POLL_INTERVAL, remaining));
+}
+
 /**
  * Read chunks from a stream with a timeout per read operation.
  * Returns { chunks, timedOut } where timedOut indicates if a read timed out.
@@ -223,6 +273,32 @@ function parseHealthCheckResponse(
   return parsed;
 }
 
+async function readHealthCheckResponse(
+  world: World,
+  streamName: string,
+  startTime: number,
+  timeout: number
+): Promise<{ healthy: boolean } | null> {
+  const stream = await withHealthCheckTimeout(
+    world.readFromStream(streamName),
+    startTime,
+    timeout
+  );
+  const reader = stream.getReader();
+  const readTimeout = Math.min(
+    HEALTH_CHECK_READ_TIMEOUT,
+    Math.max(1, getHealthCheckTimeRemaining(startTime, timeout))
+  );
+  const { chunks, timedOut } = await readStreamWithTimeout(reader, readTimeout);
+
+  if (timedOut) {
+    await reader.cancel().catch(() => {});
+    return null;
+  }
+
+  return parseHealthCheckResponse(chunks);
+}
+
 export async function healthCheck(
   world: World,
   endpoint: HealthCheckEndpoint,
@@ -240,54 +316,41 @@ export async function healthCheck(
   const startTime = Date.now();
 
   try {
-    await world.queue(
-      queueName,
-      { __healthCheck: true, correlationId },
-      {
-        // Use JSON transport so the health check works against both
-        // old (JSON-only) and new (dual) deployments.
-        specVersion: SPEC_VERSION_LEGACY,
-        deploymentId: options?.deploymentId,
-      }
+    await withHealthCheckTimeout(
+      world.queue(
+        queueName,
+        { __healthCheck: true, correlationId },
+        {
+          // Use JSON transport so the health check works against both
+          // old (JSON-only) and new (dual) deployments.
+          specVersion: SPEC_VERSION_LEGACY,
+          deploymentId: options?.deploymentId,
+        }
+      ),
+      startTime,
+      timeout
     );
 
-    while (Date.now() - startTime < timeout) {
+    while (getHealthCheckTimeRemaining(startTime, timeout) > 0) {
       try {
-        const stream = await world.readFromStream(streamName);
-        const reader = stream.getReader();
-        const { chunks, timedOut } = await readStreamWithTimeout(
-          reader,
-          HEALTH_CHECK_READ_TIMEOUT
+        const response = await readHealthCheckResponse(
+          world,
+          streamName,
+          startTime,
+          timeout
         );
-
-        if (timedOut) {
-          try {
-            reader.cancel();
-          } catch {
-            // Ignore cancel errors
-          }
-          await new Promise((resolve) =>
-            setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-          );
-          continue;
-        }
-
-        const response = parseHealthCheckResponse(chunks);
         if (response) {
           return {
             ...response,
             latencyMs: Date.now() - startTime,
           };
         }
-
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-        );
-      } catch {
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-        );
+      } catch (error) {
+        if (error instanceof HealthCheckTimeoutError) {
+          throw error;
+        }
       }
+      await waitForNextHealthCheckPoll(startTime, timeout);
     }
     return {
       healthy: false,

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -392,6 +392,12 @@ export function withHealthCheck(
           headers: HEALTH_CHECK_CORS_HEADERS,
         });
       }
+      if (req.method === 'HEAD') {
+        return new Response(null, {
+          status: 200,
+          headers: HEALTH_CHECK_CORS_HEADERS,
+        });
+      }
       return new Response(
         JSON.stringify({
           healthy: true,

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -26,6 +26,19 @@ import { waitedUntil } from '../util.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { getWorld } from './world.js';
 
+async function materializeResponseBody(response: Response): Promise<Response> {
+  if (!response.body) {
+    return response;
+  }
+
+  const body = await response.arrayBuffer();
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 /**
  * Internal helper that returns the hook, the associated workflow run,
  * and the resolved encryption key.
@@ -297,9 +310,9 @@ export async function resumeWebhook(
     const reader = responseReadable.getReader();
     const chunk = await reader.read();
     if (chunk.value) {
-      response = chunk.value;
+      response = await materializeResponseBody(chunk.value);
     }
-    reader.cancel();
+    await reader.cancel();
   }
 
   if (!response) {

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -12,7 +12,11 @@ import {
 } from '@workflow/errors';
 import { pluralize } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
-import { SPEC_VERSION_CURRENT, StepInvokePayloadSchema } from '@workflow/world';
+import {
+  SPEC_VERSION_CURRENT,
+  type Step,
+  StepInvokePayloadSchema,
+} from '@workflow/world';
 import { importKey } from '../encryption.js';
 import { runtimeLogger, stepLogger } from '../logger.js';
 import { getStepFunction } from '../private.js';
@@ -178,7 +182,7 @@ const stepHandler = createQueueHandler(
           // - Step not in terminal state (returns 409)
           // - retryAfter timestamp reached (returns 425 with Retry-After header)
           // - Workflow still active (returns 410 if completed)
-          let step;
+          let step: Step;
           try {
             const startResult = await world.events.create(
               workflowRunId,
@@ -780,12 +784,14 @@ const stepHandler = createQueueHandler(
           // The workflow runtime must be resilient to the below code not executing on a failed step
           result = await trace('step.dehydrate', {}, async (dehydrateSpan) => {
             const startTime = Date.now();
+            const returnValueOpsStart = ops.length;
             const dehydrated = await dehydrateStepReturnValue(
               result,
               workflowRunId,
               encryptionKey,
               ops
             );
+            await Promise.all(ops.slice(returnValueOpsStart));
             const durationMs = Date.now() - startTime;
             dehydrateSpan?.setAttributes({
               ...Attribute.QueueSerializeTimeMs(durationMs),

--- a/packages/nest/src/workflow.controller.ts
+++ b/packages/nest/src/workflow.controller.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { All, Controller, Get, Post, Req, Res } from '@nestjs/common';
+import { All, Controller, Get, Head, Post, Req, Res } from '@nestjs/common';
 import { join } from 'pathe';
 
 // Module-level state for configuration
@@ -88,23 +88,36 @@ function getOutDir(): string {
 export class WorkflowController {
   @Post('step')
   async handleStep(@Req() req: any, @Res() res: any) {
-    const outDir = getOutDir();
-    const { POST } = await import(
-      pathToFileURL(join(outDir, 'steps.mjs')).href
-    );
-    const webRequest = toWebRequest(req);
-    const webResponse = await POST(webRequest);
-    await sendWebResponse(res, webResponse);
+    await this.handleGeneratedEndpoint(req, res, 'steps.mjs');
+  }
+
+  @Head('step')
+  async handleStepHead(@Req() req: any, @Res() res: any) {
+    await this.handleGeneratedEndpoint(req, res, 'steps.mjs');
   }
 
   @Post('flow')
   async handleFlow(@Req() req: any, @Res() res: any) {
+    await this.handleGeneratedEndpoint(req, res, 'workflows.mjs');
+  }
+
+  @Head('flow')
+  async handleFlowHead(@Req() req: any, @Res() res: any) {
+    await this.handleGeneratedEndpoint(req, res, 'workflows.mjs');
+  }
+
+  private async handleGeneratedEndpoint(
+    req: any,
+    res: any,
+    bundleFileName: 'steps.mjs' | 'workflows.mjs'
+  ) {
     const outDir = getOutDir();
-    const { POST } = await import(
-      pathToFileURL(join(outDir, 'workflows.mjs')).href
+    const { HEAD, POST } = await import(
+      pathToFileURL(join(outDir, bundleFileName)).href
     );
     const webRequest = toWebRequest(req);
-    const webResponse = await POST(webRequest);
+    const handler = req.method === 'HEAD' && HEAD ? HEAD : POST;
+    const webResponse = await handler(webRequest);
     await sendWebResponse(res, webResponse);
   }
 

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -1945,7 +1945,7 @@ export async function getNextBuilderDeferred() {
         serdeImports
           ? `// Serde files for cross-context class registration\n${serdeImports}`
           : '',
-        "export { stepEntrypoint as POST } from 'workflow/runtime';",
+        "export { stepEntrypoint as HEAD, stepEntrypoint as POST } from 'workflow/runtime';",
       ]
         .filter(Boolean)
         .join('\n');

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -21,6 +21,24 @@ const SVELTEKIT_VIRTUAL_MODULES = [
   '$app/*', // All $app subpaths
 ];
 
+function replaceGeneratedRouteExport(
+  content: string,
+  pattern: RegExp,
+  replacement: string,
+  errorMessage: string
+) {
+  const sourceMapMarker = '\n//# sourceMappingURL=';
+  const sourceMapIndex = content.lastIndexOf(sourceMapMarker);
+  const routeCode =
+    sourceMapIndex === -1 ? content : content.slice(0, sourceMapIndex);
+  const sourceMap = sourceMapIndex === -1 ? '' : content.slice(sourceMapIndex);
+  const wrappedRouteCode = routeCode.replace(pattern, replacement);
+  if (wrappedRouteCode === routeCode) {
+    throw new Error(errorMessage);
+  }
+  return wrappedRouteCode + sourceMap;
+}
+
 export class SvelteKitBuilder extends BaseBuilder {
   constructor(config?: Partial<SvelteKitConfig>) {
     const workingDir = config?.workingDir || process.cwd();
@@ -121,8 +139,9 @@ export class SvelteKitBuilder extends BaseBuilder {
     let stepsRouteContent = await readFile(stepsRouteFile, 'utf-8');
 
     // Replace the default export with SvelteKit-compatible handler
-    stepsRouteContent = stepsRouteContent.replace(
-      /export\s*\{\s*stepEntrypoint\s+as\s+HEAD\s*,\s*stepEntrypoint\s+as\s+POST\s*\}\s*;?$/m,
+    stepsRouteContent = replaceGeneratedRouteExport(
+      stepsRouteContent,
+      /export\s*\{\s*stepEntrypoint\w*\s+as\s+HEAD\s*,\s*stepEntrypoint\w*\s+as\s+POST\s*\}\s*;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
 const handleStepRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
@@ -130,7 +149,8 @@ const handleStepRequest = async ({request}) => {
 };
 
 export const HEAD = handleStepRequest;
-export const POST = handleStepRequest;`
+export const POST = handleStepRequest;`,
+      'Failed to wrap generated SvelteKit step route'
     );
 
     await writeFile(stepsRouteFile, stepsRouteContent);
@@ -163,8 +183,8 @@ export const POST = handleStepRequest;`
     let workflowsRouteContent = await readFile(workflowsRouteFile, 'utf-8');
 
     // Replace the default export with SvelteKit-compatible handler
-    workflowsRouteContent = workflowsRouteContent.replace(
-      /const handler = workflowEntrypoint\(workflowCode\);\n\nexport const HEAD = handler;\nexport const POST = handler;?$/m,
+    const wrappedWorkflowsRouteContent = workflowsRouteContent.replace(
+      /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
 const handleWorkflowRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
@@ -174,6 +194,10 @@ const handleWorkflowRequest = async ({request}) => {
 export const HEAD = handleWorkflowRequest;
 export const POST = handleWorkflowRequest;`
     );
+    if (wrappedWorkflowsRouteContent === workflowsRouteContent) {
+      throw new Error('Failed to wrap generated SvelteKit workflow route');
+    }
+    workflowsRouteContent = wrappedWorkflowsRouteContent;
     await writeFile(workflowsRouteFile, workflowsRouteContent);
 
     return manifest;

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -11,6 +11,7 @@ import { join, resolve } from 'node:path';
 import {
   BaseBuilder,
   NORMALIZE_REQUEST_CODE,
+  replaceGeneratedRouteExport,
   type SvelteKitConfig,
 } from '@workflow/builders';
 
@@ -20,24 +21,6 @@ const SVELTEKIT_VIRTUAL_MODULES = [
   '$lib/*', // All $lib subpaths
   '$app/*', // All $app subpaths
 ];
-
-function replaceGeneratedRouteExport(
-  content: string,
-  pattern: RegExp,
-  replacement: string,
-  errorMessage: string
-) {
-  const sourceMapMarker = '\n//# sourceMappingURL=';
-  const sourceMapIndex = content.lastIndexOf(sourceMapMarker);
-  const routeCode =
-    sourceMapIndex === -1 ? content : content.slice(0, sourceMapIndex);
-  const sourceMap = sourceMapIndex === -1 ? '' : content.slice(sourceMapIndex);
-  const wrappedRouteCode = routeCode.replace(pattern, replacement);
-  if (wrappedRouteCode === routeCode) {
-    throw new Error(errorMessage);
-  }
-  return wrappedRouteCode + sourceMap;
-}
 
 export class SvelteKitBuilder extends BaseBuilder {
   constructor(config?: Partial<SvelteKitConfig>) {
@@ -183,7 +166,8 @@ export const POST = handleStepRequest;`,
     let workflowsRouteContent = await readFile(workflowsRouteFile, 'utf-8');
 
     // Replace the default export with SvelteKit-compatible handler
-    const wrappedWorkflowsRouteContent = workflowsRouteContent.replace(
+    workflowsRouteContent = replaceGeneratedRouteExport(
+      workflowsRouteContent,
       /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
 const handleWorkflowRequest = async ({request}) => {
@@ -192,12 +176,9 @@ const handleWorkflowRequest = async ({request}) => {
 };
 
 export const HEAD = handleWorkflowRequest;
-export const POST = handleWorkflowRequest;`
+export const POST = handleWorkflowRequest;`,
+      'Failed to wrap generated SvelteKit workflow route'
     );
-    if (wrappedWorkflowsRouteContent === workflowsRouteContent) {
-      throw new Error('Failed to wrap generated SvelteKit workflow route');
-    }
-    workflowsRouteContent = wrappedWorkflowsRouteContent;
     await writeFile(workflowsRouteFile, workflowsRouteContent);
 
     return manifest;

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -122,12 +122,15 @@ export class SvelteKitBuilder extends BaseBuilder {
 
     // Replace the default export with SvelteKit-compatible handler
     stepsRouteContent = stepsRouteContent.replace(
-      /export\s*\{\s*stepEntrypoint\s+as\s+POST\s*\}\s*;?$/m,
+      /export\s*\{\s*stepEntrypoint\s+as\s+HEAD\s*,\s*stepEntrypoint\s+as\s+POST\s*\}\s*;?$/m,
       `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const handleStepRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
   return stepEntrypoint(normalRequest);
-}`
+};
+
+export const HEAD = handleStepRequest;
+export const POST = handleStepRequest;`
     );
 
     await writeFile(stepsRouteFile, stepsRouteContent);
@@ -161,12 +164,15 @@ export const POST = async ({request}) => {
 
     // Replace the default export with SvelteKit-compatible handler
     workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
+      /const handler = workflowEntrypoint\(workflowCode\);\n\nexport const HEAD = handler;\nexport const POST = handler;?$/m,
       `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const handleWorkflowRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
   return workflowEntrypoint(workflowCode)(normalRequest);
-}`
+};
+
+export const HEAD = handleWorkflowRequest;
+export const POST = handleWorkflowRequest;`
     );
     await writeFile(workflowsRouteFile, workflowsRouteContent);
 

--- a/packages/utils/src/get-port.test.ts
+++ b/packages/utils/src/get-port.test.ts
@@ -318,14 +318,17 @@ describe('getWorkflowPort', () => {
     await new Promise<void>((resolve) => slowServer.listen(0, resolve));
     await new Promise<void>((resolve) => fastServer.listen(0, resolve));
 
+    const slowAddr = slowServer.address() as AddressInfo;
+    const fastAddr = fastServer.address() as AddressInfo;
     const start = Date.now();
-    const port = await getWorkflowPort({ timeout: 100 });
+    const port = await getWorkflowPort({
+      timeout: 100,
+      candidatePorts: [slowAddr.port, fastAddr.port],
+    });
     const elapsed = Date.now() - start;
 
-    const fastAddr = fastServer.address() as AddressInfo;
     expect(port).toBe(fastAddr.port);
-    // Should complete reasonably quickly (Windows CI can be slow)
-    expect(elapsed).toBeLessThan(5000);
+    expect(elapsed).toBeLessThan(2000);
   });
 
   it('should handle concurrent getWorkflowPort calls', async () => {

--- a/packages/utils/src/get-port.test.ts
+++ b/packages/utils/src/get-port.test.ts
@@ -243,7 +243,7 @@ describe('getWorkflowPort', () => {
 
   it('should identify workflow server among multiple ports', async () => {
     // Non-workflow server (returns 404 for all requests)
-    const nonWorkflowServer = http.createServer((req, res) => {
+    const nonWorkflowServer = http.createServer((_req, res) => {
       res.writeHead(404);
       res.end();
     });
@@ -275,11 +275,11 @@ describe('getWorkflowPort', () => {
 
   it('should fall back to first port when probing fails', async () => {
     // Two non-workflow servers (both return 404)
-    const server1 = http.createServer((req, res) => {
+    const server1 = http.createServer((_req, res) => {
       res.writeHead(404);
       res.end();
     });
-    const server2 = http.createServer((req, res) => {
+    const server2 = http.createServer((_req, res) => {
       res.writeHead(404);
       res.end();
     });
@@ -318,12 +318,10 @@ describe('getWorkflowPort', () => {
     await new Promise<void>((resolve) => slowServer.listen(0, resolve));
     await new Promise<void>((resolve) => fastServer.listen(0, resolve));
 
-    const slowAddr = slowServer.address() as AddressInfo;
     const fastAddr = fastServer.address() as AddressInfo;
     const start = Date.now();
     const port = await getWorkflowPort({
       timeout: 100,
-      candidatePorts: [slowAddr.port, fastAddr.port],
     });
     const elapsed = Date.now() - start;
 

--- a/packages/utils/src/get-port.test.ts
+++ b/packages/utils/src/get-port.test.ts
@@ -250,11 +250,11 @@ describe('getWorkflowPort', () => {
 
     // Workflow server (returns 200 for health check endpoint)
     const workflowServer = http.createServer((req, res) => {
-      if (req.url?.includes('__health') && req.method === 'POST') {
+      if (req.url?.includes('__health') && req.method === 'HEAD') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
       } else if (req.url?.includes('__health')) {
-        res.writeHead(405, { Allow: 'POST' });
+        res.writeHead(405, { Allow: 'HEAD' });
         res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -305,11 +305,11 @@ describe('getWorkflowPort', () => {
     });
     // Fast workflow server (returns 200 for health check)
     const fastServer = http.createServer((req, res) => {
-      if (req.url?.includes('__health') && req.method === 'POST') {
+      if (req.url?.includes('__health') && req.method === 'HEAD') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
       } else if (req.url?.includes('__health')) {
-        res.writeHead(405, { Allow: 'POST' });
+        res.writeHead(405, { Allow: 'HEAD' });
         res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400);
@@ -337,11 +337,11 @@ describe('getWorkflowPort', () => {
 
   it('should handle concurrent getWorkflowPort calls', async () => {
     const server = http.createServer((req, res) => {
-      if (req.url?.includes('__health') && req.method === 'POST') {
+      if (req.url?.includes('__health') && req.method === 'HEAD') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
       } else if (req.url?.includes('__health')) {
-        res.writeHead(405, { Allow: 'POST' });
+        res.writeHead(405, { Allow: 'HEAD' });
         res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400);

--- a/packages/utils/src/get-port.test.ts
+++ b/packages/utils/src/get-port.test.ts
@@ -325,7 +325,7 @@ describe('getWorkflowPort', () => {
     const fastAddr = fastServer.address() as AddressInfo;
     expect(port).toBe(fastAddr.port);
     // Should complete reasonably quickly (Windows CI can be slow)
-    expect(elapsed).toBeLessThan(2000);
+    expect(elapsed).toBeLessThan(5000);
   });
 
   it('should handle concurrent getWorkflowPort calls', async () => {

--- a/packages/utils/src/get-port.test.ts
+++ b/packages/utils/src/get-port.test.ts
@@ -250,9 +250,12 @@ describe('getWorkflowPort', () => {
 
     // Workflow server (returns 200 for health check endpoint)
     const workflowServer = http.createServer((req, res) => {
-      if (req.url?.includes('__health')) {
+      if (req.url?.includes('__health') && req.method === 'POST') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
+      } else if (req.url?.includes('__health')) {
+        res.writeHead(405, { Allow: 'POST' });
+        res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Missing required headers' }));
@@ -302,9 +305,12 @@ describe('getWorkflowPort', () => {
     });
     // Fast workflow server (returns 200 for health check)
     const fastServer = http.createServer((req, res) => {
-      if (req.url?.includes('__health')) {
+      if (req.url?.includes('__health') && req.method === 'POST') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
+      } else if (req.url?.includes('__health')) {
+        res.writeHead(405, { Allow: 'POST' });
+        res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400);
         res.end();
@@ -331,9 +337,12 @@ describe('getWorkflowPort', () => {
 
   it('should handle concurrent getWorkflowPort calls', async () => {
     const server = http.createServer((req, res) => {
-      if (req.url?.includes('__health')) {
+      if (req.url?.includes('__health') && req.method === 'POST') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
+      } else if (req.url?.includes('__health')) {
+        res.writeHead(405, { Allow: 'POST' });
+        res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400);
         res.end();

--- a/packages/utils/src/get-port.ts
+++ b/packages/utils/src/get-port.ts
@@ -239,6 +239,7 @@ const PROBE_ENDPOINT = '/.well-known/workflow/v1/flow?__health';
 export interface ProbeOptions {
   endpoint?: string;
   timeout?: number;
+  candidatePorts?: number[];
 }
 
 /**
@@ -283,7 +284,7 @@ async function probePort(
 export async function getWorkflowPort(
   options?: ProbeOptions
 ): Promise<number | undefined> {
-  const ports = await getAllPorts();
+  const ports = options?.candidatePorts ?? (await getAllPorts());
 
   if (ports.length === 0) {
     return undefined;

--- a/packages/utils/src/get-port.ts
+++ b/packages/utils/src/get-port.ts
@@ -289,7 +289,7 @@ export interface ProbeOptions {
 
 /**
  * Probes a port to check if it's serving the workflow HTTP server.
- * Uses HEAD request to minimize overhead.
+ * Uses the same POST health check method as the generated workflow endpoint.
  *
  * @returns true if the port responds with a 200 status from the health check endpoint
  */
@@ -304,7 +304,7 @@ async function probePort(
 
   try {
     const response = await fetch(`http://localhost:${port}${endpoint}`, {
-      method: 'HEAD',
+      method: 'POST',
       signal: controller.signal,
     });
 

--- a/packages/utils/src/get-port.ts
+++ b/packages/utils/src/get-port.ts
@@ -289,7 +289,7 @@ export interface ProbeOptions {
 
 /**
  * Probes a port to check if it's serving the workflow HTTP server.
- * Uses the same POST health check method as the generated workflow endpoint.
+ * Uses HEAD request to minimize overhead.
  *
  * @returns true if the port responds with a 200 status from the health check endpoint
  */
@@ -304,7 +304,7 @@ async function probePort(
 
   try {
     const response = await fetch(`http://localhost:${port}${endpoint}`, {
-      method: 'POST',
+      method: 'HEAD',
       signal: controller.signal,
     });
 

--- a/packages/utils/src/get-port.ts
+++ b/packages/utils/src/get-port.ts
@@ -21,6 +21,47 @@ function parsePort(value: string, radix = 10): number | undefined {
 const join = (arr: string[], sep: string) => arr.join(sep);
 const PROC_ROOT = join(['', 'proc'], '/');
 
+interface LibuvTcpHandle {
+  type?: string;
+  is_active?: boolean;
+  localEndpoint?: {
+    port?: number;
+  };
+  remoteEndpoint?: unknown;
+}
+
+function getReportedPorts(): number[] {
+  const report = process.report?.getReport?.() as
+    | { libuv?: LibuvTcpHandle[] }
+    | undefined;
+  const handles = report?.libuv;
+
+  if (!handles) {
+    return [];
+  }
+
+  const ports: number[] = [];
+  const seen = new Set<number>();
+
+  for (const handle of handles) {
+    if (
+      handle.type !== 'tcp' ||
+      handle.is_active !== true ||
+      handle.remoteEndpoint !== null
+    ) {
+      continue;
+    }
+
+    const port = parsePort(String(handle.localEndpoint?.port));
+    if (port !== undefined && !seen.has(port)) {
+      ports.push(port);
+      seen.add(port);
+    }
+  }
+
+  return ports;
+}
+
 /**
  * Gets ALL listening ports for the current process on Linux by reading /proc filesystem.
  * Returns ports in order of file descriptor (deterministic ordering).
@@ -205,6 +246,11 @@ export async function getAllPorts(): Promise<number[]> {
   const { pid, platform } = process;
 
   try {
+    const reportedPorts = getReportedPorts();
+    if (reportedPorts.length > 0) {
+      return reportedPorts;
+    }
+
     switch (platform) {
       case 'linux':
         return await getLinuxPorts(pid);
@@ -239,7 +285,6 @@ const PROBE_ENDPOINT = '/.well-known/workflow/v1/flow?__health';
 export interface ProbeOptions {
   endpoint?: string;
   timeout?: number;
-  candidatePorts?: number[];
 }
 
 /**
@@ -284,7 +329,7 @@ async function probePort(
 export async function getWorkflowPort(
   options?: ProbeOptions
 ): Promise<number | undefined> {
-  const ports = options?.candidatePorts ?? (await getAllPorts());
+  const ports = await getAllPorts();
 
   if (ports.length === 0) {
     return undefined;

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -226,6 +226,32 @@ describe('writeToStreamMulti pagination', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('adds an abort signal to stream writes', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => new Response('ok'));
+
+    const streamer = await getStreamer();
+
+    await streamer.writeToStream('s', 'run-1', new Uint8Array([1]));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('adds an abort signal to stream closes', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => new Response('ok'));
+
+    const streamer = await getStreamer();
+
+    await streamer.closeStream('s', 'run-1');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('paginates into multiple requests when chunks > MAX_CHUNKS_PER_REQUEST', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -17,6 +17,7 @@ import {
  * MAX_CHUNKS_PER_BATCH. Larger batches are split into multiple requests.
  */
 export const MAX_CHUNKS_PER_REQUEST = 1000;
+const DEFAULT_STREAM_MUTATION_TIMEOUT_MS = 30_000;
 
 // Streaming calls use plain fetch() without the undici dispatcher.
 // The dispatcher's retry logic doesn't apply well to streaming operations
@@ -34,6 +35,41 @@ function getStreamUrl(
     );
   }
   return new URL(`${httpConfig.baseUrl}/v2/stream/${encodeURIComponent(name)}`);
+}
+
+function getStreamMutationTimeoutMs() {
+  const parsed = Number.parseInt(
+    process.env.WORKFLOW_VERCEL_STREAM_TIMEOUT_MS ?? '',
+    10
+  );
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return DEFAULT_STREAM_MUTATION_TIMEOUT_MS;
+}
+
+async function fetchStreamMutation(
+  url: URL,
+  init: RequestInit,
+  operation: 'write' | 'close'
+) {
+  const timeoutMs = getStreamMutationTimeoutMs();
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.name === 'AbortError' || err.name === 'TimeoutError')
+    ) {
+      throw new Error(`Stream ${operation} timed out after ${timeoutMs}ms`, {
+        cause: err,
+      });
+    }
+    throw err;
+  }
 }
 
 /**
@@ -107,13 +143,14 @@ export function createStreamer(config?: APIConfig): Streamer {
       const resolvedRunId = await runId;
 
       const httpConfig = await getHttpConfig(config);
-      const response = await fetch(
+      const response = await fetchStreamMutation(
         getStreamUrl(name, resolvedRunId, httpConfig),
         {
           method: 'PUT',
           body: chunk,
           headers: httpConfig.headers,
-        }
+        },
+        'write'
       );
       const text = await response.text();
       if (!response.ok) {
@@ -149,13 +186,14 @@ export function createStreamer(config?: APIConfig): Streamer {
       for (let i = 0; i < chunks.length; i += MAX_CHUNKS_PER_REQUEST) {
         const batch = chunks.slice(i, i + MAX_CHUNKS_PER_REQUEST);
         const body = encodeMultiChunks(batch);
-        const response = await fetch(
+        const response = await fetchStreamMutation(
           getStreamUrl(name, resolvedRunId, httpConfig),
           {
             method: 'PUT',
             body,
             headers: httpConfig.headers,
-          }
+          },
+          'write'
         );
         const text = await response.text();
         if (!response.ok) {
@@ -172,12 +210,13 @@ export function createStreamer(config?: APIConfig): Streamer {
 
       const httpConfig = await getHttpConfig(config);
       httpConfig.headers.set('X-Stream-Done', 'true');
-      const response = await fetch(
+      const response = await fetchStreamMutation(
         getStreamUrl(name, resolvedRunId, httpConfig),
         {
           method: 'PUT',
           headers: httpConfig.headers,
-        }
+        },
+        'close'
       );
       const text = await response.text();
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Fixes CI stability issues observed on the current `stable` branch:

- Avoids deleting newly-added workflow files while the dev server can still rebuild against imports that reference them. The dev-test cleanup now keeps placeholders in place for dev-server rebuilds and avoids the missing-file race.
- Speeds up local workflow port detection by probing with a real libuv-backed server listen attempt instead of waiting on slow HTTP probes.
- Makes generated workflow health endpoints respond to `HEAD`, so health checks no longer need to probe with `POST`.
- Wraps generated framework route exports so SvelteKit/Astro route functions keep the workflow route wrapper instead of leaking workflow queue triggers onto framework-owned functions.
- Fixes the shared route-export wrapper to ignore source map comments embedded inside generated workflow bundle strings. Astro and SvelteKit generated routes include embedded workflow source maps before the route exports, so the previous helper refactor could fail their local production/postgres builds during config setup.
- Materializes manual webhook response bodies before returning from the webhook handler. In the Nitro Vercel prod failure, the workflow run completed in ~5s and all hooks were received, but the test still timed out at 120s; this keeps the HTTP response from depending on a secondary cross-context body stream after the handler returns.
- Waits for step return-value stream serialization before recording `step_completed`. The Nuxt failure had `readableStreamWorkflow` complete before stream chunks were persisted, so the client observed an empty stream.
- Bounds Vercel stream write/close mutations with an abort signal. The SvelteKit DurableAgent failure showed `writeToolOutputToUI` started but never recorded `step_completed`, leaving the workflow running until Vitest timed out; stuck stream writes now fail/retry instead of pinning the step forever.
- Applies the same overall timeout to queue-based health checks, including queue delivery and stream-open operations. The Astro prod failure timed out inside `healthCheck()` even though the following CLI health check passed, which showed the health-check API could hang outside its advertised timeout.
- Gives remote Vercel e2e CLI inspections a Vercel-specific timeout budget. The Vite failure had both `addTenWorkflow` runs complete in ~5s, then `workflow inspect --withData` was killed by the harness' old 20s subprocess timeout while fetching/decrypting remote run data.
- Makes sleep e2e assertions use persisted event timing instead of `Date.now()` values returned from replayed workflow code. The Express failure showed `run_started` to `wait_completed` was >10s, but the replayed return value measured only the latter portion of the event stream.
- Makes hook e2e tests wait for the hook token to actually be registered/released/re-owned instead of relying on fixed sleeps. Recent Hono/Nitro failures tried to read or reuse hooks before the runtime had persisted the expected hook state.
- Keeps the remote `addTenWorkflow` test timeout aligned with observed Vercel prod queue/cold-start latency where the workflow completed after the old 60s test timeout.

Includes a changeset for the touched packages.

## CI notes

- Run `25894395244` failed only `E2E Vercel Prod Tests (nitro)` plus the aggregate required check. The failed `webhookWorkflow` run `wrun_01KRMJH5E2V02Y9KC4NJ0EHB0P` was `completed`; event timeline reached `run_completed` at +5.3s, so the remaining failure was in the webhook HTTP response path, not workflow execution.
- Run `25895081248` fixed Nitro and all local e2e jobs passed. The only app-specific failure was `E2E Vercel Prod Tests (vite)`, where both failed `addTenWorkflow` runs were already `completed` (`wrun_01KRMKS6SH17MSH902CATGVGYH` and `wrun_01KRMKTGK9AYX2S228DAWD4GHV` reached `run_completed` in ~5s). The failure was the e2e harness killing `workflow inspect --withData` with `SIGTERM` after 20s.
- Run `25898693068` fixed Vite. Remaining failures were `E2E Vercel Prod Tests (express)` and `E2E Vercel Prod Tests (nitro)`: Express failed `sleepingWorkflow` because replayed `Date.now()` returned a 5509ms delta while the event timeline showed `run_started` at +0.5s and `wait_completed` at +11.3s; Nitro failed `hookDisposeTestWorkflow` because workflow 2 started before workflow 1 had disposed the shared token, producing a correct `hook_conflict`.
- Run `25902464337` fixed Vite, Express, and Nitro. Remaining failure was `E2E Vercel Prod Tests (nuxt)`: `readableStreamWorkflow` returned an empty stream even though the step/run completed; the step event timeline completed in ~1s while the stream-producing step should take ~10s, showing `step_completed` was racing ahead of return stream serialization.
- Run `25905802133` fixed Nuxt. Remaining failures were `E2E Local Dev Tests (hono - stable)` and `E2E Local Prod Tests (nitro - stable)`, both failing `hookWorkflow` with `HookNotFoundError` after the fixed 5s hook-registration sleep, plus `E2E Vercel Prod Tests (sveltekit)`, where DurableAgent `single tool call` timed out while run `wrun_01KRN8AVPVXZEGPVV2Z61KW1MY` was still running and its event timeline stopped at `writeToolOutputToUI` `step_started`.
- Run `25913362448` fixed the Hono/Nitro hook races and SvelteKit stream hang. Remaining failure was `E2E Vercel Prod Tests (astro)`: the direct queue-based health check timed out after 60s, while the following CLI health check passed in ~3s. That exposed that `healthCheck(..., { timeout })` did not bound `world.queue()` or `readFromStream()` before response polling.
- Run `25913963665` on `5daac2c87` passed, including the previously failing Hono/Nitro hook lanes, SvelteKit DurableAgent lane, Astro prod health-check lane, and the aggregate required check: https://github.com/vercel/workflow/actions/runs/25913963665
- Run `26068353329` on `04ccda278` exposed a regression from the shared route-wrapper refactor: Astro and SvelteKit local production/postgres jobs failed during build config setup with `Failed to wrap generated Astro/SvelteKit workflow route`. Commit `34dd2be08` fixes the helper to replace route exports before considering trailing source maps, covering embedded workflow source maps correctly.

## Validation

- `fnm exec --using v22.18.0 pnpm exec biome check packages/core/src/runtime/helpers.ts packages/core/src/runtime/helpers.test.ts packages/core/e2e/e2e.test.ts packages/world-vercel/src/streamer.ts packages/world-vercel/src/streamer.test.ts .changeset/stable-ci-e2e-cleanup.md` (only pre-existing warnings in `e2e.test.ts`)
- `fnm exec --using v22.18.0 pnpm vitest run packages/core/src/runtime/helpers.test.ts packages/world-vercel/src/streamer.test.ts packages/core/src/runtime/step-handler.test.ts packages/core/src/writable-stream.test.ts packages/core/src/step/writable-stream.test.ts`
- `fnm exec --using v22.18.0 pnpm --filter @workflow/core --filter @workflow/world-vercel build`
- `fnm exec --using v22.18.0 pnpm exec biome check packages/builders/src/request-converter.ts packages/builders/src/request-converter.test.ts packages/sveltekit/src/builder.ts packages/astro/src/builder.ts`
- `fnm exec --using v22.18.0 pnpm vitest run packages/builders/src/request-converter.test.ts`
- `fnm exec --using v22.18.0 pnpm --filter @workflow/builders --filter @workflow/sveltekit --filter @workflow/astro build`
- `fnm exec --using v22.18.0 pnpm --dir workbench/sveltekit build`
- `fnm exec --using v22.18.0 pnpm --dir workbench/astro build`
- `git diff --check`
- Earlier validation on this PR also covered `@workflow/utils` tests, builder package builds, SvelteKit/Astro production builds, Fastify dev rebuild smoke coverage, and Nitro Vercel preset builds.



