### PR TITLE
ci: restore community-world E2E kickstart + fast-fail preflight

### DIFF
--- a/.changeset/disable-community-world-e2e-stable.md
+++ b/.changeset/disable-community-world-e2e-stable.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: temporarily disable MongoDB/Redis community-world E2E jobs on stable (they hang until timeout since the workbench world-kickstart was removed) and drop them from the required check.

--- a/.changeset/fix-community-world-e2e-kickstart.md
+++ b/.changeset/fix-community-world-e2e-kickstart.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: re-enable MongoDB/Redis community-world E2E by restoring the world-kickstart in the test lane, and add a fast-fail dispatch preflight so a missing kickstart can no longer hang the job until timeout.

--- a/.github/fixtures/community-world-instrumentation.ts
+++ b/.github/fixtures/community-world-instrumentation.ts
@@ -1,0 +1,20 @@
+// CI-only Next.js instrumentation, copied into the workbench app by
+// .github/workflows/e2e-community-world.yml before the dev server starts.
+//
+// The shipped workbench intentionally has no instrumentation file so it matches
+// the Next.js getting-started docs (removed in #1959/#1963). The community world
+// adapters (e.g. MongoDB, Redis), however, dispatch created runs from an
+// in-process queue worker that only runs once `getWorld().start()` is called.
+// Without this kickstart every run stays `pending` and the E2E suite hangs until
+// the job timeout. This restores the previous workbench instrumentation for the
+// community-world E2E lane only.
+import { registerOTel } from '@vercel/otel';
+
+registerOTel({ serviceName: 'example-nextjs-workflow' });
+
+if (process.env.NEXT_RUNTIME !== 'edge') {
+  // kickstart the world
+  import('workflow/runtime').then(async ({ getWorld }) => {
+    await getWorld().start?.();
+  });
+}

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -44,7 +44,10 @@ jobs:
   e2e:
     name: E2E ${{ inputs.world-name }}
     runs-on: ubuntu-latest
-    continue-on-error: true
+    # Intentionally NOT continue-on-error: real test failures (and hangs caught by
+    # the preflight) surface as a red job + a ⚠️ warning on the PR comment. This job
+    # is non-blocking because it is excluded from e2e-required-check in tests.yml,
+    # not because failures are swallowed.
     # Successful community runs historically finish in ~12-15 min. Cap at 20 so a
     # regression can't burn 30 min; the preflight below fails much faster than this.
     timeout-minutes: 20
@@ -138,9 +141,15 @@ jobs:
             echo "Preflight finished without hanging (exit $rc); continuing to full suite."
           fi
 
-          pnpm vitest run packages/core/e2e/dev.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-community-${{ inputs.world-id }}-dev.json || true
+          # Run both suites regardless of individual outcomes (so both result
+          # artifacts are produced for the summary), then fail the step if either
+          # suite failed. The job is non-blocking via its exclusion from
+          # e2e-required-check, so this surfaces failures without gating merges.
+          fail=0
+          pnpm vitest run packages/core/e2e/dev.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-community-${{ inputs.world-id }}-dev.json || fail=1
           sleep 10
-          pnpm vitest run packages/core/e2e/e2e.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-community-${{ inputs.world-id }}.json || true
+          pnpm vitest run packages/core/e2e/e2e.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-community-${{ inputs.world-id }}.json || fail=1
+          exit $fail
         env:
           NODE_OPTIONS: "--enable-source-maps"
           APP_NAME: ${{ inputs.app-name }}

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -45,7 +45,9 @@ jobs:
     name: E2E ${{ inputs.world-name }}
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 30
+    # Successful community runs historically finish in ~12-15 min. Cap at 20 so a
+    # regression can't burn 30 min; the preflight below fails much faster than this.
+    timeout-minutes: 20
 
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -98,6 +100,14 @@ jobs:
       - name: Resolve symlinks
         run: ./scripts/resolve-symlinks.sh workbench/${{ inputs.app-name }}
 
+      # Community world adapters dispatch created runs from an in-process queue
+      # worker started via `getWorld().start()`. The shipped workbench has no
+      # instrumentation file (matches the getting-started docs, #1959), so start
+      # the world here for the E2E lane only. Without this, runs stay `pending`
+      # and the suite hangs until the job timeout.
+      - name: Restore world kickstart (CI only)
+        run: cp .github/fixtures/community-world-instrumentation.ts "workbench/${{ inputs.app-name }}/instrumentation.ts"
+
       - name: Set environment variables
         run: |
           echo '${{ inputs.env-vars }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
@@ -105,7 +115,19 @@ jobs:
       - name: Run E2E Tests
         run: |
           cd workbench/${{ inputs.app-name }} && pnpm dev &
+          cd "$GITHUB_WORKSPACE"
           echo "Waiting for dev server to start..." && sleep 15
