### PR TITLE
Retry replay divergence before failing event logs

### DIFF
--- a/.changeset/replay-divergence-redelivery.md
+++ b/.changeset/replay-divergence-redelivery.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/errors': patch
+'@workflow/world': patch
+---
+
+Retry transient workflow replay divergence before classifying repeated divergence as a corrupted event log.

--- a/docs/content/docs/v4/errors/corrupted-event-log.mdx
+++ b/docs/content/docs/v4/errors/corrupted-event-log.mdx
@@ -9,21 +9,21 @@ related:
   - /docs/foundations/errors-and-retries
 ---
 
-This error occurs when the Workflow runtime encounters an event in the event log that no registered consumer can process. This means the event log is in an invalid state — typically due to duplicate or orphaned events.
+This error occurs when the Workflow runtime repeatedly cannot replay events in the event log. This usually means the event log is in an invalid state, such as duplicate or orphaned events, or that a runtime determinism bug persists across retry attempts.
 
-This is a **workflow-level fatal error**. It cannot be caught or handled inside your workflow code. A corrupted event log immediately fails the entire run without executing any more user code. The run must be retried from outside the workflow.
+This is a **workflow-level fatal error**. It cannot be caught or handled inside your workflow code. The runtime first retries transient replay divergence automatically; it marks the run as failed with this error only after replay still cannot recover.
 
 ## Error Message
 
 ```
-Unconsumed event in event log: eventType=<type>, correlationId=<id>, eventId=<id>. This indicates a corrupted or invalid event log.
+Workflow replay diverged <divergenceCount> times after <maxRecoveryReplays> recovery replays; latest divergent event was <eventId>. Last divergence: <details>
 ```
 
 ## Why This Happens
 
 Workflows persist their progress as an ordered event log. During replay, the runtime processes each event in sequence — every event must be consumed by a matching callback (e.g., a step or sleep waiting for its result). When an event has no matching consumer, the runtime cannot advance past it, which would block all subsequent events and hang the workflow indefinitely.
 
-Instead of silently hanging, the runtime raises a `WorkflowRuntimeError` to fail the workflow fast and surface the problem.
+Instead of silently hanging, the runtime retries a divergent replay before failing the workflow and surfacing this terminal error.
 
 Common scenarios that produce this error:
 
@@ -45,7 +45,7 @@ npm install workflow@latest
 
 ### 2. Retry the failed run
 
-Since this is a fatal error, the run is automatically marked as `failed`. You can re-run it using the **Re-run** button in the Workflow Dashboard.
+If this error is displayed, automatic replay recovery has already been exhausted and the run has been marked as `failed`. You can re-run it using the **Re-run** button in the Workflow Dashboard.
 
 ### 3. Report the issue
 

--- a/docs/content/docs/v4/errors/index.mdx
+++ b/docs/content/docs/v4/errors/index.mdx
@@ -37,6 +37,9 @@ Fix common mistakes when creating and executing workflows in the **Workflow SDK*
     <Card href="/docs/errors/corrupted-event-log" title="corrupted-event-log">
         Learn how to handle corrupted or invalid event logs.
     </Card>
+    <Card href="/docs/errors/replay-divergence" title="replay-divergence">
+        Learn how workflow replay divergence is recovered automatically.
+    </Card>
     <Card href="/docs/errors/step-not-registered" title="step-not-registered">
         Resolve step not registered errors caused by deployment mismatches.
     </Card>

--- a/docs/content/docs/v4/errors/replay-divergence.mdx
+++ b/docs/content/docs/v4/errors/replay-divergence.mdx
@@ -1,0 +1,27 @@
+---
+title: replay-divergence
+description: A workflow replay temporarily followed a path that did not match its recorded events.
+type: troubleshooting
+summary: Understand automatic recovery when a workflow replay diverges from its event history.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/errors/corrupted-event-log
+  - /docs/foundations/errors-and-retries
+---
+
+A replay divergence occurs when one invocation of a workflow cannot consume the durable event history using the promises, hooks, sleeps, or steps it created during replay.
+
+This is an SDK/runtime signal, not an error thrown by your workflow code. It is not catchable inside a workflow function.
+
+## Automatic Recovery
+
+A single divergent replay does not prove that persisted history is corrupted. For example, asynchronous delivery ordering may cause one invocation to follow the wrong side of a race while another replay can follow the recorded history correctly.
+
+The runtime automatically queues another replay when an invocation reports `REPLAY_DIVERGENCE`. No terminal `run_failed` event is written during these recovery attempts.
+
+If recovery replays continue to diverge after the retry budget is exhausted, the runtime marks the run as failed with `CORRUPTED_EVENT_LOG` and records the latest divergent event for diagnosis.
+
+## What To Do
+
+Most replay divergence signals recover without action. If a run ultimately fails with `CORRUPTED_EVENT_LOG`, update to the latest `workflow` package and report the run ID and error details if the failure persists.

--- a/docs/content/docs/v5/errors/corrupted-event-log.mdx
+++ b/docs/content/docs/v5/errors/corrupted-event-log.mdx
@@ -9,21 +9,21 @@ related:
   - /docs/foundations/errors-and-retries
 ---
 
-This error occurs when the Workflow runtime encounters an event in the event log that no registered consumer can process. This means the event log is in an invalid state — typically due to duplicate or orphaned events.
+This error occurs when the Workflow runtime repeatedly cannot replay events in the event log. This usually means the event log is in an invalid state, such as duplicate or orphaned events, or that a runtime determinism bug persists across retry attempts.
 
