### PR TITLE
Fix flickering on the detail panel when navigating the trace viewer

### DIFF
--- a/.changeset/fix-detail-panel-flicker.md
+++ b/.changeset/fix-detail-panel-flicker.md
@@ -2,4 +2,4 @@
 '@workflow/web-shared': patch
 ---
 
-Fix the trace span detail panel showing stale or mixed data while navigating spans: the host-fetched detail could briefly belong to a previously selected span (often a different resource type), unioning a step's fields into a hook's panel and flickering the Created/Started/Completed timestamps. Reject detail that doesn't match the current selection, and keep the span's own event-derived identity and timestamps authoritative.
+Fix the trace span detail panel showing stale or mixed data while navigating spans

--- a/.changeset/fix-detail-panel-flicker.md
+++ b/.changeset/fix-detail-panel-flicker.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Fix the trace span detail panel showing stale or mixed data while navigating spans: the host-fetched detail could briefly belong to a previously selected span (often a different resource type), unioning a step's fields into a hook's panel and flickering the Created/Started/Completed timestamps. Reject detail that doesn't match the current selection, and keep the span's own event-derived identity and timestamps authoritative.

--- a/.changeset/fix-event-detail-stream-links.md
+++ b/.changeset/fix-event-detail-stream-links.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Make stream and run reference links inside event details clickable in the span detail panel.

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -284,6 +284,7 @@ const attributeDisplayNames: Partial<Record<AttributeKey, string>> = {
   runId: 'Run ID',
   token: 'Token',
   eventType: 'Event Type',
+  errorCode: 'Error Code',
   correlationId: 'Correlation ID',
   deploymentId: 'Deployment ID',
   specVersion: 'Spec Version',

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -10,6 +10,10 @@ import { AttributePanel } from './attribute-panel';
 import { EventsList } from './events-list';
 import { ResolveHookModal } from './resolve-hook-modal';
 import { useSidebarDataOptional } from './sidebar-data-context';
+import {
+  mergeSpanDetail,
+  spanDetailMatchesSelection,
+} from './span-detail-merge';
 
 // Type guards for runtime validation of span attribute data
 function isStep(data: unknown): data is Step {
@@ -215,19 +219,27 @@ export function EntityDetailPanel({
   const error = spanDetailError ?? undefined;
   const loading = spanDetailLoading ?? false;
 
+  const matchedSpanDetailData = useMemo(
+    () =>
+      spanDetailMatchesSelection(spanDetailData, resource, resourceId)
+        ? spanDetailData
+        : null,
+    [spanDetailData, resource, resourceId]
+  );
+
   // Get the hook token for resolving (prefer fetched data, then hooks array fallback)
   const hookToken = useMemo(() => {
     if (resource !== 'hook' || !resourceId) return undefined;
     // 1. Try the externally-fetched detail data first
-    if (isHook(spanDetailData) && spanDetailData.token) {
-      return spanDetailData.token;
+    if (isHook(matchedSpanDetailData) && matchedSpanDetailData.token) {
+      return matchedSpanDetailData.token;
     }
     // 2. Try the span's inline data (reconstructed from hook_created event)
     if (isHook(data) && (data as Hook).token) {
       return (data as Hook).token;
     }
     return undefined;
-  }, [resource, resourceId, spanDetailData, data]);
+  }, [resource, resourceId, matchedSpanDetailData, data]);
 
   useEffect(() => {
     if (error && selectedSpan && resource) {
@@ -289,7 +301,7 @@ export function EntityDetailPanel({
 
       try {
         setResolvingHook(true);
-        const candidate = spanDetailData ?? data;
+        const candidate = matchedSpanDetailData ?? data;
         const hook = isHook(candidate) ? candidate : undefined;
         await onResolveHook(hookToken, payload, hook);
         toast.success('Hook resolved', {
@@ -310,17 +322,18 @@ export function EntityDetailPanel({
         setResolvingHook(false);
       }
     },
-    [onResolveHook, hookToken, resolvingHook, spanDetailData, data]
+    [onResolveHook, hookToken, resolvingHook, matchedSpanDetailData, data]
   );
 
-  // Prefer externally-fetched details when available. For sleep spans, the
-  // host fetches full correlated events (withData=true) and materializes a wait
-  // entity, so this includes resumeAt/completedAt without bloating trace payloads.
-  const displayData = (spanDetailData ?? data) as
-    | WorkflowRun
-    | Step
-    | Hook
-    | Event;
+  const displayData = useMemo(
+    () =>
+      mergeSpanDetail(data, matchedSpanDetailData) as
+        | WorkflowRun
+        | Step
+        | Hook
+        | Event,
+    [data, matchedSpanDetailData]
+  );
 
   const moduleSpecifier = useMemo(() => {
     const displayRecord = displayData as Record<string, unknown>;
@@ -435,6 +448,8 @@ export function EntityDetailPanel({
             <EventsList
               events={rawEvents}
               onLoadEventData={onLoadEventData}
+              onStreamClick={onStreamClick}
+              onRunClick={onRunClick}
               encryptionKey={encryptionKey}
             />
           )}

--- a/packages/web-shared/src/components/sidebar/events-list.tsx
+++ b/packages/web-shared/src/components/sidebar/events-list.tsx
@@ -3,6 +3,7 @@
 import { EVENT_DATA_REF_FIELDS, type Event } from '@workflow/world';
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { hasEncryptedFields, isExpiredMarker } from '../../lib/hydration';
+import { RunClickContext, StreamClickContext } from '../ui/data-inspector';
 import { ErrorCard } from '../ui/error-card';
 import { ErrorStackBlock, isStructuredError } from '../ui/error-stack-block';
 import { Skeleton } from '../ui/skeleton';
@@ -256,6 +257,8 @@ export function EventsList({
   isLoading = false,
   error,
   onLoadEventData,
+  onStreamClick,
+  onRunClick,
   encryptionKey,
 }: {
   events: Event[];
@@ -265,6 +268,10 @@ export function EventsList({
     correlationId: string,
     eventId: string
   ) => Promise<unknown | null>;
+  /** Callback when a stream reference inside event data is clicked */
+  onStreamClick?: (streamId: string) => void;
+  /** Callback when a run reference inside event data is clicked */
+  onRunClick?: (runId: string) => void;
   /** When provided, signals that decryption is active (triggers re-load of expanded events) */
   encryptionKey?: Uint8Array;
 }) {
@@ -285,31 +292,35 @@ export function EventsList({
   }
 
   return (
-    <DetailCard summary="Events" contentClassName="mb-0" defaultOpen>
-      {isLoading ? (
-        <div className="flex flex-col -mx-4">
-          {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="flex items-center justify-between gap-3 bg-background-200 px-4 py-2"
-            >
-              <Skeleton className="h-4 w-32 rounded" />
-              <Skeleton className="h-3 w-16 rounded" />
+    <RunClickContext.Provider value={onRunClick}>
+      <StreamClickContext.Provider value={onStreamClick}>
+        <DetailCard summary="Events" contentClassName="mb-0" defaultOpen>
+          {isLoading ? (
+            <div className="flex flex-col -mx-4">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between gap-3 bg-background-200 px-4 py-2"
+                >
+                  <Skeleton className="h-4 w-32 rounded" />
+                  <Skeleton className="h-3 w-16 rounded" />
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      ) : (
-        <div className="flex flex-col -mx-4">
-          {sortedEvents.map((event) => (
-            <EventItem
-              key={event.eventId}
-              event={event}
-              onLoadEventData={onLoadEventData}
-              encryptionKey={encryptionKey}
-            />
-          ))}
-        </div>
-      )}
-    </DetailCard>
+          ) : (
+            <div className="flex flex-col -mx-4">
+              {sortedEvents.map((event) => (
+                <EventItem
+                  key={event.eventId}
+                  event={event}
+                  onLoadEventData={onLoadEventData}
+                  encryptionKey={encryptionKey}
+                />
+              ))}
+            </div>
+          )}
+        </DetailCard>
+      </StreamClickContext.Provider>
+    </RunClickContext.Provider>
   );
 }

--- a/packages/web-shared/src/components/sidebar/events-list.tsx
+++ b/packages/web-shared/src/components/sidebar/events-list.tsx
@@ -268,9 +268,7 @@ export function EventsList({
     correlationId: string,
     eventId: string
   ) => Promise<unknown | null>;
-  /** Callback when a stream reference inside event data is clicked */
   onStreamClick?: (streamId: string) => void;
-  /** Callback when a run reference inside event data is clicked */
   onRunClick?: (runId: string) => void;
   /** When provided, signals that decryption is active (triggers re-load of expanded events) */
   encryptionKey?: Uint8Array;

--- a/packages/web-shared/src/components/sidebar/span-detail-merge.ts
+++ b/packages/web-shared/src/components/sidebar/span-detail-merge.ts
@@ -1,0 +1,65 @@
+const hasField = (
+  value: object,
+  key: string
+): value is Record<string, unknown> => key in value;
+
+/**
+ * Returns true when the fetched `detail` belongs to the current selection.
+ * The fetch lags selection, so it can briefly hold a previously selected span
+ * (even a different resource type); reject it before merging or its fields
+ * union into the wrong panel. Steps/hooks/waits carry their parent `runId`, so
+ * a `run` selection excludes objects identifiable as a child resource.
+ */
+export function spanDetailMatchesSelection(
+  detail: unknown,
+  resource: string | undefined,
+  resourceId: string | undefined
+): boolean {
+  if (!detail || typeof detail !== 'object' || !resource || !resourceId) {
+    return false;
+  }
+  switch (resource) {
+    case 'step':
+      return hasField(detail, 'stepId') && detail.stepId === resourceId;
+    case 'hook':
+      return hasField(detail, 'hookId') && detail.hookId === resourceId;
+    case 'sleep':
+      return hasField(detail, 'waitId') && detail.waitId === resourceId;
+    case 'run':
+      return (
+        hasField(detail, 'runId') &&
+        !('stepId' in detail) &&
+        !('hookId' in detail) &&
+        !('waitId' in detail) &&
+        detail.runId === resourceId
+      );
+    default:
+      return false;
+  }
+}
+
+/**
+ * Merges fetched `detail` over the span's own data. The detail supplies the
+ * heavy fields the trace strips (input/output/error/metadata, sleep resumeAt);
+ * the span's identity, status, and event-derived timestamps stay authoritative
+ * so they don't flicker to the backend row's millisecond-different values.
+ */
+export function mergeSpanDetail(spanData: unknown, detail: unknown): unknown {
+  if (!detail || typeof detail !== 'object') {
+    return spanData;
+  }
+  if (!spanData || typeof spanData !== 'object') {
+    return detail;
+  }
+  // Skip `undefined` span fields so they don't clobber a value the detail
+  // legitimately provides (e.g. a step's optional startedAt).
+  const merged: Record<string, unknown> = { ...detail };
+  for (const [key, value] of Object.entries(
+    spanData as Record<string, unknown>
+  )) {
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}

--- a/packages/web-shared/test/span-detail-merge.test.ts
+++ b/packages/web-shared/test/span-detail-merge.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeSpanDetail,
+  spanDetailMatchesSelection,
+} from '../src/components/sidebar/span-detail-merge.js';
+
+describe('mergeSpanDetail', () => {
+  const spanStep = {
+    stepId: 'step_a',
+    runId: 'wrun_1',
+    createdAt: new Date('2026-06-05T16:55:18.569Z'),
+    startedAt: new Date('2026-06-05T16:55:18.812Z'),
+    completedAt: new Date('2026-06-05T16:55:18.913Z'),
+  };
+
+  const fetchedStep = {
+    stepId: 'step_a',
+    runId: 'wrun_1',
+    createdAt: new Date('2026-06-05T16:55:18.571Z'),
+    startedAt: new Date('2026-06-05T16:55:18.820Z'),
+    completedAt: new Date('2026-06-05T16:55:18.911Z'),
+    output: { ok: true },
+  };
+
+  it('keeps span-derived timestamps when the fetched detail swaps in', () => {
+    const merged = mergeSpanDetail(spanStep, fetchedStep) as Record<
+      string,
+      unknown
+    >;
+    expect(merged.createdAt).toBe(spanStep.createdAt);
+    expect(merged.startedAt).toBe(spanStep.startedAt);
+    expect(merged.completedAt).toBe(spanStep.completedAt);
+  });
+
+  it('takes non-timestamp fields from the fetched detail', () => {
+    const merged = mergeSpanDetail(spanStep, fetchedStep) as Record<
+      string,
+      unknown
+    >;
+    expect(merged.output).toEqual({ ok: true });
+  });
+
+  it('fills timestamps missing from the span data with fetched values', () => {
+    const { startedAt: _ignored, ...spanWithoutStartedAt } = spanStep;
+    const merged = mergeSpanDetail(spanWithoutStartedAt, fetchedStep) as Record<
+      string,
+      unknown
+    >;
+    expect(merged.startedAt).toBe(fetchedStep.startedAt);
+  });
+
+  it('returns span data when there is no fetched detail', () => {
+    expect(mergeSpanDetail(spanStep, null)).toBe(spanStep);
+    expect(mergeSpanDetail(spanStep, undefined)).toBe(spanStep);
+  });
+
+  it('returns fetched detail when there is no span data', () => {
+    expect(mergeSpanDetail(null, fetchedStep)).toBe(fetchedStep);
+    expect(mergeSpanDetail(undefined, fetchedStep)).toBe(fetchedStep);
+  });
+});
+
+describe('spanDetailMatchesSelection', () => {
+  const step = { stepId: 'step_a', runId: 'wrun_1' };
+  const hook = { hookId: 'hook_a', runId: 'wrun_1', token: 'tok' };
+  const run = { runId: 'wrun_1', workflowName: 'workflows/main' };
+  const wait = { waitId: 'wait_a', runId: 'wrun_1' };
+
+  it('matches a detail to its own resource and id', () => {
+    expect(spanDetailMatchesSelection(step, 'step', 'step_a')).toBe(true);
+    expect(spanDetailMatchesSelection(hook, 'hook', 'hook_a')).toBe(true);
+    expect(spanDetailMatchesSelection(wait, 'sleep', 'wait_a')).toBe(true);
+    expect(spanDetailMatchesSelection(run, 'run', 'wrun_1')).toBe(true);
+  });
+
+  it('rejects a stale step detail while a hook is selected', () => {
+    // Navigating from a step onto a hook leaves the step detail set for a
+    // frame; it must not match the hook (would union their fields).
+    expect(spanDetailMatchesSelection(step, 'hook', 'hook_a')).toBe(false);
+  });
+
+  it('rejects a detail whose id differs from the current selection', () => {
+    expect(spanDetailMatchesSelection(step, 'step', 'step_b')).toBe(false);
+    expect(spanDetailMatchesSelection(hook, 'hook', 'hook_b')).toBe(false);
+  });
+
+  it('rejects child resources for a run selection despite their runId', () => {
+    expect(spanDetailMatchesSelection(step, 'run', 'wrun_1')).toBe(false);
+    expect(spanDetailMatchesSelection(hook, 'run', 'wrun_1')).toBe(false);
+    expect(spanDetailMatchesSelection(wait, 'run', 'wrun_1')).toBe(false);
+  });
+
+  it('returns false for missing detail, resource, or id', () => {
+    expect(spanDetailMatchesSelection(null, 'step', 'step_a')).toBe(false);
+    expect(spanDetailMatchesSelection(step, undefined, 'step_a')).toBe(false);
+    expect(spanDetailMatchesSelection(step, 'step', undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Navigating spans in the trace viewer (clicking, or `J`/`K`) made the detail panel flicker: it briefly showed stale or mixed-up data — e.g. a previously selected step's fields appearing under a hook — and the Created/Started/Completed timestamps jumped.

The span detail (input/output/etc.) is fetched asynchronously and lags the current selection, so for a render or two `spanDetailData` still holds the *previous* span — sometimes a different resource type. The panel merged that into the current span, unioning two resources' fields and replacing the event-derived timestamps with the backend row's millisecond-different ones.

## What

- Gate the fetched detail to the current selection (`spanDetailMatchesSelection`) so stale/non-matching detail is ignored — one span's fields can no longer bleed into another's panel.
- When merging the matched detail in (`mergeSpanDetail`), keep the span's own event-derived identity, status, and timestamps authoritative so they stop flickering to the backend values.
- Also: make stream and run reference links inside event details clickable, and label `errorCode` as "Error Code".

web-shared only — no host or API changes. Unit tests cover the gate and merge.
