### PR TITLE
fix(docs): add version prefix to 'Edit this page on GitHub' links

### DIFF
--- a/docs/app/[lang]/cookbook/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/cookbook/[[...slug]]/page.tsx
@@ -60,7 +60,7 @@ const Page = async ({ params }: PageProps<'/[lang]/cookbook/[[...slug]]'>) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v4" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -57,7 +57,7 @@ const Page = async ({ params }: PageProps<'/[lang]/docs/[[...slug]]'>) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v4" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/app/[lang]/v5/cookbook/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/cookbook/[[...slug]]/page.tsx
@@ -67,7 +67,7 @@ const Page = async ({
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v5" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
@@ -74,7 +74,7 @@ const Page = async ({ params }: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v5" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/components/geistdocs/edit-source.tsx
+++ b/docs/components/geistdocs/edit-source.tsx
@@ -3,13 +3,14 @@ import { github } from '@/geistdocs';
 
 type EditSourceProps = {
   path: string | undefined;
+  version: 'v4' | 'v5';
 };
 
-export const EditSource = ({ path }: EditSourceProps) => {
+export const EditSource = ({ path, version }: EditSourceProps) => {
   let url: string | undefined;
 
   if (github.owner && github.repo && path) {
-    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/content/docs/${path}`;
+    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/content/docs/${version}/${path}`;
   }
 
   if (!url) {


### PR DESCRIPTION
## Summary
- All "Edit this page on GitHub" links produce 404s — regression from #1948 (v4/v5 content split)
- `EditSource` was not updated to include the `v4/` or `v5/` directory prefix in the GitHub URL
- Adds a `version` prop to `EditSource`, passed from each page route matching the existing server-side v4/v5 routing pattern

Fixes #2119

## Test plan
- [x] v4 docs/cookbook pages link to `docs/content/docs/v4/...`
- [x] v5 docs/cookbook pages link to `docs/content/docs/v5/...`
- [x] Confirmed links resolve to valid files on GitHub
- [x] Verified locally with `pnpm dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)