### PR TITLE
[codex] Handle lazy stream key request failures

### DIFF
--- a/.changeset/lazy-stream-key-request-diagnostics.md
+++ b/.changeset/lazy-stream-key-request-diagnostics.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': patch
+'@workflow/world-vercel': patch
+---
+
+Avoid unhandled run lookups for unused or empty readable streams and include Vercel request correlation headers in world transport errors.

--- a/packages/core/src/runtime/run.ts
+++ b/packages/core/src/runtime/run.ts
@@ -17,12 +17,12 @@ import {
   hydrateWorkflowReturnValue,
 } from '../serialization.js';
 import { getWorkflowRunStreamId } from '../util.js';
+import { getWorldLazy } from './get-world-lazy.js';
 import {
   type StopSleepOptions,
   type StopSleepResult,
   wakeUpRun,
 } from './runs.js';
-import { getWorldLazy } from './get-world-lazy.js';
 
 /**
  * A `ReadableStream` extended with workflow-specific helpers.
@@ -134,6 +134,16 @@ export class Run<TResult> {
       })();
     }
     return this.#encryptionKeyPromise;
+  }
+
+  /**
+   * Defer fetching the run and its encryption key until serialized stream data
+   * is actually read. An empty or metadata-only stream must not start an
+   * unobserved run lookup.
+   * @internal
+   */
+  #getEncryptionKeyLazily(): () => Promise<CryptoKey | undefined> {
+    return () => this.#getEncryptionKey();
   }
 
   /**
@@ -264,9 +274,10 @@ export class Run<TResult> {
     'use step';
     const { ops = [], global = globalThis, startIndex, namespace } = options;
     const name = getWorkflowRunStreamId(this.runId, namespace);
-    // Pass the key as a promise — it will be resolved lazily inside
-    // the first async transform() call of the deserialize stream.
-    const encryptionKey = this.#getEncryptionKey();
+    // The resolver starts only when the deserialize stream sees its first
+    // chunk, so creating or probing an empty stream cannot reject in the
+    // background.
+    const encryptionKey = this.#getEncryptionKeyLazily();
     const stream = getExternalRevivers(global, ops, this.runId, encryptionKey)
       .ReadableStream!({
       name,

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -148,6 +148,33 @@ describe('Run.exists', () => {
   });
 });
 
+describe('Run.getReadable', () => {
+  afterEach(() => {
+    setWorld(undefined as unknown as World);
+  });
+
+  it('does not fetch the run encryption key for an empty stream', async () => {
+    const world = createMockWorld();
+    world.getEncryptionKeyForRun = vi.fn().mockResolvedValue(undefined);
+    world.streams = {
+      get: vi.fn().mockResolvedValue(
+        new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        })
+      ),
+    } as unknown as World['streams'];
+    setWorld(world);
+
+    new Run('wrun_123').getReadable();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(world.runs.get).not.toHaveBeenCalled();
+    expect(world.getEncryptionKeyForRun).not.toHaveBeenCalled();
+  });
+});
+
 describe('Run.wakeUp', () => {
   afterEach(() => {
     setWorld(undefined as unknown as World);

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -30,6 +30,7 @@ import {
   decrypt,
   type EncryptionKeyParam,
   encrypt,
+  resolveEncryptionKey,
 } from './serialization/encryption.js';
 import {
   formatSerializationError,
@@ -162,8 +163,8 @@ export function getSerializeStream(
   cryptoKey: EncryptionKeyParam
 ): TransformStream<any, Uint8Array> {
   const encoder = new TextEncoder();
-  // Resolve the key promise once on first use and cache the result.
-  // Note: if the cryptoKey promise rejects (e.g., network error fetching
+  // Resolve the key input once on first use and cache the result.
+  // Note: if resolving cryptoKey rejects (e.g., network error fetching
   // the derived key), the rejection won't surface until the first chunk
   // is processed — not at stream construction time.
   const keyState = { resolved: false, key: undefined as CryptoKey | undefined };
@@ -171,7 +172,7 @@ export function getSerializeStream(
     async transform(chunk, controller) {
       try {
         if (!keyState.resolved) {
-          keyState.key = await cryptoKey;
+          keyState.key = await resolveEncryptionKey(cryptoKey);
           keyState.resolved = true;
         }
         const serialized = stringify(chunk, reducers);
@@ -224,7 +225,7 @@ export function getDeserializeStream(
 ): TransformStream<Uint8Array, any> {
   const decoder = new TextDecoder();
   let buffer = new Uint8Array(0);
-  // Resolve the key promise once on first use and cache the result.
+  // Resolve the key input once on first use and cache the result.
   const keyState = { resolved: false, key: undefined as CryptoKey | undefined };
 
   function appendToBuffer(data: Uint8Array) {
@@ -237,9 +238,9 @@ export function getDeserializeStream(
   async function processFrames(
     controller: TransformStreamDefaultController<any>
   ) {
-    // Resolve the key promise once on first use and cache the result
+    // Resolve the key input once on first use and cache the result
     if (!keyState.resolved) {
-      keyState.key = await cryptoKey;
+      keyState.key = await resolveEncryptionKey(cryptoKey);
       keyState.resolved = true;
     }
 
@@ -739,7 +740,7 @@ function attachAbortListenerOnce(
             // Errors, custom classes, etc.) and respects the run's encryption key.
             // A bare JSON.stringify here would write a packet the reader can't
             // decode and the listener-side abort would propagate with no reason.
-            const key = await cryptoKey;
+            const key = await resolveEncryptionKey(cryptoKey);
             const payload = await dehydrateStepArguments(
               { aborted: true, reason: signal.reason },
               runId,

--- a/packages/core/src/serialization/encryption.ts
+++ b/packages/core/src/serialization/encryption.ts
@@ -22,12 +22,19 @@ export type { CryptoKey };
 
 /**
  * Encryption key parameter type. Accepts a resolved key, undefined (no encryption),
- * or a promise that resolves to either.
+ * a promise, or a resolver that can defer fetching the key until data needs it.
  */
 export type EncryptionKeyParam =
   | CryptoKey
   | undefined