+
+          # Fast-fail preflight: a representative workflow run must complete within
+          # ~2 min. If the world isn't dispatching runs (e.g. the kickstart above
+          # failed), bail now instead of letting every test burn its 60s timeout
+          # and pushing the job to its hard limit.
+          echo "Running community-world dispatch preflight (${{ inputs.world-id }})..."
+          if ! timeout 150 pnpm vitest run packages/core/e2e/e2e.test.ts -t "addTenWorkflow" --reporter=default; then
+            echo "::error::Community world '${{ inputs.world-id }}' preflight failed — workflow runs are not being dispatched. Aborting before the job timeout."
+            exit 1
+          fi
+
           pnpm vitest run packages/core/e2e/dev.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-community-${{ inputs.world-id }}-dev.json || true
           sleep 10
           pnpm vitest run packages/core/e2e/e2e.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-community-${{ inputs.world-id }}.json || true

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -100,12 +100,15 @@ jobs:
       - name: Resolve symlinks
         run: ./scripts/resolve-symlinks.sh workbench/${{ inputs.app-name }}
 
-      # Community world adapters dispatch created runs from an in-process queue
-      # worker started via `getWorld().start()`. The shipped workbench has no
-      # instrumentation file (matches the getting-started docs, #1959), so start
-      # the world here for the E2E lane only. Without this, runs stay `pending`
-      # and the suite hangs until the job timeout.
+      # Adapters with an in-process queue worker (mongodb, redis) only dispatch
+      # created runs once `getWorld().start()` has been called. The shipped
+      # workbench has no instrumentation file (matches the getting-started docs,
+      # #1959), so start the world here for the E2E lane only. Without this, runs
+      # stay `pending` and the suite hangs until the job timeout. Worlds that
+      # dispatch without an explicit start (e.g. turso) don't get this — adding it
+      # changes their setup/init and is unnecessary.
       - name: Restore world kickstart (CI only)
+        if: ${{ inputs.service-type == 'mongodb' || inputs.service-type == 'redis' }}
         run: cp .github/fixtures/community-world-instrumentation.ts "workbench/${{ inputs.app-name }}/instrumentation.ts"
 
       - name: Set environment variables
@@ -118,14 +121,21 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           echo "Waiting for dev server to start..." && sleep 15
 
-          # Fast-fail preflight: a representative workflow run must complete within
-          # ~2 min. If the world isn't dispatching runs (e.g. the kickstart above
-          # failed), bail now instead of letting every test burn its 60s timeout
-          # and pushing the job to its hard limit.
-          echo "Running community-world dispatch preflight (${{ inputs.world-id }})..."
-          if ! timeout 150 pnpm vitest run packages/core/e2e/e2e.test.ts -t "addTenWorkflow" --reporter=default; then
-            echo "::error::Community world '${{ inputs.world-id }}' preflight failed — workflow runs are not being dispatched. Aborting before the job timeout."
-            exit 1
+          # Fast-fail preflight (worlds with an in-process worker only). When such
+          # a world isn't dispatching, runs stay `pending` and every test burns its
+          # full timeout, so the suite would hang for the entire job timeout. Run
+          # one representative set under a short wall-clock cap and bail only if it
+          # *times out* (exit 124 — the hang signature). Ordinary test failures
+          # don't abort; they're left to the full suite below.
+          if [[ "$SERVICE_TYPE" == "mongodb" || "$SERVICE_TYPE" == "redis" ]]; then
+            echo "Running community-world dispatch preflight ($WORLD_ID)..."
+            rc=0
+            timeout 150 pnpm vitest run packages/core/e2e/e2e.test.ts -t "addTenWorkflow" --reporter=default || rc=$?
+            if [[ $rc -eq 124 ]]; then
+              echo "::error::Community world '$WORLD_ID' preflight timed out — workflow runs are not being dispatched. Aborting before the job timeout."
+              exit 1
+            fi
+            echo "Preflight finished without hanging (exit $rc); continuing to full suite."
           fi
 
           pnpm vitest run packages/core/e2e/dev.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-community-${{ inputs.world-id }}-dev.json || true
@@ -134,6 +144,8 @@ jobs:
         env:
           NODE_OPTIONS: "--enable-source-maps"
           APP_NAME: ${{ inputs.app-name }}
+          SERVICE_TYPE: ${{ inputs.service-type }}
+          WORLD_ID: ${{ inputs.world-id }}
           DEPLOYMENT_URL: "http://localhost:3000"
           DEV_TEST_CONFIG: '{"name":"${{ inputs.app-name }}","project":"workbench-${{ inputs.app-name }}-workflow","generatedStepPath":"app/.well-known/workflow/v1/step/route.js","generatedWorkflowPath":"app/.well-known/workflow/v1/flow/route.js","apiFilePath":"app/api/chat/route.ts","apiFileImportPath":"../../.."}'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -688,15 +688,15 @@ jobs:
           if-no-files-found: ignore
 
   # Community World E2E Tests (dynamically generated from worlds-manifest.json)
