### PR TITLE
[codex] Forward port stale wait replay fix

### DIFF
--- a/.changeset/bright-waits-refresh.md
+++ b/.changeset/bright-waits-refresh.md
@@ -1,0 +1,9 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+'@workflow/world-local': patch
+'@workflow/world-postgres': patch
+'@workflow/world-vercel': patch
+---
+
+Refresh workflow events after completing elapsed waits so concurrent hook events preserve deterministic replay order.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -648,10 +648,10 @@ export function workflowEntrypoint(
                           eventsCursor
                         );
                         // Dedupe by eventId: a previous iteration may have
-                        // pushed events manually (see the wait_completed
-                        // write loop below) without advancing the cursor,
-                        // so an incremental fetch can return events we
-                        // already have locally.
+                        // appended a refreshed wait-completion delta before
+                        // the next loop observes the advanced cursor, so an
+                        // incremental fetch can return events we already have
+                        // locally.
                         if (loaded.events.length > 0) {
                           const existingIds = new Set(
                             cachedEvents.map((e) => e.eventId)

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -102,57 +102,6 @@ export {
   setWorld,
 } from './runtime/world.js';
 
-function appendMissingEvents(events: Event[], loadedEvents: Event[]): boolean {
-  const existingIds = new Set(events.map((event) => event.eventId));
-  let hasNewEvents = false;
-
-  for (const event of loadedEvents) {
-    if (!existingIds.has(event.eventId)) {
-      events.push(event);
-      hasNewEvents = true;
-    }
-  }
-
-  return hasNewEvents;
-}
-
-async function refreshEventsAfterReplaySnapshot({
-  runId,
-  events,
-  cursor,
-}: {
-  runId: string;
-  events: Event[];
-  cursor: string | null;
-}): Promise<{
-  events: Event[];
-  cursor: string | null;
-  hasNewEvents: boolean;
-}> {
-  // Replay decisions are only valid for the event snapshot they saw. Before
-  // committing events derived from that replay (suspension, completed, or
-  // failed), do a cheap cursor delta check so concurrent events become part of
-  // the deterministic replay order.
-  if (cursor) {
-    const loaded = await loadWorkflowRunEvents(runId, cursor);
-    return {
-      events,
-      cursor: loaded.cursor ?? cursor,
-      hasNewEvents: appendMissingEvents(events, loaded.events),
-    };
-  }
-
-  const loaded = await loadWorkflowRunEvents(runId);
-  const existingIds = new Set(events.map((event) => event.eventId));
-  return {
-    events: loaded.events,
-    cursor: loaded.cursor,
-    hasNewEvents: loaded.events.some(
-      (event) => !existingIds.has(event.eventId)
-    ),
-  };
-}
-
 /**
  * Creates a single route which handles workflow execution requests,
  * executing steps inline when possible to reduce function invocations
@@ -645,17 +594,6 @@ export function workflowEntrypoint(
                   );
                   const encryptionKey = await getEncryptionKey();
 
-                  const refreshEventsAfterReplay = async (events: Event[]) => {
-                    const refreshed = await refreshEventsAfterReplaySnapshot({
-                      runId,
-                      events,
-                      cursor: eventsCursor,
-                    });
-                    eventsCursor = refreshed.cursor;
-                    cachedEvents = refreshed.events;
-                    return refreshed;
-                  };
-
                   // Main replay loop
                   // biome-ignore lint/correctness/noConstantCondition: intentional loop
                   while (true) {
@@ -687,11 +625,11 @@ export function workflowEntrypoint(
                     }
 
                     let replayStart = 0;
-                    let events: Event[] | undefined;
                     try {
                       // Load events — use cached events with incremental fetch on subsequent iterations.
                       // The server always returns a cursor when there are events (even on the
                       // final page), so we can reliably use it for incremental loading.
+                      let events: Event[];
                       if (cachedEvents === null) {
                         // First iteration: use preloaded events if available,
                         // otherwise do a full load with cursor.
@@ -897,20 +835,6 @@ export function workflowEntrypoint(
                         replayMs: Date.now() - replayStart,
                       });
 
-                      const refreshed = await refreshEventsAfterReplay(events);
-                      events = refreshed.events;
-                      if (refreshed.hasNewEvents) {
-                        runtimeLogger.debug(
-                          'New events arrived after replay; replaying before completing run',
-                          {
-                            workflowRunId: runId,
-                            loopIteration,
-                            eventCount: events.length,
-                          }
-                        );
-                        continue;
-                      }
-
                       // Workflow completed
                       try {
                         await world.events.create(
@@ -958,23 +882,6 @@ export function workflowEntrypoint(
                           );
                         if (suspensionMessage) {
                           runtimeLogger.debug(suspensionMessage);
-                        }
-
-                        if (events) {
-                          const refreshed =
-                            await refreshEventsAfterReplay(events);
-                          events = refreshed.events;
-                          if (refreshed.hasNewEvents) {
-                            runtimeLogger.debug(
-                              'New events arrived after suspended replay; replaying before handling suspension',
-                              {
-                                workflowRunId: runId,
-                                loopIteration,
-                                eventCount: events.length,
-                              }
-                            );
-                            continue;
-                          }
                         }
 
                         // V2: handle suspension without queuing steps
@@ -1213,23 +1120,6 @@ export function workflowEntrypoint(
                           errorName,
                           errorStack,
                         });
-
-                        if (events) {
-                          const refreshed =
-                            await refreshEventsAfterReplay(events);
-                          events = refreshed.events;
-                          if (refreshed.hasNewEvents) {
-                            runtimeLogger.debug(
-                              'New events arrived after failed replay; replaying before failing run',
-                              {
-                                workflowRunId: runId,
-                                loopIteration,
-                                eventCount: events.length,
-                              }
-                            );
-                            continue;
-                          }
-                        }
 
                         // Apply the source-map-remapped stack to the thrown
                         // value so that the serialized error preserves it

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -102,6 +102,57 @@ export {
   setWorld,
 } from './runtime/world.js';
 
+function appendMissingEvents(events: Event[], loadedEvents: Event[]): boolean {
+  const existingIds = new Set(events.map((event) => event.eventId));
+  let hasNewEvents = false;
+
+  for (const event of loadedEvents) {
+    if (!existingIds.has(event.eventId)) {
+      events.push(event);
+      hasNewEvents = true;
+    }
+  }
+
+  return hasNewEvents;
+}
+
+async function refreshEventsAfterReplaySnapshot({
+  runId,
+  events,
+  cursor,
+}: {
+  runId: string;
+  events: Event[];
+  cursor: string | null;
+}): Promise<{
+  events: Event[];
+  cursor: string | null;
+  hasNewEvents: boolean;
+}> {
+  // Replay decisions are only valid for the event snapshot they saw. Before
+  // committing events derived from that replay (suspension, completed, or
+  // failed), do a cheap cursor delta check so concurrent events become part of
+  // the deterministic replay order.
+  if (cursor) {
+    const loaded = await loadWorkflowRunEvents(runId, cursor);
+    return {
+      events,
+      cursor: loaded.cursor ?? cursor,
+      hasNewEvents: appendMissingEvents(events, loaded.events),
+    };
+  }
+
+  const loaded = await loadWorkflowRunEvents(runId);
+  const existingIds = new Set(events.map((event) => event.eventId));
+  return {
+    events: loaded.events,
+    cursor: loaded.cursor,
+    hasNewEvents: loaded.events.some(
+      (event) => !existingIds.has(event.eventId)
+    ),
+  };
+}
+
 /**
  * Creates a single route which handles workflow execution requests,
  * executing steps inline when possible to reduce function invocations
@@ -594,6 +645,17 @@ export function workflowEntrypoint(
                   );
                   const encryptionKey = await getEncryptionKey();
 
+                  const refreshEventsAfterReplay = async (events: Event[]) => {
+                    const refreshed = await refreshEventsAfterReplaySnapshot({
+                      runId,
+                      events,
+                      cursor: eventsCursor,
+                    });
+                    eventsCursor = refreshed.cursor;
+                    cachedEvents = refreshed.events;
+                    return refreshed;
+                  };
+
                   // Main replay loop
                   // biome-ignore lint/correctness/noConstantCondition: intentional loop
                   while (true) {
@@ -625,11 +687,11 @@ export function workflowEntrypoint(
                     }
 
                     let replayStart = 0;
+                    let events: Event[] | undefined;
                     try {
                       // Load events — use cached events with incremental fetch on subsequent iterations.
                       // The server always returns a cursor when there are events (even on the
                       // final page), so we can reliably use it for incremental loading.
-                      let events: Event[];
                       if (cachedEvents === null) {
                         // First iteration: use preloaded events if available,
                         // otherwise do a full load with cursor.
@@ -835,6 +897,20 @@ export function workflowEntrypoint(
                         replayMs: Date.now() - replayStart,
                       });
 
+                      const refreshed = await refreshEventsAfterReplay(events);
+                      events = refreshed.events;
+                      if (refreshed.hasNewEvents) {
+                        runtimeLogger.debug(
+                          'New events arrived after replay; replaying before completing run',
+                          {
+                            workflowRunId: runId,
+                            loopIteration,
+                            eventCount: events.length,
+                          }
+                        );
+                        continue;
+                      }
+
                       // Workflow completed
                       try {
                         await world.events.create(
@@ -882,6 +958,23 @@ export function workflowEntrypoint(
                           );
                         if (suspensionMessage) {
                           runtimeLogger.debug(suspensionMessage);
+                        }
+
+                        if (events) {
+                          const refreshed =
+                            await refreshEventsAfterReplay(events);
+                          events = refreshed.events;
+                          if (refreshed.hasNewEvents) {
+                            runtimeLogger.debug(
+                              'New events arrived after suspended replay; replaying before handling suspension',
+                              {
+                                workflowRunId: runId,
+                                loopIteration,
+                                eventCount: events.length,
+                              }
+                            );
+                            continue;
+                          }
                         }
 
                         // V2: handle suspension without queuing steps
@@ -1120,6 +1213,23 @@ export function workflowEntrypoint(
                           errorName,
                           errorStack,
                         });
+
+                        if (events) {
+                          const refreshed =
+                            await refreshEventsAfterReplay(events);
+                          events = refreshed.events;
+                          if (refreshed.hasNewEvents) {
+                            runtimeLogger.debug(
+                              'New events arrived after failed replay; replaying before failing run',
+                              {
+                                workflowRunId: runId,
+                                loopIteration,
+                                eventCount: events.length,
+                              }
+                            );
+                            continue;
+                          }
+                        }
 
                         // Apply the source-map-remapped stack to the thrown
                         // value so that the serialized error preserves it

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -328,6 +328,7 @@ export function workflowEntrypoint(
                   let workflowRun: WorkflowRun | undefined;
                   let workflowStartedAt = -1;
                   let preloadedEvents: Event[] | undefined;
+                  let preloadedEventsCursor: string | null | undefined;
 
                   // If incoming message has a stepId, this is a background step
                   // execution. Execute the step, then check if all parallel steps
@@ -484,8 +485,13 @@ export function workflowEntrypoint(
 
                       // If the response includes events, use them to skip
                       // the initial events.list call and reduce TTFB.
-                      if (result.events && result.events.length > 0) {
+                      if (
+                        result.events &&
+                        result.events.length > 0 &&
+                        result.hasMore !== true
+                      ) {
                         preloadedEvents = result.events;
+                        preloadedEventsCursor = result.cursor;
                       }
 
                       if (!workflowRun.startedAt) {
@@ -629,8 +635,7 @@ export function workflowEntrypoint(
                         // otherwise do a full load with cursor.
                         if (preloadedEvents) {
                           events = preloadedEvents;
-                          // No cursor from preloaded events — next iteration
-                          // will fall through to the full reload path below.
+                          eventsCursor = preloadedEventsCursor ?? null;
                         } else {
                           const loaded = await loadWorkflowRunEvents(runId);
                           events = loaded.events;
@@ -742,12 +747,9 @@ export function workflowEntrypoint(
 
                       for (const waitEvent of waitsToComplete) {
                         try {
-                          const result = await world.events.create(
-                            runId,
-                            waitEvent,
-                            { requestId }
-                          );
-                          events.push(result.event!);
+                          await world.events.create(runId, waitEvent, {
+                            requestId,
+                          });
                         } catch (err) {
                           if (EntityConflictError.is(err)) {
                             runtimeLogger.info(
@@ -760,6 +762,54 @@ export function workflowEntrypoint(
                             continue;
                           }
                           throw err;
+                        }
+                      }
+
+                      if (waitsToComplete.length > 0) {
+                        // The event list above may be stale by the time an
+                        // elapsed wait is committed. Load only events after
+                        // the original snapshot cursor so concurrent durable
+                        // events, such as hook_received, keep their ordering
+                        // relative to wait_completed. Fall back to a full
+                        // reload for older worlds that cannot give us a stable
+                        // cursor, or if the cursor delta does not include the
+                        // wait completion this handler just attempted.
+                        if (eventsCursor) {
+                          const loaded = await loadWorkflowRunEvents(
+                            runId,
+                            eventsCursor
+                          );
+                          const completedWaitIdsAfterCursor = new Set(
+                            loaded.events
+                              .filter((e) => e.eventType === 'wait_completed')
+                              .map((e) => e.correlationId)
+                          );
+                          const sawAllWaitCompletions = waitsToComplete.every(
+                            (waitEvent) =>
+                              completedWaitIdsAfterCursor.has(
+                                waitEvent.correlationId
+                              )
+                          );
+
+                          if (sawAllWaitCompletions) {
+                            const existingIds = new Set(
+                              events.map((e) => e.eventId)
+                            );
+                            for (const event of loaded.events) {
+                              if (!existingIds.has(event.eventId)) {
+                                events.push(event);
+                              }
+                            }
+                            eventsCursor = loaded.cursor ?? eventsCursor;
+                          } else {
+                            const loaded = await loadWorkflowRunEvents(runId);
+                            events = loaded.events;
+                            eventsCursor = loaded.cursor;
+                          }
+                        } else {
+                          const loaded = await loadWorkflowRunEvents(runId);
+                          events = loaded.events;
+                          eventsCursor = loaded.cursor;
                         }
                       }
 

--- a/packages/core/src/runtime/wait-completion-replay.test.ts
+++ b/packages/core/src/runtime/wait-completion-replay.test.ts
@@ -1,0 +1,474 @@
+import {
+  type CreateEventRequest,
+  type Event,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+  type World,
+} from '@workflow/world';
+import { monotonicFactory } from 'ulid';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { workflowEntrypoint } from '../runtime.js';
+import {
+  dehydrateStepArguments,
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from '../serialization.js';
+import { createContext } from '../vm/index.js';
+import { setWorld } from './world.js';
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn(),
+}));
+
+vi.mock('@workflow/utils/get-port', () => ({
+  getPort: vi.fn().mockResolvedValue(3000),
+}));
+
+const fixedNow = new Date('2026-05-19T12:00:20.000Z');
+
+function getWorkflowTransformCode(workflowName: string) {
+  return `;globalThis.__private_workflows = new Map([[${JSON.stringify(workflowName)}, ${workflowName}]]);`;
+}
+
+/**
+ * Drives the real workflow queue handler with a fake World so the test can
+ * control the storage interleaving that is hard to reproduce with wall-clock
+ * timing: the handler sees a stale event snapshot, then completing the elapsed
+ * wait races with a hook payload that landed durably first.
+ */
+async function runStaleWaitReplayScenario(options: {
+  includePreloadedCursor: boolean;
+  preloadedHasMore?: boolean;
+  omitWaitCompletionFromDelta?: boolean;
+}) {
+  vi.spyOn(Date, 'now').mockReturnValue(+fixedNow);
+
+  const runId = 'wrun_stale_wait_replay';
+  const workflowName = 'workflow';
+  const deploymentId = 'dpl_stale_wait_replay';
+  const hookToken = 'stale-wait-hook-token';
+  const startedAt = new Date('2026-05-19T12:00:00.000Z');
+  const workflowArgs = await dehydrateWorkflowArguments(
+    [hookToken],
+    runId,
+    undefined
+  );
+
+  const { globalThis: vmGlobalThis } = createContext({
+    seed: `${runId}:${workflowName}:${+startedAt}`,
+    fixedTimestamp: +startedAt,
+  });
+  const ulid = monotonicFactory(() => vmGlobalThis.Math.random());
+  const hookCorrelationId = `hook_${ulid(+startedAt)}`;
+  const syncStep0CorrelationId = `step_${ulid(+startedAt)}`;
+  const waitCorrelationId = `wait_${ulid(+startedAt)}`;
+
+  const workflowRun: WorkflowRun = {
+    runId,
+    workflowName,
+    status: 'running',
+    input: workflowArgs,
+    deploymentId,
+    specVersion: SPEC_VERSION_CURRENT,
+    startedAt,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  };
+
+  let eventIndex = 0;
+  const event = (
+    data: CreateEventRequest,
+    createdAt = new Date(+startedAt + ++eventIndex * 100)
+  ): Event =>
+    ({
+      ...data,
+      specVersion: data.specVersion ?? SPEC_VERSION_CURRENT,
+      runId,
+      eventId: `evt_${eventIndex.toString().padStart(3, '0')}`,
+      createdAt,
+    }) as Event;
+
+  const runCreatedEvent = {
+    eventType: 'run_created',
+    specVersion: SPEC_VERSION_CURRENT,
+    eventData: {
+      deploymentId,
+      workflowName,
+      input: workflowArgs,
+    },
+  } satisfies CreateEventRequest;
+
+  const staleEvents: Event[] = [
+    event(runCreatedEvent),
+    event({
+      eventType: 'run_started',
+      specVersion: SPEC_VERSION_CURRENT,
+    }),
+    event({
+      eventType: 'hook_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: hookCorrelationId,
+      eventData: { token: hookToken },
+    }),
+    event({
+      eventType: 'step_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: syncStep0CorrelationId,
+      eventData: {
+        stepName: 'syncStep',
+        input: await dehydrateStepArguments(
+          {
+            args: [{ index: 0 }],
+            closureVars: undefined,
+            thisVal: undefined,
+          },
+          runId,
+          undefined
+        ),
+      },
+    }),
+    event({
+      eventType: 'step_started',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: syncStep0CorrelationId,
+    }),
+    event({
+      eventType: 'step_completed',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: syncStep0CorrelationId,
+      eventData: {
+        result: await dehydrateStepReturnValue(undefined, runId, undefined),
+      },
+    }),
+    event({
+      eventType: 'wait_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: waitCorrelationId,
+      eventData: {
+        resumeAt: new Date(+startedAt - 1_000),
+      },
+    }),
+  ];
+
+  const staleEventsCursor = 'cursor-after-stale-events';
+  const hookReceivedEvent = event({
+    eventType: 'hook_received',
+    specVersion: SPEC_VERSION_CURRENT,
+    correlationId: hookCorrelationId,
+    eventData: {
+      payload: await dehydrateStepReturnValue(
+        { value: 'hook-wins' },
+        runId,
+        undefined
+      ),
+    },
+  });
+
+  const durableEvents = [...staleEvents];
+  const createdEvents: Event[] = [];
+  const listedPages: Event[][] = [];
+  let capturedHandler:
+    | ((
+        message: unknown,
+        metadata: { queueName: string; messageId: string; attempt: number }
+      ) => Promise<unknown>)
+    | undefined;
+
+  const listEvents = vi.fn(
+    async (params: {
+      runId: string;
+      pagination?: { cursor?: string; sortOrder?: 'asc' | 'desc' };
+    }) => {
+      // Cursor reads simulate the optimized delta fetch. Without a cursor, the
+      // runtime has fallen back to a full reload from the beginning.
+      let data =
+        params.pagination?.cursor === staleEventsCursor
+          ? durableEvents.slice(staleEvents.length)
+          : [...durableEvents];
+      if (
+        params.pagination?.cursor === staleEventsCursor &&
+        options.omitWaitCompletionFromDelta
+      ) {
+        data = data.filter((event) => event.eventType !== 'wait_completed');
+      }
+      listedPages.push(data);
+      return {
+        data,
+        hasMore: false,
+        cursor: params.pagination?.cursor
+          ? (data.at(-1)?.eventId ?? null)
+          : staleEventsCursor,
+      };
+    }
+  );
+
+  const createEvent = vi.fn(
+    async (_runId: string, request: CreateEventRequest) => {
+      if (request.eventType === 'run_started') {
+        return {
+          run: workflowRun,
+          events: [...staleEvents],
+          ...(options.includePreloadedCursor
+            ? {
+                cursor: staleEventsCursor,
+                hasMore: options.preloadedHasMore ?? false,
+              }
+            : {}),
+        };
+      }
+
+      if (request.eventType === 'wait_completed') {
+        // This is the race: the wait-triggered handler is committing
+        // wait_completed, but a hook_received event became durable just before
+        // that commit. Replay must observe both events in that durable order.
+        if (!durableEvents.includes(hookReceivedEvent)) {
+          durableEvents.push(hookReceivedEvent);
+        }
+      }
+
+      const created = event(request);
+      durableEvents.push(created);
+      createdEvents.push(created);
+      return { event: created };
+    }
+  );
+
+  const queue = vi.fn().mockResolvedValue({ messageId: 'msg_step' });
+  const fakeWorld = {
+    specVersion: SPEC_VERSION_CURRENT,
+    createQueueHandler: vi.fn((_prefix, handler) => {
+      capturedHandler = handler;
+      return vi.fn();
+    }),
+    events: {
+      list: listEvents,
+      create: createEvent,
+    },
+    queue,
+    getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
+  } as unknown as World;
+
+  setWorld(fakeWorld);
+
+  const workflowCode = `
+    const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
+    const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+    const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+    const syncStep = useStep("syncStep");
+    const drainStep = useStep("drainStep");
+
+    async function workflow(token) {
+      const hook = createHook({ token });
+      const iterator = hook[Symbol.asyncIterator]();
+      let pendingRead;
+
+      try {
+        for (let index = 0; index < 2; index += 1) {
+          await syncStep({ index });
+          pendingRead ??= iterator.next();
+          const result = await Promise.race([
+            pendingRead.then((value) => ({ kind: "hook", value })),
+            sleep("5s").then(() => ({ kind: "sleep" })),
+          ]);
+
+          if (result.kind === "sleep") {
+            continue;
+          }
+
+          pendingRead = undefined;
+          await Promise.all([drainStep({ index }), sleep("1h")]);
+          return result.value.value;
+        }
+
+        return "sleep";
+      } finally {
+        hook.dispose();
+      }
+    }
+
+    ${getWorkflowTransformCode(workflowName)}
+  `;
+
+  const handler = workflowEntrypoint(workflowCode);
+  await handler(new Request('http://localhost', { method: 'POST' }));
+  expect(capturedHandler).toBeDefined();
+
+  await capturedHandler?.(
+    { runId },
+    {
+      queueName: `__wkf_workflow_${workflowName}`,
+      messageId: 'msg_workflow',
+      attempt: 1,
+    }
+  );
+
+  return {
+    createdEvents,
+    listEvents,
+    listedPages,
+    staleEventsCursor,
+    waitCorrelationId,
+  };
+}
+
+function expectHookBranchQueued(
+  result: Awaited<ReturnType<typeof runStaleWaitReplayScenario>>
+) {
+  expect(result.createdEvents).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        eventType: 'wait_completed',
+        correlationId: result.waitCorrelationId,
+      }),
+      expect.objectContaining({
+        eventType: 'step_created',
+        eventData: expect.objectContaining({
+          stepName: 'drainStep',
+        }),
+      }),
+    ])
+  );
+  expect(result.createdEvents).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        eventType: 'step_created',
+        eventData: expect.objectContaining({
+          stepName: 'syncStep',
+        }),
+      }),
+    ])
+  );
+}
+
+describe('workflow handler wait completion replay', () => {
+  afterEach(() => {
+    setWorld(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it('loads only events after the preloaded cursor after completing an elapsed wait', async () => {
+    // Happy path: run_started gave the handler a complete snapshot and cursor,
+    // so after wait_completed it only needs the delta containing the hook and
+    // wait completion.
+    const result = await runStaleWaitReplayScenario({
+      includePreloadedCursor: true,
+    });
+
+    expect(result.listEvents).toHaveBeenCalledTimes(1);
+    expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
+      expect.objectContaining({
+        sortOrder: 'asc',
+        cursor: result.staleEventsCursor,
+      })
+    );
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'hook_received',
+      'wait_completed',
+    ]);
+    expectHookBranchQueued(result);
+  });
+
+  it('falls back to a full reload when preloaded events do not include a cursor', async () => {
+    // Backward compatibility path for worlds/servers that return preloaded
+    // events but do not yet return pagination metadata with them.
+    const result = await runStaleWaitReplayScenario({
+      includePreloadedCursor: false,
+    });
+
+    expect(result.listEvents).toHaveBeenCalledTimes(1);
+    expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
+      expect.objectContaining({
+        sortOrder: 'asc',
+        cursor: undefined,
+      })
+    );
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'run_created',
+      'run_started',
+      'hook_created',
+      'step_created',
+      'step_started',
+      'step_completed',
+      'wait_created',
+      'hook_received',
+      'wait_completed',
+    ]);
+    expectHookBranchQueued(result);
+  });
+
+  it('falls back to a full reload when preloaded events are partial', async () => {
+    // A run_started response can return a preloaded page and still say more
+    // pages exist. That page is not a complete replay input, so the handler
+    // must discard it and load from the beginning before completing waits.
+    const result = await runStaleWaitReplayScenario({
+      includePreloadedCursor: true,
+      preloadedHasMore: true,
+    });
+
+    expect(result.listEvents).toHaveBeenCalledTimes(2);
+    expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
+      expect.objectContaining({
+        sortOrder: 'asc',
+        cursor: undefined,
+      })
+    );
+    expect(result.listEvents.mock.calls[1]?.[0].pagination).toEqual(
+      expect.objectContaining({
+        sortOrder: 'asc',
+        cursor: result.staleEventsCursor,
+      })
+    );
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'run_created',
+      'run_started',
+      'hook_created',
+      'step_created',
+      'step_started',
+      'step_completed',
+      'wait_created',
+    ]);
+    expect(result.listedPages[1]?.map((event) => event.eventType)).toEqual([
+      'hook_received',
+      'wait_completed',
+    ]);
+    expectHookBranchQueued(result);
+  });
+
+  it('falls back to a full reload when the cursor delta misses the attempted wait completion', async () => {
+    // Defensive path: if the cursor read does not include the wait completion
+    // this handler just wrote, the cursor was not a safe replay boundary.
+    const result = await runStaleWaitReplayScenario({
+      includePreloadedCursor: true,
+      omitWaitCompletionFromDelta: true,
+    });
+
+    expect(result.listEvents).toHaveBeenCalledTimes(2);
+    expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
+      expect.objectContaining({
+        sortOrder: 'asc',
+        cursor: result.staleEventsCursor,
+      })
+    );
+    expect(result.listEvents.mock.calls[1]?.[0].pagination).toEqual(
+      expect.objectContaining({
+        sortOrder: 'asc',
+        cursor: undefined,
+      })
+    );
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'hook_received',
+    ]);
+    expect(result.listedPages[1]?.map((event) => event.eventType)).toEqual([
+      'run_created',
+      'run_started',
+      'hook_created',
+      'step_created',
+      'step_started',
+      'step_completed',
+      'wait_created',
+      'hook_received',
+      'wait_completed',
+    ]);
+    expectHookBranchQueued(result);
+  });
+});

