### PR TITLE
fix(nitro): respect workflow.dirs option

### DIFF
--- a/.changeset/nitro-workflow-dirs.md
+++ b/.changeset/nitro-workflow-dirs.md
@@ -1,0 +1,5 @@
+---
+'@workflow/nitro': patch
+---
+
+Respect the `workflow.dirs` Nitro module option when configuring workflow builders.

--- a/packages/nitro/src/builders.ts
+++ b/packages/nitro/src/builders.ts
@@ -24,7 +24,7 @@ export class VercelBuilder extends VercelBuildOutputAPIBuilder {
     super({
       ...createBaseBuilderConfig({
         workingDir: nitro.options.rootDir,
-        dirs: ['.'], // Different apps that use nitro have different directories
+        dirs: nitro.options.workflow?.dirs ?? ['.'], // Different apps that use nitro have different directories
         runtime: nitro.options.workflow?.runtime,
         sourcemap: nitro.options.workflow?.sourcemap,
         externalPackages: getNitroStringExternals(nitro),
@@ -53,7 +53,7 @@ export class LocalBuilder extends BaseBuilder {
       ...createBaseBuilderConfig({
         workingDir: nitro.options.rootDir,
         watch: nitro.options.dev,
-        dirs: ['.'], // Different apps that use nitro have different directories
+        dirs: nitro.options.workflow?.dirs ?? ['.'], // Different apps that use nitro have different directories
         sourcemap: nitro.options.workflow?.sourcemap,
         externalPackages: getNitroStringExternals(nitro),
       }),

--- a/packages/nitro/src/index.test.ts
+++ b/packages/nitro/src/index.test.ts
@@ -5,11 +5,13 @@ import nitroModule from './index.js';
 function createNitroStub({
   routing,
   externals,
+  workflow,
 }: {
   routing: boolean;
   externals?: {
     external?: Array<string | RegExp | ((id: string) => boolean)>;
   };
+  workflow?: Record<string, unknown>;
 }) {
   return {
     routing,
@@ -23,7 +25,7 @@ function createNitroStub({
       rootDir: '/tmp/project',
       typescript: {},
       virtual: {},
-      workflow: {},
+      workflow: workflow ?? {},
     },
     hooks: {
       hook() {},
@@ -96,6 +98,32 @@ describe('@workflow/nitro externals forwarding', () => {
         });
         const builder = new Builder(nitro) as any;
         expect(builder.config.externalPackages).toBeUndefined();
+      });
+    });
+  }
+});
+
+describe('@workflow/nitro workflow.dirs forwarding', () => {
+  for (const [label, Builder] of [
+    ['VercelBuilder', VercelBuilder],
+    ['LocalBuilder', LocalBuilder],
+  ] as const) {
+    describe(label, () => {
+      it('keeps the Nitro-wide scan default when workflow.dirs is unset', () => {
+        const nitro = createNitroStub({ routing: true });
+        const builder = new Builder(nitro) as any;
+
+        expect(builder.config.dirs).toEqual(['.']);
+      });
+
+      it('forwards workflow.dirs to the workflow builder', () => {
+        const nitro = createNitroStub({
+          routing: true,
+          workflow: { dirs: ['workflows', 'src/jobs'] },
+        });
+        const builder = new Builder(nitro) as any;
+
+        expect(builder.config.dirs).toEqual(['workflows', 'src/jobs']);
       });
     });
   }


### PR DESCRIPTION
## Summary
- Forward `nitro.options.workflow?.dirs` into both Nitro workflow builders
- Preserve the existing `[`'.'`]` scan default when `workflow.dirs` is unset\n- Add regression coverage for `VercelBuilder` and `LocalBuilder`\n- Add a patch changeset for `@workflow/nitro`\n\nCloses #1684.\n\n## Verification\n- `pnpm --filter @workflow/rollup build`\n- `pnpm --filter @workflow/builders build`\n- `pnpm --filter @workflow/vite build`\n- `pnpm --filter @workflow/nitro exec vitest run src/index.test.ts -t 'workflow.dirs forwarding'`\n- `pnpm --filter @workflow/nitro build`\n- `pnpm exec biome check packages/nitro/src/builders.ts packages/nitro/src/index.test.ts .changeset/nitro-workflow-dirs.md`\n- `git diff --check`\n- `pnpm changeset status --since=origin/main`\n\nNote: local pnpm commands warn because this machine is on Node v26.0.0 while the repo engine allows Node 18/20/22/24. A direct full `vitest run src/index.test.ts` currently fails in two pre-existing virtual-handler assertions unrelated to this builder-config change; the new `workflow.dirs forwarding` tests pass.