### PR TITLE
[e2e] event-log-race-repro: actionable summary, slow≠stuck, fetch retries

### DIFF
--- a/.changeset/repro-ci-summary-improvements.md
+++ b/.changeset/repro-ci-summary-improvements.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: the event-log-race-repro CI job now renders an actionable summary (every gating regression listed in full with a dashboard link; harness noise grouped by error code with explanations), treats slow-but-completed runs as non-gating instead of `stuck`, records where a stuck run wedged, and retries transient `fetch failed` network errors so a single dropped connection never aborts tracking a run.

--- a/.github/scripts/render-event-log-race-repro-results.js
+++ b/.github/scripts/render-event-log-race-repro-results.js
@@ -123,6 +123,92 @@ function infraCount(distribution) {
   return distribution.infra ?? 0;
 }
 
+// Human-readable, one-line explanations keyed by outcome (for gating
+// regressions) and by errorCode (for non-gating `infra` noise). Rendered next
+// to the counts so a human reading the PR comment knows what each row means
+// without spelunking the test source.
+const OUTCOME_NOTES = {
+  CORRUPTED_EVENT_LOG:
+    'Event log failed an integrity/ordering check — a real durability regression.',
+  USER_ERROR: 'Workflow surfaced a user-visible error during the run.',
+  RUNTIME_ERROR: 'Runtime/platform error thrown while executing the run.',
+  stuck:
+    'Run never reached a terminal state before the timeout — possible wedged event log. Open the linked run and check its latest event.',
+  other: 'Uncategorised non-completion — inspect the linked run.',
+};
+
+const INFRA_CODE_NOTES = {
+  HOOK_RESUME_FAILED:
+    'Resume lost the race: the run already completed (sleep budget elapsed) before the harness delivered the hook resume. Expected under load.',
+  NO_WAKE_BRANCH:
+    'Sleep branch won the race, so the hook-wake path was not exercised this run. Coverage loss, not corruption.',
+  HARNESS_ERROR:
+    'Repro driver/transport error (e.g. `fetch failed`) talking to the deployment — not an SDK failure.',
+};
+
+const MAX_MESSAGE_LENGTH = 160;
+// Gating regressions are always listed in full (normally a handful); this cap
+// is only a runaway guard. Infra noise can number in the thousands, so we keep
+// counts for every code but only a few example links per code.
+const REGRESSION_ROW_CAP = 200;
+const INFRA_EXAMPLES_PER_CODE = 3;
+
+function truncateMessage(message) {
+  if (!message) {
+    return '';
+  }
+  const oneLine = String(message).replace(/\s+/g, ' ').trim();
+  return oneLine.length > MAX_MESSAGE_LENGTH
+    ? `${oneLine.slice(0, MAX_MESSAGE_LENGTH - 1)}…`
+    : oneLine;
+}
+
+// A stuck run carries no errorMessage, so synthesise one from its duration.
+function describeFailure(result) {
+  const explicit = truncateMessage(result.errorMessage);
+  if (explicit) {
+    return explicit;
+  }
+  if (result.outcome === 'stuck' && result.durationMs) {
+    return `no terminal state after ${result.durationMs}ms`;
+  }
+  return '';
+}
+
+function projectFailure(result) {
+  return {
+    attempt: result.attempt,
+    scenario: result.scenario,
+    outcome: result.outcome,
+    status: result.status,
+    errorCode: result.errorCode,
+    message: describeFailure(result),
+    durationMs: result.durationMs,
+    runId: result.runId,
+    dashboardUrl: result.dashboardUrl,
+  };
+}
+
+// Count non-completions by a stable key (errorCode, falling back to the
+// outcome) and retain a few example runs per key for inspection links.
+function breakdownByCode(results) {
+  const counts = {};
+  const examples = {};
+  for (const result of results) {
+    const key = result.errorCode || `(${result.outcome})`;
+    counts[key] = (counts[key] ?? 0) + 1;
+    examples[key] ??= [];
+    if (examples[key].length < INFRA_EXAMPLES_PER_CODE) {
+      examples[key].push({
+        runId: result.runId,
+        dashboardUrl: result.dashboardUrl,
+        message: describeFailure(result),
+      });
+    }
+  }
+  return { counts, examples };
+}
+
 function compactTimestamp(value) {
   const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) {
@@ -224,9 +310,16 @@ function compactHistoryEntry(entry, keepFailures = false) {
     infraCount: entry.infraCount ?? infraCount(entry.distribution ?? {}),
     total: entry.total ?? 0,
     config: compactConfig(entry.config),
-    failing: keepFailures ? (entry.failing ?? []) : [],
-    truncatedFailingCount: keepFailures
-      ? (entry.truncatedFailingCount ?? 0)
+    // Per-code counts are tiny, so keep them on every history entry. The full
+    // regression list and example links are only kept for the latest entry.
+    regressionBreakdown: entry.regressionBreakdown ?? {
+      counts: {},
+      examples: {},
+    },
+    infraBreakdown: entry.infraBreakdown ?? { counts: {}, examples: {} },
+    regressions: keepFailures ? (entry.regressions ?? []) : [],
+    truncatedRegressionCount: keepFailures
+      ? (entry.truncatedRegressionCount ?? 0)
       : 0,
   };
 }
