### PR TITLE
[core] Forward-port stream reconnect to getReadable level

### DIFF
--- a/.changeset/reconnect-object-streams.md
+++ b/.changeset/reconnect-object-streams.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Automatically reconnect object streams when the server stream connection times out.

--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -1,0 +1,383 @@
+import type { World } from '@workflow/world';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./version.js', () => ({ version: '0.0.0-test' }));
+
+import { setWorld } from './runtime/world.js';
+import {
+  createReconnectingFramedStream,
+  FRAMED_STREAM_MAX_RECONNECTS,
+  FRAMED_STREAM_MAX_TOTAL_RECONNECTS,
+} from './serialization.js';
+
+const FRAME_HEADER_SIZE = 4;
+const RUN_ID = 'run-1';
+
+function encodeFrame(payload: Uint8Array): Uint8Array {
+  const out = new Uint8Array(FRAME_HEADER_SIZE + payload.length);
+  new DataView(out.buffer).setUint32(0, payload.length, false);
+  out.set(payload, FRAME_HEADER_SIZE);
+  return out;
+}
+
+function payloadFrame(n: number): Uint8Array {
+  return encodeFrame(new Uint8Array([n]));
+}
+
+/**
+ * Build a stream from a scripted pull sequence. Each entry either
+ * enqueues a value or errors — this keeps the stream from transitioning
+ * to the errored state before earlier values are actually read (which
+ * `start()`-time `controller.error` does immediately).
+ */
+function scriptedStream(
+  steps: Array<
+    | { kind: 'value'; value: Uint8Array }
+    | { kind: 'error'; err: unknown }
+    | { kind: 'close' }
+  >,
+  onCancel?: (reason?: unknown) => void
+): ReadableStream<Uint8Array> {
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const step = steps[i++];
+      if (!step) {
+        controller.close();
+        return;
+      }
+      if (step.kind === 'value') controller.enqueue(step.value);
+      else if (step.kind === 'error') controller.error(step.err);
+      else controller.close();
+    },
+    cancel(reason) {
+      onCancel?.(reason);
+    },
+  });
+}
+
+async function readAll(
+  stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array[]> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const r = await reader.read();
+    if (r.done) break;
+    if (r.value) chunks.push(r.value);
+  }
+  return chunks;
+}
+
+/**
+ * Builds a mock world whose `streams.get` returns a prepared sequence per
+ * `startIndex`. Each call records the requested startIndex so assertions can
+ * check reconnect positioning.
+ */
+function makeWorldWithScriptedStreams(
+  scripts: Record<number, () => ReadableStream<Uint8Array>>
+): { world: World; calls: number[] } {
+  const calls: number[] = [];
+  const world = {
+    streams: {
+      get: vi.fn(async (_runId: string, _name: string, startIndex?: number) => {
+        const idx = startIndex ?? 0;
+        calls.push(idx);
+        const factory = scripts[idx];
+        if (!factory) {
+          throw new Error(`unexpected startIndex ${idx}`);
+        }
+        return factory();
+      }),
+    },
+  } as unknown as World;
+  return { world, calls };
+}
+
+describe('createReconnectingFramedStream', () => {
+  afterEach(() => {
+    setWorld(undefined as unknown as World);
+  });
+
+  it('passes through complete frames and closes cleanly on EOF', async () => {
+    const { world, calls } = makeWorldWithScriptedStreams({
+      0: () =>
+        scriptedStream([
+          { kind: 'value', value: payloadFrame(1) },
+          { kind: 'value', value: payloadFrame(2) },
+          { kind: 'value', value: payloadFrame(3) },
+          { kind: 'close' },
+        ]),
+    });
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([payloadFrame(1), payloadFrame(2), payloadFrame(3)]);
+    expect(calls).toEqual([0]);
+  });
+
+  it('forwards a frame delivered across multiple reads', async () => {
+    const full = payloadFrame(42);
+    const { world } = makeWorldWithScriptedStreams({
+      0: () =>
+        scriptedStream([
+          // Split frame into 3 byte-level reads to prove boundary-aware
+          // buffering works regardless of transport chunking.
+          { kind: 'value', value: full.slice(0, 2) },
+          { kind: 'value', value: full.slice(2, 4) },
+          { kind: 'value', value: full.slice(4) },
+          { kind: 'close' },
+        ]),
+    });
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toEqual(full);
+  });
+
+  it('reconnects with startIndex = consumed count on upstream error', async () => {
+    const { world, calls } = makeWorldWithScriptedStreams({
+      0: () =>
+        scriptedStream([
+          { kind: 'value', value: payloadFrame(1) },
+          { kind: 'value', value: payloadFrame(2) },
+          // Simulate server 2-minute abort mid-frame: deliver the first
+          // 3 bytes of a frame then error. The wrapper should discard
+          // those partial bytes and reopen at the right index.
+          { kind: 'value', value: payloadFrame(3).slice(0, 3) },
+          { kind: 'error', err: new Error('max-duration abort') },
+        ]),
+      2: () =>
+        scriptedStream([
+          { kind: 'value', value: payloadFrame(3) },
+          { kind: 'value', value: payloadFrame(4) },
+          { kind: 'close' },
+        ]),
+    });
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([
+      payloadFrame(1),
+      payloadFrame(2),
+      payloadFrame(3),
+      payloadFrame(4),
+    ]);
+    // First connection: startIndex=0. After 2 frames consumed, reconnect
+    // opens a fresh stream at startIndex=2.
+    expect(calls).toEqual([0, 2]);
+  });
+
+  it('respects an initial non-zero startIndex on reconnect', async () => {
+    const { world, calls } = makeWorldWithScriptedStreams({
+      10: () =>
+        scriptedStream([
+          { kind: 'value', value: payloadFrame(10) },
+          { kind: 'error', err: new Error('abort') },
+        ]),
+      11: () =>
+        scriptedStream([
+          { kind: 'value', value: payloadFrame(11) },
+          { kind: 'close' },
+        ]),
+    });
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 10);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([payloadFrame(10), payloadFrame(11)]);
+    expect(calls).toEqual([10, 11]);
+  });
+
+  it('does not reconnect when startIndex is negative', async () => {
+    const { world, calls } = makeWorldWithScriptedStreams({
+      [-5]: () =>
+        scriptedStream([
+          { kind: 'value', value: payloadFrame(99) },
+          { kind: 'error', err: new Error('abort') },
+        ]),
+    });
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', -5);
+    await expect(readAll(stream)).rejects.toThrow(/abort/);
+    expect(calls).toEqual([-5]);
+  });
+
+  it('cancel aborts the upstream reader', async () => {
+    const cancelSpy = vi.fn();
+    const { world } = makeWorldWithScriptedStreams({
+      0: () => {
+        // Keep the upstream pending after the first value so cancel
+        // actually has a live stream to abort; an auto-closed upstream
+        // would swallow the cancel per web-streams spec.
+        let pulls = 0;
+        return new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            if (pulls++ === 0) {
+              controller.enqueue(payloadFrame(1));
+              return;
+            }
+            await new Promise(() => {}); // hang forever
+          },
+          cancel(reason) {
+            cancelSpy(reason);
+          },
+        });
+      },
+    });
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const reader = stream.getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+
+    await reader.cancel('client abort');
+
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  it('emits every complete frame packed into a single read', async () => {
+    // One transport read carrying three back-to-back frames must surface as
+    // three separate downstream chunks — exercises the inner drain loop.
+    const packed = new Uint8Array([
+      ...payloadFrame(1),
+      ...payloadFrame(2),
+      ...payloadFrame(3),
+    ]);
+    const { world } = makeWorldWithScriptedStreams({
+      0: () =>
+        scriptedStream([{ kind: 'value', value: packed }, { kind: 'close' }]),
+    });
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([payloadFrame(1), payloadFrame(2), payloadFrame(3)]);
+  });
+
+  it('threads runId through to streams.get', async () => {
+    const getSpy = vi.fn(
+      async (_runId: string, _name: string, _startIndex?: number) =>
+        scriptedStream([
+          { kind: 'value', value: payloadFrame(7) },
+          { kind: 'close' },
+        ])
+    );
+    const world = { streams: { get: getSpy } } as unknown as World;
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream('run-abc', 'my-stream', 3);
+    await readAll(stream);
+
+    expect(getSpy).toHaveBeenCalledWith('run-abc', 'my-stream', 3);
+  });
+
+  it('errors after the maximum consecutive reconnects with no progress', async () => {
+    // Every connection errors before delivering a frame, so no forward
+    // progress is ever made. The wrapper must give up rather than reconnect
+    // forever.
+    const calls: number[] = [];
+    const world = {
+      streams: {
+        get: vi.fn(
+          async (_runId: string, _name: string, startIndex?: number) => {
+            calls.push(startIndex ?? 0);
+            return scriptedStream([
+              { kind: 'error', err: new Error('always fails') },
+            ]);
+          }
+        ),
+      },
+    } as unknown as World;
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    await expect(readAll(stream)).rejects.toThrow(
+      /exceeded maximum reconnection attempts/
+    );
+    // Initial connect + one connect per allowed reconnect; the following
+    // reconnect throws before opening another stream.
+    expect(calls).toHaveLength(FRAMED_STREAM_MAX_RECONNECTS + 1);
+    // No progress ⇒ every attempt resumes from the original index.
+    expect(calls.every((i) => i === 0)).toBe(true);
+  });
+
+  it('resets the reconnect budget after forward progress', async () => {
+    // Deliver exactly one frame per connection and then error, far more
+    // times than the consecutive-failure cap. Because every reconnect makes
+    // progress, the budget resets and the stream must NOT be capped — it
+    // completes once a connection finally closes cleanly. Without the reset
+    // this would throw at FRAMED_STREAM_MAX_RECONNECTS.
+    const lastIndex = FRAMED_STREAM_MAX_RECONNECTS + 5;
+    const calls: number[] = [];
+    const world = {
+      streams: {
+        get: vi.fn(
+          async (_runId: string, _name: string, startIndex?: number) => {
+            const idx = startIndex ?? 0;
+            calls.push(idx);
+            // Payload encodes the absolute index so ordering can be asserted.
+            return scriptedStream([
+              { kind: 'value', value: payloadFrame(idx) },
+              idx < lastIndex
+                ? { kind: 'error', err: new Error('transient') }
+                : { kind: 'close' },
+            ]);
+          }
+        ),
+      },
+    } as unknown as World;
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    // One frame per index 0..lastIndex inclusive, in order.
+    expect(chunks.map((c) => c[FRAME_HEADER_SIZE])).toEqual(
+      Array.from({ length: lastIndex + 1 }, (_, i) => i)
+    );
+    // Reconnected once per error — well beyond the cap — without erroring,
+    // and each reconnect resumed at the next index.
+    expect(calls.length).toBeGreaterThan(FRAMED_STREAM_MAX_RECONNECTS + 1);
+    expect(calls).toEqual(Array.from({ length: lastIndex + 1 }, (_, i) => i));
+  });
+
+  it('errors at the absolute backstop when a world ignores startIndex and loops forever', async () => {
+    // Pathological world: ignores startIndex and always re-delivers a frame
+    // then errors. Every reconnect "makes progress", so the consecutive cap
+    // never trips — only the absolute total backstop can stop the loop. This
+    // guards against a misbehaving backend turning reconnect into a hang.
+    let calls = 0;
+    const world = {
+      streams: {
+        get: vi.fn(async () => {
+          calls++;
+          return scriptedStream([
+            { kind: 'value', value: payloadFrame(0) },
+            { kind: 'error', err: new Error('always errors after one frame') },
+          ]);
+        }),
+      },
+    } as unknown as World;
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    await expect(readAll(stream)).rejects.toThrow(
+      /exceeded maximum total reconnection attempts/
+    );
+    // Initial connect + one connect per allowed total reconnect; the next
+    // reconnect throws before opening another stream.
+    expect(calls).toBe(FRAMED_STREAM_MAX_TOTAL_RECONNECTS + 1);
+  });
+});

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -396,6 +396,182 @@ export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
 }
 
 /**
+ * Maximum consecutive reconnect attempts for a single framed stream session.
+ * The counter resets to zero whenever a reconnect makes forward progress (a
+ * frame is delivered), so this bounds *consecutive* failures, not the lifetime
+ * total — a long-lived serverless stream may legitimately reconnect far more
+ * than this many times as long as each reconnect keeps delivering data. We only
+ * give up after this many reconnects in a row produce nothing.
+ */
+export const FRAMED_STREAM_MAX_RECONNECTS = 50;
+
+/**
+ * Absolute backstop on total reconnects for a single session, independent of
+ * progress. The consecutive cap above resets on forward progress, which is
+ * correct for a well-behaved backend that honors `startIndex`. But if a World's
+ * `streams.get` ever ignored `startIndex` and re-delivered earlier chunks,
+ * "progress" would be reported every reconnect and the consecutive cap would
+ * never trip — turning a bounded failure into an unbounded reconnect loop. This
+ * hard ceiling guarantees the loop always terminates. It is set high enough
+ * (hours of streaming at realistic per-session timeouts) to never interfere
+ * with legitimate long-lived streams.
+ */
+export const FRAMED_STREAM_MAX_TOTAL_RECONNECTS = 1000;
+
+/**
+ * Wraps the length-prefix-framed byte stream from `world.streams.get` with
+ * transparent auto-reconnect.
+ *
+ * Every fully-decoded outer frame corresponds to exactly one server-side
+ * chunk (the serialize transform enqueues one frame per workflow write, and
+ * the writable buffers one frame per chunk when multi-writing). The wrapper
+ * counts completed frames and, on upstream error, reopens the connection
+ * with `startIndex = resolvedStartIndex + consumedFrames`. Partial-frame
+ * bytes buffered before the cut are discarded — the server will resend the
+ * in-flight chunk in full from the new startIndex.
+ *
+ * A clean upstream close (EOF with no error) signals the stream is truly
+ * done; we close the wrapper and do not reconnect.
+ *
+ * Negative `startIndex` values (last-N semantics) skip the reconnect
+ * machinery because we cannot compute an absolute resume position without
+ * a tail-index lookup — the returned stream behaves as a single-shot read.
+ */
+export function createReconnectingFramedStream(
+  runId: string,
+  name: string,
+  startIndex?: number
+): ReadableStream<Uint8Array> {
+  const reconnectSupported = startIndex === undefined || startIndex >= 0;
+  let currentStartIndex = startIndex ?? 0;
+  let consumedFrames = 0;
+  let reconnectCount = 0;
+  let totalReconnectCount = 0;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let buffer = new Uint8Array(0);
+
+  async function connect(): Promise<void> {
+    const world = await getWorldLazy();
+    const effectiveStartIndex = reconnectSupported
+      ? currentStartIndex + consumedFrames
+      : startIndex;
+    const stream = await world.streams.get(runId, name, effectiveStartIndex);
+    reader = stream.getReader();
+  }
+
+  async function reconnect(): Promise<void> {
+    reconnectCount++;
+    totalReconnectCount++;
+    if (reconnectCount > FRAMED_STREAM_MAX_RECONNECTS) {
+      throw new Error(
+        `Stream "${name}" exceeded maximum reconnection attempts (${FRAMED_STREAM_MAX_RECONNECTS})`
+      );
+    }
+    if (totalReconnectCount > FRAMED_STREAM_MAX_TOTAL_RECONNECTS) {
+      throw new Error(
+        `Stream "${name}" exceeded maximum total reconnection attempts (${FRAMED_STREAM_MAX_TOTAL_RECONNECTS})`
+      );
+    }
+    if (reader) {
+      await reader.cancel().catch(() => {});
+      reader = undefined;
+    }
+    currentStartIndex += consumedFrames;
+    consumedFrames = 0;
+    buffer = new Uint8Array(0);
+    await connect();
+  }
+
+  return new ReadableStream<Uint8Array>({
+    pull: async (controller) => {
+      // Loop until we emit something, hit EOF, or fatally error. Reads that
+      // only extend the in-flight-frame buffer don't enqueue anything — we
+      // keep reading rather than returning empty-handed.
+      for (;;) {
+        if (!reader) {
+          try {
+            await connect();
+          } catch (err) {
+            controller.error(err);
+            return;
+          }
+        }
+
+        let result: { done: boolean; value?: Uint8Array };
+        try {
+          // biome-ignore lint/style/noNonNullAssertion: connect() guarantees reader
+          result = await reader!.read();
+        } catch (err) {
+          if (!reconnectSupported) {
+            controller.error(err);
+            return;
+          }
+          try {
+            await reconnect();
+          } catch (reconnectErr) {
+            controller.error(reconnectErr);
+            return;
+          }
+          continue;
+        }
+
+        if (result.done || !result.value) {
+          // Clean EOF — stream is truly complete. Drop any partial-frame
+          // bytes (there shouldn't be any; a well-formed stream ends on a
+          // frame boundary).
+          reader = undefined;
+          controller.close();
+          return;
+        }
+
+        // Append to buffer and emit all complete frames.
+        const incoming = result.value;
+        if (incoming.length > 0) {
+          const combined = new Uint8Array(buffer.length + incoming.length);
+          combined.set(buffer, 0);
+          combined.set(incoming, buffer.length);
+          buffer = combined;
+        }
+
+        let emitted = false;
+        while (buffer.length >= FRAME_HEADER_SIZE) {
+          const frameLength = new DataView(
+            buffer.buffer,
+            buffer.byteOffset,
+            buffer.byteLength
+          ).getUint32(0, false);
+          const total = FRAME_HEADER_SIZE + frameLength;
+          if (buffer.length < total) break;
+          // Forward the entire framed chunk (header + payload) to the
+          // downstream deserializer, which already expects this layout.
+          controller.enqueue(buffer.slice(0, total));
+          buffer = buffer.slice(total);
+          consumedFrames++;
+          emitted = true;
+        }
+
+        if (emitted) {
+          // Forward progress on the current connection — clear the
+          // consecutive-failure budget so a long stream that reconnects
+          // many times (but keeps delivering) is never falsely capped.
+          reconnectCount = 0;
+          return;
+        }
+        // Only partial bytes — read more.
+      }
+    },
+    cancel: async () => {
+      if (reader) {
+        await reader.cancel().catch((err) => {
+          console.warn('Error closing ReadableStream reader:', err);
+        });
+        reader = undefined;
+      }
+    },
+  });
+}
+
+/**
  * Default flush interval in milliseconds for buffered stream writes.
  * Chunks are accumulated and flushed together to reduce network overhead.
  */