--- a/packages/core/src/runtime/wait-completion-replay.test.ts
+++ b/packages/core/src/runtime/wait-completion-replay.test.ts
@@ -150,8 +150,7 @@ async function runStaleWaitReplayScenario(options: {
     }),
   ];
 
-  const staleEventsCursor =
-    staleEvents.at(-1)?.eventId ?? 'cursor-after-stale-events';
+  const staleEventsCursor = 'cursor-after-stale-events';
   const hookReceivedEvent = event({
     eventType: 'hook_received',
     specVersion: SPEC_VERSION_CURRENT,
@@ -182,19 +181,10 @@ async function runStaleWaitReplayScenario(options: {
     }) => {
       // Cursor reads simulate the optimized delta fetch. Without a cursor, the
       // runtime has fallen back to a full reload from the beginning.
-      const cursor = params.pagination?.cursor;
-      let data: Event[];
-      if (cursor) {
-        const cursorIndex = durableEvents.findIndex(
-          (event) => event.eventId === cursor
-        );
-        data =
-          cursorIndex === -1
-            ? [...durableEvents]
-            : durableEvents.slice(cursorIndex + 1);
-      } else {
-        data = [...durableEvents];
-      }
+      let data =
+        params.pagination?.cursor === staleEventsCursor
+          ? durableEvents.slice(staleEvents.length)
+          : [...durableEvents];
       if (
         params.pagination?.cursor === staleEventsCursor &&
         options.omitWaitCompletionFromDelta
@@ -205,7 +195,9 @@ async function runStaleWaitReplayScenario(options: {
       return {
         data,
         hasMore: false,
-        cursor: data.at(-1)?.eventId ?? cursor ?? null,
+        cursor: params.pagination?.cursor
+          ? (data.at(-1)?.eventId ?? null)
+          : staleEventsCursor,
       };
     }
   );
@@ -348,230 +340,6 @@ function expectHookBranchQueued(
   );
 }
 
-/**
- * Covers the V5-only unified handler shape where replay itself suspends before
- * writing new step/wait events. If a hook payload lands after the stale replay
- * snapshot but before the suspension handler writes the sleep branch's
- * wait_created, the handler must refresh and replay instead of committing that
- * stale suspension.
- */
-async function runStaleSuspensionReplayScenario() {
-  vi.spyOn(Date, 'now').mockReturnValue(+fixedNow);
-
-  const runId = 'wrun_stale_suspension_replay';
-  const workflowName = 'workflow';
-  const deploymentId = 'dpl_stale_suspension_replay';
-  const hookToken = 'stale-suspension-hook-token';
-  const startedAt = new Date('2026-05-19T12:00:00.000Z');
-  const workflowArgs = await dehydrateWorkflowArguments(
-    [hookToken],
-    runId,
-    undefined
-  );
-
-  const { globalThis: vmGlobalThis } = createContext({
-    seed: `${runId}:${workflowName}:${+startedAt}`,
-    fixedTimestamp: +startedAt,
-  });
-  const ulid = monotonicFactory(() => vmGlobalThis.Math.random());
-  const hookCorrelationId = `hook_${ulid(+startedAt)}`;
-
-  const workflowRun: WorkflowRun = {
-    runId,
-    workflowName,
-    status: 'running',
-    input: workflowArgs,
-    deploymentId,
-    specVersion: SPEC_VERSION_CURRENT,
-    startedAt,
-    createdAt: startedAt,
-    updatedAt: startedAt,
-  };
-
-  let eventIndex = 0;
-  const event = (
-    data: CreateEventRequest,
-    createdAt = new Date(+startedAt + ++eventIndex * 100)
-  ): Event =>
-    ({
-      ...data,
-      specVersion: data.specVersion ?? SPEC_VERSION_CURRENT,
-      runId,
-      eventId: `evt_${eventIndex.toString().padStart(3, '0')}`,
-      createdAt,
-    }) as Event;
-
-  const staleEvents: Event[] = [
-    event({
-      eventType: 'run_created',
-      specVersion: SPEC_VERSION_CURRENT,
-      eventData: {
-        deploymentId,
-        workflowName,
-        input: workflowArgs,
-      },
-    }),
-    event({
-      eventType: 'run_started',
-      specVersion: SPEC_VERSION_CURRENT,
-    }),
-    event({
-      eventType: 'hook_created',
-      specVersion: SPEC_VERSION_CURRENT,
-      correlationId: hookCorrelationId,
-      eventData: { token: hookToken },
-    }),
-  ];
-
-  const staleEventsCursor =
-    staleEvents.at(-1)?.eventId ?? 'cursor-after-stale-events';
-  const hookReceivedEvent = event({
-    eventType: 'hook_received',
-    specVersion: SPEC_VERSION_CURRENT,
-    correlationId: hookCorrelationId,
-    eventData: {
-      payload: await dehydrateStepReturnValue(
-        { value: 'hook-wins' },
-        runId,
-        undefined
-      ),
-    },
-  });
-
-  const durableEvents = [...staleEvents];
-  const createdEvents: Event[] = [];
-  const listedPages: Event[][] = [];
-  let injectedHookReceived = false;
-  let capturedHandler:
-    | ((
-        message: unknown,
-        metadata: { queueName: string; messageId: string; attempt: number }
-      ) => Promise<unknown>)
-    | undefined;
-
-  const listEvents = vi.fn(
-    async (params: {
-      runId: string;
-      pagination?: { cursor?: string; sortOrder?: 'asc' | 'desc' };
-    }) => {
-      const cursor = params.pagination?.cursor;
-      if (cursor === staleEventsCursor && !injectedHookReceived) {
-        // The hook becomes durable in the window between stale replay and
-        // writing suspension events from that replay.
-        durableEvents.push(hookReceivedEvent);
-        injectedHookReceived = true;
-      }
-
-      let data: Event[];
-      if (cursor) {
-        const cursorIndex = durableEvents.findIndex(
-          (event) => event.eventId === cursor
-        );
-        data =
-          cursorIndex === -1
-            ? [...durableEvents]
-            : durableEvents.slice(cursorIndex + 1);
-      } else {
-        data = [...durableEvents];
-      }
-
-      listedPages.push(data);
-      return {
-        data,
-        hasMore: false,
-        cursor: data.at(-1)?.eventId ?? cursor ?? null,
-      };
-    }
-  );
-
-  const createEvent = vi.fn(
-    async (_runId: string, request: CreateEventRequest) => {
-      if (request.eventType === 'run_started') {
-        return {
-          run: workflowRun,
-          events: [...staleEvents],
-          cursor: staleEventsCursor,
-          hasMore: false,
-        };
-      }
-
-      const created = event(request);
-      durableEvents.push(created);
-      createdEvents.push(created);
-      return { event: created };
-    }
-  );
-
-  const queue = vi.fn().mockResolvedValue({ messageId: 'msg_step' });
-  const fakeWorld = {
-    specVersion: SPEC_VERSION_CURRENT,
-    createQueueHandler: vi.fn((_prefix, handler) => {
-      capturedHandler = handler;
-      return vi.fn();
-    }),
-    events: {
-      list: listEvents,
-      create: createEvent,
-    },
-    queue,
-    getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
-  } as unknown as World;
-
-  setWorld(fakeWorld);
-
-  const workflowCode = `
-    const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
-    const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
-    const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
-    const syncStep = useStep("syncStep");
-    const drainStep = useStep("drainStep");
-
-    async function workflow(token) {
-      const hook = createHook({ token });
-      const iterator = hook[Symbol.asyncIterator]();
-
-      try {
-        const result = await Promise.race([
-          iterator.next().then((value) => ({ kind: "hook", value })),
-          sleep("5s").then(() => ({ kind: "sleep" })),
-        ]);
-
-        if (result.kind === "hook") {
-          await Promise.all([drainStep({ index: 0 }), sleep("1h")]);
-          return result.value.value;
-        }
-
-        await syncStep({ index: 0 });
-        return "sleep";
-      } finally {
-        hook.dispose();
-      }
-    }
-
-    ${getWorkflowTransformCode(workflowName)}
-  `;
-
-  const handler = workflowEntrypoint(workflowCode);
-  await handler(new Request('http://localhost', { method: 'POST' }));
-  expect(capturedHandler).toBeDefined();
-
-  await capturedHandler?.(
-    { runId },
-    {
-      queueName: `__wkf_workflow_${workflowName}`,
-      messageId: 'msg_workflow',
-      attempt: 1,
-    }
-  );
-
-  return {
-    createdEvents,
-    listEvents,
-    listedPages,
-    staleEventsCursor,
-  };
-}
-
 describe('workflow handler wait completion replay', () => {
   afterEach(() => {
     setWorld(undefined);
@@ -586,7 +354,7 @@ describe('workflow handler wait completion replay', () => {
       includePreloadedCursor: true,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(2);
+    expect(result.listEvents).toHaveBeenCalledTimes(1);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -597,7 +365,6 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
-    expect(result.listedPages[1]).toEqual([]);
     expectHookBranchQueued(result);
   });
 
@@ -608,7 +375,7 @@ describe('workflow handler wait completion replay', () => {
       includePreloadedCursor: false,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(2);
+    expect(result.listEvents).toHaveBeenCalledTimes(1);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -626,7 +393,6 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
-    expect(result.listedPages[1]).toEqual([]);
     expectHookBranchQueued(result);
   });
 
@@ -639,7 +405,7 @@ describe('workflow handler wait completion replay', () => {
       preloadedHasMore: true,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(3);
+    expect(result.listEvents).toHaveBeenCalledTimes(2);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -665,7 +431,6 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
-    expect(result.listedPages[2]).toEqual([]);
     expectHookBranchQueued(result);
   });
 
@@ -677,7 +442,7 @@ describe('workflow handler wait completion replay', () => {
       omitWaitCompletionFromDelta: true,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(3);
+    expect(result.listEvents).toHaveBeenCalledTimes(2);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -704,41 +469,6 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
-    expect(result.listedPages[2]).toEqual([]);
     expectHookBranchQueued(result);
-  });
-
-  it('refreshes before writing suspension events from a stale replay', async () => {
-    const result = await runStaleSuspensionReplayScenario();
-
-    expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
-      expect.objectContaining({
-        sortOrder: 'asc',
-        cursor: result.staleEventsCursor,
-      })
-    );
-    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
-      'hook_received',
-    ]);
-    expect(result.createdEvents).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          eventType: 'step_created',
-          eventData: expect.objectContaining({
-            stepName: 'drainStep',
-          }),
-        }),
-      ])
-    );
-    expect(result.createdEvents).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          eventType: 'step_created',
-          eventData: expect.objectContaining({
-            stepName: 'syncStep',
-          }),
-        }),
-      ])
-    );
   });
 });

