### PR TITLE
fix(web-shared): match Geist Button hover, focus, and radius

### DIFF
--- a/.changeset/geist-button-states.md
+++ b/.changeset/geist-button-states.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Fix `Button` hover, focus, and corner radius to match Geist. The dark-mode hover no longer relies on an unregistered Tailwind variant (it previously turned the inverted button's background dark/transparent depending on the consumer), the focus-visible ring is now rendered, and the `xs` size uses Geist's 4px tiny radius. Styles are written to work under both Tailwind v3 and v4.

--- a/packages/web-shared/src/components/ui/button.tsx
+++ b/packages/web-shared/src/components/ui/button.tsx
@@ -10,7 +10,14 @@ const buttonVariants = cva(
     '!text-gray-100',
     'bg-gray-1000',
     'transition-[border-color,background,color,transform,box-shadow] duration-150 ease-in-out',
-    'hover:bg-[var(--themed-hover-bg,_hsl(0,_0%,_22%))] dark-theme:hover:bg-[var(--themed-hover-bg,_hsl(0,_0%,_80%))]',
+    // Geist invert hover: literal fallbacks (no token dep, so it resolves in any
+    // consuming app), darkened via ancestor theme class without a registered variant.
+    'hover:bg-[var(--themed-hover-bg,_hsl(0,_0%,_22%))]',
+    '[.dark-theme_&]:hover:bg-[var(--themed-hover-bg,_hsl(0,_0%,_80%))]',
+    '[[data-theme=dark]_&]:hover:bg-[var(--themed-hover-bg,_hsl(0,_0%,_80%))]',
+    // Geist focus ring as arbitrary properties (no bare `outline`/ambiguous
+    // arbitrary-color utilities, which differ between Tailwind v3 and v4).
+    'focus-visible:[outline:2px_solid_var(--ds-focus-color)] focus-visible:[outline-offset:2px]',
     // disabled styles
     'disabled:cursor-not-allowed aria-disabled:cursor-not-allowed',
     'disabled:bg-gray-100 disabled:!text-gray-700 disabled:hover:bg-gray-100',
@@ -28,7 +35,7 @@ const buttonVariants = cva(
       size: {
         default: 'h-10 px-4 text-[14px]',
         sm: 'h-8 px-3 text-[14px]',
-        xs: 'h-6 px-1.5 py-0.5 text-button-12',
+        xs: 'h-6 px-1.5 py-0.5 text-button-12 rounded-[4px]',
         icon: 'h-8 w-8',
       },
     },

--- a/packages/web-shared/src/styles.css
+++ b/packages/web-shared/src/styles.css
@@ -36,6 +36,9 @@
   --ds-gray-alpha-700: hsla(0, 0%, 0%, 0.44);
   --ds-gray-alpha-1000: hsla(0, 0%, 0%, 0.91);
 
+  /* Focus */
+  --ds-focus-color: var(--ds-blue-700);
+
   /* Blue */
   --ds-blue-100: hsl(212, 100%, 97%);
   --ds-blue-200: hsl(210, 100%, 96%);
@@ -125,6 +128,8 @@
   --ds-gray-alpha-400: rgba(255, 255, 255, 0.14);
   --ds-gray-alpha-700: rgba(255, 255, 255, 0.45);
   --ds-gray-alpha-1000: rgba(255, 255, 255, 0.92);
+
+  --ds-focus-color: var(--ds-blue-900);
 
   --ds-blue-100: hsl(216, 50%, 12%);
   --ds-blue-200: hsl(214, 59%, 15%);


### PR DESCRIPTION
## Summary

Brings the shared `Button` (`packages/web-shared/src/components/ui/button.tsx`) to 1:1 with the Geist `Button` (verified against the Geist source: `packages/geist/src/components/button/button.module.css`). Fixes three issues, most visibly on the encrypted-data "Decrypt" overlay (`EncryptedDataBlock`):

- **Hover (was broken):** the inverted/default button drove its dark-mode hover with a `dark-theme:hover:` class, but `dark-theme` is **not a registered Tailwind variant** in our setup (theming is done by flipping `--ds-*` tokens), so the class compiled to nothing. In dark mode the white button fell back to the hardcoded *light* hover (`hsl(0,0%,22%)`) and turned dark gray; when imported into apps that supply their own Geist tokens (e.g. `vercel/front`), an earlier token-based attempt resolved to nothing and the background went **transparent**. Now uses Geist's literal hover fallbacks (`hsl(0,0%,22%)` / `hsl(0,0%,80%)`) driven by arbitrary ancestor-theme variants (`[.dark-theme_&]:` and `[[data-theme=dark]_&]:`) — no token dependency, so it resolves in any consumer.
- **Focus (was missing):** added Geist's focus ring (`outline: 2px solid var(--ds-focus-color)` + `2px` offset). Also defines `--ds-focus-color` (blue-700 / blue-900) in `web-shared/styles.css`, which was referenced but undefined (also fixes `icon-button`'s colorless focus outline).
- **Radius:** `xs` (24px) now uses Geist's tiny `4px` radius instead of inheriting `rounded-md` (6px).

## Tailwind v3 + v4 compatibility

web-shared is consumed by both TW3 and TW4 apps, so the focus ring uses arbitrary *properties* (`[outline:...]`) rather than the bare `outline` / `outline-[var()]` utilities (which differ between versions). Verified by compiling the exact class string through **Tailwind 3.3.6** and **4.2.4** — both emit the correct `.dark-theme …:hover`, `[data-theme=dark] …:hover`, focus-ring, and `border-radius:4px` rules, with literal `hsl()` fallbacks present (so the background can never resolve to `transparent`).

## Test plan

- [x] `pnpm build` for `@workflow/web-shared` (button/styles changes typecheck)
- [x] Compiled button classes through Tailwind v3.3.6 and v4.2.4 — output verified
- [x] Visual check of idle / hover / focus / decrypted states in dark mode
- [ ] Confirm hover/focus render correctly when web-shared is imported into `vercel/front`

> [!NOTE]
> CI's `pnpm turbo run build` may flag a **pre-existing, unrelated** `tsc` error on `main`: `attribute-panel.tsx:423` declares an `attributes` display fn whose key isn't in the `AttributeKey` type (`TS2353`). It is independent of this change (resolved separately on the `ms/trace-search` branch). Not touched here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)