@@ -1481,13 +1657,16 @@ export function getExternalRevivers(
         return response.body;
       }
 
-      const readable = new WorkflowServerReadableStream(
-        runId,
-        value.name,
-        value.startIndex
-      );
       if (value.type === 'bytes') {
-        // For byte streams, use flushable pipe with lock polling
+        // For byte streams, use flushable pipe with lock polling. No
+        // auto-reconnect here: raw byte streams have no wire framing, so
+        // we cannot count consumed chunks to compute a resume index.
+        // Byte-stream reconnect is a separate follow-up.
+        const readable = new WorkflowServerReadableStream(
+          runId,
+          value.name,
+          value.startIndex
+        );
         const state = createFlushableState();
         ops.push(state.promise);
 
@@ -1505,6 +1684,14 @@ export function getExternalRevivers(
 
         return userReadable;
       } else {
+        // Non-byte streams carry length-prefixed frames, so we can count
+        // completed frames and transparently reconnect when the server
+        // stream connection times out mid-run.
+        const readable = createReconnectingFramedStream(
+          runId,
+          value.name,
+          value.startIndex
+        );
         const transform = getDeserializeStream(
           getExternalRevivers(global, ops, runId, cryptoKey),
           cryptoKey


### PR DESCRIPTION
Forward-port of #1847 (which targets `stable`) onto `main`.

Same mechanism: object/serialized streams now transparently auto-reconnect at the getReadable level. When the upstream server stream connection errors mid-run (e.g. a per-session duration timeout), the wrapper reopens the stream at `startIndex + consumedFrames`, counting 4-byte length-prefixed wire frames to compute the resume position. Partial in-flight frame bytes are discarded and resent in full from the new index. A clean EOF (no error) is treated as stream completion and does not reconnect. Negative `startIndex` (last-N) skips reconnect and behaves as a single-shot read.

Adapted to `main`'s world API: reads go through `world.streams.get(runId, name, startIndex)`, so `runId` is threaded into `createReconnectingFramedStream`.

Bounded by a consecutive-failure cap (resets on forward progress) and an absolute total-reconnect backstop so a misbehaving backend can never loop forever.

Object streams only. Byte-stream reconnect is a separate follow-up since it depends on byte-stream framing (#1853).

🤖 Generated with [Claude Code](https://claude.com/claude-code)