### PR TITLE
Fix namespaced queue routing reliability

### DIFF
--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -71,11 +71,11 @@ export class LocalBuilder extends BaseBuilder {
 
     // Normalize request, needed for preserving request through astro
     workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
-      `${NORMALIZE_REQUEST_CODE}
+      /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
+      (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
 export const POST = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode)(normalRequest);
+  return workflowEntrypoint(workflowCode${options})(normalRequest);
 }
 
 export const prerender = false;`

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -43,7 +43,6 @@
     "@workflow/core": "workspace:*",
     "@workflow/errors": "workspace:*",
     "@workflow/utils": "workspace:*",
-    "@workflow/world": "workspace:*",
     "@workflow/swc-plugin": "workspace:*",
     "builtin-modules": "5.0.0",
     "chalk": "5.6.2",

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -14,6 +14,7 @@ import {
   applySwcTransform,
   type WorkflowManifest,
 } from './apply-swc-transform.js';
+import { createWorkflowEntrypointOptionsCode } from './constants.js';
 import { createDiscoverEntriesPlugin } from './discover-entries-esbuild-plugin.js';
 import { getEsbuildTsconfigOptions } from './esbuild-tsconfig.js';
 import {
@@ -1175,6 +1176,9 @@ export abstract class BaseBuilder {
         }
       }
 
+      const workflowEntrypointOptionsCode =
+        createWorkflowEntrypointOptionsCode();
+
       const bundleFinal = async (interimBundle: string) => {
         const workflowBundleCode = interimBundle;
 
@@ -1184,7 +1188,7 @@ import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${workflowBundleCode.replace(/[\\`$]/g, '\\$&')}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
         // we skip the final bundling step for Next.js so it can bundle itself
         if (!bundleFinalOutput) {
@@ -1363,6 +1367,7 @@ export const POST = workflowEntrypoint(workflowCode);`;
     // 3. Generate combined route file
     const stepsRelativePath = './' + basename(stepsOutfile).replace(/\\/g, '/');
     const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
+    const workflowEntrypointOptionsCode = createWorkflowEntrypointOptionsCode();
 
     const combinedFunctionCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
@@ -1374,7 +1379,7 @@ void __steps_registered;
 
 const workflowCode = \`${escapedVMCode}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
     if (!bundleFinalOutput) {
       // Write directly (Next.js will bundle)
@@ -1435,6 +1440,8 @@ export const POST = workflowEntrypoint(workflowCode);`;
     // Create a custom bundleFinal for watch mode that uses workflowEntrypoint
     const combinedBundleFinal = async (interimBundleText: string) => {
       const escaped = interimBundleText.replace(/[\\`$]/g, '\\$&');
+      const workflowEntrypointOptionsCode =
+        createWorkflowEntrypointOptionsCode();
       const code = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import { __steps_registered } from '${stepsRelativePath}';
@@ -1444,7 +1451,7 @@ void __steps_registered;
 
 const workflowCode = \`${escaped}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
       const outputDir = dirname(flowOutfile);
       await mkdir(outputDir, { recursive: true });

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createWorkflowQueueTrigger } from './constants.js';
+
+describe('createWorkflowQueueTrigger', () => {
+  afterEach(() => {
+    delete process.env.WORKFLOW_QUEUE_NAMESPACE;
+  });
+
+  it('uses the default workflow topic without a namespace', () => {
+    expect(createWorkflowQueueTrigger().topic).toBe('__wkf_workflow_*');
+  });
+
+  it('uses an explicit namespace when provided', () => {
+    expect(createWorkflowQueueTrigger({ namespace: 'custom' }).topic).toBe(
+      '__custom_wkf_workflow_*'
+    );
+  });
+
+  it('uses WORKFLOW_QUEUE_NAMESPACE when no explicit namespace is provided', () => {
+    process.env.WORKFLOW_QUEUE_NAMESPACE = 'custom';
+
+    expect(createWorkflowQueueTrigger().topic).toBe('__custom_wkf_workflow_*');
+  });
+});

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { createWorkflowQueueTrigger } from './constants.js';
+import {
+  createWorkflowEntrypointOptionsCode,
+  createWorkflowQueueTrigger,
+} from './constants.js';
 
 describe('createWorkflowQueueTrigger', () => {
   afterEach(() => {
@@ -20,5 +23,29 @@ describe('createWorkflowQueueTrigger', () => {
     process.env.WORKFLOW_QUEUE_NAMESPACE = 'custom';
 
     expect(createWorkflowQueueTrigger().topic).toBe('__custom_wkf_workflow_*');
+  });
+});
+
+describe('createWorkflowEntrypointOptionsCode', () => {
+  afterEach(() => {
+    delete process.env.WORKFLOW_QUEUE_NAMESPACE;
+  });
+
+  it('omits runtime options without a namespace', () => {
+    expect(createWorkflowEntrypointOptionsCode()).toBe('');
+  });
+
+  it('inlines an explicit namespace', () => {
+    expect(createWorkflowEntrypointOptionsCode({ namespace: 'custom' })).toBe(
+      ', { namespace: "custom" }'
+    );
+  });
+
+  it('inlines WORKFLOW_QUEUE_NAMESPACE at build time', () => {
+    process.env.WORKFLOW_QUEUE_NAMESPACE = 'custom';
+
+    expect(createWorkflowEntrypointOptionsCode()).toBe(
+      ', { namespace: "custom" }'
+    );
   });
 });

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -1,4 +1,22 @@
-import { getQueueTopicPrefix, resolveQueueNamespace } from '@workflow/world';
+const QUEUE_NAMESPACE_PATTERN = /^[a-z][a-z0-9]*$/;
+
+function resolveQueueNamespace(namespace?: string): string | undefined {
+  return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined;
+}
+
+function getQueueTopicPrefix(kind: 'workflow' | 'step', namespace?: string) {
+  if (namespace !== undefined) {
+    if (!QUEUE_NAMESPACE_PATTERN.test(namespace)) {
+      throw new Error(
+        `Invalid queue namespace "${namespace}": must be lowercase alphanumeric, starting with a letter`
+      );
+    }
+
+    return `__${namespace}_wkf_${kind}_`;
+  }
+
+  return `__wkf_${kind}_`;
+}
 
 /**
  * Creates a queue trigger configuration for the workflow handler.

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -30,6 +30,26 @@ export function createWorkflowQueueTrigger(options?: { namespace?: string }) {
 }
 
 /**
+ * Creates the optional second argument for generated `workflowEntrypoint()`
+ * calls. The namespace is resolved while building so generated route files do
+ * not need `WORKFLOW_QUEUE_NAMESPACE` at runtime.
+ */
+export function createWorkflowEntrypointOptionsCode(options?: {
+  namespace?: string;
+}) {
+  const namespace = resolveQueueNamespace(options?.namespace);
+
+  if (!namespace) {
+    return '';
+  }
+
+  // Reuse prefix construction for namespace validation.
+  getQueueTopicPrefix('workflow', namespace);
+
+  return `, { namespace: ${JSON.stringify(namespace)} }`;
+}
+
+/**
  * Default queue trigger (no namespace). Backward compatible.
  */
 export const WORKFLOW_QUEUE_TRIGGER = createWorkflowQueueTrigger();

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -1,4 +1,4 @@
-import { getQueueTopicPrefix } from '@workflow/world';
+import { getQueueTopicPrefix, resolveQueueNamespace } from '@workflow/world';
 
 /**
  * Creates a queue trigger configuration for the workflow handler.
@@ -18,9 +18,11 @@ import { getQueueTopicPrefix } from '@workflow/world';
  * createWorkflowQueueTrigger({ namespace: 'custom' })
  */
 export function createWorkflowQueueTrigger(options?: { namespace?: string }) {
+  const namespace = resolveQueueNamespace(options?.namespace);
+
   return {
     type: 'queue/v2beta' as const,
-    topic: `${getQueueTopicPrefix('workflow', options?.namespace)}*`,
+    topic: `${getQueueTopicPrefix('workflow', namespace)}*`,
     consumer: 'default',
     retryAfterSeconds: 5, // Delay between retries (default: 60)
     initialDelaySeconds: 0, // Initial delay before first delivery (default: 0)

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -10,6 +10,7 @@ export {
   getDecoratorOptionsForDirectoryWithConfigPath,
 } from './config-helpers.js';
 export {
+  createWorkflowEntrypointOptionsCode,
   createWorkflowQueueTrigger,
   WORKFLOW_QUEUE_TRIGGER,
 } from './constants.js';

--- a/packages/core/src/runtime-import.test.ts
+++ b/packages/core/src/runtime-import.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@vercel/functions', () => {
+  throw new Error('@vercel/functions should not load during runtime import');
+});
+
+describe('runtime entrypoint', () => {
+  test('does not load @vercel/functions during module evaluation', async () => {
+    await expect(import('./runtime')).resolves.toBeDefined();
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -13,6 +13,7 @@ import { parseWorkflowName } from '@workflow/utils/parse-name';
 import {
   type Event,
   getQueueTopicPrefix,
+  resolveQueueNamespace,
   SPEC_VERSION_CURRENT,
   WorkflowInvokePayloadSchema,
   type WorkflowRun,
@@ -221,7 +222,8 @@ export function workflowEntrypoint(
   const NO_INLINE_REPLAY_AFTER_MS =
     Number(process.env.WORKFLOW_V2_TIMEOUT_MS) || 120_000;
 
-  const workflowPrefix = getQueueTopicPrefix('workflow', options?.namespace);
+  const namespace = resolveQueueNamespace(options?.namespace);
+  const workflowPrefix = getQueueTopicPrefix('workflow', namespace);
 
   const handler = (worldHandlers: WorldHandlers) =>
     worldHandlers.createQueueHandler(
@@ -434,7 +436,7 @@ export function workflowEntrypoint(
                       ) {
                         await queueMessage(
                           world,
-                          getWorkflowQueueName(workflowName),
+                          getWorkflowQueueName(workflowName, namespace),
                           {
                             runId,
                             traceCarrier: await serializeTraceCarrier(),
@@ -693,7 +695,7 @@ export function workflowEntrypoint(
                       );
                       await queueMessage(
                         world,
-                        getWorkflowQueueName(workflowName),
+                        getWorkflowQueueName(workflowName, namespace),
                         {
                           runId,
                           traceCarrier: await serializeTraceCarrier(),
@@ -1055,7 +1057,7 @@ export function workflowEntrypoint(
                           const traceCarrier = await serializeTraceCarrier();
                           await queueMessage(
                             world,
-                            getWorkflowQueueName(workflowName),
+                            getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
                               stepId: step.correlationId,
@@ -1108,7 +1110,7 @@ export function workflowEntrypoint(
                           const traceCarrier = await serializeTraceCarrier();
                           await queueMessage(
                             world,
-                            getWorkflowQueueName(workflowName),
+                            getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
                               stepId: inlineStep.correlationId,
@@ -1159,7 +1161,7 @@ export function workflowEntrypoint(
                           );
                           await queueMessage(
                             world,
-                            getWorkflowQueueName(workflowName),
+                            getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
                               traceCarrier: await serializeTraceCarrier(),
@@ -1202,7 +1204,7 @@ export function workflowEntrypoint(
                             );
                             await queueMessage(
                               world,
-                              getWorkflowQueueName(workflowName),
+                              getWorkflowQueueName(workflowName, namespace),
                               {
                                 runId,
                                 traceCarrier: await serializeTraceCarrier(),

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   ERROR_SLUGS,
   HookNotFoundError,
@@ -22,9 +21,9 @@ import {
 import { WEBHOOK_RESPONSE_WRITABLE } from '../symbols.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanContextForTraceCarrier, trace } from '../telemetry.js';
-import { waitedUntil } from '../util.js';
 import { getWorldLazy } from './get-world-lazy.js';
 import { getWorkflowQueueName } from './helpers.js';
+import { waitedUntil, waitUntil } from './wait-until.js';
 
 /**
  * Internal helper that returns the hook, the associated workflow run,

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   ThrottleError,
@@ -18,11 +17,11 @@ import type { Serializable } from '../schemas.js';
 import { dehydrateWorkflowArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { serializeTraceCarrier, trace } from '../telemetry.js';
-import { waitedUntil } from '../util.js';
 import { version as workflowCoreVersion } from '../version.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { Run } from './run.js';
 import { getWorldLazy } from './get-world-lazy.js';
+import { waitedUntil, waitUntil } from './wait-until.js';
 
 /** ULID generator for client-side runId generation */
 const ulid = monotonicFactory();

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -1,5 +1,4 @@
 import { types } from 'node:util';
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   FatalError,
@@ -32,6 +31,7 @@ import {
 } from '../types.js';
 import { getPortLazy } from './get-port-lazy.js';
 import { memoizeEncryptionKey } from './helpers.js';
+import { waitUntil } from './wait-until.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
 

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -14,7 +14,9 @@ import { formatStepName, pluralize } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
 import {
   getQueueTopicPrefix,
+  resolveQueueNamespace,
   SPEC_VERSION_CURRENT,
+  type Step,
   StepInvokePayloadSchema,
 } from '@workflow/world';
 import { describeError } from '../describe-error.js';
@@ -57,7 +59,8 @@ import { getWorld, getWorldHandlers, type WorldHandlers } from './world.js';
 const DEFAULT_STEP_MAX_RETRIES = 3;
 
 function createStepHandler(namespace?: string) {
-  const stepPrefix = getQueueTopicPrefix('step', namespace);
+  const resolvedNamespace = resolveQueueNamespace(namespace);
+  const stepPrefix = getQueueTopicPrefix('step', resolvedNamespace);
 
   return (worldHandlers: WorldHandlers) =>
     worldHandlers.createQueueHandler(stepPrefix, async (message_, metadata) => {
@@ -132,11 +135,15 @@ function createStepHandler(namespace?: string) {
             { requestId }
           );
           // Re-queue the workflow to handle the failed step
-          await queueMessage(world, getWorkflowQueueName(workflowName), {
-            runId: workflowRunId,
-            traceCarrier: await serializeTraceCarrier(),
-            requestedAt: new Date(),
-          });
+          await queueMessage(
+            world,
+            getWorkflowQueueName(workflowName, resolvedNamespace),
+            {
+              runId: workflowRunId,
+              traceCarrier: await serializeTraceCarrier(),
+              requestedAt: new Date(),
+            }
+          );
         } catch (err) {
           if (EntityConflictError.is(err) || RunExpiredError.is(err)) {
             return;
@@ -215,7 +222,7 @@ function createStepHandler(namespace?: string) {
             // - Step not in terminal state (returns 409)
             // - retryAfter timestamp reached (returns 425 with Retry-After header)
             // - Workflow still active (returns 410 if completed)
-            let step;
+            let step!: Step;
             try {
               const startResult = await world.events.create(
                 workflowRunId,
@@ -276,11 +283,15 @@ function createStepHandler(namespace?: string) {
                   'step.name': stepName,
                   'step.id': stepId,
                 });
-                await queueMessage(world, getWorkflowQueueName(workflowName), {
-                  runId: workflowRunId,
-                  traceCarrier: await serializeTraceCarrier(),
-                  requestedAt: new Date(),
-                });
+                await queueMessage(
+                  world,
+                  getWorkflowQueueName(workflowName, resolvedNamespace),
+                  {
+                    runId: workflowRunId,
+                    traceCarrier: await serializeTraceCarrier(),
+                    requestedAt: new Date(),
+                  }
+                );
                 return;
               }
 
@@ -376,11 +387,15 @@ function createStepHandler(namespace?: string) {
               });
 
               // Re-invoke the workflow to handle the failed step
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
 
@@ -472,11 +487,15 @@ function createStepHandler(namespace?: string) {
               });
 
               // Re-invoke the workflow to handle the failed step
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
 
@@ -520,11 +539,15 @@ function createStepHandler(namespace?: string) {
                 throw failErr;
               }
               // Re-queue the workflow so it can process the step failure
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
             // Capture startedAt for use in async callback (TypeScript narrowing doesn't persist)
@@ -952,11 +975,15 @@ function createStepHandler(namespace?: string) {
               }
 
               // Re-invoke the workflow to handle the failed/retrying step
-              await queueMessage(world, getWorkflowQueueName(workflowName), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, resolvedNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
 
@@ -1025,11 +1052,15 @@ function createStepHandler(namespace?: string) {
             });
 
             // Queue the workflow continuation with the concurrently-resolved trace carrier
-            await queueMessage(world, getWorkflowQueueName(workflowName), {
-              runId: workflowRunId,
-              traceCarrier,
-              requestedAt: new Date(),
-            });
+            await queueMessage(
+              world,
+              getWorkflowQueueName(workflowName, resolvedNamespace),
+              {
+                runId: workflowRunId,
+                traceCarrier,
+                requestedAt: new Date(),
+              }
+            );
           }
         );
       });

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   FatalError,
@@ -54,6 +53,7 @@ import {
   queueMessage,
   withHealthCheck,
 } from './helpers.js';
+import { waitUntil } from './wait-until.js';
 import { getWorld, getWorldHandlers, type WorldHandlers } from './world.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -1,5 +1,4 @@
 import type { Span } from '@opentelemetry/api';
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   HookNotFoundError,
@@ -23,6 +22,7 @@ import { runtimeLogger } from '../logger.js';
 import { dehydrateStepArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getAbortStreamIdFromToken } from '../util.js';
+import { waitUntil } from './wait-until.js';
 
 export interface SuspensionHandlerParams {
   suspension: WorkflowSuspension;

--- a/packages/core/src/runtime/wait-until.ts
+++ b/packages/core/src/runtime/wait-until.ts
@@ -1,0 +1,21 @@
+export function waitUntil(promise: Promise<unknown>): void {
+  void import('@vercel/functions').then(({ waitUntil }) => {
+    waitUntil(promise);
+  });
+}
+
+/**
+ * A small wrapper around `waitUntil` that also returns
+ * the result of the awaited promise.
+ */
+export async function waitedUntil<T>(fn: () => Promise<T>): Promise<T> {
+  const result = fn();
+  waitUntil(
+    result.catch(() => {
+      // Ignore error from the promise being rejected.
+      // It's expected that the invoker of `waitedUntil`
+      // will handle the error.
+    })
+  );
+  return result;
+}

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import { pluralize } from '@workflow/utils';
 
 /**
@@ -91,20 +90,4 @@ export function getAbortStreamIdFromToken(hookToken: string): string {
     );
   }
   return getAbortStreamId(hookToken.slice(ABORT_TOKEN_PREFIX.length));
-}
-
-/**
- * A small wrapper around `waitUntil` that also returns
- * the result of the awaited promise.
- */
-export async function waitedUntil<T>(fn: () => Promise<T>): Promise<T> {
-  const result = fn();
-  waitUntil(
-    result.catch(() => {
-      // Ignore error from the promise being rejected.
-      // It's expected that the invoker of `waitedUntil`
-      // will handle the error.
-    })
-  );
-  return result;
 }

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -52,6 +52,7 @@ export async function getNextBuilderDeferred() {
   const {
     BaseBuilder: BaseBuilderClass,
     WORKFLOW_QUEUE_TRIGGER,
+    createWorkflowEntrypointOptionsCode,
     detectWorkflowPatterns,
     applySwcTransform,
     getImportPath,
@@ -648,6 +649,8 @@ export async function getNextBuilderDeferred() {
       const stepManifest =
         await this.createDeferredStepManifest(stepAndSerdeFiles);
       const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
+      const workflowEntrypointOptionsCode =
+        createWorkflowEntrypointOptionsCode();
       const routeCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import 'workflow/internal/builtins';
@@ -656,7 +659,7 @@ import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${escapedVMCode}\`;
 
-export const POST = workflowEntrypoint(workflowCode);`;
+export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
 
       await this.writeFileIfChanged(flowOutfile, routeCode);
 

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -82,11 +82,11 @@ export class SvelteKitBuilder extends BaseBuilder {
 
     // Replace the default export with SvelteKit-compatible handler
     workflowsRouteContent = workflowsRouteContent.replace(
-      /export const POST = workflowEntrypoint\(workflowCode\);?$/m,
-      `${NORMALIZE_REQUEST_CODE}
+      /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
+      (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
 export const POST = async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode)(normalRequest);
+  return workflowEntrypoint(workflowCode${options})(normalRequest);
 }`
     );
     await writeFile(workflowsRouteFile, workflowsRouteContent);

--- a/packages/world-local/src/queue.test.ts
+++ b/packages/world-local/src/queue.test.ts
@@ -144,6 +144,27 @@ describe('queue timeout re-enqueue', () => {
     });
   });
 
+  it('routes namespaced queues to namespaced direct handlers', async () => {
+    const handlerImpl = vi.fn(
+      async (_message: unknown, metadata: { queueName: string }) => {
+        expect(metadata.queueName).toBe('__custom_wkf_step_test');
+        return undefined;
+      }
+    );
+    const handler = localQueue.createQueueHandler(
+      '__custom_wkf_step_',
+      handlerImpl
+    );
+
+    localQueue.registerHandler('__custom_wkf_step_', handler);
+
+    await localQueue.queue('__custom_wkf_step_test' as any, stepPayload);
+
+    await vi.waitFor(() => {
+      expect(handlerImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('queue retries immediately when handler returns timeoutSeconds: 0', async () => {
     const { setTimeout: mockSetTimeout } = await import('node:timers/promises');
     vi.mocked(mockSetTimeout).mockClear();

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -2,8 +2,9 @@ import { setTimeout } from 'node:timers/promises';
 import type { Transport } from '@vercel/queue';
 import {
   MessageId,
+  parseQueueName,
   type Queue,
-  QueuePrefix,
+  type QueuePrefix,
   ValidQueueName,
 } from '@workflow/world';
 import { Sema } from 'async-sema';
@@ -96,20 +97,11 @@ function getQueueRoute(queueName: ValidQueueName): {
   pathname: 'flow' | 'step';
   prefix: QueuePrefix;
 } {
-  // extract prefix + kind from the queue name via regex capture.
-  // the extracted prefix is then validated through the QueuePrefix schema
-  // to ensure it conforms to the namespace format.
-  const match = queueName.match(
-    /^(__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_)/
-  );
-
-  if (!match) {
-    throw new Error('Unknown queue name prefix');
-  }
+  const { kind, prefix } = parseQueueName(queueName);
 
   return {
-    pathname: match[2] === 'workflow' ? 'flow' : 'step',
-    prefix: QueuePrefix.parse(match[1]),
+    pathname: kind === 'workflow' ? 'flow' : 'step',
+    prefix,
   };
 }
 

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -1,13 +1,13 @@
 import { createServer, type Server } from 'node:http';
 import { JsonTransport } from '@vercel/queue';
 import { getWorkflowPort } from '@workflow/utils/get-port';
-import { MessageId, type QueuePayload } from '@workflow/world';
+import { MessageId, parseQueueName, type QueuePayload } from '@workflow/world';
+import { createLocalWorld } from '@workflow/world-local';
 import { makeWorkerUtils, run, type WorkerUtils } from 'graphile-worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createLocalWorld } from '@workflow/world-local';
 import { stepEntrypoint } from '../../core/dist/runtime/step-handler.js';
-import { createQueue } from './queue.js';
 import { MessageData } from './message.js';
+import { createQueue } from './queue.js';
 
 const transport = new JsonTransport();
 const createdQueues: Array<ReturnType<typeof createQueue>> = [];
@@ -256,6 +256,74 @@ describe('postgres queue http execution', () => {
     }
   });
 
+  it('serializes namespaced workflow queue execution for the same runId', async () => {
+    let resolveFirstRequestStarted!: () => void;
+    const firstRequestStarted = new Promise<void>((resolve) => {
+      resolveFirstRequestStarted = resolve;
+    });
+    let resolveReleaseFirstRequest!: () => void;
+    const releaseFirstRequest = new Promise<void>((resolve) => {
+      resolveReleaseFirstRequest = resolve;
+    });
+    let requestCount = 0;
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const fetchMock = vi.fn(async () => {
+      requestCount += 1;
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+
+      if (requestCount === 1) {
+        resolveFirstRequestStarted();
+        await releaseFirstRequest;
+      }
+
+      activeRequests -= 1;
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.WORKFLOW_LOCAL_BASE_URL = 'http://localhost:3000';
+
+    const queue = buildQueue(
+      { connectionString: 'postgres://test', namespace: 'custom' },
+      pool
+    );
+    try {
+      await queue.start();
+
+      const task = getTaskHandler('workflow_flows');
+      const payload = {
+        runId: 'wrun_01ABC',
+      };
+      const firstExecution = task(
+        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
+          messageId: MessageId.parse('msg_01ABC'),
+        }),
+        {} as any
+      );
+      const secondExecution = task(
+        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
+          messageId: MessageId.parse('msg_01ABD'),
+        }),
+        {} as any
+      );
+
+      await firstRequestStarted;
+      await Promise.resolve();
+      expect(requestCount).toBe(1);
+      expect(maxActiveRequests).toBe(1);
+
+      resolveReleaseFirstRequest();
+      await Promise.all([firstExecution, secondExecution]);
+
+      expect(requestCount).toBe(2);
+      expect(maxActiveRequests).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('does not require a runId for workflow health-check payloads', async () => {
     const fetchMock = vi.fn(async () => Response.json({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
@@ -328,6 +396,40 @@ describe('postgres queue http execution', () => {
       vi.useRealTimers();
     }
   });
+
+  it('queues namespaced producer messages in graphile job metadata', async () => {
+    const queue = buildQueue(
+      { connectionString: 'postgres://test', namespace: 'custom' },
+      pool
+    );
+    await queue.start();
+
+    await queue.queue(
+      '__custom_wkf_step_test-step',
+      {
+        workflowName: 'test-workflow',
+        workflowRunId: 'run_01ABC',
+        workflowStartedAt: Date.now(),
+        stepId: 'step_01ABC',
+      },
+      {
+        idempotencyKey: 'step_01ABC',
+      }
+    );
+
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'workflow_steps',
+      expect.objectContaining({
+        attempt: 1,
+        id: 'test-step',
+        idempotencyKey: 'step_01ABC',
+      }),
+      expect.objectContaining({
+        jobKey: 'step_01ABC',
+        maxAttempts: 3,
+      })
+    );
+  });
 });
 
 function buildQueue(
@@ -349,9 +451,7 @@ function buildMessageData(
     messageId?: MessageId;
   }
 ) {
-  const [, id] = queueName.startsWith('__wkf_step_')
-    ? ['__wkf_step_', queueName.slice('__wkf_step_'.length)]
-    : ['__wkf_workflow_', queueName.slice('__wkf_workflow_'.length)];
+  const { id } = parseQueueName(queueName);
 
   return MessageData.encode({
     id,

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -2,8 +2,10 @@ import * as Stream from 'node:stream';
 import type { Transport } from '@vercel/queue';
 import { getWorkflowPort } from '@workflow/utils/get-port';
 import {
+  getQueuePrefixKind,
   getQueueTopicPrefix,
   MessageId,
+  parseQueueName,
   type Queue,
   QueuePayloadSchema,
   type QueuePrefix,
@@ -121,9 +123,9 @@ export function createQueue(
   function getJobQueueName(queuePrefix: QueuePrefix): string {
     const jobPrefix = config.jobPrefix || 'workflow_';
 
-    if (queuePrefix.endsWith('wkf_workflow_')) return `${jobPrefix}flows`;
-    if (queuePrefix.endsWith('wkf_step_')) return `${jobPrefix}steps`;
-    throw new Error(`Unknown queue prefix: ${queuePrefix}`);
+    return getQueuePrefixKind(queuePrefix) === 'workflow'
+      ? `${jobPrefix}flows`
+      : `${jobPrefix}steps`;
   }
 
   const createQueueHandler = localWorld.createQueueHandler;
@@ -224,13 +226,7 @@ export function createQueue(
   }
 
   function getQueueRoute(queueName: ValidQueueName): 'flow' | 'step' {
-    if (queueName.startsWith('__wkf_step_')) {
-      return 'step';
-    }
-    if (queueName.startsWith('__wkf_workflow_')) {
-      return 'flow';
-    }
-    throw new Error('Unknown queue name prefix');
+    return parseQueueName(queueName).kind === 'workflow' ? 'flow' : 'step';
   }
 
   async function executeMessageOverHttp({
@@ -355,7 +351,7 @@ export function createQueue(
 
   const queue: Queue['queue'] = async (queue, message, opts) => {
     await start();
-    const [queuePrefix, queueId] = parseQueueName(queue);
+    const { prefix: queuePrefix, id: queueId } = parseQueueName(queue);
     const body = transport.serialize(message) as Buffer;
     const messageId = MessageId.parse(`msg_${generateMessageId()}`);
     await addGraphileJob({
@@ -373,13 +369,15 @@ export function createQueue(
   };
 
   function createTaskHandler(queue: QueuePrefix) {
+    const queueKind = getQueuePrefixKind(queue);
+
     return async (payload: unknown, helpers: unknown) => {
       const messageData = MessageData.parse(payload);
       const graphileAttempt = GraphileHelpers.safeParse(helpers);
       const attempt = graphileAttempt.success
         ? graphileAttempt.data.job.attempts
         : messageData.attempt;
-      const queueName = `${queue}${messageData.id}` as const;
+      const queueName = `${queue}${messageData.id}` as ValidQueueName;
       const bodyStream = Stream.Readable.toWeb(
         Stream.Readable.from([messageData.data])
       );
@@ -388,7 +386,7 @@ export function createQueue(
       );
       QueuePayloadSchema.parse(body);
       const workflowRunSerializationKey =
-        queue === '__wkf_workflow_'
+        queueKind === 'workflow'
           ? (() => {
               const workflowInvoke =
                 WorkflowInvokePayloadSchema.safeParse(body);
@@ -534,13 +532,3 @@ export function createQueue(
     },
   };
 }
-
-const parseQueueName = (name: ValidQueueName): [QueuePrefix, string] => {
-  const prefixes: QueuePrefix[] = ['__wkf_step_', '__wkf_workflow_'];
-  for (const prefix of prefixes) {
-    if (name.startsWith(prefix)) {
-      return [prefix, name.slice(prefix.length)];
-    }
-  }
-  throw new Error(`Invalid queue name: ${name}`);
-};

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -1,12 +1,12 @@
 export type * from './attributes.js';
 export {
-  applyAttributeChanges,
   ATTRIBUTE_KEY_MAX_LENGTH,
   ATTRIBUTE_MAX_PER_RUN,
   ATTRIBUTE_VALUE_MAX_BYTES,
   AttributeChangeSchema,
   AttributeChangesSchema,
   AttributeValidationError,
+  applyAttributeChanges,
   RESERVED_ATTRIBUTE_KEY_PREFIX,
   validateAttributeChanges,
   validateAttributeKey,
@@ -26,13 +26,15 @@ export { HookSchema } from './hooks.js';
 export type * from './interfaces.js';
 export type * from './queue.js';
 export {
+  getQueuePrefixKind,
   getQueueTopicPrefix,
   HealthCheckPayloadSchema,
   MessageId,
+  parseQueueName,
   QueuePayloadSchema,
   QueuePrefix,
-  resolveQueueNamespace,
   RunInputSchema,
+  resolveQueueNamespace,
   StepInvokePayloadSchema,
   ValidQueueName,
   WorkflowInvokePayloadSchema,

--- a/packages/world/src/queue.test.ts
+++ b/packages/world/src/queue.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getQueueTopicPrefix, QueuePrefix, ValidQueueName } from './queue.js';
+import {
+  getQueuePrefixKind,
+  getQueueTopicPrefix,
+  parseQueueName,
+  QueuePrefix,
+  ValidQueueName,
+} from './queue.js';
 
 describe('getQueueTopicPrefix', () => {
   it('returns default workflow prefix without namespace', () => {
@@ -82,6 +88,18 @@ describe('QueuePrefix schema', () => {
   });
 });
 
+describe('getQueuePrefixKind', () => {
+  it('identifies default prefixes', () => {
+    expect(getQueuePrefixKind('__wkf_workflow_')).toBe('workflow');
+    expect(getQueuePrefixKind('__wkf_step_')).toBe('step');
+  });
+
+  it('identifies namespaced prefixes', () => {
+    expect(getQueuePrefixKind('__custom_wkf_workflow_')).toBe('workflow');
+    expect(getQueuePrefixKind('__custom_wkf_step_')).toBe('step');
+  });
+});
+
 describe('ValidQueueName schema', () => {
   it('accepts default queue names', () => {
     expect(ValidQueueName.parse('__wkf_workflow_myFlow')).toBe(
@@ -105,5 +123,31 @@ describe('ValidQueueName schema', () => {
 
   it('rejects invalid names', () => {
     expect(() => ValidQueueName.parse('not_a_queue_name')).toThrow();
+  });
+});
+
+describe('parseQueueName', () => {
+  it('parses default workflow queue names', () => {
+    expect(parseQueueName('__wkf_workflow_myFlow')).toEqual({
+      prefix: '__wkf_workflow_',
+      kind: 'workflow',
+      id: 'myFlow',
+    });
+  });
+
+  it('parses namespaced workflow queue names', () => {
+    expect(parseQueueName('__custom_wkf_workflow_myFlow')).toEqual({
+      prefix: '__custom_wkf_workflow_',
+      kind: 'workflow',
+      id: 'myFlow',
+    });
+  });
+
+  it('parses namespaced step queue names', () => {
+    expect(parseQueueName('__custom_wkf_step_myStep')).toEqual({
+      prefix: '__custom_wkf_step_',
+      kind: 'step',
+      id: 'myStep',
+    });
   });
 });

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod/v4';
 
+export type QueueKind = 'workflow' | 'step';
+
 /**
  * Pattern matching valid queue prefixes:
  * - `__wkf_workflow_` / `__wkf_step_` (default, no namespace)
@@ -45,7 +47,7 @@ export function resolveQueueNamespace(namespace?: string): string | undefined {
  * - `getQueueTopicPrefix('workflow', 'custom')` → `'__custom_wkf_workflow_'`
  */
 export function getQueueTopicPrefix(
-  kind: 'workflow' | 'step',
+  kind: QueueKind,
   namespace?: string
 ): QueuePrefix {
   if (namespace !== undefined) {
@@ -53,6 +55,38 @@ export function getQueueTopicPrefix(
     return `__${namespace}_wkf_${kind}_` as QueuePrefix;
   }
   return `__wkf_${kind}_` as QueuePrefix;
+}
+
+export function getQueuePrefixKind(prefix: QueuePrefix): QueueKind {
+  const match = QueuePrefix.parse(prefix).match(
+    /^__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_$/
+  );
+
+  if (!match) {
+    throw new Error(`Invalid queue prefix: ${prefix}`);
+  }
+
+  return match[1] as QueueKind;
+}
+
+export function parseQueueName(name: ValidQueueName): {
+  prefix: QueuePrefix;
+  kind: QueueKind;
+  id: string;
+} {
+  const match = name.match(
+    /^(__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_)(.+)$/
+  );
+
+  if (!match) {
+    throw new Error(`Invalid queue name: ${name}`);
+  }
+
+  return {
+    prefix: QueuePrefix.parse(match[1]),
+    kind: match[2] as QueueKind,
+    id: match[3],
+  };
 }
 
 export const MessageId = z

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,9 +418,6 @@ importers:
       '@workflow/utils':
         specifier: workspace:*
         version: link:../utils
-      '@workflow/world':
-        specifier: workspace:*
-        version: link:../world
       builtin-modules:
         specifier: 5.0.0
         version: 5.0.0


### PR DESCRIPTION
## Summary
- centralize queue name parsing for namespaced workflow and step queues
- use shared parsing in local/postgres worlds and preserve namespaced workflow-run serialization
- inline the build-time queue namespace into generated workflow routes so runtime does not require WORKFLOW_QUEUE_NAMESPACE
- keep runtime requeues on the resolved namespace

## Tests
- pnpm exec vitest run packages/world/src/queue.test.ts packages/world-local/src/queue.test.ts packages/world-postgres/src/queue.test.ts packages/builders/src/constants.test.ts
- pnpm --filter @workflow/builders build
- pnpm --filter @workflow/next build
- pnpm --filter @workflow/astro build
- pnpm --filter @workflow/sveltekit build