### PR TITLE
[codex] Guard event consumers during replay

### DIFF
--- a/.changeset/guard-step-consumer-events.md
+++ b/.changeset/guard-step-consumer-events.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+---
+
+Validate step, wait, and hook lifecycle events against replay ownership metadata.

--- a/packages/core/src/abort-consistency.test.ts
+++ b/packages/core/src/abort-consistency.test.ts
@@ -340,7 +340,9 @@ describe('AbortController consistency', () => {
               runId: 'wrun_test',
               eventType: 'hook_created',
               correlationId: hookItem.correlationId,
-              eventData: {},
+              eventData: {
+                token: 'test-token',
+              },
               createdAt: new Date(),
             },
             {
@@ -348,7 +350,10 @@ describe('AbortController consistency', () => {
               runId: 'wrun_test',
               eventType: 'hook_received',
               correlationId: hookItem.correlationId,
-              eventData: { payload: { reason: 'hook worked' } },
+              eventData: {
+                token: 'test-token',
+                payload: { reason: 'hook worked' },
+              },
               createdAt: new Date(),
             },
           ];

--- a/packages/core/src/abort-controller.test.ts
+++ b/packages/core/src/abort-controller.test.ts
@@ -6,12 +6,15 @@
  * (for real-time step propagation).
  */
 
+import { WorkflowRuntimeError } from '@workflow/errors';
+import { withResolvers } from '@workflow/utils';
 import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
 import { monotonicFactory } from 'ulid';
 import { describe, expect, it, vi } from 'vitest';
 import { EventsConsumer } from './events-consumer.js';
 import type { WorkflowOrchestratorContext } from './private.js';
+import { dehydrateStepReturnValue } from './serialization.js';
 import { createContext } from './vm/index.js';
 import {
   createCreateAbortController,
@@ -113,6 +116,51 @@ describe('AbortController in workflow VM', () => {
       // The queue item was deleted by the event consumer for hook_received,
       // so there should be no items left requesting abort
       expect(controller.signal.aborted).toBe(true);
+    });
+
+    it('reports a WorkflowRuntimeError when abort hook_received token mismatches the controller', async () => {
+      ctx = setupWorkflowContext([]);
+      const ProbeAbortController = createCreateAbortController(ctx);
+      new ProbeAbortController();
+      const probeHookItem = [...ctx.invocationsQueue.values()].find(
+        (item) => item.type === 'hook'
+      );
+      expect(probeHookItem).toBeDefined();
+      if (!probeHookItem || probeHookItem.type !== 'hook') {
+        throw new Error('Expected abort hook item');
+      }
+
+      const ops: Promise<any>[] = [];
+      ctx = setupWorkflowContext([
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: probeHookItem.correlationId,
+          eventData: {
+            token: 'wrong-token',
+            payload: await dehydrateStepReturnValue(
+              { reason: 'aborted' },
+              'wrun_test',
+              undefined,
+              ops
+            ),
+          },
+          createdAt: new Date(),
+        },
+      ]);
+
+      const errorReceived = withResolvers<Error>();
+      ctx.onWorkflowError = errorReceived.resolve;
+
+      const AbortController = createCreateAbortController(ctx);
+      new AbortController();
+
+      const workflowError = await errorReceived.promise;
+      expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+      expect(workflowError?.message).toContain('hook_received');
+      expect(workflowError?.message).toContain('wrong-token');
+      expect(workflowError?.message).toContain(probeHookItem.token);
     });
 
     it('signal.aborted is false initially', () => {

--- a/packages/core/src/async-deserialization-ordering.test.ts
+++ b/packages/core/src/async-deserialization-ordering.test.ts
@@ -90,7 +90,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: { result: resultA },
+        eventData: {
+          stepName: 'stepA',
+          result: resultA,
+        },
         createdAt: new Date(),
       },
       {
@@ -98,7 +101,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCW',
-        eventData: { result: resultB },
+        eventData: {
+          stepName: 'stepB',
+          result: resultB,
+        },
         createdAt: new Date(),
       },
     ]);
@@ -160,7 +166,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: { result: results[0] },
+        eventData: {
+          stepName: 'step1',
+          result: results[0],
+        },
         createdAt: new Date(),
       },
       {
@@ -168,7 +177,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCW',
-        eventData: { result: results[1] },
+        eventData: {
+          stepName: 'step2',
+          result: results[1],
+        },
         createdAt: new Date(),
       },
       {
@@ -176,7 +188,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCX',
-        eventData: { result: results[2] },
+        eventData: {
+          stepName: 'step3',
+          result: results[2],
+        },
         createdAt: new Date(),
       },
     ]);
@@ -246,7 +261,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: { payload: payloadA },
+        eventData: {
+          token: 'test-token',
+          payload: payloadA,
+        },
         createdAt: new Date(),
       },
       {
@@ -254,7 +272,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: { payload: payloadB },
+        eventData: {
+          token: 'test-token',
+          payload: payloadB,
+        },
         createdAt: new Date(),
       },
       {
@@ -262,6 +283,9 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -282,7 +306,7 @@ describe('async deserialization ordering', () => {
     );
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Await two payloads from the hook
     const resolveOrder: string[] = [];
@@ -329,7 +353,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: { result: resultA },
+        eventData: {
+          stepName: 'stepA',
+          result: resultA,
+        },
         createdAt: new Date(),
       },
       {
@@ -337,7 +364,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_failed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCW',
-        eventData: { error: errorB },
+        eventData: {
+          stepName: 'stepB',
+          error: errorB,
+        },
         createdAt: new Date(),
       },
       {
@@ -345,7 +375,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCX',
-        eventData: { result: resultC },
+        eventData: {
+          stepName: 'stepC',
+          result: resultC,
+        },
         createdAt: new Date(),
       },
     ]);
@@ -481,7 +514,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: { result: resultA },
+        eventData: {
+          stepName: 'stepA',
+          result: resultA,
+        },
         createdAt: new Date(),
       },
       {
@@ -497,6 +533,9 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCW',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:05.000Z'),
+        },
         createdAt: new Date(),
       },
       {
@@ -504,7 +543,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCX',
-        eventData: { result: resultC },
+        eventData: {
+          stepName: 'stepC',
+          result: resultC,
+        },
         createdAt: new Date(),
       },
     ]);