--- a/packages/core/src/runtime/wait-completion-replay.test.ts
+++ b/packages/core/src/runtime/wait-completion-replay.test.ts
@@ -150,7 +150,8 @@ async function runStaleWaitReplayScenario(options: {
     }),
   ];
 
-  const staleEventsCursor = 'cursor-after-stale-events';
+  const staleEventsCursor =
+    staleEvents.at(-1)?.eventId ?? 'cursor-after-stale-events';
   const hookReceivedEvent = event({
     eventType: 'hook_received',
     specVersion: SPEC_VERSION_CURRENT,
@@ -181,10 +182,19 @@ async function runStaleWaitReplayScenario(options: {
     }) => {
       // Cursor reads simulate the optimized delta fetch. Without a cursor, the
       // runtime has fallen back to a full reload from the beginning.
-      let data =
-        params.pagination?.cursor === staleEventsCursor
-          ? durableEvents.slice(staleEvents.length)
-          : [...durableEvents];
+      const cursor = params.pagination?.cursor;
+      let data: Event[];
+      if (cursor) {
+        const cursorIndex = durableEvents.findIndex(
+          (event) => event.eventId === cursor
+        );
+        data =
+          cursorIndex === -1
+            ? [...durableEvents]
+            : durableEvents.slice(cursorIndex + 1);
+      } else {
+        data = [...durableEvents];
+      }
       if (
         params.pagination?.cursor === staleEventsCursor &&
         options.omitWaitCompletionFromDelta
@@ -195,9 +205,7 @@ async function runStaleWaitReplayScenario(options: {
       return {
         data,
         hasMore: false,
-        cursor: params.pagination?.cursor
-          ? (data.at(-1)?.eventId ?? null)
-          : staleEventsCursor,
+        cursor: data.at(-1)?.eventId ?? cursor ?? null,
       };
     }
   );
@@ -340,6 +348,230 @@ function expectHookBranchQueued(
   );
 }
 
+/**
+ * Covers the V5-only unified handler shape where replay itself suspends before
+ * writing new step/wait events. If a hook payload lands after the stale replay
+ * snapshot but before the suspension handler writes the sleep branch's
+ * wait_created, the handler must refresh and replay instead of committing that
+ * stale suspension.
+ */
+async function runStaleSuspensionReplayScenario() {
+  vi.spyOn(Date, 'now').mockReturnValue(+fixedNow);
+
+  const runId = 'wrun_stale_suspension_replay';
+  const workflowName = 'workflow';
+  const deploymentId = 'dpl_stale_suspension_replay';
+  const hookToken = 'stale-suspension-hook-token';
+  const startedAt = new Date('2026-05-19T12:00:00.000Z');
+  const workflowArgs = await dehydrateWorkflowArguments(
+    [hookToken],
+    runId,
+    undefined
+  );
+
+  const { globalThis: vmGlobalThis } = createContext({
+    seed: `${runId}:${workflowName}:${+startedAt}`,
+    fixedTimestamp: +startedAt,
+  });
+  const ulid = monotonicFactory(() => vmGlobalThis.Math.random());
+  const hookCorrelationId = `hook_${ulid(+startedAt)}`;
+
+  const workflowRun: WorkflowRun = {
+    runId,
+    workflowName,
+    status: 'running',
+    input: workflowArgs,
+    deploymentId,
+    specVersion: SPEC_VERSION_CURRENT,
+    startedAt,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  };
+
+  let eventIndex = 0;
+  const event = (
+    data: CreateEventRequest,
+    createdAt = new Date(+startedAt + ++eventIndex * 100)
+  ): Event =>
+    ({
+      ...data,
+      specVersion: data.specVersion ?? SPEC_VERSION_CURRENT,
+      runId,
+      eventId: `evt_${eventIndex.toString().padStart(3, '0')}`,
+      createdAt,
+    }) as Event;
+
+  const staleEvents: Event[] = [
+    event({
+      eventType: 'run_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      eventData: {
+        deploymentId,
+        workflowName,
+        input: workflowArgs,
+      },
+    }),
+    event({
+      eventType: 'run_started',
+      specVersion: SPEC_VERSION_CURRENT,
+    }),
+    event({
+      eventType: 'hook_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: hookCorrelationId,
+      eventData: { token: hookToken },
+    }),
+  ];
+
+  const staleEventsCursor =
+    staleEvents.at(-1)?.eventId ?? 'cursor-after-stale-events';
+  const hookReceivedEvent = event({
+    eventType: 'hook_received',
+    specVersion: SPEC_VERSION_CURRENT,
+    correlationId: hookCorrelationId,
+    eventData: {
+      payload: await dehydrateStepReturnValue(
+        { value: 'hook-wins' },
+        runId,
+        undefined
+      ),
+    },
+  });
+
+  const durableEvents = [...staleEvents];
+  const createdEvents: Event[] = [];
+  const listedPages: Event[][] = [];
+  let injectedHookReceived = false;
+  let capturedHandler:
+    | ((
+        message: unknown,
+        metadata: { queueName: string; messageId: string; attempt: number }
+      ) => Promise<unknown>)
+    | undefined;
+
+  const listEvents = vi.fn(
+    async (params: {
+      runId: string;
+      pagination?: { cursor?: string; sortOrder?: 'asc' | 'desc' };
+    }) => {
+      const cursor = params.pagination?.cursor;
+      if (cursor === staleEventsCursor && !injectedHookReceived) {
+        // The hook becomes durable in the window between stale replay and
+        // writing suspension events from that replay.
+        durableEvents.push(hookReceivedEvent);
+        injectedHookReceived = true;
+      }
+
+      let data: Event[];
+      if (cursor) {
+        const cursorIndex = durableEvents.findIndex(
+          (event) => event.eventId === cursor
+        );
+        data =
+          cursorIndex === -1
+            ? [...durableEvents]
+            : durableEvents.slice(cursorIndex + 1);
+      } else {
+        data = [...durableEvents];
+      }
+
+      listedPages.push(data);
+      return {
+        data,
+        hasMore: false,
+        cursor: data.at(-1)?.eventId ?? cursor ?? null,
+      };
+    }
+  );
+
+  const createEvent = vi.fn(
+    async (_runId: string, request: CreateEventRequest) => {
+      if (request.eventType === 'run_started') {
+        return {
+          run: workflowRun,
+          events: [...staleEvents],
+          cursor: staleEventsCursor,
+          hasMore: false,
+        };
+      }
+
+      const created = event(request);
+      durableEvents.push(created);
+      createdEvents.push(created);
+      return { event: created };
+    }
+  );
+
+  const queue = vi.fn().mockResolvedValue({ messageId: 'msg_step' });
+  const fakeWorld = {
+    specVersion: SPEC_VERSION_CURRENT,
+    createQueueHandler: vi.fn((_prefix, handler) => {
+      capturedHandler = handler;
+      return vi.fn();
+    }),
+    events: {
+      list: listEvents,
+      create: createEvent,
+    },
+    queue,
+    getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
+  } as unknown as World;
+
+  setWorld(fakeWorld);
+
+  const workflowCode = `
+    const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
+    const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+    const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+    const syncStep = useStep("syncStep");
+    const drainStep = useStep("drainStep");
+
+    async function workflow(token) {
+      const hook = createHook({ token });
+      const iterator = hook[Symbol.asyncIterator]();
+
+      try {
+        const result = await Promise.race([
+          iterator.next().then((value) => ({ kind: "hook", value })),
+          sleep("5s").then(() => ({ kind: "sleep" })),
+        ]);
+
+        if (result.kind === "hook") {
+          await Promise.all([drainStep({ index: 0 }), sleep("1h")]);
+          return result.value.value;
+        }
+
+        await syncStep({ index: 0 });
+        return "sleep";
+      } finally {
+        hook.dispose();
+      }
+    }
+
+    ${getWorkflowTransformCode(workflowName)}
+  `;
+
+  const handler = workflowEntrypoint(workflowCode);
+  await handler(new Request('http://localhost', { method: 'POST' }));
+  expect(capturedHandler).toBeDefined();
+
+  await capturedHandler?.(
+    { runId },
+    {
+      queueName: `__wkf_workflow_${workflowName}`,
+      messageId: 'msg_workflow',
+      attempt: 1,
+    }
+  );
+
+  return {
+    createdEvents,
+    listEvents,
+    listedPages,
+    staleEventsCursor,
+  };
+}
+
 describe('workflow handler wait completion replay', () => {
   afterEach(() => {
     setWorld(undefined);
@@ -354,7 +586,7 @@ describe('workflow handler wait completion replay', () => {
       includePreloadedCursor: true,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(1);
+    expect(result.listEvents).toHaveBeenCalledTimes(2);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -365,6 +597,7 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
+    expect(result.listedPages[1]).toEqual([]);
     expectHookBranchQueued(result);
   });
 
@@ -375,7 +608,7 @@ describe('workflow handler wait completion replay', () => {
       includePreloadedCursor: false,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(1);
+    expect(result.listEvents).toHaveBeenCalledTimes(2);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -393,6 +626,7 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
+    expect(result.listedPages[1]).toEqual([]);
     expectHookBranchQueued(result);
   });
 
@@ -405,7 +639,7 @@ describe('workflow handler wait completion replay', () => {
       preloadedHasMore: true,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(2);
+    expect(result.listEvents).toHaveBeenCalledTimes(3);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -431,6 +665,7 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
+    expect(result.listedPages[2]).toEqual([]);
     expectHookBranchQueued(result);
   });
 
@@ -442,7 +677,7 @@ describe('workflow handler wait completion replay', () => {
       omitWaitCompletionFromDelta: true,
     });
 
-    expect(result.listEvents).toHaveBeenCalledTimes(2);
+    expect(result.listEvents).toHaveBeenCalledTimes(3);
     expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
       expect.objectContaining({
         sortOrder: 'asc',
@@ -469,6 +704,41 @@ describe('workflow handler wait completion replay', () => {
       'hook_received',
       'wait_completed',
     ]);
+    expect(result.listedPages[2]).toEqual([]);
     expectHookBranchQueued(result);
+  });
+
+  it('refreshes before writing suspension events from a stale replay', async () => {
+    const result = await runStaleSuspensionReplayScenario();
+
+    expect(result.listEvents.mock.calls[0]?.[0].pagination).toEqual(
+      expect.objectContaining({
+        sortOrder: 'asc',
+        cursor: result.staleEventsCursor,
+      })
+    );
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'hook_received',
+    ]);
+    expect(result.createdEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: 'step_created',
+          eventData: expect.objectContaining({
+            stepName: 'drainStep',
+          }),
+        }),
+      ])
+    );
+    expect(result.createdEvents).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: 'step_created',
+          eventData: expect.objectContaining({
+            stepName: 'syncStep',
+          }),
+        }),
+      ])
+    );
   });
 });

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -1107,16 +1107,21 @@ export function createEventsStorage(
         // For run_started: include all events so the runtime can skip
         // the initial events.list call and reduce TTFB.
         let events: Event[] | undefined;
+        let cursor: string | null | undefined;
+        let hasMore: boolean | undefined;
         if (data.eventType === 'run_started' && run) {
           const allEvents = await paginatedFileSystemQuery({
             directory: path.join(basedir, 'events'),
             schema: EventSchema,
             filePrefix: `${effectiveRunId}-`,
             sortOrder: 'asc',
+            limit: 1000,
             getCreatedAt: getObjectCreatedAt('evnt'),
             getId: (e) => e.eventId,
           });
           events = allEvents.data;
+          cursor = allEvents.cursor;
+          hasMore = allEvents.hasMore;
         }
 
         // Return EventResult with event and any created/updated entity
@@ -1127,6 +1132,8 @@ export function createEventsStorage(
           hook,
           wait,
           events,
+          cursor,
+          hasMore,
         };
       } // end createImpl
     },

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -1104,8 +1104,8 @@ export function createEventsStorage(
         const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
         const filteredEvent = stripEventDataRefs(event, resolveData);
 
-        // For run_started: include all events so the runtime can skip
-        // the initial events.list call and reduce TTFB.
+        // For run_started: preload one page of events so the runtime can skip
+        // the initial events.list call when hasMore is false.
         let events: Event[] | undefined;
         let cursor: string | null | undefined;
         let hasMore: boolean | undefined;

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -1275,6 +1275,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
       // For run_started: include all events so the runtime can skip
       // the initial events.list call and reduce TTFB.
       let allEvents: Event[] | undefined;
+      let cursor: string | null | undefined;
+      let hasMore: boolean | undefined;
       if (data.eventType === 'run_started' && run) {
         const eventRows = await drizzle
           .select()
@@ -1286,6 +1288,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
           const parsed = EventSchema.parse(compact(e));
           return stripEventDataRefs(parsed, resolveData);
         });
