### PR TITLE
docs(next): document workflow discovery and server actions

### DIFF
--- a/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
@@ -64,6 +64,7 @@ Workflow bundles wrap imported modules during transformation. When a bundled
 module contains a top-level `"use server"` directive, Next.js can treat the
 generated wrapper as a Server Action module and fail validation with errors such
 as `Server Actions must be async functions`.
+
 ### Monorepos and Workspace Imports
 
 By default, Next.js detects the correct workspace root automatically. If your Next.js app lives in a subdirectory such as `apps/web` and workspace resolution is not working correctly, you can set `outputFileTracingRoot` as a workaround:

--- a/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
@@ -47,18 +47,6 @@ scanned.
 The `start()` call must be statically reachable from one of those Next.js
 entries so the compiler can find the workflow function and transform any
 `"use workflow"` and `"use step"` directives it imports.
-
-```typescript title="app/api/signup/route.ts" lineNumbers
-import { start } from "workflow/api";
-import { handleUserSignup } from "@/workflows/user-signup";
-
-export async function POST(request: Request) {
-  const { email } = await request.json();
-
-  await start(handleUserSignup, [email]);
-
-  return Response.json({ ok: true });
-}
 ```
 
 <Callout type="info">
@@ -77,34 +65,6 @@ Workflow bundles wrap imported modules during transformation. When a bundled
 module contains a top-level `"use server"` directive, Next.js can treat the
 generated wrapper as a Server Action module and fail validation with errors such
 as `Server Actions must be async functions`.
-
-Split Server Action wrappers from reusable workflow logic:
-
-```typescript title="app/actions.ts" lineNumbers
-"use server";
-
-import { start } from "workflow/api";
-import { processSignup } from "@/workflows/signup";
-
-export async function signupAction(email: string) {
-  await start(processSignup, [email]);
-}
-```
-
-```typescript title="workflows/signup.ts" lineNumbers
-export async function processSignup(email: string) {
-  "use workflow";
-
-  await createUser(email);
-}
-
-async function createUser(email: string) {
-  "use step";
-
-  return { email };
-}
-```
-
 ### Monorepos and Workspace Imports
 
 By default, Next.js detects the correct workspace root automatically. If your Next.js app lives in a subdirectory such as `apps/web` and workspace resolution is not working correctly, you can set `outputFileTracingRoot` as a workaround:

--- a/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
@@ -47,7 +47,6 @@ scanned.
 The `start()` call must be statically reachable from one of those Next.js
 entries so the compiler can find the workflow function and transform any
 `"use workflow"` and `"use step"` directives it imports.