@@ -244,7 +337,10 @@ function buildEntry(resultsFile) {
       total: 0,
       config: {},
       scenarioDistribution: {},
-      failing: [],
+      regressions: [],
+      truncatedRegressionCount: 0,
+      regressionBreakdown: { counts: {}, examples: {} },
+      infraBreakdown: { counts: {}, examples: {} },
     };
   }
 
@@ -258,22 +354,23 @@ function buildEntry(resultsFile) {
     (sum, outcome) => sum + (distribution[outcome] ?? 0),
     0
   );
-  // Surface regressions before infra so the 20-row cap never hides a real
-  // failure behind a flood of harness-timing `infra` rows.
-  const nonCompleted = results
-    .filter((result) => result.outcome !== 'completed')
-    .sort(
-      (a, b) => Number(a.outcome === 'infra') - Number(b.outcome === 'infra')
-    );
-  const failing = nonCompleted.slice(0, 20).map((result) => ({
-    attempt: result.attempt,
-    scenario: result.scenario,
-    outcome: result.outcome,
-    status: result.status,
-    errorCode: result.errorCode,
-    runId: result.runId,
-    dashboardUrl: result.dashboardUrl,
-  }));
+  // Gating regressions (stuck / corruption / errors) are what a human must
+  // act on, so list every one of them in full. Infra noise can be thousands of
+  // rows, so we keep per-code counts plus a few example links instead.
+  const regressionResults = results.filter(
+    (result) => result.outcome !== 'completed' && result.outcome !== 'infra'
+  );
+  const infraResults = results.filter((result) => result.outcome === 'infra');
+
+  const regressions = regressionResults
+    .slice(0, REGRESSION_ROW_CAP)
+    .map(projectFailure);
+  const truncatedRegressionCount = Math.max(
+    0,
+    regressionResults.length - regressions.length
+  );
+  const regressionBreakdown = breakdownByCode(regressionResults);
+  const infraBreakdown = breakdownByCode(infraResults);
 
   return {
     timestamp,
@@ -287,8 +384,10 @@ function buildEntry(resultsFile) {
     infraCount: infra,
     total,
     config: compactConfig(resultsFile.config),
-    failing,
-    truncatedFailingCount: Math.max(0, nonCompleted.length - failing.length),
+    regressions,
+    truncatedRegressionCount,
+    regressionBreakdown,
+    infraBreakdown,
   };
 }
 
@@ -350,30 +449,81 @@ function renderLatestScenarioBreakdown(entry) {
   console.log('');
 }
 
