### PR TITLE
Reduce width on trace viewer detail pane

### DIFF
--- a/.changeset/narrow-trace-detail-pane.md
+++ b/.changeset/narrow-trace-detail-pane.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Reduce the new trace viewer detail pane width.

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -562,7 +562,7 @@ function NewTraceViewerContent({
     <div
       data-pane="pane-root"
       data-has-detail={activeSpan ? '' : undefined}
-      className="grid w-full h-full max-h-full grid-cols-[minmax(100px,1fr)] data-[has-detail]:grid-cols-[minmax(100px,1fr)_clamp(280px,420px,100%)]"
+      className="grid w-full h-full max-h-full grid-cols-[minmax(100px,1fr)] data-[has-detail]:grid-cols-[minmax(100px,1fr)_clamp(280px,360px,100%)]"
     >
       <div
         id="trace-parent"


### PR DESCRIPTION
Making detail pane smaller, took up a lot of space of the timeline. 