### PR TITLE
[core] Forward-port: preserve event-log order in hook-vs-sleep replay races (#2171)

### DIFF
--- a/.changeset/hook-sleep-replay-ordering.md
+++ b/.changeset/hook-sleep-replay-ordering.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Fix `CorruptedEventLogError` on replay when a workflow races a hook read against a `sleep()` (e.g. `Promise.race([hook, sleep])`). Branch-deciding deliveries (buffered hook payloads and wait completions) are now handed to the workflow in strict event-log order — anchored on event position rather than on microtask-resolution timing — so the committed branch wins the race deterministically, independent of decryption/hydration time or `Promise.race` argument order.

--- a/packages/core/src/async-deserialization-ordering.test.ts
+++ b/packages/core/src/async-deserialization-ordering.test.ts
@@ -62,6 +62,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     onWorkflowError: vi.fn(),
     promiseQueue: Promise.resolve(),
     pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
   };
 }
 
@@ -681,5 +682,82 @@ describe('async deserialization ordering', () => {
 
     // Step A must resolve before step B (event log order)
     expect(resolveOrder).toEqual(['A:value_A', 'B:value_B']);
+  });
+
+  // Regression for the buffered-hook delivery rework: a buffered payload's
+  // hydration outcome is captured and only turned into a resolved/rejected
+  // promise when a consumer claims it. It must never reject a promise that no
+  // consumer has attached a handler to (which would surface as an unhandled
+  // rejection and crash the process).
+  it('should not emit an unhandled rejection before a buffered hook payload is claimed', async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const ctx = setupWorkflowContext([
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+          eventData: {
+            payload: new Uint8Array([101, 110, 99, 114]), // "encr" without a key
+          },
+          createdAt: new Date(),
+        },
+      ]);
+
+      const createHook = createCreateHook(ctx);
+      const hook = createHook();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toEqual([]);
+      await expect(hook).rejects.toThrow(
+        'Encrypted data encountered but no encryption key'
+      );
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  // Regression for the delivery-barrier registry: when a buffered hook is
+  // never claimed because another branch wins, its barrier must still be
+  // retired (at idle) so `pendingDeliveryBarriers` does not retain one entry
+  // per abandoned payload.
+  it('should discard an unclaimed hook delivery barrier after a later wait proceeds', async () => {
+    const payload = await dehydrateStepReturnValue(
+      'unused',
+      'wrun_test',
+      undefined
+    );
+    const resumeAt = new Date('2024-01-01T00:00:05.000Z');
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_test',
+        eventType: 'hook_received',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: { payload },
+        createdAt: new Date(),
+      },
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_test',
+        eventType: 'wait_completed',
+        correlationId: 'wait_01K11TFZ62YS0YYFDQ3E8B9YCW',
+        eventData: { resumeAt },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const createHook = createCreateHook(ctx);
+    const sleep = createSleep(ctx);
+    createHook();
+    await sleep(resumeAt);
+
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(0);
   });
 });

--- a/packages/core/src/hook-sleep-interaction.test.ts
+++ b/packages/core/src/hook-sleep-interaction.test.ts
@@ -67,6 +67,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
       promiseQueueHolder.current = value;
     },
     pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
   };
   ctxRef.current = ctx;
   return ctx;
@@ -314,7 +315,7 @@ function defineTests(mode: 'sync' | 'async') {
       expect(result).toEqual(['first', 'second']);
     });
 
