### PR TITLE
fix(workbench): cache `.vercel/output` for Next workbench builds

### DIFF
--- a/.changeset/turbo-next-workbench-vercel-output.md
+++ b/.changeset/turbo-next-workbench-vercel-output.md
@@ -1,0 +1,4 @@
+---
+---
+
+Include `.vercel/output/**` in the Next workbench Turbo outputs so cached builds restore the Vercel diagnostics manifest (`.vercel/output/diagnostics/workflows-manifest.json`), which the Vercel platform requires to finalize the deployment.

--- a/workbench/nextjs-turbopack/turbo.json
+++ b/workbench/nextjs-turbopack/turbo.json
@@ -8,7 +8,8 @@
         "!.next/cache/**",
         "_workflows.ts",
         "app/.well-known/workflow/**",
-        "public/.well-known/workflow/**"
+        "public/.well-known/workflow/**",
+        ".vercel/output/**"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Add `.vercel/output/**` to the `nextjs-turbopack` workbench's Turbo `outputs` so the Vercel diagnostics manifest (`.vercel/output/diagnostics/workflows-manifest.json`) is restored on cached replays. Also applies to `nextjs-webpack` (its `turbo.json` is a symlink to `nextjs-turbopack/turbo.json`).

## Why
A recent deployment of `example-nextjs-workflow-turbopack` ([dpl_8Jig1fYV8CygS4V6GW2krUkpDMWm](https://vercel.com/vercel-labs/example-nextjs-workflow-turbopack/8Jig1fYV8CygS4V6GW2krUkpDMWm)) failed with `status: Error` despite the build itself succeeding (`Tasks: 26 successful, 26 total`, `>>> FULL TURBO`).

Investigation showed:
- `packages/builders/src/base-builder.ts` writes `.vercel/output/diagnostics/workflows-manifest.json` whenever `shouldEmitVercelDiagnostics` is true (i.e., when targeting the Vercel world).
- The Vercel platform requires this file post-build to finalize the deployment.
- The root `turbo.json` includes `.vercel/output` in its outputs, but per-workspace `outputs` arrays **replace** (not merge with) the root config in Turborepo. The `nextjs-turbopack/turbo.json` was missing `.vercel/output/**`, so cached replays didn't restore the file → deployment error.

A previous fix ([#2071](https://github.com/vercel/workflow/pull/2071) / commit 05bf9389) added other generated files (`_workflows.ts`, `app/.well-known/workflow/**`, etc.) but missed `.vercel/output/**`. This PR adds it.

## Verification
- `workbench/nextjs-turbopack/.vercel/output/diagnostics/workflows-manifest.json` exists locally after a fresh build, confirming the file is produced; it just wasn't in the Turbo outputs.
- No other workbench `turbo.json` declares `.vercel/output/**` either, but only the two Next.js workbenches currently use `withWorkflow` + the deferred builder path that emits the diagnostics manifest in a way that ends up at this exact path during Vercel builds, and only those two have been observed failing. Per the scoping decision, this PR is limited to those.