### PR TITLE
[core] Import waitUntil in resume-hook.ts to unblock tsc on stable

### DIFF
--- a/.changeset/stable-resume-hook-waituntil-import.md
+++ b/.changeset/stable-resume-hook-waituntil-import.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Import `waitUntil` in `resume-hook.ts`, which used it without importing it. Unblocks `tsc` on the stable branch.

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -23,6 +23,7 @@ import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanContextForTraceCarrier, trace } from '../telemetry.js';
 import { waitedUntil } from '../util.js';
 import { getWorkflowQueueName } from './helpers.js';
+import { waitUntil } from './wait-until.js';
 import { getWorld } from './world.js';
 
 async function materializeResponseBody(response: Response): Promise<Response> {


### PR DESCRIPTION
> **Blocked by #2349** (broken stable lockfile). Land order: **#2349 → #2347 (this) → #2346**. Until #2349 lands, every stable CI job fails in `pnpm install --frozen-lockfile`, before `tsc` even runs.

## What

One-line fix: `packages/core/src/runtime/resume-hook.ts` calls `waitUntil(...)` at line 165 but only imports `waitedUntil` from `../util.js`. On a pristine `stable` checkout this fails type-checking:

```
src/runtime/resume-hook.ts(165,9): error TS2552: Cannot find name 'waitUntil'. Did you mean 'waitedUntil'?
```

This PR adds the missing import, sourcing the **lazy** local `waitUntil` from `./wait-until.js` (which defers `@vercel/functions` via `void import(...)`). That matches the file's existing fire-and-forget usage and intentionally avoids adding a second *static* `@vercel/functions` import, so the runtime module-evaluation graph is unchanged.

## Why a separate PR

`tsc` currently fails on `stable` because of this, which blocks CI for **any** PR targeting `stable` — including #2346. Keeping this isolated to a single line means it can land fast and unblock the others without entangling the durability fix.

**#2346 depends on this landing first** (it can't go green on `stable` CI until `tsc` is unblocked).

## Verification

- `pnpm --filter @workflow/core typecheck` → **exit 0** with the import (clean).
- Proven load-bearing: temporarily removing the import reproduces exactly `TS2552 ... Cannot find name 'waitUntil'` at `resume-hook.ts:165`, exit 1; restoring it returns to exit 0.
- `runtime-import.test.ts` ("does not load @vercel/functions during module evaluation") still fails for the **pre-existing** reason — `src/util.ts:1`'s static `import { waitUntil } from '@vercel/functions'` — which is unrelated to this change and not made worse by it (this fix uses the lazy wrapper). That test failure is orthogonal and out of scope here.

## Related

- #2349 — fixes the broken stable lockfile that currently fails CI install on all stable PRs. Must land before this.
- #2346 — `[core] Never ack orchestrator message before step dispatch sends complete (stable)`. Depends on this PR to get a green `tsc` on `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)