### PR TITLE
Forward-port #1920: tighten world-local ID validation

### DIFF
--- a/.changeset/world-local-tighten-id-validation.md
+++ b/.changeset/world-local-tighten-id-validation.md
@@ -2,4 +2,4 @@
 '@workflow/world-local': patch
 ---
 
-Reject dots in entity IDs and empty `correlationId` values in `assertSafeEntityId` — defense-in-depth follow-up to the path traversal fix. Dots in IDs would be misparsed by `stripTag()` / `getObjectCreatedAt()`, and empty `correlationId` would produce malformed `${runId}-` composite keys.
+Reject dots and empty correlationId values in entity ID validation.

--- a/.changeset/world-local-tighten-id-validation.md
+++ b/.changeset/world-local-tighten-id-validation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Reject dots in entity IDs and empty `correlationId` values in `assertSafeEntityId` — defense-in-depth follow-up to the path traversal fix. Dots in IDs would be misparsed by `stripTag()` / `getObjectCreatedAt()`, and empty `correlationId` would produce malformed `${runId}-` composite keys.

--- a/packages/world-local/src/fs.test.ts
+++ b/packages/world-local/src/fs.test.ts
@@ -861,11 +861,11 @@ describe('fs utilities', () => {
       'vitest-0', // tag
       'strm_01ARZ3_user', // stream id with underscores
       'strm_01ARZ3_user_bmFtZXNwYWNl', // stream id with base64url namespace
-      'wrun_ABC.vitest-0', // tagged file id
       'a', // minimal valid value
     ];
 
-    // Values that should be rejected: real-world path traversal attempts.
+    // Values that should be rejected: real-world path traversal attempts
+    // plus dotted inputs that would confuse stripTag()/getObjectCreatedAt().
     const unsafeIds = [
       '',
       '.',
@@ -883,6 +883,14 @@ describe('fs utilities', () => {
       'foo\0bar', // null byte
       'a/../b',
       'a\\..\\b',
+      // Dots in entity IDs would be misparsed by stripTag(), which strips
+      // a trailing `.[tag]` suffix from filenames. A runId like
+      // `wrun_123.foo` would be silently mangled to `wrun_123` during
+      // listing/pagination, breaking lookups for tagged file handling.
+      'wrun_ABC.vitest-0',
+      'wrun_123.foo',
+      'foo.bar',
+      'wrun_ABC.',
     ];
 
     for (const id of safeIds) {

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -28,7 +28,7 @@ function truncateForError(value: unknown): string {
 export class UnsafeEntityIdError extends WorkflowWorldError {
   constructor(kind: string, value: string) {
     super(
-      `Unsafe ${kind} "${truncateForError(value)}": must not be empty, start with ".", or contain path separators or null bytes`
+      `Unsafe ${kind} "${truncateForError(value)}": must not be empty, contain ".", "/", "\\", or null bytes`
     );
     this.name = 'UnsafeEntityIdError';
   }
@@ -44,6 +44,9 @@ export class UnsafeEntityIdError extends WorkflowWorldError {
  *   - empty
  *   - starting with `.` (blocks `.`, `..`, `.locks`, `.tmp`, and other
  *     hidden or reserved filenames)
+ *   - containing `.` (would collide with the `.tag` / `.json` suffix the
+ *     tagging logic strips from filenames; see {@link stripTag} /
+ *     {@link getObjectCreatedAt})
  *   - containing `/`, `\`, or a NUL byte
  *
  * This is the primary defense against path-traversal attacks where a
@@ -62,7 +65,8 @@ export function assertSafeEntityId(kind: string, value: string): void {
     value.startsWith('.') ||
     value.includes('/') ||
     value.includes('\\') ||
-    value.includes('\0')
+    value.includes('\0') ||
+    value.includes('.')
   ) {
     throw new UnsafeEntityIdError(kind, value);
   }

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -3165,6 +3165,54 @@ describe('Storage', () => {
       ).rejects.toThrow(/Unsafe correlationId/);
     });
 
+    // Empty correlationId would be accepted by the event schema (which only
+    // requires `z.string()`) and produce composite keys like `${runId}-`,
+    // leaving malformed entities/events in storage. Reject it up front.
+    it('rejects empty correlationId on step_created', async () => {
+      const run = await createRun(storage, {
+        deploymentId: 'deployment-123',
+        workflowName: 'test-workflow',
+        input: new Uint8Array(),
+      });
+      await expect(
+        storage.events.create(run.runId, {
+          eventType: 'step_created',
+          correlationId: '',
+          eventData: { stepName: 'step', input: new Uint8Array() },
+        })
+      ).rejects.toThrow(/Unsafe correlationId/);
+    });
+
+    it('rejects empty correlationId on hook_created', async () => {
+      const run = await createRun(storage, {
+        deploymentId: 'deployment-123',
+        workflowName: 'test-workflow',
+        input: new Uint8Array(),
+      });
+      await expect(
+        storage.events.create(run.runId, {
+          eventType: 'hook_created',
+          correlationId: '',
+          eventData: { token: 'tok' },
+        })
+      ).rejects.toThrow(/Unsafe correlationId/);
+    });
+
+    it('rejects empty correlationId on wait_created', async () => {
+      const run = await createRun(storage, {
+        deploymentId: 'deployment-123',
+        workflowName: 'test-workflow',
+        input: new Uint8Array(),
+      });
+      await expect(
+        storage.events.create(run.runId, {
+          eventType: 'wait_created',
+          correlationId: '',
+          eventData: { resumeAt: new Date(Date.now() + 1000) },
+        })
+      ).rejects.toThrow(/Unsafe correlationId/);
+    });
+
     it('rejects traversal hookId on hooks.get', async () => {
       await expect(storage.hooks.get('../escape')).rejects.toThrow(
         /Unsafe hookId/

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -138,14 +138,16 @@ export function createEventsStorage(
       // attacks where a client supplies runId / correlationId values like
       // "../../../package" to read or write files outside the storage root.
       // Run before taking the per-step mutex so malformed inputs fail fast.
+      //
+      // Empty `correlationId` values are also rejected here: the event
+      // schemas only require `z.string()`, so without this check a
+      // step_created / hook_created / wait_created request with
+      // `correlationId: ''` would silently be written under a malformed
+      // composite key like `${runId}-`.
       if (runId != null && runId !== '') {
         assertSafeEntityId('runId', runId);
       }
-      if (
-        'correlationId' in data &&
-        typeof data.correlationId === 'string' &&
-        data.correlationId.length > 0
-      ) {
+      if ('correlationId' in data && typeof data.correlationId === 'string') {
         assertSafeEntityId('correlationId', data.correlationId);
       }
 


### PR DESCRIPTION
## Summary

Forward-port of the code review fixes applied to #1920 (the `stable` backport of #1829), so `main` and `stable` stay in sync on this hardening.

The original path-traversal fix (#1829) is already on `main`. This PR forward-ports the two follow-up fixes from #1920 that apply equally to `main`:

- **Reject `.` inside entity IDs in `assertSafeEntityId`.** Internal IDs (ULIDs, `step_N`, etc.) never contain dots, but `stripTag()` / `getObjectCreatedAt()` strip a trailing `.[tag]` suffix from filenames. A request-supplied `runId` like `wrun_123.foo` would be silently mangled to `wrun_123` during listing/pagination, breaking lookups for tagged file handling. The previously-"safe" `wrun_ABC.vitest-0` example in `fs.test.ts` moved to the unsafe set, since that shape is only ever constructed internally by `taggedPath` — never passed in as a request ID.

- **Reject empty `correlationId` on events that include one.** The event schemas only require `z.string()`, so without this check a `step_created` / `hook_created` / `wait_created` request with `correlationId: ''` would silently be written under a malformed `${runId}-` composite key. Dropped the `data.correlationId.length > 0` guard so empty values now throw `UnsafeEntityIdError` up-front.

The third fix from #1920 — streamer regression tests for `writeToStream` / `closeStream` / `listStreamsByRunId` / `getStreamChunks` — is **not** forward-ported because `main`'s streamer surface differs from `stable`'s v4 shape (renamed methods, separate test coverage).

## Test plan

```bash
cd packages/world-local && pnpm test
```

All 351 tests pass, including the new regression tests for empty `correlationId` (`step_created`, `hook_created`, `wait_created`) and the additional dotted-ID cases in `fs.test.ts`.