### PR TITLE
fix(docs): declare Nitro auto-import globals for code samples

### DIFF
--- a/packages/docs-typecheck/src/docs-globals.d.ts
+++ b/packages/docs-typecheck/src/docs-globals.d.ts
@@ -261,4 +261,20 @@ declare global {
   const myWorkflow: (...args: any[]) => Promise<any>;
   const childWorkflow: (...args: any[]) => Promise<any>;
   const orderId: string;
+
+  // Nitro server-side auto-imports. These are globally available inside a
+  // Nitro runtime (and therefore inside `"use step"` functions when running
+  // under the native Nitro v3 bundling), so they appear unimported in docs
+  // samples. Liberal types keep the type-checker happy without pulling in
+  // Nitro's full type surface.
+  function useStorage(base?: string): {
+    getItem(key: string): Promise<any>;
+    setItem(key: string, value: any): Promise<void>;
+    removeItem(key: string): Promise<void>;
+    getKeys(base?: string): Promise<string[]>;
+    clear(base?: string): Promise<void>;
+    [key: string]: any;
+  };
+  function useDatabase(name?: string): any;
+  function useRuntimeConfig(event?: any): any;
 }


### PR DESCRIPTION
## Summary

Fixes the failing **Docs Code Samples** check on `main`. The [native Nitro v3 bundling changelog](https://github.com/vercel/workflow/blob/main/docs/content/docs/v5/internal/nitro-native-build.mdx) (added in #2232) includes a code sample that calls `useStorage("cache")` — a Nitro server-side auto-import — from a `"use step"` function. The docs type-checker has no knowledge of Nitro's auto-imports, so it failed with:

```
docs/content/docs/v5/internal/nitro-native-build.mdx line 25
  Line 4: Cannot find name 'useStorage'. Did you mean 'storage'? (TS2552)
```

This was failing on `main`, independent of any feature PR.

## Changes

- `packages/docs-typecheck/src/docs-globals.d.ts`: Declare liberal global types for the Nitro server-side auto-imports referenced in docs samples (`useStorage`, `useDatabase`, `useRuntimeConfig`). These are globally available inside a Nitro runtime (and thus inside steps under native Nitro v3 bundling), so they legitimately appear unimported in samples.

## Validation

- `pnpm test:docs` — all docs samples pass (918 passed, 0 failed; previously 1 failed)
- `pnpm biome check packages/docs-typecheck/src/docs-globals.d.ts` — clean
- No changeset needed (`@workflow/docs-typecheck` is private tooling)