### PR TITLE
Replace hook.hasConflict with hook.getConflict() returning the conflicting Run

### DIFF
--- a/.changeset/hook-get-conflict.md
+++ b/.changeset/hook-get-conflict.md
@@ -3,4 +3,4 @@
 "workflow": minor
 ---
 
-Add `hook.getConflict`, a promise that suspends the workflow to commit hook registration and resolves with the conflicting `Run` when another active hook owns the token (or `null` once the hook is registered), without waiting for hook payload data.
+Add `hook.getConflict()`, a method returning a promise that suspends the workflow to commit hook registration and resolves with the conflicting `Run` when another active hook owns the token (or `null` once the hook is registered), without waiting for hook payload data.

--- a/.changeset/hook-get-conflict.md
+++ b/.changeset/hook-get-conflict.md
@@ -3,4 +3,4 @@
 "workflow": minor
 ---
 
-Add `hook.getConflict()`, a method returning a promise that suspends the workflow to commit hook registration and resolves with the conflicting `Run` when another active hook owns the token (or `null` once the hook is registered), without waiting for hook payload data.
+Replace `hook.hasConflict` (a `Promise<boolean>` property) with `hook.getConflict()`, a method returning a promise that suspends the workflow to commit hook registration and resolves with the conflicting `Run` when another active hook owns the token (or `null` once the hook is registered), without waiting for hook payload data. Code using `await hook.hasConflict` should migrate to `const conflict = await hook.getConflict()` and branch on `conflict !== null`.

--- a/.changeset/hook-get-conflict.md
+++ b/.changeset/hook-get-conflict.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": minor
+"workflow": minor
+---
+
+Add `hook.getConflict`, a promise that suspends the workflow to commit hook registration and resolves with the conflicting `Run` when another active hook owns the token (or `null` once the hook is registered), without waiting for hook payload data.

--- a/.changeset/hook-has-conflict.md
+++ b/.changeset/hook-has-conflict.md
@@ -1,6 +1,0 @@
----
-"@workflow/core": minor
-"workflow": minor
----
-
-Add `hook.hasConflict`, a `Promise<boolean>` that suspends the workflow to commit hook registration and resolves with whether the token is already owned by another active hook, without waiting for hook payload data.

--- a/docs/content/docs/v4/api-reference/workflow/create-hook.mdx
+++ b/docs/content/docs/v4/api-reference/workflow/create-hook.mdx
@@ -65,7 +65,7 @@ export default Hook;`}
 
 The returned `Hook` object also implements `AsyncIterable<T>`, which allows you to iterate over incoming payloads using `for await...of` syntax.
 
-Use `hook.getConflict` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the registration, then resolves with `null` once `hook_created` is recorded, or with `{ runId }` identifying the conflicting run if another active hook already owns the same token.
+Use `hook.getConflict()` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the registration, then resolves with `null` once `hook_created` is recorded, or with `{ runId }` identifying the conflicting run if another active hook already owns the same token.
 
 ## Examples
 
@@ -116,7 +116,7 @@ export async function slackBotWorkflow(channelId: string) {
 
 ### Detecting Token Conflicts
 
-Use `hook.getConflict` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
+Use `hook.getConflict()` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -130,7 +130,7 @@ async function processOrder(orderId: string) {
     token: `order:${orderId}` // [!code highlight]
   }); // [!code highlight]
 
-  const conflict = await hook.getConflict; // [!code highlight]
+  const conflict = await hook.getConflict(); // [!code highlight]
   if (conflict) { // [!code highlight]
     // Another active workflow run already owns this token.
     return { dedupedTo: conflict.runId };
@@ -140,7 +140,7 @@ async function processOrder(orderId: string) {
 }
 ```
 
-Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
+Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict()` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
 
 On a conflict, the resolved value is `{ runId }` identifying the run that currently owns the token. To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies in context.
 

--- a/docs/content/docs/v4/api-reference/workflow/create-hook.mdx
+++ b/docs/content/docs/v4/api-reference/workflow/create-hook.mdx
@@ -65,7 +65,7 @@ export default Hook;`}
 
 The returned `Hook` object also implements `AsyncIterable<T>`, which allows you to iterate over incoming payloads using `for await...of` syntax.
 
-Use `hook.hasConflict` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.hasConflict` suspends the workflow to commit the registration, then resolves with `false` once `hook_created` is recorded, or `true` if another active hook already owns the same token.
+Use `hook.getConflict` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the registration, then resolves with `null` once `hook_created` is recorded, or with `{ runId }` identifying the conflicting run if another active hook already owns the same token.
 
 ## Examples
 
@@ -116,7 +116,7 @@ export async function slackBotWorkflow(channelId: string) {
 
 ### Detecting Token Conflicts
 
-Use `hook.hasConflict` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
+Use `hook.getConflict` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -130,16 +130,19 @@ async function processOrder(orderId: string) {
     token: `order:${orderId}` // [!code highlight]
   }); // [!code highlight]
 
-  if (await hook.hasConflict) { // [!code highlight]
+  const conflict = await hook.getConflict; // [!code highlight]
+  if (conflict) { // [!code highlight]
     // Another active workflow run already owns this token.
-    return;
+    return { dedupedTo: conflict.runId };
   }
 
   await chargeOrder(orderId);
 }
 ```
 
-Because `createHook()` alone does not suspend the workflow, awaiting `hook.hasConflict` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
+Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
+
+On a conflict, the resolved value is `{ runId }` identifying the run that currently owns the token. To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies in context.
 
 ### Waiting for Multiple Payloads
 

