### PR TITLE
feat(core): add optional namespace for queue topic prefix

### DIFF
--- a/.changeset/queue-namespace-primitive.md
+++ b/.changeset/queue-namespace-primitive.md
@@ -5,19 +5,4 @@
 "@workflow/world-local": minor
 ---
 
-Add queue namespace primitive for framework isolation. When multiple frameworks (or a framework + direct SDK usage) share the same deployment, their workflow queue triggers can collide because both subscribe to `__wkf_workflow_*`. This change introduces an optional `namespace` parameter that scopes queue topic prefixes to `__{namespace}_wkf_workflow_*`, preventing cross-framework message misdelivery.
-
-**New APIs:**
-- `getQueueTopicPrefix(kind, namespace?)` in `@workflow/world` — builds namespaced queue prefixes
-- `createWorkflowQueueTrigger({ namespace })` in `@workflow/builders` — trigger factory with optional namespace
-- `workflowEntrypoint(code, { namespace })` in `@workflow/core` — namespace-aware workflow handler
-- `getWorkflowQueueName(name, namespace)` in `@workflow/core` — namespace-aware queue name construction
-- `healthCheck(world, endpoint, { namespace })` in `@workflow/core` — namespace-aware health checks
-
-**Updated types:**
-- `QueuePrefix` widened from `'__wkf_step_' | '__wkf_workflow_'` to regex-validated string accepting namespaced variants
-- `ValidQueueName` widened to match
-- `LocalQueue.registerHandler` accepts `QueuePrefix` instead of hardcoded literal union
-- `getQueueRoute` in world-local uses regex matching for namespaced prefixes
-
-**Backward compatible:** Default behavior (no namespace) is unchanged. `WORKFLOW_QUEUE_TRIGGER` remains the same. All existing queue name strings remain valid.
+Add an optional `namespace` parameter that scopes queue topic prefixes to `__{namespace}_wkf_workflow_*`. This allows configuring multiple frameworks in the same deployment without queue topic collision.

--- a/.changeset/queue-namespace-primitive.md
+++ b/.changeset/queue-namespace-primitive.md
@@ -3,6 +3,7 @@
 "@workflow/builders": minor
 "@workflow/core": minor
 "@workflow/world-local": minor
+"@workflow/world-postgres": minor
 ---
 
 Add an optional `namespace` parameter that scopes queue topic prefixes to `__{namespace}_wkf_workflow_*`. This allows configuring multiple frameworks in the same deployment without queue topic collision.

