### PR TITLE
otel: explicit traceparent injection + linked-trace mode for bounded per-invocation traces

### DIFF
--- a/.changeset/otel-linked-trace-mode.md
+++ b/.changeset/otel-linked-trace-mode.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'workflow': minor
+'@workflow/world-vercel': minor
+---
+
+Add `WORKFLOW_TRACE_MODE` with a new `linked` default that creates each workflow/step invocation span as its own trace root linked to the delivery and run-origin contexts (instead of one giant trace per run); set `WORKFLOW_TRACE_MODE=continuous` to restore the previous behavior. world-vercel now explicitly injects W3C `traceparent`/`tracestate`/`baggage` headers on outgoing workflow-server requests.

--- a/.changeset/otel-linked-trace-mode.md
+++ b/.changeset/otel-linked-trace-mode.md
@@ -4,4 +4,13 @@
 '@workflow/world-vercel': minor
 ---
 
-Add `WORKFLOW_TRACE_MODE` with a new `linked` default that creates each workflow/step invocation span as its own trace root linked to the delivery and run-origin contexts (instead of one giant trace per run); set `WORKFLOW_TRACE_MODE=continuous` to restore the previous behavior. world-vercel now explicitly injects W3C `traceparent`/`tracestate`/`baggage` headers on outgoing workflow-server requests.
+Add `WORKFLOW_TRACE_MODE` with a new `linked` default: each workflow/step invocation span is now its own trace root with span links to the delivery and run-origin contexts, instead of one trace spanning the entire run. world-vercel now explicitly injects W3C `traceparent`/`tracestate`/`baggage` headers on outgoing workflow-server requests.
+
+Behavioral changes to telemetry under the new default (set `WORKFLOW_TRACE_MODE=continuous` to restore the previous shape exactly):
+
+- A run no longer shares one trace ID: the trace of the request that called `start()` no longer contains the workflow's execution spans — navigate via span links or the `workflow.run.id` attribute instead.
+- Sampling decisions are made independently per invocation root (previously one parent-based decision covered the whole run), and the number of root spans/traces increases to one per invocation.
+- `WORKFLOW_V2`/`STEP` invocation spans become parentless roots, which changes parent/child-based queries and service-map edges.
+- Re-enqueued queue messages forward the original run-origin trace carrier unchanged, rather than each invocation's current context.
+
+Span names, existing attributes, and baggage keys are unchanged, and everything remains a no-op when no OpenTelemetry SDK is registered.

