### PR TITLE
[codex] Fix partial world-local exclusive writes

### DIFF
--- a/.changeset/atomic-runs-publish.md
+++ b/.changeset/atomic-runs-publish.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Prevent concurrent readers from observing partially written local entity files.

--- a/packages/world-local/src/fs.test.ts
+++ b/packages/world-local/src/fs.test.ts
@@ -24,6 +24,7 @@ import {
   taggedPath,
   UnsafeEntityIdError,
   ulidToDate,
+  writeExclusive,
   writeJSON,
 } from './fs.js';
 
@@ -66,6 +67,7 @@ describe('fs utilities', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
@@ -862,6 +864,67 @@ describe('fs utilities', () => {
           createdAt: testTime,
         }),
       ]);
+    });
+  });
+
+  describe('writeExclusive', () => {
+    it('does not expose the destination until the full contents are written', async () => {
+      const filePath = path.join(testDir, 'exclusive.json');
+      const contents = JSON.stringify({ value: 'complete' });
+      const originalWriteFile = fs.writeFile.bind(fs);
+      let notifyWriteStarted: () => void = () => {};
+      let releaseWrite: () => void = () => {};
+      const writeStarted = new Promise<void>((resolve) => {
+        notifyWriteStarted = resolve;
+      });
+      const writeReleased = new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+
+      vi.spyOn(fs, 'writeFile').mockImplementation(
+        async (target, data, options) => {
+          const targetPath = target.toString();
+          if (
+            targetPath === filePath ||
+            targetPath.startsWith(`${filePath}.tmp.`)
+          ) {
+            await originalWriteFile(target, '{"value":', options);
+            notifyWriteStarted();
+            await writeReleased;
+            await originalWriteFile(target, data);
+            return;
+          }
+          await originalWriteFile(target, data, options);
+        }
+      );
+
+      const writePromise = writeExclusive(filePath, contents);
+      await writeStarted;
+
+      try {
+        await expect(fs.readFile(filePath, 'utf8')).rejects.toMatchObject({
+          code: 'ENOENT',
+        });
+      } finally {
+        releaseWrite();
+        await writePromise;
+      }
+
+      expect(await fs.readFile(filePath, 'utf8')).toBe(contents);
+    });
+
+    it('allows exactly one concurrent writer to publish the destination', async () => {
+      const filePath = path.join(testDir, 'exclusive.json');
+      const values = Array.from({ length: 16 }, (_, index) => `value-${index}`);
+
+      const results = await Promise.all(
+        values.map((value) => writeExclusive(filePath, value))
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+      const winner = results.findIndex(Boolean);
+      expect(await fs.readFile(filePath, 'utf8')).toBe(values[winner]);
+      expect(await fs.readdir(testDir)).toEqual(['exclusive.json']);
     });
   });
 

--- a/packages/world-local/src/fs.test.ts
+++ b/packages/world-local/src/fs.test.ts
@@ -926,6 +926,20 @@ describe('fs utilities', () => {
       expect(await fs.readFile(filePath, 'utf8')).toBe(values[winner]);
       expect(await fs.readdir(testDir)).toEqual(['exclusive.json']);
     });
+
+    it('does not clean up a temp file that it failed to create', async () => {
+      const filePath = path.join(testDir, 'exclusive.json');
+      const unlink = vi.spyOn(fs, 'unlink');
+      vi.spyOn(fs, 'writeFile').mockRejectedValueOnce(
+        Object.assign(new Error('file already exists'), { code: 'EEXIST' })
+      );
+
+      await expect(writeExclusive(filePath, 'value')).rejects.toMatchObject({
+        code: 'EEXIST',
+      });
+
+      expect(unlink).not.toHaveBeenCalled();
+    });
   });
 
   describe('assertSafeEntityId (path traversal prevention)', () => {

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -397,23 +397,35 @@ export async function deleteJSON(filePath: string): Promise<void> {
 }
 
 /**
- * Atomically create a file using O_CREAT | O_EXCL flags.
- * Returns true if the file was created, false if it already exists.
- * This is atomic at the OS level, safe for concurrent access.
+ * Atomically publish a fully-written file without overwriting an existing one.
+ *
+ * Writing directly with O_CREAT | O_EXCL makes the destination visible before
+ * its contents are complete, so concurrent readers can observe a partial file.
+ * Instead, write to a unique file in the same directory, then hard-link it into
+ * place. Creating the link is atomic and fails with EEXIST if another writer
+ * published the destination first.
  */
 export async function writeExclusive(
   filePath: string,
   data: string
 ): Promise<boolean> {
   await ensureDir(path.dirname(filePath));
+  const tempPath = `${filePath}.tmp.${ulid()}`;
+
   try {
-    await fs.writeFile(filePath, data, { flag: 'wx' });
-    return true;
-  } catch (error: any) {
-    if (error.code === 'EEXIST') {
-      return false;
+    await fs.writeFile(tempPath, data, { flag: 'wx' });
+
+    try {
+      await withWindowsRetry(() => fs.link(tempPath, filePath));
+      return true;
+    } catch (error: any) {
+      if (error.code === 'EEXIST') {
+        return false;
+      }
+      throw error;
     }
-    throw error;
+  } finally {
+    await withWindowsRetry(() => fs.unlink(tempPath), 3).catch(() => {});
   }
 }
 

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -411,9 +411,11 @@ export async function writeExclusive(
 ): Promise<boolean> {
   await ensureDir(path.dirname(filePath));
   const tempPath = `${filePath}.tmp.${ulid()}`;
+  let tempFileCreated = false;
 
   try {
     await fs.writeFile(tempPath, data, { flag: 'wx' });
+    tempFileCreated = true;
 
     try {
       await withWindowsRetry(() => fs.link(tempPath, filePath));
@@ -425,7 +427,9 @@ export async function writeExclusive(
       throw error;
     }
   } finally {
-    await withWindowsRetry(() => fs.unlink(tempPath), 3).catch(() => {});
+    if (tempFileCreated) {
+      await withWindowsRetry(() => fs.unlink(tempPath), 3).catch(() => {});
+    }
   }
 }
 

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -281,11 +281,10 @@ export function createEventsStorage(
               runInputData.workflowName &&
               runInputData.input !== undefined
             ) {
-              // Atomically try to create the run entity. writeExclusive
-              // uses O_CREAT|O_EXCL so only the first writer wins,
-              // preventing a TOCTOU race where a concurrent run_created
-              // from start() could overwrite a run that was already
-              // transitioned to 'running'.
+              // Atomically try to publish the run entity so only the first
+              // writer wins, preventing a TOCTOU race where a concurrent
+              // run_created from start() could overwrite a run that was
+              // already transitioned to 'running'.
               const createdRun: WorkflowRun = {
                 runId: effectiveRunId,
                 deploymentId: runInputData.deploymentId,
@@ -552,10 +551,10 @@ export function createEventsStorage(
             createdAt: now,
             updatedAt: now,
           };
-          // Use writeExclusive (O_CREAT|O_EXCL) to atomically create the
-          // run entity file. This prevents a TOCTOU race with the resilient
-          // start path (run_started on non-existent run) that could result
-          // in duplicate run_created events in the event log.
+          // Atomically publish the run entity file without overwriting an
+          // existing winner. This prevents a TOCTOU race with the resilient
+          // start path (run_started on non-existent run) that could result in
+          // duplicate run_created events in the event log.
           const runPath = taggedPath(basedir, 'runs', effectiveRunId, tag);
           const created = await writeExclusive(
             runPath,
@@ -711,11 +710,11 @@ export function createEventsStorage(
           // must be deduped — otherwise both writes succeed and the event log
           // ends up with duplicate step_created entries. The outer
           // withStepLock mutex serializes within a single process; this
-          // O_CREAT|O_EXCL constraint file additionally protects against
-          // cross-process races (two pnpm workers, redelivered queue
-          // messages, etc.). The loser throws EntityConflictError so the
-          // runtime's existing catch path can swallow it and avoid
-          // double-queuing the step.
+          // The exclusive constraint file additionally protects against
+          // cross-process races (two pnpm workers, redelivered queue messages,
+          // etc.). The loser throws EntityConflictError so the runtime's
+          // existing catch path can swallow it and avoid double-queuing the
+          // step.
           const stepCreatedLockName = tag
             ? `${effectiveRunId}-${data.correlationId}.created.${tag}`
             : `${effectiveRunId}-${data.correlationId}.created`;


### PR DESCRIPTION
## Summary

- write exclusive local files to a unique temporary path before publishing them
- use an atomic hard link to preserve first-writer-wins behavior without exposing partial contents
- add deterministic coverage for publication visibility and concurrent writers
- add a patch changeset for `@workflow/world-local`

## Root cause

`writeExclusive()` previously called `fs.writeFile()` directly on the final path with the `wx` flag. The exclusive create prevented another writer from winning, but the final path became visible before the JSON body was fully written. A concurrent `runs.get()` could therefore read an empty or truncated run file and fail with `SyntaxError: Unexpected end of JSON input`.

The new implementation writes and closes a temporary file first, then hard-links it into the final path. Link creation is atomic and returns `EEXIST` when another writer has already published the destination.

## Verification

- `pnpm --filter @workflow/world-local test` (368 tests)
- `pnpm --filter @workflow/world-local typecheck`
- `pnpm turbo run build --filter=@workflow/world-local...`
- targeted Biome check (existing complexity warnings only)