### PR TITLE
fix(core,errors): classify SDK encryption failures as RUNTIME_ERROR

### DIFF
--- a/.changeset/runtime-decryption-error.md
+++ b/.changeset/runtime-decryption-error.md
@@ -3,4 +3,4 @@
 "@workflow/core": patch
 ---
 
-Classify SDK-level encryption failures as `RUNTIME_ERROR` instead of `USER_ERROR`. Introduces a new `RuntimeDecryptionError` (subclass of `WorkflowRuntimeError`) that the AES-GCM encryption module throws when the Web Crypto API fails — most notably the native `OperationError` from `AESCipherJob.onDone` on GCM auth-tag mismatch. The wrapped error carries the original DOMException as `cause` plus diagnostic context (byte length, printable header prefix).
+Classify SDK-level AES-GCM encryption failures as `RUNTIME_ERROR` instead of `USER_ERROR` via a new `RuntimeDecryptionError`.

--- a/.changeset/runtime-decryption-error.md
+++ b/.changeset/runtime-decryption-error.md
@@ -1,0 +1,6 @@
+---
+"@workflow/errors": patch
+"@workflow/core": patch
+---
+
+Classify SDK-level encryption failures as `RUNTIME_ERROR` instead of `USER_ERROR`. Introduces a new `RuntimeDecryptionError` (subclass of `WorkflowRuntimeError`) that the AES-GCM encryption module throws when the Web Crypto API fails — most notably the native `OperationError` from `AESCipherJob.onDone` on GCM auth-tag mismatch. The wrapped error carries the original DOMException as `cause` plus diagnostic context (byte length, printable header prefix).

--- a/docs/content/docs/v4/errors/index.mdx
+++ b/docs/content/docs/v4/errors/index.mdx
@@ -43,6 +43,9 @@ Fix common mistakes when creating and executing workflows in the **Workflow SDK*
     <Card href="/docs/errors/workflow-not-registered" title="workflow-not-registered">
         Resolve workflow not registered errors caused by deployment mismatches.
     </Card>
+    <Card href="/docs/errors/runtime-decryption-failed" title="runtime-decryption-failed">
+        Resolve runtime decryption failures from the SDK's encryption layer.
+    </Card>
 </Cards>
 
 ## Learn More

