### PR TITLE
trace viewer bug fix + file cleanup

### DIFF
--- a/.changeset/modern-penguins-peel.md
+++ b/.changeset/modern-penguins-peel.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+trace viewer bug fix + file cleanup

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -24,7 +24,7 @@ export const TIMELINE_PADDING_PX = 16;
 
 const SEGMENT_CLASSES: Record<SegmentStatus, string> = {
   queued: 'bg-gray-400 border border-gray-500',
-  retrying: 'box-border bg-gray-400 border border-gray-500',
+  retrying: 'bg-gray-400 border border-gray-500',
   waiting: 'bg-gray-400 border border-gray-500',
   running: 'bg-blue-200 border border-blue-500',
   failed: 'bg-red-200 border border-red-500',

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -40,10 +40,6 @@ const TIMELINE_INSET_STYLE: CSSProperties = {
   right: TIMELINE_PADDING_PX,
 };
 
-const DURATION_LABEL_STYLE: CSSProperties = {
-  textShadow: '0 1px 1px rgba(0, 0, 0, 0.45)',
-};
-
 // ---------------------------------------------------------------------------
 // Bar geometry
 // ---------------------------------------------------------------------------
@@ -182,15 +178,11 @@ function projectSegments(
 // Small render helpers
 // ---------------------------------------------------------------------------
 
-function minLabelWidthPx(label: string): number {
-  return Math.max(40, label.length * 6 + 12);
-}
-
 function DurationLabel({ label }: { label: string }): ReactNode {
   return (
     <span
       className="pointer-events-none absolute inset-0 flex items-center justify-start overflow-hidden px-1 text-[10px] font-mono font-medium leading-none whitespace-nowrap text-left text-white tabular-nums opacity-0 group-hover/timeline-row:opacity-100"
-      style={DURATION_LABEL_STYLE}
+      style={{ textShadow: '0 1px 1px rgba(0, 0, 0, 0.45)' }}
     >
       {label}
     </span>
@@ -232,7 +224,8 @@ function SegmentBar({ segments }: { segments: VisibleSegment[] }): ReactNode {
     <div className="relative h-6 w-full">
       {segments.map((seg, i) => {
         const label = formatDuration(seg.fullDurationMs);
-        const showLabel = seg.pixelWidth >= minLabelWidthPx(label);
+        // Only render the label when there's enough room for it without clipping.
+        const showLabel = seg.pixelWidth >= Math.max(40, label.length * 6 + 12);
         // Beef up the queued segment when it's too narrow to read.
         const overrideBg =
           seg.status === 'queued' && seg.pixelWidth < 20
@@ -316,7 +309,7 @@ const TimelineBar = memo(function TimelineBar({
 
   const totalLabel = formatDuration(totalDurationMs);
   const showTotalLabel =
-    geometry.visiblePixelWidth >= minLabelWidthPx(totalLabel);
+    geometry.visiblePixelWidth >= Math.max(40, totalLabel.length * 6 + 12);
 
   const handleClick = useCallback(() => {
     onSelect(span.spanId);

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -1,45 +1,377 @@
 'use client';
 
 import { ArrowLeft, ArrowRight } from 'lucide-react';
-import type { ReactNode } from 'react';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../../../lib/utils';
 import type { Span } from '../../trace-viewer/types';
 import { formatDuration, getHighResInMs } from '../../trace-viewer/util/timing';
-import type { SegmentStatus, TimeMarker } from '../utils';
+import type { Segment, SegmentStatus, TimeMarker } from '../utils';
 import {
   computeSpanGaps,
   computeSpanSegments,
-  getSpanDurationMs,
   getResourceColor,
+  getSpanDurationMs,
 } from '../utils';
 
-const SEGMENT_CONFIG: Record<
-  SegmentStatus,
-  { className?: string; style?: React.CSSProperties }
-> = {
-  queued: { className: 'bg-gray-500' },
-  retrying: {
-    className: 'box-border bg-gray-500',
-  },
-  waiting: { className: 'bg-gray-500' },
-  running: { className: 'bg-blue-700' },
-  failed: { className: 'bg-red-700' },
-  succeeded: { className: 'bg-green-700' },
-  sleeping: { className: 'bg-gray-500' },
-  received: { className: 'bg-blue-700' },
-};
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
-const BAR_HEIGHT_PX = 24;
 const TINY_BAR_BOX_SIZE_PX = 24;
 const TINY_BAR_WIDTH_PX = 4;
-const SEGMENT_GAP_PX = 1;
-// Keep this in sync with the rendered row height in the timeline/event list.
-const ROW_HEIGHT = 40;
-const CONTAINER_PAD_Y = 8;
-const END_CAP_HEIGHT = 8;
 export const TIMELINE_PADDING_PX = 16;
-const ORIGIN_MARKER_EPSILON = 0.000001;
+
+const SEGMENT_CLASSES: Record<SegmentStatus, string> = {
+  queued: 'bg-gray-500',
+  retrying: 'box-border bg-gray-500',
+  waiting: 'bg-gray-500',
+  running: 'bg-blue-700',
+  failed: 'bg-red-700',
+  succeeded: 'bg-green-700',
+  sleeping: 'bg-gray-500',
+  received: 'bg-blue-700',
+};
+
+// Hoisted style constants. These are referentially stable so they don't
+// trigger unnecessary diffs in style props across renders.
+const TIMELINE_INSET_STYLE: CSSProperties = {
+  left: TIMELINE_PADDING_PX,
+  right: TIMELINE_PADDING_PX,
+};
+
+const DURATION_LABEL_STYLE: CSSProperties = {
+  textShadow: '0 1px 1px rgba(0, 0, 0, 0.45)',
+};
+
+// ---------------------------------------------------------------------------
+// Bar geometry
+// ---------------------------------------------------------------------------
+
+type BarMode =
+  | { kind: 'arrow'; direction: 'left' | 'right' }
+  | { kind: 'tiny' }
+  | { kind: 'full' };
+
+interface BarGeometry {
+  mode: BarMode;
+  leftPct: number;
+  widthPct: number;
+  visibleStartMs: number;
+  visibleEndMs: number;
+  visiblePixelWidth: number;
+}
+
+/**
+ * Compute the bar's geometry inside the timeline viewport. Percentages are
+ * always in [0, 100] so we never emit CSS values that exceed browser layout
+ * limits at extreme zoom.
+ */
+function computeBarGeometry(
+  startMs: number,
+  endMs: number,
+  viewStart: number,
+  viewEnd: number,
+  containerWidth: number
+): BarGeometry {
+  const viewDuration = viewEnd - viewStart;
+  const visibleStartMs = Math.max(startMs, viewStart);
+  const visibleEndMs = Math.min(endMs, viewEnd);
+  const visibleDurationMs = Math.max(0, visibleEndMs - visibleStartMs);
+  const widthFrac = viewDuration > 0 ? visibleDurationMs / viewDuration : 0;
+  const visiblePixelWidth = widthFrac * containerWidth;
+
+  const isTiny = containerWidth > 0 && visiblePixelWidth < TINY_BAR_BOX_SIZE_PX;
+  const extendsOffLeft = startMs < viewStart;
+  const extendsOffRight = endMs > viewEnd;
+
+  const mode: BarMode =
+    isTiny && (extendsOffLeft || extendsOffRight)
+      ? { kind: 'arrow', direction: extendsOffRight ? 'right' : 'left' }
+      : isTiny
+        ? { kind: 'tiny' }
+        : { kind: 'full' };
+
+  return {
+    mode,
+    leftPct:
+      viewDuration > 0
+        ? ((visibleStartMs - viewStart) / viewDuration) * 100
+        : 0,
+    widthPct: widthFrac * 100,
+    visibleStartMs,
+    visibleEndMs,
+    visiblePixelWidth,
+  };
+}
+
+function getBarPositionStyle(geometry: BarGeometry): {
+  left: string;
+  width: string;
+} {
+  switch (geometry.mode.kind) {
+    case 'arrow':
+      return {
+        left:
+          geometry.mode.direction === 'right'
+            ? `calc(100% - ${TINY_BAR_BOX_SIZE_PX}px)`
+            : '0px',
+        width: `${TINY_BAR_BOX_SIZE_PX}px`,
+      };
+    case 'tiny':
+      return {
+        left: `min(${geometry.leftPct}%, calc(100% - ${TINY_BAR_WIDTH_PX}px))`,
+        width: `${TINY_BAR_WIDTH_PX}px`,
+      };
+    case 'full':
+      return {
+        left: `${geometry.leftPct}%`,
+        width: `max(${geometry.widthPct}%, 4px)`,
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Segment projection
+// ---------------------------------------------------------------------------
+
+interface VisibleSegment {
+  status: SegmentStatus;
+  leftPct: number;
+  widthPct: number;
+  pixelWidth: number;
+  fullDurationMs: number;
+}
+
+/**
+ * Project status segments onto the visible portion of a bar. Segments fully
+ * outside the visible window are dropped; segments crossing the edge are
+ * clipped to [0%, 100%] of the visible bar.
+ */
+function projectSegments(
+  segments: Segment[],
+  spanStartMs: number,
+  spanDurationMs: number,
+  geometry: BarGeometry
+): VisibleSegment[] {
+  const visibleDurationMs = geometry.visibleEndMs - geometry.visibleStartMs;
+  if (visibleDurationMs <= 0) return [];
+
+  return segments.flatMap((seg) => {
+    const segStartMs = spanStartMs + seg.startFraction * spanDurationMs;
+    const segEndMs = spanStartMs + seg.endFraction * spanDurationMs;
+    const startMs = Math.max(segStartMs, geometry.visibleStartMs);
+    const endMs = Math.min(segEndMs, geometry.visibleEndMs);
+    if (endMs <= startMs) return [];
+
+    const widthFrac = (endMs - startMs) / visibleDurationMs;
+    return [
+      {
+        status: seg.status,
+        leftPct:
+          ((startMs - geometry.visibleStartMs) / visibleDurationMs) * 100,
+        widthPct: widthFrac * 100,
+        pixelWidth: widthFrac * geometry.visiblePixelWidth,
+        fullDurationMs: (seg.endFraction - seg.startFraction) * spanDurationMs,
+      },
+    ];
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Small render helpers
+// ---------------------------------------------------------------------------
+
+function minLabelWidthPx(label: string): number {
+  return Math.max(40, label.length * 6 + 12);
+}
+
+function DurationLabel({ label }: { label: string }): ReactNode {
+  return (
+    <span
+      className="pointer-events-none absolute inset-0 flex items-center justify-start overflow-hidden px-1 text-[10px] font-mono font-medium leading-none whitespace-nowrap text-left text-white tabular-nums opacity-0 group-hover/timeline-row:opacity-100"
+      style={DURATION_LABEL_STYLE}
+    >
+      {label}
+    </span>
+  );
+}
+
+function BoundaryArrow({
+  direction,
+}: {
+  direction: 'left' | 'right';
+}): ReactNode {
+  const Icon = direction === 'right' ? ArrowRight : ArrowLeft;
+  return (
+    <div className="flex h-6 w-6 items-center justify-center rounded-[0.25rem]">
+      <Icon className="size-3 text-gray-900" />
+    </div>
+  );
+}
+
+function PlainBar({
+  color,
+  label,
+}: {
+  color: string;
+  label: string | null;
+}): ReactNode {
+  return (
+    <div
+      className="relative h-6 w-full min-w-1 rounded-[0.25rem]"
+      style={{ background: color }}
+    >
+      {label ? <DurationLabel label={label} /> : null}
+    </div>
+  );
+}
+
+function SegmentBar({ segments }: { segments: VisibleSegment[] }): ReactNode {
+  return (
+    <div className="relative h-6 w-full">
+      {segments.map((seg, i) => {
+        const label = formatDuration(seg.fullDurationMs);
+        const showLabel = seg.pixelWidth >= minLabelWidthPx(label);
+        // Beef up the queued segment when it's too narrow to read.
+        const overrideBg =
+          seg.status === 'queued' && seg.pixelWidth < 20
+            ? 'var(--ds-gray-500)'
+            : undefined;
+
+        return (
+          <div
+            key={`${seg.status}-${i}`}
+            className={cn(
+              'absolute h-full rounded-[0.25rem]',
+              SEGMENT_CLASSES[seg.status]
+            )}
+            style={{
+              // 1px gap between adjacent segments, distributed equally.
+              left: `calc(${seg.leftPct}% + 0.5px)`,
+              width: `calc(${seg.widthPct}% - 1px)`,
+              minWidth: 1,
+              background: overrideBg,
+            }}
+          >
+            {showLabel ? <DurationLabel label={label} /> : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TimelineBar
+// ---------------------------------------------------------------------------
+
+const TimelineBar = memo(function TimelineBar({
+  span,
+  viewStart,
+  viewDuration,
+  containerWidth,
+  isSelected,
+  onSelect,
+}: {
+  span: Span;
+  viewStart: number;
+  viewDuration: number;
+  containerWidth: number;
+  isSelected: boolean;
+  onSelect: (spanId: string) => void;
+}): ReactNode {
+  const startMs = getHighResInMs(span.startTime);
+  const endMs = getHighResInMs(span.endTime);
+  const totalDurationMs = getSpanDurationMs(span);
+
+  const geometry = useMemo(
+    () =>
+      computeBarGeometry(
+        startMs,
+        endMs,
+        viewStart,
+        viewStart + viewDuration,
+        containerWidth
+      ),
+    [startMs, endMs, viewStart, viewDuration, containerWidth]
+  );
+
+  const baseSegments = useMemo(() => computeSpanSegments(span), [span]);
+  const segments = useMemo(
+    () =>
+      geometry.mode.kind === 'full'
+        ? projectSegments(baseSegments, startMs, totalDurationMs, geometry)
+        : [],
+    [geometry, baseSegments, startMs, totalDurationMs]
+  );
+
+  const workflowStatus = (span.attributes.data as Record<string, unknown>)
+    ?.status as string | undefined;
+  const isErrored = span.status.code === 2 || workflowStatus === 'failed';
+  const colors = getResourceColor(span.resource);
+  const fallbackColor = isErrored
+    ? (colors.errorBar ?? 'var(--ds-red-700)')
+    : colors.bar;
+
+  const totalLabel = formatDuration(totalDurationMs);
+  const showTotalLabel =
+    geometry.visiblePixelWidth >= minLabelWidthPx(totalLabel);
+
+  const handleClick = useCallback(() => {
+    onSelect(span.spanId);
+  }, [onSelect, span.spanId]);
+
+  return (
+    <div
+      role="treeitem"
+      aria-selected={isSelected}
+      aria-expanded={isSelected}
+      aria-level={1}
+      className="group/timeline-row h-10 relative flex items-center hover:bg-gray-100 aria-selected:bg-gray-100 aria-selected:hover:bg-gray-200"
+      onClick={handleClick}
+    >
+      <div className="absolute inset-y-0" style={TIMELINE_INSET_STYLE}>
+        <div
+          className="absolute top-1/2 h-6 -translate-y-1/2"
+          style={getBarPositionStyle(geometry)}
+        >
+          {geometry.mode.kind === 'arrow' ? (
+            <BoundaryArrow direction={geometry.mode.direction} />
+          ) : geometry.mode.kind === 'tiny' ? (
+            <div
+              className="h-6 rounded-[0.25rem]"
+              style={{ background: fallbackColor }}
+            />
+          ) : segments.length > 0 ? (
+            <SegmentBar segments={segments} />
+          ) : (
+            <PlainBar
+              color={fallbackColor}
+              label={showTotalLabel ? totalLabel : null}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export { TimelineBar };
+
+// ---------------------------------------------------------------------------
+// DeltaIndicator (Alt-key gap overlay)
+// ---------------------------------------------------------------------------
+
+// Row and indicator sizes are local to DeltaIndicator since it's the only
+// place that needs to compute Y positions from a row index. ROW_HEIGHT must
+// match the `h-10` (40px) row used in TimelineBar.
+const DELTA_ROW_HEIGHT_PX = 40;
+const DELTA_CAP_HEIGHT_PX = 8;
+// Vertical offset to sit the indicator inside the gap between row N and N+1,
+// aligned with where the bar starts in the next row (rows center a 24px bar
+// inside 40px, so bars start ~8px from the top of the row).
+const DELTA_ROW_OFFSET_PX = 8;
 
 const DeltaIndicator = memo(function DeltaIndicator({
   leftFrac,
@@ -52,7 +384,7 @@ const DeltaIndicator = memo(function DeltaIndicator({
   label: string;
   rowIndex: number;
 }) {
-  const centerY = CONTAINER_PAD_Y + (rowIndex + 1) * ROW_HEIGHT;
+  const centerY = DELTA_ROW_OFFSET_PX + (rowIndex + 1) * DELTA_ROW_HEIGHT_PX;
 
   return (
     <div
@@ -60,8 +392,8 @@ const DeltaIndicator = memo(function DeltaIndicator({
       style={{
         left: `${leftFrac * 100}%`,
         width: `${(rightFrac - leftFrac) * 100}%`,
-        top: centerY - END_CAP_HEIGHT / 2,
-        height: END_CAP_HEIGHT,
+        top: centerY - DELTA_CAP_HEIGHT_PX / 2,
+        height: DELTA_CAP_HEIGHT_PX,
       }}
     >
       <div className="absolute left-0 top-0 w-px h-full bg-amber-800" />
@@ -74,172 +406,9 @@ const DeltaIndicator = memo(function DeltaIndicator({
   );
 });
 
-const TimelineBar = memo(function TimelineBar({
-  span,
-  viewStart,
-  viewDuration,
-  containerWidth,
-  isSelected,
-  onClick,
-}: {
-  span: Span;
-  viewStart: number;
-  viewDuration: number;
-  containerWidth: number;
-  isSelected: boolean;
-  onClick: () => void;
-}): ReactNode {
-  const startTime = getHighResInMs(span.startTime);
-  const endTime = getHighResInMs(span.endTime);
-  const totalDurationMs = getSpanDurationMs(span);
-
-  const leftFracRaw =
-    viewDuration > 0 ? (startTime - viewStart) / viewDuration : 0;
-  const rightFracRaw =
-    viewDuration > 0 ? (endTime - viewStart) / viewDuration : 0;
-  const widthFrac = rightFracRaw - leftFracRaw;
-
-  const leftPct = leftFracRaw * 100;
-  const widthPct = widthFrac * 100;
-
-  const pixelWidth = widthFrac * containerWidth;
-  const visibleLeftFrac = Math.max(0, Math.min(1, leftFracRaw));
-  const visibleRightFrac = Math.max(0, Math.min(1, rightFracRaw));
-  const visiblePixelWidth =
-    Math.max(0, visibleRightFrac - visibleLeftFrac) * containerWidth;
-  const isTinyBar =
-    containerWidth > 0 && visiblePixelWidth < TINY_BAR_BOX_SIZE_PX;
-  const [isRowHovered, setIsRowHovered] = useState(false);
-
-  const segments = useMemo(() => computeSpanSegments(span), [span]);
-
-  const workflowStatus = (span.attributes.data as Record<string, unknown>)
-    ?.status as string | undefined;
-  const isErrored = span.status.code === 2 || workflowStatus === 'failed';
-  const colors = getResourceColor(span.resource);
-  const fallbackColor = isErrored
-    ? (colors.errorBar ?? 'var(--ds-red-700)')
-    : colors.bar;
-  const renderDurationLabel = (label: string) => (
-    <span
-      className="pointer-events-none absolute inset-0 flex items-center justify-start overflow-hidden px-1 text-[10px] font-mono font-medium leading-none whitespace-nowrap text-left text-white tabular-nums"
-      style={{ textShadow: '0 1px 1px rgba(0, 0, 0, 0.45)' }}
-    >
-      {label}
-    </span>
-  );
-  const getMinDurationLabelWidthPx = (label: string) =>
-    Math.max(40, label.length * 6 + 12);
-  const totalDurationLabel = formatDuration(totalDurationMs);
-  const showBarDurationLabel =
-    isRowHovered &&
-    pixelWidth >= getMinDurationLabelWidthPx(totalDurationLabel);
-
-  const showBoundaryArrow = isTinyBar && (leftFracRaw < 0 || rightFracRaw > 1);
-  const BoundaryArrow = leftFracRaw < 0.5 ? ArrowLeft : ArrowRight;
-  const barContent = showBoundaryArrow ? (
-    <div className="flex h-6 w-6 items-center justify-center rounded-[0.25rem]">
-      <BoundaryArrow className="size-3 text-gray-900" />
-    </div>
-  ) : isTinyBar ? (
-    <div
-      className="h-6 rounded-[0.25rem]"
-      style={{ background: fallbackColor }}
-    />
-  ) : segments.length > 0 ? (
-    <div className="relative h-6 w-full">
-      {segments.map((seg, i) => {
-        const segPixelWidth =
-          (seg.endFraction - seg.startFraction) * pixelWidth;
-        const segDurationLabel = formatDuration(
-          (seg.endFraction - seg.startFraction) * totalDurationMs
-        );
-        const showSegmentDurationLabel =
-          isRowHovered &&
-          segPixelWidth >= getMinDurationLabelWidthPx(segDurationLabel);
-        const segStyle =
-          seg.status === 'queued' && segPixelWidth < 20
-            ? { background: 'var(--ds-gray-500)' }
-            : SEGMENT_CONFIG[seg.status].style;
-
-        return (
-          <div
-            key={`${seg.status}-${i}`}
-            className={cn(
-              'absolute h-full rounded-[0.25rem]',
-              SEGMENT_CONFIG[seg.status].className
-            )}
-            style={{
-              left: `calc(${seg.startFraction * 100}% + ${SEGMENT_GAP_PX / 2}px)`,
-              width: `calc(${(seg.endFraction - seg.startFraction) * 100}% - ${SEGMENT_GAP_PX}px)`,
-              minWidth: 1,
-              ...segStyle,
-            }}
-          >
-            {showSegmentDurationLabel
-              ? renderDurationLabel(segDurationLabel)
-              : null}
-          </div>
-        );
-      })}
-    </div>
-  ) : (
-    <div
-      className="relative h-6 rounded-[0.25rem]"
-      style={{
-        width: '100%',
-        minWidth: 4,
-        background: fallbackColor,
-      }}
-    >
-      {showBarDurationLabel ? renderDurationLabel(totalDurationLabel) : null}
-    </div>
-  );
-
-  return (
-    <div
-      role="treeitem"
-      aria-selected={isSelected}
-      aria-expanded={isSelected}
-      aria-level={1}
-      className={cn(
-        'h-10 relative flex items-center hover:bg-gray-100 aria-selected:bg-gray-100 aria-selected:hover:bg-gray-200'
-      )}
-      onMouseEnter={() => setIsRowHovered(true)}
-      onMouseLeave={() => setIsRowHovered(false)}
-      onClick={onClick}
-    >
-      <div
-        className="absolute inset-y-0"
-        style={{
-          left: TIMELINE_PADDING_PX,
-          right: TIMELINE_PADDING_PX,
-        }}
-      >
-        <div
-          className="absolute top-1/2 -translate-y-1/2"
-          style={{
-            left: showBoundaryArrow
-              ? `min(max(${leftPct}%, 0px), calc(100% - ${TINY_BAR_BOX_SIZE_PX}px))`
-              : isTinyBar
-                ? `min(${leftPct}%, calc(100% - ${TINY_BAR_WIDTH_PX}px))`
-                : `${leftPct}%`,
-            width: showBoundaryArrow
-              ? `${TINY_BAR_BOX_SIZE_PX}px`
-              : isTinyBar
-                ? `${TINY_BAR_WIDTH_PX}px`
-                : `max(${widthPct}%, 4px)`,
-            height: BAR_HEIGHT_PX,
-          }}
-        >
-          {barContent}
-        </div>
-      </div>
-    </div>
-  );
-});
-
-export { TimelineBar };
+// ---------------------------------------------------------------------------
+// TimelineHeader
+// ---------------------------------------------------------------------------
 
 export function TimelineHeader({
   markers,
@@ -272,6 +441,10 @@ export function TimelineHeader({
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Timeline
+// ---------------------------------------------------------------------------
 
 export function Timeline({
   spans,
@@ -317,13 +490,11 @@ export function Timeline({
       <div
         aria-hidden
         className="absolute inset-y-0 pointer-events-none"
-        style={{
-          left: TIMELINE_PADDING_PX,
-          right: TIMELINE_PADDING_PX,
-        }}
+        style={TIMELINE_INSET_STYLE}
       >
         {markers.map((marker) =>
-          Math.abs(marker.value) > ORIGIN_MARKER_EPSILON ? (
+          // Skip the "0s" origin marker since the left edge already implies it.
+          Math.abs(marker.value) > 0.000001 ? (
             <div
               key={`${marker.position}-${marker.label}`}
               className="absolute top-0 bottom-0 w-px bg-gray-alpha-300"
@@ -335,10 +506,7 @@ export function Timeline({
       {hoverFraction != null && (
         <div
           className="absolute inset-y-0 pointer-events-none z-10"
-          style={{
-            left: TIMELINE_PADDING_PX,
-            right: TIMELINE_PADDING_PX,
-          }}
+          style={TIMELINE_INSET_STYLE}
         >
           <div
             className="absolute top-0 bottom-0 w-px bg-gray-alpha-400"
@@ -354,17 +522,14 @@ export function Timeline({
           viewDuration={viewDuration}
           containerWidth={timelineWidth}
           isSelected={selectedId === span.spanId}
-          onClick={() => onSelect(span.spanId)}
+          onSelect={onSelect}
         />
       ))}
       {altHeld && (
         <div
           aria-hidden
           className="absolute inset-y-0 pointer-events-none"
-          style={{
-            left: TIMELINE_PADDING_PX,
-            right: TIMELINE_PADDING_PX,
-          }}
+          style={TIMELINE_INSET_STYLE}
         >
           {gaps.map((gap) => (
             <DeltaIndicator

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -24,7 +24,7 @@ export const TIMELINE_PADDING_PX = 16;
 
 const SEGMENT_CLASSES: Record<SegmentStatus, string> = {
   queued: 'bg-gray-500',
-  retrying: 'box-border bg-gray-500',
+  retrying: 'bg-gray-500',
   waiting: 'bg-gray-500',
   running: 'bg-blue-700',
   failed: 'bg-red-700',
@@ -33,8 +33,6 @@ const SEGMENT_CLASSES: Record<SegmentStatus, string> = {
   received: 'bg-blue-700',
 };
 
-// Hoisted style constants. These are referentially stable so they don't
-// trigger unnecessary diffs in style props across renders.
 const TIMELINE_INSET_STYLE: CSSProperties = {
   left: TIMELINE_PADDING_PX,
   right: TIMELINE_PADDING_PX,


### PR DESCRIPTION
There was a bug where the timeline would get clipped into the left if zoomed in too much, or zoomed into a certain step. 

Before
<img width="1032" height="760" alt="CleanShot 2026-05-20 at 14 55 21@2x" src="https://github.com/user-attachments/assets/7d68057a-bddc-4c8f-924a-e1291b6b6cfb" />

After:
<img width="1430" height="686" alt="CleanShot 2026-05-20 at 15 00 33@2x" src="https://github.com/user-attachments/assets/50dd6cf0-d76f-47c9-9f66-27124e3cb9ed" />

Also, refactored the timeline file a bit so it's easier to parse and removed unneeded code. 
