### PR TITLE
Fix Next workbench cached outputs

### DIFF
--- a/.changeset/turbo-next-workbench-outputs.md
+++ b/.changeset/turbo-next-workbench-outputs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Declare generated Next workbench files as Turbo outputs so cached builds restore traced artifacts.

--- a/workbench/nextjs-turbopack/turbo.json
+++ b/workbench/nextjs-turbopack/turbo.json
@@ -3,7 +3,13 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "_workflows.ts",
+        "app/.well-known/workflow/**",
+        "public/.well-known/workflow/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- include generated Next workbench files in Turbo build outputs
- ensure cache hits restore `_workflows.ts` and generated workflow route/public manifest artifacts traced by `.next`

x-ref: https://vercel.com/vercel-labs/example-nextjs-workflow-turbopack/77i7JujYBXqndFyVMUBiCrxh37Sr

## Verification
- `pnpm turbo run build --filter=nextjs-turbopack --dry=json`
- `pnpm changeset status --since=main`
- `git diff --check`