### PR TITLE
[swc-plugin] Fix nested-step-arguments fixture stepId on stable

### DIFF
--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-arguments/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-arguments/output-step.js
@@ -1,5 +1,5 @@
 import { registerStepFunction } from "workflow/internal/private";
-/**__internal_workflows{"workflows":{"input.js":{"outer":{"workflowId":"workflow//./input//outer"}}},"steps":{"input.js":{"step":{"stepId":"step//./input//step"}}}}*/;
+/**__internal_workflows{"workflows":{"input.js":{"outer":{"workflowId":"workflow//./input//outer"}}},"steps":{"input.js":{"step":{"stepId":"step//./input//outer/step"}}}}*/;
 async function outer$step() {
     return arguments[0];
 }

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-arguments/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-arguments/output-workflow.js
@@ -1,4 +1,4 @@
-/**__internal_workflows{"workflows":{"input.js":{"outer":{"workflowId":"workflow//./input//outer"}}},"steps":{"input.js":{"step":{"stepId":"step//./input//step"}}}}*/;
+/**__internal_workflows{"workflows":{"input.js":{"outer":{"workflowId":"workflow//./input//outer"}}},"steps":{"input.js":{"step":{"stepId":"step//./input//outer/step"}}}}*/;
 // `arguments` inside a nested `function`-form step body must NOT be treated
 // as a closure variable — it's a per-function intrinsic binding that
 // reflects the positional args the runtime passes via `stepFn.apply(thisVal,


### PR DESCRIPTION
## Summary

Fixes the failing `@workflow/swc-plugin#test` unit-test job on `stable` (e.g. https://github.com/vercel/workflow/actions/runs/26303165602/job/77434934126).

Two fixture tests were failing:
- `step_mode_tests__fixture__nested_step_arguments__input_js`
- `workflow_mode_tests__fixture__nested_step_arguments__input_js`

## Root cause

A messy interaction between two backports:

1. **#1945** (backport of #1935 — *"Capture lexical `this` for nested arrow step functions"*) introduced the `nested-step-arguments/` fixture. It snapshotted the pre-namespacing step ID `"step//./input//step"` in the `__internal_workflows` manifest comment, matching the plugin's behavior at that point.
2. **#1946** (backport of #1944 — *"Preserve imports referenced by hoisted nested steps"* / *"Namespace nested step IDs..."*) shipped the namespacing fix in `lib.rs` but did not update this fixture, because on `main` the two PRs landed in the opposite order and #1944's diff already covered the fixture there.

Result: `stable`'s plugin now emits `"step//./input//outer/step"`, while the fixture still expects `"step//./input//step"`.

## Fix

Update the manifest-comment expectation in both `output-step.js` and `output-workflow.js` to `"step//./input//outer/step"` — the value `main` already has and the value the plugin actually emits on `stable`.

Pure test-snapshot fix; no `lib.rs` or runtime changes, so no changeset needed.

## Verification

```
$ cd packages/swc-plugin-workflow && pnpm test
test result: ok. 165 passed; 0 failed; 0 ignored
```