### PR TITLE
docs(stable): update docs/README for tarballs move

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -1,8 +1,8 @@
 # On stable, docs/ is a minimal placeholder that only builds a
-# blank Next.js app and packs per-deployment SDK tarballs. The real
-# docs site is deployed from main. This workflow is kept as a no-op
-# on stable so that any branch protection rules referencing these
-# job names still pass.
+# blank Next.js app. The real docs site is deployed from main, and
+# per-deployment SDK tarballs are built by the separate tarballs/
+# app. This workflow is kept as a no-op on stable so that any
+# branch protection rules referencing these job names still pass.
 name: Docs Checks
 
 on:

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,16 +3,15 @@
 This is a minimal placeholder Next.js app that lives on the `stable` branch
 only. The real docs site is maintained on `main` and deployed from there.
 
-The purpose of the stub is twofold:
-
-1. Keep the `Vercel – workflow-docs` deploy check green on PRs targeting
-   `stable` (the Vercel project has `docs/` as its root directory).
-2. Keep the `prebuild` pack script (`scripts/pack.ts`), which publishes
-   per-deployment package tarballs under the preview URL so that pre-release
-   builds of the SDK can be installed against backport PRs for testing.
+The stub exists to keep the docs Vercel deploy check green on PRs targeting
+`stable` — the corresponding Vercel project has `docs/` as its root directory.
 
 `docs/content/` is the canonical markdown bundled into npm packages via their
-`prepack` scripts — do not remove it.
+`prepack` scripts (see `packages/{workflow,core,next,ai}/package.json`) — do
+not remove it.
+
+Per-deployment SDK tarballs are no longer built from this project; they are
+served by the separate `tarballs/` app. See `tarballs/README.md` for details.
 
 Do not grow this stub into a real app. The backport workflow auto-resolves any
 cherry-pick conflict under `docs/` (outside `docs/content/`) by deleting the


### PR DESCRIPTION
## Summary

`docs/README.md` on `stable` claimed the stub still kept `scripts/pack.ts`
around to publish per-deployment SDK tarballs. That hasn't been true for a
while — the tarballs are now built by the separate `tarballs/` app (see
`tarballs/README.md`), and `docs/scripts/` no longer exists.

- Rewrite `docs/README.md` to drop the stale tarball claim and point
  readers at `tarballs/` instead.
- Add a tiny pointer to the `prepack` scripts that consume `docs/content/`
  so future readers can verify the "do not remove" note.
- Fix the same outdated wording in the header comment of
  `.github/workflows/docs-checks.yml`.

No code/behavior changes.