### PR TITLE
[world-vercel] [builders] Add WORKFLOW_SEQUENTIAL_REPLAYS option to limit flow route concurrency to one

### DIFF
--- a/.changeset/enforce-strict-concurrency.md
+++ b/.changeset/enforce-strict-concurrency.md
@@ -1,0 +1,8 @@
+---
+"@workflow/world-vercel": minor
+"@workflow/builders": minor
+"@workflow/next": minor
+"@workflow/sveltekit": patch
+---
+
+Add opt-in `WORKFLOW_SEQUENTIAL_REPLAYS` env var. When set to `1`, flow (orchestrator) routes are limited to one invocation per run at a time via a per-run queue topic and `maxConcurrency: 1` on the flow trigger. Step routes are unaffected.

--- a/.changeset/enforce-strict-concurrency.md
+++ b/.changeset/enforce-strict-concurrency.md
@@ -5,4 +5,4 @@
 "@workflow/sveltekit": patch
 ---
 
-Add opt-in `WORKFLOW_SEQUENTIAL_REPLAYS` env var. When set to `1`, flow (orchestrator) routes are limited to one invocation per run at a time via a per-run queue topic and `maxConcurrency: 1` on the flow trigger. Step routes are unaffected.
+Add opt-in `WORKFLOW_SEQUENTIAL_REPLAYS` env var (also enabled by the `WORKFLOW_SAFE_MODE=1` umbrella flag when not set explicitly). When set to `1`, flow (orchestrator) routes are limited to one invocation per run at a time via a per-run queue topic and `maxConcurrency: 1` on the flow trigger. Step routes are unaffected.

