### PR TITLE
[codex] Handle stream write failures without unhandled rejections

### DIFF
--- a/.changeset/stream-failure-diagnostics.md
+++ b/.changeset/stream-failure-diagnostics.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': patch
+'@workflow/world-vercel': patch
+---
+
+Prevent failed stream writes from surfacing as unhandled rejections and include request correlation details in stream errors.

--- a/packages/core/src/flushable-stream.test.ts
+++ b/packages/core/src/flushable-stream.test.ts
@@ -8,6 +8,26 @@ import {
 } from './flushable-stream.js';
 
 describe('flushable stream behavior', () => {
+  it('does not emit an unhandled rejection before the runtime awaits a failed operation', async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const state = createFlushableState();
+      state.reject(new Error('Stream write failed'));
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandledRejections).toEqual([]);
+      await expect(state.promise).rejects.toThrow('Stream write failed');
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
   it('promise should resolve when writable stream lock is released (polling)', async () => {
     // Test the pattern: user writes, releases lock, polling detects it, promise resolves
     const chunks: string[] = [];

--- a/packages/core/src/flushable-stream.ts
+++ b/packages/core/src/flushable-stream.ts
@@ -49,12 +49,18 @@ export interface FlushableStreamState extends PromiseWithResolvers<void> {
 }
 
 export function createFlushableState(): FlushableStreamState {
-  return {
+  const state: FlushableStreamState = {
     ...withResolvers<void>(),
     pendingOps: 0,
     doneResolved: false,
     streamEnded: false,
   };
+
+  // The runtime awaits this promise after user code returns. Observe early
+  // stream failures now so they do not become unhandled rejections first.
+  state.promise.catch(() => {});
+
+  return state;
 }
 
 /**

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -221,6 +221,38 @@ describe('streams.get', () => {
   });
 });
 
+describe('streams.write error diagnostics', () => {
+  async function getStreamer() {
+    const { createStreamer } = await import('./streamer.js');
+    return createStreamer();
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes endpoint and Vercel correlation headers in failed writes', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response('Internal Server Error\nrequest-token', {
+          status: 500,
+          headers: {
+            'x-vercel-id': 'sfo1::abc',
+            'x-vercel-error': 'FUNCTION_INVOCATION_FAILED',
+          },
+        })
+    );
+
+    const streamer = await getStreamer();
+
+    await expect(
+      streamer.streams.write('wrun_test', 'user', 'chunk')
+    ).rejects.toThrow(
+      'Stream write failed: HTTP 500 (PUT https://test.example.com/v2/runs/wrun_test/stream/user; x-vercel-id=sfo1::abc; x-vercel-error=FUNCTION_INVOCATION_FAILED): Internal Server Error\nrequest-token'
+    );
+  });
+});
+
 describe('writeMulti pagination', () => {
   /**
    * Decode length-prefixed multi-chunk body to count chunks per request.

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -29,6 +29,25 @@ function getStreamUrl(name: string, runId: string, httpConfig: HttpConfig) {
   );
 }
 
+function createStreamRequestError(
+  operation: 'write' | 'close',
+  url: URL,
+  response: Response,
+  text: string
+): Error {
+  const context = [`PUT ${url.origin}${url.pathname}`];
+  for (const header of ['x-vercel-id', 'x-vercel-error']) {
+    const value = response.headers.get(header);
+    if (value) {
+      context.push(`${header}=${value}`);
+    }
+  }
+
+  return new Error(
+    `Stream ${operation} failed: HTTP ${response.status} (${context.join('; ')}): ${text}`
+  );
+}
+
 /**
  * Encode multiple chunks into a length-prefixed binary format.
  * Format: [4 bytes big-endian length][chunk bytes][4 bytes length][chunk bytes]...
@@ -101,19 +120,15 @@ export function createStreamer(config?: APIConfig): Streamer {
         const resolvedRunId = await runId;
 
         const httpConfig = await getHttpConfig(config);
-        const response = await fetch(
-          getStreamUrl(name, resolvedRunId, httpConfig),
-          {
-            method: 'PUT',
-            body: chunk,
-            headers: httpConfig.headers,
-          }
-        );
+        const url = getStreamUrl(name, resolvedRunId, httpConfig);
+        const response = await fetch(url, {
+          method: 'PUT',
+          body: chunk,
+          headers: httpConfig.headers,
+        });
         const text = await response.text();
         if (!response.ok) {
-          throw new Error(
-            `Stream write failed: HTTP ${response.status}: ${text}`
-          );
+          throw createStreamRequestError('write', url, response, text);
         }
       },
 
@@ -143,19 +158,15 @@ export function createStreamer(config?: APIConfig): Streamer {
         for (let i = 0; i < chunks.length; i += MAX_CHUNKS_PER_REQUEST) {
           const batch = chunks.slice(i, i + MAX_CHUNKS_PER_REQUEST);
           const body = encodeMultiChunks(batch);
-          const response = await fetch(
-            getStreamUrl(name, resolvedRunId, httpConfig),
-            {
-              method: 'PUT',
-              body,
-              headers: httpConfig.headers,
-            }
-          );
+          const url = getStreamUrl(name, resolvedRunId, httpConfig);
+          const response = await fetch(url, {
+            method: 'PUT',
+            body,
+            headers: httpConfig.headers,
+          });
           const text = await response.text();
           if (!response.ok) {
-            throw new Error(
-              `Stream write failed: HTTP ${response.status}: ${text}`
-            );
+            throw createStreamRequestError('write', url, response, text);
           }
         }
       },
@@ -166,18 +177,14 @@ export function createStreamer(config?: APIConfig): Streamer {
 
         const httpConfig = await getHttpConfig(config);
         httpConfig.headers.set('X-Stream-Done', 'true');
-        const response = await fetch(
-          getStreamUrl(name, resolvedRunId, httpConfig),
-          {
-            method: 'PUT',
-            headers: httpConfig.headers,
-          }
-        );
+        const url = getStreamUrl(name, resolvedRunId, httpConfig);
+        const response = await fetch(url, {
+          method: 'PUT',
+          headers: httpConfig.headers,
+        });
         const text = await response.text();
         if (!response.ok) {
-          throw new Error(
-            `Stream close failed: HTTP ${response.status}: ${text}`
-          );
+          throw createStreamRequestError('close', url, response, text);
         }
       },
 


### PR DESCRIPTION
## Summary

- observe flushable stream-state rejections immediately so failed writes are still propagated through runtime operations without first surfacing as `unhandledRejection`
- include the stream `PUT` endpoint and safe Vercel response correlation headers (`x-vercel-id`, `x-vercel-error`) in write/close failure errors while preserving the response body
- add patch changesets for `@workflow/core` and `@workflow/world-vercel`

## Root cause

A streaming step can fail a server write while user code is still running. `flushablePipe()` rejects `state.promise`, but the step runtime only waits on its collected operation promises after the step body returns. During that gap Node can classify the rejection as unhandled, allowing a transient stream failure to terminate the invocation instead of being handled through the runtime error path.

This PR attaches an immediate no-op rejection observer to the existing promise while leaving that original rejected promise in place for the runtime to await and propagate normally.

## Retry behavior

This intentionally does not add automatic retries for failed stream writes. Writes are not currently idempotent, and a response failure after server acceptance cannot be distinguished from a failed write; blind retries can duplicate stream chunks.

## Validation

- `pnpm exec biome check --write packages/core/src/flushable-stream.ts packages/core/src/flushable-stream.test.ts packages/world-vercel/src/streamer.ts packages/world-vercel/src/streamer.test.ts`
- `pnpm --filter @workflow/core... build`
- `WORKFLOW_TARGET_WORLD=local pnpm --filter @workflow/core exec vitest run src` (1,034 tests passed)
- `pnpm --filter @workflow/world-vercel exec vitest run src` (110 tests passed)
- `pnpm changeset status --since=origin-https/main`
- `git diff --check`