-This is a **workflow-level fatal error**. It cannot be caught or handled inside your workflow code. A corrupted event log immediately fails the entire run without executing any more user code. The run must be retried from outside the workflow.
+This is a **workflow-level fatal error**. It cannot be caught or handled inside your workflow code. The runtime first retries transient replay divergence automatically; it marks the run as failed with this error only after replay still cannot recover.
 
 ## Error Message
 
 ```
-Unconsumed event in event log: eventType=<type>, correlationId=<id>, eventId=<id>. This indicates a corrupted or invalid event log.
+Workflow replay diverged <n> times after automatic recovery replays; latest divergent event was <eventId>. Last divergence: <details>
 ```
 
 ## Why This Happens
 
 Workflows persist their progress as an ordered event log. During replay, the runtime processes each event in sequence — every event must be consumed by a matching callback (e.g., a step or sleep waiting for its result). When an event has no matching consumer, the runtime cannot advance past it, which would block all subsequent events and hang the workflow indefinitely.
 
-Instead of silently hanging, the runtime raises a `WorkflowRuntimeError` to fail the workflow fast and surface the problem.
+Instead of silently hanging, the runtime retries a divergent replay before failing the workflow and surfacing this terminal error.
 
 Common scenarios that produce this error:
 
@@ -45,7 +45,7 @@ npm install workflow@latest
 
 ### 2. Retry the failed run
 
-Since this is a fatal error, the run is automatically marked as `failed`. You can re-run it using the **Re-run** button in the Workflow Dashboard.
+If this error is displayed, automatic replay recovery has already been exhausted and the run has been marked as `failed`. You can re-run it using the **Re-run** button in the Workflow Dashboard.
 
 ### 3. Report the issue
 

--- a/docs/content/docs/v5/errors/corrupted-event-log.mdx
+++ b/docs/content/docs/v5/errors/corrupted-event-log.mdx
@@ -16,7 +16,7 @@ This is a **workflow-level fatal error**. It cannot be caught or handled inside 
 ## Error Message
 
 ```
-Workflow replay diverged <n> times after automatic recovery replays; latest divergent event was <eventId>. Last divergence: <details>
+Workflow replay diverged <divergenceCount> times after <maxRecoveryReplays> recovery replays; latest divergent event was <eventId>. Last divergence: <details>
 ```
 
 ## Why This Happens

--- a/docs/content/docs/v5/errors/index.mdx
+++ b/docs/content/docs/v5/errors/index.mdx
@@ -37,6 +37,9 @@ Fix common mistakes when creating and executing workflows in the **Workflow SDK*
     <Card href="/docs/errors/corrupted-event-log" title="corrupted-event-log">
         Learn how to handle corrupted or invalid event logs.
     </Card>
+    <Card href="/docs/errors/replay-divergence" title="replay-divergence">
+        Learn how workflow replay divergence is recovered automatically.
+    </Card>
     <Card href="/docs/errors/step-not-registered" title="step-not-registered">
         Resolve step not registered errors caused by deployment mismatches.
     </Card>

--- a/docs/content/docs/v5/errors/replay-divergence.mdx
+++ b/docs/content/docs/v5/errors/replay-divergence.mdx
@@ -1,0 +1,27 @@
+---
+title: replay-divergence
+description: A workflow replay temporarily followed a path that did not match its recorded events.
+type: troubleshooting
+summary: Understand automatic recovery when a workflow replay diverges from its event history.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/errors/corrupted-event-log
+  - /docs/foundations/errors-and-retries
+---
+
+A replay divergence occurs when one invocation of a workflow cannot consume the durable event history using the promises, hooks, sleeps, or steps it created during replay.
+
+This is an SDK/runtime signal, not an error thrown by your workflow code. It is not catchable inside a workflow function.
+
+## Automatic Recovery
+
+A single divergent replay does not prove that persisted history is corrupted. For example, asynchronous delivery ordering may cause one invocation to follow the wrong side of a race while another replay can follow the recorded history correctly.
+
+The runtime automatically queues another replay when an invocation reports `REPLAY_DIVERGENCE`. No terminal `run_failed` event is written during these recovery attempts.
+
+If recovery replays continue to diverge after the retry budget is exhausted, the runtime marks the run as failed with `CORRUPTED_EVENT_LOG` and records the latest divergent event for diagnosis.
+
+## What To Do
+
+Most replay divergence signals recover without action. If a run ultimately fails with `CORRUPTED_EVENT_LOG`, update to the latest `workflow` package and report the run ID and error details if the failure persists.

--- a/packages/core/src/abort-controller.test.ts
+++ b/packages/core/src/abort-controller.test.ts
@@ -6,7 +6,7 @@
  * (for real-time step propagation).
  */
 
