### PR TITLE
Backport #2191: fix forwarded stream encryption across deployments

### DIFF
--- a/.changeset/cross-deployment-stream-keys.md
+++ b/.changeset/cross-deployment-stream-keys.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": patch
+"@workflow/world": patch
+---
+
+Fix forwarded writable stream encryption when child workflows execute on a newer deployment than their parent.

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -481,7 +481,10 @@ const stepHandler = createQueueHandler(
                 step.input,
                 workflowRunId,
                 encryptionKey,
-                ops
+                ops,
+                globalThis,
+                {},
+                process.env.VERCEL_DEPLOYMENT_ID
               );
               const durationMs = Date.now() - startTime;
               hydrateSpan?.setAttributes({
@@ -523,6 +526,7 @@ const stepHandler = createQueueHandler(
                       ? `https://${process.env.VERCEL_URL}`
                       : `http://localhost:${port ?? 3000}`,
                   },
+                  workflowDeploymentId: process.env.VERCEL_DEPLOYMENT_ID,
                   ops,
                   closureVars: hydratedInput.closureVars,
                   encryptionKey,

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -1,10 +1,11 @@
 import { runInContext } from 'node:vm';
 import type { WorkflowRuntimeError } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { registerSerializationClass } from './class-serialization.js';
 import { decrypt, encrypt, importKey } from './encryption.js';
 import { getStepFunction, registerStepFunction } from './private.js';
+import { setWorld } from './runtime/world.js';
 import {
   decodeFormatPrefix,
   dehydrateStepArguments,
@@ -28,6 +29,7 @@ import {
 import {
   STABLE_ULID,
   STREAM_NAME_SYMBOL,
+  STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
 } from './symbols.js';
 import { createContext } from './vm/index.js';
@@ -477,6 +479,10 @@ describe('workflow arguments', () => {
       value: 'wrun_parent',
       writable: false,
     });
+    Object.defineProperty(userWritable, STREAM_SERVER_DEPLOYMENT_ID_SYMBOL, {
+      value: 'dpl_parent',
+      writable: false,
+    });
 
     expect(userWritable.locked).toBe(false);
     const serialized = await dehydrateWorkflowArguments(
@@ -494,6 +500,122 @@ describe('workflow arguments', () => {
     const text = new TextDecoder().decode(serialized as Uint8Array);
     expect(text).toContain('strm_parentstreamname');
     expect(text).toContain('wrun_parent');
+    expect(text).toContain('dpl_parent');
+  });
+
+  it('uses the forwarded stream deployment to resolve its encryption key', async () => {
+    const getEncryptionKeyForRun = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32).fill(7));
+    const runsGet = vi.fn();
+    const world = {
+      writeToStream: vi.fn().mockResolvedValue(undefined),
+      closeStream: vi.fn().mockResolvedValue(undefined),
+      runs: { get: runsGet },
+      getEncryptionKeyForRun,
+    } as any;
+    setWorld(world);
+
+    try {
+      const parentWritable = new WritableStream();
+      Object.defineProperty(parentWritable, STREAM_NAME_SYMBOL, {
+        value: 'strm_parentstreamname',
+        writable: false,
+      });
+      Object.defineProperty(parentWritable, STREAM_SERVER_RUN_ID_SYMBOL, {
+        value: 'wrun_parent',
+        writable: false,
+      });
+      Object.defineProperty(
+        parentWritable,
+        STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+        {
+          value: 'dpl_parent',
+          writable: false,
+        }
+      );
+
+      const serialized = await dehydrateStepArguments(
+        parentWritable,
+        'wrun_child',
+        noEncryptionKey
+      );
+      const ops: Promise<void>[] = [];
+      const hydrated = (await hydrateStepArguments(
+        serialized,
+        'wrun_child',
+        noEncryptionKey,
+        ops,
+        globalThis,
+        {},
+        'dpl_child'
+      )) as WritableStream<string>;
+
+      const writer = hydrated.getWriter();
+      await writer.write('cross-deployment');
+      await writer.close();
+      await Promise.all(ops);
+
+      expect(getEncryptionKeyForRun).toHaveBeenCalledWith('wrun_parent', {
+        deploymentId: 'dpl_parent',
+      });
+      expect(runsGet).not.toHaveBeenCalled();
+    } finally {
+      setWorld(undefined);
+    }
+  });
+
+  it('loads the owner run for forwarded descriptors from older deployments', async () => {
+    const parentRun = {
+      runId: 'wrun_parent',
+      deploymentId: 'dpl_parent',
+    };
+    const getEncryptionKeyForRun = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32).fill(9));
+    const runsGet = vi.fn().mockResolvedValue(parentRun);
+    const world = {
+      writeToStream: vi.fn().mockResolvedValue(undefined),
+      closeStream: vi.fn().mockResolvedValue(undefined),
+      runs: { get: runsGet },
+      getEncryptionKeyForRun,
+    } as any;
+    setWorld(world);
+
+    try {
+      const legacyWritable = new WritableStream();
+      Object.defineProperty(legacyWritable, STREAM_NAME_SYMBOL, {
+        value: 'strm_legacyparent',
+        writable: false,
+      });
+      Object.defineProperty(legacyWritable, STREAM_SERVER_RUN_ID_SYMBOL, {
+        value: 'wrun_parent',
+        writable: false,
+      });
+
+      const serialized = await dehydrateStepArguments(
+        legacyWritable,
+        'wrun_child',
+        noEncryptionKey
+      );
+      const ops: Promise<void>[] = [];
+      const hydrated = (await hydrateStepArguments(
+        serialized,
+        'wrun_child',
+        noEncryptionKey,
+        ops
+      )) as WritableStream<string>;
+
+      const writer = hydrated.getWriter();
+      await writer.write('legacy-descriptor');
+      await writer.close();
+      await Promise.all(ops);
+
+      expect(runsGet).toHaveBeenCalledWith('wrun_parent');
+      expect(getEncryptionKeyForRun).toHaveBeenCalledWith(parentRun);
+    } finally {
+      setWorld(undefined);
+    }
   });
 
   it('should work with ReadableStream', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -36,6 +36,7 @@ import {
   BODY_INIT_SYMBOL,
   STABLE_ULID,
   STREAM_NAME_SYMBOL,
+  STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
   STREAM_TYPE_SYMBOL,
   WEBHOOK_RESPONSE_WRITABLE,
@@ -663,6 +664,11 @@ export interface SerializableSpecial {
      * belongs to the receiving run (the normal in-run case).
      */
     runId?: string;
+    /**
+     * The deployment that owns the server stream. Carried with `runId`
+     * so a child on a newer deployment can resolve the parent's key.
+     */
+    deploymentId?: string;
   };
 }
 
@@ -947,7 +953,17 @@ export function getExternalReducers(
         typeof existingName === 'string' &&
         typeof existingRunId === 'string'
       ) {
-        return { name: existingName, runId: existingRunId };
+        const descriptor: SerializableSpecial['WritableStream'] = {
+          name: existingName,
+          runId: existingRunId,
+        };
+        const existingDeploymentId = (value as any)[
+          STREAM_SERVER_DEPLOYMENT_ID_SYMBOL
+        ];
+        if (typeof existingDeploymentId === 'string') {
+          descriptor.deploymentId = existingDeploymentId;
+        }
+        return descriptor;
       }
 
       const streamId = ((global as any)[STABLE_ULID] || defaultUlid)();
@@ -1008,6 +1024,10 @@ export function getWorkflowReducers(
       // reviver opens the writable against the original stream.
       const foreignRunId = value[STREAM_SERVER_RUN_ID_SYMBOL];
       if (typeof foreignRunId === 'string') s.runId = foreignRunId;
+      const foreignDeploymentId = value[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL];
+      if (typeof foreignDeploymentId === 'string') {
+        s.deploymentId = foreignDeploymentId;
+      }
       return s;
     },
   };
@@ -1094,6 +1114,12 @@ function getStepReducers(
 
       const s: SerializableSpecial['WritableStream'] = { name };
       if (typeof foreignRunId === 'string') s.runId = foreignRunId;
+      const foreignDeploymentId = (value as any)[
+        STREAM_SERVER_DEPLOYMENT_ID_SYMBOL
+      ];
+      if (typeof foreignDeploymentId === 'string') {
+        s.deploymentId = foreignDeploymentId;
+      }
       return s;
     },
   };
