### PR TITLE
[test] Reproduce reused-sleep replay divergence in core runtime

### DIFF
--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -66,6 +66,7 @@ const CORR_IDS = [
   '01K11TFZ62YS0YYFDQ3E8B9YCX',
   '01K11TFZ62YS0YYFDQ3E8B9YCY',
   '01K11TFZ62YS0YYFDQ3E8B9YCZ',
+  '01K11TFZ62YS0YYFDQ3E8B9YD0',
 ];
 const DEFAULT_HOOK_TOKEN = '51reay3g91mW9qOHSORA_';
 
@@ -538,6 +539,244 @@ function defineTests(mode: 'sync' | 'async') {
 
     it('should let a queued hook payload win when iterator.next is pending before the setup step completes', async () => {
       await expectRawRaceToChooseQueuedHook(true);
+    });
+
+    async function replayEarlyWaiterAcrossDrain(options: {
+      winner: 'hook' | 'sleep';
+    }) {
+      await setupHydrateMock();
+      const ops: Promise<any>[] = [];
+      const [
+        payload0,
+        payload1,
+        progress0Result,
+        drain0Result,
+        progress1Result,
+      ] = await Promise.all([
+        dehydrateStepReturnValue(
+          { value: 'first-wake' },
+          'wrun_test',
+          undefined,
+          ops
+        ),
+        dehydrateStepReturnValue(
+          { value: 'second-wake' },
+          'wrun_test',
+          undefined,
+          ops
+        ),
+        dehydrateStepReturnValue(undefined, 'wrun_test', undefined, ops),
+        dehydrateStepReturnValue(undefined, 'wrun_test', undefined, ops),
+        dehydrateStepReturnValue(undefined, 'wrun_test', undefined, ops),
+      ]);
+      const resumeAt = new Date('2026-05-29T23:14:03.369Z');
+
+      const secondHookEvent: Event = {
+        eventId: 'evnt_8',
+        runId: 'wrun_test',
+        eventType: 'hook_received',
+        correlationId: `hook_${CORR_IDS[0]}`,
+        eventData: { token: 'test-token', payload: payload1 },
+        createdAt: new Date(),
+      };
+      const waitCompletedEvent: Event = {
+        eventId: 'evnt_10',
+        runId: 'wrun_test',
+        eventType: 'wait_completed',
+        correlationId: `wait_${CORR_IDS[2]}`,
+        eventData: { resumeAt },
+        createdAt: new Date(),
+      };
+      const decidingEvents =
+        options.winner === 'hook'
+          ? [secondHookEvent, waitCompletedEvent]
+          : [waitCompletedEvent, secondHookEvent];
+      const finalStepName =
+        options.winner === 'hook' ? 'drainStep' : 'progressStep';
+
+      // This models the deployed loop after the user moved iterator.next()
+      // before the progress step. The second payload and the reused wait can
+      // become ready while the first hook-winning drain is still running.
+      const ctx = setupWorkflowContext([
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_created',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', isWebhook: false },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'progressStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_2',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'progressStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_3',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'progressStep', result: progress0Result },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_4',
+          runId: 'wrun_test',
+          eventType: 'wait_created',
+          correlationId: `wait_${CORR_IDS[2]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_5',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', payload: payload0 },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_6',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'drainStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_7',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'drainStep' },
+          createdAt: new Date(),
+        },
+        ...decidingEvents,
+        {
+          eventId: 'evnt_9',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'drainStep', result: drain0Result },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_11',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[4]}`,
+          eventData: { stepName: 'progressStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_12',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[4]}`,
+          eventData: { stepName: 'progressStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_13',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[4]}`,
+          eventData: { stepName: 'progressStep', result: progress1Result },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_14',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[5]}`,
+          eventData: { stepName: finalStepName },
+          createdAt: new Date(),
+        },
+      ]);
+
+      const createHook = createCreateHook(ctx);
+      const sleep = createSleep(ctx);
+      const useStep = createUseStep(ctx);
+
+      const { error } = await runWithDiscontinuation(ctx, async () => {
+        const hook = createHook<{ value: string }>({ token: 'test-token' });
+        const iterator = hook[Symbol.asyncIterator]();
+        const progressStep = useStep('progressStep');
+        const drainStep = useStep('drainStep');
+        let pendingSleep: Promise<void> | undefined;
+
+        for (let index = 0; index < 2; index++) {
+          const pendingRead = iterator.next();
+          await progressStep();
+          pendingSleep ??= sleep(resumeAt);
+
+          const result = await Promise.race([
+            pendingRead.then((value) => ({ kind: 'hook' as const, value })),
+            pendingSleep.then(() => ({ kind: 'sleep' as const })),
+          ]);
+
+          if (result.kind === 'hook') {
+            await drainStep();
+            continue;
+          }
+
+          pendingSleep = undefined;
+          if (index === 1) {
+            await progressStep();
+          }
+        }
+      });
+
+      return { ctx, error };
+    }
+
+    it('should preserve the early waiter with a reused sleep when the buffered hook wins', async () => {
+      const { ctx, error } = await replayEarlyWaiterAcrossDrain({
+        winner: 'hook',
+      });
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+
+      const pendingSteps = [...ctx.invocationsQueue.values()].filter(
+        (i) => i.type === 'step'
+      );
+      expect(pendingSteps).toHaveLength(1);
+      expect(pendingSteps[0].type === 'step' && pendingSteps[0].stepName).toBe(
+        'drainStep'
+      );
+    });
+
+    it('should preserve the early waiter with a reused sleep when wait completion wins', async () => {
+      const { ctx, error } = await replayEarlyWaiterAcrossDrain({
+        winner: 'sleep',
+      });
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+
+      const pendingSteps = [...ctx.invocationsQueue.values()].filter(
+        (i) => i.type === 'step'
+      );
+      expect(pendingSteps).toHaveLength(1);
+      expect(pendingSteps[0].type === 'step' && pendingSteps[0].stepName).toBe(
+        'progressStep'
+      );
     });
   });
 

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -404,6 +404,127 @@ function defineTests(mode: 'sync' | 'async') {
         'drainStep'
       );
     });
