### PR TITLE
[web-shared] Show precise durations in the new trace viewer

### DIFF
--- a/.changeset/precise-trace-viewer-durations.md
+++ b/.changeset/precise-trace-viewer-durations.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Show precise, unrounded durations in the new trace viewer: the events list and timeline bar labels now display two-decimal seconds for durations over 1s (e.g. "1.63s") instead of rounding to whole seconds.

--- a/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
@@ -2,7 +2,7 @@ import { Circle } from 'lucide-react';
 import { useRef } from 'react';
 import { cn } from '../../../lib/utils';
 import type { Span } from '../types';
-import { formatDuration } from '../../trace-viewer/util/timing';
+import { formatDurationPrecise } from '../../trace-viewer/util/timing';
 import {
   SleepIcon,
   StepForwardIcon,
@@ -86,7 +86,7 @@ const EventRow = ({
           </div>
           <div className="ml-2 shrink-0">
             <span className="text-label-14 text-gray-900 tabular-nums">
-              {formatDuration(durationMs)}
+              {formatDurationPrecise(durationMs)}
             </span>
           </div>
         </div>

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -5,7 +5,11 @@ import type { CSSProperties, ReactNode } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../../../lib/utils';
 import type { Span } from '../types';
-import { formatDuration, getHighResInMs } from '../../trace-viewer/util/timing';
+import {
+  formatDuration,
+  formatDurationPrecise,
+  getHighResInMs,
+} from '../../trace-viewer/util/timing';
 import { isSpanDimmedBySearch, type SpanSearchResult } from '../search';
 import type { Segment, SegmentStatus, TimeMarker } from '../utils';
 import {
@@ -222,7 +226,7 @@ function SegmentBar({ segments }: { segments: VisibleSegment[] }): ReactNode {
   return (
     <div className="relative h-6 w-full">
       {segments.map((seg, i) => {
-        const label = formatDuration(seg.fullDurationMs);
+        const label = formatDurationPrecise(seg.fullDurationMs);
         // Only render the label when there's enough room for it without clipping.
         const showLabel = seg.pixelWidth >= Math.max(40, label.length * 6 + 12);
         // Beef up the queued segment when it's too narrow to read.
@@ -313,7 +317,7 @@ const TimelineBar = memo(function TimelineBar({
     ? (colors.errorBorder ?? 'var(--ds-red-500)')
     : colors.border;
 
-  const totalLabel = formatDuration(totalDurationMs);
+  const totalLabel = formatDurationPrecise(totalDurationMs);
   const showTotalLabel =
     geometry.visiblePixelWidth >= Math.max(40, totalLabel.length * 6 + 12);
 

--- a/packages/web-shared/src/components/trace-viewer/util/timing.ts
+++ b/packages/web-shared/src/components/trace-viewer/util/timing.ts
@@ -1,6 +1,6 @@
-import { formatDuration } from '../../../lib/utils';
+import { formatDuration, formatDurationPrecise } from '../../../lib/utils';
 
-export { formatDuration };
+export { formatDuration, formatDurationPrecise };
 
 export function getHighResInMs([seconds, nanoseconds]: [
   number,

--- a/packages/web-shared/src/index.ts
+++ b/packages/web-shared/src/index.ts
@@ -64,6 +64,7 @@ export type { StreamStep } from './lib/utils';
 export {
   extractConversation,
   formatDuration,
+  formatDurationPrecise,
   identifyStreamSteps,
   isDoStreamStep,
 } from './lib/utils';

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -12,11 +12,6 @@ const MS_IN_MINUTE = 60 * MS_IN_SECOND;
 const MS_IN_HOUR = 60 * MS_IN_MINUTE;
 const MS_IN_DAY = 24 * MS_IN_HOUR;
 
-const CS_IN_SECOND = 100;
-const CS_IN_MINUTE = 60 * CS_IN_SECOND;
-const CS_IN_HOUR = 60 * CS_IN_MINUTE;
-const CS_IN_DAY = 24 * CS_IN_HOUR;
-
 /**
  * Formats a duration in milliseconds to a human-readable string.
  *
@@ -108,28 +103,23 @@ export function formatDurationPrecise(ms: number): string {
     return '0s';
   }
 
-  // Sub-second: whole-millisecond precision. If rounding carries to a full
-  // second, fall through to the second/decompose handling below.
   if (ms < MS_IN_SECOND) {
     const roundedMs = Math.round(ms);
     if (roundedMs < MS_IN_SECOND) {
       return `${roundedMs}ms`;
     }
-    ms = roundedMs;
   }
 
-  // Round to centisecond (two-decimal second) precision FIRST, then decompose
-  // in integer space so values like 59.999s never render as "60.00s".
-  const centiseconds = Math.round(ms / 10);
+  const normalizedMs = Math.round(ms / 10) * 10;
 
-  const days = Math.floor(centiseconds / CS_IN_DAY);
-  const hours = Math.floor((centiseconds % CS_IN_DAY) / CS_IN_HOUR);
-  const minutes = Math.floor((centiseconds % CS_IN_HOUR) / CS_IN_MINUTE);
-  const seconds = (centiseconds % CS_IN_MINUTE) / CS_IN_SECOND;
-
-  if (centiseconds < CS_IN_MINUTE) {
-    return `${preciseSecondsFormatter.format(seconds)}s`;
+  if (normalizedMs < MS_IN_MINUTE) {
+    return `${preciseSecondsFormatter.format(normalizedMs / MS_IN_SECOND)}s`;
   }
+
+  const days = Math.floor(normalizedMs / MS_IN_DAY);
+  const hours = Math.floor((normalizedMs % MS_IN_DAY) / MS_IN_HOUR);
+  const minutes = Math.floor((normalizedMs % MS_IN_HOUR) / MS_IN_MINUTE);
+  const seconds = (normalizedMs % MS_IN_MINUTE) / MS_IN_SECOND;
 
   const parts: string[] = [];
 

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -80,6 +80,58 @@ export function formatDuration(ms: number, compact = false): string {
   return parts.join(' ');
 }
 
+// Locale-aware formatter that always renders exactly two fraction digits.
+// Used for the seconds component of precise durations so values are never
+// snapped to a whole second (and thousands separators stay correct).
+const preciseSecondsFormatter = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+/**
+ * Formats a duration in milliseconds without snapping to whole seconds.
+ *
+ * Unlike {@link formatDuration}, this never rounds a sub-minute value up to
+ * the next whole second (e.g. 1626ms renders as "1.63s", not "2s").
+ *
+ * - < 1s: shows whole milliseconds (e.g. "626ms")
+ * - 1s – 1m: shows seconds with two decimals (e.g. "1.63s", "45.20s")
+ * - >= 1m: decomposes into d/h/m with two-decimal seconds (e.g. "1m 13.45s")
+ */
+export function formatDurationPrecise(ms: number): string {
+  if (ms === 0) {
+    return '0s';
+  }
+
+  if (ms < MS_IN_SECOND) {
+    return `${Math.round(ms)}ms`;
+  }
+
+  if (ms < MS_IN_MINUTE) {
+    return `${preciseSecondsFormatter.format(ms / MS_IN_SECOND)}s`;
+  }
+
+  const days = Math.floor(ms / MS_IN_DAY);
+  const hours = Math.floor((ms % MS_IN_DAY) / MS_IN_HOUR);
+  const minutes = Math.floor((ms % MS_IN_HOUR) / MS_IN_MINUTE);
+  const seconds = (ms % MS_IN_MINUTE) / MS_IN_SECOND;
+
+  const parts: string[] = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+  parts.push(`${preciseSecondsFormatter.format(seconds)}s`);
+
+  return parts.join(' ');
+}
+
 /**
  * Returns a formatted pagination display string
  * @param currentPage - The current page number

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -12,6 +12,11 @@ const MS_IN_MINUTE = 60 * MS_IN_SECOND;
 const MS_IN_HOUR = 60 * MS_IN_MINUTE;
 const MS_IN_DAY = 24 * MS_IN_HOUR;
 
+const CS_IN_SECOND = 100;
+const CS_IN_MINUTE = 60 * CS_IN_SECOND;
+const CS_IN_HOUR = 60 * CS_IN_MINUTE;
+const CS_IN_DAY = 24 * CS_IN_HOUR;
+
 /**
  * Formats a duration in milliseconds to a human-readable string.
  *
@@ -103,18 +108,28 @@ export function formatDurationPrecise(ms: number): string {
     return '0s';
   }
 
+  // Sub-second: whole-millisecond precision. If rounding carries to a full
+  // second, fall through to the second/decompose handling below.
   if (ms < MS_IN_SECOND) {
-    return `${Math.round(ms)}ms`;
+    const roundedMs = Math.round(ms);
+    if (roundedMs < MS_IN_SECOND) {
+      return `${roundedMs}ms`;
+    }
+    ms = roundedMs;
   }
 
-  if (ms < MS_IN_MINUTE) {
-    return `${preciseSecondsFormatter.format(ms / MS_IN_SECOND)}s`;
-  }
+  // Round to centisecond (two-decimal second) precision FIRST, then decompose
+  // in integer space so values like 59.999s never render as "60.00s".
+  const centiseconds = Math.round(ms / 10);
 
-  const days = Math.floor(ms / MS_IN_DAY);
-  const hours = Math.floor((ms % MS_IN_DAY) / MS_IN_HOUR);
-  const minutes = Math.floor((ms % MS_IN_HOUR) / MS_IN_MINUTE);
-  const seconds = (ms % MS_IN_MINUTE) / MS_IN_SECOND;
+  const days = Math.floor(centiseconds / CS_IN_DAY);
+  const hours = Math.floor((centiseconds % CS_IN_DAY) / CS_IN_HOUR);
+  const minutes = Math.floor((centiseconds % CS_IN_HOUR) / CS_IN_MINUTE);
+  const seconds = (centiseconds % CS_IN_MINUTE) / CS_IN_SECOND;
+
+  if (centiseconds < CS_IN_MINUTE) {
+    return `${preciseSecondsFormatter.format(seconds)}s`;
+  }
 
   const parts: string[] = [];
 

--- a/packages/web-shared/test/format-duration-precise.test.ts
+++ b/packages/web-shared/test/format-duration-precise.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatDurationPrecise } from '../src/lib/utils.js';
+
+/**
+ * Tests for `formatDurationPrecise`, with particular focus on unit-boundary
+ * carry cases. The formatter rounds to centisecond precision FIRST and then
+ * decomposes in integer space, so a value just below a unit boundary (e.g.
+ * 59999ms) re-buckets into the next unit ("1m 0.00s") instead of rendering an
+ * impossible component like "60.00s".
+ */
+describe('formatDurationPrecise', () => {
+  it('formats normal durations', () => {
+    expect(formatDurationPrecise(0)).toBe('0s');
+    expect(formatDurationPrecise(626)).toBe('626ms');
+    expect(formatDurationPrecise(1626)).toBe('1.63s');
+    expect(formatDurationPrecise(45200)).toBe('45.20s');
+    expect(formatDurationPrecise(73450)).toBe('1m 13.45s');
+  });
+
+  it('re-buckets values that carry across unit boundaries', () => {
+    expect(formatDurationPrecise(999.6)).toBe('1.00s');
+    expect(formatDurationPrecise(999.5)).toBe('1.00s');
+    expect(formatDurationPrecise(59999)).toBe('1m 0.00s');
+    expect(formatDurationPrecise(59995)).toBe('1m 0.00s');
+    expect(formatDurationPrecise(119999)).toBe('2m 0.00s');
+    expect(formatDurationPrecise(3659999)).toBe('1h 1m 0.00s');
+    expect(formatDurationPrecise(86459999)).toBe('1d 1m 0.00s');
+  });
+});


### PR DESCRIPTION
## Summary

The events list and new-trace-viewer timeline bar labels were rounding durations to whole seconds (e.g. 1.63s → "2s"). They now use a new locale-aware `formatDurationPrecise` that never snaps to whole seconds and shows two-decimal seconds above 1s. Sub-second values show whole ms; ≥1m decomposes into d/h/m with two-decimal seconds. The gap delta label still uses the compact `formatDuration`.

## Test plan

- [x] `pnpm --filter @workflow/web-shared typecheck` passes
- [ ] Visually verify events list + timeline labels in the new trace viewer show precise values (two-decimal seconds above 1s, whole ms below 1s)

Made with [Cursor](https://cursor.com)