### PR TITLE
Prevent local tests from hanging

### DIFF
--- a/.changeset/fix-local-test-hangs.md
+++ b/.changeset/fix-local-test-hangs.md
@@ -1,0 +1,7 @@
+---
+"@workflow/nuxt": patch
+"@workflow/world-testing": patch
+"@workflow/world-vercel": patch
+---
+
+Use non-interactive test and Nuxt build scripts so local `pnpm test` exits cleanly.

--- a/.changeset/fix-local-test-hangs.md
+++ b/.changeset/fix-local-test-hangs.md
@@ -1,7 +1,6 @@
 ---
-"@workflow/nuxt": patch
 "@workflow/world-testing": patch
 "@workflow/world-vercel": patch
 ---
 
-Use non-interactive test and Nuxt build scripts so local `pnpm test` exits cleanly.
+Use `vitest run` instead of watch mode so local `pnpm test` exits cleanly.

--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,0 +1,5 @@
+# Disable Nuxt telemetry for all Nuxt invocations in this workspace
+# (packages/nuxt's nuxt-module-build and workbench/nuxt's nuxt build/dev).
+# Without this, a fresh environment with no ~/.nuxtrc hits an interactive
+# consent prompt that hangs local builds/tests.
+telemetry.enabled=false

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -30,8 +30,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "NUXT_TELEMETRY_DISABLED=1 nuxt-module-build prepare && NUXT_TELEMETRY_DISABLED=1 nuxt-module-build build",
-    "dev": "NUXT_TELEMETRY_DISABLED=1 nuxt-module-build build --stub && NUXT_TELEMETRY_DISABLED=1 nuxt-module-build prepare",
+    "build": "nuxt-module-build prepare && nuxt-module-build build",
+    "dev": "nuxt-module-build build --stub && nuxt-module-build prepare",
     "clean": "nuxi cleanup && rm -rf dist/"
   },
   "dependencies": {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -30,8 +30,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "nuxt-module-build prepare && nuxt-module-build build",
-    "dev": "nuxt-module-build build --stub && nuxt-module-build prepare",
+    "build": "NUXT_TELEMETRY_DISABLED=1 nuxt-module-build prepare && NUXT_TELEMETRY_DISABLED=1 nuxt-module-build build",
+    "dev": "NUXT_TELEMETRY_DISABLED=1 nuxt-module-build build --stub && NUXT_TELEMETRY_DISABLED=1 nuxt-module-build prepare",
     "clean": "nuxi cleanup && rm -rf dist/"
   },
   "dependencies": {

--- a/packages/world-testing/package.json
+++ b/packages/world-testing/package.json
@@ -19,7 +19,7 @@
     "build": "wf build && node scripts/generate-well-known-dts.mjs && tsc && cp .well-known/workflow/v1/*.mjs dist/.well-known/workflow/v1/",
     "clean": "tsc --build --clean && rm -rf dist .well-known* .workflow-data",
     "start": "node --watch src/server.mts",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@hono/node-server": "1.19.13",

--- a/packages/world-vercel/package.json
+++ b/packages/world-vercel/package.json
@@ -30,7 +30,7 @@
     "build": "genversion --es6 src/version.ts && tsc",
     "dev": "genversion --es6 src/version.ts && tsc --watch",
     "clean": "tsc --build --clean && rm -rf dist src/version.ts",
-    "test": "vitest",
+    "test": "vitest run src",
     "typecheck": "genversion --es6 src/version.ts && tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

This commit fixes the ability to manually run `pnpm test`:

- use `vitest run` to stop `world-vercel` and `world-testing` when complete
- disable Nuxt telemetry to prevent interactive telemetry prompt

## Background

On a fresh clone of this repo on my own machine, I ran setup with `pnpm i`. Then I ran `pnpm test`, and the tests hung on three workers:

- `nuxt`
- `world-testing`
- `world-vercel`

The `world-vercel` test passed but hung on the following:

```text
 Test Files  9 passed (9)
      Tests  131 passed (131)
   Start at  16:43:36
   Duration  20.31s (transform 23.92s, setup 0ms, import 47.11s, tests 2.21s, environment 1ms)

 PASS  Waiting for file changes...
       press h to show help, press q to quit
```

Likewise for `world-testing`.

Meanwhile `nuxt` hung because of an interactive prompt asking for telemetry:

```text
> @workflow/nuxt@5.0.0-beta.13 build /home/j437xu/projects/vercel/workflow/packages/nuxt
> nuxt-module-build prepare && nuxt-module-build build


ℹ Nuxt collects completely anonymous data about usage.                                                                                               5:01:40 p.m.
  This will help us improve Nuxt developer experience over time.
  Read more on https://github.com/nuxt/telemetry


❯ Are you interested in participating?
○ Yes / ● No
```

I encountered this because I have never configured Nuxt on my machine, and this will occur to anyone else in the same situation. You can reproduce this by deleting the `telemetry.enabled` line in `~/.nuxtrc`.

For various reasons I don't understand these hangs do not occur in CI.

## Changes

- Using `vitest run` instead of `vitest` (watch mode) so that `world-testing` and `world-vercel` both stop when tests pass
- Using `NUXT_TELEMETRY_DISABLED=1` to prevent telemetry during the build for testing (I'm less sure about this one, maybe it's undesirable)

After these tests `pnpm test` runs to completion as expected.