+
+    it('should let a queued hook payload win without mapping the race promises', async () => {
+      await setupHydrateMock();
+      const ops: Promise<any>[] = [];
+      const [payload, setupResult] = await Promise.all([
+        dehydrateStepReturnValue(
+          { value: 'hook-wins' },
+          'wrun_test',
+          undefined,
+          ops
+        ),
+        dehydrateStepReturnValue(undefined, 'wrun_test', undefined, ops),
+      ]);
+      const resumeAt = new Date('2026-05-20T22:16:57.197Z');
+
+      // This is the same ordered durable history as the mapped-race test.
+      const ctx = setupWorkflowContext([
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_created',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', isWebhook: false },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_test',
+          eventType: 'wait_created',
+          correlationId: `wait_${CORR_IDS[1]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_2',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', payload },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_3',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'setupStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_4',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'setupStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_5',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'setupStep', result: setupResult },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_6',
+          runId: 'wrun_test',
+          eventType: 'wait_completed',
+          correlationId: `wait_${CORR_IDS[1]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_7',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'drainStep' },
+          createdAt: new Date(),
+        },
+      ]);
+
+      const createHook = createCreateHook(ctx);
+      const sleep = createSleep(ctx);
+      const useStep = createUseStep(ctx);
+
+      const { error } = await runWithDiscontinuation(ctx, async () => {
+        const hook = createHook<{ value: string }>({ token: 'test-token' });
+        const iterator = hook[Symbol.asyncIterator]();
+        const pendingSleep = sleep(resumeAt);
+        const setupStep = useStep('setupStep');
+        const drainStep = useStep('drainStep');
+        const syncNextStep = useStep('syncNextStep');
+
+        await setupStep();
+
+        const result = await Promise.race([iterator.next(), pendingSleep]);
+
+        if (result !== undefined) {
+          await drainStep();
+          return result.value.value;
+        }
+
+        await syncNextStep();
+        return 'sleep';
+      });
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+
+      const pendingSteps = [...ctx.invocationsQueue.values()].filter(
+        (i) => i.type === 'step'
+      );
+      expect(pendingSteps).toHaveLength(1);
+      expect(pendingSteps[0].type === 'step' && pendingSteps[0].stepName).toBe(
+        'drainStep'
+      );
+    });
   });
 
   describe(`hook + incomplete step ${label}`, () => {

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -405,7 +405,9 @@ function defineTests(mode: 'sync' | 'async') {
       );
     });
 
