### PR TITLE
Fix Next lazy discovery step imports

### DIFF
--- a/.changeset/lazy-next-step-imports.md
+++ b/.changeset/lazy-next-step-imports.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Avoid creating a separate esbuild steps bundle in Next.js lazy discovery mode.

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -47,11 +47,13 @@ export function createDevTests(config?: DevTestConfig) {
     );
     const testWorkflowFile = finalConfig.testWorkflowFile ?? '3_streams.ts';
     const workflowsDir = finalConfig.workflowsDir ?? 'workflows';
-    const usesDeferredBuilder = generatedStep.includes(
-      path.join('.well-known', 'workflow', 'v1', 'step', 'route.js')
+    const usesNextFlowRoute = generatedWorkflow.includes(
+      path.join('app', '.well-known', 'workflow', 'v1', 'flow', 'route.js')
     );
+    const usesDeferredBuilder =
+      isNextLazyDiscoveryEnabledForTest() && usesNextFlowRoute;
     const usesNextEagerBuilder =
-      !isNextLazyDiscoveryEnabledForTest() && usesDeferredBuilder;
+      !isNextLazyDiscoveryEnabledForTest() && usesNextFlowRoute;
     const workflowManifestPath = path.join(
       appPath,
       'app/.well-known/workflow/v1/manifest.json'
@@ -64,6 +66,23 @@ export function createDevTests(config?: DevTestConfig) {
       return Object.values(manifest.steps || {}).flatMap((entry) =>
         Object.keys(entry)
       );
+    };
+    const readFileIfExists = async (
+      filePath: string
+    ): Promise<string | null> => {
+      try {
+        return await fs.readFile(filePath, 'utf8');
+      } catch (error) {
+        if (
+          error &&
+          typeof error === 'object' &&
+          'code' in error &&
+          error.code === 'ENOENT'
+        ) {
+          return null;
+        }
+        throw error;
+      }
     };
     const restoreFiles: Array<{ path: string; content: string }> = [];
 
@@ -158,8 +177,8 @@ export function createDevTests(config?: DevTestConfig) {
       // Restore file contents before deleting any files. If a deletion races
       // ahead of an api-file restore, the dev server briefly sees an import
       // pointing at a missing module and fails compilation. On Windows that
-      // failure can stick — Turbopack leaves stale imports in the generated
-      // step route bundle — and every subsequent step request returns 500.
+      // failure can stick in Turbopack's generated workflow outputs, and every
+      // subsequent step request returns 500.
       const toRestore = restoreFiles.filter((item) => item.content !== '');
       const toDelete = restoreFiles.filter((item) => item.content === '');
       await Promise.all(
@@ -218,14 +237,16 @@ export async function myNewStep() {
       await pollUntil({
         description: 'generated step outputs to include myNewStep',
         check: async () => {
-          const stepRouteContent = await fs.readFile(generatedStep, 'utf8');
-          if (stepRouteContent.includes('myNewStep')) {
+          const stepRouteContent = await readFileIfExists(generatedStep);
+          if (stepRouteContent?.includes('myNewStep')) {
             return;
           }
 
-          // The deferred builder regenerates manifest.json on every rebuild.
-          // Check the manifest for the new step function name.
-          if (usesDeferredBuilder) {
+          // Next flow-route builders regenerate manifest.json on every
+          // rebuild. In lazy mode there is no standalone step registration
+          // file; in eager mode the bundled file may not preserve function
+          // names as plain text.
+          if (usesNextFlowRoute) {
             const manifestFunctionNames = await readManifestStepFunctionNames();
             expect(manifestFunctionNames).toContain('myNewStep');
             return;
@@ -412,8 +433,8 @@ ${apiFileContent}`
 
         // Tear down in-test (rather than relying on afterEach) so we can wait
         // for the deferred builder to drop the discovered step from the
-        // manifest before the next test file runs. The generated step route
-        // bundle holds a literal `import '../workflows/discovered-via-workflow-step.ts'`
+        // manifest before the next test file runs. The generated flow route
+        // holds a literal `import '../workflows/discovered-via-workflow-step.ts'`
         // that is only pruned when the deferred builder rebuilds and
         // `filterExistingFiles` excludes the now-missing source. On Windows
         // the rebuild can lag behind the deletion, leaving the bundle
@@ -451,7 +472,7 @@ ${apiFileContent}`
       async () => {
         await pollUntil({
           description:
-            'generated step route to reference @workflow/ai package steps',
+            'generated workflow outputs to reference @workflow/ai package steps',
           timeoutMs: 25_000,
           check: async () => {
             await fetchWithTimeout('/api/chat');
@@ -465,17 +486,22 @@ ${apiFileContent}`
             const manifestStepFiles = Object.keys(manifest.steps || {});
             expect(
               manifestStepFiles.some((filePath) =>
-                filePath.includes('ai/dist/agent/durable-agent.js')
+                /ai\/(src|dist)\/agent\/durable-agent\.(ts|js)$/.test(filePath)
               )
             ).toBe(true);
 
             // Package step sources are imported directly (not copied). Verify
-            // the generated step route imports the @workflow/ai package or
+            // the generated route imports the @workflow/ai package or
             // otherwise references `durable-agent` via its resolved path.
-            const stepRouteContent = await fs.readFile(generatedStep, 'utf8');
+            const generatedRouteContent =
+              (await readFileIfExists(generatedStep)) ??
+              (await readFileIfExists(generatedWorkflow));
+            if (!generatedRouteContent) {
+              throw new Error('generated workflow outputs were not found');
+            }
             expect(
-              stepRouteContent.includes('@workflow/ai') ||
-                stepRouteContent.includes('durable-agent')
+              generatedRouteContent.includes('@workflow/ai') ||
+                generatedRouteContent.includes('durable-agent')
             ).toBe(true);
           },
         });

--- a/packages/core/e2e/local-build.test.ts
+++ b/packages/core/e2e/local-build.test.ts
@@ -98,6 +98,11 @@ const DEFERRED_BUILD_MODE_PROJECTS = new Set([
 ]);
 const DEFERRED_BUILD_UNSUPPORTED_WARNING = 'lazyDiscovery requires Next.js >=';
 const EAGER_DISCOVERY_LOG = 'Discovering workflow directives';
+const WORKFLOW_BUNDLE_LOGS = [
+  'Created intermediate workflow bundle',
+  'Created final workflow bundle',
+];
+const STEP_BUNDLE_LOG = 'Created steps bundle';
 
 describe.each([
   'example',
@@ -137,6 +142,10 @@ describe.each([
       );
       if (deferredBuildSupported) {
         expect(result.output).not.toContain(EAGER_DISCOVERY_LOG);
+        for (const workflowBundleLog of WORKFLOW_BUNDLE_LOGS) {
+          expect(result.output).not.toContain(workflowBundleLog);
+        }
+        expect(result.output).not.toContain(STEP_BUNDLE_LOG);
       }
     }
 

--- a/packages/core/e2e/utils.test.ts
+++ b/packages/core/e2e/utils.test.ts
@@ -43,14 +43,14 @@ describe('hasStepSourceMaps', () => {
     expect(hasStepSourceMaps()).toBe(true);
   });
 
-  test('expects source filenames for webpack local dev with lazy discovery disabled', () => {
+  test('does not expect source filenames for webpack local dev with lazy discovery disabled', () => {
     setStepSourceMapEnv({
       appName: 'nextjs-webpack',
       dev: true,
       lazyDiscovery: false,
     });
 
-    expect(hasStepSourceMaps()).toBe(true);
+    expect(hasStepSourceMaps()).toBe(false);
   });
 
   test('does not expect source filenames for turbopack local dev with lazy discovery disabled', () => {

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -61,23 +61,17 @@ export function hasStepSourceMaps(): boolean {
   if (appName === 'nextjs-turbopack') {
     return false;
   }
-  // V2: webpack inlines the step bundle into the combined flow route, and the
-  // re-bundled output no longer surfaces original step filenames in error
-  // stacks (neither dev mode nor production builds). Pre-V2 dev mode imported
-  // step sources directly and preserved filenames, but the combined route
-  // pipeline collapses them. Treat both dev and prod as "no source maps".
-  // TODO: revisit once webpack's combined-bundle source maps surface step paths.
-  if (appName === 'nextjs-webpack') {
+  // Webpack's eager Next flow route executes steps from the generated
+  // __step_registrations.js bundle. Lazy discovery imports step sources through
+  // the flow route and preserves source filenames in local dev stacks.
+  if (appName === 'nextjs-webpack' && !isNextLazyDiscoveryEnabledForTest()) {
     return false;
   }
-
   // V2 carve-out: the V2 combined flow handler does not yet wire up inline
   // source maps for step bundles across the framework integrations on Vercel.
-  // Only nextjs-webpack and sveltekit are currently in a known-good state, and
-  // both happen to assert "no source maps" via the earlier branches above. To
-  // unblock CI while V2 source-map coverage catches up, treat every other
+  // To unblock CI while V2 source-map coverage catches up, treat every
   // framework on Vercel as not having step source maps. Re-evaluate once the
-  // V2 esbuild pipeline emits consumable source maps for all frameworks.
+  // V2 route pipeline emits consumable source maps for all frameworks.
   // TODO: restore the per-framework matrix once source maps are wired up.
   if (!isLocalDeployment()) {
     return false;

--- a/packages/next/src/builder-deferred.test.ts
+++ b/packages/next/src/builder-deferred.test.ts
@@ -1,0 +1,137 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getNextBuilderDeferred } from './builder-deferred.js';
+
+const tempDirs: string[] = [];
+// biome-ignore lint/security/noGlobalEval: The test preserves the builder's dynamic import shim while stubbing one import.
+const originalEval = globalThis.eval;
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+  tempDirs.length = 0;
+  vi.unstubAllGlobals();
+});
+
+describe('NextDeferredBuilder', () => {
+  it('lets Next bundle step registrations from source imports', async () => {
+    const workingDir = await mkdtemp(join(tmpdir(), 'workflow-next-deferred-'));
+    tempDirs.push(workingDir);
+    vi.stubGlobal('eval', (source: string) => {
+      if (source === 'import("@workflow/builders")') {
+        return import('@workflow/builders');
+      }
+      return originalEval(source);
+    });
+
+    const NextDeferredBuilder = await getNextBuilderDeferred();
+    const builder = new NextDeferredBuilder({
+      dirs: [],
+      workingDir,
+      buildTarget: 'next',
+      workflowsBundlePath: '',
+      stepsBundlePath: '',
+      webhookBundlePath: '',
+    }) as any;
+
+    const workflowFile = join(workingDir, 'workflows/example.ts');
+    const routeDir = join(workingDir, 'app/.well-known/workflow/v1/flow');
+    const flowOutfile = join(routeDir, 'route.js.temp');
+    const stepManifest = {
+      steps: {
+        'workflows/example.ts': {
+          step: { stepId: 'step//./workflows/example//step' },
+        },
+      },
+    };
+    const workflowManifest = {
+      workflows: {
+        'workflows/example.ts': {
+          run: { workflowId: 'workflow//./workflows/example//run' },
+        },
+      },
+    };
+
+    builder.createStepsBundle = vi.fn();
+    builder.createWorkflowsBundle = vi.fn(async () => ({
+      interimBundleText: 'globalThis.__private_workflows = new Map();',
+      manifest: workflowManifest,
+    }));
+    builder.createDeferredStepManifest = vi.fn(async () => stepManifest);
+
+    const result = await builder.createDeferredFlowRoute({
+      inputFiles: [workflowFile],
+      flowOutfile,
+      discoveredEntries: {
+        discoveredSteps: new Set([workflowFile]),
+        discoveredWorkflows: new Set([workflowFile]),
+        discoveredSerdeFiles: new Set(),
+      },
+    });
+
+    expect(builder.createStepsBundle).not.toHaveBeenCalled();
+    expect(result.manifest).toEqual({
+      ...stepManifest,
+      workflows: workflowManifest.workflows,
+      classes: {},
+    });
+
+    const routeCode = await readFile(flowOutfile, 'utf8');
+    const expectedStepImport = relative(routeDir, workflowFile).replace(
+      /\\/g,
+      '/'
+    );
+    expect(routeCode).toContain("import 'workflow/internal/builtins';");
+    expect(routeCode).toContain(`import "${expectedStepImport}";`);
+    expect(routeCode).toContain(
+      "import { workflowEntrypoint } from 'workflow/runtime';"
+    );
+    expect(routeCode).not.toContain('__step_registrations');
+  });
+
+  it('imports workspace package step sources from dist output outside packages directories', async () => {
+    const workingDir = await mkdtemp(join(tmpdir(), 'workflow-next-deferred-'));
+    tempDirs.push(workingDir);
+    vi.stubGlobal('eval', (source: string) => {
+      if (source === 'import("@workflow/builders")') {
+        return import('@workflow/builders');
+      }
+      return originalEval(source);
+    });
+
+    const NextDeferredBuilder = await getNextBuilderDeferred();
+    const builder = new NextDeferredBuilder({
+      dirs: [],
+      workingDir,
+      buildTarget: 'next',
+      workflowsBundlePath: '',
+      stepsBundlePath: '',
+      webhookBundlePath: '',
+    }) as any;
+
+    const packageDir = join(workingDir, '../libs/demo');
+    const packageSourceFile = join(packageDir, 'src/runtime/run.ts');
+    const packageDistFile = join(packageDir, 'dist/runtime/run.js');
+    const routeDir = join(workingDir, 'app/.well-known/workflow/v1/flow');
+    await mkdir(join(packageDir, 'src/runtime'), { recursive: true });
+    await mkdir(join(packageDir, 'dist/runtime'), { recursive: true });
+    await writeFile(
+      join(packageDir, 'package.json'),
+      JSON.stringify({ name: '@demo/workflow-steps', type: 'module' })
+    );
+    await writeFile(packageSourceFile, 'export async function step() {}');
+    await writeFile(packageDistFile, 'export async function step() {}');
+
+    const importSpecifier = await builder.getDeferredRouteImportSpecifier(
+      packageSourceFile,
+      routeDir
+    );
+
+    expect(importSpecifier).toBe(
+      relative(routeDir, packageDistFile).replace(/\\/g, '/')
+    );
+  });
+});

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -21,6 +21,7 @@ import {
   relative,
   resolve,
 } from 'node:path';
+import type { WorkflowManifest } from '@workflow/builders';
 import {
   cleanupStaleSocketInfoFiles,
   createSocketServer,
@@ -42,7 +43,7 @@ export async function getNextBuilderDeferred() {
     return CachedNextBuilderDeferred;
   }
 
-  // V2: STEP_QUEUE_TRIGGER, getImportPath, and enhanced-resolve infrastructure
+  // V2: STEP_QUEUE_TRIGGER and enhanced-resolve infrastructure
   // were removed because the V2 combined handler eliminates the separate step
   // route/topic. The step copy import rewriting (getRelativeImportSpecifier,
   // getStepCopyFileName, rewriteRelativeImportsForCopiedStep) from main was also
@@ -53,6 +54,7 @@ export async function getNextBuilderDeferred() {
     WORKFLOW_QUEUE_TRIGGER,
     detectWorkflowPatterns,
     applySwcTransform,
+    getImportPath,
     resolveWorkflowAliasRelativePath,
     // biome-ignore lint/security/noGlobalEval: Need to use eval here to avoid TypeScript from transpiling the import statement into `require()`
   } = (await eval(
@@ -206,7 +208,7 @@ export async function getNextBuilderDeferred() {
     private async getGeneratedRouteState(
       routeFilePath: string
     ): Promise<'missing' | 'stub' | 'generated'> {
-      let routeStats;
+      let routeStats: Awaited<ReturnType<typeof stat>>;
       try {
         routeStats = await stat(routeFilePath);
       } catch {
@@ -517,21 +519,12 @@ export async function getNextBuilderDeferred() {
 
       const tsconfigPath = await this.findTsConfigPath();
 
-      // V2: Build combined route (replaces separate step + flow routes)
       const flowRouteDir = join(workflowGeneratedDir, 'flow');
       await mkdir(flowRouteDir, { recursive: true });
-      // Write step registrations to final name directly (not temp) so the
-      // import path in the flow route is correct. The flow route uses temp
-      // naming to avoid HMR churn via copyFileIfChanged, but the step
-      // registrations file is a side-effect import and doesn't need that.
-      const stepsOutfile = join(flowRouteDir, '__step_registrations.js');
-      const combinedResult = await this.createCombinedBundle({
-        format: 'esm',
+
+      const combinedResult = await this.createDeferredFlowRoute({
         inputFiles: buildInputFiles,
-        stepsOutfile,
         flowOutfile: join(flowRouteDir, tempRouteFileName),
-        bundleFinalOutput: false,
-        externalizeNonSteps: true,
         tsconfigPath,
         discoveredEntries,
       });
@@ -603,6 +596,250 @@ export async function getNextBuilderDeferred() {
 
       // Notify deferred entry loaders waiting on route.js stubs.
       this.socketIO?.emit('build-complete');
+    }
+
+    private async createDeferredFlowRoute({
+      inputFiles,
+      flowOutfile,
+      tsconfigPath,
+      discoveredEntries,
+    }: {
+      inputFiles: string[];
+      flowOutfile: string;
+      tsconfigPath?: string;
+      discoveredEntries: {
+        discoveredSteps: Set<string>;
+        discoveredWorkflows: Set<string>;
+        discoveredSerdeFiles: Set<string>;
+      };
+    }): Promise<{ manifest: WorkflowManifest }> {
+      const workflowResult = await this.createWorkflowsBundle({
+        inputFiles,
+        outfile: `${flowOutfile}.__wf_tmp.js`,
+        format: 'esm',
+        bundleFinalOutput: false,
+        tsconfigPath,
+        discoveredEntries,
+      });
+
+      const workflowVMCode = workflowResult.interimBundleText;
+      if (!workflowVMCode) {
+        throw new Error(
+          'createWorkflowsBundle did not return interimBundleText'
+        );
+      }
+
+      try {
+        await rm(`${flowOutfile}.__wf_tmp.js`, { force: true });
+      } catch {
+        // Ignore cleanup errors.
+      }
+
+      const stepAndSerdeFiles = Array.from(
+        new Set([
+          ...discoveredEntries.discoveredSteps,
+          ...discoveredEntries.discoveredSerdeFiles,
+        ])
+      ).sort();
+      const stepImports = await this.createDeferredStepSideEffectImports(
+        stepAndSerdeFiles,
+        dirname(flowOutfile)
+      );
+      const stepManifest =
+        await this.createDeferredStepManifest(stepAndSerdeFiles);
+      const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
+      const routeCode = `// biome-ignore-all lint: generated file
+/* eslint-disable */
+import 'workflow/internal/builtins';
+${stepImports}
+import { workflowEntrypoint } from 'workflow/runtime';
+
+const workflowCode = \`${escapedVMCode}\`;
+
+export const POST = workflowEntrypoint(workflowCode);`;
+
+      await this.writeFileIfChanged(flowOutfile, routeCode);
+
+      return {
+        manifest: {
+          ...stepManifest,
+          workflows: {
+            ...stepManifest.workflows,
+            ...workflowResult.manifest.workflows,
+          },
+          classes: {
+            ...stepManifest.classes,
+            ...workflowResult.manifest.classes,
+          },
+        },
+      };
+    }
+
+    private async createDeferredStepSideEffectImports(
+      files: string[],
+      routeDir: string
+    ): Promise<string> {
+      const importSpecifiers = await Promise.all(
+        files.map((file) =>
+          this.getDeferredRouteImportSpecifier(file, routeDir)
+        )
+      );
+
+      return importSpecifiers
+        .map((specifier) => `import ${JSON.stringify(specifier)};`)
+        .join('\n');
+    }
+
+    private async getDeferredRouteImportSpecifier(
+      file: string,
+      routeDir: string
+    ): Promise<string> {
+      const { importPath, isPackage } = getImportPath(
+        file,
+        this.config.workingDir
+      );
+
+      if (isPackage) {
+        return importPath;
+      }
+
+      const absolutePath = await this.resolveDeferredRouteImportFilePath(
+        resolve(this.config.workingDir, importPath)
+      );
+      let relativePath = relative(routeDir, absolutePath).replace(/\\/g, '/');
+      if (!relativePath.startsWith('./') && !relativePath.startsWith('../')) {
+        relativePath = `./${relativePath}`;
+      }
+      return relativePath;
+    }
+
+    private async resolveDeferredRouteImportFilePath(
+      filePath: string
+    ): Promise<string> {
+      const packageDistPath =
+        this.resolvePackageSourceDistFilePathForRouteImport(filePath);
+      if (packageDistPath) {
+        return packageDistPath;
+      }
+
+      return filePath;
+    }
+
+    private resolvePackageSourceDistFilePathForRouteImport(
+      filePath: string
+    ): string | null {
+      const relativeToWorkingDir = relative(this.config.workingDir, filePath);
+      if (
+        !relativeToWorkingDir.startsWith('..') &&
+        !isAbsolute(relativeToWorkingDir)
+      ) {
+        return null;
+      }
+
+      const packageRoot = this.findPackageRootForRouteImportSource(filePath);
+      if (!packageRoot) {
+        return null;
+      }
+
+      const relativeToPackageRoot = relative(packageRoot, filePath).replace(
+        /\\/g,
+        '/'
+      );
+      const srcPrefix = 'src/';
+      if (!relativeToPackageRoot.startsWith(srcPrefix)) {
+        return null;
+      }
+
+      const extension = extname(relativeToPackageRoot);
+      const outputExtension =
+        extension === '.mts' ? '.mjs' : extension === '.cts' ? '.cjs' : '.js';
+      const withoutExtension = relativeToPackageRoot.slice(
+        srcPrefix.length,
+        relativeToPackageRoot.length - extension.length
+      );
+      const distPath = join(
+        packageRoot,
+        'dist',
+        `${withoutExtension}${outputExtension}`
+      );
+
+      return existsSync(distPath) ? distPath : null;
+    }
+
+    private findPackageRootForRouteImportSource(
+      filePath: string
+    ): string | null {
+      let currentDir = dirname(filePath);
+
+      while (true) {
+        if (existsSync(join(currentDir, 'package.json'))) {
+          return currentDir;
+        }
+
+        const parentDir = dirname(currentDir);
+        if (parentDir === currentDir) {
+          return null;
+        }
+        currentDir = parentDir;
+      }
+    }
+
+    private async createDeferredStepManifest(
+      files: string[]
+    ): Promise<WorkflowManifest> {
+      const manifest: WorkflowManifest = {};
+      const manifestFiles = Array.from(
+        new Set([
+          ...files,
+          ...(await this.resolveBuiltInStepFilesForManifest()),
+        ])
+      ).sort();
+
+      for (const file of manifestFiles) {
+        const source = await readFile(file, 'utf8').catch(() => undefined);
+        if (!source) {
+          continue;
+        }
+
+        const relativeFilepath = await this.getRelativeFilenameForSwc(file);
+        const { workflowManifest } = await applySwcTransform(
+          relativeFilepath,
+          source,
+          'step',
+          file,
+          this.transformProjectRoot
+        );
+        this.mergeWorkflowManifest(manifest, workflowManifest);
+      }
+
+      return manifest;
+    }
+
+    private async resolveBuiltInStepFilesForManifest(): Promise<string[]> {
+      try {
+        const workflowRequire = createRequire(
+          join(this.config.workingDir, 'package.json')
+        );
+        return [
+          this.normalizeDiscoveredFilePath(
+            workflowRequire.resolve('workflow/internal/builtins')
+          ),
+        ];
+      } catch {
+        return [];
+      }
+    }
+
+    private mergeWorkflowManifest(
+      target: WorkflowManifest,
+      source: WorkflowManifest
+    ): void {
+      target.workflows = Object.assign(
+        target.workflows || {},
+        source.workflows
+      );
+      target.steps = Object.assign(target.steps || {}, source.steps);
+      target.classes = Object.assign(target.classes || {}, source.classes);
     }
 
     private async cleanupGeneratedArtifactsOnBoot(


### PR DESCRIPTION
## Summary
- avoid creating a separate esbuild steps bundle for Next.js lazy discovery
- import discovered step files through the generated flow route for Turbopack
- map workspace package source files to built dist files for route imports

## Testing
- pnpm exec tsc -p packages/next/tsconfig.json --noEmit
- pnpm exec vitest run packages/next/src/builder-deferred.test.ts packages/next/src/builder.test.ts packages/next/src/index.test.ts
- cd packages/next && pnpm build
- cd workbench/nextjs-turbopack && pnpm build