-  # Temporarily disabled: the MongoDB/Redis community worlds stopped dispatching
-  # runs after the workbench world-kickstart (`getWorld().start()`) was removed
-  # in #1963, so these jobs hang until the 30-minute timeout on every run. Kept
-  # off the required check until the follow-up PR restores the kickstart in the
-  # community E2E lane and adds a fast-fail preflight.
+  # Non-blocking on stable (continue-on-error in the reusable workflow; surfaced
+  # as a warning in the summary). The community world adapters need an in-process
+  # queue worker, which the reusable workflow starts via a CI-only instrumentation
+  # kickstart. A fast-fail preflight there guards against the 30-minute hang that
+  # occurred when that kickstart was missing (see e2e-community-world.yml).
   getCommunityWorldsMatrix:
     name: Get Community Worlds Matrix
     runs-on: ubuntu-latest
-    if: false
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -715,7 +715,7 @@ jobs:
 
   e2e-community:
     name: E2E Community World (${{ matrix.world.name }})
-    if: false
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
     needs: getCommunityWorldsMatrix
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -688,10 +688,15 @@ jobs:
           if-no-files-found: ignore
 
   # Community World E2E Tests (dynamically generated from worlds-manifest.json)
+  # Temporarily disabled: the MongoDB/Redis community worlds stopped dispatching
+  # runs after the workbench world-kickstart (`getWorld().start()`) was removed
+  # in #1963, so these jobs hang until the 30-minute timeout on every run. Kept
+  # off the required check until the follow-up PR restores the kickstart in the
+  # community E2E lane and adds a fast-fail preflight.
   getCommunityWorldsMatrix:
     name: Get Community Worlds Matrix
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: false
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -710,7 +715,7 @@ jobs:
 
   e2e-community:
     name: E2E Community World (${{ matrix.world.name }})
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
+    if: false
     needs: getCommunityWorldsMatrix
     strategy:
       fail-fast: false
@@ -822,11 +827,13 @@ jobs:
 
             Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
-  # Final required check: passes only when unit + all E2E jobs succeed
+  # Final required check: passes only when unit + all E2E jobs succeed.
+  # Community worlds are intentionally excluded — they are temporarily disabled
+  # (see getCommunityWorldsMatrix above).
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows, e2e-community]
+    needs: [unit, e2e-vercel-prod, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows]
     if: always()
     timeout-minutes: 5
 
@@ -839,7 +846,6 @@ jobs:
           LOCAL_PROD_STATUS: ${{ needs.e2e-local-prod.result }}
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
           WINDOWS_STATUS: ${{ needs.e2e-windows.result }}
-          COMMUNITY_STATUS: ${{ needs.e2e-community.result }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
         run: |
           FAILED_JOBS=()
@@ -856,7 +862,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "skipped" ]] || echo "Warning: e2e-local-prod was not skipped ($LOCAL_PROD_STATUS)"
             [[ "$POSTGRES_STATUS" == "skipped" ]] || echo "Warning: e2e-local-postgres was not skipped ($POSTGRES_STATUS)"
             [[ "$WINDOWS_STATUS" == "skipped" ]] || echo "Warning: e2e-windows was not skipped ($WINDOWS_STATUS)"
-            [[ "$COMMUNITY_STATUS" == "skipped" ]] || echo "Warning: e2e-community was not skipped ($COMMUNITY_STATUS)"
           else
             echo "Standard PR - checking all jobs"
             [[ "$UNIT_STATUS" == "success" ]] || FAILED_JOBS+=("unit ($UNIT_STATUS)")
@@ -865,7 +870,6 @@ jobs:
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")
             [[ "$WINDOWS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-windows ($WINDOWS_STATUS)")
-            [[ "$COMMUNITY_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-community ($COMMUNITY_STATUS)")
           fi
 
           if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then


### PR DESCRIPTION
The MongoDB/Redis community-world E2E jobs hung until the 30-min timeout on every stable run. Root cause: `4bc53fc7a` ("Remove instrumentation from workbench", #1959/#1963) deleted `workbench/nextjs-turbopack/instrumentation.ts`, whose only payload was the world kickstart:

```ts
import('workflow/runtime').then(async ({ getWorld }) => {
  await getWorld().start?.();
});
```

The community world adapters dispatch created runs from an in-process queue worker that only runs once `getWorld().start()` is called. Without it, every run stayed `pending` at `run_created`.

## This PR (options 1 + 2)

1. **Restore the kickstart, test-lane only.** A CI-only fixture (`.github/fixtures/community-world-instrumentation.ts`) is copied into the workbench app before the dev server starts. The shipped workbench keeps no instrumentation file, so it still matches the getting-started docs (#1959's intent); only the community E2E lane gets the kickstart.
2. **Fast-fail preflight + lower timeout.** Before the full suite, one representative run (`addTenWorkflow`) must complete within ~2 min; otherwise the job aborts immediately with a clear error instead of letting ~25 tests each burn their 60s timeout. `timeout-minutes` lowered 30 → 20 as a backstop.

Re-enables the jobs disabled in #2188. They stay **non-blocking** (the reusable workflow is `continue-on-error`, and `summary` surfaces failures as a ⚠️ warning) and remain out of the required check. Whether to make them required again is a separate decision — happy to do it here if preferred.