### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-workflow-dev/action.yml
+++ b/.github/actions/setup-workflow-dev/action.yml
@@ -32,12 +32,12 @@ runs:
   steps:
     - name: Setup Rust
       if: ${{ inputs.setup-rust == 'true' }}
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         toolchain: stable
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
     - name: Setup Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Setup pnpm
         if: steps.existing-pr.outputs.exists != 'true'
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
         if: steps.existing-pr.outputs.exists != 'true'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Find existing benchmark comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Create new benchmark comment
         if: steps.find-comment.outputs.comment-id == ''
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: benchmark-results
           message: |
@@ -102,14 +102,14 @@ jobs:
 
       - name: Update existing benchmark comment with stale warning
         if: steps.find-comment.outputs.comment-id != '' && steps.get-comment.outputs.has-results == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: benchmark-results
           path: ${{ steps.get-comment.outputs.stale-comment-path }}
 
       - name: Update existing benchmark comment without results
         if: steps.find-comment.outputs.comment-id != '' && steps.get-comment.outputs.has-results != 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: benchmark-results
           message: |
@@ -192,7 +192,7 @@ jobs:
       - name: Download baseline from PR base branch
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: benchmarks.yml
           branch: ${{ github.event.pull_request.base.ref }}
@@ -292,7 +292,7 @@ jobs:
       - name: Download baseline from PR base branch
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: benchmarks.yml
           branch: ${{ github.event.pull_request.base.ref }}
@@ -386,7 +386,7 @@ jobs:
       - name: Download baseline from PR base branch
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: benchmarks.yml
           branch: ${{ github.event.pull_request.base.ref }}
@@ -511,7 +511,7 @@ jobs:
       - name: Download baseline from PR base branch
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: benchmarks.yml
           branch: ${{ github.event.pull_request.base.ref }}
@@ -562,14 +562,14 @@ jobs:
 
       - name: Update PR comment with results
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: benchmark-results
           path: benchmark-summary.md
 
       - name: Append failure notice to PR comment
         if: github.event_name == 'pull_request' && steps.check-status.outputs.has_failures == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: benchmark-results
           append: true
@@ -585,7 +585,7 @@ jobs:
 
       - name: Append community warning to PR comment
         if: github.event_name == 'pull_request' && steps.check-status.outputs.has_warnings == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: benchmark-results
           append: true

--- a/.github/workflows/debug-windows.yml
+++ b/.github/workflows/debug-windows.yml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
@@ -42,7 +42,7 @@ jobs:
         run: pnpm turbo run build --filter='!./workbench/*' --filter='!./docs'
 
       - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
         timeout-minutes: ${{ fromJSON(github.event.inputs.timeout_minutes) }}
         with:
           limit-access-to-actor: true

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
@@ -56,7 +56,7 @@ jobs:
           cache: "pnpm"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 24.x
         uses: actions/setup-node@v4
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: pnpm ci:version
           publish: pnpm ci:publish

--- a/.github/workflows/tarballs-checks.yml
+++ b/.github/workflows/tarballs-checks.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Find existing test comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Create new test comment
         if: steps.find-comment.outputs.comment-id == ''
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-test-results
           message: |
@@ -103,14 +103,14 @@ jobs:
 
       - name: Update existing test comment with stale warning
         if: steps.find-comment.outputs.comment-id != '' && steps.get-comment.outputs.has-results == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-test-results
           path: ${{ steps.get-comment.outputs.stale-comment-path }}
 
       - name: Update existing test comment without results
         if: steps.find-comment.outputs.comment-id != '' && steps.get-comment.outputs.has-results != 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-test-results
           message: |
@@ -167,7 +167,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
@@ -630,13 +630,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
@@ -851,14 +851,14 @@ jobs:
 
       - name: Update PR comment with results
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-test-results
           path: e2e-summary.md
 
       - name: Append failure notice to PR comment
         if: github.event_name == 'pull_request' && steps.check-status.outputs.has_failures == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-test-results
           append: true


### PR DESCRIPTION
## Summary

Pin every third-party \`uses:\` reference in the CI workflows to a full commit SHA, with the corresponding version as a trailing comment. The major-version refs we were using (e.g. \`@v2\`, \`@v5\`) are mutable upstream — sometimes tags, sometimes branches (e.g. \`marocchino/sticky-pull-request-comment\` keeps \`v1\`/\`v2\`/\`v3\` as branches, and \`dawidd6/action-download-artifact\` force-pushes the bare \`v6\` tag forward outside of releases).

Pinned actions:

| Action | SHA | Version |
|---|---|---|
| \`changesets/action\` | \`63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b\` | v1.8.0 |
| \`pnpm/action-setup\` | \`fc06bc1257f339d1d5d8b3a19a8cae5388b55320\` | v5.0.0 |
| \`oven-sh/setup-bun\` | \`0c5077e51419868618aeaa5fe8019c62421857d6\` | v2.2.0 |
| \`actions-rust-lang/setup-rust-toolchain\` | \`46268bd060767258de96ed93c1251119784f2ab6\` | v1.16.1 |
| \`peter-evans/find-comment\` | \`3eae4d37986fb5a8592848f6a574fdf654e61f9e\` | v3.1.0 |
| \`marocchino/sticky-pull-request-comment\` | \`773744901bac0e8cbb5a0dc842800d45e9b2b405\` | v2.9.4 |
| \`dawidd6/action-download-artifact\` | \`bf251b5aa9c2f7eeb574a96ee720e24f801b7c11\` | v6 (floating major tag) |
| \`mxschmitt/action-tmate\` | \`c0afd6f790e3a5564914980036ebf83216678101\` | v3.23 |

GitHub-published \`actions/*\` and local \`./.github/actions/*\` are not pinned — those are first-party.

Going forward, Dependabot/Renovate can keep these fresh and the version comment makes it obvious during review what upstream release the SHA corresponds to.

## Test plan

- [ ] CI runs cleanly on this PR — all workflows resolve the pinned SHAs successfully.
- [ ] Spot-check that PR comment plumbing still works (benchmarks/tests sticky comments update on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)