### PR TITLE
[e2e] Separate event-log-race-repro harness noise from real regressions

### DIFF
--- a/.changeset/event-log-race-repro-infra.md
+++ b/.changeset/event-log-race-repro-infra.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: the event-log-race-repro CI job now classifies hook-resume timing races and transport errors as non-gating `infra` outcomes (separate from real event-log regressions), and raises the default hook/sleep iteration ceiling so the wake branch is reliably exercised.

--- a/.github/scripts/render-event-log-race-repro-results.js
+++ b/.github/scripts/render-event-log-race-repro-results.js
@@ -41,7 +41,17 @@ const orderedOutcomes = [
   'RUNTIME_ERROR',
   'stuck',
   'other',
+  // Harness-side, non-gating outcomes (hook-resume vs. sleep-budget timing
+  // races and transport errors in the repro driver). Reported but never fail
+  // the job — see `gatingOutcomes` / `regressionCount`.
+  'infra',
 ];
+
+// Outcomes that represent a real SDK regression and therefore gate the job.
+// Everything that is not `completed` and not `infra`.
+const gatingOutcomes = orderedOutcomes.filter(
+  (outcome) => outcome !== 'completed' && outcome !== 'infra'
+);
 
 function emptyDistribution() {
   return Object.fromEntries(orderedOutcomes.map((outcome) => [outcome, 0]));
@@ -101,10 +111,16 @@ function summarizeByScenario(results) {
   return byScenario;
 }
 
-function nonCompletedCount(distribution) {
-  return orderedOutcomes
-    .filter((outcome) => outcome !== 'completed')
-    .reduce((sum, outcome) => sum + (distribution[outcome] ?? 0), 0);
+// Count of regression-class outcomes — the number the job gates on.
+function regressionCount(distribution) {
+  return gatingOutcomes.reduce(
+    (sum, outcome) => sum + (distribution[outcome] ?? 0),
+    0
+  );
+}
+
+function infraCount(distribution) {
+  return distribution.infra ?? 0;
 }
 
 function compactTimestamp(value) {
@@ -136,9 +152,11 @@ function renderResult(entry) {
   if (entry.missingResults) {
     return 'missing result file';
   }
+  const infra = entry.infraCount ?? infraCount(entry.distribution ?? {});
+  const infraSuffix = infra > 0 ? ` (+${infra} infra)` : '';
   return entry.failedCount === 0
-    ? 'all completed'
-    : `${entry.failedCount}/${entry.total} non-completed`;
+    ? `no regressions${infraSuffix}`
+    : `${entry.failedCount}/${entry.total} regressions${infraSuffix}`;
 }
 
 function renderConfig(entry) {
@@ -203,6 +221,7 @@ function compactHistoryEntry(entry, keepFailures = false) {
     distribution: entry.distribution ?? emptyDistribution(),
     scenarioDistribution: entry.scenarioDistribution ?? {},
     failedCount: entry.failedCount ?? 0,
+    infraCount: entry.infraCount ?? infraCount(entry.distribution ?? {}),
     total: entry.total ?? 0,
     config: compactConfig(entry.config),
     failing: keepFailures ? (entry.failing ?? []) : [],
@@ -233,23 +252,28 @@ function buildEntry(resultsFile) {
   const distribution = resultsFile.distribution ?? summarize(results);
   const scenarioDistribution =
     resultsFile.scenarioDistribution ?? summarizeByScenario(results);
-  const failedCount = nonCompletedCount(distribution);
+  const failedCount = regressionCount(distribution);
+  const infra = infraCount(distribution);
   const total = orderedOutcomes.reduce(
     (sum, outcome) => sum + (distribution[outcome] ?? 0),
     0
   );
-  const failing = results
+  // Surface regressions before infra so the 20-row cap never hides a real
+  // failure behind a flood of harness-timing `infra` rows.
+  const nonCompleted = results
     .filter((result) => result.outcome !== 'completed')
-    .slice(0, 20)
-    .map((result) => ({
-      attempt: result.attempt,
-      scenario: result.scenario,
-      outcome: result.outcome,
-      status: result.status,
-      errorCode: result.errorCode,
-      runId: result.runId,
-      dashboardUrl: result.dashboardUrl,
-    }));
+    .sort(
+      (a, b) => Number(a.outcome === 'infra') - Number(b.outcome === 'infra')
+    );
+  const failing = nonCompleted.slice(0, 20).map((result) => ({
+    attempt: result.attempt,
+    scenario: result.scenario,
+    outcome: result.outcome,
+    status: result.status,
+    errorCode: result.errorCode,
+    runId: result.runId,
+    dashboardUrl: result.dashboardUrl,
+  }));
 
   return {
     timestamp,
@@ -260,14 +284,11 @@ function buildEntry(resultsFile) {
     distribution,
     scenarioDistribution,
     failedCount,
+    infraCount: infra,
     total,
     config: compactConfig(resultsFile.config),
     failing,
-    truncatedFailingCount: Math.max(
-      0,
-      results.filter((result) => result.outcome !== 'completed').length -
-        failing.length
-    ),
+    truncatedFailingCount: Math.max(0, nonCompleted.length - failing.length),
   };
 }
 
@@ -365,14 +386,23 @@ function render(resultsFile, previousComment) {
   );
   const latest = history[history.length - 1];
 
+  const latestInfra =
+    latest.infraCount ?? infraCount(latest.distribution ?? {});
+  const infraNote =
+    latestInfra > 0
+      ? ` ${latestInfra} run${latestInfra === 1 ? '' : 's'} hit harness-side ` +
+        '`infra` outcomes (hook-resume timing races / transport errors); ' +
+        'these are reported but do not fail the job.'
+      : '';
+
   console.log('<!-- event-log-race-repro-results -->');
   console.log('## Event Log Race Repro\n');
   console.log(
     latest.missingResults
       ? 'No result file was produced by the latest repro job.'
       : latest.failedCount === 0
-        ? 'The latest repro job completed all runs cleanly.'
-        : `${latest.failedCount} of ${latest.total} latest repro runs did not complete cleanly.`
+        ? `No event-log regressions in the latest repro job.${infraNote}`
+        : `${latest.failedCount} of ${latest.total} latest repro runs hit event-log regressions.${infraNote}`
   );
   console.log('');
   console.log(historyMarkerStart);
@@ -385,21 +415,39 @@ function render(resultsFile, previousComment) {
   renderLatestFailures(latest);
 }
 
-const resultsFile = loadResults();
-const previousComment = loadPreviousComment();
+function main() {
+  const resultsFile = loadResults();
+  const previousComment = loadPreviousComment();
 
-if (!resultsFile) {
-  if (!check) {
-    render(null, previousComment);
+  if (!resultsFile) {
+    if (!check) {
+      render(null, previousComment);
+    }
+    process.exit(check ? 1 : 0);
   }
-  process.exit(check ? 1 : 0);
+
+  if (!check) {
+    render(resultsFile, previousComment);
+    process.exit(0);
+  }
+
+  const distribution =
+    resultsFile.distribution ?? summarize(resultsFile.results ?? []);
+  process.exit(regressionCount(distribution) > 0 ? 1 : 0);
 }
 
-if (!check) {
-  render(resultsFile, previousComment);
-  process.exit(0);
-}
+// Pure helpers are exported for unit testing; the CLI only runs when the
+// script is executed directly (not when required by the test).
+module.exports = {
+  orderedOutcomes,
+  gatingOutcomes,
+  summarize,
+  summarizeByScenario,
+  regressionCount,
+  infraCount,
+  buildEntry,
+};
 
-const distribution =
-  resultsFile.distribution ?? summarize(resultsFile.results ?? []);
-process.exit(nonCompletedCount(distribution) > 0 ? 1 : 0);
+if (require.main === module) {
+  main();
+}

--- a/.github/scripts/render-event-log-race-repro-results.test.js
+++ b/.github/scripts/render-event-log-race-repro-results.test.js
@@ -1,0 +1,151 @@
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const {
+  gatingOutcomes,
+  regressionCount,
+  infraCount,
+  buildEntry,
+  summarize,
+} = require('./render-event-log-race-repro-results.js');
+
+const SCRIPT = path.join(__dirname, 'render-event-log-race-repro-results.js');
+
+function writeTempResults(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repro-render-'));
+  const file = path.join(dir, 'event-log-race-repro-results.json');
+  fs.writeFileSync(file, JSON.stringify(contents));
+  return file;
+}
+
+function runCheck(file) {
+  try {
+    execFileSync('node', [SCRIPT, file, '--check'], { stdio: 'ignore' });
+    return 0;
+  } catch (err) {
+    return err.status ?? 1;
+  }
+}
+
+test('infra is not a gating outcome', () => {
+  assert.ok(!gatingOutcomes.includes('infra'));
+  assert.ok(!gatingOutcomes.includes('completed'));
+  assert.ok(gatingOutcomes.includes('CORRUPTED_EVENT_LOG'));
+  assert.ok(gatingOutcomes.includes('stuck'));
+});
+
+test('regressionCount ignores completed and infra', () => {
+  const distribution = {
+    completed: 1000,
+    CORRUPTED_EVENT_LOG: 0,
+    USER_ERROR: 0,
+    RUNTIME_ERROR: 0,
+    stuck: 0,
+    other: 0,
+    infra: 1231,
+  };
+  assert.strictEqual(regressionCount(distribution), 0);
+  assert.strictEqual(infraCount(distribution), 1231);
+});
+
+test('regressionCount counts real corruption-class outcomes', () => {
+  const distribution = {
+    completed: 10,
+    CORRUPTED_EVENT_LOG: 2,
+    USER_ERROR: 0,
+    RUNTIME_ERROR: 1,
+    stuck: 3,
+    other: 1,
+    infra: 50,
+  };
+  // 2 + 1 + 3 + 1 = 7 regressions; the 50 infra runs do not count.
+  assert.strictEqual(regressionCount(distribution), 7);
+});
+
+test('buildEntry treats an all-infra run as zero regressions', () => {
+  // Mirrors the production comment: a flood of HOOK_RESUME_FAILED infra
+  // outcomes and not a single corruption-class failure.
+  const results = [
+    ...Array.from({ length: 769 }, (_, i) => ({
+      attempt: i,
+      scenario: 'hook-sleep',
+      outcome: 'completed',
+      status: 'completed',
+    })),
+    ...Array.from({ length: 1231 }, (_, i) => ({
+      attempt: i,
+      scenario: 'hook-sleep',
+      outcome: 'infra',
+      status: 'completed',
+      errorCode: 'HOOK_RESUME_FAILED',
+    })),
+  ];
+  const entry = buildEntry({ results });
+  assert.strictEqual(entry.failedCount, 0, 'no regressions should be counted');
+  assert.strictEqual(entry.infraCount, 1231);
+  assert.strictEqual(entry.total, 2000);
+  // Regressions sort ahead of infra so they are never truncated away.
+  assert.ok(entry.failing.every((r) => r.outcome === 'infra'));
+});
+
+test('buildEntry surfaces regressions ahead of infra rows', () => {
+  const results = [
+    ...Array.from({ length: 30 }, (_, i) => ({
+      attempt: i,
+      scenario: 'hook-sleep',
+      outcome: 'infra',
+      errorCode: 'HOOK_RESUME_FAILED',
+    })),
+    {
+      attempt: 999,
+      scenario: 'step-fanout',
+      outcome: 'CORRUPTED_EVENT_LOG',
+      errorCode: 'CORRUPTED_EVENT_LOG',
+    },
+  ];
+  const entry = buildEntry({ results });
+  assert.strictEqual(entry.failedCount, 1);
+  assert.strictEqual(
+    entry.failing[0].outcome,
+    'CORRUPTED_EVENT_LOG',
+    'regression must appear first despite being last in the input'
+  );
+});
+
+test('summarize buckets infra outcomes', () => {
+  const distribution = summarize([
+    { outcome: 'completed' },
+    { outcome: 'infra' },
+    { outcome: 'infra' },
+    { outcome: 'CORRUPTED_EVENT_LOG' },
+  ]);
+  assert.strictEqual(distribution.infra, 2);
+  assert.strictEqual(distribution.completed, 1);
+  assert.strictEqual(distribution.CORRUPTED_EVENT_LOG, 1);
+});
+
+test('--check exits 0 when only infra outcomes are present', () => {
+  const file = writeTempResults({
+    results: [
+      { outcome: 'completed' },
+      { outcome: 'infra', errorCode: 'HOOK_RESUME_FAILED' },
+      { outcome: 'infra', errorCode: 'NO_WAKE_BRANCH' },
+    ],
+  });
+  assert.strictEqual(runCheck(file), 0);
+});
+
+test('--check exits 1 on a corruption-class regression', () => {
+  const file = writeTempResults({
+    results: [
+      { outcome: 'completed' },
+      { outcome: 'infra', errorCode: 'HOOK_RESUME_FAILED' },
+      { outcome: 'CORRUPTED_EVENT_LOG', errorCode: 'CORRUPTED_EVENT_LOG' },
+    ],
+  });
+  assert.strictEqual(runCheck(file), 1);
+});

--- a/.github/workflows/event-log-race-repro.yml
+++ b/.github/workflows/event-log-race-repro.yml
@@ -27,9 +27,9 @@ on:
         required: false
         default: '50'
       iterations:
-        description: 'Hook/sleep race iterations per workflow run'
+        description: 'Hook/sleep race iterations per workflow run (ceiling; the run returns as soon as the wake branch wins, so this mainly widens the window for the resume to land before the sleep budget is exhausted)'
         required: false
-        default: '5'
+        default: '8'
       run_timeout_ms:
         description: 'Per-run timeout before classifying as stuck'
         required: false
@@ -113,7 +113,7 @@ jobs:
           EVENT_LOG_RACE_REPRO_STEP_SLEEP_RACE_ATTEMPTS: ${{ inputs.step_sleep_race_attempts || '250' }}
           EVENT_LOG_RACE_REPRO_CONCURRENCY: ${{ inputs.concurrency || '50' }}
           EVENT_LOG_RACE_REPRO_STEP_CONCURRENCY: ${{ inputs.step_concurrency || '50' }}
-          EVENT_LOG_RACE_REPRO_ITERATIONS: ${{ inputs.iterations || '5' }}
+          EVENT_LOG_RACE_REPRO_ITERATIONS: ${{ inputs.iterations || '8' }}
           EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms || '150000' }}
           EVENT_LOG_RACE_REPRO_SLEEP_MS: ${{ inputs.sleep_ms || '5000' }}
           EVENT_LOG_RACE_REPRO_RESUME_DELAY_MS: ${{ inputs.resume_delay_ms || '15000' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,21 @@ jobs:
             exit 1
           fi
 
+  scripts-tests:
+    name: CI Scripts Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Run .github/scripts unit tests
+        run: node --test ".github/scripts/**/*.test.js"
+
   docs-links:
     name: Docs Links
     runs-on: ubuntu-latest

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -35,7 +35,13 @@ type Outcome =
   | 'USER_ERROR'
   | 'RUNTIME_ERROR'
   | 'stuck'
-  | 'other';
+  | 'other'
+  // Harness-side, non-gating outcomes: timing races in the repro driver
+  // itself (hook resume vs. the workflow's sleep budget) and transport
+  // errors talking to the deployment. These are NOT event-log regressions,
+  // so they are reported but never fail the job. See `infra` handling in
+  // `.github/scripts/render-event-log-race-repro-results.js`.
+  | 'infra';
 
 interface ReproConfig {
   hookSleepAttempts: number;
@@ -109,7 +115,14 @@ const config: ReproConfig = {
   ),
   concurrency: envNumber('EVENT_LOG_RACE_REPRO_CONCURRENCY', 50),
   stepConcurrency: envNumber('EVENT_LOG_RACE_REPRO_STEP_CONCURRENCY', 50),
-  iterations: envNumber('EVENT_LOG_RACE_REPRO_ITERATIONS', 5),
+  // Ceiling on hook/sleep race iterations. The run short-circuits via
+  // `returnOnWake` as soon as the hook wins, so a higher ceiling does not add
+  // runtime — it widens the window for the delayed hook resume
+  // (resumeDelayMs + resumeJitterMs, up to ~25s) to land before the workflow
+  // exhausts its sleep budget (iterations * sleepMs) and exits via the no-wake
+  // path. Keep iterations * sleepMs comfortably above the resume ceiling so the
+  // wake branch is actually exercised instead of being lost to a timing race.
+  iterations: envNumber('EVENT_LOG_RACE_REPRO_ITERATIONS', 8),
   sleepMs: envNumber('EVENT_LOG_RACE_REPRO_SLEEP_MS', 5000),
   resumeDelayMs: envNumber('EVENT_LOG_RACE_REPRO_RESUME_DELAY_MS', 15_000),
   resumeJitterMs: envNumber('EVENT_LOG_RACE_REPRO_RESUME_JITTER_MS', 10_000),
@@ -357,7 +370,7 @@ async function pollTerminalRun(
         scenario,
         token: '',
         runId: run.runId,
-        outcome: 'other',
+        outcome: 'infra',
         status: runData.status,
         errorCode: 'CANCELLED',
         durationMs: Date.now() - startedAt,
@@ -447,7 +460,10 @@ async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
           attempt,
           scenario,
           token,
-          outcome: 'other',
+          // The run completed; only the harness's own resume call failed
+          // (typically because the sleep branch already finished the run and
+          // disposed the hook). Harness timing, not an SDK regression.
+          outcome: 'infra',
           errorCode: 'HOOK_RESUME_FAILED',
           errorMessage: String(resumeFailure.reason),
         };
@@ -464,7 +480,10 @@ async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
           attempt,
           scenario,
           token,
-          outcome: 'other',
+          // The run completed cleanly but the sleep branch won the race before
+          // the resume landed, so the wake branch was never taken. This means
+          // the attempt lost its intended coverage, not that the log is wrong.
+          outcome: 'infra',
           errorCode: 'NO_WAKE_BRANCH',
           errorMessage: 'Run completed without taking the hook wake branch.',
         };
@@ -502,7 +521,11 @@ async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
       attempt,
       scenario,
       token,
-      outcome: 'other',
+      // A non-WorkflowRunFailedError thrown in the driver is a transport /
+      // harness problem (deployment unreachable, hook never appeared, resume
+      // or return-value read timed out), not an event-log regression.
+      outcome: 'infra',
+      errorCode: 'HARNESS_ERROR',
       errorMessage: err instanceof Error ? err.message : String(err),
       durationMs: Date.now() - startedAt,
     };
@@ -598,7 +621,11 @@ async function runStepFanoutAttempt(attempt: number): Promise<ReproRunResult> {
       attempt,
       scenario,
       token,
-      outcome: 'other',
+      // A non-WorkflowRunFailedError thrown in the driver is a transport /
+      // harness problem (deployment unreachable, hook never appeared, resume
+      // or return-value read timed out), not an event-log regression.
+      outcome: 'infra',
+      errorCode: 'HARNESS_ERROR',
       errorMessage: err instanceof Error ? err.message : String(err),
       durationMs: Date.now() - startedAt,
     };
@@ -689,7 +716,11 @@ async function runStepSleepRaceAttempt(
       attempt,
       scenario,
       token,
-      outcome: 'other',
+      // A non-WorkflowRunFailedError thrown in the driver is a transport /
+      // harness problem (deployment unreachable, hook never appeared, resume
+      // or return-value read timed out), not an event-log regression.
+      outcome: 'infra',
+      errorCode: 'HARNESS_ERROR',
       errorMessage: err instanceof Error ? err.message : String(err),
       durationMs: Date.now() - startedAt,
     };
@@ -735,8 +766,21 @@ function summarize(results: ReproRunResult[]) {
       RUNTIME_ERROR: 0,
       stuck: 0,
       other: 0,
+      infra: 0,
     }
   );
+}
+
+function emptyOutcomeCounts(): Record<Outcome, number> {
+  return {
+    completed: 0,
+    CORRUPTED_EVENT_LOG: 0,
+    USER_ERROR: 0,
+    RUNTIME_ERROR: 0,
+    stuck: 0,
+    other: 0,
+    infra: 0,
+  };
 }
 
 function summarizeByScenario(results: ReproRunResult[]) {
@@ -746,38 +790,10 @@ function summarizeByScenario(results: ReproRunResult[]) {
       return acc;
     },
     {
-      'hook-sleep': {
-        completed: 0,
-        CORRUPTED_EVENT_LOG: 0,
-        USER_ERROR: 0,
-        RUNTIME_ERROR: 0,
-        stuck: 0,
-        other: 0,
-      },
-      'step-fanout': {
-        completed: 0,
-        CORRUPTED_EVENT_LOG: 0,
-        USER_ERROR: 0,
-        RUNTIME_ERROR: 0,
-        stuck: 0,
-        other: 0,
-      },
-      'step-sleep-race-step-biased': {
-        completed: 0,
-        CORRUPTED_EVENT_LOG: 0,
-        USER_ERROR: 0,
-        RUNTIME_ERROR: 0,
-        stuck: 0,
-        other: 0,
-      },
-      'step-sleep-race-sleep-biased': {
-        completed: 0,
-        CORRUPTED_EVENT_LOG: 0,
-        USER_ERROR: 0,
-        RUNTIME_ERROR: 0,
-        stuck: 0,
-        other: 0,
-      },
+      'hook-sleep': emptyOutcomeCounts(),
+      'step-fanout': emptyOutcomeCounts(),
+      'step-sleep-race-step-biased': emptyOutcomeCounts(),
+      'step-sleep-race-sleep-biased': emptyOutcomeCounts(),
     }
   );
 }
@@ -840,6 +856,23 @@ const testTimeoutMs =
 describe('event log race repro', () => {
   beforeAll(() => {
     setupWorld(deploymentUrl);
+
+    // The hook resume must land before the workflow exhausts its sleep budget,
+    // otherwise the sleep branch wins and the run exits via the no-wake path,
+    // recording an `infra` outcome (NO_WAKE_BRANCH / HOOK_RESUME_FAILED) and
+    // losing the wake-branch coverage this scenario exists to exercise.
+    const sleepBudgetMs = config.iterations * config.sleepMs;
+    const resumeCeilingMs = config.resumeDelayMs + config.resumeJitterMs;
+    if (resumeCeilingMs >= sleepBudgetMs) {
+      console.warn(
+        `[event-log-race-repro] resume ceiling (${resumeCeilingMs}ms = ` +
+          `resumeDelayMs ${config.resumeDelayMs} + resumeJitterMs ${config.resumeJitterMs}) ` +
+          `is not below the hook-sleep budget (${sleepBudgetMs}ms = iterations ` +
+          `${config.iterations} * sleepMs ${config.sleepMs}). Many hook-sleep ` +
+          `attempts will lose the wake branch to the sleep race and be recorded ` +
+          `as infra. Raise iterations/sleepMs or lower the resume delay.`
+      );
+    }
   });
 
   test(
@@ -872,10 +905,14 @@ describe('event log race repro', () => {
       ];
       writeResults(results);
 
-      const nonCompleted = results.filter(
-        (result) => result.outcome !== 'completed'
+      // Only event-log regressions fail the job. `infra` outcomes are
+      // harness-side timing races (hook resume vs. sleep budget) and transport
+      // errors — they are recorded and surfaced in the summary, but do not
+      // gate, matching `--check` in the renderer script.
+      const regressions = results.filter(
+        (result) => result.outcome !== 'completed' && result.outcome !== 'infra'
       );
-      expect(nonCompleted).toEqual([]);
+      expect(regressions).toEqual([]);
     }
   );
 });


### PR DESCRIPTION
## Summary

The `event-log-race-repro` job is currently red for the wrong reason. In [a recent run](https://github.com/vercel/workflow/pull/2177#issuecomment-4586273422), it reported **1231 of 2000 runs "did not complete cleanly"** — yet `CORRUPTED_EVENT_LOG` / `USER_ERROR` / `RUNTIME_ERROR` were all **0**. The entire count was harness-side noise.

### What the `other` column was

The repro sorts each run into `completed`, `CORRUPTED_EVENT_LOG`, `USER_ERROR`, `RUNTIME_ERROR`, `stuck`, or `other`. Only the three named error codes mapped to their own bucket; **everything else fell into `other`**, and the `--check` gate failed the job on any non-completed run. So `other` conflated genuine corruption with:

- `HOOK_RESUME_FAILED` — the run **completed fine**, but the harness's own `resumeHook()` rejected (typically because the sleep branch already finished the run and disposed the hook).
- `NO_WAKE_BRANCH` — the run completed but the sleep branch won every iteration, so the wake path was never taken.
- transport errors / timeouts thrown in the driver, and cancellations.

### What was actually going wrong

A **timing race in the test harness**, not an SDK bug. The workflow's sleep budget is `iterations × sleepMs = 5 × 5000 = 25000ms`; the harness resumes the hook at `resumeDelayMs + rand(resumeJitterMs)` = up to **25000ms** — the resume ceiling exactly equals the budget. On a fast/warm deployment the workflow exhausts its sleeps before the resume lands, so the resume hits a disposed hook and/or the wake branch is never taken.

The smoking gun: the **#2 retry against the same already-warm deployment** jumped 767→1231 `other` while `stuck` dropped to 0 and the step scenarios stayed perfect. Faster execution = the resume misses the window more often. It also means most "green" runs weren't even exercising the wake-branch shape the repro is meant to stress.

## Changes

1. **Reclassify** harness-side, non-corruption outcomes into a dedicated **non-gating `infra` bucket** (test + renderer). The job now gates only on regression-class outcomes (`CORRUPTED_EVENT_LOG` / `USER_ERROR` / `RUNTIME_ERROR` / `stuck` / `other`); `infra` is reported but never fails the job. The PR comment now reads "No event-log regressions… N runs hit harness-side `infra` outcomes (… do not fail the job)."
2. **Surface regressions ahead of infra** in the failures table so the 20-row cap never hides a real failure behind a flood of timing rows.
3. **Restore wake-branch coverage**: raise the default `iterations` ceiling (5 → 8). Because the run short-circuits via `returnOnWake` the moment the hook wins, a higher ceiling **widens the window for the resume to land before sleep-budget exhaustion at ~no runtime cost**. Added a `beforeAll` guard that warns when the resume ceiling is not below the sleep budget.
4. **Testability**: the renderer's pure helpers are now exported and covered by `node:test` (run via a new lightweight Lint job).

## Tests

`node --test .github/scripts/**/*.test.js` (8 tests) covers: `infra` is non-gating; `regressionCount` ignores `completed`/`infra`; an all-infra results file (mirroring the production comment) yields 0 regressions; regressions sort ahead of infra; `--check` exits 0 on infra-only and 1 on a corruption-class outcome.

Note: the full 2000-run repro only runs against a deployment behind the `event-log-race-repro` label, so the reclassification's end-to-end effect is best confirmed by adding that label to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)