### PR TITLE
fix(core): resolve forwarded stream keys across deployments

### DIFF
--- a/.changeset/cross-deployment-stream-keys.md
+++ b/.changeset/cross-deployment-stream-keys.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": patch
+"@workflow/world": patch
+---
+
+Fix forwarded writable stream encryption when child workflows execute on a newer deployment than their parent.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -375,6 +375,7 @@ export function workflowEntrypoint(
                         stepResult = await executeStep({
                           world,
                           workflowRunId: runId,
+                          workflowDeploymentId: bgRun.deploymentId,
                           workflowName,
                           workflowStartedAt: bgStartedAt,
                           stepId: incomingStepId,
@@ -1066,6 +1067,7 @@ export function workflowEntrypoint(
                           stepResult = await executeStep({
                             world,
                             workflowRunId: runId,
+                            workflowDeploymentId: workflowRun.deploymentId,
                             workflowName,
                             workflowStartedAt,
                             stepId: inlineStep.correlationId,

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -38,6 +38,8 @@ const DEFAULT_STEP_MAX_RETRIES = 3;
 export interface StepExecutorParams {
   world: World;
   workflowRunId: string;
+  /** Deployment that owns the workflow run, for forwarded writable streams. */
+  workflowDeploymentId?: string;
   workflowName: string;
   workflowStartedAt: number;
   stepId: string;
@@ -294,7 +296,10 @@ export async function executeStep(
             step.input,
             workflowRunId,
             encryptionKey,
-            ops
+            ops,
+            globalThis,
+            {},
+            params.workflowDeploymentId
           );
           const durationMs = Date.now() - startTime;
           hydrateSpan?.setAttributes({
@@ -328,6 +333,7 @@ export async function executeStep(
                 : `http://localhost:${port ?? 3000}`,
               features: { encryption: !!encryptionKey },
             },
+            workflowDeploymentId: params.workflowDeploymentId,
             ops,
             closureVars: hydratedInput.closureVars,
             encryptionKey,

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -546,7 +546,10 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                   step.input,
                   workflowRunId,
                   encryptionKey,
-                  ops
+                  ops,
+                  globalThis,
+                  {},
+                  process.env.VERCEL_DEPLOYMENT_ID
                 );
                 const durationMs = Date.now() - startTime;
                 hydrateSpan?.setAttributes({
@@ -589,6 +592,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
                         : `http://localhost:${port ?? 3000}`,
                       features: { encryption: !!encryptionKey },
                     },
+                    workflowDeploymentId: process.env.VERCEL_DEPLOYMENT_ID,
                     ops,
                     closureVars: hydratedInput.closureVars,
                     encryptionKey,

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -42,6 +42,7 @@ import {
   ABORT_STREAM_NAME,
   STABLE_ULID,
   STREAM_NAME_SYMBOL,
+  STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
 } from './symbols.js';
 import { createContext } from './vm/index.js';
@@ -519,6 +520,10 @@ describe('workflow arguments', () => {
       value: 'wrun_parent',
       writable: false,
     });
+    Object.defineProperty(userWritable, STREAM_SERVER_DEPLOYMENT_ID_SYMBOL, {
+      value: 'dpl_parent',
+      writable: false,
+    });
 
     expect(userWritable.locked).toBe(false);
     const serialized = await dehydrateWorkflowArguments(
@@ -536,6 +541,122 @@ describe('workflow arguments', () => {
     const text = new TextDecoder().decode(serialized as Uint8Array);
     expect(text).toContain('strm_parentstreamname');
     expect(text).toContain('wrun_parent');
+    expect(text).toContain('dpl_parent');
+  });
+
+  it('uses the forwarded stream deployment to resolve its encryption key', async () => {
+    const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
+    const getEncryptionKeyForRun = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32).fill(7));
+    const runsGet = vi.fn();
+    const world = {
+      ...makeMockWorld(),
+      runs: { get: runsGet },
+      getEncryptionKeyForRun,
+    } as any;
+    vi.mocked(getWorldLazy).mockReturnValue(world);
+
+    try {
+      const parentWritable = new WritableStream();
+      Object.defineProperty(parentWritable, STREAM_NAME_SYMBOL, {
+        value: 'strm_parentstreamname',
+        writable: false,
+      });
+      Object.defineProperty(parentWritable, STREAM_SERVER_RUN_ID_SYMBOL, {
+        value: 'wrun_parent',
+        writable: false,
+      });
+      Object.defineProperty(
+        parentWritable,
+        STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+        {
+          value: 'dpl_parent',
+          writable: false,
+        }
+      );
+
+      const serialized = await dehydrateStepArguments(
+        parentWritable,
+        'wrun_child',
+        noEncryptionKey
+      );
+      const ops: Promise<void>[] = [];
+      const hydrated = (await hydrateStepArguments(
+        serialized,
+        'wrun_child',
+        noEncryptionKey,
+        ops,
+        globalThis,
+        {},
+        'dpl_child'
+      )) as WritableStream<string>;
+
+      const writer = hydrated.getWriter();
+      await writer.write('cross-deployment');
+      await writer.close();
+      await Promise.all(ops);
+
+      expect(getEncryptionKeyForRun).toHaveBeenCalledWith('wrun_parent', {
+        deploymentId: 'dpl_parent',
+      });
+      expect(runsGet).not.toHaveBeenCalled();
+    } finally {
+      vi.mocked(getWorldLazy).mockImplementation(() => makeMockWorld() as any);
+    }
+  });
+
+  it('loads the owner run for forwarded descriptors from older deployments', async () => {
+    const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
+    const parentRun = {
+      runId: 'wrun_parent',
+      deploymentId: 'dpl_parent',
+    };
+    const getEncryptionKeyForRun = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32).fill(9));
+    const runsGet = vi.fn().mockResolvedValue(parentRun);
+    const world = {
+      ...makeMockWorld(),
+      runs: { get: runsGet },
+      getEncryptionKeyForRun,
+    } as any;
+    vi.mocked(getWorldLazy).mockReturnValue(world);
+
+    try {
+      const legacyWritable = new WritableStream();
+      Object.defineProperty(legacyWritable, STREAM_NAME_SYMBOL, {
+        value: 'strm_legacyparent',
+        writable: false,
+      });
+      Object.defineProperty(legacyWritable, STREAM_SERVER_RUN_ID_SYMBOL, {
+        value: 'wrun_parent',
+        writable: false,
+      });
+
+      const serialized = await dehydrateStepArguments(
+        legacyWritable,
+        'wrun_child',
+        noEncryptionKey
+      );
+      const ops: Promise<void>[] = [];
+      const hydrated = (await hydrateStepArguments(
+        serialized,
+        'wrun_child',
+        noEncryptionKey,
+        ops
+      )) as WritableStream<string>;
+
+      const writer = hydrated.getWriter();
+      await writer.write('legacy-descriptor');
+      await writer.close();
+      await Promise.all(ops);
+
+      expect(runsGet).toHaveBeenCalledWith('wrun_parent');
+      expect(getEncryptionKeyForRun).toHaveBeenCalledWith(parentRun);
+    } finally {
+      vi.mocked(getWorldLazy).mockImplementation(() => makeMockWorld() as any);
+    }
   });
 
   it('should work with ReadableStream', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -70,6 +70,7 @@ import {
   BODY_INIT_SYMBOL,
   STABLE_ULID,
   STREAM_NAME_SYMBOL,
+  STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
   STREAM_TYPE_SYMBOL,
   WEBHOOK_RESPONSE_WRITABLE,
@@ -834,7 +835,17 @@ export function getExternalReducers(
         typeof existingName === 'string' &&
         typeof existingRunId === 'string'
       ) {
-        return { name: existingName, runId: existingRunId };
+        const descriptor: SerializableSpecial['WritableStream'] = {
+          name: existingName,
+          runId: existingRunId,
+        };
+        const existingDeploymentId = (value as any)[
+          STREAM_SERVER_DEPLOYMENT_ID_SYMBOL
+        ];
+        if (typeof existingDeploymentId === 'string') {
+          descriptor.deploymentId = existingDeploymentId;
+        }
+        return descriptor;
       }
 
       const streamId = ((global as any)[STABLE_ULID] || defaultUlid)();
@@ -928,6 +939,10 @@ export function getWorkflowReducers(
       // reviver opens the writable against the original stream.
       const foreignRunId = value[STREAM_SERVER_RUN_ID_SYMBOL];
       if (typeof foreignRunId === 'string') s.runId = foreignRunId;
+      const foreignDeploymentId = value[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL];
+      if (typeof foreignDeploymentId === 'string') {
+        s.deploymentId = foreignDeploymentId;
+      }
       return s;
     },
 
@@ -1046,6 +1061,12 @@ function getStepReducers(
 
       const s: SerializableSpecial['WritableStream'] = { name };
       if (typeof foreignRunId === 'string') s.runId = foreignRunId;
+      const foreignDeploymentId = (value as any)[
+        STREAM_SERVER_DEPLOYMENT_ID_SYMBOL
+      ];
+      if (typeof foreignDeploymentId === 'string') {
+        s.deploymentId = foreignDeploymentId;
+      }
       return s;
     },
 
@@ -1368,6 +1389,24 @@ export function getCommonRevivers(global: Record<string, any> = globalThis) {
 }
 
 /**
+ * Resolve the encrypt-only key needed when a child writes into another run's
+ * stream. New descriptors include the owner's deployment ID; descriptors
+ * created by older SDK versions fall back to loading the owning run.
+ */
+async function getForwardedWritableEncryptionKey(
+  runId: string,
+  deploymentId: string | undefined
+): Promise<CryptoKey | undefined> {
+  const world = await getWorldLazy();
+  if (!world.getEncryptionKeyForRun) return undefined;
+
+  const rawKey = deploymentId
+    ? await world.getEncryptionKeyForRun(runId, { deploymentId })
+    : await world.getEncryptionKeyForRun(await world.runs.get(runId));
+  return rawKey ? await importKey(rawKey, ['encrypt']) : undefined;
+}
+
+/**
  * Revivers for deserialization boundary from the client side,
  * receiving the return value from the workflow handler.
  *
@@ -1491,11 +1530,7 @@ export function getExternalRevivers(
       const targetKey: EncryptionKeyParam =
         targetRunId === runId
           ? cryptoKey
-          : (async () => {
-              const world = await getWorldLazy();
-              const rawKey = await world.getEncryptionKeyForRun?.(targetRunId);
-              return rawKey ? await importKey(rawKey, ['encrypt']) : undefined;
-            })();
+          : getForwardedWritableEncryptionKey(targetRunId, value.deploymentId);
 
       const serialize = getSerializeStream(
         getExternalReducers(global, ops, targetRunId, targetKey),
@@ -1526,6 +1561,16 @@ export function getExternalRevivers(
         value: targetRunId,
         writable: false,
       });
+      if (typeof value.deploymentId === 'string') {
+        Object.defineProperty(
+          serialize.writable,
+          STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+          {
+            value: value.deploymentId,
+            writable: false,
+          }
+        );
+      }
 
       return serialize.writable;
     },
@@ -1626,6 +1671,12 @@ export function getWorkflowRevivers(
           writable: false,
         };
       }
+      if (typeof value.deploymentId === 'string') {
+        descriptor[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL] = {
+          value: value.deploymentId,
+          writable: false,
+        };
+      }
       return Object.create(global.WritableStream.prototype, descriptor);
     },
 
@@ -1667,7 +1718,8 @@ function getStepRevivers(
   global: Record<string, any> = globalThis,
   ops: Promise<void>[],
   runId: string,
-  cryptoKey: EncryptionKeyParam
+  cryptoKey: EncryptionKeyParam,
+  deploymentId?: string
 ): Partial<Revivers> {
   return {
     ...getCommonRevivers(global),
@@ -1826,7 +1878,7 @@ function getStepRevivers(
         return userReadable;
       } else {
         const transform = getDeserializeStream(
-          getStepRevivers(global, ops, runId, cryptoKey),
+          getStepRevivers(global, ops, runId, cryptoKey, deploymentId),
           cryptoKey
         );
         const state = createFlushableState();
@@ -1857,14 +1909,16 @@ function getStepRevivers(
       // so the receiving run can never decrypt anything else on the
       // owning run's stream — it can only contribute new writes.
       const targetRunId = typeof value.runId === 'string' ? value.runId : runId;
+      const targetDeploymentId =
+        typeof value.deploymentId === 'string'
+          ? value.deploymentId
+          : targetRunId === runId
+            ? deploymentId
+            : undefined;
       const targetKey: EncryptionKeyParam =
         targetRunId === runId
           ? cryptoKey
-          : (async () => {
-              const world = await getWorldLazy();
-              const rawKey = await world.getEncryptionKeyForRun?.(targetRunId);
-              return rawKey ? await importKey(rawKey, ['encrypt']) : undefined;
-            })();
+          : getForwardedWritableEncryptionKey(targetRunId, targetDeploymentId);
 
       const serialize = getSerializeStream(
         getStepReducers(global, ops, targetRunId, targetKey),
@@ -1901,6 +1955,16 @@ function getStepRevivers(
         value: targetRunId,
         writable: false,
       });
+      if (targetDeploymentId) {
+        Object.defineProperty(
+          serialize.writable,
+          STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+          {
+            value: targetDeploymentId,
+            writable: false,
+          }
+        );
+      }
 
       return serialize.writable;
     },
@@ -2091,12 +2155,15 @@ export async function hydrateStepArguments(
   key: CryptoKey | undefined,
   ops: Promise<any>[] = [],
   global: Record<string, any> = globalThis,
-  extraRevivers: Record<string, (value: any) => any> = {}
+  extraRevivers: Record<string, (value: any) => any> = {},
+  deploymentId?: string
 ): Promise<any> {
   return stepModule.deserialize(value, key, {
     global,
     extraRevivers: {
-      ...getStreamAndRequestRevivers(getStepRevivers(global, ops, runId, key)),
+      ...getStreamAndRequestRevivers(
+        getStepRevivers(global, ops, runId, key, deploymentId)
+      ),
       ...extraRevivers,
     },
   });

--- a/packages/core/src/serialization/types.ts
+++ b/packages/core/src/serialization/types.ts
@@ -169,6 +169,12 @@ export interface SerializableSpecial {
      * belongs to the receiving run (the normal in-run case).
      */
     runId?: string;
+    /**
+     * The deployment that owns the server stream. Carried with `runId`
+     * so a child running on a newer deployment can encrypt chunks with
+     * the parent's key without fetching the parent run first.
+     */
+    deploymentId?: string;
   };
   AbortController: {
     streamName: string;

--- a/packages/core/src/step/context-storage.ts
+++ b/packages/core/src/step/context-storage.ts
@@ -20,6 +20,8 @@ export interface CachedWritable {
 export type StepContext = {
   stepMetadata: StepMetadata;
   workflowMetadata: WorkflowMetadata;
+  /** Deployment that owns the current workflow run, used for forwarded streams. */
+  workflowDeploymentId?: string;
   ops: Promise<void>[];
   closureVars?: Record<string, any>;
   encryptionKey?: CryptoKey;

--- a/packages/core/src/step/writable-stream.test.ts
+++ b/packages/core/src/step/writable-stream.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LOCK_POLL_INTERVAL_MS } from '../flushable-stream.js';
 import { setWorld } from '../runtime/world.js';
+import { STREAM_SERVER_DEPLOYMENT_ID_SYMBOL } from '../symbols.js';
 
 // Captures every chunk written to `world.streams.write` / `writeMulti`
 // in arrival order, so tests can assert the on-wire sequence after
@@ -218,5 +219,23 @@ describe('step-level getWritable', () => {
     });
 
     expect(ops).toHaveLength(2);
+  });
+
+  it('tags a writable with its owning deployment for child workflow forwarding', async () => {
+    const { contextStorage } = await import('./context-storage.js');
+    const ctx = {
+      ...makeStepCtx(),
+      workflowDeploymentId: 'dpl_parent',
+    };
+
+    const writable = await contextStorage.run(ctx, async () => {
+      const { getWritable } = await import('./writable-stream.js');
+      return getWritable<string>();
+    });
+
+    expect((writable as any)[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL]).toBe(
+      'dpl_parent'
+    );
+    await Promise.all(ctx.ops);
   });
 });

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -9,7 +9,11 @@ import {
   getSerializeStream,
   WorkflowServerWritableStream,
 } from '../serialization.js';
-import { STREAM_NAME_SYMBOL, STREAM_SERVER_RUN_ID_SYMBOL } from '../symbols.js';
+import {
+  STREAM_NAME_SYMBOL,
+  STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+  STREAM_SERVER_RUN_ID_SYMBOL,
+} from '../symbols.js';
 import { getWorkflowRunStreamId } from '../util.js';
 import { type CachedWritable, contextStorage } from './context-storage.js';
 
@@ -103,6 +107,16 @@ export function getWritable<W = any>(
     value: runId,
     writable: false,
   });
+  if (ctx.workflowDeploymentId) {
+    Object.defineProperty(
+      serialize.writable,
+      STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+      {
+        value: ctx.workflowDeploymentId,
+        writable: false,
+      }
+    );
+  }
 
   cache.set(name, { writable: serialize.writable, state });
 

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -24,6 +24,14 @@ export const STREAM_TYPE_SYMBOL = Symbol.for('WORKFLOW_STREAM_TYPE');
 export const STREAM_SERVER_RUN_ID_SYMBOL = Symbol.for(
   'WORKFLOW_STREAM_SERVER_RUN_ID'
 );
+/**
+ * Stamped alongside `STREAM_SERVER_RUN_ID_SYMBOL` when the deployment that
+ * owns a forwarded writable stream is known. Cross-deployment consumers use
+ * it to resolve the owning run's encryption key without loading the run first.
+ */
+export const STREAM_SERVER_DEPLOYMENT_ID_SYMBOL = Symbol.for(
+  'WORKFLOW_STREAM_SERVER_DEPLOYMENT_ID'
+);
 export const BODY_INIT_SYMBOL = Symbol.for('BODY_INIT');
 export const WEBHOOK_RESPONSE_WRITABLE = Symbol.for(
   'WEBHOOK_RESPONSE_WRITABLE'

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -349,10 +349,11 @@ export interface World extends Queue, Streamer, Storage {
    *   the run entity already exists. The World reads any context it needs
    *   (e.g., `deploymentId`) directly from the run.
    *
-   * - `getEncryptionKeyForRun(runId, context?)` — Used only by `start()`
-   *   when the run entity has not yet been created. The `context` parameter
-   *   carries opaque world-specific data (e.g., `{ deploymentId }` for
-   *   world-vercel) that the World needs to resolve the correct key.
+   * - `getEncryptionKeyForRun(runId, context?)` — Used when the run entity
+   *   is not locally available, such as `start()` before run creation or a
+   *   forwarded writable stream carrying its owning deployment context. The
+   *   `context` parameter carries opaque world-specific data (e.g.,
+   *   `{ deploymentId }` for world-vercel) needed to resolve the correct key.
    *   When `context` is omitted, the World assumes the current deployment.
    *
    * When not implemented, encryption is disabled — data is stored unencrypted.


### PR DESCRIPTION
## Summary
- carry the owning deployment ID on forwarded writable stream descriptors so a child on a newer deployment encrypts parent-stream chunks with the parent key
- fall back to loading the owning run for descriptors already serialized by older SDK versions
- add focused regression tests and document the expanded World key-resolution usage

## Root Cause
Cross-run writable revivers only carried the parent `runId` and called `getEncryptionKeyForRun(targetRunId)`. In `@workflow/world-vercel`, a string lookup without deployment context resolves against the executing deployment, so a child started on a newer deployment encrypted new chunks using its key while the parent stream is read using the older run key.

## Context
This upstreams the behavior temporarily patched downstream in https://github.com/vercel/ash/pull/852, while avoiding its extra owner-run lookup for newly serialized descriptors. Legacy or in-flight descriptors retain a correctness fallback.

## Validation
- `pnpm turbo build --filter=@workflow/core...`
- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/core exec vitest run src/serialization.test.ts src/step/writable-stream.test.ts`
- `pnpm --filter @workflow/core test`
- `pnpm biome format <changed files>`
- `pnpm changeset status --since=main`