@@ -1220,6 +1246,24 @@ export function getCommonRevivers(global: Record<string, any> = globalThis) {
 }
 
 /**
+ * Resolve the encrypt-only key needed when a child writes into another run's
+ * stream. New descriptors include the owner's deployment ID; descriptors
+ * created by older SDK versions fall back to loading the owning run.
+ */
+async function getForwardedWritableEncryptionKey(
+  runId: string,
+  deploymentId: string | undefined
+): Promise<CryptoKey | undefined> {
+  const world = getWorld();
+  if (!world.getEncryptionKeyForRun) return undefined;
+
+  const rawKey = deploymentId
+    ? await world.getEncryptionKeyForRun(runId, { deploymentId })
+    : await world.getEncryptionKeyForRun(await world.runs.get(runId));
+  return rawKey ? await importKey(rawKey, ['encrypt']) : undefined;
+}
+
+/**
  * Revivers for deserialization boundary from the client side,
  * receiving the return value from the workflow handler.
  *
@@ -1319,11 +1363,7 @@ export function getExternalRevivers(
       const targetKey: EncryptionKeyParam =
         targetRunId === runId
           ? cryptoKey
-          : (async () => {
-              const world = getWorld();
-              const rawKey = await world.getEncryptionKeyForRun?.(targetRunId);
-              return rawKey ? await importKey(rawKey, ['encrypt']) : undefined;
-            })();
+          : getForwardedWritableEncryptionKey(targetRunId, value.deploymentId);
 
       const serialize = getSerializeStream(
         getExternalReducers(global, ops, targetRunId, targetKey),
@@ -1354,6 +1394,16 @@ export function getExternalRevivers(
         value: targetRunId,
         writable: false,
       });
+      if (typeof value.deploymentId === 'string') {
+        Object.defineProperty(
+          serialize.writable,
+          STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+          {
+            value: value.deploymentId,
+            writable: false,
+          }
+        );
+      }
 
       return serialize.writable;
     },
@@ -1469,6 +1519,12 @@ export function getWorkflowRevivers(
           writable: false,
         };
       }
+      if (typeof value.deploymentId === 'string') {
+        descriptor[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL] = {
+          value: value.deploymentId,
+          writable: false,
+        };
+      }
       return Object.create(global.WritableStream.prototype, descriptor);
     },
   };
@@ -1487,7 +1543,8 @@ function getStepRevivers(
   global: Record<string, any> = globalThis,
   ops: Promise<void>[],
   runId: string,
-  cryptoKey: EncryptionKeyParam
+  cryptoKey: EncryptionKeyParam,
+  deploymentId?: string
 ): Revivers {
   return {
     ...getCommonRevivers(global),
@@ -1624,7 +1681,7 @@ function getStepRevivers(
         return userReadable;
       } else {
         const transform = getDeserializeStream(
-          getStepRevivers(global, ops, runId, cryptoKey),
+          getStepRevivers(global, ops, runId, cryptoKey, deploymentId),
           cryptoKey
         );
         const state = createFlushableState();
@@ -1655,14 +1712,16 @@ function getStepRevivers(
       // so the receiving run can never decrypt anything else on the
       // owning run's stream — it can only contribute new writes.
       const targetRunId = typeof value.runId === 'string' ? value.runId : runId;
+      const targetDeploymentId =
+        typeof value.deploymentId === 'string'
+          ? value.deploymentId
+          : targetRunId === runId
+            ? deploymentId
+            : undefined;
       const targetKey: EncryptionKeyParam =
         targetRunId === runId
           ? cryptoKey
-          : (async () => {
-              const world = getWorld();
-              const rawKey = await world.getEncryptionKeyForRun?.(targetRunId);
-              return rawKey ? await importKey(rawKey, ['encrypt']) : undefined;
-            })();
+          : getForwardedWritableEncryptionKey(targetRunId, targetDeploymentId);
 
       const serialize = getSerializeStream(
         getStepReducers(global, ops, targetRunId, targetKey),
@@ -1699,6 +1758,16 @@ function getStepRevivers(
         value: targetRunId,
         writable: false,
       });
+      if (targetDeploymentId) {
+        Object.defineProperty(
+          serialize.writable,
+          STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+          {
+            value: targetDeploymentId,
+            writable: false,
+          }
+        );
+      }
 
       return serialize.writable;
     },
@@ -2000,7 +2069,8 @@ export async function hydrateStepArguments(
   key: CryptoKey | undefined,
   ops: Promise<any>[] = [],
   global: Record<string, any> = globalThis,
-  extraRevivers: Record<string, (value: any) => any> = {}
+  extraRevivers: Record<string, (value: any) => any> = {},
+  deploymentId?: string
 ) {
   // Decrypt if needed
   const decrypted = await maybeDecrypt(value, key);
@@ -2010,7 +2080,7 @@ export async function hydrateStepArguments(
   // via devalue's unflatten().
   if (!(decrypted instanceof Uint8Array)) {
     return unflatten(decrypted as any[], {
-      ...getStepRevivers(global, ops, runId, key),
+      ...getStepRevivers(global, ops, runId, key, deploymentId),
       ...extraRevivers,
     });
   }
@@ -2020,7 +2090,7 @@ export async function hydrateStepArguments(
   if (format === SerializationFormat.DEVALUE_V1) {
     const str = new TextDecoder().decode(payload);
     const obj = parse(str, {
-      ...getStepRevivers(global, ops, runId, key),
+      ...getStepRevivers(global, ops, runId, key, deploymentId),
       ...extraRevivers,
     });
     return obj;

--- a/packages/core/src/step/context-storage.ts
+++ b/packages/core/src/step/context-storage.ts
@@ -6,6 +6,8 @@ import type { StepMetadata } from './get-step-metadata.js';
 export type StepContext = {
   stepMetadata: StepMetadata;
   workflowMetadata: WorkflowMetadata;
+  /** Deployment that owns the current workflow run, used for forwarded streams. */
+  workflowDeploymentId?: string;
   ops: Promise<void>[];
   closureVars?: Record<string, any>;
   encryptionKey?: CryptoKey;

