### PR TITLE
[core] Retry transient world response-body parse failures instead of failing the run

### DIFF
--- a/.changeset/retry-transient-event-parse-failures.md
+++ b/.changeset/retry-transient-event-parse-failures.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Retry transient world response-body parse failures (e.g. a truncated `events.list` response during replay) by propagating them to the queue instead of failing the run. Genuine schema-validation contract errors remain fatal.

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -3,12 +3,18 @@ import {
   HookConflictError,
   RUN_ERROR_CODES,
   RuntimeDecryptionError,
+  ThrottleError,
+  TooEarlyError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
   WorkflowWorldError,
 } from '@workflow/errors';
 import { describe, expect, it } from 'vitest';
-import { classifyRunError } from './classify-error.js';
+import {
+  classifyRunError,
+  isRetryableWorldError,
+  isWorldContractError,
+} from './classify-error.js';
 
 describe('classifyRunError', () => {
   it('classifies CorruptedEventLogError as CORRUPTED_EVENT_LOG', () => {
@@ -60,15 +66,45 @@ describe('classifyRunError', () => {
     ).toBe(RUN_ERROR_CODES.WORLD_CONTRACT_ERROR);
   });
 
-  it('classifies world response parse failures as WORLD_CONTRACT_ERROR', () => {
+  it('does NOT classify world response parse failures as WORLD_CONTRACT_ERROR', () => {
+    // A parse failure means we could not read/decode the response body — a
+    // transient infra blip (truncated stream, gateway HTML, connection reset),
+    // not a genuine protocol disagreement. It must stay retryable so callers
+    // propagate it to the queue instead of failing the run.
+    const parseError = new WorkflowWorldError(
+      'Failed to parse response body for GET /v3/runs/wrun/events',
+      { code: 'PARSE_ERROR' }
+    );
+    expect(isWorldContractError(parseError)).toBe(false);
+    expect(classifyRunError(parseError)).not.toBe(
+      RUN_ERROR_CODES.WORLD_CONTRACT_ERROR
+    );
+  });
+
+  it('isWorldContractError distinguishes schema validation (fatal) from parse failures (retryable)', () => {
     expect(
-      classifyRunError(
+      isWorldContractError(
+        new WorkflowWorldError(
+          'Schema validation failed for GET /v3/runs/wrun/events',
+          { code: 'SCHEMA_VALIDATION' }
+        )
+      )
+    ).toBe(true);
+    expect(
+      isWorldContractError(
         new WorkflowWorldError(
           'Failed to parse response body for GET /v3/runs/wrun/events',
           { code: 'PARSE_ERROR' }
         )
       )
-    ).toBe(RUN_ERROR_CODES.WORLD_CONTRACT_ERROR);
+    ).toBe(false);
+    // A status-bearing HTTP error (e.g. 5xx) is never a contract error — it
+    // is already retryable via the status check.
+    expect(
+      isWorldContractError(
+        new WorkflowWorldError('Internal Server Error', { status: 500 })
+      )
+    ).toBe(false);
   });
 
   it('classifies string throw as USER_ERROR', () => {
@@ -104,5 +140,56 @@ describe('classifyRunError', () => {
     );
     native.name = 'OperationError';
     expect(classifyRunError(native)).toBe(RUN_ERROR_CODES.USER_ERROR);
+  });
+});
+
+describe('isRetryableWorldError', () => {
+  it('treats response-body parse failures as retryable', () => {
+    expect(
+      isRetryableWorldError(
+        new WorkflowWorldError(
+          'Failed to parse response body for GET /v3/runs/wrun/events',
+          { code: 'PARSE_ERROR' }
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('treats world 5xx errors as retryable', () => {
+    expect(
+      isRetryableWorldError(
+        new WorkflowWorldError('Bad Gateway', { status: 502 })
+      )
+    ).toBe(true);
+  });
+
+  it('treats throttle and too-early errors as retryable', () => {
+    expect(isRetryableWorldError(new ThrottleError('rate limited'))).toBe(true);
+    expect(isRetryableWorldError(new TooEarlyError('too early'))).toBe(true);
+  });
+
+  it('does NOT treat schema validation (contract) errors as retryable', () => {
+    expect(
+      isRetryableWorldError(
+        new WorkflowWorldError('Schema validation failed for GET /events', {
+          code: 'SCHEMA_VALIDATION',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('does NOT treat client (4xx) errors as retryable', () => {
+    expect(
+      isRetryableWorldError(
+        new WorkflowWorldError('Bad Request', { status: 400 })
+      )
+    ).toBe(false);
+  });
+
+  it('does NOT treat plain user/runtime errors as retryable', () => {
+    expect(isRetryableWorldError(new Error('boom'))).toBe(false);
+    expect(
+      isRetryableWorldError(new WorkflowRuntimeError('runtime boom'))
+    ).toBe(false);
   });
 });

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -4,13 +4,26 @@ import {
   type RunErrorCode,
   RuntimeDecryptionError,
   StepNotRegisteredError,
+  ThrottleError,
+  TooEarlyError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
   WorkflowWorldError,
 } from '@workflow/errors';
 
+// Codes that represent a genuine, non-recoverable disagreement about the
+// world protocol: the server returned a structurally valid response whose
+// *shape* is wrong. Retrying these would replay the same poison response,
+// so they fail the run.
+//
+// `PARSE_ERROR` is deliberately NOT in this set. A parse failure means we
+// could not read or decode the response body at all (a truncated/terminated
+// stream, a connection reset mid-body, or a gateway returning a 200 with an
+// HTML error page). On the Vercel platform these are overwhelmingly transient
+// infrastructure blips, so they must propagate to the queue handler for an
+// automatic retry rather than permanently failing the run. See
+// `isWorldContractError` and its callers in `runtime.ts`.
 const WORLD_CONTRACT_ERROR_CODES = new Set([
-  'PARSE_ERROR',
   'SCHEMA_VALIDATION',
   RUN_ERROR_CODES.WORLD_CONTRACT_ERROR,
 ]);
@@ -57,13 +70,57 @@ export function isWorldContractError(err: unknown): err is WorkflowWorldError {
   const cause = 'cause' in err ? err.cause : undefined;
   return (
     (err.code !== undefined && WORLD_CONTRACT_ERROR_CODES.has(err.code)) ||
-    err.message.startsWith('Failed to parse response body for ') ||
     err.message.startsWith('Schema validation failed for ') ||
     (typeof cause === 'object' &&
       cause !== null &&
       'name' in cause &&
       cause.name === 'ZodError')
   );
+}
+
+/**
+ * True when an error is a transient infrastructure failure that should
+ * propagate to the queue handler for an automatic retry, rather than being
+ * recorded as a `run_failed` event.
+ *
+ * The replay loop loads the event log (`events.list`) and talks to the world
+ * on every iteration. When one of those calls fails transiently — a server
+ * error, a rate limit, or a failure reading/decoding the response body — the
+ * run is not broken; the next queue delivery can simply replay it. Failing
+ * the run on such a blip is the bug this guards against.
+ *
+ * Retryable:
+ *  - `ThrottleError` (429) and `TooEarlyError` (425): the backend explicitly
+ *    asked us to back off. (These subclass `WorkflowWorldError` but override
+ *    `name`, so the `WorkflowWorldError.is` branch below does not catch them.)
+ *  - `WorkflowWorldError` with HTTP 5xx: server-side failure.
+ *  - `WorkflowWorldError` with no HTTP status that is not a contract error:
+ *    a response-body parse failure (`PARSE_ERROR`) — truncated/terminated
+ *    stream, connection reset, or a gateway returning a non-CBOR/JSON body.
+ *
+ * Not retryable (these fall through to `run_failed`):
+ *  - World *contract* violations (schema validation): a well-formed response
+ *    of the wrong shape — replaying yields the same poison response.
+ *  - Client errors (4xx other than 425/429): the request itself is wrong.
+ *  - User-code errors, `WorkflowRuntimeError`, corrupted event logs.
+ */
+export function isRetryableWorldError(err: unknown): boolean {
+  if (ThrottleError.is(err) || TooEarlyError.is(err)) {
+    return true;
+  }
+  if (!WorkflowWorldError.is(err)) {
+    return false;
+  }
+  // Read `status` while `err` is still narrowed to WorkflowWorldError.
+  // `isWorldContractError` is an `err is WorkflowWorldError` guard, so its
+  // negative branch would narrow `err` to `never` and lose `.status`.
+  const status = err.status;
+  if (isWorldContractError(err)) {
+    return false;
+  }
+  // A WorkflowWorldError that is not a contract violation: retry on a server
+  // error (5xx) or a status-less response-body parse failure.
+  return status === undefined || status >= 500;
 }
 
 export function classifyRunError(err: unknown): RunErrorCode {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -276,7 +276,10 @@ describe('workflowEntrypoint replay guards', () => {
     );
   });
 
-  it('records run_failed when run_started response parsing fails', async () => {
+  it('propagates (does not fail the run) when run_started response parsing fails', async () => {
+    // A parse failure is a transient infra blip (truncated/terminated body),
+    // not a permanent fault. It must propagate to the queue handler for a
+    // retry instead of recording a terminal run_failed event.
     const createdEvents: unknown[] = [];
     const parseError = new WorkflowWorldError(
       'Failed to parse response body for POST /v3/runs/wrun_parse/events (Content-Type: application/cbor):\n\nError: unexpected end of file',
@@ -306,6 +309,8 @@ describe('workflowEntrypoint replay guards', () => {
           handler: (message: unknown, metadata: unknown) => Promise<unknown>
         ) => {
           return async () => {
+            // Surface a thrown handler error so the test can assert the
+            // message is retried (rejection) rather than acknowledged.
             await handler(
               {
                 runId: 'wrun_parse',
@@ -343,16 +348,109 @@ describe('workflowEntrypoint replay guards', () => {
       }${getWorkflowTransformCode('workflow')}`
     );
 
-    const response = await handler(new Request('https://example.test'));
+    await expect(handler(new Request('https://example.test'))).rejects.toThrow(
+      /Failed to parse response body/
+    );
 
-    expect(response.status).toBe(204);
-    expect(createdEvents).toContainEqual(
-      expect.objectContaining({
-        eventType: 'run_failed',
-        eventData: expect.objectContaining({
-          errorCode: RUN_ERROR_CODES.WORLD_CONTRACT_ERROR,
+    // The run must NOT be marked failed on a transient parse blip.
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
+    );
+  });
+
+  it('propagates (does not fail the run) when events.list parsing fails during replay', async () => {
+    // Regression: a sporadic failure reading/decoding the events.list
+    // response body during replay must be retried by the queue, not turned
+    // into a terminal run_failed. Contrast with the SCHEMA_VALIDATION case
+    // above, which is a genuine contract violation and stays fatal.
+    const createdEvents: unknown[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_events_parse',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_events_parse',
+        undefined,
+        []
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const parseError = new WorkflowWorldError(
+      'Failed to parse response body for GET /v3/runs/wrun_events_parse/events (Content-Type: application/cbor):\n\nError: unexpected end of file',
+      { code: 'PARSE_ERROR' }
+    );
+
+    const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+      if (data.eventType !== 'run_started') {
+        createdEvents.push(data);
+      }
+      // run_started returns the run WITHOUT preloaded events, forcing the
+      // replay loop down the events.list path.
+      return data.eventType === 'run_started'
+        ? { run: workflowRun }
+        : {
+            event: {
+              eventId: `event-${createdEvents.length}`,
+              runId: workflowRun.runId,
+              createdAt: new Date(),
+              ...data,
+            },
+          };
+    });
+
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      createQueueHandler: vi.fn(
+        (
+          _prefix: string,
+          handler: (message: unknown, metadata: unknown) => Promise<unknown>
+        ) => {
+          return async () => {
+            await handler(
+              {
+                runId: workflowRun.runId,
+                requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+              },
+              {
+                requestId: 'req_test',
+                attempt: 1,
+                queueName: '__wkf_workflow_workflow',
+                messageId: 'msg_test',
+              }
+            );
+            return new Response(null, { status: 204 });
+          };
+        }
+      ),
+      events: {
+        create: eventsCreate,
+        list: vi.fn(async () => {
+          throw parseError;
         }),
-      })
+      },
+      runs: {
+        get: vi.fn(async () => workflowRun),
+      },
+      queue: vi.fn(),
+      getEncryptionKeyForRun: vi.fn(async () => undefined),
+    } as any);
+
+    const handler = workflowEntrypoint(
+      `async function workflow() {
+        return 'done';
+      }${getWorkflowTransformCode('workflow')}`
+    );
+
+    await expect(handler(new Request('https://example.test'))).rejects.toThrow(
+      /Failed to parse response body/
+    );
+
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
     );
   });
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -15,7 +15,11 @@ import {
   type WorkflowRun,
   type World,
 } from '@workflow/world';
-import { classifyRunError, isWorldContractError } from './classify-error.js';
+import {
+  classifyRunError,
+  isRetryableWorldError,
+  isWorldContractError,
+} from './classify-error.js';
 import { describeError } from './describe-error.js';
 import { WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
@@ -1152,6 +1156,29 @@ export function workflowEntrypoint(
                           // Loop back to replay which will re-evaluate
                         }
                       } else {
+                        // Transient infrastructure failures (e.g. a failure
+                        // reading the event-log response body while loading
+                        // events for replay, a 5xx from the world, or a
+                        // rate-limit) must not fail the run. Re-throw so the
+                        // error propagates to the queue handler for an
+                        // automatic retry. Genuine world contract violations,
+                        // user-code errors, and runtime errors fall through to
+                        // run_failed below.
+                        if (isRetryableWorldError(err)) {
+                          runtimeLogger.warn(
+                            'Transient world error during replay; propagating to queue for retry.',
+                            {
+                              workflowRunId: runId,
+                              loopIteration,
+                              error:
+                                err instanceof Error
+                                  ? err.message
+                                  : String(err),
+                            }
+                          );
+                          throw err;
+                        }
+
                         // User code error from runWorkflow — create run_failed.
                         if (err instanceof Error) {
                           span?.recordException?.(err);


### PR DESCRIPTION
## Problem

When the runtime loads the event log during replay (`events.list`), the fetch can fail sporadically — a truncated/terminated response body, a connection reset mid-stream, or a gateway returning a 200 with a non-CBOR/JSON body. The world adapter wraps these as a status-less `WorkflowWorldError` with code `PARSE_ERROR`.

`isWorldContractError` classified `PARSE_ERROR` as a **fatal world contract error**, so a transient blip was written as a terminal `run_failed` event instead of being retried.

## Fix

- Drop `PARSE_ERROR` from the world-contract classification. A parse failure means we couldn't read/decode the response body at all — overwhelmingly a transient infrastructure issue. Only schema validation (a well-formed response of the *wrong shape*) remains a fatal contract error.
- Add `isRetryableWorldError` (transient infra: parse failures, 5xx, 425/429 back-off signals) and re-throw such errors from the replay loop's `catch` so they propagate to the queue handler for an automatic retry rather than failing the run.

## Tests

- `classify-error.test.ts`: `PARSE_ERROR` is no longer a contract error; `isRetryableWorldError` covers parse/5xx/throttle (retryable) vs schema-validation/4xx/user errors (fatal).
- `runtime.test.ts`: a `PARSE_ERROR` from `events.list` during replay now propagates (queue retry) and writes **no** `run_failed`; the schema-validation case stays fatal.