--- a/.changeset/queue-namespace-primitive.md
+++ b/.changeset/queue-namespace-primitive.md
@@ -1,0 +1,23 @@
+---
+"@workflow/world": minor
+"@workflow/builders": minor
+"@workflow/core": minor
+"@workflow/world-local": minor
+---
+
+Add queue namespace primitive for framework isolation. When multiple frameworks (or a framework + direct SDK usage) share the same deployment, their workflow queue triggers can collide because both subscribe to `__wkf_workflow_*`. This change introduces an optional `namespace` parameter that scopes queue topic prefixes to `__{namespace}_wkf_workflow_*`, preventing cross-framework message misdelivery.
+
+**New APIs:**
+- `getQueueTopicPrefix(kind, namespace?)` in `@workflow/world` — builds namespaced queue prefixes
+- `createWorkflowQueueTrigger({ namespace })` in `@workflow/builders` — trigger factory with optional namespace
+- `workflowEntrypoint(code, { namespace })` in `@workflow/core` — namespace-aware workflow handler
+- `getWorkflowQueueName(name, namespace)` in `@workflow/core` — namespace-aware queue name construction
+- `healthCheck(world, endpoint, { namespace })` in `@workflow/core` — namespace-aware health checks
+
+**Updated types:**
+- `QueuePrefix` widened from `'__wkf_step_' | '__wkf_workflow_'` to regex-validated string accepting namespaced variants
+- `ValidQueueName` widened to match
+- `LocalQueue.registerHandler` accepts `QueuePrefix` instead of hardcoded literal union
+- `getQueueRoute` in world-local uses regex matching for namespaced prefixes
+
+**Backward compatible:** Default behavior (no namespace) is unchanged. `WORKFLOW_QUEUE_TRIGGER` remains the same. All existing queue name strings remain valid.

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -71,11 +71,11 @@ export class LocalBuilder extends BaseBuilder {
 
     // Normalize request, needed for preserving request through astro
     workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
-      `${NORMALIZE_REQUEST_CODE}
+      /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
+      (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
 export const POST = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode)(normalRequest);
+  return workflowEntrypoint(workflowCode${options})(normalRequest);
 }
 
 export const prerender = false;`

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -43,6 +43,7 @@
     "@workflow/core": "workspace:*",
     "@workflow/errors": "workspace:*",
     "@workflow/utils": "workspace:*",
+    "@workflow/world": "workspace:*",
     "@workflow/swc-plugin": "workspace:*",
     "builtin-modules": "5.0.0",
     "chalk": "5.6.2",

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -43,7 +43,6 @@
     "@workflow/core": "workspace:*",
     "@workflow/errors": "workspace:*",
     "@workflow/utils": "workspace:*",
-    "@workflow/world": "workspace:*",
     "@workflow/swc-plugin": "workspace:*",
     "builtin-modules": "5.0.0",
     "chalk": "5.6.2",

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -14,6 +14,7 @@ import {
   applySwcTransform,
   type WorkflowManifest,
 } from './apply-swc-transform.js';
+import { createWorkflowEntrypointOptionsCode } from './constants.js';
 import { createDiscoverEntriesPlugin } from './discover-entries-esbuild-plugin.js';
 import { getEsbuildTsconfigOptions } from './esbuild-tsconfig.js';
 import {
@@ -1175,6 +1176,9 @@ export abstract class BaseBuilder {
         }
       }
 
+      const workflowEntrypointOptionsCode =
+        createWorkflowEntrypointOptionsCode();
+
       const bundleFinal = async (interimBundle: string) => {
         const workflowBundleCode = interimBundle;
 
@@ -1184,7 +1188,7 @@ import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${workflowBundleCode.replace(/[\\`$]/g, '\\$&')}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
         // we skip the final bundling step for Next.js so it can bundle itself
         if (!bundleFinalOutput) {
@@ -1363,6 +1367,7 @@ export const POST = workflowEntrypoint(workflowCode);`;
     // 3. Generate combined route file
     const stepsRelativePath = './' + basename(stepsOutfile).replace(/\\/g, '/');
     const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
+    const workflowEntrypointOptionsCode = createWorkflowEntrypointOptionsCode();
 
     const combinedFunctionCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
@@ -1374,7 +1379,7 @@ void __steps_registered;
 
 const workflowCode = \`${escapedVMCode}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
     if (!bundleFinalOutput) {
       // Write directly (Next.js will bundle)
@@ -1435,6 +1440,8 @@ export const POST = workflowEntrypoint(workflowCode);`;
     // Create a custom bundleFinal for watch mode that uses workflowEntrypoint
     const combinedBundleFinal = async (interimBundleText: string) => {
       const escaped = interimBundleText.replace(/[\\`$]/g, '\\$&');
+      const workflowEntrypointOptionsCode =
+        createWorkflowEntrypointOptionsCode();
       const code = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import { __steps_registered } from '${stepsRelativePath}';
@@ -1444,7 +1451,7 @@ void __steps_registered;
 
 const workflowCode = \`${escaped}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
       const outputDir = dirname(flowOutfile);
       await mkdir(outputDir, { recursive: true });

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createWorkflowEntrypointOptionsCode,
+  createWorkflowQueueTrigger,
+} from './constants.js';
+
+describe('createWorkflowQueueTrigger', () => {
+  afterEach(() => {
+    delete process.env.WORKFLOW_QUEUE_NAMESPACE;
+  });
+
+  it('uses the default workflow topic without a namespace', () => {
+    expect(createWorkflowQueueTrigger().topic).toBe('__wkf_workflow_*');
+  });
+
+  it('uses an explicit namespace when provided', () => {
+    expect(createWorkflowQueueTrigger({ namespace: 'custom' }).topic).toBe(
+      '__custom_wkf_workflow_*'
+    );
+  });
+
+  it('uses WORKFLOW_QUEUE_NAMESPACE when no explicit namespace is provided', () => {
+    process.env.WORKFLOW_QUEUE_NAMESPACE = 'custom';
+
+    expect(createWorkflowQueueTrigger().topic).toBe('__custom_wkf_workflow_*');
+  });
+});
+
+describe('createWorkflowEntrypointOptionsCode', () => {
+  afterEach(() => {
+    delete process.env.WORKFLOW_QUEUE_NAMESPACE;
+  });
+
+  it('omits runtime options without a namespace', () => {
+    expect(createWorkflowEntrypointOptionsCode()).toBe('');
+  });
+
+  it('inlines an explicit namespace', () => {
+    expect(createWorkflowEntrypointOptionsCode({ namespace: 'custom' })).toBe(
+      ', { namespace: "custom" }'
+    );
+  });
+
+  it('inlines WORKFLOW_QUEUE_NAMESPACE at build time', () => {
+    process.env.WORKFLOW_QUEUE_NAMESPACE = 'custom';
+
+    expect(createWorkflowEntrypointOptionsCode()).toBe(
+      ', { namespace: "custom" }'
+    );
+  });
+});

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -1,4 +1,22 @@
-import { getQueueTopicPrefix } from '@workflow/world';
+const QUEUE_NAMESPACE_PATTERN = /^[a-z][a-z0-9]*$/;
+
+function resolveQueueNamespace(namespace?: string): string | undefined {
+  return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined;
+}
+
+function getQueueTopicPrefix(kind: 'workflow' | 'step', namespace?: string) {
+  if (namespace !== undefined) {
+    if (!QUEUE_NAMESPACE_PATTERN.test(namespace)) {
+      throw new Error(
+        `Invalid queue namespace "${namespace}": must be lowercase alphanumeric, starting with a letter`
+      );
+    }
+
+    return `__${namespace}_wkf_${kind}_`;
+  }
+
+  return `__wkf_${kind}_`;
+}
 
 /**
  * Creates a queue trigger configuration for the workflow handler.
@@ -18,13 +36,35 @@ import { getQueueTopicPrefix } from '@workflow/world';
  * createWorkflowQueueTrigger({ namespace: 'custom' })
  */
 export function createWorkflowQueueTrigger(options?: { namespace?: string }) {
+  const namespace = resolveQueueNamespace(options?.namespace);
+
   return {
     type: 'queue/v2beta' as const,
-    topic: `${getQueueTopicPrefix('workflow', options?.namespace)}*`,
+    topic: `${getQueueTopicPrefix('workflow', namespace)}*`,
     consumer: 'default',
     retryAfterSeconds: 5, // Delay between retries (default: 60)
     initialDelaySeconds: 0, // Initial delay before first delivery (default: 0)
   };
+}
+
+/**
+ * Creates the optional second argument for generated `workflowEntrypoint()`
+ * calls. The namespace is resolved while building so generated route files do
+ * not need `WORKFLOW_QUEUE_NAMESPACE` at runtime.
+ */
+export function createWorkflowEntrypointOptionsCode(options?: {
+  namespace?: string;
+}) {
+  const namespace = resolveQueueNamespace(options?.namespace);
+
+  if (!namespace) {
+    return '';
+  }
+
+  // Reuse prefix construction for namespace validation.
+  getQueueTopicPrefix('workflow', namespace);
+
+  return `, { namespace: ${JSON.stringify(namespace)} }`;
 }
 
 /**

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -1,12 +1,33 @@
+import { getQueueTopicPrefix } from '@workflow/world';
+
 /**
- * Queue trigger configuration for the workflow handler.
+ * Creates a queue trigger configuration for the workflow handler.
  * Handles both workflow orchestration and step execution on the same route.
- * Background steps are queued back to __wkf_workflow_* with a stepId.
+ * Background steps are queued back to the workflow topic with a stepId.
+ *
+ * When `namespace` is provided, the trigger topic is scoped to avoid
+ * collisions with other frameworks or direct Workflow SDK usage in the
+ * same deployment.
+ *
+ * @example
+ * // default: topic = '__wkf_workflow_*'
+ * createWorkflowQueueTrigger()
+ *
+ * @example
+ * // namespaced: topic = '__custom_wkf_workflow_*'
+ * createWorkflowQueueTrigger({ namespace: 'custom' })
  */
-export const WORKFLOW_QUEUE_TRIGGER = {
-  type: 'queue/v2beta' as const,
-  topic: '__wkf_workflow_*',
-  consumer: 'default',
-  retryAfterSeconds: 5, // Delay between retries (default: 60)
-  initialDelaySeconds: 0, // Initial delay before first delivery (default: 0)
-};
+export function createWorkflowQueueTrigger(options?: { namespace?: string }) {
+  return {
+    type: 'queue/v2beta' as const,
+    topic: `${getQueueTopicPrefix('workflow', options?.namespace)}*`,
+    consumer: 'default',
+    retryAfterSeconds: 5, // Delay between retries (default: 60)
+    initialDelaySeconds: 0, // Initial delay before first delivery (default: 0)
+  };
+}
+
+/**
+ * Default queue trigger (no namespace). Backward compatible.
+ */
+export const WORKFLOW_QUEUE_TRIGGER = createWorkflowQueueTrigger();

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -10,6 +10,7 @@ export {
   getDecoratorOptionsForDirectoryWithConfigPath,
 } from './config-helpers.js';
 export {
+  createWorkflowEntrypointOptionsCode,
   createWorkflowQueueTrigger,
   WORKFLOW_QUEUE_TRIGGER,
 } from './constants.js';

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -9,7 +9,10 @@ export {
   getDecoratorOptionsForDirectory,
   getDecoratorOptionsForDirectoryWithConfigPath,
 } from './config-helpers.js';
-export { WORKFLOW_QUEUE_TRIGGER } from './constants.js';
+export {
+  createWorkflowQueueTrigger,
+  WORKFLOW_QUEUE_TRIGGER,
+} from './constants.js';
 export { createDiscoverEntriesPlugin } from './discover-entries-esbuild-plugin.js';
 export {
   clearModuleSpecifierCache,

--- a/packages/core/src/runtime-import.test.ts
+++ b/packages/core/src/runtime-import.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@vercel/functions', () => {
+  throw new Error('@vercel/functions should not load during runtime import');
+});
+
+describe('runtime entrypoint', () => {
+  test('does not load @vercel/functions during module evaluation', async () => {
+    await expect(import('./runtime')).resolves.toBeDefined();
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -12,6 +12,7 @@ import {
 import { parseWorkflowName } from '@workflow/utils/parse-name';
 import {
   type Event,
+  getQueueTopicPrefix,
   SPEC_VERSION_CURRENT,
   WorkflowInvokePayloadSchema,
   type WorkflowRun,
@@ -214,14 +215,17 @@ function hasRecordedTerminalRunEvent(events: Event[], runId: string): boolean {
  * @returns A function that can be used as a Vercel API route
  */
 export function workflowEntrypoint(
-  workflowCode: string
+  workflowCode: string,
+  options?: { namespace?: string }
 ): (req: Request) => Promise<Response> {
   const NO_INLINE_REPLAY_AFTER_MS =
     Number(process.env.WORKFLOW_V2_TIMEOUT_MS) || 120_000;
 
+  const workflowPrefix = getQueueTopicPrefix('workflow', options?.namespace);
+
   const handler = (worldHandlers: WorldHandlers) =>
     worldHandlers.createQueueHandler(
-      '__wkf_workflow_',
+      workflowPrefix,
       async (message_, metadata) => {
         // Check if this is a health check message
         // NOTE: Health check messages are intentionally unauthenticated for monitoring purposes.
@@ -247,7 +251,7 @@ export function workflowEntrypoint(
           runInput,
         } = WorkflowInvokePayloadSchema.parse(message_);
         const { requestId } = metadata;
-        const workflowName = metadata.queueName.slice('__wkf_workflow_'.length);
+        const workflowName = metadata.queueName.slice(workflowPrefix.length);
 
         // --- Max delivery check ---
         // Enforce max delivery limit before any infrastructure calls.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -13,6 +13,7 @@ import { parseWorkflowName } from '@workflow/utils/parse-name';
 import {
   type Event,
   getQueueTopicPrefix,
+  resolveQueueNamespace,
   SPEC_VERSION_CURRENT,
   WorkflowInvokePayloadSchema,
   type WorkflowRun,
@@ -221,7 +222,8 @@ export function workflowEntrypoint(
   const NO_INLINE_REPLAY_AFTER_MS =
     Number(process.env.WORKFLOW_V2_TIMEOUT_MS) || 120_000;
 
-  const workflowPrefix = getQueueTopicPrefix('workflow', options?.namespace);
+  const namespace = resolveQueueNamespace(options?.namespace);
+  const workflowPrefix = getQueueTopicPrefix('workflow', namespace);
 
   const handler = (worldHandlers: WorldHandlers) =>
     worldHandlers.createQueueHandler(
@@ -434,7 +436,7 @@ export function workflowEntrypoint(
                       ) {
                         await queueMessage(
                           world,
-                          getWorkflowQueueName(workflowName),
+                          getWorkflowQueueName(workflowName, namespace),
                           {
                             runId,
                             traceCarrier: await serializeTraceCarrier(),
@@ -693,7 +695,7 @@ export function workflowEntrypoint(
                       );
                       await queueMessage(
                         world,
-                        getWorkflowQueueName(workflowName),
+                        getWorkflowQueueName(workflowName, namespace),
                         {
                           runId,
                           traceCarrier: await serializeTraceCarrier(),
@@ -1055,7 +1057,7 @@ export function workflowEntrypoint(
                           const traceCarrier = await serializeTraceCarrier();
                           await queueMessage(
                             world,
-                            getWorkflowQueueName(workflowName),
+                            getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
                               stepId: step.correlationId,
@@ -1108,7 +1110,7 @@ export function workflowEntrypoint(
                           const traceCarrier = await serializeTraceCarrier();
                           await queueMessage(
                             world,
-                            getWorkflowQueueName(workflowName),
+                            getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
                               stepId: inlineStep.correlationId,
@@ -1159,7 +1161,7 @@ export function workflowEntrypoint(
                           );
                           await queueMessage(
                             world,
-                            getWorkflowQueueName(workflowName),
+                            getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
                               traceCarrier: await serializeTraceCarrier(),
@@ -1202,7 +1204,7 @@ export function workflowEntrypoint(
                             );
                             await queueMessage(
                               world,
-                              getWorkflowQueueName(workflowName),
+                              getWorkflowQueueName(workflowName, namespace),
                               {
                                 runId,
                                 traceCarrier: await serializeTraceCarrier(),

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -104,6 +104,23 @@ describe('getWorkflowQueueName', () => {
   it('should throw for empty string', () => {
     expect(() => getWorkflowQueueName('')).toThrow('Invalid workflow name');
   });
+
+  it('should use default prefix when no namespace is provided', () => {
+    expect(getWorkflowQueueName('myFlow')).toBe('__wkf_workflow_myFlow');
+    expect(getWorkflowQueueName('myFlow', undefined)).toBe(
+      '__wkf_workflow_myFlow'
+    );
+  });
+
+  it('should use namespaced prefix when namespace is provided', () => {
+    expect(getWorkflowQueueName('myFlow', 'custom')).toBe(
+      '__custom_wkf_workflow_myFlow'
+    );
+  });
+
+  it('should reject invalid namespace in queue name construction', () => {
+    expect(() => getWorkflowQueueName('myFlow', '123bad')).toThrow();
+  });
 });
 
 describe('healthCheck response parsing', () => {

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -32,6 +32,14 @@ const DEFAULT_HEALTH_CHECK_TIMEOUT = 30_000;
 const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@]+$/;
 
 /**
+ * Resolves the active queue namespace from an explicit argument or the
+ * `WORKFLOW_QUEUE_NAMESPACE` env var.
+ */
+function resolveNamespace(namespace?: string): string | undefined {
+  return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined;
+}
+
+/**
  * Validates a workflow name and returns the corresponding queue name.
  * Ensures the workflow name only contains safe characters before
  * interpolating it into the queue name string.
@@ -45,7 +53,7 @@ export function getWorkflowQueueName(
       `Invalid workflow name "${workflowName}": must only contain alphanumeric characters, underscores, hyphens, dots, forward slashes, or at signs`
     );
   }
-  const prefix = getQueueTopicPrefix('workflow', namespace);
+  const prefix = getQueueTopicPrefix('workflow', resolveNamespace(namespace));
   return `${prefix}${workflowName}` as ValidQueueName;
 }
 
@@ -258,7 +266,7 @@ export async function healthCheck(
   const streamName = getHealthCheckStreamName(correlationId);
 
   const queueName =
-    `${getQueueTopicPrefix(endpoint, options?.namespace)}health_check` as ValidQueueName;
+    `${getQueueTopicPrefix(endpoint, resolveNamespace(options?.namespace))}health_check` as ValidQueueName;
 
   const startTime = Date.now();
 

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -7,6 +7,7 @@ import type {
   World,
 } from '@workflow/world';
 import {
+  getQueueTopicPrefix,
   HealthCheckPayloadSchema,
   SPEC_VERSION_CURRENT,
   SPEC_VERSION_LEGACY,
@@ -35,13 +36,17 @@ const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@]+$/;
  * Ensures the workflow name only contains safe characters before
  * interpolating it into the queue name string.
  */
-export function getWorkflowQueueName(workflowName: string): ValidQueueName {
+export function getWorkflowQueueName(
+  workflowName: string,
+  namespace?: string
+): ValidQueueName {
   if (!SAFE_WORKFLOW_NAME_PATTERN.test(workflowName)) {
     throw new Error(
       `Invalid workflow name "${workflowName}": must only contain alphanumeric characters, underscores, hyphens, dots, forward slashes, or at signs`
     );
   }
-  return `__wkf_workflow_${workflowName}` as ValidQueueName;
+  const prefix = getQueueTopicPrefix('workflow', namespace);
+  return `${prefix}${workflowName}` as ValidQueueName;
 }
 
 const generateId = monotonicFactory();
@@ -246,16 +251,14 @@ function parseHealthCheckResponse(chunks: Uint8Array[]): {
 export async function healthCheck(
   world: World,
   endpoint: HealthCheckEndpoint,
-  options?: HealthCheckOptions
+  options?: HealthCheckOptions & { namespace?: string }
 ): Promise<HealthCheckResult> {
   const timeout = options?.timeout ?? DEFAULT_HEALTH_CHECK_TIMEOUT;
   const correlationId = generateId();
   const streamName = getHealthCheckStreamName(correlationId);
 
-  const queueName: ValidQueueName =
-    endpoint === 'workflow'
-      ? '__wkf_workflow_health_check'
-      : '__wkf_step_health_check';
+  const queueName =
+    `${getQueueTopicPrefix(endpoint, options?.namespace)}health_check` as ValidQueueName;
 
   const startTime = Date.now();
 

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -9,6 +9,7 @@ import type {
 import {
   getQueueTopicPrefix,
   HealthCheckPayloadSchema,
+  resolveQueueNamespace,
   SPEC_VERSION_CURRENT,
   SPEC_VERSION_LEGACY,
 } from '@workflow/world';
@@ -32,14 +33,6 @@ const DEFAULT_HEALTH_CHECK_TIMEOUT = 30_000;
 const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@]+$/;
 
 /**
- * Resolves the active queue namespace from an explicit argument or the
- * `WORKFLOW_QUEUE_NAMESPACE` env var.
- */
-function resolveNamespace(namespace?: string): string | undefined {
-  return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined;
-}
-
-/**
  * Validates a workflow name and returns the corresponding queue name.
  * Ensures the workflow name only contains safe characters before
  * interpolating it into the queue name string.
@@ -53,7 +46,10 @@ export function getWorkflowQueueName(
       `Invalid workflow name "${workflowName}": must only contain alphanumeric characters, underscores, hyphens, dots, forward slashes, or at signs`
     );
   }
-  const prefix = getQueueTopicPrefix('workflow', resolveNamespace(namespace));
+  const prefix = getQueueTopicPrefix(
+    'workflow',
+    resolveQueueNamespace(namespace)
+  );
   return `${prefix}${workflowName}` as ValidQueueName;
 }
 
@@ -266,7 +262,7 @@ export async function healthCheck(
   const streamName = getHealthCheckStreamName(correlationId);
 
   const queueName =
-    `${getQueueTopicPrefix(endpoint, resolveNamespace(options?.namespace))}health_check` as ValidQueueName;
+    `${getQueueTopicPrefix(endpoint, resolveQueueNamespace(options?.namespace))}health_check` as ValidQueueName;
 
   const startTime = Date.now();
 

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   ERROR_SLUGS,
   HookNotFoundError,
@@ -22,9 +21,9 @@ import {
 import { WEBHOOK_RESPONSE_WRITABLE } from '../symbols.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanContextForTraceCarrier, trace } from '../telemetry.js';
-import { waitedUntil } from '../util.js';
 import { getWorldLazy } from './get-world-lazy.js';
 import { getWorkflowQueueName } from './helpers.js';
+import { waitedUntil, waitUntil } from './wait-until.js';
 
 /**
  * Internal helper that returns the hook, the associated workflow run,

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   ThrottleError,
@@ -18,11 +17,11 @@ import type { Serializable } from '../schemas.js';
 import { dehydrateWorkflowArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { serializeTraceCarrier, trace } from '../telemetry.js';
-import { waitedUntil } from '../util.js';
 import { version as workflowCoreVersion } from '../version.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { Run } from './run.js';
 import { getWorldLazy } from './get-world-lazy.js';
+import { waitedUntil, waitUntil } from './wait-until.js';
 
 /** ULID generator for client-side runId generation */
 const ulid = monotonicFactory();

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -1,5 +1,4 @@
 import { types } from 'node:util';
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   FatalError,
@@ -32,6 +31,7 @@ import {
 } from '../types.js';
 import { getPortLazy } from './get-port-lazy.js';
 import { memoizeEncryptionKey } from './helpers.js';
+import { waitUntil } from './wait-until.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
 

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -12,7 +12,11 @@ import {
 } from '@workflow/errors';
 import { formatStepName, pluralize } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
-import { SPEC_VERSION_CURRENT, StepInvokePayloadSchema } from '@workflow/world';
+import {
+  getQueueTopicPrefix,
+  SPEC_VERSION_CURRENT,
+  StepInvokePayloadSchema,
+} from '@workflow/world';
 import { describeError } from '../describe-error.js';
 import { runtimeLogger, stepLogger } from '../logger.js';
 import { getStepFunction } from '../private.js';
@@ -52,10 +56,11 @@ import { getWorld, getWorldHandlers, type WorldHandlers } from './world.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
 
-const stepHandler = (worldHandlers: WorldHandlers) =>
-  worldHandlers.createQueueHandler(
-    '__wkf_step_',
-    async (message_, metadata) => {
+function createStepHandler(namespace?: string) {
+  const stepPrefix = getQueueTopicPrefix('step', namespace);
+
+  return (worldHandlers: WorldHandlers) =>
+    worldHandlers.createQueueHandler(stepPrefix, async (message_, metadata) => {
       // Check if this is a health check message
       // NOTE: Health check messages are intentionally unauthenticated for monitoring purposes.
       // They only write a simple status response to a stream and do not expose sensitive data.
@@ -89,7 +94,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
       // is still consumed but with adequate logging that an error occurred.
       // Scoped logger for this step invocation — attaches run/step context to
       // every log line below so callers don't repeat it.
-      const stepNameFromQueue = metadata.queueName.slice('__wkf_step_'.length);
+      const stepNameFromQueue = metadata.queueName.slice(stepPrefix.length);
       const stepRuntimeLogger = runtimeLogger.forRun(
         workflowRunId,
         workflowName,
@@ -159,7 +164,7 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
       // Execute step within the propagated trace context
       return await withTraceContext(traceContext, async () => {
         // Extract the step name from the topic name
-        const stepName = metadata.queueName.slice('__wkf_step_'.length);
+        const stepName = metadata.queueName.slice(stepPrefix.length);
         const world = await getWorld();
         const isVercel = process.env.VERCEL_URL !== undefined;
 
@@ -1028,8 +1033,10 @@ const stepHandler = (worldHandlers: WorldHandlers) =>
           }
         );
       });
-    }
-  );
+    });
+}
+
+const stepHandler = createStepHandler();
 
 /**
  * A single route that handles any step execution request and routes to the

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   FatalError,
@@ -14,7 +13,9 @@ import { formatStepName, pluralize } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
 import {
   getQueueTopicPrefix,
+  resolveQueueNamespace,
   SPEC_VERSION_CURRENT,
+  type Step,
   StepInvokePayloadSchema,
 } from '@workflow/world';
 import { describeError } from '../describe-error.js';
@@ -52,12 +53,14 @@ import {
   queueMessage,
   withHealthCheck,
 } from './helpers.js';
+import { waitUntil } from './wait-until.js';
 import { getWorld, getWorldHandlers, type WorldHandlers } from './world.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
 
 function createStepHandler(namespace?: string) {
-  const stepPrefix = getQueueTopicPrefix('step', namespace);
+  const resolvedNamespace = resolveQueueNamespace(namespace);
+  const stepPrefix = getQueueTopicPrefix('step', resolvedNamespace);
 
   return (worldHandlers: WorldHandlers) =>
     worldHandlers.createQueueHandler(stepPrefix, async (message_, metadata) => {
@@ -132,11 +135,15 @@ function createStepHandler(namespace?: string) {
             { requestId }
           );
           // Re-queue the workflow to handle the failed step
-          await queueMessage(world, getWorkflowQueueName(workflowName), {
-            runId: workflowRunId,
-            traceCarrier: await serializeTraceCarrier(),
-            requestedAt: new Date(),
-          });
+          await queueMessage(
+            world,
+            getWorkflowQueueName(workflowName, resolvedNamespace),
+            {
+              runId: workflowRunId,
+              traceCarrier: await serializeTraceCarrier(),
+              requestedAt: new Date(),
+            }
+          );
         } catch (err) {
           if (EntityConflictError.is(err) || RunExpiredError.is(err)) {
             return;
@@ -215,7 +222,7 @@ function createStepHandler(namespace?: string) {
             // - Step not in terminal state (returns 409)
             // - retryAfter timestamp reached (returns 425 with Retry-After header)
             // - Workflow still active (returns 410 if completed)
-            let step;
+            let step!: Step;
             try {
               const startResult = await world.events.create(
                 workflowRunId,
@@ -276,11 +283,15 @@ function createStepHandler(namespace?: string) {
                   'step.name': stepName,
                   'step.id': stepId,
                 });
-                await queueMessage(world, getWorkflowQueueName(workflowName), {
-                  runId: workflowRunId,
-                  traceCarrier: await serializeTraceCarrier(),
-                  requestedAt: new Date(),
-                });
+                await queueMessage(
+                  world,
+                  getWorkflowQueueName(workflowName, resolvedNamespace),
+                  {
+                    runId: workflowRunId,
+                    traceCarrier: await serializeTraceCarrier(),
+                    requestedAt: new Date(),
+                  }
+                );
                 return;
               }
 
@@ -376,11 +387,15 @@ function createStepHandler(namespace?: string) {
               });
 
               // Re-invoke the workflow to handle the failed step
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
 
@@ -472,11 +487,15 @@ function createStepHandler(namespace?: string) {
               });
 
               // Re-invoke the workflow to handle the failed step
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
 
@@ -520,11 +539,15 @@ function createStepHandler(namespace?: string) {
                 throw failErr;
               }
               // Re-queue the workflow so it can process the step failure
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
             // Capture startedAt for use in async callback (TypeScript narrowing doesn't persist)
@@ -952,11 +975,15 @@ function createStepHandler(namespace?: string) {
               }
 
               // Re-invoke the workflow to handle the failed/retrying step
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
 
@@ -1025,11 +1052,15 @@ function createStepHandler(namespace?: string) {
             });
 
             // Queue the workflow continuation with the concurrently-resolved trace carrier
-            await queueMessage(world, getWorkflowQueueName(workflowName), {
-              runId: workflowRunId,
-              traceCarrier,
-              requestedAt: new Date(),
-            });
+            await queueMessage(
+              world,
+              getWorkflowQueueName(workflowName, resolvedNamespace),
+              {
+                runId: workflowRunId,
+                traceCarrier,
+                requestedAt: new Date(),
+              }
+            );
           }
         );
       });

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -1,5 +1,4 @@
 import type { Span } from '@opentelemetry/api';
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   HookNotFoundError,
@@ -23,6 +22,7 @@ import { runtimeLogger } from '../logger.js';
 import { dehydrateStepArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getAbortStreamIdFromToken } from '../util.js';
+import { waitUntil } from './wait-until.js';
 
 export interface SuspensionHandlerParams {
   suspension: WorkflowSuspension;

--- a/packages/core/src/runtime/wait-until.ts
+++ b/packages/core/src/runtime/wait-until.ts
@@ -1,0 +1,21 @@
+export function waitUntil(promise: Promise<unknown>): void {
+  void import('@vercel/functions').then(({ waitUntil }) => {
+    waitUntil(promise);
+  });
+}
+
+/**
+ * A small wrapper around `waitUntil` that also returns
+ * the result of the awaited promise.
+ */
+export async function waitedUntil<T>(fn: () => Promise<T>): Promise<T> {
+  const result = fn();
+  waitUntil(
+    result.catch(() => {
+      // Ignore error from the promise being rejected.
+      // It's expected that the invoker of `waitedUntil`
+      // will handle the error.
+    })
+  );
+  return result;
+}

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import { pluralize } from '@workflow/utils';
 
 /**
@@ -91,20 +90,4 @@ export function getAbortStreamIdFromToken(hookToken: string): string {
     );
   }
   return getAbortStreamId(hookToken.slice(ABORT_TOKEN_PREFIX.length));
-}
-
-/**
- * A small wrapper around `waitUntil` that also returns
- * the result of the awaited promise.
- */
-export async function waitedUntil<T>(fn: () => Promise<T>): Promise<T> {
-  const result = fn();
-  waitUntil(
-    result.catch(() => {
-      // Ignore error from the promise being rejected.
-      // It's expected that the invoker of `waitedUntil`
-      // will handle the error.
-    })
-  );
-  return result;
 }

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -52,6 +52,7 @@ export async function getNextBuilderDeferred() {
   const {
     BaseBuilder: BaseBuilderClass,
     WORKFLOW_QUEUE_TRIGGER,
+    createWorkflowEntrypointOptionsCode,
     detectWorkflowPatterns,
     applySwcTransform,
     getImportPath,
@@ -648,6 +649,8 @@ export async function getNextBuilderDeferred() {
       const stepManifest =
         await this.createDeferredStepManifest(stepAndSerdeFiles);
       const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
+      const workflowEntrypointOptionsCode =
+        createWorkflowEntrypointOptionsCode();
       const routeCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import 'workflow/internal/builtins';
@@ -656,7 +659,7 @@ import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${escapedVMCode}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
       await this.writeFileIfChanged(flowOutfile, routeCode);
 

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -82,11 +82,11 @@ export class SvelteKitBuilder extends BaseBuilder {
 
     // Replace the default export with SvelteKit-compatible handler
     workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
-      `${NORMALIZE_REQUEST_CODE}
+      /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
+      (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
 export const POST = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode)(normalRequest);
+  return workflowEntrypoint(workflowCode${options})(normalRequest);
 }`
     );
     await writeFile(workflowsRouteFile, workflowsRouteContent);

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
-import type { World } from '@workflow/world';
+import type { QueuePrefix, World } from '@workflow/world';
 import { reenqueueActiveRuns, SPEC_VERSION_CURRENT } from '@workflow/world';
 import type { Config } from './config.js';
 import { config } from './config.js';
@@ -34,10 +34,7 @@ export type { DirectHandler } from './queue.js';
 
 export type LocalWorld = World & {
   /** Register a direct in-process handler for a queue prefix, bypassing HTTP. */
-  registerHandler(
-    prefix: '__wkf_step_' | '__wkf_workflow_',
-    handler: DirectHandler
-  ): void;
+  registerHandler(prefix: QueuePrefix, handler: DirectHandler): void;
   /** Clear all workflow data (runs, steps, events, hooks, streams). */
   clear(): Promise<void>;
 };

--- a/packages/world-local/src/queue.test.ts
+++ b/packages/world-local/src/queue.test.ts
@@ -144,6 +144,27 @@ describe('queue timeout re-enqueue', () => {
     });
   });
 
+  it('routes namespaced queues to namespaced direct handlers', async () => {
+    const handlerImpl = vi.fn(
+      async (_message: unknown, metadata: { queueName: string }) => {
+        expect(metadata.queueName).toBe('__custom_wkf_step_test');
+        return undefined;
+      }
+    );
+    const handler = localQueue.createQueueHandler(
+      '__custom_wkf_step_',
+      handlerImpl
+    );
+
+    localQueue.registerHandler('__custom_wkf_step_', handler);
+
+    await localQueue.queue('__custom_wkf_step_test' as any, stepPayload);
+
+    await vi.waitFor(() => {
+      expect(handlerImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('queue retries immediately when handler returns timeoutSeconds: 0', async () => {
     const { setTimeout: mockSetTimeout } = await import('node:timers/promises');
     vi.mocked(mockSetTimeout).mockClear();

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -2,8 +2,9 @@ import { setTimeout } from 'node:timers/promises';
 import type { Transport } from '@vercel/queue';
 import {
   MessageId,
+  parseQueueName,
   type Queue,
-  QueuePrefix,
+  type QueuePrefix,
   ValidQueueName,
 } from '@workflow/world';
 import { Sema } from 'async-sema';
@@ -96,20 +97,11 @@ function getQueueRoute(queueName: ValidQueueName): {
   pathname: 'flow' | 'step';
   prefix: QueuePrefix;
 } {
-  // extract prefix + kind from the queue name via regex capture.
-  // the extracted prefix is then validated through the QueuePrefix schema
-  // to ensure it conforms to the namespace format.
-  const match = queueName.match(
-    /^(__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_)/
-  );
-
-  if (!match) {
-    throw new Error('Unknown queue name prefix');
-  }
+  const { kind, prefix } = parseQueueName(queueName);
 
   return {
-    pathname: match[2] === 'workflow' ? 'flow' : 'step',
-    prefix: QueuePrefix.parse(match[1]),
+    pathname: kind === 'workflow' ? 'flow' : 'step',
+    prefix,
   };
 }
 

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -1,6 +1,11 @@
 import { setTimeout } from 'node:timers/promises';
 import type { Transport } from '@vercel/queue';
-import { MessageId, type Queue, ValidQueueName } from '@workflow/world';
+import {
+  MessageId,
+  type Queue,
+  QueuePrefix,
+  ValidQueueName,
+} from '@workflow/world';
 import { Sema } from 'async-sema';
 import { monotonicFactory } from 'ulid';
 import { Agent } from 'undici';
@@ -60,10 +65,7 @@ export type LocalQueue = Queue & {
   /** Close the HTTP agent and release resources. */
   close(): Promise<void>;
   /** Register a direct in-process handler for a queue prefix, bypassing HTTP. */
-  registerHandler(
-    prefix: '__wkf_step_' | '__wkf_workflow_',
-    handler: DirectHandler
-  ): void;
+  registerHandler(prefix: QueuePrefix, handler: DirectHandler): void;
 };
 
 const DETACHED_ARRAYBUFFER_ERROR =
@@ -92,15 +94,23 @@ function isDetachedArrayBufferQueueError(error: unknown): boolean {
 
 function getQueueRoute(queueName: ValidQueueName): {
   pathname: 'flow' | 'step';
-  prefix: '__wkf_step_' | '__wkf_workflow_';
+  prefix: QueuePrefix;
 } {
-  if (queueName.startsWith('__wkf_step_')) {
-    return { pathname: 'step', prefix: '__wkf_step_' };
+  // extract prefix + kind from the queue name via regex capture.
+  // the extracted prefix is then validated through the QueuePrefix schema
+  // to ensure it conforms to the namespace format.
+  const match = queueName.match(
+    /^(__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_)/
+  );
+
+  if (!match) {
+    throw new Error('Unknown queue name prefix');
   }
-  if (queueName.startsWith('__wkf_workflow_')) {
-    return { pathname: 'flow', prefix: '__wkf_workflow_' };
-  }
-  throw new Error('Unknown queue name prefix');
+
+  return {
+    pathname: match[2] === 'workflow' ? 'flow' : 'step',
+    prefix: QueuePrefix.parse(match[1]),
+  };
 }
 
 export function createQueue(config: Partial<Config>): LocalQueue {
@@ -353,10 +363,7 @@ export function createQueue(config: Partial<Config>): LocalQueue {
     queue,
     createQueueHandler,
     getDeploymentId,
-    registerHandler(
-      prefix: '__wkf_step_' | '__wkf_workflow_',
-      handler: DirectHandler
-    ) {
+    registerHandler(prefix: QueuePrefix, handler: DirectHandler) {
       directHandlers.set(prefix, handler);
     },
     async close() {

--- a/packages/world-postgres/src/config.ts
+++ b/packages/world-postgres/src/config.ts
@@ -6,6 +6,11 @@ type PgConnectionConfig =
 
 export type PostgresWorldConfig = PgConnectionConfig & {
   jobPrefix?: string;
+  /**
+   * namespace for queue topic prefixes (e.g. 'custom' → '__custom_wkf_workflow_').
+   * defaults to WORKFLOW_QUEUE_NAMESPACE env var if not provided.
+   */
+  namespace?: string;
   queueConcurrency?: number;
   /**
    * Override the flush interval (in ms) for buffered stream writes.

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -1,13 +1,13 @@
 import { createServer, type Server } from 'node:http';
 import { JsonTransport } from '@vercel/queue';
 import { getWorkflowPort } from '@workflow/utils/get-port';
-import { MessageId, type QueuePayload } from '@workflow/world';
+import { MessageId, parseQueueName, type QueuePayload } from '@workflow/world';
+import { createLocalWorld } from '@workflow/world-local';
 import { makeWorkerUtils, run, type WorkerUtils } from 'graphile-worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createLocalWorld } from '@workflow/world-local';
 import { stepEntrypoint } from '../../core/dist/runtime/step-handler.js';
-import { createQueue } from './queue.js';
 import { MessageData } from './message.js';
+import { createQueue } from './queue.js';
 
 const transport = new JsonTransport();
 const createdQueues: Array<ReturnType<typeof createQueue>> = [];
@@ -256,6 +256,74 @@ describe('postgres queue http execution', () => {
     }
   });
 
+  it('serializes namespaced workflow queue execution for the same runId', async () => {
+    let resolveFirstRequestStarted!: () => void;
+    const firstRequestStarted = new Promise<void>((resolve) => {
+      resolveFirstRequestStarted = resolve;
+    });
+    let resolveReleaseFirstRequest!: () => void;
+    const releaseFirstRequest = new Promise<void>((resolve) => {
+      resolveReleaseFirstRequest = resolve;
+    });
+    let requestCount = 0;
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const fetchMock = vi.fn(async () => {
+      requestCount += 1;
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+
+      if (requestCount === 1) {
+        resolveFirstRequestStarted();
+        await releaseFirstRequest;
+      }
+
+      activeRequests -= 1;
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.WORKFLOW_LOCAL_BASE_URL = 'http://localhost:3000';
+
+    const queue = buildQueue(
+      { connectionString: 'postgres://test', namespace: 'custom' },
+      pool
+    );
+    try {
+      await queue.start();
+
+      const task = getTaskHandler('workflow_flows');
+      const payload = {
+        runId: 'wrun_01ABC',
+      };
+      const firstExecution = task(
+        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
+          messageId: MessageId.parse('msg_01ABC'),
+        }),
+        {} as any
+      );
+      const secondExecution = task(
+        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
+          messageId: MessageId.parse('msg_01ABD'),
+        }),
+        {} as any
+      );
+
+      await firstRequestStarted;
+      await Promise.resolve();
+      expect(requestCount).toBe(1);
+      expect(maxActiveRequests).toBe(1);
+
+      resolveReleaseFirstRequest();
+      await Promise.all([firstExecution, secondExecution]);
+
+      expect(requestCount).toBe(2);
+      expect(maxActiveRequests).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('does not require a runId for workflow health-check payloads', async () => {
     const fetchMock = vi.fn(async () => Response.json({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
@@ -328,6 +396,40 @@ describe('postgres queue http execution', () => {
       vi.useRealTimers();
     }
   });
+
+  it('queues namespaced producer messages in graphile job metadata', async () => {
+    const queue = buildQueue(
+      { connectionString: 'postgres://test', namespace: 'custom' },
+      pool
+    );
+    await queue.start();
+
+    await queue.queue(
+      '__custom_wkf_step_test-step',
+      {
+        workflowName: 'test-workflow',
+        workflowRunId: 'run_01ABC',
+        workflowStartedAt: Date.now(),
+        stepId: 'step_01ABC',
+      },
+      {
+        idempotencyKey: 'step_01ABC',
+      }
+    );
+
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'workflow_steps',
+      expect.objectContaining({
+        attempt: 1,
+        id: 'test-step',
+        idempotencyKey: 'step_01ABC',
+      }),
+      expect.objectContaining({
+        jobKey: 'step_01ABC',
+        maxAttempts: 3,
+      })
+    );
+  });
 });
 
 function buildQueue(
@@ -349,9 +451,7 @@ function buildMessageData(
     messageId?: MessageId;
   }
 ) {
-  const [, id] = queueName.startsWith('__wkf_step_')
-    ? ['__wkf_step_', queueName.slice('__wkf_step_'.length)]
-    : ['__wkf_workflow_', queueName.slice('__wkf_workflow_'.length)];
+  const { id } = parseQueueName(queueName);
 
   return MessageData.encode({
     id,

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -117,10 +117,10 @@ export function createQueue(
   const generateMessageId = monotonicFactory();
 
   const prefix = config.jobPrefix || 'workflow_';
-  const Queues = {
+  const Queues: Record<QueuePrefix, string> = {
     __wkf_workflow_: `${prefix}flows`,
     __wkf_step_: `${prefix}steps`,
-  } as const satisfies Record<QueuePrefix, string>;
+  };
 
   const createQueueHandler = localWorld.createQueueHandler;
 
@@ -180,8 +180,14 @@ export function createQueue(
         ? new Date(Date.now() + delaySeconds * 1000)
         : undefined;
 
+    const jobQueue = Queues[queuePrefix];
+
+    if (!jobQueue) {
+      throw new Error(`Unknown queue prefix: ${queuePrefix}`);
+    }
+
     await utils.addJob(
-      Queues[queuePrefix],
+      jobQueue,
       MessageData.encode({
         id: queueId,
         data: Buffer.from(body),

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -2,8 +2,10 @@ import * as Stream from 'node:stream';
 import type { Transport } from '@vercel/queue';
 import { getWorkflowPort } from '@workflow/utils/get-port';
 import {
+  getQueuePrefixKind,
   getQueueTopicPrefix,
   MessageId,
+  parseQueueName,
   type Queue,
   QueuePayloadSchema,
   type QueuePrefix,
@@ -121,9 +123,9 @@ export function createQueue(
   function getJobQueueName(queuePrefix: QueuePrefix): string {
     const jobPrefix = config.jobPrefix || 'workflow_';
 
-    if (queuePrefix.endsWith('wkf_workflow_')) return `${jobPrefix}flows`;
-    if (queuePrefix.endsWith('wkf_step_')) return `${jobPrefix}steps`;
-    throw new Error(`Unknown queue prefix: ${queuePrefix}`);
+    return getQueuePrefixKind(queuePrefix) === 'workflow'
+      ? `${jobPrefix}flows`
+      : `${jobPrefix}steps`;
   }
 
   const createQueueHandler = localWorld.createQueueHandler;
@@ -224,13 +226,7 @@ export function createQueue(
   }
 
   function getQueueRoute(queueName: ValidQueueName): 'flow' | 'step' {
-    if (queueName.startsWith('__wkf_step_')) {
-      return 'step';
-    }
-    if (queueName.startsWith('__wkf_workflow_')) {
-      return 'flow';
-    }
-    throw new Error('Unknown queue name prefix');
+    return parseQueueName(queueName).kind === 'workflow' ? 'flow' : 'step';
   }
 
   async function executeMessageOverHttp({
@@ -355,7 +351,7 @@ export function createQueue(
 
   const queue: Queue['queue'] = async (queue, message, opts) => {
     await start();
-    const [queuePrefix, queueId] = parseQueueName(queue);
+    const { prefix: queuePrefix, id: queueId } = parseQueueName(queue);
     const body = transport.serialize(message) as Buffer;
     const messageId = MessageId.parse(`msg_${generateMessageId()}`);
     await addGraphileJob({
@@ -373,13 +369,15 @@ export function createQueue(
   };
 
   function createTaskHandler(queue: QueuePrefix) {
+    const queueKind = getQueuePrefixKind(queue);
+
     return async (payload: unknown, helpers: unknown) => {
       const messageData = MessageData.parse(payload);
       const graphileAttempt = GraphileHelpers.safeParse(helpers);
       const attempt = graphileAttempt.success
         ? graphileAttempt.data.job.attempts
         : messageData.attempt;
-      const queueName = `${queue}${messageData.id}` as const;
+      const queueName = `${queue}${messageData.id}` as ValidQueueName;
       const bodyStream = Stream.Readable.toWeb(
         Stream.Readable.from([messageData.data])
       );
@@ -388,7 +386,7 @@ export function createQueue(
       );
       QueuePayloadSchema.parse(body);
       const workflowRunSerializationKey =
-        queue === '__wkf_workflow_'
+        queueKind === 'workflow'
           ? (() => {
               const workflowInvoke =
                 WorkflowInvokePayloadSchema.safeParse(body);
@@ -534,13 +532,3 @@ export function createQueue(
     },
   };
 }
-
-const parseQueueName = (name: ValidQueueName): [QueuePrefix, string] => {
-  const prefixes: QueuePrefix[] = ['__wkf_step_', '__wkf_workflow_'];
-  for (const prefix of prefixes) {
-    if (name.startsWith(prefix)) {
-      return [prefix, name.slice(prefix.length)];
-    }
-  }
-  throw new Error(`Invalid queue name: ${name}`);
-};

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -116,11 +116,13 @@ export function createQueue(
   };
   const generateMessageId = monotonicFactory();
 
-  const prefix = config.jobPrefix || 'workflow_';
-  const Queues: Record<QueuePrefix, string> = {
-    __wkf_workflow_: `${prefix}flows`,
-    __wkf_step_: `${prefix}steps`,
-  };
+  function getJobQueueName(queuePrefix: QueuePrefix): string {
+    const jobPrefix = config.jobPrefix || 'workflow_';
+
+    if (queuePrefix.endsWith('wkf_workflow_')) return `${jobPrefix}flows`;
+    if (queuePrefix.endsWith('wkf_step_')) return `${jobPrefix}steps`;
+    throw new Error(`Unknown queue prefix: ${queuePrefix}`);
+  }
 
   const createQueueHandler = localWorld.createQueueHandler;
 
@@ -180,14 +182,8 @@ export function createQueue(
         ? new Date(Date.now() + delaySeconds * 1000)
         : undefined;
 
-    const jobQueue = Queues[queuePrefix];
-
-    if (!jobQueue) {
-      throw new Error(`Unknown queue prefix: ${queuePrefix}`);
-    }
-
     await utils.addJob(
-      jobQueue,
+      getJobQueueName(queuePrefix),
       MessageData.encode({
         id: queueId,
         data: Buffer.from(body),

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -2,10 +2,12 @@ import * as Stream from 'node:stream';
 import type { Transport } from '@vercel/queue';
 import { getWorkflowPort } from '@workflow/utils/get-port';
 import {
+  getQueueTopicPrefix,
   MessageId,
   type Queue,
   QueuePayloadSchema,
   type QueuePrefix,
+  resolveQueueNamespace,
   type ValidQueueName,
   WorkflowInvokePayloadSchema,
 } from '@workflow/world';
@@ -488,10 +490,12 @@ export function createQueue(
       string,
       (payload: unknown, helpers: unknown) => Promise<void>
     > = {};
-    const prefixes: QueuePrefix[] = ['__wkf_step_', '__wkf_workflow_'];
-    for (const prefix of prefixes) {
-      taskList[getJobQueueName(prefix)] = createTaskHandler(prefix);
-    }
+    const namespace = resolveQueueNamespace(config.namespace);
+    const workflowPrefix = getQueueTopicPrefix('workflow', namespace);
+    const stepPrefix = getQueueTopicPrefix('step', namespace);
+    taskList[getJobQueueName(workflowPrefix)] =
+      createTaskHandler(workflowPrefix);
+    taskList[getJobQueueName(stepPrefix)] = createTaskHandler(stepPrefix);
 
     runner = await run({
       pgPool: pool,

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -488,11 +488,9 @@ export function createQueue(
       string,
       (payload: unknown, helpers: unknown) => Promise<void>
     > = {};
-    for (const [prefix, jobName] of Object.entries(Queues) as [
-      QueuePrefix,
-      string,
-    ][]) {
-      taskList[jobName] = createTaskHandler(prefix);
+    const prefixes: QueuePrefix[] = ['__wkf_step_', '__wkf_workflow_'];
+    for (const prefix of prefixes) {
+      taskList[getJobQueueName(prefix)] = createTaskHandler(prefix);
     }
 
     runner = await run({

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -31,6 +31,7 @@ export {
   MessageId,
   QueuePayloadSchema,
   QueuePrefix,
+  resolveQueueNamespace,
   RunInputSchema,
   StepInvokePayloadSchema,
   ValidQueueName,

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -26,6 +26,7 @@ export { HookSchema } from './hooks.js';
 export type * from './interfaces.js';
 export type * from './queue.js';
 export {
+  getQueueTopicPrefix,
   HealthCheckPayloadSchema,
   MessageId,
   QueuePayloadSchema,

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -1,12 +1,12 @@
 export type * from './attributes.js';
 export {
-  applyAttributeChanges,
   ATTRIBUTE_KEY_MAX_LENGTH,
   ATTRIBUTE_MAX_PER_RUN,
   ATTRIBUTE_VALUE_MAX_BYTES,
   AttributeChangeSchema,
   AttributeChangesSchema,
   AttributeValidationError,
+  applyAttributeChanges,
   RESERVED_ATTRIBUTE_KEY_PREFIX,
   validateAttributeChanges,
   validateAttributeKey,
@@ -26,13 +26,15 @@ export { HookSchema } from './hooks.js';
 export type * from './interfaces.js';
 export type * from './queue.js';
 export {
+  getQueuePrefixKind,
   getQueueTopicPrefix,
   HealthCheckPayloadSchema,
   MessageId,
+  parseQueueName,
   QueuePayloadSchema,
   QueuePrefix,
-  resolveQueueNamespace,
   RunInputSchema,
+  resolveQueueNamespace,
   StepInvokePayloadSchema,
   ValidQueueName,
   WorkflowInvokePayloadSchema,

--- a/packages/world/src/queue.test.ts
+++ b/packages/world/src/queue.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { getQueueTopicPrefix, QueuePrefix, ValidQueueName } from './queue.js';
+
+describe('getQueueTopicPrefix', () => {
+  it('returns default workflow prefix without namespace', () => {
+    expect(getQueueTopicPrefix('workflow')).toBe('__wkf_workflow_');
+  });
+
+  it('returns default step prefix without namespace', () => {
+    expect(getQueueTopicPrefix('step')).toBe('__wkf_step_');
+  });
+
+  it('returns namespaced workflow prefix', () => {
+    expect(getQueueTopicPrefix('workflow', 'custom')).toBe(
+      '__custom_wkf_workflow_'
+    );
+  });
+
+  it('returns namespaced step prefix', () => {
+    expect(getQueueTopicPrefix('step', 'custom')).toBe('__custom_wkf_step_');
+  });
+
+  it('accepts multi-character namespace', () => {
+    expect(getQueueTopicPrefix('workflow', 'myframework123')).toBe(
+      '__myframework123_wkf_workflow_'
+    );
+  });
+
+  it('throws for namespace starting with a digit', () => {
+    expect(() => getQueueTopicPrefix('workflow', '123abc')).toThrow();
+  });
+
+  it('throws for uppercase namespace', () => {
+    expect(() => getQueueTopicPrefix('workflow', 'Custom')).toThrow();
+  });
+
+  it('throws for empty namespace', () => {
+    expect(() => getQueueTopicPrefix('workflow', '')).toThrow();
+  });
+
+  it('throws for namespace with special characters', () => {
+    expect(() => getQueueTopicPrefix('workflow', 'my-framework')).toThrow();
+    expect(() => getQueueTopicPrefix('workflow', 'my_framework')).toThrow();
+  });
+
+  it('returns undefined namespace same as no namespace', () => {
+    expect(getQueueTopicPrefix('workflow', undefined)).toBe(
+      getQueueTopicPrefix('workflow')
+    );
+  });
+});
+
+describe('QueuePrefix schema', () => {
+  it('accepts default workflow prefix', () => {
+    expect(QueuePrefix.parse('__wkf_workflow_')).toBe('__wkf_workflow_');
+  });
+
+  it('accepts default step prefix', () => {
+    expect(QueuePrefix.parse('__wkf_step_')).toBe('__wkf_step_');
+  });
+
+  it('accepts namespaced workflow prefix', () => {
+    expect(QueuePrefix.parse('__custom_wkf_workflow_')).toBe(
+      '__custom_wkf_workflow_'
+    );
+  });
+
+  it('accepts namespaced step prefix', () => {
+    expect(QueuePrefix.parse('__custom_wkf_step_')).toBe('__custom_wkf_step_');
+  });
+
+  it('rejects invalid prefix', () => {
+    expect(() => QueuePrefix.parse('bad_prefix')).toThrow();
+  });
+
+  it('rejects prefix without trailing underscore', () => {
+    expect(() => QueuePrefix.parse('__wkf_workflow')).toThrow();
+  });
+
+  it('rejects uppercase namespace', () => {
+    expect(() => QueuePrefix.parse('__Custom_wkf_workflow_')).toThrow();
+  });
+});
+
+describe('ValidQueueName schema', () => {
+  it('accepts default queue names', () => {
+    expect(ValidQueueName.parse('__wkf_workflow_myFlow')).toBe(
+      '__wkf_workflow_myFlow'
+    );
+  });
+
+  it('accepts namespaced queue names', () => {
+    expect(ValidQueueName.parse('__custom_wkf_workflow_myFlow')).toBe(
+      '__custom_wkf_workflow_myFlow'
+    );
+  });
+
+  it('accepts step queue names', () => {
+    expect(ValidQueueName.parse('__wkf_step_myStep')).toBe('__wkf_step_myStep');
+  });
+
+  it('rejects prefix-only without a name', () => {
+    expect(() => ValidQueueName.parse('__wkf_workflow_')).toThrow();
+  });
+
+  it('rejects invalid names', () => {
+    expect(() => ValidQueueName.parse('not_a_queue_name')).toThrow();
+  });
+});

--- a/packages/world/src/queue.test.ts
+++ b/packages/world/src/queue.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getQueueTopicPrefix, QueuePrefix, ValidQueueName } from './queue.js';
+import {
+  getQueuePrefixKind,
+  getQueueTopicPrefix,
+  parseQueueName,
+  QueuePrefix,
+  ValidQueueName,
+} from './queue.js';
 
 describe('getQueueTopicPrefix', () => {
   it('returns default workflow prefix without namespace', () => {
@@ -82,6 +88,18 @@ describe('QueuePrefix schema', () => {
   });
 });
 
+describe('getQueuePrefixKind', () => {
+  it('identifies default prefixes', () => {
+    expect(getQueuePrefixKind('__wkf_workflow_')).toBe('workflow');
+    expect(getQueuePrefixKind('__wkf_step_')).toBe('step');
+  });
+
+  it('identifies namespaced prefixes', () => {
+    expect(getQueuePrefixKind('__custom_wkf_workflow_')).toBe('workflow');
+    expect(getQueuePrefixKind('__custom_wkf_step_')).toBe('step');
+  });
+});
+
 describe('ValidQueueName schema', () => {
   it('accepts default queue names', () => {
     expect(ValidQueueName.parse('__wkf_workflow_myFlow')).toBe(
@@ -105,5 +123,31 @@ describe('ValidQueueName schema', () => {
 
   it('rejects invalid names', () => {
     expect(() => ValidQueueName.parse('not_a_queue_name')).toThrow();
+  });
+});
+
+describe('parseQueueName', () => {
+  it('parses default workflow queue names', () => {
+    expect(parseQueueName('__wkf_workflow_myFlow')).toEqual({
+      prefix: '__wkf_workflow_',
+      kind: 'workflow',
+      id: 'myFlow',
+    });
+  });
+
+  it('parses namespaced workflow queue names', () => {
+    expect(parseQueueName('__custom_wkf_workflow_myFlow')).toEqual({
+      prefix: '__custom_wkf_workflow_',
+      kind: 'workflow',
+      id: 'myFlow',
+    });
+  });
+
+  it('parses namespaced step queue names', () => {
+    expect(parseQueueName('__custom_wkf_step_myStep')).toEqual({
+      prefix: '__custom_wkf_step_',
+      kind: 'step',
+      id: 'myStep',
+    });
   });
 });

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -31,6 +31,14 @@ const QueueNamespace = z
   );
 
 /**
+ * Resolves the active queue namespace from an explicit argument or the
+ * `WORKFLOW_QUEUE_NAMESPACE` env var.
+ */
+export function resolveQueueNamespace(namespace?: string): string | undefined {
+  return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined;
+}
+
+/**
  * Builds a queue topic prefix for the given kind and optional namespace.
  *
  * - `getQueueTopicPrefix('workflow')` → `'__wkf_workflow_'`

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod/v4';
 
+export type QueueKind = 'workflow' | 'step';
+
 /**
  * Pattern matching valid queue prefixes:
  * - `__wkf_workflow_` / `__wkf_step_` (default, no namespace)
@@ -45,7 +47,7 @@ export function resolveQueueNamespace(namespace?: string): string | undefined {
  * - `getQueueTopicPrefix('workflow', 'custom')` → `'__custom_wkf_workflow_'`
  */
 export function getQueueTopicPrefix(
-  kind: 'workflow' | 'step',
+  kind: QueueKind,
   namespace?: string
 ): QueuePrefix {
   if (namespace !== undefined) {
@@ -53,6 +55,38 @@ export function getQueueTopicPrefix(
     return `__${namespace}_wkf_${kind}_` as QueuePrefix;
   }
   return `__wkf_${kind}_` as QueuePrefix;
+}
+
+export function getQueuePrefixKind(prefix: QueuePrefix): QueueKind {
+  const match = QueuePrefix.parse(prefix).match(
+    /^__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_$/
+  );
+
+  if (!match) {
+    throw new Error(`Invalid queue prefix: ${prefix}`);
+  }
+
+  return match[1] as QueueKind;
+}
+
+export function parseQueueName(name: ValidQueueName): {
+  prefix: QueuePrefix;
+  kind: QueueKind;
+  id: string;
+} {
+  const match = name.match(
+    /^(__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_)(.+)$/
+  );
+
+  if (!match) {
+    throw new Error(`Invalid queue name: ${name}`);
+  }
+
+  return {
+    prefix: QueuePrefix.parse(match[1]),
+    kind: match[2] as QueueKind,
+    id: match[3],
+  };
 }
 
 export const MessageId = z

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -1,13 +1,51 @@
 import { z } from 'zod/v4';
 
-export const QueuePrefix = z.union([
-  z.literal('__wkf_step_'),
-  z.literal('__wkf_workflow_'),
-]);
+/**
+ * Pattern matching valid queue prefixes:
+ * - `__wkf_workflow_` / `__wkf_step_` (default, no namespace)
+ * - `__{namespace}_wkf_workflow_` / `__{namespace}_wkf_step_` (namespaced)
+ *
+ * Namespace must be lowercase alphanumeric starting with a letter.
+ */
+export const QueuePrefix = z
+  .string()
+  .regex(
+    /^__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_$/,
+    'Must match __wkf_{workflow|step}_ or __{namespace}_wkf_{workflow|step}_'
+  );
 export type QueuePrefix = z.infer<typeof QueuePrefix>;
 
-export const ValidQueueName = z.templateLiteral([QueuePrefix, z.string()]);
+export const ValidQueueName = z
+  .string()
+  .regex(
+    /^__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_.+$/,
+    'Must be a valid queue name with a recognized prefix'
+  );
 export type ValidQueueName = z.infer<typeof ValidQueueName>;
+
+const QueueNamespace = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9]*$/,
+    'Must be lowercase alphanumeric, starting with a letter'
+  );
+
+/**
+ * Builds a queue topic prefix for the given kind and optional namespace.
+ *
+ * - `getQueueTopicPrefix('workflow')` → `'__wkf_workflow_'`
+ * - `getQueueTopicPrefix('workflow', 'custom')` → `'__custom_wkf_workflow_'`
+ */
+export function getQueueTopicPrefix(
+  kind: 'workflow' | 'step',
+  namespace?: string
+): QueuePrefix {
+  if (namespace !== undefined) {
+    QueueNamespace.parse(namespace);
+    return `__${namespace}_wkf_${kind}_` as QueuePrefix;
+  }
+  return `__wkf_${kind}_` as QueuePrefix;
+}
 
 export const MessageId = z
   .string()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       '@workflow/utils':
         specifier: workspace:*
         version: link:../utils
+      '@workflow/world':
+        specifier: workspace:*
+        version: link:../world
       builtin-modules:
         specifier: 5.0.0
         version: 5.0.0
@@ -831,7 +834,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: 1.0.2
-        version: 1.0.2(@nuxt/cli@3.35.2(@nuxt/schema@4.4.7)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))
+        version: 1.0.2(@nuxt/cli@3.35.2(@nuxt/schema@4.4.7)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))
       '@nuxt/schema':
         specifier: 4.4.7
         version: 4.4.7
@@ -20525,7 +20528,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.35.2(@nuxt/schema@4.4.7)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.35.2(@nuxt/schema@4.4.7)(cac@6.7.14)(magicast@0.5.2))(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))':
     dependencies:
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.7)(cac@6.7.14)(magicast@0.5.2)
       citty: 0.1.6
@@ -20533,14 +20536,14 @@ snapshots:
       defu: 6.1.4
       jiti: 2.6.1
       magic-regexp: 0.10.0
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
       tsconfck: 3.1.6(typescript@5.9.3)
       typescript: 5.9.3
-      unbuild: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3))
+      unbuild: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - esbuild
@@ -31394,7 +31397,7 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3)):
+  mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -31412,7 +31415,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       vue: 3.5.35(typescript@5.9.3)
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3))
 
   mlly@1.8.0:
     dependencies:
@@ -35729,7 +35732,7 @@ snapshots:
 
   ultrahtml@1.6.0: {}
 
-  unbuild@3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3)):
+  unbuild@3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.60.0)
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.60.0)
@@ -35745,7 +35748,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
       mlly: 1.8.2
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -36798,11 +36801,11 @@ snapshots:
       '@vue/compiler-sfc': 3.5.35
       vite: 7.3.5(@types/node@22.19.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
 
-  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)):
+  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)):
     dependencies:
       '@babel/parser': 7.28.5
       '@vue/compiler-core': 3.5.35
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       vue: 3.5.35(typescript@5.9.3)
 
   vue@3.5.30(typescript@5.9.3):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,9 +418,6 @@ importers:
       '@workflow/utils':
         specifier: workspace:*
         version: link:../utils
-      '@workflow/world':
-        specifier: workspace:*
-        version: link:../world
       builtin-modules:
         specifier: 5.0.0
         version: 5.0.0


### PR DESCRIPTION
* add optional `namespace` configuration to queue topic prefixes
* update `QueuePrefix` / `ValidQueueName` Zod schemas and world-local routing to accept namespaced prefixes
* update `world-postgres` job queue prefix parsing
* update/create tests to validate queuePrefix parsing