-import { CorruptedEventLogError } from '@workflow/errors';
+import { ReplayDivergenceError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
@@ -121,7 +121,7 @@ describe('AbortController in workflow VM', () => {
       expect(controller.signal.aborted).toBe(true);
     });
 
-    it('reports a CorruptedEventLogError when abort hook_received token mismatches the controller', async () => {
+    it('reports a ReplayDivergenceError when abort hook_received token mismatches the controller', async () => {
       ctx = setupWorkflowContext([]);
       const ProbeAbortController = createCreateAbortController(ctx);
       new ProbeAbortController();
@@ -160,7 +160,8 @@ describe('AbortController in workflow VM', () => {
       new AbortController();
 
       const workflowError = await errorReceived.promise;
-      expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+      expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
+      expect((workflowError as ReplayDivergenceError).eventId).toBe('evnt_0');
       expect(workflowError?.message).toContain('hook_received');
       expect(workflowError?.message).toContain('wrong-token');
       expect(workflowError?.message).toContain(probeHookItem.token);

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -1,6 +1,7 @@
 import {
   CorruptedEventLogError,
   HookConflictError,
+  ReplayDivergenceError,
   RUN_ERROR_CODES,
   RuntimeDecryptionError,
   WorkflowNotRegisteredError,
@@ -15,6 +16,16 @@ describe('classifyRunError', () => {
     expect(
       classifyRunError(new CorruptedEventLogError('corrupted event log'))
     ).toBe(RUN_ERROR_CODES.CORRUPTED_EVENT_LOG);
+  });
+
+  it('classifies ReplayDivergenceError as REPLAY_DIVERGENCE', () => {
+    expect(
+      classifyRunError(
+        new ReplayDivergenceError('replay took another path', {
+          eventId: 'event-1',
+        })
+      )
+    ).toBe(RUN_ERROR_CODES.REPLAY_DIVERGENCE);
   });
 
   it('classifies WorkflowRuntimeError as RUNTIME_ERROR', () => {

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -1,5 +1,6 @@
 import {
   CorruptedEventLogError,
+  ReplayDivergenceError,
   RUN_ERROR_CODES,
   type RunErrorCode,
   RuntimeDecryptionError,
@@ -67,6 +68,10 @@ export function isWorldContractError(err: unknown): err is WorkflowWorldError {
 }
 
 export function classifyRunError(err: unknown): RunErrorCode {
+  if (ReplayDivergenceError.is(err)) {
+    return RUN_ERROR_CODES.REPLAY_DIVERGENCE;
+  }
+
   if (CorruptedEventLogError.is(err)) {
     return RUN_ERROR_CODES.CORRUPTED_EVENT_LOG;
   }

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -5,6 +5,7 @@ import {
   type WorkflowRun,
 } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { REPLAY_DIVERGENCE_MAX_RETRIES } from './runtime/constants.js';
 import { setWorld } from './runtime/world.js';
 import { workflowEntrypoint } from './runtime.js';
 import {
@@ -19,9 +20,15 @@ vi.mock('@vercel/functions', () => ({
 async function runWorkflowHandlerWithEvents(
   workflowCode: string,
   workflowRun: WorkflowRun,
-  events: Event[]
+  events: Event[],
+  options: {
+    attempt?: number;
+    createdEvents?: unknown[];
+    queuedMessages?: unknown[];
+    replayDivergence?: { eventId: string; count: number };
+  } = {}
 ) {
-  const createdEvents: unknown[] = [];
+  const createdEvents = options.createdEvents ?? [];
   const eventsCreate = vi.fn(async (_runId: string, data: any) => {
     createdEvents.push(data);
 
@@ -54,10 +61,11 @@ async function runWorkflowHandlerWithEvents(
             {
               runId: workflowRun.runId,
               requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+              replayDivergence: options.replayDivergence,
             },
             {
               requestId: 'req_test',
-              attempt: 1,
+              attempt: options.attempt ?? 1,
               queueName: '__wkf_workflow_workflow',
               messageId: 'msg_test',
             }
@@ -77,7 +85,10 @@ async function runWorkflowHandlerWithEvents(
     runs: {
       get: vi.fn(async () => workflowRun),
     },
-    queue: vi.fn(),
+    queue: vi.fn(async (_queueName: string, message: unknown) => {
+      options.queuedMessages?.push(message);
+      return { messageId: null };
+    }),
     getEncryptionKeyForRun: vi.fn(async () => undefined),
   } as any);
 
@@ -356,7 +367,7 @@ describe('workflowEntrypoint replay guards', () => {
     );
   });
 
-  it('records run_failed when a committed wait_completed targets the wrong wait', async () => {
+  it('redrives an initial replay divergence and fails after the recovery budget', async () => {
     const ops: Promise<any>[] = [];
     const workflowRun: WorkflowRun = {
       runId: 'wrun_runtime_wait_guard',
@@ -397,17 +408,51 @@ describe('workflowEntrypoint replay guards', () => {
       },
     ];
 
-    const createdEvents = await runWorkflowHandlerWithEvents(
+    const initialAttemptEvents: unknown[] = [];
+    const queuedMessages: unknown[] = [];
+    await runWorkflowHandlerWithEvents(
       `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
       async function workflow() {
         await sleep('5s');
         return 'done';
       }${getWorkflowTransformCode('workflow')}`,
       workflowRun,
-      events
+      events,
+      {
+        createdEvents: initialAttemptEvents,
+        queuedMessages,
+      }
     );
 
-    expect(createdEvents).toContainEqual(
+    expect(initialAttemptEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
+    );
+    expect(queuedMessages).toContainEqual(
+      expect.objectContaining({
+        replayDivergence: {
+          eventId: 'event-0',
+          count: 1,
+        },
+      })
+    );
+
+    const terminalAttemptEvents = await runWorkflowHandlerWithEvents(
+      `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+      async function workflow() {
+        await sleep('5s');
+        return 'done';
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events,
+      {
+        replayDivergence: {
+          eventId: 'different-event',
+          count: REPLAY_DIVERGENCE_MAX_RETRIES,
+        },
+      }
+    );
+
+    expect(terminalAttemptEvents).toContainEqual(
       expect.objectContaining({
         eventType: 'run_failed',
         eventData: expect.objectContaining({
@@ -417,7 +462,7 @@ describe('workflowEntrypoint replay guards', () => {
     );
   });
 
-  it('records run_failed when a committed hook_received targets the wrong hook', async () => {
+  it('redrives an initial replay divergence for a mismatched recorded hook', async () => {
     const ops: Promise<any>[] = [];
     const workflowRun: WorkflowRun = {
       runId: 'wrun_runtime_hook_guard',
@@ -454,7 +499,9 @@ describe('workflowEntrypoint replay guards', () => {
       },
     ];
 
-    const createdEvents = await runWorkflowHandlerWithEvents(
+    const createdEvents: unknown[] = [];
+    const queuedMessages: unknown[] = [];
+    await runWorkflowHandlerWithEvents(
       `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       async function workflow() {
         const hook = createHook({ token: 'expected-token' });
@@ -462,15 +509,16 @@ describe('workflowEntrypoint replay guards', () => {
         return payload.message;
       }${getWorkflowTransformCode('workflow')}`,
       workflowRun,
-      events
+      events,
+      { createdEvents, queuedMessages }
     );
 
-    expect(createdEvents).toContainEqual(
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
+    );
+    expect(queuedMessages).toContainEqual(
       expect.objectContaining({
-        eventType: 'run_failed',
-        eventData: expect.objectContaining({
-          errorCode: RUN_ERROR_CODES.CORRUPTED_EVENT_LOG,
-        }),
+        replayDivergence: { eventId: 'event-0', count: 1 },
       })
     );
   });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,7 +1,9 @@
 import { types } from 'node:util';
 import {
+  CorruptedEventLogError,
   EntityConflictError,
   FatalError,
+  ReplayDivergenceError,
   RUN_ERROR_CODES,
   type RunErrorCode,
   RunExpiredError,
@@ -19,7 +21,10 @@ import { classifyRunError, isWorldContractError } from './classify-error.js';
 import { describeError } from './describe-error.js';
 import { WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
-import { MAX_QUEUE_DELIVERIES } from './runtime/constants.js';
+import {
+  MAX_QUEUE_DELIVERIES,
+  REPLAY_DIVERGENCE_MAX_RETRIES,
+} from './runtime/constants.js';
 import {
   getQueueOverhead,
   getWorkflowQueueName,
@@ -213,6 +218,7 @@ export function workflowEntrypoint(
           requestedAt,
           stepId: incomingStepId,
           stepName: incomingStepName,
+          replayDivergence,
           runInput,
         } = WorkflowInvokePayloadSchema.parse(message_);
         const { requestId } = metadata;
@@ -1152,18 +1158,62 @@ export function workflowEntrypoint(
                           // Loop back to replay which will re-evaluate
                         }
                       } else {
-                        // User code error from runWorkflow — create run_failed.
-                        if (err instanceof Error) {
-                          span?.recordException?.(err);
+                        let terminalError = err;
+                        if (ReplayDivergenceError.is(err)) {
+                          const divergenceCount =
+                            (replayDivergence?.count ?? 0) + 1;
+
+                          if (
+                            divergenceCount <= REPLAY_DIVERGENCE_MAX_RETRIES
+                          ) {
+                            runLogger.warn(
+                              'Workflow replay diverged; queueing a recovery replay before declaring the event log corrupted',
+                              {
+                                errorCode: RUN_ERROR_CODES.REPLAY_DIVERGENCE,
+                                divergenceEventId: err.eventId,
+                                priorDivergenceEventId:
+                                  replayDivergence?.eventId,
+                                divergenceCount,
+                                deliveryAttempt: metadata.attempt,
+                                maxRecoveryReplays:
+                                  REPLAY_DIVERGENCE_MAX_RETRIES,
+                                errorMessage: err.message,
+                              }
+                            );
+                            await queueMessage(
+                              world,
+                              getWorkflowQueueName(workflowName),
+                              {
+                                runId,
+                                traceCarrier: await serializeTraceCarrier(),
+                                requestedAt: new Date(),
+                                replayDivergence: {
+                                  eventId: err.eventId,
+                                  count: divergenceCount,
+                                },
+                              }
+                            );
+                            return;
+                          }
+
+                          terminalError = new CorruptedEventLogError(
+                            `Workflow replay diverged ${divergenceCount} times after ${REPLAY_DIVERGENCE_MAX_RETRIES} recovery replays; latest divergent event was ${err.eventId}. Last divergence: ${err.message}`,
+                            { cause: err }
+                          );
+                        }
+
+                        // User code errors and terminal runtime errors fail the run.
+                        if (terminalError instanceof Error) {
+                          span?.recordException?.(terminalError);
                         }
 
                         const normalizedError =
-                          await normalizeUnknownError(err);
+                          await normalizeUnknownError(terminalError);
                         const errorName =
-                          normalizedError.name || getErrorName(err);
+                          normalizedError.name || getErrorName(terminalError);
                         const errorMessage = normalizedError.message;
                         let errorStack =
-                          normalizedError.stack || getErrorStack(err);
+                          normalizedError.stack || getErrorStack(terminalError);
 
                         if (errorStack) {
                           const parsedName = parseWorkflowName(workflowName);
@@ -1179,7 +1229,7 @@ export function workflowEntrypoint(
                         // Classify the error: WorkflowRuntimeError indicates
                         // an SDK/runtime issue, and selected subclasses use
                         // more specific codes for backend tracking.
-                        const errorCode = classifyRunError(err);
+                        const errorCode = classifyRunError(terminalError);
 
                         runtimeLogger.error('Error while running workflow', {
                           workflowRunId: runId,
@@ -1196,8 +1246,8 @@ export function workflowEntrypoint(
                         // class is distinct from the host's, so `instanceof
                         // Error` is `false` for VM-thrown errors. The V8
                         // type tag works across realms.
-                        if (types.isNativeError(err) && errorStack) {
-                          (err as Error).stack = errorStack;
+                        if (types.isNativeError(terminalError) && errorStack) {
+                          (terminalError as Error).stack = errorStack;
                         }
 
                         // Fail the workflow run via event (event-sourced).
@@ -1212,7 +1262,7 @@ export function workflowEntrypoint(
                               specVersion: SPEC_VERSION_CURRENT,
                               eventData: {
                                 error: await dehydrateRunError(
-                                  err,
+                                  terminalError,
                                   runId,
                                   encryptionKey
                                 ),

--- a/packages/core/src/runtime/constants.ts
+++ b/packages/core/src/runtime/constants.ts
@@ -117,3 +117,8 @@ export function _resetReplayTimeoutWarnCacheForTests(): void {
 // handler exits without writing run_failed so the queue retries the message.
 // On the next attempt the run is marked as failed.
 export const REPLAY_TIMEOUT_MAX_RETRIES = 3;
+
+// A replay-consumer mismatch can be caused by a transient divergent replay
+// rather than an invalid persisted history. Queue bounded recovery replays
+// before recording terminal corruption for a run that cannot replay.
+export const REPLAY_DIVERGENCE_MAX_RETRIES = 3;

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -1,6 +1,6 @@
 import {
-  CorruptedEventLogError,
   FatalError,
+  ReplayDivergenceError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
@@ -463,8 +463,8 @@ describe('createUseStep', () => {
     void add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
-    expect(workflowError.message).toContain('Corrupted event log');
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
+    expect(workflowError.message).toContain('Replay divergence');
     expect(workflowError.message).toContain('step_created');
     expect(workflowError.message).toContain('subtract');
     expect(workflowError.message).toContain('add');
@@ -572,8 +572,8 @@ describe('createUseStep', () => {
     void add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
-    expect(workflowError.message).toContain('Corrupted event log');
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
+    expect(workflowError.message).toContain('Replay divergence');
     expect(workflowError.message).toContain('step_completed');
     expect(workflowError.message).toContain('subtract');
     expect(workflowError.message).toContain('add');
@@ -633,8 +633,8 @@ describe('createUseStep', () => {
     void add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
-    expect(workflowError.message).toContain('Corrupted event log');
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
+    expect(workflowError.message).toContain('Replay divergence');
     expect(workflowError.message).toContain('step_failed');
     expect(workflowError.message).toContain('subtract');
     expect(workflowError.message).toContain('add');
@@ -757,7 +757,7 @@ describe('createUseStep', () => {
     expect(error?.message).toBe('Plain error message');
   });
 
-  it('should invoke workflow error handler with CorruptedEventLogError for unexpected event type', async () => {
+  it('should invoke workflow error handler with ReplayDivergenceError for unexpected event type', async () => {
     // Simulate a corrupted event log where a step receives an unexpected event type
     // (e.g., a wait_completed event when expecting step_completed/step_failed)
     const ctx = setupWorkflowContext([
@@ -783,7 +783,7 @@ describe('createUseStep', () => {
     const stepPromise = add(1, 2);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('Unexpected event type for step');
     expect(workflowError?.message).toContain('step_01K11TFZ62YS0YYFDQ3E8B9YCV');
     expect(workflowError?.message).toContain('add');

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -1,4 +1,4 @@
-import { CorruptedEventLogError, FatalError } from '@workflow/errors';
+import { FatalError, ReplayDivergenceError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import { EventConsumerResult } from './events-consumer.js';
 import { type StepInvocationQueueItem, WorkflowSuspension } from './global.js';
@@ -88,8 +88,9 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
         if (typeof eventStepName === 'string' && eventStepName !== stepName) {
           ctx.promiseQueue = ctx.promiseQueue.then(() => {
             ctx.onWorkflowError(
-              new CorruptedEventLogError(
-                `Corrupted event log: step event ${event.eventType} for ${correlationId} belongs to "${eventStepName}", but the current step consumer is "${stepName}"`
+              new ReplayDivergenceError(
+                `Replay divergence: step event ${event.eventType} for ${correlationId} belongs to "${eventStepName}", but the current step consumer is "${stepName}"`,
+                { eventId: event.eventId }
               )
             );
           });
@@ -106,8 +107,9 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
             // but the step was never invoked in the workflow during replay.
             ctx.promiseQueue = ctx.promiseQueue.then(() => {
               reject(
-                new CorruptedEventLogError(
-                  `Corrupted event log: step ${correlationId} (${stepName}) created but not found in invocation queue`
+                new ReplayDivergenceError(
+                  `Replay divergence: step ${correlationId} (${stepName}) created but not found in invocation queue`,
+                  { eventId: event.eventId }
                 )
               );
             });
@@ -200,11 +202,12 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
           return EventConsumerResult.Finished;
         }
 
-        // An unexpected event type has been received, this event log looks corrupted. Let's fail immediately.
+        // This replay installed a different consumer than the stored event needs.
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
           ctx.onWorkflowError(
-            new CorruptedEventLogError(
-              `Unexpected event type for step ${correlationId} (name: ${stepName}) "${event.eventType}"`
+            new ReplayDivergenceError(
+              `Replay divergence: Unexpected event type for step ${correlationId} (name: ${stepName}) "${event.eventType}"`,
+              { eventId: event.eventId }
             )
           );
         });

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -3680,7 +3680,7 @@ describe('runWorkflow', () => {
           workflowRun,
           events
         )
-      ).rejects.toThrow('Unconsumed event in event log');
+      ).rejects.toThrow('Replay could not consume event');
     });
 
     it('should reject with WorkflowRuntimeError for duplicate step_completed blocking subsequent events', async () => {

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -1,7 +1,7 @@
 import { runInContext } from 'node:vm';
 import {
-  CorruptedEventLogError,
   ERROR_SLUGS,
+  ReplayDivergenceError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
@@ -170,8 +170,9 @@ export async function runWorkflow(
     const eventsConsumer = new EventsConsumer(events, {
       onUnconsumedEvent: (event) => {
         workflowDiscontinuation.reject(
-          new CorruptedEventLogError(
-            `Unconsumed event in event log: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}. This indicates a corrupted or invalid event log.`
+          new ReplayDivergenceError(
+            `Replay could not consume event: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}.`,
+            { eventId: event.eventId }
           )
         );
       },
@@ -816,8 +817,9 @@ export async function runWorkflow(
 
       return dehydrated;
     } catch (err) {
-      // Let WorkflowSuspension propagate — handled separately by the runtime
-      if (WorkflowSuspension.is(err)) {
+      // Control-flow signals are handled by the runtime and do not mean the
+      // workflow has terminally failed.
+      if (WorkflowSuspension.is(err) || ReplayDivergenceError.is(err)) {
         throw err;
       }
 

--- a/packages/core/src/workflow/abort-controller.ts
+++ b/packages/core/src/workflow/abort-controller.ts
@@ -1,4 +1,4 @@
-import { CorruptedEventLogError } from '@workflow/errors';
+import { ReplayDivergenceError } from '@workflow/errors';
 import { EventConsumerResult } from '../events-consumer.js';
 import type { WorkflowOrchestratorContext } from '../private.js';
 import { hydrateStepReturnValue } from '../serialization.js';
@@ -147,8 +147,9 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
         ) {
           ctx.promiseQueue = ctx.promiseQueue.then(() => {
             ctx.onWorkflowError(
-              new CorruptedEventLogError(
-                `Corrupted event log: abort hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current abort hook expects "${this[ABORT_HOOK_TOKEN]}"`
+              new ReplayDivergenceError(
+                `Replay divergence: abort hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current abort hook expects "${this[ABORT_HOOK_TOKEN]}"`,
+                { eventId: event.eventId }
               )
             );
           });

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -1,6 +1,6 @@
 import {
-  CorruptedEventLogError,
   HookConflictError,
+  ReplayDivergenceError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
@@ -92,7 +92,7 @@ describe('createCreateHook', () => {
     createHook({ token: 'expected-token' });
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('hook_created');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -127,7 +127,7 @@ describe('createCreateHook', () => {
     void hook.then((v) => v);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('hook_received');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -154,7 +154,7 @@ describe('createCreateHook', () => {
     createHook({ token: 'expected-token' });
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('hook_disposed');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -182,7 +182,7 @@ describe('createCreateHook', () => {
     createHook({ token: 'expected-token' });
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('hook_conflict');
     expect(workflowError?.message).toContain('wrong-token');
     expect(workflowError?.message).toContain('expected-token');
@@ -204,7 +204,7 @@ describe('createCreateHook', () => {
     expect(workflowError).toBeInstanceOf(WorkflowSuspension);
   });
 
-  it('should invoke workflow error handler with CorruptedEventLogError for unexpected event type', async () => {
+  it('should invoke workflow error handler with ReplayDivergenceError for unexpected event type', async () => {
     // Simulate a corrupted event log where a hook receives an unexpected event type
     // (e.g., a step_completed event when expecting hook_created/hook_received/hook_disposed)
     const ctx = setupWorkflowContext([
@@ -231,7 +231,7 @@ describe('createCreateHook', () => {
     const hookPromise = hook.then((v) => v);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('Unexpected event type for hook');
     expect(workflowError?.message).toContain('hook_01K11TFZ62YS0YYFDQ3E8B9YCV');
     expect(workflowError?.message).toContain('step_completed');
@@ -414,7 +414,7 @@ describe('createCreateHook', () => {
     const hookPromise = hook.then((v) => v);
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('my-custom-token');
   });
 

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -1,4 +1,4 @@
-import { CorruptedEventLogError, HookConflictError } from '@workflow/errors';
+import { HookConflictError, ReplayDivergenceError } from '@workflow/errors';
 import { type PromiseWithResolvers, withResolvers } from '@workflow/utils';
 import type { HookConflictEvent, HookReceivedEvent } from '@workflow/world';
 import type { Hook, HookOptions } from '../create-hook.js';
@@ -74,8 +74,9 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
       if (typeof eventToken === 'string' && eventToken !== token) {
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
           ctx.onWorkflowError(
-            new CorruptedEventLogError(
-              `Corrupted event log: hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current hook consumer expects "${token}"`
+            new ReplayDivergenceError(
+              `Replay divergence: hook event ${event.eventType} for ${correlationId} belongs to token "${eventToken}", but the current hook consumer expects "${token}"`,
+              { eventId: event.eventId }
             )
           );
         });
@@ -163,11 +164,12 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         return EventConsumerResult.Finished;
       }
 
-      // An unexpected event type has been received, this event log looks corrupted. Let's fail immediately.
+      // This replay installed a different consumer than the stored event needs.
       ctx.promiseQueue = ctx.promiseQueue.then(() => {
         ctx.onWorkflowError(
-          new CorruptedEventLogError(
-            `Unexpected event type for hook ${correlationId} (token: ${token}) "${event.eventType}"`
+          new ReplayDivergenceError(
+            `Replay divergence: Unexpected event type for hook ${correlationId} (token: ${token}) "${event.eventType}"`,
+            { eventId: event.eventId }
           )
         );
       });

--- a/packages/core/src/workflow/sleep.test.ts
+++ b/packages/core/src/workflow/sleep.test.ts
@@ -1,4 +1,4 @@
-import { CorruptedEventLogError } from '@workflow/errors';
+import { ReplayDivergenceError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
@@ -26,8 +26,9 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     eventsConsumer: new EventsConsumer(events, {
       onUnconsumedEvent: (event) => {
         ctx.onWorkflowError(
-          new CorruptedEventLogError(
-            `Unconsumed event in event log: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}. This indicates a corrupted or invalid event log.`
+          new ReplayDivergenceError(
+            `Replay could not consume event: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}.`,
+            { eventId: event.eventId }
           )
         );
       },
@@ -136,7 +137,7 @@ describe('createSleep', () => {
     void sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('wait_completed');
     expect(workflowError?.message).toContain('resumeAt');
     expect(workflowError?.message).toContain('wait_01K11TFZ62YS0YYFDQ3E8B9YCV');
@@ -173,7 +174,7 @@ describe('createSleep', () => {
     void sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('wait_completed');
     expect(workflowError?.message).toContain('Invalid Date');
   });
@@ -193,7 +194,7 @@ describe('createSleep', () => {
     expect(workflowError).toBeInstanceOf(WorkflowSuspension);
   });
 
-  it('should invoke workflow error handler with CorruptedEventLogError for unexpected event type', async () => {
+  it('should invoke workflow error handler with ReplayDivergenceError for unexpected event type', async () => {
     // Simulate a corrupted event log where a sleep/wait receives an unexpected event type
     // (e.g., a step_completed event when expecting wait_created/wait_completed)
     const ctx = setupWorkflowContext([
@@ -219,7 +220,7 @@ describe('createSleep', () => {
     const sleepPromise = sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('Unexpected event type for wait');
     expect(workflowError?.message).toContain('wait_01K11TFZ62YS0YYFDQ3E8B9YCV');
     expect(workflowError?.message).toContain('step_completed');
@@ -286,7 +287,7 @@ describe('createSleep', () => {
     const sleepPromise = sleep('1s');
 
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('Unexpected event type for wait');
     expect(workflowError?.message).toContain('hook_received');
   });
@@ -361,11 +362,11 @@ describe('createSleep', () => {
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
   });
 
-  it('should raise CorruptedEventLogError when duplicate wait_completed events exist in the event log', async () => {
+  it('should raise ReplayDivergenceError when duplicate wait_completed events cannot be consumed', async () => {
     // When the event log has 2 wait_completed for a single wait_created,
     // the first wait_completed removes the callback (Finished), but the second
     // wait_completed has no consumer. The onUnconsumedEvent callback should
-    // trigger a CorruptedEventLogError via onWorkflowError.
+    // trigger a ReplayDivergenceError via onWorkflowError.
     const ctx = setupWorkflowContext([
       {
         eventId: 'evnt_0',
@@ -407,7 +408,7 @@ describe('createSleep', () => {
 
     // The duplicate wait_completed at index 2 is orphaned and triggers the error
     const workflowError = await errorReceived.promise;
-    expect(workflowError).toBeInstanceOf(CorruptedEventLogError);
+    expect(workflowError).toBeInstanceOf(ReplayDivergenceError);
     expect(workflowError?.message).toContain('evnt_2');
   });
 

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -1,4 +1,4 @@
-import { CorruptedEventLogError } from '@workflow/errors';
+import { ReplayDivergenceError } from '@workflow/errors';
 import { parseDurationToDate, withResolvers } from '@workflow/utils';
 import type { StringValue } from 'ms';
 import { EventConsumerResult } from '../events-consumer.js';
@@ -74,8 +74,9 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
           if (eventResumeAtMs !== expectedResumeAtMs) {
             ctx.promiseQueue = ctx.promiseQueue.then(() => {
               ctx.onWorkflowError(
-                new CorruptedEventLogError(
-                  `Corrupted event log: wait_completed event for ${correlationId} has resumeAt "${eventResumeAtForMessage}", but the current wait consumer expects "${expectedResumeAt.toISOString()}"`
+                new ReplayDivergenceError(
+                  `Replay divergence: wait_completed event for ${correlationId} has resumeAt "${eventResumeAtForMessage}", but the current wait consumer expects "${expectedResumeAt.toISOString()}"`,
+                  { eventId: event.eventId }
                 )
               );
             });
@@ -94,11 +95,12 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
         return EventConsumerResult.Finished;
       }
 
-      // An unexpected event type has been received, this event log looks corrupted. Let's fail immediately.
+      // This replay installed a different consumer than the stored event needs.
       ctx.promiseQueue = ctx.promiseQueue.then(() => {
         ctx.onWorkflowError(
-          new CorruptedEventLogError(
-            `Unexpected event type for wait ${correlationId} "${event.eventType}"`
+          new ReplayDivergenceError(
+            `Replay divergence: Unexpected event type for wait ${correlationId} "${event.eventType}"`,
+            { eventId: event.eventId }
           )
         );
       });

--- a/packages/errors/src/error-codes.ts
+++ b/packages/errors/src/error-codes.ts
@@ -10,6 +10,8 @@ export const RUN_ERROR_CODES = {
   RUNTIME_ERROR: 'RUNTIME_ERROR',
   /** Event log contains orphaned or mismatched events and cannot be replayed */
   CORRUPTED_EVENT_LOG: 'CORRUPTED_EVENT_LOG',
+  /** One replay could not consume the event log deterministically; retryable */
+  REPLAY_DIVERGENCE: 'REPLAY_DIVERGENCE',
   /** Run exceeded the maximum number of queue deliveries */
   MAX_DELIVERIES_EXCEEDED: 'MAX_DELIVERIES_EXCEEDED',
   /** Workflow replay exceeded the maximum allowed duration */

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -344,7 +344,11 @@ export class ReplayDivergenceError extends WorkflowRuntimeError {
   }
 
   static is(value: unknown): value is ReplayDivergenceError {
-    return isError(value) && value.name === 'ReplayDivergenceError';
+    return (
+      isError(value) &&
+      value.name === 'ReplayDivergenceError' &&
+      typeof (value as { eventId?: unknown }).eventId === 'string'
+    );
   }
 }
 

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -85,6 +85,7 @@ export const ERROR_SLUGS = {
   TIMEOUT_FUNCTIONS_IN_WORKFLOW: 'timeout-in-workflow',
   HOOK_CONFLICT: 'hook-conflict',
   CORRUPTED_EVENT_LOG: 'corrupted-event-log',
+  REPLAY_DIVERGENCE: 'replay-divergence',
   STEP_NOT_REGISTERED: 'step-not-registered',
   WORKFLOW_NOT_REGISTERED: 'workflow-not-registered',
   RUNTIME_DECRYPTION_FAILED: 'runtime-decryption-failed',
@@ -321,6 +322,29 @@ export class CorruptedEventLogError extends WorkflowRuntimeError {
 
   static is(value: unknown): value is CorruptedEventLogError {
     return isError(value) && value.name === 'CorruptedEventLogError';
+  }
+}
+
+/**
+ * Thrown when the current workflow replay cannot follow the path described by
+ * the recorded event log. A single divergence does not prove that the
+ * persisted history is invalid: a subsequent replay may observe or schedule
+ * work correctly, so the runtime may redeliver before declaring corruption.
+ */
+export class ReplayDivergenceError extends WorkflowRuntimeError {
+  readonly eventId: string;
+
+  constructor(message: string, options: ErrorOptions & { eventId: string }) {
+    super(message, {
+      ...options,
+      slug: ERROR_SLUGS.REPLAY_DIVERGENCE,
+    });
+    this.name = 'ReplayDivergenceError';
+    this.eventId = options.eventId;
+  }
+
+  static is(value: unknown): value is ReplayDivergenceError {
+    return isError(value) && value.name === 'ReplayDivergenceError';
   }
 }
 

--- a/packages/errors/src/replay-divergence-error.test.ts
+++ b/packages/errors/src/replay-divergence-error.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { ReplayDivergenceError, WorkflowRuntimeError } from './index.js';
+
+describe('ReplayDivergenceError', () => {
+  test('is a retryable replay signal with its own documentation link', () => {
+    const err = new ReplayDivergenceError('consumer mismatch', {
+      eventId: 'event-1',
+    });
+
+    expect(err.name).toBe('ReplayDivergenceError');
+    expect(err).toBeInstanceOf(WorkflowRuntimeError);
+    expect(err.eventId).toBe('event-1');
+    expect(err.message).toContain('replay-divergence');
+    expect(ReplayDivergenceError.is(err)).toBe(true);
+  });
+});

--- a/packages/errors/src/replay-divergence-error.test.ts
+++ b/packages/errors/src/replay-divergence-error.test.ts
@@ -13,4 +13,11 @@ describe('ReplayDivergenceError', () => {
     expect(err.message).toContain('replay-divergence');
     expect(ReplayDivergenceError.is(err)).toBe(true);
   });
+
+  test('does not treat an error without an event id as replay divergence', () => {
+    const err = new WorkflowRuntimeError('not a replay signal');
+    err.name = 'ReplayDivergenceError';
+
+    expect(ReplayDivergenceError.is(err)).toBe(false);
+  });
 });

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -40,6 +40,13 @@ export const WorkflowInvokePayloadSchema = z.object({
   runId: z.string(),
   traceCarrier: TraceCarrierSchema.optional(),
   requestedAt: z.coerce.date().optional(),
+  /** Consecutive replay divergences in this recovery chain and latest position. */
+  replayDivergence: z
+    .object({
+      eventId: z.string(),
+      count: z.number().int().positive(),
+    })
+    .optional(),
   /** Number of times this message has been re-enqueued due to server errors (5xx) */
   serverErrorRetryCount: z.number().int().optional(),
   /** Step ID for inline step execution in combined handler. If provided, the flow execution


### PR DESCRIPTION
## Summary

- Forward-ports #2208 from `stable` to `main`.
- Classifies transient replay path mismatches as `REPLAY_DIVERGENCE`, redrives up to three recovery replays, and only persists `CORRUPTED_EVENT_LOG` after that recovery budget is exhausted.
- Integrates the recovery policy into `main`'s combined workflow handler and retains its newer error serialization/runtime behavior.

## Validation

- `pnpm --filter '@workflow/core...' build` (Node `v22.18.0`)
- `pnpm --filter @workflow/core test` (1084 passing)
- `pnpm --filter @workflow/errors test` (37 passing)
- `pnpm exec biome format $(git diff --name-only origin-https/main...HEAD -- packages | rg '\.ts$')`
- `git diff --check origin-https/main...HEAD`

## Note

`pnpm lint` currently reports existing repository-wide diagnostics outside this port, including `.github` scripts, generated `docs/.source` files, and pre-existing lint findings in touched source files. The changed TypeScript files pass the formatter check above.