### PR TITLE
[core] Retry stream reopen against the reconnect budget

### DIFF
--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -175,6 +175,53 @@ describe('createReconnectingFramedStream', () => {
     expect(calls).toEqual([0, 2]);
   });
 
+  it('retries the reopen itself against the budget instead of failing fatally', async () => {
+    // After 2 frames the connection drops (read error → reconnect at index 2).
+    // The first *reopen* attempt also fails — the server is briefly
+    // unavailable during the reconnect window. That transient failure of the
+    // reopen is the exact blip this wrapper exists to survive, so it must be
+    // counted against the budget and retried, not treated as fatal. The
+    // second reopen succeeds and the stream completes.
+    const calls: number[] = [];
+    let reopenAttempts = 0;
+    const world = {
+      streams: {
+        get: vi.fn(
+          async (_runId: string, _name: string, startIndex?: number) => {
+            const idx = startIndex ?? 0;
+            calls.push(idx);
+            if (idx === 0) {
+              return scriptedStream([
+                { kind: 'value', value: payloadFrame(1) },
+                { kind: 'value', value: payloadFrame(2) },
+                { kind: 'error', err: new Error('max-duration abort') },
+              ]);
+            }
+            // Reopen at index 2: throw on the first attempt, succeed on the next.
+            reopenAttempts++;
+            if (reopenAttempts === 1) {
+              throw new Error('reopen failed: server briefly unavailable');
+            }
+            return scriptedStream([
+              { kind: 'value', value: payloadFrame(3) },
+              { kind: 'close' },
+            ]);
+          }
+        ),
+      },
+    } as unknown as World;
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    // The failed reopen did not surface to the consumer; the stream recovered.
+    expect(chunks).toEqual([payloadFrame(1), payloadFrame(2), payloadFrame(3)]);
+    // index 0 once, then index 2 twice — the failed reopen and the retry both
+    // resume from the same position.
+    expect(calls).toEqual([0, 2, 2]);
+  });
+
   it('respects an initial non-zero startIndex on reconnect', async () => {
     const { world, calls } = makeWorldWithScriptedStreams({
       10: () =>

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -659,26 +659,44 @@ export function createReconnectingFramedStream(
   }
 
   async function reconnect(): Promise<void> {
-    reconnectCount++;
-    totalReconnectCount++;
-    if (reconnectCount > FRAMED_STREAM_MAX_RECONNECTS) {
-      throw new Error(
-        `Stream "${name}" exceeded maximum reconnection attempts (${FRAMED_STREAM_MAX_RECONNECTS})`
-      );
-    }
-    if (totalReconnectCount > FRAMED_STREAM_MAX_TOTAL_RECONNECTS) {
-      throw new Error(
-        `Stream "${name}" exceeded maximum total reconnection attempts (${FRAMED_STREAM_MAX_TOTAL_RECONNECTS})`
-      );
-    }
     if (reader) {
       await reader.cancel().catch(() => {});
       reader = undefined;
     }
+    // Advance the resume position past the frames already delivered, then
+    // drop any partial-frame bytes — the reopened connection re-sends from a
+    // frame boundary at the new index.
     currentStartIndex += consumedFrames;
     consumedFrames = 0;
     buffer = new Uint8Array(0);
-    await connect();
+
+    // Retry the reopen itself against the reconnect budget. A transient
+    // failure of connect() — the server briefly unavailable during the
+    // reconnect window — is the exact blip this wrapper exists to survive, so
+    // count it against the budget and try again rather than treating it as
+    // fatal. Only budget exhaustion (a server that stays down) terminates the
+    // stream.
+    for (;;) {
+      reconnectCount++;
+      totalReconnectCount++;
+      if (reconnectCount > FRAMED_STREAM_MAX_RECONNECTS) {
+        throw new Error(
+          `Stream "${name}" exceeded maximum reconnection attempts (${FRAMED_STREAM_MAX_RECONNECTS})`
+        );
+      }
+      if (totalReconnectCount > FRAMED_STREAM_MAX_TOTAL_RECONNECTS) {
+        throw new Error(
+          `Stream "${name}" exceeded maximum total reconnection attempts (${FRAMED_STREAM_MAX_TOTAL_RECONNECTS})`
+        );
+      }
+      try {
+        await connect();
+        return;
+      } catch {
+        // Reopen failed transiently; loop to retry, counting against the
+        // budget so a server that never recovers still terminates the stream.
+      }
+    }
   }
 
   return new ReadableStream<Uint8Array>({


### PR DESCRIPTION
Follow-up to #2318 (now merged), addressing @TooTallNate's review note on it.

#2318's forward-port made object-stream reconnect retry on `reader.read()` errors, but a transient failure of the **reopen itself** — `connect()` throwing inside `reconnect()` because the server is briefly unavailable during the reconnect window — was fatal. That's exactly the blip the wrapper exists to survive.

This makes the reopen retry against the reconnect budget instead of erroring the stream: each reopen attempt counts against the consecutive-failure cap (and the absolute backstop), so a server that stays down still terminates the stream, but a momentary blip no longer kills it. The cancel/reset of buffered state moves ahead of the retry loop so every attempt resumes from the same frame index.

## Test
New case in `reconnecting-framed-stream.test.ts`: a reopen that throws once then succeeds recovers transparently (the failed reopen never surfaces to the consumer; resume index is unchanged). All 12 reconnect tests pass.

## Notes
- Scoped to `@workflow/core`; user-facing behavior is unchanged (object streams reconnect) — this hardens the path against the blip it targets.
- Same sequencing as the stable line (#1847): the reconnect path only triggers once the coordinated server-side change errors timed-out connections instead of closing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)