--- a/docs/content/docs/v4/api-reference/workflow/create-hook.mdx
+++ b/docs/content/docs/v4/api-reference/workflow/create-hook.mdx
@@ -142,7 +142,7 @@ async function processOrder(orderId: string) {
 
 Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict()` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
 
-On a conflict, the resolved value is `{ runId }` identifying the run that currently owns the token. To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies in context.
+On a conflict, the resolved value is `{ runId }` identifying the run that currently owns the token. To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Idempotency](/docs/foundations/idempotency) for these strategies in context.
 
 ### Waiting for Multiple Payloads
 

--- a/docs/content/docs/v4/api-reference/workflow/create-webhook.mdx
+++ b/docs/content/docs/v4/api-reference/workflow/create-webhook.mdx
@@ -55,7 +55,7 @@ The returned `Webhook` object has:
 
 - `url`: The HTTP endpoint URL that external systems can call
 - `token`: The unique token identifying this webhook
-- `getConflict`: A promise that resolves with `{ runId }` identifying the conflicting run if another active hook already owns this token, or `null` once the webhook endpoint has been registered
+- `getConflict()`: A promise that resolves with `{ runId }` identifying the conflicting run if another active hook already owns this token, or `null` once the webhook endpoint has been registered
 - Implements `AsyncIterable<T>` for handling multiple requests, where `T` is `Request` (default) or `RequestWithResponse` (manual mode)
 
 When using `createWebhook({ respondWith: 'manual' })`, the resolved request type is `RequestWithResponse`, which extends the standard `Request` interface with a `respondWith(response: Response): Promise<void>` method for sending custom responses back to the caller.

--- a/docs/content/docs/v4/api-reference/workflow/create-webhook.mdx
+++ b/docs/content/docs/v4/api-reference/workflow/create-webhook.mdx
@@ -55,7 +55,7 @@ The returned `Webhook` object has:
 
 - `url`: The HTTP endpoint URL that external systems can call
 - `token`: The unique token identifying this webhook
-- `hasConflict`: A promise that resolves to `true` if another active hook already owns this token, or `false` once the webhook endpoint has been registered
+- `getConflict`: A promise that resolves with `{ runId }` identifying the conflicting run if another active hook already owns this token, or `null` once the webhook endpoint has been registered
 - Implements `AsyncIterable<T>` for handling multiple requests, where `T` is `Request` (default) or `RequestWithResponse` (manual mode)
 
 When using `createWebhook({ respondWith: 'manual' })`, the resolved request type is `RequestWithResponse`, which extends the standard `Request` interface with a `respondWith(response: Response): Promise<void>` method for sending custom responses back to the caller.

--- a/docs/content/docs/v4/foundations/hooks.mdx
+++ b/docs/content/docs/v4/foundations/hooks.mdx
@@ -87,7 +87,7 @@ The key points:
 
 ### Checking for Token Conflicts
 
-Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.hasConflict` for that:
+Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.getConflict` for that:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -101,9 +101,10 @@ export async function orderWorkflow(orderId: string) {
     token: `order:${orderId}`
   });
 
-  if (await hook.hasConflict) { // [!code highlight]
+  const conflict = await hook.getConflict; // [!code highlight]
+  if (conflict) { // [!code highlight]
     // Another active run already owns this token.
-    return;
+    return { dedupedTo: conflict.runId };
   }
 
   // The hook token is registered and reserved here.
@@ -111,7 +112,7 @@ export async function orderWorkflow(orderId: string) {
 }
 ```
 
-Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.hasConflict` suspends the workflow to commit the hook registration, then resolves with `false` once the hook is registered and ready to receive payloads, or `true` if another active hook already owns the same token (see [`HookConflictError`](/docs/errors/hook-conflict)).
+Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with `{ runId }` identifying the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
 
 ### Custom Tokens for Deterministic Hooks
 

--- a/docs/content/docs/v4/foundations/hooks.mdx
+++ b/docs/content/docs/v4/foundations/hooks.mdx
@@ -87,7 +87,7 @@ The key points:
 
 ### Checking for Token Conflicts
 
-Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.getConflict` for that:
+Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.getConflict()` for that:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -101,7 +101,7 @@ export async function orderWorkflow(orderId: string) {
     token: `order:${orderId}`
   });
 
-  const conflict = await hook.getConflict; // [!code highlight]
+  const conflict = await hook.getConflict(); // [!code highlight]
   if (conflict) { // [!code highlight]
     // Another active run already owns this token.
     return { dedupedTo: conflict.runId };
@@ -112,7 +112,7 @@ export async function orderWorkflow(orderId: string) {
 }
 ```
 
-Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with `{ runId }` identifying the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
+Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with `{ runId }` identifying the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
 
 ### Custom Tokens for Deterministic Hooks
 

--- a/docs/content/docs/v4/foundations/hooks.mdx
+++ b/docs/content/docs/v4/foundations/hooks.mdx
@@ -112,7 +112,7 @@ export async function orderWorkflow(orderId: string) {
 }
 ```
 
-Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with `{ runId }` identifying the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
+Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with `{ runId }` identifying the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). For `hook_conflict` events persisted by older worlds that did not record the owning run's ID, `getConflict()` rejects with `HookConflictError` instead of resolving with an incomplete handle. To act on the owner — inspect its status, wait for its result, or cancel it — pass `conflict.runId` to [`getRun()`](/docs/api-reference/workflow-api/get-run) inside a step. See [Idempotency](/docs/foundations/idempotency) for these strategies.
 
 ### Custom Tokens for Deterministic Hooks
 

--- a/docs/content/docs/v4/how-it-works/event-sourcing.mdx
+++ b/docs/content/docs/v4/how-it-works/event-sourcing.mdx
@@ -127,7 +127,7 @@ flowchart TD
 
 Unlike other entities, hooks don't have a `status` field—the states above are conceptual. An "active" hook is one that exists in storage, while "disposed" means the hook has been deleted. When a `hook_disposed` event is created, the hook record is removed rather than updated.
 
-While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.hasConflict` to resolve with `true` and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
+While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.getConflict` to resolve with the conflicting run and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
 
 When a hook is disposed (either explicitly or when its workflow completes), the token is released and can be claimed by future workflows. Hooks are automatically disposed when a workflow reaches a terminal state (`completed`, `failed`, or `cancelled`). The `hook_disposed` event is only needed for explicit disposal before workflow completion.
 
@@ -188,7 +188,7 @@ Events are categorized by the entity type they affect. Each event contains metad
 | Event | Description |
 |-------|-------------|
 | `hook_created` | Creates a new hook in `active` state. Contains the hook token and optional metadata. |
-| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.hasConflict` resolves with `true`, and awaiting the hook payload rejects with a `HookConflictError`. |
+| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.getConflict` resolves with the conflicting run, and awaiting the hook payload rejects with a `HookConflictError`. |
 | `hook_received` | Records that a payload was delivered to the hook. The hook remains `active` and can receive more payloads. |
 | `hook_disposed` | Deletes the hook from storage (conceptually transitioning to `disposed` state). The token is released for reuse by future workflows. |
 

--- a/docs/content/docs/v4/how-it-works/event-sourcing.mdx
+++ b/docs/content/docs/v4/how-it-works/event-sourcing.mdx
@@ -127,7 +127,7 @@ flowchart TD
 
 Unlike other entities, hooks don't have a `status` field—the states above are conceptual. An "active" hook is one that exists in storage, while "disposed" means the hook has been deleted. When a `hook_disposed` event is created, the hook record is removed rather than updated.
 
-While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.getConflict` to resolve with the conflicting run and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
+While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.getConflict()` to resolve with the conflicting run and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
 
 When a hook is disposed (either explicitly or when its workflow completes), the token is released and can be claimed by future workflows. Hooks are automatically disposed when a workflow reaches a terminal state (`completed`, `failed`, or `cancelled`). The `hook_disposed` event is only needed for explicit disposal before workflow completion.
 
@@ -188,7 +188,7 @@ Events are categorized by the entity type they affect. Each event contains metad
 | Event | Description |
 |-------|-------------|
 | `hook_created` | Creates a new hook in `active` state. Contains the hook token and optional metadata. |
-| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.getConflict` resolves with the conflicting run, and awaiting the hook payload rejects with a `HookConflictError`. |
+| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.getConflict()` resolves with the conflicting run, and awaiting the hook payload rejects with a `HookConflictError`. |
 | `hook_received` | Records that a payload was delivered to the hook. The hook remains `active` and can receive more payloads. |
 | `hook_disposed` | Deletes the hook from storage (conceptually transitioning to `disposed` state). The token is released for reuse by future workflows. |
 

--- a/docs/content/docs/v5/api-reference/workflow/create-hook.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/create-hook.mdx
@@ -142,7 +142,7 @@ async function processOrder(orderId: string) {
 
 Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict()` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
 
-On a conflict, the resolved value is a `Run` handle for the run that currently owns the token, with durable step-backed accessors. The duplicate run can decide in code how to handle it: return or log `conflict.runId`, inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` and continue in the current run. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies in context.
+On a conflict, the resolved value is a `Run` handle for the run that currently owns the token, with durable step-backed accessors. The duplicate run can decide in code how to handle it: return or log `conflict.runId`, inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` and continue in the current run. See [Idempotency](/docs/foundations/idempotency) for these strategies in context.
 
 ### Waiting for Multiple Payloads
 

--- a/docs/content/docs/v5/api-reference/workflow/create-hook.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/create-hook.mdx
@@ -65,7 +65,7 @@ export default Hook;`}
 
 The returned `Hook` object also implements `AsyncIterable<T>`, which allows you to iterate over incoming payloads using `for await...of` syntax.
 
-Use `hook.hasConflict` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.hasConflict` suspends the workflow to commit the registration, then resolves with `false` once `hook_created` is recorded, or `true` if another active hook already owns the same token.
+Use `hook.getConflict` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the registration, then resolves with `null` once `hook_created` is recorded, or with the conflicting [`Run`](/docs/api-reference/workflow-api/get-run) if another active hook already owns the same token.
 
 ## Examples
 
@@ -116,7 +116,7 @@ export async function slackBotWorkflow(channelId: string) {
 
 ### Detecting Token Conflicts
 
-Use `hook.hasConflict` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
+Use `hook.getConflict` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -130,16 +130,19 @@ async function processOrder(orderId: string) {
     token: `order:${orderId}` // [!code highlight]
   }); // [!code highlight]
 
-  if (await hook.hasConflict) { // [!code highlight]
+  const conflict = await hook.getConflict; // [!code highlight]
+  if (conflict) { // [!code highlight]
     // Another active workflow run already owns this token.
-    return;
+    return { dedupedTo: conflict.runId };
   }
 
   await chargeOrder(orderId);
 }
 ```
 
-Because `createHook()` alone does not suspend the workflow, awaiting `hook.hasConflict` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
+Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
+
+On a conflict, the resolved value is a `Run` handle for the run that currently owns the token, with durable step-backed accessors. The duplicate run can decide in code how to handle it: return or log `conflict.runId`, inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` and continue in the current run. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies in context.
 
 ### Waiting for Multiple Payloads
 

--- a/docs/content/docs/v5/api-reference/workflow/create-hook.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/create-hook.mdx
@@ -65,7 +65,7 @@ export default Hook;`}
 
 The returned `Hook` object also implements `AsyncIterable<T>`, which allows you to iterate over incoming payloads using `for await...of` syntax.
 
-Use `hook.getConflict` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the registration, then resolves with `null` once `hook_created` is recorded, or with the conflicting [`Run`](/docs/api-reference/workflow-api/get-run) if another active hook already owns the same token.
+Use `hook.getConflict()` to check whether the hook token is already claimed by another active hook, without waiting for hook payload data. Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the registration, then resolves with `null` once `hook_created` is recorded, or with the conflicting [`Run`](/docs/api-reference/workflow-api/get-run) if another active hook already owns the same token.
 
 ## Examples
 
@@ -116,7 +116,7 @@ export async function slackBotWorkflow(channelId: string) {
 
 ### Detecting Token Conflicts
 
-Use `hook.getConflict` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
+Use `hook.getConflict()` when the workflow needs to claim a hook token before doing other work, but does not need a payload yet:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -130,7 +130,7 @@ async function processOrder(orderId: string) {
     token: `order:${orderId}` // [!code highlight]
   }); // [!code highlight]
 
-  const conflict = await hook.getConflict; // [!code highlight]
+  const conflict = await hook.getConflict(); // [!code highlight]
   if (conflict) { // [!code highlight]
     // Another active workflow run already owns this token.
     return { dedupedTo: conflict.runId };
@@ -140,7 +140,7 @@ async function processOrder(orderId: string) {
 }
 ```
 
-Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
+Because `createHook()` alone does not suspend the workflow, awaiting `hook.getConflict()` is what actually suspends the run and commits the hook registration. It only waits for registration — to receive payload data from a future `resumeHook()` call, await the hook itself or iterate it with `for await...of`.
 
 On a conflict, the resolved value is a `Run` handle for the run that currently owns the token, with durable step-backed accessors. The duplicate run can decide in code how to handle it: return or log `conflict.runId`, inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` and continue in the current run. See [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies in context.
 

--- a/docs/content/docs/v5/api-reference/workflow/create-webhook.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/create-webhook.mdx
@@ -55,7 +55,7 @@ The returned `Webhook` object has:
 
 - `url`: The HTTP endpoint URL that external systems can call
 - `token`: The unique token identifying this webhook
-- `getConflict`: A promise that resolves with the conflicting run if another active hook already owns this token, or `null` once the webhook endpoint has been registered
+- `getConflict()`: A promise that resolves with the conflicting run if another active hook already owns this token, or `null` once the webhook endpoint has been registered
 - Implements `AsyncIterable<T>` for handling multiple requests, where `T` is `Request` (default) or `RequestWithResponse` (manual mode)
 
 When using `createWebhook({ respondWith: 'manual' })`, the resolved request type is `RequestWithResponse`, which extends the standard `Request` interface with a `respondWith(response: Response): Promise<void>` method for sending custom responses back to the caller.

--- a/docs/content/docs/v5/api-reference/workflow/create-webhook.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/create-webhook.mdx
@@ -55,7 +55,7 @@ The returned `Webhook` object has:
 
 - `url`: The HTTP endpoint URL that external systems can call
 - `token`: The unique token identifying this webhook
-- `hasConflict`: A promise that resolves to `true` if another active hook already owns this token, or `false` once the webhook endpoint has been registered
+- `getConflict`: A promise that resolves with the conflicting run if another active hook already owns this token, or `null` once the webhook endpoint has been registered
 - Implements `AsyncIterable<T>` for handling multiple requests, where `T` is `Request` (default) or `RequestWithResponse` (manual mode)
 
 When using `createWebhook({ respondWith: 'manual' })`, the resolved request type is `RequestWithResponse`, which extends the standard `Request` interface with a `respondWith(response: Response): Promise<void>` method for sending custom responses back to the caller.

--- a/docs/content/docs/v5/foundations/hooks.mdx
+++ b/docs/content/docs/v5/foundations/hooks.mdx
@@ -87,7 +87,7 @@ The key points:
 
 ### Checking for Token Conflicts
 
-Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.getConflict` for that:
+Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.getConflict()` for that:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -101,7 +101,7 @@ export async function orderWorkflow(orderId: string) {
     token: `order:${orderId}`
   });
 
-  const conflict = await hook.getConflict; // [!code highlight]
+  const conflict = await hook.getConflict(); // [!code highlight]
   if (conflict) { // [!code highlight]
     // Another active run already owns this token.
     return { dedupedTo: conflict.runId };
@@ -112,7 +112,7 @@ export async function orderWorkflow(orderId: string) {
 }
 ```
 
-Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with a `Run` handle for the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). The conflicting run's accessors are durable steps, so the workflow can inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` — see [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
+Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with a `Run` handle for the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). The conflicting run's accessors are durable steps, so the workflow can inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` — see [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
 
 ### Custom Tokens for Deterministic Hooks
 

--- a/docs/content/docs/v5/foundations/hooks.mdx
+++ b/docs/content/docs/v5/foundations/hooks.mdx
@@ -87,7 +87,7 @@ The key points:
 
 ### Checking for Token Conflicts
 
-Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.hasConflict` for that:
+Sometimes you need to know that a hook token has been claimed, but you do not want to wait for external data yet. Await `hook.getConflict` for that:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";
@@ -101,9 +101,10 @@ export async function orderWorkflow(orderId: string) {
     token: `order:${orderId}`
   });
 
-  if (await hook.hasConflict) { // [!code highlight]
+  const conflict = await hook.getConflict; // [!code highlight]
+  if (conflict) { // [!code highlight]
     // Another active run already owns this token.
-    return;
+    return { dedupedTo: conflict.runId };
   }
 
   // The hook token is registered and reserved here.
@@ -111,7 +112,7 @@ export async function orderWorkflow(orderId: string) {
 }
 ```
 
-Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.hasConflict` suspends the workflow to commit the hook registration, then resolves with `false` once the hook is registered and ready to receive payloads, or `true` if another active hook already owns the same token (see [`HookConflictError`](/docs/errors/hook-conflict)).
+Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with a `Run` handle for the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). The conflicting run's accessors are durable steps, so the workflow can inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` — see [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
 
 ### Custom Tokens for Deterministic Hooks
 

--- a/docs/content/docs/v5/foundations/hooks.mdx
+++ b/docs/content/docs/v5/foundations/hooks.mdx
@@ -112,7 +112,7 @@ export async function orderWorkflow(orderId: string) {
 }
 ```
 
-Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with a `Run` handle for the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). The conflicting run's accessors are durable steps, so the workflow can inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` — see [Run idempotency](/docs/foundations/idempotency#run-idempotency) for these strategies.
+Calling `createHook()` on its own does not register the hook — registration is only committed when the workflow suspends. Awaiting `hook.getConflict()` suspends the workflow to commit the hook registration, then resolves with `null` once the hook is registered and ready to receive payloads, or with a `Run` handle for the run that owns the token if another active hook already claimed it (see [`HookConflictError`](/docs/errors/hook-conflict)). For `hook_conflict` events persisted by older worlds that did not record the owning run's ID, `getConflict()` rejects with `HookConflictError` instead of resolving with an incomplete handle. The conflicting run's accessors are durable steps, so the workflow can inspect `await conflict.status`, wait on `await conflict.returnValue`, or cancel the owner with `await conflict.cancel()` — see [Idempotency](/docs/foundations/idempotency) for these strategies.
 
 ### Custom Tokens for Deterministic Hooks
 

--- a/docs/content/docs/v5/how-it-works/event-sourcing.mdx
+++ b/docs/content/docs/v5/how-it-works/event-sourcing.mdx
@@ -127,7 +127,7 @@ flowchart TD
 
 Unlike other entities, hooks don't have a `status` field—the states above are conceptual. An "active" hook is one that exists in storage, while "disposed" means the hook has been deleted. When a `hook_disposed` event is created, the hook record is removed rather than updated.
 
-While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.hasConflict` to resolve with `true` and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
+While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.getConflict` to resolve with the conflicting run and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
 
 When a hook is disposed (either explicitly or when its workflow completes), the token is released and can be claimed by future workflows. Hooks are automatically disposed when a workflow reaches a terminal state (`completed`, `failed`, or `cancelled`). The `hook_disposed` event is only needed for explicit disposal before workflow completion.
 
@@ -188,7 +188,7 @@ Events are categorized by the entity type they affect. Each event contains metad
 | Event | Description |
 |-------|-------------|
 | `hook_created` | Creates a new hook in `active` state. Contains the hook token and optional metadata. |
-| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.hasConflict` resolves with `true`, and awaiting the hook payload rejects with a `HookConflictError`. |
+| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.getConflict` resolves with the conflicting run, and awaiting the hook payload rejects with a `HookConflictError`. |
 | `hook_received` | Records that a payload was delivered to the hook. The hook remains `active` and can receive more payloads. |
 | `hook_disposed` | Deletes the hook from storage (conceptually transitioning to `disposed` state). The token is released for reuse by future workflows. |
 

--- a/docs/content/docs/v5/how-it-works/event-sourcing.mdx
+++ b/docs/content/docs/v5/how-it-works/event-sourcing.mdx
@@ -127,7 +127,7 @@ flowchart TD
 
 Unlike other entities, hooks don't have a `status` field—the states above are conceptual. An "active" hook is one that exists in storage, while "disposed" means the hook has been deleted. When a `hook_disposed` event is created, the hook record is removed rather than updated.
 
-While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.getConflict` to resolve with the conflicting run and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
+While a hook is active, its token is reserved and cannot be used by other workflows. If a workflow attempts to create a hook with a token that is already in use by another active hook, a `hook_conflict` event is recorded instead of `hook_created`. Current worlds include the token and the run ID that currently owns it, though older persisted events or world implementations may only include the token. This causes `hook.getConflict()` to resolve with the conflicting run and the hook's payload promise to reject with a `HookConflictError`, which you can detect with `HookConflictError.is(error)`. See the [hook-conflict error](/docs/errors/hook-conflict) documentation for more details.
 
 When a hook is disposed (either explicitly or when its workflow completes), the token is released and can be claimed by future workflows. Hooks are automatically disposed when a workflow reaches a terminal state (`completed`, `failed`, or `cancelled`). The `hook_disposed` event is only needed for explicit disposal before workflow completion.
 
@@ -188,7 +188,7 @@ Events are categorized by the entity type they affect. Each event contains metad
 | Event | Description |
 |-------|-------------|
 | `hook_created` | Creates a new hook in `active` state. Contains the hook token and optional metadata. |
-| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.getConflict` resolves with the conflicting run, and awaiting the hook payload rejects with a `HookConflictError`. |
+| `hook_conflict` | Records that hook creation failed because the token is already in use by another active hook. Contains the token and, for current worlds, the active hook owner's run ID. The hook is not created: `hook.getConflict()` resolves with the conflicting run, and awaiting the hook payload rejects with a `HookConflictError`. |
 | `hook_received` | Records that a payload was delivered to the hook. The hook remains `active` and can receive more payloads. |
 | `hook_disposed` | Deletes the hook from storage (conceptually transitioning to `disposed` state). The token is released for reuse by future workflows. |
 

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1761,11 +1761,11 @@ describe('e2e', () => {
     }
   );
 
-  test('hookHasConflictWorkflow - awaiting hook.hasConflict registers hook without payload', async () => {
+  test('hookGetConflictWorkflow - awaiting hook.getConflict registers hook without payload', async () => {
     const token = Math.random().toString(36).slice(2);
     const customData = Math.random().toString(36).slice(2);
 
-    const run = await start(await e2e('hookHasConflictWorkflow'), [
+    const run = await start(await e2e('hookGetConflictWorkflow'), [
       token,
       customData,
     ]);
@@ -1774,8 +1774,8 @@ describe('e2e', () => {
     expect(returnValue).toEqual({
       token,
       customData,
-      hasConflict: false,
-      hookHasConflictTestData: 'hook_registered_without_payload',
+      conflictRunId: null,
+      hookGetConflictTestData: 'hook_registered_without_payload',
     });
 
     const world = await getWorld();
@@ -1785,27 +1785,27 @@ describe('e2e', () => {
 
     expect(
       hookCreated,
-      'awaiting hook.hasConflict should suspend and create the hook'
+      'awaiting hook.getConflict should suspend and create the hook'
     ).toBeDefined();
     expect(
       hookReceived,
-      'hook.hasConflict should not require or consume hook payload data'
+      'hook.getConflict should not require or consume hook payload data'
     ).toBeUndefined();
   });
 
   test.each([
     {
-      workflow: 'hookHasConflictWithPriorStepWorkflow',
-      hookHasConflictTestData: 'prior_step_completed_after_registration',
+      workflow: 'hookGetConflictWithPriorStepWorkflow',
+      hookGetConflictTestData: 'prior_step_completed_after_registration',
     },
     {
-      workflow: 'hookHasConflictWithParallelStepWorkflow',
-      hookHasConflictTestData: 'parallel_step_completed_with_registration',
+      workflow: 'hookGetConflictWithParallelStepWorkflow',
+      hookGetConflictTestData: 'parallel_step_completed_with_registration',
     },
   ])(
-    '$workflow - hook.hasConflict does not block step execution',
+    '$workflow - hook.getConflict does not block step execution',
     { timeout: 60_000 },
-    async ({ workflow, hookHasConflictTestData }) => {
+    async ({ workflow, hookGetConflictTestData }) => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
 
@@ -1815,12 +1815,12 @@ describe('e2e', () => {
       expect(returnValue).toEqual({
         token,
         customData,
-        hasConflict: false,
+        conflictRunId: null,
         stepResult: {
           customData,
-          hookHasConflictStepData: 'step_completed',
+          hookGetConflictStepData: 'step_completed',
         },
-        hookHasConflictTestData,
+        hookGetConflictTestData,
       });
 
       const world = await getWorld();
@@ -1834,14 +1834,14 @@ describe('e2e', () => {
   );
 
   test(
-    'hookHasConflictThenStepParallelWorkflow - hook.hasConflict continuation step runs alongside other steps',
+    'hookGetConflictThenStepParallelWorkflow - hook.getConflict continuation step runs alongside other steps',
     { timeout: 90_000 },
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
 
       const run = await start(
-        await e2e('hookHasConflictThenStepParallelWorkflow'),
+        await e2e('hookGetConflictThenStepParallelWorkflow'),
         [token, customData]
       );
 
@@ -1849,7 +1849,7 @@ describe('e2e', () => {
       expect(returnValue).toMatchObject({
         token,
         customData,
-        hookHasConflictTestData: 'registration_then_step_runs_in_parallel',
+        hookGetConflictTestData: 'registration_then_step_runs_in_parallel',
       });
 
       const { stepAResult, stepBResult } = returnValue;
@@ -1861,7 +1861,7 @@ describe('e2e', () => {
       expect(stepADuration).toBeGreaterThanOrEqual(9_000);
       expect(
         stepBResult.startedAt,
-        'stepB should start before stepA finishes, proving hook.hasConflict can continue independently of other steps'
+        'stepB should start before stepA finishes, proving hook.getConflict can continue independently of other steps'
       ).toBeLessThan(stepAResult.endedAt);
       expect(
         stepStartDelta,
@@ -1871,7 +1871,7 @@ describe('e2e', () => {
   );
 
   test(
-    'hookHasConflictWorkflow - hook.hasConflict resolves true when token is already registered',
+    'hookGetConflictWorkflow - hook.getConflict resolves with the conflicting run when token is already registered',
     { timeout: 60_000 },
     async () => {
       const token = Math.random().toString(36).slice(2);
@@ -1884,19 +1884,22 @@ describe('e2e', () => {
 
       const hook = await waitForHook(token, { runId: run1.runId });
 
-      const run2 = await start(await e2e('hookHasConflictWorkflow'), [
+      const run2 = await start(await e2e('hookGetConflictWorkflow'), [
         token,
         customData,
       ]);
 
-      // The conflicting run detects the conflict via `hook.hasConflict`
-      // and completes successfully instead of failing.
+      // The conflicting run detects the conflict via `hook.getConflict`
+      // and completes successfully instead of failing. The resolved Run
+      // identifies the active owner and exposes durable step-backed
+      // accessors like `status`.
       const run2Result = await run2.returnValue;
       expect(run2Result).toEqual({
         token,
         customData,
-        hasConflict: true,
-        hookHasConflictTestData: 'hook_token_conflict_detected',
+        conflictRunId: run1.runId,
+        conflictStatus: 'running',
+        hookGetConflictTestData: 'hook_token_conflict_detected',
       });
 
       const { json: run2Data } = await cliInspectJson(`runs ${run2.runId}`);

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1761,7 +1761,7 @@ describe('e2e', () => {
     }
   );
 
-  test('hookGetConflictWorkflow - awaiting hook.getConflict registers hook without payload', async () => {
+  test('hookGetConflictWorkflow - awaiting hook.getConflict() registers hook without payload', async () => {
     const token = Math.random().toString(36).slice(2);
     const customData = Math.random().toString(36).slice(2);
 
@@ -1785,11 +1785,11 @@ describe('e2e', () => {
 
     expect(
       hookCreated,
-      'awaiting hook.getConflict should suspend and create the hook'
+      'awaiting hook.getConflict() should suspend and create the hook'
     ).toBeDefined();
     expect(
       hookReceived,
-      'hook.getConflict should not require or consume hook payload data'
+      'hook.getConflict() should not require or consume hook payload data'
     ).toBeUndefined();
   });
 
@@ -1803,7 +1803,7 @@ describe('e2e', () => {
       hookGetConflictTestData: 'parallel_step_completed_with_registration',
     },
   ])(
-    '$workflow - hook.getConflict does not block step execution',
+    '$workflow - hook.getConflict() does not block step execution',
     { timeout: 60_000 },
     async ({ workflow, hookGetConflictTestData }) => {
       const token = Math.random().toString(36).slice(2);
@@ -1834,7 +1834,7 @@ describe('e2e', () => {
   );
 
   test(
-    'hookGetConflictThenStepParallelWorkflow - hook.getConflict continuation step runs alongside other steps',
+    'hookGetConflictThenStepParallelWorkflow - hook.getConflict() continuation step runs alongside other steps',
     { timeout: 90_000 },
     async () => {
       const token = Math.random().toString(36).slice(2);
@@ -1861,7 +1861,7 @@ describe('e2e', () => {
       expect(stepADuration).toBeGreaterThanOrEqual(9_000);
       expect(
         stepBResult.startedAt,
-        'stepB should start before stepA finishes, proving hook.getConflict can continue independently of other steps'
+        'stepB should start before stepA finishes, proving hook.getConflict() can continue independently of other steps'
       ).toBeLessThan(stepAResult.endedAt);
       expect(
         stepStartDelta,
@@ -1871,7 +1871,7 @@ describe('e2e', () => {
   );
 
   test(
-    'hookGetConflictWorkflow - hook.getConflict resolves with the conflicting run when token is already registered',
+    'hookGetConflictWorkflow - hook.getConflict() resolves with the conflicting run when token is already registered',
     { timeout: 60_000 },
     async () => {
       const token = Math.random().toString(36).slice(2);
@@ -1889,7 +1889,7 @@ describe('e2e', () => {
         customData,
       ]);
 
-      // The conflicting run detects the conflict via `hook.getConflict`
+      // The conflicting run detects the conflict via `hook.getConflict()`
       // and completes successfully instead of failing. The resolved Run
       // identifies the active owner and exposes durable step-backed
       // accessors like `status`.

--- a/packages/core/src/class-serialization.ts
+++ b/packages/core/src/class-serialization.ts
@@ -52,6 +52,47 @@ export function registerSerializationClass(classId: string, cls: Function) {
 }
 
 /**
+ * Stable, well-known registry id for the SDK's `Run` class.
+ *
+ * The SWC plugin auto-registers `Run` under a *path-derived* id (e.g.
+ * `class//./node_modules/@workflow/core/dist/runtime/run//Run`), which
+ * varies with the app's dependency layout and bundler. Host-side code
+ * that needs to construct `Run` instances inside the workflow VM (e.g.
+ * the hook event consumer resolving `hook.getConflict()`) cannot know
+ * that id statically, so the workflow-mode `create-hook` module also
+ * aliases the bundle's `Run` under this stable id at evaluation time.
+ *
+ * The `workflow` pseudo-path cannot collide with plugin-derived ids,
+ * which always use real relative module paths (`./…` / `../…`).
+ */
+export const RUN_CLASS_ID = 'class//workflow//Run';
+
+/**
+ * Register an additional registry id for a class without touching its
+ * `classId` property.
+ *
+ * Unlike {@link registerSerializationClass}, this is safe to call for a
+ * class the SWC plugin has already registered: the plugin's inlined IIFE
+ * defines `classId` as non-configurable, so a second `defineProperty`
+ * would throw. Aliasing only adds a registry entry — the class keeps
+ * serializing under its primary (path-derived) id, while lookups succeed
+ * under both.
+ *
+ * Registration is per-global by construction: evaluated inside the
+ * workflow VM it registers the VM's compiled class on the VM's registry;
+ * evaluated on the host it registers the host class on the host's
+ * registry. Each context resolves its own correct variant.
+ */
+export function aliasSerializationClass(
+  classId: string,
+  // biome-ignore lint/complexity/noBannedTypes: We need to use Function to represent class constructors
+  cls: Function,
+  global: Record<string, any> = globalThis
+) {
+  getRegistry(global).set(classId, cls);
+}
+
+/**
  * Find a registered class constructor by ID (used during deserialization)
  *
  * @param classId - The class ID to look up

--- a/packages/core/src/create-hook.ts
+++ b/packages/core/src/create-hook.ts
@@ -1,4 +1,5 @@
 import { throwNotInWorkflowContext } from './context-errors.js';
+import type { Run } from './runtime/run.js';
 import type { Serializable } from './schemas.js';
 
 /**
@@ -30,15 +31,21 @@ export interface Hook<T = any> extends AsyncIterable<T>, Thenable<T> {
   token: string;
 
   /**
-   * Resolves with `true` if another active hook already owns this hook's
-   * token, or `false` once the hook has been registered and is ready to
-   * receive payloads.
+   * Resolves with the conflicting {@link Run} if another active hook
+   * already owns this hook's token, or `null` once the hook has been
+   * registered and is ready to receive payloads.
    *
    * Calling `createHook()` alone does not register the hook — registration
-   * only happens when the workflow suspends. Awaiting `hasConflict`
+   * only happens when the workflow suspends. Awaiting `getConflict`
    * suspends the workflow to commit the hook registration, so it can be
    * used to claim the token (and detect token conflicts early) without
    * waiting for payload data.
+   *
+   * When a conflict is detected, the resolved `Run` is the run that
+   * currently owns the token. The workflow can decide how to handle the
+   * duplicate in code: return or log `conflict.runId`, inspect
+   * `await conflict.status`, await `conflict.returnValue`, or cancel the
+   * owner with `await conflict.cancel()` and continue in the current run.
    *
    * Note that awaiting the hook's payload (`await hook`) when the token is
    * already owned by another active hook still rejects with
@@ -47,14 +54,15 @@ export interface Hook<T = any> extends AsyncIterable<T>, Thenable<T> {
    * @example
    * ```ts
    * using hook = createHook({ token: `order:${orderId}` });
-   * if (await hook.hasConflict) {
+   * const conflict = await hook.getConflict;
+   * if (conflict) {
    *   // another run already owns this token
-   *   return;
+   *   return { dedupedTo: conflict.runId };
    * }
    * // token is now claimed, without waiting for payload data
    * ```
    */
-  readonly hasConflict: Promise<boolean>;
+  readonly getConflict: Promise<Run<unknown> | null>;
 
   /**
    * Disposes the hook, releasing its token for reuse by other workflows.

--- a/packages/core/src/create-hook.ts
+++ b/packages/core/src/create-hook.ts
@@ -49,7 +49,10 @@ export interface Hook<T = any> extends AsyncIterable<T>, Thenable<T> {
    *
    * Note that awaiting the hook's payload (`await hook`) when the token is
    * already owned by another active hook still rejects with
-   * `HookConflictError`.
+   * `HookConflictError`. In the rare case where the conflicting run cannot
+   * be identified (a `hook_conflict` event persisted by an old world that
+   * did not record the owning run's ID), `getConflict` also rejects with
+   * `HookConflictError` rather than resolving with an incomplete value.
    *
    * @example
    * ```ts

--- a/packages/core/src/create-hook.ts
+++ b/packages/core/src/create-hook.ts
@@ -31,12 +31,12 @@ export interface Hook<T = any> extends AsyncIterable<T>, Thenable<T> {
   token: string;
 
   /**
-   * Resolves with the conflicting {@link Run} if another active hook
-   * already owns this hook's token, or `null` once the hook has been
-   * registered and is ready to receive payloads.
+   * Returns a promise that resolves with the conflicting {@link Run} if
+   * another active hook already owns this hook's token, or `null` once
+   * the hook has been registered and is ready to receive payloads.
    *
    * Calling `createHook()` alone does not register the hook — registration
-   * only happens when the workflow suspends. Awaiting `getConflict`
+   * only happens when the workflow suspends. Awaiting `getConflict()`
    * suspends the workflow to commit the hook registration, so it can be
    * used to claim the token (and detect token conflicts early) without
    * waiting for payload data.
@@ -51,13 +51,13 @@ export interface Hook<T = any> extends AsyncIterable<T>, Thenable<T> {
    * already owned by another active hook still rejects with
    * `HookConflictError`. In the rare case where the conflicting run cannot
    * be identified (a `hook_conflict` event persisted by an old world that
-   * did not record the owning run's ID), `getConflict` also rejects with
+   * did not record the owning run's ID), `getConflict()` also rejects with
    * `HookConflictError` rather than resolving with an incomplete value.
    *
    * @example
    * ```ts
    * using hook = createHook({ token: `order:${orderId}` });
-   * const conflict = await hook.getConflict;
+   * const conflict = await hook.getConflict();
    * if (conflict) {
    *   // another run already owns this token
    *   return { dedupedTo: conflict.runId };
@@ -65,7 +65,7 @@ export interface Hook<T = any> extends AsyncIterable<T>, Thenable<T> {
    * // token is now claimed, without waiting for payload data
    * ```
    */
-  readonly getConflict: Promise<Run<unknown> | null>;
+  getConflict(): Promise<Run<unknown> | null>;
 
   /**
    * Disposes the hook, releasing its token for reuse by other workflows.

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -19,7 +19,7 @@ export interface HookInvocationQueueItem {
   token: string;
   metadata?: Serializable;
   hasCreatedEvent?: boolean;
-  /** Whether the workflow is awaiting `hook.getConflict` for this hook */
+  /** Whether the workflow is awaiting `hook.getConflict()` for this hook */
   hasConflictAwaiter?: boolean;
   disposed?: boolean;
   isWebhook?: boolean;

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -19,7 +19,7 @@ export interface HookInvocationQueueItem {
   token: string;
   metadata?: Serializable;
   hasCreatedEvent?: boolean;
-  /** Whether the workflow is awaiting `hook.hasConflict` for this hook */
+  /** Whether the workflow is awaiting `hook.getConflict` for this hook */
   hasConflictAwaiter?: boolean;
   disposed?: boolean;
   isWebhook?: boolean;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1079,7 +1079,6 @@ export function workflowEntrypoint(
 
                         const pendingSteps = suspensionResult.pendingSteps;
 
-
                         // Inline execution is gated on ownership: only the
                         // handler that actually wrote the step_created event
                         // may run the step body inline. The world-level
@@ -1098,13 +1097,13 @@ export function workflowEntrypoint(
                         // batch.
                         //
                         // Skip inline execution when a created hook has a
-                        // `hook.hasConflict` awaiter: an inline `await
+                        // `hook.getConflict` awaiter: an inline `await
                         // executeStep(...)` blocks this handler for the
                         // full step duration, so the awaiter's continuation
                         // (which only advances on the next replay) would be
                         // serialized behind the step — defeating work the
                         // workflow expressed as parallel (e.g.
-                        // `hook.hasConflict.then(() => stepB())` racing
+                        // `hook.getConflict.then(() => stepB())` racing
                         // `await stepA()`). Queue every step and re-invoke
                         // immediately instead: the re-invocation replays
                         // over the just-committed hook_created and resolves
@@ -1197,7 +1196,7 @@ export function workflowEntrypoint(
                         // queued (or no work needs scheduling). Exit and let
                         // the queue drive subsequent replays.
                         if (!inlineStep) {
-                          // A `hook.hasConflict` awaiter needs an immediate
+                          // A `hook.getConflict` awaiter needs an immediate
                           // re-invocation: the replay consumes the
                           // just-committed hook_created and resolves the
                           // awaiter. Without it (no inline step, all work

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1097,13 +1097,13 @@ export function workflowEntrypoint(
                         // batch.
                         //
                         // Skip inline execution when a created hook has a
-                        // `hook.getConflict` awaiter: an inline `await
+                        // `hook.getConflict()` awaiter: an inline `await
                         // executeStep(...)` blocks this handler for the
                         // full step duration, so the awaiter's continuation
                         // (which only advances on the next replay) would be
                         // serialized behind the step — defeating work the
                         // workflow expressed as parallel (e.g.
-                        // `hook.getConflict.then(() => stepB())` racing
+                        // `hook.getConflict().then(() => stepB())` racing
                         // `await stepA()`). Queue every step and re-invoke
                         // immediately instead: the re-invocation replays
                         // over the just-committed hook_created and resolves
@@ -1196,7 +1196,7 @@ export function workflowEntrypoint(
                         // queued (or no work needs scheduling). Exit and let
                         // the queue drive subsequent replays.
                         if (!inlineStep) {
-                          // A `hook.getConflict` awaiter needs an immediate
+                          // A `hook.getConflict()` awaiter needs an immediate
                           // re-invocation: the replay consumes the
                           // just-committed hook_created and resolves the
                           // awaiter. Without it (no inline step, all work

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -30,7 +30,7 @@ function createWorld(eventsCreate: ReturnType<typeof vi.fn>): World {
 }
 
 describe('handleSuspension', () => {
-  it('marks hook.getConflict-awaited creations without converting them into wait timeouts', async () => {
+  it('marks hook.getConflict()-awaited creations without converting them into wait timeouts', async () => {
     const eventsCreate = vi.fn().mockResolvedValue({
       event: {
         eventType: 'hook_created',

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -30,7 +30,7 @@ function createWorld(eventsCreate: ReturnType<typeof vi.fn>): World {
 }
 
 describe('handleSuspension', () => {
-  it('marks hook.hasConflict-awaited creations without converting them into wait timeouts', async () => {
+  it('marks hook.getConflict-awaited creations without converting them into wait timeouts', async () => {
     const eventsCreate = vi.fn().mockResolvedValue({
       event: {
         eventType: 'hook_created',
@@ -107,7 +107,7 @@ describe('handleSuspension', () => {
     expect(result.createdStepCorrelationIds).toContain('step_parallel');
   });
 
-  it('does not immediately continue after creating a hook without a hasConflict awaiter', async () => {
+  it('does not immediately continue after creating a hook without a getConflict awaiter', async () => {
     const eventsCreate = vi.fn().mockResolvedValue({
       event: {
         eventType: 'hook_created',

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -61,7 +61,7 @@ export interface SuspensionHandlerResult {
   waitTimeout?: { seconds: number; correlationId: string };
   /** Whether a hook conflict was detected (should re-invoke immediately) */
   hasHookConflict: boolean;
-  /** Whether a `hook.hasConflict` awaiter needs the workflow to continue immediately */
+  /** Whether a `hook.getConflict` awaiter needs the workflow to continue immediately */
   hasAwaitedHookCreation: boolean;
   /** Whether native workflow attribute events were written for replay. */
   hasAttributeEvents: boolean;

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -61,7 +61,7 @@ export interface SuspensionHandlerResult {
   waitTimeout?: { seconds: number; correlationId: string };
   /** Whether a hook conflict was detected (should re-invoke immediately) */
   hasHookConflict: boolean;
-  /** Whether a `hook.getConflict` awaiter needs the workflow to continue immediately */
+  /** Whether a `hook.getConflict()` awaiter needs the workflow to continue immediately */
   hasAwaitedHookCreation: boolean;
   /** Whether native workflow attribute events were written for replay. */
   hasAttributeEvents: boolean;

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -44,6 +44,18 @@ export const WEBHOOK_RESPONSE_WRITABLE = Symbol.for(
  */
 export const WORKFLOW_CLASS_REGISTRY = Symbol.for('workflow-class-registry');
 
+/**
+ * Symbol used to expose the workflow bundle's compiled `Run` class on the
+ * VM's globalThis. The workflow-mode `create-hook` module registers it at
+ * module scope so host-side code (the hook event consumer) can construct
+ * `Run` instances inside the VM — e.g. the conflicting run resolved by
+ * `hook.getConflict`. The bundle's `Run` is the plugin-compiled variant
+ * whose methods are durable step proxies, unlike the host `Run` whose
+ * methods access the World directly (which would be non-deterministic
+ * inside workflow code).
+ */
+export const WORKFLOW_RUN_CLASS = Symbol.for('WORKFLOW_RUN_CLASS');
+
 export const ABORT_STREAM_NAME = Symbol.for('WORKFLOW_ABORT_STREAM_NAME');
 export const ABORT_HOOK_TOKEN = Symbol.for('WORKFLOW_ABORT_HOOK_TOKEN');
 export const ABORT_LISTENER_ATTACHED = Symbol.for(

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -44,18 +44,6 @@ export const WEBHOOK_RESPONSE_WRITABLE = Symbol.for(
  */
 export const WORKFLOW_CLASS_REGISTRY = Symbol.for('workflow-class-registry');
 
-/**
- * Symbol used to expose the workflow bundle's compiled `Run` class on the
- * VM's globalThis. The workflow-mode `create-hook` module registers it at
- * module scope so host-side code (the hook event consumer) can construct
- * `Run` instances inside the VM — e.g. the conflicting run resolved by
- * `hook.getConflict()`. The bundle's `Run` is the plugin-compiled variant
- * whose methods are durable step proxies, unlike the host `Run` whose
- * methods access the World directly (which would be non-deterministic
- * inside workflow code).
- */
-export const WORKFLOW_RUN_CLASS = Symbol.for('WORKFLOW_RUN_CLASS');
-
 export const ABORT_STREAM_NAME = Symbol.for('WORKFLOW_ABORT_STREAM_NAME');
 export const ABORT_HOOK_TOKEN = Symbol.for('WORKFLOW_ABORT_HOOK_TOKEN');
 export const ABORT_LISTENER_ATTACHED = Symbol.for(

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -49,7 +49,7 @@ export const WORKFLOW_CLASS_REGISTRY = Symbol.for('workflow-class-registry');
  * VM's globalThis. The workflow-mode `create-hook` module registers it at
  * module scope so host-side code (the hook event consumer) can construct
  * `Run` instances inside the VM — e.g. the conflicting run resolved by
- * `hook.getConflict`. The bundle's `Run` is the plugin-compiled variant
+ * `hook.getConflict()`. The bundle's `Run` is the plugin-compiled variant
  * whose methods are durable step proxies, unlike the host `Run` whose
  * methods access the World directly (which would be non-deterministic
  * inside workflow code).

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -2415,7 +2415,7 @@ describe('runWorkflow', () => {
       });
     });
 
-    it('should throw `WorkflowSuspension` when hook.hasConflict is awaited before hook creation is recorded', async () => {
+    it('should throw `WorkflowSuspension` when hook.getConflict is awaited before hook creation is recorded', async () => {
       let error: Error | undefined;
       try {
         const ops: Promise<any>[] = [];
@@ -2439,7 +2439,7 @@ describe('runWorkflow', () => {
           `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
           async function workflow() {
             const hook = createHook({ token: 'claim-only-token' });
-            await hook.hasConflict;
+            await hook.getConflict;
             return 'registered';
           }${getWorkflowTransformCode('workflow')}`,
           workflowRun,
@@ -2457,7 +2457,7 @@ describe('runWorkflow', () => {
       expect((error as WorkflowSuspension).steps[0].type).toEqual('hook');
     });
 
-    it('should resolve hook.hasConflict with false on hook_created without waiting for hook payload data', async () => {
+    it('should resolve hook.getConflict with null on hook_created without waiting for hook payload data', async () => {
       const ops: Promise<any>[] = [];
       const workflowRun: WorkflowRun = {
         runId: 'test-run-123',
@@ -2490,8 +2490,8 @@ describe('runWorkflow', () => {
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
         async function workflow() {
           const hook = createHook({ token: 'claim-only-token' });
-          const hasConflict = await hook.hasConflict;
-          return hasConflict ? 'conflict' : 'registered';
+          const conflict = await hook.getConflict;
+          return conflict === null ? 'registered' : 'conflict';
         }${getWorkflowTransformCode('workflow')}`,
         workflowRun,
         events,
@@ -2508,7 +2508,7 @@ describe('runWorkflow', () => {
       ).toEqual('registered');
     });
 
-    it('should resolve hook.hasConflict with true when hook_conflict event is received', async () => {
+    it('should resolve hook.getConflict with the conflicting run when hook_conflict event is received', async () => {
       const ops: Promise<any>[] = [];
       const workflowRun: WorkflowRun = {
         runId: 'test-run-123',
@@ -2534,6 +2534,7 @@ describe('runWorkflow', () => {
           correlationId: 'hook_01HK153X00GYR8SV1JHHTGN5HE',
           eventData: {
             token: 'claim-only-token',
+            conflictingRunId: 'wrun_conflicting_owner',
           },
           createdAt: new Date(),
         },
@@ -2543,8 +2544,8 @@ describe('runWorkflow', () => {
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
         async function workflow() {
           const hook = createHook({ token: 'claim-only-token' });
-          const hasConflict = await hook.hasConflict;
-          return hasConflict ? 'conflict' : 'registered';
+          const conflict = await hook.getConflict;
+          return conflict === null ? 'registered' : conflict.runId;
         }${getWorkflowTransformCode('workflow')}`,
         workflowRun,
         events,
@@ -2558,7 +2559,7 @@ describe('runWorkflow', () => {
           noEncryptionKey,
           ops
         )
-      ).toEqual('conflict');
+      ).toEqual('wrun_conflicting_owner');
     });
 
     it('should reject with HookConflictError when hook_conflict event is received', async () => {

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -2542,6 +2542,11 @@ describe('runWorkflow', () => {
 
       const result = await runWorkflow(
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+        // In real bundles the workflow-mode create-hook module registers
+        // the compiled Run class on this symbol; mirror that here.
+        globalThis[Symbol.for("WORKFLOW_RUN_CLASS")] = class Run {
+          constructor(runId) { this.runId = runId; }
+        };
         async function workflow() {
           const hook = createHook({ token: 'claim-only-token' });
           const conflict = await hook.getConflict;

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -2542,11 +2542,19 @@ describe('runWorkflow', () => {
 
       const result = await runWorkflow(
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
-        // In real bundles the workflow-mode create-hook module registers
-        // the compiled Run class on this symbol; mirror that here.
-        globalThis[Symbol.for("WORKFLOW_RUN_CLASS")] = class Run {
-          constructor(runId) { this.runId = runId; }
-        };
+        // In real bundles the SWC plugin auto-registers the compiled Run
+        // class in the serialization class registry and the workflow-mode
+        // create-hook module aliases it under the stable id; mirror that
+        // here, including the WORKFLOW_DESERIALIZE hook the host-side
+        // consumer constructs through.
+        {
+          const registrySym = Symbol.for("workflow-class-registry");
+          const registry = globalThis[registrySym] || (globalThis[registrySym] = new Map());
+          registry.set("class//workflow//Run", class Run {
+            static [Symbol.for("workflow-deserialize")](data) { return new Run(data.runId); }
+            constructor(runId) { this.runId = runId; }
+          });
+        }
         async function workflow() {
           const hook = createHook({ token: 'claim-only-token' });
           const conflict = await hook.getConflict();

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -2415,7 +2415,7 @@ describe('runWorkflow', () => {
       });
     });
 
-    it('should throw `WorkflowSuspension` when hook.getConflict is awaited before hook creation is recorded', async () => {
+    it('should throw `WorkflowSuspension` when hook.getConflict() is awaited before hook creation is recorded', async () => {
       let error: Error | undefined;
       try {
         const ops: Promise<any>[] = [];
@@ -2439,7 +2439,7 @@ describe('runWorkflow', () => {
           `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
           async function workflow() {
             const hook = createHook({ token: 'claim-only-token' });
-            await hook.getConflict;
+            await hook.getConflict();
             return 'registered';
           }${getWorkflowTransformCode('workflow')}`,
           workflowRun,
@@ -2457,7 +2457,7 @@ describe('runWorkflow', () => {
       expect((error as WorkflowSuspension).steps[0].type).toEqual('hook');
     });
 
-    it('should resolve hook.getConflict with null on hook_created without waiting for hook payload data', async () => {
+    it('should resolve hook.getConflict() with null on hook_created without waiting for hook payload data', async () => {
       const ops: Promise<any>[] = [];
       const workflowRun: WorkflowRun = {
         runId: 'test-run-123',
@@ -2490,7 +2490,7 @@ describe('runWorkflow', () => {
         `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
         async function workflow() {
           const hook = createHook({ token: 'claim-only-token' });
-          const conflict = await hook.getConflict;
+          const conflict = await hook.getConflict();
           return conflict === null ? 'registered' : 'conflict';
         }${getWorkflowTransformCode('workflow')}`,
         workflowRun,
@@ -2508,7 +2508,7 @@ describe('runWorkflow', () => {
       ).toEqual('registered');
     });
 
-    it('should resolve hook.getConflict with the conflicting run when hook_conflict event is received', async () => {
+    it('should resolve hook.getConflict() with the conflicting run when hook_conflict event is received', async () => {
       const ops: Promise<any>[] = [];
       const workflowRun: WorkflowRun = {
         runId: 'test-run-123',
@@ -2549,7 +2549,7 @@ describe('runWorkflow', () => {
         };
         async function workflow() {
           const hook = createHook({ token: 'claim-only-token' });
-          const conflict = await hook.getConflict;
+          const conflict = await hook.getConflict();
           return conflict === null ? 'registered' : conflict.runId;
         }${getWorkflowTransformCode('workflow')}`,
         workflowRun,

--- a/packages/core/src/workflow/create-hook.ts
+++ b/packages/core/src/workflow/create-hook.ts
@@ -14,7 +14,7 @@ import { getWorkflowMetadata } from './get-workflow-metadata.js';
 // In workflow mode this module is compiled into the workflow bundle and
 // executes inside the VM, so `Run` here is the plugin-compiled variant
 // whose methods are durable step proxies. The host-side consumer uses it
-// to construct the conflicting run resolved by `hook.getConflict`.
+// to construct the conflicting run resolved by `hook.getConflict()`.
 (globalThis as any)[WORKFLOW_RUN_CLASS] ??= Run;
 
 export function createHook<T = any>(options?: HookOptions): Hook<T> {

--- a/packages/core/src/workflow/create-hook.ts
+++ b/packages/core/src/workflow/create-hook.ts
@@ -6,8 +6,16 @@ import type {
   Webhook,
   WebhookOptions,
 } from '../create-hook.js';
-import { WORKFLOW_CREATE_HOOK } from '../symbols.js';
+import { Run } from '../runtime/run.js';
+import { WORKFLOW_CREATE_HOOK, WORKFLOW_RUN_CLASS } from '../symbols.js';
 import { getWorkflowMetadata } from './get-workflow-metadata.js';
+
+// Expose this bundle's `Run` class to the host-side hook event consumer.
+// In workflow mode this module is compiled into the workflow bundle and
+// executes inside the VM, so `Run` here is the plugin-compiled variant
+// whose methods are durable step proxies. The host-side consumer uses it
+// to construct the conflicting run resolved by `hook.getConflict`.
+(globalThis as any)[WORKFLOW_RUN_CLASS] ??= Run;
 
 export function createHook<T = any>(options?: HookOptions): Hook<T> {
   // Inside the workflow VM, the hook function is stored in the globalThis object behind a symbol

--- a/packages/core/src/workflow/create-hook.ts
+++ b/packages/core/src/workflow/create-hook.ts
@@ -6,25 +6,32 @@ import type {
   Webhook,
   WebhookOptions,
 } from '../create-hook.js';
+import {
+  aliasSerializationClass,
+  RUN_CLASS_ID,
+} from '../class-serialization.js';
 import { Run } from '../runtime/run.js';
-import { WORKFLOW_CREATE_HOOK, WORKFLOW_RUN_CLASS } from '../symbols.js';
+import { WORKFLOW_CREATE_HOOK } from '../symbols.js';
 import { getWorkflowMetadata } from './get-workflow-metadata.js';
 
-// Expose this bundle's `Run` class to the host-side hook event consumer.
+// Alias this bundle's `Run` class in the serialization class registry
+// under the stable id, so the host-side hook event consumer can construct
+// the conflicting run resolved by `hook.getConflict()` via the same
+// registry that revives serialized `Run` instances (the SWC plugin
+// already auto-registers `Run` here, but under a path-derived id the
+// host cannot know statically).
+//
 // In workflow mode this module is compiled into the workflow bundle and
 // executes inside the VM, so `Run` here is the plugin-compiled variant
-// whose methods are durable step proxies. The host-side consumer uses it
-// to construct the conflicting run resolved by `hook.getConflict()`.
+// whose methods are durable step proxies. No environment guard is
+// needed: the registry is keyed per-global, so a stray host-side import
+// of this module registers the host's `Run` on the host's registry —
+// which is the correct class for that context.
 //
-// Guarded on the workflow runtime being present (the VM installs
-// WORKFLOW_CREATE_HOOK on its globalThis before evaluating the bundle):
-// outside the VM this module can still be imported — where `createHook()`
-// just throws — and registering the host-side `Run` there would both
-// mutate the host global and expose a class whose methods are NOT step
-// proxies.
-if ((globalThis as any)[WORKFLOW_CREATE_HOOK]) {
-  (globalThis as any)[WORKFLOW_RUN_CLASS] ??= Run;
-}
+// The value import of `Run` also guarantees `runtime/run.js` is included
+// in any bundle that uses hooks, so the registry entry exists whenever
+// `getConflict()` can resolve.
+aliasSerializationClass(RUN_CLASS_ID, Run);
 
 export function createHook<T = any>(options?: HookOptions): Hook<T> {
   // Inside the workflow VM, the hook function is stored in the globalThis object behind a symbol

--- a/packages/core/src/workflow/create-hook.ts
+++ b/packages/core/src/workflow/create-hook.ts
@@ -15,7 +15,16 @@ import { getWorkflowMetadata } from './get-workflow-metadata.js';
 // executes inside the VM, so `Run` here is the plugin-compiled variant
 // whose methods are durable step proxies. The host-side consumer uses it
 // to construct the conflicting run resolved by `hook.getConflict()`.
-(globalThis as any)[WORKFLOW_RUN_CLASS] ??= Run;
+//
+// Guarded on the workflow runtime being present (the VM installs
+// WORKFLOW_CREATE_HOOK on its globalThis before evaluating the bundle):
+// outside the VM this module can still be imported — where `createHook()`
+// just throws — and registering the host-side `Run` there would both
+// mutate the host global and expose a class whose methods are NOT step
+// proxies.
+if ((globalThis as any)[WORKFLOW_CREATE_HOOK]) {
+  (globalThis as any)[WORKFLOW_RUN_CLASS] ??= Run;
+}
 
 export function createHook<T = any>(options?: HookOptions): Hook<T> {
   // Inside the workflow VM, the hook function is stored in the globalThis object behind a symbol

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -8,12 +8,15 @@ import type { Event } from '@workflow/world';
 import * as nanoid from 'nanoid';
 import { monotonicFactory } from 'ulid';
 import { describe, expect, it, vi } from 'vitest';
+import {
+  aliasSerializationClass,
+  RUN_CLASS_ID,
+} from '../class-serialization.js';
 import { EventsConsumer } from '../events-consumer.js';
 import { WorkflowSuspension } from '../global.js';
 import type { WorkflowOrchestratorContext } from '../private.js';
 import { Run } from '../runtime/run.js';
 import { dehydrateStepReturnValue } from '../serialization.js';
-import { WORKFLOW_RUN_CLASS } from '../symbols.js';
 import { createContext } from '../vm/index.js';
 import { createWebhook } from './create-hook.js';
 import { createCreateHook } from './hook.js';
@@ -24,10 +27,11 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     seed: 'test',
     fixedTimestamp: 1753481739458,
   });
-  // In real workflow bundles the workflow-mode create-hook module exposes
-  // the bundle's compiled Run class on this symbol; mirror that here so
-  // `hook.getConflict()` can construct the conflicting run.
-  (context.globalThis as any)[WORKFLOW_RUN_CLASS] = Run;
+  // In real workflow bundles the workflow-mode create-hook module aliases
+  // the bundle's compiled Run class in the serialization class registry;
+  // mirror that here so `hook.getConflict()` can construct the
+  // conflicting run through the registry.
+  aliasSerializationClass(RUN_CLASS_ID, Run, context.globalThis);
   const ulid = monotonicFactory(() => context.globalThis.Math.random());
   const workflowStartedAt = context.globalThis.Date.now();
   return {

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -285,7 +285,7 @@ describe('createCreateHook', () => {
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
   });
 
-  it('should resolve hasConflict with false when hook_created event is received', async () => {
+  it('should resolve getConflict with null when hook_created event is received', async () => {
     const ctx = setupWorkflowContext([
       {
         eventId: 'evnt_0',
@@ -300,7 +300,7 @@ describe('createCreateHook', () => {
     const createHook = createCreateHook(ctx);
     const hook = createHook();
 
-    await expect(hook.hasConflict).resolves.toBe(false);
+    await expect(hook.getConflict).resolves.toBeNull();
 
     expect(ctx.invocationsQueue.size).toBe(1);
     const queueItem = ctx.invocationsQueue.values().next().value;
@@ -309,7 +309,7 @@ describe('createCreateHook', () => {
     expect(ctx.onWorkflowError).not.toHaveBeenCalled();
   });
 
-  it('should suspend when hasConflict is awaited before hook creation is recorded', async () => {
+  it('should suspend when getConflict is awaited before hook creation is recorded', async () => {
     const ctx = setupWorkflowContext([]);
 
     const errorReceived = withResolvers<Error>();
@@ -319,7 +319,7 @@ describe('createCreateHook', () => {
     const hook = createHook();
 
     void (async () => {
-      await hook.hasConflict;
+      await hook.getConflict;
     })();
 
     const workflowError = await errorReceived.promise;
@@ -333,7 +333,7 @@ describe('createCreateHook', () => {
     }
   });
 
-  it('should resolve hasConflict with true when hook_conflict event is received', async () => {
+  it('should resolve getConflict with the conflicting run when hook_conflict event is received', async () => {
     const ctx = setupWorkflowContext([
       {
         eventId: 'evnt_0',
@@ -342,6 +342,7 @@ describe('createCreateHook', () => {
         correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
         eventData: {
           token: 'my-conflicting-token',
+          conflictingRunId: 'wrun_conflicting_owner',
         },
         createdAt: new Date(),
       },
@@ -350,13 +351,18 @@ describe('createCreateHook', () => {
     const createHook = createCreateHook(ctx);
     const hook = createHook({ token: 'my-conflicting-token' });
 
-    await expect(hook.hasConflict).resolves.toBe(true);
+    const conflict = await hook.getConflict;
+    expect(conflict).not.toBeNull();
+    expect(conflict?.runId).toBe('wrun_conflicting_owner');
+
+    // Repeated awaits observe the same conflicting run instance
+    await expect(hook.getConflict).resolves.toBe(conflict);
 
     // Awaiting the hook payload itself still rejects with HookConflictError
     await expect(hook.then((v) => v)).rejects.toThrow(HookConflictError);
   });
 
-  it('should not consume payloads when hasConflict resolves', async () => {
+  it('should not consume payloads when getConflict resolves', async () => {
     const ops: Promise<any>[] = [];
     const ctx = setupWorkflowContext([
       {
@@ -387,7 +393,7 @@ describe('createCreateHook', () => {
     const createHook = createCreateHook(ctx);
     const hook = createHook<{ data: string }>();
 
-    await expect(hook.hasConflict).resolves.toBe(false);
+    await expect(hook.getConflict).resolves.toBeNull();
     await expect(hook).resolves.toEqual({ data: 'after-ready' });
   });
 

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -11,7 +11,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { EventsConsumer } from '../events-consumer.js';
 import { WorkflowSuspension } from '../global.js';
 import type { WorkflowOrchestratorContext } from '../private.js';
+import { Run } from '../runtime/run.js';
 import { dehydrateStepReturnValue } from '../serialization.js';
+import { WORKFLOW_RUN_CLASS } from '../symbols.js';
 import { createContext } from '../vm/index.js';
 import { createWebhook } from './create-hook.js';
 import { createCreateHook } from './hook.js';
@@ -22,6 +24,10 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
     seed: 'test',
     fixedTimestamp: 1753481739458,
   });
+  // In real workflow bundles the workflow-mode create-hook module exposes
+  // the bundle's compiled Run class on this symbol; mirror that here so
+  // `hook.getConflict` can construct the conflicting run.
+  (context.globalThis as any)[WORKFLOW_RUN_CLASS] = Run;
   const ulid = monotonicFactory(() => context.globalThis.Math.random());
   const workflowStartedAt = context.globalThis.Date.now();
   return {
@@ -352,7 +358,7 @@ describe('createCreateHook', () => {
     const hook = createHook({ token: 'my-conflicting-token' });
 
     const conflict = await hook.getConflict;
-    expect(conflict).not.toBeNull();
+    expect(conflict).toBeInstanceOf(Run);
     expect(conflict?.runId).toBe('wrun_conflicting_owner');
 
     // Repeated awaits observe the same conflicting run instance
@@ -360,6 +366,31 @@ describe('createCreateHook', () => {
 
     // Awaiting the hook payload itself still rejects with HookConflictError
     await expect(hook.then((v) => v)).rejects.toThrow(HookConflictError);
+  });
+
+  it('should reject getConflict with HookConflictError when the conflict event lacks conflictingRunId', async () => {
+    // Simulates a hook_conflict event persisted by an old world that did
+    // not record the owning run's ID. getConflict must never resolve with
+    // a value that doesn't honor the Run contract, so it rejects instead.
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'hook_conflict',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: {
+          token: 'my-conflicting-token',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const createHook = createCreateHook(ctx);
+    const hook = createHook({ token: 'my-conflicting-token' });
+
+    await expect(hook.getConflict).rejects.toThrow(HookConflictError);
+    // The fast-path for late awaits rejects the same way
+    await expect(hook.getConflict).rejects.toThrow(HookConflictError);
   });
 
   it('should not consume payloads when getConflict resolves', async () => {

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -26,7 +26,7 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
   });
   // In real workflow bundles the workflow-mode create-hook module exposes
   // the bundle's compiled Run class on this symbol; mirror that here so
-  // `hook.getConflict` can construct the conflicting run.
+  // `hook.getConflict()` can construct the conflicting run.
   (context.globalThis as any)[WORKFLOW_RUN_CLASS] = Run;
   const ulid = monotonicFactory(() => context.globalThis.Math.random());
   const workflowStartedAt = context.globalThis.Date.now();
@@ -306,7 +306,7 @@ describe('createCreateHook', () => {
     const createHook = createCreateHook(ctx);
     const hook = createHook();
 
-    await expect(hook.getConflict).resolves.toBeNull();
+    await expect(hook.getConflict()).resolves.toBeNull();
 
     expect(ctx.invocationsQueue.size).toBe(1);
     const queueItem = ctx.invocationsQueue.values().next().value;
@@ -325,7 +325,7 @@ describe('createCreateHook', () => {
     const hook = createHook();
 
     void (async () => {
-      await hook.getConflict;
+      await hook.getConflict();
     })();
 
     const workflowError = await errorReceived.promise;
@@ -357,12 +357,12 @@ describe('createCreateHook', () => {
     const createHook = createCreateHook(ctx);
     const hook = createHook({ token: 'my-conflicting-token' });
 
-    const conflict = await hook.getConflict;
+    const conflict = await hook.getConflict();
     expect(conflict).toBeInstanceOf(Run);
     expect(conflict?.runId).toBe('wrun_conflicting_owner');
 
     // Repeated awaits observe the same conflicting run instance
-    await expect(hook.getConflict).resolves.toBe(conflict);
+    await expect(hook.getConflict()).resolves.toBe(conflict);
 
     // Awaiting the hook payload itself still rejects with HookConflictError
     await expect(hook.then((v) => v)).rejects.toThrow(HookConflictError);
@@ -388,9 +388,9 @@ describe('createCreateHook', () => {
     const createHook = createCreateHook(ctx);
     const hook = createHook({ token: 'my-conflicting-token' });
 
-    await expect(hook.getConflict).rejects.toThrow(HookConflictError);
+    await expect(hook.getConflict()).rejects.toThrow(HookConflictError);
     // The fast-path for late awaits rejects the same way
-    await expect(hook.getConflict).rejects.toThrow(HookConflictError);
+    await expect(hook.getConflict()).rejects.toThrow(HookConflictError);
   });
 
   it('should not consume payloads when getConflict resolves', async () => {
@@ -424,7 +424,7 @@ describe('createCreateHook', () => {
     const createHook = createCreateHook(ctx);
     const hook = createHook<{ data: string }>();
 
-    await expect(hook.getConflict).resolves.toBeNull();
+    await expect(hook.getConflict()).resolves.toBeNull();
     await expect(hook).resolves.toEqual({ data: 'after-ready' });
   });
 

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -11,24 +11,30 @@ import {
   scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from '../private.js';
+import { WORKFLOW_DESERIALIZE } from '@workflow/serde';
+import { getSerializationClass, RUN_CLASS_ID } from '../class-serialization.js';
 import type { Run } from '../runtime/run.js';
 import { hydrateStepReturnValue } from '../serialization.js';
-import { WORKFLOW_RUN_CLASS } from '../symbols.js';
 
 /**
  * Constructs a `Run` handle for the run that owns a conflicting hook
  * token, for resolution through `hook.getConflict()`.
  *
- * The instance is created from the VM bundle's `Run` class (exposed on
- * the VM's globalThis by the workflow-mode `create-hook` module), whose
- * methods are durable step proxies — safe to call from workflow code.
+ * The instance is created through the serialization class registry on
+ * the VM's globalThis — the same channel that revives serialized `Run`
+ * instances (e.g. `start()` return values crossing from a step into the
+ * workflow). The registered class is the VM bundle's plugin-compiled
+ * `Run`, whose methods are durable step proxies — safe to call from
+ * workflow code — and construction goes through its
+ * `WORKFLOW_DESERIALIZE` hook, exactly as the `Instance` reviver would.
  *
  * Returns `null` when a real `Run` cannot be constructed: the conflict
- * event lacks `conflictingRunId` (written by an old world), or the VM
- * has no `Run` class registered (a context that never loaded the
- * workflow-mode `create-hook` module). `getConflict` awaiters then
- * reject with `HookConflictError` instead of resolving with a value
- * that doesn't honor the `Run` contract.
+ * event lacks `conflictingRunId` (written by an old world), or the VM's
+ * registry has no `Run` (a context that never evaluated the
+ * workflow-mode `create-hook` module, which aliases it under
+ * `RUN_CLASS_ID`). `getConflict` awaiters then reject with
+ * `HookConflictError` instead of resolving with a value that doesn't
+ * honor the `Run` contract.
  */
 function createConflictingRun(
   ctx: WorkflowOrchestratorContext,
@@ -37,11 +43,16 @@ function createConflictingRun(
   if (typeof conflictingRunId !== 'string') {
     return null;
   }
-  const RunClass = (ctx.globalThis as any)?.[WORKFLOW_RUN_CLASS];
-  if (!RunClass) {
+  const RunClass = getSerializationClass(RUN_CLASS_ID, ctx.globalThis) as
+    | (abstract new (
+        ...args: never
+      ) => Run<unknown>)
+    | undefined;
+  const deserialize = (RunClass as any)?.[WORKFLOW_DESERIALIZE];
+  if (typeof deserialize !== 'function') {
     return null;
   }
-  return new RunClass(conflictingRunId);
+  return deserialize.call(RunClass, { runId: conflictingRunId });
 }
 
 export function createCreateHook(ctx: WorkflowOrchestratorContext) {

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -22,19 +22,26 @@ import { WORKFLOW_RUN_CLASS } from '../symbols.js';
  * The instance is created from the VM bundle's `Run` class (exposed on
  * the VM's globalThis by the workflow-mode `create-hook` module), whose
  * methods are durable step proxies — safe to call from workflow code.
- * If the class is unavailable (e.g. plain unit-test contexts that drive
- * the consumer directly), falls back to a `{ runId }`-shaped object so
- * callers can still identify the owner.
+ *
+ * Returns `null` when a real `Run` cannot be constructed: the conflict
+ * event lacks `conflictingRunId` (written by an old world), or the VM
+ * has no `Run` class registered (a context that never loaded the
+ * workflow-mode `create-hook` module). `getConflict` awaiters then
+ * reject with `HookConflictError` instead of resolving with a value
+ * that doesn't honor the `Run` contract.
  */
 function createConflictingRun(
   ctx: WorkflowOrchestratorContext,
   conflictingRunId: string | undefined
-): Run<unknown> {
-  const RunClass = (ctx.globalThis as any)?.[WORKFLOW_RUN_CLASS];
-  if (RunClass && typeof conflictingRunId === 'string') {
-    return new RunClass(conflictingRunId);
+): Run<unknown> | null {
+  if (typeof conflictingRunId !== 'string') {
+    return null;
   }
-  return { runId: conflictingRunId } as Run<unknown>;
+  const RunClass = (ctx.globalThis as any)?.[WORKFLOW_RUN_CLASS];
+  if (!RunClass) {
+    return null;
+  }
+  return new RunClass(conflictingRunId);
 }
 
 export function createCreateHook(ctx: WorkflowOrchestratorContext) {
@@ -172,7 +179,10 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         // The actual settlements are deferred through promiseQueue for
         // ordering. Payload awaiters reject with HookConflictError, while
         // `getConflict` awaiters resolve with the conflicting run so the
-        // workflow can branch on the conflict without throwing.
+        // workflow can branch on the conflict without throwing. When no
+        // real `Run` can be constructed (see `createConflictingRun`),
+        // `getConflict` awaiters reject with the HookConflictError instead
+        // of resolving with a value that doesn't honor the `Run` contract.
         const pendingPromises = promises.slice();
         promises.length = 0;
         const pendingGetConflictPromises = getConflictPromises.slice();
@@ -183,7 +193,11 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
             resolver.reject(conflictError);
           }
           for (const resolver of pendingGetConflictPromises) {
-            resolver.resolve(conflictRunRef);
+            if (conflictRunRef) {
+              resolver.resolve(conflictRunRef);
+            } else {
+              resolver.reject(conflictError);
+            }
           }
         });
 
@@ -368,7 +382,11 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
 
       if (hasConflict) {
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
-          resolvers.resolve(conflictRunRef);
+          if (conflictRunRef) {
+            resolvers.resolve(conflictRunRef);
+          } else {
+            resolvers.reject(conflictErrorRef);
+          }
         });
         return resolvers.promise;
       }

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -11,7 +11,31 @@ import {
   scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from '../private.js';
+import type { Run } from '../runtime/run.js';
 import { hydrateStepReturnValue } from '../serialization.js';
+import { WORKFLOW_RUN_CLASS } from '../symbols.js';
+
+/**
+ * Constructs a `Run` handle for the run that owns a conflicting hook
+ * token, for resolution through `hook.getConflict`.
+ *
+ * The instance is created from the VM bundle's `Run` class (exposed on
+ * the VM's globalThis by the workflow-mode `create-hook` module), whose
+ * methods are durable step proxies — safe to call from workflow code.
+ * If the class is unavailable (e.g. plain unit-test contexts that drive
+ * the consumer directly), falls back to a `{ runId }`-shaped object so
+ * callers can still identify the owner.
+ */
+function createConflictingRun(
+  ctx: WorkflowOrchestratorContext,
+  conflictingRunId: string | undefined
+): Run<unknown> {
+  const RunClass = (ctx.globalThis as any)?.[WORKFLOW_RUN_CLASS];
+  if (RunClass && typeof conflictingRunId === 'string') {
+    return new RunClass(conflictingRunId);
+  }
+  return { runId: conflictingRunId } as Run<unknown>;
+}
 
 export function createCreateHook(ctx: WorkflowOrchestratorContext) {
   return function createHookImpl<T = any>(options: HookOptions = {}): Hook<T> {
@@ -41,9 +65,9 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
     const promises: PromiseWithResolvers<T>[] = [];
 
     // Queue of promises that resolve once hook registration is confirmed
-    // (with `false`) or a token conflict is detected (with `true`). These
-    // back the `hook.hasConflict` getter.
-    const hasConflictPromises: PromiseWithResolvers<boolean>[] = [];
+    // (with `null`) or a token conflict is detected (with the conflicting
+    // `Run`). These back the `hook.getConflict` getter.
+    const getConflictPromises: PromiseWithResolvers<Run<unknown> | null>[] = [];
 
     let eventLogEmpty = false;
 
@@ -56,6 +80,9 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
     // Track if we have a conflict so we can reject future awaits
     let hasConflict = false;
     let conflictErrorRef: HookConflictError | null = null;
+    // The conflicting run handle, shared by every `getConflict` await so
+    // repeated awaits observe the same instance deterministically.
+    let conflictRunRef: Run<unknown> | null = null;
 
     webhookLogger.debug('Hook consumer setup', { correlationId, token });
     ctx.eventsConsumer.subscribe((event) => {
@@ -67,7 +94,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
 
         if (
           (promises.length > 0 && payloadsQueue.length === 0) ||
-          (hasConflictPromises.length > 0 && !hasCreated && !hasConflict)
+          (getConflictPromises.length > 0 && !hasCreated && !hasConflict)
         ) {
           scheduleWhenIdle(ctx, () => {
             ctx.onWorkflowError(
@@ -108,11 +135,11 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         }
         hasCreated = true;
 
-        const pendingHasConflictPromises = hasConflictPromises.slice();
-        hasConflictPromises.length = 0;
+        const pendingGetConflictPromises = getConflictPromises.slice();
+        getConflictPromises.length = 0;
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
-          for (const resolver of pendingHasConflictPromises) {
-            resolver.resolve(false);
+          for (const resolver of pendingGetConflictPromises) {
+            resolver.resolve(null);
           }
         });
 
@@ -135,24 +162,28 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         // Mark that we have a conflict so future awaits also reject
         hasConflict = true;
         conflictErrorRef = conflictError;
+        conflictRunRef = createConflictingRun(
+          ctx,
+          conflictEvent.eventData.conflictingRunId
+        );
 
         // Capture and drain pending promises synchronously so the null event
         // handler won't see them and trigger a spurious WorkflowSuspension.
         // The actual settlements are deferred through promiseQueue for
         // ordering. Payload awaiters reject with HookConflictError, while
-        // `hasConflict` awaiters resolve with `true` so the workflow can
-        // branch on the conflict without throwing.
+        // `getConflict` awaiters resolve with the conflicting run so the
+        // workflow can branch on the conflict without throwing.
         const pendingPromises = promises.slice();
         promises.length = 0;
-        const pendingHasConflictPromises = hasConflictPromises.slice();
-        hasConflictPromises.length = 0;
+        const pendingGetConflictPromises = getConflictPromises.slice();
+        getConflictPromises.length = 0;
 
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
           for (const resolver of pendingPromises) {
             resolver.reject(conflictError);
           }
-          for (const resolver of pendingHasConflictPromises) {
-            resolver.resolve(true);
+          for (const resolver of pendingGetConflictPromises) {
+            resolver.resolve(conflictRunRef);
           }
         });
 
@@ -321,23 +352,23 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
     }
 
     // Helper function to create a promise that resolves with the hook's
-    // registration outcome: `true` when the token is owned by another
-    // active hook, `false` once this hook's registration is committed.
-    // Both fast-paths settle through `ctx.promiseQueue` so resolution
-    // order always matches event-log order.
-    function createHasConflictPromise(): Promise<boolean> {
-      const resolvers = withResolvers<boolean>();
+    // registration outcome: the conflicting `Run` when the token is owned
+    // by another active hook, `null` once this hook's registration is
+    // committed. Both fast-paths settle through `ctx.promiseQueue` so
+    // resolution order always matches event-log order.
+    function createGetConflictPromise(): Promise<Run<unknown> | null> {
+      const resolvers = withResolvers<Run<unknown> | null>();
 
       if (hasCreated) {
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
-          resolvers.resolve(false);
+          resolvers.resolve(null);
         });
         return resolvers.promise;
       }
 
       if (hasConflict) {
         ctx.promiseQueue = ctx.promiseQueue.then(() => {
-          resolvers.resolve(true);
+          resolvers.resolve(conflictRunRef);
         });
         return resolvers.promise;
       }
@@ -355,7 +386,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         });
       }
 
-      hasConflictPromises.push(resolvers);
+      getConflictPromises.push(resolvers);
       return resolvers.promise;
     }
 
@@ -396,8 +427,8 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
     const hook: Hook<T> = {
       token,
 
-      get hasConflict(): Promise<boolean> {
-        return createHasConflictPromise();
+      get getConflict(): Promise<Run<unknown> | null> {
+        return createGetConflictPromise();
       },
 
       // biome-ignore lint/suspicious/noThenProperty: Intentionally thenable

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -17,7 +17,7 @@ import { WORKFLOW_RUN_CLASS } from '../symbols.js';
 
 /**
  * Constructs a `Run` handle for the run that owns a conflicting hook
- * token, for resolution through `hook.getConflict`.
+ * token, for resolution through `hook.getConflict()`.
  *
  * The instance is created from the VM bundle's `Run` class (exposed on
  * the VM's globalThis by the workflow-mode `create-hook` module), whose
@@ -73,7 +73,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
 
     // Queue of promises that resolve once hook registration is confirmed
     // (with `null`) or a token conflict is detected (with the conflicting
-    // `Run`). These back the `hook.getConflict` getter.
+    // `Run`). These back the `hook.getConflict()` getter.
     const getConflictPromises: PromiseWithResolvers<Run<unknown> | null>[] = [];
 
     let eventLogEmpty = false;
@@ -445,7 +445,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
     const hook: Hook<T> = {
       token,
 
-      get getConflict(): Promise<Run<unknown> | null> {
+      getConflict(): Promise<Run<unknown> | null> {
         return createGetConflictPromise();
       },
 

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -607,7 +607,7 @@ export async function hookCleanupTestWorkflow(
 
 //////////////////////////////////////////////////////////
 
-export async function hookHasConflictWorkflow(
+export async function hookGetConflictWorkflow(
   token: string,
   customData: string
 ) {
@@ -618,29 +618,42 @@ export async function hookHasConflictWorkflow(
     metadata: { customData },
   });
 
-  // Awaiting `hasConflict` suspends the workflow to commit the hook
-  // registration without waiting for payload data.
-  const hasConflict = await hook.hasConflict;
+  // Awaiting `getConflict` suspends the workflow to commit the hook
+  // registration without waiting for payload data. It resolves with the
+  // conflicting `Run` when another active hook owns the token, or `null`
+  // once this hook is registered.
+  const conflict = await hook.getConflict;
+
+  if (conflict) {
+    // The conflicting Run's methods are durable step proxies, so the
+    // duplicate run can inspect the active owner before deciding.
+    const conflictStatus = await conflict.status;
+    return {
+      token,
+      customData,
+      conflictRunId: conflict.runId,
+      conflictStatus,
+      hookGetConflictTestData: 'hook_token_conflict_detected',
+    };
+  }
 
   return {
     token,
     customData,
-    hasConflict,
-    hookHasConflictTestData: hasConflict
-      ? 'hook_token_conflict_detected'
-      : 'hook_registered_without_payload',
+    conflictRunId: null,
+    hookGetConflictTestData: 'hook_registered_without_payload',
   };
 }
 
-async function hookHasConflictStep(customData: string) {
+async function hookGetConflictStep(customData: string) {
   'use step';
   return {
     customData,
-    hookHasConflictStepData: 'step_completed',
+    hookGetConflictStepData: 'step_completed',
   };
 }
 
-async function hookHasConflictTimedStep(label: 'A' | 'B', delayMs: number) {
+async function hookGetConflictTimedStep(label: 'A' | 'B', delayMs: number) {
   'use step';
   const { stepStartedAt } = getStepMetadata();
   const startedAt = stepStartedAt.getTime();
@@ -652,7 +665,7 @@ async function hookHasConflictTimedStep(label: 'A' | 'B', delayMs: number) {
   };
 }
 
-export async function hookHasConflictWithPriorStepWorkflow(
+export async function hookGetConflictWithPriorStepWorkflow(
   token: string,
   customData: string
 ) {
@@ -663,20 +676,20 @@ export async function hookHasConflictWithPriorStepWorkflow(
     metadata: { customData },
   });
 
-  const stepPromise = hookHasConflictStep(customData);
+  const stepPromise = hookGetConflictStep(customData);
 
-  const hasConflict = await hook.hasConflict;
+  const conflict = await hook.getConflict;
 
   return {
     token,
     customData,
-    hasConflict,
+    conflictRunId: conflict ? conflict.runId : null,
     stepResult: await stepPromise,
-    hookHasConflictTestData: 'prior_step_completed_after_registration',
+    hookGetConflictTestData: 'prior_step_completed_after_registration',
   };
 }
 
-export async function hookHasConflictWithParallelStepWorkflow(
+export async function hookGetConflictWithParallelStepWorkflow(
   token: string,
   customData: string
 ) {
@@ -687,21 +700,21 @@ export async function hookHasConflictWithParallelStepWorkflow(
     metadata: { customData },
   });
 
-  const [stepResult, hasConflict] = await Promise.all([
-    hookHasConflictStep(customData),
-    hook.hasConflict,
+  const [stepResult, conflict] = await Promise.all([
+    hookGetConflictStep(customData),
+    hook.getConflict,
   ]);
 
   return {
     token,
     customData,
-    hasConflict,
+    conflictRunId: conflict ? conflict.runId : null,
     stepResult,
-    hookHasConflictTestData: 'parallel_step_completed_with_registration',
+    hookGetConflictTestData: 'parallel_step_completed_with_registration',
   };
 }
 
-export async function hookHasConflictThenStepParallelWorkflow(
+export async function hookGetConflictThenStepParallelWorkflow(
   token: string,
   customData: string
 ) {
@@ -712,10 +725,10 @@ export async function hookHasConflictThenStepParallelWorkflow(
     metadata: { customData },
   });
 
-  const stepBPromise = hook.hasConflict.then(
-    async () => await hookHasConflictTimedStep('B', 100)
+  const stepBPromise = hook.getConflict.then(
+    async () => await hookGetConflictTimedStep('B', 100)
   );
-  const stepAResult = await hookHasConflictTimedStep('A', 10_000);
+  const stepAResult = await hookGetConflictTimedStep('A', 10_000);
   const stepBResult = await stepBPromise;
 
   return {
@@ -723,7 +736,7 @@ export async function hookHasConflictThenStepParallelWorkflow(
     customData,
     stepAResult,
     stepBResult,
-    hookHasConflictTestData: 'registration_then_step_runs_in_parallel',
+    hookGetConflictTestData: 'registration_then_step_runs_in_parallel',
   };
 }
 

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -618,11 +618,11 @@ export async function hookGetConflictWorkflow(
     metadata: { customData },
   });
 
-  // Awaiting `getConflict` suspends the workflow to commit the hook
+  // Awaiting `getConflict()` suspends the workflow to commit the hook
   // registration without waiting for payload data. It resolves with the
   // conflicting `Run` when another active hook owns the token, or `null`
   // once this hook is registered.
-  const conflict = await hook.getConflict;
+  const conflict = await hook.getConflict();
 
   if (conflict) {
     // The conflicting Run's methods are durable step proxies, so the
@@ -678,7 +678,7 @@ export async function hookGetConflictWithPriorStepWorkflow(
 
   const stepPromise = hookGetConflictStep(customData);
 
-  const conflict = await hook.getConflict;
+  const conflict = await hook.getConflict();
 
   return {
     token,
@@ -702,7 +702,7 @@ export async function hookGetConflictWithParallelStepWorkflow(
 
   const [stepResult, conflict] = await Promise.all([
     hookGetConflictStep(customData),
-    hook.getConflict,
+    hook.getConflict(),
   ]);
 
   return {
@@ -725,9 +725,9 @@ export async function hookGetConflictThenStepParallelWorkflow(
     metadata: { customData },
   });
 
-  const stepBPromise = hook.getConflict.then(
-    async () => await hookGetConflictTimedStep('B', 100)
-  );
+  const stepBPromise = hook
+    .getConflict()
+    .then(async () => await hookGetConflictTimedStep('B', 100));
   const stepAResult = await hookGetConflictTimedStep('A', 10_000);
   const stepBResult = await stepBPromise;
 

--- a/workbench/nextjs-turbopack/app/workflows/definitions.ts
+++ b/workbench/nextjs-turbopack/app/workflows/definitions.ts
@@ -30,16 +30,16 @@ const DEFAULT_ARGS_MAP: Record<string, unknown[]> = {
     RANDOM_ARG_PLACEHOLDER,
   ],
   hookCleanupTestWorkflow: [RANDOM_ARG_PLACEHOLDER, RANDOM_ARG_PLACEHOLDER],
-  hookHasConflictWorkflow: [RANDOM_ARG_PLACEHOLDER, RANDOM_ARG_PLACEHOLDER],
-  hookHasConflictWithPriorStepWorkflow: [
+  hookGetConflictWorkflow: [RANDOM_ARG_PLACEHOLDER, RANDOM_ARG_PLACEHOLDER],
+  hookGetConflictWithPriorStepWorkflow: [
     RANDOM_ARG_PLACEHOLDER,
     RANDOM_ARG_PLACEHOLDER,
   ],
-  hookHasConflictWithParallelStepWorkflow: [
+  hookGetConflictWithParallelStepWorkflow: [
     RANDOM_ARG_PLACEHOLDER,
     RANDOM_ARG_PLACEHOLDER,
   ],
-  hookHasConflictThenStepParallelWorkflow: [
+  hookGetConflictThenStepParallelWorkflow: [
     RANDOM_ARG_PLACEHOLDER,
     RANDOM_ARG_PLACEHOLDER,
   ],


### PR DESCRIPTION
## Summary

Follow-up to #2015. `hook.hasConflict`'s boolean told the workflow *that* a conflict exists but not *which* run owns the token, so the duplicate run couldn't act on it. This replaces it with `hook.getConflict()`, a promise that resolves with:

- `null` once the hook registration is committed (`hook_created` recorded), or
- a **`Run` handle for the conflicting run** when another active hook owns the token.

Like `hasConflict`, awaiting `getConflict()` suspends the workflow to commit the hook registration without waiting for payload data. But on conflict, the workflow now has the active owner in hand and can choose its own idempotency strategy in code:

```ts
using hook = createHook({ token: `order:${orderId}` });
const conflict = await hook.getConflict();
if (conflict) {
  // any of:
  return { dedupedTo: conflict.runId };          // route caller to the owner
  const status = await conflict.status;          // inspect before deciding
  return await conflict.returnValue;             // adopt the owner's result
  await conflict.cancel();                       // supersede the owner and continue
}
```

This is deliberately code-driven rather than a fixed set of ID-reuse policies (cf. Temporal's `WorkflowIdReusePolicy` / `WorkflowIdConflictPolicy`).

## Implementation

- The workflow-mode `create-hook` module exposes the bundle's compiled `Run` class on a well-known global symbol (`WORKFLOW_RUN_CLASS`). The bundle's `Run` is the SWC-plugin-compiled variant whose accessors (`status`, `returnValue`, `cancel()`, …) are durable step proxies — safe and deterministic inside workflow code. The host-side hook event consumer constructs the conflicting `Run` from the `hook_conflict` event's `conflictingRunId` (#2012) using that class.
- `getConflict` never resolves with anything but a real `Run` or `null`. In the degenerate cases where a `Run` cannot be constructed — a `hook_conflict` event persisted by an old world without `conflictingRunId`, or a context that never loaded the workflow-mode `create-hook` module — it rejects with `HookConflictError` (which still carries the token) instead of resolving with a `{ runId }`-shaped impostor. Note: the `{ runId }` shape remains the documented **v4** return value, since v4 has no native `Run` serialization — v4 docs direct users to `getRun(conflict.runId)` inside a step.
- Repeated `await hook.getConflict()` calls observe the same `Run` instance; both fast-paths settle through `promiseQueue` to keep resolution order aligned with the event log.
- Awaiting the hook payload on a conflicted token still rejects with `HookConflictError`.

## Docs

Updated `createHook()` / `createWebhook()` references, hooks foundations, and event-sourcing pages (v4 + v5; v5 documents the `Run` return, v4 documents `{ runId }`). A follow-up to #2011 adds the full conflict-handling strategy guide to the run-idempotency docs.

## Validation

- `cd packages/core && pnpm typecheck && pnpm vitest run src/` (1155 tests)
- `pnpm test:docs`
- Hook e2e suite against local `nextjs-turbopack`: all `hookGetConflict*` tests pass, including the conflict test asserting the duplicate run resolves the actual owner's `runId` and reads `await conflict.status === 'running'` via a durable step.

