### PR TITLE
[web-shared] Fix HookConflictError web hydration

### DIFF
--- a/.changeset/hook-conflict-web-reviver.md
+++ b/.changeset/hook-conflict-web-reviver.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Hydrate serialized HookConflictError values in the web trace viewer.

--- a/packages/web-shared/src/lib/hydration.ts
+++ b/packages/web-shared/src/lib/hydration.ts
@@ -135,7 +135,8 @@ export function getWebRevivers(): Revivers {
     // Error family. The reducer side (see
     // `packages/core/src/serialization/reducers/common.ts`) emits a tagged
     // entry for each built-in Error subclass plus the workflow-specific
-    // `FatalError` / `RetryableError` and `AggregateError`. Without
+    // `FatalError` / `RetryableError` / `HookConflictError` and
+    // `AggregateError`. Without
     // matching revivers here, `devalue.unflatten` throws "Unknown type X"
     // — which surfaces in the web o11y UI as "Failed to load resource
     // details: Unknown type FatalError".
@@ -180,6 +181,20 @@ export function getWebRevivers(): Revivers {
       const opts = 'cause' in value ? { cause: value.cause } : undefined;
       const error = new Error(value.message, opts);
       error.name = 'FatalError';
+      if (value.stack !== undefined) error.stack = value.stack;
+      return error;
+    },
+    HookConflictError: (value) => {
+      const opts = 'cause' in value ? { cause: value.cause } : undefined;
+      const error = new Error(value.message, opts) as Error & {
+        token?: string;
+        conflictingRunId?: string;
+      };
+      error.name = 'HookConflictError';
+      error.token = value.token;
+      if (value.conflictingRunId !== undefined) {
+        error.conflictingRunId = value.conflictingRunId;
+      }
       if (value.stack !== undefined) error.stack = value.stack;
       return error;
     },

--- a/packages/web-shared/test/hydration.test.ts
+++ b/packages/web-shared/test/hydration.test.ts
@@ -91,6 +91,26 @@ describe('getWebRevivers — error family', () => {
     expect(revived.message).toBe('cannot retry');
   });
 
+  it('hydrates a HookConflictError with token details preserved', () => {
+    const revived = hydrateData(
+      [
+        ['HookConflictError', 1],
+        { message: 2, stack: 3, token: 4, conflictingRunId: 5 },
+        'Hook token "approval-token" is already in use by another workflow (run "wrun_conflicting")',
+        'HookConflictError: Hook token "approval-token" is already in use by another workflow',
+        'approval-token',
+        'wrun_conflicting',
+      ],
+      REVIVERS
+    ) as Error & { token?: string; conflictingRunId?: string };
+
+    expect(revived).toBeInstanceOf(Error);
+    expect(revived.name).toBe('HookConflictError');
+    expect(revived.message).toContain('already in use');
+    expect(revived.token).toBe('approval-token');
+    expect(revived.conflictingRunId).toBe('wrun_conflicting');
+  });
+
   it('hydrates a RetryableError with retryAfter as a Date', async () => {
     const retryAt = new Date('2025-01-01T00:00:00.000Z');
     const revived = await roundTrip<Error & { retryAfter: Date }>(


### PR DESCRIPTION
## Summary

- Add a web reviver for serialized HookConflictError payloads in web-shared.
- Preserve token and conflictingRunId when the trace viewer hydrates hook conflict errors.
- Add regression coverage and a patch changeset for @workflow/web-shared.

## Root Cause

Core serializes HookConflictError with a dedicated devalue type, but the browser reviver set did not include that type, so trace viewer detail hydration could throw Unknown type HookConflictError.

## Validation

- pnpm --filter @workflow/web-shared test
- pnpm --filter @workflow/web-shared typecheck