### PR TITLE
fix(docs): right-align sidebar folder carets consistently

### DIFF
--- a/docs/components/geistdocs/sidebar.tsx
+++ b/docs/components/geistdocs/sidebar.tsx
@@ -104,7 +104,7 @@ export const Folder: SidebarPageTreeComponents['Folder'] = ({
     <SidebarFolder defaultOpen={defaultOpen}>
       {item.index ? (
         <SidebarFolderLink
-          className="flex items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground [&_svg]:size-3.5"
+          className="flex w-full items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground data-[active=true]:text-foreground [&_svg]:size-3.5"
           external={item.index.external}
           href={item.index.url}
         >
@@ -112,7 +112,7 @@ export const Folder: SidebarPageTreeComponents['Folder'] = ({
           {item.name}
         </SidebarFolderLink>
       ) : (
-        <SidebarFolderTrigger className="flex items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground [&_svg]:size-3.5">
+        <SidebarFolderTrigger className="flex w-full items-center gap-2 text-pretty py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground [&_svg]:size-3.5">
           {item.icon}
           {item.name}
         </SidebarFolderTrigger>


### PR DESCRIPTION
## Problem

In the docs sidebar, some folder carets sat directly next to the folder name while others were right-aligned:

| Folder | Caret position |
|---|---|
| Getting Started, Foundations, Observability, Deploying, Errors, Migration Guides, API Reference | right edge |
| How it works, AI Agents, Testing | inline, next to the text |

## Cause

Both fumadocs chevrons use `ms-auto`, but the two folder variants render different elements:

- Folders **with** an index link use `SidebarFolderLink`, which renders an `<a>`. With `display: flex` it becomes a block-level box spanning the full sidebar width, so `ms-auto` pushes the chevron to the right edge.
- Folders **without** an index link (`how-it-works` has no `index.mdx`; `ai` and `testing` list `"index"` as a regular child page in their `meta.json`) use `SidebarFolderTrigger`, which renders a `<button>`. Buttons shrink-to-fit their content regardless of `display: flex`, so the chevron stays glued to the text.

Neither className in `docs/components/geistdocs/sidebar.tsx` set a width.

## Fix

Add `w-full` to both `SidebarFolderLink` and `SidebarFolderTrigger` classNames so every folder row spans the sidebar and all carets right-align consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)