--- a/packages/core/src/step/writable-stream.test.ts
+++ b/packages/core/src/step/writable-stream.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LOCK_POLL_INTERVAL_MS } from '../flushable-stream.js';
+import { STREAM_SERVER_DEPLOYMENT_ID_SYMBOL } from '../symbols.js';
 
 vi.mock('../runtime/world.js', () => ({
   getWorld: vi.fn(),
@@ -107,5 +108,36 @@ describe('step-level getWritable', () => {
         ),
       ])
     ).resolves.not.toThrow();
+  });
+
+  it('tags a writable with its owning deployment for child workflow forwarding', async () => {
+    const { contextStorage } = await import('./context-storage.js');
+    const ops: Promise<void>[] = [];
+    const ctx = {
+      stepMetadata: {
+        stepName: 'test-step',
+        stepId: 'step_001',
+        stepStartedAt: new Date(),
+        attempt: 1,
+      },
+      workflowMetadata: {
+        workflowName: 'test-workflow',
+        workflowRunId: 'wrun_test123',
+        workflowStartedAt: new Date(),
+      },
+      workflowDeploymentId: 'dpl_parent',
+      ops,
+      encryptionKey: undefined,
+    };
+
+    const writable = await contextStorage.run(ctx, async () => {
+      const { getWritable } = await import('./writable-stream.js');
+      return getWritable<string>();
+    });
+
+    expect((writable as any)[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL]).toBe(
+      'dpl_parent'
+    );
+    await Promise.all(ops);
   });
 });

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -8,7 +8,11 @@ import {
   getSerializeStream,
   WorkflowServerWritableStream,
 } from '../serialization.js';
