### PR TITLE
[core] Allow settings attributes from inside step functions

### DIFF
--- a/.changeset/step-attributes.md
+++ b/.changeset/step-attributes.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": patch
+"workflow": patch
+---
+
+Allow `experimental_setAttributes()` to be called from step functions.

--- a/docs/content/docs/v5/api-reference/workflow/experimental-set-attributes.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/experimental-set-attributes.mdx
@@ -2,7 +2,7 @@
 title: experimental_setAttributes
 description: Attach string metadata to workflow run for observability.
 type: reference
-summary: Use experimental_setAttributes inside a workflow function to set run attributes.
+summary: Use experimental_setAttributes inside a workflow or step function to set run attributes.
 prerequisites:
   - /docs/foundations/workflows-and-steps
 related:
@@ -42,7 +42,7 @@ showSections={['parameters']}
 
 ## Usage
 
-Call `experimental_setAttributes` from a `"use workflow"` function. Calling it from a `"use step"` function or plain application code is not supported.
+Call `experimental_setAttributes` from a `"use workflow"` function or a `"use step"` function. Calling it from plain application code is not supported because there is no active workflow run.
 
 Attribute values must be strings. Pass `undefined` to remove an attribute:
 
@@ -59,3 +59,5 @@ export async function cleanupAttributes() {
 Attribute keys must be 1-256 characters, values must be strings up to 256 bytes, and each run can have up to 64 attributes. Keys that start with `$` are reserved for framework and library code.
 
 Validation errors throw [`FatalError`](/docs/api-reference/workflow/fatal-error) and fail the run before an attribute write is attempted.
+
+When called from a workflow body, the write is recorded through an internal step. When called from a step body, the step posts the attributes directly to the World. Storage errors from step-body calls throw from `experimental_setAttributes`, so catch them inside the step if the write should be best-effort.

--- a/docs/content/docs/v5/changelog/attributes-mvp.mdx
+++ b/docs/content/docs/v5/changelog/attributes-mvp.mdx
@@ -15,7 +15,7 @@ The MVP lets workflow code attach plaintext `string → string` metadata to a ru
 - Attributes are materialized onto the `WorkflowRun` entity, plaintext, and visible via `world.runs.get()` / `world.runs.list()` and any observability UI built on top of those
 - World implementations emit a side-channel observability record per successful write (in `world-vercel`, this hooks into the same observability/analytics pipeline already used for other run lifecycle events)
 
-Calling `experimental_setAttributes` from a step body or plain host code is intentionally not supported in the MVP — the host-side export throws `FatalError` directing callers back to a workflow body. This keeps the implementation a single dispatch path; step-body support can be added later without breaking the workflow-body contract.
+Calling `experimental_setAttributes` from a step body was intentionally not supported in the MVP, but step-body calls are now supported as a follow-up. Plain host code remains unsupported because there is no active workflow run to attach attributes to.
 
 ## What MVP does **not** support (deferred to 5.0.0)
 
@@ -136,7 +136,7 @@ await experimental_setAttributes(
 
 The flag is per-call (no run-level "this run accepts reserved keys" mode), so each framework call site explicitly declares intent. Don't enable it from user code — misuse can conflict with observability surfaces, agent dashboards, or future platform features that rely on the reserved namespace.
 
-`experimental_setAttributes` is callable only from a workflow body:
+`experimental_setAttributes` is callable from a workflow body:
 
 ```ts
 import { experimental_setAttributes } from 'workflow';
@@ -151,7 +151,7 @@ export async function myWorkflow(orderId: string) {
 
 The workflow-body path validates input inside the VM and then dispatches the canonical `AttributeChange[]` through an internal `__builtin_set_attributes` step bridge — see "How workflow-body dispatch works" below. The mutation is materialized on the run entity by the step body.
 
-The host-side export (the one resolved when the `workflow` package-exports condition is **not** `workflow`, i.e. step bodies and plain host code) throws `FatalError` with a message pointing callers back to the workflow body. There is no step-side dispatch path in the MVP — the workflow-body-only restriction is a scope cut for the MVP, not an architectural constraint, and may be relaxed in a follow-up.
+Step-body calls resolve to the host-side export. In a step context, that export validates the input and posts the attribute changes directly to `world.runs.experimentalSetAttributes(runId, changes)`. Plain host code still throws `FatalError`.
 
 #### Usage patterns
 
@@ -266,7 +266,8 @@ Unit tests in `@workflow/world` (validation surface) and `@workflow/core` (VM-si
 - `undefined` value normalizes to a `null`-valued change on the wire
 - The `{ allowReservedAttributes: true }` opt-in is forwarded through the step bridge so the world receives the flag
 - Workflow VM with no `WORKFLOW_USE_STEP` bound throws `FatalError`
-- Host-side stub (resolved when not in the workflow VM) throws `FatalError` directing the caller back to a workflow body
+- Host-side implementation posts directly to the world when called from a step context
+- Host-side implementation throws `FatalError` when called from plain host code
 
 Unit tests in `workflow` (internal built-in step behavior):
 
@@ -324,9 +325,11 @@ This puts the mutation on the event log as a normal `step_created → step_compl
 
 The internal step is best-effort during the experimental phase. It sets `maxRetries = 2`, for three total attempts. If `world.runs.experimentalSetAttributes` fails on attempts 1 or 2, the error is rethrown so the runtime retries the step normally. If it still fails on attempt 3, the step logs `console.error` and returns; the workflow run continues instead of receiving a retry-exhaustion `FatalError` for failed tag posting.
 
+Step-body calls do not use the internal built-in step. They run in host context already, so they post directly to the World. Storage errors throw from `experimental_setAttributes` like any other step-side side effect and can be caught by user code inside the step.
+
 The step body intentionally does **not** import anything from `@workflow/core`. That keeps the Next.js deferred-entries discoverer from walking a `__builtin_set_attributes` → `@workflow/core/...` → world adapter → `@vercel/queue` chain, which earlier drafts triggered (blowing the call stack of webpack's regex-based extractor with `RangeError: Maximum call stack size exceeded at RegExpStringIterator.next` on tarball-installed `nextjs-webpack` builds).
 
-The host-side `experimental_setAttributes` export (`packages/core/src/set-attributes.ts`, resolved by everything that isn't the workflow VM) throws `FatalError` with a message pointing the caller back to a workflow body. Step-body support can be added in a follow-up without changing this contract.
+The host-side `experimental_setAttributes` export (`packages/core/src/set-attributes.ts`, resolved by everything that isn't the workflow VM) supports step bodies by reading the current run id from step context and posting directly to the World. It still throws `FatalError` when called from plain host code.
 
 When the full 5.0.0 attributes feature lands, `__builtin_set_attributes` is replaced by an `events.create(runId, { eventType: 'attr_set', ... })` dispatch path; SDK signatures don't change.
 

--- a/docs/content/docs/v5/observability/attributes.mdx
+++ b/docs/content/docs/v5/observability/attributes.mdx
@@ -37,7 +37,7 @@ export async function orderWorkflow(orderId: string) {
 
 ## Usage
 
-Call [`experimental_setAttributes`](/docs/api-reference/workflow/experimental-set-attributes) from a `"use workflow"` function. Calling it from a `"use step"` function or plain application code is not supported.
+Call [`experimental_setAttributes`](/docs/api-reference/workflow/experimental-set-attributes) from a `"use workflow"` function or a `"use step"` function. Plain application code is not supported because there is no active workflow run to attach attributes to.
 
 Values must be strings. Pass `undefined` to remove a key:
 
@@ -58,8 +58,9 @@ Attribute keys must be 1-256 characters, values must be strings up to 256 bytes,
 While attributes are experimental:
 
 - Worlds that do not support attributes log a warning and ignore the call.
-- Storage errors are logged after retries, but do not fail the workflow run.
-- Setting attributes is currently slower than the final API will be, because each write goes through an internal workflow step. Prefer batching related attributes in one call.
+- Workflow-body storage errors are logged after retries, but do not fail the workflow run.
+- Step-body storage errors throw from `experimental_setAttributes` like any other step-side network write. Catch the error inside the step if the attribute is best-effort.
+- Setting attributes from a workflow body is currently slower than the final API will be, because each write goes through an internal workflow step. Step-body calls post directly to the World. Prefer batching related attributes in one call.
 - Reading and querying attributes is not available yet. A query API is planned.
 
 In a future release, using attributes with a World that does not support them, or when the World fails to store them, will fail with a [world error](/docs/api-reference/workflow-errors/workflow-world-error). This can be caught and handled to prevent failing a run.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -3424,7 +3424,7 @@ describe('e2e', () => {
 
       // Workflow should still be running (grace period), so hook should still be findable
       await sleep(1_000);
-      const hookAfterAbort = await getHookByToken(token).catch(() => null);
+      const _hookAfterAbort = await getHookByToken(token).catch(() => null);
       // Hook may or may not be disposed depending on timing, but run should complete
       const returnValue = await run1.returnValue;
       expect(returnValue.aborted).toBe(true);
@@ -3471,6 +3471,42 @@ describe('e2e', () => {
             )
         );
         expect(attrStepEvents.length).toBeGreaterThanOrEqual(2);
+      }
+    );
+
+    test(
+      'experimentalSetAttributesInsideStepWorkflow: step-body calls post directly to the world',
+      { timeout: 30_000 },
+      async () => {
+        const run = await start(
+          await e2e('experimentalSetAttributesInsideStepWorkflow'),
+          [9]
+        );
+        const output = await run.returnValue;
+        expect(output).toBe(36);
+
+        const world = await getWorld();
+        const persisted = await world.runs.get(run.runId);
+
+        expect(persisted?.attributes).toEqual({
+          phase: 'step-done',
+          source: 'step-body',
+          input: '9',
+        });
+
+        const { data: events } = await world.events.list({ runId: run.runId });
+        expect(
+          events.some(
+            (e) =>
+              (e.eventType === 'step_created' ||
+                e.eventType === 'step_completed') &&
+              typeof (e.eventData as { stepName?: string } | undefined)
+                ?.stepName === 'string' &&
+              (e.eventData as { stepName: string }).stepName.includes(
+                '__builtin_set_attributes'
+              )
+          )
+        ).toBe(false);
       }
     );
 

--- a/packages/core/src/attribute-changes.ts
+++ b/packages/core/src/attribute-changes.ts
@@ -1,0 +1,43 @@
+import { FatalError } from '@workflow/errors';
+import {
+  type AttributeChange,
+  AttributeValidationError,
+  validateAttributeChanges,
+} from '@workflow/world';
+
+interface AttributeChangeOptions {
+  allowReservedAttributes?: boolean;
+}
+
+export function normalizeAttributeChanges(
+  attrs: Record<string, string | undefined>,
+  options: AttributeChangeOptions = {}
+): AttributeChange[] {
+  if (attrs === null || typeof attrs !== 'object' || Array.isArray(attrs)) {
+    throw new FatalError(
+      `experimental_setAttributes requires a plain object, got ${
+        attrs === null ? 'null' : Array.isArray(attrs) ? 'array' : typeof attrs
+      }`
+    );
+  }
+
+  const changes: AttributeChange[] = Object.entries(attrs).map(
+    ([key, value]) => ({
+      key,
+      value: value === undefined ? null : value,
+    })
+  );
+  if (changes.length === 0) return changes;
+
+  const allowReservedAttributes = options.allowReservedAttributes === true;
+  try {
+    validateAttributeChanges(changes, { allowReservedAttributes });
+  } catch (err) {
+    if (err instanceof AttributeValidationError) {
+      throw new FatalError(err.message);
+    }
+    throw err;
+  }
+
+  return changes;
+}

--- a/packages/core/src/set-attributes.test.ts
+++ b/packages/core/src/set-attributes.test.ts
@@ -1,19 +1,146 @@
 import { FatalError } from '@workflow/errors';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { experimental_setAttributes } from './set-attributes.js';
+import { contextStorage, type StepContext } from './step/context-storage.js';
 
-describe('experimental_setAttributes (host-side stub)', () => {
-  // The host-side `experimental_setAttributes` is the fallback resolved when callers
-  // are NOT in the workflow VM. The real implementation lives in
-  // `workflow/set-attributes.ts` and is selected via the `workflow`
-  // package-exports condition. Reaching this file from a step body or
-  // plain host code is unsupported and must surface a clear error.
-  it('throws FatalError telling the user experimental_setAttributes is workflow-body only', async () => {
-    await expect(experimental_setAttributes({ phase: 'init' })).rejects.toBeInstanceOf(
-      FatalError
-    );
+const WORLD_CACHE = Symbol.for('@workflow/world//cache');
+const UNSUPPORTED_WORLD_WARNED = Symbol.for(
+  '@workflow/setAttributes//unsupportedWorldWarned'
+);
+const globals = globalThis as Record<symbol, unknown>;
+
+function stepContext(runId = 'run_123'): StepContext {
+  return {
+    stepMetadata: {
+      stepName: 'setAttributesStep',
+      stepId: 'step',
+      stepStartedAt: new Date('2026-01-01T00:00:00.000Z'),
+      attempt: 1,
+    },
+    workflowMetadata: {
+      workflowName: 'workflow',
+      workflowRunId: runId,
+      workflowStartedAt: new Date('2026-01-01T00:00:00.000Z'),
+      url: 'http://localhost/.well-known/workflow/v1/flow',
+      features: { encryption: false },
+    },
+    ops: [],
+  };
+}
+
+async function runInStepContext<T>(
+  callback: () => Promise<T>,
+  runId?: string
+): Promise<T> {
+  return contextStorage.run(stepContext(runId), callback);
+}
+
+describe('experimental_setAttributes (host-side)', () => {
+  let originalWorld: unknown;
+  let originalUnsupportedWorldWarned: unknown;
+
+  beforeEach(() => {
+    originalWorld = globals[WORLD_CACHE];
+    originalUnsupportedWorldWarned = globals[UNSUPPORTED_WORLD_WARNED];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalWorld === undefined) {
+      delete globals[WORLD_CACHE];
+    } else {
+      globals[WORLD_CACHE] = originalWorld;
+    }
+
+    if (originalUnsupportedWorldWarned === undefined) {
+      delete globals[UNSUPPORTED_WORLD_WARNED];
+    } else {
+      globals[UNSUPPORTED_WORLD_WARNED] = originalUnsupportedWorldWarned;
+    }
+  });
+
+  it('throws FatalError when called from plain host code', async () => {
+    await expect(
+      experimental_setAttributes({ phase: 'init' })
+    ).rejects.toBeInstanceOf(FatalError);
     await expect(experimental_setAttributes({ phase: 'init' })).rejects.toThrow(
-      /workflow.*function/i
+      /workflow.*step.*function/i
     );
+  });
+
+  it('posts normalized changes directly to the world when called from a step', async () => {
+    const experimentalSetAttributes = vi.fn().mockResolvedValue({
+      attributes: { phase: 'ready' },
+    });
+    globals[WORLD_CACHE] = {
+      name: 'test-world',
+      runs: { experimentalSetAttributes },
+    };
+
+    await runInStepContext(() =>
+      experimental_setAttributes({ phase: 'ready', stale: undefined })
+    );
+
+    expect(experimentalSetAttributes).toHaveBeenCalledWith(
+      'run_123',
+      [
+        { key: 'phase', value: 'ready' },
+        { key: 'stale', value: null },
+      ],
+      {}
+    );
+  });
+
+  it('forwards allowReservedAttributes for step-side reserved namespace writes', async () => {
+    const experimentalSetAttributes = vi.fn().mockResolvedValue({
+      attributes: { '$agent.kind': 'durable-agent' },
+    });
+    globals[WORLD_CACHE] = {
+      runs: { experimentalSetAttributes },
+    };
+
+    await runInStepContext(() =>
+      experimental_setAttributes(
+        { '$agent.kind': 'durable-agent' },
+        { allowReservedAttributes: true }
+      )
+    );
+
+    expect(experimentalSetAttributes).toHaveBeenCalledWith(
+      'run_123',
+      [{ key: '$agent.kind', value: 'durable-agent' }],
+      { allowReservedAttributes: true }
+    );
+  });
+
+  it('rejects validation errors before posting from a step', async () => {
+    const experimentalSetAttributes = vi.fn();
+    globals[WORLD_CACHE] = {
+      runs: { experimentalSetAttributes },
+    };
+
+    await expect(
+      runInStepContext(() => experimental_setAttributes({ $sys: 'x' }))
+    ).rejects.toBeInstanceOf(FatalError);
+    expect(experimentalSetAttributes).not.toHaveBeenCalled();
+  });
+
+  it('warns once and no-ops in a step when the world does not support attributes', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globals[WORLD_CACHE] = {
+      name: 'legacy-world',
+      runs: {},
+    };
+
+    await runInStepContext(() =>
+      experimental_setAttributes({ phase: 'ignored' })
+    );
+    await runInStepContext(() =>
+      experimental_setAttributes({ phase: 'ignored-again' })
+    );
+
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(consoleWarn.mock.calls[0]?.[0]).toContain('legacy-world');
   });
 });

--- a/packages/core/src/set-attributes.ts
+++ b/packages/core/src/set-attributes.ts
@@ -1,25 +1,60 @@
 import { FatalError } from '@workflow/errors';
+import { normalizeAttributeChanges } from './attribute-changes.js';
+import { getWorldLazy } from './runtime/get-world-lazy.js';
+import { contextStorage } from './step/context-storage.js';
 import type { ExperimentalSetAttributesOptions } from './workflow/set-attributes.js';
 
 export type { ExperimentalSetAttributesOptions };
 
+const UNSUPPORTED_WORLD_WARNED = Symbol.for(
+  '@workflow/setAttributes//unsupportedWorldWarned'
+);
+
 /**
- * Host-side stub for `experimental_setAttributes`. The real
- * implementation lives in `./workflow/set-attributes.ts` and is
- * selected by the `workflow` package-exports condition when the
- * workflow VM bundle is resolved.
+ * Host-side implementation for `experimental_setAttributes`. Workflow
+ * bodies resolve to `./workflow/set-attributes.ts` via the `workflow`
+ * package-exports condition; step bodies resolve here and can perform
+ * the world write directly because they already run in host context.
  *
- * Reaching this stub means the function was called outside a workflow
- * body — most likely from a `'use step'` function or plain host code.
- * That isn't supported in the MVP: attribute mutations must be
- * event-sourced through the workflow runtime so they survive replay.
+ * Plain application code still has no active workflow run, so it throws
+ * a clear `FatalError`.
  */
 export async function experimental_setAttributes(
-  _attrs: Record<string, string | undefined>,
-  _options?: ExperimentalSetAttributesOptions
+  attrs: Record<string, string | undefined>,
+  options: ExperimentalSetAttributesOptions = {}
 ): Promise<void> {
-  throw new FatalError(
-    "experimental_setAttributes() must be called from a 'use workflow' function. " +
-      'Calling it from a step body or plain host code is not supported.'
+  const store = contextStorage.getStore();
+  const runId = store?.workflowMetadata?.workflowRunId;
+  if (!runId) {
+    throw new FatalError(
+      "experimental_setAttributes() must be called from a 'use workflow' or 'use step' function. " +
+        'Calling it from plain host code is not supported.'
+    );
+  }
+
+  const changes = normalizeAttributeChanges(attrs, options);
+  if (changes.length === 0) return;
+
+  const world = await getWorldLazy();
+  if (typeof world.runs.experimentalSetAttributes !== 'function') {
+    const g = globalThis as Record<symbol, unknown>;
+    if (!g[UNSUPPORTED_WORLD_WARNED]) {
+      g[UNSUPPORTED_WORLD_WARNED] = true;
+      const name =
+        'name' in world && typeof world.name === 'string' ? world.name : '';
+      const worldName = name ? ` (${name})` : '';
+      console.warn(
+        `[workflow] setAttributes: the current world implementation${worldName} does not implement experimentalSetAttributes; this call (and any subsequent setAttributes calls in this process) is a no-op. Attributes will become available once the world adapter adds support.`
+      );
+    }
+    return;
+  }
+
+  await world.runs.experimentalSetAttributes(
+    runId,
+    changes,
+    options.allowReservedAttributes === true
+      ? { allowReservedAttributes: true }
+      : {}
   );
 }

--- a/packages/core/src/workflow/set-attributes.ts
+++ b/packages/core/src/workflow/set-attributes.ts
@@ -1,9 +1,6 @@
 import { FatalError } from '@workflow/errors';
-import {
-  type AttributeChange,
-  AttributeValidationError,
-  validateAttributeChanges,
-} from '@workflow/world';
+import type { AttributeChange } from '@workflow/world';
+import { normalizeAttributeChanges } from '../attribute-changes.js';
 import { WORKFLOW_USE_STEP } from '../symbols.js';
 
 /**
@@ -83,29 +80,9 @@ export async function experimental_setAttributes(
   attrs: Record<string, string | undefined>,
   options: ExperimentalSetAttributesOptions = {}
 ): Promise<void> {
-  if (attrs === null || typeof attrs !== 'object' || Array.isArray(attrs)) {
-    throw new FatalError(
-      `experimental_setAttributes requires a plain object, got ${
-        attrs === null ? 'null' : Array.isArray(attrs) ? 'array' : typeof attrs
-      }`
-    );
-  }
-  const changes: AttributeChange[] = Object.entries(attrs).map(
-    ([key, value]) => ({
-      key,
-      value: value === undefined ? null : value,
-    })
-  );
+  const changes = normalizeAttributeChanges(attrs, options);
   if (changes.length === 0) return;
   const allowReservedAttributes = options.allowReservedAttributes === true;
-  try {
-    validateAttributeChanges(changes, { allowReservedAttributes });
-  } catch (err) {
-    if (err instanceof AttributeValidationError) {
-      throw new FatalError(err.message);
-    }
-    throw err;
-  }
   const useStep = (globalThis as Record<symbol, unknown>)[WORKFLOW_USE_STEP] as
     | ((
         stepName: string

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -3177,7 +3177,7 @@ export async function writableForwardedFromStepWorkflow(payload: string) {
 }
 
 //////////////////////////////////////////////////////////
-// Workflow Attributes MVP — workflow-body-only API.
+// Workflow Attributes MVP — workflow and step API.
 
 /**
  * Calls `experimental_setAttributes` directly from the workflow body.
@@ -3193,6 +3193,29 @@ export async function experimentalSetAttributesWorkflow(input: number) {
   await experimental_setAttributes({ phase: 'done' });
   await experimental_setAttributes({ source: undefined });
   return tripled;
+}
+
+async function setAttributesFromStep(input: number) {
+  'use step';
+  await experimental_setAttributes({
+    phase: 'step-started',
+    source: 'step-body',
+    input: String(input),
+  });
+  await experimental_setAttributes({ phase: 'step-done' });
+  return input * 4;
+}
+
+/**
+ * Calls `experimental_setAttributes` from inside a normal user step. Step
+ * bodies already run in host context, so the helper posts directly to the
+ * world instead of creating a nested `__builtin_set_attributes` step.
+ */
+export async function experimentalSetAttributesInsideStepWorkflow(
+  input: number
+) {
+  'use workflow';
+  return setAttributesFromStep(input);
 }
 
 /**


### PR DESCRIPTION
Expands on #2134 to allow running `experimental_setAttributes()` from inside a `"use step"` function.

Shares SDK-side attribute normalization/validation between workflow and step entrypoints. Add unit and e2e coverage for step-side writes, and updates docs.

This is forward-compatible with event-based attributes if we accept attributes set from a step-level potentially racing with other calls, and accept not supporting deterministic getAttribute calls from within a workflow context. This will need to be documented when we move to the new implementation.