### PR TITLE
[world-postgres] Bootstrap graphile-worker schema in setup CLI

### DIFF
--- a/.changeset/setup-graphile-worker-schema.md
+++ b/.changeset/setup-graphile-worker-schema.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-postgres": patch
+---
+
+`workflow-postgres-setup` now also bootstraps the `graphile_worker` schema, so concurrent `world.start()` callers (e.g. dev server + test runner on a fresh DB) don't race on the not-race-safe `CREATE SCHEMA IF NOT EXISTS` and fail with `duplicate key value violates unique constraint "pg_namespace_nspname_index"`.

--- a/.changeset/setup-graphile-worker-schema.md
+++ b/.changeset/setup-graphile-worker-schema.md
@@ -2,4 +2,4 @@
 "@workflow/world-postgres": patch
 ---
 
-`workflow-postgres-setup` now also bootstraps the `graphile_worker` schema, so concurrent `world.start()` callers (e.g. dev server + test runner on a fresh DB) don't race on the not-race-safe `CREATE SCHEMA IF NOT EXISTS` and fail with `duplicate key value violates unique constraint "pg_namespace_nspname_index"`.
+`workflow-postgres-setup` now also bootstraps the `graphile_worker` schema, fixing potential race on setup when starting the app and a test runner at the same time

--- a/packages/world-postgres/src/cli.ts
+++ b/packages/world-postgres/src/cli.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { config } from 'dotenv';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { makeWorkerUtils } from 'graphile-worker';
 import { Pool } from 'pg';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -43,6 +44,23 @@ async function setupDatabase() {
       migrationsTable: 'workflow_migrations',
       migrationsSchema: 'workflow_drizzle',
     });
+
+    // Also bootstrap the graphile-worker schema. Without this, the first
+    // process to call `world.start()` against a fresh DB is responsible
+    // for running graphile-worker's `installSchema`, and concurrent
+    // callers (e.g. the dev server + the test runner) can race on the
+    // not-race-safe `CREATE SCHEMA IF NOT EXISTS` and fail with
+    // `duplicate key value violates unique constraint
+    // "pg_namespace_nspname_index"`. Running it here, single-process,
+    // before any consumer starts means later `installSchema` calls find
+    // the schema present and skip the racing DDL path entirely.
+    console.log('📂 Bootstrapping graphile-worker schema...');
+    const workerUtils = await makeWorkerUtils({ pgPool: pool });
+    try {
+      await workerUtils.migrate();
+    } finally {
+      await workerUtils.release();
+    }
 
     console.log('✅ Database schema created successfully!');
 


### PR DESCRIPTION
## Summary

`workflow-postgres-setup` now installs the `graphile_worker` schema in addition to the drizzle migrations. Once both schemas exist, later `world.start()` calls find them present and skip the racing DDL path entirely.

## Why

`E2E Local Postgres Tests` was flaking on a fresh DB because two processes — the vitest test runner (which initializes a postgres world because `WORKFLOW_TARGET_WORLD=@workflow/world-postgres` is set) and the workbench dev server — both lazily call `world.start()` and race in graphile-worker's `installSchema`. PostgreSQL's `CREATE SCHEMA IF NOT EXISTS` is not race-safe across concurrent sessions: both can pass the MVCC-snapshotted existence check and one then fails with `duplicate key value violates unique constraint "pg_namespace_nspname_index"`.

Since CI already runs `./packages/world-postgres/bin/setup.js` once before either process starts (the `Setup PostgreSQL Database` step in `tests.yml`), the cleanest fix is to do the graphile-worker bootstrap there — single-process, serialized, and consumer-agnostic. No lock, no migration changes, no production code path touched.

Alternative to #1966.

## Verification

- `pnpm --filter @workflow/world-postgres typecheck` ✓
- `pnpm --filter @workflow/world-postgres build` ✓
- `pnpm --filter @workflow/world-postgres test` ✓ (104 pass; one pre-existing failure in `storage.test.ts > should enforce token uniqueness across different runs` is also failing on `main`, unrelated to this change)
- **Race repro against a fresh `postgres:18-alpine`**: 8 parallel `makeWorkerUtils({pgPool}).migrate()` calls. Without the pre-bootstrap, 7/8 fail with `pg_namespace_nspname_index`. After running the patched `workflow-postgres-setup` first, 0/8 fail.