### PR TITLE
Add allowReservedAttributes option to start()

### DIFF
--- a/.changeset/start-allow-reserved-attributes.md
+++ b/.changeset/start-allow-reserved-attributes.md
@@ -1,0 +1,7 @@
+---
+'workflow': minor
+'@workflow/core': minor
+'@workflow/world': minor
+---
+
+Add an `allowReservedAttributes` option to `start()` so framework-level callers can seed reserved `$`-prefixed run attributes at creation, matching the existing `experimental_setAttributes` option. The flag is carried through the resilient-start queue input so lazy run creation validates identically.

--- a/docs/content/docs/v5/api-reference/workflow-api/start.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-api/start.mdx
@@ -56,7 +56,7 @@ Learn more about [`WorkflowReadableStreamOptions`](/docs/api-reference/workflow-
 * The function returns immediately after enqueuing the workflow - it doesn't wait for the workflow to complete.
 * All arguments must be [serializable](/docs/foundations/serialization).
 * When `deploymentId` is provided, the argument types and return type become `unknown` since there is no guarantee the workflow function's types will be consistent across different deployments.
-* `attributes` seeds plaintext run metadata as part of creation and requires a World implementing spec version 4 or later.
+* `attributes` seeds plaintext run metadata as part of creation and requires a World implementing spec version 4 or later. Keys that start with `$` are reserved for framework and library code; framework-level callers can pass `allowReservedAttributes: true` to seed reserved keys, with the same semantics as the [`experimental_setAttributes`](/docs/api-reference/workflow/experimental-set-attributes) option of the same name.
 
 <Callout type="info">
 If `start()` throws `'start' received an invalid workflow function. Ensure the Workflow Development Kit is configured correctly and the function includes a 'use workflow' directive.`, the passed function was not transformed as a workflow. The two most common causes are a missing `"use workflow"` directive or missing framework integration. See [start-invalid-workflow-function](/docs/errors/start-invalid-workflow-function).

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -3760,6 +3760,33 @@ describe('e2e', () => {
     );
 
     test(
+      'start: reserved-prefix initial attributes are seeded with allowReservedAttributes',
+      { timeout: 30_000 },
+      async () => {
+        const run = await start(
+          await e2e('experimentalSetAttributesWorkflow'),
+          [2],
+          {
+            attributes: { $seededByFramework: 'e2e', tenant: 't1' },
+            allowReservedAttributes: true,
+          }
+        );
+        await run.returnValue;
+
+        // The reserved key passes validation on the client and at the
+        // world/server boundary, lands on the run at creation, and
+        // survives the workflow's own attr_set writes.
+        const world = await getWorld();
+        const persisted = await world.runs.get(run.runId);
+        expect(persisted.attributes).toEqual({
+          $seededByFramework: 'e2e',
+          tenant: 't1',
+          phase: 'done',
+        });
+      }
+    );
+
+    test(
       'experimentalSetAttributesWorkflow: workflow-body calls append native attr_set events and merge correctly',
       { timeout: 30_000 },
       async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -555,6 +555,8 @@ export function workflowEntrypoint(
                                   workflowName: runInput.workflowName,
                                   executionContext: runInput.executionContext,
                                   attributes: runInput.attributes,
+                                  allowReservedAttributes:
+                                    runInput.allowReservedAttributes,
                                 },
                               }
                             : {}),

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -214,6 +214,14 @@ describe('start', () => {
       expect(mockQueue.mock.calls[0]?.[1].runInput.attributes).toEqual({
         tenant: 't1',
       });
+      // The reserved-namespace escape hatch was not requested, so the
+      // flag must not appear on either payload.
+      expect(mockEventsCreate.mock.calls[0]?.[1].eventData).not.toHaveProperty(
+        'allowReservedAttributes'
+      );
+      expect(mockQueue.mock.calls[0]?.[1].runInput).not.toHaveProperty(
+        'allowReservedAttributes'
+      );
     });
 
     it('rejects initial attributes for pre-v4 runs', async () => {
@@ -262,6 +270,64 @@ describe('start', () => {
       await expect(
         start(validWorkflow, [], { attributes: { $system: 'x' } })
       ).rejects.toThrow(/reserved prefix/);
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+    });
+
+    it('seeds reserved-prefix initial attributes with allowReservedAttributes and forwards the flag on both payloads', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setWorld({
+        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+
+      await start(validWorkflow, [], {
+        attributes: { $rootRunId: 'wrun_root', tenant: 't1' },
+        allowReservedAttributes: true,
+      });
+
+      // run_created carries the attributes and the flag, so server-side
+      // validation permits the reserved keys the same way the client did.
+      expect(mockEventsCreate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          eventData: expect.objectContaining({
+            attributes: { $rootRunId: 'wrun_root', tenant: 't1' },
+            allowReservedAttributes: true,
+          }),
+        }),
+        expect.anything()
+      );
+      // The resilient-start queue input carries both too, so a run
+      // bootstrapped from run_started validates identically.
+      expect(mockQueue.mock.calls[0]?.[1].runInput).toEqual(
+        expect.objectContaining({
+          attributes: { $rootRunId: 'wrun_root', tenant: 't1' },
+          allowReservedAttributes: true,
+        })
+      );
+    });
+
+    it('still enforces non-reserved validation rules when allowReservedAttributes is set', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setWorld({
+        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+
+      await expect(
+        start(validWorkflow, [], {
+          attributes: { $note: 'v'.repeat(257) },
+          allowReservedAttributes: true,
+        })
+      ).rejects.toThrow(/exceeds limit 256/);
       expect(mockEventsCreate).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -58,6 +58,20 @@ export interface StartOptionsBase {
    * Available for native-attributes runs (spec version 4 and later).
    */
   attributes?: Record<string, string>;
+
+  /**
+   * Permit reserved `$`-prefixed keys in `attributes`. The `$` namespace
+   * is reserved for framework/library code built on top of the workflow
+   * SDK (telemetry, agent metadata, platform-emitted tags, etc.); user
+   * code MUST NOT write keys in it, and validation rejects them so
+   * accidental collisions with tooling-owned keys can't slip through.
+   *
+   * Only flip this to `true` if your caller is itself a framework or
+   * library that owns a `$`-prefixed sub-namespace and knows the
+   * conventions of any other tools writing into it. Same semantics as
+   * the `experimental_setAttributes` option of the same name.
+   */
+  allowReservedAttributes?: boolean;
 }
 
 export interface StartOptionsWithDeploymentId extends StartOptionsBase {
@@ -229,6 +243,7 @@ export async function start<TArgs extends unknown[], TResult>(
         world.specVersion ??
         SPEC_VERSION_SUPPORTS_EVENT_SOURCING;
       const v1Compat = isLegacySpecVersion(specVersion);
+      const allowReservedAttributes = opts.allowReservedAttributes === true;
       let attributes: Record<string, string> | undefined;
       if (opts.attributes && Object.keys(opts.attributes).length > 0) {
         if (specVersion < SPEC_VERSION_SUPPORTS_ATTRIBUTES) {
@@ -247,11 +262,24 @@ export async function start<TArgs extends unknown[], TResult>(
             );
           }
         }
-        const changes = normalizeAttributeChanges(opts.attributes);
+        const changes = normalizeAttributeChanges(opts.attributes, {
+          allowReservedAttributes,
+        });
         attributes = Object.fromEntries(
           changes.map(({ key, value }) => [key, value as string])
         );
       }
+      // Seed payload shared by run_created and the resilient-start queue
+      // input. The flag rides along so server-side validation matches the
+      // client-side check above on both paths.
+      const attributeSeed = attributes
+        ? {
+            attributes,
+            ...(allowReservedAttributes
+              ? { allowReservedAttributes: true as const }
+              : {}),
+          }
+        : {};
 
       // Resolve encryption key for the new run. The runId has already been
       // generated above (client-generated ULID) and will be used for both
@@ -298,7 +326,7 @@ export async function start<TArgs extends unknown[], TResult>(
               workflowName: workflowName,
               input: workflowArguments,
               executionContext,
-              ...(attributes ? { attributes } : {}),
+              ...attributeSeed,
             },
           },
           { v1Compat }
@@ -316,7 +344,7 @@ export async function start<TArgs extends unknown[], TResult>(
                     workflowName,
                     specVersion,
                     executionContext,
-                    ...(attributes ? { attributes } : {}),
+                    ...attributeSeed,
                   },
                 }
               : {}),

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -115,6 +115,12 @@ export const RunInputSchema = z.object({
   executionContext: z.record(z.string(), z.any()).optional(),
   /** Initial plaintext run attributes, for resilient run creation. */
   attributes: z.record(z.string(), z.string()).optional(),
+  /**
+   * Permits reserved `$`-prefixed keys in `attributes`, mirrored from the
+   * `start()` option so resilient run creation validates the same way as
+   * the original `run_created` attempt.
+   */
+  allowReservedAttributes: z.literal(true).optional(),
 });
 export type RunInput = z.infer<typeof RunInputSchema>;
 


### PR DESCRIPTION
## Summary

#2226 added `start(..., { attributes })` to seed plaintext attributes at run creation, but always validates them with the reserved `$` prefix disallowed and exposes no opt-out. That leaves a gap relative to the rest of the attributes surface: `experimental_setAttributes` accepts `{ allowReservedAttributes: true }` for framework-level callers, and the `run_created` / `run_started` event schemas plus the local and Postgres worlds already accept and validate the flag — so the wire format supports seeding reserved attributes at creation, just not through the public `start()` API.

This closes that gap by threading the same option through `start()`:

- `StartOptions.allowReservedAttributes` (same semantics and guidance as the `experimental_setAttributes` option) is passed to client-side validation and forwarded on the `run_created` eventData.
- The flag rides along in the queue `runInput` (new optional field on `RunInputSchema`) and is forwarded into the `run_started` eventData, so the resilient-start path (run bootstrapped from the queue message when `run_created` was missed) validates the seeded attributes identically to the original attempt.

No world changes needed — world-local and world-postgres already honor `allowReservedAttributes` on both the `run_created` and `run_started` creation paths.

This unblocks framework-level use cases like cross-run lineage (#2153, `$rootRunId` / `$parentRunId`) that need reserved keys present from creation time.

## Testing

- `pnpm --filter @workflow/core test`
- `pnpm exec turbo run typecheck test --filter=@workflow/world --filter=@workflow/core --filter=@workflow/world-local`
- New unit tests: reserved keys + flag accepted and forwarded on both `run_created` and the queue `runInput`; flag absent from both payloads when not requested; size/cap validation still enforced with the flag set; reserved keys still rejected without the flag (existing test).
- New e2e test (run locally against the nextjs-turbopack dev server): `start()` with a `$`-prefixed key + `allowReservedAttributes: true` completes, the reserved key is persisted on the run, and it survives the workflow's own `attr_set` writes.
- workflow-server already validates and honors the flag on initial run attributes (`InitialRunAttributesSchema`) and forwards it on its own resilient path, so no server change is needed.

## Docs Preview

| Page | v5 |
| --- | --- |
| `start()` API reference | [/v5/docs/api-reference/workflow-api/start](https://workflow-docs-git-start-allow-reserved-attributes.vercel.sh/v5/docs/api-reference/workflow-api/start) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