@@ -567,7 +609,9 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_started',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          stepName: 'stepA',
+        },
         createdAt: new Date(),
       },
       {
@@ -575,7 +619,9 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_started',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCW',
-        eventData: {},
+        eventData: {
+          stepName: 'stepB',
+        },
         createdAt: new Date(),
       },
       {
@@ -583,7 +629,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: { result: resultA },
+        eventData: {
+          stepName: 'stepA',
+          result: resultA,
+        },
         createdAt: new Date(),
       },
       {
@@ -591,7 +640,10 @@ describe('async deserialization ordering', () => {
         runId: 'wrun_test',
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCW',
-        eventData: { result: resultB },
+        eventData: {
+          stepName: 'stepB',
+          result: resultB,
+        },
         createdAt: new Date(),
       },
     ]);

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -164,7 +164,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { isWebhook: false },
           createdAt: new Date(),
         },
         {
@@ -247,7 +247,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { isWebhook: false },
           createdAt: new Date(),
         },
         {
@@ -308,7 +308,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { isWebhook: false },
           createdAt: new Date(),
         },
         {
@@ -655,7 +655,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { isWebhook: false },
           createdAt: new Date(),
         },
         {
@@ -777,7 +777,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { isWebhook: false },
           createdAt: new Date(),
         },
         {

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -164,7 +164,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { isWebhook: false },
+          eventData: {
+            token: 'test-token',
+            isWebhook: false,
+          },
           createdAt: new Date(),
         },
         {
@@ -180,7 +183,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload1 },
+          eventData: {
+            token: 'test-token',
+            payload: payload1,
+          },
           createdAt: new Date(),
         },
         {
@@ -188,7 +194,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload2 },
+          eventData: {
+            token: 'test-token',
+            payload: payload2,
+          },
           createdAt: new Date(),
         },
         {
@@ -196,7 +205,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload3 },
+          eventData: {
+            token: 'test-token',
+            payload: payload3,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -206,7 +218,7 @@ function defineTests(mode: 'sync' | 'async') {
       const useStep = createUseStep(ctx);
 
       const { error } = await runWithDiscontinuation(ctx, async () => {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         void sleep('1d');
 
         const myStep = useStep('myStep');
@@ -247,7 +259,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { isWebhook: false },
+          eventData: {
+            token: 'test-token',
+            isWebhook: false,
+          },
           createdAt: new Date(),
         },
         {
@@ -263,7 +278,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload1 },
+          eventData: {
+            token: 'test-token',
+            payload: payload1,
+          },
           createdAt: new Date(),
         },
         {
@@ -271,7 +289,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload2 },
+          eventData: {
+            token: 'test-token',
+            payload: payload2,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -280,7 +301,7 @@ function defineTests(mode: 'sync' | 'async') {
       const sleep = createSleep(ctx);
 
       const { result, error } = await runWithDiscontinuation(ctx, async () => {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         void sleep('1d');
 
         const val1 = await hook;
@@ -308,7 +329,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { isWebhook: false },
+          eventData: {
+            token: 'test-token',
+            isWebhook: false,
+          },
           createdAt: new Date(),
         },
         {
@@ -324,7 +348,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[1]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'incompleteStep',
+          },
           createdAt: new Date(),
         },
         {
@@ -332,7 +358,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload1 },
+          eventData: {
+            token: 'test-token',
+            payload: payload1,
+          },
           createdAt: new Date(),
         },
         {
@@ -340,7 +369,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload2 },
+          eventData: {
+            token: 'test-token',
+            payload: payload2,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -350,7 +382,7 @@ function defineTests(mode: 'sync' | 'async') {
 
       const { result, error } = await runWithDiscontinuation(ctx, async () => {
         const incompleteStep = useStep('incompleteStep');
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
 
         void incompleteStep().then(() => {});
 
@@ -396,7 +428,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[1]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'stepA',
+          },
           createdAt: new Date(),
         },
         {
@@ -404,7 +438,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_completed',
           correlationId: `step_${CORR_IDS[1]}`,
-          eventData: { result: resultA },
+          eventData: {
+            stepName: 'stepA',
+            result: resultA,
+          },
           createdAt: new Date(),
         },
         {
@@ -420,7 +457,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[2]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'stepB',
+          },
           createdAt: new Date(),
         },
         {
@@ -428,7 +467,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_completed',
           correlationId: `step_${CORR_IDS[2]}`,
-          eventData: { result: resultB },
+          eventData: {
+            stepName: 'stepB',
+            result: resultB,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -480,7 +522,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[1]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'stepA',
+          },
           createdAt: new Date(),
         },
         {
@@ -488,7 +532,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_completed',
           correlationId: `step_${CORR_IDS[1]}`,
-          eventData: { result: resultA },
+          eventData: {
+            stepName: 'stepA',
+            result: resultA,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -541,7 +588,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[0]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'incompleteStep',
+          },
           createdAt: new Date(),
         },
         {
@@ -557,7 +606,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[1]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'stepB',
+          },
           createdAt: new Date(),
         },
         {
@@ -565,7 +616,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_completed',
           correlationId: `step_${CORR_IDS[1]}`,
-          eventData: { result: resultB },
+          eventData: {
+            stepName: 'stepB',
+            result: resultB,
+          },
           createdAt: new Date(),
         },
         {
@@ -581,7 +635,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[2]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'stepC',
+          },
           createdAt: new Date(),
         },
         {
@@ -589,7 +645,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_completed',
           correlationId: `step_${CORR_IDS[2]}`,
-          eventData: { result: resultC },
+          eventData: {
+            stepName: 'stepC',
+            result: resultC,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -655,7 +714,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { isWebhook: false },
+          eventData: {
+            token: 'test-token',
+            isWebhook: false,
+          },
           createdAt: new Date(),
         },
         {
@@ -672,7 +734,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload1 },
+          eventData: {
+            token: 'test-token',
+            payload: payload1,
+          },
           createdAt: new Date(),
         },
         {
@@ -688,7 +753,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[2]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'processPayload',
+          },
           createdAt: new Date(),
         },
         {
@@ -696,7 +763,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_completed',
           correlationId: `step_${CORR_IDS[2]}`,
-          eventData: { result: stepResult1 },
+          eventData: {
+            stepName: 'processPayload',
+            result: stepResult1,
+          },
           createdAt: new Date(),
         },
         // Second hook payload → step lifecycle
@@ -705,7 +775,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload2 },
+          eventData: {
+            token: 'test-token',
+            payload: payload2,
+          },
           createdAt: new Date(),
         },
         {
@@ -721,7 +794,9 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_started',
           correlationId: `step_${CORR_IDS[3]}`,
-          eventData: {},
+          eventData: {
+            stepName: 'processPayload',
+          },
           createdAt: new Date(),
         },
         {
@@ -729,7 +804,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'step_completed',
           correlationId: `step_${CORR_IDS[3]}`,
-          eventData: { result: stepResult2 },
+          eventData: {
+            stepName: 'processPayload',
+            result: stepResult2,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -739,7 +817,7 @@ function defineTests(mode: 'sync' | 'async') {
       const useStep = createUseStep(ctx);
 
       const { result, error } = await runWithDiscontinuation(ctx, async () => {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         void sleep('1d');
 
         const processPayload = useStep<[any], any>('processPayload');
@@ -777,7 +855,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { isWebhook: false },
+          eventData: {
+            token: 'test-token',
+            isWebhook: false,
+          },
           createdAt: new Date(),
         },
         {
@@ -785,7 +866,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload1 },
+          eventData: {
+            token: 'test-token',
+            payload: payload1,
+          },
           createdAt: new Date(),
         },
         {
@@ -793,7 +877,10 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { payload: payload2 },
+          eventData: {
+            token: 'test-token',
+            payload: payload2,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -802,7 +889,7 @@ function defineTests(mode: 'sync' | 'async') {
       const useStep = createUseStep(ctx);
 
       const { error } = await runWithDiscontinuation(ctx, async () => {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         const myStep = useStep('myStep');
         const received: any[] = [];
 

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,0 +1,218 @@
+import { RUN_ERROR_CODES } from '@workflow/errors';
+import {
+  type Event,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+} from '@workflow/world';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setWorld } from './runtime/world.js';
+import { workflowEntrypoint } from './runtime.js';
+import {
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from './serialization.js';
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn(),
+}));
+
+async function runWorkflowHandlerWithEvents(
+  workflowCode: string,
+  workflowRun: WorkflowRun,
+  events: Event[]
+) {
+  const createdEvents: unknown[] = [];
+  const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+    createdEvents.push(data);
+
+    if (data.eventType === 'run_started') {
+      return {
+        run: workflowRun,
+        events,
+      };
+    }
+
+    return {
+      event: {
+        eventId: `event-${createdEvents.length}`,
+        runId: workflowRun.runId,
+        createdAt: new Date(),
+        ...data,
+      },
+    };
+  });
+
+  setWorld({
+    specVersion: SPEC_VERSION_CURRENT,
+    createQueueHandler: vi.fn(
+      (
+        _prefix: string,
+        handler: (message: unknown, metadata: unknown) => Promise<unknown>
+      ) => {
+        return async () => {
+          await handler(
+            {
+              runId: workflowRun.runId,
+              requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+            },
+            {
+              requestId: 'req_test',
+              attempt: 1,
+              queueName: '__wkf_workflow_workflow',
+              messageId: 'msg_test',
+            }
+          );
+          return new Response(null, { status: 204 });
+        };
+      }
+    ),
+    events: {
+      create: eventsCreate,
+      list: vi.fn(async () => ({
+        data: events,
+        hasMore: false,
+        cursor: 'cursor_test',
+      })),
+    },
+    runs: {
+      get: vi.fn(async () => workflowRun),
+    },
+    queue: vi.fn(),
+    getEncryptionKeyForRun: vi.fn(async () => undefined),
+  } as any);
+
+  const handler = workflowEntrypoint(workflowCode);
+  await handler(new Request('https://example.test'));
+
+  return createdEvents;
+}
+
+describe('workflowEntrypoint replay guards', () => {
+  afterEach(() => {
+    setWorld(undefined);
+    vi.clearAllMocks();
+  });
+
+  const getWorkflowTransformCode = (workflowName: string) =>
+    `;globalThis.__private_workflows = new Map();
+    globalThis.__private_workflows.set(${JSON.stringify(workflowName)}, ${workflowName});`;
+
+  it('records run_failed when a committed wait_completed targets the wrong wait', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_runtime_wait_guard',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_runtime_wait_guard',
+        undefined,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+
+    const events: Event[] = [
+      {
+        eventId: 'event-0',
+        runId: workflowRun.runId,
+        eventType: 'wait_created',
+        correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:05.000Z'),
+        },
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      {
+        eventId: 'event-1',
+        runId: workflowRun.runId,
+        eventType: 'wait_completed',
+        correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:06.000Z'),
+        },
+        createdAt: new Date('2024-01-01T00:00:05.000Z'),
+      },
+    ];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+      async function workflow() {
+        await sleep('5s');
+        return 'done';
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events
+    );
+
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({
+        eventType: 'run_failed',
+        eventData: expect.objectContaining({
+          errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+        }),
+      })
+    );
+  });
+
+  it('records run_failed when a committed hook_received targets the wrong hook', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_runtime_hook_guard',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_runtime_hook_guard',
+        undefined,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+
+    const events: Event[] = [
+      {
+        eventId: 'event-0',
+        runId: workflowRun.runId,
+        eventType: 'hook_received',
+        correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
+        eventData: {
+          token: 'wrong-token',
+          payload: await dehydrateStepReturnValue(
+            { message: 'hello' },
+            'wrun_runtime_hook_guard',
+            undefined,
+            ops
+          ),
+        },
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+    ];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+      async function workflow() {
+        const hook = createHook({ token: 'expected-token' });
+        const payload = await hook;
+        return payload.message;
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events
+    );
+
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({
+        eventType: 'run_failed',
+        eventData: expect.objectContaining({
+          errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+        }),
+      })
+    );
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -728,7 +728,12 @@ export function workflowEntrypoint(
                       );
                       const waitsToComplete = events
                         .filter(
-                          (e): e is typeof e & { correlationId: string } =>
+                          (
+                            e
+                          ): e is Extract<
+                            Event,
+                            { eventType: 'wait_created' }
+                          > & { correlationId: string } =>
                             e.eventType === 'wait_created' &&
                             e.correlationId !== undefined &&
                             !completedWaitIds.has(e.correlationId) &&
@@ -738,6 +743,9 @@ export function workflowEntrypoint(
                           eventType: 'wait_completed' as const,
                           specVersion: SPEC_VERSION_CURRENT,
                           correlationId: e.correlationId,
+                          eventData: {
+                            resumeAt: e.eventData.resumeAt,
+                          },
                         }));
 
                       for (const waitEvent of waitsToComplete) {

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -164,6 +164,7 @@ export async function resumeHook<T = any>(
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: hook.hookId,
             eventData: {
+              ...(v1Compat ? {} : { token: hook.token }),
               payload: dehydratedPayload,
             },
           },

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -177,6 +177,9 @@ describe('Run.wakeUp', () => {
       'wrun_123',
       expect.objectContaining({
         eventType: 'wait_completed',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         correlationId: 'wait_abc',
       }),
       expect.anything()
@@ -216,6 +219,9 @@ describe('Run.wakeUp', () => {
       'wrun_123',
       expect.objectContaining({
         eventType: 'wait_completed',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         correlationId: 'wait_abc',
       }),
       expect.anything()

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -189,6 +189,9 @@ export async function wakeUpRun(
             eventType: 'wait_completed' as const,
             correlationId: waitEvent.correlationId,
             specVersion: run.specVersion,
+            eventData: {
+              resumeAt: waitEvent.eventData.resumeAt,
+            },
           };
       try {
         await world.events.create(runId, eventData, { v1Compat: compatMode });

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -107,6 +107,7 @@ export async function executeStep(
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
           eventData: {
+            stepName,
             error: await dehydrateStepError(
               new FatalError(errorMessage),
               workflowRunId,
@@ -140,6 +141,7 @@ export async function executeStep(
         eventType: 'step_started',
         specVersion: SPEC_VERSION_CURRENT,
         correlationId: stepId,
+        eventData: { stepName },
       });
 
       if (!startResult.step) {
@@ -239,6 +241,7 @@ export async function executeStep(
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
           eventData: {
+            stepName,
             error: await dehydrateStepError(
               wrappedError,
               workflowRunId,
@@ -382,6 +385,7 @@ export async function executeStep(
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
           eventData: {
+            stepName,
             result: result as Uint8Array,
           },
         })
@@ -468,6 +472,7 @@ export async function executeStep(
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: stepId,
             eventData: {
+              stepName,
               error: await dehydrateStepError(
                 err,
                 workflowRunId,
@@ -532,6 +537,7 @@ export async function executeStep(
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: stepId,
             eventData: {
+              stepName,
               error: await dehydrateStepError(
                 wrappedError,
                 workflowRunId,
@@ -590,6 +596,7 @@ export async function executeStep(
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
           eventData: {
+            stepName,
             error: await dehydrateStepError(
               err,
               workflowRunId,

--- a/packages/core/src/runtime/step-handler.test.ts
+++ b/packages/core/src/runtime/step-handler.test.ts
@@ -585,6 +585,10 @@ describe('step-handler max deliveries', () => {
       expect.objectContaining({
         eventType: 'step_failed',
         correlationId: 'step_abc',
+        eventData: expect.objectContaining({
+          stepName: 'myStep',
+          error: expect.any(Uint8Array),
+        }),
       }),
       expect.anything()
     );
@@ -669,6 +673,9 @@ describe('step-handler step not found', () => {
       'wrun_test123',
       expect.objectContaining({
         eventType: 'step_started',
+        eventData: expect.objectContaining({
+          stepName: 'missingStep',
+        }),
       }),
       expect.anything()
     );
@@ -680,6 +687,7 @@ describe('step-handler step not found', () => {
         eventType: 'step_failed',
         correlationId: 'step_abc',
         eventData: expect.objectContaining({
+          stepName: 'missingStep',
           error: expect.any(Uint8Array),
         }),
       }),
@@ -712,6 +720,7 @@ describe('step-handler step not found', () => {
       expect.objectContaining({
         eventType: 'step_failed',
         eventData: expect.objectContaining({
+          stepName: 'badStep',
           error: expect.any(Uint8Array),
         }),
       }),

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -115,6 +115,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
               specVersion: SPEC_VERSION_CURRENT,
               correlationId: stepId,
               eventData: {
+                stepName: stepNameFromQueue,
                 error: await dehydrateStepError(
                   err,
                   workflowRunId,
@@ -216,6 +217,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   eventType: 'step_started',
                   specVersion: SPEC_VERSION_CURRENT,
                   correlationId: stepId,
+                  eventData: { stepName },
                 },
                 { requestId }
               );
@@ -336,6 +338,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                     specVersion: SPEC_VERSION_CURRENT,
                     correlationId: stepId,
                     eventData: {
+                      stepName,
                       error: await dehydrateStepError(
                         err,
                         workflowRunId,
@@ -431,6 +434,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                     specVersion: SPEC_VERSION_CURRENT,
                     correlationId: stepId,
                     eventData: {
+                      stepName,
                       error: await dehydrateStepError(
                         wrappedError,
                         workflowRunId,
@@ -493,6 +497,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                     specVersion: SPEC_VERSION_CURRENT,
                     correlationId: stepId,
                     eventData: {
+                      stepName,
                       error: await dehydrateStepError(
                         new FatalError(errorMessage),
                         workflowRunId,
@@ -735,6 +740,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                       specVersion: SPEC_VERSION_CURRENT,
                       correlationId: stepId,
                       eventData: {
+                        stepName,
                         error: await dehydrateStepError(
                           err,
                           workflowRunId,
@@ -819,6 +825,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                         specVersion: SPEC_VERSION_CURRENT,
                         correlationId: stepId,
                         eventData: {
+                          stepName,
                           error: await dehydrateStepError(
                             wrappedError,
                             workflowRunId,
@@ -887,6 +894,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                         specVersion: SPEC_VERSION_CURRENT,
                         correlationId: stepId,
                         eventData: {
+                          stepName,
                           error: await dehydrateStepError(
                             err,
                             workflowRunId,
@@ -981,6 +989,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                     specVersion: SPEC_VERSION_CURRENT,
                     correlationId: stepId,
                     eventData: {
+                      stepName,
                       result: result as Uint8Array,
                     },
                   },

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -21,8 +21,8 @@ import type {
 } from '../global.js';
 import { runtimeLogger } from '../logger.js';
 import { dehydrateStepArguments } from '../serialization.js';
-import { getAbortStreamIdFromToken } from '../util.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
+import { getAbortStreamIdFromToken } from '../util.js';
 
 export interface SuspensionHandlerParams {
   suspension: WorkflowSuspension;
@@ -163,6 +163,9 @@ export async function handleSuspension({
           eventType: 'hook_disposed' as const,
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: queueItem.correlationId,
+          eventData: {
+            token: queueItem.token,
+          },
         };
         try {
           await world.events.create(runId, hookDisposedEvent, { requestId });
@@ -224,6 +227,7 @@ export async function handleSuspension({
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: queueItem.correlationId,
             eventData: {
+              token: queueItem.token,
               payload: abortPayload,
             },
           });

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -74,6 +74,7 @@ describe('createUseStep', () => {
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(3, 'wrun_test', undefined),
         },
         createdAt: new Date(),
@@ -99,6 +100,7 @@ describe('createUseStep', () => {
         eventType: 'step_failed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'add',
           error: serializedError,
         },
         createdAt: new Date(),
@@ -230,6 +232,7 @@ describe('createUseStep', () => {
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'step//input.js//my_step_function',
           result: await dehydrateStepReturnValue(
             undefined,
             'wrun_test',
@@ -471,7 +474,9 @@ describe('createUseStep', () => {
         runId: 'wrun_123',
         eventType: 'step_started',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -510,6 +515,7 @@ describe('createUseStep', () => {
         eventType: 'step_retrying',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'add',
           error: new Uint8Array(),
         },
         createdAt: new Date(),
@@ -578,6 +584,7 @@ describe('createUseStep', () => {
         eventType: 'step_completed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(42, 'wrun_test', undefined),
         },
         createdAt: new Date(),
@@ -643,6 +650,7 @@ describe('createUseStep', () => {
         eventType: 'step_failed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'add',
           error: serializedError,
         },
         createdAt: new Date(),
@@ -683,6 +691,7 @@ describe('createUseStep', () => {
         eventType: 'step_failed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'add',
           error: serializedError,
         },
         createdAt: new Date(),
@@ -723,6 +732,7 @@ describe('createUseStep', () => {
         eventType: 'step_failed',
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'add',
           error: serializedError,
         },
         createdAt: new Date(),
@@ -752,6 +762,9 @@ describe('createUseStep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed', // Wrong event type for a step!
         correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date(),
+        },
         createdAt: new Date(),
       },
     ]);
@@ -899,7 +912,9 @@ describe('AbortController hook integration', () => {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId,
-          eventData: {},
+          eventData: {
+            token: ABORT_HOOK_TOKEN,
+          },
           createdAt: new Date(),
         },
         {
@@ -907,7 +922,10 @@ describe('AbortController hook integration', () => {
           runId: 'wrun_test',
           eventType: 'hook_received',
           correlationId,
-          eventData: { payload: dehydratedPayload as any },
+          eventData: {
+            token: ABORT_HOOK_TOKEN,
+            payload: dehydratedPayload as any,
+          },
           createdAt: new Date(),
         },
       ]);
@@ -944,7 +962,9 @@ describe('AbortController hook integration', () => {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId,
-          eventData: {},
+          eventData: {
+            token: ABORT_HOOK_TOKEN,
+          },
           createdAt: new Date(),
         },
       ]);

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -433,6 +433,36 @@ describe('createUseStep', () => {
     });
   });
 
+  it('should fail when step_created has the right correlationId but wrong stepName', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'step_created',
+        correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          stepName: 'subtract',
+          input: new Uint8Array(),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const useStep = createUseStep(ctx);
+    const add = useStep('add');
+    void add(1, 2);
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError.message).toContain('Corrupted event log');
+    expect(workflowError.message).toContain('step_created');
+    expect(workflowError.message).toContain('subtract');
+    expect(workflowError.message).toContain('add');
+  });
+
   it('should consume step_started without removing from queue', async () => {
     // step_started is consumed but item stays in queue for potential re-enqueue
     const ctx = setupWorkflowContext([
@@ -509,6 +539,37 @@ describe('createUseStep', () => {
     expect(ctx.invocationsQueue.size).toBe(1);
   });
 
+  it('should fail when step_completed has the right correlationId but wrong stepName', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'step_completed',
+        correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          stepName: 'subtract',
+          result: await dehydrateStepReturnValue(42, 'wrun_test', undefined),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const useStep = createUseStep(ctx);
+    const add = useStep('add');
+    void add(1, 2);
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError.message).toContain('Corrupted event log');
+    expect(workflowError.message).toContain('step_completed');
+    expect(workflowError.message).toContain('subtract');
+    expect(workflowError.message).toContain('add');
+    expect(ctx.invocationsQueue.size).toBe(1);
+  });
+
   it('should remove queue item when step_completed (terminal state)', async () => {
     const ctx = setupWorkflowContext([
       {
@@ -531,6 +592,42 @@ describe('createUseStep', () => {
     expect(result).toBe(42);
     // Queue should be empty after completion (terminal state)
     expect(ctx.invocationsQueue.size).toBe(0);
+  });
+
+  it('should fail when step_failed has the right correlationId but wrong stepName', async () => {
+    const serializedError = await dehydrateStepError(
+      new FatalError('test error'),
+      'wrun_test',
+      undefined
+    );
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'step_failed',
+        correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          stepName: 'subtract',
+          error: serializedError,
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const useStep = createUseStep(ctx);
+    const add = useStep('add');
+    void add(1, 2);
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError.message).toContain('Corrupted event log');
+    expect(workflowError.message).toContain('step_failed');
+    expect(workflowError.message).toContain('subtract');
+    expect(workflowError.message).toContain('add');
+    expect(ctx.invocationsQueue.size).toBe(1);
   });
 
   it('should remove queue item when step_failed (terminal state)', async () => {

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -78,6 +78,24 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
           return EventConsumerResult.NotConsumed;
         }
 
+        const eventStepName =
+          'eventData' in event &&
+          event.eventData &&
+          'stepName' in event.eventData
+            ? event.eventData.stepName
+            : undefined;
+
+        if (typeof eventStepName === 'string' && eventStepName !== stepName) {
+          ctx.promiseQueue = ctx.promiseQueue.then(() => {
+            ctx.onWorkflowError(
+              new WorkflowRuntimeError(
+                `Corrupted event log: step event ${event.eventType} for ${correlationId} belongs to "${eventStepName}", but the current step consumer is "${stepName}"`
+              )
+            );
+          });
+          return EventConsumerResult.Finished;
+        }
+
         if (event.eventType === 'step_created') {
           // Step has been created (registered for execution) - mark as having event
           // but keep in queue so suspension handler knows to queue execution without

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -175,6 +175,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date(),
       },
       {
@@ -183,6 +186,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(
             3,
             'wrun_123',
@@ -254,6 +258,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:00.600Z'),
       },
       {
@@ -261,6 +268,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:01.000Z'),
       },
       {
@@ -269,6 +279,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(
             3,
             'wrun_123',
@@ -283,6 +294,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PK',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:02.500Z'),
       },
       {
@@ -290,6 +304,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PK',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:03.000Z'),
       },
       {
@@ -298,6 +315,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PK',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(
             3,
             'wrun_123',
@@ -312,6 +330,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:04.500Z'),
       },
       {
@@ -319,6 +340,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:05.000Z'),
       },
       {
@@ -327,6 +351,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(
             3,
             'wrun_123',
@@ -421,6 +446,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'wait_completed',
         correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date('2024-01-01T00:00:03.000Z'),
       },
     ];
@@ -451,6 +479,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:02.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:04.000Z'),
         },
       ],
@@ -499,6 +530,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date(),
         },
         {
@@ -506,6 +540,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date(),
         },
         {
@@ -514,6 +551,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               3,
               'wrun_123',
@@ -529,6 +567,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               7,
               'wrun_123',
@@ -585,6 +624,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date(),
         },
         {
@@ -592,6 +634,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date(),
         },
         {
@@ -600,6 +645,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               3,
               'wrun_123',
@@ -615,6 +661,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               7,
               'wrun_123',
@@ -671,6 +718,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date(),
         },
         {
@@ -678,6 +728,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date(),
         },
         {
@@ -686,6 +739,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               7,
               'wrun_123',
@@ -701,6 +755,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               3,
               'wrun_123',
@@ -756,6 +811,9 @@ describe('runWorkflow', () => {
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCH',
           runId: 'wrun_01K75533W56DAE35VY3082DN3P',
           eventId: 'evnt_01K755385N02MMWXYHFCQSP9P0',
+          eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
+          },
           createdAt: new Date('2025-10-09T18:52:51.253Z'),
         },
         {
@@ -763,6 +821,9 @@ describe('runWorkflow', () => {
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCJ',
           runId: 'wrun_01K75533W56DAE35VY3082DN3P',
           eventId: 'evnt_01K755386GHGAFYYDC58V17E3T',
+          eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
+          },
           createdAt: new Date('2025-10-09T18:52:51.280Z'),
         },
         {
@@ -770,6 +831,9 @@ describe('runWorkflow', () => {
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCK',
           runId: 'wrun_01K75533W56DAE35VY3082DN3P',
           eventId: 'evnt_01K75538D4Q4X8PJ1ZNDZD5R0W',
+          eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
+          },
           createdAt: new Date('2025-10-09T18:52:51.492Z'),
         },
         {
@@ -777,6 +841,9 @@ describe('runWorkflow', () => {
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCM',
           runId: 'wrun_01K75533W56DAE35VY3082DN3P',
           eventId: 'evnt_01K75538Y9GEHXJQXT3JB89M4C',
+          eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
+          },
           createdAt: new Date('2025-10-09T18:52:52.041Z'),
         },
         {
@@ -784,12 +851,16 @@ describe('runWorkflow', () => {
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCN',
           runId: 'wrun_01K75533W56DAE35VY3082DN3P',
           eventId: 'evnt_01K75539CD2PAH419SKJ2X5V5T',
+          eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
+          },
           createdAt: new Date('2025-10-09T18:52:52.493Z'),
         },
         {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCN',
           eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
             result: await dehydrateStepReturnValue(
               4,
               'wrun_123',
@@ -805,6 +876,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCM',
           eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
             result: await dehydrateStepReturnValue(
               3,
               'wrun_123',
@@ -820,6 +892,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCK',
           eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
             result: await dehydrateStepReturnValue(
               2,
               'wrun_123',
@@ -835,6 +908,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCJ',
           eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
             result: await dehydrateStepReturnValue(
               1,
               'wrun_123',
@@ -850,6 +924,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00XRNYC8CR128NPYCH',
           eventData: {
+            stepName: 'promiseRaceStressTestDelayStep',
             result: await dehydrateStepReturnValue(
               0,
               'wrun_123',
@@ -1136,6 +1211,9 @@ describe('runWorkflow', () => {
             runId: workflowRun.runId,
             eventType: 'step_started',
             correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+            eventData: {
+              stepName: 'add',
+            },
             createdAt: new Date(),
           },
         ];
@@ -1590,6 +1668,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { message: 'Hello from hook' },
               'wrun_123',
@@ -1604,7 +1683,7 @@ describe('runWorkflow', () => {
       const result = await runWorkflow(
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       async function workflow() {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         const payload = await hook;
         return payload.message;
       }${getWorkflowTransformCode('workflow')}`,
@@ -1699,6 +1778,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { message: 'First payload' },
               'wrun_123',
@@ -1714,6 +1794,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { message: 'Second payload' },
               'wrun_123',
@@ -1728,7 +1809,7 @@ describe('runWorkflow', () => {
       const result = await runWorkflow(
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       async function workflow() {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         const payload1 = await hook;
         const payload2 = await hook;
         return [payload1.message, payload2.message];
@@ -1772,6 +1853,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { count: 1, status: 'active' },
               'wrun_123',
@@ -1787,6 +1869,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { count: 2, status: 'complete' },
               'wrun_123',
@@ -1801,7 +1884,7 @@ describe('runWorkflow', () => {
       const result = await runWorkflow(
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       async function workflow() {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         const payloads = [];
         for await (const payload of hook) {
           payloads.push({ count: payload.count, status: payload.status });
@@ -1853,6 +1936,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { value: 100 },
               'wrun_123',
@@ -1868,6 +1952,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { value: 200 },
               'wrun_123',
@@ -1882,7 +1967,7 @@ describe('runWorkflow', () => {
       const result = await runWorkflow(
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       async function workflow() {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         const payload = await hook;
         return payload.value;
       }${getWorkflowTransformCode('workflow')}`,
@@ -1925,6 +2010,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { data: 'first' },
               'wrun_123',
@@ -1940,6 +2026,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { data: 'second' },
               'wrun_123',
@@ -1954,6 +2041,9 @@ describe('runWorkflow', () => {
           runId: workflowRun.runId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date('2024-01-01T00:00:03.000Z'),
         },
         {
@@ -1962,6 +2052,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               42,
               'wrun_123',
@@ -1977,7 +2068,7 @@ describe('runWorkflow', () => {
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       const add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("add");
       async function workflow() {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         const payload1 = await hook;
         const stepResult = await add(1, 2);
         const payload2 = await hook;
@@ -2030,6 +2121,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'test-token',
             payload: await dehydrateStepReturnValue(
               { iteration: 1 },
               'wrun_123',
@@ -2044,6 +2136,9 @@ describe('runWorkflow', () => {
           runId: workflowRun.runId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date('2024-01-01T00:00:02.000Z'),
         },
         {
@@ -2052,6 +2147,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               10,
               'wrun_123',
@@ -2069,7 +2165,7 @@ describe('runWorkflow', () => {
           `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       const add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("add");
       async function workflow() {
-        const hook = createHook();
+        const hook = createHook({ token: 'test-token' });
         for await (const payload of hook) {
           await add(payload.iteration, 2);
         }
@@ -2113,6 +2209,7 @@ describe('runWorkflow', () => {
           eventType: 'hook_received',
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            token: 'my-custom-token',
             payload: await dehydrateStepReturnValue(
               { result: 'success' },
               'wrun_123',
@@ -3054,6 +3151,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:05.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:05.000Z'),
         },
       ];
@@ -3223,6 +3323,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:02.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:02.000Z'),
         },
         {
@@ -3230,6 +3333,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:05.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:05.000Z'),
         },
       ];
@@ -3301,6 +3407,9 @@ describe('runWorkflow', () => {
             runId: workflowRunId,
             eventType: 'wait_completed',
             correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+            eventData: {
+              resumeAt: new Date('2024-01-01T00:00:02.000Z'),
+            },
             createdAt: new Date('2024-01-01T00:00:02.000Z'),
           },
         ];
@@ -3349,6 +3458,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            stepName: 'add',
+          },
           createdAt: new Date('2024-01-01T00:00:00.000Z'),
         },
         {
@@ -3357,6 +3469,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'add',
             result: await dehydrateStepReturnValue(
               42,
               'wrun_123',
@@ -3381,6 +3494,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:03.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:03.000Z'),
         },
       ];
@@ -3446,6 +3562,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            resumeAt: resumeAt,
+          },
           createdAt: resumeAt,
         },
       ];
@@ -3506,6 +3625,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:05.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:05.000Z'),
         },
         {
@@ -3518,6 +3640,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:05.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:05.000Z'),
         },
         {
@@ -3525,6 +3650,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            stepName: 'doWork',
+          },
           createdAt: new Date('2024-01-01T00:00:06.000Z'),
         },
         {
@@ -3533,6 +3661,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
           eventData: {
+            stepName: 'doWork',
             result: await dehydrateStepReturnValue('step done', ops),
           },
           createdAt: new Date('2024-01-01T00:00:07.000Z'),
@@ -3579,6 +3708,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            stepName: 'doWork1',
+          },
           createdAt: new Date('2024-01-01T00:00:00.000Z'),
         },
         {
@@ -3587,6 +3719,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'doWork1',
             result: await dehydrateStepReturnValue('first done', ops),
           },
           createdAt: new Date('2024-01-01T00:00:01.000Z'),
@@ -3598,6 +3731,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'doWork1',
             result: await dehydrateStepReturnValue('duplicate', ops),
           },
           createdAt: new Date('2024-01-01T00:00:02.000Z'),
@@ -3607,6 +3741,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
+          eventData: {
+            stepName: 'doWork2',
+          },
           createdAt: new Date('2024-01-01T00:00:03.000Z'),
         },
         {
@@ -3615,6 +3752,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HF',
           eventData: {
+            stepName: 'doWork2',
             result: await dehydrateStepReturnValue('second done', ops),
           },
           createdAt: new Date('2024-01-01T00:00:04.000Z'),
@@ -3662,6 +3800,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_UNKNOWN_CORRELATION_ID',
           eventData: {
+            stepName: 'doWork',
             result: await dehydrateStepReturnValue('orphan', ops),
           },
           createdAt: new Date('2024-01-01T00:00:00.000Z'),
@@ -3671,6 +3810,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            stepName: 'doWork',
+          },
           createdAt: new Date('2024-01-01T00:00:01.000Z'),
         },
         {
@@ -3679,6 +3821,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'doWork',
             result: await dehydrateStepReturnValue('done', ops),
           },
           createdAt: new Date('2024-01-01T00:00:02.000Z'),
@@ -3723,6 +3866,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'wait_completed',
           correlationId: 'wait_ORPHAN',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:00.000Z'),
+          },
           createdAt: new Date('2024-01-01T00:00:00.000Z'),
         },
         {
@@ -3730,6 +3876,9 @@ describe('runWorkflow', () => {
           runId: workflowRunId,
           eventType: 'step_started',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            stepName: 'doWork',
+          },
           createdAt: new Date('2024-01-01T00:00:01.000Z'),
         },
         {
@@ -3738,6 +3887,7 @@ describe('runWorkflow', () => {
           eventType: 'step_completed',
           correlationId: 'step_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
+            stepName: 'doWork',
             result: await dehydrateStepReturnValue('done', ops),
           },
           createdAt: new Date('2024-01-01T00:00:02.000Z'),
@@ -3999,6 +4149,7 @@ describe('runWorkflow', () => {
             eventType: 'hook_received',
             correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
             eventData: {
+              token: 'test-token',
               payload: await dehydrateStepReturnValue(
                 { message: 'hello' },
                 'wrun_123',
@@ -4013,6 +4164,9 @@ describe('runWorkflow', () => {
             runId: workflowRun.runId,
             eventType: 'hook_disposed',
             correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
+            eventData: {
+              token: 'test-token',
+            },
             createdAt: new Date(),
           },
         ];
@@ -4022,7 +4176,7 @@ describe('runWorkflow', () => {
         await runWorkflow(
           `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
           async function workflow() {
-            const hook = createHook();
+            const hook = createHook({ token: 'test-token' });
             const result = await hook;
             hook.dispose();
             return result.message;
@@ -4138,6 +4292,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: stepA,
+        eventData: {
+          stepName: 'doWork',
+        },
         createdAt: new Date('2024-01-01T00:00:01.000Z'),
       },
       {
@@ -4145,6 +4302,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: stepB,
+        eventData: {
+          stepName: 'doWork',
+        },
         createdAt: new Date('2024-01-01T00:00:01.020Z'),
       },
       // B finishes first
@@ -4153,6 +4313,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: stepB,
+        eventData: {
+          stepName: 'doWork',
+        },
         createdAt: new Date('2024-01-01T00:00:02.000Z'),
       },
       {
@@ -4161,6 +4324,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: stepB,
         eventData: {
+          stepName: 'doWork',
           result: await dehydrateStepReturnValue(
             'resultB',
             workflowRunId,
@@ -4176,6 +4340,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: stepA,
+        eventData: {
+          stepName: 'doWork',
+        },
         createdAt: new Date('2024-01-01T00:00:03.000Z'),
       },
       {
@@ -4184,6 +4351,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: stepA,
         eventData: {
+          stepName: 'doWork',
           result: await dehydrateStepReturnValue(
             'resultA',
             workflowRunId,
@@ -4199,6 +4367,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: stepC,
+        eventData: {
+          stepName: 'doWork',
+        },
         createdAt: new Date('2024-01-01T00:00:04.000Z'),
       },
       {
@@ -4206,6 +4377,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: stepC,
+        eventData: {
+          stepName: 'doWork',
+        },
         createdAt: new Date('2024-01-01T00:00:04.500Z'),
       },
       {
@@ -4214,6 +4388,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: stepC,
         eventData: {
+          stepName: 'doWork',
           result: await dehydrateStepReturnValue(
             'resultC',
             workflowRunId,
@@ -4341,7 +4516,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'hook_received',
         correlationId: 'hook_01HK153X00SP082GGA0AAJC6PJ',
-        eventData: { payload: payload1 },
+        eventData: {
+          token: 'test-token',
+          payload: payload1,
+        },
         createdAt: new Date('2024-01-01T00:00:01.000Z'),
       },
       {
@@ -4357,6 +4535,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
+        eventData: {
+          stepName: 'processPayload',
+        },
         createdAt: new Date('2024-01-01T00:00:01.200Z'),
       },
       {
@@ -4364,7 +4545,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
-        eventData: { result: stepResult1 },
+        eventData: {
+          stepName: 'processPayload',
+          result: stepResult1,
+        },
         createdAt: new Date('2024-01-01T00:00:01.300Z'),
       },
       {
@@ -4372,7 +4556,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'hook_received',
         correlationId: 'hook_01HK153X00SP082GGA0AAJC6PJ',
-        eventData: { payload: payload2 },
+        eventData: {
+          token: 'test-token',
+          payload: payload2,
+        },
         createdAt: new Date('2024-01-01T00:00:02.000Z'),
       },
       {
@@ -4388,6 +4575,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PN',
+        eventData: {
+          stepName: 'processPayload',
+        },
         createdAt: new Date('2024-01-01T00:00:02.200Z'),
       },
       {
@@ -4395,7 +4585,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PN',
-        eventData: { result: stepResult2 },
+        eventData: {
+          stepName: 'processPayload',
+          result: stepResult2,
+        },
         createdAt: new Date('2024-01-01T00:00:02.300Z'),
       },
     ];
@@ -4495,6 +4688,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:01.000Z'),
       },
       {
@@ -4502,6 +4698,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:01.500Z'),
       },
       {
@@ -4510,6 +4709,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PJ',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(
             'first',
             workflowRunId,
@@ -4525,6 +4725,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PK',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:02.100Z'),
       },
       {
@@ -4532,6 +4735,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PK',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:02.500Z'),
       },
       {
@@ -4540,6 +4746,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PK',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(
             'second',
             workflowRunId,
@@ -4555,6 +4762,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_created',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:03.100Z'),
       },
       {
@@ -4562,6 +4772,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
+        eventData: {
+          stepName: 'add',
+        },
         createdAt: new Date('2024-01-01T00:00:03.500Z'),
       },
       {
@@ -4570,6 +4783,7 @@ describe('runWorkflow', () => {
         eventType: 'step_completed',
         correlationId: 'step_01HK153X00SP082GGA0AAJC6PM',
         eventData: {
+          stepName: 'add',
           result: await dehydrateStepReturnValue(
             'third',
             workflowRunId,
@@ -4605,7 +4819,7 @@ describe('runWorkflow', () => {
 
   it('should not trigger unconsumed event error for for-await hook loop + unawaited sleep when hydrate latency exceeds the deferred-check window', async () => {
     // Regression test for the v0chat production incident: a workflow that
-    // combines `createHook()`, fire-and-forget `sleep()`, and a per-payload
+    // combines `createHook({ token: 'test-token' })`, fire-and-forget `sleep()`, and a per-payload
     // step inside `for await` would falsely reject with
     // `Corrupted event log` during replay. When hydrate latency exceeds the
     // EventsConsumer's deferred-check timer, the second round of async work
@@ -4686,7 +4900,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'hook_created',
         correlationId: hookCorr,
-        eventData: { isWebhook: false },
+        eventData: {
+          token: 'test-token',
+          isWebhook: false,
+        },
         createdAt: startedAt,
       },
       {
@@ -4702,7 +4919,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'hook_received',
         correlationId: hookCorr,
-        eventData: { payload: payload1 },
+        eventData: {
+          token: 'test-token',
+          payload: payload1,
+        },
         createdAt: startedAt,
       },
       {
@@ -4710,7 +4930,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'hook_received',
         correlationId: hookCorr,
-        eventData: { payload: payload2 },
+        eventData: {
+          token: 'test-token',
+          payload: payload2,
+        },
         createdAt: startedAt,
       },
       {
@@ -4726,6 +4949,9 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_started',
         correlationId: stepCorr,
+        eventData: {
+          stepName: 'doStep',
+        },
         createdAt: startedAt,
       },
       {
@@ -4733,7 +4959,10 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'step_completed',
         correlationId: stepCorr,
-        eventData: { result: stepResult },
+        eventData: {
+          stepName: 'doStep',
+          result: stepResult,
+        },
         createdAt: startedAt,
       },
     ];
@@ -4759,7 +4988,7 @@ describe('runWorkflow', () => {
         const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
         const doStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("doStep");
         async function workflow() {
-          const hook = createHook();
+          const hook = createHook({ token: 'test-token' });
           // Fire-and-forget timeout, not awaited — mirrors the production
           // agent-stop pattern.
           void sleep("1d");

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -1622,6 +1622,58 @@ describe('runWorkflow', () => {
       ).toEqual('Hello from hook');
     });
 
+    it('should reject with WorkflowRuntimeError when hook_received token mismatches the hook', async () => {
+      const ops: Promise<any>[] = [];
+      const workflowRun: WorkflowRun = {
+        runId: 'test-run-123',
+        workflowName: 'workflow',
+        status: 'running',
+        input: await dehydrateWorkflowArguments(
+          [],
+          'wrun_123',
+          noEncryptionKey,
+          ops
+        ),
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+        startedAt: new Date('2024-01-01T00:00:00.000Z'),
+        deploymentId: 'test-deployment',
+      };
+
+      const events: Event[] = [
+        {
+          eventId: 'event-0',
+          runId: workflowRun.runId,
+          eventType: 'hook_received',
+          correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            token: 'wrong-token',
+            payload: await dehydrateStepReturnValue(
+              { message: 'Hello from hook' },
+              'wrun_123',
+              noEncryptionKey,
+              ops
+            ),
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      await expect(
+        runWorkflow(
+          `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+          async function workflow() {
+            const hook = createHook({ token: "expected-token" });
+            const payload = await hook;
+            return payload.message;
+          }${getWorkflowTransformCode('workflow')}`,
+          workflowRun,
+          events,
+          noEncryptionKey
+        )
+      ).rejects.toThrow(WorkflowRuntimeError);
+    });
+
     it('should resolve multiple `createHook` awaits upon "hook_received" events', async () => {
       const ops: Promise<any>[] = [];
       const workflowRun: WorkflowRun = {
@@ -3024,6 +3076,63 @@ describe('runWorkflow', () => {
           ops
         )
       ).toEqual('sleep completed');
+    });
+
+    it('should reject with WorkflowRuntimeError when wait_completed resumeAt mismatches the wait', async () => {
+      const ops: Promise<any>[] = [];
+      const workflowRunId = 'test-run-123';
+      const workflowRun: WorkflowRun = {
+        runId: workflowRunId,
+        workflowName: 'workflow',
+        status: 'running',
+        input: await dehydrateWorkflowArguments(
+          [],
+          'wrun_123',
+          noEncryptionKey,
+          ops
+        ),
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+        startedAt: new Date('2024-01-01T00:00:00.000Z'),
+        deploymentId: 'test-deployment',
+      };
+
+      const resumeAt = new Date('2024-01-01T00:00:05.000Z');
+      const events: Event[] = [
+        {
+          eventId: 'event-0',
+          runId: workflowRunId,
+          eventType: 'wait_created',
+          correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            resumeAt,
+          },
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        },
+        {
+          eventId: 'event-1',
+          runId: workflowRunId,
+          eventType: 'wait_completed',
+          correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+          eventData: {
+            resumeAt: new Date('2024-01-01T00:00:06.000Z'),
+          },
+          createdAt: new Date('2024-01-01T00:00:05.000Z'),
+        },
+      ];
+
+      await expect(
+        runWorkflow(
+          `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+          async function workflow() {
+            await sleep('5s');
+            return 'sleep completed';
+          }${getWorkflowTransformCode('workflow')}`,
+          workflowRun,
+          events,
+          noEncryptionKey
+        )
+      ).rejects.toThrow(WorkflowRuntimeError);
     });
 
     it('should throw `WorkflowSuspension` when sleep has no wait_completed event', async () => {

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -3990,9 +3990,7 @@ describe('runWorkflow', () => {
             runId: workflowRun.runId,
             eventType: 'hook_created' as const,
             correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
-            eventData: {
-              token: 'test-token',
-            },
+            eventData: {},
             createdAt: new Date(),
           },
           {
@@ -4688,7 +4686,7 @@ describe('runWorkflow', () => {
         runId: workflowRunId,
         eventType: 'hook_created',
         correlationId: hookCorr,
-        eventData: { token: 'tok', isWebhook: false },
+        eventData: { isWebhook: false },
         createdAt: startedAt,
       },
       {

--- a/packages/core/src/workflow/abort-controller.ts
+++ b/packages/core/src/workflow/abort-controller.ts
@@ -1,3 +1,4 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
 import { EventConsumerResult } from '../events-consumer.js';
 import type { WorkflowOrchestratorContext } from '../private.js';
 import { hydrateStepReturnValue } from '../serialization.js';
@@ -135,6 +136,25 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
           return EventConsumerResult.NotConsumed;
         }
 
+        const eventToken =
+          'eventData' in event && event.eventData && 'token' in event.eventData
+            ? event.eventData.token
+            : undefined;
+
+        if (
+          typeof eventToken === 'string' &&
+          eventToken !== this[ABORT_HOOK_TOKEN]
+        ) {
+          ctx.promiseQueue = ctx.promiseQueue.then(() => {
+            ctx.onWorkflowError(
+              new WorkflowRuntimeError(
+                `Corrupted event log: abort hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current abort hook expects "${this[ABORT_HOOK_TOKEN]}"`
+              )
+            );
+          });
+          return EventConsumerResult.Finished;
+        }
+
         if (event.eventType === 'hook_created') {
           const queueItem = ctx.invocationsQueue.get(correlationId);
           if (queueItem && queueItem.type === 'hook') {
@@ -158,7 +178,7 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
           // ends up undefined on replay.
           const rawPayload = event.eventData?.payload;
           ctx.promiseQueue = ctx.promiseQueue.then(async () => {
-            let reason: unknown = undefined;
+            let reason: unknown;
             if (rawPayload !== undefined) {
               try {
                 const hydrated = (await hydrateStepReturnValue(

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -49,6 +49,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'hello' },
             'wrun_test',
@@ -60,7 +61,7 @@ describe('createCreateHook', () => {
       },
     ]);
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
     const result = await hook;
     expect(result).toEqual({ message: 'hello' });
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
@@ -209,6 +210,7 @@ describe('createCreateHook', () => {
         eventType: 'step_completed', // Wrong event type for a hook!
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'unexpectedStep',
           result: ['test'],
         },
         createdAt: new Date(),
@@ -239,7 +241,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -248,6 +252,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { data: 'test' },
             'wrun_test',
@@ -260,7 +265,7 @@ describe('createCreateHook', () => {
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // After creating the hook, it should be in the queue
     expect(ctx.invocationsQueue.size).toBe(1);
@@ -283,13 +288,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for event processing (hook_disposed removes from invocationsQueue)
     await vi.waitFor(() => {
@@ -313,7 +320,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -322,6 +331,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'first' },
             'wrun_test',
@@ -337,6 +347,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'second' },
             'wrun_test',
@@ -351,13 +362,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ message: string }>();
+    const hook = createHook<{ message: string }>({ token: 'test-token' });
 
     const payloads: { message: string }[] = [];
     for await (const payload of hook) {
@@ -379,6 +392,7 @@ describe('createCreateHook', () => {
         eventType: 'step_completed', // Wrong event type
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'unexpectedStep',
           result: ['test'],
         },
         createdAt: new Date(),
@@ -465,7 +479,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -474,6 +490,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { data: 'test' },
             'wrun_test',
@@ -488,13 +505,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ data: string }>();
+    const hook = createHook<{ data: string }>({ token: 'test-token' });
 
     const result = await hook;
     expect(result).toEqual({ data: 'test' });
@@ -553,7 +572,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -564,7 +585,7 @@ describe('createCreateHook', () => {
     };
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for events to process (hook_created sets hasCreatedEvent on queue item)
     await vi.waitFor(() => {
@@ -593,7 +614,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -602,6 +625,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'first' },
             'wrun_test',
@@ -617,6 +641,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'second' },
             'wrun_test',
@@ -631,13 +656,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ message: string }>();
+    const hook = createHook<{ message: string }>({ token: 'test-token' });
 
     // The iterator should yield both payloads even though hook_disposed
     // was eagerly processed by the event consumer before the iterator consumed them
@@ -696,7 +723,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -707,7 +736,7 @@ describe('createCreateHook', () => {
     };
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for events to process (hook_created sets hasCreatedEvent on queue item)
     await vi.waitFor(() => {
@@ -860,7 +889,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -869,6 +900,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'hello' },
             'wrun_test',
@@ -881,7 +913,7 @@ describe('createCreateHook', () => {
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ message: string }>();
+    const hook = createHook<{ message: string }>({ token: 'test-token' });
 
     // Use iterator with break but no dispose()
     for await (const payload of hook) {
@@ -906,7 +938,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -915,7 +949,7 @@ describe('createCreateHook', () => {
     ctx.onWorkflowError = errorReceived.resolve;
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for events to process (hook_created sets hasCreatedEvent on queue item)
     await vi.waitFor(() => {

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -66,6 +66,123 @@ describe('createCreateHook', () => {
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
   });
 
+  it('should invoke workflow error handler when hook_created token mismatches the hook', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_created',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    createHook({ token: 'expected-token' });
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_created');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
+  });
+
+  it('should invoke workflow error handler when hook_received token mismatches the hook', async () => {
+    const ops: Promise<any>[] = [];
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_received',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+          payload: await dehydrateStepReturnValue(
+            { message: 'hello' },
+            'wrun_test',
+            undefined,
+            ops
+          ),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    const hook = createHook({ token: 'expected-token' });
+    void hook.then((v) => v);
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_received');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
+  });
+
+  it('should invoke workflow error handler when hook_disposed token mismatches the hook', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_disposed',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    createHook({ token: 'expected-token' });
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_disposed');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
+  });
+
+  it('should invoke workflow error handler when hook_conflict token mismatches the hook', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_conflict',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+          conflictingRunId: 'wrun_conflicting',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    createHook({ token: 'expected-token' });
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_conflict');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
+  });
+
   it('should throw WorkflowSuspension when no events are available', async () => {
     const ctx = setupWorkflowContext([]);
 

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -66,6 +66,22 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         return EventConsumerResult.NotConsumed;
       }
 
+      const eventToken =
+        'eventData' in event && event.eventData && 'token' in event.eventData
+          ? event.eventData.token
+          : undefined;
+
+      if (typeof eventToken === 'string' && eventToken !== token) {
+        ctx.promiseQueue = ctx.promiseQueue.then(() => {
+          ctx.onWorkflowError(
+            new WorkflowRuntimeError(
+              `Corrupted event log: hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current hook consumer expects "${token}"`
+            )
+          );
+        });
+        return EventConsumerResult.Finished;
+      }
+
       // Check for hook_created event to mark this hook as already created
       if (event.eventType === 'hook_created') {
         const queueItem = ctx.invocationsQueue.get(correlationId);

--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -75,6 +75,71 @@ describe('createSleep', () => {
     expect(ctx.invocationsQueue.size).toBe(0);
   });
 
+  it('should resolve old wait_completed events without eventData', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
+        eventType: 'wait_completed',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        createdAt: new Date(),
+      },
+    ]);
+
+    const sleep = createSleep(ctx);
+    await sleep('1s');
+
+    expect(ctx.onWorkflowError).not.toHaveBeenCalled();
+    expect(ctx.invocationsQueue.size).toBe(0);
+  });
+
+  it('should invoke workflow error handler when wait_completed resumeAt mismatches the wait', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
+        eventType: 'wait_completed',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:02.000Z'),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const sleep = createSleep(ctx);
+    void sleep('1s');
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('wait_completed');
+    expect(workflowError?.message).toContain('resumeAt');
+    expect(workflowError?.message).toContain('wait_01K11TFZ62YS0YYFDQ3E8B9YCV');
+  });
+
   it('should throw WorkflowSuspension when no events are available', async () => {
     const ctx = setupWorkflowContext([]);
 

--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -140,6 +140,42 @@ describe('createSleep', () => {
     expect(workflowError?.message).toContain('wait_01K11TFZ62YS0YYFDQ3E8B9YCV');
   });
 
+  it('should invoke workflow error handler when wait_completed resumeAt is invalid', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
+        eventType: 'wait_completed',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date(Number.NaN),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const sleep = createSleep(ctx);
+    void sleep('1s');
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('wait_completed');
+    expect(workflowError?.message).toContain('Invalid Date');
+  });
+
   it('should throw WorkflowSuspension when no events are available', async () => {
     const ctx = setupWorkflowContext([]);
 

--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -63,7 +63,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
     ]);
@@ -201,6 +203,7 @@ describe('createSleep', () => {
         eventType: 'step_completed', // Wrong event type for a wait!
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'unexpectedStep',
           result: ['test'],
         },
         createdAt: new Date(),
@@ -269,6 +272,7 @@ describe('createSleep', () => {
         eventType: 'hook_received', // Wrong event type for a wait!
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: { data: 'test' },
         },
         createdAt: new Date(),
@@ -338,7 +342,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
     ]);
@@ -376,7 +382,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
       {
@@ -384,7 +392,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed', // Duplicate!
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
     ]);
@@ -402,13 +412,26 @@ describe('createSleep', () => {
   });
 
   it('should resolve with void when wait_completed', async () => {
+    const resumeAt = new Date('2024-01-01T00:00:01.000Z');
     const ctx = setupWorkflowContext([
       {
         eventId: 'evnt_0',
         runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt,
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt,
+        },
         createdAt: new Date(),
       },
     ]);

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -57,6 +57,30 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
 
       // Check for wait_completed event
       if (event.eventType === 'wait_completed') {
+        const eventResumeAt = event.eventData?.resumeAt;
+        if (eventResumeAt !== undefined) {
+          const queueItem = ctx.invocationsQueue.get(correlationId);
+          const expectedResumeAt =
+            queueItem && queueItem.type === 'wait'
+              ? queueItem.resumeAt
+              : resumeAt;
+          const eventResumeAtMs = new Date(eventResumeAt).getTime();
+          const expectedResumeAtMs = expectedResumeAt.getTime();
+
+          if (eventResumeAtMs !== expectedResumeAtMs) {
+            ctx.promiseQueue = ctx.promiseQueue.then(() => {
+              ctx.onWorkflowError(
+                new WorkflowRuntimeError(
+                  `Corrupted event log: wait_completed event for ${correlationId} has resumeAt "${new Date(
+                    eventResumeAt
+                  ).toISOString()}", but the current wait consumer expects "${expectedResumeAt.toISOString()}"`
+                )
+              );
+            });
+            return EventConsumerResult.Finished;
+          }
+        }
+
         // Remove this wait from the invocations queue (O(1) delete using Map)
         ctx.invocationsQueue.delete(correlationId);
 

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -64,16 +64,18 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
             queueItem && queueItem.type === 'wait'
               ? queueItem.resumeAt
               : resumeAt;
-          const eventResumeAtMs = new Date(eventResumeAt).getTime();
+          const eventResumeAtDate = new Date(eventResumeAt);
+          const eventResumeAtMs = eventResumeAtDate.getTime();
           const expectedResumeAtMs = expectedResumeAt.getTime();
+          const eventResumeAtForMessage = Number.isFinite(eventResumeAtMs)
+            ? eventResumeAtDate.toISOString()
+            : String(eventResumeAt);
 
           if (eventResumeAtMs !== expectedResumeAtMs) {
             ctx.promiseQueue = ctx.promiseQueue.then(() => {
               ctx.onWorkflowError(
                 new WorkflowRuntimeError(
-                  `Corrupted event log: wait_completed event for ${correlationId} has resumeAt "${new Date(
-                    eventResumeAt
-                  ).toISOString()}", but the current wait consumer expects "${expectedResumeAt.toISOString()}"`
+                  `Corrupted event log: wait_completed event for ${correlationId} has resumeAt "${eventResumeAtForMessage}", but the current wait consumer expects "${expectedResumeAt.toISOString()}"`
                 )
               );
             });

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -96,6 +96,7 @@ const StepCompletedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('step_completed'),
   correlationId: z.string(),
   eventData: z.object({
+    stepName: z.string().optional(),
     result: SerializedDataSchema,
   }),
 });
@@ -104,6 +105,7 @@ const StepFailedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('step_failed'),
   correlationId: z.string(),
   eventData: z.object({
+    stepName: z.string().optional(),
     // The thrown value, serialized via the workflow serialization pipeline.
     // Can be any JavaScript value (string, number, object, Error, etc.)
     error: SerializedDataSchema,
@@ -119,6 +121,7 @@ const StepRetryingEventSchema = BaseEventSchema.extend({
   eventType: z.literal('step_retrying'),
   correlationId: z.string(),
   eventData: z.object({
+    stepName: z.string().optional(),
     // The thrown value, serialized via the workflow serialization pipeline.
     // Can be any JavaScript value (string, number, object, Error, etc.)
     error: SerializedDataSchema,
@@ -131,6 +134,7 @@ const StepStartedEventSchema = BaseEventSchema.extend({
   correlationId: z.string(),
   eventData: z
     .object({
+      stepName: z.string().optional(),
       attempt: z.number().optional(),
     })
     .optional(),
@@ -168,6 +172,7 @@ const HookReceivedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('hook_received'),
   correlationId: z.string(),
   eventData: z.object({
+    token: z.string().optional(),
     payload: SerializedDataSchema,
   }),
 });
@@ -175,6 +180,11 @@ const HookReceivedEventSchema = BaseEventSchema.extend({
 const HookDisposedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('hook_disposed'),
   correlationId: z.string(),
+  eventData: z
+    .object({
+      token: z.string().optional(),
+    })
+    .optional(),
 });
 
 /**
@@ -207,6 +217,11 @@ const WaitCreatedEventSchema = BaseEventSchema.extend({
 const WaitCompletedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('wait_completed'),
   correlationId: z.string(),
+  eventData: z
+    .object({
+      resumeAt: z.coerce.date().optional(),
+    })
+    .optional(),
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Adds replay-time ownership guards for step, wait, and hook lifecycle events so consumers do not resolve solely by correlation ID when guard metadata is present.

- Persists optional guard metadata on new events: step names, wait `resumeAt`, and hook tokens.
- Validates guard metadata in step, sleep, user hook, and abort-hook consumers during replay.
- Keeps storage permissive for wait/hook guard mismatches so suspicious events remain committed and replay deterministically records `run_failed` with `RUNTIME_ERROR`.
- Adds focused unit tests plus runtime-entrypoint coverage for committed bad wait/hook events becoming `run_failed` instead of retrying forever.

## Validation

- `pnpm --filter @workflow/core exec vitest run src/workflow/sleep.test.ts src/workflow/hook.test.ts src/abort-controller.test.ts src/runtime.test.ts`
- `pnpm --filter @workflow/core exec vitest run src/workflow.test.ts -t "resumeAt mismatches|hook_received token mismatches"`
- `pnpm --filter @workflow/core typecheck`
- `git diff --check`

Note: `pnpm exec biome check ...` still reports pre-existing complexity/legacy lint diagnostics in touched runtime files; safe formatter/import fixes were applied.
