### PR TITLE
Fix non-faithful backport of #2305 to stable

### DIFF
--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -21,7 +21,7 @@ import {
 import { WEBHOOK_RESPONSE_WRITABLE } from '../symbols.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanContextForTraceCarrier, trace } from '../telemetry.js';
-import { waitedUntil } from '../util.js';
+import { waitUntil, waitedUntil } from './wait-until.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { getWorld } from './world.js';
 

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   ThrottleError,
@@ -21,7 +20,7 @@ import { serializeTraceCarrier, trace } from '../telemetry.js';
 import { version as workflowCoreVersion } from '../version.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { Run } from './run.js';
-import { waitedUntil } from '../util.js';
+import { waitedUntil, waitUntil } from './wait-until.js';
 import { getWorld } from './world.js';
 
 /** ULID generator for client-side runId generation */

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   FatalError,
@@ -49,6 +48,7 @@ import {
   queueMessage,
   withHealthCheck,
 } from './helpers.js';
+import { waitUntil } from './wait-until.js';
 import { getWorld, getWorldHandlers } from './world.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
@@ -115,11 +115,15 @@ const stepHandler = createQueueHandler(
           { requestId }
         );
         // Re-queue the workflow to handle the failed step
-        await queueMessage(world, getWorkflowQueueName(workflowName, stepNamespace), {
-          runId: workflowRunId,
-          traceCarrier: await serializeTraceCarrier(),
-          requestedAt: new Date(),
-        });
+        await queueMessage(
+          world,
+          getWorkflowQueueName(workflowName, stepNamespace),
+          {
+            runId: workflowRunId,
+            traceCarrier: await serializeTraceCarrier(),
+            requestedAt: new Date(),
+          }
+        );
       } catch (err) {
         if (EntityConflictError.is(err) || RunExpiredError.is(err)) {
           return;
@@ -247,11 +251,15 @@ const stepHandler = createQueueHandler(
                 'step.name': stepName,
                 'step.id': stepId,
               });
-              await queueMessage(world, getWorkflowQueueName(workflowName, stepNamespace), {
-                runId: workflowRunId,
-                traceCarrier: await serializeTraceCarrier(),
-                requestedAt: new Date(),
-              });
+              await queueMessage(
+                world,
+                getWorkflowQueueName(workflowName, stepNamespace),
+                {
+                  runId: workflowRunId,
+                  traceCarrier: await serializeTraceCarrier(),
+                  requestedAt: new Date(),
+                }
+              );
               return;
             }
 
@@ -346,11 +354,15 @@ const stepHandler = createQueueHandler(
             });
 
             // Re-invoke the workflow to handle the failed step
-            await queueMessage(world, getWorkflowQueueName(workflowName, stepNamespace), {
-              runId: workflowRunId,
-              traceCarrier: await serializeTraceCarrier(),
-              requestedAt: new Date(),
-            });
+            await queueMessage(
+              world,
+              getWorkflowQueueName(workflowName, stepNamespace),
+              {
+                runId: workflowRunId,
+                traceCarrier: await serializeTraceCarrier(),
+                requestedAt: new Date(),
+              }
+            );
             return;
           }
 
@@ -413,11 +425,15 @@ const stepHandler = createQueueHandler(
             });
 
             // Re-invoke the workflow to handle the failed step
-            await queueMessage(world, getWorkflowQueueName(workflowName, stepNamespace), {
-              runId: workflowRunId,
-              traceCarrier: await serializeTraceCarrier(),
-              requestedAt: new Date(),
-            });
+            await queueMessage(
+              world,
+              getWorkflowQueueName(workflowName, stepNamespace),
+              {
+                runId: workflowRunId,
+                traceCarrier: await serializeTraceCarrier(),
+                requestedAt: new Date(),
+              }
+            );
             return;
           }
 
@@ -460,11 +476,15 @@ const stepHandler = createQueueHandler(
               throw failErr;
             }
             // Re-queue the workflow so it can process the step failure
-            await queueMessage(world, getWorkflowQueueName(workflowName, stepNamespace), {
-              runId: workflowRunId,
-              traceCarrier: await serializeTraceCarrier(),
-              requestedAt: new Date(),
-            });
+            await queueMessage(
+              world,
+              getWorkflowQueueName(workflowName, stepNamespace),
+              {
+                runId: workflowRunId,
+                traceCarrier: await serializeTraceCarrier(),
+                requestedAt: new Date(),
+              }
+            );
             return;
           }
           // Capture startedAt for use in async callback (TypeScript narrowing doesn't persist)
@@ -785,11 +805,15 @@ const stepHandler = createQueueHandler(
             }
 
             // Re-invoke the workflow to handle the failed/retrying step
