### PR TITLE
feat(next): add /_workflow web ui during dev

### DIFF
--- a/.changeset/next-dashboard-route.md
+++ b/.changeset/next-dashboard-route.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': minor
+---
+
+Add `/_workflow` route in dev mode that opens the workflow observability dashboard.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -37,6 +37,7 @@
     "@workflow/builders": "workspace:*",
     "@workflow/core": "workspace:*",
     "@workflow/swc-plugin": "workspace:*",
+    "@workflow/web": "workspace:*",
     "semver": "catalog:",
     "watchpack": "2.5.1"
   },

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -33,6 +33,26 @@ const workflowSerdeComputedPropertyPattern =
 const PSEUDO_EXTERNAL_PACKAGES = new Set(['server-only', 'client-only']);
 const warnedAutoRemovedServerExternalPackages = new Set<string>();
 
+let dashboardServerPromise: Promise<string> | undefined;
+
+function ensureDashboardServer(): Promise<string> {
+  if (!dashboardServerPromise) {
+    dashboardServerPromise = (async () => {
+      const { startServer } = (await import('@workflow/web/server')) as {
+        startServer: (port?: number) => Promise<import('node:http').Server>;
+      };
+      const server = await startServer(0);
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 3456;
+      return `http://localhost:${port}`;
+    })().catch((error: unknown) => {
+      dashboardServerPromise = undefined;
+      throw error;
+    });
+  }
+  return dashboardServerPromise;
+}
+
 interface WorkflowPatternMatch {
   hasUseWorkflow: boolean;
   hasUseStep: boolean;
@@ -627,6 +647,33 @@ export function withWorkflow(
 
       await workflowBuilder.build();
       process.env.WORKFLOW_NEXT_PRIVATE_BUILT = '1';
+    }
+
+    if (phase === 'phase-development-server') {
+      const dashboardUrl = await ensureDashboardServer().catch(
+        (error: unknown) => {
+          console.error('Failed to start workflow dashboard:', error);
+          return undefined;
+        }
+      );
+
+      if (dashboardUrl) {
+        const existingRedirects = nextConfig.redirects;
+        nextConfig.redirects = async () => {
+          const userRedirects = existingRedirects
+            ? await existingRedirects()
+            : [];
+          return [
+            ...userRedirects,
+            {
+              source: '/_workflow',
+              destination: dashboardUrl,
+              permanent: false,
+              basePath: false,
+            },
+          ];
+        };
+      }
     }
 
     return nextConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,6 +754,9 @@ importers:
       '@workflow/swc-plugin':
         specifier: workspace:*
         version: link:../swc-plugin-workflow
+      '@workflow/web':
+        specifier: workspace:*
+        version: link:../web
       semver:
         specifier: 'catalog:'
         version: 7.7.4
@@ -23203,14 +23206,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
 
-  '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3)
-
   '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -32243,7 +32238,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -32282,7 +32277,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
Adds a `/_workflow` redirect during `next dev` that boots the `@workflow/web` observability dashboard on a random port and redirects the browser to it.

Mirrors #2110 for the Next.js integration.

## Test plan

- [x] `pnpm build` in `packages/next` succeeds
- [x] `curl -i http://localhost:3000/_workflow` from `workbench/nextjs-turbopack` returns 307 to `http://localhost:<random-port>/`
- [x] Dashboard root responds 200 with `<title>Workflow Observability UI</title>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)