### PR TITLE
Animate in-progress segments in the timeline

### DIFF
--- a/.changeset/chatty-walls-appear.md
+++ b/.changeset/chatty-walls-appear.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Animate in-progress segments in the timeline

--- a/packages/web-shared/package.json
+++ b/packages/web-shared/package.json
@@ -38,7 +38,7 @@
     "directory": "packages/web-shared"
   },
   "scripts": {
-    "build": "tsc && cp -r src/components/trace-viewer/*.css dist/components/trace-viewer/ && cp src/styles.css dist/styles.css",
+    "build": "tsc && cp -r src/components/trace-viewer/*.css dist/components/trace-viewer/ && cp src/components/new-trace-viewer/components/*.module.css dist/components/new-trace-viewer/components/ && cp src/styles.css dist/styles.css",
     "dev": "tsc --watch",
     "clean": "tsc --build --clean && rm -r dist ||:",
     "test": "vitest run",

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.module.css
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.module.css
@@ -1,0 +1,31 @@
+.runningStripes {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 0.25rem;
+  opacity: 0.5;
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--ds-blue-500) 0,
+    var(--ds-blue-500) 1.5px,
+    transparent 1.5px,
+    transparent 8px
+  );
+  background-size: 11.314px 11.314px;
+  animation: running-stripes 0.6s linear infinite;
+}
+
+@keyframes running-stripes {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 11.314px 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .runningStripes {
+    animation: none;
+  }
+}

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -19,6 +19,7 @@ import {
   getSpanDurationMs,
 } from '../utils';
 import { ROW_HEIGHT_PX, useRowWindow } from './use-row-window';
+import styles from './timeline.module.css';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -33,6 +34,7 @@ const SEGMENT_CLASSES: Record<SegmentStatus, string> = {
   retrying: 'bg-gray-400 border border-gray-500',
   waiting: 'bg-gray-400 border border-gray-500',
   running: 'bg-blue-200 border border-blue-500',
+  completed: 'bg-blue-200 border border-blue-500',
   failed: 'bg-red-200 border border-red-500',
   succeeded: 'bg-green-200 border border-green-500',
   sleeping: 'bg-gray-400 border border-gray-500',
@@ -43,6 +45,15 @@ const TIMELINE_INSET_STYLE: CSSProperties = {
   left: TIMELINE_PADDING_PX,
   right: TIMELINE_PADDING_PX,
 };
+
+const ACTIVE_SEGMENT_STATUSES: ReadonlySet<SegmentStatus> = new Set([
+  'running',
+  'received',
+]);
+
+function RunningStripes(): ReactNode {
+  return <div aria-hidden className={styles.runningStripes} />;
+}
 
 // ---------------------------------------------------------------------------
 // Bar geometry
@@ -272,7 +283,7 @@ function SegmentBar({ segments }: { segments: VisibleSegment[] }): ReactNode {
           <div
             key={i}
             className={cn(
-              'absolute h-full rounded-[0.25rem]',
+              'absolute h-full overflow-hidden rounded-[0.25rem]',
               SEGMENT_CLASSES[seg.status]
             )}
             style={{
@@ -282,6 +293,9 @@ function SegmentBar({ segments }: { segments: VisibleSegment[] }): ReactNode {
               minWidth: 1,
             }}
           >
+            {ACTIVE_SEGMENT_STATUSES.has(seg.status) ? (
+              <RunningStripes />
+            ) : null}
             {showLabel ? <DurationLabel label={label} /> : null}
           </div>
         );

--- a/packages/web-shared/src/components/new-trace-viewer/utils.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.ts
@@ -185,6 +185,7 @@ export function getResourceColor(resource: string): {
 export type SegmentStatus =
   | 'queued'
   | 'running'
+  | 'completed'
   | 'failed'
   | 'retrying'
   | 'succeeded'
@@ -373,6 +374,12 @@ function computeSleepSegmentsFromSpan(
   return [{ startFraction: 0, endFraction: 1, status: 'sleeping' }];
 }
 
+function runSegmentStatus(runStatus: string | undefined): SegmentStatus {
+  if (runStatus === 'failed') return 'failed';
+  if (runStatus === 'running' || runStatus === 'pending') return 'running';
+  return 'completed';
+}
+
 function computeRunSegmentsFromSpan(
   startMs: number,
   duration: number,
@@ -387,11 +394,12 @@ function computeRunSegmentsFromSpan(
     .map((e) => ({ name: e.name, time: getHighResInMs(e.timestamp) }))
     .sort((a, b) => a.time - b.time);
 
+  const runData = attributes?.data as Record<string, unknown> | undefined;
+  const runStatus = runData?.status as string | undefined;
+
   const hasRunCreated = sorted.some((e) => e.name === 'run_created');
 
   if (!hasRunCreated) {
-    const runData = attributes?.data as Record<string, unknown> | undefined;
-    const runStatus = runData?.status as string | undefined;
     return computeV1RunSegments(startMs, duration, activeStartMs, runStatus);
   }
 
@@ -413,7 +421,7 @@ function computeRunSegmentsFromSpan(
   segments.push({
     startFraction: cursor,
     endFraction: 1,
-    status: failedEvent ? 'failed' : 'running',
+    status: failedEvent ? 'failed' : runSegmentStatus(runStatus),
   });
 
   return segments;
@@ -443,7 +451,7 @@ function computeV1RunSegments(
   segments.push({
     startFraction: cursor,
     endFraction: 1,
-    status: runStatus === 'failed' ? 'failed' : 'running',
+    status: runSegmentStatus(runStatus),
   });
 
   return segments;


### PR DESCRIPTION
## What

Adds an animated diagonal "barber-pole" stripe overlay to **in-progress** (`running`/`received`) segments in the new trace viewer timeline, so it's obvious at a glance which work is still live. Completed runs stay a static blue bar; the queued lead-in stays a static line.


https://github.com/user-attachments/assets/9c006f66-a21b-4c59-b15f-4ada0a778553

