### PR TITLE
[DO NOT MERGE] diagnostic: log replay event log + fail run on replay divergence

### DIFF
--- a/.changeset/log-replay-event-log.md
+++ b/.changeset/log-replay-event-log.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Log the event log (event identities and ordering, without payloads) on every workflow run replay to aid diagnosing replay divergence and corrupted-event-log errors.

--- a/.changeset/log-replay-event-log.md
+++ b/.changeset/log-replay-event-log.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Log the event log (event identities and ordering, without payloads) on every workflow run replay to aid diagnosing replay divergence and corrupted-event-log errors.
+Log the event log (event identities and ordering, without payloads) on every workflow run replay, and (diagnostically) fail the run on the first replay divergence instead of redriving via the queue, so replay divergences become immediately visible for investigation.

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -1,10 +1,14 @@
 import {
   CorruptedEventLogError,
+  EntityConflictError,
   ReplayDivergenceError,
   RUN_ERROR_CODES,
   type RunErrorCode,
+  RunExpiredError,
   RuntimeDecryptionError,
   StepNotRegisteredError,
+  ThrottleError,
+  TooEarlyError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
   WorkflowWorldError,
@@ -32,6 +36,18 @@ const RUNTIME_ERROR_CHECKS = [
   // `AESCipherJob.onDone`) are wrapped in `RuntimeDecryptionError` at
   // the encryption module boundary.
   RuntimeDecryptionError.is,
+  // The `WorkflowWorldError` subclasses below are infrastructure-level
+  // conditions surfaced by the runtime's own calls into the world (CAS/fence
+  // rejections, run cleanup, retry-after, rate limits). The runtime normally
+  // retries past them; if they reach `classifyRunError`, the retry budget
+  // exhausted — a transient infra failure, not user code, so `RUNTIME_ERROR`
+  // is the truthful classification. The bare `WorkflowWorldError` parent is
+  // deliberately NOT listed: it can also surface from user-code `fetch` calls
+  // into the workflow API, which should remain `USER_ERROR`.
+  EntityConflictError.is,
+  RunExpiredError.is,
+  TooEarlyError.is,
+  ThrottleError.is,
 ];
 
 /**

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -5,7 +5,6 @@ import {
   type WorkflowRun,
 } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { REPLAY_DIVERGENCE_MAX_RETRIES } from './runtime/constants.js';
 import { setWorld } from './runtime/world.js';
 import { workflowEntrypoint } from './runtime.js';
 import {
@@ -459,7 +458,11 @@ describe('workflowEntrypoint replay guards', () => {
     expect(queuedMessages).toEqual([]);
   });
 
-  it('redrives an initial replay divergence and fails after the recovery budget', async () => {
+  it('fails the run on the first replay divergence without redriving (diagnostic)', async () => {
+    // DIAGNOSTIC behavior: replay divergence no longer queues recovery replays.
+    // The first ReplayDivergenceError fails the run as a terminal
+    // CORRUPTED_EVENT_LOG so divergences are immediately visible rather than
+    // being masked by a redrive that happens to read a consistent snapshot.
     const ops: Promise<any>[] = [];
     const workflowRun: WorkflowRun = {
       runId: 'wrun_runtime_wait_guard',
@@ -516,35 +519,12 @@ describe('workflowEntrypoint replay guards', () => {
       }
     );
 
-    expect(initialAttemptEvents).not.toContainEqual(
-      expect.objectContaining({ eventType: 'run_failed' })
+    // No recovery replay is queued...
+    expect(queuedMessages).not.toContainEqual(
+      expect.objectContaining({ replayDivergence: expect.anything() })
     );
-    expect(queuedMessages).toContainEqual(
-      expect.objectContaining({
-        replayDivergence: {
-          eventId: 'event-0',
-          count: 1,
-        },
-      })
-    );
-
-    const terminalAttemptEvents = await runWorkflowHandlerWithEvents(
-      `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
-      async function workflow() {
-        await sleep('5s');
-        return 'done';
-      }${getWorkflowTransformCode('workflow')}`,
-      workflowRun,
-      events,
-      {
-        replayDivergence: {
-          eventId: 'different-event',
-          count: REPLAY_DIVERGENCE_MAX_RETRIES,
-        },
-      }
-    );
-
-    expect(terminalAttemptEvents).toContainEqual(
+    // ...the run fails immediately with CORRUPTED_EVENT_LOG.
+    expect(initialAttemptEvents).toContainEqual(
       expect.objectContaining({
         eventType: 'run_failed',
         eventData: expect.objectContaining({
@@ -554,7 +534,7 @@ describe('workflowEntrypoint replay guards', () => {
     );
   });
 
-  it('redrives an initial replay divergence for a mismatched recorded hook', async () => {
+  it('fails the run on a mismatched recorded hook without redriving (diagnostic)', async () => {
     const ops: Promise<any>[] = [];
     const workflowRun: WorkflowRun = {
       runId: 'wrun_runtime_hook_guard',
@@ -605,12 +585,17 @@ describe('workflowEntrypoint replay guards', () => {
       { createdEvents, queuedMessages }
     );
 
-    expect(createdEvents).not.toContainEqual(
-      expect.objectContaining({ eventType: 'run_failed' })
+    // DIAGNOSTIC: a mismatched recorded hook diverges and fails immediately
+    // instead of queueing a recovery replay.
+    expect(queuedMessages).not.toContainEqual(
+      expect.objectContaining({ replayDivergence: expect.anything() })
     );
-    expect(queuedMessages).toContainEqual(
+    expect(createdEvents).toContainEqual(
       expect.objectContaining({
-        replayDivergence: { eventId: 'event-0', count: 1 },
+        eventType: 'run_failed',
+        eventData: expect.objectContaining({
+          errorCode: RUN_ERROR_CODES.CORRUPTED_EVENT_LOG,
+        }),
       })
     );
   });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -674,6 +674,34 @@ export function workflowEntrypoint(
                   ? await importKey(rawKey)
                   : undefined;
 
+                // Log the full event log (identities + ordering only, no
+                // payloads) that this replay is about to consume. Replay
+                // divergence ("Replay could not consume event ...") and
+                // corrupted-event-log errors are a function of which events are
+                // present and in what order, so capturing that snapshot for
+                // every replay lets us reconstruct, after the fact, exactly what
+                // the runtime saw when a divergence/corruption was raised —
+                // including whether the event log handed back by the world was
+                // itself incomplete or mis-ordered. Payloads (eventData) are
+                // intentionally omitted: they can be large, encrypted, or
+                // contain user data, and are not needed to diagnose a
+                // branching/ordering divergence.
+                runtimeLogger.info('Workflow replay event log', {
+                  workflowRunId: runId,
+                  eventCount: events.length,
+                  eventsCursor,
+                  eventLog: events.map((event, index) => ({
+                    index,
+                    eventId: event.eventId,
+                    eventType: event.eventType,
+                    correlationId: event.correlationId,
+                    createdAt:
+                      event.createdAt instanceof Date
+                        ? event.createdAt.toISOString()
+                        : event.createdAt,
+                  })),
+                });
+
                 // --- User code execution ---
                 // Only errors from runWorkflow() (user workflow code) should
                 // produce run_failed. Infrastructure errors (network, server)

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -10,7 +10,6 @@ import { parseWorkflowName } from '@workflow/utils/parse-name';
 import {
   type Event,
   SPEC_VERSION_CURRENT,
-  SPEC_VERSION_LEGACY,
   WorkflowInvokePayloadSchema,
   type WorkflowRun,
 } from '@workflow/world';
@@ -20,17 +19,14 @@ import { WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
 import {
   MAX_QUEUE_DELIVERIES,
-  REPLAY_DIVERGENCE_MAX_RETRIES,
   REPLAY_TIMEOUT_MAX_RETRIES,
   REPLAY_TIMEOUT_MS,
 } from './runtime/constants.js';
 import {
   getQueueOverhead,
-  getWorkflowQueueName,
   getWorkflowRunEvents,
   handleHealthCheckMessage,
   parseHealthCheckPayload,
-  queueMessage,
   withHealthCheck,
 } from './runtime/helpers.js';
 import { handleSuspension } from './runtime/suspension-handler.js';
@@ -754,45 +750,38 @@ export function workflowEntrypoint(
 
                   let terminalError = err;
                   if (ReplayDivergenceError.is(err)) {
+                    // DIAGNOSTIC: fail the run immediately on the first replay
+                    // divergence instead of queueing recovery replays.
+                    //
+                    // The recovery-replay redrive (see #2208/#2212) masks
+                    // divergences: in CI we never observe a failed run because a
+                    // subsequent redrive happens to read a consistent snapshot
+                    // and succeed, so we lose the signal needed to understand
+                    // *why* the log diverged. Failing fast makes every
+                    // divergence visible as a terminal CORRUPTED_EVENT_LOG run,
+                    // which — together with the per-replay event-log logging —
+                    // lets us capture and inspect the exact diverging event log.
+                    //
+                    // This is intentionally aggressive for investigation; the
+                    // recovery budget can be reinstated once the root cause is
+                    // understood.
                     const divergenceCount = (replayDivergence?.count ?? 0) + 1;
 
-                    if (divergenceCount <= REPLAY_DIVERGENCE_MAX_RETRIES) {
-                      runtimeLogger.warn(
-                        'Workflow replay diverged; queueing a recovery replay before declaring the event log corrupted',
-                        {
-                          workflowRunId: runId,
-                          errorCode: RUN_ERROR_CODES.REPLAY_DIVERGENCE,
-                          divergenceEventId: err.eventId,
-                          priorDivergenceEventId: replayDivergence?.eventId,
-                          divergenceCount,
-                          deliveryAttempt: metadata.attempt,
-                          maxRecoveryReplays: REPLAY_DIVERGENCE_MAX_RETRIES,
-                          errorMessage: err.message,
-                        }
-                      );
-                      await queueMessage(
-                        world,
-                        getWorkflowQueueName(workflowName),
-                        {
-                          runId,
-                          traceCarrier: traceContext,
-                          requestedAt: new Date(),
-                          replayDivergence: {
-                            eventId: err.eventId,
-                            count: divergenceCount,
-                          },
-                        },
-                        {
-                          deploymentId: workflowRun.deploymentId,
-                          specVersion:
-                            workflowRun.specVersion ?? SPEC_VERSION_LEGACY,
-                        }
-                      );
-                      return;
-                    }
+                    runtimeLogger.error(
+                      'Workflow replay diverged; failing the run (recovery redrive disabled for diagnosis)',
+                      {
+                        workflowRunId: runId,
+                        errorCode: RUN_ERROR_CODES.REPLAY_DIVERGENCE,
+                        divergenceEventId: err.eventId,
+                        priorDivergenceEventId: replayDivergence?.eventId,
+                        divergenceCount,
+                        deliveryAttempt: metadata.attempt,
+                        errorMessage: err.message,
+                      }
+                    );
 
                     terminalError = new CorruptedEventLogError(
-                      `Workflow replay diverged ${divergenceCount} times after ${REPLAY_DIVERGENCE_MAX_RETRIES} recovery replays; latest divergent event was ${err.eventId}. Last divergence: ${err.message}`,
+                      `Workflow replay diverged on event ${err.eventId}: ${err.message}`,
                       { cause: err }
                     );
                   }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -741,12 +741,23 @@ export function workflowEntrypoint(
                       runtimeLogger.debug(suspensionMessage);
                     }
 
+                    // Pass the load-time tail eventId so the handler can
+                    // fence its branch-decision writes (step_created,
+                    // hook_created, hook_disposed, wait_created) against this
+                    // snapshot of the log. Extends OCC fencing to the writes
+                    // whose outcome depends on a branch decision the workflow
+                    // VM made from the loaded log.
+                    const suspensionFenceEventId =
+                      events.length > 0
+                        ? events[events.length - 1].eventId
+                        : undefined;
                     const result = await handleSuspension({
                       suspension: err,
                       world,
                       run: workflowRun,
                       span,
                       requestId,
+                      fenceEventId: suspensionFenceEventId,
                     });
 
                     if (result.timeoutSeconds !== undefined) {
@@ -903,6 +914,13 @@ export function workflowEntrypoint(
                 // This is outside the user-code try/catch so that failures
                 // here (e.g., network errors) propagate to the queue handler.
                 try {
+                  // Fence run_completed against the load-time tail: a stale
+                  // snapshot that branched to "complete" must not overwrite a
+                  // log a concurrent canonical replay has already advanced.
+                  const completedFence =
+                    events.length > 0
+                      ? events[events.length - 1].eventId
+                      : undefined;
                   await world.events.create(
                     runId,
                     {
@@ -912,12 +930,17 @@ export function workflowEntrypoint(
                         output: workflowResult,
                       },
                     },
-                    { requestId }
+                    {
+                      requestId,
+                      ...(completedFence
+                        ? { lastKnownEventId: completedFence }
+                        : {}),
+                    }
                   );
                 } catch (err) {
                   if (EntityConflictError.is(err) || RunExpiredError.is(err)) {
                     runtimeLogger.info(
-                      'Tried completing workflow run, but run has already finished.',
+                      'Tried completing workflow run, but run has already finished (or fence conflict).',
                       {
                         workflowRunId: runId,
                         message: err.message,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -682,21 +682,30 @@ export function workflowEntrypoint(
                 // intentionally omitted: they can be large, encrypted, or
                 // contain user data, and are not needed to diagnose a
                 // branching/ordering divergence.
-                runtimeLogger.info('Workflow replay event log', {
-                  workflowRunId: runId,
-                  eventCount: events.length,
-                  eventsCursor,
-                  eventLog: events.map((event, index) => ({
-                    index,
-                    eventId: event.eventId,
-                    eventType: event.eventType,
-                    correlationId: event.correlationId,
-                    createdAt:
-                      event.createdAt instanceof Date
-                        ? event.createdAt.toISOString()
-                        : event.createdAt,
-                  })),
-                });
+                //
+                // Emitted via console.log (not runtimeLogger.info) so it is
+                // ALWAYS captured: runtimeLogger.info only routes to the `debug`
+                // library and is dropped unless DEBUG=workflow:* is set, whereas
+                // console.log is always collected by the platform's runtime
+                // logs. Serialized as a single JSON string so the full array
+                // survives log rendering without being truncated/collapsed.
+                console.log(
+                  `[replay-event-log] ${JSON.stringify({
+                    workflowRunId: runId,
+                    eventCount: events.length,
+                    eventsCursor,
+                    eventLog: events.map((event, index) => ({
+                      index,
+                      eventId: event.eventId,
+                      eventType: event.eventType,
+                      correlationId: event.correlationId,
+                      createdAt:
+                        event.createdAt instanceof Date
+                          ? event.createdAt.toISOString()
+                          : event.createdAt,
+                    })),
+                  })}`
+                );
 
                 // --- User code execution ---
                 // Only errors from runWorkflow() (user workflow code) should

--- a/packages/core/src/runtime/fenced-write.ts
+++ b/packages/core/src/runtime/fenced-write.ts
@@ -1,0 +1,183 @@
+/**
+ * Helper for "branch-decision" event writes that need OCC fencing.
+ *
+ * Used by the writes whose outcome depends on a branch decision the
+ * workflow VM made from its loaded event log:
+ *
+ *   suspension-handler.ts:
+ *     - step_created
+ *     - hook_created
+ *     - hook_disposed
+ *     - wait_created
+ *
+ *   runtime.ts terminal writes:
+ *     - run_completed
+ *     - run_failed
+ *
+ * `hook_received` is deliberately NOT fenced: fencing the user's signal
+ * would drop it on contention; stale-snapshot protection belongs on the
+ * writes that consume hooks, not the writes that deliver them.
+ *
+ * On a fence conflict, this helper **bails the current write** rather
+ * than retrying in place. A fence conflict means some other invocation
+ * has already advanced the event log past our snapshot, so the work
+ * implied by our snapshot is either already done or will be done by
+ * whoever advanced the log. Retrying in place caused two problems:
+ *
+ *  1. Under high contention (e.g. a hook flood firing many concurrent
+ *     ticks), the retry loop became a stuck-fence spin: lambdas would
+ *     spend their budget retrying against an ever-changing tail and
+ *     either succeed by luck or exhaust MAX_FENCE_RETRIES and throw.
+ *     A thrown EntityConflictError surfaces as `run_failed` (a
+ *     transient infra issue mis-classified as terminal failure).
+ *
+ *  2. The retries-against-the-same-fence shape, paired with the
+ *     server-side patch-then-PUT non-atomicity, made stuck-fence runs
+ *     measurably worse: every retry attempt against an already-advanced
+ *     fence is wasted compute, and the spin keeps the run stuck
+ *     longer in the affected-runs-per-stress-cycle window.
+ *
+ * The simpler model matches Peter's existing workflow-server comment
+ * ("the @workflow/core suspension handler swallows it"): a fence
+ * conflict signals "another replay is canonical; this one isn't" —
+ * exit cleanly, trust the canonical replay, no error, no retry, no
+ * re-enqueue.
+ */
+import { EntityConflictError } from '@workflow/errors';
+import type { CreateEventRequest, World } from '@workflow/world';
+import { runtimeLogger } from '../logger.js';
+
+/**
+ * Returns true when an EntityConflictError carries the fence-conflict
+ * shape. Anything else with a 409/410/etc shape is some other kind of
+ * conflict (entity already exists, run already terminal, hook token taken)
+ * that the caller's existing handlers want to keep dealing with.
+ *
+ * TODO: switch to a typed error class once the wire format exposes one.
+ */
+function isFenceConflict(err: unknown): boolean {
+  return (
+    EntityConflictError.is(err) &&
+    typeof err.message === 'string' &&
+    /fence conflict/i.test(err.message)
+  );
+}
+
+export interface FencedWriteParams {
+  world: World;
+  runId: string;
+  event: CreateEventRequest;
+  requestId?: string;
+  /**
+   * Caller-provided fence value. Pass `undefined` for the first attempt
+   * if no fence has been observed yet (e.g. on a fresh resume); the
+   * helper will then issue an unfenced write — which still atomically
+   * advances `run.lastKnownEventId` on the server side so future fenced
+   * writers see the materialized value.
+   */
+  fenceEventId: string | undefined;
+  /**
+   * Called when the server rejects with a *non-fence* EntityConflictError
+   * (e.g. the entity already exists because a concurrent handler beat us
+   * to it). Returning `'abort'` is the typical answer — the existing
+   * handlers in suspension-handler / runtime already log + skip. Returning
+   * `'rethrow'` re-throws so the caller can deal with it.
+   */
+  onEntityConflict: (err: EntityConflictError) => 'abort' | 'rethrow';
+}
+
+export interface FencedWriteResult {
+  /**
+   * Whether the event was actually written.
+   *
+   * `false` covers two cases the caller usually wants to treat the same
+   * way (no further action required for this write):
+   *  - Fence conflict — another invocation has the canonical view.
+   *  - Non-fence EntityConflictError with `onEntityConflict: 'abort'`
+   *    (entity already exists, run already terminal, etc.).
+   */
+  written: boolean;
+  /**
+   * eventId of the newly-written event (when `written` is true), so
+   * the caller can advance its tracked fence value.
+   */
+  newFenceEventId?: string;
+  /**
+   * The server's response event, when `written` is true. Allows callers
+   * to read fields like the resolved eventType (e.g. `hook_conflict`
+   * instead of `hook_created` when the server detected a token clash).
+   */
+  event?: { eventType: string; eventId: string };
+}
+
+/**
+ * Issues `world.events.create(runId, event, { requestId, lastKnownEventId })`
+ * once. On fence conflict, returns `{ written: false }` immediately
+ * (no retry, no throw, no re-enqueue) — see the file-level comment for
+ * the reasoning.
+ *
+ * On any non-fence EntityConflictError, defers to `onEntityConflict` for
+ * the abort-vs-rethrow decision (preserves the existing
+ * "EntityConflictError → log and skip" behavior for callers that want it).
+ */
+export async function fencedEventCreate(
+  params: FencedWriteParams
+): Promise<FencedWriteResult> {
+  const { world, runId, event, requestId, fenceEventId, onEntityConflict } =
+    params;
+  try {
+    const result = await world.events.create(runId, event, {
+      requestId,
+      ...(fenceEventId ? { lastKnownEventId: fenceEventId } : {}),
+    });
+    // The server response schema marks `event` as optional for legacy
+    // compatibility. In practice creates always return the persisted
+    // event, but if it's missing we keep the caller's fence at its
+    // prior value rather than silently advancing to a value we didn't
+    // observe on the wire.
+    if (!result.event) {
+      runtimeLogger.warn(
+        'Branch-decision write missing event in response; keeping prior fence',
+        {
+          workflowRunId: runId,
+          eventType: event.eventType,
+          correlationId: event.correlationId,
+          fenceEventId,
+        }
+      );
+    }
+    return {
+      written: true,
+      newFenceEventId: result.event?.eventId ?? fenceEventId,
+      event: result.event
+        ? {
+            eventType: result.event.eventType,
+            eventId: result.event.eventId,
+          }
+        : undefined,
+    };
+  } catch (err) {
+    if (isFenceConflict(err)) {
+      // Another invocation has the canonical view of the event log.
+      // Bail out cleanly: no retry, no throw. The canonical invocation
+      // is responsible for whatever progress the workflow needs.
+      runtimeLogger.info(
+        'Branch-decision write fence conflict; yielding to canonical replay',
+        {
+          workflowRunId: runId,
+          eventType: event.eventType,
+          correlationId: event.correlationId,
+        }
+      );
+      return { written: false };
+    }
+    if (EntityConflictError.is(err)) {
+      const decision = onEntityConflict(err);
+      if (decision === 'abort') {
+        return { written: false };
+      }
+      throw err;
+    }
+    throw err;
+  }
+}

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -1,10 +1,6 @@
 import type { Span } from '@opentelemetry/api';
 import { waitUntil } from '@vercel/functions';
-import {
-  EntityConflictError,
-  HookNotFoundError,
-  RunExpiredError,
-} from '@workflow/errors';
+import { HookNotFoundError, RunExpiredError } from '@workflow/errors';
 import {
   type CreateEventRequest,
   type SerializedData,
@@ -24,6 +20,7 @@ import { dehydrateStepArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { serializeTraceCarrier } from '../telemetry.js';
 import { queueMessage } from './helpers.js';
+import { fencedEventCreate } from './fenced-write.js';
 
 /**
  * Extracts W3C trace context headers from a trace carrier for HTTP propagation.
@@ -48,6 +45,13 @@ export interface SuspensionHandlerParams {
   run: WorkflowRun;
   span?: Span;
   requestId?: string;
+  /**
+   * Caller's load-time view of the event log (tail eventId), used as the OCC
+   * fence on branch-decision writes (hook_created, hook_disposed, step_created,
+   * wait_created). `undefined` => unfenced (server still advances the
+   * materialized lastKnownEventId). See `fenced-write.ts`.
+   */
+  fenceEventId?: string;
 }
 
 export interface SuspensionHandlerResult {
@@ -69,10 +73,16 @@ export async function handleSuspension({
   run,
   span,
   requestId,
+  fenceEventId: initialFenceEventId,
 }: SuspensionHandlerParams): Promise<SuspensionHandlerResult> {
   const runId = run.runId;
   const workflowName = run.workflowName;
   const workflowStartedAt = run.startedAt ? +run.startedAt : Date.now();
+  // Per-suspension OCC fence. Each successful fenced branch-decision write
+  // advances this so subsequent writes from this handler chain off it. The
+  // server fence is a single-tip CAS; on conflict fencedEventCreate bails the
+  // write (yields to the canonical replay) rather than throwing.
+  let fenceEventId = initialFenceEventId;
   // Separate queue items by type
   const stepItems = suspension.steps.filter(
     (item): item is StepInvocationQueueItem => item.type === 'step'
@@ -126,84 +136,88 @@ export async function handleSuspension({
   // Track any hook conflicts that occur - these will be handled by re-enqueueing the workflow
   let hasHookConflict = false;
 
-  if (hookEvents.length > 0) {
-    await Promise.all(
-      hookEvents.map(async (hookEvent) => {
-        try {
-          const result = await world.events.create(runId, hookEvent, {
-            requestId,
-          });
-          // Check if the world returned a hook_conflict event instead of hook_created
-          // The hook_conflict event is stored in the event log and will be replayed
-          // on the next workflow invocation, causing the hook's promise to reject
-          // Note: hook events always create an event (legacy runs throw, not return undefined)
-          if (result.event!.eventType === 'hook_conflict') {
-            hasHookConflict = true;
-          }
-        } catch (err) {
-          if (EntityConflictError.is(err) || RunExpiredError.is(err)) {
-            runtimeLogger.info(
-              'Workflow run already completed, skipping hook',
-              {
-                workflowRunId: runId,
-                message: err.message,
-              }
-            );
-          } else {
-            throw err;
-          }
-        }
-      })
-    );
+  // Sequential (not Promise.all) so each fenced write chains off the prior
+  // event id — the server fence is a single-tip CAS.
+  for (const hookEvent of hookEvents) {
+    try {
+      const writeResult = await fencedEventCreate({
+        world,
+        runId,
+        event: hookEvent,
+        requestId,
+        fenceEventId,
+        onEntityConflict: () => 'abort',
+      });
+      if (writeResult.newFenceEventId) {
+        fenceEventId = writeResult.newFenceEventId;
+      }
+      if (!writeResult.written) {
+        runtimeLogger.info(
+          'Workflow run already completed or hook already created, skipping',
+          { workflowRunId: runId, correlationId: hookEvent.correlationId }
+        );
+        continue;
+      }
+      // Check if the world returned a hook_conflict event instead of hook_created
+      if (writeResult.event?.eventType === 'hook_conflict') {
+        hasHookConflict = true;
+      }
+    } catch (err) {
+      if (RunExpiredError.is(err)) {
+        runtimeLogger.info('Workflow run already completed, skipping hook', {
+          workflowRunId: runId,
+          message: err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
   }
 
-  // Process hook disposals - these release hook tokens for reuse by other workflows
-  if (hooksNeedingDisposal.length > 0) {
-    await Promise.all(
-      hooksNeedingDisposal.map(async (queueItem) => {
-        const hookDisposedEvent: CreateEventRequest = {
-          eventType: 'hook_disposed' as const,
-          specVersion: SPEC_VERSION_CURRENT,
-          correlationId: queueItem.correlationId,
-          eventData: {
-            token: queueItem.token,
-          },
-        };
-        try {
-          await world.events.create(runId, hookDisposedEvent, { requestId });
-        } catch (err) {
-          if (EntityConflictError.is(err)) {
-            // Hook was already disposed by a concurrent invocation — safe to skip
-            runtimeLogger.info(
-              'Hook already disposed, skipping duplicate disposal',
-              {
-                workflowRunId: runId,
-                correlationId: queueItem.correlationId,
-                message: err.message,
-              }
-            );
-          } else if (RunExpiredError.is(err)) {
-            runtimeLogger.info(
-              'Workflow run already completed, skipping hook disposal',
-              {
-                workflowRunId: runId,
-                correlationId: queueItem.correlationId,
-                message: err.message,
-              }
-            );
-          } else if (HookNotFoundError.is(err)) {
-            // Hook may have already been disposed or never created
-            runtimeLogger.info('Hook not found for disposal, continuing', {
-              workflowRunId: runId,
-              correlationId: queueItem.correlationId,
-              message: err.message,
-            });
-          } else {
-            throw err;
+  // Process hook disposals - these release hook tokens for reuse by other
+  // workflows. Sequential + fenced (see hook_created above).
+  for (const queueItem of hooksNeedingDisposal) {
+    const hookDisposedEvent: CreateEventRequest = {
+      eventType: 'hook_disposed' as const,
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: queueItem.correlationId,
+      eventData: {
+        token: queueItem.token,
+      },
+    };
+    try {
+      const writeResult = await fencedEventCreate({
+        world,
+        runId,
+        event: hookDisposedEvent,
+        requestId,
+        fenceEventId,
+        onEntityConflict: () => 'abort',
+      });
+      if (writeResult.newFenceEventId) {
+        fenceEventId = writeResult.newFenceEventId;
+      }
+    } catch (err) {
+      if (RunExpiredError.is(err)) {
+        runtimeLogger.info(
+          'Workflow run already completed, skipping hook disposal',
+          {
+            workflowRunId: runId,
+            correlationId: queueItem.correlationId,
+            message: err.message,
           }
-        }
-      })
-    );
+        );
+      } else if (HookNotFoundError.is(err)) {
+        // Hook may have already been disposed or never created
+        runtimeLogger.info('Hook not found for disposal, continuing', {
+          workflowRunId: runId,
+          correlationId: queueItem.correlationId,
+          message: err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
   }
 
   // Build a map of stepId -> step event for steps that need creation
@@ -213,55 +227,99 @@ export async function handleSuspension({
       .map((queueItem) => queueItem.correlationId)
   );
 
-  // Process steps and waits in parallel
-  // Each step: create event (if needed) -> queue message
-  // Each wait: create event (if needed)
-  const ops: Promise<void>[] = [];
-
-  // Steps: create event then queue message, all in parallel
+  // Phase 1: create branch-decision events (step_created, wait_created)
+  // SEQUENTIALLY so each fenced write chains off the prior event id (the
+  // server fence is a single-tip CAS). On fence conflict, fencedEventCreate
+  // bails the write — a concurrent canonical replay owns the log.
+  //
+  // Only steps whose step_created THIS handler actually wrote should be
+  // queued for execution (single-owner), so we track those correlationIds.
+  const stepsToQueue: StepInvocationQueueItem[] = [];
   for (const queueItem of stepItems) {
+    if (stepsNeedingCreation.has(queueItem.correlationId)) {
+      const dehydratedInput = await dehydrateStepArguments(
+        {
+          args: queueItem.args,
+          closureVars: queueItem.closureVars,
+          thisVal: queueItem.thisVal,
+        },
+        runId,
+        encryptionKey,
+        suspension.globalThis
+      );
+      const stepEvent: CreateEventRequest = {
+        eventType: 'step_created' as const,
+        specVersion: SPEC_VERSION_CURRENT,
+        correlationId: queueItem.correlationId,
+        eventData: {
+          stepName: queueItem.stepName,
+          input: dehydratedInput as SerializedData,
+        },
+      };
+      const writeResult = await fencedEventCreate({
+        world,
+        runId,
+        event: stepEvent,
+        requestId,
+        fenceEventId,
+        onEntityConflict: () => 'abort',
+      });
+      if (writeResult.newFenceEventId) {
+        fenceEventId = writeResult.newFenceEventId;
+      }
+      if (!writeResult.written) {
+        // Fence conflict or step already exists — a concurrent canonical
+        // replay owns this step. Do not queue it from here.
+        runtimeLogger.info(
+          'Step create skipped (fence conflict or already exists), not queuing',
+          { workflowRunId: runId, correlationId: queueItem.correlationId }
+        );
+        continue;
+      }
+      stepsToQueue.push(queueItem);
+    } else {
+      // step_created already existed before this handler ran — still queue
+      // (matches prior behavior of always queuing every stepItem).
+      stepsToQueue.push(queueItem);
+    }
+  }
+
+  for (const queueItem of waitItems) {
+    if (!queueItem.hasCreatedEvent) {
+      const waitEvent: CreateEventRequest = {
+        eventType: 'wait_created' as const,
+        specVersion: SPEC_VERSION_CURRENT,
+        correlationId: queueItem.correlationId,
+        eventData: {
+          resumeAt: queueItem.resumeAt,
+        },
+      };
+      const writeResult = await fencedEventCreate({
+        world,
+        runId,
+        event: waitEvent,
+        requestId,
+        fenceEventId,
+        onEntityConflict: () => 'abort',
+      });
+      if (writeResult.newFenceEventId) {
+        fenceEventId = writeResult.newFenceEventId;
+      }
+      if (!writeResult.written) {
+        runtimeLogger.info(
+          'Wait create skipped (fence conflict or already exists)',
+          { workflowRunId: runId, correlationId: queueItem.correlationId }
+        );
+      }
+    }
+  }
+
+  // Phase 2: queue step execution messages in parallel (no fence interaction).
+  const ops: Promise<void>[] = [];
+  for (const queueItem of stepsToQueue) {
     ops.push(
       (async () => {
-        // Create step event if not already created
-        if (stepsNeedingCreation.has(queueItem.correlationId)) {
-          const dehydratedInput = await dehydrateStepArguments(
-            {
-              args: queueItem.args,
-              closureVars: queueItem.closureVars,
-              thisVal: queueItem.thisVal,
-            },
-            runId,
-            encryptionKey,
-            suspension.globalThis
-          );
-          const stepEvent: CreateEventRequest = {
-            eventType: 'step_created' as const,
-            specVersion: SPEC_VERSION_CURRENT,
-            correlationId: queueItem.correlationId,
-            eventData: {
-              stepName: queueItem.stepName,
-              input: dehydratedInput as SerializedData,
-            },
-          };
-          try {
-            await world.events.create(runId, stepEvent, { requestId });
-          } catch (err) {
-            if (EntityConflictError.is(err)) {
-              runtimeLogger.info('Step already exists, continuing', {
-                workflowRunId: runId,
-                correlationId: queueItem.correlationId,
-                message: err.message,
-              });
-            } else {
-              throw err;
-            }
-          }
-        }
-
-        // Queue step execution message
         // Serialize trace context once and include in both payload and headers
-        // Payload: for manual context restoration in step handler
-        // Headers: for automatic trace propagation by Vercel's infrastructure
         const traceCarrier = await serializeTraceCarrier();
         await queueMessage(
           world,
@@ -283,37 +341,6 @@ export async function handleSuspension({
         );
       })()
     );
-  }
-
-  // Waits: create events in parallel (no queueing needed for waits)
-  for (const queueItem of waitItems) {
-    if (!queueItem.hasCreatedEvent) {
-      ops.push(
-        (async () => {
-          const waitEvent: CreateEventRequest = {
-            eventType: 'wait_created' as const,
-            specVersion: SPEC_VERSION_CURRENT,
-            correlationId: queueItem.correlationId,
-            eventData: {
-              resumeAt: queueItem.resumeAt,
-            },
-          };
-          try {
-            await world.events.create(runId, waitEvent, { requestId });
-          } catch (err) {
-            if (EntityConflictError.is(err)) {
-              runtimeLogger.info('Wait already exists, continuing', {
-                workflowRunId: runId,
-                correlationId: queueItem.correlationId,
-                message: err.message,
-              });
-            } else {
-              throw err;
-            }
-          }
-        })()
-      );
-    }
   }
 
   // Wait for all step and wait operations to complete

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -457,6 +457,9 @@ async function createWorkflowRunEventInner(
         ...data,
         remoteRefBehavior,
         ...(params?.requestId ? { vercelId: params.requestId } : {}),
+        ...(params?.lastKnownEventId
+          ? { lastKnownEventId: params.lastKnownEventId }
+          : {}),
       },
       config,
       schema: EventResultResolveWireSchema,
@@ -482,6 +485,9 @@ async function createWorkflowRunEventInner(
       ...data,
       remoteRefBehavior,
       ...(params?.requestId ? { vercelId: params.requestId } : {}),
+      ...(params?.lastKnownEventId
+        ? { lastKnownEventId: params.lastKnownEventId }
+        : {}),
     },
     config,
     schema: EventResultLazyWireSchema,

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -65,7 +65,7 @@ function httpLog(
 // (OCC fence) so this validation build exercises the ported SDK fence + the
 // server fence end to end. Must be '' on any mergeable branch.
 const WORKFLOW_SERVER_URL_OVERRIDE =
-  'https://workflow-server-qccj339st.vercel.sh';
+  'https://workflow-server-git-peter-event-write-cas.vercel.sh';
 
 /**
  * Per-request timeout for HTTP calls to workflow-server (in ms).

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -61,7 +61,11 @@ function httpLog(
  *
  * Example: 'https://workflow-server-git-branch-name.vercel.sh'
  */
-const WORKFLOW_SERVER_URL_OVERRIDE = '';
+// [debug branch — NOT FOR MERGE] Pinned to the workflow-server #447 preview
+// (OCC fence) so this validation build exercises the ported SDK fence + the
+// server fence end to end. Must be '' on any mergeable branch.
+const WORKFLOW_SERVER_URL_OVERRIDE =
+  'https://workflow-server-qccj339st.vercel.sh';
 
 /**
  * Per-request timeout for HTTP calls to workflow-server (in ms).
@@ -273,6 +277,13 @@ export const getHeaders = (
   const workflowServerUrlOverride = getWorkflowServerUrlOverride();
   if (workflowServerUrlOverride && options.usingProxy) {
     headers.set('x-vercel-workflow-api-url', workflowServerUrlOverride);
+  }
+  // [debug branch] Vercel Deployment Protection bypass for the pinned
+  // workflow-server #447 preview. Bare `x-vercel-protection-bypass` only —
+  // do NOT set `x-vercel-set-bypass-cookie` (307 redirect loop on undici).
+  const bypassToken = process.env.WORKFLOW_VERCEL_PROTECTION_BYPASS;
+  if (bypassToken) {
+    headers.set('x-vercel-protection-bypass', bypassToken);
   }
   return headers;
 };

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -485,6 +485,20 @@ export async function makeRequest<T>({
           if (response.status === 409) {
             throwWithTrace(new EntityConflictError(defaultMessage));
           }
+          if (response.status === 412) {
+            // OCC fence conflict. Surface as EntityConflictError so the
+            // existing conflict branching downstream applies, and ensure the
+            // message carries a "fence conflict" marker even when the
+            // response body didn't parse — the fence-conflict handling in
+            // runtime/fenced-write.ts dispatches off that marker, and
+            // upstream error pages (CDN HTML, gateway timeouts, etc.)
+            // shouldn't be allowed to demote a fence conflict to a generic
+            // EntityConflictError that callers treat as terminal.
+            const fenceMessage = /fence conflict/i.test(defaultMessage)
+              ? defaultMessage
+              : `fence conflict: ${defaultMessage}`;
+            throwWithTrace(new EntityConflictError(fenceMessage));
+          }
           if (response.status === 410) {
             throwWithTrace(new RunExpiredError(defaultMessage));
           }

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -65,7 +65,7 @@ function httpLog(
 // (OCC fence) so this validation build exercises the ported SDK fence + the
 // server fence end to end. Must be '' on any mergeable branch.
 const WORKFLOW_SERVER_URL_OVERRIDE =
-  'https://workflow-server-git-peter-event-write-cas.vercel.sh';
+  'https://workflow-server-qccj339st.vercel.sh';
 
 /**
  * Per-request timeout for HTTP calls to workflow-server (in ms).
@@ -238,12 +238,21 @@ export const getHttpUrl = (
   config?: APIConfig
 ): { baseUrl: string; usingProxy: boolean } => {
   const projectConfig = config?.projectConfig;
-  const defaultHost =
-    getWorkflowServerUrlOverride() || 'https://vercel-workflow.com';
+  const serverUrlOverride = getWorkflowServerUrlOverride();
+  const defaultHost = serverUrlOverride || 'https://vercel-workflow.com';
   const customProxyUrl = process.env.WORKFLOW_VERCEL_BACKEND_URL;
   const defaultProxyUrl = 'https://api.vercel.com/v1/workflow';
-  // Use proxy when we have project config (for authentication via Vercel API)
-  const usingProxy = Boolean(projectConfig?.projectId && projectConfig?.teamId);
+  // Use proxy when we have project config (for authentication via Vercel API).
+  //
+  // [debug branch] EXCEPT when a server URL override is set: in that case we
+  // want to hit the overridden workflow-server directly (e.g. a #447 preview),
+  // NOT route through the api.vercel.com proxy with an x-vercel-workflow-api-url
+  // header. Going through the proxy both ignores the preview we want and,
+  // empirically, breaks the request body (undici "expected non-null body
+  // source") on this path. Direct mode is what we want for validation.
+  const usingProxy =
+    !serverUrlOverride &&
+    Boolean(projectConfig?.projectId && projectConfig?.teamId);
   // When using proxy, requests go through api.vercel.com (with x-vercel-workflow-api-url header if override is set)
   // When not using proxy, use the default workflow-server URL (with /api path appended)
   const baseUrl = usingProxy

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -378,6 +378,13 @@ export interface CreateEventParams {
   resolveData?: ResolveData;
   /** Request ID (x-vercel-id when on Vercel) for correlating request logs with workflow events. */
   requestId?: string;
+  /**
+   * Optimistic concurrency control fence: when set, the event write is
+   * rejected with a conflict unless the run's materialized `lastKnownEventId`
+   * equals this value. Lets the runtime stop an invocation operating on a stale
+   * event log snapshot from advancing the log.
+   */
+  lastKnownEventId?: string;
 }
 
 /**


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE.** This is a throwaway diagnostic / debugging branch used to investigate replay divergence in production. It intentionally disables the `REPLAY_DIVERGENCE` recovery redrive so divergences fail fast and become visible, and adds verbose per-replay event-log logging. Not intended for release.

## Purpose
Make replay divergence (`REPLAY_DIVERGENCE` / corrupted-event-log) diagnosable. Build a tarball from this branch and run it to capture what the runtime actually sees when a divergence occurs.

### 1. Log the event log on every replay
Logs the full event log — **identities + ordering only, no payloads** — immediately before every replay (`runtime.ts`, before `runWorkflow`). One `info` line per replay: `workflowRunId`, `eventCount`, `eventsCursor`, `eventLog: [{ index, eventId, eventType, correlationId, createdAt }]`. Payloads omitted (large/encrypted/PII; not needed for ordering divergence).

### 2. Fail the run on the first replay divergence (no redrive)
We weren't seeing any failed runs in CI after many retries — the recovery redrive (#2208/#2212) was masking divergences (a later redrive reads a consistent snapshot and succeeds). This makes the first `ReplayDivergenceError` fail the run as a terminal `CORRUPTED_EVENT_LOG` so every divergence is visible and the diverging event log is captured.

The `REPLAY_DIVERGENCE_MAX_RETRIES` constant is left defined so the redrive is trivial to restore.

## Status
Diagnostic only. Tests/typecheck updated to keep the branch green for building tarballs, but **this branch should be closed, not merged**, once the investigation concludes.