### PR TITLE
fix(web-shared): type Tailwind trace viewer duration utility

### DIFF
--- a/.changeset/quiet-trace-viewer-duration.md
+++ b/.changeset/quiet-trace-viewer-duration.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Use a typed Tailwind duration utility in the trace viewer controls.

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -543,7 +543,7 @@ function NewTraceViewerContent({ trace }: NewTraceViewerProps): ReactNode {
         <div className="absolute right-3 bottom-3 z-[5] flex items-center border border-gray-alpha-400 rounded-lg bg-background-100 shadow-sm overflow-hidden divide-x divide-gray-alpha-400">
           <button
             type="button"
-            className="flex items-center justify-center w-8 h-8 text-gray-900 cursor-pointer transition-colors duration-[120ms] ease-in-out hover:text-gray-1000 hover:bg-gray-alpha-100"
+            className="flex items-center justify-center w-8 h-8 text-gray-900 cursor-pointer transition-colors duration-[time:120ms] ease-in-out hover:text-gray-1000 hover:bg-gray-alpha-100"
             onClick={zoomOut}
             aria-label="Zoom out"
           >
@@ -551,7 +551,7 @@ function NewTraceViewerContent({ trace }: NewTraceViewerProps): ReactNode {
           </button>
           <button
             type="button"
-            className="flex items-center justify-center w-8 h-8 text-gray-900 cursor-pointer transition-colors duration-[120ms] ease-in-out hover:text-gray-1000 hover:bg-gray-alpha-100"
+            className="flex items-center justify-center w-8 h-8 text-gray-900 cursor-pointer transition-colors duration-[time:120ms] ease-in-out hover:text-gray-1000 hover:bg-gray-alpha-100"
             onClick={resetZoom}
             aria-label="Reset zoom"
           >
@@ -559,7 +559,7 @@ function NewTraceViewerContent({ trace }: NewTraceViewerProps): ReactNode {
           </button>
           <button
             type="button"
-            className="flex items-center justify-center w-8 h-8 text-gray-900 cursor-pointer transition-colors duration-[120ms] ease-in-out hover:text-gray-1000 hover:bg-gray-alpha-100"
+            className="flex items-center justify-center w-8 h-8 text-gray-900 cursor-pointer transition-colors duration-[time:120ms] ease-in-out hover:text-gray-1000 hover:bg-gray-alpha-100"
             onClick={zoomIn}
             aria-label="Zoom in"
           >


### PR DESCRIPTION
## Summary
@workflow/web-shared ships the trace viewer controls that downstream apps may include in their Tailwind content scan. The zoom controls used `duration-[120ms]`, which Tailwind v3 can treat as an ambiguous arbitrary utility when scanning the package.

This PR changes those controls to `duration-[time:120ms]`, preserving the same transition duration while giving Tailwind an explicit type hint. It also adds a patch changeset for `@workflow/web-shared`.

## Verification
- `rg -n "duration-\[(?!time:)|ease-\[(?!easing-function:)" --pcre2 packages/web-shared/src`
- `git diff --check`
- `pnpm --filter @workflow/web-shared lint` (blocked by existing unrelated Biome diagnostics in `web-shared`)
- `pnpm --filter @workflow/web-shared typecheck` (blocked by existing unrelated `attribute-panel.tsx` type error)