### PR TITLE
[codex] Skip replay for terminal run events

### DIFF
--- a/.changeset/terminal-run-event-replay.md
+++ b/.changeset/terminal-run-event-replay.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Skip workflow replay when the event log already contains a terminal run event.

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -367,6 +367,52 @@ describe('workflowEntrypoint replay guards', () => {
     );
   });
 
+  it('does not replay or redrive a snapshot that already contains run_failed', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_already_failed',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_already_failed',
+        undefined,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const events: Event[] = [
+      {
+        eventId: 'event-failed',
+        runId: workflowRun.runId,
+        eventType: 'run_failed',
+        eventData: {
+          error: { message: 'failure already recorded' },
+        },
+        createdAt: new Date('2024-01-01T00:00:01.000Z'),
+      },
+    ];
+    const createdEvents: unknown[] = [];
+    const queuedMessages: unknown[] = [];
+
+    await runWorkflowHandlerWithEvents(
+      `async function workflow() {
+        await new Promise(() => {});
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events,
+      { createdEvents, queuedMessages }
+    );
+
+    expect(createdEvents).toEqual([
+      expect.objectContaining({ eventType: 'run_started' }),
+    ]);
+    expect(queuedMessages).toEqual([]);
+  });
+
   it('redrives an initial replay divergence and fails after the recovery budget', async () => {
     const ops: Promise<any>[] = [];
     const workflowRun: WorkflowRun = {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -400,7 +400,7 @@ describe('workflowEntrypoint replay guards', () => {
 
     await runWorkflowHandlerWithEvents(
       `async function workflow() {
-        await new Promise(() => {});
+        throw new Error('workflow must not execute after run_failed');
       }${getWorkflowTransformCode('workflow')}`,
       workflowRun,
       events,
@@ -410,6 +410,52 @@ describe('workflowEntrypoint replay guards', () => {
     expect(createdEvents).toEqual([
       expect.objectContaining({ eventType: 'run_started' }),
     ]);
+    expect(queuedMessages).toEqual([]);
+  });
+
+  it('does not treat a terminal event from another run as this run outcome', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_foreign_failed_event',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_foreign_failed_event',
+        undefined,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const events: Event[] = [
+      {
+        eventId: 'event-foreign-failed',
+        runId: 'wrun_other',
+        eventType: 'run_failed',
+        eventData: {
+          error: { message: 'another run failed' },
+        },
+        createdAt: new Date('2024-01-01T00:00:01.000Z'),
+      },
+    ];
+    const createdEvents: unknown[] = [];
+    const queuedMessages: unknown[] = [];
+
+    await runWorkflowHandlerWithEvents(
+      `async function workflow() {
+        return 'done';
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events,
+      { createdEvents, queuedMessages }
+    );
+
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({ eventType: 'run_completed' })
+    );
     expect(queuedMessages).toEqual([]);
   });
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -96,9 +96,10 @@ export {
 function hasRecordedTerminalRunEvent(events: Event[], runId: string): boolean {
   const terminalEvent = events.find(
     (event) =>
-      event.eventType === 'run_completed' ||
-      event.eventType === 'run_failed' ||
-      event.eventType === 'run_cancelled'
+      event.runId === runId &&
+      (event.eventType === 'run_completed' ||
+        event.eventType === 'run_failed' ||
+        event.eventType === 'run_cancelled')
   );
 
   if (!terminalEvent) {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -93,6 +93,29 @@ export {
   setWorld,
 } from './runtime/world.js';
 
+function hasRecordedTerminalRunEvent(events: Event[], runId: string): boolean {
+  const terminalEvent = events.find(
+    (event) =>
+      event.eventType === 'run_completed' ||
+      event.eventType === 'run_failed' ||
+      event.eventType === 'run_cancelled'
+  );
+
+  if (!terminalEvent) {
+    return false;
+  }
+
+  runtimeLogger.info(
+    'Workflow event log already contains a terminal run event, skipping replay',
+    {
+      workflowRunId: runId,
+      eventType: terminalEvent.eventType,
+      eventId: terminalEvent.eventId,
+    }
+  );
+  return true;
+}
+
 /**
  * Function that creates a single route which handles any workflow execution
  * request and routes to the appropriate workflow function.
@@ -534,6 +557,13 @@ export function workflowEntrypoint(
                   throw err;
                 }
 
+                // The materialized run returned by run_started can race a
+                // terminal event in the loaded snapshot. Do not replay a run
+                // whose event log already establishes its terminal outcome.
+                if (hasRecordedTerminalRunEvent(events, runId)) {
+                  return;
+                }
+
                 // Check for any elapsed waits and create wait_completed events
                 const now = Date.now();
 
@@ -627,6 +657,12 @@ export function workflowEntrypoint(
                       workflowRun.runId
                     );
                     events = loadedEvents.events;
+                  }
+
+                  // A concurrent terminal write may have landed while
+                  // committing an elapsed wait and refreshing the snapshot.
+                  if (hasRecordedTerminalRunEvent(events, runId)) {
+                    return;
                   }
                 }
 

--- a/packages/core/src/runtime/wait-completion-replay.test.ts
+++ b/packages/core/src/runtime/wait-completion-replay.test.ts
@@ -41,6 +41,7 @@ async function runStaleWaitReplayScenario(options: {
   preloadedHasMore?: boolean;
   omitWaitCompletionFromDelta?: boolean;
   restartDeltaAtBeginning?: boolean;
+  terminalFailureAfterWaitCompletion?: boolean;
 }) {
   vi.spyOn(Date, 'now').mockReturnValue(+fixedNow);
 
@@ -231,6 +232,20 @@ async function runStaleWaitReplayScenario(options: {
       const created = event(request);
       durableEvents.push(created);
       createdEvents.push(created);
+      if (
+        request.eventType === 'wait_completed' &&
+        options.terminalFailureAfterWaitCompletion
+      ) {
+        durableEvents.push(
+          event({
+            eventType: 'run_failed',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              error: { message: 'failure recorded while completing wait' },
+            },
+          })
+        );
+      }
       return { event: created };
     }
   );
@@ -307,6 +322,7 @@ async function runStaleWaitReplayScenario(options: {
     createdEvents,
     listEvents,
     listedPages,
+    queue,
     staleEventsCursor,
     waitCorrelationId,
   };
@@ -367,6 +383,26 @@ describe('workflow handler wait completion replay', () => {
       'wait_completed',
     ]);
     expectHookBranchQueued(result);
+  });
+
+  it('skips replay when run_failed becomes durable during the post-wait refresh', async () => {
+    const result = await runStaleWaitReplayScenario({
+      includePreloadedCursor: true,
+      terminalFailureAfterWaitCompletion: true,
+    });
+
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'hook_received',
+      'wait_completed',
+      'run_failed',
+    ]);
+    expect(result.createdEvents).toEqual([
+      expect.objectContaining({
+        eventType: 'wait_completed',
+        correlationId: result.waitCorrelationId,
+      }),
+    ]);
+    expect(result.queue).not.toHaveBeenCalled();
   });
 
   it('deduplicates a cursor delta that unexpectedly restarts at the beginning', async () => {


### PR DESCRIPTION
## Summary

- Skip workflow replay when the loaded event snapshot already contains a terminal run event (`run_failed`, `run_cancelled`, or `run_completed`).
- Recheck for a terminal event after refreshing history following elapsed wait completion.
- Add regression coverage for a `running` materialized run whose event log already records `run_failed`, plus a patch changeset for `@workflow/core`.

## Root Cause

A replay invocation can observe a materialized run as `running` while its loaded event snapshot already contains `run_failed`. The runtime previously proceeded into `runWorkflow()`, where `EventsConsumer` had no consumer for that terminal event and reported it as `REPLAY_DIVERGENCE`, queueing recovery replays for an already-failed run.

## Validation

- `pnpm --filter '@workflow/core...' build`
- `pnpm changeset status --since=origin/stable`
- `pnpm --dir packages/core exec vitest run src/runtime.test.ts src/runtime/wait-completion-replay.test.ts` (11 passed)
- `git diff --check`
- `pnpm exec biome check packages/core/src/runtime.ts packages/core/src/runtime.test.ts` completed with the pre-existing cognitive-complexity warnings in `packages/core/src/runtime.ts`.

## Additional Test Note

`pnpm --dir packages/core test` fails outside this diff in the untouched `src/serialization.test.ts`: seven `DOMException serialization` tests fail with `DevalueError: Cannot stringify arbitrary non-POJOs`.
