### PR TITLE
fix(core): skip replay after terminal event refresh

### DIFF
--- a/.changeset/terminal-run-event-replay-main.md
+++ b/.changeset/terminal-run-event-replay-main.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Skip workflow replay when a refreshed event log already contains a terminal run event.

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -367,6 +367,47 @@ describe('workflowEntrypoint replay guards', () => {
     );
   });
 
+  it('does not treat a terminal event from another run as this run outcome', async () => {
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_foreign_failed_event',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_foreign_failed_event',
+        undefined,
+        []
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const events: Event[] = [
+      {
+        eventId: 'event-foreign-failed',
+        runId: 'wrun_other',
+        eventType: 'run_failed',
+        eventData: {
+          error: { message: 'another run failed' },
+        },
+        createdAt: new Date('2024-01-01T00:00:01.000Z'),
+      },
+    ];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      `async function workflow() {
+        return 'done';
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      events
+    );
+
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({ eventType: 'run_completed' })
+    );
+  });
+
   it('redrives an initial replay divergence and fails after the recovery budget', async () => {
     const ops: Promise<any>[] = [];
     const workflowRun: WorkflowRun = {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -177,6 +177,31 @@ async function recordFatalRunError({
   }
 }
 
+function hasRecordedTerminalRunEvent(events: Event[], runId: string): boolean {
+  // Terminal run events are always last by construction (no event creation
+  // succeeds against a terminal run), but scan the full array for
+  // defense-in-depth: a World/backend ordering bug shouldn't make us miss an
+  // actual termination signal.
+  const terminalRunEvent = events.find(
+    (e) =>
+      e.runId === runId &&
+      (e.eventType === 'run_completed' ||
+        e.eventType === 'run_failed' ||
+        e.eventType === 'run_cancelled')
+  );
+
+  if (!terminalRunEvent) {
+    return false;
+  }
+
+  runtimeLogger.debug('Run reached terminal event, exiting', {
+    workflowRunId: runId,
+    eventType: terminalRunEvent.eventType,
+    eventId: terminalRunEvent.eventId,
+  });
+  return true;
+}
+
 /**
  * Creates a single route which handles workflow execution requests,
  * executing steps inline when possible to reduce function invocations
@@ -753,25 +778,7 @@ export function workflowEntrypoint(
                       // derived from these events, so checking the log here
                       // gives us the same signal as a runs.get() round-trip
                       // without the extra request per loop iteration.
-                      // Terminal run events are always last by construction
-                      // (no event creation succeeds against a terminal run),
-                      // but scan the full array for defense-in-depth: a
-                      // World/backend ordering bug shouldn't make us miss
-                      // an actual termination signal.
-                      const terminalRunEvent = events.find(
-                        (e) =>
-                          e.eventType === 'run_completed' ||
-                          e.eventType === 'run_failed' ||
-                          e.eventType === 'run_cancelled'
-                      );
-                      if (terminalRunEvent) {
-                        runtimeLogger.debug(
-                          'Run completed by concurrent handler, exiting',
-                          {
-                            workflowRunId: runId,
-                            eventType: terminalRunEvent.eventType,
-                          }
-                        );
+                      if (hasRecordedTerminalRunEvent(events, runId)) {
                         return;
                       }
 
@@ -871,6 +878,15 @@ export function workflowEntrypoint(
                           events = loaded.events;
                           eventsCursor = loaded.cursor;
                         }
+                      }
+
+                      // Completing elapsed waits refreshes the event snapshot.
+                      // A concurrent handler may have written the terminal run
+                      // event after the initial snapshot but before this
+                      // replay. Once the event log records that outcome, this
+                      // delivery is done.
+                      if (hasRecordedTerminalRunEvent(events, runId)) {
+                        return;
                       }
 
                       // Update cache reference (may have been set for first time)

--- a/packages/core/src/runtime/wait-completion-replay.test.ts
+++ b/packages/core/src/runtime/wait-completion-replay.test.ts
@@ -40,6 +40,7 @@ async function runStaleWaitReplayScenario(options: {
   includePreloadedCursor: boolean;
   preloadedHasMore?: boolean;
   omitWaitCompletionFromDelta?: boolean;
+  terminalFailureAfterWaitCompletion?: boolean;
 }) {
   vi.spyOn(Date, 'now').mockReturnValue(+fixedNow);
 
@@ -229,6 +230,20 @@ async function runStaleWaitReplayScenario(options: {
       const created = event(request);
       durableEvents.push(created);
       createdEvents.push(created);
+      if (
+        request.eventType === 'wait_completed' &&
+        options.terminalFailureAfterWaitCompletion
+      ) {
+        durableEvents.push(
+          event({
+            eventType: 'run_failed',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              error: { message: 'failure recorded while completing wait' },
+            },
+          })
+        );
+      }
       return { event: created };
     }
   );
@@ -306,6 +321,7 @@ async function runStaleWaitReplayScenario(options: {
     createdEvents,
     listEvents,
     listedPages,
+    queue,
     staleEventsCursor,
     waitCorrelationId,
   };
@@ -470,5 +486,26 @@ describe('workflow handler wait completion replay', () => {
       'wait_completed',
     ]);
     expectHookBranchQueued(result);
+  });
+
+  it('stops after wait refresh when the event log contains a terminal run event', async () => {
+    const result = await runStaleWaitReplayScenario({
+      includePreloadedCursor: true,
+      terminalFailureAfterWaitCompletion: true,
+    });
+
+    expect(result.listEvents).toHaveBeenCalledTimes(1);
+    expect(result.listedPages[0]?.map((event) => event.eventType)).toEqual([
+      'hook_received',
+      'wait_completed',
+      'run_failed',
+    ]);
+    expect(result.createdEvents).toEqual([
+      expect.objectContaining({
+        eventType: 'wait_completed',
+        correlationId: result.waitCorrelationId,
+      }),
+    ]);
+    expect(result.queue).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Forward-ports the terminal run event replay guard from stable PR #2214 to `main`'s refactored runtime path.

`main` already skipped replay when the initially loaded/preloaded event snapshot contained a terminal run event. This adds the same terminal-event check after the elapsed-wait completion path refreshes the event snapshot, so a concurrently recorded `run_failed`, `run_cancelled`, or `run_completed` ends the current delivery instead of being passed into workflow replay as an orphaned event.

## Root Cause

A handler can load a running materialized run and an event snapshot, complete an elapsed wait, then refresh events before replaying. If another handler records a terminal run event during that refresh window, the refreshed event log already establishes the run outcome even though this handler's materialized `workflowRun.status` is still `running`.

Without a post-refresh terminal check, `runWorkflow` can see the terminal event as unrelated replay input and the runtime can record or queue an additional divergence/failure path for a run that is already terminal.

## Validation

- `fnm exec --using v22.18.0 pnpm install`
- `fnm exec --using v22.18.0 pnpm --filter '@workflow/core...' build`
- `fnm exec --using v22.18.0 pnpm --dir packages/core exec vitest run src/runtime.test.ts src/runtime/wait-completion-replay.test.ts`
- `git diff --check`
- `fnm exec --using v22.18.0 pnpm exec biome check packages/core/src/runtime.ts packages/core/src/runtime/wait-completion-replay.test.ts .changeset/terminal-run-event-replay-main.md`

Validation caveat: the Biome check completed with the pre-existing `runtime.ts` complexity warnings and the existing unused suppression warning around the constant replay loop; no formatting fixes were applied.
