### PR TITLE
docs(python): Add short URL forwarding for python

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -161,6 +161,11 @@ const config: NextConfig = {
         destination: '/cookbook/agent-patterns/agent-cancellation',
         permanent: true,
       },
+      {
+        source: '/python',
+        destination: '/docs/getting-started/python',
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
Adds a short, memorable URL for redirecting to the Python getting started page.