### PR TITLE
fix(builders): decode escaped workflowCode templates

### DIFF
--- a/.changeset/quiet-lamps-parse.md
+++ b/.changeset/quiet-lamps-parse.md
@@ -1,0 +1,5 @@
+---
+"@workflow/builders": patch
+---
+
+Decode escaped workflowCode template literals before graph extraction so unicode-escape identifiers parse correctly.

--- a/packages/builders/src/workflows-extractor.test.ts
+++ b/packages/builders/src/workflows-extractor.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { extractWorkflowGraphs } from './workflows-extractor.js';
+
+describe('extractWorkflowGraphs', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('parses workflowCode template literals with unicode-escape identifiers', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'workflow-builders-'));
+    const bundlePath = join(tempDir, 'workflow-bundle.js');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    await writeFile(
+      bundlePath,
+      [
+        'const workflowCode = `',
+        'function workflow() {',
+        '  var DEBURR_MAP = new Map(Object.entries({\\\\u00C6: "Ae"}));',
+        '  return DEBURR_MAP;',
+        '}',
+        'workflow.workflowId = "workflow//./input.js//workflow";',
+        '`;',
+      ].join('\n')
+    );
+
+    await expect(extractWorkflowGraphs(bundlePath)).resolves.toEqual({
+      './input.js': {
+        workflow: expect.objectContaining({
+          workflowId: 'workflow//./input.js//workflow',
+        }),
+      },
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builders/src/workflows-extractor.ts
+++ b/packages/builders/src/workflows-extractor.ts
@@ -277,7 +277,9 @@ function extractWorkflowCodeFromBundle(ast: Program): string | null {
           decl.init
         ) {
           if (decl.init.type === 'TemplateLiteral') {
-            return decl.init.quasis.map((q) => q.cooked || q.raw).join('');
+            return decl.init.quasis
+              .map((q) => decodeEscapedWorkflowCode(q.raw))
+              .join('');
           }
           if (decl.init.type === 'StringLiteral') {
             return decl.init.value;
@@ -287,6 +289,10 @@ function extractWorkflowCodeFromBundle(ast: Program): string | null {
     }
   }
   return null;
+}
+
+function decodeEscapedWorkflowCode(rawTemplateElement: string): string {
+  return rawTemplateElement.replace(/\\([\\`$])/g, '$1');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Decode raw workflowCode template literal quasis using the escaping produced by the builders bundle wrapper before graph extraction
- Add a regression test for unicode-escape object identifiers like `\u00C6` in bundled workflow code
- Add a patch changeset for `@workflow/builders`

Closes #1958.

## Verification
- `pnpm --filter @workflow/builders exec vitest run src/workflows-extractor.test.ts`
- `pnpm --filter @workflow/builders typecheck`
- `pnpm --filter @workflow/builders build`
- `pnpm exec biome check packages/builders/src/workflows-extractor.ts packages/builders/src/workflows-extractor.test.ts .changeset/quiet-lamps-parse.md`

Note: local pnpm commands warn because this machine is on Node v26.0.0 while the repo engine allows Node 18/20/22/24. Biome also reports pre-existing complexity warnings in `workflows-extractor.ts`; no formatting fixes remain.