### PR TITLE
ci(backport): include full commit SHA in no-backport comment

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -375,7 +375,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const reasoning = process.env.REASONING;
-            const sha = process.env.SHA.slice(0, 7);
+            const fullSha = process.env.SHA;
+            const shortSha = fullSha.slice(0, 7);
             const prNumber = Number(process.env.PR_NUMBER);
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/backport.yml`;
@@ -384,11 +385,19 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
               body: [
-                `**No backport to \`stable\`** for ${sha} ([AI decision](${runUrl})).`,
+                `**No backport to \`stable\`** for ${shortSha} ([AI decision](${runUrl})).`,
                 '',
                 reasoning,
                 '',
-                `To override, re-run the [Backport to stable](${workflowUrl}) workflow manually via \`workflow_dispatch\` with this commit SHA.`
+                // GitHub Actions doesn't support prefilling workflow_dispatch
+                // inputs via URL query params (community/community#51159), so
+                // we paste the full SHA here for easy copy-paste into the
+                // "Commit SHA" input on the workflow run page.
+                `To override, re-run the [Backport to stable](${workflowUrl}) workflow manually via \`workflow_dispatch\` and paste this commit SHA into the \`ref\` input:`,
+                '',
+                '```',
+                fullSha,
+                '```'
               ].join('\n')
             });
 


### PR DESCRIPTION
## Summary

The no-backport comment posted by the backport workflow ends with:

> To override, re-run the [Backport to stable](...) workflow manually via `workflow_dispatch` with this commit SHA.

…but "this commit SHA" was never actually included in the comment, so anyone wanting to override the AI's decision had to go look it up.

GitHub Actions does **not** currently support prefilling `workflow_dispatch` inputs via URL query params ([`community/community#51159`](https://github.com/orgs/community/discussions/51159), open since 2023), so we can't link the user directly to a prefilled form. Instead, this PR pastes the full 40-char SHA into the comment inside a fenced code block, making it a one-click copy into the "Commit SHA" input on the workflow run page.

Also includes a code comment explaining why we're not just linking to a prefilled dispatch form, so the next person who has the same idea finds the answer immediately.

## Before/after

Before:
> To override, re-run the [Backport to stable] workflow manually via `workflow_dispatch` with this commit SHA.

After:
> To override, re-run the [Backport to stable] workflow manually via `workflow_dispatch` and paste this commit SHA into the `ref` input:
> ```
> b062b28d55d85c737ba0d21084cf0439d200ab9d
> ```

## Test plan

Workflow-only change; control flow and tool permissions are unchanged. Will be exercised by the next AI no-backport decision after merge.