### PR TITLE
fix(docs): repair broken links, fix the link linter, and version-correct v5 Card + edit links

### DIFF
--- a/docs/app/[lang]/cookbook/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/cookbook/[[...slug]]/page.tsx
@@ -60,7 +60,7 @@ const Page = async ({ params }: PageProps<'/[lang]/cookbook/[[...slug]]'>) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v4" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -57,7 +57,7 @@ const Page = async ({ params }: PageProps<'/[lang]/docs/[[...slug]]'>) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v4" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/app/[lang]/v5/cookbook/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/cookbook/[[...slug]]/page.tsx
@@ -75,7 +75,7 @@ const Page = async ({
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v5" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/app/[lang]/v5/cookbook/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/cookbook/[[...slug]]/page.tsx
@@ -1,14 +1,10 @@
+import { Card, type CardProps } from 'fumadocs-ui/components/card';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import type { ComponentProps } from 'react';
-import {
-  rewriteCookbookUrlForVersion,
-  rewriteCookbookUrlsInText,
-} from '@/lib/geistdocs/cookbook-source';
-import { MobileDocsBar } from '@/components/geistdocs/mobile-docs-bar';
 import { AskAI } from '@/components/geistdocs/ask-ai';
 import { CopyPage } from '@/components/geistdocs/copy-page';
 import {
@@ -20,10 +16,15 @@ import {
 import { EditSource } from '@/components/geistdocs/edit-source';
 import { Feedback } from '@/components/geistdocs/feedback';
 import { getMDXComponents } from '@/components/geistdocs/mdx-components';
+import { MobileDocsBar } from '@/components/geistdocs/mobile-docs-bar';
 import { OpenInChat } from '@/components/geistdocs/open-in-chat';
 import { ScrollTop } from '@/components/geistdocs/scroll-top';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
+import {
+  rewriteCookbookUrlForVersion,
+  rewriteCookbookUrlsInText,
+} from '@/lib/geistdocs/cookbook-source';
 import { getLLMText, getPageImage, v5Source } from '@/lib/geistdocs/source';
 import { PRE_RELEASE_VERSION } from '@/lib/geistdocs/versions';
 
@@ -49,15 +50,22 @@ const Page = async ({
 
   // Rewrite /docs/cookbook/... links to /v5/cookbook/... and other /docs/...
   // links to /v5/docs/... so inline MDX links stay within the v5 context.
+  // Card renders its own Link (not the `a` component), so it needs the same
+  // rewrite applied separately.
+  function v5Href<T>(href: T): T {
+    if (typeof href !== 'string') return href;
+    let rewritten = rewriteCookbookUrlForVersion(href, VERSION_PREFIX);
+    if (rewritten.startsWith('/docs/'))
+      rewritten = `${VERSION_PREFIX}${rewritten}`;
+    return rewritten as T;
+  }
   const RelativeLink = createRelativeLink(v5Source, publicPage);
-  const V5CookbookLink = (props: ComponentProps<typeof RelativeLink>) => {
-    let href = props.href;
-    if (typeof href === 'string') {
-      href = rewriteCookbookUrlForVersion(href, VERSION_PREFIX);
-      if (href.startsWith('/docs/')) href = `${VERSION_PREFIX}${href}`;
-    }
-    return <RelativeLink {...props} href={href} />;
-  };
+  const V5CookbookLink = (props: ComponentProps<typeof RelativeLink>) => (
+    <RelativeLink {...props} href={v5Href(props.href)} />
+  );
+  const V5CookbookCard = (props: CardProps) => (
+    <Card {...props} href={v5Href(props.href)} />
+  );
 
   return (
     <DocsPage
@@ -86,6 +94,7 @@ const Page = async ({
         <MDX
           components={getMDXComponents({
             a: V5CookbookLink,
+            Card: V5CookbookCard,
             Badge,
             Step,
             Steps,

--- a/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
@@ -80,7 +80,7 @@ const Page = async ({ params }: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} version="v5" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
@@ -1,9 +1,10 @@
+import { Card, type CardProps } from 'fumadocs-ui/components/card';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { Metadata } from 'next';
-import type { ComponentProps } from 'react';
 import { notFound, permanentRedirect } from 'next/navigation';
+import type { ComponentProps } from 'react';
 import { AgentTraces } from '@/components/custom/agent-traces';
 import { FluidComputeCallout } from '@/components/custom/fluid-compute-callout';
 import { AskAI } from '@/components/geistdocs/ask-ai';
@@ -56,14 +57,19 @@ const Page = async ({ params }: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
   // browsing under /v5/docs/..., those links would escape to the v4 route.
   // Rewrite /docs/... → /v5/docs/... so all inline links stay inside the v5
   // context, matching how the sidebar tree is rewritten by rewriteNodeUrls in
-  // version-source.ts.
+  // version-source.ts. Card renders its own Link (not the `a` component), so
+  // it needs the same rewrite applied separately.
+  function v5Href<T>(href: T): T {
+    return typeof href === 'string' && href.startsWith('/docs/')
+      ? (`/v5${href}` as T)
+      : href;
+  }
   const baseLink = createRelativeLink(v5Source, page);
   function v5Link(props: ComponentProps<typeof baseLink>) {
-    const href =
-      typeof props.href === 'string' && props.href.startsWith('/docs/')
-        ? `/v5${props.href}`
-        : props.href;
-    return baseLink({ ...props, href });
+    return baseLink({ ...props, href: v5Href(props.href) });
+  }
+  function V5Card(props: CardProps) {
+    return <Card {...props} href={v5Href(props.href)} />;
   }
 
   return (
@@ -93,6 +99,7 @@ const Page = async ({ params }: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
         <MDX
           components={getMDXComponents({
             a: v5Link,
+            Card: V5Card,
             AgentTraces,
             FluidComputeCallout,
             Badge,

--- a/docs/components/geistdocs/edit-source.tsx
+++ b/docs/components/geistdocs/edit-source.tsx
@@ -3,13 +3,14 @@ import { github } from '@/geistdocs';
 
 type EditSourceProps = {
   path: string | undefined;
+  version: 'v4' | 'v5';
 };
 
-export const EditSource = ({ path }: EditSourceProps) => {
+export const EditSource = ({ path, version }: EditSourceProps) => {
   let url: string | undefined;
 
   if (github.owner && github.repo && path) {
-    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/content/docs/${path}`;
+    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/content/docs/${version}/${path}`;
   }
 
   if (!url) {

--- a/docs/content/docs/v4/api-reference/vitest/index.mdx
+++ b/docs/content/docs/v4/api-reference/vitest/index.mdx
@@ -69,7 +69,7 @@ export async function setup() {
 
 ### `setupWorkflowTests()`
 
-Sets up an in-process workflow runtime in each test worker. Imports pre-built bundles, creates a [Local World](/docs/worlds/local) instance with direct handlers, and sets it as the global world. Clears all workflow data on each invocation for full test isolation.
+Sets up an in-process workflow runtime in each test worker. Imports pre-built bundles, creates a [Local World](/worlds/local) instance with direct handlers, and sets it as the global world. Clears all workflow data on each invocation for full test isolation.
 
 Called automatically by the `workflow()` plugin in `setupFiles`. Use directly only for [manual setup](/docs/testing#manual-setup).
 

--- a/docs/content/docs/v4/api-reference/workflow-errors/index.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-errors/index.mdx
@@ -1,0 +1,85 @@
+---
+title: "workflow/errors"
+description: Semantic error types thrown by the Workflow SDK and its storage backends.
+type: overview
+summary: Explore the error classes exported from workflow/errors for handling workflow failures.
+related:
+  - /docs/foundations/errors-and-retries
+---
+
+API reference for the error classes exported from the `workflow/errors` package.
+
+All errors extend [`WorkflowError`](/docs/api-reference/workflow-errors/workflow-error), so you can catch any SDK error with a single `instanceof` check, or narrow to a specific class for fine-grained handling.
+
+## Base Classes
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/workflow-error" title="WorkflowError">
+        Base class for all workflow error types.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-world-error" title="WorkflowWorldError">
+        Base error for failures from workflow storage backends.
+    </Card>
+</Cards>
+
+## Registration Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/workflow-not-registered-error" title="WorkflowNotRegisteredError">
+        Thrown when a workflow function is not registered in the current deployment.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/step-not-registered-error" title="StepNotRegisteredError">
+        Thrown when a step function is not registered in the current deployment.
+    </Card>
+</Cards>
+
+## Run Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-not-found-error" title="WorkflowRunNotFoundError">
+        Thrown when operating on a workflow run that does not exist.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-failed-error" title="WorkflowRunFailedError">
+        Thrown when awaiting the return value of a failed workflow run.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-cancelled-error" title="WorkflowRunCancelledError">
+        Thrown when awaiting the return value of a cancelled workflow run.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-not-completed-error" title="WorkflowRunNotCompletedError">
+        Thrown when requesting the result of a workflow run that has not completed yet.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-runtime-error" title="WorkflowRuntimeError">
+        Thrown when the workflow runtime encounters an execution error, such as serialization failures or timeouts.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/run-expired-error" title="RunExpiredError">
+        Thrown when a workflow run has expired and can no longer be operated on.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/run-not-supported-error" title="RunNotSupportedError">
+        Thrown when a workflow run requires a newer workflow spec version than the installed SDK supports.
+    </Card>
+</Cards>
+
+## Hook Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/hook-not-found-error" title="HookNotFoundError">
+        Thrown when resuming a hook that does not exist.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/hook-conflict-error" title="HookConflictError">
+        Thrown when creating a hook with a token that is already in use by another workflow run.
+    </Card>
+</Cards>
+
+## Backend Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/throttle-error" title="ThrottleError">
+        Thrown when a request is rate-limited by the workflow backend.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/entity-conflict-error" title="EntityConflictError">
+        Thrown when a storage operation conflicts with the current entity state.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/too-early-error" title="TooEarlyError">
+        Thrown when a request is made before the system is ready to process it.
+    </Card>
+</Cards>

--- a/docs/content/docs/v4/changelog/index.mdx
+++ b/docs/content/docs/v4/changelog/index.mdx
@@ -12,4 +12,4 @@ Stay up to date with the latest changes to Workflow SDK.
 
 ## 2026
 
-- [Serializable AbortController and AbortSignal](/docs/changelog/serializable-abort-controller) — March 12, 2026
+- Serializable AbortController and AbortSignal — March 12, 2026

--- a/docs/content/docs/v4/cookbook/advanced/child-workflows.mdx
+++ b/docs/content/docs/v4/cookbook/advanced/child-workflows.mdx
@@ -158,7 +158,7 @@ Polling with `getRun().status` in a `sleep()` loop works, but hook resume is pre
 - **Zero compute while waiting** — the parent suspends on the hook instead of waking every poll interval
 - **Immediate wake-up** — the parent resumes as soon as the child finishes, not on the next poll tick
 - **Typed payloads** — the child sends `{ status, value | error }` directly; no separate `returnValue` fetch step
-- **No worker-pool pressure** — `Run#returnValue` polling inside steps can hold worker slots while waiting for children (see [Eager Processing](/changelog/eager-processing))
+- **No worker-pool pressure** — `Run#returnValue` polling inside steps can hold worker slots while waiting for children (see [Eager Processing](/v5/docs/changelog/eager-processing))
 
 When a parent calls a child workflow inline with `await` (flattened into the same run), the same wrapper and hook handshake still works — pass the token and `await processDocumentWithCompletion(...)` inside `startAndWait()` instead of calling `start()`.
 

--- a/docs/content/docs/v4/cookbook/advanced/publishing-libraries.mdx
+++ b/docs/content/docs/v4/cookbook/advanced/publishing-libraries.mdx
@@ -330,7 +330,7 @@ Before publishing a workflow library:
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) — marks functions for durable execution
-- [`start`](/docs/api-reference/workflow/start) — starts a workflow run
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — marks functions for durable execution
+- [`start`](/docs/api-reference/workflow-api/start) — starts a workflow run
 - [`getWorkflowMetadata`](/docs/api-reference/workflow/get-workflow-metadata) — runtime detection and run ID access

--- a/docs/content/docs/v4/cookbook/advanced/serializable-steps.mdx
+++ b/docs/content/docs/v4/cookbook/advanced/serializable-steps.mdx
@@ -6,7 +6,7 @@ summary: Return a callback from a step to defer construction of a non-owned clas
 related:
   - /docs/foundations/serialization
   - /docs/foundations/serialization#custom-class-serialization
-  - /docs/api-reference/workflow/use-step
+  - /docs/foundations/workflows-and-steps#step-functions
 ---
 
 <Callout>
@@ -141,7 +141,7 @@ async function uploadFile(
 
 ## Key APIs
 
-- [`"use step"`](/docs/api-reference/workflow/use-step) — marks a function for extraction and serialization
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — marks a function for extraction and serialization
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
 - [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — accepts a model factory for durable AI agent streaming
 - [Custom class serialization](/docs/foundations/serialization#custom-class-serialization) — the companion pattern for classes you own (`WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE`)

--- a/docs/content/docs/v4/cookbook/agent-patterns/durable-agent.mdx
+++ b/docs/content/docs/v4/cookbook/agent-patterns/durable-agent.mdx
@@ -147,8 +147,8 @@ export async function POST(req: Request) {
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) — declares step functions with retries and full Node.js access
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — declares step functions with retries and full Node.js access
 - [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — durable wrapper around AI SDK's Agent
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) — streams agent output to the client
 - [`start()`](/docs/api-reference/workflow-api/start) — starts a workflow run from an API route

--- a/docs/content/docs/v4/cookbook/agent-patterns/human-in-the-loop.mdx
+++ b/docs/content/docs/v4/cookbook/agent-patterns/human-in-the-loop.mdx
@@ -247,8 +247,8 @@ const approvalResult = messages
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) — declares step functions with retries
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — declares step functions with retries
 - [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook with schema validation
 - [`sleep()`](/docs/api-reference/workflow/sleep) — durable timeout for approval expiry
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) — stream custom data parts from steps

--- a/docs/content/docs/v4/cookbook/common-patterns/idempotency.mdx
+++ b/docs/content/docs/v4/cookbook/common-patterns/idempotency.mdx
@@ -101,7 +101,7 @@ If your external API doesn't support idempotency keys natively, consider adding 
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) -- declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) -- declares step functions with full Node.js access
-- [`getStepMetadata()`](/docs/api-reference/step/get-step-metadata) -- provides the deterministic `stepId` for idempotency keys
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) -- declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) -- declares step functions with full Node.js access
+- [`getStepMetadata()`](/docs/api-reference/workflow/get-step-metadata) -- provides the deterministic `stepId` for idempotency keys
 - [`start()`](/docs/api-reference/workflow-api/start) -- starts a new workflow run

--- a/docs/content/docs/v4/cookbook/common-patterns/rate-limiting.mdx
+++ b/docs/content/docs/v4/cookbook/common-patterns/rate-limiting.mdx
@@ -224,5 +224,5 @@ export async function downloadWithRetry(url: string) {
 - [`"use step"`](/docs/foundations/workflows-and-steps) -- marks functions that run with full Node.js access
 - [`RetryableError`](/docs/api-reference/workflow/retryable-error) -- signals the runtime to retry after a delay
 - [`FatalError`](/docs/api-reference/workflow/fatal-error) -- signals a permanent failure, skipping retries
-- [`getStepMetadata()`](/docs/api-reference/step/get-step-metadata) -- provides the current attempt number and step ID
+- [`getStepMetadata()`](/docs/api-reference/workflow/get-step-metadata) -- provides the current attempt number and step ID
 - [`sleep()`](/docs/api-reference/workflow/sleep) -- durable pause for circuit breaker cooldowns

--- a/docs/content/docs/v4/cookbook/common-patterns/saga.mdx
+++ b/docs/content/docs/v4/cookbook/common-patterns/saga.mdx
@@ -241,7 +241,7 @@ export async function subscriptionUpgradeSaga(accountId: string, seats: number) 
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) -- declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) -- declares step functions with full Node.js access
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) -- declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) -- declares step functions with full Node.js access
 - [`FatalError`](/docs/api-reference/workflow/fatal-error) -- non-retryable error that triggers compensation
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) -- streams data from workflows for real-time UI updates

--- a/docs/content/docs/v4/cookbook/integrations/ai-sdk.mdx
+++ b/docs/content/docs/v4/cookbook/integrations/ai-sdk.mdx
@@ -376,7 +376,7 @@ Use `DurableAgent` for most agent use cases. Use `streamText` when you need the 
 
 **Workflow SDK**
 
-* [`"use step"`](/docs/api-reference/workflow/use-step) — applied to `runTurn` to make each turn a durable, retryable unit
+* [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — applied to `runTurn` to make each turn a durable, retryable unit
 * [`defineHook()`](/docs/api-reference/workflow/define-hook) — suspension point for follow-up messages
 * [`getWritable()`](/docs/api-reference/workflow/get-writable) — resumable stream output
 * [`getRun()`](/docs/api-reference/workflow-api/get-run) — `run.getReadable({ startIndex })` for slicing per-turn streams

--- a/docs/content/docs/v4/errors/step-not-registered.mdx
+++ b/docs/content/docs/v4/errors/step-not-registered.mdx
@@ -4,7 +4,7 @@ description: A step function is not registered in the current deployment.
 type: troubleshooting
 summary: Resolve step not registered errors caused by build issues.
 prerequisites:
-  - /docs/foundations/steps
+  - /docs/foundations/workflows-and-steps
 related:
   - /docs/errors/workflow-not-registered
   - /docs/api-reference/workflow-errors/step-not-registered-error

--- a/docs/content/docs/v4/internal/index.mdx
+++ b/docs/content/docs/v4/internal/index.mdx
@@ -14,6 +14,4 @@ This page is only visible on preview deployments and local development. It does 
 
 ## Draft Changelogs
 
-Changelog entries staged here for review before publishing to the Vercel website.
-
-- [Serializable AbortController and AbortSignal](/docs/internal/serializable-abort-controller) — March 12, 2026
+Changelog entries staged here for review before publishing to the Vercel website. There are currently no drafts staged for v4.

--- a/docs/content/docs/v4/migration-guides/migrating-from-temporal.mdx
+++ b/docs/content/docs/v4/migration-guides/migrating-from-temporal.mdx
@@ -300,7 +300,7 @@ Remove the Worker process, `@temporalio/*` dependencies, and the Temporal Server
 - **Event history archival.** Temporal archives histories to S3/GCS for long-term retention. Workflow SDK event logs are durable, but retention depends on the integration you are using. For example, see [Vercel Workflow Storage Retention](https://vercel.com/docs/workflows/pricing#storage-retention) for Vercel.
 - **Per-activity timeouts (`startToCloseTimeout`, `scheduleToCloseTimeout`, `heartbeatTimeout`).** Implement deadlines inside the step with `AbortSignal.timeout(ms)`, or wrap the call in `Promise.race(step(), sleep(...))` from the workflow.
 - **Rich retry policy (`initialInterval`, `backoffCoefficient`, `maximumInterval`, `nonRetryableErrorTypes`).** Only `maxRetries` is configurable. Classify retryability with `RetryableError`/`FatalError`; control delay between attempts via `new RetryableError(msg, { retryAfter: '5s' })`.
-- **Workers + task queues.** Managed deployments replace workers; self-hosted deployments still need a `World` implementation (see [/docs/deploying/world](/docs/deploying/world)).
+- **Workers + task queues.** Managed deployments replace workers; self-hosted deployments still need a `World` implementation (see [/docs/deploying/building-a-world](/docs/deploying/building-a-world)).
 
 ## Quick-start checklist
 

--- a/docs/content/docs/v4/testing/index.mdx
+++ b/docs/content/docs/v4/testing/index.mdx
@@ -109,7 +109,7 @@ That's it. The plugin automatically:
 
 1. Transforms `"use workflow"` and `"use step"` directives via SWC
 2. Builds workflow and step bundles before tests run
-3. Sets up an in-process workflow runtime using a fresh [Local World](/docs/worlds/local) instance in each test worker — all workflow data is cleared automatically between test files for full isolation
+3. Sets up an in-process workflow runtime using a fresh [Local World](/worlds/local) instance in each test worker — all workflow data is cleared automatically between test files for full isolation
 
 <Callout type="info">
 Use a separate Vitest configuration and a distinct file naming convention (e.g. `*.integration.test.ts`) to keep unit tests and integration tests separate. Unit tests run with a standard Vitest config without the workflow plugin, while integration tests use the config above.
@@ -117,7 +117,7 @@ Use a separate Vitest configuration and a distinct file naming convention (e.g. 
 
 ### Writing Integration Tests
 
-Use [`start()`](/docs/api-reference/workflow-api/start) to trigger a workflow and [`run.returnValue`](/docs/api-reference/workflow-api/start#returnvalue) to get the result. `returnValue` is a promise that blocks until the workflow completes (or throws if it fails):
+Use [`start()`](/docs/api-reference/workflow-api/start) to trigger a workflow and [`run.returnValue`](/docs/api-reference/workflow-api/start#returns) to get the result. `returnValue` is a promise that blocks until the workflow completes (or throws if it fails):
 
 ```typescript title="workflows/calculate.integration.test.ts" lineNumbers
 import { describe, it, expect } from "vitest";

--- a/docs/content/docs/v5/api-reference/vitest/index.mdx
+++ b/docs/content/docs/v5/api-reference/vitest/index.mdx
@@ -69,7 +69,7 @@ export async function setup() {
 
 ### `setupWorkflowTests()`
 
-Sets up an in-process workflow runtime in each test worker. Imports pre-built bundles, creates a [Local World](/docs/worlds/local) instance with direct handlers, and sets it as the global world. Clears all workflow data on each invocation for full test isolation.
+Sets up an in-process workflow runtime in each test worker. Imports pre-built bundles, creates a [Local World](/worlds/local) instance with direct handlers, and sets it as the global world. Clears all workflow data on each invocation for full test isolation.
 
 Called automatically by the `workflow()` plugin in `setupFiles`. Use directly only for [manual setup](/docs/testing#manual-setup).
 

--- a/docs/content/docs/v5/api-reference/workflow-errors/index.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-errors/index.mdx
@@ -1,0 +1,85 @@
+---
+title: "workflow/errors"
+description: Semantic error types thrown by the Workflow SDK and its storage backends.
+type: overview
+summary: Explore the error classes exported from workflow/errors for handling workflow failures.
+related:
+  - /docs/foundations/errors-and-retries
+---
+
+API reference for the error classes exported from the `workflow/errors` package.
+
+All errors extend [`WorkflowError`](/docs/api-reference/workflow-errors/workflow-error), so you can catch any SDK error with a single `instanceof` check, or narrow to a specific class for fine-grained handling.
+
+## Base Classes
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/workflow-error" title="WorkflowError">
+        Base class for all workflow error types.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-world-error" title="WorkflowWorldError">
+        Base error for failures from workflow storage backends.
+    </Card>
+</Cards>
+
+## Registration Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/workflow-not-registered-error" title="WorkflowNotRegisteredError">
+        Thrown when a workflow function is not registered in the current deployment.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/step-not-registered-error" title="StepNotRegisteredError">
+        Thrown when a step function is not registered in the current deployment.
+    </Card>
+</Cards>
+
+## Run Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-not-found-error" title="WorkflowRunNotFoundError">
+        Thrown when operating on a workflow run that does not exist.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-failed-error" title="WorkflowRunFailedError">
+        Thrown when awaiting the return value of a failed workflow run.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-cancelled-error" title="WorkflowRunCancelledError">
+        Thrown when awaiting the return value of a cancelled workflow run.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-run-not-completed-error" title="WorkflowRunNotCompletedError">
+        Thrown when requesting the result of a workflow run that has not completed yet.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-runtime-error" title="WorkflowRuntimeError">
+        Thrown when the workflow runtime encounters an execution error, such as serialization failures or timeouts.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/run-expired-error" title="RunExpiredError">
+        Thrown when a workflow run has expired and can no longer be operated on.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/run-not-supported-error" title="RunNotSupportedError">
+        Thrown when a workflow run requires a newer workflow spec version than the installed SDK supports.
+    </Card>
+</Cards>
+
+## Hook Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/hook-not-found-error" title="HookNotFoundError">
+        Thrown when resuming a hook that does not exist.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/hook-conflict-error" title="HookConflictError">
+        Thrown when creating a hook with a token that is already in use by another workflow run.
+    </Card>
+</Cards>
+
+## Backend Errors
+
+<Cards>
+    <Card href="/docs/api-reference/workflow-errors/throttle-error" title="ThrottleError">
+        Thrown when a request is rate-limited by the workflow backend.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/entity-conflict-error" title="EntityConflictError">
+        Thrown when a storage operation conflicts with the current entity state.
+    </Card>
+    <Card href="/docs/api-reference/workflow-errors/too-early-error" title="TooEarlyError">
+        Thrown when a request is made before the system is ready to process it.
+    </Card>
+</Cards>

--- a/docs/content/docs/v5/changelog/index.mdx
+++ b/docs/content/docs/v5/changelog/index.mdx
@@ -13,4 +13,4 @@ Stay up to date with the latest changes to Workflow SDK.
 ## 2026
 
 - [Eager processing of steps and incremental event replay](/docs/changelog/eager-processing) - March 2026
-- [Serializable AbortController and AbortSignal](/docs/changelog/serializable-abort-controller) — March 12, 2026
+- Serializable AbortController and AbortSignal — March 12, 2026

--- a/docs/content/docs/v5/cookbook/advanced/child-workflows.mdx
+++ b/docs/content/docs/v5/cookbook/advanced/child-workflows.mdx
@@ -145,7 +145,7 @@ Polling with `getRun().status` in a `sleep()` loop works, but hook resume is pre
 - **Zero compute while waiting** — the parent suspends on the hook instead of waking every poll interval
 - **Immediate wake-up** — the parent resumes as soon as the child finishes, not on the next poll tick
 - **Typed payloads** — the child sends `{ status, value | error }` directly; no separate `returnValue` fetch step
-- **No worker-pool pressure** — `Run#returnValue` polling inside steps can hold worker slots while waiting for children (see [Eager Processing](/changelog/eager-processing))
+- **No worker-pool pressure** — `Run#returnValue` polling inside steps can hold worker slots while waiting for children (see [Eager Processing](/docs/changelog/eager-processing))
 
 When a parent calls a child workflow inline with `await` (flattened into the same run), the same wrapper and hook handshake still works — pass the token and `await processDocumentWithCompletion(...)` inside `startAndWait()` instead of calling `start()`.
 

--- a/docs/content/docs/v5/cookbook/advanced/publishing-libraries.mdx
+++ b/docs/content/docs/v5/cookbook/advanced/publishing-libraries.mdx
@@ -330,7 +330,7 @@ Before publishing a workflow library:
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) — marks functions for durable execution
-- [`start`](/docs/api-reference/workflow/start) — starts a workflow run
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — marks functions for durable execution
+- [`start`](/docs/api-reference/workflow-api/start) — starts a workflow run
 - [`getWorkflowMetadata`](/docs/api-reference/workflow/get-workflow-metadata) — runtime detection and run ID access

--- a/docs/content/docs/v5/cookbook/advanced/serializable-steps.mdx
+++ b/docs/content/docs/v5/cookbook/advanced/serializable-steps.mdx
@@ -6,7 +6,7 @@ summary: Return a callback from a step to defer construction of a non-owned clas
 related:
   - /docs/foundations/serialization
   - /docs/foundations/serialization#custom-class-serialization
-  - /docs/api-reference/workflow/use-step
+  - /docs/foundations/workflows-and-steps#step-functions
 ---
 
 <Callout>
@@ -141,7 +141,7 @@ async function uploadFile(
 
 ## Key APIs
 
-- [`"use step"`](/docs/api-reference/workflow/use-step) — marks a function for extraction and serialization
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — marks a function for extraction and serialization
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
 - [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — accepts a model factory for durable AI agent streaming
 - [Custom class serialization](/docs/foundations/serialization#custom-class-serialization) — the companion pattern for classes you own (`WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE`)

--- a/docs/content/docs/v5/cookbook/agent-patterns/human-in-the-loop.mdx
+++ b/docs/content/docs/v5/cookbook/agent-patterns/human-in-the-loop.mdx
@@ -247,8 +247,8 @@ const approvalResult = messages
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) — declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) — declares step functions with retries
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — declares step functions with retries
 - [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook with schema validation
 - [`sleep()`](/docs/api-reference/workflow/sleep) — durable timeout for approval expiry
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) — stream custom data parts from steps

--- a/docs/content/docs/v5/cookbook/common-patterns/idempotency.mdx
+++ b/docs/content/docs/v5/cookbook/common-patterns/idempotency.mdx
@@ -101,7 +101,7 @@ If your external API doesn't support idempotency keys natively, consider adding 
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) -- declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) -- declares step functions with full Node.js access
-- [`getStepMetadata()`](/docs/api-reference/step/get-step-metadata) -- provides the deterministic `stepId` for idempotency keys
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) -- declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) -- declares step functions with full Node.js access
+- [`getStepMetadata()`](/docs/api-reference/workflow/get-step-metadata) -- provides the deterministic `stepId` for idempotency keys
 - [`start()`](/docs/api-reference/workflow-api/start) -- starts a new workflow run

--- a/docs/content/docs/v5/cookbook/common-patterns/rate-limiting.mdx
+++ b/docs/content/docs/v5/cookbook/common-patterns/rate-limiting.mdx
@@ -224,5 +224,5 @@ export async function downloadWithRetry(url: string) {
 - [`"use step"`](/docs/foundations/workflows-and-steps) -- marks functions that run with full Node.js access
 - [`RetryableError`](/docs/api-reference/workflow/retryable-error) -- signals the runtime to retry after a delay
 - [`FatalError`](/docs/api-reference/workflow/fatal-error) -- signals a permanent failure, skipping retries
-- [`getStepMetadata()`](/docs/api-reference/step/get-step-metadata) -- provides the current attempt number and step ID
+- [`getStepMetadata()`](/docs/api-reference/workflow/get-step-metadata) -- provides the current attempt number and step ID
 - [`sleep()`](/docs/api-reference/workflow/sleep) -- durable pause for circuit breaker cooldowns

--- a/docs/content/docs/v5/cookbook/common-patterns/saga.mdx
+++ b/docs/content/docs/v5/cookbook/common-patterns/saga.mdx
@@ -241,7 +241,7 @@ export async function subscriptionUpgradeSaga(accountId: string, seats: number) 
 
 ## Key APIs
 
-- [`"use workflow"`](/docs/api-reference/workflow/use-workflow) -- declares the orchestrator function
-- [`"use step"`](/docs/api-reference/workflow/use-step) -- declares step functions with full Node.js access
+- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) -- declares the orchestrator function
+- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) -- declares step functions with full Node.js access
 - [`FatalError`](/docs/api-reference/workflow/fatal-error) -- non-retryable error that triggers compensation
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) -- streams data from workflows for real-time UI updates

--- a/docs/content/docs/v5/cookbook/integrations/ai-sdk.mdx
+++ b/docs/content/docs/v5/cookbook/integrations/ai-sdk.mdx
@@ -376,7 +376,7 @@ Use `DurableAgent` for most agent use cases. Use `streamText` when you need the 
 
 **Workflow SDK**
 
-* [`"use step"`](/docs/api-reference/workflow/use-step) — applied to `runTurn` to make each turn a durable, retryable unit
+* [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — applied to `runTurn` to make each turn a durable, retryable unit
 * [`defineHook()`](/docs/api-reference/workflow/define-hook) — suspension point for follow-up messages
 * [`getWritable()`](/docs/api-reference/workflow/get-writable) — resumable stream output
 * [`getRun()`](/docs/api-reference/workflow-api/get-run) — `run.getReadable({ startIndex })` for slicing per-turn streams

--- a/docs/content/docs/v5/errors/step-not-registered.mdx
+++ b/docs/content/docs/v5/errors/step-not-registered.mdx
@@ -4,7 +4,7 @@ description: A step function is not registered in the current deployment.
 type: troubleshooting
 summary: Resolve step not registered errors caused by build issues.
 prerequisites:
-  - /docs/foundations/steps
+  - /docs/foundations/workflows-and-steps
 related:
   - /docs/errors/workflow-not-registered
   - /docs/api-reference/workflow-errors/step-not-registered-error

--- a/docs/content/docs/v5/foundations/cancellation.mdx
+++ b/docs/content/docs/v5/foundations/cancellation.mdx
@@ -6,7 +6,6 @@ summary: Cancel in-flight work with AbortSignal or stop entire workflow runs.
 prerequisites:
   - /docs/foundations/workflows-and-steps
 related:
-  - /docs/foundations/common-patterns
   - /docs/foundations/hooks
   - /docs/how-it-works/cancellation
 ---
@@ -455,6 +454,6 @@ This is safe even if both steps have already completed — aborting a finished o
 
 - [How Cancellation Works](/docs/how-it-works/cancellation) — Hook and stream backing, serialization internals
 - [Serialization](/docs/foundations/serialization) — Understanding serializable types
-- [Common Patterns](/docs/foundations/common-patterns) — Timeout and race patterns
+- [Cookbook](/v5/cookbook) — Timeout, race, and other reliability patterns
 - [Hooks](/docs/foundations/hooks) — Pausing workflows for external events
 - [Errors and Retries](/docs/foundations/errors-and-retries) — Handling step failures

--- a/docs/content/docs/v5/migration-guides/migrating-from-temporal.mdx
+++ b/docs/content/docs/v5/migration-guides/migrating-from-temporal.mdx
@@ -295,7 +295,7 @@ Remove the Worker process, `@temporalio/*` dependencies, and the Temporal Server
 - **Event history archival.** Temporal archives histories to S3/GCS for long-term retention. Workflow SDK event logs are durable, but retention depends on the integration you are using. For example, see [Vercel Workflow Storage Retention](https://vercel.com/docs/workflows/pricing#storage-retention) for Vercel.
 - **Per-activity timeouts (`startToCloseTimeout`, `scheduleToCloseTimeout`, `heartbeatTimeout`).** Implement deadlines inside the step with `AbortSignal.timeout(ms)`, or wrap the call in `Promise.race(step(), sleep(...))` from the workflow.
 - **Rich retry policy (`initialInterval`, `backoffCoefficient`, `maximumInterval`, `nonRetryableErrorTypes`).** Only `maxRetries` is configurable. Classify retryability with `RetryableError`/`FatalError`; control delay between attempts via `new RetryableError(msg, { retryAfter: '5s' })`.
-- **Workers + task queues.** Managed deployments replace workers; self-hosted deployments still need a `World` implementation (see [/docs/deploying/world](/docs/deploying/world)).
+- **Workers + task queues.** Managed deployments replace workers; self-hosted deployments still need a `World` implementation (see [/docs/deploying/building-a-world](/docs/deploying/building-a-world)).
 
 ## Quick-start checklist
 

--- a/docs/content/docs/v5/testing/index.mdx
+++ b/docs/content/docs/v5/testing/index.mdx
@@ -109,7 +109,7 @@ That's it. The plugin automatically:
 
 1. Transforms `"use workflow"` and `"use step"` directives via SWC
 2. Builds workflow and step bundles before tests run
-3. Sets up an in-process workflow runtime using a fresh [Local World](/docs/worlds/local) instance in each test worker — all workflow data is cleared automatically between test files for full isolation
+3. Sets up an in-process workflow runtime using a fresh [Local World](/worlds/local) instance in each test worker — all workflow data is cleared automatically between test files for full isolation
 
 <Callout type="info">
 Use a separate Vitest configuration and a distinct file naming convention (e.g. `*.integration.test.ts`) to keep unit tests and integration tests separate. Unit tests run with a standard Vitest config without the workflow plugin, while integration tests use the config above.
@@ -117,7 +117,7 @@ Use a separate Vitest configuration and a distinct file naming convention (e.g. 
 
 ### Writing Integration Tests
 
-Use [`start()`](/docs/api-reference/workflow-api/start) to trigger a workflow and [`run.returnValue`](/docs/api-reference/workflow-api/start#returnvalue) to get the result. `returnValue` is a promise that blocks until the workflow completes (or throws if it fails):
+Use [`start()`](/docs/api-reference/workflow-api/start) to trigger a workflow and [`run.returnValue`](/docs/api-reference/workflow-api/start#returns) to get the result. `returnValue` is a promise that blocks until the workflow completes (or throws if it fails):
 
 ```typescript title="workflows/calculate.integration.test.ts" lineNumbers
 import { describe, it, expect } from "vitest";

--- a/docs/scripts/lint.ts
+++ b/docs/scripts/lint.ts
@@ -1,14 +1,16 @@
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import GithubSlugger from 'github-slugger';
 import {
   type FileObject,
   printErrors,
-  scanURLs,
   validateFiles,
 } from 'next-validate-link';
-import { source } from '../lib/geistdocs/source';
+import { rewriteCookbookUrl } from '../lib/geistdocs/cookbook-source';
+import { source, v5Source } from '../lib/geistdocs/source';
+import { getWorldIds } from '../lib/worlds-data';
+import nextConfig from '../next.config';
 
 const DOCS_DIR = fileURLToPath(new URL('..', import.meta.url));
 const STATIC_APP_LINK_FILES = [
@@ -17,43 +19,168 @@ const STATIC_APP_LINK_FILES = [
 ];
 const KNOWN_APP_PATHS = new Set(['/', '/docs', '/cookbook', '/worlds']);
 
-async function checkLinks() {
-  // Pre-fetch all page content and headings
-  const pages = await Promise.all(
-    source.getPages().map(async (page) => {
+type UrlMeta = { hashes?: string[] };
+type Scanned = {
+  urls: Map<string, UrlMeta>;
+  fallbackUrls: { url: RegExp; meta: UrlMeta }[];
+};
+
+type LoadedPage = {
+  page: ReturnType<typeof source.getPages>[number];
+  raw: string;
+  hashes: string[];
+};
+
+async function loadPages(src: typeof source): Promise<LoadedPage[]> {
+  return Promise.all(
+    src.getPages().map(async (page) => {
       const raw = await page.data.getText('raw');
-      return {
-        page,
-        hashes: getHeadingsFromMarkdown(raw),
-      };
+      return { page, raw, hashes: getHeadingsFromMarkdown(raw) };
     })
   );
+}
 
-  const scanned = await scanURLs({
-    preset: 'next',
-    populate: {
-      'docs/[[...slug]]': pages.map(({ page, hashes }) => ({
-        value: {
-          slug: page.slugs,
-        },
-        hashes,
-      })),
-    },
-  });
+/**
+ * Static (non-fumadocs) routes that exist in the app for both versions:
+ * the home page, section landing pages, worlds detail pages, and files
+ * served from public/.
+ */
+async function getSharedUrls(): Promise<Map<string, UrlMeta>> {
+  const urls = new Map<string, UrlMeta>();
+  for (const path of [
+    '/',
+    '/docs',
+    '/v5/docs',
+    '/cookbook',
+    '/v5/cookbook',
+    '/worlds',
+    '/worlds/compare',
+    '/llms.txt',
+    '/sitemap.md',
+  ]) {
+    urls.set(path, {});
+  }
+  for (const id of getWorldIds()) {
+    urls.set(`/worlds/${id}`, {});
+  }
+  for (const asset of await listFilesRecursive(join(DOCS_DIR, 'public'))) {
+    urls.set(`/${asset}`, {});
+  }
+  return urls;
+}
 
-  const errors = await validateFiles(await getFiles(), {
-    scanned,
-    markdown: {
-      components: {
-        Card: { attributes: ['href'] },
-      },
-    },
-    checkRelativePaths: 'as-url',
-  });
+async function listFilesRecursive(dir: string, prefix = ''): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      out.push(...(await listFilesRecursive(join(dir, entry.name), rel)));
+    } else {
+      out.push(rel);
+    }
+  }
+  return out;
+}
 
-  printErrors(errors, true);
+/**
+ * Build the two URL spaces links are resolved against.
+ *
+ * v4 space — how hrefs resolve when rendered on a v4 (unversioned) page:
+ *   /docs/X        → v4 page X
+ *   /cookbook/X    → v4 cookbook page
+ *   /v5/docs/X     → v5 page X (explicit cross-version link)
+ *   /v5/cookbook/X → v5 cookbook page
+ *
+ * v5 space — how hrefs resolve when rendered on a /v5 page. The v5 routes
+ * rewrite /docs/... hrefs (inline links and Card hrefs) to /v5/docs/... at
+ * render time, so an unversioned /docs/X href on a v5 page resolves to the
+ * v5 page X — it is broken unless X exists in the v5 content tree:
+ *   /docs/X        → v5 page X (rewritten at render time)
+ *   /cookbook/X    → v4 cookbook page (not rewritten)
+ *   /v5/docs/X     → v5 page X
+ *   /v5/cookbook/X → v5 cookbook page
+ */
+function buildSpaces(
+  v4Pages: LoadedPage[],
+  v5Pages: LoadedPage[],
+  shared: Map<string, UrlMeta>
+): { v4Space: Scanned; v5Space: Scanned } {
+  const v4Space: Scanned = { urls: new Map(shared), fallbackUrls: [] };
+  const v5Space: Scanned = { urls: new Map(shared), fallbackUrls: [] };
 
-  await checkStaticAppLinks();
+  for (const { page, hashes } of v4Pages) {
+    const meta = { hashes };
+    v4Space.urls.set(page.url, meta);
+    const cookbookUrl = rewriteCookbookUrl(page.url);
+    if (cookbookUrl !== page.url) {
+      // /docs/cookbook/X is served at /cookbook/X — valid in both spaces
+      // (cookbook links are not version-rewritten on v5 pages).
+      v4Space.urls.set(cookbookUrl, meta);
+      v5Space.urls.set(cookbookUrl, meta);
+    }
+  }
+
+  for (const { page, hashes } of v5Pages) {
+    const meta = { hashes };
+    v4Space.urls.set(`/v5${page.url}`, meta);
+    v5Space.urls.set(`/v5${page.url}`, meta);
+    // On v5 pages, unversioned /docs/... hrefs are rewritten to /v5/docs/...
+    // at render time, so they resolve to the v5 page.
+    v5Space.urls.set(page.url, meta);
+    const cookbookUrl = rewriteCookbookUrl(page.url);
+    if (cookbookUrl !== page.url) {
+      v4Space.urls.set(`/v5${cookbookUrl}`, meta);
+      v5Space.urls.set(`/v5${cookbookUrl}`, meta);
+    }
+  }
+
+  return { v4Space, v5Space };
+}
+
+/**
+ * Mark next.config.ts redirect sources as valid wherever their destination
+ * is valid. Parameterized sources (/a/:path*) are expanded against the
+ * concrete URLs already in the space, so a redirect never blanket-validates
+ * URLs whose destination doesn't exist.
+ *
+ * Sources under /docs are only reachable from v4 pages (on v5 pages the
+ * render-time rewrite turns /docs/... into /v5/docs/..., which skips the
+ * redirect), so they are only added to the v4 space.
+ */
+async function applyRedirects(v4Space: Scanned, v5Space: Scanned) {
+  const redirects = (await nextConfig.redirects?.()) ?? [];
+
+  for (const { source: src, destination: dest } of redirects) {
+    if (src.includes(':') !== dest.includes(':')) continue;
+
+    const spaces =
+      src.startsWith('/docs') && !src.startsWith('/docs/cookbook')
+        ? [v4Space]
+        : [v4Space, v5Space];
+
+    for (const space of spaces) {
+      applyRedirectToSpace(space, src, dest);
+    }
+  }
+}
+
+function applyRedirectToSpace(space: Scanned, src: string, dest: string) {
+  if (!src.includes(':')) {
+    const meta = space.urls.get(dest);
+    if (meta) space.urls.set(src, meta);
+    return;
+  }
+
+  // Parameterized: both source and destination are a static prefix followed
+  // by the same parameter (e.g. /docs/cookbook/:path* → /cookbook/:path*).
+  // Expand by swapping prefixes against known URLs.
+  const srcPrefix = src.slice(0, src.indexOf('/:'));
+  const destPrefix = dest.slice(0, dest.indexOf('/:'));
+  for (const [url, meta] of [...space.urls]) {
+    if (url.startsWith(`${destPrefix}/`)) {
+      space.urls.set(srcPrefix + url.slice(destPrefix.length), meta);
+    }
+  }
 }
 
 function getHeadingsFromMarkdown(content: string): string[] {
@@ -71,16 +198,119 @@ function getHeadingsFromMarkdown(content: string): string[] {
   return headings;
 }
 
-function getFiles() {
-  const promises = source.getPages().map(
-    async (page): Promise<FileObject> => ({
-      path: page.absolutePath,
-      content: await page.data.getText('raw'),
-      url: page.url,
-      data: page.data,
-    })
-  );
-  return Promise.all(promises);
+function toFileObjects(pages: LoadedPage[]): FileObject[] {
+  return pages.map(({ page, raw }) => ({
+    path: page.absolutePath,
+    content: raw,
+    url: page.url,
+    data: page.data,
+  }));
+}
+
+/**
+ * Extract `related` and `prerequisites` list entries from a page's raw
+ * frontmatter.
+ */
+function getFrontmatterRefs(raw: string): string[] {
+  const frontmatter = raw.match(/^---\n([\s\S]*?)\n---/)?.[1];
+  if (!frontmatter) return [];
+
+  const refs: string[] = [];
+  let inRefBlock = false;
+  for (const line of frontmatter.split('\n')) {
+    if (/^(related|prerequisites):\s*$/.test(line)) {
+      inRefBlock = true;
+      continue;
+    }
+    const item = inRefBlock && line.match(/^\s+-\s+(\/\S+)\s*$/);
+    if (item) {
+      refs.push(item[1]);
+    } else if (!/^\s/.test(line)) {
+      inRefBlock = false;
+    }
+  }
+  return refs;
+}
+
+/**
+ * Validate frontmatter `related` and `prerequisites` references. These are
+ * version-relative: a /docs/... reference on a v5 page must exist in the v5
+ * content tree (matching how the page's links resolve when rendered).
+ */
+function checkFrontmatterRefs(
+  pages: LoadedPage[],
+  space: Scanned,
+  errors: { href: string; reason: string; sourcePath: string }[]
+) {
+  for (const { page, raw } of pages) {
+    for (const ref of getFrontmatterRefs(raw)) {
+      const [pathname, fragment] = ref.split('#', 2);
+      const meta = space.urls.get(pathname.replace(/\/$/, '') || '/');
+      if (!meta) {
+        errors.push({
+          href: ref,
+          sourcePath: page.absolutePath,
+          reason: 'not found',
+        });
+      } else if (fragment && meta.hashes && !meta.hashes.includes(fragment)) {
+        errors.push({
+          href: ref,
+          sourcePath: page.absolutePath,
+          reason: `heading #${fragment} not found`,
+        });
+      }
+    }
+  }
+}
+
+async function checkLinks() {
+  const [v4Pages, v5Pages, shared] = await Promise.all([
+    loadPages(source),
+    loadPages(v5Source),
+    getSharedUrls(),
+  ]);
+
+  const { v4Space, v5Space } = buildSpaces(v4Pages, v5Pages, shared);
+  await applyRedirects(v4Space, v5Space);
+
+  const markdown = {
+    components: {
+      Card: { attributes: ['href'] },
+    },
+  };
+
+  const [v4Errors, v5Errors] = await Promise.all([
+    validateFiles(toFileObjects(v4Pages), {
+      scanned: v4Space,
+      markdown,
+      checkRelativePaths: 'as-url',
+    }),
+    validateFiles(toFileObjects(v5Pages), {
+      scanned: v5Space,
+      markdown,
+      checkRelativePaths: 'as-url',
+    }),
+  ]);
+
+  printErrors([...v4Errors, ...v5Errors], true);
+
+  const frontmatterErrors: {
+    href: string;
+    reason: string;
+    sourcePath: string;
+  }[] = [];
+  checkFrontmatterRefs(v4Pages, v4Space, frontmatterErrors);
+  checkFrontmatterRefs(v5Pages, v5Space, frontmatterErrors);
+
+  if (frontmatterErrors.length > 0) {
+    console.error('\nBroken frontmatter references:');
+    for (const error of frontmatterErrors) {
+      console.error(`- ${error.sourcePath} -> ${error.href}: ${error.reason}`);
+    }
+    process.exitCode = 1;
+  }
+
+  await checkStaticAppLinks();
 }
 
 async function checkStaticAppLinks() {


### PR DESCRIPTION
## Summary

The docs link checker (`docs/scripts/lint.ts`, the "Docs Links" CI job) has been a silent no-op since #552 moved the app routes under `app/[lang]/`: the `next-validate-link` populate key no longer matched any route, and the unpopulated `[lang]` homepage route produced a fallback regex (`^\/(.+)$`) that matched **every** href — so any link, no matter how broken, validated. It also only ever scanned v4 content. This PR fixes the checker, the link-rewriting gaps it should have caught, and all of the dead links that accumulated while it was off.

### 1. Make the link linter actually validate (`docs/scripts/lint.ts`)

- Builds explicit v4/v5 URL spaces from both fumadocs sources, including cookbook URL variants, app routes (`/worlds/:id` from `getWorldIds()`, etc.), `public/` assets, and `next.config.ts` redirects (parameterized redirects are expanded against concrete known URLs, so a redirect never blanket-validates dead targets).
- Validates each version's content with render-correct semantics: on v5 pages, `/docs/...` hrefs resolve to `/v5/docs/...` at render time, so they must exist in the v5 tree.
- Also validates heading fragments (`#anchors`) and frontmatter `related`/`prerequisites` references (version-relative), which were never checked before.
- Verified by injection: missing pages, bad fragments, broken `Card` hrefs, and bad frontmatter refs are all caught.

### 2. Version-rewrite `Card` hrefs on v5 pages

The v5 routes rewrote inline markdown links from `/docs/...` to `/v5/docs/...`, but `Card` renders its own `Link` and bypassed the rewrite — so ~105 Cards on v5 pages silently escaped to the v4 docs, and Cards pointing at v5-only pages (e.g. `/v5/docs/observability` → Attributes) 404'd. Both v5 routes now apply the same rewrite to `Card`.

### 3. Add version prefix to "Edit this page on GitHub" links

Every edit link 404'd since the v4/v5 content split (#1948): `page.path` is relative to the per-version content dir, but `EditSource` built URLs without the `v4`/`v5` segment. Incorporates #2120 by @gldkhoward (co-authored), rebased onto the v5 route changes in this branch.

### 4. Fix all 56 dead content links (v4 + v5)

- Links to nonexistent `use-workflow` / `use-step` / `start` API pages → `foundations/workflows-and-steps#workflow-functions` / `#step-functions` / `workflow-api/start` (28 occurrences across cookbook pages)
- `api-reference/step/get-step-metadata` → `api-reference/workflow/get-step-metadata`
- `/docs/worlds/local` → `/worlds/local`; `foundations/steps` → `foundations/workflows-and-steps`; `deploying/world` → `deploying/building-a-world`
- New `api-reference/workflow-errors` index page (both versions) — linked from the API reference landing page but never existed
- Dead changelog/internal `serializable-abort-controller` references unlinked/removed; `eager-processing` links point at the v5 page where it lives; retired `foundations/common-patterns` references point at the cookbook; dead `#returnvalue` anchor → `#returns`

Fixes #2119
Supersedes #2120 (its fix is included here with co-authorship — close it when this merges)

## Test plan

- [x] `bun ./scripts/lint.ts` passes (0 errors) and demonstrably fails on injected broken links/fragments/Card hrefs/frontmatter refs
- [x] Verified rendered output on local dev server: v5 Cards render `/v5/docs/...` hrefs; `/docs/api-reference/workflow-errors` and `/v5/docs/observability/attributes` return 200
- [x] Edit links verified on v4/v5 docs and cookbook pages — all resolve to real files under `docs/content/docs/v4|v5/...`
- [x] Biome clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Docs Preview

Preview deployment: https://workflow-docs-git-pgp-docs-fix.vercel.sh (requires Vercel team access)

Key changed pages:

| Page | v4 | v5 |
| :--- | :--- | :--- |
| Observability (reported broken Card) | — | [/v5/docs/observability](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/observability) |
| Attributes (was 404 from Card) | — | [/v5/docs/observability/attributes](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/observability/attributes) |
| workflow/errors index (new page) | [/docs/api-reference/workflow-errors](https://workflow-docs-git-pgp-docs-fix.vercel.sh/docs/api-reference/workflow-errors) | [/v5/docs/api-reference/workflow-errors](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/api-reference/workflow-errors) |
| API reference index (Card links) | [/docs/api-reference](https://workflow-docs-git-pgp-docs-fix.vercel.sh/docs/api-reference) | [/v5/docs/api-reference](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/api-reference) |
| workflow package index (Card rewrite) | — | [/v5/docs/api-reference/workflow](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/api-reference/workflow) |
| Testing (worlds/anchor links) | [/docs/testing](https://workflow-docs-git-pgp-docs-fix.vercel.sh/docs/testing) | [/v5/docs/testing](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/testing) |
| Changelog (unlinked dead entry) | [/docs/changelog](https://workflow-docs-git-pgp-docs-fix.vercel.sh/docs/changelog) | [/v5/docs/changelog](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/changelog) |
| Cancellation (related links) | — | [/v5/docs/foundations/cancellation](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/foundations/cancellation) |
| Migrating from Temporal (world link) | [/docs/migration-guides/migrating-from-temporal](https://workflow-docs-git-pgp-docs-fix.vercel.sh/docs/migration-guides/migrating-from-temporal) | [/v5/docs/migration-guides/migrating-from-temporal](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/docs/migration-guides/migrating-from-temporal) |
| Idempotency cookbook (Key APIs links) | [/cookbook/common-patterns/idempotency](https://workflow-docs-git-pgp-docs-fix.vercel.sh/cookbook/common-patterns/idempotency) | [/v5/cookbook/common-patterns/idempotency](https://workflow-docs-git-pgp-docs-fix.vercel.sh/v5/cookbook/common-patterns/idempotency) |

"Edit this page on GitHub" links (footer of any docs page) now resolve to real files under `docs/content/docs/v4|v5/`.
