### PR TITLE
fix: settle aborted parallel steps before completing abortParallelWorkflow

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2749,8 +2749,10 @@ describe('e2e', () => {
         const returnValue = await run.returnValue;
 
         // The workflow races 3 parallel long steps against a 3s sleep.
-        // The sleep wins, so the workflow returns timed out status.
+        // The sleep wins, so the workflow returns timed out status after all
+        // in-flight steps observe the abort and settle through the abort path.
         expect(returnValue.status).toBe('timed out');
+        expect(returnValue.results).toEqual(['aborted', 'aborted', 'aborted']);
       }
     );
 

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -1845,8 +1845,8 @@ export async function abortParallelWorkflow() {
     // Wait for the in-flight steps to observe the abort before completing the
     // workflow. Returning immediately leaves the parallel branch dangling and
     // can keep the run open until the steps hit their natural 30s completion.
-    await parallelSteps;
-    return { status: 'timed out' };
+    const results = await parallelSteps;
+    return { status: 'timed out', results };
   }
 
   return { status: 'completed', results: result };

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -1829,18 +1829,23 @@ export async function abortParallelWorkflow() {
   'use workflow';
 
   const controller = new AbortController();
+  const parallelSteps = Promise.all([
+    longStep(controller.signal),
+    longStep(controller.signal),
+    longStep(controller.signal),
+  ]);
 
   const result = await Promise.race([
-    Promise.all([
-      longStep(controller.signal),
-      longStep(controller.signal),
-      longStep(controller.signal),
-    ]),
+    parallelSteps,
     sleep('3s').then(() => 'timeout' as const),
   ]);
 
   if (result === 'timeout') {
     controller.abort();
+    // Wait for the in-flight steps to observe the abort before completing the
+    // workflow. Returning immediately leaves the parallel branch dangling and
+    // can keep the run open until the steps hit their natural 30s completion.
+    await parallelSteps;
     return { status: 'timed out' };
   }
 


### PR DESCRIPTION
## Summary
- keep the parallel `longStep()` promises alive as a named promise so the workflow can await them after aborting
- return the settled parallel step results after timeout so the test can prove all three steps actually observed the abort
- assert `AbortController > abortParallelWorkflow: abort cancels all parallel steps` returns `["aborted", "aborted", "aborted"]`

## Validation
- `git diff --check`
- `WORKFLOW_PUBLIC_MANIFEST=1 pnpm dev` in `workbench/nextjs-turbopack`
- `DEPLOYMENT_URL="http://localhost:3000" APP_NAME="nextjs-turbopack" pnpm vitest run packages/core/e2e/e2e.test.ts -t "abortParallelWorkflow: abort cancels all parallel steps"`

## Notes
- The focused local E2E still does not reach the assertion because local Next dev fails earlier with `Workflow "workflow//./workflows/99_e2e//abortParallelWorkflow" is not registered in the current deployment`.
- Dev logs continue to show the concurrent local bundling warning `Module not found: Can't resolve <dynamic>` from `packages/core/dist/runtime/world.js`.
- That local registration/bundling issue appears unrelated to this workflow/test change, so CI remains the real verification path for the timeout fix.