### PR TITLE
[ci] Attribute backport changelog entries to original PR author

### DIFF
--- a/.changeset/changelog.mjs
+++ b/.changeset/changelog.mjs
@@ -1,0 +1,263 @@
+// Custom changelog generator that wraps `@changesets/changelog-github`.
+//
+// Why this exists
+// ---------------
+// Our backport workflow (.github/workflows/backport.yml) replays commits
+// from `main` onto `stable` using GitHub's GraphQL `createCommitOnBranch`
+// mutation so the resulting commits are signed by GitHub's internal key.
+// A consequence is that the backport commit, and the PR that wraps it,
+// are both attributed to `github-actions[bot]` — not the original author.
+//
+// `@changesets/changelog-github` resolves the author/PR of a changeset
+// commit via the GraphQL `associatedPullRequests` field. For commits that
+// landed on `stable` via the backport flow, that resolves to the backport
+// PR (e.g. "Backport #2046: ...") authored by `github-actions[bot]`, and
+// the rendered changelog ends up with "Thanks @github-actions!".
+//
+// What this wrapper does
+// ----------------------
+// 1. For each changeset commit, look up its associated PR title and body.
+// 2. Detect backport PRs by matching the title (`Backport #N: ...`) or
+//    body (`Automated backport of #N to \`stable\``) — both formats are
+//    produced by .github/workflows/backport.yml.
+// 3. When a backport PR is detected, inject `pr: <originalPR>` and
+//    `commit: <backportSha>` lines into the changeset summary before
+//    handing off to the upstream changelog generator. Those lines are a
+//    documented `@changesets/changelog-github` feature
+//    (https://github.com/changesets/changesets/blob/main/packages/changelog-github/README.md#usage)
+//    and trigger a PR-number-based lookup, which attributes the entry to
+//    the original PR's author while keeping the commit link pointing at
+//    the backport commit on the release branch.
+// 4. Falls back to plain delegation when no backport is detected, when
+//    the commit has no associated PR, or when any lookup fails — we never
+//    want a flaky network call to break `pnpm changeset version`.
+//
+// Note: this file is loaded by `@changesets/apply-release-plan` via a
+// synchronous `require()`. Node 22.12+ supports `require()`'ing ESM
+// modules with static imports, which we rely on (the release workflow
+// uses Node 24). If you add a dynamic import or a top-level await here,
+// the loader will throw.
+
+import changelogGithub from '@changesets/changelog-github';
+
+const upstream = changelogGithub.default ?? changelogGithub;
+
+// Match the PR titles and bodies produced by .github/workflows/backport.yml.
+// Title examples:
+//   "Backport #2046: Report corrupted event logs distinctly"
+//   "Backport a1b2c3d: <subject>"  (when no source PR was associated)
+// Body examples:
+//   "Automated backport of #2046 to `stable` ..."
+//   "Automated backport of a1b2c3def456 to `stable` ..."
+const BACKPORT_TITLE_PR_RE = /^Backport\s+#(\d+):/i;
+const BACKPORT_BODY_PR_RE = /Automated\s+backport\s+of\s+#(\d+)\s+to\s+`stable`/i;
+
+function readEnv() {
+  return {
+    GITHUB_GRAPHQL_URL:
+      process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql',
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  };
+}
+
+// Lightweight in-process cache so multiple changesets pointing at the
+// same commit don't trigger duplicate GraphQL lookups. The values are
+// promises so concurrent callers share a single in-flight request.
+const commitLookupCache = new Map();
+const prLookupCache = new Map();
+
+async function githubGraphql(query) {
+  const { GITHUB_GRAPHQL_URL, GITHUB_TOKEN } = readEnv();
+  if (!GITHUB_TOKEN) {
+    // No token means the upstream `getInfo` call would have failed too —
+    // let it surface the error so behavior is consistent with the
+    // unwrapped generator.
+    return null;
+  }
+  const res = await fetch(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Token ${GITHUB_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub GraphQL request failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  const json = await res.json();
+  if (json.errors) {
+    throw new Error(
+      `GitHub GraphQL request returned errors: ${JSON.stringify(json.errors)}`,
+    );
+  }
+  return json.data;
+}
+
+// Returns the associated PR (number, title, body) for a commit, or null
+// if no PR is associated / the lookup failed.
+function lookupCommitPR(repo, commit) {
+  const cacheKey = `${repo}@${commit}`;
+  if (!commitLookupCache.has(cacheKey)) {
+    commitLookupCache.set(
+      cacheKey,
+      (async () => {
+        const [owner, name] = repo.split('/');
+        const query = `
+          query {
+            repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) {
+              object(expression: ${JSON.stringify(commit)}) {
+                ... on Commit {
+                  associatedPullRequests(first: 10) {
+                    nodes {
+                      number
+                      title
+                      body
+                      mergedAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `;
+        try {
+          const data = await githubGraphql(query);
+          const nodes =
+            data?.repository?.object?.associatedPullRequests?.nodes ?? [];
+          if (nodes.length === 0) return null;
+          // Only consider *merged* PRs — open PRs that happen to share
+          // a commit (e.g. a draft backport branched off the same SHA)
+          // shouldn't influence attribution. Then sort ascending by
+          // `mergedAt` (oldest first) to match `@changesets/get-github-info`'s
+          // selection logic: the oldest merged PR is the one that *first*
+          // introduced the commit to the repository.
+          const merged = nodes
+            .filter((n) => n.mergedAt !== null)
+            .sort((a, b) =>
+              new Date(a.mergedAt) > new Date(b.mergedAt) ? 1 : -1,
+            );
+          if (merged.length === 0) return null;
+          return merged[0];
+        } catch (err) {
+          console.warn(
+            `[changelog] failed to look up associated PR for ${commit}: ${err.message}`,
+          );
+          return null;
+        }
+      })(),
+    );
+  }
+  return commitLookupCache.get(cacheKey);
+}
+
+// Returns { number, title, body } for a PR number, or null if the lookup
+// failed.
+function lookupPR(repo, prNumber) {
+  const cacheKey = `${repo}#${prNumber}`;
+  if (!prLookupCache.has(cacheKey)) {
+    prLookupCache.set(
+      cacheKey,
+      (async () => {
+        const [owner, name] = repo.split('/');
+        const query = `
+          query {
+            repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) {
+              pullRequest(number: ${prNumber}) {
+                number
+                title
+                body
+              }
+            }
+          }
+        `;
+        try {
+          const data = await githubGraphql(query);
+          return data?.repository?.pullRequest ?? null;
+        } catch (err) {
+          console.warn(
+            `[changelog] failed to look up PR #${prNumber}: ${err.message}`,
+          );
+          return null;
+        }
+      })(),
+    );
+  }
+  return prLookupCache.get(cacheKey);
+}
+
+// Returns the original PR number if `pr` is a backport PR, else null.
+// Recurses one level in case of unusual chains (a backport of a backport),
+// bounded so we can never loop on cycles in the PR graph.
+async function resolveOriginalPR(repo, pr, depth = 0) {
+  if (!pr || depth > 3) return null;
+  const titleMatch = pr.title?.match(BACKPORT_TITLE_PR_RE);
+  const bodyMatch = pr.body?.match(BACKPORT_BODY_PR_RE);
+  const originalPRNumber = titleMatch
+    ? Number(titleMatch[1])
+    : bodyMatch
+      ? Number(bodyMatch[1])
+      : null;
+  if (!originalPRNumber || originalPRNumber === pr.number) return null;
+  const originalPR = await lookupPR(repo, originalPRNumber);
+  if (!originalPR) return originalPRNumber; // best-effort: still attribute
+  // If the "original" is itself a backport (unusual but defensible),
+  // peel one more layer.
+  const deeper = await resolveOriginalPR(repo, originalPR, depth + 1);
+  return deeper ?? originalPR.number;
+}
+
+// Mutate a changeset summary by injecting `pr:`, `commit:` lines if and
+// only if the commit's associated PR is a backport. Returns a new
+// changeset object (does not modify the caller's input).
+async function maybeRewriteChangesetForBackport(changeset, options) {
+  if (!changeset.commit) return changeset;
+  if (!options || !options.repo) return changeset;
+
+  // Don't rewrite if the user already supplied explicit `pr:` / `commit:`
+  // / `author:` directives in the summary — they win.
+  const summary = changeset.summary ?? '';
+  if (
+    /^\s*(?:pr|pull|pull\s+request|commit|author|user):/im.test(summary)
+  ) {
+    return changeset;
+  }
+
+  const pr = await lookupCommitPR(options.repo, changeset.commit);
+  if (!pr) return changeset;
+
+  const originalPRNumber = await resolveOriginalPR(options.repo, pr);
+  if (!originalPRNumber) return changeset;
+
+  // Inject directives at the top of the summary. The upstream parser
+  // strips them out before rendering the body, so they won't appear in
+  // the final changelog.
+  const rewrittenSummary =
+    `pr: #${originalPRNumber}\n` +
+    `commit: ${changeset.commit}\n` +
+    summary;
+
+  return { ...changeset, summary: rewrittenSummary };
+}
+
+export async function getDependencyReleaseLine(
+  changesets,
+  dependenciesUpdated,
+  options,
+) {
+  // For the dependency-updates roll-up line, the upstream generator
+  // only renders commit links (no "Thanks" attribution), so we don't
+  // need any rewriting here.
+  return upstream.getDependencyReleaseLine(
+    changesets,
+    dependenciesUpdated,
+    options,
+  );
+}
+
+export async function getReleaseLine(changeset, type, options) {
+  const rewritten = await maybeRewriteChangesetForBackport(changeset, options);
+  return upstream.getReleaseLine(rewritten, type, options);
+}

--- a/.changeset/changelog.mjs
+++ b/.changeset/changelog.mjs
@@ -66,6 +66,14 @@ function readEnv() {
 const commitLookupCache = new Map();
 const prLookupCache = new Map();
 
+// Defensive error formatter — we don't want a non-Error throw (e.g.
+// `throw null`, or a non-conforming Error from a transport polyfill) to
+// turn a benign GitHub lookup failure into a hard crash inside the catch
+// block itself.
+function formatError(err) {
+  return err instanceof Error ? err.message : String(err);
+}
+
 async function githubGraphql(query) {
   const { GITHUB_GRAPHQL_URL, GITHUB_TOKEN } = readEnv();
   if (!GITHUB_TOKEN) {
@@ -77,7 +85,7 @@ async function githubGraphql(query) {
   const res = await fetch(GITHUB_GRAPHQL_URL, {
     method: 'POST',
     headers: {
-      Authorization: `Token ${GITHUB_TOKEN}`,
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ query }),
@@ -143,7 +151,7 @@ function lookupCommitPR(repo, commit) {
           return merged[0];
         } catch (err) {
           console.warn(
-            `[changelog] failed to look up associated PR for ${commit}: ${err.message}`,
+            `[changelog] failed to look up associated PR for ${commit}: ${formatError(err)}`,
           );
           return null;
         }
@@ -178,7 +186,7 @@ function lookupPR(repo, prNumber) {
           return data?.repository?.pullRequest ?? null;
         } catch (err) {
           console.warn(
-            `[changelog] failed to look up PR #${prNumber}: ${err.message}`,
+            `[changelog] failed to look up PR #${prNumber}: ${formatError(err)}`,
           );
           return null;
         }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./changelog.mjs",
     {
       "repo": "vercel/workflow"
     }


### PR DESCRIPTION
## Summary

`@changesets/changelog-github` resolves a changeset commit to its associated PR via the GitHub GraphQL `associatedPullRequests` field. For commits that landed on `stable` via the backport workflow, that resolves to the backport PR authored by `github-actions[bot]` (since `.github/workflows/backport.yml` uses GraphQL `createCommitOnBranch` to produce signed commits), so the generated changelog ends up with `Thanks @github-actions!` instead of the original contributor. See e.g. the `Thanks @github-actions!` lines in the diff for #1921.

This adds a small wrapper at `.changeset/changelog.mjs` around `@changesets/changelog-github` that:

1. Queries GitHub GraphQL for the PRs associated with each changeset commit, picking the oldest-merged one (matching `@changesets/get-github-info`'s own selection logic).
2. Detects backport PRs by matching the title (e.g. `Backport #N: ...`) or body (e.g. ``Automated backport of #N to `stable` ...``) — both formats produced by `.github/workflows/backport.yml`.
3. When a backport is detected, resolves the original PR number and injects `pr: #<original>` and `commit: <backportSha>` directives into the changeset summary before delegating to the upstream generator. Both directives are documented `@changesets/changelog-github` features.

The result: the rendered changelog entry attributes the change to the original PR and author (e.g. `Thanks @pranaygp!` with a link to PR #2046) while the commit link still points at the backport commit on the release branch.

Non-backport commits, commits without an associated PR, and any lookup failures all fall through to plain upstream delegation — a flaky network call can never break `pnpm changeset version`.

Loaded via Node's `require(esm)` (the release workflow uses Node 24 which supports it).

## Verification

Verified end-to-end on a `stable` worktree by running `pnpm changeset version` and inspecting the rendered changelog. The new 4.2.5 section in `packages/core/CHANGELOG.md` rendered as:

> - #2046 `8407c1e` Thanks @pranaygp! — Report corrupted event logs ...
> - #2029 `a434184` Thanks @pranaygp! — Refresh workflow events ...
> - #2030 `c347509` Thanks @pranaygp! — Validate step, wait, and hook lifecycle events ...
> - #2060 `ca5f355` Thanks @pranaygp! — Record fatal world response contract failures ...
> - #1986 `16f2c23` Thanks @pranaygp! — Fix local workflow port detection ...

All five entries that previously rendered as `Thanks @github-actions!` (see the diff in #1921) now correctly attribute to the original PR and author. Non-backport entries are unchanged.

No changeset entry is required — this is a release-tooling-only change with no impact on published packages.
