### PR TITLE
Fix broken stable lockfile (mkdist/esbuild peer qualifier)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32040,7 +32040,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0


### PR DESCRIPTION
## What

One-line correction to `pnpm-lock.yaml`: a single `mkdist@2.4.1` snapshot key referenced `esbuild@0.27.7` through its `vue-sfc-transformer` peer chain, while the resolved tree uses `esbuild@0.28.0`. This is a bad merge resolution, not anyone's code change.

```diff
-      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(...)
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.28.0)(...)
```

## Why this is stable-wide, not PR-specific

`origin/stable` HEAD itself fails CI with this exact error. Its own Tests workflow ([run 27323836295](https://github.com/vercel/workflow/actions/runs/27323836295)) dies in the **Setup environment** step at `pnpm install --frozen-lockfile --ignore-scripts` with:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.35)(esbuild@0.27.7)(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))'
in pnpm-lock.yaml
```

Because this is the install step, **every job** on stable goes red within seconds, before any test or build code runs. No PR targeting stable can go green until this lands.

## The fix

Regenerated only that one snapshot key via `pnpm install --no-frozen-lockfile` (yields the exact one-line diff above). After it, `pnpm install --frozen-lockfile --ignore-scripts` exits **0** locally.

No changeset: lockfile-only change, publishes no package change; the repo has no PR-gating changeset check.

## Dependency chain (land in this order)

1. **this PR** — unblocks `pnpm install --frozen-lockfile` for all stable CI
2. #2347 — `resume-hook.ts` missing `waitUntil` import (unblocks `tsc` on stable)
3. #2346 — ack-ordering durability fix (depends on #2347)

🤖 Generated with [Claude Code](https://claude.com/claude-code)