### PR TITLE
Move run attributes into their own detail card

### DIFF
--- a/.changeset/empty-worlds-throw.md
+++ b/.changeset/empty-worlds-throw.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Move run attributes into their own detail card

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -258,6 +258,7 @@ const attributeOrder: AttributeKey[] = [
   'retryAfter',
   'error',
   'metadata',
+  'attributes',
   'eventData',
   'input',
   'output',
@@ -415,11 +416,11 @@ const attributeToDisplayFn: Record<
   environment: (_value: unknown) => null,
   executionContext: (_value: unknown) => null,
   // Attributes MVP — string-string metadata attached to the run.
-  // Rendered as a JSON block; if empty/missing, hidden by the
-  // hasDisplayContent gate above.
+  // Rendered in its own collapsible DetailCard; if empty/missing, hidden
+  // by the hasDisplayContent gate.
   attributes: (value: unknown) => {
     if (!hasDisplayContent(value)) return null;
-    return JsonBlock(value);
+    return <DetailCard summary="Attributes">{JsonBlock(value)}</DetailCard>;
   },
   // Dates — wrapped with TimestampTooltip showing UTC/local + relative time
   createdAt: timestampWithTooltipOrNull,
@@ -588,6 +589,7 @@ const resolvableAttributes = [
   'output',
   'error',
   'metadata',
+  'attributes',
   'eventData',
 ];
 
@@ -597,6 +599,7 @@ const selfHeaderedAttributes = new Set([
   'input',
   'output',
   'error',
+  'attributes',
   'eventData',
 ]);
 

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -258,10 +258,10 @@ const attributeOrder: AttributeKey[] = [
   'retryAfter',
   'error',
   'metadata',
-  'attributes',
   'eventData',
   'input',
   'output',
+  'attributes',
   'resumeAt',
 ];
 


### PR DESCRIPTION
## Summary

Render a run's `attributes` field as its own collapsible `DetailCard` in the entity detail panel, instead of squeezing it into the top metadata key/value list where its JSON value rendered cramped in a right-aligned row.
