### PR TITLE
fix(world-local): skip Nov 2025 ghost versions on npm

### DIFF
--- a/.changeset/skip-world-local-nov-ghosts.md
+++ b/.changeset/skip-world-local-nov-ghosts.md
@@ -2,4 +2,4 @@
 '@workflow/world-local': patch
 ---
 
-Skip past abandoned `5.0.0-beta.8/9/10` npm slots (left over from the November 2025 5.x attempt) so the next Changesets publish lands on a fresh, unoccupied beta.N. The bumped local version is `5.0.0-beta.10`; the next Version Packages PR will compute `5.0.0-beta.11`, which is free. No functional code changes.
+Skip past abandoned `5.0.0-beta.8/9/10` npm slots from the November 2025 5.x attempt so the next Changesets publish lands on a fresh `5.0.0-beta.11`.

--- a/.changeset/skip-world-local-nov-ghosts.md
+++ b/.changeset/skip-world-local-nov-ghosts.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Skip past abandoned `5.0.0-beta.8/9/10` npm slots (left over from the November 2025 5.x attempt) so the next Changesets publish lands on a fresh, unoccupied beta.N. The bumped local version is `5.0.0-beta.10`; the next Version Packages PR will compute `5.0.0-beta.11`, which is free. No functional code changes.

--- a/packages/world-local/package.json
+++ b/packages/world-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workflow/world-local",
-  "version": "5.0.0-beta.8",
+  "version": "5.0.0-beta.10",
   "description": "Local development World implementation for Workflow SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Why

\`@workflow/world-local@5.0.0-beta.9\` (latest published, May 29 2026) is broken: it imports \`createLocalWorld\` from \`@workflow/world-local\`, but \`@workflow/world-local@5.0.0-beta.8\` (the pinned version) is a **November 2025 ghost** that exports the old \`createEmbeddedWorld\` name and uses 4.x dependencies.

Downstream consumers (e.g. Ash) hit:

\`\`\`
[MISSING_EXPORT] "createLocalWorld" is not exported by ".../@workflow/world-local@5.0.0-beta.8/.../dist/index.js"
[MISSING_EXPORT] "WorkflowAPIError" is not exported by ".../@workflow/errors@5.0.0-beta.5/.../dist/index.js"
\`\`\`

(The \`WorkflowAPIError\` failure is a downstream symptom: \`world-local@beta.8\` pins \`@workflow/errors@5.0.0-beta.4\`, which predates \`WorkflowAPIError\`.)

## Root cause: npm version-slot contamination

\`@workflow/world-local\` has two non-overlapping release trains sharing the \`5.0.0-beta.N\` namespace:

| Slot | Published | Source | Exports |
|------|-----------|--------|---------|
| \`5.0.0-beta.0\` – \`5.0.0-beta.7\` | Apr–May 2026 | current \`main\` | \`createLocalWorld\` |
| \`5.0.0-beta.8\` – \`5.0.0-beta.10\` | **Nov 2025 (ghost)** | abandoned 5.x attempt | \`createEmbeddedWorld\`, 4.x deps |

PR #2147 (last night's Version Packages) bumped \`packages/world-local/package.json\` from \`beta.7\` → \`beta.8\`. The actual publish to npm either silently failed or 409'd because the slot was occupied — but \`@workflow/core\` had already been published as \`beta.9\` with the new pin baked in via \`workspace:*\` rewriting:

\`\`\`json
// @workflow/core@5.0.0-beta.9 package.json
"@workflow/world-local": "5.0.0-beta.8"  // ← ghost
\`\`\`

So every consumer of \`core@beta.9\` resolves to the November \`world-local\`.

### Evidence

- npm publish history (ghosts vs current): https://www.npmjs.com/package/@workflow/world-local?activeTab=versions (\`beta.8/9/10\` show "6 months ago"; \`beta.0\`–\`beta.7\` show today/yesterday)
- \`core@beta.9\` pin: https://www.npmjs.com/package/@workflow/core/v/5.0.0-beta.9?activeTab=code → \`package.json\` → \`"@workflow/world-local": "5.0.0-beta.8"\`
- \`world-local@beta.8\` exports: https://www.npmjs.com/package/@workflow/world-local/v/5.0.0-beta.8?activeTab=code → \`dist/index.js\` exports \`createEmbeddedWorld\`, not \`createLocalWorld\`
- Only \`world-local\` is affected. \`world-vercel@beta.8\` was published cleanly today (2026-05-29 18:01 UTC) and matches \`core@beta.9\`'s pin. All other workspace packages bumped in #2147 are also fine.

## Fix

Bump \`packages/world-local/package.json\` from \`5.0.0-beta.8\` → \`5.0.0-beta.10\` (the highest contaminated slot). The next "Version Packages (beta)" PR (#2162) will compute the next pre-release after \`beta.10\` = \`5.0.0-beta.11\`, which is free on npm.

That cascade-bumps consumers via \`updateInternalDependencies: patch\` + \`workspace:*\` rewriting:

- \`@workflow/world-local\`: \`beta.8\` → \`beta.11\`
- \`@workflow/core\`: \`beta.9\` → \`beta.10\` (cascaded patch, fixed-with workflow)
- \`workflow\`: \`beta.9\` → \`beta.10\` (fixed with core)
- ...any other workspace consumers of \`world-local\`

The intermediate workspace marker \`beta.10\` is **never published** — \`changeset publish\` queries npm and skips occupied slots, and only \`beta.11\` (computed by the Version Packages PR) is in \`package.json\` by the time \`pnpm ci:publish\` runs.

## Validation

- [x] \`pnpm install\` clean (lockfile unchanged — \`workspace:*\` resolves locally)
- [x] Bump only affects an unconsumed version number; no code/API changes
- [ ] After merge: confirm Version Packages PR #2162 picks up the bump and proposes \`world-local@5.0.0-beta.11\`
- [ ] After Version Packages merge: confirm \`world-local@5.0.0-beta.11\` and \`core@5.0.0-beta.10\` are published; \`@workflow/core@5.0.0-beta.10\`'s \`package.json\` shows \`"@workflow/world-local": "5.0.0-beta.11"\`

## Why not \`unpublish\` the ghosts?

npm publishes are immutable; unpublish has a 72-hour window only, and the ghost versions are 6 months old. Skipping past them is the only path forward.

## Follow-up

Once this lands, downstream Ash work blocked on PR #2157 (step-side \`experimental_setAttributes\`) can resume by bumping to the cascaded \`@workflow/core@5.0.0-beta.10\`.