--- a/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
@@ -1,0 +1,77 @@
+---
+title: runtime-decryption-failed
+description: The SDK's built-in AES-GCM encryption layer failed to encrypt or decrypt a workflow payload.
+type: troubleshooting
+summary: Resolve runtime decryption failures caused by ciphertext corruption, key mismatch, or malformed envelopes.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/foundations/errors-and-retries
+---
+
+This error occurs when the Workflow SDK's built-in AES-GCM encryption layer fails while encrypting or decrypting a workflow payload. The SDK encrypts step inputs, step outputs, hook payloads, and other event-log data with a per-run AES-256 key whenever encryption is configured for the deployment.
+
+This is an **internal SDK failure** — your workflow code never invokes the encryption primitives directly. When this surfaces, it means the ciphertext, nonce, or auth tag the SDK tried to verify is not the bytes that were originally produced. The run is failed with the `RUNTIME_ERROR` classification.
+
+## Error Message
+
+```
+AES-256-GCM decryption failed: The operation failed for an operation-specific reason
+```
+
+The underlying cause is a native Web Crypto [`OperationError`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#operationerror) — most commonly raised by `AESCipherJob.onDone` in Node's `node:internal/crypto/util` module when the GCM authentication tag does not verify.
+
+The thrown `RuntimeDecryptionError` carries a small `context` object with diagnostic fields to help triangulate the source:
+
+- `operation` — `'encrypt'` or `'decrypt'`
+- `byteLength` — total byte length of the payload at the failure site
+- `formatPrefix` — the first 4 bytes of the input (`'encr'` for a well-formed encrypted envelope, otherwise a hex dump)
+
+## Why This Happens
+
+Common causes, in rough order of likelihood:
+
+1. **Ciphertext mutation or truncation in transit.** The encrypted payload reached the SDK with bytes that differ from what storage holds. Possible sources include a truncated HTTP response from a workflow-server ref endpoint, an edge-cache miss returning a partial 200, or a proxy drop during streaming. A truncated body whose first 4 bytes happen to still spell `encr` produces the exact "auth tag mismatch" symptom.
+2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
+3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
+
+## What To Do
+
+This error indicates an SDK or infrastructure problem — not a bug in your workflow code. Your workflow code does not need to change.
+
+### 1. Upgrade to the latest `workflow` package
+
+The underlying issue may have already been identified and fixed:
+
+```bash
+npm install workflow@latest
+```
+
+### 2. Retry the failed run
+
+Since this is a fatal error, the run is automatically marked as `failed`. You can re-run it using the **Re-run** button in the Workflow Dashboard.
+
+### 3. Report the issue
+
+If the error persists after upgrading, please [open an issue on GitHub](https://github.com/vercel/workflow/issues/new) so we can investigate. Include:
+
+- The version of the `workflow` package you are using
+- The run ID(s) of the affected workflow run(s)
+- The full error message, including the `context` fields (`operation`, `byteLength`, `formatPrefix`)
+- Whether the affected workflows make heavy use of large step inputs/outputs (which may indicate the failure is on the lazy-loaded ref read path)
+
+## This Error Cannot Be Caught
+
+Like other `WorkflowRuntimeError` subclasses, a runtime decryption failure is **not catchable** inside your workflow function. The runtime cannot safely continue executing user code when an event-log payload can't be verified, so the entire run fails immediately and is marked as `failed`.
+
+To handle this programmatically from outside the workflow, check the run status:
+
+```typescript lineNumbers
+import { getRun } from "workflow/api";
+
+const run = getRun("wrun_abc123");
+const status = await run.status;
+if (status === "failed") {
+  console.error("Run failed");
+}
+```

--- a/docs/content/docs/v5/errors/index.mdx
+++ b/docs/content/docs/v5/errors/index.mdx
@@ -43,6 +43,9 @@ Fix common mistakes when creating and executing workflows in the **Workflow SDK*
     <Card href="/docs/errors/workflow-not-registered" title="workflow-not-registered">
         Resolve workflow not registered errors caused by deployment mismatches.
     </Card>
+    <Card href="/docs/errors/runtime-decryption-failed" title="runtime-decryption-failed">
+        Resolve runtime decryption failures from the SDK's encryption layer.
+    </Card>
 </Cards>
 
 ## Learn More

--- a/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
@@ -1,0 +1,77 @@
+---
+title: runtime-decryption-failed
+description: The SDK's built-in AES-GCM encryption layer failed to encrypt or decrypt a workflow payload.
+type: troubleshooting
+summary: Resolve runtime decryption failures caused by ciphertext corruption, key mismatch, or malformed envelopes.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/foundations/errors-and-retries
+---
+
+This error occurs when the Workflow SDK's built-in AES-GCM encryption layer fails while encrypting or decrypting a workflow payload. The SDK encrypts step inputs, step outputs, hook payloads, and other event-log data with a per-run AES-256 key whenever encryption is configured for the deployment.
+
+This is an **internal SDK failure** — your workflow code never invokes the encryption primitives directly. When this surfaces, it means the ciphertext, nonce, or auth tag the SDK tried to verify is not the bytes that were originally produced. The run is failed with the `RUNTIME_ERROR` classification.
+
+## Error Message
+
+```
+AES-256-GCM decryption failed: The operation failed for an operation-specific reason
+```
+
+The underlying cause is a native Web Crypto [`OperationError`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#operationerror) — most commonly raised by `AESCipherJob.onDone` in Node's `node:internal/crypto/util` module when the GCM authentication tag does not verify.
+
+The thrown `RuntimeDecryptionError` carries a small `context` object with diagnostic fields to help triangulate the source:
+
+- `operation` — `'encrypt'` or `'decrypt'`
+- `byteLength` — total byte length of the payload at the failure site
+- `formatPrefix` — the first 4 bytes of the input (`'encr'` for a well-formed encrypted envelope, otherwise a hex dump)
+
+## Why This Happens
+
+Common causes, in rough order of likelihood:
+
+1. **Ciphertext mutation or truncation in transit.** The encrypted payload reached the SDK with bytes that differ from what storage holds. Possible sources include a truncated HTTP response from a workflow-server ref endpoint, an edge-cache miss returning a partial 200, or a proxy drop during streaming. A truncated body whose first 4 bytes happen to still spell `encr` produces the exact "auth tag mismatch" symptom.
+2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
+3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
+
+## What To Do
+
+This error indicates an SDK or infrastructure problem — not a bug in your workflow code. Your workflow code does not need to change.
+
+### 1. Upgrade to the latest `workflow` package
+
+The underlying issue may have already been identified and fixed:
+
+```bash
+npm install workflow@latest
+```
+
+### 2. Retry the failed run
+
+Since this is a fatal error, the run is automatically marked as `failed`. You can re-run it using the **Re-run** button in the Workflow Dashboard.
+
+### 3. Report the issue
+
+If the error persists after upgrading, please [open an issue on GitHub](https://github.com/vercel/workflow/issues/new) so we can investigate. Include:
+
+- The version of the `workflow` package you are using
+- The run ID(s) of the affected workflow run(s)
+- The full error message, including the `context` fields (`operation`, `byteLength`, `formatPrefix`)
+- Whether the affected workflows make heavy use of large step inputs/outputs (which may indicate the failure is on the lazy-loaded ref read path)
+
+## This Error Cannot Be Caught
+
+Like other `WorkflowRuntimeError` subclasses, a runtime decryption failure is **not catchable** inside your workflow function. The runtime cannot safely continue executing user code when an event-log payload can't be verified, so the entire run fails immediately and is marked as `failed`.
+
+To handle this programmatically from outside the workflow, check the run status:
+
+```typescript lineNumbers
+import { getRun } from "workflow/api";
+
+const run = getRun("wrun_abc123");
+const status = await run.status;
+if (status === "failed") {
+  console.error("Run failed");
+}
+```

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -90,20 +90,15 @@ describe('classifyRunError', () => {
   });
 
   it('classifies RuntimeDecryptionError as RUNTIME_ERROR', () => {
-    // SDK-level encryption is never the user's responsibility, so a
-    // decrypt failure must not surface as USER_ERROR.
     expect(classifyRunError(new RuntimeDecryptionError('decrypt failed'))).toBe(
       RUN_ERROR_CODES.RUNTIME_ERROR
     );
   });
 
-  it('classifies a raw native OperationError as USER_ERROR (sanity check)', () => {
-    // This documents the previous (and still current, for unwrapped
-    // errors) behavior: a bare DOMException-shaped OperationError from
-    // the Web Crypto API would still classify as USER_ERROR because
-    // its name does not match any RUNTIME_ERROR_CHECKS entry. The fix
-    // is to make sure the encryption module always wraps these in
-    // RuntimeDecryptionError before they bubble up.
+  it('classifies a raw native OperationError as USER_ERROR', () => {
+    // A bare DOMException-shaped OperationError does not match any
+    // RUNTIME_ERROR_CHECKS entry — the encryption module is expected to
+    // wrap these in RuntimeDecryptionError before they bubble up here.
     const native = new Error(
       'The operation failed for an operation-specific reason'
     );

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -2,6 +2,7 @@ import {
   CorruptedEventLogError,
   HookConflictError,
   RUN_ERROR_CODES,
+  RuntimeDecryptionError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
   WorkflowWorldError,
@@ -86,5 +87,27 @@ describe('classifyRunError', () => {
     expect(classifyRunError(new HookConflictError('my-token'))).toBe(
       RUN_ERROR_CODES.USER_ERROR
     );
+  });
+
+  it('classifies RuntimeDecryptionError as RUNTIME_ERROR', () => {
+    // SDK-level encryption is never the user's responsibility, so a
+    // decrypt failure must not surface as USER_ERROR.
+    expect(classifyRunError(new RuntimeDecryptionError('decrypt failed'))).toBe(
+      RUN_ERROR_CODES.RUNTIME_ERROR
+    );
+  });
+
+  it('classifies a raw native OperationError as USER_ERROR (sanity check)', () => {
+    // This documents the previous (and still current, for unwrapped
+    // errors) behavior: a bare DOMException-shaped OperationError from
+    // the Web Crypto API would still classify as USER_ERROR because
+    // its name does not match any RUNTIME_ERROR_CHECKS entry. The fix
+    // is to make sure the encryption module always wraps these in
+    // RuntimeDecryptionError before they bubble up.
+    const native = new Error(
+      'The operation failed for an operation-specific reason'
+    );
+    native.name = 'OperationError';
+    expect(classifyRunError(native)).toBe(RUN_ERROR_CODES.USER_ERROR);
   });
 });

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -29,9 +29,7 @@ const RUNTIME_ERROR_CHECKS = [
   // SDK-level encryption failures (most notably AES-GCM auth-tag
   // mismatches surfacing as a native `OperationError` from
   // `AESCipherJob.onDone`) are wrapped in `RuntimeDecryptionError` at
-  // the encryption module boundary. Without this check they'd fall
-  // through to `USER_ERROR`, which is incorrect — the user never
-  // touched the ciphertext.
+  // the encryption module boundary.
   RuntimeDecryptionError.is,
 ];
 

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -2,6 +2,7 @@ import {
   CorruptedEventLogError,
   RUN_ERROR_CODES,
   type RunErrorCode,
+  RuntimeDecryptionError,
   StepNotRegisteredError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
@@ -25,6 +26,13 @@ const RUNTIME_ERROR_CHECKS = [
   WorkflowRuntimeError.is,
   StepNotRegisteredError.is,
   WorkflowNotRegisteredError.is,
+  // SDK-level encryption failures (most notably AES-GCM auth-tag
+  // mismatches surfacing as a native `OperationError` from
+  // `AESCipherJob.onDone`) are wrapped in `RuntimeDecryptionError` at
+  // the encryption module boundary. Without this check they'd fall
+  // through to `USER_ERROR`, which is incorrect — the user never
+  // touched the ciphertext.
+  RuntimeDecryptionError.is,
 ];
 
 /**

--- a/packages/core/src/encryption.test.ts
+++ b/packages/core/src/encryption.test.ts
@@ -52,11 +52,10 @@ describe('encryption', () => {
     });
 
     it('throws RuntimeDecryptionError (not a bare OperationError) on auth-tag failure', async () => {
-      // This is the exact code path that surfaced in production as
-      // `OperationError: The operation failed for an operation-specific
-      // reason at AESCipherJob.onDone (node:internal/crypto/util:646:19)`.
-      // It must surface as a RuntimeDecryptionError so classifyRunError
-      // routes it to RUNTIME_ERROR, not USER_ERROR.
+      // GCM auth-tag verification failure surfaces from Node's Web
+      // Crypto API as `OperationError: The operation failed for an
+      // operation-specific reason at AESCipherJob.onDone`. The
+      // encryption module must rewrap this as a RuntimeDecryptionError.
       const key = await getKey();
       const plaintext = new TextEncoder().encode('hello, workflow');
       const ciphertext = await encrypt(key, plaintext);

--- a/packages/core/src/encryption.test.ts
+++ b/packages/core/src/encryption.test.ts
@@ -1,0 +1,143 @@
+import { RuntimeDecryptionError } from '@workflow/errors';
+import { describe, expect, it } from 'vitest';
+import { type CryptoKey, decrypt, encrypt, importKey } from './encryption.js';
+
+const RAW_KEY = new Uint8Array(32).fill(7);
+const OTHER_RAW_KEY = new Uint8Array(32).fill(8);
+const SHORT_RAW_KEY = new Uint8Array(16).fill(7);
+
+async function getKey(): Promise<CryptoKey> {
+  return importKey(RAW_KEY);
+}
+
+async function getOtherKey(): Promise<CryptoKey> {
+  return importKey(OTHER_RAW_KEY);
+}
+
+describe('encryption', () => {
+  describe('round-trip', () => {
+    it('encrypt() + decrypt() returns the original plaintext', async () => {
+      const key = await getKey();
+      const plaintext = new TextEncoder().encode('hello, workflow');
+      const ciphertext = await encrypt(key, plaintext);
+
+      // Ciphertext is longer than plaintext: 12-byte nonce + 16-byte GCM tag.
+      expect(ciphertext.byteLength).toBe(plaintext.byteLength + 12 + 16);
+
+      const decoded = await decrypt(key, ciphertext);
+      expect(new TextDecoder().decode(decoded)).toBe('hello, workflow');
+    });
+  });
+
+  describe('importKey', () => {
+    it('rejects keys that are not exactly 32 bytes', async () => {
+      await expect(importKey(SHORT_RAW_KEY)).rejects.toThrow(
+        /must be exactly 32 bytes, got 16/
+      );
+    });
+  });
+
+  describe('decrypt failure cases', () => {
+    it('throws RuntimeDecryptionError when input is shorter than the GCM envelope', async () => {
+      const key = await getKey();
+      // 12-byte nonce + 16-byte tag = 28 bytes minimum. 10 bytes is too short.
+      const tooShort = new Uint8Array(10).fill(0);
+      const error = await decrypt(key, tooShort).catch((e) => e);
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      expect(error.message).toMatch(/Encrypted data too short/);
+      expect(error.context).toMatchObject({
+        operation: 'decrypt',
+        byteLength: 10,
+      });
+    });
+
+    it('throws RuntimeDecryptionError (not a bare OperationError) on auth-tag failure', async () => {
+      // This is the exact code path that surfaced in production as
+      // `OperationError: The operation failed for an operation-specific
+      // reason at AESCipherJob.onDone (node:internal/crypto/util:646:19)`.
+      // It must surface as a RuntimeDecryptionError so classifyRunError
+      // routes it to RUNTIME_ERROR, not USER_ERROR.
+      const key = await getKey();
+      const plaintext = new TextEncoder().encode('hello, workflow');
+      const ciphertext = await encrypt(key, plaintext);
+
+      // Corrupt the last byte of the GCM auth tag — guaranteed tag verification failure.
+      const tampered = new Uint8Array(ciphertext);
+      tampered[tampered.length - 1] ^= 0xff;
+
+      const error = await decrypt(key, tampered).catch((e) => e);
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      expect(error.cause).toBeDefined();
+      // The original DOMException carries name OperationError on Node 20+,
+      // which is what the wrapping is meant to capture as cause.
+      const cause = error.cause as { name?: string };
+      expect(cause?.name).toBe('OperationError');
+      expect(error.context).toMatchObject({
+        operation: 'decrypt',
+        byteLength: tampered.byteLength,
+      });
+    });
+
+    it('throws RuntimeDecryptionError when the wrong key is used', async () => {
+      const writerKey = await getKey();
+      const readerKey = await getOtherKey();
+      const ciphertext = await encrypt(
+        writerKey,
+        new TextEncoder().encode('secret')
+      );
+
+      const error = await decrypt(readerKey, ciphertext).catch((e) => e);
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      // Wrong key → auth tag mismatch → same OperationError as ciphertext corruption.
+      const cause = error.cause as { name?: string };
+      expect(cause?.name).toBe('OperationError');
+    });
+
+    it('records a printable format prefix when the input bytes are ASCII', async () => {
+      const key = await getKey();
+      // 28 bytes — passes the length check, but the bytes are bogus.
+      const fakeEncrypted = new TextEncoder().encode('encr' + 'A'.repeat(24));
+      const error = await decrypt(key, fakeEncrypted).catch((e) => e);
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      expect(error.context).toMatchObject({
+        operation: 'decrypt',
+        byteLength: 28,
+        formatPrefix: 'encr',
+      });
+    });
+
+    it('records a hex format prefix when the input bytes are not printable ASCII', async () => {
+      const key = await getKey();
+      const binary = new Uint8Array(28);
+      binary[0] = 0x00;
+      binary[1] = 0xff;
+      binary[2] = 0x80;
+      binary[3] = 0x1f;
+      const error = await decrypt(key, binary).catch((e) => e);
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      expect(error.context).toMatchObject({
+        operation: 'decrypt',
+        byteLength: 28,
+        formatPrefix: '00ff801f',
+      });
+    });
+  });
+
+  describe('encrypt failure cases', () => {
+    it('throws RuntimeDecryptionError when the underlying crypto call fails', async () => {
+      // Importing the key with only `decrypt` usage makes any subsequent
+      // encrypt() call fail inside subtle.encrypt with an
+      // InvalidAccessError. This exercises the encryption-path catch.
+      const decryptOnly = await importKey(RAW_KEY, ['decrypt']);
+      const error = await encrypt(
+        decryptOnly,
+        new TextEncoder().encode('nope')
+      ).catch((e) => e);
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      expect(error.context).toMatchObject({
+        operation: 'encrypt',
+        byteLength: 4,
+      });
+    });
+  });
+});

--- a/packages/core/src/encryption.test.ts
+++ b/packages/core/src/encryption.test.ts
@@ -92,33 +92,21 @@ describe('encryption', () => {
       expect(cause?.name).toBe('OperationError');
     });
 
-    it('records a printable format prefix when the input bytes are ASCII', async () => {
+    it('does not record a formatPrefix at the low-level layer', async () => {
+      // This function only ever sees the stripped AES payload
+      // (`[nonce][ciphertext+tag]`), never the outer `encr` envelope marker.
+      // Capturing the first bytes here would record nonce bytes and be
+      // misleading, so the low-level layer records only operation/byteLength.
+      // The serialization layer attaches the real envelope prefix.
       const key = await getKey();
-      // 28 bytes — passes the length check, but the bytes are bogus.
-      const fakeEncrypted = new TextEncoder().encode('encr' + 'A'.repeat(24));
-      const error = await decrypt(key, fakeEncrypted).catch((e) => e);
+      const bogus = new Uint8Array(28).fill(0x41); // 28 bytes, passes length check
+      const error = await decrypt(key, bogus).catch((e) => e);
       expect(RuntimeDecryptionError.is(error)).toBe(true);
       expect(error.context).toMatchObject({
         operation: 'decrypt',
         byteLength: 28,
-        formatPrefix: 'encr',
       });
-    });
-
-    it('records a hex format prefix when the input bytes are not printable ASCII', async () => {
-      const key = await getKey();
-      const binary = new Uint8Array(28);
-      binary[0] = 0x00;
-      binary[1] = 0xff;
-      binary[2] = 0x80;
-      binary[3] = 0x1f;
-      const error = await decrypt(key, binary).catch((e) => e);
-      expect(RuntimeDecryptionError.is(error)).toBe(true);
-      expect(error.context).toMatchObject({
-        operation: 'decrypt',
-        byteLength: 28,
-        formatPrefix: '00ff801f',
-      });
+      expect(error.context.formatPrefix).toBeUndefined();
     });
   });
 

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -112,12 +112,8 @@ export async function encrypt(
     );
   } catch (cause) {
     // Re-wrap any Web Crypto failure (DOMException etc.) as a
-    // RuntimeDecryptionError so the run-failure classifier surfaces it
-    // as RUNTIME_ERROR rather than misattributing it to user code.
-    // Encryption failures from this path are exceedingly rare in
-    // practice — they happen e.g. when a CryptoKey was imported with
-    // `usages: ['decrypt']` only — but lumping them with USER_ERROR is
-    // still wrong, so the same wrap applies here.
+    // RuntimeDecryptionError. Failures here are rare — they happen e.g.
+    // when a CryptoKey was imported with `usages: ['decrypt']` only.
     throw new RuntimeDecryptionError(
       `AES-256-GCM encryption failed: ${cause instanceof Error ? cause.message : String(cause)}`,
       {
@@ -141,12 +137,11 @@ export async function encrypt(
  * Any failure inside the Web Crypto layer — most commonly an
  * `OperationError: The operation failed for an operation-specific reason`
  * raised by `AESCipherJob.onDone` when the GCM authentication tag does
- * not verify — is rewrapped as {@link RuntimeDecryptionError} so the
- * run-failure classifier treats it as a `RUNTIME_ERROR` rather than a
- * `USER_ERROR`. The wrapped error carries the original DOMException as
- * `cause`, plus a small diagnostic context (input byte length, printable
- * header prefix) to help disambiguate ciphertext corruption from key
- * mismatch from truncated transport reads.
+ * not verify — is rewrapped as {@link RuntimeDecryptionError}. The
+ * wrapped error carries the original DOMException as `cause`, plus a
+ * small diagnostic context (input byte length, printable header prefix)
+ * to help disambiguate ciphertext corruption from key mismatch from
+ * truncated transport reads.
  *
  * @param key - CryptoKey from `importKey()`
  * @param data - `[nonce (12 bytes)][ciphertext + GCM auth tag]`
@@ -183,13 +178,8 @@ export async function decrypt(
     // `name: 'OperationError'` and message "The operation failed for
     // an operation-specific reason" — this is what Web Crypto throws
     // when the GCM auth tag does not verify. Re-throw as
-    // RuntimeDecryptionError so:
-    //   1. `classifyRunError` lifts it to RUNTIME_ERROR (instead of
-    //      falling through to USER_ERROR, which would misattribute the
-    //      failure to the workflow author).
-    //   2. The downstream error log carries diagnostic context (byte
-    //      length and a printable header prefix) that the bare
-    //      DOMException lacks.
+    // RuntimeDecryptionError, attaching diagnostic context (byte length
+    // and a printable header prefix) that the bare DOMException lacks.
     const causeMsg = cause instanceof Error ? cause.message : String(cause);
     throw new RuntimeDecryptionError(
       `AES-256-GCM decryption failed: ${causeMsg}`,

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -27,34 +27,6 @@ const NONCE_LENGTH = 12;
 const TAG_LENGTH = 128; // bits
 const KEY_LENGTH = 32; // bytes (AES-256)
 
-/** Number of header bytes to capture for diagnostics on a failed decrypt. */
-const DIAGNOSTIC_PREFIX_BYTES = 4;
-
-/**
- * Extract a short, printable preview of the first few input bytes for
- * diagnostic context. Returns a UTF-8 decoded string when every byte is
- * a printable ASCII character (0x20–0x7e); otherwise returns a hex dump.
- * Falls back to `undefined` for empty inputs.
- *
- * Kept tiny on purpose — this is only for surfacing in error messages
- * and telemetry where a few bytes of header context is enough to tell
- * "encrypted payload that failed auth-tag check" apart from "garbage
- * bytes from a truncated HTTP response that happen to start with non-
- * printable noise".
- */
-function getDiagnosticPrefix(data: Uint8Array): string | undefined {
-  if (data.byteLength === 0) return undefined;
-  const head = data.subarray(0, DIAGNOSTIC_PREFIX_BYTES);
-  // Printable ASCII range (no control chars, no DEL).
-  const allPrintable = head.every((b) => b >= 0x20 && b <= 0x7e);
-  if (allPrintable) {
-    return new TextDecoder().decode(head);
-  }
-  return Array.from(head)
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-
 /**
  * Import a raw AES-256 key as a `CryptoKey` for use with `encrypt()`/`decrypt()`.
  *
@@ -139,9 +111,15 @@ export async function encrypt(
  * raised by `AESCipherJob.onDone` when the GCM authentication tag does
  * not verify — is rewrapped as {@link RuntimeDecryptionError}. The
  * wrapped error carries the original DOMException as `cause`, plus a
- * small diagnostic context (input byte length, printable header prefix)
- * to help disambiguate ciphertext corruption from key mismatch from
- * truncated transport reads.
+ * small diagnostic context (`operation`, input `byteLength`) to help
+ * disambiguate ciphertext corruption from key mismatch from truncated
+ * transport reads.
+ *
+ * Note: `data` is the raw AES payload (`[nonce][ciphertext + tag]`), not a
+ * format-prefixed envelope — callers strip the `encr` marker via
+ * `decodeFormatPrefix()` before reaching this function. The outer
+ * envelope's format prefix is therefore attached by the serialization
+ * layer (`serialization/encryption.ts`), which is the layer that has it.
  *
  * @param key - CryptoKey from `importKey()`
  * @param data - `[nonce (12 bytes)][ciphertext + GCM auth tag]`
@@ -159,7 +137,6 @@ export async function decrypt(
         context: {
           operation: 'decrypt',
           byteLength: data.byteLength,
-          formatPrefix: getDiagnosticPrefix(data),
         },
       }
     );
@@ -178,8 +155,8 @@ export async function decrypt(
     // `name: 'OperationError'` and message "The operation failed for
     // an operation-specific reason" — this is what Web Crypto throws
     // when the GCM auth tag does not verify. Re-throw as
-    // RuntimeDecryptionError, attaching diagnostic context (byte length
-    // and a printable header prefix) that the bare DOMException lacks.
+    // RuntimeDecryptionError, attaching diagnostic context (byte length)
+    // that the bare DOMException lacks.
     const causeMsg = cause instanceof Error ? cause.message : String(cause);
     throw new RuntimeDecryptionError(
       `AES-256-GCM decryption failed: ${causeMsg}`,
@@ -188,7 +165,6 @@ export async function decrypt(
         context: {
           operation: 'decrypt',
           byteLength: data.byteLength,
-          formatPrefix: getDiagnosticPrefix(data),
         },
       }
     );

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -1,4 +1,4 @@
-import { WorkflowRuntimeError } from '@workflow/errors';
+import { RuntimeDecryptionError, WorkflowRuntimeError } from '@workflow/errors';
 
 /**
  * Browser-compatible AES-256-GCM encryption module.
@@ -26,6 +26,34 @@ export type CryptoKey = import('node:crypto').webcrypto.CryptoKey;
 const NONCE_LENGTH = 12;
 const TAG_LENGTH = 128; // bits
 const KEY_LENGTH = 32; // bytes (AES-256)
+
+/** Number of header bytes to capture for diagnostics on a failed decrypt. */
+const DIAGNOSTIC_PREFIX_BYTES = 4;
+
+/**
+ * Extract a short, printable preview of the first few input bytes for
+ * diagnostic context. Returns a UTF-8 decoded string when every byte is
+ * a printable ASCII character (0x20–0x7e); otherwise returns a hex dump.
+ * Falls back to `undefined` for empty inputs.
+ *
+ * Kept tiny on purpose — this is only for surfacing in error messages
+ * and telemetry where a few bytes of header context is enough to tell
+ * "encrypted payload that failed auth-tag check" apart from "garbage
+ * bytes from a truncated HTTP response that happen to start with non-
+ * printable noise".
+ */
+function getDiagnosticPrefix(data: Uint8Array): string | undefined {
+  if (data.byteLength === 0) return undefined;
+  const head = data.subarray(0, DIAGNOSTIC_PREFIX_BYTES);
+  // Printable ASCII range (no control chars, no DEL).
+  const allPrintable = head.every((b) => b >= 0x20 && b <= 0x7e);
+  if (allPrintable) {
+    return new TextDecoder().decode(head);
+  }
+  return Array.from(head)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
 
 /**
  * Import a raw AES-256 key as a `CryptoKey` for use with `encrypt()`/`decrypt()`.
@@ -75,11 +103,32 @@ export async function encrypt(
   data: Uint8Array
 ): Promise<Uint8Array> {
   const nonce = globalThis.crypto.getRandomValues(new Uint8Array(NONCE_LENGTH));
-  const ciphertext = await globalThis.crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
-    key,
-    data
-  );
+  let ciphertext: ArrayBuffer;
+  try {
+    ciphertext = await globalThis.crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
+      key,
+      data
+    );
+  } catch (cause) {
+    // Re-wrap any Web Crypto failure (DOMException etc.) as a
+    // RuntimeDecryptionError so the run-failure classifier surfaces it
+    // as RUNTIME_ERROR rather than misattributing it to user code.
+    // Encryption failures from this path are exceedingly rare in
+    // practice — they happen e.g. when a CryptoKey was imported with
+    // `usages: ['decrypt']` only — but lumping them with USER_ERROR is
+    // still wrong, so the same wrap applies here.
+    throw new RuntimeDecryptionError(
+      `AES-256-GCM encryption failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      {
+        cause,
+        context: {
+          operation: 'encrypt',
+          byteLength: data.byteLength,
+        },
+      }
+    );
+  }
   const result = new Uint8Array(NONCE_LENGTH + ciphertext.byteLength);
   result.set(nonce, 0);
   result.set(new Uint8Array(ciphertext), NONCE_LENGTH);
@@ -88,6 +137,16 @@ export async function encrypt(
 
 /**
  * Decrypt data using AES-256-GCM.
+ *
+ * Any failure inside the Web Crypto layer — most commonly an
+ * `OperationError: The operation failed for an operation-specific reason`
+ * raised by `AESCipherJob.onDone` when the GCM authentication tag does
+ * not verify — is rewrapped as {@link RuntimeDecryptionError} so the
+ * run-failure classifier treats it as a `RUNTIME_ERROR` rather than a
+ * `USER_ERROR`. The wrapped error carries the original DOMException as
+ * `cause`, plus a small diagnostic context (input byte length, printable
+ * header prefix) to help disambiguate ciphertext corruption from key
+ * mismatch from truncated transport reads.
  *
  * @param key - CryptoKey from `importKey()`
  * @param data - `[nonce (12 bytes)][ciphertext + GCM auth tag]`
@@ -99,16 +158,50 @@ export async function decrypt(
 ): Promise<Uint8Array> {
   const minLength = NONCE_LENGTH + TAG_LENGTH / 8; // nonce + auth tag
   if (data.byteLength < minLength) {
-    throw new WorkflowRuntimeError(
-      `Encrypted data too short: expected at least ${minLength} bytes, got ${data.byteLength}`
+    throw new RuntimeDecryptionError(
+      `Encrypted data too short: expected at least ${minLength} bytes, got ${data.byteLength}`,
+      {
+        context: {
+          operation: 'decrypt',
+          byteLength: data.byteLength,
+          formatPrefix: getDiagnosticPrefix(data),
+        },
+      }
     );
   }
   const nonce = data.subarray(0, NONCE_LENGTH);
   const ciphertext = data.subarray(NONCE_LENGTH);
-  const plaintext = await globalThis.crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
-    key,
-    ciphertext
-  );
+  let plaintext: ArrayBuffer;
+  try {
+    plaintext = await globalThis.crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
+      key,
+      ciphertext
+    );
+  } catch (cause) {
+    // The most common shape we see in the wild is a DOMException with
+    // `name: 'OperationError'` and message "The operation failed for
+    // an operation-specific reason" — this is what Web Crypto throws
+    // when the GCM auth tag does not verify. Re-throw as
+    // RuntimeDecryptionError so:
+    //   1. `classifyRunError` lifts it to RUNTIME_ERROR (instead of
+    //      falling through to USER_ERROR, which would misattribute the
+    //      failure to the workflow author).
+    //   2. The downstream error log carries diagnostic context (byte
+    //      length and a printable header prefix) that the bare
+    //      DOMException lacks.
+    const causeMsg = cause instanceof Error ? cause.message : String(cause);
+    throw new RuntimeDecryptionError(
+      `AES-256-GCM decryption failed: ${causeMsg}`,
+      {
+        cause,
+        context: {
+          operation: 'decrypt',
+          byteLength: data.byteLength,
+          formatPrefix: getDiagnosticPrefix(data),
+        },
+      }
+    );
+  }
   return new Uint8Array(plaintext);
 }

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -4,6 +4,7 @@ import {
   FatalError,
   HookConflictError,
   RetryableError,
+  RuntimeDecryptionError,
 } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
@@ -4180,6 +4181,44 @@ describe('dehydrate/hydrateRunError', () => {
     expect(cause.message).toBe('root type error');
   });
 
+  it('should round-trip a RuntimeDecryptionError preserving its diagnostic context', async () => {
+    // RuntimeDecryptionError self-registers on globalThis via Symbol.for
+    // when `@workflow/errors` is imported, so the reviver can resolve it.
+    const original = new RuntimeDecryptionError(
+      'AES-256-GCM decryption failed: The operation failed for an operation-specific reason',
+      {
+        cause: Object.assign(new Error('boom'), { name: 'OperationError' }),
+        context: {
+          operation: 'decrypt',
+          byteLength: 1234,
+          formatPrefix: 'encr',
+        },
+      }
+    );
+    const serialized = await dehydrateRunError(
+      original,
+      mockRunId,
+      noEncryptionKey
+    );
+    const hydrated = (await hydrateRunError(
+      serialized,
+      mockRunId,
+      noEncryptionKey
+    )) as RuntimeDecryptionError;
+
+    expect(RuntimeDecryptionError.is(hydrated)).toBe(true);
+    expect(hydrated.message).toContain('AES-256-GCM decryption failed');
+    // The diagnostic context must survive the dehydrate → hydrate round trip.
+    expect(hydrated.context).toEqual({
+      operation: 'decrypt',
+      byteLength: 1234,
+      formatPrefix: 'encr',
+    });
+    // The underlying DOMException cause is preserved too.
+    const cause = (hydrated as Error).cause as Error;
+    expect(cause?.name).toBe('OperationError');
+  });
+
   it('should produce DEVALUE_V1-prefixed binary output', async () => {
     const serialized = await dehydrateRunError(
       new Error('x'),
@@ -4202,6 +4241,48 @@ describe('dehydrate/hydrateRunError', () => {
     }
     expect(err).toBeDefined();
     expect(err?.message).toContain('run error');
+  });
+});
+
+describe('encryption-failure propagation through dehydrate wrappers', () => {
+  // A CryptoKey imported with only the 'decrypt' usage makes subtle.encrypt()
+  // throw, which the encryption layer wraps as RuntimeDecryptionError. The
+  // dehydrate wrappers must NOT reframe that as a SerializationError, or the
+  // run-failure classifier would mislabel an SDK encryption failure as a
+  // USER_ERROR.
+  async function decryptOnlyKey() {
+    return importKey(crypto.getRandomValues(new Uint8Array(32)), ['decrypt']);
+  }
+
+  it('dehydrateWorkflowReturnValue preserves RuntimeDecryptionError', async () => {
+    const key = await decryptOnlyKey();
+    const error = await dehydrateWorkflowReturnValue(
+      { hello: 'world' },
+      mockRunId,
+      key
+    ).catch((e) => e);
+    expect(RuntimeDecryptionError.is(error)).toBe(true);
+    expect(error.context?.operation).toBe('encrypt');
+  });
+
+  it('dehydrateStepReturnValue preserves RuntimeDecryptionError', async () => {
+    const key = await decryptOnlyKey();
+    const error = await dehydrateStepReturnValue(
+      { hello: 'world' },
+      mockRunId,
+      key
+    ).catch((e: unknown) => e);
+    expect(RuntimeDecryptionError.is(error)).toBe(true);
+  });
+
+  it('dehydrateRunError preserves RuntimeDecryptionError', async () => {
+    const key = await decryptOnlyKey();
+    const error = await dehydrateRunError(
+      new Error('thrown by workflow'),
+      mockRunId,
+      key
+    ).catch((e) => e);
+    expect(RuntimeDecryptionError.is(error)).toBe(true);
   });
 });
 

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -4649,8 +4649,8 @@ describe('getDeserializeStream legacy fallback', () => {
     const { stringify } = await import('devalue');
     const encoder = new TextEncoder();
 
-    const line1 = stringify({ hello: 'world' }) + '\n';
-    const line2 = stringify(42) + '\n';
+    const line1 = `${stringify({ hello: 'world' })}\n`;
+    const line2 = `${stringify(42)}\n`;
     const legacyData = encoder.encode(line1 + line2);
 
     const results = await deserializeChunks([legacyData]);
@@ -4663,8 +4663,8 @@ describe('getDeserializeStream legacy fallback', () => {
     const { stringify } = await import('devalue');
     const encoder = new TextEncoder();
 
-    const chunk1 = encoder.encode(stringify('hello') + '\n');
-    const chunk2 = encoder.encode(stringify('world') + '\n');
+    const chunk1 = encoder.encode(`${stringify('hello')}\n`);
+    const chunk2 = encoder.encode(`${stringify('world')}\n`);
 
     const results = await deserializeChunks([chunk1, chunk2]);
     expect(results).toHaveLength(2);
@@ -4831,6 +4831,40 @@ describe('stream encryption round-trip', () => {
     await expect(readPromise).rejects.toThrow(
       'Encrypted stream data encountered but no encryption key is available'
     );
+  });
+
+  it('should error with a RuntimeDecryptionError carrying the encr prefix when a frame is tampered', async () => {
+    const encrypted = await encryptedSerialize([{ secret: true }]);
+    const frame = encrypted[0];
+
+    // Tamper with the last byte (inside the GCM auth tag) to force an
+    // auth-tag verification failure during stream decryption.
+    const tampered = new Uint8Array(frame);
+    tampered[tampered.length - 1] ^= 0xff;
+
+    const deserialize = getDeserializeStream(revivers, cryptoKey);
+    const readPromise = (async () => {
+      const reader = deserialize.readable.getReader();
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    })();
+
+    const writer = deserialize.writable.getWriter();
+    // The write/close may reject because controller.error() aborts the stream.
+    await writer.write(tampered).catch(() => {});
+    await writer.close().catch(() => {});
+
+    const error = await readPromise.catch((e) => e);
+    expect(RuntimeDecryptionError.is(error)).toBe(true);
+    // The stream decrypt path must enrich the context with the real outer
+    // envelope prefix (`encr`), not the nonce bytes — mirroring the regular
+    // payload decryption path.
+    expect(error.context).toMatchObject({
+      operation: 'decrypt',
+      formatPrefix: 'encr',
+    });
   });
 
   it('should not encrypt when cryptoKey is undefined', async () => {
@@ -5660,102 +5694,93 @@ describe('AbortController serialization', () => {
 
   describe('step arguments (workflow → step)', () => {
     it('AbortController dehydrated with workflow reducers, hydrated with step revivers', async () => {
-      try {
-        // Create a controller stub as the workflow VM would produce:
-        // a plain object with ABORT_STREAM_NAME/ABORT_HOOK_TOKEN symbols
-        // and a signal property (mimicking workflow revivers output)
-        const controller: any = {};
-        controller[ABORT_STREAM_NAME] =
-          'strm_01ABORT0000000000006_system_abort';
-        controller[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000006';
-        const signal: any = {};
-        signal[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000006_system_abort';
-        signal[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000006';
-        signal.aborted = false;
-        signal.reason = undefined;
-        controller.signal = signal;
+      // Create a controller stub as the workflow VM would produce:
+      // a plain object with ABORT_STREAM_NAME/ABORT_HOOK_TOKEN symbols
+      // and a signal property (mimicking workflow revivers output)
+      const controller: any = {};
+      controller[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000006_system_abort';
+      controller[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000006';
+      const signal: any = {};
+      signal[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000006_system_abort';
+      signal[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000006';
+      signal.aborted = false;
+      signal.reason = undefined;
+      controller.signal = signal;
 
-        // The workflow reducers check instanceof, so we need the VM
-        // to recognize these as AbortController/AbortSignal. Set up
-        // simple constructors whose prototypes these objects inherit from.
-        const origAC = vmGlobalThis.AbortController;
-        const origAS = vmGlobalThis.AbortSignal;
-        function FakeAC() {}
-        function FakeAS() {}
-        Object.setPrototypeOf(controller, FakeAC.prototype);
-        Object.setPrototypeOf(signal, FakeAS.prototype);
-        vmGlobalThis.AbortController = FakeAC;
-        vmGlobalThis.AbortSignal = FakeAS;
+      // The workflow reducers check instanceof, so we need the VM
+      // to recognize these as AbortController/AbortSignal. Set up
+      // simple constructors whose prototypes these objects inherit from.
+      const origAC = vmGlobalThis.AbortController;
+      const origAS = vmGlobalThis.AbortSignal;
+      function FakeAC() {}
+      function FakeAS() {}
+      Object.setPrototypeOf(controller, FakeAC.prototype);
+      Object.setPrototypeOf(signal, FakeAS.prototype);
+      vmGlobalThis.AbortController = FakeAC;
+      vmGlobalThis.AbortSignal = FakeAS;
 
-        const serialized = await dehydrateStepArguments(
-          controller,
-          mockRunId,
-          noEncryptionKey,
-          vmGlobalThis
-        );
+      const serialized = await dehydrateStepArguments(
+        controller,
+        mockRunId,
+        noEncryptionKey,
+        vmGlobalThis
+      );
 
-        const ops: Promise<void>[] = [];
-        const hydrated = await hydrateStepArguments(
-          serialized,
-          mockRunId,
-          noEncryptionKey,
-          ops
-        );
+      const ops: Promise<void>[] = [];
+      const hydrated = await hydrateStepArguments(
+        serialized,
+        mockRunId,
+        noEncryptionKey,
+        ops
+      );
 
-        // Step revivers use reviveAbortController which creates a real AbortController
-        expect(hydrated).toBeInstanceOf(AbortController);
-        expect(hydrated.signal.aborted).toBe(false);
-        expect((hydrated as any)[ABORT_STREAM_NAME]).toBe(
-          'strm_01ABORT0000000000006_system_abort'
-        );
-        expect((hydrated as any)[ABORT_HOOK_TOKEN]).toBe(
-          'abrt_01ABORT0000000000006'
-        );
+      // Step revivers use reviveAbortController which creates a real AbortController
+      expect(hydrated).toBeInstanceOf(AbortController);
+      expect(hydrated.signal.aborted).toBe(false);
+      expect((hydrated as any)[ABORT_STREAM_NAME]).toBe(
+        'strm_01ABORT0000000000006_system_abort'
+      );
+      expect((hydrated as any)[ABORT_HOOK_TOKEN]).toBe(
+        'abrt_01ABORT0000000000006'
+      );
 
-        vmGlobalThis.AbortController = origAC;
-        vmGlobalThis.AbortSignal = origAS;
-      } catch (e) {
-        throw e;
-      }
+      vmGlobalThis.AbortController = origAC;
+      vmGlobalThis.AbortSignal = origAS;
     });
 
     it('AbortSignal as standalone step argument', async () => {
-      try {
-        // Create a signal stub as the workflow VM would produce
-        const signal: any = {};
-        signal[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000007_system_abort';
-        signal[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000007';
-        signal.aborted = false;
-        signal.reason = undefined;
+      // Create a signal stub as the workflow VM would produce
+      const signal: any = {};
+      signal[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000007_system_abort';
+      signal[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000007';
+      signal.aborted = false;
+      signal.reason = undefined;
 
-        const origAS = vmGlobalThis.AbortSignal;
-        function FakeAS() {}
-        Object.setPrototypeOf(signal, FakeAS.prototype);
-        vmGlobalThis.AbortSignal = FakeAS;
+      const origAS = vmGlobalThis.AbortSignal;
+      function FakeAS() {}
+      Object.setPrototypeOf(signal, FakeAS.prototype);
+      vmGlobalThis.AbortSignal = FakeAS;
 
-        const serialized = await dehydrateStepArguments(
-          signal,
-          mockRunId,
-          noEncryptionKey,
-          vmGlobalThis
-        );
+      const serialized = await dehydrateStepArguments(
+        signal,
+        mockRunId,
+        noEncryptionKey,
+        vmGlobalThis
+      );
 
-        const ops: Promise<void>[] = [];
-        const hydrated = await hydrateStepArguments(
-          serialized,
-          mockRunId,
-          noEncryptionKey,
-          ops
-        );
+      const ops: Promise<void>[] = [];
+      const hydrated = await hydrateStepArguments(
+        serialized,
+        mockRunId,
+        noEncryptionKey,
+        ops
+      );
 
-        // Step revivers revive AbortSignal via reviveAbortController().signal
-        expect(hydrated).toBeInstanceOf(AbortSignal);
-        expect(hydrated.aborted).toBe(false);
+      // Step revivers revive AbortSignal via reviveAbortController().signal
+      expect(hydrated).toBeInstanceOf(AbortSignal);
+      expect(hydrated.aborted).toBe(false);
 
-        vmGlobalThis.AbortSignal = origAS;
-      } catch (e) {
-        throw e;
-      }
+      vmGlobalThis.AbortSignal = origAS;
     });
 
     it('stream reader triggers abort when abort payload arrives', async () => {
@@ -5792,57 +5817,51 @@ describe('AbortController serialization', () => {
       vi.mocked(getWorld).mockReturnValueOnce(oneShotWorld);
       const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
       vi.mocked(getWorldLazy).mockReturnValueOnce(oneShotWorld);
+      const controller: any = {};
+      controller[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000STRM_system_abort';
+      controller[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000STRM';
+      const signal: any = {};
+      signal[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000STRM_system_abort';
+      signal[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000STRM';
+      signal.aborted = false;
+      signal.reason = undefined;
+      controller.signal = signal;
 
-      try {
-        const controller: any = {};
-        controller[ABORT_STREAM_NAME] =
-          'strm_01ABORT0000000000STRM_system_abort';
-        controller[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000STRM';
-        const signal: any = {};
-        signal[ABORT_STREAM_NAME] = 'strm_01ABORT0000000000STRM_system_abort';
-        signal[ABORT_HOOK_TOKEN] = 'abrt_01ABORT0000000000STRM';
-        signal.aborted = false;
-        signal.reason = undefined;
-        controller.signal = signal;
+      const origAC = vmGlobalThis.AbortController;
+      const origAS = vmGlobalThis.AbortSignal;
+      function FakeAC() {}
+      function FakeAS() {}
+      Object.setPrototypeOf(controller, FakeAC.prototype);
+      Object.setPrototypeOf(signal, FakeAS.prototype);
+      vmGlobalThis.AbortController = FakeAC;
+      vmGlobalThis.AbortSignal = FakeAS;
 
-        const origAC = vmGlobalThis.AbortController;
-        const origAS = vmGlobalThis.AbortSignal;
-        function FakeAC() {}
-        function FakeAS() {}
-        Object.setPrototypeOf(controller, FakeAC.prototype);
-        Object.setPrototypeOf(signal, FakeAS.prototype);
-        vmGlobalThis.AbortController = FakeAC;
-        vmGlobalThis.AbortSignal = FakeAS;
+      const serialized = await dehydrateStepArguments(
+        controller,
+        mockRunId,
+        noEncryptionKey,
+        vmGlobalThis
+      );
 
-        const serialized = await dehydrateStepArguments(
-          controller,
-          mockRunId,
-          noEncryptionKey,
-          vmGlobalThis
-        );
+      const ops: Promise<void>[] = [];
+      const hydrated = await hydrateStepArguments(
+        serialized,
+        mockRunId,
+        noEncryptionKey,
+        ops
+      );
 
-        const ops: Promise<void>[] = [];
-        const hydrated = await hydrateStepArguments(
-          serialized,
-          mockRunId,
-          noEncryptionKey,
-          ops
-        );
+      expect(hydrated).toBeInstanceOf(AbortController);
+      expect(hydrated.signal.aborted).toBe(false);
 
-        expect(hydrated).toBeInstanceOf(AbortController);
-        expect(hydrated.signal.aborted).toBe(false);
+      // Wait for the stream reader op to process the abort payload
+      await Promise.all(ops);
 
-        // Wait for the stream reader op to process the abort payload
-        await Promise.all(ops);
+      expect(hydrated.signal.aborted).toBe(true);
+      expect(hydrated.signal.reason).toBe('stream-abort-reason');
 
-        expect(hydrated.signal.aborted).toBe(true);
-        expect(hydrated.signal.reason).toBe('stream-abort-reason');
-
-        vmGlobalThis.AbortController = origAC;
-        vmGlobalThis.AbortSignal = origAS;
-      } catch (e) {
-        throw e;
-      }
+      vmGlobalThis.AbortController = origAC;
+      vmGlobalThis.AbortSignal = origAS;
     });
 
     it('aborting the original signal after serialization fires the listener and writes the abort packet', async () => {
@@ -6067,13 +6086,13 @@ describe('AbortController serialization', () => {
         };
         const readerCancel = hydratedSignal[ABORT_READER_CANCEL];
         expect(readerCancel).toBeInstanceOf(AbortController);
-        expect(readerCancel!.signal.aborted).toBe(false);
+        expect(readerCancel?.signal.aborted).toBe(false);
 
         // Simulate step completion — cancelAbortReaders walks the step args.
         // The Request wraps the signal, so the walker must descend into it.
         cancelAbortReaders(hydrated);
 
-        expect(readerCancel!.signal.aborted).toBe(true);
+        expect(readerCancel?.signal.aborted).toBe(true);
       } finally {
         (globalThis as any)[STABLE_ULID] = originalStableUlid;
       }

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -31,7 +31,10 @@ import {
   type EncryptionKeyParam,
   encrypt,
 } from './serialization/encryption.js';
-import { formatSerializationError } from './serialization/errors.js';
+import {
+  formatSerializationError,
+  rethrowIfRuntimeError,
+} from './serialization/errors.js';
 import {
   decodeFormatPrefix,
   encodeWithFormatPrefix,
@@ -133,8 +136,17 @@ const FRAME_HEADER_SIZE = 4;
  * arguments" instead of generic "workflow value"), so they unwrap the
  * inner SerializationError and reformat with the original cause. Errors
  * that aren't already SerializationError flow through unchanged.
+ *
+ * `RuntimeDecryptionError` is an exception: it must keep its identity (and
+ * `context`) so the run-failure classifier routes it to `RUNTIME_ERROR`,
+ * so this rethrows it unchanged before any unwrapping. Note this guard
+ * must run before the generic `WorkflowRuntimeError` unwrap below, since
+ * `RuntimeDecryptionError` extends `WorkflowRuntimeError` and carries a
+ * `cause` (the underlying DOMException) that would otherwise be unwrapped
+ * and reframed as a `SerializationError`.
  */
 function unwrapSerializationCause(error: unknown): unknown {
+  rethrowIfRuntimeError(error);
   if (error instanceof SerializationError && error.cause !== undefined) {
     return error.cause;
   }
@@ -185,6 +197,13 @@ export function getSerializeStream(
         frame.set(prefixed, FRAME_HEADER_SIZE);
         controller.enqueue(frame);
       } catch (error) {
+        // Encryption failures must keep their RuntimeDecryptionError
+        // identity (RUNTIME_ERROR) rather than be reframed as a
+        // SerializationError (USER_ERROR).
+        if (RuntimeDecryptionError.is(error)) {
+          controller.error(error);
+          return;
+        }
         const { message, hint } = formatSerializationError(
           'stream chunk',
           error

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -282,7 +282,19 @@ export function getDeserializeStream(
           );
           return;
         }
-        const decrypted = await aesGcmDecrypt(keyState.key, payload);
+        let decrypted: Uint8Array;
+        try {
+          decrypted = await aesGcmDecrypt(keyState.key, payload);
+        } catch (error) {
+          // The low-level AES layer only sees the stripped payload, so it
+          // cannot record the outer envelope prefix. We peeked it here
+          // (`encr`), so enrich the diagnostic context with the real format
+          // prefix before propagating — mirroring serialization/encryption.ts.
+          if (RuntimeDecryptionError.is(error) && error.context) {
+            error.context.formatPrefix = format;
+          }
+          throw error;
+        }
         ({ format, payload } = decodeFormatPrefix(decrypted));
       }
 
@@ -937,7 +949,7 @@ export function getWorkflowReducers(
     },
     AbortSignal: (value) => {
       const signal = value as (AbortSignal & AbortInternals) | undefined;
-      const hasAbortSymbol = signal && signal[ABORT_STREAM_NAME];
+      const hasAbortSymbol = signal?.[ABORT_STREAM_NAME];
       const isNativeAbortSignal =
         global.AbortSignal &&
         typeof global.AbortSignal === 'function' &&

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1,4 +1,8 @@
-import { SerializationError, WorkflowRuntimeError } from '@workflow/errors';
+import {
+  RuntimeDecryptionError,
+  SerializationError,
+  WorkflowRuntimeError,
+} from '@workflow/errors';
 import { parse, stringify, unflatten } from 'devalue';
 import { monotonicFactory } from 'ulid';
 import {
@@ -245,9 +249,16 @@ export function getDeserializeStream(
       if (format === SerializationFormat.ENCRYPTED) {
         if (!keyState.key) {
           controller.error(
-            new WorkflowRuntimeError(
+            new RuntimeDecryptionError(
               'Encrypted stream data encountered but no encryption key is available. ' +
-                'Encryption is not configured or no key was provided for this run.'
+                'Encryption is not configured or no key was provided for this run.',
+              {
+                context: {
+                  operation: 'decrypt',
+                  byteLength: payload.byteLength,
+                  formatPrefix: 'encr',
+                },
+              }
             )
           );
           return;

--- a/packages/core/src/serialization/client.ts
+++ b/packages/core/src/serialization/client.ts
@@ -13,7 +13,7 @@ import {
   decrypt as decryptData,
   encrypt as encryptData,
 } from './encryption.js';
-import { formatSerializationError } from './errors.js';
+import { formatSerializationError, rethrowIfRuntimeError } from './errors.js';
 import { decodeFormatPrefix, encodeWithFormatPrefix } from './format.js';
 import { SerializationFormat } from './types.js';
 
@@ -33,6 +33,7 @@ export async function serialize(
     ) as Uint8Array;
     return encryptData(prefixed, encryptionKey);
   } catch (error) {
+    rethrowIfRuntimeError(error);
     const { message, hint } = formatSerializationError('client value', error);
     throw new SerializationError(message, { hint, cause: error });
   }

--- a/packages/core/src/serialization/encryption.ts
+++ b/packages/core/src/serialization/encryption.ts
@@ -82,5 +82,16 @@ export async function decrypt(
   if (format !== SerializationFormat.ENCRYPTED) return data;
 
   const { payload } = decodeFormatPrefix(data);
-  return aesGcmDecrypt(key!, payload);
+  try {
+    return await aesGcmDecrypt(key!, payload);
+  } catch (error) {
+    // The low-level AES layer only sees the stripped payload, so it cannot
+    // record the outer envelope prefix. This layer peeked it (`encr`), so
+    // enrich the diagnostic context with the real format prefix before
+    // rethrowing.
+    if (RuntimeDecryptionError.is(error) && error.context) {
+      error.context.formatPrefix = format;
+    }
+    throw error;
+  }
 }

--- a/packages/core/src/serialization/encryption.ts
+++ b/packages/core/src/serialization/encryption.ts
@@ -64,10 +64,6 @@ export async function decrypt(
   const format = peekFormatPrefix(data);
 
   // If the data is encrypted but no key was provided, fail fast.
-  // RuntimeDecryptionError extends WorkflowRuntimeError, preserving the
-  // legacy error contract while ensuring the run-failure classifier
-  // routes this to RUNTIME_ERROR rather than misattributing it to user
-  // code (USER_ERROR).
   if (format === SerializationFormat.ENCRYPTED && !key) {
     throw new RuntimeDecryptionError(
       'Encrypted data encountered but no encryption key is available. ' +

--- a/packages/core/src/serialization/encryption.ts
+++ b/packages/core/src/serialization/encryption.ts
@@ -5,7 +5,7 @@
  * using the format prefix system to mark encrypted data.
  */
 
-import { WorkflowRuntimeError } from '@workflow/errors';
+import { RuntimeDecryptionError } from '@workflow/errors';
 import {
   decrypt as aesGcmDecrypt,
   encrypt as aesGcmEncrypt,
@@ -64,12 +64,21 @@ export async function decrypt(
   const format = peekFormatPrefix(data);
 
   // If the data is encrypted but no key was provided, fail fast.
-  // Uses WorkflowRuntimeError to preserve the error contract from the
-  // legacy maybeDecrypt() implementation that callers may rely on.
+  // RuntimeDecryptionError extends WorkflowRuntimeError, preserving the
+  // legacy error contract while ensuring the run-failure classifier
+  // routes this to RUNTIME_ERROR rather than misattributing it to user
+  // code (USER_ERROR).
   if (format === SerializationFormat.ENCRYPTED && !key) {
-    throw new WorkflowRuntimeError(
+    throw new RuntimeDecryptionError(
       'Encrypted data encountered but no encryption key is available. ' +
-        'Encryption is not configured or no key was provided for this run.'
+        'Encryption is not configured or no key was provided for this run.',
+      {
+        context: {
+          operation: 'decrypt',
+          byteLength: data.byteLength,
+          formatPrefix: 'encr',
+        },
+      }
     );
   }
 

--- a/packages/core/src/serialization/errors.ts
+++ b/packages/core/src/serialization/errors.ts
@@ -10,8 +10,27 @@
  * into the message string.
  */
 
+import { RuntimeDecryptionError } from '@workflow/errors';
 import { DevalueError } from 'devalue';
 import { runtimeLogger } from '../logger.js';
+
+/**
+ * Rethrow SDK runtime errors that must not be reframed as
+ * `SerializationError`.
+ *
+ * The serialize/dehydrate wrappers catch every throw and reframe it as a
+ * `SerializationError` (which classifies as `USER_ERROR`). That's correct
+ * for genuine serialization failures, but a `RuntimeDecryptionError` from
+ * the AES-GCM layer is an SDK-internal failure that must keep its identity
+ * so the run-failure classifier routes it to `RUNTIME_ERROR`. Call this at
+ * the top of each serialize catch block to let those errors propagate
+ * unchanged.
+ */
+export function rethrowIfRuntimeError(error: unknown): void {
+  if (RuntimeDecryptionError.is(error)) {
+    throw error;
+  }
+}
 
 /**
  * Format a serialization error with context about what failed.

--- a/packages/core/src/serialization/reducers/common.ts
+++ b/packages/core/src/serialization/reducers/common.ts
@@ -14,6 +14,7 @@ import {
   FatalError,
   HookConflictError,
   RetryableError,
+  RuntimeDecryptionError,
 } from '@workflow/errors';
 import type { Reducers, Revivers, SerializableSpecial } from '../types.js';
 
@@ -259,6 +260,24 @@ export function getCommonReducers(
         retryAfter,
       } satisfies SerializableSpecial['RetryableError'];
     },
+    // RuntimeDecryptionError carries an extra `context` object (operation,
+    // byteLength, formatPrefix) that the generic Error reducer would drop.
+    // Preserve it so the diagnostic data survives the run-error round trip.
+    RuntimeDecryptionError: (value) => {
+      const base = reduceNamedErrorSubclassBase(
+        'RuntimeDecryptionError',
+        value
+      );
+      if (!base) return false;
+      const reduced: SerializableSpecial['RuntimeDecryptionError'] = {
+        ...base,
+      };
+      const context = (value as RuntimeDecryptionError).context;
+      if (context !== undefined) {
+        reduced.context = context;
+      }
+      return reduced;
+    },
     SyntaxError: makeErrorSubclassReducer('SyntaxError'),
     TypeError: makeErrorSubclassReducer('TypeError'),
     URIError: makeErrorSubclassReducer('URIError'),
@@ -407,6 +426,21 @@ export function getCommonRevivers(
       });
       if (value.stack !== undefined) error.stack = value.stack;
       if ('cause' in value) error.cause = value.cause;
+      return error;
+    },
+    RuntimeDecryptionError: (value) => {
+      // Resolve from the consumer's globalThis (see the FatalError reviver
+      // above) so `instanceof RuntimeDecryptionError` holds across realms.
+      const Ctor =
+        ((global as Record<symbol, unknown>)[
+          Symbol.for('@workflow/errors//RuntimeDecryptionError')
+        ] as typeof RuntimeDecryptionError | undefined) ??
+        RuntimeDecryptionError;
+      const opts: ConstructorParameters<typeof RuntimeDecryptionError>[1] = {};
+      if ('cause' in value) opts.cause = value.cause;
+      if (value.context !== undefined) opts.context = value.context;
+      const error = new Ctor(value.message, opts);
+      if (value.stack !== undefined) error.stack = value.stack;
       return error;
     },
     SyntaxError: makeErrorSubclassReviver(global, 'SyntaxError'),

--- a/packages/core/src/serialization/serialization.test.ts
+++ b/packages/core/src/serialization/serialization.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeDecryptionError } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { describe, expect, it, vi } from 'vitest';
 import { registerSerializationClass } from '../class-serialization.js';
@@ -336,6 +337,30 @@ describe('decrypt', () => {
     const encrypted = await encrypt(data, key);
     const decrypted = await decrypt(encrypted, key);
     expect(decrypted).toEqual(data);
+  });
+
+  it('attaches the real `encr` envelope prefix to the diagnostic context on auth-tag failure', async () => {
+    // The low-level AES layer only sees the stripped payload; this
+    // serialization layer is the one that knows the outer envelope marker.
+    // Verify it enriches the RuntimeDecryptionError context with the real
+    // `encr` prefix (not the first nonce bytes).
+    const key = await makeKey();
+    const data = encodeWithFormatPrefix(
+      SerializationFormat.DEVALUE_V1,
+      new Uint8Array([10, 20, 30])
+    ) as Uint8Array;
+    const encrypted = (await encrypt(data, key)) as Uint8Array;
+
+    // Tamper with the last byte (GCM tag) to force an auth-tag failure.
+    const tampered = new Uint8Array(encrypted);
+    tampered[tampered.length - 1] ^= 0xff;
+
+    const error = await decrypt(tampered, key).catch((e) => e);
+    expect(RuntimeDecryptionError.is(error)).toBe(true);
+    expect(error.context).toMatchObject({
+      operation: 'decrypt',
+      formatPrefix: 'encr',
+    });
   });
 });
 

--- a/packages/core/src/serialization/step.ts
+++ b/packages/core/src/serialization/step.ts
@@ -13,7 +13,7 @@ import {
   decrypt as decryptData,
   encrypt as encryptData,
 } from './encryption.js';
-import { formatSerializationError } from './errors.js';
+import { formatSerializationError, rethrowIfRuntimeError } from './errors.js';
 import { decodeFormatPrefix, encodeWithFormatPrefix } from './format.js';
 import { SerializationFormat } from './types.js';
 
@@ -33,6 +33,7 @@ export async function serialize(
     ) as Uint8Array;
     return encryptData(prefixed, encryptionKey);
   } catch (error) {
+    rethrowIfRuntimeError(error);
     const { message, hint } = formatSerializationError('step value', error);
     throw new SerializationError(message, { hint, cause: error });
   }

--- a/packages/core/src/serialization/types.ts
+++ b/packages/core/src/serialization/types.ts
@@ -2,6 +2,8 @@
  * Shared types for the serialization system.
  */
 
+import type { RuntimeDecryptionErrorContext } from '@workflow/errors';
+
 // ---- Format Prefix ----
 
 /**
@@ -85,6 +87,12 @@ export interface SerializableSpecial {
     stack?: string;
     cause?: unknown;
     retryAfter: number;
+  };
+  RuntimeDecryptionError: {
+    message: string;
+    stack?: string;
+    cause?: unknown;
+    context?: RuntimeDecryptionErrorContext;
   };
   Request: {
     method: string;

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -905,6 +905,9 @@ const RETRYABLE_ERROR_KEY = Symbol.for('@workflow/errors//RetryableError');
 const HOOK_CONFLICT_ERROR_KEY = Symbol.for(
   '@workflow/errors//HookConflictError'
 );
+const RUNTIME_DECRYPTION_ERROR_KEY = Symbol.for(
+  '@workflow/errors//RuntimeDecryptionError'
+);
 
 if (typeof globalThis !== 'undefined') {
   if (!Object.hasOwn(globalThis, FATAL_ERROR_KEY)) {
@@ -926,6 +929,14 @@ if (typeof globalThis !== 'undefined') {
   if (!Object.hasOwn(globalThis, HOOK_CONFLICT_ERROR_KEY)) {
     Object.defineProperty(globalThis, HOOK_CONFLICT_ERROR_KEY, {
       value: HookConflictError,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+  if (!Object.hasOwn(globalThis, RUNTIME_DECRYPTION_ERROR_KEY)) {
+    Object.defineProperty(globalThis, RUNTIME_DECRYPTION_ERROR_KEY, {
+      value: RuntimeDecryptionError,
       writable: false,
       enumerable: false,
       configurable: false,

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -87,6 +87,7 @@ export const ERROR_SLUGS = {
   CORRUPTED_EVENT_LOG: 'corrupted-event-log',
   STEP_NOT_REGISTERED: 'step-not-registered',
   WORKFLOW_NOT_REGISTERED: 'workflow-not-registered',
+  RUNTIME_DECRYPTION_FAILED: 'runtime-decryption-failed',
 } as const;
 
 type ErrorSlug = (typeof ERROR_SLUGS)[keyof typeof ERROR_SLUGS];
@@ -320,6 +321,70 @@ export class CorruptedEventLogError extends WorkflowRuntimeError {
 
   static is(value: unknown): value is CorruptedEventLogError {
     return isError(value) && value.name === 'CorruptedEventLogError';
+  }
+}
+
+/**
+ * Optional structured context attached to a {@link RuntimeDecryptionError},
+ * carried over from the underlying decrypt call site to help diagnose the
+ * failure without poking through stacks.
+ */
+export interface RuntimeDecryptionErrorContext {
+  /** The operation that failed — useful to tell encrypt vs decrypt apart. */
+  operation?: 'encrypt' | 'decrypt';
+  /** Byte length of the input payload at the time of the failure. */
+  byteLength?: number;
+  /**
+   * The first 4 bytes of the input payload, decoded as UTF-8 if printable.
+   * Useful for telling apart truncated-but-valid-looking encrypted payloads
+   * from completely unrelated corruption (e.g. an HTML error page surfaced
+   * as a 200 OK).
+   */
+  formatPrefix?: string;
+}
+
+/**
+ * Thrown when the SDK's built-in AES-GCM encryption layer fails to encrypt
+ * or decrypt a workflow payload.
+ *
+ * This is **never** a user code error — the user never directly invokes
+ * the SDK's encryption primitives. A failure here means the SDK encountered
+ * an internal problem such as:
+ *
+ * - A ciphertext / auth tag mismatch (commonly surfaces as the native Web
+ *   Crypto `OperationError: The operation failed for an operation-specific
+ *   reason`), typically caused by ciphertext mutation or truncation in
+ *   transit between storage and read (e.g. a truncated HTTP response from
+ *   a workflow-server ref endpoint, an edge-cache miss returning a partial
+ *   200, a proxy drop during streaming, etc.).
+ * - A key resolution mismatch (wrong deployment, missing key material).
+ * - A malformed encrypted envelope (too short to contain the GCM nonce
+ *   and tag).
+ *
+ * Extending {@link WorkflowRuntimeError} ensures these failures classify
+ * as `RUNTIME_ERROR` rather than `USER_ERROR` when they bubble up to the
+ * run-failure handler.
+ */
+export class RuntimeDecryptionError extends WorkflowRuntimeError {
+  /** Optional structured context about the failed encrypt/decrypt call. */
+  readonly context?: RuntimeDecryptionErrorContext;
+
+  constructor(
+    message: string,
+    options?: ErrorOptions & { context?: RuntimeDecryptionErrorContext }
+  ) {
+    super(message, {
+      cause: options?.cause,
+      slug: ERROR_SLUGS.RUNTIME_DECRYPTION_FAILED,
+    });
+    this.name = 'RuntimeDecryptionError';
+    if (options?.context !== undefined) {
+      this.context = options.context;
+    }
+  }
+
+  static is(value: unknown): value is RuntimeDecryptionError {
+    return isError(value) && value.name === 'RuntimeDecryptionError';
   }
 }
 

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -347,23 +347,20 @@ export interface RuntimeDecryptionErrorContext {
  * Thrown when the SDK's built-in AES-GCM encryption layer fails to encrypt
  * or decrypt a workflow payload.
  *
- * This is **never** a user code error — the user never directly invokes
- * the SDK's encryption primitives. A failure here means the SDK encountered
- * an internal problem such as:
+ * This is an internal SDK failure — user code never invokes the SDK's
+ * encryption primitives directly. Common causes:
  *
- * - A ciphertext / auth tag mismatch (commonly surfaces as the native Web
+ * - A ciphertext / auth tag mismatch, typically surfaced as the native Web
  *   Crypto `OperationError: The operation failed for an operation-specific
- *   reason`), typically caused by ciphertext mutation or truncation in
- *   transit between storage and read (e.g. a truncated HTTP response from
- *   a workflow-server ref endpoint, an edge-cache miss returning a partial
- *   200, a proxy drop during streaming, etc.).
+ *   reason`. Usually caused by ciphertext mutation or truncation in transit
+ *   between storage and read (truncated HTTP response, edge-cache miss
+ *   returning a partial 200, proxy drop during streaming, etc.).
  * - A key resolution mismatch (wrong deployment, missing key material).
  * - A malformed encrypted envelope (too short to contain the GCM nonce
  *   and tag).
  *
- * Extending {@link WorkflowRuntimeError} ensures these failures classify
- * as `RUNTIME_ERROR` rather than `USER_ERROR` when they bubble up to the
- * run-failure handler.
+ * Extends {@link WorkflowRuntimeError} so the run-failure classifier
+ * routes it to `RUNTIME_ERROR`.
  */
 export class RuntimeDecryptionError extends WorkflowRuntimeError {
   /** Optional structured context about the failed encrypt/decrypt call. */

--- a/packages/errors/src/runtime-decryption-error.test.ts
+++ b/packages/errors/src/runtime-decryption-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest';
+import {
+  RuntimeDecryptionError,
+  WorkflowError,
+  WorkflowRuntimeError,
+} from './index.js';
+
+describe('RuntimeDecryptionError', () => {
+  test('sets the name and extends WorkflowRuntimeError', () => {
+    const err = new RuntimeDecryptionError('decrypt failed');
+    expect(err.name).toBe('RuntimeDecryptionError');
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err).toBeInstanceOf(WorkflowRuntimeError);
+    expect(err).toBeInstanceOf(RuntimeDecryptionError);
+  });
+
+  test('adds the runtime-decryption-failed docs link', () => {
+    const err = new RuntimeDecryptionError('decrypt failed');
+    expect(err.message).toContain(
+      'https://workflow-sdk.dev/err/runtime-decryption-failed'
+    );
+  });
+
+  test('preserves cause for debugging', () => {
+    const cause = new Error('underlying OperationError');
+    const err = new RuntimeDecryptionError('decrypt failed', { cause });
+    expect(err.cause).toBe(cause);
+  });
+
+  test('records optional diagnostic context', () => {
+    const err = new RuntimeDecryptionError('decrypt failed', {
+      context: {
+        operation: 'decrypt',
+        byteLength: 42,
+        formatPrefix: 'encr',
+      },
+    });
+    expect(err.context).toEqual({
+      operation: 'decrypt',
+      byteLength: 42,
+      formatPrefix: 'encr',
+    });
+  });
+
+  test('omits the context property when not provided', () => {
+    const err = new RuntimeDecryptionError('decrypt failed');
+    expect('context' in err).toBe(false);
+  });
+
+  test('RuntimeDecryptionError.is discriminates by name', () => {
+    const err = new RuntimeDecryptionError('decrypt failed');
+    const other = new Error('decrypt failed');
+    const runtimeOnly = new WorkflowRuntimeError('decrypt failed');
+    expect(RuntimeDecryptionError.is(err)).toBe(true);
+    // .is() is a name-based duck check, so a plain WorkflowRuntimeError
+    // does NOT pass — subclassing alone is not enough.
+    expect(RuntimeDecryptionError.is(runtimeOnly)).toBe(false);
+    expect(RuntimeDecryptionError.is(other)).toBe(false);
+    expect(RuntimeDecryptionError.is(null)).toBe(false);
+    expect(RuntimeDecryptionError.is(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Workflow runs that fail inside the SDK's AES-GCM encryption layer were being misclassified as `USER_ERROR`. SDK-level decryption is never user code — the user never directly invokes `subtle.decrypt` — so failures here should be `RUNTIME_ERROR`.

This PR adds a new error class and wires it into the run-failure classifier, **without** addressing the root cause of the decryption failure itself (that investigation is ongoing). The change is intentionally narrow: better classification + diagnostic context, so the next mystery report is properly categorized and immediately actionable.

## What I observed

Production reports surface as:

```
[Workflow] Error while running workflow {
  workflowRunId: 'wrun_01KSG6WQKPKNMH37C401KYHQ9M',
  errorCode: 'USER_ERROR',
  errorName: 'OperationError',
  errorStack: 'OperationError: The operation failed for an operation-specific reason\n' +
    '    at AESCipherJob.onDone (node:internal/crypto/util:646:19)'
}
```

`OperationError` from `AESCipherJob.onDone` is what Node's Web Crypto API throws when an AES-GCM auth-tag verification fails. The bare native DOMException doesn't match any of `classifyRunError`'s `RUNTIME_ERROR_CHECKS` (which are name-based duck checks), so it falls through to `USER_ERROR`.

## Changes

**`@workflow/errors`** (`packages/errors/src/index.ts`):
- New `RUNTIME_DECRYPTION_FAILED` slug.
- New `RuntimeDecryptionError` (extends `WorkflowRuntimeError`) with optional structured `context` (operation, byteLength, formatPrefix).

**`@workflow/core`**:
- `packages/core/src/encryption.ts`: wrap both `encrypt()` and `decrypt()` Web Crypto calls; rewrap any failure as `RuntimeDecryptionError` with diagnostic context (printable or hex prefix of the input header, byte length, operation). The existing length-precheck now also throws `RuntimeDecryptionError`.
- `packages/core/src/serialization/encryption.ts` & `packages/core/src/serialization.ts`: the two "encrypted-but-no-key" throw paths now use `RuntimeDecryptionError`.
- `packages/core/src/classify-error.ts`: `RuntimeDecryptionError.is` added to `RUNTIME_ERROR_CHECKS` so `classifyRunError` routes these failures to `RUNTIME_ERROR`.

## Test coverage

- `packages/errors/src/runtime-decryption-error.test.ts` (new, 6 tests): name, inheritance, docs URL, cause preservation, context shape, name-based `is()` duck check.
- `packages/core/src/encryption.test.ts` (new, 8 tests): happy-path round-trip, length-check failure, **GCM auth-tag tamper → `RuntimeDecryptionError` (cause = OperationError)**, wrong-key decryption → same, encrypt-only key used for encrypt → `RuntimeDecryptionError`, printable + hex format-prefix capture.
- `packages/core/src/classify-error.test.ts` (extended): `RuntimeDecryptionError → RUNTIME_ERROR`, plus a documentation test that a **bare native `OperationError` still classifies as `USER_ERROR`** (proves the encryption module's wrap is what does the work).

All existing tests still pass:
- `@workflow/errors`: 36/36 ✅
- `@workflow/core`: 1024/1024 ✅
- `pnpm typecheck` (full repo): 40/40 packages ✅

## What this does NOT fix

The actual decryption failure. Root cause is still under investigation — see the prior analysis. Strongest current hypothesis remains transport-level corruption/truncation of ciphertext between storage and read (in particular the workflow-server `/refs` endpoint, where a guard against truncated bodies was prototyped on a feature branch but never landed on `main`).

The diagnostic context added here is specifically what we need to triangulate the source on the next occurrence: byte length distinguishes "truncated" from "tampered", and format prefix distinguishes "valid `encr` envelope with bad ciphertext" from "garbage bytes that happened to land in a decrypt path".