### PR TITLE
fix(core): advance workflow clock only for consumed events

### DIFF
--- a/.changeset/replay-consumed-event-clock.md
+++ b/.changeset/replay-consumed-event-clock.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Prevent replayed workflows from advancing their deterministic clock when a future event is inspected before its matching operation is invoked.

--- a/packages/core/src/events-consumer.test.ts
+++ b/packages/core/src/events-consumer.test.ts
@@ -285,6 +285,32 @@ describe('EventsConsumer', () => {
       expect(normalCallback).toHaveBeenCalledWith(event);
     });
 
+    it('should continue processing when onConsumedEvent throws', async () => {
+      const event1 = createMockEvent({ id: 'event-1' });
+      const event2 = createMockEvent({ id: 'event-2' });
+      const onConsumedEvent = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Observer error');
+        })
+        .mockImplementation(() => undefined);
+      const consumer = new EventsConsumer([event1, event2], {
+        ...defaultOptions,
+        onConsumedEvent,
+      });
+      const callback1 = vi.fn().mockReturnValue(EventConsumerResult.Finished);
+      const callback2 = vi.fn().mockReturnValue(EventConsumerResult.Finished);
+
+      consumer.subscribe(callback1);
+      consumer.subscribe(callback2);
+      await waitForNextTick();
+      await waitForNextTick();
+
+      expect(onConsumedEvent).toHaveBeenNthCalledWith(1, event1);
+      expect(onConsumedEvent).toHaveBeenNthCalledWith(2, event2);
+      expect(consumer.eventIndex).toBe(2);
+    });
+
     it('should handle callback removal during iteration', async () => {
       const event = createMockEvent();
       const consumer = new EventsConsumer([event], defaultOptions);

--- a/packages/core/src/events-consumer.ts
+++ b/packages/core/src/events-consumer.ts
@@ -20,6 +20,12 @@ type EventConsumerCallback = (event: Event | null) => EventConsumerResult;
 
 export interface EventsConsumerOptions {
   /**
+   * Callback invoked after an event has been consumed. Consumers such as the
+   * deterministic workflow clock must not observe events that are merely
+   * inspected while waiting for user code to subscribe to the next operation.
+   */
+  onConsumedEvent?: (event: Event) => void;
+  /**
    * Callback invoked when a non-null event cannot be consumed by any registered
    * callback, indicating an orphaned or invalid event in the event log. The
    * check is deferred until after the promise queue has drained, ensuring that
@@ -40,6 +46,7 @@ export class EventsConsumer {
   eventIndex: number;
   readonly events: Event[] = [];
   readonly callbacks: EventConsumerCallback[] = [];
+  private onConsumedEvent?: (event: Event) => void;
   private onUnconsumedEvent: (event: Event) => void;
   private getPromiseQueue: () => Promise<void>;
   private pendingUnconsumedCheck: Promise<void> | null = null;
@@ -49,6 +56,7 @@ export class EventsConsumer {
   constructor(events: Event[], options: EventsConsumerOptions) {
     this.events = events;
     this.eventIndex = 0;
+    this.onConsumedEvent = options.onConsumedEvent;
     this.onUnconsumedEvent = options.onUnconsumedEvent;
     this.getPromiseQueue = options.getPromiseQueue;
   }
@@ -92,6 +100,9 @@ export class EventsConsumer {
         handled === EventConsumerResult.Consumed ||
         handled === EventConsumerResult.Finished
       ) {
+        if (currentEvent !== null) {
+          this.onConsumedEvent?.(currentEvent);
+        }
         // consumer handled this event, so increase the event index
         this.eventIndex++;
 

--- a/packages/core/src/events-consumer.ts
+++ b/packages/core/src/events-consumer.ts
@@ -86,6 +86,19 @@ export class EventsConsumer {
     process.nextTick(this.consume);
   }
 
+  private notifyConsumedEvent(event: Event) {
+    if (!this.onConsumedEvent) {
+      return;
+    }
+    try {
+      this.onConsumedEvent(event);
+    } catch (error) {
+      eventsLogger.error('onConsumedEvent callback threw an error', {
+        error,
+      });
+    }
+  }
+
   private consume = () => {
     const currentEvent = this.events[this.eventIndex] ?? null;
     for (let i = 0; i < this.callbacks.length; i++) {
@@ -101,7 +114,7 @@ export class EventsConsumer {
         handled === EventConsumerResult.Finished
       ) {
         if (currentEvent !== null) {
-          this.onConsumedEvent?.(currentEvent);
+          this.notifyConsumedEvent(currentEvent);
         }
         // consumer handled this event, so increase the event index
         this.eventIndex++;

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -485,29 +485,30 @@ describe('runWorkflow', () => {
        }${getWorkflowTransformCode('workflow')}`;
 
     const replayCount = 200;
-    const outcomes = await Promise.all(
-      Array.from({ length: replayCount }, async () => {
-        try {
-          const result = await runWorkflow(
-            workflowCode,
-            workflowRun,
-            events,
-            noEncryptionKey
-          );
-          const value = await hydrateWorkflowReturnValue(
-            result as any,
-            workflowRunId,
-            noEncryptionKey,
-            ops
-          );
-          return value === 'drained'
+    const outcomes: string[] = [];
+    for (let replayIndex = 0; replayIndex < replayCount; replayIndex++) {
+      try {
+        const result = await runWorkflow(
+          workflowCode,
+          workflowRun,
+          events,
+          noEncryptionKey
+        );
+        const value = await hydrateWorkflowReturnValue(
+          result as any,
+          workflowRunId,
+          noEncryptionKey,
+          ops
+        );
+        outcomes.push(
+          value === 'drained'
             ? 'drained'
-            : `unexpected replay result: ${String(value)}`;
-        } catch (error) {
-          return error instanceof Error ? error.message : String(error);
-        }
-      })
-    );
+            : `unexpected replay result: ${String(value)}`
+        );
+      } catch (error) {
+        outcomes.push(error instanceof Error ? error.message : String(error));
+      }
+    }
     const failures = outcomes.filter((outcome) => outcome !== 'drained');
 
     expect({

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -355,8 +355,8 @@ describe('runWorkflow', () => {
     );
     // Timestamps:
     // - Initial: 0s (from startedAt)
-    // - After step 1 completes (at 2s), timestamp advances to step2_created (2.5s)
-    // - After step 2 completes (at 4s), timestamp advances to step3_created (4.5s)
+    // - After step 1 completes, timestamp advances to the consumed completion at 2s
+    // - After step 2 completes, timestamp advances to the consumed completion at 4s
     // - After step 3 completes: 6s
     expect(
       await hydrateWorkflowReturnValue(
@@ -367,10 +367,136 @@ describe('runWorkflow', () => {
       )
     ).toEqual([
       new Date('2024-01-01T00:00:00.000Z'),
-      1704067202500, // 2.5s (step2_created timestamp)
-      1704067204500, // 4.5s (step3_created timestamp)
+      1704067202000,
+      1704067204000,
       new Date('2024-01-01T00:00:06.000Z'),
     ]);
+  });
+
+  it('should not let a future recorded step advance Date before choosing that step branch', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRunId = 'wrun_123';
+    const workflowRun: WorkflowRun = {
+      runId: workflowRunId,
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        workflowRunId,
+        noEncryptionKey,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+
+    const startStepId = 'step_01HK153X00SP082GGA0AAJC6PJ';
+    const branchStepId = 'step_01HK153X00SP082GGA0AAJC6PK';
+    const events: Event[] = [
+      {
+        eventId: 'event-run-created',
+        runId: workflowRunId,
+        eventType: 'run_created',
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      {
+        eventId: 'event-run-started',
+        runId: workflowRunId,
+        eventType: 'run_started',
+        createdAt: new Date('2024-01-01T00:00:00.500Z'),
+      },
+      {
+        eventId: 'event-start-created',
+        runId: workflowRunId,
+        eventType: 'step_created',
+        correlationId: startStepId,
+        eventData: { stepName: 'startQueuedLogicalRunStep' },
+        createdAt: new Date('2024-01-01T00:00:01.000Z'),
+      },
+      {
+        eventId: 'event-start-started',
+        runId: workflowRunId,
+        eventType: 'step_started',
+        correlationId: startStepId,
+        eventData: { stepName: 'startQueuedLogicalRunStep' },
+        createdAt: new Date('2024-01-01T00:00:01.500Z'),
+      },
+      {
+        eventId: 'event-start-completed',
+        runId: workflowRunId,
+        eventType: 'step_completed',
+        correlationId: startStepId,
+        eventData: {
+          stepName: 'startQueuedLogicalRunStep',
+          result: await dehydrateStepReturnValue(
+            'started',
+            workflowRunId,
+            noEncryptionKey,
+            ops
+          ),
+        },
+        createdAt: new Date('2024-01-01T00:00:02.000Z'),
+      },
+      {
+        eventId: 'event-drain-created',
+        runId: workflowRunId,
+        eventType: 'step_created',
+        correlationId: branchStepId,
+        eventData: { stepName: 'drainLogicalRunRuntimeStep' },
+        createdAt: new Date('2024-01-01T00:00:02.500Z'),
+      },
+      {
+        eventId: 'event-drain-started',
+        runId: workflowRunId,
+        eventType: 'step_started',
+        correlationId: branchStepId,
+        eventData: { stepName: 'drainLogicalRunRuntimeStep' },
+        createdAt: new Date('2024-01-01T00:00:03.000Z'),
+      },
+      {
+        eventId: 'event-drain-completed',
+        runId: workflowRunId,
+        eventType: 'step_completed',
+        correlationId: branchStepId,
+        eventData: {
+          stepName: 'drainLogicalRunRuntimeStep',
+          result: await dehydrateStepReturnValue(
+            'drained',
+            workflowRunId,
+            noEncryptionKey,
+            ops
+          ),
+        },
+        createdAt: new Date('2024-01-01T00:00:03.500Z'),
+      },
+    ];
+
+    const result = await runWorkflow(
+      `const start = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("startQueuedLogicalRunStep");
+       const drain = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("drainLogicalRunRuntimeStep");
+       const settle = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("settleQueueActionStep");
+       async function workflow() {
+         await start();
+         if (Date.now() < 1704067202250) {
+           return await drain();
+         }
+         return await settle();
+       }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events,
+      noEncryptionKey
+    );
+
+    expect(
+      await hydrateWorkflowReturnValue(
+        result as any,
+        workflowRunId,
+        noEncryptionKey,
+        ops
+      )
+    ).toBe('drained');
   });
 
   // TODO: Date.now determinism is currently broken in the workflow!!

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -485,8 +485,8 @@ describe('runWorkflow', () => {
        }${getWorkflowTransformCode('workflow')}`;
 
     const replayCount = 200;
-    const outcomes: string[] = [];
-    for (let replayIndex = 0; replayIndex < replayCount; replayIndex++) {
+    const maxConcurrentReplays = 8;
+    const replay = async () => {
       try {
         const result = await runWorkflow(
           workflowCode,
@@ -500,14 +500,26 @@ describe('runWorkflow', () => {
           noEncryptionKey,
           ops
         );
-        outcomes.push(
-          value === 'drained'
-            ? 'drained'
-            : `unexpected replay result: ${String(value)}`
-        );
+        return value === 'drained'
+          ? 'drained'
+          : `unexpected replay result: ${String(value)}`;
       } catch (error) {
-        outcomes.push(error instanceof Error ? error.message : String(error));
+        return error instanceof Error ? error.message : String(error);
       }
+    };
+    const outcomes: string[] = [];
+    for (
+      let replayIndex = 0;
+      replayIndex < replayCount;
+      replayIndex += maxConcurrentReplays
+    ) {
+      const batchSize = Math.min(
+        maxConcurrentReplays,
+        replayCount - replayIndex
+      );
+      outcomes.push(
+        ...(await Promise.all(Array.from({ length: batchSize }, replay)))
+      );
     }
     const failures = outcomes.filter((outcome) => outcome !== 'drained');
 

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -373,7 +373,7 @@ describe('runWorkflow', () => {
     ]);
   });
 
-  it('should not let a future recorded step advance Date before choosing that step branch', async () => {
+  it('should repeatedly replay a recorded step branch without looking ahead through Date', async () => {
     const ops: Promise<any>[] = [];
     const workflowRunId = 'wrun_123';
     const workflowRun: WorkflowRun = {
@@ -473,8 +473,7 @@ describe('runWorkflow', () => {
       },
     ];
 
-    const result = await runWorkflow(
-      `const start = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("startQueuedLogicalRunStep");
+    const workflowCode = `const start = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("startQueuedLogicalRunStep");
        const drain = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("drainLogicalRunRuntimeStep");
        const settle = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("settleQueueActionStep");
        async function workflow() {
@@ -483,20 +482,45 @@ describe('runWorkflow', () => {
            return await drain();
          }
          return await settle();
-       }${getWorkflowTransformCode('workflow')}`,
-      workflowRun,
-      events,
-      noEncryptionKey
-    );
+       }${getWorkflowTransformCode('workflow')}`;
 
-    expect(
-      await hydrateWorkflowReturnValue(
-        result as any,
-        workflowRunId,
-        noEncryptionKey,
-        ops
-      )
-    ).toBe('drained');
+    const replayCount = 200;
+    const outcomes = await Promise.all(
+      Array.from({ length: replayCount }, async () => {
+        try {
+          const result = await runWorkflow(
+            workflowCode,
+            workflowRun,
+            events,
+            noEncryptionKey
+          );
+          const value = await hydrateWorkflowReturnValue(
+            result as any,
+            workflowRunId,
+            noEncryptionKey,
+            ops
+          );
+          return value === 'drained'
+            ? 'drained'
+            : `unexpected replay result: ${String(value)}`;
+        } catch (error) {
+          return error instanceof Error ? error.message : String(error);
+        }
+      })
+    );
+    const failures = outcomes.filter((outcome) => outcome !== 'drained');
+
+    expect({
+      replayCount,
+      drainedCount: outcomes.length - failures.length,
+      failureCount: failures.length,
+      firstFailure: failures[0],
+    }).toEqual({
+      replayCount,
+      drainedCount: replayCount,
+      failureCount: 0,
+      firstFailure: undefined,
+    });
   });
 
   // TODO: Date.now determinism is currently broken in the workflow!!

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -125,6 +125,9 @@ export async function runWorkflow(
     const promiseQueueHolder = { current: Promise.resolve() };
 
     const eventsConsumer = new EventsConsumer(events, {
+      onConsumedEvent: (event) => {
+        updateTimestamp(+event.createdAt);
+      },
       onUnconsumedEvent: (event) => {
         workflowDiscontinuation.reject(
           new CorruptedEventLogError(
@@ -155,16 +158,6 @@ export async function runWorkflow(
       pendingDeliveries: 0,
       pendingDeliveryBarriers: new Map(),
     };
-
-    // Subscribe to the events log to update the timestamp in the vm context
-    workflowContext.eventsConsumer.subscribe((event) => {
-      const createdAt = event?.createdAt;
-      if (createdAt) {
-        updateTimestamp(+createdAt);
-      }
-      // Never consume events - this is only a passive subscriber
-      return EventConsumerResult.NotConsumed;
-    });
 
     // Consume run lifecycle events - these are structural events that don't
     // need special handling in the workflow, but must be consumed to advance


### PR DESCRIPTION
## Summary

- advance deterministic workflow time only after an event is consumed
- add a 200-invocation engine replay regression for the `drainLogicalRunRuntimeStep` versus `settleQueueActionStep` corrupted-event-log shape
- issue a patch changeset for `@workflow/core`

## Runtime cause reproduced locally

`runWorkflow()` updates the VM timestamp from a passive event subscriber before the event is consumed. During replay, after `step_completed(startQueuedLogicalRunStep)` resolves, `EventsConsumer` can inspect the following recorded `step_created(drainLogicalRunRuntimeStep)` before workflow code resumes. If workflow code selects the next operation using `Date.now()` between those timestamps, it observes future logical time and invokes `settleQueueActionStep`, causing the recorded `drainLogicalRunRuntimeStep` event to mismatch.

This is distinct from #2171: in the observed production failure the mismatching stored drain step predates the run's first `hook_received` and first `wait_created` record, and the failing run used `@workflow/core` 4.2.6, which includes #2171.

The customer workflow source is not available in this investigation, so this proves a runtime path that creates the exact observed mismatch from the recorded event prefix; confirming that the customer's branch directly depends on logical time still requires its source or decrypted branch inputs.

## Production evidence

Customer run `wrun_01KT2B665GDZR0TB7J21GY1PJX` failed with:

```text
Corrupted event log: step event step_created for step_01KT2B66B8HWTA3ZVCDZFYGC9A belongs to "step//./src/workflows/runtime-workflows//drainLogicalRunRuntimeStep", but the current step consumer is "step//./src/workflows/runtime-workflows//settleQueueActionStep"
```

Its persisted event prefix is:

```text
19:40:17.121 step_completed  startQueuedLogicalRunStep
19:40:17.906 step_created    drainLogicalRunRuntimeStep
19:40:18.790 step_completed  drainLogicalRunRuntimeStep
19:40:23.414 hook_received   ...
19:40:26.756 wait_created    ...
```

Strongly consistent event reads were already active in `workflow-server` for the run, and retained request logs identify the same application deployment throughout.

## Fixed-history replay hammer

The regression invokes the real `runWorkflow()` engine 200 times against one fixed recorded history whose second stored operation is `drainLogicalRunRuntimeStep`, while the alternate time-selected path invokes `settleQueueActionStep`.

With the previous passive clock subscriber restored in a disposable worktree, it reports:

```text
replayCount: 200
drainedCount: 0
failureCount: 200
firstFailure: Corrupted event log: step event step_created ... belongs to "drainLogicalRunRuntimeStep", but the current step consumer is "settleQueueActionStep"
```

This minimized shape is deterministic under the old runtime: it does not require hooks, waits, DynamoDB, deployment skew, or production hammering to reproduce.

After this fix:

```sh
pnpm --filter @workflow/core exec cross-env WORKFLOW_TARGET_WORLD=local vitest run src/workflow.test.ts -t 'should repeatedly replay a recorded step branch without looking ahead through Date'
pnpm --filter @workflow/core exec cross-env WORKFLOW_TARGET_WORLD=local vitest run src/workflow.test.ts src/events-consumer.test.ts src/hook-sleep-interaction.test.ts src/runtime/wait-completion-replay.test.ts
pnpm --filter @workflow/core typecheck
```

passes, including all 200 replay invocations and `134` affected suite tests.

`pnpm --filter @workflow/core test` still exposes 7 failures in untouched `src/serialization.test.ts` around `DOMException` serialization under local Node v22.18.0; those failures are outside this timestamp path.