-    it('should let a queued hook payload win without mapping the race promises', async () => {
+    async function expectRawRaceToChooseQueuedHook(
+      hookWaitBeforeSetup: boolean
+    ) {
       await setupHydrateMock();
       const ops: Promise<any>[] = [];
       const [payload, setupResult] = await Promise.all([
@@ -494,6 +496,7 @@ function defineTests(mode: 'sync' | 'async') {
       const { error } = await runWithDiscontinuation(ctx, async () => {
         const hook = createHook<{ value: string }>({ token: 'test-token' });
         const iterator = hook[Symbol.asyncIterator]();
+        const pendingHook = hookWaitBeforeSetup ? iterator.next() : undefined;
         const pendingSleep = sleep(resumeAt);
         const setupStep = useStep('setupStep');
         const drainStep = useStep('drainStep');
@@ -501,7 +504,10 @@ function defineTests(mode: 'sync' | 'async') {
 
         await setupStep();
 
-        const result = await Promise.race([iterator.next(), pendingSleep]);
+        const result = await Promise.race([
+          pendingHook ?? iterator.next(),
+          pendingSleep,
+        ]);
 
         if (result !== undefined) {
           await drainStep();
@@ -524,6 +530,14 @@ function defineTests(mode: 'sync' | 'async') {
       expect(pendingSteps[0].type === 'step' && pendingSteps[0].stepName).toBe(
         'drainStep'
       );
+    }
+
+    it('should let a queued hook payload win without mapping the race promises', async () => {
+      await expectRawRaceToChooseQueuedHook(false);
+    });
+
+    it('should let a queued hook payload win when iterator.next is pending before the setup step completes', async () => {
+      await expectRawRaceToChooseQueuedHook(true);
     });
   });
 

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -279,6 +279,131 @@ function defineTests(mode: 'sync' | 'async') {
       expect(error).toBeUndefined();
       expect(result).toEqual(['first', 'second']);
     });
+
+    it('should let a queued hook payload win when a reused wait completes after the step that installs the race', async () => {
+      await setupHydrateMock();
+      const ops: Promise<any>[] = [];
+      const [payload, setupResult] = await Promise.all([
+        dehydrateStepReturnValue(
+          { value: 'hook-wins' },
+          'wrun_test',
+          undefined,
+          ops
+        ),
+        dehydrateStepReturnValue(undefined, 'wrun_test', undefined, ops),
+      ]);
+      const resumeAt = new Date('2026-05-20T22:16:57.197Z');
+
+      // This is an ordered durable history where the hook branch already won.
+      // setupWorkflowContext exercises core replay without a World backend.
+      const ctx = setupWorkflowContext([
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_created',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', isWebhook: false },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_test',
+          eventType: 'wait_created',
+          correlationId: `wait_${CORR_IDS[1]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_2',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', payload },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_3',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'setupStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_4',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'setupStep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_5',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'setupStep', result: setupResult },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_6',
+          runId: 'wrun_test',
+          eventType: 'wait_completed',
+          correlationId: `wait_${CORR_IDS[1]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_7',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'drainStep' },
+          createdAt: new Date(),
+        },
+      ]);
+
+      const createHook = createCreateHook(ctx);
+      const sleep = createSleep(ctx);
+      const useStep = createUseStep(ctx);
+
+      const { error } = await runWithDiscontinuation(ctx, async () => {
+        const hook = createHook<{ value: string }>({ token: 'test-token' });
+        const iterator = hook[Symbol.asyncIterator]();
+        const pendingSleep = sleep(resumeAt);
+        const setupStep = useStep('setupStep');
+        const drainStep = useStep('drainStep');
+        const syncNextStep = useStep('syncNextStep');
+
+        await setupStep();
+
+        const result = await Promise.race([
+          iterator.next().then((value) => ({ kind: 'hook' as const, value })),
+          pendingSleep.then(() => ({ kind: 'sleep' as const })),
+        ]);
+
+        if (result.kind === 'hook') {
+          await drainStep();
+          return result.value.value;
+        }
+
+        await syncNextStep();
+        return 'sleep';
+      });
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+
+      const pendingSteps = [...ctx.invocationsQueue.values()].filter(
+        (i) => i.type === 'step'
+      );
+      expect(pendingSteps).toHaveLength(1);
+      expect(pendingSteps[0].type === 'step' && pendingSteps[0].stepName).toBe(
+        'drainStep'
+      );
+    });
   });
 
   describe(`hook + incomplete step ${label}`, () => {

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -533,7 +533,7 @@ function defineTests(mode: 'sync' | 'async') {
       );
     }
 
-    it('should let a queued hook payload win without mapping the race promises', async () => {
+    it.fails('should let a queued hook payload win without mapping the race promises', async () => {
       await expectRawRaceToChooseQueuedHook(false);
     });
 
@@ -760,7 +760,7 @@ function defineTests(mode: 'sync' | 'async') {
       );
     });
 
-    it('should preserve the early waiter with a reused sleep when wait completion wins', async () => {
+    it.fails('should preserve the early waiter with a reused sleep when wait completion wins', async () => {
       const { ctx, error } = await replayEarlyWaiterAcrossDrain({
         winner: 'sleep',
       });

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -281,7 +281,7 @@ function defineTests(mode: 'sync' | 'async') {
       expect(result).toEqual(['first', 'second']);
     });
 
-    it('should let a queued hook payload win when a reused wait completes after the step that installs the race', async () => {
+    it.fails('should let a queued hook payload win when a reused wait completes after the step that installs the race', async () => {
       await setupHydrateMock();
       const ops: Promise<any>[] = [];
       const [payload, setupResult] = await Promise.all([


### PR DESCRIPTION
## What this proves

This adds core-runtime regression and discriminator tests for the observed `Promise.race([iterator.next(), reused sleep])` divergence. The tests drive `setupWorkflowContext()` with explicitly ordered in-memory event histories, so they do not involve DynamoDB, Postgres, `world-local`, a Vercel deployment, or network timing.

The original ordered durable history is:

```txt
hook_created
wait_created
hook_received
step_created setupStep
step_started setupStep
step_completed setupStep
wait_completed
step_created drainStep
```

That history records the hook branch having won: the durable next operation is `drainStep`. Current `stable` replay instead follows the sleep branch and attempts to consume `syncNextStep`, reporting the same path-divergence corruption observed in hosted runs.

## Early waiter across a drain

The hosted repro was subsequently changed to install `iterator.next()` before `syncStatusSurfaceLikeStep`, matching this PR's original positive control. That narrows the original boundary, but it is not a complete workaround when the loop reuses its sleep.

This PR now includes a two-iteration history matching the remaining window:

```txt
iteration 0: progressStep -> create reused wait -> hook wins -> drainStep starts
during drainStep: second hook_received and reused wait_completed become ready
iteration 1: installs iterator.next() before progressStep
```

There are two order-controlled tests for that history:

- If the buffered second hook is delivered first, replay follows the recorded `drainStep` branch and passes.
- If the reused `wait_completed` is delivered first, the recorded next operation is `progressStep`, but current `stable` replay consumes the hook branch and attempts `drainStep`.

The failing error is:

```txt
Corrupted event log: step event step_created ... belongs to "progressStep", but the current step consumer is "drainStep"
```

This reproduces the failure direction seen in `wrun_01KSV07R3NQ9C26F4E0D0RTA8S` from a complete, ordered in-memory event history. Moving `iterator.next()` before the progress step cannot cover the interval while the previous hook-winning `drainStep` is awaited.

## Expected failing validation

```sh
fnm exec --using 24 pnpm --filter '@workflow/core...' build
fnm exec --using 24 pnpm --filter @workflow/core exec vitest run src/hook-sleep-interaction.test.ts --reporter=verbose
```

The targeted suite deterministically fails in both synchronous and asynchronous deserialization modes. This PR is intentionally test-only and expected to be red: its purpose is to preserve the minimal runtime-only reproductions while the fix is developed.

## Promise-shape discriminator

For the original one-race history, both the mapped race

```ts
Promise.race([
  iterator.next().then((value) => ({ kind: 'hook', value })),
  pendingSleep.then(() => ({ kind: 'sleep' })),
]);
```

and raw `Promise.race([iterator.next(), pendingSleep])` fail with the same `drainStep` versus `syncNextStep` divergence. Installing the iterator read before `setupStep` makes that original history pass.

The new two-iteration test demonstrates why that source-level adjustment does not resolve the overall bug: after the first hook value is consumed, no next iterator read is pending while the hook-side drain step is awaited. Reused sleep completion and buffered hook delivery can still be consumed into a trajectory different from the recorded next operation.

## Relationship to the candidate fix

#2048 repairs the original single-iteration waiter-installation reproduction. I also applied the new two-iteration drain-window test to its current candidate commit (`6164a6dd9`) locally: the hook-first control passes, but the wait-first case still fails in both deserialization modes with the same `progressStep` versus `drainStep` corruption. The new test therefore captures a remaining runtime boundary not covered by that candidate repair.
