### PR TITLE
ci: disable MongoDB/Redis community-world E2E on stable

### DIFF
--- a/.changeset/disable-community-world-e2e-stable.md
+++ b/.changeset/disable-community-world-e2e-stable.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: temporarily disable MongoDB/Redis community-world E2E jobs on stable (they hang until timeout since the workbench world-kickstart was removed) and drop them from the required check.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -688,10 +688,15 @@ jobs:
           if-no-files-found: ignore
 
   # Community World E2E Tests (dynamically generated from worlds-manifest.json)
+  # Temporarily disabled: the MongoDB/Redis community worlds stopped dispatching
+  # runs after the workbench world-kickstart (`getWorld().start()`) was removed
+  # in #1963, so these jobs hang until the 30-minute timeout on every run. Kept
+  # off the required check until the follow-up PR restores the kickstart in the
+  # community E2E lane and adds a fast-fail preflight.
   getCommunityWorldsMatrix:
     name: Get Community Worlds Matrix
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: false
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -710,7 +715,7 @@ jobs:
 
   e2e-community:
     name: E2E Community World (${{ matrix.world.name }})
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: false
     needs: getCommunityWorldsMatrix
     strategy:
       fail-fast: false
@@ -822,11 +827,13 @@ jobs:
 
             Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
-  # Final required check: passes only when unit + all E2E jobs succeed
+  # Final required check: passes only when unit + all E2E jobs succeed.
+  # Community worlds are intentionally excluded — they are temporarily disabled
+  # (see getCommunityWorldsMatrix above).
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows, e2e-community]
+    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows]
     if: always()
     timeout-minutes: 5
 
@@ -839,7 +846,6 @@ jobs:
           LOCAL_PROD_STATUS: ${{ needs.e2e-local-prod.result }}
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
           WINDOWS_STATUS: ${{ needs.e2e-windows.result }}
-          COMMUNITY_STATUS: ${{ needs.e2e-community.result }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
         run: |
           FAILED_JOBS=()
@@ -856,7 +862,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "skipped" ]] || echo "Warning: e2e-local-prod was not skipped ($LOCAL_PROD_STATUS)"
             [[ "$POSTGRES_STATUS" == "skipped" ]] || echo "Warning: e2e-local-postgres was not skipped ($POSTGRES_STATUS)"
             [[ "$WINDOWS_STATUS" == "skipped" ]] || echo "Warning: e2e-windows was not skipped ($WINDOWS_STATUS)"
-            [[ "$COMMUNITY_STATUS" == "skipped" ]] || echo "Warning: e2e-community was not skipped ($COMMUNITY_STATUS)"
           else
             echo "Standard PR - checking all jobs"
             [[ "$UNIT_STATUS" == "success" ]] || FAILED_JOBS+=("unit ($UNIT_STATUS)")
@@ -865,7 +870,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")
             [[ "$WINDOWS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-windows ($WINDOWS_STATUS)")
-            [[ "$COMMUNITY_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-community ($COMMUNITY_STATUS)")
           fi
 
           if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Problem

`E2E Community World (MongoDB)` and `E2E Community World (Redis)` hang until the 30-minute job timeout on **every** `stable` run, and they are part of the required `E2E Required Check` — so every stable PR/push fails the gate after burning ~30 min × 2 runners.

### Root cause (when & what)

Bisected across stable runs: last green was `a350e8ddf` (2026-05-18 22:00 UTC), first timeout was the very next commit `4bc53fc7a` — **"Remove instrumentation from workbench (#1959) (#1963)"** (2026-05-18 22:01 UTC).

That commit deleted `workbench/nextjs-turbopack/instrumentation.ts`, whose only payload was the world kickstart:

```ts
import('workflow/runtime').then(async ({ getWorld }) => {
  await getWorld().start?.();
});
```

The MongoDB/Redis community adapters dispatch created runs via an in-process queue worker that only runs if `getWorld().start()` is called. With the stub gone, every run stays `pending` at `run_created`; each `e2e.test.ts` case waits its full ~60s timeout, and 25+ sequential cases blow past `timeout-minutes: 30`. Other lanes (vercel/local/postgres) are unaffected — they don't depend on that side effect, and Turso (no service container) still passes.

## This PR (stop the bleeding)

- `if: false` on `getCommunityWorldsMatrix` + `e2e-community` (no more 30-min waste).
- Drop `e2e-community` from `e2e-required-check` so the gate stops failing.
- `summary` is untouched (it already treats community as a non-blocking warning and handles the skipped status fine).

## Follow-up

A separate PR will restore the world kickstart **in the community E2E lane only** (keeping the shipped workbench aligned with the getting-started docs, per #1959's intent) and add a fast-fail preflight + lower timeout, so these jobs provide real signal again and can never silently hang for 30 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)