### PR TITLE
Report corrupted event logs distinctly

### DIFF
--- a/.changeset/corrupted-event-log-code.md
+++ b/.changeset/corrupted-event-log-code.md
@@ -1,0 +1,7 @@
+---
+"@workflow/core": patch
+"@workflow/errors": patch
+"@workflow/world": patch
+---
+
+Report corrupted event logs with a distinct `CorruptedEventLogError` type and `CORRUPTED_EVENT_LOG` run error code.

--- a/packages/core/src/abort-controller.test.ts
+++ b/packages/core/src/abort-controller.test.ts
@@ -6,7 +6,7 @@
  * (for real-time step propagation).
  */
 
-import { WorkflowRuntimeError } from '@workflow/errors';
+import { CorruptedEventLogError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
@@ -118,7 +118,7 @@ describe('AbortController in workflow VM', () => {
       expect(controller.signal.aborted).toBe(true);
     });
 
-    it('reports a WorkflowRuntimeError when abort hook_received token mismatches the controller', async () => {
+    it('reports a CorruptedEventLogError when abort hook_received token mismatches the controller', async () => {
       ctx = setupWorkflowContext([]);
       const ProbeAbortController = createCreateAbortController(ctx);
       new ProbeAbortController();
@@ -157,7 +157,7 @@ describe('AbortController in workflow VM', () => {
       new AbortController();
 
       const workflowError = await errorReceived.promise;
-      expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+      expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
       expect(workflowError?.message).toContain('hook_received');
       expect(workflowError?.message).toContain('wrong-token');
       expect(workflowError?.message).toContain(probeHookItem.token);

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -1,4 +1,5 @@
 import {
+  CorruptedEventLogError,
   HookConflictError,
   RUN_ERROR_CODES,
   WorkflowNotRegisteredError,
@@ -9,6 +10,12 @@ import { describe, expect, it } from 'vitest';
 import { classifyRunError } from './classify-error.js';
 
 describe('classifyRunError', () => {
+  it('classifies CorruptedEventLogError as CORRUPTED_EVENT_LOG', () => {
+    expect(
+      classifyRunError(new CorruptedEventLogError('corrupted event log'))
+    ).toBe(RUN_ERROR_CODES.CORRUPTED_EVENT_LOG);
+  });
+
   it('classifies WorkflowRuntimeError as RUNTIME_ERROR', () => {
     expect(
       classifyRunError(new WorkflowRuntimeError('corrupted event log'))

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -1,4 +1,5 @@
 import {
+  CorruptedEventLogError,
   RUN_ERROR_CODES,
   type RunErrorCode,
   StepNotRegisteredError,
@@ -7,7 +8,7 @@ import {
 } from '@workflow/errors';
 
 /**
- * Set of error names that should classify as `RUNTIME_ERROR`. Each
+ * Set of error names that should classify as generic `RUNTIME_ERROR`. Each
  * `*.is()` static does a name-based duck check, so subclassing alone is
  * not enough — we have to enumerate every concrete subclass we want to
  * recognize. Keep in sync with the `WorkflowRuntimeError` class hierarchy
@@ -25,8 +26,8 @@ const RUNTIME_ERROR_CHECKS = [
  * After the structural separation of infrastructure vs user code error
  * handling, the only errors that reach the `run_failed` try/catch are:
  * - User code errors (throws from workflow functions, propagated step failures)
- * - WorkflowRuntimeError and subclasses (corrupted event log, missing
- *   timestamps, workflow/step not registered, etc.)
+ * - WorkflowRuntimeError and subclasses (missing timestamps, workflow/step
+ *   not registered, corrupted event log, etc.)
  *
  * Uses each subclass's `.is()` static (a name-based duck check) instead of
  * a single `instanceof` check because workflows execute in a separate
@@ -36,6 +37,10 @@ const RUNTIME_ERROR_CHECKS = [
  * errors as user errors.
  */
 export function classifyRunError(err: unknown): RunErrorCode {
+  if (CorruptedEventLogError.is(err)) {
+    return RUN_ERROR_CODES.CORRUPTED_EVENT_LOG;
+  }
+
   for (const isMatch of RUNTIME_ERROR_CHECKS) {
     if (isMatch(err)) {
       return RUN_ERROR_CODES.RUNTIME_ERROR;

--- a/packages/core/src/describe-error.test.ts
+++ b/packages/core/src/describe-error.test.ts
@@ -1,4 +1,5 @@
 import {
+  CorruptedEventLogError,
   RUN_ERROR_CODES,
   SerializationError,
   StepNotRegisteredError,
@@ -61,6 +62,15 @@ describe('describeError', () => {
     expect(result.attribution).toBe('sdk');
     expect(result.errorCode).toBe(RUN_ERROR_CODES.RUNTIME_ERROR);
     expect(result.hint).toContain('internal workflow SDK error');
+  });
+
+  test('CorruptedEventLogError is attributed to the SDK with a distinct code', () => {
+    const result = describeError(
+      new CorruptedEventLogError('corrupted event log')
+    );
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.CORRUPTED_EVENT_LOG);
+    expect(result.hint).toContain('event log contains');
   });
 
   test('StepNotRegisteredError (subclass of WorkflowRuntimeError) is attributed to the SDK', () => {
@@ -144,6 +154,23 @@ describe('describeRunError', () => {
     expect(result.hint).toContain('replay took too long');
   });
 
+  test('CORRUPTED_EVENT_LOG errorCode is attributed to the SDK', () => {
+    const result = describeRunError({
+      errorCode: RUN_ERROR_CODES.CORRUPTED_EVENT_LOG,
+    });
+    expect(result.attribution).toBe('sdk');
+    expect(result.hint).toContain('event log contains');
+  });
+
+  test('CorruptedEventLogError name restores the distinct code', () => {
+    const result = describeRunError({
+      errorName: 'CorruptedEventLogError',
+    });
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.CORRUPTED_EVENT_LOG);
+    expect(result.hint).toContain('event log contains');
+  });
+
   test('MAX_DELIVERIES_EXCEEDED errorCode is attributed to the SDK', () => {
     const result = describeRunError({
       errorCode: RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED,
@@ -222,6 +249,18 @@ describe('describeError — payload shape snapshots', () => {
           "attribution": "sdk",
           "errorCode": "RUNTIME_ERROR",
           "hint": "This is an internal workflow SDK error, not a bug in your code. If it keeps happening, please report it with the stack trace and the runId.",
+        }
+      `);
+  });
+
+  test('CorruptedEventLogError payload', () => {
+    expect(
+      describeError(new CorruptedEventLogError('event mismatch'))
+    ).toMatchInlineSnapshot(`
+        {
+          "attribution": "sdk",
+          "errorCode": "CORRUPTED_EVENT_LOG",
+          "hint": "The workflow event log contains orphaned or mismatched events and cannot be replayed. This is an internal workflow SDK error; please report it with the runId.",
         }
       `);
   });

--- a/packages/core/src/describe-error.ts
+++ b/packages/core/src/describe-error.ts
@@ -1,4 +1,5 @@
 import {
+  CorruptedEventLogError,
   RUN_ERROR_CODES,
   type RunErrorCode,
   SerializationError,
@@ -76,6 +77,8 @@ const CONTEXT_ERROR_HINT =
   'A workflow-only or step-only API was called from the wrong context. The error message includes the exact API and how to move the call.';
 const RUNTIME_ERROR_HINT =
   'This is an internal workflow SDK error, not a bug in your code. If it keeps happening, please report it with the stack trace and the runId.';
+const CORRUPTED_EVENT_LOG_HINT =
+  'The workflow event log contains orphaned or mismatched events and cannot be replayed. This is an internal workflow SDK error; please report it with the runId.';
 const REPLAY_TIMEOUT_HINT =
   'The workflow replay took too long. This usually means the event log is unusually large or the workflow function is doing heavy synchronous work between step boundaries.';
 const MAX_DELIVERIES_HINT =
@@ -100,8 +103,11 @@ function normalizeErrorCode(code: string | undefined): RunErrorCode {
 export function describeRunError(
   signal: PersistedErrorSignal
 ): ErrorDescription {
-  const errorCode = normalizeErrorCode(signal.errorCode);
   const name = signal.errorName;
+  const errorCode =
+    name === 'CorruptedEventLogError'
+      ? RUN_ERROR_CODES.CORRUPTED_EVENT_LOG
+      : normalizeErrorCode(signal.errorCode);
 
   if (name === 'SerializationError') {
     return { attribution: 'user', errorCode, hint: SERIALIZATION_ERROR_HINT };
@@ -109,14 +115,28 @@ export function describeRunError(
   if (name && CONTEXT_ERROR_NAMES.has(name)) {
     return { attribution: 'user', errorCode, hint: CONTEXT_ERROR_HINT };
   }
-  if (name === 'WorkflowRuntimeError' || name === 'StepNotRegisteredError') {
-    return { attribution: 'sdk', errorCode, hint: RUNTIME_ERROR_HINT };
+  if (name === 'CorruptedEventLogError') {
+    return {
+      attribution: 'sdk',
+      errorCode,
+      hint: CORRUPTED_EVENT_LOG_HINT,
+    };
   }
   if (errorCode === RUN_ERROR_CODES.REPLAY_TIMEOUT) {
     return { attribution: 'sdk', errorCode, hint: REPLAY_TIMEOUT_HINT };
   }
   if (errorCode === RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED) {
     return { attribution: 'sdk', errorCode, hint: MAX_DELIVERIES_HINT };
+  }
+  if (errorCode === RUN_ERROR_CODES.CORRUPTED_EVENT_LOG) {
+    return {
+      attribution: 'sdk',
+      errorCode,
+      hint: CORRUPTED_EVENT_LOG_HINT,
+    };
+  }
+  if (name === 'WorkflowRuntimeError' || name === 'StepNotRegisteredError') {
+    return { attribution: 'sdk', errorCode, hint: RUNTIME_ERROR_HINT };
   }
   if (errorCode === RUN_ERROR_CODES.RUNTIME_ERROR) {
     return { attribution: 'sdk', errorCode, hint: RUNTIME_ERROR_HINT };
@@ -167,6 +187,14 @@ export function describeError(
     };
   }
 
+  if (CorruptedEventLogError.is(err)) {
+    return {
+      attribution: 'sdk',
+      errorCode: effectiveCode,
+      hint: CORRUPTED_EVENT_LOG_HINT,
+    };
+  }
+
   if (err instanceof WorkflowRuntimeError) {
     return {
       attribution: 'sdk',
@@ -188,6 +216,14 @@ export function describeError(
       attribution: 'sdk',
       errorCode: effectiveCode,
       hint: MAX_DELIVERIES_HINT,
+    };
+  }
+
+  if (effectiveCode === RUN_ERROR_CODES.CORRUPTED_EVENT_LOG) {
+    return {
+      attribution: 'sdk',
+      errorCode: effectiveCode,
+      hint: CORRUPTED_EVENT_LOG_HINT,
     };
   }
 

--- a/packages/core/src/log-format.test.ts
+++ b/packages/core/src/log-format.test.ts
@@ -74,21 +74,21 @@ describe('composeLogLine', () => {
   test('renders sdk-attributed errors with the sdk badge', () => {
     const out = composeLogLine(
       PREFIX,
-      'Workflow myFlow failed due to an SDK runtime error\nWorkflowRuntimeError: corrupted event log',
+      'Workflow myFlow failed due to an SDK runtime error\nCorruptedEventLogError: corrupted event log',
       {
-        errorCode: 'RUNTIME_ERROR',
+        errorCode: 'CORRUPTED_EVENT_LOG',
         errorAttribution: 'sdk',
-        errorName: 'WorkflowRuntimeError',
+        errorName: 'CorruptedEventLogError',
         errorMessage: 'corrupted event log',
         hint: 'This is an internal workflow SDK error.',
       }
     );
     expect(out).toMatchInlineSnapshot(`
       "[workflow-sdk] Workflow myFlow failed due to an SDK runtime error
-        sdk error · WorkflowRuntimeError
-        code   RUNTIME_ERROR
+        sdk error · CorruptedEventLogError
+        code   CORRUPTED_EVENT_LOG
         hint: This is an internal workflow SDK error.
-      WorkflowRuntimeError: corrupted event log"
+      CorruptedEventLogError: corrupted event log"
     `);
   });
 

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -152,7 +152,7 @@ describe('workflowEntrypoint replay guards', () => {
       expect.objectContaining({
         eventType: 'run_failed',
         eventData: expect.objectContaining({
-          errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+          errorCode: RUN_ERROR_CODES.CORRUPTED_EVENT_LOG,
         }),
       })
     );
@@ -210,7 +210,7 @@ describe('workflowEntrypoint replay guards', () => {
       expect.objectContaining({
         eventType: 'run_failed',
         eventData: expect.objectContaining({
-          errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+          errorCode: RUN_ERROR_CODES.CORRUPTED_EVENT_LOG,
         }),
       })
     );

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1067,9 +1067,9 @@ export function workflowEntrypoint(
                           );
                         }
 
-                        // Classify the error: WorkflowRuntimeError indicates an
-                        // internal issue (corrupted event log, missing data);
-                        // everything else is a user code error.
+                        // Classify the error: WorkflowRuntimeError indicates
+                        // an SDK/runtime issue, and selected subclasses use
+                        // more specific codes for backend tracking.
                         const errorCode = classifyRunError(err);
 
                         runtimeLogger.error('Error while running workflow', {

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -1,4 +1,8 @@
-import { FatalError, WorkflowRuntimeError } from '@workflow/errors';
+import {
+  CorruptedEventLogError,
+  FatalError,
+  WorkflowRuntimeError,
+} from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
@@ -459,7 +463,7 @@ describe('createUseStep', () => {
     void add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError.message).toContain('Corrupted event log');
     expect(workflowError.message).toContain('step_created');
     expect(workflowError.message).toContain('subtract');
@@ -568,7 +572,7 @@ describe('createUseStep', () => {
     void add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError.message).toContain('Corrupted event log');
     expect(workflowError.message).toContain('step_completed');
     expect(workflowError.message).toContain('subtract');
@@ -629,7 +633,7 @@ describe('createUseStep', () => {
     void add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError.message).toContain('Corrupted event log');
     expect(workflowError.message).toContain('step_failed');
     expect(workflowError.message).toContain('subtract');
@@ -753,7 +757,7 @@ describe('createUseStep', () => {
     expect(error?.message).toBe('Plain error message');
   });
 
-  it('should invoke workflow error handler with WorkflowRuntimeError for unexpected event type', async () => {
+  it('should invoke workflow error handler with CorruptedEventLogError for unexpected event type', async () => {
     // Simulate a corrupted event log where a step receives an unexpected event type
     // (e.g., a wait_completed event when expecting step_completed/step_failed)
     const ctx = setupWorkflowContext([
@@ -779,7 +783,7 @@ describe('createUseStep', () => {
     const stepPromise = add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('Unexpected event type for step');
     expect(workflowError?.message).toContain('step_01K11TFZ62YS0YYFDQ3E8B9YCV');
     expect(workflowError?.message).toContain('add');

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -1,4 +1,4 @@
-import { FatalError, WorkflowRuntimeError } from '@workflow/errors';
+import { CorruptedEventLogError, FatalError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import { EventConsumerResult } from './events-consumer.js';
 import { type StepInvocationQueueItem, WorkflowSuspension } from './global.js';
@@ -88,7 +88,7 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
         if (typeof eventStepName === 'string' && eventStepName !== stepName) {
           ctx.promiseQueue = ctx.promiseQueue.then(() => {
             ctx.onWorkflowError(
-              new WorkflowRuntimeError(
+              new CorruptedEventLogError(
                 `Corrupted event log: step event ${event.eventType} for ${correlationId} belongs to "${eventStepName}", but the current step consumer is "${stepName}"`
               )
             );
@@ -106,7 +106,7 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
             // but the step was never invoked in the workflow during replay.
             ctx.promiseQueue = ctx.promiseQueue.then(() => {
               reject(
-                new WorkflowRuntimeError(
+                new CorruptedEventLogError(
                   `Corrupted event log: step ${correlationId} (${stepName}) created but not found in invocation queue`
                 )
               );
@@ -203,7 +203,7 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
         // An unexpected event type has been received, this event log looks corrupted. Let's fail immediately.
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
           ctx.onWorkflowError(
-            new WorkflowRuntimeError(
+            new CorruptedEventLogError(
               `Unexpected event type for step ${correlationId} (name: ${stepName}) "${event.eventType}"`
             )
           );

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -1,5 +1,6 @@
 import { runInContext } from 'node:vm';
 import {
+  CorruptedEventLogError,
   ERROR_SLUGS,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
@@ -160,9 +161,8 @@ export async function runWorkflow(
     const eventsConsumer = new EventsConsumer(events, {
       onUnconsumedEvent: (event) => {
         workflowDiscontinuation.reject(
-          new WorkflowRuntimeError(
-            `Unconsumed event in event log: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}. This indicates a corrupted or invalid event log.`,
-            { slug: ERROR_SLUGS.CORRUPTED_EVENT_LOG }
+          new CorruptedEventLogError(
+            `Unconsumed event in event log: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}. This indicates a corrupted or invalid event log.`
           )
         );
       },

--- a/packages/core/src/workflow/abort-controller.ts
+++ b/packages/core/src/workflow/abort-controller.ts
@@ -1,4 +1,4 @@
-import { WorkflowRuntimeError } from '@workflow/errors';
+import { CorruptedEventLogError } from '@workflow/errors';
 import { EventConsumerResult } from '../events-consumer.js';
 import type { WorkflowOrchestratorContext } from '../private.js';
 import { hydrateStepReturnValue } from '../serialization.js';
@@ -147,7 +147,7 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
         ) {
           ctx.promiseQueue = ctx.promiseQueue.then(() => {
             ctx.onWorkflowError(
-              new WorkflowRuntimeError(
+              new CorruptedEventLogError(
                 `Corrupted event log: abort hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current abort hook expects "${this[ABORT_HOOK_TOKEN]}"`
               )
             );

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -1,4 +1,8 @@
-import { HookConflictError, WorkflowRuntimeError } from '@workflow/errors';
+import {
+  CorruptedEventLogError,
+  HookConflictError,
+  WorkflowRuntimeError,
+} from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
@@ -88,7 +92,7 @@ describe('createCreateHook', () => {
     createHook({ token: 'expected-token' });
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('hook_created');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -123,7 +127,7 @@ describe('createCreateHook', () => {
     void hook.then((v) => v);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('hook_received');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -150,7 +154,7 @@ describe('createCreateHook', () => {
     createHook({ token: 'expected-token' });
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('hook_disposed');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -178,7 +182,7 @@ describe('createCreateHook', () => {
     createHook({ token: 'expected-token' });
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('hook_conflict');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -200,7 +204,7 @@ describe('createCreateHook', () => {
     expect(workflowError).toBeInstanceOf(WorkflowSuspension);
   });
 
-  it('should invoke workflow error handler with WorkflowRuntimeError for unexpected event type', async () => {
+  it('should invoke workflow error handler with CorruptedEventLogError for unexpected event type', async () => {
     // Simulate a corrupted event log where a hook receives an unexpected event type
     // (e.g., a step_completed event when expecting hook_created/hook_received/hook_disposed)
     const ctx = setupWorkflowContext([
@@ -227,7 +231,7 @@ describe('createCreateHook', () => {
     const hookPromise = hook.then((v) => v);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('Unexpected event type for hook');
     expect(workflowError?.message).toContain('hook_01K11TFZ62YS0YYFDQ3E8B9YCV');
     expect(workflowError?.message).toContain('step_completed');
@@ -410,7 +414,7 @@ describe('createCreateHook', () => {
     const hookPromise = hook.then((v) => v);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('my-custom-token');
   });
 

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -1,4 +1,4 @@
-import { HookConflictError, WorkflowRuntimeError } from '@workflow/errors';
+import { CorruptedEventLogError, HookConflictError } from '@workflow/errors';
 import { type PromiseWithResolvers, withResolvers } from '@workflow/utils';
 import type { HookConflictEvent, HookReceivedEvent } from '@workflow/world';
 import type { Hook, HookOptions } from '../create-hook.js';
@@ -74,7 +74,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
       if (typeof eventToken === 'string' && eventToken !== token) {
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
           ctx.onWorkflowError(
-            new WorkflowRuntimeError(
+            new CorruptedEventLogError(
               `Corrupted event log: hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current hook consumer expects "${token}"`
             )
           );
@@ -166,7 +166,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
       // An unexpected event type has been received, this event log looks corrupted. Let's fail immediately.
       ctx.promiseQueue = ctx.promiseQueue.then(() => {
         ctx.onWorkflowError(
-          new WorkflowRuntimeError(
+          new CorruptedEventLogError(
             `Unexpected event type for hook ${correlationId} (token: ${token}) "${event.eventType}"`
           )
         );

--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -1,4 +1,4 @@
-import { WorkflowRuntimeError } from '@workflow/errors';
+import { CorruptedEventLogError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
@@ -26,7 +26,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     eventsConsumer: new EventsConsumer(events, {
       onUnconsumedEvent: (event) => {
         ctx.onWorkflowError(
-          new WorkflowRuntimeError(
+          new CorruptedEventLogError(
             `Unconsumed event in event log: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}. This indicates a corrupted or invalid event log.`
           )
         );
@@ -136,7 +136,7 @@ describe('createSleep', () => {
     void sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('wait_completed');
     expect(workflowError?.message).toContain('resumeAt');
     expect(workflowError?.message).toContain('wait_01K11TFZ62YS0YYFDQ3E8B9YCV');
@@ -173,7 +173,7 @@ describe('createSleep', () => {
     void sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('wait_completed');
     expect(workflowError?.message).toContain('Invalid Date');
   });
@@ -193,7 +193,7 @@ describe('createSleep', () => {
     expect(workflowError).toBeInstanceOf(WorkflowSuspension);
   });
 
-  it('should invoke workflow error handler with WorkflowRuntimeError for unexpected event type', async () => {
+  it('should invoke workflow error handler with CorruptedEventLogError for unexpected event type', async () => {
     // Simulate a corrupted event log where a sleep/wait receives an unexpected event type
     // (e.g., a step_completed event when expecting wait_created/wait_completed)
     const ctx = setupWorkflowContext([
@@ -219,7 +219,7 @@ describe('createSleep', () => {
     const sleepPromise = sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('Unexpected event type for wait');
     expect(workflowError?.message).toContain('wait_01K11TFZ62YS0YYFDQ3E8B9YCV');
     expect(workflowError?.message).toContain('step_completed');
@@ -286,7 +286,7 @@ describe('createSleep', () => {
     const sleepPromise = sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('Unexpected event type for wait');
     expect(workflowError?.message).toContain('hook_received');
   });
@@ -361,11 +361,11 @@ describe('createSleep', () => {
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
   });
 
-  it('should raise WorkflowRuntimeError when duplicate wait_completed events exist in the event log', async () => {
+  it('should raise CorruptedEventLogError when duplicate wait_completed events exist in the event log', async () => {
     // When the event log has 2 wait_completed for a single wait_created,
     // the first wait_completed removes the callback (Finished), but the second
     // wait_completed has no consumer. The onUnconsumedEvent callback should
-    // trigger a WorkflowRuntimeError via onWorkflowError.
+    // trigger a CorruptedEventLogError via onWorkflowError.
     const ctx = setupWorkflowContext([
       {
         eventId: 'evnt_0',
@@ -407,7 +407,7 @@ describe('createSleep', () => {
 
     // The duplicate wait_completed at index 2 is orphaned and triggers the error
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(WorkflowRuntimeError);
+    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
     expect(workflowError?.message).toContain('evnt_2');
   });
 

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -1,4 +1,4 @@
-import { WorkflowRuntimeError } from '@workflow/errors';
+import { CorruptedEventLogError } from '@workflow/errors';
 import { parseDurationToDate, withResolvers } from '@workflow/utils';
 import type { StringValue } from 'ms';
 import { EventConsumerResult } from '../events-consumer.js';
@@ -74,7 +74,7 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
           if (eventResumeAtMs !== expectedResumeAtMs) {
             ctx.promiseQueue = ctx.promiseQueue.then(() => {
               ctx.onWorkflowError(
-                new WorkflowRuntimeError(
+                new CorruptedEventLogError(
                   `Corrupted event log: wait_completed event for ${correlationId} has resumeAt "${eventResumeAtForMessage}", but the current wait consumer expects "${expectedResumeAt.toISOString()}"`
                 )
               );
@@ -97,7 +97,7 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
       // An unexpected event type has been received, this event log looks corrupted. Let's fail immediately.
       ctx.promiseQueue = ctx.promiseQueue.then(() => {
         ctx.onWorkflowError(
-          new WorkflowRuntimeError(
+          new CorruptedEventLogError(
             `Unexpected event type for wait ${correlationId} "${event.eventType}"`
           )
         );

--- a/packages/errors/src/corrupted-event-log-error.test.ts
+++ b/packages/errors/src/corrupted-event-log-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import {
+  CorruptedEventLogError,
+  WorkflowError,
+  WorkflowRuntimeError,
+} from './index.js';
+
+describe('CorruptedEventLogError', () => {
+  test('sets the name and extends WorkflowRuntimeError', () => {
+    const err = new CorruptedEventLogError('event mismatch');
+    expect(err.name).toBe('CorruptedEventLogError');
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowRuntimeError);
+    expect(err).toBeInstanceOf(CorruptedEventLogError);
+  });
+
+  test('adds the corrupted event log docs link', () => {
+    const err = new CorruptedEventLogError('event mismatch');
+    expect(err.message).toContain(
+      'https://workflow-sdk.dev/err/corrupted-event-log'
+    );
+  });
+
+  test('preserves cause for debugging', () => {
+    const cause = new Error('underlying mismatch');
+    const err = new CorruptedEventLogError('event mismatch', { cause });
+    expect(err.cause).toBe(cause);
+  });
+
+  test('CorruptedEventLogError.is discriminates by name', () => {
+    const err = new CorruptedEventLogError('event mismatch');
+    const other = new Error('event mismatch');
+    expect(CorruptedEventLogError.is(err)).toBe(true);
+    expect(CorruptedEventLogError.is(other)).toBe(false);
+    expect(CorruptedEventLogError.is(null)).toBe(false);
+  });
+});

--- a/packages/errors/src/error-codes.ts
+++ b/packages/errors/src/error-codes.ts
@@ -6,8 +6,10 @@
 export const RUN_ERROR_CODES = {
   /** Error thrown in user workflow or step code */
   USER_ERROR: 'USER_ERROR',
-  /** Internal runtime error (corrupted event log, missing timestamps) */
+  /** Internal runtime error (missing timestamps, runtime invariant failures) */
   RUNTIME_ERROR: 'RUNTIME_ERROR',
+  /** Event log contains orphaned or mismatched events and cannot be replayed */
+  CORRUPTED_EVENT_LOG: 'CORRUPTED_EVENT_LOG',
   /** Run exceeded the maximum number of queue deliveries */
   MAX_DELIVERIES_EXCEEDED: 'MAX_DELIVERIES_EXCEEDED',
   /** Workflow replay exceeded the maximum allowed duration */

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -300,6 +300,29 @@ export class WorkflowRuntimeError extends WorkflowError {
   }
 }
 
+/**
+ * Thrown when the persisted workflow event log cannot be replayed because it
+ * contains orphaned, duplicate, or mismatched events.
+ *
+ * This is a runtime/infrastructure failure rather than user code throwing.
+ * When this reaches run failure handling, it is recorded with the distinct
+ * `CORRUPTED_EVENT_LOG` code so worlds and backends can track it separately
+ * from generic runtime failures.
+ */
+export class CorruptedEventLogError extends WorkflowRuntimeError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, {
+      ...options,
+      slug: ERROR_SLUGS.CORRUPTED_EVENT_LOG,
+    });
+    this.name = 'CorruptedEventLogError';
+  }
+
+  static is(value: unknown): value is CorruptedEventLogError {
+    return isError(value) && value.name === 'CorruptedEventLogError';
+  }
+}
+
 interface WorkflowBuildErrorOptions extends ErrorOptions {
   /**
    * An optional actionable hint appended to the main message, explaining how

--- a/packages/world/src/shared.ts
+++ b/packages/world/src/shared.ts
@@ -53,7 +53,7 @@ export type ResolveData = 'none' | 'all';
 export const StructuredErrorSchema = z.object({
   message: z.string(),
   stack: z.string().optional(),
-  code: z.string().optional(), // Populated with RunErrorCode values (USER_ERROR, RUNTIME_ERROR) for run_failed events
+  code: z.string().optional(), // Populated with RunErrorCode values (USER_ERROR, RUNTIME_ERROR, etc.) for run_failed events
 });
 
 export type StructuredError = z.infer<typeof StructuredErrorSchema>;


### PR DESCRIPTION
## Summary

- add `CorruptedEventLogError` and `CORRUPTED_EVENT_LOG` as a distinct run failure code
- throw the new error type from corrupted event-log replay guards instead of generic `WorkflowRuntimeError`
- update runtime/error description tests so worlds receive the distinct `run_failed.eventData.errorCode`

## Testing

- `pnpm --filter @workflow/errors test`
- `pnpm --filter @workflow/core build`
- `pnpm --filter @workflow/core exec vitest run src/classify-error.test.ts src/describe-error.test.ts src/runtime.test.ts src/workflow/sleep.test.ts src/workflow/hook.test.ts src/step.test.ts src/abort-controller.test.ts src/log-format.test.ts`
- `git diff --check`

Note: local commands were run on Node v25.2.1, which is outside the repo engine range, but the focused build/tests passed.