--- a/docs/content/docs/v4/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v4/deploying/world/vercel-world.mdx
@@ -122,6 +122,9 @@ When enabled, each run is given its own queue topic and the flow route is config
 
   Enabling sequential replays has a cost. Per [Vercel Queues pricing](https://vercel.com/docs/queues/pricing), push deliveries under `maxConcurrency` are billed at **2x units** for that operation, so every flow-route delivery costs double while this is enabled. It also creates one queue topic per run, which increases the number of distinct queues surfaced in queue observability, and each flow invocation waits for a per-run concurrency slot before delivery, which can add queueing latency. Leave it off unless you specifically need the per-run serialization guarantee.
 
+
+  While a replay holds a run's slot — including time spent executing steps inline — other wake messages for that run (hook resumes, aborts and cancellations, and run-timeout enforcement) wait for the slot. Expect aborts and timeouts to be delayed by up to the duration of the longest single invocation.
+
   The guarantee covers messages sent by the Workflow SDK itself. External producers that compute a flow topic name directly (rather than enqueueing through the SDK) still deliver, but bypass the per-run serialization slot.
 </Callout>
 

--- a/docs/content/docs/v4/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v4/deploying/world/vercel-world.mdx
@@ -113,7 +113,7 @@ Custom base URL for the Vercel workflow API. Automatically detected.
 
 ### `WORKFLOW_SEQUENTIAL_REPLAYS`
 
-Set `WORKFLOW_SEQUENTIAL_REPLAYS=1` to guarantee that **at most one orchestrator (flow) invocation runs at a time per workflow run**. This behavior is off by default; without it, the runtime relies on idempotency and the event log to tolerate concurrent flow invocations of the same run.
+Set `WORKFLOW_SEQUENTIAL_REPLAYS=1` to guarantee that **at most one orchestrator (flow) invocation runs at a time per workflow run**. This behavior is off by default; without it, the runtime relies on idempotency and the event log to tolerate concurrent flow invocations of the same run. It is also enabled by `WORKFLOW_SAFE_MODE=1` when `WORKFLOW_SEQUENTIAL_REPLAYS` is not set explicitly.
 
 When enabled, each run is given its own queue topic and the flow route is configured with `maxConcurrency: 1`, so [Vercel Queues](https://vercel.com/docs/queues) processes flow messages for a given run strictly one at a time. Step routes are unaffected and continue to run with full concurrency.
 

--- a/docs/content/docs/v4/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v4/deploying/world/vercel-world.mdx
@@ -111,6 +111,20 @@ Vercel team ID for API requests. Automatically detected.
 
 Custom base URL for the Vercel workflow API. Automatically detected.
 
+### `WORKFLOW_SEQUENTIAL_REPLAYS`
+
+Set `WORKFLOW_SEQUENTIAL_REPLAYS=1` to guarantee that **at most one orchestrator (flow) invocation runs at a time per workflow run**. This behavior is off by default; without it, the runtime relies on idempotency and the event log to tolerate concurrent flow invocations of the same run.
+
+When enabled, each run is given its own queue topic and the flow route is configured with `maxConcurrency: 1`, so [Vercel Queues](https://vercel.com/docs/queues) processes flow messages for a given run strictly one at a time. Step routes are unaffected and continue to run with full concurrency.
+
+<Callout type="warn">
+  This variable is read at **both build time and runtime**, so it must be set as a project-level environment variable that applies to your build and your deployed functions. Setting it for only one will produce an inconsistent configuration. The same applies to framework integrations that write their own queue trigger configuration instead of using `getWorkflowQueueTrigger()` from `@workflow/builders`: they only get the runtime half (per-run topics) unless they also emit `maxConcurrency: 1` on their flow trigger.
+
+  Enabling sequential replays has a cost. Per [Vercel Queues pricing](https://vercel.com/docs/queues/pricing), push deliveries under `maxConcurrency` are billed at **2x units** for that operation, so every flow-route delivery costs double while this is enabled. It also creates one queue topic per run, which increases the number of distinct queues surfaced in queue observability, and each flow invocation waits for a per-run concurrency slot before delivery, which can add queueing latency. Leave it off unless you specifically need the per-run serialization guarantee.
+
+  The guarantee covers messages sent by the Workflow SDK itself. External producers that compute a flow topic name directly (rather than enqueueing through the SDK) still deliver, but bypass the per-run serialization slot.
+</Callout>
+
 ### Programmatic configuration
 
 {/*@skip-typecheck: incomplete code sample*/}

--- a/docs/content/docs/v4/how-it-works/framework-integrations.mdx
+++ b/docs/content/docs/v4/how-it-works/framework-integrations.mdx
@@ -414,7 +414,7 @@ const flowTriggers = [getWorkflowQueueTrigger()];
 const stepTriggers = [STEP_QUEUE_TRIGGER];
 ```
 
-If your integration constructs the flow trigger object itself instead of calling `getWorkflowQueueTrigger()`, it must add `maxConcurrency: 1` to that trigger when `WORKFLOW_SEQUENTIAL_REPLAYS=1` is set at build time. The runtime half of the feature (per-run queue topics) activates from the environment variable alone — without the trigger half, those per-run topics are not serialized and the setting only adds queue-topic cardinality.
+If your integration constructs the flow trigger object itself instead of calling `getWorkflowQueueTrigger()`, it must add `maxConcurrency: 1` to that trigger when sequential replays are enabled at build time (`WORKFLOW_SEQUENTIAL_REPLAYS=1`, or `WORKFLOW_SAFE_MODE=1` when the specific variable is unset — the exported `isSequentialReplaysEnabled()` helper implements this check). The runtime half of the feature (per-run queue topics) activates from the environment variable alone — without the trigger half, those per-run topics are not serialized and the setting only adds queue-topic cardinality.
 
 
 ### Custom implementations

--- a/docs/content/docs/v4/how-it-works/framework-integrations.mdx
+++ b/docs/content/docs/v4/how-it-works/framework-integrations.mdx
@@ -405,11 +405,16 @@ Two queue topics are created per deployment:
 | `step.func` | `__wkf_step_*` | Step execution (long-running, `maxDuration: max`) |
 | `flow.func` | `__wkf_workflow_*` | Workflow orchestration (`maxDuration: 60`) |
 
-If you're building a framework integration that targets Vercel, you should write these triggers into the `.vc-config.json` for each generated function. The `STEP_QUEUE_TRIGGER` and `WORKFLOW_QUEUE_TRIGGER` constants are exported from `@workflow/builders` for this purpose:
+If you're building a framework integration that targets Vercel, you should write these triggers into the `.vc-config.json` for each generated function. Use `getWorkflowQueueTrigger()` for flow functions so `WORKFLOW_SEQUENTIAL_REPLAYS=1` is reflected in the generated trigger configuration (it also accepts a `namespace` option, matching `createWorkflowQueueTrigger`); `STEP_QUEUE_TRIGGER` is exported for step functions:
 
 ```typescript
-import { STEP_QUEUE_TRIGGER, WORKFLOW_QUEUE_TRIGGER } from "@workflow/builders";
+import { getWorkflowQueueTrigger, STEP_QUEUE_TRIGGER } from "@workflow/builders";
+
+const flowTriggers = [getWorkflowQueueTrigger()];
+const stepTriggers = [STEP_QUEUE_TRIGGER];
 ```
+
+If your integration constructs the flow trigger object itself instead of calling `getWorkflowQueueTrigger()`, it must add `maxConcurrency: 1` to that trigger when `WORKFLOW_SEQUENTIAL_REPLAYS=1` is set at build time. The runtime half of the feature (per-run queue topics) activates from the environment variable alone — without the trigger half, those per-run topics are not serialized and the setting only adds queue-topic cardinality.
 
 
 ### Custom implementations

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -201,7 +201,7 @@ Platform-provided values such as `VERCEL_DEPLOYMENT_ID`, `VERCEL_PROJECT_ID`, an
 - Default: disabled
 - Set `1` to serialize orchestrator (flow) invocations per run: each run's replays get their own queue topic and the flow trigger is generated with `maxConcurrency: 1`. Inline step executions get per-step topics and keep full parallelism.
 - Read at **both build time and runtime** — set it as a project-level environment variable so the generated trigger and the runtime queue routing agree.
-- Costs: flow-route push deliveries under `maxConcurrency` are billed at 2x units, queue observability sees one topic per run, and deliveries can queue behind the per-run slot. See [Vercel World](/docs/deploying/world/vercel-world#workflow_sequential_replays) for details.
+- Costs: flow-route push deliveries under `maxConcurrency` are billed at 2x units, queue observability sees one topic per run, and deliveries can queue behind the per-run slot — including hook resumes, aborts, and run-timeout enforcement, which are delayed while a replay is in flight. See [Vercel World](/docs/deploying/world/vercel-world#workflow_sequential_replays) for details.
 
 ### `VERCEL_WORKFLOW_SERVER_URL`
 

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -196,6 +196,13 @@ Platform-provided values such as `VERCEL_DEPLOYMENT_ID`, `VERCEL_PROJECT_ID`, an
 - Default: `https://api.vercel.com/v1/workflow`
 - Workflow API proxy URL for external tooling.
 
+### `WORKFLOW_SEQUENTIAL_REPLAYS`
+
+- Default: disabled
+- Set `1` to serialize orchestrator (flow) invocations per run: each run's replays get their own queue topic and the flow trigger is generated with `maxConcurrency: 1`. Inline step executions get per-step topics and keep full parallelism.
+- Read at **both build time and runtime** — set it as a project-level environment variable so the generated trigger and the runtime queue routing agree.
+- Costs: flow-route push deliveries under `maxConcurrency` are billed at 2x units, queue observability sees one topic per run, and deliveries can queue behind the per-run slot. See [Vercel World](/docs/deploying/world/vercel-world#workflow_sequential_replays) for details.
+
 ### `VERCEL_WORKFLOW_SERVER_URL`
 
 - Factory option: none

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -201,6 +201,7 @@ Platform-provided values such as `VERCEL_DEPLOYMENT_ID`, `VERCEL_PROJECT_ID`, an
 - Default: disabled
 - Set `1` to serialize orchestrator (flow) invocations per run: each run's replays get their own queue topic and the flow trigger is generated with `maxConcurrency: 1`. Inline step executions get per-step topics and keep full parallelism.
 - Read at **both build time and runtime** — set it as a project-level environment variable so the generated trigger and the runtime queue routing agree.
+- Also enabled by `WORKFLOW_SAFE_MODE=1` when not set explicitly.
 - Costs: flow-route push deliveries under `maxConcurrency` are billed at 2x units, queue observability sees one topic per run, and deliveries can queue behind the per-run slot — including hook resumes, aborts, and run-timeout enforcement, which are delayed while a replay is in flight. See [Vercel World](/docs/deploying/world/vercel-world#workflow_sequential_replays) for details.
 
 ### `VERCEL_WORKFLOW_SERVER_URL`

--- a/docs/content/docs/v5/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v5/deploying/world/vercel-world.mdx
@@ -136,6 +136,9 @@ When enabled, each run's orchestrator messages are given their own queue topic a
 
   Enabling sequential replays has a cost. Per [Vercel Queues pricing](https://vercel.com/docs/queues/pricing), push deliveries under `maxConcurrency` are billed at **2x units** for that operation, so every flow-route delivery costs double while this is enabled. It also creates one queue topic per run, which increases the number of distinct queues surfaced in queue observability, and each flow invocation waits for a per-run concurrency slot before delivery, which can add queueing latency. Leave it off unless you specifically need the per-run serialization guarantee.
 
+
+  While a replay holds a run's slot — including time spent executing steps inline — other wake messages for that run (hook resumes, aborts and cancellations, and run-timeout enforcement) wait for the slot. Expect aborts and timeouts to be delayed by up to the duration of the longest single invocation.
+
   The guarantee covers messages sent by the Workflow SDK itself. External producers that compute a flow topic name directly (rather than enqueueing through the SDK) still deliver, but bypass the per-run serialization slot.
 </Callout>
 

--- a/docs/content/docs/v5/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v5/deploying/world/vercel-world.mdx
@@ -125,6 +125,20 @@ Custom base URL for the Vercel workflow API proxy. Default: `https://api.vercel.
 
 Custom workflow-server URL for direct runtime requests, or for the proxy to forward to via `WORKFLOW_VERCEL_BACKEND_URL`. Default: unset; normal deployments should not need this.
 
+### `WORKFLOW_SEQUENTIAL_REPLAYS`
+
+Set `WORKFLOW_SEQUENTIAL_REPLAYS=1` to guarantee that **at most one orchestrator (flow) invocation runs at a time per workflow run**. This behavior is off by default; without it, the runtime relies on idempotency and the event log to tolerate concurrent flow invocations of the same run.
+
+When enabled, each run's orchestrator messages are given their own queue topic and the flow trigger is configured with `maxConcurrency: 1`, so [Vercel Queues](https://vercel.com/docs/queues) processes replays for a given run strictly one at a time. Step executions (which ride the flow topic in the combined handler model) get a per-step topic, so steps keep full parallelism.
+
+<Callout type="warn">
+  This variable is read at **both build time and runtime**, so it must be set as a project-level environment variable that applies to your build and your deployed functions. Setting it for only one will produce an inconsistent configuration. The same applies to framework integrations that write their own queue trigger configuration instead of using `getWorkflowQueueTrigger()` from `@workflow/builders`: they only get the runtime half (per-run topics) unless they also emit `maxConcurrency: 1` on their flow trigger.
+
+  Enabling sequential replays has a cost. Per [Vercel Queues pricing](https://vercel.com/docs/queues/pricing), push deliveries under `maxConcurrency` are billed at **2x units** for that operation, so every flow-route delivery costs double while this is enabled. It also creates one queue topic per run, which increases the number of distinct queues surfaced in queue observability, and each flow invocation waits for a per-run concurrency slot before delivery, which can add queueing latency. Leave it off unless you specifically need the per-run serialization guarantee.
+
+  The guarantee covers messages sent by the Workflow SDK itself. External producers that compute a flow topic name directly (rather than enqueueing through the SDK) still deliver, but bypass the per-run serialization slot.
+</Callout>
+
 ### `VERCEL_QUEUE_MAX_DELAY_SECONDS`
 
 Maximum delay, in seconds, that Workflow uses for one Vercel Queues continuation message when implementing `sleep()`. If a workflow sleeps longer than this, the runtime schedules another continuation message when the first one fires, repeating until the sleep's target time is reached. Default: `82800` (23 hours).

--- a/docs/content/docs/v5/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v5/deploying/world/vercel-world.mdx
@@ -127,7 +127,7 @@ Custom workflow-server URL for direct runtime requests, or for the proxy to forw
 
 ### `WORKFLOW_SEQUENTIAL_REPLAYS`
 
-Set `WORKFLOW_SEQUENTIAL_REPLAYS=1` to guarantee that **at most one orchestrator (flow) invocation runs at a time per workflow run**. This behavior is off by default; without it, the runtime relies on idempotency and the event log to tolerate concurrent flow invocations of the same run.
+Set `WORKFLOW_SEQUENTIAL_REPLAYS=1` to guarantee that **at most one orchestrator (flow) invocation runs at a time per workflow run**. This behavior is off by default; without it, the runtime relies on idempotency and the event log to tolerate concurrent flow invocations of the same run. It is also enabled by `WORKFLOW_SAFE_MODE=1` when `WORKFLOW_SEQUENTIAL_REPLAYS` is not set explicitly.
 
 When enabled, each run's orchestrator messages are given their own queue topic and the flow trigger is configured with `maxConcurrency: 1`, so [Vercel Queues](https://vercel.com/docs/queues) processes replays for a given run strictly one at a time. Step executions (which ride the flow topic in the combined handler model) get a per-step topic, so steps keep full parallelism.
 

--- a/docs/content/docs/v5/how-it-works/framework-integrations.mdx
+++ b/docs/content/docs/v5/how-it-works/framework-integrations.mdx
@@ -414,7 +414,7 @@ const flowTriggers = [getWorkflowQueueTrigger()];
 const stepTriggers = [STEP_QUEUE_TRIGGER];
 ```
 
-If your integration constructs the flow trigger object itself instead of calling `getWorkflowQueueTrigger()`, it must add `maxConcurrency: 1` to that trigger when `WORKFLOW_SEQUENTIAL_REPLAYS=1` is set at build time. The runtime half of the feature (per-run queue topics) activates from the environment variable alone — without the trigger half, those per-run topics are not serialized and the setting only adds queue-topic cardinality.
+If your integration constructs the flow trigger object itself instead of calling `getWorkflowQueueTrigger()`, it must add `maxConcurrency: 1` to that trigger when sequential replays are enabled at build time (`WORKFLOW_SEQUENTIAL_REPLAYS=1`, or `WORKFLOW_SAFE_MODE=1` when the specific variable is unset — the exported `isSequentialReplaysEnabled()` helper implements this check). The runtime half of the feature (per-run queue topics) activates from the environment variable alone — without the trigger half, those per-run topics are not serialized and the setting only adds queue-topic cardinality.
 
 
 ### Custom implementations

--- a/docs/content/docs/v5/how-it-works/framework-integrations.mdx
+++ b/docs/content/docs/v5/how-it-works/framework-integrations.mdx
@@ -405,11 +405,16 @@ Two queue topics are created per deployment:
 | `step.func` | `__wkf_step_*` | Step execution (long-running, `maxDuration: max`) |
 | `flow.func` | `__wkf_workflow_*` | Workflow orchestration (`maxDuration: 60`) |
 
-If you're building a framework integration that targets Vercel, you should write these triggers into the `.vc-config.json` for each generated function. The `STEP_QUEUE_TRIGGER` and `WORKFLOW_QUEUE_TRIGGER` constants are exported from `@workflow/builders` for this purpose:
+If you're building a framework integration that targets Vercel, you should write these triggers into the `.vc-config.json` for each generated function. Use `getWorkflowQueueTrigger()` for flow functions so `WORKFLOW_SEQUENTIAL_REPLAYS=1` is reflected in the generated trigger configuration (it also accepts a `namespace` option, matching `createWorkflowQueueTrigger`); `STEP_QUEUE_TRIGGER` is exported for step functions:
 
 ```typescript
-import { STEP_QUEUE_TRIGGER, WORKFLOW_QUEUE_TRIGGER } from "@workflow/builders";
+import { getWorkflowQueueTrigger, STEP_QUEUE_TRIGGER } from "@workflow/builders";
+
+const flowTriggers = [getWorkflowQueueTrigger()];
+const stepTriggers = [STEP_QUEUE_TRIGGER];
 ```
+
+If your integration constructs the flow trigger object itself instead of calling `getWorkflowQueueTrigger()`, it must add `maxConcurrency: 1` to that trigger when `WORKFLOW_SEQUENTIAL_REPLAYS=1` is set at build time. The runtime half of the feature (per-run queue topics) activates from the environment variable alone — without the trigger half, those per-run topics are not serialized and the setting only adds queue-topic cardinality.
 
 
 ### Custom implementations

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -2164,6 +2164,7 @@ export const OPTIONS = handler;`;
         topic: string;
         consumer: string;
         maxDeliveries?: number;
+        maxConcurrency?: number;
         retryAfterSeconds?: number;
         initialDelaySeconds?: number;
       }>;

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -1,8 +1,66 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
 import {
   createWorkflowEntrypointOptionsCode,
   createWorkflowQueueTrigger,
+  getWorkflowQueueTrigger,
 } from './constants.js';
+
+describe('getWorkflowQueueTrigger', () => {
+  let originalStrict: string | undefined;
+
+  beforeEach(() => {
+    originalStrict = process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+  });
+
+  afterEach(() => {
+    if (originalStrict !== undefined) {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = originalStrict;
+    } else {
+      delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+    }
+  });
+
+  it('omits maxConcurrency by default', () => {
+    delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+    const trigger = getWorkflowQueueTrigger();
+    expect(trigger.topic).toBe('__wkf_workflow_*');
+    expect('maxConcurrency' in trigger).toBe(false);
+  });
+
+  it('sets maxConcurrency: 1 when WORKFLOW_SEQUENTIAL_REPLAYS=1', () => {
+    process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+    const trigger = getWorkflowQueueTrigger();
+    expect(trigger).toMatchObject({
+      topic: '__wkf_workflow_*',
+      maxConcurrency: 1,
+    });
+  });
+
+  it('does not set maxConcurrency for non-"1" values', () => {
+    process.env.WORKFLOW_SEQUENTIAL_REPLAYS = 'true';
+    const trigger = getWorkflowQueueTrigger();
+    expect('maxConcurrency' in trigger).toBe(false);
+  });
+
+  it('composes with an explicit namespace option', () => {
+    process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+    expect(getWorkflowQueueTrigger({ namespace: 'custom' })).toMatchObject({
+      topic: '__custom_wkf_workflow_*',
+      maxConcurrency: 1,
+    });
+  });
+
+  it('resolves WORKFLOW_QUEUE_NAMESPACE at call time', () => {
+    delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+    process.env.WORKFLOW_QUEUE_NAMESPACE = 'callns';
+    try {
+      expect(getWorkflowQueueTrigger().topic).toBe('__callns_wkf_workflow_*');
+    } finally {
+      delete process.env.WORKFLOW_QUEUE_NAMESPACE;
+    }
+  });
+});
 
 describe('createWorkflowQueueTrigger', () => {
   afterEach(() => {

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -21,9 +21,7 @@ describe('getWorkflowQueueTrigger', () => {
     }
   });
 
-  // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
-  // REVERT BEFORE MERGE (drop the TEMP commit to restore).
-  it.skip('omits maxConcurrency by default', () => {
+  it('omits maxConcurrency by default', () => {
     delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
     const trigger = getWorkflowQueueTrigger();
     expect(trigger.topic).toBe('__wkf_workflow_*');
@@ -39,9 +37,7 @@ describe('getWorkflowQueueTrigger', () => {
     });
   });
 
-  // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
-  // REVERT BEFORE MERGE (drop the TEMP commit to restore).
-  it.skip('does not set maxConcurrency for non-"1" values', () => {
+  it('does not set maxConcurrency for non-"1" values', () => {
     process.env.WORKFLOW_SEQUENTIAL_REPLAYS = 'true';
     const trigger = getWorkflowQueueTrigger();
     expect('maxConcurrency' in trigger).toBe(false);

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -21,7 +21,9 @@ describe('getWorkflowQueueTrigger', () => {
     }
   });
 
-  it('omits maxConcurrency by default', () => {
+  // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
+  // REVERT BEFORE MERGE (drop the TEMP commit to restore).
+  it.skip('omits maxConcurrency by default', () => {
     delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
     const trigger = getWorkflowQueueTrigger();
     expect(trigger.topic).toBe('__wkf_workflow_*');
@@ -37,7 +39,9 @@ describe('getWorkflowQueueTrigger', () => {
     });
   });
 
-  it('does not set maxConcurrency for non-"1" values', () => {
+  // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
+  // REVERT BEFORE MERGE (drop the TEMP commit to restore).
+  it.skip('does not set maxConcurrency for non-"1" values', () => {
     process.env.WORKFLOW_SEQUENTIAL_REPLAYS = 'true';
     const trigger = getWorkflowQueueTrigger();
     expect('maxConcurrency' in trigger).toBe(false);

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -8,9 +8,12 @@ import {
 
 describe('getWorkflowQueueTrigger', () => {
   let originalStrict: string | undefined;
+  let originalSafeMode: string | undefined;
 
   beforeEach(() => {
     originalStrict = process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+    originalSafeMode = process.env.WORKFLOW_SAFE_MODE;
+    delete process.env.WORKFLOW_SAFE_MODE;
   });
 
   afterEach(() => {
@@ -18,6 +21,11 @@ describe('getWorkflowQueueTrigger', () => {
       process.env.WORKFLOW_SEQUENTIAL_REPLAYS = originalStrict;
     } else {
       delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+    }
+    if (originalSafeMode !== undefined) {
+      process.env.WORKFLOW_SAFE_MODE = originalSafeMode;
+    } else {
+      delete process.env.WORKFLOW_SAFE_MODE;
     }
   });
 
@@ -41,6 +49,18 @@ describe('getWorkflowQueueTrigger', () => {
     process.env.WORKFLOW_SEQUENTIAL_REPLAYS = 'true';
     const trigger = getWorkflowQueueTrigger();
     expect('maxConcurrency' in trigger).toBe(false);
+  });
+
+  it('WORKFLOW_SAFE_MODE=1 sets maxConcurrency when the specific variable is unset', () => {
+    delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+    process.env.WORKFLOW_SAFE_MODE = '1';
+    expect(getWorkflowQueueTrigger()).toMatchObject({ maxConcurrency: 1 });
+  });
+
+  it('an explicit WORKFLOW_SEQUENTIAL_REPLAYS=0 wins over WORKFLOW_SAFE_MODE', () => {
+    process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '0';
+    process.env.WORKFLOW_SAFE_MODE = '1';
+    expect('maxConcurrency' in getWorkflowQueueTrigger()).toBe(false);
   });
 
   it('composes with an explicit namespace option', () => {

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -118,10 +118,12 @@ export const WORKFLOW_QUEUE_TRIGGER = createWorkflowQueueTrigger();
  * the route's `experimentalTriggers` config.
  */
 export function getWorkflowQueueTrigger(options?: { namespace?: string }) {
+  // TEMP(ci-default-on): force sequential replays ON regardless of the env var
+  // so CI e2e jobs exercise maxConcurrency + payload-dependent topics. REVERT
+  // BEFORE MERGE — restore the `...(process.env.WORKFLOW_SEQUENTIAL_REPLAYS
+  // === '1' && { maxConcurrency: 1 })` gate.
   return {
     ...createWorkflowQueueTrigger(options),
-    ...(process.env.WORKFLOW_SEQUENTIAL_REPLAYS === '1' && {
-      maxConcurrency: 1,
-    }),
+    maxConcurrency: 1,
   };
 }

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -97,3 +97,31 @@ export const OPTIONS = POST;`;
  * Default queue trigger (no namespace). Backward compatible.
  */
 export const WORKFLOW_QUEUE_TRIGGER = createWorkflowQueueTrigger();
+
+/**
+ * Returns the queue trigger configuration for workflow (flow) routes.
+ *
+ * Builds on `createWorkflowQueueTrigger()` — the namespace comes from
+ * `options` or `WORKFLOW_QUEUE_NAMESPACE`, resolved at call time. When
+ * `WORKFLOW_SEQUENTIAL_REPLAYS` is enabled, sets `maxConcurrency: 1` so the
+ * queue processes at most one flow invocation per concrete topic at a time.
+ * Paired with the per-run physical topic naming in `@workflow/world-vercel`
+ * (which appends the run id to the flow topic), this enforces at most one
+ * orchestrator invocation per run. Step routes are intentionally excluded.
+ *
+ * Integrations that write their own flow trigger config instead of calling
+ * this must mirror the conditional `maxConcurrency: 1` themselves — the
+ * runtime half (per-run topics) activates from the env var alone, and without
+ * the trigger half those topics are not serialized.
+ *
+ * Must be read at build time, where the env var gates what is written into
+ * the route's `experimentalTriggers` config.
+ */
+export function getWorkflowQueueTrigger(options?: { namespace?: string }) {
+  return {
+    ...createWorkflowQueueTrigger(options),
+    ...(process.env.WORKFLOW_SEQUENTIAL_REPLAYS === '1' && {
+      maxConcurrency: 1,
+    }),
+  };
+}

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -117,10 +117,24 @@ export const WORKFLOW_QUEUE_TRIGGER = createWorkflowQueueTrigger();
  * Must be read at build time, where the env var gates what is written into
  * the route's `experimentalTriggers` config.
  */
+/**
+ * Whether sequential replays are enabled: `WORKFLOW_SEQUENTIAL_REPLAYS=1`,
+ * or `WORKFLOW_SAFE_MODE=1` when `WORKFLOW_SEQUENTIAL_REPLAYS` is not set
+ * explicitly (safe mode fills the default of every safety-over-performance
+ * flag; an explicit per-flag value always wins). Read at call time.
+ */
+export function isSequentialReplaysEnabled(): boolean {
+  const explicit = process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+  if (explicit !== undefined && explicit !== '') {
+    return explicit === '1';
+  }
+  return process.env.WORKFLOW_SAFE_MODE === '1';
+}
+
 export function getWorkflowQueueTrigger(options?: { namespace?: string }) {
   return {
     ...createWorkflowQueueTrigger(options),
-    ...(process.env.WORKFLOW_SEQUENTIAL_REPLAYS === '1' && {
+    ...(isSequentialReplaysEnabled() && {
       maxConcurrency: 1,
     }),
   };

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -118,12 +118,10 @@ export const WORKFLOW_QUEUE_TRIGGER = createWorkflowQueueTrigger();
  * the route's `experimentalTriggers` config.
  */
 export function getWorkflowQueueTrigger(options?: { namespace?: string }) {
-  // TEMP(ci-default-on): force sequential replays ON regardless of the env var
-  // so CI e2e jobs exercise maxConcurrency + payload-dependent topics. REVERT
-  // BEFORE MERGE — restore the `...(process.env.WORKFLOW_SEQUENTIAL_REPLAYS
-  // === '1' && { maxConcurrency: 1 })` gate.
   return {
     ...createWorkflowQueueTrigger(options),
-    maxConcurrency: 1,
+    ...(process.env.WORKFLOW_SEQUENTIAL_REPLAYS === '1' && {
+      maxConcurrency: 1,
+    }),
   };
 }

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -15,6 +15,7 @@ export {
   createWorkflowEntrypointOptionsCode,
   createWorkflowQueueTrigger,
   getWorkflowQueueTrigger,
+  isSequentialReplaysEnabled,
   WORKFLOW_QUEUE_TRIGGER,
 } from './constants.js';
 export {

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   createWorkflowEntrypointOptionsCode,
   createWorkflowQueueTrigger,
+  getWorkflowQueueTrigger,
   WORKFLOW_QUEUE_TRIGGER,
 } from './constants.js';
 export {

--- a/packages/builders/src/vercel-build-output-api.ts
+++ b/packages/builders/src/vercel-build-output-api.ts
@@ -1,7 +1,7 @@
 import { copyFile, mkdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { BaseBuilder } from './base-builder.js';
-import { WORKFLOW_QUEUE_TRIGGER } from './constants.js';
+import { getWorkflowQueueTrigger } from './constants.js';
 
 export class VercelBuildOutputAPIBuilder extends BaseBuilder {
   async build(): Promise<void> {
@@ -38,7 +38,7 @@ export class VercelBuildOutputAPIBuilder extends BaseBuilder {
       // serves no purpose without maps.
       shouldAddSourcemapSupport: this.sourcemapsEnabled,
       maxDuration: 'max',
-      experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
+      experimentalTriggers: [getWorkflowQueueTrigger()],
       runtime: this.config.runtime,
     });
 

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -351,14 +351,22 @@ async function pollTerminalRun(
     }
 
     if (runData.status === 'failed') {
+      // A failed WorkflowRun carries its reason in `error: { code, message }`
+      // — the run has no top-level `errorCode`. Reading the structured error
+      // is what lets us classify USER_ERROR/RUNTIME_ERROR/CORRUPTED_EVENT_LOG
+      // (vs. uncategorised `other`) and surface *why* it failed in the summary.
+      const structuredError = (
+        runData as { error?: { code?: string; message?: string } }
+      ).error;
       return {
         attempt: -1,
         scenario,
         token: '',
         runId: run.runId,
-        outcome: classifyFailure(runData.errorCode),
+        outcome: classifyFailure(structuredError?.code),
         status: runData.status,
-        errorCode: runData.errorCode,
+        errorCode: structuredError?.code,
+        errorMessage: structuredError?.message,
         durationMs: Date.now() - startedAt,
         dashboardUrl: getDashboardUrl(run.runId),
       };

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -41,7 +41,7 @@ export async function getNextBuilderEager(
 
   const {
     BaseBuilder: BaseBuilderClass,
-    WORKFLOW_QUEUE_TRIGGER,
+    getWorkflowQueueTrigger,
     detectWorkflowPatterns,
     parentHasChild,
   } = buildersModule ??
@@ -667,7 +667,7 @@ export async function getNextBuilderEager(
         version: '0',
         workflows: {
           maxDuration: 'max',
-          experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
+          experimentalTriggers: [getWorkflowQueueTrigger()],
         },
       };
 

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { WORKFLOW_QUEUE_TRIGGER } from '@workflow/builders';
+import { getWorkflowQueueTrigger } from '@workflow/builders';
 import fs from 'fs-extra';
 
 import { SvelteKitBuilder } from './builder.js';
@@ -24,7 +24,7 @@ process.on('beforeExit', () => {
       file: '.vercel/output/functions/.well-known/workflow/v1/flow.func/.vc-config.json',
       config: {
         maxDuration: 'max',
-        experimentalTriggers: [WORKFLOW_QUEUE_TRIGGER],
+        experimentalTriggers: [getWorkflowQueueTrigger()],
       },
     },
   ]) {

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -460,7 +460,9 @@ describe('createQueue', () => {
       expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_test_wrun_abc');
     });
 
-    it('does not rewrite the topic when the flag is unset', async () => {
+    // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
+    // REVERT BEFORE MERGE (drop the TEMP commit to restore).
+    it.skip('does not rewrite the topic when the flag is unset', async () => {
       delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
 
       const queue = createQueue();
@@ -538,7 +540,9 @@ describe('createQueue', () => {
       );
     });
 
-    it('does not rewrite health check topics when the flag is unset', async () => {
+    // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
+    // REVERT BEFORE MERGE (drop the TEMP commit to restore).
+    it.skip('does not rewrite health check topics when the flag is unset', async () => {
       delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
 
       const queue = createQueue();

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -397,10 +397,13 @@ describe('createQueue', () => {
   describe('strict concurrency (WORKFLOW_SEQUENTIAL_REPLAYS)', () => {
     let originalDeploymentId: string | undefined;
     let originalStrict: string | undefined;
+    let originalSafeMode: string | undefined;
 
     beforeEach(() => {
       originalDeploymentId = process.env.VERCEL_DEPLOYMENT_ID;
       originalStrict = process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+      originalSafeMode = process.env.WORKFLOW_SAFE_MODE;
+      delete process.env.WORKFLOW_SAFE_MODE;
       process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
       mockSend.mockResolvedValue({ messageId: 'msg-123' });
     });
@@ -415,6 +418,11 @@ describe('createQueue', () => {
         process.env.WORKFLOW_SEQUENTIAL_REPLAYS = originalStrict;
       } else {
         delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+      }
+      if (originalSafeMode !== undefined) {
+        process.env.WORKFLOW_SAFE_MODE = originalSafeMode;
+      } else {
+        delete process.env.WORKFLOW_SAFE_MODE;
       }
     });
 
@@ -481,6 +489,26 @@ describe('createQueue', () => {
       });
 
       expect(mockSend.mock.calls[0][0]).toBe('__wkf_step_myStep');
+    });
+
+    it('WORKFLOW_SAFE_MODE=1 routes to per-run topics when the specific variable is unset', async () => {
+      delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+      process.env.WORKFLOW_SAFE_MODE = '1';
+
+      const queue = createQueue();
+      await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc' });
+
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_test_wrun_abc');
+    });
+
+    it('an explicit WORKFLOW_SEQUENTIAL_REPLAYS=0 wins over WORKFLOW_SAFE_MODE', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '0';
+      process.env.WORKFLOW_SAFE_MODE = '1';
+
+      const queue = createQueue();
+      await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc' });
+
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_test');
     });
 
     it('gives inline step executions (flow topic + stepId) a per-step topic for full parallelism', async () => {

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -394,6 +394,203 @@ describe('createQueue', () => {
     });
   });
 
+  describe('strict concurrency (WORKFLOW_SEQUENTIAL_REPLAYS)', () => {
+    let originalDeploymentId: string | undefined;
+    let originalStrict: string | undefined;
+
+    beforeEach(() => {
+      originalDeploymentId = process.env.VERCEL_DEPLOYMENT_ID;
+      originalStrict = process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+    });
+
+    afterEach(() => {
+      if (originalDeploymentId !== undefined) {
+        process.env.VERCEL_DEPLOYMENT_ID = originalDeploymentId;
+      } else {
+        delete process.env.VERCEL_DEPLOYMENT_ID;
+      }
+      if (originalStrict !== undefined) {
+        process.env.WORKFLOW_SEQUENTIAL_REPLAYS = originalStrict;
+      } else {
+        delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+      }
+    });
+
+    it('appends runId to the physical flow topic while keeping the logical queueName', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc' });
+
+      // send(physicalTopic, wrapper, options)
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_test_wrun_abc');
+      // The logical queue name is preserved so the handler + re-enqueue path
+      // resolves the same per-run physical topic on the next invocation.
+      expect(mockSend.mock.calls[0][1].queueName).toBe('__wkf_workflow_test');
+    });
+
+    it('re-enqueues delayed flow messages to the same per-run physical topic', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      let capturedHandler: (
+        message: unknown,
+        metadata: unknown
+      ) => Promise<void>;
+      mockHandleCallback.mockImplementation((handler) => {
+        capturedHandler = handler;
+        return async () => new Response('ok');
+      });
+
+      const queue = createQueue();
+      queue.createQueueHandler('__wkf_workflow_', async () => ({
+        timeoutSeconds: 300,
+      }));
+
+      await capturedHandler!(
+        {
+          payload: { runId: 'wrun_abc' },
+          queueName: '__wkf_workflow_test',
+          deploymentId: 'dpl_original',
+        },
+        { messageId: 'msg-123', deliveryCount: 1, createdAt: new Date() }
+      );
+
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_test_wrun_abc');
+    });
+
+    it('does not rewrite the topic when the flag is unset', async () => {
+      delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+
+      const queue = createQueue();
+      await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc' });
+
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_test');
+    });
+
+    it('does not rewrite step topics even when the flag is set', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      await queue.queue('__wkf_step_myStep', {
+        workflowName: 'test-workflow',
+        workflowRunId: 'wrun_abc',
+        workflowStartedAt: Date.now(),
+        stepId: 'step_xyz',
+      });
+
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_step_myStep');
+    });
+
+    it('gives inline step executions (flow topic + stepId) a per-step topic for full parallelism', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      // Inline step executions ride the flow topic as WorkflowInvokePayload
+      // with a stepId. They must NOT share the per-run serialized topic, or
+      // a run's parallel steps would execute one at a time.
+      await queue.queue('__wkf_workflow_test', {
+        runId: 'wrun_abc',
+        stepId: 'step_one',
+      });
+      await queue.queue('__wkf_workflow_test', {
+        runId: 'wrun_abc',
+        stepId: 'step_two',
+      });
+
+      expect(mockSend.mock.calls[0][0]).toBe(
+        '__wkf_workflow_test_wrun_abc_step_one'
+      );
+      expect(mockSend.mock.calls[1][0]).toBe(
+        '__wkf_workflow_test_wrun_abc_step_two'
+      );
+      // The wrapper keeps the logical queue name for handler dispatch.
+      expect(mockSend.mock.calls[0][1].queueName).toBe('__wkf_workflow_test');
+    });
+
+    it('gives each health check its own physical topic so concurrent probes never serialize', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      // Concurrent probes: with maxConcurrency: 1 applied per concrete topic,
+      // a single shared `…_health_check` topic would process probes one at a
+      // time and let a slow probe time out its successors. Distinct
+      // per-correlation topics keep them independent.
+      await queue.queue('__wkf_workflow_health_check', {
+        __healthCheck: true as const,
+        correlationId: 'corr_123',
+      });
+      await queue.queue('__wkf_workflow_health_check', {
+        __healthCheck: true as const,
+        correlationId: 'corr_456',
+      });
+
+      expect(mockSend.mock.calls[0][0]).toBe(
+        '__wkf_workflow_health_check_corr_123'
+      );
+      expect(mockSend.mock.calls[1][0]).toBe(
+        '__wkf_workflow_health_check_corr_456'
+      );
+      // The wrapper keeps the logical queue name for handler dispatch.
+      expect(mockSend.mock.calls[0][1].queueName).toBe(
+        '__wkf_workflow_health_check'
+      );
+    });
+
+    it('does not rewrite health check topics when the flag is unset', async () => {
+      delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+
+      const queue = createQueue();
+      await queue.queue('__wkf_workflow_health_check', {
+        __healthCheck: true as const,
+        correlationId: 'corr_123',
+      });
+
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_health_check');
+    });
+
+    it('does not rewrite step health check topics even when the flag is set', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      await queue.queue('__wkf_step_health_check', {
+        __healthCheck: true as const,
+        correlationId: 'corr_123',
+      });
+
+      expect(mockSend.mock.calls[0][0]).toBe('__wkf_step_health_check');
+    });
+
+    it('appends runId to namespaced flow topics so it composes with WORKFLOW_QUEUE_NAMESPACE', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      await queue.queue('__custom_wkf_workflow_test', { runId: 'wrun_abc' });
+
+      expect(mockSend.mock.calls[0][0]).toBe(
+        '__custom_wkf_workflow_test_wrun_abc'
+      );
+      expect(mockSend.mock.calls[0][1].queueName).toBe(
+        '__custom_wkf_workflow_test'
+      );
+    });
+
+    it('does not rewrite namespaced step topics even when the flag is set', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      await queue.queue('__custom_wkf_step_myStep', {
+        workflowName: 'test-workflow',
+        workflowRunId: 'wrun_abc',
+        workflowStartedAt: Date.now(),
+        stepId: 'step_xyz',
+      });
+
+      expect(mockSend.mock.calls[0][0]).toBe('__custom_wkf_step_myStep');
+    });
+  });
+
   describe('createQueueHandler()', () => {
     const setupHandler = ({ timeoutSeconds }: { timeoutSeconds: number }) => {
       let capturedHandler: (

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -460,9 +460,7 @@ describe('createQueue', () => {
       expect(mockSend.mock.calls[0][0]).toBe('__wkf_workflow_test_wrun_abc');
     });
 
-    // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
-    // REVERT BEFORE MERGE (drop the TEMP commit to restore).
-    it.skip('does not rewrite the topic when the flag is unset', async () => {
+    it('does not rewrite the topic when the flag is unset', async () => {
       delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
 
       const queue = createQueue();
@@ -540,9 +538,7 @@ describe('createQueue', () => {
       );
     });
 
-    // TEMP(ci-default-on): skipped while sequential replays are forced on for CI.
-    // REVERT BEFORE MERGE (drop the TEMP commit to restore).
-    it.skip('does not rewrite health check topics when the flag is unset', async () => {
+    it('does not rewrite health check topics when the flag is unset', async () => {
       delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
 
       const queue = createQueue();

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -234,8 +234,10 @@ function getPhysicalQueueName(
     loggedSequentialReplays = true;
     // One-time breadcrumb so a half-applied configuration (env var set without
     // a maxConcurrency-bearing flow trigger, or vice versa) is diagnosable
-    // from function logs.
-    console.log(
+    // from function logs. Must go to stderr: this code also runs inside CLI
+    // commands whose stdout is a machine-parsed JSON contract (e.g.
+    // `workflow health --json`).
+    console.warn(
       '[workflow] WORKFLOW_SEQUENTIAL_REPLAYS=1: routing flow messages to per-run queue topics'
     );
   }

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -224,10 +224,10 @@ function getPhysicalQueueName(
   queueName: ValidQueueName,
   payload: QueuePayload
 ): string {
-  // TEMP(ci-default-on): force payload-dependent topic routing ON regardless
-  // of the env var so CI e2e jobs exercise it. REVERT BEFORE MERGE — restore
-  // the `process.env.WORKFLOW_SEQUENTIAL_REPLAYS !== '1' ||` clause.
-  if (!FLOW_TOPIC_PATTERN.test(queueName)) {
+  if (
+    process.env.WORKFLOW_SEQUENTIAL_REPLAYS !== '1' ||
+    !FLOW_TOPIC_PATTERN.test(queueName)
+  ) {
     return queueName;
   }
   if (!loggedSequentialReplays) {

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -186,6 +186,73 @@ function getHeadersFromPayload(
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
+/**
+ * Resolves the physical VQS topic for a message.
+ *
+ * Normally this is just the logical queue name. When
+ * `WORKFLOW_SEQUENTIAL_REPLAYS` is enabled, messages on flow (workflow)
+ * topics get a payload-dependent physical topic. VQS scopes `maxConcurrency`
+ * per concrete topic, so combined with `maxConcurrency: 1` on the flow
+ * trigger:
+ *
+ * - Orchestrator replays (`WorkflowInvokePayload` without a `stepId`) get a
+ *   per-run topic — at most one replay per run at a time.
+ * - Inline step executions (`WorkflowInvokePayload` WITH a `stepId` — they
+ *   ride the flow topic in the combined handler model) get a per-step topic
+ *   so steps keep full parallelism across a run; only redeliveries of the
+ *   same step serialize.
+ * - Health checks get a per-probe topic (their correlation id) so concurrent
+ *   probes never queue behind one shared `…_health_check` slot.
+ *
+ * Legacy `*_wkf_step_*` topics are intentionally excluded.
+ *
+ * The flow-topic match allows an optional queue namespace prefix
+ * (`__<namespace>_wkf_workflow_`, see `@workflow/builders` constants) so the
+ * behavior composes with `WORKFLOW_QUEUE_NAMESPACE`.
+ *
+ * This rewrite only serializes messages sent through this adapter (the
+ * wrapper's logical `queueName` keeps handler dispatch and re-enqueues on the
+ * same physical topic). A producer that computes the shared topic name itself
+ * still delivers (the trigger subscribes with a wildcard), but bypasses the
+ * per-run concurrency slot.
+ */
+const FLOW_TOPIC_PATTERN = /^__([a-z][a-z0-9]*_)?wkf_workflow_/;
+
+let loggedSequentialReplays = false;
+
+function getPhysicalQueueName(
+  queueName: ValidQueueName,
+  payload: QueuePayload
+): string {
+  if (
+    process.env.WORKFLOW_SEQUENTIAL_REPLAYS !== '1' ||
+    !FLOW_TOPIC_PATTERN.test(queueName)
+  ) {
+    return queueName;
+  }
+  if (!loggedSequentialReplays) {
+    loggedSequentialReplays = true;
+    // One-time breadcrumb so a half-applied configuration (env var set without
+    // a maxConcurrency-bearing flow trigger, or vice versa) is diagnosable
+    // from function logs.
+    console.log(
+      '[workflow] WORKFLOW_SEQUENTIAL_REPLAYS=1: routing flow messages to per-run queue topics'
+    );
+  }
+  if ('runId' in payload && typeof payload.runId === 'string') {
+    // Inline step execution: full parallelism via a per-step topic.
+    if ('stepId' in payload && typeof payload.stepId === 'string') {
+      return `${queueName}_${payload.runId}_${payload.stepId}`;
+    }
+    // Orchestrator replay: serialize per run.
+    return `${queueName}_${payload.runId}`;
+  }
+  if ('__healthCheck' in payload && typeof payload.correlationId === 'string') {
+    return `${queueName}_${payload.correlationId}`;
+  }
+  return queueName;
+}
+
 type QueueFunction = (
   queueName: ValidQueueName,
   payload: QueuePayload,
@@ -252,11 +319,16 @@ export function createQueue(config?: APIConfig): Queue {
     // preserving Uint8Array values (workflow input in specVersion >= 2).
     const wrapper = {
       payload,
+      // Keep the logical queue name so the handler and re-enqueue path
+      // resolve the same per-run physical topic on the next invocation.
       queueName,
       // Store deploymentId in the message so it can be preserved when re-enqueueing
       deploymentId: opts?.deploymentId,
     };
-    const sanitizedQueueName = queueName.replace(/[^A-Za-z0-9-_]/g, '-');
+    const sanitizedQueueName = getPhysicalQueueName(queueName, payload).replace(
+      /[^A-Za-z0-9-_]/g,
+      '-'
+    );
     try {
       const { messageId } = await client.send(sanitizedQueueName, wrapper, {
         idempotencyKey: opts?.idempotencyKey,

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -224,10 +224,10 @@ function getPhysicalQueueName(
   queueName: ValidQueueName,
   payload: QueuePayload
 ): string {
-  if (
-    process.env.WORKFLOW_SEQUENTIAL_REPLAYS !== '1' ||
-    !FLOW_TOPIC_PATTERN.test(queueName)
-  ) {
+  // TEMP(ci-default-on): force payload-dependent topic routing ON regardless
+  // of the env var so CI e2e jobs exercise it. REVERT BEFORE MERGE — restore
+  // the `process.env.WORKFLOW_SEQUENTIAL_REPLAYS !== '1' ||` clause.
+  if (!FLOW_TOPIC_PATTERN.test(queueName)) {
     return queueName;
   }
   if (!loggedSequentialReplays) {

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -220,14 +220,27 @@ const FLOW_TOPIC_PATTERN = /^__([a-z][a-z0-9]*_)?wkf_workflow_/;
 
 let loggedSequentialReplays = false;
 
+/**
+ * Whether sequential replays are enabled: `WORKFLOW_SEQUENTIAL_REPLAYS=1`,
+ * or `WORKFLOW_SAFE_MODE=1` when `WORKFLOW_SEQUENTIAL_REPLAYS` is not set
+ * explicitly (safe mode fills the default of every safety-over-performance
+ * flag; an explicit per-flag value always wins). Mirrors
+ * `isSequentialReplaysEnabled` in `@workflow/builders` — world-vercel must
+ * not depend on the build-time package, so the check is duplicated.
+ */
+function isSequentialReplaysEnabled(): boolean {
+  const explicit = process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
+  if (explicit !== undefined && explicit !== '') {
+    return explicit === '1';
+  }
+  return process.env.WORKFLOW_SAFE_MODE === '1';
+}
+
 function getPhysicalQueueName(
   queueName: ValidQueueName,
   payload: QueuePayload
 ): string {
-  if (
-    process.env.WORKFLOW_SEQUENTIAL_REPLAYS !== '1' ||
-    !FLOW_TOPIC_PATTERN.test(queueName)
-  ) {
+  if (!isSequentialReplaysEnabled() || !FLOW_TOPIC_PATTERN.test(queueName)) {
     return queueName;
   }
   if (!loggedSequentialReplays) {


### PR DESCRIPTION
Adds an opt-in `WORKFLOW_SEQUENTIAL_REPLAYS=1` environment variable, which serializes orchestrator (flow) invocations per run at the queue level. Off by default. Both the build-time and runtime readers go through an exported `isSequentialReplaysEnabled()` helper that integrations with hand-rolled trigger configs can reuse.

This is done in two halves:
- **Build time:** when enabled, the flow route's `experimentalTriggers` config gets `maxConcurrency: 1`. Centralized via a new `getWorkflowQueueTrigger()` getter in `@workflow/builders` (accepts a `namespace` option and resolves `WORKFLOW_QUEUE_NAMESPACE` at call time), consumed by the Build Output API builder, the Next.js builder, and the SvelteKit adapter.
- **Runtime (`@workflow/world-vercel` only):** when enabled, messages on flow topics get a **payload-dependent physical VQS topic** while the logical `queueName` in the message wrapper stays unchanged (so handler dispatch and the sleep/delay re-enqueue path resolve the same physical topic):
  - orchestrator replays (`WorkflowInvokePayload` without `stepId`) → per-run topic `__wkf_workflow_<name>_<runId>` — at most one replay per run at a time;
  - inline step executions (`WorkflowInvokePayload` **with** `stepId`, which ride the flow topic in the combined-handler model) → per-step topic — steps keep full parallelism;
  - health checks → per-probe topic — concurrent probes never queue behind one shared slot.

  A one-time log line records when per-run routing arms, so a half-applied configuration is diagnosable.

The o11y run actions from #2874 (`reenqueueRun()`, `wakeUpRun()`, namespaced health checks) enqueue through `world.queue()` and therefore participate in the same physical-topic resolution automatically.

## Notes

- Routing each run's flow invocations through a dedicated `maxConcurrency: 1` queue topic might lead to higher queue performance overhead.
- **Both halves must agree:** the variable is read at **both build time and runtime**. On Vercel a project env var covers both. Integrations that hand-roll their flow trigger config only get the runtime half unless they mirror `maxConcurrency: 1` — documented in the framework-integrations guide (v4+v5).
- **Serialization boundary:** only messages sent through `world-vercel`'s `queue()` participate. An external producer that computes the shared topic name itself still delivers (wildcard trigger) but bypasses the per-run slot.
- **Topic length:** the queue backend validates topic names by charset only (`[A-Za-z0-9_-]`, uppercase run-id ULIDs included) with no length cap, and topics are virtual (no per-topic resource, unlimited topics per project). No hash-suffix fallback needed.

## Docs

`WORKFLOW_SEQUENTIAL_REPLAYS` is documented on the v4 and v5 Vercel World pages and the v5 `configuration/worlds` page (this PR previously targeted `stable` and the docs lived in a separate main-only PR, #2875, which is now folded in here).

## Testing

Unit coverage for the trigger getter (default/off/namespace/call-time resolution), the physical-topic resolution (per-run, per-step parallelism, per-probe health checks, namespaced topics, flag-off passthrough, legacy step-topic exclusion), and the re-enqueue path.

Paired OFF/ON event-log-race-repro on this head (2000 runs each): OFF 1999 completed / 0 stuck / 1 failed, p50 26.6s, p99 35.4s; ON 1995 completed / 0 stuck / 5 failed, p50 30.4s, p99 49.6s. All six failures across both legs are the same pre-existing unconsumed-`wait_created` CorruptedEventLogError family (decrypted and verified per run), not a new failure mode. Details in the PR comments. Reproduction deployments must set the variable as a project-level env var before building and deploying.
