### PR TITLE
ci: use claude-fable-5 for backport AI model

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,10 +18,10 @@ concurrency: backport-stable
 
 # AI model used by every opencode invocation in this workflow. The
 # `vercel/` provider prefix is added at each use site, so this should
-# be specified as `<provider>/<model>` (e.g. `anthropic/claude-opus-4.7`).
+# be specified as `<provider>/<model>` (e.g. `anthropic/claude-fable-5`).
 # Manual `workflow_dispatch` runs may override this via the `model` input.
 env:
-  AI_MODEL: ${{ inputs.model || 'anthropic/claude-opus-4.7' }}
+  AI_MODEL: ${{ inputs.model || 'anthropic/claude-fable-5' }}
 
 jobs:
   backport:


### PR DESCRIPTION
## Summary

- Updates the backport workflow's default AI model from `anthropic/claude-opus-4.7` to `anthropic/claude-fable-5` (via Vercel AI Gateway)
- The `workflow_dispatch` `model` input override is unchanged

No changeset needed — CI-only change, no package code affected.