### PR TITLE
Forward-port stable CI hardening

### DIFF
--- a/.changeset/stable-ci-e2e-cleanup.md
+++ b/.changeset/stable-ci-e2e-cleanup.md
@@ -1,0 +1,12 @@
+---
+"@workflow/astro": patch
+"@workflow/builders": patch
+"@workflow/core": patch
+"@workflow/nest": patch
+"@workflow/sveltekit": patch
+"@workflow/utils": patch
+"@workflow/world-vercel": patch
+"workflow": patch
+---
+
+Fix local workflow port detection, make generated health endpoints respond to HEAD requests, materialize manual webhook response bodies before returning them, wait for step return stream serialization before completing the step, bound Vercel stream and health-check operations so stuck writes or queue sends retry or time out instead of hanging, and stabilize remote Vercel e2e checks around CLI inspection, sleep timing, and hook registration/disposal.

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -5,6 +5,7 @@ import {
   BaseBuilder,
   createBaseBuilderConfig,
   NORMALIZE_REQUEST_CODE,
+  replaceGeneratedRouteExport,
   VercelBuildOutputAPIBuilder,
 } from '@workflow/builders';
 
@@ -70,15 +71,20 @@ export class LocalBuilder extends BaseBuilder {
     let workflowsRouteContent = await readFile(workflowsRouteFile, 'utf-8');
 
     // Normalize request, needed for preserving request through astro
-    workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
+    workflowsRouteContent = replaceGeneratedRouteExport(
+      workflowsRouteContent,
+      /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const handleWorkflowRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
   return workflowEntrypoint(workflowCode)(normalRequest);
-}
+};
 