-function renderLatestFailures(entry) {
+function runLink(result) {
+  if (result.dashboardUrl && result.runId) {
+    return `[${result.runId}](${result.dashboardUrl})`;
+  }
+  return result.runId ?? '';
+}
+
+// Every gating regression, listed in full with its message, duration and a
+// direct dashboard link — this is the table a human acts on.
+function renderRegressions(entry) {
   if (entry.missingResults) {
     return;
   }
 
-  if (entry.failing.length === 0) {
+  const regressions = entry.regressions ?? [];
+  if (regressions.length === 0) {
+    console.log('### Event-Log Regressions\n');
+    console.log('None — no gating outcomes in the latest run. ✅\n');
     return;
   }
 
-  console.log('### Latest Non-Completed Runs\n');
-  console.log('| Scenario | Attempt | Outcome | Status | Error code | Run |');
-  console.log('|:--|--:|:--|:--|:--|:--|');
-  for (const result of entry.failing) {
-    const run =
-      result.dashboardUrl && result.runId
-        ? `[${result.runId}](${result.dashboardUrl})`
-        : (result.runId ?? '');
+  console.log(`### 🚨 Event-Log Regressions (${entry.failedCount})\n`);
+  console.log(
+    'These gate the job. Each row links to the workflow run on the dashboard.\n'
+  );
+  console.log(
+    '| Scenario | Attempt | Outcome | Status | Duration | Detail | Run |'
+  );
+  console.log('|:--|--:|:--|:--|--:|:--|:--|');
+  for (const result of regressions) {
+    const duration =
+      typeof result.durationMs === 'number' ? `${result.durationMs}ms` : '';
+    const detail =
+      result.message || OUTCOME_NOTES[result.outcome] || result.errorCode || '';
     console.log(
-      `| ${result.scenario ?? ''} | ${result.attempt} | ${result.outcome} | ${result.status ?? ''} | ${result.errorCode ?? ''} | ${run} |`
+      `| ${result.scenario ?? ''} | ${result.attempt} | ${result.outcome} | ${result.status ?? ''} | ${duration} | ${detail} | ${runLink(result)} |`
     );
   }
-  if (entry.truncatedFailingCount > 0) {
+  if (entry.truncatedRegressionCount > 0) {
     console.log(
-      `\nShowing 20 of ${entry.failing.length + entry.truncatedFailingCount} non-completed runs.`
+      `\nShowing ${regressions.length} of ${regressions.length + entry.truncatedRegressionCount} regressions (capped). See the run logs artifact for the full list.`
+    );
+  }
+  console.log('');
+}
+
+// Non-gating harness noise, grouped by error code with a plain-language note
+// and a couple of example runs so a human can confirm the classification.
+function renderInfraBreakdown(entry) {
+  if (entry.missingResults) {
+    return;
+  }
+
+  const breakdown = entry.infraBreakdown ?? { counts: {}, examples: {} };
+  const codes = Object.keys(breakdown.counts ?? {});
+  if (codes.length === 0) {
+    return;
+  }
+
+  codes.sort((a, b) => breakdown.counts[b] - breakdown.counts[a]);
+
+  console.log('### Infra (non-gating)\n');
+  console.log(
+    `${entry.infraCount} harness-side non-completion${entry.infraCount === 1 ? '' : 's'} that do **not** fail the job:\n`
+  );
+  console.log('| Error code | Count | What it means | Examples |');
+  console.log('|:--|--:|:--|:--|');
+  for (const code of codes) {
+    const note = INFRA_CODE_NOTES[code] ?? 'Harness-side non-completion.';
+    const examples = (breakdown.examples?.[code] ?? [])
+      .map((example) => runLink(example))
+      .filter(Boolean)
+      .join('<br>');
+    console.log(
+      `| ${code} | ${breakdown.counts[code]} | ${note} | ${examples} |`
     );
   }
   console.log('');
@@ -388,11 +538,18 @@ function render(resultsFile, previousComment) {
 
   const latestInfra =
     latest.infraCount ?? infraCount(latest.distribution ?? {});
+
+  // Compact "904 HOOK_RESUME_FAILED, 61 NO_WAKE_BRANCH" style summary of the
+  // infra noise so the headline says *why* the non-completions happened.
+  const infraCounts = latest.infraBreakdown?.counts ?? {};
+  const infraDigest = Object.keys(infraCounts)
+    .sort((a, b) => infraCounts[b] - infraCounts[a])
+    .map((code) => `${infraCounts[code]} ${code}`)
+    .join(', ');
   const infraNote =
     latestInfra > 0
-      ? ` ${latestInfra} run${latestInfra === 1 ? '' : 's'} hit harness-side ` +
-        '`infra` outcomes (hook-resume timing races / transport errors); ' +
-        'these are reported but do not fail the job.'
+      ? ` ${latestInfra} non-gating infra non-completion${latestInfra === 1 ? '' : 's'}` +
+        `${infraDigest ? ` (${infraDigest})` : ''} are reported but do not fail the job.`
       : '';
 
   console.log('<!-- event-log-race-repro-results -->');
@@ -401,8 +558,8 @@ function render(resultsFile, previousComment) {
     latest.missingResults
       ? 'No result file was produced by the latest repro job.'
       : latest.failedCount === 0
-        ? `No event-log regressions in the latest repro job.${infraNote}`
-        : `${latest.failedCount} of ${latest.total} latest repro runs hit event-log regressions.${infraNote}`
+        ? `✅ No event-log regressions in the latest repro job.${infraNote}`
+        : `🚨 ${latest.failedCount} of ${latest.total} latest repro runs hit event-log regressions — see the linked runs below.${infraNote}`
   );
   console.log('');
   console.log(historyMarkerStart);
@@ -410,9 +567,10 @@ function render(resultsFile, previousComment) {
   console.log(historyMarkerEnd);
   console.log('');
 
+  renderRegressions(latest);
+  renderInfraBreakdown(latest);
   renderHistoryTable(history);
   renderLatestScenarioBreakdown(latest);
-  renderLatestFailures(latest);
 }
 
 function main() {
@@ -446,6 +604,9 @@ module.exports = {
   regressionCount,
   infraCount,
   buildEntry,
+  breakdownByCode,
+  truncateMessage,
+  describeFailure,
 };
 
 if (require.main === module) {

--- a/.github/scripts/render-event-log-race-repro-results.js
+++ b/.github/scripts/render-event-log-race-repro-results.js
@@ -142,6 +142,10 @@ const INFRA_CODE_NOTES = {
     'Resume lost the race: the run already completed (sleep budget elapsed) before the harness delivered the hook resume. Expected under load.',
   NO_WAKE_BRANCH:
     'Sleep branch won the race, so the hook-wake path was not exercised this run. Coverage loss, not corruption.',
+  SLOW_COMPLETION:
+    'Run completed, but only after the poll budget (within the grace window) — slow under load, not wedged. Not an SDK failure.',
+  CANCELLED:
+    'Run was cancelled (superseded or aborted) rather than completing — not an SDK failure.',
   HARNESS_ERROR:
     'Repro driver/transport error (e.g. `fetch failed`) talking to the deployment — not an SDK failure.',
 };
@@ -512,7 +516,7 @@ function renderInfraBreakdown(entry) {
 
   console.log('### Infra (non-gating)\n');
   console.log(
-    `${entry.infraCount} harness-side non-completion${entry.infraCount === 1 ? '' : 's'} that do **not** fail the job:\n`
+    `${entry.infraCount} harness-side non-completion${entry.infraCount === 1 ? ' that does' : 's that do'} **not** fail the job:\n`
   );
   console.log('| Error code | Count | What it means | Examples |');
   console.log('|:--|--:|:--|:--|');
@@ -549,7 +553,7 @@ function render(resultsFile, previousComment) {
   const infraNote =
     latestInfra > 0
       ? ` ${latestInfra} non-gating infra non-completion${latestInfra === 1 ? '' : 's'}` +
-        `${infraDigest ? ` (${infraDigest})` : ''} are reported but do not fail the job.`
+        `${infraDigest ? ` (${infraDigest})` : ''} ${latestInfra === 1 ? 'is reported but does' : 'are reported but do'} not fail the job.`
       : '';
 
   console.log('<!-- event-log-race-repro-results -->');

--- a/.github/scripts/render-event-log-race-repro-results.test.js
+++ b/.github/scripts/render-event-log-race-repro-results.test.js
@@ -181,6 +181,26 @@ test('truncateMessage collapses whitespace and caps length', () => {
   assert.ok(out.endsWith('…'));
 });
 
+test('a slow run that completed past the budget is infra, not gating', () => {
+  // Mirrors the observed false positive: a run flagged at the poll budget that
+  // actually completed during the grace window is reclassified SLOW_COMPLETION.
+  const results = [
+    { attempt: 1, scenario: 'step-fanout', outcome: 'completed' },
+    {
+      attempt: 2,
+      scenario: 'step-fanout',
+      outcome: 'infra',
+      errorCode: 'SLOW_COMPLETION',
+      durationMs: 151849,
+    },
+  ];
+  const entry = buildEntry({ results });
+  assert.strictEqual(entry.failedCount, 0);
+  assert.strictEqual(entry.infraCount, 1);
+  assert.strictEqual(entry.regressions.length, 0);
+  assert.strictEqual(entry.infraBreakdown.counts.SLOW_COMPLETION, 1);
+});
+
 test('summarize buckets infra outcomes', () => {
   const distribution = summarize([
     { outcome: 'completed' },

--- a/.github/scripts/render-event-log-race-repro-results.test.js
+++ b/.github/scripts/render-event-log-race-repro-results.test.js
@@ -11,6 +11,9 @@ const {
   infraCount,
   buildEntry,
   summarize,
+  breakdownByCode,
+  truncateMessage,
+  describeFailure,
 } = require('./render-event-log-race-repro-results.js');
 
 const SCRIPT = path.join(__dirname, 'render-event-log-race-repro-results.js');
@@ -88,11 +91,12 @@ test('buildEntry treats an all-infra run as zero regressions', () => {
   assert.strictEqual(entry.failedCount, 0, 'no regressions should be counted');
   assert.strictEqual(entry.infraCount, 1231);
   assert.strictEqual(entry.total, 2000);
-  // Regressions sort ahead of infra so they are never truncated away.
-  assert.ok(entry.failing.every((r) => r.outcome === 'infra'));
+  // No gating regressions listed; the infra flood is summarised by code only.
+  assert.strictEqual(entry.regressions.length, 0);
+  assert.strictEqual(entry.infraBreakdown.counts.HOOK_RESUME_FAILED, 1231);
 });
 
-test('buildEntry surfaces regressions ahead of infra rows', () => {
+test('buildEntry lists regressions in full and never via the infra path', () => {
   const results = [
     ...Array.from({ length: 30 }, (_, i) => ({
       attempt: i,
@@ -109,11 +113,72 @@ test('buildEntry surfaces regressions ahead of infra rows', () => {
   ];
   const entry = buildEntry({ results });
   assert.strictEqual(entry.failedCount, 1);
+  assert.strictEqual(entry.regressions.length, 1);
+  assert.strictEqual(entry.regressions[0].outcome, 'CORRUPTED_EVENT_LOG');
+  // Infra rows are summarised, not listed as regressions.
+  assert.ok(entry.regressions.every((r) => r.outcome !== 'infra'));
+});
+
+test('buildEntry keeps every gating regression even past the infra flood', () => {
+  // 50 stuck regressions interleaved with 500 infra rows — all 50 must survive.
+  const results = [
+    ...Array.from({ length: 500 }, (_, i) => ({
+      attempt: i,
+      scenario: 'hook-sleep',
+      outcome: 'infra',
+      errorCode: 'HOOK_RESUME_FAILED',
+    })),
+    ...Array.from({ length: 50 }, (_, i) => ({
+      attempt: 1000 + i,
+      scenario: 'hook-sleep',
+      outcome: 'stuck',
+      status: 'running',
+      durationMs: 150000,
+    })),
+  ];
+  const entry = buildEntry({ results });
+  assert.strictEqual(entry.failedCount, 50);
+  assert.strictEqual(entry.regressions.length, 50);
+  assert.strictEqual(entry.truncatedRegressionCount, 0);
+  // Stuck runs get a synthesised, inspectable detail line from their duration.
   assert.strictEqual(
-    entry.failing[0].outcome,
-    'CORRUPTED_EVENT_LOG',
-    'regression must appear first despite being last in the input'
+    entry.regressions[0].message,
+    'no terminal state after 150000ms'
   );
+});
+
+test('breakdownByCode counts by errorCode and keeps example links', () => {
+  const { counts, examples } = breakdownByCode([
+    { outcome: 'infra', errorCode: 'HOOK_RESUME_FAILED', runId: 'a' },
+    { outcome: 'infra', errorCode: 'HOOK_RESUME_FAILED', runId: 'b' },
+    { outcome: 'infra', errorCode: 'NO_WAKE_BRANCH', runId: 'c' },
+    { outcome: 'stuck', durationMs: 1000, runId: 'd' },
+  ]);
+  assert.strictEqual(counts.HOOK_RESUME_FAILED, 2);
+  assert.strictEqual(counts.NO_WAKE_BRANCH, 1);
+  // No errorCode falls back to a parenthesised outcome key.
+  assert.strictEqual(counts['(stuck)'], 1);
+  assert.strictEqual(examples.HOOK_RESUME_FAILED.length, 2);
+  assert.strictEqual(examples.HOOK_RESUME_FAILED[0].runId, 'a');
+});
+
+test('describeFailure synthesises a message for stuck runs without one', () => {
+  assert.strictEqual(
+    describeFailure({ outcome: 'stuck', durationMs: 150578 }),
+    'no terminal state after 150578ms'
+  );
+  assert.strictEqual(
+    describeFailure({ outcome: 'infra', errorMessage: 'fetch  failed\n' }),
+    'fetch failed'
+  );
+});
+
+test('truncateMessage collapses whitespace and caps length', () => {
+  assert.strictEqual(truncateMessage('  a\n  b  '), 'a b');
+  const long = 'x'.repeat(500);
+  const out = truncateMessage(long);
+  assert.ok(out.length <= 160);
+  assert.ok(out.endsWith('…'));
 });
 
 test('summarize buckets infra outcomes', () => {

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -324,6 +324,40 @@ function validateStepRaceReturn(value: unknown) {
   }
 }
 
+// When a run never reaches a terminal state we still want the summary to say
+// *where* it wedged, not just that it did. Fetch the event log and describe the
+// latest event (type, step, elapsed) so the "stuck" row is directly
+// inspectable. Best-effort: any failure here falls back to a duration-only note.
+async function describeStuckRun(
+  world: Awaited<ReturnType<typeof getWorld>>,
+  runId: string,
+  startedAt: number
+): Promise<string | undefined> {
+  try {
+    const { data: events } = await world.events.list({ runId });
+    if (!events.length) {
+      return undefined;
+    }
+    const latest = events[events.length - 1];
+    const elapsedS = (
+      ((latest.createdAt?.getTime?.() ?? Date.now()) - startedAt) /
+      1000
+    ).toFixed(1);
+    let detail = latest.eventType;
+    const data =
+      'eventData' in latest
+        ? (latest as { eventData?: unknown }).eventData
+        : undefined;
+    const stepName = (data as { stepName?: string } | undefined)?.stepName;
+    if (stepName) {
+      detail += ` (${stepName})`;
+    }
+    return `stuck after ${events.length} events; latest ${detail} at +${elapsedS}s`;
+  } catch {
+    return undefined;
+  }
+}
+
 async function pollTerminalRun(
   run: Run<unknown>,
   startedAt: number,
@@ -388,6 +422,7 @@ async function pollTerminalRun(
     runId: run.runId,
     outcome: 'stuck',
     status: lastStatus,
+    errorMessage: await describeStuckRun(world, run.runId, startedAt),
     durationMs: Date.now() - startedAt,
     dashboardUrl: getDashboardUrl(run.runId),
   };

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -54,6 +54,7 @@ interface ReproConfig {
   resumeDelayMs: number;
   resumeJitterMs: number;
   runTimeoutMs: number;
+  stuckGraceMs: number;
   hookTimeoutMs: number;
   sleepBranchWaitCount: number;
   sleepBranchWaitMs: number;
@@ -127,6 +128,10 @@ const config: ReproConfig = {
   resumeDelayMs: envNumber('EVENT_LOG_RACE_REPRO_RESUME_DELAY_MS', 15_000),
   resumeJitterMs: envNumber('EVENT_LOG_RACE_REPRO_RESUME_JITTER_MS', 10_000),
   runTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS', 150_000),
+  // Generous grace after the poll budget: a run that finishes within it was
+  // slow (non-gating SLOW_COMPLETION), not wedged. Only a run still
+  // non-terminal after budget + grace is treated as a gating `stuck` wedge.
+  stuckGraceMs: envNumber('EVENT_LOG_RACE_REPRO_STUCK_GRACE_MS', 120_000),
   hookTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_HOOK_TIMEOUT_MS', 60_000),
   sleepBranchWaitCount: envNumber(
     'EVENT_LOG_RACE_REPRO_SLEEP_BRANCH_WAIT_COUNT',
@@ -364,24 +369,46 @@ async function pollTerminalRun(
   scenario: Scenario
 ): Promise<ReproRunResult> {
   const world = await getWorld();
-  const deadline = startedAt + config.runTimeoutMs;
+  const budgetDeadline = startedAt + config.runTimeoutMs;
+  // Two-phase wait. A run that crosses the finish line only during the grace
+  // window was *slow* (preview deployments under load routinely complete just
+  // past the budget), not wedged — those are reported as non-gating `infra`
+  // (`SLOW_COMPLETION`) instead of failing the job. Only a run that is still
+  // non-terminal after the grace window is treated as a genuine wedge
+  // (gating `stuck`).
+  const graceDeadline = budgetDeadline + config.stuckGraceMs;
   let lastStatus: string | undefined;
 
-  while (Date.now() < deadline) {
+  while (Date.now() < graceDeadline) {
     const runData = await world.runs.get(run.runId);
     lastStatus = runData.status;
+    const durationMs = Date.now() - startedAt;
+    const pastBudget = durationMs >= config.runTimeoutMs;
 
     if (runData.status === 'completed') {
-      return {
-        attempt: -1,
-        scenario,
-        token: '',
-        runId: run.runId,
-        outcome: 'completed',
-        status: runData.status,
-        durationMs: Date.now() - startedAt,
-        dashboardUrl: getDashboardUrl(run.runId),
-      };
+      return pastBudget
+        ? {
+            attempt: -1,
+            scenario,
+            token: '',
+            runId: run.runId,
+            outcome: 'infra',
+            status: runData.status,
+            errorCode: 'SLOW_COMPLETION',
+            errorMessage: `completed after ${durationMs}ms, exceeding the ${config.runTimeoutMs}ms poll budget`,
+            durationMs,
+            dashboardUrl: getDashboardUrl(run.runId),
+          }
+        : {
+            attempt: -1,
+            scenario,
+            token: '',
+            runId: run.runId,
+            outcome: 'completed',
+            status: runData.status,
+            durationMs,
+            dashboardUrl: getDashboardUrl(run.runId),
+          };
     }
 
     if (runData.status === 'failed') {
@@ -393,7 +420,7 @@ async function pollTerminalRun(
         outcome: classifyFailure(runData.errorCode),
         status: runData.status,
         errorCode: runData.errorCode,
-        durationMs: Date.now() - startedAt,
+        durationMs,
         dashboardUrl: getDashboardUrl(run.runId),
       };
     }
@@ -407,12 +434,13 @@ async function pollTerminalRun(
         outcome: 'infra',
         status: runData.status,
         errorCode: 'CANCELLED',
-        durationMs: Date.now() - startedAt,
+        durationMs,
         dashboardUrl: getDashboardUrl(run.runId),
       };
     }
 
-    await sleep(1000);
+    // Poll tightly within the budget; back off during the grace tail.
+    await sleep(pastBudget ? 5000 : 1000);
   }
 
   return {
@@ -886,6 +914,9 @@ const testTimeoutMs =
     Math.ceil(
       Math.floor(config.stepSleepRaceAttempts / 2) / config.stepConcurrency
     ) +
+  // Headroom for a wave whose slow runs spill into the post-budget grace
+  // window before being classified.
+  config.stuckGraceMs +
   60_000;
 
 describe('event log race repro', () => {

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -55,6 +55,7 @@ interface ReproConfig {
   resumeJitterMs: number;
   runTimeoutMs: number;
   stuckGraceMs: number;
+  networkRetries: number;
   hookTimeoutMs: number;
   sleepBranchWaitCount: number;
   sleepBranchWaitMs: number;
@@ -132,6 +133,10 @@ const config: ReproConfig = {
   // slow (non-gating SLOW_COMPLETION), not wedged. Only a run still
   // non-terminal after budget + grace is treated as a gating `stuck` wedge.
   stuckGraceMs: envNumber('EVENT_LOG_RACE_REPRO_STUCK_GRACE_MS', 120_000),
+  // Retries for transient network failures (e.g. `fetch failed`) when the
+  // harness talks to the deployment. A flaky GET must never abort tracking a
+  // run that is otherwise progressing — see `withRetry` / `pollTerminalRun`.
+  networkRetries: envNumber('EVENT_LOG_RACE_REPRO_NETWORK_RETRIES', 4),
   hookTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_HOOK_TIMEOUT_MS', 60_000),
   sleepBranchWaitCount: envNumber(
     'EVENT_LOG_RACE_REPRO_SLEEP_BRANCH_WAIT_COUNT',
@@ -186,13 +191,53 @@ const config: ReproConfig = {
   ),
 };
 
+// Transient transport failures the harness sees when reaching the deployment.
+// These are network blips, not SDK behaviour, so the driver retries them
+// rather than turning a single dropped connection into a HARNESS_ERROR.
+function isTransientNetworkError(err: unknown): boolean {
+  const message = (err instanceof Error ? err.message : String(err)) ?? '';
+  const code =
+    err && typeof err === 'object' && 'code' in err
+      ? String((err as { code?: unknown }).code)
+      : '';
+  return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|EPIPE|socket hang up|network|terminated|other side closed|aborted/i.test(
+    `${message} ${code}`
+  );
+}
+
+// Retry `fn` on transient network errors with linear backoff. On final failure
+// the error is rethrown prefixed with `label` so the recorded HARNESS_ERROR
+// says *where* the call was (e.g. "start: fetch failed"), making the infra
+// breakdown in the summary directly diagnosable. Non-transient errors (real
+// run failures) are rethrown immediately and unwrapped.
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= config.networkRetries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt === config.networkRetries || !isTransientNetworkError(err)) {
+        break;
+      }
+      await sleep(500 * (attempt + 1));
+    }
+  }
+  if (isTransientNetworkError(lastError)) {
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(`${label}: ${message}`);
+  }
+  throw lastError;
+}
+
 async function start(
   scenario: Scenario,
   workflowFn: string,
   workflow: { workflowId: string },
   args: unknown[]
 ): Promise<Run<unknown>> {
-  const run = await rawStart(workflow, args);
+  const run = await withRetry('start', () => rawStart(workflow, args));
   trackRun(run, {
     testName: `event-log-race-repro:${scenario}`,
     workflowFile: WORKFLOW_FILE,
@@ -218,9 +263,14 @@ async function waitForHook(token: string, runId: string) {
     }
     await sleep(250);
   }
-  throw lastError instanceof Error
-    ? lastError
-    : new Error(`Timed out waiting for hook ${token}`);
+  // Label the surfaced error so a HARNESS_ERROR reads "waitForHook: Hook not
+  // found" — pinpointing that the hook never propagated within the timeout
+  // (typically the run completed and disposed the hook before we observed it).
+  const reason =
+    lastError instanceof Error
+      ? lastError.message
+      : `Timed out waiting for hook ${token}`;
+  throw new Error(`waitForHook: ${reason}`);
 }
 
 function getDashboardUrl(runId: string): string | undefined {
@@ -363,80 +413,98 @@ async function describeStuckRun(
   }
 }
 
+// Map a terminal run status to a result, or return null if the run has not
+// settled yet. `completed` past the poll budget is downgraded to a non-gating
+// SLOW_COMPLETION (slow, not wedged); `failed`/`cancelled` keep their meaning.
+function classifyTerminalRun(
+  runData: { status: string; errorCode?: string },
+  context: {
+    runId: string;
+    scenario: Scenario;
+    durationMs: number;
+    pastBudget: boolean;
+  }
+): ReproRunResult | null {
+  const { runId, scenario, durationMs, pastBudget } = context;
+  const base = {
+    attempt: -1,
+    scenario,
+    token: '',
+    runId,
+    status: runData.status,
+    durationMs,
+    dashboardUrl: getDashboardUrl(runId),
+  };
+
+  if (runData.status === 'completed') {
+    return pastBudget
+      ? {
+          ...base,
+          outcome: 'infra',
+          errorCode: 'SLOW_COMPLETION',
+          errorMessage: `completed after ${durationMs}ms, exceeding the ${config.runTimeoutMs}ms poll budget`,
+        }
+      : { ...base, outcome: 'completed' };
+  }
+
+  if (runData.status === 'failed') {
+    return {
+      ...base,
+      outcome: classifyFailure(runData.errorCode),
+      errorCode: runData.errorCode,
+    };
+  }
+
+  if (runData.status === 'cancelled') {
+    return { ...base, outcome: 'infra', errorCode: 'CANCELLED' };
+  }
+
+  return null;
+}
+
 async function pollTerminalRun(
   run: Run<unknown>,
   startedAt: number,
   scenario: Scenario
 ): Promise<ReproRunResult> {
   const world = await getWorld();
-  const budgetDeadline = startedAt + config.runTimeoutMs;
   // Two-phase wait. A run that crosses the finish line only during the grace
   // window was *slow* (preview deployments under load routinely complete just
   // past the budget), not wedged — those are reported as non-gating `infra`
   // (`SLOW_COMPLETION`) instead of failing the job. Only a run that is still
   // non-terminal after the grace window is treated as a genuine wedge
   // (gating `stuck`).
-  const graceDeadline = budgetDeadline + config.stuckGraceMs;
+  const graceDeadline = startedAt + config.runTimeoutMs + config.stuckGraceMs;
   let lastStatus: string | undefined;
 
   while (Date.now() < graceDeadline) {
-    const runData = await world.runs.get(run.runId);
+    let runData: Awaited<ReturnType<typeof world.runs.get>>;
+    try {
+      // A flaky GET must not abort tracking of a run that may be progressing
+      // fine; withRetry rides out brief blips, and a longer outage just falls
+      // through to the next poll until the deadline.
+      runData = await withRetry('poll runs.get', () =>
+        world.runs.get(run.runId)
+      );
+    } catch (err) {
+      if (isTransientNetworkError(err) && Date.now() < graceDeadline) {
+        await sleep(2000);
+        continue;
+      }
+      throw err;
+    }
+
     lastStatus = runData.status;
     const durationMs = Date.now() - startedAt;
     const pastBudget = durationMs >= config.runTimeoutMs;
-
-    if (runData.status === 'completed') {
-      return pastBudget
-        ? {
-            attempt: -1,
-            scenario,
-            token: '',
-            runId: run.runId,
-            outcome: 'infra',
-            status: runData.status,
-            errorCode: 'SLOW_COMPLETION',
-            errorMessage: `completed after ${durationMs}ms, exceeding the ${config.runTimeoutMs}ms poll budget`,
-            durationMs,
-            dashboardUrl: getDashboardUrl(run.runId),
-          }
-        : {
-            attempt: -1,
-            scenario,
-            token: '',
-            runId: run.runId,
-            outcome: 'completed',
-            status: runData.status,
-            durationMs,
-            dashboardUrl: getDashboardUrl(run.runId),
-          };
-    }
-
-    if (runData.status === 'failed') {
-      return {
-        attempt: -1,
-        scenario,
-        token: '',
-        runId: run.runId,
-        outcome: classifyFailure(runData.errorCode),
-        status: runData.status,
-        errorCode: runData.errorCode,
-        durationMs,
-        dashboardUrl: getDashboardUrl(run.runId),
-      };
-    }
-
-    if (runData.status === 'cancelled') {
-      return {
-        attempt: -1,
-        scenario,
-        token: '',
-        runId: run.runId,
-        outcome: 'infra',
-        status: runData.status,
-        errorCode: 'CANCELLED',
-        durationMs,
-        dashboardUrl: getDashboardUrl(run.runId),
-      };
+    const terminal = classifyTerminalRun(runData, {
+      runId: run.runId,
+      scenario,
+      durationMs,
+      pastBudget,
+    });
+    if (terminal) {
+      return terminal;
     }
 
     // Poll tightly within the budget; back off during the grace tail.
@@ -475,10 +543,12 @@ async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
     .slice(2)}`;
 
   try {
-    const workflow = await getWorkflowMetadata(
-      deploymentUrl,
-      WORKFLOW_FILE,
-      'hookSleepReproWorkflow'
+    const workflow = await withRetry('getWorkflowMetadata', () =>
+      getWorkflowMetadata(
+        deploymentUrl,
+        WORKFLOW_FILE,
+        'hookSleepReproWorkflow'
+      )
     );
     const run = await start(scenario, 'hookSleepReproWorkflow', workflow, [
       {
@@ -501,7 +571,9 @@ async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
         : 0;
     const resumeDelayMs = config.resumeDelayMs + jitter;
     const resumePromise = sleep(resumeDelayMs).then(() =>
-      resumeHook(hook, { attempt, sentAt: Date.now() })
+      withRetry('resumeHook', () =>
+        resumeHook(hook, { attempt, sentAt: Date.now() })
+      )
     );
 
     const runResult = await pollTerminalRun(run, startedAt, scenario);
@@ -613,10 +685,12 @@ async function runStepFanoutAttempt(attempt: number): Promise<ReproRunResult> {
     .slice(2)}`;
 
   try {
-    const workflow = await getWorkflowMetadata(
-      deploymentUrl,
-      WORKFLOW_FILE,
-      'stepFanoutReplayReproWorkflow'
+    const workflow = await withRetry('getWorkflowMetadata', () =>
+      getWorkflowMetadata(
+        deploymentUrl,
+        WORKFLOW_FILE,
+        'stepFanoutReplayReproWorkflow'
+      )
     );
     const run = await start(
       scenario,
@@ -709,10 +783,12 @@ async function runStepSleepRaceAttempt(
     .slice(2)}`;
 
   try {
-    const workflow = await getWorkflowMetadata(
-      deploymentUrl,
-      WORKFLOW_FILE,
-      'stepSleepRaceReproWorkflow'
+    const workflow = await withRetry('getWorkflowMetadata', () =>
+      getWorkflowMetadata(
+        deploymentUrl,
+        WORKFLOW_FILE,
+        'stepSleepRaceReproWorkflow'
+      )
     );
     const run = await start(scenario, 'stepSleepRaceReproWorkflow', workflow, [
       {


### PR DESCRIPTION
Standalone CI-only changes for the `event-log-race-repro` job, extracted so they can be merged independently of any core fix. All on top of the classification work already on `stable` (#2194).

### Actionable result summary
- 🚨 **Event-Log Regressions** table lists *every* gating run in full (never truncated), each with duration, a synthesised detail line, and a direct dashboard link.
- **Infra (non-gating)** section groups harness noise by error code with a plain-language explanation and example run links, instead of flooding one table with thousands of rows.
- Headline names the regression count and digests the infra noise.

### Slow ≠ stuck
A run flagged at the poll budget can simply be slow on a loaded preview deployment (observed: a `stuck` run that actually completed shortly after). Added a generous post-budget **grace window**: a run that reaches a terminal state during grace is classified by its real outcome — `completed` → non-gating `SLOW_COMPLETION`, `failed` → its error class. Only a run still non-terminal after budget + grace is a genuine wedge (gating `stuck`). Stuck runs also record *where* they wedged (latest event/step).

### Retry transient fetch failures
Investigating two `HARNESS_ERROR`s (`fetch failed`, `Hook not found`): both came from harness-side network calls to the deployment, not the SDK. Added `withRetry` (linear backoff, transient-network detection) around the harness network calls (getWorkflowMetadata, start, resumeHook, run-status poll); the poll no longer aborts on a flaky GET. On final failure the error is prefixed with the call site (e.g. `start: fetch failed`) so the infra breakdown says *where* it happened.

Renderer is unit-tested (`node:test`, run by the **CI Scripts Tests** job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)