### PR TITLE
Backport #2030: [codex] Guard event consumers during replay

### DIFF
--- a/.changeset/guard-step-consumer-events.md
+++ b/.changeset/guard-step-consumer-events.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+---
+
+Validate step, wait, and hook lifecycle events against replay ownership metadata.

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -67,6 +67,7 @@ const CORR_IDS = [
   '01K11TFZ62YS0YYFDQ3E8B9YCY',
   '01K11TFZ62YS0YYFDQ3E8B9YCZ',
 ];
+const DEFAULT_HOOK_TOKEN = '51reay3g91mW9qOHSORA_';
 
 // ─── Helpers ───────────────────────────────────────────
 
@@ -151,7 +152,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { token: DEFAULT_HOOK_TOKEN, isWebhook: false },
           createdAt: new Date(),
         },
         {
@@ -234,7 +235,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { token: DEFAULT_HOOK_TOKEN, isWebhook: false },
           createdAt: new Date(),
         },
         {
@@ -295,7 +296,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { token: DEFAULT_HOOK_TOKEN, isWebhook: false },
           createdAt: new Date(),
         },
         {
@@ -614,7 +615,7 @@ function defineTests(mode: 'sync' | 'async') {
           runId: 'wrun_test',
           eventType: 'hook_created',
           correlationId: `hook_${CORR_IDS[0]}`,
-          eventData: { token: 'test-token', isWebhook: false },
+          eventData: { token: DEFAULT_HOOK_TOKEN, isWebhook: false },
           createdAt: new Date(),
         },
         {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,0 +1,218 @@
+import { RUN_ERROR_CODES } from '@workflow/errors';
+import {
+  type Event,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+} from '@workflow/world';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setWorld } from './runtime/world.js';
+import { workflowEntrypoint } from './runtime.js';
+import {
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from './serialization.js';
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn(),
+}));
+
+async function runWorkflowHandlerWithEvents(
+  workflowCode: string,
+  workflowRun: WorkflowRun,
+  events: Event[]
+) {
+  const createdEvents: unknown[] = [];
+  const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+    createdEvents.push(data);
+
+    if (data.eventType === 'run_started') {
+      return {
+        run: workflowRun,
+        events,
+      };
+    }
+
+    return {
+      event: {
+        eventId: `event-${createdEvents.length}`,
+        runId: workflowRun.runId,
+        createdAt: new Date(),
+        ...data,
+      },
+    };
+  });
+
+  setWorld({
+    specVersion: SPEC_VERSION_CURRENT,
+    createQueueHandler: vi.fn(
+      (
+        _prefix: string,
+        handler: (message: unknown, metadata: unknown) => Promise<unknown>
+      ) => {
+        return async () => {
+          await handler(
+            {
+              runId: workflowRun.runId,
+              requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+            },
+            {
+              requestId: 'req_test',
+              attempt: 1,
+              queueName: '__wkf_workflow_workflow',
+              messageId: 'msg_test',
+            }
+          );
+          return new Response(null, { status: 204 });
+        };
+      }
+    ),
+    events: {
+      create: eventsCreate,
+      list: vi.fn(async () => ({
+        data: events,
+        hasMore: false,
+        cursor: 'cursor_test',
+      })),
+    },
+    runs: {
+      get: vi.fn(async () => workflowRun),
+    },
+    queue: vi.fn(),
+    getEncryptionKeyForRun: vi.fn(async () => undefined),
+  } as any);
+
+  const handler = workflowEntrypoint(workflowCode);
+  await handler(new Request('https://example.test'));
+
+  return createdEvents;
+}
+
+describe('workflowEntrypoint replay guards', () => {
+  afterEach(() => {
+    setWorld(undefined);
+    vi.clearAllMocks();
+  });
+
+  const getWorkflowTransformCode = (workflowName: string) =>
+    `;globalThis.__private_workflows = new Map();
+    globalThis.__private_workflows.set(${JSON.stringify(workflowName)}, ${workflowName});`;
+
+  it('records run_failed when a committed wait_completed targets the wrong wait', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_runtime_wait_guard',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_runtime_wait_guard',
+        undefined,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+
+    const events: Event[] = [
+      {
+        eventId: 'event-0',
+        runId: workflowRun.runId,
+        eventType: 'wait_created',
+        correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:05.000Z'),
+        },
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      {
+        eventId: 'event-1',
+        runId: workflowRun.runId,
+        eventType: 'wait_completed',
+        correlationId: 'wait_01HK153X00GYR8SV1JHHTGN5HE',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:06.000Z'),
+        },
+        createdAt: new Date('2024-01-01T00:00:05.000Z'),
+      },
+    ];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+      async function workflow() {
+        await sleep('5s');
+        return 'done';
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events
+    );
+
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({
+        eventType: 'run_failed',
+        eventData: expect.objectContaining({
+          errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+        }),
+      })
+    );
+  });
+
+  it('records run_failed when a committed hook_received targets the wrong hook', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_runtime_hook_guard',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_runtime_hook_guard',
+        undefined,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+
+    const events: Event[] = [
+      {
+        eventId: 'event-0',
+        runId: workflowRun.runId,
+        eventType: 'hook_received',
+        correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
+        eventData: {
+          token: 'wrong-token',
+          payload: await dehydrateStepReturnValue(
+            { message: 'hello' },
+            'wrun_runtime_hook_guard',
+            undefined,
+            ops
+          ),
+        },
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+    ];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+      async function workflow() {
+        const hook = createHook({ token: 'expected-token' });
+        const payload = await hook;
+        return payload.message;
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events
+    );
+
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({
+        eventType: 'run_failed',
+        eventData: expect.objectContaining({
+          errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+        }),
+      })
+    );
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -423,7 +423,11 @@ export function workflowEntrypoint(
                 // Collect all waits that need completion
                 const waitsToComplete = events
                   .filter(
-                    (e): e is typeof e & { correlationId: string } =>
+                    (
+                      e
+                    ): e is Extract<Event, { eventType: 'wait_created' }> & {
+                      correlationId: string;
+                    } =>
                       e.eventType === 'wait_created' &&
                       e.correlationId !== undefined &&
                       !completedWaitIds.has(e.correlationId) &&
@@ -433,6 +437,9 @@ export function workflowEntrypoint(
                     eventType: 'wait_completed' as const,
                     specVersion: SPEC_VERSION_CURRENT,
                     correlationId: e.correlationId,
+                    eventData: {
+                      resumeAt: e.eventData.resumeAt,
+                    },
                   }));
 
                 // Create all wait_completed events

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -177,6 +177,7 @@ export async function resumeHook<T = any>(
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: hook.hookId,
             eventData: {
+              ...(v1Compat ? {} : { token: hook.token }),
               payload: dehydratedPayload,
             },
           },

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -168,6 +168,9 @@ describe('Run.wakeUp', () => {
       'wrun_123',
       expect.objectContaining({
         eventType: 'wait_completed',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         correlationId: 'wait_abc',
       }),
       expect.anything()
@@ -207,6 +210,9 @@ describe('Run.wakeUp', () => {
       'wrun_123',
       expect.objectContaining({
         eventType: 'wait_completed',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         correlationId: 'wait_abc',
       }),
       expect.anything()

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -189,6 +189,9 @@ export async function wakeUpRun(
             eventType: 'wait_completed' as const,
             correlationId: waitEvent.correlationId,
             specVersion: run.specVersion,
+            eventData: {
+              resumeAt: waitEvent.eventData.resumeAt,
+            },
           };
       try {
         await world.events.create(runId, eventData, { v1Compat: compatMode });

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -75,6 +75,7 @@ const stepHandler = createQueueHandler(
       requestedAt,
     } = StepInvokePayloadSchema.parse(message_);
     const { requestId } = metadata;
+    const stepNameFromQueue = metadata.queueName.slice('__wkf_step_'.length);
 
     // --- Max delivery check ---
     // Enforce max delivery limit before any infrastructure calls.
@@ -89,7 +90,7 @@ const stepHandler = createQueueHandler(
         {
           workflowRunId,
           stepId,
-          stepName: metadata.queueName.slice('__wkf_step_'.length),
+          stepName: stepNameFromQueue,
           attempt: metadata.attempt,
         }
       );
@@ -102,6 +103,7 @@ const stepHandler = createQueueHandler(
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: stepId,
             eventData: {
+              stepName: stepNameFromQueue,
               error: `Step exceeded maximum queue deliveries (${metadata.attempt}/${MAX_QUEUE_DELIVERIES})`,
             },
           },
@@ -190,6 +192,7 @@ const stepHandler = createQueueHandler(
                 eventType: 'step_started',
                 specVersion: SPEC_VERSION_CURRENT,
                 correlationId: stepId,
+                eventData: { stepName },
               },
               { requestId }
             );
@@ -309,6 +312,7 @@ const stepHandler = createQueueHandler(
                   specVersion: SPEC_VERSION_CURRENT,
                   correlationId: stepId,
                   eventData: {
+                    stepName,
                     error: err.message,
                     stack: err.stack,
                   },
@@ -375,6 +379,7 @@ const stepHandler = createQueueHandler(
                   specVersion: SPEC_VERSION_CURRENT,
                   correlationId: stepId,
                   eventData: {
+                    stepName,
                     error: errorMessage,
                     stack: step.error?.stack,
                   },
@@ -436,6 +441,7 @@ const stepHandler = createQueueHandler(
                   specVersion: SPEC_VERSION_CURRENT,
                   correlationId: stepId,
                   eventData: {
+                    stepName,
                     error: errorMessage,
                     stack: new Error(errorMessage).stack ?? '',
                   },
@@ -600,6 +606,7 @@ const stepHandler = createQueueHandler(
                     specVersion: SPEC_VERSION_CURRENT,
                     correlationId: stepId,
                     eventData: {
+                      stepName,
                       error: normalizedError.message,
                       stack: normalizedStack,
                     },
@@ -660,6 +667,7 @@ const stepHandler = createQueueHandler(
                       specVersion: SPEC_VERSION_CURRENT,
                       correlationId: stepId,
                       eventData: {
+                        stepName,
                         error: errorMessage,
                         stack: normalizedStack,
                       },
@@ -716,6 +724,7 @@ const stepHandler = createQueueHandler(
                       specVersion: SPEC_VERSION_CURRENT,
                       correlationId: stepId,
                       eventData: {
+                        stepName,
                         error: normalizedError.message,
                         stack: normalizedStack,
                         ...(RetryableError.is(err) && {
@@ -821,6 +830,7 @@ const stepHandler = createQueueHandler(
                   specVersion: SPEC_VERSION_CURRENT,
                   correlationId: stepId,
                   eventData: {
+                    stepName,
                     result: result as Uint8Array,
                   },
                 },

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -165,6 +165,9 @@ export async function handleSuspension({
           eventType: 'hook_disposed' as const,
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: queueItem.correlationId,
+          eventData: {
+            token: queueItem.token,
+          },
         };
         try {
           await world.events.create(runId, hookDisposedEvent, { requestId });

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -59,6 +59,33 @@ describe('createUseStep', () => {
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
   });
 
+  it('should invoke workflow error handler when step event stepName mismatches the step', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'step_completed',
+        correlationId: 'step_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          stepName: 'subtract',
+          result: await dehydrateStepReturnValue(3, 'wrun_test', undefined),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+    const workflowError = withResolvers<Error>();
+    ctx.onWorkflowError = workflowError.resolve;
+
+    const useStep = createUseStep(ctx);
+    const add = useStep('add');
+    void add(1, 2);
+
+    const error = await workflowError.promise;
+    expect(error).toBeInstanceOf(WorkflowRuntimeError);
+    expect(error.message).toContain('belongs to "subtract"');
+    expect(error.message).toContain('current step consumer is "add"');
+  });
+
   it('should reject with a fatal error if the step fails', async () => {
     const ctx = setupWorkflowContext([
       {

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -78,6 +78,24 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
           return EventConsumerResult.NotConsumed;
         }
 
+        const eventStepName =
+          'eventData' in event &&
+          event.eventData &&
+          'stepName' in event.eventData
+            ? event.eventData.stepName
+            : undefined;
+
+        if (typeof eventStepName === 'string' && eventStepName !== stepName) {
+          ctx.promiseQueue = ctx.promiseQueue.then(() => {
+            ctx.onWorkflowError(
+              new WorkflowRuntimeError(
+                `Corrupted event log: step event ${event.eventType} for ${correlationId} belongs to "${eventStepName}", but the current step consumer is "${stepName}"`
+              )
+            );
+          });
+          return EventConsumerResult.Finished;
+        }
+
         if (event.eventType === 'step_created') {
           // Step has been created (registered for execution) - mark as having event
           // but keep in queue so suspension handler knows to queue execution without

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -12,6 +12,7 @@ import { runWorkflow } from './workflow.js';
 
 // No encryption key = encryption disabled
 const noEncryptionKey = undefined;
+const DEFAULT_HOOK_TOKEN = 'cJLiI7UTsKFAH_aaZ7DPQ';
 
 describe('runWorkflow', () => {
   const getWorkflowTransformCode = (workflowName?: string) =>
@@ -3871,7 +3872,7 @@ describe('runWorkflow', () => {
             eventType: 'hook_created' as const,
             correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
             eventData: {
-              token: 'test-token',
+              token: DEFAULT_HOOK_TOKEN,
             },
             createdAt: new Date(),
           },

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -49,6 +49,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'hello' },
             'wrun_test',
@@ -60,10 +61,127 @@ describe('createCreateHook', () => {
       },
     ]);
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
     const result = await hook;
     expect(result).toEqual({ message: 'hello' });
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
+  });
+
+  it('should invoke workflow error handler when hook_created token mismatches the hook', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_created',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    createHook({ token: 'expected-token' });
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_created');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
+  });
+
+  it('should invoke workflow error handler when hook_received token mismatches the hook', async () => {
+    const ops: Promise<any>[] = [];
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_received',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+          payload: await dehydrateStepReturnValue(
+            { message: 'hello' },
+            'wrun_test',
+            undefined,
+            ops
+          ),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    const hook = createHook({ token: 'expected-token' });
+    void hook.then((v) => v);
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_received');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
+  });
+
+  it('should invoke workflow error handler when hook_disposed token mismatches the hook', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_disposed',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    createHook({ token: 'expected-token' });
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_disposed');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
+  });
+
+  it('should invoke workflow error handler when hook_conflict token mismatches the hook', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_conflict',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'wrong-token',
+          conflictingRunId: 'wrun_conflicting',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const createHook = createCreateHook(ctx);
+    createHook({ token: 'expected-token' });
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('hook_conflict');
+    expect(workflowError?.message).toContain('wrong-token');
+    expect(workflowError?.message).toContain('expected-token');
   });
 
   it('should throw WorkflowSuspension when no events are available', async () => {
@@ -92,6 +210,7 @@ describe('createCreateHook', () => {
         eventType: 'step_completed', // Wrong event type for a hook!
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'unexpectedStep',
           result: ['test'],
         },
         createdAt: new Date(),
@@ -122,7 +241,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -131,6 +252,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { data: 'test' },
             'wrun_test',
@@ -143,7 +265,7 @@ describe('createCreateHook', () => {
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // After creating the hook, it should be in the queue
     expect(ctx.invocationsQueue.size).toBe(1);
@@ -166,13 +288,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for event processing (hook_disposed removes from invocationsQueue)
     await vi.waitFor(() => {
@@ -196,7 +320,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -205,6 +331,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'first' },
             'wrun_test',
@@ -220,6 +347,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'second' },
             'wrun_test',
@@ -234,13 +362,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ message: string }>();
+    const hook = createHook<{ message: string }>({ token: 'test-token' });
 
     const payloads: { message: string }[] = [];
     for await (const payload of hook) {
@@ -262,6 +392,7 @@ describe('createCreateHook', () => {
         eventType: 'step_completed', // Wrong event type
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'unexpectedStep',
           result: ['test'],
         },
         createdAt: new Date(),
@@ -338,7 +469,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -347,6 +480,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { data: 'test' },
             'wrun_test',
@@ -361,13 +495,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ data: string }>();
+    const hook = createHook<{ data: string }>({ token: 'test-token' });
 
     const result = await hook;
     expect(result).toEqual({ data: 'test' });
@@ -426,7 +562,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -437,7 +575,7 @@ describe('createCreateHook', () => {
     };
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for events to process (hook_created sets hasCreatedEvent on queue item)
     await vi.waitFor(() => {
@@ -466,7 +604,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -475,6 +615,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'first' },
             'wrun_test',
@@ -490,6 +631,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'second' },
             'wrun_test',
@@ -504,13 +646,15 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_disposed',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ message: string }>();
+    const hook = createHook<{ message: string }>({ token: 'test-token' });
 
     // The iterator should yield both payloads even though hook_disposed
     // was eagerly processed by the event consumer before the iterator consumed them
@@ -569,7 +713,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -580,7 +726,7 @@ describe('createCreateHook', () => {
     };
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for events to process (hook_created sets hasCreatedEvent on queue item)
     await vi.waitFor(() => {
@@ -733,7 +879,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
       {
@@ -742,6 +890,7 @@ describe('createCreateHook', () => {
         eventType: 'hook_received',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: await dehydrateStepReturnValue(
             { message: 'hello' },
             'wrun_test',
@@ -754,7 +903,7 @@ describe('createCreateHook', () => {
     ]);
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook<{ message: string }>();
+    const hook = createHook<{ message: string }>({ token: 'test-token' });
 
     // Use iterator with break but no dispose()
     for await (const payload of hook) {
@@ -779,7 +928,9 @@ describe('createCreateHook', () => {
         runId: 'wrun_123',
         eventType: 'hook_created',
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          token: 'test-token',
+        },
         createdAt: new Date(),
       },
     ]);
@@ -788,7 +939,7 @@ describe('createCreateHook', () => {
     ctx.onWorkflowError = errorReceived.resolve;
 
     const createHook = createCreateHook(ctx);
-    const hook = createHook();
+    const hook = createHook({ token: 'test-token' });
 
     // Wait for events to process (hook_created sets hasCreatedEvent on queue item)
     await vi.waitFor(() => {

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -66,6 +66,22 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         return EventConsumerResult.NotConsumed;
       }
 
+      const eventToken =
+        'eventData' in event && event.eventData && 'token' in event.eventData
+          ? event.eventData.token
+          : undefined;
+
+      if (typeof eventToken === 'string' && eventToken !== token) {
+        ctx.promiseQueue = ctx.promiseQueue.then(() => {
+          ctx.onWorkflowError(
+            new WorkflowRuntimeError(
+              `Corrupted event log: hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current hook consumer expects "${token}"`
+            )
+          );
+        });
+        return EventConsumerResult.Finished;
+      }
+
       // Check for hook_created event to mark this hook as already created
       if (event.eventType === 'hook_created') {
         const queueItem = ctx.invocationsQueue.get(correlationId);

--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -63,7 +63,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
     ]);
@@ -73,6 +75,107 @@ describe('createSleep', () => {
 
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
     expect(ctx.invocationsQueue.size).toBe(0);
+  });
+
+  it('should resolve old wait_completed events without eventData', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
+        eventType: 'wait_completed',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        createdAt: new Date(),
+      },
+    ]);
+
+    const sleep = createSleep(ctx);
+    await sleep('1s');
+
+    expect(ctx.onWorkflowError).not.toHaveBeenCalled();
+    expect(ctx.invocationsQueue.size).toBe(0);
+  });
+
+  it('should invoke workflow error handler when wait_completed resumeAt mismatches the wait', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
+        eventType: 'wait_completed',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:02.000Z'),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const sleep = createSleep(ctx);
+    void sleep('1s');
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('wait_completed');
+    expect(workflowError?.message).toContain('resumeAt');
+    expect(workflowError?.message).toContain('wait_01K11TFZ62YS0YYFDQ3E8B9YCV');
+  });
+
+  it('should invoke workflow error handler when wait_completed resumeAt is invalid', async () => {
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
+        eventType: 'wait_completed',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt: new Date(Number.NaN),
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const errorReceived = withResolvers<Error>();
+    ctx.onWorkflowError = errorReceived.resolve;
+
+    const sleep = createSleep(ctx);
+    void sleep('1s');
+
+    const workflowError = await errorReceived.promise;
+    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError?.message).toContain('wait_completed');
+    expect(workflowError?.message).toContain('Invalid Date');
   });
 
   it('should throw WorkflowSuspension when no events are available', async () => {
@@ -100,6 +203,7 @@ describe('createSleep', () => {
         eventType: 'step_completed', // Wrong event type for a wait!
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          stepName: 'unexpectedStep',
           result: ['test'],
         },
         createdAt: new Date(),
@@ -168,6 +272,7 @@ describe('createSleep', () => {
         eventType: 'hook_received', // Wrong event type for a wait!
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
+          token: 'test-token',
           payload: { data: 'test' },
         },
         createdAt: new Date(),
@@ -237,7 +342,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
     ]);
@@ -275,7 +382,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
       {
@@ -283,7 +392,9 @@ describe('createSleep', () => {
         runId: 'wrun_123',
         eventType: 'wait_completed', // Duplicate!
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt: new Date('2024-01-01T00:00:01.000Z'),
+        },
         createdAt: new Date(),
       },
     ]);
@@ -301,13 +412,26 @@ describe('createSleep', () => {
   });
 
   it('should resolve with void when wait_completed', async () => {
+    const resumeAt = new Date('2024-01-01T00:00:01.000Z');
     const ctx = setupWorkflowContext([
       {
         eventId: 'evnt_0',
         runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          resumeAt,
+        },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_123',
         eventType: 'wait_completed',
         correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCV',
-        eventData: {},
+        eventData: {
+          resumeAt,
+        },
         createdAt: new Date(),
       },
     ]);

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -57,6 +57,32 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
 
       // Check for wait_completed event
       if (event.eventType === 'wait_completed') {
+        const eventResumeAt = event.eventData?.resumeAt;
+        if (eventResumeAt !== undefined) {
+          const queueItem = ctx.invocationsQueue.get(correlationId);
+          const expectedResumeAt =
+            queueItem && queueItem.type === 'wait'
+              ? queueItem.resumeAt
+              : resumeAt;
+          const eventResumeAtDate = new Date(eventResumeAt);
+          const eventResumeAtMs = eventResumeAtDate.getTime();
+          const expectedResumeAtMs = expectedResumeAt.getTime();
+          const eventResumeAtForMessage = Number.isFinite(eventResumeAtMs)
+            ? eventResumeAtDate.toISOString()
+            : String(eventResumeAt);
+
+          if (eventResumeAtMs !== expectedResumeAtMs) {
+            ctx.promiseQueue = ctx.promiseQueue.then(() => {
+              ctx.onWorkflowError(
+                new WorkflowRuntimeError(
+                  `Corrupted event log: wait_completed event for ${correlationId} has resumeAt "${eventResumeAtForMessage}", but the current wait consumer expects "${expectedResumeAt.toISOString()}"`
+                )
+              );
+            });
+            return EventConsumerResult.Finished;
+          }
+        }
+
         // Remove this wait from the invocations queue (O(1) delete using Map)
         ctx.invocationsQueue.delete(correlationId);
 

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -96,6 +96,7 @@ const StepCompletedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('step_completed'),
   correlationId: z.string(),
   eventData: z.object({
+    stepName: z.string().optional(),
     result: SerializedDataSchema,
   }),
 });
@@ -104,6 +105,7 @@ const StepFailedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('step_failed'),
   correlationId: z.string(),
   eventData: z.object({
+    stepName: z.string().optional(),
     error: z.any(),
     stack: z.string().optional(),
   }),
@@ -118,6 +120,7 @@ const StepRetryingEventSchema = BaseEventSchema.extend({
   eventType: z.literal('step_retrying'),
   correlationId: z.string(),
   eventData: z.object({
+    stepName: z.string().optional(),
     error: z.any(),
     stack: z.string().optional(),
     retryAfter: z.coerce.date().optional(),
@@ -129,6 +132,7 @@ const StepStartedEventSchema = BaseEventSchema.extend({
   correlationId: z.string(),
   eventData: z
     .object({
+      stepName: z.string().optional(),
       attempt: z.number().optional(),
     })
     .optional(),
@@ -164,6 +168,7 @@ const HookReceivedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('hook_received'),
   correlationId: z.string(),
   eventData: z.object({
+    token: z.string().optional(),
     payload: SerializedDataSchema,
   }),
 });
@@ -171,6 +176,11 @@ const HookReceivedEventSchema = BaseEventSchema.extend({
 const HookDisposedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('hook_disposed'),
   correlationId: z.string(),
+  eventData: z
+    .object({
+      token: z.string().optional(),
+    })
+    .optional(),
 });
 
 /**
@@ -200,6 +210,11 @@ const WaitCreatedEventSchema = BaseEventSchema.extend({
 const WaitCompletedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('wait_completed'),
   correlationId: z.string(),
+  eventData: z
+    .object({
+      resumeAt: z.coerce.date().optional(),
+    })
+    .optional(),
 });
 
 // =============================================================================


### PR DESCRIPTION
Manual backport of #2030 (cherry-pick b124365e14b0c47a5c830c7009dd5bf0149d5a59) to `stable`.

Conflict resolution notes:
- Preserved the `stable` runtime/step-handler shape while adding replay guard metadata for step, wait, and hook events.
- Kept files that do not exist on `stable` deleted instead of reviving main-only runtime splits.

Validation:
- `pnpm --filter @workflow/errors --filter @workflow/utils --filter @workflow/serde --filter @workflow/world --filter @workflow/world-local --filter @workflow/world-vercel build`
- `pnpm --filter @workflow/core exec vitest run src/workflow/sleep.test.ts src/workflow/hook.test.ts src/step.test.ts src/runtime.test.ts src/runtime/runs.test.ts`
- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/core build`
- `pnpm changeset status --since=main` -> no changeset needed
- `git diff --check HEAD~1 HEAD`

Note: local checks were run with Node v25.2.1, which emits the repo engine warning (`^18 || ^20 || ^22 || ^24`).