-export const prerender = false;`
+export const HEAD = handleWorkflowRequest;
+export const POST = handleWorkflowRequest;
+
+export const prerender = false;`,
+      'Failed to wrap generated Astro workflow route'
     );
     await writeFile(workflowsRouteFile, workflowsRouteContent);
 

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -1120,7 +1120,10 @@ import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${workflowBundleCode.replace(/[\\`$]/g, '\\$&')}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+const handler = workflowEntrypoint(workflowCode);
+
+export const HEAD = handler;
+export const POST = handler;`;
 
         // we skip the final bundling step for Next.js so it can bundle itself
         if (!bundleFinalOutput) {
@@ -1310,7 +1313,10 @@ void __steps_registered;
 
 const workflowCode = \`${escapedVMCode}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+const handler = workflowEntrypoint(workflowCode);
+
+export const HEAD = handler;
+export const POST = handler;`;
 
     if (!bundleFinalOutput) {
       // Write directly (Next.js will bundle)
@@ -1380,7 +1386,10 @@ void __steps_registered;
 
 const workflowCode = \`${escaped}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+const handler = workflowEntrypoint(workflowCode);
+
+export const HEAD = handler;
+export const POST = handler;`;
 
       const outputDir = dirname(flowOutfile);
       await mkdir(outputDir, { recursive: true });

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -23,7 +23,10 @@ export {
   createPseudoPackagePlugin,
   PSEUDO_PACKAGES,
 } from './pseudo-package-esbuild-plugin.js';
-export { NORMALIZE_REQUEST_CODE } from './request-converter.js';
+export {
+  NORMALIZE_REQUEST_CODE,
+  replaceGeneratedRouteExport,
+} from './request-converter.js';
 export {
   analyzeSerdeCompliance,
   extractClassEntries,

--- a/packages/builders/src/request-converter.test.ts
+++ b/packages/builders/src/request-converter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { replaceGeneratedRouteExport } from './request-converter.js';
+
+describe('replaceGeneratedRouteExport', () => {
+  it('replaces route code before an inline source map', () => {
+    const result = replaceGeneratedRouteExport(
+      'export const POST = handler;\n//# sourceMappingURL=data:application/json;base64,abc',
+      /export const POST = handler;$/,
+      'export const POST = wrappedHandler;',
+      'not found'
+    );
+
+    expect(result).toBe(
+      'export const POST = wrappedHandler;\n//# sourceMappingURL=data:application/json;base64,abc'
+    );
+  });
+
+  it('ignores source map comments embedded before route exports', () => {
+    const result = replaceGeneratedRouteExport(
+      [
+        'const workflowCode = `',
+        '//# sourceMappingURL=data:application/json;base64,inner',
+        '`;',
+        'const handler = workflowEntrypoint(workflowCode);',
+        'export const HEAD = handler;',
+        'export const POST = handler;',
+      ].join('\n'),
+      /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
+      'export const POST = wrappedHandler;',
+      'not found'
+    );
+
+    expect(result).toBe(
+      [
+        'const workflowCode = `',
+        '//# sourceMappingURL=data:application/json;base64,inner',
+        '`;',
+        'export const POST = wrappedHandler;',
+      ].join('\n')
+    );
+  });
+
+  it('throws when the route export pattern is not found', () => {
+    expect(() =>
+      replaceGeneratedRouteExport(
+        'export const GET = handler;',
+        /export const POST = handler;$/,
+        'export const POST = wrappedHandler;',
+        'missing route export'
+      )
+    ).toThrow('missing route export');
+  });
+});

--- a/packages/builders/src/request-converter.ts
+++ b/packages/builders/src/request-converter.ts
@@ -11,4 +11,30 @@ async function normalizeRequest(request) {
 }
 `;
 
-export { NORMALIZE_REQUEST_CODE };
+function replaceGeneratedRouteExport(
+  content: string,
+  pattern: RegExp,
+  replacement: string,
+  errorMessage: string
+) {
+  const replacedContent = content.replace(pattern, replacement);
+  if (replacedContent !== content) {
+    return replacedContent;
+  }
+
+  const sourceMapMarker = '\n//# sourceMappingURL=';
+  const sourceMapIndex = content.lastIndexOf(sourceMapMarker);
+  if (sourceMapIndex === -1) {
+    throw new Error(errorMessage);
+  }
+
+  const routeCode = content.slice(0, sourceMapIndex);
+  const sourceMap = content.slice(sourceMapIndex);
+  const wrappedRouteCode = routeCode.replace(pattern, replacement);
+  if (wrappedRouteCode === routeCode) {
+    throw new Error(errorMessage);
+  }
+  return wrappedRouteCode + sourceMap;
+}
+
+export { NORMALIZE_REQUEST_CODE, replaceGeneratedRouteExport };

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -1,10 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
-import {
-  getWorkbenchAppPath,
-  isNextLazyDiscoveryEnabledForTest,
-} from './utils';
+import { getWorkbenchAppPath } from './utils';
 
 export interface DevTestConfig {
   generatedStepPath: string;
@@ -45,13 +42,14 @@ export function createDevTests(config?: DevTestConfig) {
       appPath,
       finalConfig.generatedWorkflowPath
     );
+    const usesNextBuilder = generatedWorkflow.endsWith(
+      path.join('app', '.well-known', 'workflow', 'v1', 'flow', 'route.js')
+    );
     const testWorkflowFile = finalConfig.testWorkflowFile ?? '3_streams.ts';
     const workflowsDir = finalConfig.workflowsDir ?? 'workflows';
     const usesDeferredBuilder = generatedStep.includes(
       path.join('.well-known', 'workflow', 'v1', 'step', 'route.js')
     );
-    const usesNextEagerBuilder =
-      !isNextLazyDiscoveryEnabledForTest() && usesDeferredBuilder;
     const workflowManifestPath = path.join(
       appPath,
       'app/.well-known/workflow/v1/manifest.json'
@@ -67,12 +65,13 @@ export function createDevTests(config?: DevTestConfig) {
     };
     const restoreFiles: Array<{ path: string; content: string }> = [];
 
-    const fetchWithTimeout = (pathname: string) => {
+    const fetchWithTimeout = (pathname: string, init?: RequestInit) => {
       if (!deploymentUrl) {
         return Promise.resolve();
       }
 
       return fetch(new URL(pathname, deploymentUrl), {
+        ...init,
         signal: AbortSignal.timeout(5_000),
       });
     };
@@ -112,6 +111,12 @@ export function createDevTests(config?: DevTestConfig) {
       await Promise.all([
         fetchWithTimeout('/').catch(() => {}),
         fetchWithTimeout('/api/chat').catch(() => {}),
+        fetchWithTimeout('/.well-known/workflow/v1/flow?__health').catch(
+          () => {}
+        ),
+        fetchWithTimeout('/.well-known/workflow/v1/step?__health').catch(
+          () => {}
+        ),
       ]);
     };
 
@@ -155,23 +160,25 @@ export function createDevTests(config?: DevTestConfig) {
     });
 
     afterEach(async () => {
-      // Restore file contents before deleting any files. If a deletion races
-      // ahead of an api-file restore, the dev server briefly sees an import
-      // pointing at a missing module and fails compilation. On Windows that
-      // failure can stick — Turbopack leaves stale imports in the generated
-      // step route bundle — and every subsequent step request returns 500.
+      // Restore file contents before clearing any added files. Dev servers can
+      // keep generated imports alive briefly after a rebuild. Next's generated
+      // step route imports deferred copies, so added workflow files need to
+      // keep their real contents until shutdown. Other builders can use empty
+      // placeholders to drop workflow directives while avoiding missing imports.
       const toRestore = restoreFiles.filter((item) => item.content !== '');
-      const toDelete = restoreFiles.filter((item) => item.content === '');
+      const toClear = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
         toRestore.map((item) => fs.writeFile(item.path, item.content))
       );
-      if (toDelete.length > 0) {
+      if (toClear.length > 0) {
         await prewarm();
+        if (!usesDeferredBuilder) {
+          await Promise.all(toClear.map((item) => fs.writeFile(item.path, '')));
+          await prewarm();
+        }
       }
-      await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
-      await prewarm();
       restoreFiles.length = 0;
-    });
+    }, 30_000);
 
     test('should rebuild on workflow change', { timeout: 30_000 }, async () => {
       const workflowFile = path.join(appPath, workflowsDir, testWorkflowFile);
@@ -292,11 +299,15 @@ export async function ${marker}() {
       'should rebuild on adding workflow file',
       { timeout: 60_000 },
       async () => {
+        const apiFile = path.join(appPath, finalConfig.apiFilePath);
         const workflowFile = path.join(
           appPath,
           workflowsDir,
           'new-workflow.ts'
         );
+        const workflowImportPath = usesNextBuilder
+          ? `@/${workflowsDir}/new-workflow`
+          : `${finalConfig.apiFileImportPath}/${workflowsDir}/new-workflow`;
 
         await fs.writeFile(
           workflowFile,
@@ -307,22 +318,27 @@ export async function ${marker}() {
 `
         );
         restoreFiles.push({ path: workflowFile, content: '' });
-        const apiFile = path.join(appPath, finalConfig.apiFilePath);
 
         const apiFileContent = await fs.readFile(apiFile, 'utf8');
         restoreFiles.push({ path: apiFile, content: apiFileContent });
 
         await fs.writeFile(
           apiFile,
-          `import '${finalConfig.apiFileImportPath}/${workflowsDir}/new-workflow';
+          `import '${workflowImportPath}';
 ${apiFileContent}`
         );
 
         await pollUntil({
-          description: 'generated workflow to include newWorkflowFile',
+          description:
+            'generated workflow manifest or route to include newWorkflowFile',
           timeoutMs: 50_000,
           check: async () => {
-            if (usesNextEagerBuilder) {
+            if (usesNextBuilder) {
+              await fetchWithTimeout('/api/chat', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: '{',
+              }).catch(() => {});
               const manifestJson = await fs.readFile(
                 workflowManifestPath,
                 'utf8'

--- a/packages/core/e2e/local-build.test.ts
+++ b/packages/core/e2e/local-build.test.ts
@@ -67,6 +67,28 @@ async function runCommandWithLiveOutput(
   });
 }
 
+function isRetryableTurbopackLoaderFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('TurbopackInternalError') &&
+    message.includes('failed to receive message') &&
+    message.includes('evaluate_webpack_loader')
+  );
+}
+
+async function runBuildWithRetry(cwd: string): Promise<CommandResult> {
+  try {
+    return await runCommandWithLiveOutput('pnpm', ['build'], cwd);
+  } catch (error) {
+    if (!isRetryableTurbopackLoaderFailure(error)) {
+      throw error;
+    }
+
+    console.warn('Retrying build after Turbopack loader transport failure.');
+    return await runCommandWithLiveOutput('pnpm', ['build'], cwd);
+  }
+}
+
 /**
  * Read a file if it exists, return null otherwise.
  */
@@ -121,11 +143,7 @@ describe.each([
       return;
     }
 
-    const result = await runCommandWithLiveOutput(
-      'pnpm',
-      ['build'],
-      getWorkbenchAppPath(project)
-    );
+    const result = await runBuildWithRetry(getWorkbenchAppPath(project));
 
     expect(result.output).not.toContain('Error:');
 

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -12,7 +12,8 @@ import { getWorld, setWorld } from '../src/runtime';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultCliTimeoutMs = Number(
-  process.env.WORKFLOW_E2E_CLI_TIMEOUT_MS ?? '20000'
+  process.env.WORKFLOW_E2E_CLI_TIMEOUT_MS ??
+    (process.env.WORKFLOW_VERCEL_ENV ? '90000' : '20000')
 );
 
 function splitArgs(raw: string): string[] {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -424,15 +424,29 @@ export function workflowEntrypoint(
                         return;
                       }
 
-                      // All steps done — fall through to the main replay loop.
-                      // Set up shared state so the loop can continue.
+                      // All steps done. Queue one workflow continuation instead
+                      // of letting every racing background step replay inline.
+                      // Without the idempotent handoff, multiple background
+                      // handlers can all observe the completed batch and race
+                      // into the next batch, creating duplicate step_started
+                      // and hook_received events.
                       runtimeLogger.debug(
-                        'All parallel steps done, replaying inline after background step',
+                        'All parallel steps done, queueing workflow continuation',
                         { workflowRunId: runId }
                       );
-                      workflowRun = bgRun;
-                      workflowStartedAt = bgStartedAt;
-                      // cachedEvents and eventsCursor already set from load above
+                      await queueMessage(
+                        world,
+                        getWorkflowQueueName(workflowName),
+                        {
+                          runId,
+                          traceCarrier: await serializeTraceCarrier(),
+                          requestedAt: new Date(),
+                        },
+                        {
+                          idempotencyKey: `workflow-continuation:${runId}:${eventsCursor ?? incomingStepId}`,
+                        }
+                      );
+                      return;
                     } else {
                       return;
                     }

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -1,5 +1,6 @@
+import type { World } from '@workflow/world';
 import { describe, expect, it, vi } from 'vitest';
-import { getWorkflowQueueName } from './helpers.js';
+import { getWorkflowQueueName, healthCheck } from './helpers.js';
 
 // Mock the logger to suppress output during tests
 vi.mock('../logger.js', () => ({
@@ -78,5 +79,66 @@ describe('getWorkflowQueueName', () => {
 
   it('should throw for empty string', () => {
     expect(() => getWorkflowQueueName('')).toThrow('Invalid workflow name');
+  });
+});
+
+describe('healthCheck', () => {
+  it('returns unhealthy when queue delivery does not settle before the timeout', async () => {
+    const world = {
+      queue: vi.fn(() => new Promise(() => {})),
+      streams: {
+        get: vi.fn(),
+      },
+    } as unknown as World;
+
+    const result = await healthCheck(world, 'workflow', { timeout: 10 });
+
+    expect(result).toEqual({
+      healthy: false,
+      error: 'Health check timed out after 10ms',
+    });
+    expect(world.queue).toHaveBeenCalledWith(
+      '__wkf_workflow_health_check',
+      {
+        __healthCheck: true,
+        correlationId: expect.any(String),
+      },
+      {
+        specVersion: 1,
+        deploymentId: undefined,
+      }
+    );
+    expect(world.streams.get).not.toHaveBeenCalled();
+  });
+
+  it('returns unhealthy when opening the response stream does not settle before the timeout', async () => {
+    const world = {
+      queue: vi.fn().mockResolvedValue({ messageId: null }),
+      streams: {
+        get: vi.fn(() => new Promise(() => {})),
+      },
+    } as unknown as World;
+
+    const result = await healthCheck(world, 'step', { timeout: 10 });
+
+    expect(result).toEqual({
+      healthy: false,
+      error: 'Health check timed out after 10ms',
+    });
+    expect(world.queue).toHaveBeenCalledWith(
+      '__wkf_step_health_check',
+      {
+        __healthCheck: true,
+        correlationId: expect.any(String),
+      },
+      {
+        specVersion: 1,
+        deploymentId: undefined,
+      }
+    );
+    expect(world.streams.get).toHaveBeenCalledWith(
+      expect.stringMatching(/^wrun_hc_/),
+      expect.stringMatching(/^__health_check__/)
+    );
   });
 });

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -145,6 +145,54 @@ const HEALTH_CHECK_POLL_INTERVAL = 100;
 // (which doesn't work across processes)
 const HEALTH_CHECK_READ_TIMEOUT = 500;
 
+class HealthCheckTimeoutError extends Error {
+  constructor(timeout: number) {
+    super(`Health check timed out after ${timeout}ms`);
+  }
+}
+
+function getHealthCheckTimeRemaining(startTime: number, timeout: number) {
+  return Math.max(0, timeout - (Date.now() - startTime));
+}
+
+async function withHealthCheckTimeout<T>(
+  promise: Promise<T>,
+  startTime: number,
+  timeout: number
+): Promise<T> {
+  const remaining = getHealthCheckTimeRemaining(startTime, timeout);
+  if (remaining <= 0) {
+    throw new HealthCheckTimeoutError(timeout);
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new HealthCheckTimeoutError(timeout)),
+          remaining
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+async function waitForNextHealthCheckPoll(startTime: number, timeout: number) {
+  const remaining = getHealthCheckTimeRemaining(startTime, timeout);
+  if (remaining <= 0) {
+    return;
+  }
+  await new Promise((resolve) =>
+    setTimeout(resolve, Math.min(HEALTH_CHECK_POLL_INTERVAL, remaining))
+  );
+}
+
 /**
  * Read chunks from a stream with a timeout per read operation.
  * Returns { chunks, timedOut } where timedOut indicates if a read timed out.
@@ -225,6 +273,33 @@ function parseHealthCheckResponse(
   return parsed;
 }
 
+async function readHealthCheckResponse(
+  world: World,
+  correlationId: string,
+  streamName: string,
+  startTime: number,
+  timeout: number
+): Promise<{ healthy: boolean } | null> {
+  const stream = await withHealthCheckTimeout(
+    world.streams.get(generateHealthCheckRunId(correlationId), streamName),
+    startTime,
+    timeout
+  );
+  const reader = stream.getReader();
+  const readTimeout = Math.min(
+    HEALTH_CHECK_READ_TIMEOUT,
+    Math.max(1, getHealthCheckTimeRemaining(startTime, timeout))
+  );
+  const { chunks, timedOut } = await readStreamWithTimeout(reader, readTimeout);
+
+  if (timedOut) {
+    await reader.cancel().catch(() => {});
+    return null;
+  }
+
+  return parseHealthCheckResponse(chunks);
+}
+
 export async function healthCheck(
   world: World,
   endpoint: HealthCheckEndpoint,
@@ -242,57 +317,42 @@ export async function healthCheck(
   const startTime = Date.now();
 
   try {
-    await world.queue(
-      queueName,
-      { __healthCheck: true, correlationId },
-      {
-        // Use JSON transport so the health check works against both
-        // old (JSON-only) and new (dual) deployments.
-        specVersion: SPEC_VERSION_LEGACY,
-        deploymentId: options?.deploymentId,
-      }
+    await withHealthCheckTimeout(
+      world.queue(
+        queueName,
+        { __healthCheck: true, correlationId },
+        {
+          // Use JSON transport so the health check works against both
+          // old (JSON-only) and new (dual) deployments.
+          specVersion: SPEC_VERSION_LEGACY,
+          deploymentId: options?.deploymentId,
+        }
+      ),
+      startTime,
+      timeout
     );
 
-    while (Date.now() - startTime < timeout) {
+    while (getHealthCheckTimeRemaining(startTime, timeout) > 0) {
       try {
-        const stream = await world.streams.get(
-          generateHealthCheckRunId(correlationId),
-          streamName
+        const response = await readHealthCheckResponse(
+          world,
+          correlationId,
+          streamName,
+          startTime,
+          timeout
         );
-        const reader = stream.getReader();
-        const { chunks, timedOut } = await readStreamWithTimeout(
-          reader,
-          HEALTH_CHECK_READ_TIMEOUT
-        );
-
-        if (timedOut) {
-          try {
-            reader.cancel();
-          } catch {
-            // Ignore cancel errors
-          }
-          await new Promise((resolve) =>
-            setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-          );
-          continue;
-        }
-
-        const response = parseHealthCheckResponse(chunks);
         if (response) {
           return {
             ...response,
             latencyMs: Date.now() - startTime,
           };
         }
-
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-        );
-      } catch {
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-        );
+      } catch (error) {
+        if (error instanceof HealthCheckTimeoutError) {
+          throw error;
+        }
       }
+      await waitForNextHealthCheckPoll(startTime, timeout);
     }
     return {
       healthy: false,

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -26,6 +26,19 @@ import { waitedUntil } from '../util.js';
 import { getWorldLazy } from './get-world-lazy.js';
 import { getWorkflowQueueName } from './helpers.js';
 
+async function materializeResponseBody(response: Response): Promise<Response> {
+  if (!response.body) {
+    return response;
+  }
+
+  const body = await response.arrayBuffer();
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 /**
  * Internal helper that returns the hook, the associated workflow run,
  * and the resolved encryption key.
@@ -297,9 +310,9 @@ export async function resumeWebhook(
     const reader = responseReadable.getReader();
     const chunk = await reader.read();
     if (chunk.value) {
-      response = chunk.value;
+      response = await materializeResponseBody(chunk.value);
     }
-    reader.cancel();
+    await reader.cancel();
   }
 
   if (!response) {

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -12,7 +12,11 @@ import {
 } from '@workflow/errors';
 import { formatStepName, pluralize } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
-import { SPEC_VERSION_CURRENT, StepInvokePayloadSchema } from '@workflow/world';
+import {
+  SPEC_VERSION_CURRENT,
+  type Step,
+  StepInvokePayloadSchema,
+} from '@workflow/world';
 import { describeError } from '../describe-error.js';
 import { runtimeLogger, stepLogger } from '../logger.js';
 import { getStepFunction } from '../private.js';
@@ -208,7 +212,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
             // - Step not in terminal state (returns 409)
             // - retryAfter timestamp reached (returns 425 with Retry-After header)
             // - Workflow still active (returns 410 if completed)
-            let step;
+            let step: Step;
             try {
               const startResult = await world.events.create(
                 workflowRunId,
@@ -616,12 +620,14 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   {},
                   async (dehydrateSpan) => {
                     const startTime = Date.now();
+                    const returnValueOpsStart = ops.length;
                     const dehydrated = await dehydrateStepReturnValue(
                       result,
                       workflowRunId,
                       encryptionKey,
                       ops
                     );
+                    await Promise.all(ops.slice(returnValueOpsStart));
                     const durationMs = Date.now() - startTime;
                     dehydrateSpan?.setAttributes({
                       ...Attribute.QueueSerializeTimeMs(durationMs),

--- a/packages/nest/src/workflow.controller.ts
+++ b/packages/nest/src/workflow.controller.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { All, Controller, Get, Post, Req, Res } from '@nestjs/common';
+import { All, Controller, Get, Head, Post, Req, Res } from '@nestjs/common';
 import { join } from 'pathe';
 
 // Module-level state for configuration
@@ -88,14 +88,24 @@ function getOutDir(): string {
 export class WorkflowController {
   @Post('flow')
   async handleFlow(@Req() req: any, @Res() res: any) {
+    await this.handleFlowEndpoint(req, res);
+  }
+
+  @Head('flow')
+  async handleFlowHead(@Req() req: any, @Res() res: any) {
+    await this.handleFlowEndpoint(req, res);
+  }
+
+  private async handleFlowEndpoint(req: any, res: any) {
     const outDir = getOutDir();
     // Import step registrations (side effects) before the combined handler
     await import(pathToFileURL(join(outDir, 'steps.mjs')).href);
-    const { POST } = await import(
+    const { HEAD, POST } = await import(
       pathToFileURL(join(outDir, 'workflows.mjs')).href
     );
     const webRequest = toWebRequest(req);
-    const webResponse = await POST(webRequest);
+    const handler = req.method === 'HEAD' && HEAD ? HEAD : POST;
+    const webResponse = await handler(webRequest);
     await sendWebResponse(res, webResponse);
   }
 

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -88,11 +88,18 @@ export async function getNextBuilderEager() {
             'Invariant: expected steps build context in watch mode'
           );
         }
+        const interimBundleCtx = combinedResult?.interimBundleCtx;
+        const bundleFinal = combinedResult?.bundleFinal;
+        if (!interimBundleCtx || !bundleFinal) {
+          throw new Error(
+            'Invariant: expected workflows bundle context in watch mode'
+          );
+        }
 
         // Use stepsCtx for the watch rebuild (workflow interim ctx from combined)
         let workflowsCtx = {
-          interimBundleCtx: combinedResult?.interimBundleCtx!,
-          bundleFinal: combinedResult?.bundleFinal!,
+          interimBundleCtx,
+          bundleFinal,
         };
 
         const normalizePath = (pathname: string) =>
@@ -184,7 +191,13 @@ export async function getNextBuilderEager() {
           const newInputFiles = await this.getInputFiles();
           options.inputFiles = newInputFiles;
 
-          await stepsCtx!.dispose();
+          const existingStepsCtx = stepsCtx;
+          if (!existingStepsCtx) {
+            throw new Error(
+              'Invariant: expected steps build context before rebuild'
+            );
+          }
+          await existingStepsCtx.dispose();
           await workflowsCtx.interimBundleCtx.dispose();
 
           const newCombined = await this.buildCombinedFunction(options);
@@ -206,60 +219,6 @@ export async function getNextBuilderEager() {
           };
 
           await writeManifest(newCombined.manifest);
-        };
-
-        const logBuildMessages = (
-          result: {
-            errors?: import('esbuild').Message[];
-            warnings?: import('esbuild').Message[];
-          },
-          label: string
-        ) => {
-          const logByType = (
-            messages: import('esbuild').Message[] | undefined,
-            method: 'error' | 'warn'
-          ) => {
-            if (!messages || messages.length === 0) {
-              return;
-            }
-            const descriptor = method === 'error' ? 'errors' : 'warnings';
-            console[method](`${descriptor} while rebuilding ${label}`);
-            for (const message of messages) {
-              console[method](message);
-            }
-          };
-
-          logByType(result.errors, 'error');
-          logByType(result.warnings, 'warn');
-        };
-
-        const rebuildExistingFiles = async () => {
-          const rebuiltStepStart = Date.now();
-          const stepsResult = await stepsCtx!.rebuild();
-          logBuildMessages(stepsResult, 'steps bundle');
-          console.log(
-            'Rebuilt steps bundle',
-            `${Date.now() - rebuiltStepStart}ms`
-          );
-
-          const rebuiltWorkflowStart = Date.now();
-          const workflowResult = await workflowsCtx.interimBundleCtx.rebuild();
-          logBuildMessages(workflowResult, 'workflows bundle');
-
-          if (
-            !workflowResult.outputFiles ||
-            workflowResult.outputFiles.length === 0
-          ) {
-            console.error(
-              'No output generated while rebuilding workflows bundle'
-            );
-            return;
-          }
-          await workflowsCtx.bundleFinal(workflowResult.outputFiles[0].text);
-          console.log(
-            'Rebuilt workflow bundle',
-            `${Date.now() - rebuiltWorkflowStart}ms`
-          );
         };
 
         const isWatchableFile = (path: string) =>
@@ -359,13 +318,13 @@ export async function getNextBuilderEager() {
           }
 
           enqueue(async () => {
-            if (addedFiles.length > 0 || removedFiles.length > 0) {
+            if (
+              addedFiles.length > 0 ||
+              modifiedFiles.length > 0 ||
+              removedFiles.length > 0
+            ) {
               await fullRebuild();
               return;
-            }
-
-            if (modifiedFiles.length > 0) {
-              await rebuildExistingFiles();
             }
           });
         });

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -12,6 +12,7 @@ import { join, resolve } from 'node:path';
 import {
   BaseBuilder,
   NORMALIZE_REQUEST_CODE,
+  replaceGeneratedRouteExport,
   type SvelteKitConfig,
 } from '@workflow/builders';
 
@@ -81,13 +82,18 @@ export class SvelteKitBuilder extends BaseBuilder {
     let workflowsRouteContent = await readFile(workflowsRouteFile, 'utf-8');
 
     // Replace the default export with SvelteKit-compatible handler
-    workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
+    workflowsRouteContent = replaceGeneratedRouteExport(
+      workflowsRouteContent,
+      /const handler = workflowEntrypoint\(workflowCode\);\s*export const HEAD = handler;\s*export const POST = handler;?\s*$/m,
       `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const handleWorkflowRequest = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
   return workflowEntrypoint(workflowCode)(normalRequest);
-}`
+};
+
+export const HEAD = handleWorkflowRequest;
+export const POST = handleWorkflowRequest;`,
+      'Failed to wrap generated SvelteKit workflow route'
     );
     await writeFile(workflowsRouteFile, workflowsRouteContent);
 

--- a/packages/utils/src/get-port.test.ts
+++ b/packages/utils/src/get-port.test.ts
@@ -243,16 +243,19 @@ describe('getWorkflowPort', () => {
 
   it('should identify workflow server among multiple ports', async () => {
     // Non-workflow server (returns 404 for all requests)
-    const nonWorkflowServer = http.createServer((req, res) => {
+    const nonWorkflowServer = http.createServer((_req, res) => {
       res.writeHead(404);
       res.end();
     });
 
     // Workflow server (returns 200 for health check endpoint)
     const workflowServer = http.createServer((req, res) => {
-      if (req.url?.includes('__health')) {
+      if (req.url?.includes('__health') && req.method === 'HEAD') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
+      } else if (req.url?.includes('__health')) {
+        res.writeHead(405, { Allow: 'HEAD' });
+        res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Missing required headers' }));
@@ -275,11 +278,11 @@ describe('getWorkflowPort', () => {
 
   it('should fall back to first port when probing fails', async () => {
     // Two non-workflow servers (both return 404)
-    const server1 = http.createServer((req, res) => {
+    const server1 = http.createServer((_req, res) => {
       res.writeHead(404);
       res.end();
     });
-    const server2 = http.createServer((req, res) => {
+    const server2 = http.createServer((_req, res) => {
       res.writeHead(404);
       res.end();
     });
@@ -302,9 +305,12 @@ describe('getWorkflowPort', () => {
     });
     // Fast workflow server (returns 200 for health check)
     const fastServer = http.createServer((req, res) => {
-      if (req.url?.includes('__health')) {
+      if (req.url?.includes('__health') && req.method === 'HEAD') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
+      } else if (req.url?.includes('__health')) {
+        res.writeHead(405, { Allow: 'HEAD' });
+        res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400);
         res.end();
@@ -318,21 +324,25 @@ describe('getWorkflowPort', () => {
     await new Promise<void>((resolve) => slowServer.listen(0, resolve));
     await new Promise<void>((resolve) => fastServer.listen(0, resolve));
 
+    const fastAddr = fastServer.address() as AddressInfo;
     const start = Date.now();
-    const port = await getWorkflowPort({ timeout: 100 });
+    const port = await getWorkflowPort({
+      timeout: 100,
+    });
     const elapsed = Date.now() - start;
 
-    const fastAddr = fastServer.address() as AddressInfo;
     expect(port).toBe(fastAddr.port);
-    // Should complete reasonably quickly (Windows CI can be slow)
     expect(elapsed).toBeLessThan(2000);
   });
 
   it('should handle concurrent getWorkflowPort calls', async () => {
     const server = http.createServer((req, res) => {
-      if (req.url?.includes('__health')) {
+      if (req.url?.includes('__health') && req.method === 'HEAD') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('Workflow SDK endpoint is healthy');
+      } else if (req.url?.includes('__health')) {
+        res.writeHead(405, { Allow: 'HEAD' });
+        res.end();
       } else if (req.url?.startsWith('/.well-known/workflow/v1/')) {
         res.writeHead(400);
         res.end();

--- a/packages/utils/src/get-port.ts
+++ b/packages/utils/src/get-port.ts
@@ -21,6 +21,47 @@ function parsePort(value: string, radix = 10): number | undefined {
 const join = (arr: string[], sep: string) => arr.join(sep);
 const PROC_ROOT = join(['', 'proc'], '/');
 
+interface LibuvTcpHandle {
+  type?: string;
+  is_active?: boolean;
+  localEndpoint?: {
+    port?: number;
+  };
+  remoteEndpoint?: unknown;
+}
+
+function getReportedPorts(): number[] {
+  const report = process.report?.getReport?.() as
+    | { libuv?: LibuvTcpHandle[] }
+    | undefined;
+  const handles = report?.libuv;
+
+  if (!handles) {
+    return [];
+  }
+
+  const ports: number[] = [];
+  const seen = new Set<number>();
+
+  for (const handle of handles) {
+    if (
+      handle.type !== 'tcp' ||
+      handle.is_active !== true ||
+      handle.remoteEndpoint !== null
+    ) {
+      continue;
+    }
+
+    const port = parsePort(String(handle.localEndpoint?.port));
+    if (port !== undefined && !seen.has(port)) {
+      ports.push(port);
+      seen.add(port);
+    }
+  }
+
+  return ports;
+}
+
 /**
  * Gets ALL listening ports for the current process on Linux by reading /proc filesystem.
  * Returns ports in order of file descriptor (deterministic ordering).
@@ -205,6 +246,11 @@ export async function getAllPorts(): Promise<number[]> {
   const { pid, platform } = process;
 
   try {
+    const reportedPorts = getReportedPorts();
+    if (reportedPorts.length > 0) {
+      return reportedPorts;
+    }
+
     switch (platform) {
       case 'linux':
         return await getLinuxPorts(pid);

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -267,6 +267,32 @@ describe('writeMulti pagination', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('adds an abort signal to stream writes', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => new Response('ok'));
+
+    const streamer = await getStreamer();
+
+    await streamer.streams.write('run-1', 's', new Uint8Array([1]));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('adds an abort signal to stream closes', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => new Response('ok'));
+
+    const streamer = await getStreamer();
+
+    await streamer.streams.close('run-1', 's');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('paginates into multiple requests when chunks > MAX_CHUNKS_PER_REQUEST', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -17,6 +17,7 @@ import {
  * MAX_CHUNKS_PER_BATCH. Larger batches are split into multiple requests.
  */
 export const MAX_CHUNKS_PER_REQUEST = 1000;
+const DEFAULT_STREAM_MUTATION_TIMEOUT_MS = 30_000;
 
 // Streaming calls use plain fetch() without the undici dispatcher.
 // The dispatcher's retry logic doesn't apply well to streaming operations
@@ -27,6 +28,41 @@ function getStreamUrl(name: string, runId: string, httpConfig: HttpConfig) {
   return new URL(
     `${httpConfig.baseUrl}/v2/runs/${encodeURIComponent(runId)}/stream/${encodeURIComponent(name)}`
   );
+}
+
+function getStreamMutationTimeoutMs() {
+  const parsed = Number.parseInt(
+    process.env.WORKFLOW_VERCEL_STREAM_TIMEOUT_MS ?? '',
+    10
+  );
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return DEFAULT_STREAM_MUTATION_TIMEOUT_MS;
+}
+
+async function fetchStreamMutation(
+  url: URL,
+  init: RequestInit,
+  operation: 'write' | 'close'
+) {
+  const timeoutMs = getStreamMutationTimeoutMs();
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.name === 'AbortError' || err.name === 'TimeoutError')
+    ) {
+      throw new Error(`Stream ${operation} timed out after ${timeoutMs}ms`, {
+        cause: err,
+      });
+    }
+    throw err;
+  }
 }
 
 /**
@@ -101,13 +137,14 @@ export function createStreamer(config?: APIConfig): Streamer {
         const resolvedRunId = await runId;
 
         const httpConfig = await getHttpConfig(config);
-        const response = await fetch(
+        const response = await fetchStreamMutation(
           getStreamUrl(name, resolvedRunId, httpConfig),
           {
             method: 'PUT',
             body: chunk,
             headers: httpConfig.headers,
-          }
+          },
+          'write'
         );
         const text = await response.text();
         if (!response.ok) {
@@ -143,13 +180,14 @@ export function createStreamer(config?: APIConfig): Streamer {
         for (let i = 0; i < chunks.length; i += MAX_CHUNKS_PER_REQUEST) {
           const batch = chunks.slice(i, i + MAX_CHUNKS_PER_REQUEST);
           const body = encodeMultiChunks(batch);
-          const response = await fetch(
+          const response = await fetchStreamMutation(
             getStreamUrl(name, resolvedRunId, httpConfig),
             {
               method: 'PUT',
               body,
               headers: httpConfig.headers,
-            }
+            },
+            'write'
           );
           const text = await response.text();
           if (!response.ok) {
@@ -166,12 +204,13 @@ export function createStreamer(config?: APIConfig): Streamer {
 
         const httpConfig = await getHttpConfig(config);
         httpConfig.headers.set('X-Stream-Done', 'true');
-        const response = await fetch(
+        const response = await fetchStreamMutation(
           getStreamUrl(name, resolvedRunId, httpConfig),
           {
             method: 'PUT',
             headers: httpConfig.headers,
-          }
+          },
+          'close'
         );
         const text = await response.text();
         if (!response.ok) {


### PR DESCRIPTION
## Summary

Forward-ports the stable CI hardening from #1986 onto `main` now that it has landed in `stable`.

This carries over the production-code stability fixes and the applicable test harness updates:

- bound queue-based health checks so queue delivery, stream opening, stream reads, and poll sleeps all share the requested timeout budget
- add abort signals to Vercel stream write/close mutations so stuck stream writes fail and retry instead of pinning steps indefinitely
- wait for step return stream serialization before recording `step_completed`
- materialize manual webhook response bodies before returning from hook resume handling
- speed up local workflow port detection by checking Node/libuv listening handles before slower OS-specific fallbacks
- make generated workflow health endpoints support `HEAD`, including Astro, SvelteKit, Nest, and combined generated routes on `main`
- share route-export replacement logic that handles embedded source map comments and throws when wrapping fails

## Forward-port note

This PR should **not** be backported. It is itself a forward-port of changes that already landed on `stable` in #1986.

## Additional changes made on `main`

After the initial forward-port, CI exposed a few failures that were not fixed by the original #1986 changes alone. These are intentionally called out as extra stabilization work on top of the stable forward-port:

- V2 background step continuations now enqueue an idempotent workflow continuation instead of letting every completed background step handler continue replay inline. In CI, the inline replay path let racing handlers enter the next batch more than once, producing duplicate `step_started` / `hook_received` events and `Unconsumed event in event log` failures.
- The eager Next builder now does a full workflow rebuild for modified files in watch mode. The previous modified-file path only rebuilt existing esbuild contexts, which updated generated route code but did not refresh the workflow manifest when an API route import graph changed. The `nextjs-webpack` dev CI test for adding a workflow file was timing out on that stale manifest.
- The dev E2E harness was adjusted to match the Next workbench layout: added workflow files are imported through the app-root `@/workflows/...` alias, the Next POST route is hit so the module actually compiles, and cleanup gets a longer timeout for slower Windows dev-server prewarm/teardown.

These additions are still part of making `main` stable after the forward-port, but they are not meant to change the no-backport decision: this PR is itself a forward-port, and the extra changes are for failures observed on this `main` PR.

## Validation

- `fnm exec --using v22.18.0 pnpm --filter @workflow/core... --filter @workflow/world-vercel... --filter @workflow/builders... build`
- `fnm exec --using v22.18.0 pnpm exec vitest run packages/core/src/runtime/helpers.test.ts packages/world-vercel/src/streamer.test.ts packages/builders/src/request-converter.test.ts`
- `fnm exec --using v22.18.0 pnpm exec biome check .changeset/stable-ci-e2e-cleanup.md packages/astro/src/builder.ts packages/builders/src/base-builder.ts packages/builders/src/index.ts packages/builders/src/request-converter.test.ts packages/builders/src/request-converter.ts packages/core/e2e/dev.test.ts packages/core/e2e/local-build.test.ts packages/core/e2e/utils.ts packages/core/src/runtime/helpers.test.ts packages/core/src/runtime/helpers.ts packages/core/src/runtime/resume-hook.ts packages/core/src/runtime/step-handler.ts packages/nest/src/workflow.controller.ts packages/sveltekit/src/builder.ts packages/utils/src/get-port.test.ts packages/utils/src/get-port.ts packages/world-vercel/src/streamer.test.ts packages/world-vercel/src/streamer.ts` (warnings only: existing complexity/style warnings)
- `git diff --check HEAD~1..HEAD`