+        cursor = allEvents.at(-1)?.eventId ?? null;
+        hasMore = false;
       }
 
       return {
@@ -1295,6 +1299,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         hook,
         wait,
         events: allEvents,
+        cursor,
+        hasMore,
       };
     },
     async get(

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -65,6 +65,8 @@ const EventResultResolveWireSchema = z.object({
   step: StepWireSchema.optional(),
   hook: HookSchema.optional(),
   events: z.array(EventSchema).optional(),
+  cursor: z.string().nullable().optional(),
+  hasMore: z.boolean().optional(),
 });
 
 const EventResultLazyWireSchema = z.object({
@@ -73,6 +75,8 @@ const EventResultLazyWireSchema = z.object({
   step: StepWireSchema.optional(),
   hook: HookSchema.optional(),
   events: z.array(EventSchema).optional(),
+  cursor: z.string().nullable().optional(),
+  hasMore: z.boolean().optional(),
 });
 
 // Schema for events returned with `remoteRefBehavior=lazy`.
@@ -466,6 +470,8 @@ async function createWorkflowRunEventInner(
       step: wireResult.step ? deserializeStep(wireResult.step) : undefined,
       hook: wireResult.hook,
       events: wireResult.events,
+      cursor: wireResult.cursor,
+      hasMore: wireResult.hasMore,
     };
   }
 
@@ -495,5 +501,7 @@ async function createWorkflowRunEventInner(
     step: wireResult.step ? deserializeStep(wireResult.step) : undefined,
     hook: wireResult.hook,
     events: wireResult.events,
+    cursor: wireResult.cursor,
+    hasMore: wireResult.hasMore,
   };
 }

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -401,6 +401,10 @@ export interface EventResult {
    * initial events.list call and reduce TTFB.
    */
   events?: Event[];
+  /** Pagination cursor for `events`, matching events.list semantics. */
+  cursor?: string | null;
+  /** Whether additional event pages are available for `events`. */
+  hasMore?: boolean;
 }
 
 export interface GetEventParams {


### PR DESCRIPTION
## Summary

Forward-port the stale wait replay race fix from stable PR #2029 to `main`.

This keeps workflow replay deterministic when an elapsed `wait_completed` is committed from a stale event snapshot while a concurrent `hook_received` event landed durably before it. On `main`, the fix is adapted to the V2 replay loop/event cache:

- use `cursor` / `hasMore` metadata from preloaded `run_started` event snapshots
- refresh events after attempting elapsed wait completions before replaying
- fetch only the delta after the prior cursor when possible, with a full-reload fallback when cursor metadata is missing or unsafe
- add the deterministic handler-level regression test for the hook-vs-sleep wait race

## Forward-Port Note

This PR is itself a forward port from `stable`, so it should not be backported.

## Validation

- `pnpm --filter @workflow/world build`
- `pnpm --filter @workflow/utils build`
- `pnpm --filter @workflow/errors build`
- `pnpm --filter @workflow/serde build`
- `pnpm --filter @workflow/world-local build`
- `pnpm --filter @workflow/world-vercel build`
- `pnpm --filter @workflow/core build`
- `pnpm vitest run packages/core/src/runtime/wait-completion-replay.test.ts`
- `pnpm vitest run packages/core/src/hook-sleep-interaction.test.ts`
- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/world-local typecheck`
- `pnpm --filter @workflow/world-postgres typecheck`
- `pnpm --filter @workflow/world-vercel typecheck`
- `pnpm changeset status --since=main`
- `pnpm biome check --files-ignore-unknown=true .changeset/bright-waits-refresh.md packages/core/src/runtime.ts packages/core/src/runtime/wait-completion-replay.test.ts packages/world/src/events.ts packages/world-local/src/storage/events-storage.ts packages/world-postgres/src/storage.ts packages/world-vercel/src/events.ts`

Note: local commands run under Node v25.2.1, which emits the repo's unsupported-engine warning. Biome exits successfully but reports existing warnings in the large runtime/storage files.
