### PR TITLE
fix(docs): disable Geist Mono ligatures in code blocks

### DIFF
--- a/docs/app/styles/geistdocs.css
+++ b/docs/app/styles/geistdocs.css
@@ -543,6 +543,18 @@
     counter-increment: step;
     @apply mr-6 inline-block w-6 text-right tabular-nums text-muted-foreground;
   }
+
+  /*
+   * Shiki wraps each highlighted token in its own <span>, which breaks
+   * Geist Mono programming ligatures (e.g. `===`, `!==`, `=>`): the ligature
+   * collapses to a single-character advance width, causing the glyph to
+   * visually overlap adjacent text. Disable ligatures inside code blocks
+   * so each character is rendered at its true monospace width.
+   */
+  pre code,
+  pre code span {
+    font-variant-ligatures: none;
+  }
 }
 
 :root {


### PR DESCRIPTION
## Summary

On the docs site, programming ligatures in Geist Mono (`===`, `!==`, `=>`, etc.) render with the advance width of a single character, causing them to visually overlap the preceding token. Reproduces on every code block, e.g. https://workflow-sdk.dev/cookbook/common-patterns/rate-limiting.

**Root cause:** Shiki wraps each syntax-highlighted token in its own `<span>`. When `===` lands in its own span, Geist Mono substitutes a single ligature glyph but the layout box only reserves one character of width.

**Measured on the live site:**

| Span text | Width | Expected (chars × 8.4px) |
|-----------|-------|--------------------------|
| `"  if"` | 33.6px | 33.6px ✅ |
| `" (res.status "` | 109.2px | 109.2px ✅ |
| `"==="` | **8.4px** | 25.2px ❌ |
| `" 429"` | 33.6px | 33.6px ✅ |

**Fix:** Disable `font-variant-ligatures` inside `pre code`. Each character then renders at its true monospace width and code displays exactly as authored — which is the desired behavior in technical docs anyway.

## Test plan

- [ ] Local: `pnpm dev` in `docs/`, open `/cookbook/common-patterns/rate-limiting`, confirm `===`/`!==`/`=>` render as three discrete characters with proper spacing
- [ ] Visual regression: scan other code-heavy pages (`/cookbook/*`, `/api-reference/*`) for unintended changes
- [ ] Inline `\`code\`` in markdown is unaffected (single span, ligatures weren't activating there anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)