### PR TITLE
[debug] Validation run: combine #2113 SDK + #447 server e6722b2

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1163,15 +1163,38 @@ export function workflowEntrypoint(
                         // important for crash recovery, to enqueue every
                         // pending step and let queue idempotency dedupe.
                         //
-                        // Recovery exception: if this workflow queue message
-                        // is itself being redelivered, pick up pre-existing
-                        // step_created / step_retrying events from the loaded
-                        // log that never reached step_started. This covers the
-                        // crash window after a handler writes step_created but
-                        // before it queues the step.
+                        // Recovery: pick up pre-existing step_created /
+                        // step_retrying events from the loaded log that
+                        // never reached step_started, and ensure they get
+                        // queued. This covers two windows where a
+                        // step_created lands but its dispatch never does:
+                        //
+                        //  1. Crash window: a handler writes step_created
+                        //     then crashes before queueing the step.
+                        //  2. Stale-snapshot abandon: a tick writes a
+                        //     fenced step_created, then abandons on a
+                        //     *later* fenced write (returns staleSnapshot
+                        //     + re-enqueues) before reaching the queueing
+                        //     code below. The re-enqueued tick sees
+                        //     `hasCreatedEvent: true` and won't re-create
+                        //     the step, so without this recovery nobody
+                        //     dispatches it and the run stalls with a
+                        //     valid fence + an orphaned step_created.
+                        //
+                        // This runs on every invocation (not just
+                        // attempt > 1): the abandon/re-enqueue path
+                        // produces fresh queue messages, not redeliveries,
+                        // so an attempt-gated recovery would miss case 2.
+                        // It is safe to run unconditionally because step
+                        // dispatch is queued with `idempotencyKey:
+                        // step.correlationId`, so re-queueing a step that
+                        // was already dispatched is deduped by the queue.
+                        // Steps this tick just created are queued via
+                        // `createdStepCorrelationIds` below; recovery only
+                        // needs to cover orphans this tick did NOT create.
                         const recoverablePendingStepCorrelationIds =
                           new Set<string>();
-                        if (metadata.attempt > 1 && cachedEvents) {
+                        if (cachedEvents) {
                           const latestStepEvents = new Map<string, string>();
                           for (const event of cachedEvents) {
                             if (

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1078,23 +1078,49 @@ export function workflowEntrypoint(
                         // make progress.
                         if (suspensionResult.staleSnapshot) {
                           // Abandon this replay's (potentially divergent)
-                          // queue results, but re-enqueue an immediate
-                          // tick so the canonical event log gets
-                          // processed. Without the re-enqueue, work that
-                          // arrived after the winning tick's snapshot
-                          // (e.g. a burst of hook_received events that
-                          // each raced this tick) can be left unconsumed
-                          // — the run sits `running` with pending hooks
-                          // and no tick scheduled to advance it. The
-                          // re-enqueue is bounded (one per abandoned
-                          // tick) and converges: the server-side atomic
-                          // fence+event write guarantees the canonical
-                          // replay makes forward progress rather than
-                          // spinning.
+                          // queue results, but:
+                          //
+                          //  1. Dispatch the steps this tick already wrote
+                          //     a (fenced, atomic, canonical) step_created
+                          //     for before the conflict. Those are owned
+                          //     by this tick — exactly one owner — so
+                          //     queueing them is safe and can't
+                          //     double-dispatch. Skipping them would
+                          //     orphan the step_created (no owner to
+                          //     dispatch it), stalling the run.
+                          //  2. Re-enqueue an immediate tick so the
+                          //     canonical event log (incl. any work that
+                          //     arrived after this tick's snapshot, e.g. a
+                          //     hook burst that each raced this tick) gets
+                          //     processed. Bounded (one re-enqueue per
+                          //     abandoned tick) and converges: the
+                          //     server-side atomic fence+event write means
+                          //     the canonical replay makes forward
+                          //     progress instead of spinning.
                           runtimeLogger.info(
-                            'Replay abandoned (stale snapshot); re-enqueuing a tick for the canonical log',
-                            { workflowRunId: runId }
+                            'Replay abandoned (stale snapshot); dispatching owned steps + re-enqueuing a tick',
+                            {
+                              workflowRunId: runId,
+                              ownedSteps: suspensionResult.pendingSteps.length,
+                            }
                           );
+                          for (const step of suspensionResult.pendingSteps) {
+                            const traceCarrier = await serializeTraceCarrier();
+                            await queueMessage(
+                              world,
+                              getWorkflowQueueName(workflowName),
+                              {
+                                runId,
+                                stepId: step.correlationId,
+                                stepName: step.stepName,
+                                traceCarrier,
+                                requestedAt: new Date(),
+                              },
+                              {
+                                idempotencyKey: step.correlationId,
+                              }
+                            );
+                          }
                           return { timeoutSeconds: 0 };
                         }
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1163,38 +1163,15 @@ export function workflowEntrypoint(
                         // important for crash recovery, to enqueue every
                         // pending step and let queue idempotency dedupe.
                         //
-                        // Recovery: pick up pre-existing step_created /
-                        // step_retrying events from the loaded log that
-                        // never reached step_started, and ensure they get
-                        // queued. This covers two windows where a
-                        // step_created lands but its dispatch never does:
-                        //
-                        //  1. Crash window: a handler writes step_created
-                        //     then crashes before queueing the step.
-                        //  2. Stale-snapshot abandon: a tick writes a
-                        //     fenced step_created, then abandons on a
-                        //     *later* fenced write (returns staleSnapshot
-                        //     + re-enqueues) before reaching the queueing
-                        //     code below. The re-enqueued tick sees
-                        //     `hasCreatedEvent: true` and won't re-create
-                        //     the step, so without this recovery nobody
-                        //     dispatches it and the run stalls with a
-                        //     valid fence + an orphaned step_created.
-                        //
-                        // This runs on every invocation (not just
-                        // attempt > 1): the abandon/re-enqueue path
-                        // produces fresh queue messages, not redeliveries,
-                        // so an attempt-gated recovery would miss case 2.
-                        // It is safe to run unconditionally because step
-                        // dispatch is queued with `idempotencyKey:
-                        // step.correlationId`, so re-queueing a step that
-                        // was already dispatched is deduped by the queue.
-                        // Steps this tick just created are queued via
-                        // `createdStepCorrelationIds` below; recovery only
-                        // needs to cover orphans this tick did NOT create.
+                        // Recovery exception: if this workflow queue message
+                        // is itself being redelivered, pick up pre-existing
+                        // step_created / step_retrying events from the loaded
+                        // log that never reached step_started. This covers the
+                        // crash window after a handler writes step_created but
+                        // before it queues the step.
                         const recoverablePendingStepCorrelationIds =
                           new Set<string>();
-                        if (cachedEvents) {
+                        if (metadata.attempt > 1 && cachedEvents) {
                           const latestStepEvents = new Map<string, string>();
                           for (const event of cachedEvents) {
                             if (

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1077,11 +1077,25 @@ export function workflowEntrypoint(
                         // run_failed) and let the canonical invocation
                         // make progress.
                         if (suspensionResult.staleSnapshot) {
+                          // Abandon this replay's (potentially divergent)
+                          // queue results, but re-enqueue an immediate
+                          // tick so the canonical event log gets
+                          // processed. Without the re-enqueue, work that
+                          // arrived after the winning tick's snapshot
+                          // (e.g. a burst of hook_received events that
+                          // each raced this tick) can be left unconsumed
+                          // — the run sits `running` with pending hooks
+                          // and no tick scheduled to advance it. The
+                          // re-enqueue is bounded (one per abandoned
+                          // tick) and converges: the server-side atomic
+                          // fence+event write guarantees the canonical
+                          // replay makes forward progress rather than
+                          // spinning.
                           runtimeLogger.info(
-                            'Replay abandoned: stale event-log snapshot, canonical invocation has the log',
+                            'Replay abandoned (stale snapshot); re-enqueuing a tick for the canonical log',
                             { workflowRunId: runId }
                           );
-                          return;
+                          return { timeoutSeconds: 0 };
                         }
 
                         // Hook conflict: break loop, re-invoke via queue

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1062,7 +1062,27 @@ export function workflowEntrypoint(
                           pendingSteps: suspensionResult.pendingSteps.length,
                           timeoutSeconds: suspensionResult.timeoutSeconds,
                           hasHookConflict: suspensionResult.hasHookConflict,
+                          staleSnapshot: suspensionResult.staleSnapshot,
                         });
+
+                        // Stale-snapshot abandonment: a fenced write
+                        // rejected, meaning a concurrent invocation has
+                        // already advanced the canonical event log. Our
+                        // VM's queue results were derived from a snapshot
+                        // that may diverge from the canonical replay's
+                        // decisions; queueing them risks
+                        // `CorruptedEventLogError` on a future replay
+                        // when the loser's events meet the winner's
+                        // events in the log. Exit cleanly (do NOT write
+                        // run_failed) and let the canonical invocation
+                        // make progress.
+                        if (suspensionResult.staleSnapshot) {
+                          runtimeLogger.info(
+                            'Replay abandoned: stale event-log snapshot, canonical invocation has the log',
+                            { workflowRunId: runId }
+                          );
+                          return;
+                        }
 
                         // Hook conflict: break loop, re-invoke via queue
                         if (suspensionResult.hasHookConflict) {

--- a/packages/core/src/runtime/fenced-write.ts
+++ b/packages/core/src/runtime/fenced-write.ts
@@ -90,13 +90,32 @@ export interface FencedWriteResult {
   /**
    * Whether the event was actually written.
    *
-   * `false` covers two cases the caller usually wants to treat the same
-   * way (no further action required for this write):
-   *  - Fence conflict — another invocation has the canonical view.
+   * `false` covers two cases the caller usually wants to treat
+   * differently (see `staleSnapshot` below):
+   *  - Fence conflict (`staleSnapshot: true`): another invocation has
+   *    a fresher view of the event log; the caller must abandon any
+   *    further work derived from its own snapshot, because that work
+   *    could have been a different VM decision than the canonical
+   *    replay made and continuing would corrupt the log.
    *  - Non-fence EntityConflictError with `onEntityConflict: 'abort'`
-   *    (entity already exists, run already terminal, etc.).
+   *    (`staleSnapshot: false`): the entity already exists / run is
+   *    terminal; the caller can skip this write and continue.
    */
   written: boolean;
+  /**
+   * Set to `true` when `written` is `false` because of an OCC fence
+   * conflict. The caller is expected to propagate this signal up so the
+   * entire current tick / replay is abandoned (without failing the
+   * run): a stale-snapshot replay can otherwise re-derive a divergent
+   * VM decision from a log that has since been advanced by a canonical
+   * replay, and continuing past the conflict point can cause
+   * `CorruptedEventLogError` when the loser's VM consumes the
+   * canonical replay's events as if they were its own.
+   *
+   * Always `false` when `written` is `true`. Always `false` for
+   * non-fence EntityConflictError aborts.
+   */
+  staleSnapshot: boolean;
   /**
    * eventId of the newly-written event (when `written` is true), so
    * the caller can advance its tracked fence value.
@@ -148,6 +167,7 @@ export async function fencedEventCreate(
     }
     return {
       written: true,
+      staleSnapshot: false,
       newFenceEventId: result.event?.eventId ?? fenceEventId,
       event: result.event
         ? {
@@ -158,23 +178,25 @@ export async function fencedEventCreate(
     };
   } catch (err) {
     if (isFenceConflict(err)) {
-      // Another invocation has the canonical view of the event log.
-      // Bail out cleanly: no retry, no throw. The canonical invocation
-      // is responsible for whatever progress the workflow needs.
+      // Another invocation has a fresher view of the event log. The
+      // caller must surface `staleSnapshot: true` upward and abandon
+      // the current replay's queue results — see the field doc on
+      // `FencedWriteResult` for why continuing past this point is
+      // unsafe under divergent-VM-decision contention.
       runtimeLogger.info(
-        'Branch-decision write fence conflict; yielding to canonical replay',
+        'Branch-decision write fence conflict; signalling stale snapshot',
         {
           workflowRunId: runId,
           eventType: event.eventType,
           correlationId: event.correlationId,
         }
       );
-      return { written: false };
+      return { written: false, staleSnapshot: true };
     }
     if (EntityConflictError.is(err)) {
       const decision = onEntityConflict(err);
       if (decision === 'abort') {
-        return { written: false };
+        return { written: false, staleSnapshot: false };
       }
       throw err;
     }

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -64,6 +64,18 @@ export interface SuspensionHandlerResult {
   timeoutSeconds?: number;
   /** Whether a hook conflict was detected (should re-invoke immediately) */
   hasHookConflict: boolean;
+  /**
+   * `true` when at least one fenced write rejected with a fence
+   * conflict, meaning another invocation has a fresher snapshot of the
+   * event log. The caller (runtime tick) must abandon the current
+   * replay without writing `run_failed` — the canonical invocation is
+   * making progress and this replay's VM decisions could be divergent.
+   *
+   * When set, `pendingSteps` should be considered invalid and not
+   * queued; `createdStepCorrelationIds` may be a partial set (only the
+   * writes that landed before the conflict).
+   */
+  staleSnapshot: boolean;
 }
 
 /**
@@ -145,6 +157,22 @@ export async function handleSuspension({
   // so the V2 handler can re-invoke immediately.
   let hasHookConflict = false;
 
+  // Helper to build the early-return result when we detect a stale-snapshot
+  // fence conflict. Once flipped, the entire replay's queue results are
+  // invalid (a stale-snapshot VM decision could be divergent from the
+  // canonical replay's), so further writes from this invocation must not
+  // happen.
+  const staleSnapshotResult = (): SuspensionHandlerResult => ({
+    pendingSteps: [],
+    createdStepCorrelationIds,
+    hasHookConflict: false,
+    staleSnapshot: true,
+  });
+
+  // Track set of created stepIds up here so the early-return helper above
+  // can reference it. May be partially populated if we stale-snapshot mid-batch.
+  const createdStepCorrelationIds = new Set<string>();
+
   for (const hookEvent of hookEvents) {
     try {
       const writeResult = await fencedEventCreate({
@@ -155,6 +183,9 @@ export async function handleSuspension({
         fenceEventId,
         onEntityConflict: () => 'abort',
       });
+      if (writeResult.staleSnapshot) {
+        return staleSnapshotResult();
+      }
       if (writeResult.newFenceEventId) {
         fenceEventId = writeResult.newFenceEventId;
       }
@@ -208,6 +239,9 @@ export async function handleSuspension({
         fenceEventId,
         onEntityConflict: () => 'abort',
       });
+      if (writeResult.staleSnapshot) {
+        return staleSnapshotResult();
+      }
       if (writeResult.newFenceEventId) {
         fenceEventId = writeResult.newFenceEventId;
       }
@@ -312,13 +346,16 @@ export async function handleSuspension({
       .map((queueItem) => queueItem.correlationId)
   );
 
-  // Correlation IDs for which THIS suspension call actually wrote the
-  // step_created event. Populated by the ops below after a successful
-  // events.create — used by the caller to claim ownership and avoid
-  // racing with concurrent handlers on step execution.
-  const createdStepCorrelationIds = new Set<string>();
+  // `createdStepCorrelationIds` was declared up top so the
+  // `staleSnapshotResult()` helper can include it on early returns.
+  // It is populated below after each successful events.create — used by
+  // the caller to claim ownership and avoid racing with concurrent
+  // handlers on step execution.
 
-  const ops: Array<() => Promise<void>> = [];
+  // Each op returns `true` if the entire suspension handling must
+  // abandon (stale-snapshot fence conflict observed). The outer loop
+  // checks the return value and early-exits on `true`.
+  const ops: Array<() => Promise<boolean>> = [];
 
   // Steps: create step_created events (no queuing — V2 returns pending
   // steps to caller).
@@ -359,6 +396,9 @@ export async function handleSuspension({
           fenceEventId,
           onEntityConflict: () => 'abort',
         });
+        if (writeResult.staleSnapshot) {
+          return true;
+        }
         if (writeResult.newFenceEventId) {
           fenceEventId = writeResult.newFenceEventId;
         }
@@ -373,6 +413,7 @@ export async function handleSuspension({
             }
           );
         }
+        return false;
       });
     }
   }
@@ -400,6 +441,9 @@ export async function handleSuspension({
           fenceEventId,
           onEntityConflict: () => 'abort',
         });
+        if (writeResult.staleSnapshot) {
+          return true;
+        }
         if (writeResult.newFenceEventId) {
           fenceEventId = writeResult.newFenceEventId;
         }
@@ -409,12 +453,16 @@ export async function handleSuspension({
             correlationId: queueItem.correlationId,
           });
         }
+        return false;
       });
     }
   }
 
   for (const op of ops) {
-    await op();
+    const stale = await op();
+    if (stale) {
+      return staleSnapshotResult();
+    }
   }
 
   // Calculate minimum timeout from waits
@@ -442,5 +490,6 @@ export async function handleSuspension({
     createdStepCorrelationIds,
     timeoutSeconds: hasHookConflict ? 0 : (minTimeoutSeconds ?? undefined),
     hasHookConflict,
+    staleSnapshot: false,
   };
 }

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -158,12 +158,22 @@ export async function handleSuspension({
   let hasHookConflict = false;
 
   // Helper to build the early-return result when we detect a stale-snapshot
-  // fence conflict. Once flipped, the entire replay's queue results are
-  // invalid (a stale-snapshot VM decision could be divergent from the
+  // fence conflict. Once flipped, the rest of this replay's queue results
+  // are invalid (a stale-snapshot VM decision could diverge from the
   // canonical replay's), so further writes from this invocation must not
   // happen.
+  //
+  // Crucially, `pendingSteps` carries the steps this tick ALREADY wrote a
+  // (fenced, atomic) `step_created` for before the conflict. Those writes
+  // succeeded against a matching fence, so they're canonical and owned by
+  // this tick — the caller must still dispatch them, or they'd be orphaned
+  // (a step_created with no owner to queue it, stalling the run). Pairing
+  // ownership (createdStepCorrelationIds) with the dispatch avoids the
+  // double-dispatch that an unconditional recovery scan would cause.
   const staleSnapshotResult = (): SuspensionHandlerResult => ({
-    pendingSteps: [],
+    pendingSteps: stepItems.filter((s) =>
+      createdStepCorrelationIds.has(s.correlationId)
+    ),
     createdStepCorrelationIds,
     hasHookConflict: false,
     staleSnapshot: true,

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -59,13 +59,15 @@ function httpLog(
  * `main` — rewritten by external CI for branch-deployment testing.
  * Prefer `VERCEL_WORKFLOW_SERVER_URL` for deployment-time configuration.
  *
- * [debug branch] Pinned to the workflow-server PR vercel/workflow-server#447
- * preview deployment (commit e6722b2 — "events: move entity materialization
- * after fence CAS") so this validation run exercises both the SDK fixes
- * in #2113 and the server-side fence + ordering fix end to end.
+ * [debug branch] Pinned to the workflow-server branch
+ * `nate/event-write-atomic-txn` (commit e1d0ea7 — "events: atomic fence +
+ * materialization + event for fenced writes"), which builds on #447 and
+ * folds fence + materialization + event PUT into one TransactWriteItems
+ * for the fenced event types. This validates the full stack: SDK
+ * abandon-tick (#2113) + server-side atomic fenced writes.
  */
 const WORKFLOW_SERVER_URL_OVERRIDE =
-  'https://workflow-server-git-peter-event-write-cas.vercel.sh';
+  'https://workflow-server-git-nate-event-write-atomic-txn.vercel.sh';
 
 /**
  * Per-request timeout for HTTP calls to workflow-server (in ms).

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -58,8 +58,14 @@ function httpLog(
  * Inline workflow-server URL override. Must remain an empty string on
  * `main` — rewritten by external CI for branch-deployment testing.
  * Prefer `VERCEL_WORKFLOW_SERVER_URL` for deployment-time configuration.
+ *
+ * [debug branch] Pinned to the workflow-server PR vercel/workflow-server#447
+ * preview deployment (commit e6722b2 — "events: move entity materialization
+ * after fence CAS") so this validation run exercises both the SDK fixes
+ * in #2113 and the server-side fence + ordering fix end to end.
  */
-const WORKFLOW_SERVER_URL_OVERRIDE = '';
+const WORKFLOW_SERVER_URL_OVERRIDE =
+  'https://workflow-server-git-peter-event-write-cas.vercel.sh';
 
 /**
  * Per-request timeout for HTTP calls to workflow-server (in ms).
@@ -183,6 +189,15 @@ export const getHeaders = (
   const workflowServerUrlOverride = getWorkflowServerUrlOverride();
   if (workflowServerUrlOverride && options.usingProxy) {
     headers.set('x-vercel-workflow-api-url', workflowServerUrlOverride);
+  }
+  // [debug branch] Vercel Deployment Protection bypass for the pinned
+  // workflow-server preview. Must be the bare `x-vercel-protection-bypass`
+  // header — do NOT also set `x-vercel-set-bypass-cookie: true`, which
+  // triggers a 307 redirect loop on Node undici. Env var is baked at
+  // deploy time on the repro app.
+  const bypassToken = process.env.WORKFLOW_VERCEL_PROTECTION_BYPASS;
+  if (bypassToken) {
+    headers.set('x-vercel-protection-bypass', bypassToken);
   }
   return headers;
 };


### PR DESCRIPTION
**NOT FOR MERGE.** Draft PR opened only to trigger the tarballs-checks workflow so we get a tarball URL to pin the repro app to.

## Purpose

End-to-end validation that the combined fix closes the production-visible defect end to end. Pairs:
- `@workflow/core` from this branch (= top of vercel/workflow#2113 + the existing SDK fixes from e5cd68698)
- workflow-server preview deployment for vercel/workflow-server#447 at commit e6722b2 (`https://workflow-server-git-peter-event-write-cas.vercel.sh`)

## What this branch adds on top of #2113

- `WORKFLOW_SERVER_URL_OVERRIDE` pinned to the #447 preview URL
- `x-vercel-protection-bypass` header forwarded from `WORKFLOW_VERCEL_PROTECTION_BYPASS` env var (so the repro app can hit the preview through Vercel Deployment Protection)

Both changes are gated to this branch only and will not be cherry-picked into either real PR.

## Validation plan

Run the standard stress repro shape against the pinned tarball + preview pair (40 cycles × 200 workflows). Classify outcomes across:
- `completed`
- still `running` at final check
- `failed: CORRUPTED_EVENT_LOG`
- `failed: USER_ERROR`
- `failed: WORLD_CONTRACT_ERROR`
- `failed: other`

Last run pre-#447-server-fix: ~2/40 cycles surfaced `CORRUPTED_EVENT_LOG` on stable; 0/40 with this PR's predecessor against an earlier #447 preview but with 132 stuck-running + 23 USER_ERROR + 4 WORLD_CONTRACT_ERROR uncategorized.

Goal of this run: confirm not just `CORRUPTED_EVENT_LOG = 0` but also `stuck/USER_ERROR/WORLD_CONTRACT_ERROR` are clean, since those would be the symptom of the materialization-before-fence orphan scenarios Peter walked.