### PR TITLE
[core] Fix spurious "Event cursor missing after initial load" warning

### DIFF
--- a/.changeset/fix-load-events-cursor-null.md
+++ b/.changeset/fix-load-events-cursor-null.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": patch
+"workflow": patch
+---
+
+Fix spurious "Event cursor missing after initial load" warning and the redundant full-event reload it caused. `loadWorkflowRunEvents` now preserves the last non-null cursor across pages so a trailing empty page from the World (e.g. when DynamoDB returns `LastEvaluatedKey` at a page boundary) no longer clobbers it.

--- a/.changeset/fix-load-events-cursor-null.md
+++ b/.changeset/fix-load-events-cursor-null.md
@@ -3,4 +3,4 @@
 "workflow": patch
 ---
 
-Fix spurious "Event cursor missing after initial load" warning and the redundant full-event reload it caused. `loadWorkflowRunEvents` now preserves the last non-null cursor across pages so a trailing empty page from the World (e.g. when DynamoDB returns `LastEvaluatedKey` at a page boundary) no longer clobbers it.
+Fix spurious "Event cursor missing after initial load" warning

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
-import { getWorkflowQueueName } from './helpers.js';
+import type { Event } from '@workflow/world';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getWorkflowQueueName, loadWorkflowRunEvents } from './helpers.js';
 
 // Mock the logger to suppress output during tests
 vi.mock('../logger.js', () => ({
@@ -10,6 +11,25 @@ vi.mock('../logger.js', () => ({
     error: vi.fn(),
   },
 }));
+
+const eventsListMock = vi.fn();
+
+vi.mock('./get-world-lazy.js', () => ({
+  getWorldLazy: vi.fn(async () => ({
+    events: {
+      list: eventsListMock,
+    },
+  })),
+}));
+
+const makeEvent = (eventId: string): Event =>
+  ({
+    eventId,
+    runId: 'wrun_mockidnumber0001',
+    eventType: 'step_created',
+    correlationId: 'step_mock',
+    createdAt: new Date(),
+  }) as unknown as Event;
 
 describe('getWorkflowQueueName', () => {
   it('should return a valid queue name for a simple workflow name', () => {
@@ -78,5 +98,110 @@ describe('getWorkflowQueueName', () => {
 
   it('should throw for empty string', () => {
     expect(() => getWorkflowQueueName('')).toThrow('Invalid workflow name');
+  });
+});
+
+describe('loadWorkflowRunEvents', () => {
+  beforeEach(() => {
+    eventsListMock.mockReset();
+  });
+
+  it('returns the cursor from the last page when pagination terminates normally', async () => {
+    const page1 = [makeEvent('evnt_a'), makeEvent('evnt_b')];
+    eventsListMock.mockResolvedValueOnce({
+      data: page1,
+      cursor: 'eid:evnt_b',
+      hasMore: false,
+    });
+
+    const result = await loadWorkflowRunEvents('wrun_test');
+
+    expect(result.events).toHaveLength(2);
+    expect(result.cursor).toBe('eid:evnt_b');
+    expect(eventsListMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression test for the "Event cursor missing after initial load" warning.
+  //
+  // A World may legitimately return `{ data: [], cursor: null, hasMore: false }`
+  // on a trailing empty page — workflow-server does this whenever the previous
+  // page's DynamoDB query hit `Limit` exactly and DynamoDB returned a
+  // `LastEvaluatedKey` "just in case." If the pagination loop overwrites the
+  // cursor with `null` on that trailing page, the runtime's incremental-load
+  // path can't proceed and falls back to a full reload on every replay
+  // iteration, logging "Event cursor missing after initial load" each time.
+  it('preserves the cursor from the previous page when the final page is empty', async () => {
+    const page1 = [makeEvent('evnt_a'), makeEvent('evnt_b')];
+    eventsListMock.mockResolvedValueOnce({
+      data: page1,
+      cursor: 'eid:evnt_b',
+      hasMore: true,
+    });
+    eventsListMock.mockResolvedValueOnce({
+      data: [],
+      cursor: null,
+      hasMore: false,
+    });
+
+    const result = await loadWorkflowRunEvents('wrun_test');
+
+    expect(result.events).toHaveLength(2);
+    expect(result.cursor).toBe('eid:evnt_b');
+    expect(eventsListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null cursor only when no events exist at all', async () => {
+    eventsListMock.mockResolvedValueOnce({
+      data: [],
+      cursor: null,
+      hasMore: false,
+    });
+
+    const result = await loadWorkflowRunEvents('wrun_test');
+
+    expect(result.events).toHaveLength(0);
+    expect(result.cursor).toBeNull();
+  });
+
+  it('uses the latest cursor when paginating through multiple non-empty pages', async () => {
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_a')],
+      cursor: 'eid:evnt_a',
+      hasMore: true,
+    });
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_b')],
+      cursor: 'eid:evnt_b',
+      hasMore: true,
+    });
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_c')],
+      cursor: 'eid:evnt_c',
+      hasMore: false,
+    });
+
+    const result = await loadWorkflowRunEvents('wrun_test');
+
+    expect(result.events.map((e) => e.eventId)).toEqual([
+      'evnt_a',
+      'evnt_b',
+      'evnt_c',
+    ]);
+    expect(result.cursor).toBe('eid:evnt_c');
+  });
+
+  it('falls back to the afterCursor when an incremental load returns no events', async () => {
+    eventsListMock.mockResolvedValueOnce({
+      data: [],
+      cursor: null,
+      hasMore: false,
+    });
+
+    const result = await loadWorkflowRunEvents('wrun_test', 'eid:evnt_z');
+
+    expect(result.events).toHaveLength(0);
+    // Preserving the input cursor avoids the runtime treating "no new events
+    // since last poll" as "I have no idea where I am in the log."
+    expect(result.cursor).toBe('eid:evnt_z');
   });
 });

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -351,7 +351,15 @@ export async function loadWorkflowRunEvents(
 
         loadedEvents.push(...response.data);
         hasMore = response.hasMore;
-        cursor = response.cursor;
+        // Preserve the last non-null cursor across pages. A World may
+        // legitimately return `{ data: [], cursor: null, hasMore: false }`
+        // on a trailing empty page — for example when the previous page's
+        // underlying DynamoDB query hit `Limit` exactly and returned a
+        // `LastEvaluatedKey` "just in case". Overwriting with that null
+        // would lose the position past the last real event we loaded and
+        // force the runtime into the "no cursor after initial load" full-
+        // reload fallback on every subsequent replay iteration.
+        cursor = response.cursor ?? cursor;
         pagesLoaded++;
 
         runtimeLogger.debug('Loaded event page', {


### PR DESCRIPTION
## Summary

The V2 runtime's `loadWorkflowRunEvents` helper paginates through `world.events.list` and overwrites its `cursor` variable on every page. When the final page is empty (`data: [], cursor: null, hasMore: false`), the helper returns `cursor: null` despite having loaded events — which trips the `cachedEvents` ≠ null + `eventsCursor` = null branch in `runtime.ts`, logs `Event cursor missing after initial load — falling back to full reload. This indicates a bug in the World implementation.`, and forces a full event reload on every subsequent replay iteration.

The trailing empty page is a normal, contract-compliant response, not a World bug. workflow-server can produce it whenever an underlying DynamoDB `Query` hits its `Limit` exactly — DynamoDB returns `LastEvaluatedKey` "just in case", the server passes that through as `hasMore: true`, and the next call returns an empty page. This is observable in production (38 distinct runs in 24h on `agents-vade-review` alone, each logging the warning multiple times per invocation).

Fix is one line: preserve the last non-null cursor across pages.

```ts
cursor = response.cursor ?? cursor;
```

This mirrors how `runtime.ts:665` and `runtime.ts:811` already treat incremental loads.

## Test plan

- [x] `packages/core/src/runtime/helpers.test.ts` — added regression tests covering the trailing-empty-page case, multi-page traversal, and incremental loads that return zero new events. Verified the new tests fail against `main` (cursor is `null` instead of the expected last cursor) and pass with the one-line fix.
- [ ] CI green