### PR TITLE
Update @vercel/queue from 0.1.7 to 0.2.1

### DIFF
--- a/.changeset/clever-adults-ask.md
+++ b/.changeset/clever-adults-ask.md
@@ -1,0 +1,7 @@
+---
+"@workflow/world-vercel": patch
+"@workflow/world-local": patch
+"@workflow/world-postgres": patch
+---
+
+Update `@vercel/queue` from 0.1.7 to 0.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 3.2.0
       version: 3.2.0
     '@vercel/queue':
-      specifier: 0.1.7
-      version: 0.1.7
+      specifier: 0.2.1
+      version: 0.2.1
     '@vitest/coverage-v8':
       specifier: ^4.0.18
       version: 4.0.18
@@ -1325,7 +1325,7 @@ importers:
     dependencies:
       '@vercel/queue':
         specifier: 'catalog:'
-        version: 0.1.7
+        version: 0.2.1
       '@workflow/errors':
         specifier: workspace:*
         version: link:../errors
@@ -1371,7 +1371,7 @@ importers:
     dependencies:
       '@vercel/queue':
         specifier: 'catalog:'
-        version: 0.1.7
+        version: 0.2.1
       '@workflow/errors':
         specifier: workspace:*
         version: link:../errors
@@ -1478,7 +1478,7 @@ importers:
         version: 3.2.0
       '@vercel/queue':
         specifier: 'catalog:'
-        version: 0.1.7
+        version: 0.2.1
       '@workflow/errors':
         specifier: workspace:*
         version: link:../errors
@@ -8272,6 +8272,10 @@ packages:
 
   '@vercel/queue@0.1.7':
     resolution: {integrity: sha512-4Uk9LOvDPVYqBJGrNDk4fdLte4CmFERXCUJI2y7SRYX1d//dI96Ww7sgKZF4+YDj/YaBXoCZ11AU0HYkVwW9Eg==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/queue@0.2.1':
+    resolution: {integrity: sha512-18jVWNj/jroyQ+/GM3XFyr1/deFkinosg7RKjovrJbgQRRjusq9Y+pSGOKfpzus6vVRun2mqDlNI82hm5Rwi5Q==}
     engines: {node: '>=20.0.0'}
 
   '@vercel/react-router@1.2.6':
@@ -23084,6 +23088,14 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@vercel/queue@0.1.7':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      minimatch: 10.2.4
+      mixpart: 0.0.6
+      picocolors: 1.1.1
+    optional: true
+
+  '@vercel/queue@0.2.1':
     dependencies:
       '@vercel/oidc': 3.2.0
       minimatch: 10.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalog:
   "@types/node": 22.19.0
   "@vercel/functions": ^3.4.3
   "@vercel/oidc": 3.2.0
-  "@vercel/queue": 0.1.7
+  "@vercel/queue": 0.2.1
   "@vitest/coverage-v8": ^4.0.18
   ai: 6.0.116
   enhanced-resolve: 5.19.0


### PR DESCRIPTION
## Summary
- Updates `@vercel/queue` from 0.1.7 to 0.2.1 in the pnpm workspace catalog
- Affects `@workflow/world-vercel`, `@workflow/world-local`, and `@workflow/world-postgres`

## Test plan
- [x] All packages build successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)