-    it.fails('should let a queued hook payload win when a reused wait completes after the step that installs the race', async () => {
+    it('should let a queued hook payload win when a reused wait completes after the step that installs the race', async () => {
       await setupHydrateMock();
       const ops: Promise<any>[] = [];
       const [payload, setupResult] = await Promise.all([
@@ -566,7 +567,7 @@ function defineTests(mode: 'sync' | 'async') {
       );
     }
 
-    it.fails('should let a queued hook payload win without mapping the race promises', async () => {
+    it('should let a queued hook payload win without mapping the race promises', async () => {
       await expectRawRaceToChooseQueuedHook(false);
     });
 
@@ -793,6 +794,23 @@ function defineTests(mode: 'sync' | 'async') {
       );
     });
 
+    // KNOWN-INVALID (kept as `it.fails`): this scenario is not reproducible by
+    // the workflow under test and asserts an impossible replay outcome.
+    //
+    // In loop 1, `pendingSleep` is the REUSED sleep, whose `wait_completed`
+    // (evnt_8) is consumed BEFORE loop 1 begins — so `pendingSleep` is an
+    // already-resolved promise by the time loop 1 runs. Loop 1's
+    // `iterator.next()` then claims the only remaining buffered payload
+    // (`hook_received` evnt_9), which also resolves. With BOTH inputs resolved,
+    // `Promise.race([pendingRead, pendingSleep])` resolves to the FIRST array
+    // element by JS semantics — `pendingRead` (the hook). The runtime cannot
+    // change that tie-break; it lives in the workflow author's race-argument
+    // order. So a real producer run of this workflow would take the HOOK
+    // branch in loop 1 (recording `drainStep`), never the sleep branch this
+    // hand-built log encodes (`progressStep` at evnt_14). The fix for the real
+    // hook-vs-sleep ordering bug is verified by the sibling tests; this case
+    // should be re-worked (e.g. so the sleep is not pre-resolved at the race)
+    // or removed. See PR discussion.
     it.fails('should preserve the early waiter with a reused sleep when wait completion wins', async () => {
       const { ctx, error } = await replayEarlyWaiterAcrossDrain({
         winner: 'sleep',

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -2,6 +2,7 @@
  * Utils used by the bundler when transforming code
  */
 
+import { withResolvers } from '@workflow/utils';
 import type { CryptoKey } from './encryption.js';
 import type { EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
@@ -154,6 +155,137 @@ export interface WorkflowOrchestratorContext {
    * to reach 0 before firing, to avoid preempting data delivery.
    */
   pendingDeliveries: number;
+  /**
+   * Ordered registry of in-flight "branch-deciding" deliveries — the
+   * resolutions a workflow typically `Promise.race`s on: buffered hook
+   * payloads (`hook_received`) and wait completions (`wait_completed`).
+   * Keyed by the delivery's position (index) in the consumed event log.
+   *
+   * The problem: a buffered hook payload is observed via the async hook
+   * iterator (`yield await this`), costing extra microtask hops, while a
+   * `wait_completed` resolves with fewer hops — and a reused sleep can
+   * resolve in an entirely earlier loop iteration. Either way, the
+   * resolution that the committed event log ordered first can lose a
+   * `Promise.race` to a faster- or already-resolved competitor, diverging
+   * from the log and surfacing as `CorruptedEventLogError`.
+   *
+   * The fix is a strict, deterministic delivery order anchored on
+   * event-log position: a delivery does not resolve to the workflow until
+   * every earlier-in-log delivery of the OPPOSITE kind has been delivered.
+   * (Opposite kind only: sequential same-kind hook payloads must not block
+   * one another, and a wait need not wait behind a later wait.) Because the
+   * gate is "the earlier delivery resolved", not "won a timing race", the
+   * outcome is independent of microtask hops, hydration/decryption time,
+   * and `Promise.race` argument order.
+   *
+   * Index is used rather than the `eventId` string because `eventId` is an
+   * opaque, world-assigned value not guaranteed to sort in creation order
+   * (only the bundled ULID worlds happen to).
+   *
+   * Optional so older/out-of-tree contexts (and lightweight test harnesses)
+   * that do not initialize it degrade gracefully to the previous behavior.
+   */
+  pendingDeliveryBarriers?: Map<number, DeliveryBarrierEntry>;
+}
+
+/** The kind of branch-deciding delivery a barrier represents. */
+export type DeliveryKind = 'hook' | 'wait';
+
+interface DeliveryBarrierEntry {
+  kind: DeliveryKind;
+  /** Resolves once this delivery has resolved to the workflow. */
+  delivered: Promise<void>;
+}
+
+/**
+ * Awaits, in strict event-log order, every still-registered delivery whose
+ * index is earlier than `eventIndex` AND whose kind is in `deferBehindKinds`,
+ * so that this resolution is handed to the workflow only after all relevant
+ * earlier-in-log deliveries have been. This is what keeps a `Promise.race`
+ * deterministic and aligned with the committed event log, independent of
+ * microtask-hop counts, hydration time, or race-argument order.
+ *
+ * `deferBehindKinds` is the opposite kind(s): a hook defers behind earlier
+ * WAITS (not earlier hooks — those are sequential same-entity payloads), a
+ * wait defers behind earlier HOOKS.
+ */
+export async function awaitEarlierDeliveries(
+  ctx: WorkflowOrchestratorContext,
+  eventIndex: number | undefined,
+  deferBehindKinds: readonly DeliveryKind[]
+): Promise<void> {
+  // Defensive: tolerate contexts that predate this field (test harnesses).
+  if (
+    eventIndex === undefined ||
+    !ctx.pendingDeliveryBarriers ||
+    ctx.pendingDeliveryBarriers.size === 0
+  ) {
+    return;
+  }
+  const earlier: Promise<void>[] = [];
+  for (const [index, entry] of ctx.pendingDeliveryBarriers) {
+    if (index < eventIndex && deferBehindKinds.includes(entry.kind)) {
+      earlier.push(entry.delivered);
+    }
+  }
+  if (earlier.length > 0) {
+    await Promise.all(earlier);
+  }
+}
+
+/** Handle for a registered branch-deciding delivery barrier. */
+export interface DeliveryBarrier {
+  /**
+   * Mark this delivery as delivered to the workflow. Resolves its
+   * `delivered` promise so any later-in-log opposite-kind delivery gated on
+   * it (via {@link awaitEarlierDeliveries}) may proceed, and removes it from
+   * the registry. Idempotent.
+   */
+  markDelivered: () => void;
+}
+
+/**
+ * Register a branch-deciding delivery at its event-log index so that later
+ * opposite-kind deliveries can be ordered strictly after it. Returns an inert
+ * handle when `pendingDeliveryBarriers` is not initialized.
+ *
+ * To guarantee a later delivery gated on this one can never hang when this
+ * delivery is abandoned (the workflow took a different branch or is
+ * suspending and never observes it), the barrier auto-resolves at idle.
+ */
+export function registerDeliveryBarrier(
+  ctx: WorkflowOrchestratorContext,
+  eventIndex: number | undefined,
+  kind: DeliveryKind
+): DeliveryBarrier {
+  const barriers = ctx.pendingDeliveryBarriers;
+  if (!barriers || eventIndex === undefined) {
+    return { markDelivered: () => {} };
+  }
+
+  let done = false;
+  const { promise, resolve } = withResolvers<void>();
+  const entry: DeliveryBarrierEntry = { kind, delivered: promise };
+  barriers.set(eventIndex, entry);
+
+  const finish = () => {
+    if (done) {
+      return;
+    }
+    done = true;
+    if (barriers.get(eventIndex) === entry) {
+      barriers.delete(eventIndex);
+    }
+    resolve();
+  };
+
+  // Safety net: if this delivery is never delivered to the workflow (its
+  // branch was not taken / the run is suspending), resolve at idle so a
+  // later opposite-kind delivery gated on it cannot deadlock and the
+  // registry cannot leak an entry per abandoned delivery.
+  scheduleWhenIdle(ctx, finish);
+
+  return { markDelivered: finish };
 }
 
 /**

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -66,6 +66,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     onWorkflowError: vi.fn(),
     promiseQueue: Promise.resolve(),
     pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
   };
 }
 

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -196,6 +196,7 @@ export async function runWorkflow(
         promiseQueueHolder.current = value;
       },
       pendingDeliveries: 0,
+      pendingDeliveryBarriers: new Map(),
     };
 
     // Subscribe to the events log to update the timestamp in the vm context

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -1,11 +1,13 @@
 import { CorruptedEventLogError, HookConflictError } from '@workflow/errors';
 import { type PromiseWithResolvers, withResolvers } from '@workflow/utils';
-import type { HookConflictEvent, HookReceivedEvent } from '@workflow/world';
+import type { HookConflictEvent } from '@workflow/world';
 import type { Hook, HookOptions } from '../create-hook.js';
 import { EventConsumerResult } from '../events-consumer.js';
 import { WorkflowSuspension } from '../global.js';
 import { webhookLogger } from '../logger.js';
 import {
+  awaitEarlierDeliveries,
+  registerDeliveryBarrier,
   scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from '../private.js';
@@ -28,8 +30,12 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
       isWebhook,
     });
 
-    // Queue of hook events that have been received but not yet processed
-    const payloadsQueue: HookReceivedEvent[] = [];
+    // Queue of buffered hook payloads (received before the workflow awaited
+    // the hook). Each entry's `claim()` builds the consumer-facing promise
+    // from the captured hydration outcome and orders it deterministically by
+    // event-log position against any concurrent branch-deciding resolution
+    // (see `ctx.pendingDeliveryBarriers`).
+    const payloadsQueue: { claim: () => Promise<T> }[] = [];
 
     // Queue of promises that resolve to the next hook payload
     const promises: PromiseWithResolvers<T>[] = [];
@@ -124,13 +130,28 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
       }
 
       if (event.eventType === 'hook_received') {
+        // Register a 'hook' delivery barrier at this event's log index so a
+        // later-in-log `wait_completed` is delivered only after this hook,
+        // and so this hook is delivered only after every earlier-in-log
+        // `wait_completed` — keeping any `Promise.race` against a wait
+        // deterministic and aligned with the committed event log, regardless
+        // of microtask-hop count, hydration time, or race-argument order.
+        // See `ctx.pendingDeliveryBarriers`.
+        const eventIndex = ctx.eventsConsumer.eventIndex;
+        const barrier = registerDeliveryBarrier(ctx, eventIndex, 'hook');
+
         if (promises.length > 0) {
           const next = promises.shift();
           if (next) {
-            // Reconstruct the payload from the event data.
-            // Chain through ctx.promiseQueue to ensure that async
-            // deserialization (e.g., decryption) resolves in event log order.
+            // A consumer is already awaiting. Hydrate through a promiseQueue
+            // slot (so async deserialization stays in event-log order), then
+            // defer behind earlier waits before resolving. The deferral runs
+            // OFF the serial queue (it may wait on an earlier wait delivery
+            // and blocking a queue slot on that would deadlock the queue).
             ctx.pendingDeliveries++;
+            let hydrateOutcome:
+              | { ok: true; value: T }
+              | { ok: false; error: unknown };
             ctx.promiseQueue = ctx.promiseQueue.then(async () => {
               try {
                 const payload = await hydrateStepReturnValue(
@@ -139,16 +160,68 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
                   ctx.encryptionKey,
                   ctx.globalThis
                 );
-                next.resolve(payload as T);
+                hydrateOutcome = { ok: true, value: payload as T };
               } catch (error) {
-                next.reject(error);
+                hydrateOutcome = { ok: false, error };
               } finally {
                 ctx.pendingDeliveries--;
               }
+              void awaitEarlierDeliveries(ctx, eventIndex, ['wait']).then(
+                () => {
+                  barrier.markDelivered();
+                  if (hydrateOutcome.ok) {
+                    next.resolve(hydrateOutcome.value);
+                  } else {
+                    next.reject(hydrateOutcome.error);
+                  }
+                }
+              );
             });
           }
         } else {
-          payloadsQueue.push(event);
+          // No consumer is awaiting yet. Hydrate through a promiseQueue slot
+          // at this log position and park the OUTCOME (value or error) for a
+          // later `iterator.next()` / `await hook` claim. We capture the
+          // outcome rather than eagerly resolving/rejecting a promise no
+          // consumer has attached to — a rejected unclaimed promise (e.g. a
+          // buffered encrypted payload with no key) would otherwise surface
+          // as an unhandled rejection and crash the process. `claim()` builds
+          // the consumer-facing promise on demand.
+          let outcome:
+            | { ok: true; value: T }
+            | { ok: false; error: unknown }
+            | undefined;
+          const hydrated = withResolvers<void>();
+
+          const claim = (): Promise<T> =>
+            hydrated.promise
+              .then(() => awaitEarlierDeliveries(ctx, eventIndex, ['wait']))
+              .then(() => {
+                barrier.markDelivered();
+                if (outcome && !outcome.ok) {
+                  throw outcome.error;
+                }
+                return (outcome as { ok: true; value: T }).value;
+              });
+
+          ctx.pendingDeliveries++;
+          ctx.promiseQueue = ctx.promiseQueue.then(async () => {
+            try {
+              const payload = await hydrateStepReturnValue(
+                event.eventData.payload,
+                ctx.runId,
+                ctx.encryptionKey,
+                ctx.globalThis
+              );
+              outcome = { ok: true, value: payload as T };
+            } catch (error) {
+              outcome = { ok: false, error };
+            } finally {
+              ctx.pendingDeliveries--;
+              hydrated.resolve();
+            }
+          });
+          payloadsQueue.push({ claim });
         }
 
         return EventConsumerResult.Consumed;
@@ -191,27 +264,15 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
       }
 
       if (payloadsQueue.length > 0) {
-        const nextPayload = payloadsQueue.shift();
-        if (nextPayload) {
-          // Chain through ctx.promiseQueue to ensure that async
-          // deserialization (e.g., decryption) resolves in event log order.
-          ctx.pendingDeliveries++;
-          ctx.promiseQueue = ctx.promiseQueue.then(async () => {
-            try {
-              const payload = await hydrateStepReturnValue(
-                nextPayload.eventData.payload,
-                ctx.runId,
-                ctx.encryptionKey,
-                ctx.globalThis
-              );
-              resolvers.resolve(payload as T);
-            } catch (error) {
-              resolvers.reject(error);
-            } finally {
-              ctx.pendingDeliveries--;
-            }
-          });
-          return resolvers.promise;
+        const nextDelivery = payloadsQueue.shift();
+        if (nextDelivery) {
+          // The payload was hydrated through a promiseQueue slot at its log
+          // position (buffering branch above). `claim()` builds the
+          // consumer-facing promise from that outcome, deferring behind any
+          // earlier-in-log wait and marking this hook delivered — so
+          // resolution order stays anchored to the event log, not this later
+          // claim site.
+          return nextDelivery.claim();
         }
       }
 

--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -41,6 +41,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     onWorkflowError: vi.fn(),
     promiseQueue: Promise.resolve(),
     pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
   };
   return ctx;
 }

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -4,6 +4,8 @@ import type { StringValue } from 'ms';
 import { EventConsumerResult } from '../events-consumer.js';
 import { type WaitInvocationQueueItem, WorkflowSuspension } from '../global.js';
 import {
+  awaitEarlierDeliveries,
+  registerDeliveryBarrier,
   scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from '../private.js';
@@ -86,11 +88,29 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
         // Remove this wait from the invocations queue (O(1) delete using Map)
         ctx.invocationsQueue.delete(correlationId);
 
-        // Wait has elapsed - chain through promiseQueue to ensure
-        // deterministic ordering of all promise resolutions.
-        ctx.promiseQueue = ctx.promiseQueue.then(() => {
-          resolve();
-        });
+        // This `wait_completed` is a branch-deciding resolution the workflow
+        // may `Promise.race` against a hook payload. Order it deterministically
+        // by event-log position (see `pendingDeliveryBarriers`):
+        //  - Register a 'wait' barrier at this event's index so a LATER-in-log
+        //    hook payload is delivered only after this wait.
+        //  - Before resolving, defer behind every EARLIER-in-log HOOK delivery
+        //    so this wait does not preempt a hook the committed log ordered
+        //    first. Then mark this wait delivered to release later hooks.
+        const eventIndex = ctx.eventsConsumer.eventIndex;
+        const barrier = registerDeliveryBarrier(ctx, eventIndex, 'wait');
+        // Defer + resolve in a DETACHED promise (not chained onto the serial
+        // `promiseQueue`). `awaitEarlierDeliveries` may wait on an earlier
+        // hook delivery whose own resolution is itself driven by the
+        // promiseQueue; blocking a queue slot on it would deadlock the serial
+        // queue. We still anchor to the queue tail first so prior queued
+        // hydration/ordering work runs in event-log order.
+        const queueAtCompletion = ctx.promiseQueue;
+        void queueAtCompletion
+          .then(() => awaitEarlierDeliveries(ctx, eventIndex, ['hook']))
+          .then(() => {
+            barrier.markDelivered();
+            resolve();
+          });
         return EventConsumerResult.Finished;
       }
 


### PR DESCRIPTION
Forward-port of #2171 from \`stable\` to \`main\` (cherry-pick of merge commit \`38c67a7\`, applied with no conflicts).

## Summary

Fixes a replay divergence where a buffered hook payload races a concurrent \`sleep\`, and \`sleep\` can win a \`Promise.race\` that the committed event log says the hook won — surfacing as \`CorruptedEventLogError\` on replay.

Branch-deciding deliveries (buffered hook payloads and wait completions) are now handed to the workflow in strict event-log order — anchored on event position rather than microtask-resolution timing — so the committed branch wins deterministically, independent of decryption/hydration time or \`Promise.race\` argument order.

See #2171 for full root-cause analysis and fix details.

## Validation

- Cherry-picked the squashed merge commit onto \`main\`; clean auto-merge, diff identical to the original PR.
- \`@workflow/core\` typecheck: clean.
- Affected tests (hook-sleep-interaction, async-deserialization-ordering, sleep, step): **87/87 pass**.
- Remaining \`e2e/\` failures in the full suite are pre-existing on clean \`main\` (require a full build setup) and unrelated to these runtime changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>