### PR TITLE
[stable] Harden event pagination responses

### DIFF
--- a/.changeset/calm-events-guard.md
+++ b/.changeset/calm-events-guard.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Harden runtime event pagination against rejected, repeated, or overlapping cursor responses.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -600,7 +600,15 @@ export function workflowEntrypoint(
                     );
 
                     if (sawAllWaitCompletions) {
-                      events.push(...newEvents.events);
+                      const existingIds = new Set(
+                        events.map((event) => event.eventId)
+                      );
+                      for (const event of newEvents.events) {
+                        if (!existingIds.has(event.eventId)) {
+                          existingIds.add(event.eventId);
+                          events.push(event);
+                        }
+                      }
                     } else {
                       const loadedEvents = await getWorkflowRunEvents(
                         workflowRun.runId

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -1,3 +1,4 @@
+import { WorkflowWorldError } from '@workflow/errors';
 import type { Event, World } from '@workflow/world';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -263,5 +264,83 @@ describe('getWorkflowRunEvents', () => {
     // Preserving the input cursor avoids the runtime treating "no new events
     // since last poll" as "I have no idea where I am in the log."
     expect(result.cursor).toBe('eid:evnt_z');
+  });
+
+  it('deduplicates overlapping pages from a restarted continuation read', async () => {
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_a'), makeEvent('evnt_b')],
+      cursor: 'eid:evnt_b',
+      hasMore: true,
+    });
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_b'), makeEvent('evnt_c')],
+      cursor: 'eid:evnt_c',
+      hasMore: false,
+    });
+
+    const result = await getWorkflowRunEvents('wrun_test');
+
+    expect(result.events.map((event) => event.eventId)).toEqual([
+      'evnt_a',
+      'evnt_b',
+      'evnt_c',
+    ]);
+  });
+
+  it('retries a rejected continuation cursor as a full load once', async () => {
+    eventsListMock.mockRejectedValueOnce(
+      new WorkflowWorldError('invalid cursor', { status: 400 })
+    );
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_a'), makeEvent('evnt_b')],
+      cursor: 'eid:evnt_b',
+      hasMore: false,
+    });
+
+    const result = await getWorkflowRunEvents('wrun_test', 'opaque-cursor');
+
+    expect(result.events.map((event) => event.eventId)).toEqual([
+      'evnt_a',
+      'evnt_b',
+    ]);
+    expect(eventsListMock).toHaveBeenNthCalledWith(1, {
+      runId: 'wrun_test',
+      pagination: { sortOrder: 'asc', cursor: 'opaque-cursor' },
+    });
+    expect(eventsListMock).toHaveBeenNthCalledWith(2, {
+      runId: 'wrun_test',
+      pagination: { sortOrder: 'asc', cursor: undefined },
+    });
+  });
+
+  it('fails instead of looping when pagination repeats a cursor', async () => {
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_a')],
+      cursor: 'eid:evnt_a',
+      hasMore: true,
+    });
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_a')],
+      cursor: 'eid:evnt_a',
+      hasMore: true,
+    });
+
+    await expect(getWorkflowRunEvents('wrun_test')).rejects.toMatchObject({
+      code: 'WORLD_CONTRACT_ERROR',
+    });
+    expect(eventsListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails when a response reports more pages without a cursor', async () => {
+    eventsListMock.mockResolvedValueOnce({
+      data: [makeEvent('evnt_a')],
+      cursor: null,
+      hasMore: true,
+    });
+
+    await expect(getWorkflowRunEvents('wrun_test')).rejects.toMatchObject({
+      code: 'WORLD_CONTRACT_ERROR',
+    });
+    expect(eventsListMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -1,3 +1,4 @@
+import { RUN_ERROR_CODES, WorkflowWorldError } from '@workflow/errors';
 import type {
   Event,
   HealthCheckPayload,
@@ -369,6 +370,62 @@ export interface LoadedWorkflowRunEvents {
   cursor: string | null;
 }
 
+function eventPaginationContractError(
+  runId: string,
+  message: string
+): WorkflowWorldError {
+  return new WorkflowWorldError(
+    `Event pagination ${message} for workflow run "${runId}".`,
+    { code: RUN_ERROR_CODES.WORLD_CONTRACT_ERROR }
+  );
+}
+
+function appendUniqueEvents(
+  target: Event[],
+  targetIds: Set<string>,
+  events: Event[]
+): void {
+  for (const event of events) {
+    if (!targetIds.has(event.eventId)) {
+      targetIds.add(event.eventId);
+      target.push(event);
+    }
+  }
+}
+
+function assertEventPaginationProgress(
+  runId: string,
+  hasMore: boolean,
+  cursor: string | null,
+  requestedCursors: Set<string>
+): void {
+  if (!hasMore) {
+    return;
+  }
+  if (cursor === null) {
+    throw eventPaginationContractError(
+      runId,
+      'returned more pages without a cursor'
+    );
+  }
+  if (requestedCursors.has(cursor)) {
+    throw eventPaginationContractError(runId, 'repeated a cursor');
+  }
+}
+
+function shouldRetryWithoutEventCursor(
+  error: unknown,
+  cursor: string | null,
+  alreadyRetried: boolean
+): boolean {
+  return (
+    cursor !== null &&
+    !alreadyRetried &&
+    WorkflowWorldError.is(error) &&
+    error.status === 400
+  );
+}
+
 /**
  * Loads workflow run events by iterating through all pages of paginated results.
  * When a cursor is provided, only events after that cursor are loaded.
@@ -384,9 +441,12 @@ export async function getWorkflowRunEvents(
     });
 
     const allEvents: Event[] = [];
+    const loadedEventIds = new Set<string>();
+    const requestedCursors = new Set<string>();
     let nextCursor: string | null = cursor ?? null;
     let hasMore = true;
     let pagesLoaded = 0;
+    let retriedWithoutCursor = false;
 
     const world = getWorld();
     const loadStart = Date.now();
@@ -395,16 +455,50 @@ export async function getWorkflowRunEvents(
       // to lazyload the data from the world instead so that we can optimize and make the event log loading
       // much faster and memory efficient
       const pageStart = Date.now();
-      const response = await world.events.list({
-        runId,
-        pagination: {
-          sortOrder: 'asc', // Required: events must be in chronological order for replay
-          cursor: nextCursor ?? undefined,
-        },
-      });
+      const requestedCursor = nextCursor;
+      if (requestedCursor) {
+        requestedCursors.add(requestedCursor);
+      }
 
-      allEvents.push(...response.data);
+      let response: Awaited<ReturnType<typeof world.events.list>>;
+      try {
+        response = await world.events.list({
+          runId,
+          pagination: {
+            sortOrder: 'asc', // Required: events must be in chronological order for replay
+            cursor: requestedCursor ?? undefined,
+          },
+        });
+      } catch (error) {
+        if (
+          shouldRetryWithoutEventCursor(
+            error,
+            requestedCursor,
+            retriedWithoutCursor
+          )
+        ) {
+          runtimeLogger.warn(
+            'Event cursor was rejected; retrying with a full event reload.',
+            { workflowRunId: runId }
+          );
+          allEvents.length = 0;
+          loadedEventIds.clear();
+          requestedCursors.clear();
+          nextCursor = null;
+          retriedWithoutCursor = true;
+          continue;
+        }
+        throw error;
+      }
+
+      appendUniqueEvents(allEvents, loadedEventIds, response.data);
       hasMore = response.hasMore;
+      assertEventPaginationProgress(
+        runId,
+        hasMore,
+        response.cursor,
+        requestedCursors
+      );
       // Preserve the last non-null cursor across pages. A World may
       // legitimately return `{ data: [], cursor: null, hasMore: false }`
       // on a trailing empty page — for example when the previous page's

--- a/packages/core/src/runtime/wait-completion-replay.test.ts
+++ b/packages/core/src/runtime/wait-completion-replay.test.ts
@@ -40,6 +40,7 @@ async function runStaleWaitReplayScenario(options: {
   includePreloadedCursor: boolean;
   preloadedHasMore?: boolean;
   omitWaitCompletionFromDelta?: boolean;
+  restartDeltaAtBeginning?: boolean;
 }) {
   vi.spyOn(Date, 'now').mockReturnValue(+fixedNow);
 
@@ -182,7 +183,8 @@ async function runStaleWaitReplayScenario(options: {
       // Cursor reads simulate the optimized delta fetch. Without a cursor, the
       // runtime has fallen back to a full reload from the beginning.
       let data =
-        params.pagination?.cursor === staleEventsCursor
+        params.pagination?.cursor === staleEventsCursor &&
+        !options.restartDeltaAtBeginning
           ? durableEvents.slice(staleEvents.length)
           : [...durableEvents];
       if (
@@ -361,6 +363,27 @@ describe('workflow handler wait completion replay', () => {
       })
     );
     expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'hook_received',
+      'wait_completed',
+    ]);
+    expectHookBranchQueued(result);
+  });
+
+  it('deduplicates a cursor delta that unexpectedly restarts at the beginning', async () => {
+    const result = await runStaleWaitReplayScenario({
+      includePreloadedCursor: true,
+      restartDeltaAtBeginning: true,
+    });
+
+    expect(result.listEvents).toHaveBeenCalledTimes(1);
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'run_created',
+      'run_started',
+      'hook_created',
+      'step_created',
+      'step_started',
+      'step_completed',
+      'wait_created',
       'hook_received',
       'wait_completed',
     ]);


### PR DESCRIPTION
## Summary

- deduplicate overlapping event-log pages returned during cursor pagination
- retry a rejected continuation cursor once by reloading the event log from the beginning
- fail with a world contract error when pagination returns no usable progress
- deduplicate events before appending the stable runtime's wait-completion delta

## Why

This is client-side defense in depth for the cursor compatibility issue addressed by vercel/workflow-server#454. On `stable`, the optimized wait-completion replay path appends the cursor delta directly. If a server ignores the cursor and restarts the read at the beginning, previously committed events can be appended again and corrupt replay.

The server still needs to preserve legacy cursor compatibility for already deployed clients. This backport also makes the stable client tolerant of overlapping or rejected cursor reads and fails cleanly for non-progressing pagination.

## Validation

- `pnpm --filter '@workflow/core...' build`
- Node `v24.15.0`: `pnpm --filter @workflow/core typecheck`
- Node `v24.15.0`: `pnpm --filter @workflow/core test` (`639` tests passed)
- `pnpm exec biome check packages/core/src/runtime/helpers.ts packages/core/src/runtime/helpers.test.ts packages/core/src/runtime/wait-completion-replay.test.ts .changeset/calm-events-guard.md`
- `git diff --check`