-            await queueMessage(world, getWorkflowQueueName(workflowName, stepNamespace), {
-              runId: workflowRunId,
-              traceCarrier: await serializeTraceCarrier(),
-              requestedAt: new Date(),
-            });
+            await queueMessage(
+              world,
+              getWorkflowQueueName(workflowName, stepNamespace),
+              {
+                runId: workflowRunId,
+                traceCarrier: await serializeTraceCarrier(),
+                requestedAt: new Date(),
+              }
+            );
             return;
           }
 
@@ -874,11 +898,15 @@ const stepHandler = createQueueHandler(
           });
 
           // Queue the workflow continuation with the concurrently-resolved trace carrier
-          await queueMessage(world, getWorkflowQueueName(workflowName, stepNamespace), {
-            runId: workflowRunId,
-            traceCarrier,
-            requestedAt: new Date(),
-          });
+          await queueMessage(
+            world,
+            getWorkflowQueueName(workflowName, stepNamespace),
+            {
+              runId: workflowRunId,
+              traceCarrier,
+              requestedAt: new Date(),
+            }
+          );
         }
       );
     });

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -1,5 +1,4 @@
 import type { Span } from '@opentelemetry/api';
-import { waitUntil } from '@vercel/functions';
 import {
   EntityConflictError,
   HookNotFoundError,
@@ -24,6 +23,7 @@ import { dehydrateStepArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { serializeTraceCarrier } from '../telemetry.js';
 import { queueMessage } from './helpers.js';
+import { waitUntil } from './wait-until.js';
 
 /**
  * Extracts W3C trace context headers from a trace carrier for HTTP propagation.

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import { pluralize } from '@workflow/utils';
 
 /**
@@ -64,20 +63,4 @@ export function getWorkflowRunStreamId(runId: string, namespace?: string) {
     'base64url'
   );
   return `${streamId}_${encodedNamespace}`;
-}
-
-/**
- * A small wrapper around `waitUntil` that also returns
- * the result of the awaited promise.
- */
-export async function waitedUntil<T>(fn: () => Promise<T>): Promise<T> {
-  const result = fn();
-  waitUntil(
-    result.catch(() => {
-      // Ignore error from the promise being rejected.
-      // It's expected that the invoker of `waitedUntil`
-      // will handle the error.
-    })
-  );
-  return result;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32040,7 +32040,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0


### PR DESCRIPTION
## Summary

The automated backport of #2305 to `stable` (#2341, merged as 9c667e05) was not a faithful port of the original PR. This PR fixes the three issues found after auditing the backport against the original merge commit on `main` (4670c4b9).

## Issues fixed

### 1. Stale pnpm lockfile
The backport left `pnpm-lock.yaml` inconsistent with the workspace manifests.

### 2. Build error in `@workflow/core`
The backport removed the `@vercel/functions` import from `resume-hook.ts` but left a dangling `waitUntil` usage, breaking the build. Fixed by importing from the new `./wait-until.js` module.

### 3. Incomplete lazy `waitUntil` conversion
The original PR bundled fix #2340, whose "Avoid loading Vercel functions during runtime import" commit moved **all** `waitUntil` usage in the core runtime to a new lazy-loading `wait-until.ts` module. The backport added the module and the enforcement test (`runtime-import.test.ts`, which mocks `@vercel/functions` to throw if statically loaded), but only rewired one of five call sites — so the backported test was failing on `stable`. This PR completes the conversion:

- `packages/core/src/runtime/start.ts` — static `@vercel/functions` import removed; `waitUntil`/`waitedUntil` now from `./wait-until.js`
- `packages/core/src/runtime/step-handler.ts` — same conversion, plus Biome formatting the backport left broken (long `getWorkflowQueueName(workflowName, stepNamespace)` lines were failing `biome check`)
- `packages/core/src/runtime/suspension-handler.ts` — same conversion
- `packages/core/src/util.ts` — removed now-dead `waitedUntil` and its `@vercel/functions` import (matching `main`)

## Audited and confirmed as legitimate stable/main divergence (no action needed)

- `step-executor.ts` — doesn't exist on `stable` (split out of `step-handler.ts` later on `main`); the namespace logic was correctly adapted into stable's monolithic step handler
- `next/builder-deferred.ts` — untouched by the backport, but stable's Next.js routes go through `base-builder.ts`, which did receive `createWorkflowEntrypointOptionsCode()`
- `builders/request-converter.ts` — backport-only change, needed for stable's regex-based route rewriting (astro/sveltekit)
- `createStepQueueTrigger` in builders constants — correct adaptation for stable's separate step routes
- world/world-local/world-postgres queue files are byte-identical to `main` aside from pre-existing divergences (queue concurrency default, attributes module)

## Verification

- `runtime-import.test.ts` now passes (was failing on `stable`)
- `@workflow/core`: 670/670 tests pass; build + typecheck clean
- `@workflow/builders` (150) and `@workflow/world-local` (396) tests pass
- Remaining `pnpm lint` failures are pre-existing on `stable` (`.github/` scripts), unrelated to the backport