### PR TITLE
Attributes MVP (experimental and write-only) and CI hardening

### DIFF
--- a/.changeset/attributes-mvp-plan.md
+++ b/.changeset/attributes-mvp-plan.md
@@ -1,0 +1,10 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+'@workflow/world-local': patch
+'@workflow/world-postgres': patch
+'@workflow/world-vercel': patch
+'workflow': patch
+---
+
+Add `experimental_setAttributes()` workflow-level helper for attaching string key/value metadata to a workflow run, surfaced as `run.attributes`

--- a/.changeset/large-inline-sourcemap-remap.md
+++ b/.changeset/large-inline-sourcemap-remap.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Harden workflow error stack remapping for large inline sourcemaps.

--- a/docs/content/docs/v4/cookbook/common-patterns/timeouts.mdx
+++ b/docs/content/docs/v4/cookbook/common-patterns/timeouts.mdx
@@ -68,6 +68,9 @@ export async function waitForApproval(requestId: string) {
     throw new Error("Approval request expired after 7 days");
   }
 
+  // You may see warnings like `Workflow run completed with 1 uncommitted operations` in your
+  // logs when the workflow completes. This is expected behavior.
+
   return result.approved;
 }
 ```

--- a/docs/content/docs/v5/changelog/attributes-mvp.mdx
+++ b/docs/content/docs/v5/changelog/attributes-mvp.mdx
@@ -1,0 +1,365 @@
+---
+title: Workflow Attributes (MVP, experimental)
+description: A minimal, write-only subset of the planned Workflow Attributes feature, forward-compatible with the full 5.0.0 release. Lets workflow code attach plaintext string key/value metadata to a run.
+---
+
+# Workflow Attributes (MVP)
+
+This is a minimal, **experimental** subset of the [planned Workflow Attributes feature for 5.0.0](https://github.com/vercel/workflow/pull/1933). See [discussion #132](https://github.com/vercel/workflow/discussions/132) for broader background on the use cases and the full design space.
+
+The MVP lets workflow code attach plaintext `string → string` metadata to a run, viewable in any observability surface that reads the `WorkflowRun` entity. It is deliberately narrow: write-only, no reads from inside a run, no list/filter endpoints, no event-log representation. The wire format and SDK surface are chosen so the full 5.0.0 implementation replaces this without source-level breaking changes for end users.
+
+## What MVP supports
+
+- `experimental_setAttributes(record)` callable from a **workflow body** (`"use workflow"` function), dispatched via an internal `__builtin_set_attributes` step bridge so the mutation gets a `step_created → step_completed` event pair
+- Attributes are materialized onto the `WorkflowRun` entity, plaintext, and visible via `world.runs.get()` / `world.runs.list()` and any observability UI built on top of those
+- World implementations emit a side-channel observability record per successful write (in `world-vercel`, this hooks into the same observability/analytics pipeline already used for other run lifecycle events)
+
+Calling `experimental_setAttributes` from a step body or plain host code is intentionally not supported in the MVP — the host-side export throws `FatalError` directing callers back to a workflow body. This keeps the implementation a single dispatch path; step-body support can be added later without breaking the workflow-body contract.
+
+## What MVP does **not** support (deferred to 5.0.0)
+
+- Reading attributes from inside a workflow or step (`getAttribute` / `getAttributes`)
+- `start(workflow, input, { attributes })` (initial attributes at run creation)
+- Filtering runs by attribute value (`runs.list({ attributes: { ... } })`)
+- Enumerating attribute keys or values (`listAttributeKeys`, `listAttributeValues`)
+- Writer attribution / event-log history of attribute changes
+- Any non-string value type
+
+See [PR #1933](https://github.com/vercel/workflow/pull/1933) for the design of those features.
+
+## Why the MVP defers an `attr_set` event type
+
+The full design represents attribute changes as a new `attr_set` event type in the event log, replayed by the workflow runtime VM to reconstruct the attribute snapshot. That requires bumping `SPEC_VERSION_CURRENT`, because every world implementation (including community worlds) needs to handle the new event during replay, and the runtime's reconstruction logic gains a new case.
+
+A spec version bump is expensive: it gates every world adapter and ties the rollout to coordinated upgrades. We do not want to pay that cost twice — once for the MVP, again for the full feature.
+
+The MVP instead writes attributes via a direct entity-mutation path (outside the event log) which does not require a spec version bump. The downside is that MVP-era attributes have **no representation in the event log** and will not be visible to event-based reconstruction (e.g. a materialization rebuild). When the full feature ships, new writes use `attr_set` events; old runs created during the MVP window retain whatever attributes were materialized at the time, but their history is not recoverable.
+
+## Implementation plan
+
+### 1. `@workflow/world` — Storage interface addition
+
+Add an `experimentalSetAttributes` method to `Storage.runs`:
+
+{/*@skip-typecheck - snippet, not runnable code*/}
+
+```ts
+runs: {
+  get: /* unchanged */;
+  list: /* unchanged */;
+
+  /**
+   * Apply a set of attribute changes to a run. Merge semantics:
+   * keys with a string value are upserted, keys with `value: null`
+   * are removed. Other keys on the run are untouched.
+   *
+   * `options.allowReservedAttributes` permits `$`-prefixed keys for
+   * framework-level callers that own a reserved sub-namespace.
+   *
+   * OPTIONAL. World implementations may omit this method; the SDK
+   * detects absence and no-ops `experimental_setAttributes` with a warning so that
+   * third-party / community worlds continue to function without
+   * adopting the experimental API.
+   *
+   * EXPERIMENTAL: this method exists as a stopgap until the
+   * `attr_set` event type lands. See the 5.0.0 attributes design.
+   */
+  experimentalSetAttributes?(
+    runId: string,
+    changes: Array<{ key: string; value: string | null }>,
+    options?: { allowReservedAttributes?: boolean }
+  ): Promise<{ attributes: Record<string, string> }>;
+}
+```
+
+The method is **optional** to avoid forcing every World implementation (especially community-maintained adapters such as Redis, MongoDB, Turso, and similar) to ship support before the API stabilises. World implementations that do support it return the post-merge attribute snapshot so callers — notably the SDK helper and world adapters emitting observability records — have it without a follow-up read.
+
+Add `attributes?: Record<string, string>` to `WorkflowRunBaseSchema` in `packages/world/src/runs.ts`. Optional for backward compatibility: runs created before this field landed have no `attributes` and read as `undefined`.
+
+### 2. Wire format (used by `world-vercel`)
+
+`world-vercel` calls into a remote endpoint to persist attributes:
+
+```
+POST /v2/runs/:runId/attributes
+
+{
+  "changes": [
+    { "key": "phase", "value": "done" },
+    { "key": "stale", "value": null }
+  ],
+  "allowReservedAttributes": true
+}
+```
+
+Response: `{ "attributes": { "phase": "done", "tenant": "t1" } }`.
+
+The `changes` field **deliberately mirrors** the eventual `attr_set` event's `eventData.changes`. `allowReservedAttributes` is optional and framework-only; omit it for user-authored attributes. When the full feature ships, this endpoint goes away — the same `changes` shape is posted to `POST /v2/runs/:id/events` with `eventType: 'attr_set'` (plus a `writer` discriminator). No SDK signature change, no client-side migration.
+
+### 3. `@workflow/core` — SDK surface
+
+A new export from `@workflow/core` (re-exported by `workflow`):
+
+{/*@skip-typecheck - snippet, not runnable code*/}
+
+```ts
+function experimental_setAttributes(
+  attrs: Record<string, string | undefined>,
+  options?: { allowReservedAttributes?: boolean }
+): Promise<void>
+```
+
+`undefined` is normalized to `null` (unset). An empty object is a no-op (no RPC, no events).
+
+Validation (shared helper, applied both client-side and server-side):
+
+- Key: 1–256 chars, must not start with `$` (reserved — see "Reserved `$` namespace" below)
+- Value: ≤ 256 bytes UTF-8
+- Maximum 64 attributes per run (validated against the post-merge snapshot when the server applies)
+- SDK-side violations throw `FatalError` from `@workflow/errors` before the internal step is dispatched; worlds revalidate as the final authority before mutating storage
+
+#### Reserved `$` namespace
+
+Keys starting with `$` are reserved for framework and library code built on top of the workflow SDK (telemetry tags, agent metadata, future platform-emitted attributes, etc.). User code calling `experimental_setAttributes({ '$foo': 'bar' })` throws `FatalError` so accidental collisions with tooling-owned keys can't slip through.
+
+Framework / library authors that own a `$`-prefixed sub-namespace can opt in per-call:
+
+{/*@skip-typecheck - snippet, not runnable code*/}
+
+```ts
+await experimental_setAttributes(
+  { '$agent.kind': 'durable-agent' },
+  { allowReservedAttributes: true }
+);
+```
+
+The flag is per-call (no run-level "this run accepts reserved keys" mode), so each framework call site explicitly declares intent. Don't enable it from user code — misuse can conflict with observability surfaces, agent dashboards, or future platform features that rely on the reserved namespace.
+
+`experimental_setAttributes` is callable only from a workflow body:
+
+```ts
+import { experimental_setAttributes } from 'workflow';
+
+export async function myWorkflow(orderId: string) {
+  'use workflow';
+  await experimental_setAttributes({ phase: 'init', orderId });
+  // ...
+  await experimental_setAttributes({ phase: 'done' });
+}
+```
+
+The workflow-body path validates input inside the VM and then dispatches the canonical `AttributeChange[]` through an internal `__builtin_set_attributes` step bridge — see "How workflow-body dispatch works" below. The mutation is materialized on the run entity by the step body.
+
+The host-side export (the one resolved when the `workflow` package-exports condition is **not** `workflow`, i.e. step bodies and plain host code) throws `FatalError` with a message pointing callers back to the workflow body. There is no step-side dispatch path in the MVP — the workflow-body-only restriction is a scope cut for the MVP, not an architectural constraint, and may be relaxed in a follow-up.
+
+#### Usage patterns
+
+Three call patterns are supported. Pick by whether you need ordering and whether you need to know the write has landed before continuing:
+
+**Awaited (default).** The workflow blocks on the internal write step before continuing. Use this when later workflow logic should wait until the attribute write has either succeeded or exhausted the MVP's best-effort retry budget. Deterministic SDK validation errors still throw before dispatch; persistence failures from the world are retried by the internal step and then logged/dropped after three attempts so failing to post tags does not fail a run during the experimental phase.
+
+{/*@skip-typecheck - snippet, not runnable code*/}
+
+```ts
+'use workflow';
+await experimental_setAttributes({ phase: 'init' });
+const result = await processOrder();
+await experimental_setAttributes({ phase: 'done', orderId: result.id });
+```
+
+**Fire-and-forget (`void`).** Drop the `await` to let the workflow proceed without blocking. The pending step queues on the workflow's next suspension (any `await` on a runtime primitive — a step, `sleep`, a hook). This is the canonical pattern for observability / tracking metadata where the workflow doesn't depend on the write.
+
+{/*@skip-typecheck - snippet, not runnable code*/}
+
+```ts
+'use workflow';
+void experimental_setAttributes({ phase: 'init', orderId });
+// Workflow doesn't block. The step queues on the next runtime await.
+const result = await processOrder();
+void experimental_setAttributes({ phase: 'done' });
+return result;
+```
+
+Two trade-offs to know about:
+
+1. **Order of arrival at the world is not workflow-source order.** Fire-and-forget steps run out-of-band on the queue worker. A `void` write to one key followed by an `await` write to the same key may race; LWW-by-arrival applies (see "Concurrent writes" below).
+
+2. **The last `void` before `return` may not land.** If you place a `void experimental_setAttributes(...)` immediately before returning, with no intervening `await` on a runtime primitive, drain-on-completion commits the `step_created` event but the step body is not reliably dispatched before the run transitions to its terminal status — see the architectural note in the "Implementation notes" section. In practice workflows almost always have an `await` after the last fire-and-forget call (a step, a sleep, a hook); if you don't, add `await sleep('0s')` before returning, or use the awaited form for that final write.
+
+**Parallel (`Promise.all`).** Multiple calls dispatch concurrently. Writes to disjoint keys all land. Writes to the same key resolve last-write-wins by *arrival order at the world* (not the order the workflow body issued the calls) — so don't use `Promise.all` for writes that must observe a specific order to the same key.
+
+{/*@skip-typecheck - snippet, not runnable code*/}
+
+```ts
+'use workflow';
+await Promise.all([
+  experimental_setAttributes({ phase: 'init' }), // disjoint keys — all land
+  experimental_setAttributes({ orderId: 'ord_123' }),
+  experimental_setAttributes({ tenant: 't1' }),
+]);
+```
+
+#### Optional world support
+
+Because `runs.experimentalSetAttributes` is **optional** on the World interface (see §1), the `__builtin_set_attributes` step body checks for its presence before dispatching and no-ops when absent after logging a single process-wide warning. User code does not need to feature-detect; calling `experimental_setAttributes` against an unsupporting world is safe but ineffective.
+
+### 4. World implementations
+
+#### `world-local`
+
+Implement `experimentalSetAttributes(runId, changes)` by reading the run's JSON file, merging the changes into `run.attributes` (set on string value, delete on null), and writing back atomically using the same per-run write gate that protects entity writes today. Apply validation server-side before merging.
+
+#### `world-postgres`
+
+Add an `attributes JSONB` column to the runs table (default `'{}'::jsonb`, NOT NULL). Apply the merge in SQL using `jsonb_set` / `jsonb_strip_nulls` so the database does the merge atomically without a read-modify-write cycle, returning the post-merge map via `RETURNING attributes`.
+
+#### `world-vercel`
+
+Pure HTTP wrapper. Calls the wire endpoint described in §2 and returns the response's `attributes`. The backing service materializes the attribute map onto its run-row storage; where the underlying data store supports atomic per-key map updates, the merge is a single atomic operation rather than a read-modify-write cycle — the same shape the future `attr_set` event handler will use, so the storage layout is forward-compatible.
+
+After the persistence ack, the service emits a side-channel observability record carrying the post-merge attribute snapshot, decoupled from the request path so the runtime never waits on analytics emission.
+
+### 5. Observability surfaces
+
+Because attributes are stored plaintext on the `WorkflowRun` entity, any UI that already calls `world.runs.get()` / `world.runs.list()` can read them with no additional plumbing. The render details (where attributes appear in the run-detail view, formatting, etc.) are out of scope for this MVP and tracked separately from the SDK work.
+
+## Trade-offs and known limitations
+
+### Concurrent writes to the same key
+
+The MVP applies **last-write-wins by arrival order at the world**. Two concurrent `experimental_setAttributes` calls writing the same key produce a final state matching whichever request the world processes second. There is no conditional / `expectedValue` semantic and no `unique: true` mode.
+
+Writes from a single `await`-ed call chain are serialized by the workflow VM and land in workflow-source order. The concurrent / racy case applies to:
+
+- Multiple `experimental_setAttributes` calls inside one `Promise.all` writing the same key (the workflow VM dispatches them concurrently; the world sees them in scheduler order, not source order).
+- `void experimental_setAttributes(...)` followed by another call to the same key — the fire-and-forget step may still be in flight when the next call lands.
+- Multiple workflows writing the same key on the same run (rare — usually one workflow owns a run).
+
+Disjoint-key writes are unaffected: every call lands, regardless of pattern. Applications that need conditional semantics on a shared key should wait for the 5.0.0 release; we will not retrofit conditional writes onto the MVP path.
+
+### No event-log history
+
+Attribute changes do not appear in `world.events.list(runId)`. There is no record of *when* a key changed or *which step attempt* set it. The current snapshot on the run entity is authoritative; the history is lost.
+
+When the full feature ships, new writes carry writer attribution (`writer: { type: 'workflow' }` or `writer: { type: 'step', stepId, attempt }`) in their `attr_set` events. MVP-era writes will not have this — history starts at the `attr_set` cutover.
+
+### MVP attributes do not survive materialization rebuild
+
+Any tooling that reconstructs the run entity from the event log (disaster recovery, debugging, audit) will see no attributes on MVP-era runs, because the writes are not in the event log. This is the chief reason `experimentalSetAttributes` is named "experimental" — it is a known break from the otherwise-strict event-sourced model.
+
+The 5.0.0 path closes this gap.
+
+### SDK surface stability
+
+`experimental_setAttributes(record)` is intended to be stable across MVP and 5.0.0. User code calling it under the MVP will continue to work after the full feature lands; only the runtime dispatch path changes (`"use step"` indirection → workflow-VM-native intercept, parallel to `sleep`).
+
+If you need behavior the MVP does not provide (read, list, filter, initial attributes at `start`, writer attribution), wait for 5.0.0 rather than building around the MVP surface.
+
+## Test coverage
+
+Unit tests in `@workflow/world` (validation surface) and `@workflow/core` (VM-side dispatch + host-side stub):
+
+- Validation rules — key length, value byte cap, `$` prefix, per-batch duplicates, post-merge count cap (with `existingKeys` so updates of present keys don't falsely trip the cap)
+- Reserved `$` namespace — rejected by default, accepted when `allowReservedAttributes: true` is passed (both for `validateAttributeKey` and at the batch level via `validateAttributeChanges`)
+- `experimental_setAttributes({})` is a no-op (no dispatch, no events)
+- `undefined` value normalizes to a `null`-valued change on the wire
+- The `{ allowReservedAttributes: true }` opt-in is forwarded through the step bridge so the world receives the flag
+- Workflow VM with no `WORKFLOW_USE_STEP` bound throws `FatalError`
+- Host-side stub (resolved when not in the workflow VM) throws `FatalError` directing the caller back to a workflow body
+
+Unit tests in `workflow` (internal built-in step behavior):
+
+- `__builtin_set_attributes` rethrows world write failures on attempts 1 and 2 so normal step retry semantics apply
+- On attempt 3, `__builtin_set_attributes` logs a `console.error` and resolves so retry exhaustion does not turn the internal attribute write into a `FatalError`
+- The internal step is configured for three total attempts (`maxRetries = 2`)
+
+Integration tests in `world-local`:
+
+- Upsert, merge across calls, unset via `null`, set-and-unset in a single batch
+- Validation rejection (reserved prefix, oversize key, oversize value, post-merge cap)
+- Reserved-prefix escape hatch via `{ allowReservedAttributes: true }` (per-call, not sticky on the run)
+- Cap-boundary updates: a write that only updates existing keys must succeed even when the run is exactly at the cap
+- Idempotency: repeated identical calls converge to the same final snapshot
+- Concurrent writes serialize via the per-run mutex; no lost writes across 20 parallel calls
+
+Integration tests in `world-postgres`:
+
+- Upsert, merge across calls, unset via `null` (the SQL `jsonb_set` / `-` chain is exercised through these)
+- Atomic cap enforcement inside the `UPDATE`'s `WHERE` clause; concurrent writers cannot collectively push past the per-run cap
+
+End-to-end in `workbench/nextjs-turbopack` (exercises the full SWC plugin + workflow VM + step worker + `world-vercel` wire path against the production workflow-server `/v2/runs/:runId/attributes` endpoint):
+
+- Awaited workflow-body calls dispatch through the `__builtin_set_attributes` step bridge and merge correctly (the test inspects the run's event log to confirm a `step_created` / `step_completed` pair was emitted)
+- Fire-and-forget (`void experimental_setAttributes`) attributes land before the run terminates
+- `Promise.all` of disjoint-key writes — every key persists
+- Workflow throws after an awaited `experimental_setAttributes` — the attribute persists on the now-`failed` run (the per-run file lock on `run_failed` re-reads inside the critical section so the attribute snapshot survives the lifecycle write)
+
+## Migration to 5.0.0
+
+When the full attributes feature ships:
+
+- `experimental_setAttributes` (SDK) — unchanged signature, new dispatch path
+- `runs.experimentalSetAttributes` (world interface) — deprecated, then removed; replaced by `events.create(runId, { eventType: 'attr_set', eventData: { changes, writer } })`
+- Wire endpoint — `POST /v2/runs/:runId/attributes` removed; the same `changes` shape posts to `POST /v2/runs/:id/events`
+- Pre-existing attribute values on MVP-era runs remain on the run entity but are not represented in the event log
+
+Skew protection means workflows started under the MVP will continue to run with the MVP dispatch path on their original deployment. New deployments use the new path. No in-place data migration is needed.
+
+## Implementation notes (decisions made during the MVP build-out)
+
+This section records concrete decisions taken while landing the MVP that weren't in the original plan, so the next iteration has them in one place.
+
+### How workflow-body dispatch works
+
+`experimental_setAttributes` from a workflow body is wired through an internal built-in step, `__builtin_set_attributes`, defined in `packages/workflow/src/internal/builtins.ts` alongside the other workflow-side builtins (`__builtin_response_json`, etc.). The mechanism:
+
+1. The workflow VM bundle resolves `experimental_setAttributes` to `packages/core/src/workflow/set-attributes.ts` (via the `workflow` package-exports condition).
+2. That helper validates the input record inline (no shared helper, no cross-file dependency from a 'use step' file) and produces canonical `AttributeChange[]`.
+3. It dispatches through the standard workflow-VM step mechanism: `globalThis[WORKFLOW_USE_STEP]('__builtin_set_attributes')(changes)`. The `useStep` dispatcher is the same one used by every other step call from a workflow body, populated by `packages/core/src/workflow.ts` at VM bootstrap.
+4. The dispatch queues a step (`step_created`), the host runs `__builtin_set_attributes(changes, options)` from `packages/workflow/src/internal/builtins.ts`. The step body reads the active world, current run id, and attempt number directly from `globalThis` symbols (`Symbol.for('@workflow/world//cache')` and `Symbol.for('WORKFLOW_STEP_CONTEXT_STORAGE')`) — populated by the host runtime — and calls `world.runs.experimentalSetAttributes(runId, changes, options)`.
+5. The step completes (`step_completed`), the workflow resumes.
+
+This puts the mutation on the event log as a normal `step_created → step_completed` pair without inventing a new event type — that stays for the full 5.0.0 cutover.
+
+The internal step is best-effort during the experimental phase. It sets `maxRetries = 2`, for three total attempts. If `world.runs.experimentalSetAttributes` fails on attempts 1 or 2, the error is rethrown so the runtime retries the step normally. If it still fails on attempt 3, the step logs `console.error` and returns; the workflow run continues instead of receiving a retry-exhaustion `FatalError` for failed tag posting.
+
+The step body intentionally does **not** import anything from `@workflow/core`. That keeps the Next.js deferred-entries discoverer from walking a `__builtin_set_attributes` → `@workflow/core/...` → world adapter → `@vercel/queue` chain, which earlier drafts triggered (blowing the call stack of webpack's regex-based extractor with `RangeError: Maximum call stack size exceeded at RegExpStringIterator.next` on tarball-installed `nextjs-webpack` builds).
+
+The host-side `experimental_setAttributes` export (`packages/core/src/set-attributes.ts`, resolved by everything that isn't the workflow VM) throws `FatalError` with a message pointing the caller back to a workflow body. Step-body support can be added in a follow-up without changing this contract.
+
+When the full 5.0.0 attributes feature lands, `__builtin_set_attributes` is replaced by an `events.create(runId, { eventType: 'attr_set', ... })` dispatch path; SDK signatures don't change.
+
+### Endpoint lives under `v2`, not a fresh namespace
+
+The initial draft placed the new endpoint at `POST /v3/runs/:runId/attributes`, on the assumption that introducing a new wire feature warranted a major namespace bump. In practice `world-vercel` mixes `/v1/...` and `/v2/...` endpoints already, and creating a `v3Api` subrouter just for a single endpoint would have required duplicating the auth / flags / rate-limit middleware stack. The MVP endpoint is therefore mounted under the existing `v2Api`. The wire body shape is unchanged, so the migration path described above (rerouting from `/v2/runs/:runId/attributes` to `/v2/runs/:id/events`) still holds — just within the same namespace.
+
+### Concurrent writes: read-modify-write, not per-key atomic
+
+The plan called for per-key atomic `UpdateExpression` updates (`SET #attrs.#k = :v` / `REMOVE #attrs.#k`) in the `world-vercel` backing store, on the basis that it eliminates the read-modify-write race. The MVP ships with the simpler read-modify-write path instead:
+
+- **In `world-postgres`** the SQL-side `jsonb_set` / `-` chain *is* used and is genuinely atomic on the run row, so the only race is the cap check (a separate `SELECT`). Documented as LWW-by-arrival for the cap; the merge itself is atomic.
+- **In the `world-vercel` backing service** the attributes column is laid out as a native key-addressable map so the atomic `UpdateItem` variant can be enabled later without a data migration. The MVP commits the merged map via the existing entity update path. Two concurrent writers therefore race; whichever lands second wins on shared keys, and any write to a non-overlapping key is preserved.
+- **In `world-local`** an in-process per-run mutex serializes the read-merge-write sequence so parallel `experimental_setAttributes` calls from concurrent steps do not lose writes within a single process. There is a corresponding test that exercises 20 parallel writes to the same run.
+
+This is consistent with the original "concurrent writes are LWW by arrival" caveat. Promoting to per-key atomic writes is a no-API-break change once the event-sourced path lands.
+
+### `WORKFLOW_ATTRIBUTES` usage-fact schema: not introduced
+
+The plan called for a dedicated `WORKFLOW_ATTRIBUTES` usage fact carrying the post-merge snapshot. Landing that schema would have required a coordinated change to the shared usage-facts package (used by `world-vercel`'s backing service) plus an ingest-side update before the endpoint could ship.
+
+For the MVP the endpoint reuses the existing `WORKFLOW_EVENT` fact with `eventType: 'attr_set'`. That mirrors how other run-lifecycle events are reported, and it's enough for "did an attribute mutation happen" debugging without adding an analytics dependency to the critical path. A dedicated fact carrying the full snapshot can land alongside the event-sourced path without touching the SDK wire contract.
+
+### Validation rules are shared between SDK and world
+
+Validation lives in a single helper exported from `@workflow/world` (`validateAttributeChanges`, `validateAttributeKey`, `validateAttributeValue`). Both the SDK `experimental_setAttributes` helper and the `world-local` / `world-postgres` implementations call it; the `world-vercel` backing service applies the same rules independently. The shared module is the authoritative spec for the limits (256-char keys, 256-byte values, max 64 attributes per run, `$`-prefixed keys reserved) — any future change goes through one file.
+
+### Run row reconstruction had to thread `attributes` through
+
+`world-local`'s events storage rebuilds the run row on every lifecycle event (`run_started`, `run_completed`, `run_failed`, `run_cancelled`) by explicitly listing fields rather than spreading. Without forwarding `attributes` through each branch, any attribute set before the run completed would be silently dropped by the next lifecycle event. Each lifecycle write now also takes the per-run file lock (`withRunFileLock`) and re-reads the on-disk run inside the critical section, so an `experimental_setAttributes` call that lands in the same async window as a `run_completed` event is no longer clobbered.
+
+### Optional world method: feature-detect, warn once
+
+`runs.experimentalSetAttributes` is optional on the `World` interface so community worlds (Redis, MongoDB, Turso, etc.) continue to build and run without adopting the experimental API. The SDK helper feature-detects the method's presence on first dispatch; if absent, it logs a single `console.warn` for the lifetime of the process and resolves silently for that call and all subsequent calls. Users do not need to feature-detect in their own code — calling `experimental_setAttributes` against an unsupporting world is safe but ineffective.
+
+See "Test coverage" above for the full test surface that ships with this change.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -3430,4 +3430,117 @@ describe('e2e', () => {
       expect(returnValue.reason).toBe('Test complete');
     }
   );
+
+  // ==========================================================================
+  // experimental_setAttributes (experimental MVP)
+  // ==========================================================================
+
+  describe('experimental_setAttributes', () => {
+    test(
+      'experimentalSetAttributesWorkflow: workflow-body calls dispatch through the step bridge and merge correctly',
+      { timeout: 30_000 },
+      async () => {
+        const run = await start(
+          await e2e('experimentalSetAttributesWorkflow'),
+          [7]
+        );
+        const output = await run.returnValue;
+        expect(output).toBe(21);
+
+        const world = await getWorld();
+        const persisted = await world.runs.get(run.runId);
+
+        // First call sets {phase: 'init', source: 'workflow-body'}; second
+        // overwrites phase; third unsets source via undefined → null.
+        expect(persisted?.attributes).toEqual({ phase: 'done' });
+        expect(persisted?.attributes ?? {}).not.toHaveProperty('source');
+
+        // Dispatch is via a real step — verify at least one
+        // `step_created`/`step_completed` pair for the `__builtin_set_attributes`
+        // step exists on the run's event log.
+        const { data: events } = await world.events.list({ runId: run.runId });
+        const attrStepEvents = events.filter(
+          (e) =>
+            (e.eventType === 'step_created' ||
+              e.eventType === 'step_completed') &&
+            typeof (e.eventData as { stepName?: string } | undefined)
+              ?.stepName === 'string' &&
+            (e.eventData as { stepName: string }).stepName.includes(
+              '__builtin_set_attributes'
+            )
+        );
+        expect(attrStepEvents.length).toBeGreaterThanOrEqual(2);
+      }
+    );
+
+    // TODO(attributes): un-skip once the platform supports executing
+    // step bodies queued by `drainPendingQueueItems`. Today the step
+    // worker calls `executeStep` → `world.events.create('step_started')`,
+    // which the server rejects with `RunExpiredError` (HTTP 410) once
+    // the run has transitioned to a terminal state. Drain commits the
+    // `step_created` event and enqueues the message, but by the time
+    // the queue worker picks it up `run_completed` has landed and the
+    // worker skips the step ("Workflow run X has already completed,
+    // skipping step Y" in step-executor.ts).
+    //
+    // The fire-and-forget pattern itself works for `void` calls placed
+    // before any later `await` on a runtime primitive (the suspension
+    // queues the step before the run terminates) — see the awaited
+    // workflow-body test above for that coverage. What's broken is
+    // specifically "last void immediately before return". Either the
+    // platform needs to keep accepting `step_started` for steps the
+    // workflow itself queued at drain time, or attribute writes need
+    // a non-step dispatch path (planned for the full V1 attributes
+    // feature where attr_set is a first-class event type).
+    test.todo(
+      'fire-and-forget: void experimental_setAttributes lands without awaiting'
+    );
+
+    test(
+      'Promise.all of disjoint-key writes: every key lands',
+      { timeout: 30_000 },
+      async () => {
+        const run = await start(
+          await e2e('experimentalSetAttributesParallelWorkflow'),
+          []
+        );
+        const output = await run.returnValue;
+        expect(output).toBe('done');
+
+        const world = await getWorld();
+        const persisted = await world.runs.get(run.runId);
+
+        // Disjoint-key writes never collide, so all three keys must
+        // land regardless of dispatch ordering at the world.
+        expect(persisted?.attributes).toEqual({ a: '1', b: '2', c: '3' });
+      }
+    );
+
+    test(
+      'workflow throws after awaited setAttributes: attribute still persists on the failed run',
+      { timeout: 30_000 },
+      async () => {
+        const run = await start(
+          await e2e('experimentalSetAttributesThrowsAfterWorkflow'),
+          []
+        );
+        // The workflow throws — `returnValue` rejects.
+        await expect(run.returnValue).rejects.toThrow(/intentional failure/);
+
+        const world = await getWorld();
+        const persisted = await world.runs.get(run.runId);
+
+        expect(persisted?.status).toBe('failed');
+        // The attribute was awaited and therefore landed before the
+        // throw. The `run_failed` lifecycle write must preserve the
+        // attribute snapshot — the per-run file lock guarantees the
+        // lifecycle handler reads the fresh value off disk inside its
+        // critical section before writing the failed state back.
+        expect(persisted?.attributes).toEqual({
+          phase: 'about-to-fail',
+          reason: 'intentional',
+        });
+      }
+    );
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   type WebhookOptions,
 } from './create-hook.js';
 export { defineHook, type TypedHook } from './define-hook.js';
+export { experimental_setAttributes } from './set-attributes.js';
 export { sleep } from './sleep.js';
 export {
   getStepMetadata,

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -354,7 +354,7 @@ export async function loadWorkflowRunEvents(
         // Preserve the last non-null cursor across pages. A World may
         // legitimately return `{ data: [], cursor: null, hasMore: false }`
         // on a trailing empty page — for example when the previous page's
-        // underlying DynamoDB query hit `Limit` exactly and returned a
+        // underlying DB query hit the limit exactly and returned a
         // `LastEvaluatedKey` "just in case". Overwriting with that null
         // would lose the position past the last real event we loaded and
         // force the runtime into the "no cursor after initial load" full-

--- a/packages/core/src/set-attributes.test.ts
+++ b/packages/core/src/set-attributes.test.ts
@@ -1,0 +1,19 @@
+import { FatalError } from '@workflow/errors';
+import { describe, expect, it } from 'vitest';
+import { experimental_setAttributes } from './set-attributes.js';
+
+describe('experimental_setAttributes (host-side stub)', () => {
+  // The host-side `experimental_setAttributes` is the fallback resolved when callers
+  // are NOT in the workflow VM. The real implementation lives in
+  // `workflow/set-attributes.ts` and is selected via the `workflow`
+  // package-exports condition. Reaching this file from a step body or
+  // plain host code is unsupported and must surface a clear error.
+  it('throws FatalError telling the user experimental_setAttributes is workflow-body only', async () => {
+    await expect(experimental_setAttributes({ phase: 'init' })).rejects.toBeInstanceOf(
+      FatalError
+    );
+    await expect(experimental_setAttributes({ phase: 'init' })).rejects.toThrow(
+      /workflow.*function/i
+    );
+  });
+});

--- a/packages/core/src/set-attributes.ts
+++ b/packages/core/src/set-attributes.ts
@@ -1,0 +1,25 @@
+import { FatalError } from '@workflow/errors';
+import type { ExperimentalSetAttributesOptions } from './workflow/set-attributes.js';
+
+export type { ExperimentalSetAttributesOptions };
+
+/**
+ * Host-side stub for `experimental_setAttributes`. The real
+ * implementation lives in `./workflow/set-attributes.ts` and is
+ * selected by the `workflow` package-exports condition when the
+ * workflow VM bundle is resolved.
+ *
+ * Reaching this stub means the function was called outside a workflow
+ * body — most likely from a `'use step'` function or plain host code.
+ * That isn't supported in the MVP: attribute mutations must be
+ * event-sourced through the workflow runtime so they survive replay.
+ */
+export async function experimental_setAttributes(
+  _attrs: Record<string, string | undefined>,
+  _options?: ExperimentalSetAttributesOptions
+): Promise<void> {
+  throw new FatalError(
+    "experimental_setAttributes() must be called from a 'use workflow' function. " +
+      'Calling it from a step body or plain host code is not supported.'
+  );
+}

--- a/packages/core/src/source-map.test.ts
+++ b/packages/core/src/source-map.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { remapErrorStack } from './source-map.js';
+
+describe('remapErrorStack', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('extracts inline sourcemaps without regex matching the full bundle', () => {
+    const sourceMap = Buffer.from(
+      JSON.stringify({
+        version: 3,
+        sources: ['workflows/example.ts'],
+        names: [],
+        mappings: '',
+      })
+    ).toString('base64');
+    const workflowCode = [
+      `const padding = "${'a'.repeat(1024 * 1024)}";`,
+      `//# sourceMappingURL=data:application/json;base64,${sourceMap}`,
+    ].join('\n');
+    const match = vi.spyOn(String.prototype, 'match');
+
+    remapErrorStack(
+      'Error: boom\n    at example (workflow.js:1:1)',
+      'workflow.js',
+      workflowCode
+    );
+
+    expect(
+      match.mock.calls.some(([pattern]) =>
+        String(pattern).includes('sourceMappingURL')
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/source-map.ts
+++ b/packages/core/src/source-map.ts
@@ -1,5 +1,56 @@
 import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
 
+function isBase64Char(code: number): boolean {
+  return (
+    (code >= 0x41 && code <= 0x5a) ||
+    (code >= 0x61 && code <= 0x7a) ||
+    (code >= 0x30 && code <= 0x39) ||
+    code === 0x2b ||
+    code === 0x2f ||
+    code === 0x3d
+  );
+}
+
+function extractInlineSourceMapBase64(source: string): string | undefined {
+  const sourceMapPrefix = '//# sourceMappingURL=data:application/json';
+  const base64Marker = ';base64,';
+  let scanFrom = 0;
+
+  while (scanFrom < source.length) {
+    const prefixIdx = source.indexOf(sourceMapPrefix, scanFrom);
+    if (prefixIdx === -1) return undefined;
+
+    const base64Start = source.indexOf(
+      base64Marker,
+      prefixIdx + sourceMapPrefix.length
+    );
+    if (base64Start === -1) {
+      scanFrom = prefixIdx + sourceMapPrefix.length;
+      continue;
+    }
+
+    const commaBefore = source.indexOf(',', prefixIdx);
+    if (commaBefore !== -1 && commaBefore < base64Start) {
+      scanFrom = base64Start + base64Marker.length;
+      continue;
+    }
+
+    const valueStart = base64Start + base64Marker.length;
+    let valueEnd = valueStart;
+    while (valueEnd < source.length) {
+      if (!isBase64Char(source.charCodeAt(valueEnd))) {
+        break;
+      }
+      valueEnd++;
+    }
+
+    if (valueEnd > valueStart) {
+      return source.slice(valueStart, valueEnd);
+    }
+    scanFrom = valueEnd;
+  }
+}
+
 /**
  * Remaps an error stack trace using inline source maps to show original source locations.
  *
@@ -13,16 +64,12 @@ export function remapErrorStack(
   filename: string,
   workflowCode: string
 ): string {
-  // Extract inline source map from workflow code
-  const sourceMapMatch = workflowCode.match(
-    /\/\/# sourceMappingURL=data:application\/json;base64,(.+)/
-  );
-  if (!sourceMapMatch) {
+  const base64 = extractInlineSourceMapBase64(workflowCode);
+  if (!base64) {
     return stack; // No source map found
   }
 
   try {
-    const base64 = sourceMapMatch[1];
     const sourceMapJson = Buffer.from(base64, 'base64').toString('utf-8');
     const sourceMapData = JSON.parse(sourceMapJson);
 
@@ -66,7 +113,7 @@ export function remapErrorStack(
     });
 
     return remappedLines.join('\n');
-  } catch (e) {
+  } catch {
     // If source map processing fails, return original stack
     return stack;
   }

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -6,7 +6,6 @@ import {
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
-import { getPortLazy } from './runtime/get-port-lazy.js';
 import { parseWorkflowName } from '@workflow/utils/parse-name';
 import type { Event, WorkflowRun } from '@workflow/world';
 import * as nanoid from 'nanoid';
@@ -16,9 +15,10 @@ import { EventConsumerResult, EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
 import { ENOTSUP, WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
+import type { WorkflowOrchestratorContext } from './private.js';
+import { getPortLazy } from './runtime/get-port-lazy.js';
 import { handleSuspension } from './runtime/suspension-handler.js';
 import { getWorld } from './runtime/world.js';
-import type { WorkflowOrchestratorContext } from './private.js';
 import {
   dehydrateWorkflowReturnValue,
   hydrateWorkflowArguments,
@@ -36,12 +36,12 @@ import * as Attribute from './telemetry/semantic-conventions.js';
 import { trace } from './telemetry.js';
 import { getWorkflowRunStreamId } from './util.js';
 import { createContext } from './vm/index.js';
-import type { WorkflowMetadata } from './workflow/get-workflow-metadata.js';
-import { WORKFLOW_CONTEXT_SYMBOL } from './workflow/get-workflow-metadata.js';
 import {
   createAbortSignalStatics,
   createCreateAbortController,
 } from './workflow/abort-controller.js';
+import type { WorkflowMetadata } from './workflow/get-workflow-metadata.js';
+import { WORKFLOW_CONTEXT_SYMBOL } from './workflow/get-workflow-metadata.js';
 import { createCreateHook } from './workflow/hook.js';
 import { createSleep } from './workflow/sleep.js';
 
@@ -59,6 +59,15 @@ import { createSleep } from './workflow/sleep.js';
  * propagates to in-flight steps on other compute instances — without this,
  * the abort hook is created but never resumed and the cancellation never
  * reaches the running step.
+ *
+ * NOTE: drain only commits the `*_created` events; it does NOT enqueue step
+ * bodies for execution. The platform's step worker rejects `step_started`
+ * for runs that have already transitioned to terminal (`RunExpiredError`),
+ * so a step queued here would be skipped anyway. Fire-and-forget step calls
+ * with side effects therefore work only when followed by some later `await`
+ * on a runtime primitive that triggers a real suspension (the normal
+ * runtime loop in `runtime.ts` queues the step there). A `void` placed
+ * immediately before `return` is not reliably executed.
  *
  * Drain failures are swallowed: the workflow's own outcome (the user's return
  * value or thrown error) is the source of truth; secondary cleanup that fails

--- a/packages/core/src/workflow/index.ts
+++ b/packages/core/src/workflow/index.ts
@@ -10,6 +10,7 @@ export {
   type RetryableErrorOptions,
 } from '@workflow/errors';
 export type { Hook, HookOptions } from '../create-hook.js';
+export { experimental_setAttributes } from './set-attributes.js';
 export { sleep } from '../sleep.js';
 export { createHook, createWebhook } from './create-hook.js';
 export { defineHook } from './define-hook.js';

--- a/packages/core/src/workflow/set-attributes.test.ts
+++ b/packages/core/src/workflow/set-attributes.test.ts
@@ -1,0 +1,109 @@
+import { FatalError } from '@workflow/errors';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WORKFLOW_USE_STEP } from '../symbols.js';
+import { experimental_setAttributes } from './set-attributes.js';
+
+describe('workflow.experimental_setAttributes', () => {
+  const dispatchCalls: Array<{
+    stepName: string;
+    changes: Array<{ key: string; value: string | null }>;
+    options: { allowReservedAttributes?: boolean } | undefined;
+  }> = [];
+
+  beforeEach(() => {
+    dispatchCalls.length = 0;
+    (globalThis as Record<symbol, unknown>)[WORKFLOW_USE_STEP] = vi.fn(
+      (stepName: string) =>
+        async (
+          changes: Array<{ key: string; value: string | null }>,
+          options?: { allowReservedAttributes?: boolean }
+        ) => {
+          dispatchCalls.push({ stepName, changes, options });
+        }
+    );
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<symbol, unknown>)[WORKFLOW_USE_STEP];
+  });
+
+  it('dispatches normalized changes through __builtin_set_attributes', async () => {
+    await experimental_setAttributes({ phase: 'init', orderId: 'ord_1' });
+    expect(dispatchCalls).toEqual([
+      {
+        stepName: '__builtin_set_attributes',
+        changes: [
+          { key: 'phase', value: 'init' },
+          { key: 'orderId', value: 'ord_1' },
+        ],
+        options: {},
+      },
+    ]);
+  });
+
+  it('translates undefined values into null (unset semantics)', async () => {
+    await experimental_setAttributes({ phase: 'done', stale: undefined });
+    expect(dispatchCalls).toEqual([
+      {
+        stepName: '__builtin_set_attributes',
+        changes: [
+          { key: 'phase', value: 'done' },
+          { key: 'stale', value: null },
+        ],
+        options: {},
+      },
+    ]);
+  });
+
+  it('is a no-op for an empty record (no dispatch)', async () => {
+    await experimental_setAttributes({});
+    expect(dispatchCalls).toHaveLength(0);
+  });
+
+  it('throws FatalError when the workflow runtime has not initialized useStep', async () => {
+    delete (globalThis as Record<symbol, unknown>)[WORKFLOW_USE_STEP];
+    await expect(
+      experimental_setAttributes({ phase: 'init' })
+    ).rejects.toBeInstanceOf(FatalError);
+  });
+
+  it('throws FatalError for reserved-prefix keys before any dispatch', async () => {
+    await expect(
+      experimental_setAttributes({ $sys: 'x' })
+    ).rejects.toBeInstanceOf(FatalError);
+    expect(dispatchCalls).toHaveLength(0);
+  });
+
+  it('dispatches reserved-prefix keys when allowReservedAttributes opt-in is set, and forwards the flag to the step', async () => {
+    await experimental_setAttributes(
+      { '$framework.kind': 'agent' },
+      { allowReservedAttributes: true }
+    );
+    expect(dispatchCalls).toEqual([
+      {
+        stepName: '__builtin_set_attributes',
+        changes: [{ key: '$framework.kind', value: 'agent' }],
+        options: { allowReservedAttributes: true },
+      },
+    ]);
+  });
+
+  it('still rejects reserved-prefix keys when allowReservedAttributes is explicitly false', async () => {
+    await expect(
+      experimental_setAttributes(
+        { '$framework.kind': 'agent' },
+        { allowReservedAttributes: false }
+      )
+    ).rejects.toBeInstanceOf(FatalError);
+    expect(dispatchCalls).toHaveLength(0);
+  });
+
+  it('throws FatalError when called with a non-object', async () => {
+    await expect(
+      experimental_setAttributes(null as unknown as Record<string, string>)
+    ).rejects.toBeInstanceOf(FatalError);
+    await expect(
+      experimental_setAttributes([] as unknown as Record<string, string>)
+    ).rejects.toBeInstanceOf(FatalError);
+  });
+});

--- a/packages/core/src/workflow/set-attributes.ts
+++ b/packages/core/src/workflow/set-attributes.ts
@@ -1,0 +1,127 @@
+import { FatalError } from '@workflow/errors';
+import {
+  type AttributeChange,
+  AttributeValidationError,
+  validateAttributeChanges,
+} from '@workflow/world';
+import { WORKFLOW_USE_STEP } from '../symbols.js';
+
+/**
+ * Options accepted by `experimental_setAttributes`.
+ */
+export interface ExperimentalSetAttributesOptions {
+  /**
+   * Permit attribute keys that start with the reserved `$` prefix.
+   * **Default: `false`.**
+   *
+   * The `$` namespace is reserved for framework and library code that
+   * is built on top of the workflow SDK (telemetry, agent metadata,
+   * platform-emitted tags, etc.). User code MUST NOT write keys in
+   * this namespace; validation rejects them so accidental collisions
+   * with tooling-owned keys can't slip through.
+   *
+   * Only flip this to `true` if your caller is itself a framework or
+   * library that owns a `$`-prefixed sub-namespace and knows the
+   * conventions of any other tools writing into it. Misuse can
+   * conflict with observability surfaces, agent dashboards, or future
+   * platform features that rely on the reserved namespace.
+   */
+  allowReservedAttributes?: boolean;
+}
+
+/**
+ * Attach plaintext string key/value metadata to the current workflow run.
+ *
+ * **EXPERIMENTAL.** The `experimental_` prefix is deliberate — the
+ * shape, semantics, and dispatch path are likely to change before this
+ * is renamed to a stable export. Use only when you can absorb a
+ * breaking rename later.
+ *
+ * Callable only from a workflow body (`'use workflow'`). The call is
+ * dispatched through the workflow runtime as a step, so the mutation
+ * is recorded in the event log and survives replay.
+ *
+ * Validation runs in the VM (cheap, deterministic) before the step
+ * dispatch — violations throw `FatalError` without queuing a step. An
+ * empty record is a no-op. `value: undefined` removes the key from the
+ * run's attribute map.
+ *
+ * **Reserved namespace.** Keys starting with `$` are reserved for
+ * framework/library code (telemetry, agent metadata, etc.). User code
+ * trying to write a `$`-prefixed key throws `FatalError`. If you are a
+ * framework author and need to set a reserved key, pass
+ * `{ allowReservedAttributes: true }` as the second argument — see
+ * `ExperimentalSetAttributesOptions` for the trade-offs.
+ *
+ * **WARNING**: While this feature is experimental, calling e.g.
+ * `Promise.all([experimental_setAttributes({ a: '1' }), experimental_setAttributes({ a: '2' })])`
+ * is not guaranteed to be ordered consistently, but the equivalent
+ * sequential `.then()` chain is.
+ *
+ * @example
+ * ```ts
+ * import { experimental_setAttributes } from 'workflow';
+ *
+ * export async function myWorkflow() {
+ *   'use workflow';
+ *   await experimental_setAttributes({ phase: 'init' });
+ *   // ... work ...
+ *   await experimental_setAttributes({ phase: 'done', orderId: 'ord_123' });
+ *   await experimental_setAttributes({ orderId: undefined }); // remove
+ * }
+ * ```
+ *
+ * @example Framework / library code writing into the reserved namespace.
+ * ```ts
+ * await experimental_setAttributes(
+ *   { '$agent.kind': 'durable-agent' },
+ *   { allowReservedAttributes: true }
+ * );
+ * ```
+ */
+export async function experimental_setAttributes(
+  attrs: Record<string, string | undefined>,
+  options: ExperimentalSetAttributesOptions = {}
+): Promise<void> {
+  if (attrs === null || typeof attrs !== 'object' || Array.isArray(attrs)) {
+    throw new FatalError(
+      `experimental_setAttributes requires a plain object, got ${
+        attrs === null ? 'null' : Array.isArray(attrs) ? 'array' : typeof attrs
+      }`
+    );
+  }
+  const changes: AttributeChange[] = Object.entries(attrs).map(
+    ([key, value]) => ({
+      key,
+      value: value === undefined ? null : value,
+    })
+  );
+  if (changes.length === 0) return;
+  const allowReservedAttributes = options.allowReservedAttributes === true;
+  try {
+    validateAttributeChanges(changes, { allowReservedAttributes });
+  } catch (err) {
+    if (err instanceof AttributeValidationError) {
+      throw new FatalError(err.message);
+    }
+    throw err;
+  }
+  const useStep = (globalThis as Record<symbol, unknown>)[WORKFLOW_USE_STEP] as
+    | ((
+        stepName: string
+      ) => (
+        changes: AttributeChange[],
+        options?: { allowReservedAttributes?: boolean }
+      ) => Promise<void>)
+    | undefined;
+  if (!useStep) {
+    throw new FatalError(
+      'experimental_setAttributes() called outside a workflow runtime context. ' +
+        'It must be called from within a workflow body (`use workflow`).'
+    );
+  }
+  await useStep('__builtin_set_attributes')(
+    changes,
+    allowReservedAttributes ? { allowReservedAttributes: true } : {}
+  );
+}

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -965,12 +965,70 @@ export async function getNextBuilderDeferred() {
 
       const baseDirectory = dirname(bundleFilePath);
       const localSourceFiles = new Set<string>();
-      const sourceMapMatches = bundleContents.matchAll(
-        /\/\/# sourceMappingURL=data:application\/json[^,]*;base64,([A-Za-z0-9+/=]+)/g
-      );
+
+      // Extract inline base64 sourcemaps via string scanning. A previous
+      // implementation used `bundleContents.matchAll(/...[A-Za-z0-9+/=]+.../g)`
+      // which overflows V8's regex stack
+      // (`RangeError: Maximum call stack size exceeded at RegExpStringIterator.next`)
+      // on bundles with large inline sourcemaps — V8's irregexp uses
+      // recursion for greedy character-class quantifiers and certain long
+      // base64 inputs exhaust the call stack.
+      const sourceMapPrefix = '//# sourceMappingURL=data:application/json';
+      const base64Marker = ';base64,';
+      const sourceMapMatches: Array<{ base64Value: string }> = [];
+      let scanFrom = 0;
+      while (scanFrom < bundleContents.length) {
+        const prefixIdx = bundleContents.indexOf(sourceMapPrefix, scanFrom);
+        if (prefixIdx === -1) break;
+        const base64Start = bundleContents.indexOf(
+          base64Marker,
+          prefixIdx + sourceMapPrefix.length
+        );
+        if (base64Start === -1) {
+          scanFrom = prefixIdx + sourceMapPrefix.length;
+          continue;
+        }
+        // Bail if a comma appears before `;base64,` — that means this
+        // wasn't a `data:application/json[;params];base64,...` URL after
+        // all (the comma would terminate the data URL parameters).
+        const commaBefore = bundleContents.indexOf(',', prefixIdx);
+        if (commaBefore !== -1 && commaBefore < base64Start) {
+          scanFrom = base64Start;
+          continue;
+        }
+        const valueStart = base64Start + base64Marker.length;
+        // Base64 payload terminates at first non-base64 char (newline,
+        // closing `*/`, etc.). Scanning a small alphabet by char is far
+        // cheaper than backtracking a regex over a multi-MB capture.
+        let valueEnd = valueStart;
+        while (valueEnd < bundleContents.length) {
+          const code = bundleContents.charCodeAt(valueEnd);
+          // A-Z 0x41-0x5A, a-z 0x61-0x7A, 0-9 0x30-0x39, '+' 0x2B,
+          // '/' 0x2F, '=' 0x3D
+          if (
+            !(
+              (code >= 0x41 && code <= 0x5a) ||
+              (code >= 0x61 && code <= 0x7a) ||
+              (code >= 0x30 && code <= 0x39) ||
+              code === 0x2b ||
+              code === 0x2f ||
+              code === 0x3d
+            )
+          ) {
+            break;
+          }
+          valueEnd++;
+        }
+        if (valueEnd > valueStart) {
+          sourceMapMatches.push({
+            base64Value: bundleContents.slice(valueStart, valueEnd),
+          });
+        }
+        scanFrom = valueEnd;
+      }
 
       for (const match of sourceMapMatches) {
-        const base64Value = match[1];
+        const base64Value = match.base64Value;
         if (!base64Value) {
           continue;
         }

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -417,6 +417,13 @@ const attributeToDisplayFn: Record<
   projectId: (_value: unknown) => null,
   environment: (_value: unknown) => null,
   executionContext: (_value: unknown) => null,
+  // Attributes MVP — string-string metadata attached to the run.
+  // Rendered as a JSON block; if empty/missing, hidden by the
+  // hasDisplayContent gate above.
+  attributes: (value: unknown) => {
+    if (!hasDisplayContent(value)) return null;
+    return JsonBlock(value);
+  },
   // Dates — wrapped with TimestampTooltip showing UTC/local + relative time
   createdAt: timestampWithTooltipOrNull,
   startedAt: timestampWithTooltipOrNull,

--- a/packages/workflow/src/internal/builtins.test.ts
+++ b/packages/workflow/src/internal/builtins.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __builtin_set_attributes } from './builtins.js';
+
+const STEP_CONTEXT_STORAGE = Symbol.for('WORKFLOW_STEP_CONTEXT_STORAGE');
+const WORLD_CACHE = Symbol.for('@workflow/world//cache');
+const UNSUPPORTED_WORLD_WARNED = Symbol.for(
+  '@workflow/setAttributes//unsupportedWorldWarned'
+);
+
+const globals = globalThis as Record<symbol, unknown>;
+
+function setStepAttempt(attempt: number) {
+  globals[STEP_CONTEXT_STORAGE] = {
+    getStore: () => ({
+      stepMetadata: { attempt },
+      workflowMetadata: { workflowRunId: 'run_123' },
+    }),
+  };
+}
+
+describe('__builtin_set_attributes', () => {
+  let originalContextStorage: unknown;
+  let originalWorld: unknown;
+  let originalUnsupportedWorldWarned: unknown;
+
+  beforeEach(() => {
+    originalContextStorage = globals[STEP_CONTEXT_STORAGE];
+    originalWorld = globals[WORLD_CACHE];
+    originalUnsupportedWorldWarned = globals[UNSUPPORTED_WORLD_WARNED];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalContextStorage === undefined) {
+      delete globals[STEP_CONTEXT_STORAGE];
+    } else {
+      globals[STEP_CONTEXT_STORAGE] = originalContextStorage;
+    }
+
+    if (originalWorld === undefined) {
+      delete globals[WORLD_CACHE];
+    } else {
+      globals[WORLD_CACHE] = originalWorld;
+    }
+
+    if (originalUnsupportedWorldWarned === undefined) {
+      delete globals[UNSUPPORTED_WORLD_WARNED];
+    } else {
+      globals[UNSUPPORTED_WORLD_WARNED] = originalUnsupportedWorldWarned;
+    }
+  });
+
+  it('rethrows attribute write failures before the third attempt', async () => {
+    const error = new Error('world unavailable');
+    const experimentalSetAttributes = vi.fn().mockRejectedValue(error);
+    globals[WORLD_CACHE] = {
+      runs: { experimentalSetAttributes },
+    };
+
+    for (const attempt of [1, 2]) {
+      setStepAttempt(attempt);
+
+      await expect(
+        __builtin_set_attributes([{ key: '$tag.kind', value: 'agent' }], {
+          allowReservedAttributes: true,
+        })
+      ).rejects.toBe(error);
+    }
+
+    expect(experimentalSetAttributes).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs and completes after the third failed attempt', async () => {
+    const experimentalSetAttributes = vi
+      .fn()
+      .mockRejectedValue(new Error('world unavailable'));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    globals[WORLD_CACHE] = {
+      runs: { experimentalSetAttributes },
+    };
+    setStepAttempt(3);
+
+    await expect(
+      __builtin_set_attributes([{ key: '$tag.kind', value: 'agent' }], {
+        allowReservedAttributes: true,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(experimentalSetAttributes).toHaveBeenCalledWith(
+      'run_123',
+      [{ key: '$tag.kind', value: 'agent' }],
+      { allowReservedAttributes: true }
+    );
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0]?.[0]).toContain(
+      'failed to post tags after 3 attempts'
+    );
+    expect(
+      (
+        __builtin_set_attributes as typeof __builtin_set_attributes & {
+          maxRetries: number;
+        }
+      ).maxRetries
+    ).toBe(2);
+  });
+});

--- a/packages/workflow/src/internal/builtins.ts
+++ b/packages/workflow/src/internal/builtins.ts
@@ -20,3 +20,111 @@ export async function __builtin_response_text(this: Request | Response) {
   'use step';
   return this.text();
 }
+
+/**
+ * Process-wide dedupe for the unsupported-world warning so high-volume
+ * callers don't flood logs.
+ */
+const UNSUPPORTED_WORLD_WARNED = Symbol.for(
+  '@workflow/setAttributes//unsupportedWorldWarned'
+);
+
+const INTERNAL_ATTRIBUTES_MAX_ATTEMPTS = 3;
+
+function formatUnknownError(error: unknown) {
+  if (error instanceof Error) {
+    return error.stack ?? `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+/**
+ * Step bridge for workflow-body `setAttributes` calls. The VM-side
+ * helper validates input and dispatches here via `useStep`. This step
+ * runs in normal Node context with full world access.
+ *
+ * The dispatch reads the world and current run id directly from
+ * `globalThis` symbols populated by the workflow/step runtime — this
+ * intentionally avoids importing `@workflow/core` so the Next.js
+ * deferred-entries discoverer can't walk a chain into world adapters
+ * and `@vercel/queue` from this step file.
+ */
+export async function __builtin_set_attributes(
+  changes: Array<{ key: string; value: string | null }>,
+  options?: { allowReservedAttributes?: boolean }
+) {
+  'use step';
+  if (changes.length === 0) return;
+  const g = globalThis as Record<symbol, unknown>;
+
+  const contextStorage = g[Symbol.for('WORKFLOW_STEP_CONTEXT_STORAGE')] as
+    | {
+        getStore: () =>
+          | {
+              stepMetadata?: { attempt?: number };
+              workflowMetadata?: { workflowRunId?: string };
+            }
+          | undefined;
+      }
+    | undefined;
+  const store = contextStorage?.getStore?.();
+  const attempt =
+    typeof store?.stepMetadata?.attempt === 'number'
+      ? store.stepMetadata.attempt
+      : INTERNAL_ATTRIBUTES_MAX_ATTEMPTS;
+
+  const world = g[Symbol.for('@workflow/world//cache')] as
+    | {
+        name?: string;
+        runs?: {
+          experimentalSetAttributes?: (
+            runId: string,
+            changes: Array<{ key: string; value: string | null }>,
+            options?: { allowReservedAttributes?: boolean }
+          ) => Promise<unknown>;
+        };
+      }
+    | undefined;
+  if (typeof world?.runs?.experimentalSetAttributes !== 'function') {
+    // World adapter doesn't implement attributes yet — no-op the call,
+    // but emit one process-wide warning so users know their writes are
+    // being dropped. The VM-side validation already ran so the input
+    // is well-formed.
+    if (!g[UNSUPPORTED_WORLD_WARNED]) {
+      g[UNSUPPORTED_WORLD_WARNED] = true;
+      const worldName = world?.name ? ` (${world.name})` : '';
+      console.warn(
+        `[workflow] setAttributes: the current world implementation${worldName} does not implement experimentalSetAttributes; this call (and any subsequent setAttributes calls in this process) is a no-op. Attributes will become available once the world adapter adds support.`
+      );
+    }
+    return;
+  }
+
+  try {
+    const runId = store?.workflowMetadata?.workflowRunId;
+    if (!runId) {
+      throw new Error(
+        '__builtin_set_attributes: no workflow run id available in step context'
+      );
+    }
+
+    await world.runs.experimentalSetAttributes(runId, changes, options);
+  } catch (error) {
+    if (attempt < INTERNAL_ATTRIBUTES_MAX_ATTEMPTS) {
+      throw error;
+    }
+
+    // Failing to post tags should not fail a run during the experimental phase.
+    // After three attempts, log and let the internal step complete so the
+    // runtime does not convert retry exhaustion into a FatalError.
+    console.error(
+      `[workflow] setAttributes: failed to post tags after ${INTERNAL_ATTRIBUTES_MAX_ATTEMPTS} attempts; dropping the internal attribute write. ${formatUnknownError(error)}`
+    );
+  }
+}
+
+(
+  __builtin_set_attributes as typeof __builtin_set_attributes & {
+    maxRetries: number;
+  }
+).maxRetries = INTERNAL_ATTRIBUTES_MAX_ATTEMPTS - 1;

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -49,6 +49,7 @@ import { stripEventDataRefs } from './filters.js';
 import { getObjectCreatedAt, hashToken, monotonicUlid } from './helpers.js';
 import { deleteAllHooksForRun } from './hooks-storage.js';
 import { handleLegacyEvent } from './legacy.js';
+import { withRunFileLock } from './runs-storage.js';
 
 /**
  * Per-step in-process async mutex. Serializes concurrent `events.create` calls
@@ -121,6 +122,42 @@ async function deleteAllWaitsForRun(
       await deleteJSON(waitPath);
     }
   }
+}
+
+/**
+ * Persist a lifecycle-driven run update (run_started / run_completed /
+ * run_failed / run_cancelled) under the shared per-run file lock,
+ * re-reading the on-disk run inside the lock so any attribute writes
+ * that landed between the pre-validation `currentRun` read and this
+ * write are preserved. Without the re-read, an `experimentalSetAttributes`
+ * call sandwiched between the lifecycle read and write would be
+ * silently overwritten by the lifecycle write's stale attribute snapshot.
+ *
+ * `proposed` is the fully-constructed run row the caller wants to
+ * write (with the correct discriminated-union status branch). Only the
+ * `attributes` field is replaced with the freshest version inside the
+ * lock.
+ */
+async function writeRunUnderLifecycleLock<T extends WorkflowRun>(
+  basedir: string,
+  runId: string,
+  tag: string | undefined,
+  proposed: T
+): Promise<T> {
+  return withRunFileLock(runId, async () => {
+    const fresh = await readJSON(
+      taggedPath(basedir, 'runs', runId, tag),
+      WorkflowRunSchema
+    );
+    const next: T = {
+      ...proposed,
+      attributes: fresh?.attributes ?? proposed.attributes,
+    };
+    await writeJSON(taggedPath(basedir, 'runs', runId, tag), next, {
+      overwrite: true,
+    });
+    return next;
+  });
 }
 
 /**
@@ -261,6 +298,7 @@ export function createEventsStorage(
                 error: undefined,
                 startedAt: undefined,
                 completedAt: undefined,
+                attributes: {},
                 createdAt: now,
                 updatedAt: now,
               };
@@ -510,6 +548,7 @@ export function createEventsStorage(
             error: undefined,
             startedAt: undefined,
             completedAt: undefined,
+            attributes: {},
             createdAt: now,
             updatedAt: now,
           };
@@ -539,52 +578,54 @@ export function createEventsStorage(
               return { run: currentRun };
             }
 
-            run = {
-              runId: currentRun.runId,
-              deploymentId: currentRun.deploymentId,
-              workflowName: currentRun.workflowName,
-              specVersion: currentRun.specVersion,
-              executionContext: currentRun.executionContext,
-              input: currentRun.input,
-              createdAt: currentRun.createdAt,
-              expiredAt: currentRun.expiredAt,
-              status: 'running',
-              output: undefined,
-              error: undefined,
-              completedAt: undefined,
-              startedAt: currentRun.startedAt ?? now,
-              updatedAt: now,
-            };
-            await writeJSON(
-              taggedPath(basedir, 'runs', effectiveRunId, tag),
-              run,
-              { overwrite: true }
+            run = await writeRunUnderLifecycleLock(
+              basedir,
+              effectiveRunId,
+              tag,
+              {
+                runId: currentRun.runId,
+                deploymentId: currentRun.deploymentId,
+                workflowName: currentRun.workflowName,
+                specVersion: currentRun.specVersion,
+                executionContext: currentRun.executionContext,
+                input: currentRun.input,
+                createdAt: currentRun.createdAt,
+                expiredAt: currentRun.expiredAt,
+                status: 'running',
+                output: undefined,
+                error: undefined,
+                completedAt: undefined,
+                startedAt: currentRun.startedAt ?? now,
+                updatedAt: now,
+                attributes: currentRun.attributes,
+              }
             );
           }
         } else if (data.eventType === 'run_completed' && 'eventData' in data) {
           const completedData = data.eventData as { output?: any };
           // Reuse currentRun from validation (already read above)
           if (currentRun) {
-            run = {
-              runId: currentRun.runId,
-              deploymentId: currentRun.deploymentId,
-              workflowName: currentRun.workflowName,
-              specVersion: currentRun.specVersion,
-              executionContext: currentRun.executionContext,
-              input: currentRun.input,
-              createdAt: currentRun.createdAt,
-              expiredAt: currentRun.expiredAt,
-              startedAt: currentRun.startedAt,
-              status: 'completed',
-              output: completedData.output,
-              error: undefined,
-              completedAt: now,
-              updatedAt: now,
-            };
-            await writeJSON(
-              taggedPath(basedir, 'runs', effectiveRunId, tag),
-              run,
-              { overwrite: true }
+            run = await writeRunUnderLifecycleLock(
+              basedir,
+              effectiveRunId,
+              tag,
+              {
+                runId: currentRun.runId,
+                deploymentId: currentRun.deploymentId,
+                workflowName: currentRun.workflowName,
+                specVersion: currentRun.specVersion,
+                executionContext: currentRun.executionContext,
+                input: currentRun.input,
+                createdAt: currentRun.createdAt,
+                expiredAt: currentRun.expiredAt,
+                startedAt: currentRun.startedAt,
+                status: 'completed',
+                output: completedData.output,
+                error: undefined,
+                completedAt: now,
+                updatedAt: now,
+                attributes: currentRun.attributes,
+              }
             );
             await Promise.all([
               deleteAllHooksForRun(basedir, effectiveRunId),
@@ -601,27 +642,28 @@ export function createEventsStorage(
             // The error field is SerializedData (Uint8Array) produced by
             // dehydrateRunError. We store it verbatim — consumers hydrate it
             // via hydrateRunError to reconstruct the original thrown value.
-            run = {
-              runId: currentRun.runId,
-              deploymentId: currentRun.deploymentId,
-              workflowName: currentRun.workflowName,
-              specVersion: currentRun.specVersion,
-              executionContext: currentRun.executionContext,
-              input: currentRun.input,
-              createdAt: currentRun.createdAt,
-              expiredAt: currentRun.expiredAt,
-              startedAt: currentRun.startedAt,
-              status: 'failed',
-              output: undefined,
-              error: failedData.error as Uint8Array,
-              errorCode: failedData.errorCode,
-              completedAt: now,
-              updatedAt: now,
-            };
-            await writeJSON(
-              taggedPath(basedir, 'runs', effectiveRunId, tag),
-              run,
-              { overwrite: true }
+            run = await writeRunUnderLifecycleLock(
+              basedir,
+              effectiveRunId,
+              tag,
+              {
+                runId: currentRun.runId,
+                deploymentId: currentRun.deploymentId,
+                workflowName: currentRun.workflowName,
+                specVersion: currentRun.specVersion,
+                executionContext: currentRun.executionContext,
+                input: currentRun.input,
+                createdAt: currentRun.createdAt,
+                expiredAt: currentRun.expiredAt,
+                startedAt: currentRun.startedAt,
+                status: 'failed',
+                output: undefined,
+                error: failedData.error as Uint8Array,
+                errorCode: failedData.errorCode,
+                completedAt: now,
+                updatedAt: now,
+                attributes: currentRun.attributes,
+              }
             );
             await Promise.all([
               deleteAllHooksForRun(basedir, effectiveRunId),
@@ -631,26 +673,27 @@ export function createEventsStorage(
         } else if (data.eventType === 'run_cancelled') {
           // Reuse currentRun from validation (already read above)
           if (currentRun) {
-            run = {
-              runId: currentRun.runId,
-              deploymentId: currentRun.deploymentId,
-              workflowName: currentRun.workflowName,
-              specVersion: currentRun.specVersion,
-              executionContext: currentRun.executionContext,
-              input: currentRun.input,
-              createdAt: currentRun.createdAt,
-              expiredAt: currentRun.expiredAt,
-              startedAt: currentRun.startedAt,
-              status: 'cancelled',
-              output: undefined,
-              error: undefined,
-              completedAt: now,
-              updatedAt: now,
-            };
-            await writeJSON(
-              taggedPath(basedir, 'runs', effectiveRunId, tag),
-              run,
-              { overwrite: true }
+            run = await writeRunUnderLifecycleLock(
+              basedir,
+              effectiveRunId,
+              tag,
+              {
+                runId: currentRun.runId,
+                deploymentId: currentRun.deploymentId,
+                workflowName: currentRun.workflowName,
+                specVersion: currentRun.specVersion,
+                executionContext: currentRun.executionContext,
+                input: currentRun.input,
+                createdAt: currentRun.createdAt,
+                expiredAt: currentRun.expiredAt,
+                startedAt: currentRun.startedAt,
+                status: 'cancelled',
+                output: undefined,
+                error: undefined,
+                completedAt: now,
+                updatedAt: now,
+                attributes: currentRun.attributes,
+              }
             );
             await Promise.all([
               deleteAllHooksForRun(basedir, effectiveRunId),

--- a/packages/world-local/src/storage/legacy.ts
+++ b/packages/world-local/src/storage/legacy.ts
@@ -48,6 +48,7 @@ export async function handleLegacyEvent(
         error: undefined,
         completedAt: now,
         updatedAt: now,
+        attributes: currentRun.attributes,
       };
       const runPath = resolveWithinBase(basedir, 'runs', `${runId}.json`);
       await writeJSON(runPath, run, { overwrite: true });

--- a/packages/world-local/src/storage/runs-storage.test.ts
+++ b/packages/world-local/src/storage/runs-storage.test.ts
@@ -1,0 +1,234 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { WorkflowRunNotFoundError } from '@workflow/errors';
+import {
+  ATTRIBUTE_KEY_MAX_LENGTH,
+  AttributeValidationError,
+  RESERVED_ATTRIBUTE_KEY_PREFIX,
+  type Storage,
+} from '@workflow/world';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createStorage } from '../storage.js';
+import { createRun } from '../test-helpers.js';
+
+describe('runs.experimentalSetAttributes (world-local)', () => {
+  let testDir: string;
+  let storage: Storage;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attrs-test-'));
+    storage = createStorage(testDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  async function newRun() {
+    return createRun(storage, {
+      deploymentId: 'dpl_test',
+      workflowName: 'test-workflow',
+      input: new Uint8Array([1]),
+    });
+  }
+
+  it('upserts new keys', async () => {
+    const run = await newRun();
+
+    const result = await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'phase', value: 'init' },
+      { key: 'tenant', value: 't1' },
+    ]);
+
+    expect(result.attributes).toEqual({ phase: 'init', tenant: 't1' });
+    const refreshed = await storage.runs.get(run.runId);
+    expect(refreshed.attributes).toEqual({ phase: 'init', tenant: 't1' });
+  });
+
+  it('updates existing keys (merge semantics)', async () => {
+    const run = await newRun();
+    await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'phase', value: 'init' },
+      { key: 'tenant', value: 't1' },
+    ]);
+
+    const result = await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'phase', value: 'done' },
+    ]);
+
+    expect(result.attributes).toEqual({ phase: 'done', tenant: 't1' });
+  });
+
+  it('removes keys when value is null', async () => {
+    const run = await newRun();
+    await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'phase', value: 'init' },
+      { key: 'orderId', value: 'ord_123' },
+    ]);
+
+    const result = await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'orderId', value: null },
+    ]);
+
+    expect(result.attributes).toEqual({ phase: 'init' });
+    expect(result.attributes).not.toHaveProperty('orderId');
+  });
+
+  it('applies set and unset in a single call', async () => {
+    const run = await newRun();
+    await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'stale', value: 'yes' },
+    ]);
+
+    const result = await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'stale', value: null },
+      { key: 'fresh', value: 'yes' },
+    ]);
+
+    expect(result.attributes).toEqual({ fresh: 'yes' });
+  });
+
+  it('throws WorkflowRunNotFoundError for unknown run', async () => {
+    await expect(
+      storage.runs.experimentalSetAttributes!('wrun_doesnotexist', [
+        { key: 'phase', value: 'init' },
+      ])
+    ).rejects.toBeInstanceOf(WorkflowRunNotFoundError);
+  });
+
+  it('rejects keys starting with reserved prefix', async () => {
+    const run = await newRun();
+    await expect(
+      storage.runs.experimentalSetAttributes!(run.runId, [
+        { key: `${RESERVED_ATTRIBUTE_KEY_PREFIX}sys`, value: 'x' },
+      ])
+    ).rejects.toBeInstanceOf(AttributeValidationError);
+  });
+
+  it('accepts reserved-prefix keys when allowReservedAttributes is set (framework escape hatch)', async () => {
+    const run = await newRun();
+    const result = await storage.runs.experimentalSetAttributes!(
+      run.runId,
+      [
+        {
+          key: `${RESERVED_ATTRIBUTE_KEY_PREFIX}framework.kind`,
+          value: 'agent',
+        },
+        { key: 'phase', value: 'init' },
+      ],
+      { allowReservedAttributes: true }
+    );
+    expect(result.attributes).toEqual({
+      [`${RESERVED_ATTRIBUTE_KEY_PREFIX}framework.kind`]: 'agent',
+      phase: 'init',
+    });
+
+    // Without the flag on a follow-up write, the rejection still
+    // fires — the opt-in is per-call, not sticky on the run.
+    await expect(
+      storage.runs.experimentalSetAttributes!(run.runId, [
+        { key: `${RESERVED_ATTRIBUTE_KEY_PREFIX}other`, value: 'x' },
+      ])
+    ).rejects.toBeInstanceOf(AttributeValidationError);
+  });
+
+  it('rejects keys over the max length', async () => {
+    const run = await newRun();
+    await expect(
+      storage.runs.experimentalSetAttributes!(run.runId, [
+        { key: 'k'.repeat(ATTRIBUTE_KEY_MAX_LENGTH + 1), value: 'x' },
+      ])
+    ).rejects.toBeInstanceOf(AttributeValidationError);
+  });
+
+  it('rejects values exceeding the byte cap', async () => {
+    const run = await newRun();
+    await expect(
+      storage.runs.experimentalSetAttributes!(run.runId, [
+        { key: 'big', value: 'a'.repeat(257) },
+      ])
+    ).rejects.toBeInstanceOf(AttributeValidationError);
+  });
+
+  it('updates at the cap boundary do not falsely trip the limit', async () => {
+    const run = await newRun();
+    // Fill to exactly the cap.
+    const initial = Array.from({ length: 64 }, (_, i) => ({
+      key: `k${i}`,
+      value: 'v',
+    }));
+    await storage.runs.experimentalSetAttributes!(run.runId, initial);
+
+    // Updating an existing key (no growth) must succeed even at the cap.
+    const result = await storage.runs.experimentalSetAttributes!(run.runId, [
+      { key: 'k0', value: 'updated' },
+    ]);
+    expect(result.attributes.k0).toBe('updated');
+    expect(Object.keys(result.attributes)).toHaveLength(64);
+  });
+
+  it('repeated identical calls are idempotent', async () => {
+    const run = await newRun();
+    const changes = [
+      { key: 'phase', value: 'init' as string | null },
+      { key: 'tenant', value: 't1' as string | null },
+    ];
+
+    const first = await storage.runs.experimentalSetAttributes!(
+      run.runId,
+      changes
+    );
+    const second = await storage.runs.experimentalSetAttributes!(
+      run.runId,
+      changes
+    );
+    const third = await storage.runs.experimentalSetAttributes!(
+      run.runId,
+      changes
+    );
+
+    // All three converge on the same snapshot — second/third are no-op
+    // upserts of the same values.
+    expect(first.attributes).toEqual({ phase: 'init', tenant: 't1' });
+    expect(second.attributes).toEqual(first.attributes);
+    expect(third.attributes).toEqual(first.attributes);
+  });
+
+  it('rejects when post-merge count exceeds limit', async () => {
+    const run = await newRun();
+    // Pre-fill to within the cap. The MVP cap is 64.
+    const initial = Array.from({ length: 60 }, (_, i) => ({
+      key: `k${i}`,
+      value: 'v',
+    }));
+    await storage.runs.experimentalSetAttributes!(run.runId, initial);
+
+    // Adding 5 new keys would push us over.
+    const overflow = Array.from({ length: 5 }, (_, i) => ({
+      key: `extra${i}`,
+      value: 'v',
+    }));
+    await expect(
+      storage.runs.experimentalSetAttributes!(run.runId, overflow)
+    ).rejects.toBeInstanceOf(AttributeValidationError);
+  });
+
+  it('serializes concurrent writes to the same run (no lost writes)', async () => {
+    const run = await newRun();
+
+    // 20 concurrent writes; each adds a unique key. Per-run mutex must
+    // serialize them so all keys land — without it, the read-merge-write
+    // race loses some.
+    await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        storage.runs.experimentalSetAttributes!(run.runId, [
+          { key: `k${i}`, value: `v${i}` },
+        ])
+      )
+    );
+
+    const refreshed = await storage.runs.get(run.runId);
+    expect(Object.keys(refreshed.attributes ?? {})).toHaveLength(20);
+  });
+});

--- a/packages/world-local/src/storage/runs-storage.ts
+++ b/packages/world-local/src/storage/runs-storage.ts
@@ -1,18 +1,27 @@
 import path from 'node:path';
 import { WorkflowRunNotFoundError } from '@workflow/errors';
 import type {
+  AttributeChange,
+  ExperimentalSetAttributesResult,
   ListWorkflowRunsParams,
   PaginatedResponse,
   Storage,
   WorkflowRun,
   WorkflowRunWithoutData,
 } from '@workflow/world';
-import { WorkflowRunSchema } from '@workflow/world';
+import {
+  applyAttributeChanges,
+  AttributeValidationError,
+  validateAttributeChanges,
+  WorkflowRunSchema,
+} from '@workflow/world';
 import { DEFAULT_RESOLVE_DATA_OPTION } from '../config.js';
 import {
   assertSafeEntityId,
   paginatedFileSystemQuery,
   readJSONWithFallback,
+  taggedPath,
+  writeJSON,
 } from '../fs.js';
 import { filterRunData } from './filters.js';
 import { getObjectCreatedAt } from './helpers.js';
@@ -40,6 +49,47 @@ export interface LocalRunsStorage {
       params?: LocalListWorkflowRunsParams
     ): Promise<PaginatedResponse<WorkflowRun | WorkflowRunWithoutData>>;
   };
+  experimentalSetAttributes(
+    runId: string,
+    changes: AttributeChange[],
+    options?: { allowReservedAttributes?: boolean }
+  ): Promise<ExperimentalSetAttributesResult>;
+}
+
+/**
+ * Per-run in-process async mutex. Serializes concurrent writes that
+ * touch the same run JSON file — both attribute writes via
+ * `experimentalSetAttributes` and run-lifecycle writes (run_started,
+ * run_completed, run_failed, run_cancelled) acquire it. Without the
+ * shared lock, an attribute write that lands between a lifecycle
+ * handler's read and write would be silently overwritten by the
+ * lifecycle write's stale attribute snapshot.
+ *
+ * Lifecycle writers acquire the lock and re-read the run file inside
+ * the critical section to pick up any attributes that landed since
+ * their pre-validation read.
+ */
+const runFileLocks = new Map<string, Promise<unknown>>();
+
+export function withRunFileLock<T>(
+  key: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const prev = runFileLocks.get(key);
+  const taskBox: { task?: Promise<T> } = {};
+  const task = (async () => {
+    if (prev) await prev.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      if (runFileLocks.get(key) === taskBox.task) {
+        runFileLocks.delete(key);
+      }
+    }
+  })();
+  taskBox.task = task;
+  runFileLocks.set(key, task);
+  return task;
 }
 
 /**
@@ -107,5 +157,52 @@ export function createRunsStorage(
 
       return result;
     }) as LocalRunsStorage['list'],
+
+    experimentalSetAttributes: async (runId, changes, options) => {
+      assertSafeEntityId('runId', runId);
+
+      return withRunFileLock(runId, async () => {
+        const run = await readJSONWithFallback(
+          basedir,
+          'runs',
+          runId,
+          WorkflowRunSchema,
+          tag
+        );
+        if (!run) {
+          throw new WorkflowRunNotFoundError(runId);
+        }
+
+        // Server-side validation. The SDK validates before sending, but
+        // the world is the final authority — re-check so direct callers
+        // (tests, other consumers) cannot bypass the limits.
+        try {
+          validateAttributeChanges(changes, {
+            existingKeys: Object.keys(run.attributes ?? {}),
+            allowReservedAttributes: options?.allowReservedAttributes,
+          });
+        } catch (err) {
+          if (err instanceof AttributeValidationError) {
+            // Re-throw as a plain error; callers (the SDK) wrap as
+            // FatalError on their side.
+            throw err;
+          }
+          throw err;
+        }
+
+        const nextAttributes = applyAttributeChanges(run.attributes, changes);
+        const updatedRun = {
+          ...run,
+          attributes: nextAttributes,
+          updatedAt: new Date(),
+        };
+
+        await writeJSON(taggedPath(basedir, 'runs', runId, tag), updatedRun, {
+          overwrite: true,
+        });
+
+        return { attributes: nextAttributes };
+      });
+    },
   };
 }

--- a/packages/world-postgres/src/drizzle/migrations/0013_add_attributes.sql
+++ b/packages/world-postgres/src/drizzle/migrations/0013_add_attributes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflow"."workflow_runs" ADD COLUMN "attributes" jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
+++ b/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1775600000000,
       "tag": "0012_add_is_system",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1779609600000,
+      "tag": "0013_add_attributes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -95,6 +95,17 @@ export const runs = schema.table(
      * decryption or hydration.
      */
     errorCode: varchar('error_code'),
+    /**
+     * Plaintext string-string metadata attached to the run via
+     * `setAttributes()`. EXPERIMENTAL MVP: stored as JSONB to allow
+     * SQL-side merge (`jsonb_set` / `jsonb_strip_nulls`) without a
+     * read-modify-write cycle. Defaults to `{}` so existing rows
+     * (pre-migration) read as the empty map.
+     */
+    attributes: jsonb('attributes')
+      .$type<Record<string, string>>()
+      .default({})
+      .notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at')
       .defaultNow()

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -8,8 +8,10 @@ import {
   WorkflowWorldError,
 } from '@workflow/errors';
 import type {
+  AttributeChange,
   Event,
   EventResult,
+  ExperimentalSetAttributesResult,
   GetEventParams,
   Hook,
   ListEventsParams,
@@ -25,6 +27,8 @@ import type {
   WorkflowRunWithoutData,
 } from '@workflow/world';
 import {
+  ATTRIBUTE_MAX_PER_RUN,
+  AttributeValidationError,
   EventSchema,
   HookSchema,
   isLegacySpecVersion,
@@ -32,6 +36,7 @@ import {
   SPEC_VERSION_CURRENT,
   StepSchema,
   stripEventDataRefs,
+  validateAttributeChanges,
   validateUlidTimestamp,
   WorkflowRunSchema,
 } from '@workflow/world';
@@ -140,6 +145,88 @@ export function createRunsStorage(drizzle: Drizzle): Storage['runs'] {
         cursor: values.at(-1)?.runId ?? null,
       };
     }) as Storage['runs']['list'],
+
+    experimentalSetAttributes: async (
+      runId: string,
+      changes: AttributeChange[],
+      options?: { allowReservedAttributes?: boolean }
+    ): Promise<ExperimentalSetAttributesResult> => {
+      // Load existing attributes so the SDK-shape validator can produce
+      // a precise error message (cap, duplicate keys, reserved prefix,
+      // byte length). The authoritative cap enforcement happens inside
+      // the UPDATE statement below — see the `WHERE` clause — so the
+      // race between this read and the UPDATE cannot push the row past
+      // the per-run cap.
+      const [existing] = await drizzle
+        .select({ attributes: runs.attributes })
+        .from(runs)
+        .where(eq(runs.runId, runId))
+        .limit(1);
+      if (!existing) {
+        throw new WorkflowRunNotFoundError(runId);
+      }
+
+      try {
+        validateAttributeChanges(changes, {
+          existingKeys: Object.keys(existing.attributes ?? {}),
+          allowReservedAttributes: options?.allowReservedAttributes,
+        });
+      } catch (err) {
+        if (err instanceof AttributeValidationError) throw err;
+        throw err;
+      }
+
+      // Build a single SQL expression that applies all changes
+      // atomically. Sets fold into nested `jsonb_set` calls; removes
+      // fold into chained `-` (delete) operators.
+      let expr = sql`COALESCE(${runs.attributes}, '{}'::jsonb)`;
+      for (const { key, value } of changes) {
+        if (value === null) {
+          expr = sql`${expr} - ${key}`;
+        } else {
+          expr = sql`jsonb_set(${expr}, ARRAY[${key}]::text[], to_jsonb(${value}::text), true)`;
+        }
+      }
+
+      // Atomic cap enforcement: only commit the UPDATE if the
+      // post-merge key count fits the per-run cap. Computed against
+      // the *current* row state, so two concurrent writers adding
+      // disjoint keys at the cap boundary cannot both succeed.
+      // Drizzle re-renders `expr` twice in the SQL (`SET attributes =
+      // ...` + the count check); `jsonb_set` is cheap so the
+      // duplication is harmless.
+      const [updated] = await drizzle
+        .update(runs)
+        .set({
+          attributes: expr as any,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(runs.runId, runId),
+            sql`(SELECT COUNT(*) FROM jsonb_object_keys(${expr})) <= ${ATTRIBUTE_MAX_PER_RUN}`
+          )
+        )
+        .returning({ attributes: runs.attributes });
+
+      if (!updated) {
+        // Either the run vanished mid-call, or the cap-check WHERE
+        // clause rejected the UPDATE. Re-read to disambiguate.
+        const [stillThere] = await drizzle
+          .select({ attributes: runs.attributes })
+          .from(runs)
+          .where(eq(runs.runId, runId))
+          .limit(1);
+        if (!stillThere) {
+          throw new WorkflowRunNotFoundError(runId);
+        }
+        throw new AttributeValidationError(
+          `Run attribute count would exceed limit ${ATTRIBUTE_MAX_PER_RUN} after concurrent write`
+        );
+      }
+
+      return { attributes: updated.attributes ?? {} };
+    },
   };
 }
 

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -352,6 +352,57 @@ describe('Storage (Postgres integration)', () => {
         expect(page2.data[0].runId).not.toBe(page1.data[0].runId);
       });
     });
+
+    describe('experimentalSetAttributes', () => {
+      it('upserts new keys', async () => {
+        const run = await createRun(events, {
+          deploymentId: 'd',
+          workflowName: 'w',
+          input: new Uint8Array(),
+        });
+
+        const result = await runs.experimentalSetAttributes!(run.runId, [
+          { key: 'phase', value: 'init' },
+          { key: 'tenant', value: 't1' },
+        ]);
+        expect(result.attributes).toEqual({ phase: 'init', tenant: 't1' });
+
+        const fresh = await runs.get(run.runId);
+        expect(fresh.attributes).toEqual({ phase: 'init', tenant: 't1' });
+      });
+
+      it('merges across calls without clobbering prior keys', async () => {
+        const run = await createRun(events, {
+          deploymentId: 'd',
+          workflowName: 'w',
+          input: new Uint8Array(),
+        });
+
+        await runs.experimentalSetAttributes!(run.runId, [
+          { key: 'a', value: '1' },
+        ]);
+        const result = await runs.experimentalSetAttributes!(run.runId, [
+          { key: 'b', value: '2' },
+        ]);
+        expect(result.attributes).toEqual({ a: '1', b: '2' });
+      });
+
+      it('removes keys when value is null', async () => {
+        const run = await createRun(events, {
+          deploymentId: 'd',
+          workflowName: 'w',
+          input: new Uint8Array(),
+        });
+        await runs.experimentalSetAttributes!(run.runId, [
+          { key: 'a', value: '1' },
+          { key: 'b', value: '2' },
+        ]);
+        const result = await runs.experimentalSetAttributes!(run.runId, [
+          { key: 'a', value: null },
+        ]);
+        expect(result.attributes).toEqual({ b: '2' });
+      });
+    });
   });
 
   describe('steps', () => {

--- a/packages/world-vercel/src/runs.ts
+++ b/packages/world-vercel/src/runs.ts
@@ -1,7 +1,9 @@
 import { WorkflowRunNotFoundError, WorkflowWorldError } from '@workflow/errors';
 import {
+  type AttributeChange,
   type CancelWorkflowRunParams,
   type CreateWorkflowRunRequest,
+  type ExperimentalSetAttributesResult,
   type GetWorkflowRunParams,
   type ListWorkflowRunsParams,
   type PaginatedResponse,
@@ -250,6 +252,53 @@ export async function cancelWorkflowRunV1(
   } catch (error) {
     if (error instanceof WorkflowWorldError && error.status === 404) {
       throw new WorkflowRunNotFoundError(id);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Wire response schema for `experimentalSetAttributes`. The backend
+ * returns the post-merge attribute snapshot so callers don't need to
+ * issue a follow-up read.
+ */
+const ExperimentalSetAttributesResponseSchema = z.object({
+  attributes: z.record(z.string(), z.string()),
+});
+
+/**
+ * Apply attribute changes to a workflow run. The body shape mirrors the
+ * future `attr_set` event's `eventData.changes`, so the wire contract is
+ * forward-compatible with the full 5.0.0 attributes feature — only the
+ * endpoint path changes.
+ *
+ * `options.allowReservedAttributes` opts the request into permitting
+ * `$`-prefixed keys (framework-only — see the SDK helper for details).
+ * The flag is forwarded to the server via the request body.
+ *
+ * EXPERIMENTAL: tied to the MVP write-only attributes API. See
+ * `docs/content/docs/v5/changelog/attributes-mvp.mdx`.
+ */
+export async function experimentalSetAttributes(
+  runId: string,
+  changes: AttributeChange[],
+  options?: { allowReservedAttributes?: boolean },
+  config?: APIConfig
+): Promise<ExperimentalSetAttributesResult> {
+  try {
+    const response = await makeRequest({
+      endpoint: `/v2/runs/${encodeURIComponent(runId)}/attributes`,
+      options: { method: 'POST' },
+      data: options?.allowReservedAttributes
+        ? { changes, allowReservedAttributes: true }
+        : { changes },
+      config,
+      schema: ExperimentalSetAttributesResponseSchema,
+    });
+    return { attributes: response.attributes };
+  } catch (error) {
+    if (error instanceof WorkflowWorldError && error.status === 404) {
+      throw new WorkflowRunNotFoundError(runId);
     }
     throw error;
   }

--- a/packages/world-vercel/src/storage.ts
+++ b/packages/world-vercel/src/storage.ts
@@ -6,7 +6,11 @@ import {
 } from './events.js';
 import { getHook, getHookByToken, listHooks } from './hooks.js';
 import { instrumentObject } from './instrumentObject.js';
-import { getWorkflowRun, listWorkflowRuns } from './runs.js';
+import {
+  experimentalSetAttributes,
+  getWorkflowRun,
+  listWorkflowRuns,
+} from './runs.js';
 import { getStep, listWorkflowRunSteps } from './steps.js';
 import type { APIConfig } from './utils.js';
 
@@ -18,6 +22,8 @@ export function createStorage(config?: APIConfig): Storage {
         getWorkflowRun(id, params, config)) as Storage['runs']['get'],
       list: ((params?: any) =>
         listWorkflowRuns(params, config)) as Storage['runs']['list'],
+      experimentalSetAttributes: (runId, changes, options) =>
+        experimentalSetAttributes(runId, changes, options, config),
     },
     steps: {
       get: ((runId: string, stepId: string, params?: any) =>

--- a/packages/world/src/attributes.test.ts
+++ b/packages/world/src/attributes.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyAttributeChanges,
+  ATTRIBUTE_KEY_MAX_LENGTH,
+  ATTRIBUTE_MAX_PER_RUN,
+  AttributeValidationError,
+  validateAttributeChanges,
+  validateAttributeKey,
+  validateAttributeValue,
+} from './attributes.js';
+
+describe('validateAttributeKey', () => {
+  it('accepts a normal key', () => {
+    expect(validateAttributeKey('phase')).toBeNull();
+  });
+
+  it('rejects empty keys', () => {
+    expect(validateAttributeKey('')).toBeInstanceOf(AttributeValidationError);
+  });
+
+  it('rejects keys over the length cap', () => {
+    expect(
+      validateAttributeKey('k'.repeat(ATTRIBUTE_KEY_MAX_LENGTH + 1))
+    ).toBeInstanceOf(AttributeValidationError);
+  });
+
+  it('accepts keys exactly at the length cap', () => {
+    expect(
+      validateAttributeKey('k'.repeat(ATTRIBUTE_KEY_MAX_LENGTH))
+    ).toBeNull();
+  });
+
+  it('rejects keys starting with the reserved prefix by default', () => {
+    expect(validateAttributeKey('$internal')).toBeInstanceOf(
+      AttributeValidationError
+    );
+  });
+
+  it('accepts reserved-prefix keys when allowReservedAttributes is set', () => {
+    expect(
+      validateAttributeKey('$internal', { allowReservedAttributes: true })
+    ).toBeNull();
+  });
+
+  it('still rejects reserved-prefix keys when allowReservedAttributes is explicitly false', () => {
+    expect(
+      validateAttributeKey('$internal', { allowReservedAttributes: false })
+    ).toBeInstanceOf(AttributeValidationError);
+  });
+});
+
+describe('validateAttributeValue', () => {
+  it('accepts null (unset)', () => {
+    expect(validateAttributeValue(null)).toBeNull();
+  });
+
+  it('accepts a normal string', () => {
+    expect(validateAttributeValue('hello')).toBeNull();
+  });
+
+  it('rejects values over the byte cap', () => {
+    expect(validateAttributeValue('a'.repeat(257))).toBeInstanceOf(
+      AttributeValidationError
+    );
+  });
+
+  it('counts UTF-8 bytes, not characters', () => {
+    // 4-byte UTF-8 emoji; 64 of them = 256 bytes exactly (at the cap)
+    const at = '💥'.repeat(64);
+    expect(validateAttributeValue(at)).toBeNull();
+    const over = '💥'.repeat(65); // 260 bytes, over
+    expect(validateAttributeValue(over)).toBeInstanceOf(
+      AttributeValidationError
+    );
+  });
+});
+
+describe('validateAttributeChanges', () => {
+  it('accepts a small batch of valid changes', () => {
+    expect(() =>
+      validateAttributeChanges([
+        { key: 'phase', value: 'init' },
+        { key: 'stale', value: null },
+      ])
+    ).not.toThrow();
+  });
+
+  it('rejects duplicate keys within a single batch', () => {
+    expect(() =>
+      validateAttributeChanges([
+        { key: 'phase', value: 'init' },
+        { key: 'phase', value: 'done' },
+      ])
+    ).toThrow(AttributeValidationError);
+  });
+
+  it('rejects when post-merge count exceeds the per-run cap', () => {
+    const changes = Array.from({ length: ATTRIBUTE_MAX_PER_RUN }, (_, i) => ({
+      key: `k${i}`,
+      value: 'v',
+    }));
+    expect(() =>
+      validateAttributeChanges(changes, { existingKeys: ['preexisting'] })
+    ).toThrow(AttributeValidationError);
+  });
+
+  it('does not count upserts on already-present keys against the cap', () => {
+    // 64 keys already exist; the call updates one of them. Post-merge
+    // size is still 64 so the cap must accept it.
+    const existingKeys = Array.from(
+      { length: ATTRIBUTE_MAX_PER_RUN },
+      (_, i) => `k${i}`
+    );
+    expect(() =>
+      validateAttributeChanges([{ key: 'k0', value: 'updated' }], {
+        existingKeys,
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects reserved-prefix keys in a batch by default', () => {
+    expect(() =>
+      validateAttributeChanges([
+        { key: 'phase', value: 'init' },
+        { key: '$framework.kind', value: 'agent' },
+      ])
+    ).toThrow(AttributeValidationError);
+  });
+
+  it('accepts reserved-prefix keys when allowReservedAttributes is set', () => {
+    expect(() =>
+      validateAttributeChanges(
+        [
+          { key: 'phase', value: 'init' },
+          { key: '$framework.kind', value: 'agent' },
+        ],
+        { allowReservedAttributes: true }
+      )
+    ).not.toThrow();
+  });
+});
+
+describe('applyAttributeChanges', () => {
+  it('upserts new keys', () => {
+    expect(
+      applyAttributeChanges({ a: '1' }, [{ key: 'b', value: '2' }])
+    ).toEqual({ a: '1', b: '2' });
+  });
+
+  it('overwrites existing keys', () => {
+    expect(
+      applyAttributeChanges({ a: '1' }, [{ key: 'a', value: '2' }])
+    ).toEqual({ a: '2' });
+  });
+
+  it('removes keys when value is null', () => {
+    expect(
+      applyAttributeChanges({ a: '1', b: '2' }, [{ key: 'a', value: null }])
+    ).toEqual({ b: '2' });
+  });
+
+  it('applies set and unset in a single batch', () => {
+    expect(
+      applyAttributeChanges({ a: '1', stale: 'x' }, [
+        { key: 'stale', value: null },
+        { key: 'fresh', value: 'yes' },
+      ])
+    ).toEqual({ a: '1', fresh: 'yes' });
+  });
+
+  it('returns a new object (does not mutate input)', () => {
+    const before = { a: '1' };
+    const after = applyAttributeChanges(before, [{ key: 'b', value: '2' }]);
+    expect(before).toEqual({ a: '1' });
+    expect(after).not.toBe(before);
+  });
+
+  it('treats undefined existing as the empty record', () => {
+    expect(
+      applyAttributeChanges(undefined, [{ key: 'a', value: '1' }])
+    ).toEqual({ a: '1' });
+  });
+});

--- a/packages/world/src/attributes.ts
+++ b/packages/world/src/attributes.ts
@@ -1,0 +1,227 @@
+import { z } from 'zod';
+
+/**
+ * Reserved key prefix for system-managed attributes. User code may not set
+ * keys starting with `$` — those are blocked at validation time so the
+ * namespace remains available for future system use.
+ */
+export const RESERVED_ATTRIBUTE_KEY_PREFIX = '$';
+
+/** Max length of an attribute key, in characters. */
+export const ATTRIBUTE_KEY_MAX_LENGTH = 256;
+
+/** Max length of an attribute value, in bytes (UTF-8). */
+export const ATTRIBUTE_VALUE_MAX_BYTES = 256;
+
+/** Max number of attributes on a single run (post-merge). */
+export const ATTRIBUTE_MAX_PER_RUN = 64;
+
+/**
+ * A single change in an `experimentalSetAttributes` call. `value: null`
+ * means "remove this key from the run's attributes".
+ *
+ * The shape is deliberately the same as the future `attr_set` event's
+ * `eventData.changes` entries so the SDK and wire format do not change
+ * when the full attributes feature lands.
+ */
+export const AttributeChangeSchema = z.object({
+  key: z.string(),
+  value: z.union([z.string(), z.null()]),
+});
+
+export type AttributeChange = z.infer<typeof AttributeChangeSchema>;
+
+export const AttributeChangesSchema = z.array(AttributeChangeSchema);
+
+/**
+ * Result returned by `runs.experimentalSetAttributes` — the post-merge
+ * snapshot of all attributes on the run. Provided so callers (notably
+ * `setAttributes` and observability emitters) do not need a follow-up read.
+ */
+export interface ExperimentalSetAttributesResult {
+  attributes: Record<string, string>;
+}
+
+export interface AttributeValidationContext {
+  /**
+   * Existing attribute keys on the run, used to enforce the per-run
+   * cap accurately against the post-merge total — an incoming change
+   * that updates an already-present key contributes zero net adds.
+   *
+   * If omitted, the cap check assumes every non-null change is a fresh
+   * add, which is conservative but still safe (the only false-positive
+   * shape rejects updates to existing keys at the cap boundary; the
+   * authoritative server-side check uses the real post-merge size).
+   */
+  existingKeys?: Iterable<string>;
+  /**
+   * Permit keys that start with the reserved `$` prefix. Default `false`.
+   *
+   * The `$` namespace is reserved for framework / library code built on
+   * top of the workflow SDK (telemetry, agent metadata, etc.). User code
+   * MUST NOT set it; if a user tries, validation rejects the call so
+   * accidental conflicts with tooling-owned keys can't slip through.
+   *
+   * Set this to `true` only from framework-level code that is aware of
+   * the namespace conventions in use. Misuse can collide with tooling
+   * keys and break observability surfaces.
+   */
+  allowReservedAttributes?: boolean;
+}
+
+export interface AttributeKeyValidationOptions {
+  /**
+   * Permit keys that start with the reserved `$` prefix. See the
+   * `allowReservedAttributes` note on `AttributeValidationContext`.
+   */
+  allowReservedAttributes?: boolean;
+}
+
+/**
+ * Thrown when an attribute key or value violates one of the validation
+ * rules. Use a plain `Error` here so the world layer can decide whether
+ * to wrap as `FatalError` (SDK) or return a 400 (server endpoint).
+ */
+export class AttributeValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AttributeValidationError';
+  }
+}
+
+const valueByteLength = (value: string): number =>
+  new TextEncoder().encode(value).length;
+
+/**
+ * Validate a single attribute key. Returns an `AttributeValidationError`
+ * on violation, or `null` if the key is valid. Returning instead of
+ * throwing lets callers aggregate or wrap the failure as needed.
+ *
+ * The reserved `$`-prefix rule is enforced by default; framework code
+ * may pass `allowReservedAttributes: true` to opt out.
+ */
+export function validateAttributeKey(
+  key: string,
+  options: AttributeKeyValidationOptions = {}
+): AttributeValidationError | null {
+  if (typeof key !== 'string') {
+    return new AttributeValidationError(
+      `Attribute key must be a string, got ${typeof key}`
+    );
+  }
+  if (key.length === 0) {
+    return new AttributeValidationError('Attribute key must not be empty');
+  }
+  if (key.length > ATTRIBUTE_KEY_MAX_LENGTH) {
+    return new AttributeValidationError(
+      `Attribute key length ${key.length} exceeds limit ${ATTRIBUTE_KEY_MAX_LENGTH}: ${JSON.stringify(key.slice(0, 32))}…`
+    );
+  }
+  if (
+    !options.allowReservedAttributes &&
+    key.startsWith(RESERVED_ATTRIBUTE_KEY_PREFIX)
+  ) {
+    return new AttributeValidationError(
+      `Attribute key ${JSON.stringify(key)} starts with reserved prefix "${RESERVED_ATTRIBUTE_KEY_PREFIX}" — that namespace is reserved for framework/library code. Set { allowReservedAttributes: true } only if your caller is framework-level.`
+    );
+  }
+  return null;
+}
+
+/**
+ * Validate a single attribute value. `null` represents an unset and is
+ * always valid. Returns an `AttributeValidationError` on violation or
+ * `null` if the value is valid.
+ */
+export function validateAttributeValue(
+  value: string | null
+): AttributeValidationError | null {
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    return new AttributeValidationError(
+      `Attribute value must be a string or null, got ${typeof value}`
+    );
+  }
+  const bytes = valueByteLength(value);
+  if (bytes > ATTRIBUTE_VALUE_MAX_BYTES) {
+    return new AttributeValidationError(
+      `Attribute value byte length ${bytes} exceeds limit ${ATTRIBUTE_VALUE_MAX_BYTES}`
+    );
+  }
+  return null;
+}
+
+/**
+ * Validate a batch of attribute changes. Throws `AttributeValidationError`
+ * on the first violation found. Pass `existingKeys` (in `context`) so
+ * the per-run cap check can use the real post-merge total — without it
+ * the check is conservative and may reject an update to an
+ * already-present key when the run is at the cap.
+ */
+export function validateAttributeChanges(
+  changes: AttributeChange[],
+  context: AttributeValidationContext = {}
+): void {
+  const seenKeys = new Set<string>();
+  const existingKeys =
+    context.existingKeys === undefined
+      ? undefined
+      : context.existingKeys instanceof Set
+        ? (context.existingKeys as Set<string>)
+        : new Set(context.existingKeys);
+  let netAdds = 0;
+  let netDeletes = 0;
+  for (const change of changes) {
+    const keyError = validateAttributeKey(change.key, {
+      allowReservedAttributes: context.allowReservedAttributes,
+    });
+    if (keyError) throw keyError;
+    const valueError = validateAttributeValue(change.value);
+    if (valueError) throw valueError;
+    if (seenKeys.has(change.key)) {
+      throw new AttributeValidationError(
+        `Attribute key ${JSON.stringify(change.key)} appears more than once in the same batch`
+      );
+    }
+    seenKeys.add(change.key);
+    // Per-run cap accounting: an upsert on an already-present key is
+    // a zero-net change; a delete on an absent key is also zero-net.
+    // When `existingKeys` is undefined the cap check falls back to the
+    // conservative "every upsert is +1" shape, documented above.
+    if (change.value !== null) {
+      if (existingKeys === undefined || !existingKeys.has(change.key)) {
+        netAdds += 1;
+      }
+    } else if (existingKeys === undefined || existingKeys.has(change.key)) {
+      netDeletes += 1;
+    }
+  }
+  const existing = existingKeys === undefined ? 0 : existingKeys.size;
+  const postMerge = existing + netAdds - netDeletes;
+  if (postMerge > ATTRIBUTE_MAX_PER_RUN) {
+    throw new AttributeValidationError(
+      `Run attribute count would exceed limit ${ATTRIBUTE_MAX_PER_RUN} (post-merge ${postMerge})`
+    );
+  }
+}
+
+/**
+ * Apply a batch of validated changes to an existing attribute map. Returns
+ * a new map; does not mutate the input. The world layer uses this to
+ * compute the post-merge snapshot when the underlying store cannot do the
+ * merge in a single atomic operation.
+ */
+export function applyAttributeChanges(
+  existing: Record<string, string> | undefined,
+  changes: AttributeChange[]
+): Record<string, string> {
+  const next: Record<string, string> = { ...(existing ?? {}) };
+  for (const { key, value } of changes) {
+    if (value === null) {
+      delete next[key];
+    } else {
+      next[key] = value;
+    }
+  }
+  return next;
+}

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -1,3 +1,17 @@
+export type * from './attributes.js';
+export {
+  applyAttributeChanges,
+  ATTRIBUTE_KEY_MAX_LENGTH,
+  ATTRIBUTE_MAX_PER_RUN,
+  ATTRIBUTE_VALUE_MAX_BYTES,
+  AttributeChangeSchema,
+  AttributeChangesSchema,
+  AttributeValidationError,
+  RESERVED_ATTRIBUTE_KEY_PREFIX,
+  validateAttributeChanges,
+  validateAttributeKey,
+  validateAttributeValue,
+} from './attributes.js';
 export type * from './events.js';
 export {
   BaseEventSchema,

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -1,4 +1,8 @@
 import type {
+  AttributeChange,
+  ExperimentalSetAttributesResult,
+} from './attributes.js';
+import type {
   CreateEventParams,
   CreateEventRequest,
   Event,
@@ -154,6 +158,38 @@ export interface Storage {
     list(
       params?: ListWorkflowRunsParams
     ): Promise<PaginatedResponse<WorkflowRun | WorkflowRunWithoutData>>;
+
+    /**
+     * Apply a batch of attribute changes to a run. Merge semantics:
+     * - `value: string` upserts the key
+     * - `value: null` removes the key
+     * - keys not listed in `changes` are untouched
+     *
+     * Returns the post-merge attribute snapshot on the run.
+     *
+     * Pass `options.allowReservedAttributes: true` to permit keys
+     * starting with the reserved `$` prefix. Default behavior rejects
+     * those keys so user code can't accidentally collide with
+     * framework / tooling namespaces; framework callers that own a
+     * sub-namespace flip this on.
+     *
+     * OPTIONAL. World implementations may omit this method; the SDK
+     * helper (`setAttributes` in `@workflow/core`) feature-detects its
+     * absence and no-ops with a one-time warning so third-party /
+     * community worlds keep working without adopting the experimental
+     * API.
+     *
+     * EXPERIMENTAL: this method exists as a stopgap until the
+     * `attr_set` event type lands in a future spec version. When that
+     * happens, `setAttributes` will dispatch through `events.create`
+     * instead, and this method is expected to be removed. See the
+     * `attributes-mvp` changelog entry for the migration shape.
+     */
+    experimentalSetAttributes?(
+      runId: string,
+      changes: AttributeChange[],
+      options?: { allowReservedAttributes?: boolean }
+    ): Promise<ExperimentalSetAttributesResult>;
   };
 
   steps: {

--- a/packages/world/src/runs.ts
+++ b/packages/world/src/runs.ts
@@ -63,6 +63,24 @@ export const WorkflowRunBaseSchema = z.object({
    * without needing to decrypt the full error payload.
    */
   errorCode: z.string().optional(),
+  /**
+   * Plaintext string-string metadata attached to the run via
+   * `experimental_setAttributes()` (or, in the future, materialized
+   * from `attr_set` events). Stored unencrypted alongside other
+   * plaintext fields so observability surfaces can read it without
+   * going through the decryption pipeline.
+   *
+   * Defaults to `{}` after schema parsing so consumers always receive
+   * a record regardless of world. World adapters need not initialize
+   * the field on disk — `world-local` JSON files written before this
+   * field existed, and rows from any other adapter that omits the
+   * column, both read as `{}` after Zod parses them.
+   *
+   * EXPERIMENTAL (MVP): the full Workflow Attributes feature replaces
+   * the direct-mutation MVP path with an event-sourced model — see
+   * the attributes-mvp changelog entry.
+   */
+  attributes: z.record(z.string(), z.string()).default({}),
   expiredAt: z.coerce.date().optional(),
   startedAt: z.coerce.date().optional(),
   completedAt: z.coerce.date().optional(),

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -4,6 +4,7 @@ import { pathsAliasHelper } from '@repo/lib/steps/paths-alias-test';
 import {
   createHook,
   createWebhook,
+  experimental_setAttributes,
   FatalError,
   fetch,
   getStepMetadata,
@@ -3168,4 +3169,76 @@ export async function writableForwardedFromStepWorkflow(payload: string) {
   'use workflow';
   const childRunId = await startChildWithStepWritable(payload);
   return { childRunId };
+}
+
+//////////////////////////////////////////////////////////
+// Workflow Attributes MVP — workflow-body-only API.
+
+/**
+ * Calls `experimental_setAttributes` directly from the workflow body.
+ * The call is dispatched through the `__builtin_set_attributes` step
+ * bridge, so the mutation gets a `step_created`/`step_completed` event
+ * pair. The third call sets a key to `undefined` and the test verifies
+ * the key is absent from the final attribute map.
+ */
+export async function experimentalSetAttributesWorkflow(input: number) {
+  'use workflow';
+  await experimental_setAttributes({ phase: 'init', source: 'workflow-body' });
+  const tripled = input * 3;
+  await experimental_setAttributes({ phase: 'done' });
+  await experimental_setAttributes({ source: undefined });
+  return tripled;
+}
+
+/**
+ * Fire-and-forget pattern: `void experimental_setAttributes(...)` lets
+ * the workflow body proceed without blocking on the attribute write.
+ * Each `void` call queues a step on the workflow's next suspension —
+ * any later `await` on a runtime primitive (a step, a sleep, a hook).
+ * This is the canonical pattern for observability / tracking metadata
+ * where the workflow doesn't depend on the write.
+ *
+ * Note: a `void` call placed *immediately before* `return` (with no
+ * later `await`) is currently unreliable — the step is committed but
+ * the queue worker skips it once `run_completed` lands. See the
+ * `test.todo(...)` for `fire-and-forget` in `packages/core/e2e/e2e.test.ts`.
+ */
+export async function experimentalSetAttributesFireAndForgetWorkflow() {
+  'use workflow';
+  void experimental_setAttributes({ phase: 'init', mode: 'fire-and-forget' });
+  await sleep('100ms');
+  void experimental_setAttributes({ phase: 'mid' });
+  await sleep('100ms');
+  void experimental_setAttributes({ phase: 'done' });
+  return 'completed';
+}
+
+/**
+ * `Promise.all` of multiple `experimental_setAttributes` calls writing
+ * disjoint keys: every key must land. The world-side per-run mutex (or
+ * per-row atomic SQL update) serializes the writes; LWW-by-arrival only
+ * matters when two calls touch the same key.
+ */
+export async function experimentalSetAttributesParallelWorkflow() {
+  'use workflow';
+  await Promise.all([
+    experimental_setAttributes({ a: '1' }),
+    experimental_setAttributes({ b: '2' }),
+    experimental_setAttributes({ c: '3' }),
+  ]);
+  return 'done';
+}
+
+/**
+ * Workflow throws after awaiting `experimental_setAttributes`. The
+ * attribute write completes before the throw, so the persisted run row
+ * should carry the attribute even though the run ends up `failed`.
+ */
+export async function experimentalSetAttributesThrowsAfterWorkflow() {
+  'use workflow';
+  await experimental_setAttributes({
+    phase: 'about-to-fail',
+    reason: 'intentional',
+  });
+  throw new FatalError('intentional failure to test attribute persistence');
 }


### PR DESCRIPTION
Includes all of https://github.com/vercel/workflow/pull/2088/

and additionally fixes nextjs-webpack errors surfaced by doing:
- replace workflow error remapping's inline sourcemap regex with string scanning
- add regression coverage so large inline sourcemap bundles do not invoke the regex path
- add a core changeset