-import { STREAM_NAME_SYMBOL, STREAM_SERVER_RUN_ID_SYMBOL } from '../symbols.js';
+import {
+  STREAM_NAME_SYMBOL,
+  STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+  STREAM_SERVER_RUN_ID_SYMBOL,
+} from '../symbols.js';
 import { getWorkflowRunStreamId } from '../util.js';
 import { contextStorage } from './context-storage.js';
 
@@ -82,6 +86,16 @@ export function getWritable<W = any>(
     value: runId,
     writable: false,
   });
+  if (ctx.workflowDeploymentId) {
+    Object.defineProperty(
+      serialize.writable,
+      STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+      {
+        value: ctx.workflowDeploymentId,
+        writable: false,
+      }
+    );
+  }
 
   // Return the writable side of the transform stream
   return serialize.writable;

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -24,6 +24,14 @@ export const STREAM_TYPE_SYMBOL = Symbol.for('WORKFLOW_STREAM_TYPE');
 export const STREAM_SERVER_RUN_ID_SYMBOL = Symbol.for(
   'WORKFLOW_STREAM_SERVER_RUN_ID'
 );
+/**
+ * Stamped alongside `STREAM_SERVER_RUN_ID_SYMBOL` when the deployment that
+ * owns a forwarded writable stream is known. Cross-deployment consumers use
+ * it to resolve the owning run's encryption key without loading the run first.
+ */
+export const STREAM_SERVER_DEPLOYMENT_ID_SYMBOL = Symbol.for(
+  'WORKFLOW_STREAM_SERVER_DEPLOYMENT_ID'
+);
 export const BODY_INIT_SYMBOL = Symbol.for('BODY_INIT');
 export const WEBHOOK_RESPONSE_WRITABLE = Symbol.for(
   'WEBHOOK_RESPONSE_WRITABLE'

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -286,10 +286,11 @@ export interface World extends Queue, Storage, Streamer {
    *   the run entity already exists. The World reads any context it needs
    *   (e.g., `deploymentId`) directly from the run.
    *
-   * - `getEncryptionKeyForRun(runId, context?)` — Used only by `start()`
-   *   when the run entity has not yet been created. The `context` parameter
-   *   carries opaque world-specific data (e.g., `{ deploymentId }` for
-   *   world-vercel) that the World needs to resolve the correct key.
+   * - `getEncryptionKeyForRun(runId, context?)` — Used when the run entity
+   *   is not locally available, such as `start()` before run creation or a
+   *   forwarded writable stream carrying its owning deployment context. The
+   *   `context` parameter carries opaque world-specific data (e.g.,
+   *   `{ deploymentId }` for world-vercel) needed to resolve the correct key.
    *   When `context` is omitted, the World assumes the current deployment.
    *
    * When not implemented, encryption is disabled — data is stored unencrypted.


### PR DESCRIPTION
## Summary

- Backports #2191 onto `stable` now that prerequisite #2070 has merged.
- Carries the owning deployment ID with forwarded writable descriptors so child workflows resolve the parent run's encryption key when executing from a newer deployment.
- Preserves compatibility with descriptors emitted before deployment IDs were carried by loading the owning run as a fallback.

## Why this needed manual resolution

The automated #2191 backport failed with conflicts ([comment](https://github.com/vercel/workflow/pull/2191#issuecomment-4595468834), [run](https://github.com/vercel/workflow/actions/runs/26774456512)). PR #2070 has now merged the direct forwarded-stream path into `stable`, so this PR has been rebased to contain only the targeted encryption fix.

The remaining conflict resolution is specific to the `stable` layout: step execution remains in `packages/core/src/runtime/step-handler.ts`, and `SerializableSpecial` remains inline in `packages/core/src/serialization.ts` rather than bringing over main-only split modules.

## Validation

- `git diff --check origin-https/stable...HEAD`
- `fnm exec --using=22.22.0 -- pnpm turbo build --filter=@workflow/core --filter=@workflow/world`
- `fnm exec --using=22.22.0 -- pnpm --filter @workflow/core test` (645 tests passed)

Note: the local shell defaults to unsupported Node `v25.2.1`, where the untouched `src/vm/uint8array-base64.test.ts` reports cross-realm error-constructor assertion failures. The full suite passes on supported Node `v22.22.0`.