-  | Promise<CryptoKey | undefined>;
+  | Promise<CryptoKey | undefined>
+  | (() => Promise<CryptoKey | undefined>);
+
+export async function resolveEncryptionKey(
+  key: EncryptionKeyParam
+): Promise<CryptoKey | undefined> {
+  return typeof key === 'function' ? key() : key;
+}
 
 /**
  * Encrypt a format-prefixed payload if a key is provided.

--- a/packages/world-vercel/src/utils.test.ts
+++ b/packages/world-vercel/src/utils.test.ts
@@ -256,4 +256,28 @@ describe('makeRequest body-parse retry', () => {
     // A write must not be replayed — exactly one attempt.
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('includes Vercel correlation headers in HTTP response errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'upstream timed out' }), {
+        status: 504,
+        headers: {
+          'content-type': 'application/json',
+          'x-vercel-id': 'iad1::req-abc',
+          'x-vercel-error': 'FUNCTION_INVOCATION_TIMEOUT',
+        },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      makeRequest({
+        endpoint: '/v2/runs/wrun_test?remoteRefBehavior=resolve',
+        options: { method: 'GET' },
+        schema,
+      })
+    ).rejects.toThrow(
+      'upstream timed out (x-vercel-id=iad1::req-abc; x-vercel-error=FUNCTION_INVOCATION_TIMEOUT)'
+    );
+  });
 });

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -45,15 +45,31 @@ const HTTP_DEBUG_ENABLED =
 function httpLog(
   method: string,
   endpoint: string,
-  status: number,
+  response: Response,
   ms: number
 ): void {
   if (HTTP_DEBUG_ENABLED) {
+    const responseContext = getResponseDiagnosticHeaders(response);
+    const diagnosticSuffix =
+      responseContext.length > 0 ? `; ${responseContext.join('; ')}` : '';
     console.debug(
-      `[workflow:world-vercel:http] ${method} ${endpoint} -> ${status} (${ms}ms)`
+      `[workflow:world-vercel:http] ${method} ${endpoint} -> ${response.status} (${ms}ms${diagnosticSuffix})`
     );
   }
 }
+
+function getResponseDiagnosticHeaders(response: Response): string[] {
+  return ['x-vercel-id', 'x-vercel-error'].flatMap((header) => {
+    const value = response.headers.get(header);
+    return value ? [`${header}=${value}`] : [];
+  });
+}
+
+function formatResponseDiagnostics(response: Response): string {
+  const headers = getResponseDiagnosticHeaders(response);
+  return headers.length > 0 ? ` (${headers.join('; ')})` : '';
+}
+
 /**
  * Inline workflow-server URL override. Must remain an empty string on
  * `main` — rewritten by external CI for branch-deployment testing.
@@ -321,6 +337,7 @@ export async function makeRequest<T>({
       // write must not be replayed (it could be applied twice).
       const canRetryBody = IDEMPOTENT_METHODS.has(method.toUpperCase());
       let parseResult: ParseResult;
+      let responseDiagnostics = '';
       for (let attempt = 0; ; attempt++) {
         // NOTE: Set a unique header on every attempt to bypass RSC request
         // memoization (and to avoid replaying a memoized truncated body).
@@ -367,7 +384,8 @@ export async function makeRequest<T>({
         }
         const fetchMs = Date.now() - fetchStart;
 
-        httpLog(method, endpoint, response.status, fetchMs);
+        responseDiagnostics = formatResponseDiagnostics(response);
+        httpLog(method, endpoint, response, fetchMs);
 
         span?.setAttributes({
           ...HttpResponseStatusCode(response.status),
@@ -402,8 +420,9 @@ export async function makeRequest<T>({
           }
 
           const defaultMessage =
-            errorData.message ||
-            `${request.method} ${endpoint} -> HTTP ${response.status}: ${response.statusText}`;
+            (errorData.message ||
+              `${request.method} ${endpoint} -> HTTP ${response.status}: ${response.statusText}`) +
+            responseDiagnostics;
 
           // Map specific HTTP status codes to semantic error types
           const throwWithTrace = (error: Error): never => {
@@ -470,7 +489,7 @@ export async function makeRequest<T>({
           }
           const contentType = response.headers.get('Content-Type') || 'unknown';
           throw new WorkflowWorldError(
-            `Failed to parse response body for ${method} ${endpoint} (Content-Type: ${contentType}):\n\n${error}`,
+            `Failed to parse response body for ${method} ${endpoint}${responseDiagnostics} (Content-Type: ${contentType}):\n\n${error}`,
             { url, code: 'PARSE_ERROR', cause: error }
           );
         }
@@ -490,7 +509,7 @@ export async function makeRequest<T>({
             ? `\n\nResponse context: ${parseResult.getDebugContext()}`
             : '';
           throw new WorkflowWorldError(
-            `Schema validation failed for ${method} ${endpoint}:\n${issues}${debugContext}`,
+            `Schema validation failed for ${method} ${endpoint}${responseDiagnostics}:\n${issues}${debugContext}`,
             { url, code: 'SCHEMA_VALIDATION', cause: validationResult.error }
           );
         }


### PR DESCRIPTION
## Summary

- defer `Run.getReadable()` encryption-key lookup until serialized stream data is actually read
- include `x-vercel-id` and `x-vercel-error` in response-backed `world-vercel` transport errors and HTTP debug logs
- add regressions for empty readable streams and Vercel correlation diagnostics

## Root cause

`Run.getReadable()` eagerly started resolving the run encryption key. That path calls `world.runs.get()` (`GET /v2/runs/:id?remoteRefBehavior=resolve`) before any stream chunk requires deserialization. For unused or empty readable streams, a rejected lookup was not observed by a consumer and could surface as an unhandled rejection.

The Vercel request headers are only available when an HTTP response is received. A local `AbortSignal.timeout()` rejection still cannot include response headers because no `Response` exists in that path.

## Validation

- `pnpm turbo build --filter=@workflow/core... --filter=@workflow/world-vercel...`
- `pnpm --dir packages/core exec vitest run src/serialization.test.ts src/runtime/runs.test.ts`
- `pnpm --dir packages/world-vercel exec vitest run src`
- `git diff --check HEAD^ HEAD`
