### PR TITLE
fix(web-shared): make encrypted-data blur backwards compatible with Tailwind v3

### DIFF
--- a/.changeset/blur-style-prop-compat.md
+++ b/.changeset/blur-style-prop-compat.md
@@ -2,4 +2,4 @@
 "@workflow/web-shared": patch
 ---
 
-Use an inline `filter: blur(4px)` style on the encrypted data preview instead of Tailwind v4's `blur-xs` utility, so the component renders correctly for consumers on Tailwind v3.
+Use the `blur-[4px]` arbitrary-value utility on the encrypted data preview instead of Tailwind v4's `blur-xs` utility, so the component renders correctly for consumers on Tailwind v3.

--- a/.changeset/blur-style-prop-compat.md
+++ b/.changeset/blur-style-prop-compat.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Use an inline `filter: blur(4px)` style on the encrypted data preview instead of Tailwind v4's `blur-xs` utility, so the component renders correctly for consumers on Tailwind v3.

--- a/packages/web-shared/src/components/sidebar/copyable-data-block.tsx
+++ b/packages/web-shared/src/components/sidebar/copyable-data-block.tsx
@@ -19,7 +19,8 @@ export function EncryptedDataBlock() {
     <div className="relative min-h-20 overflow-hidden rounded-md border border-gray-alpha-400 bg-background-100">
       <pre
         aria-hidden="true"
-        className="pointer-events-none m-0 select-none p-3 font-mono text-label-12 text-gray-900 blur-xs"
+        className="pointer-events-none m-0 select-none p-3 font-mono text-label-12 text-gray-900"
+        style={{ filter: 'blur(4px)' }}
       >
         {encryptedPlaceholderPreview}
       </pre>

--- a/packages/web-shared/src/components/sidebar/copyable-data-block.tsx
+++ b/packages/web-shared/src/components/sidebar/copyable-data-block.tsx
@@ -19,8 +19,7 @@ export function EncryptedDataBlock() {
     <div className="relative min-h-20 overflow-hidden rounded-md border border-gray-alpha-400 bg-background-100">
       <pre
         aria-hidden="true"
-        className="pointer-events-none m-0 select-none p-3 font-mono text-label-12 text-gray-900"
-        style={{ filter: 'blur(4px)' }}
+        className="pointer-events-none m-0 select-none p-3 font-mono text-label-12 text-gray-900 blur-[4px]"
       >
         {encryptedPlaceholderPreview}
       </pre>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The encrypted-data preview on the run detail panel (`EncryptedDataBlock` in `packages/web-shared/src/components/sidebar/copyable-data-block.tsx`) was using the `blur-xs` utility class. That utility only exists in Tailwind v4 — consumers of `@workflow/web-shared` who are still on Tailwind v3 see no blur at all on the placeholder, defeating the visual treatment of the encrypted state.

This swaps `blur-xs` for the arbitrary-value utility `blur-[4px]` (4px matches v4's `blur-xs`). Arbitrary values have been supported in Tailwind since v3.0's JIT engine, so the class compiles to `filter: blur(4px)` on both v3 and v4.

### How did you test your changes?

Visual inspection of the decrypt card on the run detail panel — the `[encrypted]` placeholder still renders blurred and the Decrypt button overlay is unchanged. No JS/CSS behavior change for v4 consumers.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0AFKL7AT9N/p1779742659295679?thread_ts=1779742659.295679&cid=C0AFKL7AT9N)

<div><a href="https://cursor.com/agents/bc-9fa03aa9-bf0a-5c52-a16b-40de90231dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fa03aa9-bf0a-5c52-a16b-40de90231dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

