### PR TITLE
fix(core): advance workflow clock only for consumed events on main

### DIFF
--- a/.changeset/replay-consumed-event-clock.md
+++ b/.changeset/replay-consumed-event-clock.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Prevent replayed workflows from advancing their deterministic clock when a future event is inspected before its matching operation is invoked.

--- a/packages/core/src/events-consumer.test.ts
+++ b/packages/core/src/events-consumer.test.ts
@@ -285,6 +285,32 @@ describe('EventsConsumer', () => {
       expect(normalCallback).toHaveBeenCalledWith(event);
     });
 
+    it('should continue processing when onConsumedEvent throws', async () => {
+      const event1 = createMockEvent({ id: 'event-1' });
+      const event2 = createMockEvent({ id: 'event-2' });
+      const onConsumedEvent = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Observer error');
+        })
+        .mockImplementation(() => undefined);
+      const consumer = new EventsConsumer([event1, event2], {
+        ...defaultOptions,
+        onConsumedEvent,
+      });
+      const callback1 = vi.fn().mockReturnValue(EventConsumerResult.Finished);
+      const callback2 = vi.fn().mockReturnValue(EventConsumerResult.Finished);
+
+      consumer.subscribe(callback1);
+      consumer.subscribe(callback2);
+      await waitForNextTick();
+      await waitForNextTick();
+
+      expect(onConsumedEvent).toHaveBeenNthCalledWith(1, event1);
+      expect(onConsumedEvent).toHaveBeenNthCalledWith(2, event2);
+      expect(consumer.eventIndex).toBe(2);
+    });
+
     it('should handle callback removal during iteration', async () => {
       const event = createMockEvent();
       const consumer = new EventsConsumer([event], defaultOptions);

--- a/packages/core/src/events-consumer.ts
+++ b/packages/core/src/events-consumer.ts
@@ -28,6 +28,12 @@ type EventConsumerCallback = (event: Event | null) => EventConsumerResult;
 
 export interface EventsConsumerOptions {
   /**
+   * Callback invoked after an event has been consumed. Consumers such as the
+   * deterministic workflow clock must not observe events that are merely
+   * inspected while waiting for user code to subscribe to the next operation.
+   */
+  onConsumedEvent?: (event: Event) => void;
+  /**
    * Callback invoked when a non-null event cannot be consumed by any registered
    * callback, indicating an orphaned or invalid event in the event log. The
    * check is deferred until after the promise queue has drained, ensuring that
@@ -48,6 +54,7 @@ export class EventsConsumer {
   eventIndex: number;
   readonly events: Event[] = [];
   readonly callbacks: EventConsumerCallback[] = [];
+  private onConsumedEvent?: (event: Event) => void;
   private onUnconsumedEvent: (event: Event) => void;
   private getPromiseQueue: () => Promise<void>;
   private pendingUnconsumedCheck: Promise<void> | null = null;
@@ -57,6 +64,7 @@ export class EventsConsumer {
   constructor(events: Event[], options: EventsConsumerOptions) {
     this.events = events;
     this.eventIndex = 0;
+    this.onConsumedEvent = options.onConsumedEvent;
     this.onUnconsumedEvent = options.onUnconsumedEvent;
     this.getPromiseQueue = options.getPromiseQueue;
   }
@@ -86,6 +94,19 @@ export class EventsConsumer {
     process.nextTick(this.consume);
   }
 
+  private notifyConsumedEvent(event: Event) {
+    if (!this.onConsumedEvent) {
+      return;
+    }
+    try {
+      this.onConsumedEvent(event);
+    } catch (error) {
+      eventsLogger.error('onConsumedEvent callback threw an error', {
+        error,
+      });
+    }
+  }
+
   private consume = () => {
     const currentEvent = this.events[this.eventIndex] ?? null;
     for (let i = 0; i < this.callbacks.length; i++) {
@@ -100,6 +121,9 @@ export class EventsConsumer {
         handled === EventConsumerResult.Consumed ||
         handled === EventConsumerResult.Finished
       ) {
+        if (currentEvent !== null) {
+          this.notifyConsumedEvent(currentEvent);
+        }
         // consumer handled this event, so increase the event index
         this.eventIndex++;
 

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -382,8 +382,8 @@ describe('runWorkflow', () => {
     );
     // Timestamps:
     // - Initial: 0s (from startedAt)
-    // - After step 1 completes (at 2s), timestamp advances to step2_created (2.5s)
-    // - After step 2 completes (at 4s), timestamp advances to step3_created (4.5s)
+    // - After step 1 completes, timestamp advances to the consumed completion at 2s
+    // - After step 2 completes, timestamp advances to the consumed completion at 4s
     // - After step 3 completes: 6s
     expect(
       await hydrateWorkflowReturnValue(
@@ -394,10 +394,173 @@ describe('runWorkflow', () => {
       )
     ).toEqual([
       new Date('2024-01-01T00:00:00.000Z'),
-      1704067202500, // 2.5s (step2_created timestamp)
-      1704067204500, // 4.5s (step3_created timestamp)
+      1704067202000,
+      1704067204000,
       new Date('2024-01-01T00:00:06.000Z'),
     ]);
+  });
+
+  it('should repeatedly replay a recorded step branch without looking ahead through Date', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRunId = 'wrun_123';
+    const workflowRun: WorkflowRun = {
+      runId: workflowRunId,
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        workflowRunId,
+        noEncryptionKey,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+
+    const startStepId = 'step_01HK153X00SP082GGA0AAJC6PJ';
+    const branchStepId = 'step_01HK153X00SP082GGA0AAJC6PK';
+    const events: Event[] = [
+      {
+        eventId: 'event-run-created',
+        runId: workflowRunId,
+        eventType: 'run_created',
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      {
+        eventId: 'event-run-started',
+        runId: workflowRunId,
+        eventType: 'run_started',
+        createdAt: new Date('2024-01-01T00:00:00.500Z'),
+      },
+      {
+        eventId: 'event-start-created',
+        runId: workflowRunId,
+        eventType: 'step_created',
+        correlationId: startStepId,
+        eventData: { stepName: 'startQueuedLogicalRunStep' },
+        createdAt: new Date('2024-01-01T00:00:01.000Z'),
+      },
+      {
+        eventId: 'event-start-started',
+        runId: workflowRunId,
+        eventType: 'step_started',
+        correlationId: startStepId,
+        eventData: { stepName: 'startQueuedLogicalRunStep' },
+        createdAt: new Date('2024-01-01T00:00:01.500Z'),
+      },
+      {
+        eventId: 'event-start-completed',
+        runId: workflowRunId,
+        eventType: 'step_completed',
+        correlationId: startStepId,
+        eventData: {
+          stepName: 'startQueuedLogicalRunStep',
+          result: await dehydrateStepReturnValue(
+            'started',
+            workflowRunId,
+            noEncryptionKey,
+            ops
+          ),
+        },
+        createdAt: new Date('2024-01-01T00:00:02.000Z'),
+      },
+      {
+        eventId: 'event-drain-created',
+        runId: workflowRunId,
+        eventType: 'step_created',
+        correlationId: branchStepId,
+        eventData: { stepName: 'drainLogicalRunRuntimeStep' },
+        createdAt: new Date('2024-01-01T00:00:02.500Z'),
+      },
+      {
+        eventId: 'event-drain-started',
+        runId: workflowRunId,
+        eventType: 'step_started',
+        correlationId: branchStepId,
+        eventData: { stepName: 'drainLogicalRunRuntimeStep' },
+        createdAt: new Date('2024-01-01T00:00:03.000Z'),
+      },
+      {
+        eventId: 'event-drain-completed',
+        runId: workflowRunId,
+        eventType: 'step_completed',
+        correlationId: branchStepId,
+        eventData: {
+          stepName: 'drainLogicalRunRuntimeStep',
+          result: await dehydrateStepReturnValue(
+            'drained',
+            workflowRunId,
+            noEncryptionKey,
+            ops
+          ),
+        },
+        createdAt: new Date('2024-01-01T00:00:03.500Z'),
+      },
+    ];
+
+    const workflowCode = `const start = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("startQueuedLogicalRunStep");
+       const drain = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("drainLogicalRunRuntimeStep");
+       const settle = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("settleQueueActionStep");
+       async function workflow() {
+         await start();
+         if (Date.now() < 1704067202250) {
+           return await drain();
+         }
+         return await settle();
+       }${getWorkflowTransformCode('workflow')}`;
+
+    const replayCount = 200;
+    const maxConcurrentReplays = 8;
+    const replay = async () => {
+      try {
+        const result = await runWorkflow(
+          workflowCode,
+          workflowRun,
+          events,
+          noEncryptionKey
+        );
+        const value = await hydrateWorkflowReturnValue(
+          result as any,
+          workflowRunId,
+          noEncryptionKey,
+          ops
+        );
+        return value === 'drained'
+          ? 'drained'
+          : `unexpected replay result: ${String(value)}`;
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    };
+    const outcomes: string[] = [];
+    for (
+      let replayIndex = 0;
+      replayIndex < replayCount;
+      replayIndex += maxConcurrentReplays
+    ) {
+      const batchSize = Math.min(
+        maxConcurrentReplays,
+        replayCount - replayIndex
+      );
+      outcomes.push(
+        ...(await Promise.all(Array.from({ length: batchSize }, replay)))
+      );
+    }
+    const failures = outcomes.filter((outcome) => outcome !== 'drained');
+
+    expect({
+      replayCount,
+      drainedCount: outcomes.length - failures.length,
+      failureCount: failures.length,
+      firstFailure: failures[0],
+    }).toEqual({
+      replayCount,
+      drainedCount: replayCount,
+      failureCount: 0,
+      firstFailure: undefined,
+    });
   });
 
   // TODO: Date.now determinism is currently broken in the workflow!!

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -168,6 +168,9 @@ export async function runWorkflow(
     const promiseQueueHolder = { current: Promise.resolve() };
 
     const eventsConsumer = new EventsConsumer(events, {
+      onConsumedEvent: (event) => {
+        updateTimestamp(+event.createdAt);
+      },
       onUnconsumedEvent: (event) => {
         workflowDiscontinuation.reject(
           new CorruptedEventLogError(
@@ -197,16 +200,6 @@ export async function runWorkflow(
       },
       pendingDeliveries: 0,
     };
-
-    // Subscribe to the events log to update the timestamp in the vm context
-    workflowContext.eventsConsumer.subscribe((event) => {
-      const createdAt = event?.createdAt;
-      if (createdAt) {
-        updateTimestamp(+createdAt);
-      }
-      // Never consume events - this is only a passive subscriber
-      return EventConsumerResult.NotConsumed;
-    });
 
     // Consume run lifecycle events - these are structural events that don't
     // need special handling in the workflow, but must be consumed to advance


### PR DESCRIPTION
## Summary

Forward-port the consumed-event workflow clock fix that shipped to `stable` in #2206 onto `main`.

- move deterministic clock advancement from a passive event-log subscriber to `EventsConsumer.onConsumedEvent`
- avoid observing future events that have only been inspected while workflow code has not yet subscribed to consume them
- carry over the event-consumer and replay-branch regression tests from the shipped stable fix

## Context

#2206 was merged directly to `stable` while investigating corrupted event logs from hook/sleep replay races. `main` still had the passive timestamp subscriber shape, so it needs the same fix to keep the runtime lines aligned.

Stable merge: #2206 (`1e32d05758d590134f04f82ea41ab9add96104d5`)

## Validation

- `corepack pnpm exec turbo run build --filter='@workflow/core...'`
- `corepack pnpm --filter @workflow/core typecheck`
- `corepack pnpm --filter @workflow/core exec vitest run src/events-consumer.test.ts src/workflow.test.ts` (99 tests passed)
