### PR TITLE
ci: publish gh-pages updates via signed GraphQL commits

### DIFF
--- a/.github/actions/publish-to-gh-pages/action.yml
+++ b/.github/actions/publish-to-gh-pages/action.yml
@@ -1,0 +1,41 @@
+name: 'Publish to GitHub Pages'
+description: >-
+  Publishes files to a GitHub Pages branch via the GraphQL
+  createCommitOnBranch mutation. GitHub signs the resulting commit with its
+  internal key (the same way web-UI commits are signed), so the push
+  satisfies the repo's required-signatures rule that rejects plain
+  `git push` from CI.
+inputs:
+  source-dir:
+    description: 'Local directory whose contents will be published'
+    required: true
+  destination-dir:
+    description: 'Directory inside the target branch where files are placed'
+    required: true
+  branch:
+    description: 'Target branch'
+    required: false
+    default: 'gh-pages'
+  commit-message:
+    description: 'Commit message headline (body may follow after a blank line)'
+    required: false
+    default: 'deploy: ${{ github.sha }}'
+  github-token:
+    description: 'Token with `contents: write` permission on the target branch'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Publish via createCommitOnBranch
+      uses: actions/github-script@v7
+      env:
+        SOURCE_DIR: ${{ inputs.source-dir }}
+        DEST_DIR: ${{ inputs.destination-dir }}
+        BRANCH: ${{ inputs.branch }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        ACTION_PATH: ${{ github.action_path }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const publish = require(`${process.env.ACTION_PATH}/publish.js`);
+          await publish({ github, context, core });

--- a/.github/actions/publish-to-gh-pages/publish.js
+++ b/.github/actions/publish-to-gh-pages/publish.js
@@ -1,0 +1,110 @@
+// Publishes files from a local directory to `destination-dir` on a
+// target branch using the GraphQL `createCommitOnBranch` mutation.
+// GitHub signs the resulting commit with its internal key, which is
+// required because the repo's enterprise-level ruleset rejects unsigned
+// pushes on every ref (including gh-pages).
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = async ({ github, context, core }) => {
+  const sourceDir = process.env.SOURCE_DIR;
+  const destDir = (process.env.DEST_DIR || '').replace(/^\/+|\/+$/g, '');
+  const branch = process.env.BRANCH;
+  const message = process.env.COMMIT_MESSAGE;
+  const { owner, repo } = context.repo;
+
+  if (!fs.existsSync(sourceDir)) {
+    core.warning(
+      `Source directory "${sourceDir}" does not exist; nothing to publish.`
+    );
+    return;
+  }
+
+  const additions = [];
+  const walk = (dir, rel = '') => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      const next = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(abs, next);
+      } else if (entry.isFile()) {
+        const contents = fs.readFileSync(abs).toString('base64');
+        additions.push({
+          path: destDir ? `${destDir}/${next}` : next,
+          contents,
+        });
+      }
+    }
+  };
+  walk(sourceDir);
+
+  if (additions.length === 0) {
+    core.warning(
+      `Source directory "${sourceDir}" has no files; nothing to publish.`
+    );
+    return;
+  }
+
+  // CommitMessage GraphQL input wants headline (first line) + body
+  // (everything after the first blank line).
+  const firstNewline = message.indexOf('\n');
+  let headline;
+  let body;
+  if (firstNewline === -1) {
+    headline = message;
+    body = '';
+  } else {
+    headline = message.slice(0, firstNewline);
+    const rest = message.slice(firstNewline + 1);
+    body = rest.startsWith('\n') ? rest.slice(1) : rest;
+  }
+
+  const mutation = `
+    mutation($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit { oid url }
+      }
+    }
+  `;
+
+  // Retry once on `expectedHeadOid` mismatch — possible if another
+  // workflow run pushes to the same branch between our ref read and
+  // the mutation.
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const { data: ref } = await github.rest.git.getRef({
+      owner,
+      repo,
+      ref: `heads/${branch}`,
+    });
+    const expectedHeadOid = ref.object.sha;
+
+    try {
+      const result = await github.graphql(mutation, {
+        input: {
+          branch: {
+            repositoryNameWithOwner: `${owner}/${repo}`,
+            branchName: branch,
+          },
+          expectedHeadOid,
+          message: { headline, body },
+          fileChanges: { additions },
+        },
+      });
+      const { oid, url } = result.createCommitOnBranch.commit;
+      core.info(`Created signed commit ${oid} on ${branch} (${url})`);
+      return;
+    } catch (err) {
+      const errs = Array.isArray(err.errors) ? err.errors : [];
+      const conflicted =
+        errs.some((e) => /expected.*head/i.test(e.message || '')) ||
+        /expected.*head/i.test(err.message || '');
+      if (conflicted && attempt === 1) {
+        core.warning(
+          `Branch ${branch} HEAD moved during publish; retrying once.`
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
+};

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -638,9 +638,8 @@ jobs:
             --branch "${{ github.ref_name }}"
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: ./.github/actions/publish-to-gh-pages
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-data
-          destination_dir: ci
-          keep_files: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          source-dir: ./docs-data
+          destination-dir: ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -961,9 +961,8 @@ jobs:
             --branch "${{ github.ref_name }}"
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: ./.github/actions/publish-to-gh-pages
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-data
-          destination_dir: ci
-          keep_files: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          source-dir: ./docs-data
+          destination-dir: ci


### PR DESCRIPTION
## Summary

- The repo's enterprise-level \`~ALL\` required-signatures ruleset rejects unsigned commits on every ref, including \`gh-pages\`. The benchmark and E2E publish jobs use \`peaceiris/actions-gh-pages@v4\`, which creates an unsigned commit and then fails the subsequent push with \`GH013: Commits must have verified signatures\` ([example failure](https://github.com/vercel/workflow/actions/runs/26186135371/job/77060112326)).
- Replace those steps with a small shared composite action (\`.github/actions/publish-to-gh-pages\`) that uses the GraphQL \`createCommitOnBranch\` mutation. GitHub signs the resulting commit with its internal key, so it satisfies the rule. Same pattern \`backport.yml\` already uses for the \`backport/*\` branches.
- \`keep_files: true\` is no longer needed — \`createCommitOnBranch\` only touches paths listed in \`additions\`, leaving everything else on \`gh-pages\` untouched.
- Commits will now be attributed to \`github-actions[bot]\` instead of the workflow actor — matches how the backport workflow already behaves.

## Test plan

- [ ] Merge to \`main\` and confirm the \`Performance Benchmarks\` → \`Publish Benchmark Results\` job creates a verified commit on \`gh-pages\` (look for the green "Verified" badge).
- [ ] Confirm the \`Tests\` → \`Publish E2E Results\` job does the same.
- [ ] Confirm \`gh-pages/ci/benchmark-results.json\` and \`gh-pages/ci/e2e-results.json\` are updated as before (other files under \`ci/\` should remain untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)