### PR TITLE
Forward-port SvelteKit workflow queue trigger fix

### DIFF
--- a/.changeset/stale-sveltekit-triggers-main.md
+++ b/.changeset/stale-sveltekit-triggers-main.md
@@ -1,0 +1,5 @@
+---
+'@workflow/sveltekit': patch
+---
+
+Fix duplicate Workflow queue consumers in SvelteKit deployments by removing stale workflow queue triggers from shared Vercel function configs.

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -1,7 +1,9 @@
 import path from 'node:path';
+import { WORKFLOW_QUEUE_TRIGGER } from '@workflow/builders';
 import fs from 'fs-extra';
 
 import { SvelteKitBuilder } from './builder.js';
+import { stripWorkflowQueueTriggers } from './vc-config.js';
 
 const builder = new SvelteKitBuilder();
 
@@ -22,15 +24,7 @@ process.on('beforeExit', () => {
       file: '.vercel/output/functions/.well-known/workflow/v1/flow.func/.vc-config.json',
       config: {
         maxDuration: 'max',
-        experimentalTriggers: [
-          {
-            type: 'queue/v2beta',
-            topic: '__wkf_workflow_*',
-            consumer: 'default',
-            retryAfterSeconds: 5,
-            initialDelaySeconds: 0,
-          },
-        ],
+        experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
       },
     },
   ]) {
@@ -40,15 +34,16 @@ process.on('beforeExit', () => {
     }
     // Un-symlink these as they can't be shared due to different
     // experimental triggers config
+    const sourceFuncDir = path.join(
+      funcDir.replace(/\.func$/, ''),
+      '__data.json.func'
+    );
     const toCopy = fs.readdirSync(funcDir);
     fs.removeSync(funcDir);
     fs.mkdirSync(funcDir, { recursive: true });
 
     for (const item of toCopy) {
-      fs.copySync(
-        path.join(funcDir.replace(/\.func$/, ''), '__data.json.func', item),
-        path.join(funcDir, item)
-      );
+      fs.copySync(path.join(sourceFuncDir, item), path.join(funcDir, item));
     }
 
     // Update .vc-config.json with the new experimental triggers config
@@ -60,6 +55,10 @@ process.on('beforeExit', () => {
         ...config,
       })
     );
+
+    // The source function may be a shared catchall. It must not keep stale
+    // workflow queue triggers after the dedicated function is copied out.
+    stripWorkflowQueueTriggers(path.join(sourceFuncDir, '.vc-config.json'));
   }
 });
 

--- a/packages/sveltekit/src/vc-config.test.ts
+++ b/packages/sveltekit/src/vc-config.test.ts
@@ -1,0 +1,50 @@
+import { WORKFLOW_QUEUE_TRIGGER } from '@workflow/builders';
+import { describe, expect, it } from 'vitest';
+
+import { stripWorkflowQueueTriggersFromConfig } from './vc-config.js';
+
+describe('stripWorkflowQueueTriggersFromConfig', () => {
+  it('removes workflow queue triggers while preserving unrelated triggers', () => {
+    const unrelatedTrigger = {
+      type: 'queue/v2beta',
+      topic: 'user-topic',
+      consumer: 'default',
+    };
+
+    expect(
+      stripWorkflowQueueTriggersFromConfig({
+        runtime: 'nodejs',
+        experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER, unrelatedTrigger],
+      })
+    ).toEqual({
+      runtime: 'nodejs',
+      experimentalTriggers: [unrelatedTrigger],
+    });
+  });
+
+  it('deletes experimentalTriggers when only workflow triggers remain', () => {
+    expect(
+      stripWorkflowQueueTriggersFromConfig({
+        runtime: 'nodejs',
+        experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
+      })
+    ).toEqual({
+      runtime: 'nodejs',
+    });
+  });
+
+  it('leaves configs without workflow triggers unchanged', () => {
+    const config = {
+      runtime: 'nodejs',
+      experimentalTriggers: [
+        {
+          type: 'queue/v2beta',
+          topic: 'user-topic',
+          consumer: 'default',
+        },
+      ],
+    };
+
+    expect(stripWorkflowQueueTriggersFromConfig(config)).toBe(config);
+  });
+});

--- a/packages/sveltekit/src/vc-config.ts
+++ b/packages/sveltekit/src/vc-config.ts
@@ -1,0 +1,52 @@
+import { WORKFLOW_QUEUE_TRIGGER } from '@workflow/builders';
+import fs from 'fs-extra';
+
+const WORKFLOW_QUEUE_TOPICS = new Set([WORKFLOW_QUEUE_TRIGGER.topic]);
+
+function isWorkflowQueueTrigger(trigger: unknown) {
+  if (typeof trigger !== 'object' || trigger === null) {
+    return false;
+  }
+
+  const topic = (trigger as { topic?: unknown }).topic;
+  return typeof topic === 'string' && WORKFLOW_QUEUE_TOPICS.has(topic);
+}
+
+export function stripWorkflowQueueTriggersFromConfig<
+  TConfig extends Record<string, unknown>,
+>(existingConfig: TConfig): TConfig {
+  const experimentalTriggers = existingConfig.experimentalTriggers;
+  if (!Array.isArray(experimentalTriggers)) {
+    return existingConfig;
+  }
+
+  const filteredTriggers = experimentalTriggers.filter(
+    (trigger) => !isWorkflowQueueTrigger(trigger)
+  );
+  if (filteredTriggers.length === experimentalTriggers.length) {
+    return existingConfig;
+  }
+
+  const nextConfig: Record<string, unknown> = { ...existingConfig };
+  if (filteredTriggers.length > 0) {
+    nextConfig.experimentalTriggers = filteredTriggers;
+  } else {
+    delete nextConfig.experimentalTriggers;
+  }
+
+  return nextConfig as TConfig;
+}
+
+export function stripWorkflowQueueTriggers(file: string) {
+  if (!fs.existsSync(file)) {
+    return;
+  }
+
+  const existingConfig = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const nextConfig = stripWorkflowQueueTriggersFromConfig(existingConfig);
+  if (nextConfig === existingConfig) {
+    return;
+  }
+
+  fs.writeFileSync(file, JSON.stringify(nextConfig));
+}


### PR DESCRIPTION
## Summary

Forward-port #1984 to `main` for the SvelteKit V2 builder path.

This keeps the `main` branch from retaining stale Workflow queue triggers on the shared SvelteKit `__data.json.func/.vc-config.json` source config after the dedicated Workflow function is copied out.

## Changes

- Reuses `WORKFLOW_QUEUE_TRIGGER` from `@workflow/builders` instead of duplicating queue trigger config in the SvelteKit builder.
- Strips stale Workflow queue triggers from the shared source function config after copying `flow.func`.
- Adds focused coverage for the pure `.vc-config.json` transform.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter '@workflow/sveltekit...' build`
- `pnpm vitest run packages/sveltekit/src/vc-config.test.ts`
- `pnpm exec biome check packages/sveltekit/src/index.ts packages/sveltekit/src/vc-config.ts packages/sveltekit/src/vc-config.test.ts .changeset/stale-sveltekit-triggers-main.md`

## Related

- Stable / 4.2.x PR: #1984
