### PR TITLE
fix: stabilize abort signal E2E cancellation paths

### DIFF
--- a/.changeset/abort-e2e-flakes.md
+++ b/.changeset/abort-e2e-flakes.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Treat serialized and cross-realm `AbortError` step failures as fatal cancellations, and stabilize abort E2E readiness checkpoints.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2824,11 +2824,8 @@ describe('e2e', () => {
         const token = Math.random().toString(36).slice(2);
         const run = await start(await e2e('abortViaHookWorkflow'), [token]);
 
-        // Wait for the hook to be registered
-        await new Promise((resolve) => setTimeout(resolve, 5_000));
-
-        // Resume the hook with a cancellation payload
-        const hook = await getHookByToken(token);
+        // Resume once the hook is observable; fixed delays race slow starts.
+        const hook = await waitForHook(token, { runId: run.runId });
         expect(hook.runId).toBe(run.runId);
         await resumeHook(hook, { reason: 'user cancelled' });
 
@@ -3000,6 +2997,12 @@ describe('e2e', () => {
         // The AbortError is NOT caught in the step — it propagates as FatalError.
         expect(returnValue.threw).toBe(true);
         expect(returnValue.isFatal).toBe(true);
+
+        const world = await getWorld();
+        const { data: events } = await world.events.list({ runId: run.runId });
+        expect(
+          events.some((event) => event.eventType === 'step_retrying')
+        ).toBe(false);
       }
     );
 
@@ -3181,15 +3184,13 @@ describe('e2e', () => {
           if (resumeBeforeAbort) {
             // For "hook-first" variants, the workflow awaits a step before
             // calling abort(). We resume the hook during that window.
-            await new Promise((resolve) => setTimeout(resolve, 5_000));
-            const hook = await getHookByToken(token);
+            const hook = await waitForHook(token, { runId: run.runId });
             expect(hook.runId).toBe(run.runId);
             await resumeHook(hook, { value: 'hello' });
           } else {
             // For "abort-first" variants, abort happens before the hook
-            // is resumed. We wait then resume so the workflow can complete.
-            await new Promise((resolve) => setTimeout(resolve, 5_000));
-            const hook = await getHookByToken(token);
+            // is resumed. Resume once registration is visible.
+            const hook = await waitForHook(token, { runId: run.runId });
             expect(hook.runId).toBe(run.runId);
             await resumeHook(hook, { value: 'hello' });
           }

--- a/packages/core/src/abort-controller.test.ts
+++ b/packages/core/src/abort-controller.test.ts
@@ -12,16 +12,19 @@ import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
 import { monotonicFactory } from 'ulid';
 import { describe, expect, it, vi } from 'vitest';
-import { EventsConsumer } from './events-consumer.js';
+import { DEFERRED_CHECK_DELAY_MS, EventsConsumer } from './events-consumer.js';
 import type { WorkflowOrchestratorContext } from './private.js';
 import { dehydrateStepReturnValue } from './serialization.js';
 import { createContext } from './vm/index.js';
 import {
-  createCreateAbortController,
   createAbortSignalStatics,
+  createCreateAbortController,
 } from './workflow/abort-controller.js';
 
-function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
+function setupWorkflowContext(
+  events: Event[],
+  onUnconsumedEvent: (event: Event) => void = () => {}
+): WorkflowOrchestratorContext {
   const context = createContext({
     seed: 'test-abort',
     fixedTimestamp: 1714857600000,
@@ -33,7 +36,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     encryptionKey: undefined,
     globalThis: context.globalThis,
     eventsConsumer: new EventsConsumer(events, {
-      onUnconsumedEvent: () => {},
+      onUnconsumedEvent,
       getPromiseQueue: () => ctx.promiseQueue,
     }),
     invocationsQueue: new Map(),
@@ -161,6 +164,58 @@ describe('AbortController in workflow VM', () => {
       expect(workflowError?.message).toContain('hook_received');
       expect(workflowError?.message).toContain('wrong-token');
       expect(workflowError?.message).toContain(probeHookItem.token);
+    });
+
+    it('consumes duplicate matching abort hook receipts as idempotent aborts', async () => {
+      ctx = setupWorkflowContext([]);
+      const ProbeAbortController = createCreateAbortController(ctx);
+      new ProbeAbortController();
+      const probeHookItem = [...ctx.invocationsQueue.values()].find(
+        (item) => item.type === 'hook'
+      );
+      expect(probeHookItem).toBeDefined();
+      if (!probeHookItem || probeHookItem.type !== 'hook') {
+        throw new Error('Expected abort hook item');
+      }
+
+      const ops: Promise<any>[] = [];
+      const payload = await dehydrateStepReturnValue(
+        { reason: 'aborted' },
+        'wrun_test',
+        undefined,
+        ops
+      );
+      const makeReceipt = (eventId: string): Event => ({
+        eventId,
+        runId: 'wrun_test',
+        eventType: 'hook_received',
+        correlationId: probeHookItem.correlationId,
+        eventData: {
+          token: probeHookItem.token,
+          payload,
+        },
+        createdAt: new Date(),
+      });
+      const onUnconsumedEvent = vi.fn();
+      ctx = setupWorkflowContext(
+        [makeReceipt('evnt_0'), makeReceipt('evnt_1')],
+        onUnconsumedEvent
+      );
+
+      const AbortController = createCreateAbortController(ctx);
+      const controller = new AbortController();
+      const listener = vi.fn();
+      controller.signal.addEventListener('abort', listener);
+
+      await ctx.promiseQueue;
+      await new Promise((resolve) =>
+        setTimeout(resolve, DEFERRED_CHECK_DELAY_MS + 10)
+      );
+
+      expect(controller.signal.aborted).toBe(true);
+      expect(listener).toHaveBeenCalledOnce();
+      expect(ctx.eventsConsumer.eventIndex).toBe(2);
+      expect(onUnconsumedEvent).not.toHaveBeenCalled();
     });
 
     it('signal.aborted is false initially', () => {

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -27,8 +27,8 @@ import { trace } from '../telemetry.js';
 import {
   getErrorName,
   getErrorStack,
-  isAbortError,
   normalizeUnknownError,
+  promoteAbortErrorToFatal,
 } from '../types.js';
 import { getPortLazy } from './get-port-lazy.js';
 import { memoizeEncryptionKey } from './helpers.js';
@@ -427,12 +427,7 @@ export async function executeStep(
       // and queue a continuation so waitUntil can flush them.
       return { type: 'completed', hasPendingOps: !opsSettled };
     } catch (err: unknown) {
-      let effectiveErr: unknown = err;
-      if (isAbortError(err) && !FatalError.is(err)) {
-        const fatalErr = new FatalError(`Aborted: ${err.message}`);
-        if (err.stack) fatalErr.stack = err.stack;
-        effectiveErr = fatalErr;
-      }
+      const effectiveErr = promoteAbortErrorToFatal(err);
 
       const normalizedError = await normalizeUnknownError(effectiveErr);
       const normalizedStack =

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -27,6 +27,7 @@ import { trace } from '../telemetry.js';
 import {
   getErrorName,
   getErrorStack,
+  isAbortError,
   normalizeUnknownError,
 } from '../types.js';
 import { getPortLazy } from './get-port-lazy.js';
@@ -426,14 +427,22 @@ export async function executeStep(
       // and queue a continuation so waitUntil can flush them.
       return { type: 'completed', hasPendingOps: !opsSettled };
     } catch (err: unknown) {
-      const normalizedError = await normalizeUnknownError(err);
-      const normalizedStack = normalizedError.stack || getErrorStack(err) || '';
-
-      if (err instanceof Error) {
-        span?.recordException?.(err);
+      let effectiveErr: unknown = err;
+      if (isAbortError(err) && !FatalError.is(err)) {
+        const fatalErr = new FatalError(`Aborted: ${err.message}`);
+        if (err.stack) fatalErr.stack = err.stack;
+        effectiveErr = fatalErr;
       }
 
-      const isFatal = FatalError.is(err);
+      const normalizedError = await normalizeUnknownError(effectiveErr);
+      const normalizedStack =
+        normalizedError.stack || getErrorStack(effectiveErr) || '';
+
+      if (effectiveErr instanceof Error) {
+        span?.recordException?.(effectiveErr);
+      }
+
+      const isFatal = FatalError.is(effectiveErr);
 
       span?.setAttributes({
         ...Attribute.StepErrorName(getErrorName(err)),
@@ -463,8 +472,8 @@ export async function executeStep(
         // error preserves it for consumers. `types.isNativeError()` works
         // across VM realms (a workflow-thrown error is an instance of the
         // VM's Error class, not the host's).
-        if (types.isNativeError(err) && normalizedStack) {
-          (err as Error).stack = normalizedStack;
+        if (types.isNativeError(effectiveErr) && normalizedStack) {
+          (effectiveErr as Error).stack = normalizedStack;
         }
         try {
           await world.events.create(workflowRunId, {
@@ -474,7 +483,7 @@ export async function executeStep(
             eventData: {
               stepName,
               error: await dehydrateStepError(
-                err,
+                effectiveErr,
                 workflowRunId,
                 await getEncryptionKey()
               ),

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -445,11 +445,15 @@ export async function executeStep(
       const isFatal = FatalError.is(effectiveErr);
 
       span?.setAttributes({
-        ...Attribute.StepErrorName(getErrorName(err)),
+        ...Attribute.StepErrorName(getErrorName(effectiveErr)),
         ...Attribute.StepErrorMessage(normalizedError.message),
-        ...Attribute.ErrorType(getErrorName(err)),
+        ...Attribute.ErrorType(getErrorName(effectiveErr)),
         ...Attribute.ErrorCategory(
-          isFatal ? 'fatal' : RetryableError.is(err) ? 'retryable' : 'transient'
+          isFatal
+            ? 'fatal'
+            : RetryableError.is(effectiveErr)
+              ? 'retryable'
+              : 'transient'
         ),
         ...Attribute.ErrorRetryable(!isFatal),
       });

--- a/packages/core/src/runtime/step-handler.test.ts
+++ b/packages/core/src/runtime/step-handler.test.ts
@@ -1,4 +1,8 @@
-import { EntityConflictError, WorkflowWorldError } from '@workflow/errors';
+import {
+  EntityConflictError,
+  FatalError,
+  WorkflowWorldError,
+} from '@workflow/errors';
 import {
   afterEach,
   beforeAll,
@@ -137,16 +141,17 @@ vi.mock('../step/context-storage.js', () => ({
 
 // Mock types
 vi.mock('../types.js', () => ({
-  isAbortError: vi
+  promoteAbortErrorToFatal: vi
     .fn()
-    .mockImplementation(
-      (err: unknown) =>
-        typeof err === 'object' &&
-        err !== null &&
-        'name' in err &&
-        err.name === 'AbortError' &&
-        'message' in err &&
-        typeof err.message === 'string'
+    .mockImplementation((err: unknown) =>
+      typeof err === 'object' &&
+      err !== null &&
+      'name' in err &&
+      err.name === 'AbortError' &&
+      'message' in err &&
+      typeof err.message === 'string'
+        ? new FatalError(`Aborted: ${err.message}`)
+        : err
     ),
   normalizeUnknownError: vi.fn().mockImplementation(async (err: unknown) => ({
     message: err instanceof Error ? err.message : String(err),

--- a/packages/core/src/runtime/step-handler.test.ts
+++ b/packages/core/src/runtime/step-handler.test.ts
@@ -137,6 +137,17 @@ vi.mock('../step/context-storage.js', () => ({
 
 // Mock types
 vi.mock('../types.js', () => ({
+  isAbortError: vi
+    .fn()
+    .mockImplementation(
+      (err: unknown) =>
+        typeof err === 'object' &&
+        err !== null &&
+        'name' in err &&
+        err.name === 'AbortError' &&
+        'message' in err &&
+        typeof err.message === 'string'
+    ),
   normalizeUnknownError: vi.fn().mockImplementation(async (err: unknown) => ({
     message: err instanceof Error ? err.message : String(err),
     name: err instanceof Error ? err.name : 'Error',
@@ -157,6 +168,7 @@ vi.mock('@workflow/utils/get-port', () => ({
 }));
 
 import { getStepFunction } from '../private.js';
+import { dehydrateStepError } from '../serialization.js';
 import {
   getErrorName,
   getErrorStack,
@@ -851,6 +863,26 @@ describe('step-handler fatal vs retryable behavior', () => {
       ([, event]) => event.eventType === 'step_retrying'
     );
     expect(stepRetryingCalls).toHaveLength(0);
+  });
+
+  it('promotes an AbortError-shaped rejection to FatalError without retrying', async () => {
+    mockStepFn.mockReset().mockRejectedValue({
+      name: 'AbortError',
+      message: 'This operation was aborted',
+    });
+    mockStepFn.maxRetries = 3;
+
+    await capturedHandler(createMessage(), createMetadata('myStep'));
+
+    const stepRetryingCalls = mockEventsCreate.mock.calls.filter(
+      ([, event]) => event.eventType === 'step_retrying'
+    );
+    expect(stepRetryingCalls).toHaveLength(0);
+    expect(dehydrateStepError).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'FatalError', fatal: true }),
+      'wrun_test123',
+      undefined
+    );
   });
 
   it('schedules a retry (and does not fail the step) on the first attempt of a non-fatal Error', async () => {

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -35,8 +35,8 @@ import {
 import {
   getErrorName,
   getErrorStack,
-  isAbortError,
   normalizeUnknownError,
+  promoteAbortErrorToFatal,
 } from '../types.js';
 import { MAX_QUEUE_DELIVERIES } from './constants.js';
 import {
@@ -669,12 +669,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
 
               // Abort failures can cross VM/serialization realms, where
               // `instanceof Error` is not reliable.
-              let effectiveErr: unknown = err;
-              if (isAbortError(err) && !FatalError.is(err)) {
-                const fatalErr = new FatalError(`Aborted: ${err.message}`);
-                if (err.stack) fatalErr.stack = err.stack;
-                effectiveErr = fatalErr;
-              }
+              const effectiveErr = promoteAbortErrorToFatal(err);
               const normalizedError = await normalizeUnknownError(effectiveErr);
               const normalizedStack =
                 normalizedError.stack || getErrorStack(effectiveErr) || '';

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -694,9 +694,9 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   : 'transient';
 
               span?.setAttributes({
-                ...Attribute.StepErrorName(getErrorName(err)),
+                ...Attribute.StepErrorName(getErrorName(effectiveErr)),
                 ...Attribute.StepErrorMessage(normalizedError.message),
-                ...Attribute.ErrorType(getErrorName(err)),
+                ...Attribute.ErrorType(getErrorName(effectiveErr)),
                 ...Attribute.ErrorCategory(errorCategory),
                 ...Attribute.ErrorRetryable(!isFatal),
               });

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -35,6 +35,7 @@ import {
 import {
   getErrorName,
   getErrorStack,
+  isAbortError,
   normalizeUnknownError,
 } from '../types.js';
 import { MAX_QUEUE_DELIVERIES } from './constants.js';
@@ -666,15 +667,12 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                 }
               }
 
-              // Wrap AbortError in FatalError — abort is intentional cancellation, not retryable
+              // Abort failures can cross VM/serialization realms, where
+              // `instanceof Error` is not reliable.
               let effectiveErr: unknown = err;
-              if (
-                err instanceof Error &&
-                err.name === 'AbortError' &&
-                !FatalError.is(err)
-              ) {
+              if (isAbortError(err) && !FatalError.is(err)) {
                 const fatalErr = new FatalError(`Aborted: ${err.message}`);
-                fatalErr.stack = err.stack;
+                if (err.stack) fatalErr.stack = err.stack;
                 effectiveErr = fatalErr;
               }
               const normalizedError = await normalizeUnknownError(effectiveErr);
@@ -730,8 +728,8 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   }
                 );
                 // Fail the step via event (event-sourced architecture).
-                // Serialize the original thrown value so its full type identity
-                // and custom properties round-trip through the event log.
+                // Persist the promoted FatalError for aborts so the parent
+                // workflow can distinguish cancellation from retry exhaustion.
                 try {
                   await world.events.create(
                     workflowRunId,
@@ -742,7 +740,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                       eventData: {
                         stepName,
                         error: await dehydrateStepError(
-                          err,
+                          effectiveErr,
                           workflowRunId,
                           encryptionKey
                         ),

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,0 +1,60 @@
+import { runInNewContext } from 'node:vm';
+import { FatalError } from '@workflow/errors';
+import { describe, expect, it } from 'vitest';
+import { isAbortError, promoteAbortErrorToFatal } from './types.js';
+
+describe('isAbortError', () => {
+  it('recognizes an AbortError from another realm', () => {
+    const error = runInNewContext(
+      'Object.assign(new Error("cancelled"), { name: "AbortError" })'
+    );
+
+    expect(error).not.toBeInstanceOf(Error);
+    expect(isAbortError(error)).toBe(true);
+  });
+
+  it.each([
+    { name: 'AbortError', message: 'serialized abort' },
+    new DOMException('dom abort', 'AbortError'),
+  ])('recognizes abort-shaped values', (error) => {
+    expect(isAbortError(error)).toBe(true);
+  });
+
+  it.each([
+    null,
+    undefined,
+    { name: 'TypeError', message: 'not an abort' },
+    { name: 'AbortError' },
+    { name: 'AbortError', message: 42 },
+    { name: 'AbortError', message: 'bad stack', stack: 42 },
+  ])('rejects non-abort values', (value) => {
+    expect(isAbortError(value)).toBe(false);
+  });
+});
+
+describe('promoteAbortErrorToFatal', () => {
+  it('promotes an abort-shaped value to FatalError and preserves its stack', () => {
+    const error = {
+      name: 'AbortError',
+      message: 'cancelled',
+      stack: 'AbortError: cancelled',
+    };
+
+    const promoted = promoteAbortErrorToFatal(error);
+
+    expect(FatalError.is(promoted)).toBe(true);
+    expect(promoted).toMatchObject({
+      name: 'FatalError',
+      message: 'Aborted: cancelled',
+      stack: error.stack,
+    });
+  });
+
+  it('preserves an already fatal abort error', () => {
+    const error = Object.assign(new FatalError('already fatal'), {
+      name: 'AbortError',
+    });
+
+    expect(promoteAbortErrorToFatal(error)).toBe(error);
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
 import { types } from 'node:util';
+import { FatalError } from '@workflow/errors';
 
 export function getErrorName(v: unknown): string {
   if (types.isNativeError(v)) {
@@ -28,6 +29,18 @@ export function isAbortError(
       value.stack === undefined ||
       typeof value.stack === 'string')
   );
+}
+
+export function promoteAbortErrorToFatal(value: unknown): unknown {
+  if (!isAbortError(value) || FatalError.is(value)) {
+    return value;
+  }
+
+  const fatalError = new FatalError(`Aborted: ${value.message}`);
+  if (value.stack) {
+    fatalError.stack = value.stack;
+  }
+  return fatalError;
 }
 
 export interface NormalizedUnknownError {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,6 +14,19 @@ export function getErrorStack(v: unknown): string {
   return '';
 }
 
+export function isAbortError(
+  value: unknown
+): value is { name: 'AbortError'; message: string; stack?: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    value.name === 'AbortError' &&
+    'message' in value &&
+    typeof value.message === 'string'
+  );
+}
+
 export interface NormalizedUnknownError {
   name: string;
   message: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,7 +23,10 @@ export function isAbortError(
     'name' in value &&
     value.name === 'AbortError' &&
     'message' in value &&
-    typeof value.message === 'string'
+    typeof value.message === 'string' &&
+    (!('stack' in value) ||
+      value.stack === undefined ||
+      typeof value.stack === 'string')
   );
 }
 

--- a/packages/core/src/workflow/abort-controller.ts
+++ b/packages/core/src/workflow/abort-controller.ts
@@ -205,7 +205,11 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
           });
 
           ctx.invocationsQueue.delete(correlationId);
-          return EventConsumerResult.Finished;
+          // Multiple handlers can observe the same pending abort request and
+          // durably record it before replay removes the queue item. Abort is
+          // idempotent, so consume later matching receipts as no-ops instead
+          // of surfacing a corrupted event log after the first receipt.
+          return EventConsumerResult.Consumed;
         }
 
         if (event.eventType === 'hook_disposed') {

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -2063,6 +2063,10 @@ export async function abortAnyInStepWorkflow() {
     abortFromStep(c2, 1000),
   ]);
 
+  // Step-initiated aborts update workflow-side signal state when replay
+  // processes hook_received at a suspension boundary.
+  await sleep('1s');
+
   return {
     stepResult,
     c1Aborted: c1.signal.aborted,
@@ -2313,8 +2317,9 @@ export async function abortFetchUncaughtWorkflow() {
 
   const controller = new AbortController();
 
-  // Abort immediately so fetch will throw
-  controller.abort('fetch-abort-test');
+  // Abort without a custom reason so fetch rejects with AbortError. Supplying
+  // a reason makes fetch reject with that value directly, which is retryable.
+  controller.abort();
 
   try {
     await stepThatFetchesWithSignal(controller.signal);

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -2065,7 +2065,7 @@ export async function abortAnyInStepWorkflow() {
 
   // Step-initiated aborts update workflow-side signal state when replay
   // processes hook_received at a suspension boundary.
-  await sleep('1s');
+  await sleep('100ms');
 
   return {
     stepResult,


### PR DESCRIPTION
## What changed

- Promote `AbortError`-shaped step failures to `FatalError` in both inline and queued step execution paths, including abort failures that crossed a serialization or VM boundary.
- Persist the promoted `FatalError` from the queued handler instead of persisting the original abort rejection.
- Change `abortFetchUncaughtWorkflow` to use the default abort reason and assert that it never emits `step_retrying`.
- Add a suspension checkpoint before asserting workflow-side state in `abortAnyInStepWorkflow`.
- Replace fixed hook-registration sleeps with `waitForHook(..., { runId })` for the abort-via-hook and hook-ordering E2E paths.
- Keep the internal abort-hook consumer subscribed after a matching durable abort receipt, so duplicate matching receipts from concurrent handlers are treated as idempotent abort delivery rather than a corrupted event log.
- Add unit coverage for duplicate matching abort receipts: the signal aborts once, both events are consumed, and no orphaned-event failure is reported.

## Why

Recent E2E failures showed distinct causes:

- `abortFetchUncaughtWorkflow` emitted `step_retrying` and retried to exhaustion. Locally, this reproduced even with default `abort()` before the fix: the step rejection was AbortError-shaped but did not reach fatal classification in the inline executor, and the queued path relied on a realm-sensitive `instanceof Error` gate.
- `abortAnyInStepWorkflow` was failing only on workflow-side `c2Aborted` while the step-side native `AbortSignal.any` assertions passed. The workflow-side signal observes the step-originated abort after replay processes the hook event at a suspension boundary.
- Hook-based abort tests were occasionally attempting lookup before hook registration was observable because they used fixed sleeps instead of the existing polling helper.
- Once the hook-ordering test used observable hook registration, the first CI run consistently exposed a real `resumeHook() -> abort()` race: the internal abort-controller hook received two durable `hook_received` events and the second became an unconsumed-event failure. This appeared in local-dev SvelteKit and Astro and in Windows E2E. Abort delivery is idempotent, so replay should consume matching duplicate abort receipts without failing the run.

This does not attempt to fix unrelated delayed wait/timer delivery failures or make broader changes to step-originated abort durability beyond the checkpoint asserted by these E2Es.

## Validation

- `pnpm vitest run packages/core/src/runtime/step-handler.test.ts packages/core/src/abort-controller-step.test.ts`
- `pnpm --filter @workflow/core test` (`42` files, `1036` tests passed)
- `pnpm turbo run build --filter=nextjs-turbopack...`
- `DEPLOYMENT_URL=http://localhost:3000 APP_NAME=nextjs-turbopack pnpm vitest run packages/core/e2e/e2e.test.ts -t 'abortViaHookWorkflow|abortAnyInStepWorkflow|abortFetchUncaughtWorkflow|abortHookOrderingWorkflow'` (`7` targeted tests passed)

`pnpm exec biome check` on the touched lint surfaces still reports diagnostics already present on current `main` in these files (for example existing non-null assertions, unused locals, complexity, and banned `Function` type findings); the new import-order diagnostic from this follow-up was fixed before push.
