### PR TITLE
[world-testing] fix flow invocation counter race in inline-execution tests

### DIFF
--- a/.changeset/fix-inline-execution-flow-count-race.md
+++ b/.changeset/fix-inline-execution-flow-count-race.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-testing": patch
+---
+
+Fix race condition in test server's flow invocation counter that caused intermittent failures in the inline-execution test suite (e.g. "sequential steps complete in a single flow invocation"). The counter is now incremented before awaiting the flow handler, so the count is observable as soon as the run transitions to completed.

--- a/packages/world-testing/src/server.mts
+++ b/packages/world-testing/src/server.mts
@@ -46,10 +46,13 @@ const flowInvocationCounts = new Map<string, number>();
 
 const app = new Hono()
   .post('/.well-known/workflow/v1/flow', async (ctx) => {
-    // Clone the request to read the body for tracking without consuming it
+    // Clone the request to read the body for tracking without consuming it.
+    // We must increment the invocation counter *before* awaiting flowPOST,
+    // otherwise the workflow may complete (and the test may observe the
+    // completed status) before the counter is bumped, producing a flaky
+    // `expected 0 to be 1` failure when the test immediately queries
+    // /_flow-invocations after seeing the run as completed.
     const cloned = ctx.req.raw.clone();
-    const response = await flowPOST(ctx.req.raw);
-    // Extract runId from the request body (queue message payload)
     try {
       const body = (await cloned.json()) as Record<string, unknown>;
       const runId =
@@ -68,7 +71,7 @@ const app = new Hono()
     } catch {
       // Health check or non-JSON messages — ignore
     }
-    return response;
+    return flowPOST(ctx.req.raw);
   })
   .get('/_flow-invocations/:runId', (ctx) => {
     const count = flowInvocationCounts.get(ctx.req.param('runId')) ?? 0;


### PR DESCRIPTION
## Summary

Fixes the flaky unit test failure seen on multiple PRs (e.g. [PR #2013](https://github.com/vercel/workflow/actions/runs/26161113794/job/77037927232?pr=2013), [PR #2035](https://github.com/vercel/workflow/actions/runs/26180243484)):

```
FAIL test/spec.test.ts > sequential steps complete in a single flow invocation
AssertionError: expected +0 to be 1 // Object.is equality
 ❯ ../world-testing/src/inline-execution.mts:45:21
```

## Root cause

The test server's flow handler awaited `flowPOST` before incrementing the per-run invocation counter:

```ts
const cloned = ctx.req.raw.clone();
const response = await flowPOST(ctx.req.raw);   // (1) workflow may complete & flush DB here
// (2) read cloned body, increment counter
return response;
```

That races with the test, which polls `getRun()` until it sees `status === 'completed'` and then immediately queries `/_flow-invocations/:runId`:

1. Inside `flowPOST`, the workflow runs and writes the completed run to the DB.
2. The test's `vi.waitFor` poll sees `status === 'completed'`.
3. The test fetches the flow invocation count.
4. The counter increment in the handler hadn't run yet → count returns `0` instead of `1`.

Locally the race rarely loses (the cloned-body read is fast) but on slower CI runners it loses often enough to be visible across many PRs.

## Fix

Increment the counter before awaiting `flowPOST` so the count is observable as soon as the run transitions to completed. Same logic, just reordered.

## Test plan

- Re-ran `packages/world-testing/test/embedded.test.ts` locally — all 9 tests pass, including the four `inline-execution.mts` cases that drive the counter.
- Could not reproduce the race locally (Docker on this box is broken so postgres test was skipped), but the fix removes the only `await` between request entry and counter increment, so there is no longer a window where the run can be flushed to the DB before the counter is bumped.