### PR TITLE
test: e2e coverage for run-idempotency conflict-handling strategies

### DIFF
--- a/.changeset/idempotency-strategy-e2e.md
+++ b/.changeset/idempotency-strategy-e2e.md
@@ -1,6 +1,2 @@
 ---
-"@workflow/core": patch
-"workflow": patch
 ---
-
-Add e2e coverage for the documented run-idempotency patterns: claim-only hook mutex (token held without payload data, released on completion), adopt-owner-result via `conflict.returnValue`, signal-the-owner via `resumeHook()`, supersede via `conflict.cancel()` and reclaim, and the route-side resume-or-start retry pattern.

--- a/.changeset/idempotency-strategy-e2e.md
+++ b/.changeset/idempotency-strategy-e2e.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": patch
+"workflow": patch
+---
+
+Add e2e coverage for the documented run-idempotency patterns: claim-only hook mutex (token held without payload data, released on completion), adopt-owner-result via `conflict.returnValue`, signal-the-owner via `resumeHook()`, supersede via `conflict.cancel()` and reclaim, and the route-side resume-or-start retry pattern.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1920,6 +1920,220 @@ describe('e2e', () => {
   );
 
   test(
+    'hookClaimOnlyMutexWorkflow - hook works as a pure run mutex without payload data',
+    { timeout: 90_000 },
+    async () => {
+      const token = Math.random().toString(36).slice(2);
+
+      // Owner claims the token and holds it during unrelated work,
+      // never awaiting payload data.
+      const run1 = await start(await e2e('hookClaimOnlyMutexWorkflow'), [
+        token,
+        15_000,
+      ]);
+      await waitForHook(token, { runId: run1.runId });
+
+      // A duplicate started while the owner holds the token observes the
+      // conflict and identifies the owner.
+      const run2 = await start(await e2e('hookClaimOnlyMutexWorkflow'), [
+        token,
+        15_000,
+      ]);
+      const run2Result = await run2.returnValue;
+      expect(run2Result).toEqual({
+        role: 'duplicate',
+        conflictRunId: run1.runId,
+      });
+
+      // The owner completes without ever receiving a payload.
+      const run1Result = await run1.returnValue;
+      expect(run1Result).toMatchObject({ role: 'owner' });
+
+      const world = await getWorld();
+      const { data: events } = await world.events.list({ runId: run1.runId });
+      expect(
+        events.some((e) => e.eventType === 'hook_received'),
+        'claim-only owner should never receive hook payload data'
+      ).toBe(false);
+
+      // Completion releases the token: a later run claims it cleanly.
+      const waitForTokenRelease = async () => {
+        const timeoutAt = Date.now() + 20_000;
+        while (Date.now() < timeoutAt) {
+          try {
+            await getHookByToken(token);
+          } catch (error) {
+            if (HookNotFoundError.is(error)) {
+              return;
+            }
+            throw error;
+          }
+          await sleep(1_000);
+        }
+        throw new Error(`Timed out waiting for token ${token} to be released`);
+      };
+      await waitForTokenRelease();
+
+      const run3 = await start(await e2e('hookClaimOnlyMutexWorkflow'), [
+        token,
+        100,
+      ]);
+      const run3Result = await run3.returnValue;
+      expect(run3Result).toMatchObject({ role: 'owner' });
+    }
+  );
+
+  test(
+    'hookAdoptOwnerResultWorkflow - duplicate adopts the owner result via conflict.returnValue',
+    { timeout: 90_000 },
+    async () => {
+      const token = Math.random().toString(36).slice(2);
+
+      const run1 = await start(await e2e('hookAdoptOwnerResultWorkflow'), [
+        token,
+        'owner-marker',
+      ]);
+      await waitForHook(token, { runId: run1.runId });
+
+      // The duplicate suspends on the owner's returnValue.
+      const run2 = await start(await e2e('hookAdoptOwnerResultWorkflow'), [
+        token,
+        'duplicate-marker',
+      ]);
+
+      // Complete the owner.
+      await resumeHook(token, { value: 'adopted-value' });
+
+      const run1Result = await run1.returnValue;
+      expect(run1Result).toEqual({
+        role: 'owner',
+        marker: 'owner-marker',
+        value: 'adopted-value',
+      });
+
+      // The duplicate returns the owner's exact result, so callers cannot
+      // tell which run did the work.
+      const run2Result = await run2.returnValue;
+      expect(run2Result).toEqual({
+        role: 'duplicate',
+        conflictRunId: run1.runId,
+        adopted: run1Result,
+      });
+    }
+  );
+
+  test(
+    'hookSignalOwnerWorkflow - duplicate forwards its payload to the owner via resumeHook',
+    { timeout: 90_000 },
+    async () => {
+      const token = Math.random().toString(36).slice(2);
+
+      const run1 = await start(await e2e('hookSignalOwnerWorkflow'), [
+        token,
+        'owner-input',
+      ]);
+      await waitForHook(token, { runId: run1.runId });
+
+      // The duplicate forwards its own input into the owner's hook
+      // instead of doing the work itself.
+      const run2 = await start(await e2e('hookSignalOwnerWorkflow'), [
+        token,
+        'forwarded-from-duplicate',
+      ]);
+
+      const run2Result = await run2.returnValue;
+      expect(run2Result).toEqual({
+        role: 'duplicate',
+        forwardedTo: run1.runId,
+      });
+
+      // The owner receives the duplicate's payload and completes with it.
+      const run1Result = await run1.returnValue;
+      expect(run1Result).toEqual({
+        role: 'owner',
+        received: 'forwarded-from-duplicate',
+      });
+    }
+  );
+
+  test(
+    'hookSupersedeOwnerWorkflow - duplicate cancels the owner and claims the released token',
+    { timeout: 90_000 },
+    async () => {
+      const token = Math.random().toString(36).slice(2);
+
+      // The first run claims the token and waits for a payload.
+      const run1 = await start(await e2e('hookSupersedeOwnerWorkflow'), [
+        token,
+      ]);
+      await waitForHook(token, { runId: run1.runId });
+
+      // Newest-wins: the second run cancels the owner and claims the token.
+      const run2 = await start(await e2e('hookSupersedeOwnerWorkflow'), [
+        token,
+      ]);
+      await waitForHook(token, { runId: run2.runId, timeoutMs: 60_000 });
+
+      // The superseded owner ends up cancelled.
+      const { json: run1Data } = await cliInspectJson(`runs ${run1.runId}`);
+      expect(run1Data.status).toBe('cancelled');
+
+      // The new owner receives payloads on the reclaimed token.
+      await resumeHook(token, { message: 'post-supersede' });
+      const run2Result = await run2.returnValue;
+      expect(run2Result).toMatchObject({
+        role: 'owner',
+        received: 'post-supersede',
+      });
+    }
+  );
+
+  test(
+    'resume-or-start route pattern - resumeHook retried after start() reaches the new run',
+    { timeout: 90_000 },
+    async () => {
+      const token = Math.random().toString(36).slice(2);
+
+      // No active run yet: the resume half fails with HookNotFoundError.
+      await expect(
+        resumeHook(token, { message: 'too-early' })
+      ).rejects.toSatisfy((e: unknown) => HookNotFoundError.is(e));
+
+      // Start the workflow, then retry the resume until the run registers
+      // its deterministic hook — the documented route-side pattern.
+      const run = await start(await e2e('hookSignalOwnerWorkflow'), [
+        token,
+        'unused-owner-input',
+      ]);
+
+      const deadline = Date.now() + 30_000;
+      let resumed: Awaited<ReturnType<typeof resumeHook>> | undefined;
+      while (Date.now() < deadline) {
+        try {
+          resumed = await resumeHook(token, { message: 'delivered' });
+          break;
+        } catch (error) {
+          if (!HookNotFoundError.is(error)) throw error;
+          await sleep(250);
+        }
+      }
+      expect(
+        resumed,
+        'resume retry should reach the started run'
+      ).toBeDefined();
+
+      // The resume reached the run this request started (no concurrent
+      // racer in this test), and the payload was not dropped.
+      expect(resumed?.runId).toBe(run.runId);
+      const result = await run.returnValue;
+      expect(result).toEqual({
+        role: 'owner',
+        received: 'delivered',
+      });
+    }
+  );
+
+  test(
     'hookDisposeTestWorkflow - hook token reuse after explicit disposal while workflow still running',
     { timeout: 90_000 },
     async () => {

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1985,7 +1985,7 @@ describe('e2e', () => {
 
   test(
     'hookAdoptOwnerResultWorkflow - duplicate adopts the owner result via conflict.returnValue',
-    { timeout: 90_000 },
+    { timeout: 120_000 },
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2000,6 +2000,28 @@ describe('e2e', () => {
         token,
         'duplicate-marker',
       ]);
+
+      // Wait until run2 has actually observed the conflict before letting
+      // the owner complete. On slow runtimes run2's first invocation can
+      // otherwise land after the owner finished and released the token,
+      // turning run2 into a fresh owner that waits forever for a payload.
+      const world = await getWorld();
+      const conflictDeadline = Date.now() + 60_000;
+      let sawConflict = false;
+      while (Date.now() < conflictDeadline) {
+        const { data: run2Events } = await world.events.list({
+          runId: run2.runId,
+        });
+        if (run2Events.some((e) => e.eventType === 'hook_conflict')) {
+          sawConflict = true;
+          break;
+        }
+        await sleep(500);
+      }
+      expect(
+        sawConflict,
+        'run2 should observe the hook conflict while the owner is active'
+      ).toBe(true);
 
       // Complete the owner.
       await resumeHook(token, { value: 'adopted-value' });

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2096,7 +2096,11 @@ describe('e2e', () => {
       ]);
       await waitForHook(token, { runId: run2.runId, timeoutMs: 60_000 });
 
-      // The superseded owner ends up cancelled.
+      // The superseded owner ends up cancelled — assert via both the
+      // rejected returnValue (also prevents an unhandled rejection from
+      // leaking out of this test) and the inspected run status.
+      const run1Error = await run1.returnValue.catch((e: unknown) => e);
+      expect(WorkflowRunCancelledError.is(run1Error)).toBe(true);
       const { json: run1Data } = await cliInspectJson(`runs ${run1.runId}`);
       expect(run1Data.status).toBe('cancelled');
 

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -741,6 +741,132 @@ export async function hookGetConflictThenStepParallelWorkflow(
 }
 
 //////////////////////////////////////////////////////////
+// Run idempotency / conflict-handling strategy workflows.
+// These mirror the patterns documented in
+// docs/content/docs/*/foundations/idempotency.mdx.
+//////////////////////////////////////////////////////////
+
+/**
+ * Claim-only run mutex: the hook is used purely for run idempotency —
+ * the workflow claims the token, holds it while doing unrelated work,
+ * and never awaits hook payload data. Duplicates started while the
+ * owner holds the token observe the conflict and return early.
+ */
+export async function hookClaimOnlyMutexWorkflow(
+  token: string,
+  holdMs: number
+) {
+  'use workflow';
+
+  using hook = createHook({ token });
+
+  const conflict = await hook.getConflict();
+  if (conflict) {
+    return {
+      role: 'duplicate' as const,
+      conflictRunId: conflict.runId,
+    };
+  }
+
+  // Hold the token for the duration of the work without ever awaiting
+  // hook payload data.
+  const work = await hookGetConflictTimedStep('A', holdMs);
+
+  return {
+    role: 'owner' as const,
+    workEndedAt: work.endedAt,
+  };
+}
+
+/**
+ * "Adopt the owner's result" strategy: the duplicate run waits for the
+ * active owner to finish and returns the owner's result, so callers
+ * cannot tell which run did the work.
+ */
+export async function hookAdoptOwnerResultWorkflow(
+  token: string,
+  marker: string
+) {
+  'use workflow';
+
+  using hook = createHook<{ value: string }>({ token });
+
+  const conflict = await hook.getConflict();
+  if (conflict) {
+    const adopted = await conflict.returnValue;
+    return {
+      role: 'duplicate' as const,
+      conflictRunId: conflict.runId,
+      adopted,
+    };
+  }
+
+  const payload = await hook;
+  return {
+    role: 'owner' as const,
+    marker,
+    value: payload.value,
+  };
+}
+
+async function forwardPayloadToOwner(token: string, message: string) {
+  'use step';
+  await resumeHook(token, { message });
+}
+
+/**
+ * "Signal the owner" strategy: the duplicate run forwards its input to
+ * the active owner's hook from a step instead of doing the work itself.
+ */
+export async function hookSignalOwnerWorkflow(token: string, message: string) {
+  'use workflow';
+
+  using hook = createHook<{ message: string }>({ token });
+
+  const conflict = await hook.getConflict();
+  if (conflict) {
+    await forwardPayloadToOwner(token, message);
+    return {
+      role: 'duplicate' as const,
+      forwardedTo: conflict.runId,
+    };
+  }
+
+  const payload = await hook;
+  return {
+    role: 'owner' as const,
+    received: payload.message,
+  };
+}
+
+/**
+ * "Supersede the owner" strategy (newest-wins): cancel the active owner
+ * and claim the released token. Cancellation disposes the owner's hooks;
+ * the retry loop covers the window where disposal has not propagated.
+ */
+export async function hookSupersedeOwnerWorkflow(token: string) {
+  'use workflow';
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    using hook = createHook<{ message: string }>({ token });
+
+    const conflict = await hook.getConflict();
+    if (!conflict) {
+      const payload = await hook;
+      return {
+        role: 'owner' as const,
+        attempt,
+        received: payload.message,
+      };
+    }
+
+    await conflict.cancel();
+  }
+
+  throw new Error(`Could not claim ${token} after cancelling the owner`);
+}
+
+//////////////////////////////////////////////////////////
 
 /**
  * Workflow for testing early hook disposal - allows another workflow to reuse

--- a/workbench/nextjs-turbopack/app/workflows/definitions.ts
+++ b/workbench/nextjs-turbopack/app/workflows/definitions.ts
@@ -1,5 +1,8 @@
 import 'server-only';
 
+// NOTE: comment edit busts the turbo task hash 70724907c9dd3a29, whose
+// remote-cache entry was poisoned by an esbuild hang during the build of
+// dpl_6UXttzGpjxbrFcpRQZGR6E9v3G2Q (missing .next/routes-manifest.json).
 import { allWorkflows } from '@/_workflows';
 import type { WorkflowDefinition } from './types';
 

--- a/workbench/nextjs-turbopack/app/workflows/definitions.ts
+++ b/workbench/nextjs-turbopack/app/workflows/definitions.ts
@@ -43,6 +43,13 @@ const DEFAULT_ARGS_MAP: Record<string, unknown[]> = {
     RANDOM_ARG_PLACEHOLDER,
     RANDOM_ARG_PLACEHOLDER,
   ],
+  hookClaimOnlyMutexWorkflow: [RANDOM_ARG_PLACEHOLDER, 1000],
+  hookAdoptOwnerResultWorkflow: [
+    RANDOM_ARG_PLACEHOLDER,
+    RANDOM_ARG_PLACEHOLDER,
+  ],
+  hookSignalOwnerWorkflow: [RANDOM_ARG_PLACEHOLDER, RANDOM_ARG_PLACEHOLDER],
+  hookSupersedeOwnerWorkflow: [RANDOM_ARG_PLACEHOLDER],
   closureVariableWorkflow: [7],
   startFromWorkflow: [42],
   fibonacciWorkflow: [3],


### PR DESCRIPTION
## Summary

Adds e2e coverage for the run-idempotency patterns and conflict-handling strategies documented in #2011 (built on `hook.getConflict()` from #2373). Before this, e2e coverage proved claim-without-payload and conflict *detection*, but none of the documented *strategies* — and the purest use case (hooks purely as a run mutex, never carrying data) had no owner-side coverage.

## New tests (`packages/core/e2e/e2e.test.ts` + workflows in `workbench/example/workflows/99_e2e.ts`)

- **`hookClaimOnlyMutexWorkflow` — pure run mutex.** The owner claims the token via `getConflict()`, holds it through a slow step, and never awaits payload data (asserted via zero `hook_received` events). A duplicate started during the hold identifies the owner; after the owner completes, the token is released and a third run claims it cleanly.
- **`hookAdoptOwnerResultWorkflow` — adopt the owner's result.** The duplicate awaits `conflict.returnValue` and returns the owner's exact result, proving callers can't tell which run did the work.
- **`hookSignalOwnerWorkflow` — signal the owner.** The duplicate forwards its own input into the owner's hook via `resumeHook()` from a step; the owner completes with the forwarded payload.
- **`hookSupersedeOwnerWorkflow` — newest-wins.** The duplicate cancels the owner via `conflict.cancel()` and reclaims the released token through the documented retry loop; asserts the owner ends `cancelled` and the new owner receives payloads on the reclaimed token.
- **Resume-or-start route pattern.** Exercises the documented route-side flow directly from the test: `resumeHook` fails with `HookNotFoundError` before any run exists, then `start()` + retried resume reaches the started run without dropping the payload.

## Validation

- `cd workbench/example && pnpm build` (workflows compile through the SWC plugin)
- Full hook e2e suite against local `nextjs-turbopack` dev server: 25 tests pass, including all 5 new ones

Changeset: patch for `workflow`/`@workflow/core` (test-only; rides along on the next bump).