--- a/.changeset/otel-linked-trace-mode.md
+++ b/.changeset/otel-linked-trace-mode.md
@@ -16,5 +16,6 @@ Behavioral changes to telemetry under the new default (set `WORKFLOW_TRACE_MODE=
 - `workflow.execute`/`step.execute` invocation spans (formerly `WORKFLOW_V2`/`STEP`) become parentless roots, which changes parent/child-based queries and service-map edges.
 - Re-enqueued queue messages forward the original run-origin trace carrier unchanged, rather than each invocation's current context.
 - Queries or dashboards matching the old `WORKFLOW_V2 ...`/`STEP ...` span names must switch to the new names.
+- The queue-delivered `workflow.execute` span kind changed from `internal` to `consumer`, matching the queue-delivered `step.execute` span (this applies in both modes).
 
 Existing attributes and baggage keys are unchanged, and everything remains a no-op when no OpenTelemetry SDK is registered.

--- a/.changeset/otel-linked-trace-mode.md
+++ b/.changeset/otel-linked-trace-mode.md
@@ -13,4 +13,4 @@ Behavioral changes to telemetry under the new default (set `WORKFLOW_TRACE_MODE=
 - `WORKFLOW_V2`/`STEP` invocation spans become parentless roots, which changes parent/child-based queries and service-map edges.
 - Re-enqueued queue messages forward the original run-origin trace carrier unchanged, rather than each invocation's current context.
 
-Span names, existing attributes, and baggage keys are unchanged, and everything remains a no-op when no OpenTelemetry SDK is registered.
+Existing attributes and baggage keys are unchanged, and everything remains a no-op when no OpenTelemetry SDK is registered.

--- a/.changeset/otel-linked-trace-mode.md
+++ b/.changeset/otel-linked-trace-mode.md
@@ -2,15 +2,19 @@
 '@workflow/core': minor
 'workflow': minor
 '@workflow/world-vercel': minor
+'@workflow/utils': minor
 ---
 
 Add `WORKFLOW_TRACE_MODE` with a new `linked` default: each workflow/step invocation span is now its own trace root with span links to the delivery and run-origin contexts, instead of one trace spanning the entire run. world-vercel now explicitly injects W3C `traceparent`/`tracestate`/`baggage` headers on outgoing workflow-server requests.
 
-Behavioral changes to telemetry under the new default (set `WORKFLOW_TRACE_MODE=continuous` to restore the previous shape exactly):
+Span names are also friendlier: workflow and step spans now use the short function name (e.g. `workflow.execute processOrder`, `step.execute chargeCard`, `workflow.start processOrder`) instead of the uppercase prefixes and full machine names (`WORKFLOW_V2 workflow//./src/jobs/order//processOrder`). The full name remains available in the `workflow.name` / `step.name` span attributes, and new `workflowDisplayName` / `stepDisplayName` helpers are exported from `@workflow/utils`.
+
+Behavioral changes to telemetry under the new default (set `WORKFLOW_TRACE_MODE=continuous` to restore the previous trace shape exactly; the span-name change applies in both modes):
 
 - A run no longer shares one trace ID: the trace of the request that called `start()` no longer contains the workflow's execution spans — navigate via span links or the `workflow.run.id` attribute instead.
 - Sampling decisions are made independently per invocation root (previously one parent-based decision covered the whole run), and the number of root spans/traces increases to one per invocation.
-- `WORKFLOW_V2`/`STEP` invocation spans become parentless roots, which changes parent/child-based queries and service-map edges.
+- `workflow.execute`/`step.execute` invocation spans (formerly `WORKFLOW_V2`/`STEP`) become parentless roots, which changes parent/child-based queries and service-map edges.
 - Re-enqueued queue messages forward the original run-origin trace carrier unchanged, rather than each invocation's current context.
+- Queries or dashboards matching the old `WORKFLOW_V2 ...`/`STEP ...` span names must switch to the new names.
 
 Existing attributes and baggage keys are unchanged, and everything remains a no-op when no OpenTelemetry SDK is registered.

--- a/.changeset/otel-span-display-names.md
+++ b/.changeset/otel-span-display-names.md
@@ -1,7 +1,0 @@
----
-'@workflow/utils': minor
-'@workflow/core': minor
-'workflow': minor
----
-
-Nicer span names: workflow and step spans now use the short function name (e.g. `workflow.execute processOrder`, `step.execute chargeCard`, `workflow.start processOrder`) instead of the uppercase prefixes and full machine names (`WORKFLOW_V2 workflow//./src/jobs/order//processOrder`). The full name remains available in the `workflow.name` / `step.name` span attributes. New `workflowDisplayName` / `stepDisplayName` helpers are exported from `@workflow/utils`.

--- a/.changeset/otel-span-display-names.md
+++ b/.changeset/otel-span-display-names.md
@@ -1,0 +1,7 @@
+---
+'@workflow/utils': minor
+'@workflow/core': minor
+'workflow': minor
+---
+
+Nicer span names: workflow and step spans now use the short function name (e.g. `workflow.execute processOrder`, `step.execute chargeCard`, `workflow.start processOrder`) instead of the uppercase prefixes and full machine names (`WORKFLOW_V2 workflow//./src/jobs/order//processOrder`). The full name remains available in the `workflow.name` / `step.name` span attributes. New `workflowDisplayName` / `stepDisplayName` helpers are exported from `@workflow/utils`.

--- a/docs/content/docs/v5/observability/index.mdx
+++ b/docs/content/docs/v5/observability/index.mdx
@@ -67,6 +67,9 @@ When deployed to Vercel, workflow data is [encrypted end-to-end](/docs/how-it-wo
 ## More Observability Features
 
 <Cards>
+    <Card href="/docs/observability/tracing" title="Tracing">
+        Distributed tracing with OpenTelemetry for workflow runs, steps, and queue deliveries.
+    </Card>
     <Card href="/docs/observability/attributes" title="Attributes">
         Attach experimental metadata to workflow runs for observability.
     </Card>

--- a/docs/content/docs/v5/observability/meta.json
+++ b/docs/content/docs/v5/observability/meta.json
@@ -1,4 +1,7 @@
 {
   "title": "Observability",
-  "pages": ["attributes"]
+  "pages": [
+    "tracing",
+    "attributes"
+  ]
 }

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -61,12 +61,22 @@ Instead, the SDK creates **one bounded trace per invocation**. Each `workflow.ex
 
 A span link is OpenTelemetry's relationship for "causally related, but in a different trace." It is the standard pattern for asynchronous messaging, where producing and consuming a message can be separated by arbitrary time.
 
+```mermaid
+flowchart LR
+    O["start() request trace"]
+    A["invocation 1"]
+    B["invocation 2"]
+    C["invocation 3 ..."]
+    A -. "link" .-> O
+    B -. "link" .-> O
+    C -. "link" .-> O
+    B -. "link" .-> A
+    C -. "link" .-> B
+
+    style O fill:#a78bfa,stroke:#8b5cf6,color:#000
 ```
-start() request trace ──────────────┐
-        ▲ link            ▲ link    │ link
-        │                 │         ▼
-  [invocation 1] ──link── [invocation 2] ──link── [invocation 3] ...
-```
+
+Each invocation links back to the trace that enqueued it and to the run origin.
 
 To see a whole run, query by attribute rather than by trace ID — for example `workflow.run.id = wrun_...` in your tracing backend — or follow the span links between invocation traces.
 

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -54,7 +54,7 @@ No workflow-specific configuration is required. As soon as a tracer provider and
 
 A single workflow run can span hours or days across many separate function invocations: every step completion, `sleep()` wake-up, and retry is a new queue delivery. Stitching all of that into one trace produces giant, slow-loading traces that most tracing backends truncate.
 
-Instead, the SDK creates **one bounded trace per invocation**. Each `WORKFLOW_V2` (or background `STEP`) span starts a new trace root and attaches two **span links**:
+Instead, the SDK creates **one bounded trace per invocation**. Each `workflow.execute` (or background `step.execute`) span starts a new trace root and attaches two **span links**:
 
 - a link to the **enqueue site** — the span that queued the message which triggered this invocation, and
 - a link to the **run origin** — the trace in which `start()` was originally called.

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -34,9 +34,11 @@ No workflow-specific configuration is required. As soon as a tracer provider and
 | Span name | Kind | Emitted when |
 | --- | --- | --- |
 | `workflow.start <name>` | internal | `start()` is called in your application code |
-| `WORKFLOW_V2 <name>` | internal (root) | a queue delivery invokes the workflow — replay, orchestration, and inline steps run under it |
-| `STEP <name>` | internal | a step function executes |
+| `workflow.execute <name>` | internal (root) | a queue delivery invokes the workflow — replay, orchestration, and inline steps run under it |
+| `step.execute <name>` | internal | a step function executes |
 | `http <method>` | client | the SDK calls the workflow backend (event reads/writes) |
+
+`<name>` is the short function name (for example `processOrder`); the full machine name, including the source module, is available in the `workflow.name` / `step.name` attributes.
 
 ## Key attributes
 

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -1,0 +1,94 @@
+---
+title: Tracing
+description: Distributed tracing with OpenTelemetry for workflow runs, steps, and queue deliveries.
+type: guide
+summary: Trace workflow execution end to end with OpenTelemetry.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/observability
+  - /docs/observability/attributes
+  - /docs/how-it-works/event-sourcing
+---
+
+The Workflow SDK is instrumented with [OpenTelemetry](https://opentelemetry.io) out of the box. It emits spans for workflow starts, every workflow and step invocation, and the HTTP calls it makes to the workflow backend — and it propagates trace context across queue deliveries so a run remains traceable end to end.
+
+The SDK only depends on the OpenTelemetry **API**, never on an SDK or exporter. If your application does not register an OpenTelemetry SDK, all tracing code is a silent no-op with no overhead and no behavior change.
+
+## Enabling tracing
+
+Register any OpenTelemetry Node SDK in your application. On Vercel with Next.js, the simplest setup is [`@vercel/otel`](https://vercel.com/docs/observability/otel-overview) in `instrumentation.ts`:
+
+```typescript title="instrumentation.ts" lineNumbers
+import { registerOTel } from "@vercel/otel"
+
+export function register() {
+  registerOTel({ serviceName: "my-app" })
+}
+```
+
+No workflow-specific configuration is required. As soon as a tracer provider and propagator are registered, the SDK's spans, context propagation, and span links activate automatically.
+
+## Spans
+
+| Span name | Kind | Emitted when |
+| --- | --- | --- |
+| `workflow.start <name>` | internal | `start()` is called in your application code |
+| `WORKFLOW_V2 <name>` | internal (root) | a queue delivery invokes the workflow — replay, orchestration, and inline steps run under it |
+| `STEP <name>` | internal | a step function executes |
+| `http <method>` | client | the SDK calls the workflow backend (event reads/writes) |
+
+## Key attributes
+
+| Attribute | Description |
+| --- | --- |
+| `workflow.run.id` | The run ID (`wrun_...`). Present on every workflow and step span — the primary key for finding all spans of a run. |
+| `workflow.name` | The workflow function name. |
+| `workflow.trace.mode` | The active trace mode (`linked` or `continuous`). |
+| `workflow.trace.propagated` | Whether the invocation received trace context from the queue message. |
+| `workflow.queue.overhead_ms` | Time between the message being enqueued and the handler starting — queue dwell plus any cold start. |
+
+## Trace shape: one trace per invocation
+
+A single workflow run can span hours or days across many separate function invocations: every step completion, `sleep()` wake-up, and retry is a new queue delivery. Stitching all of that into one trace produces giant, slow-loading traces that most tracing backends truncate.
+
+Instead, the SDK creates **one bounded trace per invocation**. Each `WORKFLOW_V2` (or background `STEP`) span starts a new trace root and attaches two **span links**:
+
+- a link to the **enqueue site** — the span that queued the message which triggered this invocation, and
+- a link to the **run origin** — the trace in which `start()` was originally called.
+
+A span link is OpenTelemetry's relationship for "causally related, but in a different trace." It is the standard pattern for asynchronous messaging, where producing and consuming a message can be separated by arbitrary time.
+
+```
+start() request trace ──────────────┐
+        ▲ link            ▲ link    │ link
+        │                 │         ▼
+  [invocation 1] ──link── [invocation 2] ──link── [invocation 3] ...
+```
+
+To see a whole run, query by attribute rather than by trace ID — for example `workflow.run.id = wrun_...` in your tracing backend — or follow the span links between invocation traces.
+
+## Trace modes
+
+The `WORKFLOW_TRACE_MODE` environment variable controls the shape:
+
+| Mode | Behavior |
+| --- | --- |
+| `linked` (default) | Each invocation is its own trace root with span links to the enqueue site and the run origin. Traces stay small; sampling is decided per invocation. |
+| `continuous` | The run-origin context becomes the **parent** of every invocation, so the entire run shares one trace ID. |
+
+<Callout type="warn">
+This is a behavior change from v4, which always used `continuous`-style tracing. If you have dashboards or queries that assume one trace ID per run, either update them to use `workflow.run.id` and span links, or set `WORKFLOW_TRACE_MODE=continuous` to restore the previous shape. Note that in `linked` mode each invocation root makes its own sampling decision, and the number of root spans increases to one per invocation.
+</Callout>
+
+## Context propagation
+
+When tracing is enabled, the SDK propagates [W3C Trace Context](https://www.w3.org/TR/trace-context/) on its outbound calls:
+
+- **Backend requests** carry `traceparent`, `tracestate`, and `baggage` headers, so backend spans can join your trace.
+- **Queue messages** carry the run-origin trace context in the message payload, and the queue re-delivers the producer's context to the workflow handler, where it becomes the enqueue-site span link.
+- **Baggage** carries `workflow.run_id` and `workflow.name` entries during workflow execution, allowing downstream services you call from steps to tag their own telemetry with the run ID.
+
+<Callout>
+Baggage entries set by your application are propagated as a `baggage` HTTP header on the SDK's backend requests, like any other OpenTelemetry-instrumented HTTP call. Avoid placing sensitive values in baggage.
+</Callout>

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -34,8 +34,8 @@ No workflow-specific configuration is required. As soon as a tracer provider and
 | Span name | Kind | Emitted when |
 | --- | --- | --- |
 | `workflow.start <name>` | internal | `start()` is called in your application code |
-| `workflow.execute <name>` | internal (root) | a queue delivery invokes the workflow — replay, orchestration, and inline steps run under it |
-| `step.execute <name>` | internal | a step function executes |
+| `workflow.execute <name>` | consumer (root) | a queue delivery invokes the workflow — replay, orchestration, and inline steps run under it |
+| `step.execute <name>` | internal (inline) / consumer + root (queue-delivered) | a step function executes |
 | `http <method>` | client | the SDK calls the workflow backend (event reads/writes) |
 
 `<name>` is the short function name (for example `processOrder`); the full machine name, including the source module, is available in the `workflow.name` / `step.name` attributes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,6 +108,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-async-hooks": "1.30.1",
+    "@opentelemetry/core": "1.30.1",
+    "@opentelemetry/sdk-trace-base": "1.30.1",
     "@types/debug": "4.1.12",
     "@types/node": "catalog:",
     "@types/seedrandom": "3.0.8",

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -3,6 +3,7 @@ import {
   trace as otelTrace,
   propagation,
   type Span,
+  SpanKind,
 } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
@@ -26,10 +27,11 @@ import {
   it,
   vi,
 } from 'vitest';
+import { runtimeLogger } from './logger.js';
 import { setWorld } from './runtime/world.js';
 import { workflowEntrypoint } from './runtime.js';
 import { dehydrateWorkflowArguments } from './serialization.js';
-import { getWorkflowTraceMode } from './telemetry.js';
+import { getNextTraceCarrier, getWorkflowTraceMode } from './telemetry.js';
 
 vi.mock('@vercel/functions', () => ({
   waitUntil: vi.fn((p: Promise<unknown>) => {
@@ -77,16 +79,6 @@ const getWorkflowTransformCode = (workflowName: string) =>
 
 const simpleWorkflow = `async function workflow() {
     return 'done';
-  }${getWorkflowTransformCode('workflow')}`;
-
-// A workflow that suspends on a step AND a sleep: the pending wait makes the
-// V2 handler queue the step (with a traceCarrier) instead of executing it
-// inline, exercising the re-enqueue trace-carrier path.
-const stepWithSleepWorkflow = `const add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("add");
-  const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
-  async function workflow() {
-    const [a] = await Promise.all([add(1, 2), sleep('1h')]);
-    return a;
   }${getWorkflowTransformCode('workflow')}`;
 
 async function makeRunningRun(runId: string): Promise<WorkflowRun> {
@@ -209,6 +201,23 @@ describe('getWorkflowTraceMode', () => {
     vi.stubEnv('WORKFLOW_TRACE_MODE', 'continuous');
     expect(getWorkflowTraceMode()).toBe('continuous');
   });
+
+  it('warns once for unrecognized values and falls back to linked', () => {
+    const warnSpy = vi
+      .spyOn(runtimeLogger, 'warn')
+      .mockImplementation(() => {});
+    vi.stubEnv('WORKFLOW_TRACE_MODE', 'continous');
+
+    expect(getWorkflowTraceMode()).toBe('linked');
+    expect(getWorkflowTraceMode()).toBe('linked');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('"continous"');
+    expect(message).toContain('"linked"');
+    expect(message).toContain('"continuous"');
+    warnSpy.mockRestore();
+  });
 });
 
 describe('workflowEntrypoint trace modes', () => {
@@ -237,6 +246,28 @@ describe('workflowEntrypoint trace modes', () => {
 
     expect(workflowSpan?.attributes['workflow.trace.mode']).toBe('linked');
     expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(true);
+
+    // Queue-delivered invocation spans use the CONSUMER kind, matching
+    // queue-delivered step.execute spans.
+    expect(workflowSpan?.kind).toBe(SpanKind.CONSUMER);
+  });
+
+  it('linked: treats an empty trace carrier ({}) like an absent one', async () => {
+    const { workflowSpan, deliverySpan } = await driveHandler({
+      runId: 'wrun_trace_linked_empty_carrier',
+      workflowCode: simpleWorkflow,
+      traceCarrier: {},
+    });
+
+    expect(workflowSpan).toBeDefined();
+    expect(workflowSpan?.parentSpanId).toBeUndefined();
+    // Only the delivery link — no origin link is derived from `{}`.
+    expect(workflowSpan?.links).toHaveLength(1);
+    expect(linkTraceIds(workflowSpan)).toContain(
+      deliverySpan.spanContext().traceId
+    );
+    // An empty carrier does not count as propagated trace context.
+    expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(false);
   });
 
   it('linked: without an incoming carrier, still creates a root span with only the delivery link', async () => {
@@ -277,42 +308,52 @@ describe('workflowEntrypoint trace modes', () => {
 
     expect(workflowSpan?.attributes['workflow.trace.mode']).toBe('continuous');
   });
+});
 
-  it('linked: forwards the ORIGINAL run-origin trace carrier unchanged on re-enqueues', async () => {
-    const { workflowSpan, queuedMessages } = await driveHandler({
-      runId: 'wrun_trace_linked_reenqueue',
-      workflowCode: stepWithSleepWorkflow,
-      traceCarrier: ORIGIN_CARRIER,
-    });
-
-    const stepDispatch = queuedMessages.find((m) => m && 'stepId' in m);
-    expect(stepDispatch).toBeDefined();
-    // The original carrier flows forward unchanged — the run-origin
-    // identity is preserved for future links...
-    expect(stepDispatch.traceCarrier).toEqual(ORIGIN_CARRIER);
-    // ...and is NOT replaced with the current invocation's context.
-    expect(stepDispatch.traceCarrier.traceparent).not.toContain(
-      workflowSpan?.spanContext().traceId
-    );
+// The carrier put on re-enqueued messages is produced by getNextTraceCarrier.
+// (The combined V2 handler now executes a single owned step inline rather
+// than queueing it, so this invariant is exercised directly on the helper
+// instead of by inspecting a queued step message.)
+describe('getNextTraceCarrier (re-enqueue carrier semantics)', () => {
+  it('linked: forwards a usable run-origin carrier unchanged', async () => {
+    // The original carrier flows forward unchanged so the run-origin
+    // identity is preserved for future links.
+    const next = await getNextTraceCarrier('linked', ORIGIN_CARRIER);
+    expect(next).toEqual(ORIGIN_CARRIER);
   });
 
-  it('continuous: serializes the current invocation context on re-enqueues', async () => {
-    vi.stubEnv('WORKFLOW_TRACE_MODE', 'continuous');
-
-    const { queuedMessages } = await driveHandler({
-      runId: 'wrun_trace_continuous_reenqueue',
-      workflowCode: stepWithSleepWorkflow,
-      traceCarrier: ORIGIN_CARRIER,
+  it('linked: replaces an empty carrier with the current invocation context', async () => {
+    const tracer = otelTrace.getTracer('test');
+    let activeTraceId = '';
+    const next = await tracer.startActiveSpan('inv', async (span) => {
+      activeTraceId = span.spanContext().traceId;
+      try {
+        return await getNextTraceCarrier('linked', {});
+      } finally {
+        span.end();
+      }
     });
+    // The useless `{}` is not forwarded — this invocation serializes its
+    // own context, becoming the de-facto run origin for future links.
+    expect(next.traceparent).toContain(activeTraceId);
+    expect(next.traceparent).not.toBe(ORIGIN_CARRIER.traceparent);
+  });
 
-    const stepDispatch = queuedMessages.find((m) => m && 'stepId' in m);
-    expect(stepDispatch).toBeDefined();
-    // Continuous mode chains the trace: the queued carrier stays in the
-    // run-origin trace but points at the current invocation's span, not
-    // the original origin span.
-    expect(stepDispatch.traceCarrier.traceparent).toContain(ORIGIN_TRACE_ID);
-    expect(stepDispatch.traceCarrier.traceparent).not.toBe(
-      ORIGIN_CARRIER.traceparent
-    );
+  it('continuous: serializes the current invocation context, not the origin carrier', async () => {
+    const tracer = otelTrace.getTracer('test');
+    let activeTraceId = '';
+    const next = await tracer.startActiveSpan('inv', async (span) => {
+      activeTraceId = span.spanContext().traceId;
+      try {
+        return await getNextTraceCarrier('continuous', ORIGIN_CARRIER);
+      } finally {
+        span.end();
+      }
+    });
+    // Continuous mode always serializes the current context rather than
+    // forwarding the incoming carrier.
+    expect(next.traceparent).toContain(activeTraceId);
+    expect(next.traceparent).not.toBe(ORIGIN_CARRIER.traceparent);
+    expect(activeTraceId).not.toBe(ORIGIN_TRACE_ID);
   });
 });

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -190,7 +190,7 @@ async function driveHandler(opts: {
 
   const workflowSpan = exporter
     .getFinishedSpans()
-    .find((s) => s.name === 'WORKFLOW_V2 workflow');
+    .find((s) => s.name === 'workflow.execute workflow');
 
   return { workflowSpan, deliverySpan, queuedMessages };
 }

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -1,0 +1,318 @@
+import {
+  context,
+  trace as otelTrace,
+  propagation,
+  type Span,
+} from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import {
+  type Event,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+} from '@workflow/world';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { setWorld } from './runtime/world.js';
+import { workflowEntrypoint } from './runtime.js';
+import { dehydrateWorkflowArguments } from './serialization.js';
+import { getWorkflowTraceMode } from './telemetry.js';
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn((p: Promise<unknown>) => {
+    p.catch(() => {});
+  }),
+}));
+
+// Run-origin trace context, as carried in queue messages. Uses a fixed,
+// valid W3C traceparent so assertions are deterministic.
+const ORIGIN_TRACE_ID = '0af7651916cd43dd8448eb211c80319c';
+const ORIGIN_SPAN_ID = 'b7ad6b7169203331';
+const ORIGIN_CARRIER = {
+  traceparent: `00-${ORIGIN_TRACE_ID}-${ORIGIN_SPAN_ID}-01`,
+};
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+const contextManager = new AsyncLocalStorageContextManager();
+
+beforeAll(() => {
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+  otelTrace.setGlobalTracerProvider(provider);
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  context.disable();
+  propagation.disable();
+  otelTrace.disable();
+});
+
+afterEach(() => {
+  exporter.reset();
+  setWorld(undefined);
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+const getWorkflowTransformCode = (workflowName: string) =>
+  `;globalThis.__private_workflows = new Map();
+  globalThis.__private_workflows.set(${JSON.stringify(workflowName)}, ${workflowName});`;
+
+const simpleWorkflow = `async function workflow() {
+    return 'done';
+  }${getWorkflowTransformCode('workflow')}`;
+
+// A workflow that suspends on a step AND a sleep: the pending wait makes the
+// V2 handler queue the step (with a traceCarrier) instead of executing it
+// inline, exercising the re-enqueue trace-carrier path.
+const stepWithSleepWorkflow = `const add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("add");
+  const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+  async function workflow() {
+    const [a] = await Promise.all([add(1, 2), sleep('1h')]);
+    return a;
+  }${getWorkflowTransformCode('workflow')}`;
+
+async function makeRunningRun(runId: string): Promise<WorkflowRun> {
+  return {
+    runId,
+    workflowName: 'workflow',
+    status: 'running',
+    input: await dehydrateWorkflowArguments([], runId, undefined, []),
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    startedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deploymentId: 'test-deployment',
+  };
+}
+
+/**
+ * Drives the workflow queue handler once with the given trace carrier,
+ * inside an active "delivery" span (simulating the span the platform/queue
+ * consumer creates around the delivery request). Returns the finished
+ * WORKFLOW_V2 span, the delivery span, and all queued messages.
+ */
+async function driveHandler(opts: {
+  runId: string;
+  workflowCode: string;
+  traceCarrier?: Record<string, string>;
+}) {
+  const workflowRun = await makeRunningRun(opts.runId);
+  const queuedMessages: any[] = [];
+
+  const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+    if (data.eventType === 'run_started') {
+      return { run: workflowRun, events: [] as Event[] };
+    }
+    return {
+      event: {
+        eventId: `event-${Math.random()}`,
+        runId: workflowRun.runId,
+        createdAt: new Date(),
+        ...data,
+      },
+    };
+  });
+
+  setWorld({
+    specVersion: SPEC_VERSION_CURRENT,
+    createQueueHandler: vi.fn(
+      (
+        _prefix: string,
+        handler: (message: unknown, metadata: unknown) => Promise<unknown>
+      ) => {
+        return async () => {
+          await handler(
+            {
+              runId: workflowRun.runId,
+              requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+              traceCarrier: opts.traceCarrier,
+            },
+            {
+              requestId: 'req_test',
+              attempt: 1,
+              queueName: '__wkf_workflow_workflow',
+              messageId: 'msg_test',
+            }
+          );
+          return new Response(null, { status: 204 });
+        };
+      }
+    ),
+    events: {
+      create: eventsCreate,
+      list: vi.fn(async () => ({
+        data: [] as Event[],
+        hasMore: false,
+        cursor: 'cursor_test',
+      })),
+    },
+    runs: {
+      get: vi.fn(async () => workflowRun),
+    },
+    queue: vi.fn(async (_queueName: string, message: unknown) => {
+      queuedMessages.push(message);
+      return { messageId: null };
+    }),
+    getEncryptionKeyForRun: vi.fn(async () => undefined),
+  } as any);
+
+  const handler = workflowEntrypoint(opts.workflowCode);
+
+  // Invoke inside an active "delivery" span so linkToCurrentContext()
+  // observes a live delivery context, as it would in production.
+  const tracer = otelTrace.getTracer('test');
+  let deliverySpan!: Span;
+  await tracer.startActiveSpan('queue delivery', async (span) => {
+    deliverySpan = span;
+    try {
+      await handler(new Request('https://example.test'));
+    } finally {
+      span.end();
+    }
+  });
+
+  const workflowSpan = exporter
+    .getFinishedSpans()
+    .find((s) => s.name === 'WORKFLOW_V2 workflow');
+
+  return { workflowSpan, deliverySpan, queuedMessages };
+}
+
+function linkTraceIds(span: ReadableSpan | undefined): string[] {
+  return (span?.links ?? []).map((l) => l.context.traceId);
+}
+
+describe('getWorkflowTraceMode', () => {
+  it('defaults to linked when WORKFLOW_TRACE_MODE is unset', () => {
+    vi.stubEnv('WORKFLOW_TRACE_MODE', '');
+    expect(getWorkflowTraceMode()).toBe('linked');
+  });
+
+  it('returns continuous when WORKFLOW_TRACE_MODE=continuous', () => {
+    vi.stubEnv('WORKFLOW_TRACE_MODE', 'continuous');
+    expect(getWorkflowTraceMode()).toBe('continuous');
+  });
+});
+
+describe('workflowEntrypoint trace modes', () => {
+  it('linked (default): creates the WORKFLOW_V2 span as a new root with links to delivery and run-origin contexts', async () => {
+    const { workflowSpan, deliverySpan } = await driveHandler({
+      runId: 'wrun_trace_linked',
+      workflowCode: simpleWorkflow,
+      traceCarrier: ORIGIN_CARRIER,
+    });
+
+    expect(workflowSpan).toBeDefined();
+    // New root: no parent, and a fresh trace distinct from both the
+    // delivery trace and the run-origin trace.
+    expect(workflowSpan?.parentSpanId).toBeUndefined();
+    expect(workflowSpan?.spanContext().traceId).not.toBe(ORIGIN_TRACE_ID);
+    expect(workflowSpan?.spanContext().traceId).not.toBe(
+      deliverySpan.spanContext().traceId
+    );
+
+    // Links to BOTH the delivery context and the run-origin context.
+    expect(workflowSpan?.links).toHaveLength(2);
+    expect(linkTraceIds(workflowSpan)).toContain(
+      deliverySpan.spanContext().traceId
+    );
+    expect(linkTraceIds(workflowSpan)).toContain(ORIGIN_TRACE_ID);
+
+    expect(workflowSpan?.attributes['workflow.trace.mode']).toBe('linked');
+    expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(true);
+  });
+
+  it('linked: without an incoming carrier, still creates a root span with only the delivery link', async () => {
+    const { workflowSpan, deliverySpan } = await driveHandler({
+      runId: 'wrun_trace_linked_no_carrier',
+      workflowCode: simpleWorkflow,
+      traceCarrier: undefined,
+    });
+
+    expect(workflowSpan).toBeDefined();
+    expect(workflowSpan?.parentSpanId).toBeUndefined();
+    expect(workflowSpan?.links).toHaveLength(1);
+    expect(linkTraceIds(workflowSpan)).toContain(
+      deliverySpan.spanContext().traceId
+    );
+    expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(false);
+  });
+
+  it('continuous: preserves the legacy shape — parented to the run-origin context with a delivery link', async () => {
+    vi.stubEnv('WORKFLOW_TRACE_MODE', 'continuous');
+
+    const { workflowSpan, deliverySpan } = await driveHandler({
+      runId: 'wrun_trace_continuous',
+      workflowCode: simpleWorkflow,
+      traceCarrier: ORIGIN_CARRIER,
+    });
+
+    expect(workflowSpan).toBeDefined();
+    // Same trace as the run origin, parented to the carrier's span.
+    expect(workflowSpan?.spanContext().traceId).toBe(ORIGIN_TRACE_ID);
+    expect(workflowSpan?.parentSpanId).toBe(ORIGIN_SPAN_ID);
+
+    // Only the delivery link (no self-link to the origin).
+    expect(workflowSpan?.links).toHaveLength(1);
+    expect(linkTraceIds(workflowSpan)).toContain(
+      deliverySpan.spanContext().traceId
+    );
+
+    expect(workflowSpan?.attributes['workflow.trace.mode']).toBe('continuous');
+  });
+
+  it('linked: forwards the ORIGINAL run-origin trace carrier unchanged on re-enqueues', async () => {
+    const { workflowSpan, queuedMessages } = await driveHandler({
+      runId: 'wrun_trace_linked_reenqueue',
+      workflowCode: stepWithSleepWorkflow,
+      traceCarrier: ORIGIN_CARRIER,
+    });
+
+    const stepDispatch = queuedMessages.find((m) => m && 'stepId' in m);
+    expect(stepDispatch).toBeDefined();
+    // The original carrier flows forward unchanged — the run-origin
+    // identity is preserved for future links...
+    expect(stepDispatch.traceCarrier).toEqual(ORIGIN_CARRIER);
+    // ...and is NOT replaced with the current invocation's context.
+    expect(stepDispatch.traceCarrier.traceparent).not.toContain(
+      workflowSpan?.spanContext().traceId
+    );
+  });
+
+  it('continuous: serializes the current invocation context on re-enqueues', async () => {
+    vi.stubEnv('WORKFLOW_TRACE_MODE', 'continuous');
+
+    const { queuedMessages } = await driveHandler({
+      runId: 'wrun_trace_continuous_reenqueue',
+      workflowCode: stepWithSleepWorkflow,
+      traceCarrier: ORIGIN_CARRIER,
+    });
+
+    const stepDispatch = queuedMessages.find((m) => m && 'stepId' in m);
+    expect(stepDispatch).toBeDefined();
+    // Continuous mode chains the trace: the queued carrier stays in the
+    // run-origin trace but points at the current invocation's span, not
+    // the original origin span.
+    expect(stepDispatch.traceCarrier.traceparent).toContain(ORIGIN_TRACE_ID);
+    expect(stepDispatch.traceCarrier.traceparent).not.toBe(
+      ORIGIN_CARRIER.traceparent
+    );
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -10,7 +10,10 @@ import {
   RunExpiredError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
-import { parseWorkflowName } from '@workflow/utils/parse-name';
+import {
+  parseWorkflowName,
+  workflowDisplayName,
+} from '@workflow/utils/parse-name';
 import {
   type Event,
   getQueueTopicPrefix,
@@ -403,7 +406,7 @@ export function workflowEntrypoint(
             async () => {
               const world = await getWorld();
               return trace(
-                `WORKFLOW_V2 ${workflowName}`,
+                `workflow.execute ${workflowDisplayName(workflowName)}`,
                 traceMode === 'linked'
                   ? { root: true, links: spanLinks }
                   : { links: spanLinks },

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,5 +1,4 @@
 import { types } from 'node:util';
-import type { Link } from '@opentelemetry/api';
 import {
   CorruptedEventLogError,
   EntityConflictError,
@@ -57,10 +56,11 @@ import { dehydrateRunError } from './serialization.js';
 import { remapErrorStack } from './source-map.js';
 import * as Attribute from './telemetry/semantic-conventions.js';
 import {
+  buildInvocationSpanLinks,
+  getNextTraceCarrier,
+  getSpanKind,
   getWorkflowTraceMode,
-  linkToCurrentContext,
-  linkToTraceCarrier,
-  serializeTraceCarrier,
+  isUsableTraceCarrier,
   trace,
   withTraceContext,
   withWorkflowBaggage,
@@ -252,13 +252,21 @@ export function workflowEntrypoint(
 
         const {
           runId,
-          traceCarrier: traceContext,
+          traceCarrier: incomingTraceCarrier,
           requestedAt,
           stepId: incomingStepId,
           stepName: incomingStepName,
           replayDivergence,
           runInput,
         } = WorkflowInvokePayloadSchema.parse(message_);
+        // `start()` always attaches a trace carrier, but
+        // serializeTraceCarrier() returns `{}` when no OTEL SDK is registered
+        // or no span is active — treat an empty carrier the same as an
+        // absent one so linked mode falls back to a fresh origin instead of
+        // forwarding a useless `{}` forever.
+        const traceContext = isUsableTraceCarrier(incomingTraceCarrier)
+          ? incomingTraceCarrier
+          : undefined;
         const { requestId } = metadata;
         const workflowName = metadata.queueName.slice(workflowPrefix.length);
 
@@ -336,37 +344,17 @@ export function workflowEntrypoint(
         // becomes the parent of this invocation's spans.
         const traceMode = getWorkflowTraceMode();
 
-        // Trace carrier to attach to messages this invocation enqueues. In
-        // linked mode the ORIGINAL run-origin carrier is forwarded unchanged
-        // so every future invocation links back to the same origin; in
-        // continuous mode the current (active) context is serialized so the
-        // trace keeps chaining.
-        const getNextTraceCarrier = (): Promise<Record<string, string>> =>
-          traceMode === 'linked' && traceContext
-            ? Promise.resolve(traceContext)
-            : serializeTraceCarrier();
+        // Trace carrier to attach to messages this invocation enqueues —
+        // see getNextTraceCarrier for the linked/continuous semantics.
+        const nextTraceCarrier = (): Promise<Record<string, string>> =>
+          getNextTraceCarrier(traceMode, traceContext);
 
-        // Link to the incoming delivery context (the active span extracted
-        // from the queue delivery request, i.e. the enqueue site once the
-        // queue propagates producer context).
-        const deliveryLinks = await linkToCurrentContext();
-        let spanLinks: Link[] | undefined = deliveryLinks;
-        if (traceMode === 'linked') {
-          // Additionally link to the run-origin context from the trace
-          // carrier (skipped when absent, invalid, or identical to the
-          // delivery context).
-          const originLink = await linkToTraceCarrier(traceContext);
-          if (
-            originLink &&
-            !deliveryLinks?.some(
-              (link) =>
-                link.context.traceId === originLink.context.traceId &&
-                link.context.spanId === originLink.context.spanId
-            )
-          ) {
-            spanLinks = [...(deliveryLinks ?? []), originLink];
-          }
-        }
+        // Span links to the incoming delivery context and (in linked mode)
+        // the run-origin context from the trace carrier.
+        const spanLinks = await buildInvocationSpanLinks(
+          traceMode,
+          traceContext
+        );
 
         // --- Replay budget bookkeeping ---
         // The replay budget bounds the *non-step* portion of a single
@@ -400,6 +388,9 @@ export function workflowEntrypoint(
         // becomes a new trace root carrying span links instead.
         const parentTraceCarrier =
           traceMode === 'continuous' ? traceContext : undefined;
+        // Queue-delivered invocation: CONSUMER kind, matching the
+        // queue-delivered step.execute span.
+        const spanKind = await getSpanKind('CONSUMER');
         return await withTraceContext(parentTraceCarrier, async () => {
           return await withWorkflowBaggage(
             { workflowRunId: runId, workflowName },
@@ -408,8 +399,8 @@ export function workflowEntrypoint(
               return trace(
                 `workflow.execute ${workflowDisplayName(workflowName)}`,
                 traceMode === 'linked'
-                  ? { root: true, links: spanLinks }
-                  : { links: spanLinks },
+                  ? { kind: spanKind, links: spanLinks, root: true }
+                  : { kind: spanKind, links: spanLinks },
                 async (span) => {
                   span?.setAttributes({
                     ...Attribute.WorkflowName(workflowName),
@@ -495,7 +486,7 @@ export function workflowEntrypoint(
                           getWorkflowQueueName(workflowName, namespace),
                           {
                             runId,
-                            traceCarrier: await getNextTraceCarrier(),
+                            traceCarrier: await nextTraceCarrier(),
                             requestedAt: new Date(),
                           }
                         );
@@ -757,7 +748,7 @@ export function workflowEntrypoint(
                         getWorkflowQueueName(workflowName, namespace),
                         {
                           runId,
-                          traceCarrier: await getNextTraceCarrier(),
+                          traceCarrier: await nextTraceCarrier(),
                           requestedAt: new Date(),
                         }
                       );
@@ -1204,7 +1195,7 @@ export function workflowEntrypoint(
                         // suspension passes — see
                         // runtime/wait-continuation.ts for the full
                         // delay/key selection rationale.
-                        const traceCarrier = await getNextTraceCarrier();
+                        const traceCarrier = await nextTraceCarrier();
                         const dispatches: Promise<unknown>[] = [];
                         for (const step of pendingSteps) {
                           if (
@@ -1293,8 +1284,7 @@ export function workflowEntrypoint(
                           // Any pending wait timer was already enqueued as part
                           // of the unified dispatch above, so we can return
                           // unconditionally here.
-                          const retryTraceCarrier =
-                            await getNextTraceCarrier();
+                          const retryTraceCarrier = await nextTraceCarrier();
                           await queueMessage(
                             world,
                             getWorkflowQueueName(workflowName, namespace),
@@ -1345,7 +1335,7 @@ export function workflowEntrypoint(
                             getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
-                              traceCarrier: await getNextTraceCarrier(),
+                              traceCarrier: await nextTraceCarrier(),
                               requestedAt: new Date(),
                             }
                           );
@@ -1379,7 +1369,7 @@ export function workflowEntrypoint(
                               getWorkflowQueueName(workflowName, namespace),
                               {
                                 runId,
-                                traceCarrier: await getNextTraceCarrier(),
+                                traceCarrier: await nextTraceCarrier(),
                                 requestedAt: new Date(),
                                 replayDivergence: {
                                   eventId: err.eventId,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,4 +1,5 @@
 import { types } from 'node:util';
+import type { Link } from '@opentelemetry/api';
 import {
   CorruptedEventLogError,
   EntityConflictError,
@@ -53,7 +54,9 @@ import { dehydrateRunError } from './serialization.js';
 import { remapErrorStack } from './source-map.js';
 import * as Attribute from './telemetry/semantic-conventions.js';
 import {
+  getWorkflowTraceMode,
   linkToCurrentContext,
+  linkToTraceCarrier,
   serializeTraceCarrier,
   trace,
   withTraceContext,
@@ -320,7 +323,47 @@ export function workflowEntrypoint(
           return;
         }
 
-        const spanLinks = await linkToCurrentContext();
+        // --- Trace correlation mode ---
+        // 'linked' (default): the WORKFLOW_V2 span below starts a NEW root
+        // trace, with span links to (a) the incoming delivery context and
+        // (b) the run-origin context from the message's trace carrier. This
+        // bounds each trace to a single invocation instead of stitching an
+        // entire (potentially hours-long) run into one giant trace.
+        // 'continuous': legacy behavior — the restored run-origin context
+        // becomes the parent of this invocation's spans.
+        const traceMode = getWorkflowTraceMode();
+
+        // Trace carrier to attach to messages this invocation enqueues. In
+        // linked mode the ORIGINAL run-origin carrier is forwarded unchanged
+        // so every future invocation links back to the same origin; in
+        // continuous mode the current (active) context is serialized so the
+        // trace keeps chaining.
+        const getNextTraceCarrier = (): Promise<Record<string, string>> =>
+          traceMode === 'linked' && traceContext
+            ? Promise.resolve(traceContext)
+            : serializeTraceCarrier();
+
+        // Link to the incoming delivery context (the active span extracted
+        // from the queue delivery request, i.e. the enqueue site once the
+        // queue propagates producer context).
+        const deliveryLinks = await linkToCurrentContext();
+        let spanLinks: Link[] | undefined = deliveryLinks;
+        if (traceMode === 'linked') {
+          // Additionally link to the run-origin context from the trace
+          // carrier (skipped when absent, invalid, or identical to the
+          // delivery context).
+          const originLink = await linkToTraceCarrier(traceContext);
+          if (
+            originLink &&
+            !deliveryLinks?.some(
+              (link) =>
+                link.context.traceId === originLink.context.traceId &&
+                link.context.spanId === originLink.context.spanId
+            )
+          ) {
+            spanLinks = [...(deliveryLinks ?? []), originLink];
+          }
+        }
 
         // --- Replay budget bookkeeping ---
         // The replay budget bounds the *non-step* portion of a single
@@ -348,14 +391,22 @@ export function workflowEntrypoint(
         // single step longer than the budget.
         const replayBudget = new ReplayBudget();
 
-        return await withTraceContext(traceContext, async () => {
+        // In linked mode the run-origin context is NOT restored as the
+        // active (parent) context — passing `undefined` makes
+        // withTraceContext a passthrough, and the WORKFLOW_V2 span below
+        // becomes a new trace root carrying span links instead.
+        const parentTraceCarrier =
+          traceMode === 'continuous' ? traceContext : undefined;
+        return await withTraceContext(parentTraceCarrier, async () => {
           return await withWorkflowBaggage(
             { workflowRunId: runId, workflowName },
             async () => {
               const world = await getWorld();
               return trace(
                 `WORKFLOW_V2 ${workflowName}`,
-                { links: spanLinks },
+                traceMode === 'linked'
+                  ? { root: true, links: spanLinks }
+                  : { links: spanLinks },
                 async (span) => {
                   span?.setAttributes({
                     ...Attribute.WorkflowName(workflowName),
@@ -367,6 +418,7 @@ export function workflowEntrypoint(
                     ...getQueueOverhead({ requestedAt }),
                     ...Attribute.WorkflowRunId(runId),
                     ...Attribute.WorkflowTracePropagated(!!traceContext),
+                    ...Attribute.WorkflowTraceMode(traceMode),
                   });
 
                   const invocationStartTime = Date.now();
@@ -440,7 +492,7 @@ export function workflowEntrypoint(
                           getWorkflowQueueName(workflowName, namespace),
                           {
                             runId,
-                            traceCarrier: await serializeTraceCarrier(),
+                            traceCarrier: await getNextTraceCarrier(),
                             requestedAt: new Date(),
                           }
                         );
@@ -702,7 +754,7 @@ export function workflowEntrypoint(
                         getWorkflowQueueName(workflowName, namespace),
                         {
                           runId,
-                          traceCarrier: await serializeTraceCarrier(),
+                          traceCarrier: await getNextTraceCarrier(),
                           requestedAt: new Date(),
                         }
                       );
@@ -1149,7 +1201,7 @@ export function workflowEntrypoint(
                         // suspension passes — see
                         // runtime/wait-continuation.ts for the full
                         // delay/key selection rationale.
-                        const traceCarrier = await serializeTraceCarrier();
+                        const traceCarrier = await getNextTraceCarrier();
                         const dispatches: Promise<unknown>[] = [];
                         for (const step of pendingSteps) {
                           if (
@@ -1239,7 +1291,7 @@ export function workflowEntrypoint(
                           // of the unified dispatch above, so we can return
                           // unconditionally here.
                           const retryTraceCarrier =
-                            await serializeTraceCarrier();
+                            await getNextTraceCarrier();
                           await queueMessage(
                             world,
                             getWorkflowQueueName(workflowName, namespace),
@@ -1290,7 +1342,7 @@ export function workflowEntrypoint(
                             getWorkflowQueueName(workflowName, namespace),
                             {
                               runId,
-                              traceCarrier: await serializeTraceCarrier(),
+                              traceCarrier: await getNextTraceCarrier(),
                               requestedAt: new Date(),
                             }
                           );
@@ -1324,7 +1376,7 @@ export function workflowEntrypoint(
                               getWorkflowQueueName(workflowName, namespace),
                               {
                                 runId,
-                                traceCarrier: await serializeTraceCarrier(),
+                                traceCarrier: await getNextTraceCarrier(),
                                 requestedAt: new Date(),
                                 replayDivergence: {
                                   eventId: err.eventId,

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -21,7 +21,7 @@ import {
 } from '../serialization.js';
 import { WEBHOOK_RESPONSE_WRITABLE } from '../symbols.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
-import { getSpanContextForTraceCarrier, trace } from '../telemetry.js';
+import { linkToTraceCarrier, trace } from '../telemetry.js';
 import { getWorldLazy } from './get-world-lazy.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { safeWaitUntil, waitedUntil } from './wait-until.js';
@@ -185,13 +185,13 @@ export async function resumeHook<T = any>(
           ...Attribute.WorkflowName(workflowRun.workflowName),
         });
 
-        const traceCarrier = workflowRun.executionContext?.traceCarrier;
-
-        if (traceCarrier) {
-          const context = await getSpanContextForTraceCarrier(traceCarrier);
-          if (context) {
-            span?.addLink?.({ context });
-          }
+        // Link to the run-origin context from the workflow run's stored
+        // trace carrier (skipped when absent or invalid).
+        const originLink = await linkToTraceCarrier(
+          workflowRun.executionContext?.traceCarrier
+        );
+        if (originLink) {
+          span?.addLink?.(originLink);
         }
 
         // Re-trigger the workflow against the deployment ID associated

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -4,6 +4,7 @@ import {
   WorkflowRuntimeError,
   WorkflowWorldError,
 } from '@workflow/errors';
+import { workflowDisplayName } from '@workflow/utils/parse-name';
 import type { WorkflowInvokePayload, World } from '@workflow/world';
 import {
   isLegacySpecVersion,
@@ -165,7 +166,8 @@ export async function start<TArgs extends unknown[], TResult>(
       );
     }
 
-    return trace(`workflow.start ${workflowName}`, async (span) => {
+    const spanName = `workflow.start ${workflowDisplayName(workflowName)}`;
+    return trace(spanName, async (span) => {
       span?.setAttributes({
         ...Attribute.WorkflowName(workflowName),
         ...Attribute.WorkflowOperation('start'),

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -8,7 +8,7 @@ import {
   TooEarlyError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
-import { pluralize } from '@workflow/utils';
+import { pluralize, stepDisplayName } from '@workflow/utils';
 import type { World } from '@workflow/world';
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import type { CryptoKey } from '../encryption.js';
@@ -80,7 +80,8 @@ export async function executeStep(
   } = params;
   const isVercel = process.env.VERCEL_URL !== undefined;
 
-  return trace(`STEP ${stepName}`, {}, async (span) => {
+  const spanName = `step.execute ${stepDisplayName(stepName)}`;
+  return trace(spanName, {}, async (span) => {
     span?.setAttributes({
       ...Attribute.StepName(stepName),
       ...Attribute.WorkflowName(workflowName),

--- a/packages/core/src/runtime/step-handler.test.ts
+++ b/packages/core/src/runtime/step-handler.test.ts
@@ -96,6 +96,12 @@ vi.mock('../telemetry.js', () => ({
   withTraceContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
   getSpanKind: vi.fn().mockResolvedValue(undefined),
   getWorkflowTraceMode: vi.fn(() => 'linked'),
+  isUsableTraceCarrier: vi.fn(
+    (carrier?: Record<string, string>) =>
+      carrier !== undefined && Object.keys(carrier).length > 0
+  ),
+  getNextTraceCarrier: vi.fn().mockResolvedValue({}),
+  buildInvocationSpanLinks: vi.fn().mockResolvedValue([]),
   linkToCurrentContext: vi.fn().mockResolvedValue([]),
   linkToTraceCarrier: vi.fn().mockResolvedValue(undefined),
   withWorkflowBaggage: vi.fn((_attrs: unknown, fn: () => unknown) => fn()),

--- a/packages/core/src/runtime/step-handler.test.ts
+++ b/packages/core/src/runtime/step-handler.test.ts
@@ -95,7 +95,9 @@ vi.mock('../telemetry.js', () => ({
   }),
   withTraceContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
   getSpanKind: vi.fn().mockResolvedValue(undefined),
+  getWorkflowTraceMode: vi.fn(() => 'linked'),
   linkToCurrentContext: vi.fn().mockResolvedValue([]),
+  linkToTraceCarrier: vi.fn().mockResolvedValue(undefined),
   withWorkflowBaggage: vi.fn((_attrs: unknown, fn: () => unknown) => fn()),
 }));
 

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -1,3 +1,4 @@
+import type { Link } from '@opentelemetry/api';
 import {
   EntityConflictError,
   FatalError,
@@ -32,7 +33,9 @@ import { contextStorage } from '../step/context-storage.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import {
   getSpanKind,
+  getWorkflowTraceMode,
   linkToCurrentContext,
+  linkToTraceCarrier,
   serializeTraceCarrier,
   trace,
   withTraceContext,
@@ -89,6 +92,23 @@ function createStepHandler(namespace?: string) {
       } = StepInvokePayloadSchema.parse(message_);
       const { requestId } = metadata;
 
+      // --- Trace correlation mode ---
+      // 'linked' (default): the STEP span below starts a NEW root trace with
+      // span links to the delivery context and the run-origin context from
+      // the message's trace carrier. 'continuous': legacy behavior — the
+      // restored run-origin context parents this invocation's spans.
+      const traceMode = getWorkflowTraceMode();
+
+      // Trace carrier to attach to messages this invocation enqueues. In
+      // linked mode the ORIGINAL run-origin carrier is forwarded unchanged
+      // so every future invocation links back to the same origin; in
+      // continuous mode the current (active) context is serialized so the
+      // trace keeps chaining.
+      const getNextTraceCarrier = (): Promise<Record<string, string>> =>
+        traceMode === 'linked' && traceContext
+          ? Promise.resolve(traceContext)
+          : serializeTraceCarrier();
+
       // --- Max delivery check ---
       // Enforce max delivery limit before any infrastructure calls.
       // This prevents runaway steps from consuming infinite queue deliveries.
@@ -141,7 +161,7 @@ function createStepHandler(namespace?: string) {
             getWorkflowQueueName(workflowName, resolvedNamespace),
             {
               runId: workflowRunId,
-              traceCarrier: await serializeTraceCarrier(),
+              traceCarrier: await getNextTraceCarrier(),
               requestedAt: new Date(),
             }
           );
@@ -168,9 +188,33 @@ function createStepHandler(namespace?: string) {
         return;
       }
 
-      const spanLinks = await linkToCurrentContext();
-      // Execute step within the propagated trace context
-      return await withTraceContext(traceContext, async () => {
+      // Link to the incoming delivery context (the active span extracted
+      // from the queue delivery request).
+      const deliveryLinks = await linkToCurrentContext();
+      let spanLinks: Link[] | undefined = deliveryLinks;
+      if (traceMode === 'linked') {
+        // Additionally link to the run-origin context from the trace
+        // carrier (skipped when absent, invalid, or identical to the
+        // delivery context).
+        const originLink = await linkToTraceCarrier(traceContext);
+        if (
+          originLink &&
+          !deliveryLinks?.some(
+            (link) =>
+              link.context.traceId === originLink.context.traceId &&
+              link.context.spanId === originLink.context.spanId
+          )
+        ) {
+          spanLinks = [...(deliveryLinks ?? []), originLink];
+        }
+      }
+
+      // Execute step within the propagated trace context (continuous mode
+      // only — in linked mode the STEP span below becomes a new trace root
+      // carrying span links instead, so withTraceContext is a passthrough).
+      const parentTraceCarrier =
+        traceMode === 'continuous' ? traceContext : undefined;
+      return await withTraceContext(parentTraceCarrier, async () => {
         // Extract the step name from the topic name
         const stepName = metadata.queueName.slice(stepPrefix.length);
         const world = await getWorld();
@@ -193,7 +237,9 @@ function createStepHandler(namespace?: string) {
 
         return trace(
           `STEP ${stepName}`,
-          { kind: spanKind, links: spanLinks },
+          traceMode === 'linked'
+            ? { kind: spanKind, links: spanLinks, root: true }
+            : { kind: spanKind, links: spanLinks },
           async (span) => {
             span?.setAttributes({
               ...Attribute.StepName(stepName),
@@ -216,6 +262,7 @@ function createStepHandler(namespace?: string) {
               ...Attribute.WorkflowRunId(workflowRunId),
               ...Attribute.StepId(stepId),
               ...Attribute.StepTracePropagated(!!traceContext),
+              ...Attribute.WorkflowTraceMode(traceMode),
             });
 
             // step_started validates state and returns the step entity, so no separate
@@ -289,7 +336,7 @@ function createStepHandler(namespace?: string) {
                   getWorkflowQueueName(workflowName, resolvedNamespace),
                   {
                     runId: workflowRunId,
-                    traceCarrier: await serializeTraceCarrier(),
+                    traceCarrier: await getNextTraceCarrier(),
                     requestedAt: new Date(),
                   }
                 );
@@ -393,7 +440,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await serializeTraceCarrier(),
+                  traceCarrier: await getNextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -493,7 +540,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await serializeTraceCarrier(),
+                  traceCarrier: await getNextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -545,7 +592,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await serializeTraceCarrier(),
+                  traceCarrier: await getNextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -988,7 +1035,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await serializeTraceCarrier(),
+                  traceCarrier: await getNextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -1049,7 +1096,7 @@ function createStepHandler(namespace?: string) {
                   }
                   throw err;
                 }),
-              serializeTraceCarrier(),
+              getNextTraceCarrier(),
             ]);
 
             if (stepCompleted409) {

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -10,7 +10,7 @@ import {
   WorkflowRuntimeError,
   WorkflowWorldError,
 } from '@workflow/errors';
-import { formatStepName, pluralize } from '@workflow/utils';
+import { formatStepName, pluralize, stepDisplayName } from '@workflow/utils';
 import { getPort } from '@workflow/utils/get-port';
 import {
   getQueueTopicPrefix,
@@ -236,7 +236,7 @@ function createStepHandler(namespace?: string) {
         ]);
 
         return trace(
-          `STEP ${stepName}`,
+          `step.execute ${stepDisplayName(stepName)}`,
           traceMode === 'linked'
             ? { kind: spanKind, links: spanLinks, root: true }
             : { kind: spanKind, links: spanLinks },

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -1,4 +1,3 @@
-import type { Link } from '@opentelemetry/api';
 import {
   EntityConflictError,
   FatalError,
@@ -32,11 +31,11 @@ import {
 import { contextStorage } from '../step/context-storage.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import {
+  buildInvocationSpanLinks,
+  getNextTraceCarrier,
   getSpanKind,
   getWorkflowTraceMode,
-  linkToCurrentContext,
-  linkToTraceCarrier,
-  serializeTraceCarrier,
+  isUsableTraceCarrier,
   trace,
   withTraceContext,
 } from '../telemetry.js';
@@ -87,10 +86,17 @@ function createStepHandler(namespace?: string) {
         workflowRunId,
         workflowStartedAt,
         stepId,
-        traceCarrier: traceContext,
+        traceCarrier: incomingTraceCarrier,
         requestedAt,
       } = StepInvokePayloadSchema.parse(message_);
       const { requestId } = metadata;
+      // serializeTraceCarrier() returns `{}` when no OTEL SDK is registered
+      // or no span is active — treat an empty carrier the same as an absent
+      // one so linked mode falls back to a fresh origin instead of
+      // forwarding a useless `{}` forever.
+      const traceContext = isUsableTraceCarrier(incomingTraceCarrier)
+        ? incomingTraceCarrier
+        : undefined;
 
       // --- Trace correlation mode ---
       // 'linked' (default): the STEP span below starts a NEW root trace with
@@ -99,15 +105,10 @@ function createStepHandler(namespace?: string) {
       // restored run-origin context parents this invocation's spans.
       const traceMode = getWorkflowTraceMode();
 
-      // Trace carrier to attach to messages this invocation enqueues. In
-      // linked mode the ORIGINAL run-origin carrier is forwarded unchanged
-      // so every future invocation links back to the same origin; in
-      // continuous mode the current (active) context is serialized so the
-      // trace keeps chaining.
-      const getNextTraceCarrier = (): Promise<Record<string, string>> =>
-        traceMode === 'linked' && traceContext
-          ? Promise.resolve(traceContext)
-          : serializeTraceCarrier();
+      // Trace carrier to attach to messages this invocation enqueues — see
+      // getNextTraceCarrier for the linked/continuous semantics.
+      const nextTraceCarrier = (): Promise<Record<string, string>> =>
+        getNextTraceCarrier(traceMode, traceContext);
 
       // --- Max delivery check ---
       // Enforce max delivery limit before any infrastructure calls.
@@ -161,7 +162,7 @@ function createStepHandler(namespace?: string) {
             getWorkflowQueueName(workflowName, resolvedNamespace),
             {
               runId: workflowRunId,
-              traceCarrier: await getNextTraceCarrier(),
+              traceCarrier: await nextTraceCarrier(),
               requestedAt: new Date(),
             }
           );
@@ -188,26 +189,9 @@ function createStepHandler(namespace?: string) {
         return;
       }
 
-      // Link to the incoming delivery context (the active span extracted
-      // from the queue delivery request).
-      const deliveryLinks = await linkToCurrentContext();
-      let spanLinks: Link[] | undefined = deliveryLinks;
-      if (traceMode === 'linked') {
-        // Additionally link to the run-origin context from the trace
-        // carrier (skipped when absent, invalid, or identical to the
-        // delivery context).
-        const originLink = await linkToTraceCarrier(traceContext);
-        if (
-          originLink &&
-          !deliveryLinks?.some(
-            (link) =>
-              link.context.traceId === originLink.context.traceId &&
-              link.context.spanId === originLink.context.spanId
-          )
-        ) {
-          spanLinks = [...(deliveryLinks ?? []), originLink];
-        }
-      }
+      // Span links to the incoming delivery context and (in linked mode)
+      // the run-origin context from the trace carrier.
+      const spanLinks = await buildInvocationSpanLinks(traceMode, traceContext);
 
       // Execute step within the propagated trace context (continuous mode
       // only — in linked mode the STEP span below becomes a new trace root
@@ -336,7 +320,7 @@ function createStepHandler(namespace?: string) {
                   getWorkflowQueueName(workflowName, resolvedNamespace),
                   {
                     runId: workflowRunId,
-                    traceCarrier: await getNextTraceCarrier(),
+                    traceCarrier: await nextTraceCarrier(),
                     requestedAt: new Date(),
                   }
                 );
@@ -440,7 +424,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await getNextTraceCarrier(),
+                  traceCarrier: await nextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -540,7 +524,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await getNextTraceCarrier(),
+                  traceCarrier: await nextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -592,7 +576,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await getNextTraceCarrier(),
+                  traceCarrier: await nextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -1035,7 +1019,7 @@ function createStepHandler(namespace?: string) {
                 getWorkflowQueueName(workflowName, resolvedNamespace),
                 {
                   runId: workflowRunId,
-                  traceCarrier: await getNextTraceCarrier(),
+                  traceCarrier: await nextTraceCarrier(),
                   requestedAt: new Date(),
                 }
               );
@@ -1096,7 +1080,7 @@ function createStepHandler(namespace?: string) {
                   }
                   throw err;
                 }),
-              getNextTraceCarrier(),
+              nextTraceCarrier(),
             ]);
 
             if (stepCompleted409) {

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -23,14 +23,89 @@ import * as Attr from './telemetry/semantic-conventions.js';
  */
 export type WorkflowTraceMode = 'linked' | 'continuous';
 
+/** Unrecognized `WORKFLOW_TRACE_MODE` values we already warned about. */
+const warnedUnrecognizedTraceModes = new Set<string>();
+
 /**
  * Resolves the active trace mode from the `WORKFLOW_TRACE_MODE` env var.
  * Defaults to `'linked'`; any value other than `'continuous'` selects it.
+ * Unrecognized non-empty values (e.g. typos like `continous`) emit a
+ * one-time warning so silent fallback to `linked` is at least visible.
  */
 export function getWorkflowTraceMode(): WorkflowTraceMode {
-  return process.env.WORKFLOW_TRACE_MODE === 'continuous'
-    ? 'continuous'
-    : 'linked';
+  const value = process.env.WORKFLOW_TRACE_MODE;
+  if (value === 'continuous') return 'continuous';
+  if (value && value !== 'linked' && !warnedUnrecognizedTraceModes.has(value)) {
+    warnedUnrecognizedTraceModes.add(value);
+    runtimeLogger.warn(
+      `Unrecognized WORKFLOW_TRACE_MODE value "${value}"; expected "linked" or "continuous". Falling back to "linked".`
+    );
+  }
+  return 'linked';
+}
+
+/**
+ * Returns whether a serialized trace carrier is usable, i.e. present and
+ * non-empty. `serializeTraceCarrier()` returns `{}` when no OTEL SDK is
+ * registered or no span is active, and `start()` always attaches the
+ * carrier to the first queue message — so an empty carrier must be treated
+ * the same as an absent one wherever the trace-mode logic branches.
+ */
+export function isUsableTraceCarrier(
+  carrier: Record<string, string> | undefined
+): carrier is Record<string, string> {
+  return carrier !== undefined && Object.keys(carrier).length > 0;
+}
+
+/**
+ * Returns the trace carrier to attach to messages the current invocation
+ * enqueues. In `linked` mode the ORIGINAL run-origin carrier is forwarded
+ * unchanged (when usable) so every future invocation links back to the same
+ * origin; otherwise — `continuous` mode, or no usable incoming carrier —
+ * the current (active) context is serialized, so the trace keeps chaining
+ * (continuous) or the first instrumented invocation becomes the de-facto
+ * origin (linked).
+ */
+export function getNextTraceCarrier(
+  traceMode: WorkflowTraceMode,
+  incomingCarrier: Record<string, string> | undefined
+): Promise<Record<string, string>> {
+  return traceMode === 'linked' && isUsableTraceCarrier(incomingCarrier)
+    ? Promise.resolve(incomingCarrier)
+    : serializeTraceCarrier();
+}
+
+/**
+ * Builds the span links for a queue-delivered invocation span
+ * (`workflow.execute` / `step.execute`):
+ *
+ * - a link to the incoming delivery context (the active span extracted from
+ *   the queue delivery request, i.e. the enqueue site once the queue
+ *   propagates producer context), and
+ * - in `linked` mode, a link to the run-origin context from the message's
+ *   trace carrier (skipped when absent, empty, invalid, or identical to the
+ *   delivery context).
+ */
+export async function buildInvocationSpanLinks(
+  traceMode: WorkflowTraceMode,
+  incomingCarrier: Record<string, string> | undefined
+): Promise<api.Link[] | undefined> {
+  const deliveryLinks = await linkToCurrentContext();
+  if (traceMode !== 'linked') return deliveryLinks;
+  const originLink = await linkToTraceCarrier(
+    isUsableTraceCarrier(incomingCarrier) ? incomingCarrier : undefined
+  );
+  if (
+    !originLink ||
+    deliveryLinks?.some(
+      (link) =>
+        link.context.traceId === originLink.context.traceId &&
+        link.context.spanId === originLink.context.spanId
+    )
+  ) {
+    return deliveryLinks;
+  }
+  return [...(deliveryLinks ?? []), originLink];
 }
 
 /**

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -10,6 +10,30 @@ import * as Attr from './telemetry/semantic-conventions.js';
 // ============================================================
 
 /**
+ * Controls how workflow/step queue-handler spans relate to the run-origin
+ * trace context carried in queue messages:
+ *
+ * - `'linked'` (default): each invocation starts a NEW root trace; the
+ *   run-origin context (and the incoming delivery context) are attached as
+ *   span links. This keeps traces bounded per invocation instead of
+ *   stitching a long-lived run into one giant trace.
+ * - `'continuous'`: the restored run-origin context becomes the parent of
+ *   the invocation span (legacy behavior), producing a single trace that
+ *   spans the entire run.
+ */
+export type WorkflowTraceMode = 'linked' | 'continuous';
+
+/**
+ * Resolves the active trace mode from the `WORKFLOW_TRACE_MODE` env var.
+ * Defaults to `'linked'`; any value other than `'continuous'` selects it.
+ */
+export function getWorkflowTraceMode(): WorkflowTraceMode {
+  return process.env.WORKFLOW_TRACE_MODE === 'continuous'
+    ? 'continuous'
+    : 'linked';
+}
+
+/**
  * Serializes the current trace context into a format that can be passed through queues
  * @returns A record of strings representing the trace context
  */
@@ -187,6 +211,25 @@ export function linkToCurrentContext(): Promise<[api.Link] | undefined> {
     if (!context) return;
     return [{ context }];
   });
+}
+
+/**
+ * Builds a span link pointing at the span context embedded in a serialized
+ * trace carrier (e.g. the run-origin context flowing through queue
+ * messages). Returns `undefined` when OTEL is unavailable, the carrier is
+ * absent, or it does not contain a valid span context.
+ */
+export async function linkToTraceCarrier(
+  carrier: Record<string, string> | undefined
+): Promise<api.Link | undefined> {
+  if (!carrier) return;
+  const [context, otel] = await Promise.all([
+    getSpanContextForTraceCarrier(carrier),
+    OtelApi.value,
+  ]);
+  if (!context || !otel) return;
+  if (!otel.trace.isSpanContextValid(context)) return;
+  return { context };
 }
 
 // ============================================================

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -92,6 +92,11 @@ export const WorkflowTracePropagated = SemanticConvention<boolean>(
   'workflow.trace.propagated'
 );
 
+/** Active trace-correlation mode for this invocation (linked or continuous) */
+export const WorkflowTraceMode = SemanticConvention<'linked' | 'continuous'>(
+  'workflow.trace.mode'
+);
+
 /** Name of the error that caused workflow failure */
 export const WorkflowErrorName = SemanticConvention<string>(
   'workflow.error.name'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -5,6 +5,8 @@ export {
   parseClassName,
   parseStepName,
   parseWorkflowName,
+  stepDisplayName,
+  workflowDisplayName,
 } from './parse-name.js';
 export { once, type PromiseWithResolvers, withResolvers } from './promise.js';
 export { parseDurationToDate } from './time.js';

--- a/packages/utils/src/parse-name.test.ts
+++ b/packages/utils/src/parse-name.test.ts
@@ -5,6 +5,8 @@ import {
   parseClassName,
   parseStepName,
   parseWorkflowName,
+  stepDisplayName,
+  workflowDisplayName,
 } from './parse-name';
 
 describe('parseWorkflowName', () => {
@@ -257,6 +259,47 @@ describe('formatStepName / formatWorkflowName', () => {
     expect(formatStepName('something-weird')).toBe('something-weird');
     expect(formatWorkflowName('step//wrong-tag//fn')).toBe(
       'step//wrong-tag//fn'
+    );
+  });
+});
+
+describe('workflowDisplayName / stepDisplayName', () => {
+  test('returns the short name for raw machine names', () => {
+    expect(
+      workflowDisplayName('workflow//./src/jobs/order//processOrder')
+    ).toBe('processOrder');
+    expect(stepDisplayName('step//./src/jobs/order//chargeCard')).toBe(
+      'chargeCard'
+    );
+  });
+
+  test('returns the short name for module-specifier names', () => {
+    expect(workflowDisplayName('workflow//@myorg/shared@1.2.3//sync')).toBe(
+      'sync'
+    );
+  });
+
+  test('recovers the function name from queue-sanitized names', () => {
+    // `workflow//./src/jobs/order//processOrder` after the queue's
+    // `replace(/[^A-Za-z0-9-_]/g, '-')` sanitization:
+    expect(
+      workflowDisplayName('workflow----src-jobs-order--processOrder')
+    ).toBe('processOrder');
+    expect(stepDisplayName('step----src-jobs-order--chargeCard')).toBe(
+      'chargeCard'
+    );
+  });
+
+  test('sanitized nested functions use the leaf name', () => {
+    expect(
+      stepDisplayName('step----src-jobs-order--processOrder-innerStep')
+    ).toBe('innerStep');
+  });
+
+  test('falls back to the input when unrecognized', () => {
+    expect(workflowDisplayName('my-plain-name')).toBe('my-plain-name');
+    expect(stepDisplayName('workflow--wrong-tag--fn')).toBe(
+      'workflow--wrong-tag--fn'
     );
   });
 });

--- a/packages/utils/src/parse-name.test.ts
+++ b/packages/utils/src/parse-name.test.ts
@@ -296,6 +296,30 @@ describe('workflowDisplayName / stepDisplayName', () => {
     ).toBe('innerStep');
   });
 
+  test('sanitized default exports map to the module short name', () => {
+    // `workflow//./src/jobs/order//default` after sanitization — mirror
+    // parseName's default-export handling so the same workflow doesn't
+    // display as `order` in workflow.start but `default` in
+    // workflow.execute.
+    expect(workflowDisplayName('workflow----src-jobs-order--default')).toBe(
+      'order'
+    );
+    expect(stepDisplayName('step----src-jobs-order--default')).toBe('order');
+    // `__default` survives sanitization (underscores are preserved).
+    expect(workflowDisplayName('workflow----src-jobs-order--__default')).toBe(
+      'order'
+    );
+  });
+
+  test('sanitized names with `$` degrade to the trailing segment (best effort)', () => {
+    // `$` is a valid JS identifier character but sanitizes to `-`, so
+    // `process$Order` is indistinguishable from a nested function — the
+    // best-effort recovery returns just `Order`. Accepted limitation.
+    expect(stepDisplayName('step----src-jobs-order--process-Order')).toBe(
+      'Order'
+    );
+  });
+
   test('falls back to the input when unrecognized', () => {
     expect(workflowDisplayName('my-plain-name')).toBe('my-plain-name');
     expect(stepDisplayName('workflow--wrong-tag--fn')).toBe(

--- a/packages/utils/src/parse-name.ts
+++ b/packages/utils/src/parse-name.ts
@@ -134,10 +134,24 @@ export function stepDisplayName(name: string): string {
 function shortNameFromSanitized(tag: string, name: string): string | null {
   if (!name.startsWith(`${tag}--`)) return null;
   // The `//` separators became `--`, and within the function-name part any
-  // nested-function `/` became `-`. Function names are JS identifiers (no
-  // dashes), so the innermost name is the last dash-free segment.
-  const functionPart = name.split('--').filter(Boolean).at(-1);
-  const shortName = functionPart?.split('-').filter(Boolean).at(-1);
+  // nested-function `/` became `-`. Function names are mostly dash-free, so
+  // the innermost name is the last dash-free segment. This is best-effort:
+  // `$` is a valid JS identifier character but is also sanitized to `-`, so
+  // a name like `process$Order` displays as `Order` — accepted limitation.
+  const segments = name.split('--').filter(Boolean);
+  const functionPart = segments.at(-1);
+  let shortName = functionPart?.split('-').filter(Boolean).at(-1) ?? '';
+  // Mirror parseName's default-export handling: display default exports as
+  // the module's short name (the module part is the second-to-last `--`
+  // segment; its last `-` segment is the module short name), so the same
+  // workflow doesn't render as e.g. `order` from the raw name but
+  // `default` from the sanitized name.
+  if (['default', '__default'].includes(shortName)) {
+    const moduleShortName = segments.at(-2)?.split('-').filter(Boolean).at(-1);
+    if (moduleShortName && moduleShortName !== tag) {
+      shortName = moduleShortName;
+    }
+  }
   return shortName || null;
 }
 

--- a/packages/utils/src/parse-name.ts
+++ b/packages/utils/src/parse-name.ts
@@ -106,6 +106,41 @@ export function formatWorkflowName(name: string): string {
   return formatParsedName(parseWorkflowName(name), name);
 }
 
+/**
+ * Best-effort short display name for spans and UI labels. Accepts either the
+ * raw machine name (`workflow//./src/jobs/order//processOrder`) or the
+ * queue-sanitized form (`workflow----src-jobs-order--processOrder`, where
+ * every non-alphanumeric character was replaced with `-`) and returns just
+ * the function name (`processOrder`). Falls back to the input unchanged when
+ * neither form is recognized.
+ */
+export function workflowDisplayName(name: string): string {
+  return (
+    parseWorkflowName(name)?.shortName ??
+    shortNameFromSanitized('workflow', name) ??
+    name
+  );
+}
+
+/** See {@link workflowDisplayName} — the step-name equivalent. */
+export function stepDisplayName(name: string): string {
+  return (
+    parseStepName(name)?.shortName ??
+    shortNameFromSanitized('step', name) ??
+    name
+  );
+}
+
+function shortNameFromSanitized(tag: string, name: string): string | null {
+  if (!name.startsWith(`${tag}--`)) return null;
+  // The `//` separators became `--`, and within the function-name part any
+  // nested-function `/` became `-`. Function names are JS identifiers (no
+  // dashes), so the innermost name is the last dash-free segment.
+  const functionPart = name.split('--').filter(Boolean).at(-1);
+  const shortName = functionPart?.split('-').filter(Boolean).at(-1);
+  return shortName || null;
+}
+
 function formatParsedName(
   parsed: {
     shortName: string;

--- a/packages/world-vercel/package.json
+++ b/packages/world-vercel/package.json
@@ -52,6 +52,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-async-hooks": "1.30.1",
+    "@opentelemetry/core": "1.30.1",
+    "@opentelemetry/sdk-trace-base": "1.30.1",
     "@types/node": "catalog:",
     "@workflow/tsconfig": "workspace:*",
     "genversion": "3.2.0",

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -87,6 +87,27 @@ export async function getSpanKind(
   return otel.SpanKind[field];
 }
 
+/**
+ * Injects the active trace context into the given request headers using the
+ * registered propagator (typically W3C `traceparent`/`tracestate` plus
+ * `baggage`). Call inside an active client span so the receiving server can
+ * parent its spans to it.
+ *
+ * No-ops when `@opentelemetry/api` is unavailable or no SDK/propagator is
+ * registered (the default no-op propagator injects nothing).
+ */
+export async function injectTraceContextIntoHeaders(
+  headers: Headers
+): Promise<void> {
+  const otel = await getOtelApi();
+  if (!otel) return;
+  const carrier: Record<string, string> = {};
+  otel.propagation.inject(otel.context.active(), carrier);
+  for (const [key, value] of Object.entries(carrier)) {
+    headers.set(key, value);
+  }
+}
+
 // Semantic conventions for World/Storage tracing
 // Standard OTEL conventions: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 function SemanticConvention<T>(...names: string[]) {

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -1,0 +1,115 @@
+import { context, trace as otelTrace, propagation } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { encode } from 'cbor-x';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { z } from 'zod';
+import { injectTraceContextIntoHeaders } from './telemetry.js';
+import { makeRequest } from './utils.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn().mockRejectedValue(new Error('no OIDC')),
+}));
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+const contextManager = new AsyncLocalStorageContextManager();
+
+beforeAll(() => {
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+  otelTrace.setGlobalTracerProvider(provider);
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  context.disable();
+  propagation.disable();
+  otelTrace.disable();
+});
+
+afterEach(() => {
+  exporter.reset();
+  vi.unstubAllGlobals();
+});
+
+/** Minimal 2xx CBOR response, mirroring utils.test.ts. */
+function cborResponse(data: unknown) {
+  const bytes = encode(data);
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      get: (k: string) =>
+        k.toLowerCase() === 'content-type' ? 'application/cbor' : null,
+    },
+    arrayBuffer: async () =>
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  };
+}
+
+describe('injectTraceContextIntoHeaders', () => {
+  it('injects traceparent for the active span', async () => {
+    const tracer = otelTrace.getTracer('test');
+    await tracer.startActiveSpan('client', async (span) => {
+      const headers = new Headers();
+      await injectTraceContextIntoHeaders(headers);
+      expect(headers.get('traceparent')).toBe(
+        `00-${span.spanContext().traceId}-${span.spanContext().spanId}-01`
+      );
+      span.end();
+    });
+  });
+
+  it('is a no-op when there is no active span context', async () => {
+    const headers = new Headers();
+    await injectTraceContextIntoHeaders(headers);
+    expect(headers.get('traceparent')).toBeNull();
+  });
+});
+
+describe('makeRequest trace propagation', () => {
+  const schema = z.object({ value: z.string() });
+
+  it('sends traceparent on the outgoing workflow-server request, parented to the client span', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(cborResponse({ value: 'ok' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await makeRequest({
+      endpoint: '/v3/runs/wrun_test/events',
+      options: { method: 'GET' },
+      schema,
+    });
+    expect(result).toEqual({ value: 'ok' });
+
+    const request = fetchMock.mock.calls[0][0] as Request;
+    const traceparent = request.headers.get('traceparent');
+    expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    // The injected context must be the `http GET` CLIENT span created by
+    // makeRequest, so the server's spans become its children.
+    const clientSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'http GET');
+    expect(clientSpan).toBeDefined();
+    expect(traceparent).toBe(
+      `00-${clientSpan?.spanContext().traceId}-${clientSpan?.spanContext().spanId}-01`
+    );
+  });
+});

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -18,6 +18,7 @@ import {
   getSpanKind,
   HttpRequestMethod,
   HttpResponseStatusCode,
+  injectTraceContextIntoHeaders,
   PeerService,
   RpcService,
   RpcSystem,
@@ -331,6 +332,13 @@ export async function makeRequest<T>({
       });
 
       headers.set('Accept', 'application/cbor');
+
+      // Explicitly propagate the active trace context (traceparent /
+      // tracestate / baggage) onto the outgoing request so workflow-server
+      // can parent its spans to this client span — without relying on the
+      // customer app having undici auto-instrumentation. No-ops when no
+      // OTEL SDK is registered.
+      await injectTraceContextIntoHeaders(headers);
 
       // Encode body as CBOR if data is provided
       let body: Buffer | undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,15 @@ importers:
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
+      '@opentelemetry/context-async-hooks':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
@@ -1507,6 +1516,15 @@ importers:
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
+      '@opentelemetry/context-async-hooks':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.0
@@ -5024,6 +5042,12 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/core@1.30.1':
     resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
@@ -21178,6 +21202,10 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
 
   '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:


### PR DESCRIPTION
## Problem: mega-traces

Today the workflow queue handlers restore the run-origin trace context from the message's `traceCarrier` and make it the **parent** of every `WORKFLOW_V2` / `STEP` invocation span. Since each invocation re-serializes its own context onto the next queue message, a single workflow run becomes **one giant trace** — spanning hours of sleeps/retries and dozens of stitched-together function invocations. These mega-traces are slow to load, hard to read, and frequently broken in Datadog (span limits, late-arriving spans, partial flushes).

Separately, the `world-vercel` HTTP client creates a CLIENT span for every workflow-server request but never injects `traceparent` into the outgoing headers — propagation only happened if the customer's app happened to have undici auto-instrumentation, so workflow-server spans usually couldn't join the caller's trace.

## Linked-trace mode (new default)

This PR introduces `WORKFLOW_TRACE_MODE` with two values:

- **`linked` (new default):** each invocation's `WORKFLOW_V2 <name>` / `STEP <name>` span is created as a **new trace root** (`SpanOptions.root: true`) with **span links** to:
  - the incoming **delivery context** (the active span extracted from the queue delivery request — once the platform re-injects producer context on deliveries, this points at the enqueue site), and
  - the **run-origin context** from the message's `traceCarrier` (skipped when absent/invalid or identical to the delivery link).

  Re-enqueued messages forward the **original** run-origin `traceCarrier` unchanged, so every future invocation of the run links back to the same origin. Traces stay small and bounded per invocation, while links preserve full run-level correlation.

- **`continuous`:** exactly the previous behavior — restored run-origin context parents the invocation span, with a link to the delivery context, and re-enqueues serialize the current context. Set `WORKFLOW_TRACE_MODE=continuous` to opt back in.

Both modes keep `withWorkflowBaggage` wrapping, all existing span attributes (including `workflow.trace.propagated`), and add a new `workflow.trace.mode` attribute recording the active mode.

## Explicit traceparent injection on workflow-server calls

`world-vercel`'s `makeRequest` now injects W3C context (`traceparent`, `tracestate`, `baggage`) into the outgoing request headers from **inside** the `http <method>` CLIENT span, via a new `injectTraceContextIntoHeaders(headers)` helper in `world-vercel`'s lazy telemetry module. workflow-server can now reliably parent its spans to the SDK's client span regardless of the customer's instrumentation setup.

Queue sends (`@vercel/queue`) are intentionally untouched here — VQS treats message `headers` as allowlisted custom headers; HTTP-layer injection for queue sends is handled in the `@vercel/queue` client itself.

## Behavioral changes to telemetry (please read)

The API is backward compatible, but the new `linked` default changes the *shape* of emitted traces in ways existing dashboards and queries can feel. Set `WORKFLOW_TRACE_MODE=continuous` to restore the previous shape exactly.

1. **A run no longer shares one trace ID.** Previously, the trace of the request that called `start()` contained the entire workflow execution — every `WORKFLOW_V2`/`STEP` span across all invocations carried the run-origin trace ID. Now each invocation is its own root trace. Anything keyed on a shared per-run trace ID (saved trace queries, "open my request's trace and see the run" debugging flows, trace-ID joins) must switch to span links or the `workflow.run.id` attribute.
2. **Sampling semantics change.** Parent-based samplers previously made one decision at `start()` that covered the whole run consistently. Each invocation root now samples independently — ratio samplers will produce partially-sampled runs, and the number of root spans/traces increases to one per invocation (relevant for trace-volume-based vendor billing and rate-limiting samplers).
3. **Parent/child topology changes.** `WORKFLOW_V2`/`STEP` spans had a remote parent; they are now parentless roots. Queries filtering on parent relationships and service-map edges from the calling service to the workflow handler will change.
4. **Re-enqueue `traceCarrier` semantics change.** Queue messages now forward the *original run-origin* carrier unchanged, rather than each invocation's current context. Custom worlds or tooling that introspect message carriers and assume "carrier = most recent invocation context" will observe different values.

Not changed: all existing span attributes and baggage keys, and the no-OTEL no-op behavior. One footnote: app-set baggage entries now also leave the process as a `baggage` HTTP request header on backend calls (they already left via `traceCarrier` in events).

## Friendlier span names

Workflow/step span names previously used uppercase prefixes with full machine names (`WORKFLOW_V2 workflow//./src/jobs/order//processOrder`). They are now short and lowercase: `workflow.execute processOrder`, `step.execute chargeCard`, `workflow.start processOrder`. New `workflowDisplayName`/`stepDisplayName` helpers in `@workflow/utils` resolve both the raw machine name and the queue-sanitized form (`workflow----src-jobs-order--processOrder`) seen by queue handlers; unrecognized formats fall back to the raw string. The full machine name remains available in the `workflow.name` / `step.name` span attributes. This is also a span-name change for anyone querying `WORKFLOW_V2`/`STEP` names — same v5-beta reasoning as above.

## Backward compatibility

- **No OTEL registered:** everything no-ops exactly as before — `@opentelemetry/api` stays an optional peer dep, the default no-op propagator injects nothing, and no headers are added.
- **`WORKFLOW_TRACE_MODE=continuous`** restores the prior trace shape bit-for-bit (parenting, links, and carrier chaining).
- **Servers ignore the new headers harmlessly:** `traceparent`/`tracestate`/`baggage` are standard W3C headers; receivers without tracing simply drop them.

## Testing

- `packages/core/src/runtime-trace-mode.test.ts`: default is linked; linked creates a root span with links to both delivery + run-origin contexts; continuous preserves the legacy parented shape; linked forwards the original `traceCarrier` on re-enqueues while continuous serializes the current context. Uses a real in-memory OTEL SDK (`BasicTracerProvider` + `InMemorySpanExporter` + W3C propagator).
- `packages/world-vercel/src/trace-propagation.test.ts`: `traceparent` lands on the outgoing request and matches the `http GET` client span; clean no-op without an active span context.
- `pnpm build`, `pnpm typecheck`, full unit suites for `packages/core` (1124 passed) and `packages/world-vercel` (134 passed), Biome format/lint clean.

## Backport policy

**Do not backport to `stable` (v4).** The `linked` default is a deliberate telemetry-shape change scoped to the v5 beta major — backporting it would change trace topology, per-run trace IDs, and sampling behavior for GA v4 users mid-major. v4 keeps its current behavior until users upgrade to v5; the platform side is fully tolerant of v4 SDKs.

## Documentation

Adds `docs/content/docs/v5/observability/tracing.mdx` (linked from the Observability index): enabling OTEL, emitted spans and attributes, linked trace mode and span links, `WORKFLOW_TRACE_MODE` reference with a v4 behavior-change callout, and context-propagation/baggage notes. v4 docs intentionally untouched.

## Rollout notes

Server-side support for storing and re-injecting trace context on queue deliveries ships separately on the platform. This PR is safe to merge and release independently: without the platform-side support, behavior is unchanged apart from the new (ignorable) W3C headers and the bounded linked-trace shape.

Follow-up: bump `@vercel/queue` in `@workflow/world-vercel` once a release with HTTP-layer trace-context injection is published, so queue sends carry trace headers as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




