### PR TITLE
[codex] Hide flaky worlds indicators

### DIFF
--- a/docs/app/[lang]/worlds/page.tsx
+++ b/docs/app/[lang]/worlds/page.tsx
@@ -101,9 +101,6 @@ export default async function WorldsPage() {
               <div className="flex items-center gap-3 text-xs text-muted-foreground uppercase tracking-wider">
                 <div className="w-16" />
                 <div className="flex-1" />
-                <div className="w-14 text-right text-gray-1000 font-medium font-mono">
-                  Perf
-                </div>
               </div>
 
               {/* Benchmark bars */}

--- a/docs/components/worlds/WorldCard.tsx
+++ b/docs/components/worlds/WorldCard.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-  AlertCircle,
-  CheckCircle2,
-  Clock,
-  ExternalLinkIcon,
-  XCircle,
-} from 'lucide-react';
+import { ExternalLinkIcon } from 'lucide-react';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -16,8 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
-import { cn } from '@/lib/utils';
 import type { World } from './types';
 
 interface WorldCardProps {
@@ -25,52 +17,13 @@ interface WorldCardProps {
   world: World;
 }
 
-const statusConfig = {
-  passing: {
-    label: 'Passing',
-    icon: CheckCircle2,
-    variant: 'default' as const,
-    className: 'bg-green-500/10 text-green-600 border-green-500/20',
-  },
-  partial: {
-    label: 'Partial',
-    icon: AlertCircle,
-    variant: 'secondary' as const,
-    className: 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20',
-  },
-  failing: {
-    label: 'Failing',
-    icon: XCircle,
-    variant: 'destructive' as const,
-    className: 'bg-red-500/10 text-red-600 border-red-500/20',
-  },
-  pending: {
-    label: 'Pending',
-    icon: Clock,
-    variant: 'outline' as const,
-    className: 'bg-muted text-muted-foreground',
-  },
-};
-
 const typeEmoji = {
   official: '',
   community: '',
 };
 
-export function WorldCard({ id, world }: WorldCardProps) {
-  const e2eStatus = world.e2e?.status || 'pending';
-  const config = statusConfig[e2eStatus];
-  const StatusIcon = config.icon;
-
+export function WorldCard({ world }: WorldCardProps) {
   const isExternal = world.docs.startsWith('http');
-
-  // Calculate E2E progress excluding skipped tests from denominator
-  // so pass rate reflects actual test results (not artificially lowered by skips)
-  const effectiveTotal = world.e2e ? world.e2e.total - world.e2e.skipped : 0;
-  const displayProgress =
-    effectiveTotal > 0 && world.e2e
-      ? Math.round((world.e2e.passed / effectiveTotal) * 100)
-      : 0;
 
   return (
     <Card className="relative overflow-hidden">
@@ -92,44 +45,12 @@ export function WorldCard({ id, world }: WorldCardProps) {
               {world.package}
             </CardDescription>
           </div>
-          <Badge className={cn('gap-1', config.className)}>
-            <StatusIcon className="h-3 w-3" />
-            {config.label}
-          </Badge>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-sm text-muted-foreground line-clamp-2">
           {world.description}
         </p>
-
-        {/* E2E Progress */}
-        {world.e2e && (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">E2E Tests</span>
-              <span className="font-medium">
-                {world.e2e.passed}/{effectiveTotal} ({displayProgress}%)
-              </span>
-            </div>
-            <Progress
-              value={displayProgress}
-              className={cn(
-                'h-2',
-                displayProgress === 100
-                  ? '[&>div]:bg-green-500'
-                  : displayProgress >= 75
-                    ? '[&>div]:bg-yellow-500'
-                    : '[&>div]:bg-red-500'
-              )}
-            />
-            {world.e2e.failed > 0 && (
-              <p className="text-xs text-muted-foreground">
-                {world.e2e.failed} failing, {world.e2e.skipped} skipped
-              </p>
-            )}
-          </div>
-        )}
 
         {/* Links */}
         <div className="flex items-center gap-2 pt-2">

--- a/docs/components/worlds/WorldCardSimple.tsx
+++ b/docs/components/worlds/WorldCardSimple.tsx
@@ -10,7 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Gauge } from '@/components/ui/gauge';
 import {
   Tooltip,
   TooltipContent,
@@ -24,24 +23,6 @@ interface WorldCardSimpleProps {
 }
 
 export function WorldCardSimple({ id, world }: WorldCardSimpleProps) {
-  // Use nextjs-turbopack data for scoring if available, otherwise fall back to total
-  const turbopackData = world.e2e?.nextjsTurbopack;
-
-  // Calculate E2E progress based on nextjs-turbopack data (canonical scoring)
-  // For framework data: passed + failed = tests that ran (excludes skipped)
-  // If failed === 0, that's 100% passing
-  const effectiveFailed = turbopackData
-    ? turbopackData.failed
-    : (world.e2e?.failed ?? 0);
-  const effectivePassed = turbopackData
-    ? turbopackData.passed
-    : (world.e2e?.passed ?? 0);
-  const effectiveTotal = effectivePassed + effectiveFailed;
-  const displayProgress =
-    effectiveTotal > 0
-      ? Math.round((effectivePassed / effectiveTotal) * 100)
-      : 0;
-
   return (
     <Link href={`/worlds/${id}`} className="block group">
       <Card className="h-full transition-colors cursor-pointer overflow-hidden py-0! gap-2">
@@ -72,38 +53,7 @@ export function WorldCardSimple({ id, world }: WorldCardSimpleProps) {
             {world.description}
           </p>
         </CardContent>
-        {/* Stats footer */}
-        <div className="flex items-center justify-between px-4 pb-4 pt-2">
-          {/* E2E with gauge */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center gap-2 text-sm">
-                <Gauge
-                  value={world.e2e ? displayProgress : 0}
-                  size="tiny"
-                  colors={
-                    !world.e2e
-                      ? { primary: 'var(--ds-gray-alpha-400)' }
-                      : displayProgress >= 75
-                        ? { primary: 'var(--ds-green-700)' }
-                        : displayProgress >= 50
-                          ? { primary: 'var(--ds-amber-700)' }
-                          : { primary: 'var(--ds-red-700)' }
-                  }
-                />
-                <span className="font-normal text-gray-1000">
-                  E2E:{` `}
-                  <span className="font-mono font-normal">
-                    {world.e2e ? `${displayProgress}%` : '—'}
-                  </span>
-                </span>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="max-w-[200px]">
-              <p className="text-xs">E2E Test Suite Coverage</p>
-            </TooltipContent>
-          </Tooltip>
-          {/* Encryption badge */}
+        <div className="flex min-h-8 items-center justify-end px-4 pb-4 pt-2">
           {world.features.includes('encryption') && (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/docs/components/worlds/WorldDetailHero.tsx
+++ b/docs/components/worlds/WorldDetailHero.tsx
@@ -1,12 +1,9 @@
 'use client';
 
 import {
-  AlertCircle,
   BadgeCheck,
-  CheckCircle2,
   CheckIcon,
   ChevronRight,
-  Clock,
   Code,
   CopyIcon,
   ExternalLink,
@@ -14,8 +11,6 @@ import {
   HeartHandshake,
   Package,
   ShieldCheck,
-  Timer,
-  XCircle,
 } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -42,29 +37,6 @@ interface WorldDetailHeroProps {
   world: World;
 }
 
-const statusConfig = {
-  passing: {
-    label: 'Passing',
-    icon: CheckCircle2,
-    className: 'text-green-900',
-  },
-  partial: {
-    label: 'Partial',
-    icon: AlertCircle,
-    className: 'text-amber-900',
-  },
-  failing: {
-    label: 'Failing',
-    icon: XCircle,
-    className: 'text-red-900',
-  },
-  pending: {
-    label: 'Pending',
-    icon: Clock,
-    className: 'text-muted-foreground',
-  },
-};
-
 export function WorldDetailHero({ id, world }: WorldDetailHeroProps) {
   const [copied, setCopied] = useState(false);
 
@@ -87,25 +59,6 @@ export function WorldDetailHero({ id, world }: WorldDetailHeroProps) {
   };
 
   const CopyButtonIcon = copied ? CheckIcon : CopyIcon;
-
-  // E2E test calculations
-  const e2e = world.e2e;
-  const turbopackData = e2e?.nextjsTurbopack;
-  const scoringPassed = turbopackData
-    ? turbopackData.passed
-    : (e2e?.passed ?? 0);
-  const scoringFailed = turbopackData
-    ? turbopackData.failed
-    : (e2e?.failed ?? 0);
-  const testsRan = scoringPassed + scoringFailed;
-  const status = e2e?.status ?? 'pending';
-  const StatusIcon = statusConfig[status].icon;
-
-  // Benchmark calculations
-  const benchmark = world.benchmark;
-  const benchmarkCount = benchmark?.metrics
-    ? Object.keys(benchmark.metrics).length
-    : 0;
 
   // GitHub source URL for official worlds
   const githubUrl =
@@ -206,69 +159,6 @@ export function WorldDetailHero({ id, world }: WorldDetailHeroProps) {
 
         {/* Right side - Quick links */}
         <div className="space-y-2 text-sm">
-          {/* E2E Tests */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <a
-                href="#testing"
-                className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <StatusIcon
-                  className={`h-4 w-4 shrink-0 ${statusConfig[status].className}`}
-                />
-                <span>
-                  {e2e ? (
-                    <>
-                      <span className="text-foreground">
-                        {scoringPassed}/{testsRan}
-                      </span>{' '}
-                      tests passing
-                    </>
-                  ) : (
-                    'Tests pending'
-                  )}
-                </span>
-              </a>
-            </TooltipTrigger>
-            <TooltipContent side="top" align="start" className="max-w-[200px]">
-              <p className="text-xs">E2E Test Suite Coverage</p>
-            </TooltipContent>
-          </Tooltip>
-
-          {/* Benchmarks - show PERF time as summary */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <a
-                href="#testing"
-                className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <Timer
-                  className={`h-4 w-4 shrink-0 ${world.benchmark10SeqMs !== null ? 'text-purple-900' : ''}`}
-                />
-                <span>
-                  {world.benchmark10SeqMs !== null ? (
-                    <>
-                      PERF:{' '}
-                      <span className="text-foreground">
-                        {(world.benchmark10SeqMs / 1000).toFixed(2)}s
-                      </span>
-                    </>
-                  ) : benchmarkCount > 0 ? (
-                    `${benchmarkCount} benchmarks`
-                  ) : (
-                    'Benchmarks pending'
-                  )}
-                </span>
-              </a>
-            </TooltipTrigger>
-            <TooltipContent side="top" align="start" className="max-w-[260px]">
-              <p className="text-xs">
-                Avg time to run a 10 step workflow where each step sleeps 1
-                second
-              </p>
-            </TooltipContent>
-          </Tooltip>
-
           {/* NPM Package */}
           <a
             href={`https://www.npmjs.com/package/${world.package}`}

--- a/docs/components/worlds/WorldTestingPerformance.tsx
+++ b/docs/components/worlds/WorldTestingPerformance.tsx
@@ -5,7 +5,6 @@ import {
   CheckCircle2,
   Clock,
   Info,
-  Timer,
   TrendingUp,
   XCircle,
 } from 'lucide-react';
@@ -24,7 +23,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
 import { BenchmarkHistoryChart } from './BenchmarkHistoryChart';
 import { formatTime, type World } from './types';
 
@@ -69,9 +67,6 @@ const SlurpColumnHeader = () => (
     </Tooltip>
   </div>
 );
-
-// The main benchmark used for the PERF metric
-const PERF_BENCHMARK_NAME = 'workflow with 10 sequential steps';
 
 export interface WorldTestingPerformanceProps {
   worldId: string;
@@ -314,65 +309,40 @@ export function WorldTestingPerformance({
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {standardMetrics.map(([name, metric]) => {
-                        const isPerfBenchmark = name === PERF_BENCHMARK_NAME;
-                        return (
-                          <TableRow
-                            key={name}
-                            className={cn(
-                              'cursor-pointer hover:bg-muted/50 transition-colors',
-                              isPerfBenchmark && 'bg-muted/30'
-                            )}
-                            onClick={() => setSelectedMetric(name)}
-                          >
-                            <TableCell className="font-medium">
-                              <div className="flex items-center gap-2">
-                                {isPerfBenchmark && (
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <Timer className="h-4 w-4 text-purple-900 shrink-0" />
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                      side="top"
-                                      className="max-w-[200px]"
-                                    >
-                                      <p className="text-xs">
-                                        Primary performance benchmark (PERF)
-                                      </p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                )}
-                                {name}
-                              </div>
-                            </TableCell>
-                            <TableCell className="text-right font-mono">
-                              {metric.workflowTime !== undefined
-                                ? formatTime(metric.workflowTime)
-                                : '—'}
-                            </TableCell>
-                            {hasWorkflowRange && (
-                              <>
-                                <TableCell className="text-right font-mono text-muted-foreground">
-                                  {metric.workflowMin !== undefined
-                                    ? formatTime(metric.workflowMin)
-                                    : '—'}
-                                </TableCell>
-                                <TableCell className="text-right font-mono text-muted-foreground">
-                                  {metric.workflowMax !== undefined
-                                    ? formatTime(metric.workflowMax)
-                                    : '—'}
-                                </TableCell>
-                              </>
-                            )}
-                            <TableCell className="text-right text-muted-foreground">
-                              {metric.samples || '—'}
-                            </TableCell>
-                            <TableCell>
-                              <TrendingUp className="h-4 w-4 text-muted-foreground" />
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
+                      {standardMetrics.map(([name, metric]) => (
+                        <TableRow
+                          key={name}
+                          className="cursor-pointer hover:bg-muted/50 transition-colors"
+                          onClick={() => setSelectedMetric(name)}
+                        >
+                          <TableCell className="font-medium">{name}</TableCell>
+                          <TableCell className="text-right font-mono">
+                            {metric.workflowTime !== undefined
+                              ? formatTime(metric.workflowTime)
+                              : '—'}
+                          </TableCell>
+                          {hasWorkflowRange && (
+                            <>
+                              <TableCell className="text-right font-mono text-muted-foreground">
+                                {metric.workflowMin !== undefined
+                                  ? formatTime(metric.workflowMin)
+                                  : '—'}
+                              </TableCell>
+                              <TableCell className="text-right font-mono text-muted-foreground">
+                                {metric.workflowMax !== undefined
+                                  ? formatTime(metric.workflowMax)
+                                  : '—'}
+                              </TableCell>
+                            </>
+                          )}
+                          <TableCell className="text-right text-muted-foreground">
+                            {metric.samples || '—'}
+                          </TableCell>
+                          <TableCell>
+                            <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                          </TableCell>
+                        </TableRow>
+                      ))}
                     </TableBody>
                   </Table>
                 )}

--- a/docs/components/worlds/WorldsDashboard.tsx
+++ b/docs/components/worlds/WorldsDashboard.tsx
@@ -30,10 +30,6 @@ export function WorldsDashboard({ data }: WorldsDashboardProps) {
     total: worlds.length,
     official: officialWorlds.length,
     community: communityWorlds.length,
-    passing: worlds.filter(([, w]) => w.e2e?.status === 'passing').length,
-    partial: worlds.filter(([, w]) => w.e2e?.status === 'partial').length,
-    withBenchmarks: worlds.filter(([, w]) => w.benchmark?.status === 'measured')
-      .length,
   };
 
   // Get benchmark names for the bar chart
@@ -60,20 +56,6 @@ export function WorldsDashboard({ data }: WorldsDashboardProps) {
         <Badge variant="outline" className="text-sm py-1 px-3">
           🌐 {stats.community} Community
         </Badge>
-        <Badge
-          variant="outline"
-          className="text-sm py-1 px-3 bg-green-300 text-green-900 border-green-500/20"
-        >
-          ✅ {stats.passing} Fully Compatible
-        </Badge>
-        {stats.partial > 0 && (
-          <Badge
-            variant="outline"
-            className="text-sm py-1 px-3 bg-yellow-500/10 text-yellow-600 border-yellow-500/20"
-          >
-            ⚠️ {stats.partial} Partial
-          </Badge>
-        )}
       </div>
 
       {/* Tabs */}
@@ -87,6 +69,7 @@ export function WorldsDashboard({ data }: WorldsDashboardProps) {
           {/* Filter */}
           <div className="flex gap-2">
             <button
+              type="button"
               onClick={() => setFilter('all')}
               className={`px-3 py-1 text-sm rounded-md transition-colors ${
                 filter === 'all'
@@ -97,6 +80,7 @@ export function WorldsDashboard({ data }: WorldsDashboardProps) {
               All ({stats.total})
             </button>
             <button
+              type="button"
               onClick={() => setFilter('official')}
               className={`px-3 py-1 text-sm rounded-md transition-colors ${
                 filter === 'official'
@@ -107,6 +91,7 @@ export function WorldsDashboard({ data }: WorldsDashboardProps) {
               Official ({stats.official})
             </button>
             <button
+              type="button"
               onClick={() => setFilter('community')}
               className={`px-3 py-1 text-sm rounded-md transition-colors ${
                 filter === 'community'

--- a/docs/components/worlds/WorldsFilteredGrid.tsx
+++ b/docs/components/worlds/WorldsFilteredGrid.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import type { World } from './types';
 import { WorldCardSimple } from './WorldCardSimple';
 
-type Filter = 'all' | 'vercel' | 'community' | 'compatible' | 'encrypted';
+type Filter = 'all' | 'vercel' | 'community' | 'encrypted';
 
 interface WorldsFilteredGridProps {
   worlds: [string, World][];
@@ -52,8 +52,6 @@ export function WorldsFilteredGrid({ worlds }: WorldsFilteredGridProps) {
         return world.type === 'official';
       case 'community':
         return world.type === 'community';
-      case 'compatible':
-        return world.e2e?.status === 'passing';
       case 'encrypted':
         return world.features?.includes('encryption');
       default:
@@ -65,7 +63,6 @@ export function WorldsFilteredGrid({ worlds }: WorldsFilteredGridProps) {
     all: worlds.length,
     vercel: worlds.filter(([, w]) => w.type === 'official').length,
     community: worlds.filter(([, w]) => w.type === 'community').length,
-    compatible: worlds.filter(([, w]) => w.e2e?.status === 'passing').length,
     encrypted: worlds.filter(([, w]) => w.features.includes('encryption'))
       .length,
   };
@@ -74,7 +71,6 @@ export function WorldsFilteredGrid({ worlds }: WorldsFilteredGridProps) {
     { id: 'all', label: `Show all (${counts.all})` },
     { id: 'vercel', label: `By Vercel (${counts.vercel})` },
     { id: 'community', label: `By Community (${counts.community})` },
-    { id: 'compatible', label: `Fully Compatible (${counts.compatible})` },
     { id: 'encrypted', label: `Encrypted (${counts.encrypted})` },
   ];
 


### PR DESCRIPTION
## Summary

- Hide flaky E2E test indicators from the worlds overview and legacy dashboard surfaces.
- Remove PERF-specific labels/highlighting from worlds overview/detail benchmark UI.
- Keep the worlds cards focused on package, description, ownership, and encryption signals.

## Validation

- `pnpm changeset status --since=main` -> `no changeset needed`
- `pnpm exec biome check docs/components/worlds/WorldsFilteredGrid.tsx docs/components/worlds/WorldCardSimple.tsx docs/components/worlds/WorldDetailHero.tsx docs/components/worlds/WorldTestingPerformance.tsx docs/components/worlds/WorldsDashboard.tsx docs/components/worlds/WorldCard.tsx docs/app/[lang]/worlds/page.tsx`
- `git diff --check`
- Verified `http://localhost:3000/worlds` with Playwright at desktop and mobile widths

Note: Biome reports existing complexity warnings in `WorldTestingPerformance.tsx`, but exits successfully.
