### PR TITLE
[vitest] Fix local imports failing to load in test step bundles

### DIFF
--- a/.changeset/vitest-bundle-local-step-deps.md
+++ b/.changeset/vitest-bundle-local-step-deps.md
@@ -1,0 +1,5 @@
+---
+'@workflow/vitest': patch
+---
+
+Bundle project-local imports into the test step bundle instead of externalizing them, fixing module resolution errors when bundles are loaded by Node's native ESM loader

--- a/packages/vitest/src/index.test.ts
+++ b/packages/vitest/src/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -116,6 +116,9 @@ describe('@workflow/vitest', () => {
           '__step_registrations.mjs'
         ),
         flowOutfile: path.join(rootDir, '.workflow-vitest', 'combined.mjs'),
+        // Bundles are loaded directly by Node in the vitest worker, so
+        // project-local step dependencies must be bundled inline (#2289).
+        bundleTransitiveLocalStepDependencies: true,
       })
     );
     expect(initDataDir).toHaveBeenCalledWith(

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -53,6 +53,12 @@ class VitestBuilder extends BaseBuilder {
       format: 'esm',
       bundleFinalOutput: false,
       externalizeNonSteps: true,
+      // The generated bundles are imported directly by Node in the vitest
+      // worker (no downstream bundler), so project-local imports must be
+      // bundled inline. Externalizing them emits raw `.ts` specifiers that
+      // Node's native ESM loader can only handle with erasable-syntax-only
+      // type stripping (and not at all on older Node versions).
+      bundleTransitiveLocalStepDependencies: true,
     });
   }
 }

--- a/workbench/vitest/test/local-deps.test.ts
+++ b/workbench/vitest/test/local-deps.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression test for vercel/workflow#2289: a workflow/step importing a
+ * plain local TypeScript helper (no directives) must work under the
+ * vitest plugin. The helper uses an enum, so this fails if the helper is
+ * externalized from the step bundle (Node's native loader refuses
+ * non-erasable TypeScript syntax) instead of bundled inline.
+ */
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, it } from 'vitest';
+import { start } from 'workflow/api';
+import { localHelperWorkflow } from '../workflows/local-deps.js';
+
+it('runs a workflow whose body and steps use a local .ts helper', async () => {
+  const run = await start(localHelperWorkflow, ['hello']);
+  await expect(run.returnValue).resolves.toBe('hello:recipe');
+});
+
+it('bundles local helpers into the step bundle instead of externalizing', async () => {
+  // In this workbench, @workflow/vitest resolves to a workspace symlink, so
+  // the generated bundles happen to be loaded through vitest's module runner,
+  // which transforms `.ts` imports and masks the runtime failure. In a real
+  // app install they are loaded by Node's native ESM loader, where an
+  // externalized `.ts` import crashes. Assert on the bundle content directly
+  // so this guards the fix in either environment.
+  const bundle = await readFile(
+    join(
+      import.meta.dirname,
+      '..',
+      '.workflow-vitest',
+      '__step_registrations.mjs'
+    ),
+    'utf8'
+  );
+  expect(bundle).not.toMatch(/from\s*["'][^"']*local-helper\.ts["']/);
+  // The helper's implementation must be inlined in the bundle (esbuild
+  // inlines the enum member accesses, so assert on the function name).
+  expect(bundle).toContain('function buildPayload');
+});

--- a/workbench/vitest/test/local-deps.test.ts
+++ b/workbench/vitest/test/local-deps.test.ts
@@ -6,7 +6,8 @@
  * non-erasable TypeScript syntax) instead of bundled inline.
  */
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { expect, it } from 'vitest';
 import { start } from 'workflow/api';
 import { localHelperWorkflow } from '../workflows/local-deps.js';
@@ -25,7 +26,7 @@ it('bundles local helpers into the step bundle instead of externalizing', async 
   // so this guards the fix in either environment.
   const bundle = await readFile(
     join(
-      import.meta.dirname,
+      dirname(fileURLToPath(import.meta.url)),
       '..',
       '.workflow-vitest',
       '__step_registrations.mjs'

--- a/workbench/vitest/workflows/local-deps.ts
+++ b/workbench/vitest/workflows/local-deps.ts
@@ -1,0 +1,27 @@
+/**
+ * Workflows that import a plain local TypeScript helper and use it in
+ * the workflow body and in a step body. Regression test for
+ * vercel/workflow#2289: these helpers must be bundled into the step
+ * bundle rather than externalized, because the generated bundle is
+ * loaded directly by Node's ESM loader in the vitest worker.
+ */
+// Extensionless on purpose: it resolves to the `.ts` source, which is
+// the externalization shape reported in the issue (a `./helper.js`
+// import fails enhanced-resolve and falls back to inline bundling).
+import { buildPayload } from './local-helper';
+
+export async function echoPayload(p: { label: string; kind: string }) {
+  'use step';
+  // Use the helper inside a step body too, so the import survives in
+  // the step bundle even when workflow bodies are stubbed out.
+  const rebuilt = buildPayload(p.label);
+  return `${rebuilt.label}:${rebuilt.kind}`;
+}
+
+export async function localHelperWorkflow(label: string) {
+  'use workflow';
+  // Use the helper inside the workflow body (the shape reported in
+  // the issue).
+  const payload = buildPayload(label);
+  return await echoPayload(payload);
+}

--- a/workbench/vitest/workflows/local-helper.ts
+++ b/workbench/vitest/workflows/local-helper.ts
@@ -1,0 +1,14 @@
+/**
+ * Local helper module without workflow directives, imported by
+ * local-deps.ts. Uses an enum on purpose: enums are not erasable
+ * syntax, so Node's native type stripping cannot load this file if
+ * it gets externalized from the step bundle instead of bundled
+ * (regression test for vercel/workflow#2289).
+ */
+export enum PayloadKind {
+  Recipe = 'recipe',
+}
+
+export function buildPayload(label: string) {
+  return { label, kind: PayloadKind.Recipe };
+}


### PR DESCRIPTION
Closes #2289

## Problem

The vitest builder's generated bundles (`combined.mjs` / `__step_registrations.mjs`) are imported directly by Node's native ESM loader in the test worker — there is no downstream bundler. Project-local imports of step files were externalized, so the bundle referenced raw `.ts` sources on disk. Node can only load those via type stripping (erasable syntax only, recent Node versions), and transitive extensionless imports inside such files fail outright:

- A local helper with an `enum` fails with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`
- A local module importing another local module without an extension fails with `ERR_MODULE_NOT_FOUND`
- On the stable channel the additional `.ts`→`.js` rewrite makes every externalized local import fail with `ERR_MODULE_NOT_FOUND` (or load a stale compiled `.js` neighbor)

## Fix

Enable `bundleTransitiveLocalStepDependencies` in the vitest builder, the option introduced for the identical direct-runtime-loading situation in Nitro dev (#1965). Project-local files imported by step entries are now inlined into the step bundle; npm packages stay external, so `vi.mock()` of third-party packages keeps working (covered by existing `workbench/vitest` mock tests).

## Tests

- `workbench/vitest`: new `local-deps.test.ts` runs a workflow whose body and step use a local `.ts` helper with an enum, and asserts the helper is inlined into the generated step bundle rather than externalized. The bundle-content assertion is the regression guard: in the workbench the bundles happen to load through vitest's module runner (workspace symlinks), which masks the runtime failure that real app installs hit.
- `packages/vitest`: unit test asserts the builder passes the flag.
- Verified end-to-end with a packed tarball in a standalone app on Node 24: both issue symptoms reproduce without the fix and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)