-```
 
 <Callout type="info">
 Use `start()` in normal server-side entrypoints, including Route Handlers and

--- a/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
@@ -38,32 +38,27 @@ compiler. Remove that package from `serverExternalPackages` in your
 
 ### Workflow Discovery in Next.js
 
-`withWorkflow()` discovers workflow entrypoints from `start()` calls imported
-from `workflow/api` in your Next.js server files. In App Router projects, that
-usually means files under `app/` or `src/app/`, such as Route Handlers, pages,
-or layouts. In Pages Router projects, files under `pages/` or `src/pages/` are
-scanned.
-
-The `start()` call must be statically reachable from one of those Next.js
-entries so the compiler can find the workflow function and transform any
-`"use workflow"` and `"use step"` directives it imports.
+`withWorkflow()` discovers workflows by scanning your Next.js entrypoints — App
+Router `route`, `page`, and `layout` files (under `app/` or `src/app/`) and any
+file under `pages/` or `src/pages/` — for `start()` calls imported from
+`workflow/api`. The workflow and step files themselves can live anywhere (for
+example `src/workflows/`); they are discovered transitively through imports, as
+long as a `start()` call in an entrypoint statically reaches them.
 
 <Callout type="info">
-Use `start()` in normal server-side entrypoints, including Route Handlers and
-Server Actions. Do not call workflow functions directly from those entrypoints;
-direct invocation bypasses the workflow runtime.
+Call `start()` from server-side entrypoints, including Route Handlers and Server
+Actions. Don't call workflow functions directly — that bypasses the workflow
+runtime.
 </Callout>
 
 ### Next.js Server Actions and `"use server"`
 
-Keep top-level `"use server"` directives on files that define Server Action
-entrypoints. Do not put a top-level `"use server"` directive in modules that are
-imported by workflow or step functions.
-
-Workflow bundles wrap imported modules during transformation. When a bundled
-module contains a top-level `"use server"` directive, Next.js can treat the
-generated wrapper as a Server Action module and fail validation with errors such
-as `Server Actions must be async functions`.
+Don't put a top-level `"use server"` directive in modules imported by workflow
+or step functions. Workflow transformation wraps imported modules in synchronous
+initializers, and Next.js rejects a `"use server"` directive inside that wrapper
+with errors like `Server Actions must be async functions`. Keep `"use server"`
+on the files that define your Server Actions, and move shared logic into
+separate modules that don't carry the directive.
 
 ### Monorepos and Workspace Imports
 

--- a/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
@@ -36,6 +36,75 @@ compiler. Remove that package from `serverExternalPackages` in your
 `next.config` to silence the warning.
 </Callout>
 
+### Workflow Discovery in Next.js
+
+`withWorkflow()` discovers workflow entrypoints from `start()` calls imported
+from `workflow/api` in your Next.js server files. In App Router projects, that
+usually means files under `app/` or `src/app/`, such as Route Handlers, pages,
+or layouts. In Pages Router projects, files under `pages/` or `src/pages/` are
+scanned.
+
+The `start()` call must be statically reachable from one of those Next.js
+entries so the compiler can find the workflow function and transform any
+`"use workflow"` and `"use step"` directives it imports.
+
+```typescript title="app/api/signup/route.ts" lineNumbers
+import { start } from "workflow/api";
+import { handleUserSignup } from "@/workflows/user-signup";
+
+export async function POST(request: Request) {
+  const { email } = await request.json();
+
+  await start(handleUserSignup, [email]);
+
+  return Response.json({ ok: true });
+}
+```
+
+<Callout type="info">
+Use `start()` in normal server-side entrypoints, including Route Handlers and
+Server Actions. Do not call workflow functions directly from those entrypoints;
+direct invocation bypasses the workflow runtime.
+</Callout>
+
+### Next.js Server Actions and `"use server"`
+
+Keep top-level `"use server"` directives on files that define Server Action
+entrypoints. Do not put a top-level `"use server"` directive in modules that are
+imported by workflow or step functions.
+
+Workflow bundles wrap imported modules during transformation. When a bundled
+module contains a top-level `"use server"` directive, Next.js can treat the
+generated wrapper as a Server Action module and fail validation with errors such
+as `Server Actions must be async functions`.
+
+Split Server Action wrappers from reusable workflow logic:
+
+```typescript title="app/actions.ts" lineNumbers
+"use server";
+
+import { start } from "workflow/api";
+import { processSignup } from "@/workflows/signup";
+
+export async function signupAction(email: string) {
+  await start(processSignup, [email]);
+}
+```
+
+```typescript title="workflows/signup.ts" lineNumbers
+export async function processSignup(email: string) {
+  "use workflow";
+
+  await createUser(email);
+}
+
+async function createUser(email: string) {
+  "use step";
+
+  return { email };
+}
+```
+
 ### Monorepos and Workspace Imports
 
 By default, Next.js detects the correct workspace root automatically. If your Next.js app lives in a subdirectory such as `apps/web` and workspace resolution is not working correctly, you can set `outputFileTracingRoot` as a workaround:


### PR DESCRIPTION
## Summary

- document how the Next.js integration discovers workflows from `start()` calls in app/pages entries
- clarify that Server Actions can call `start()`, while workflow-imported modules should not carry top-level `"use server"`
- add a small split-wrapper example for Server Actions and workflow logic

Closes #817.

## Verification

- `pnpm install`
- `pnpm --filter docs lint:links`
- `pnpm --filter docs build` *(blocked by existing prerender failure on `/en/v5/docs/api-reference/workflow-api/get-hook-by-token`: `generateDefinition.code` resolved as `any`; build reached this unrelated docs page after compiling successfully)*

## Notes

The local environment warns that Node v26.0.0 is outside the repo supported engine range (`^18 || ^20 || ^22 || ^24`).