### PR TITLE
Add minimum release age configuration and exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,11 @@ onlyBuiltDependencies:
   - esbuild
 
 savePrefix: ""
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  - '@turbo/*'
+  - 'turbo'
+  - '@vercel/*'
+  - '@workflow/*'


### PR DESCRIPTION
## Summary

- Sets pnpm's `minimumReleaseAge` to 2 days
- Excludes internal scopes (`@turbo/*`, `turbo`, `@vercel/*`, `@workflow/*`) from the gate

## Test plan

- [ ] CI passes
- [ ] `pnpm install` continues to resolve internal scope packages without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)