### PR TITLE
fix(core): make deploymentId 'latest' a no-op in non-Vercel worlds

### DIFF
--- a/.changeset/deployment-id-latest-noop-non-vercel.md
+++ b/.changeset/deployment-id-latest-noop-non-vercel.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+`start({ deploymentId: 'latest' })` is now a no-op in Worlds that don't support atomic deployments (local dev, Postgres) instead of throwing — it logs a warning and targets the current deployment, so workflows that use `'latest'` on Vercel still run locally.

--- a/docs/content/docs/v4/api-reference/workflow-api/start.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-api/start.mdx
@@ -97,6 +97,8 @@ const run = await start(myWorkflow, ["arg1", "arg2"], { // [!code highlight]
 
 <Callout type="info">
 The `deploymentId` option is currently a Vercel-specific feature. Other Worlds may implement this option differently to match their own deployment runtimes, and the World spec may rename it from `deploymentId` to `version` in a future SDK version. On Vercel, `"latest"` resolves to the most recent deployment matching your current environment — the same production target for production deployments, or the same git branch for preview deployments.
+
+In Worlds without atomic, immutable deployments (such as local development or self-hosted Postgres), there is no notion of multiple deployments to resolve between, so `deploymentId: "latest"` has no effect: the SDK logs a warning and the run targets the current deployment. This means a workflow that opts into `"latest"` on Vercel still runs unchanged in local development.
 </Callout>
 
 <Callout type="warn">

--- a/docs/content/docs/v5/api-reference/workflow-api/start.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-api/start.mdx
@@ -100,6 +100,8 @@ const run = await start(myWorkflow, ["arg1", "arg2"], { // [!code highlight]
 
 <Callout type="info">
 The `deploymentId` option is currently a Vercel-specific feature. Other Worlds may implement this option differently to match their own deployment runtimes, and the World spec may rename it from `deploymentId` to `version` in a future SDK version. On Vercel, `"latest"` resolves to the most recent deployment matching your current environment — the same production target for production deployments, or the same git branch for preview deployments.
+
+In Worlds without atomic, immutable deployments (such as local development or self-hosted Postgres), there is no notion of multiple deployments to resolve between, so `deploymentId: "latest"` has no effect: the SDK logs a warning and the run targets the current deployment. This means a workflow that opts into `"latest"` on Vercel still runs unchanged in local development.
 </Callout>
 
 <Callout type="warn">

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -245,6 +245,35 @@ describe('e2e', () => {
     );
   });
 
+  // `deploymentId: 'latest'` only resolves to a different deployment in
+  // worlds with atomic, immutable deployments (Vercel). In local dev and
+  // Postgres worlds there is nothing to resolve between, so it has no effect:
+  // the SDK logs a warning and targets the current deployment instead of
+  // failing. This guards that no-op, so a workflow that opts into
+  // `deploymentId: 'latest'` on Vercel still runs in local/Postgres dev. The
+  // warning itself is asserted in start.test.ts. Skipped on Vercel, where
+  // 'latest' actually hits the resolve API.
+  test.skipIf(!!process.env.WORKFLOW_VERCEL_ENV)(
+    "deploymentId: 'latest' is a no-op in non-Vercel worlds",
+    { timeout: 60_000 },
+    async () => {
+      const run = await start(await e2e('addTenWorkflow'), [123], {
+        deploymentId: 'latest',
+      });
+
+      const returnValue = await run.returnValue;
+      expect(returnValue).toBe(133);
+
+      const { json } = await cliInspectJson(`runs ${run.runId} --withData`);
+      expect(json).toMatchObject({
+        runId: run.runId,
+        status: 'completed',
+        input: [123],
+        output: 133,
+      });
+    }
+  );
+
   // Test that "use step" / "use workflow" functions inside dot-prefixed
   // directories like `.well-known/agent/` are discovered and executed correctly.
   // Only runs on Next.js workbenches where the test file is placed.

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -18,7 +18,7 @@ import {
 import { runtimeLogger } from '../logger.js';
 import type { Run } from './run.js';
 import type { WorkflowFunction } from './start.js';
-import { start } from './start.js';
+import { _resetLatestNoOpWarnForTests, start } from './start.js';
 import { setWorld } from './world.js';
 
 // Mock @vercel/functions
@@ -441,11 +441,17 @@ describe('start', () => {
         });
       });
       mockQueue = vi.fn().mockResolvedValue(undefined);
+      // Reset the warn-once guard so the no-op warn path is exercisable
+      // regardless of test order.
+      _resetLatestNoOpWarnForTests();
     });
 
     afterEach(() => {
       setWorld(undefined);
       vi.clearAllMocks();
+      // Restore any spies (e.g. on runtimeLogger.warn) even if a test threw
+      // before its own cleanup — clearAllMocks alone doesn't restore spies.
+      vi.restoreAllMocks();
     });
 
     it('should resolve "latest" to the actual deployment ID via resolveLatestDeploymentId', async () => {
@@ -554,8 +560,35 @@ describe('start', () => {
         expect.any(Object),
         expect.objectContaining({ deploymentId: 'deploy_123' })
       );
+    });
 
-      warnSpy.mockRestore();
+    it('should only warn once per process when "latest" is used repeatedly in an unsupported World', async () => {
+      const warnSpy = vi
+        .spyOn(runtimeLogger, 'warn')
+        .mockImplementation(() => {});
+
+      setWorld({
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+        // No resolveLatestDeploymentId
+      } as any);
+
+      // Multiple runs that all hit the no-op path...
+      await start(validWorkflow, [], { deploymentId: 'latest' });
+      await start(validWorkflow, [], { deploymentId: 'latest' });
+      await start(validWorkflow, [], { deploymentId: 'latest' });
+
+      // ...should only log the warning a single time.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // ...but every run still falls back to the current deployment.
+      expect(mockQueue).toHaveBeenCalledTimes(3);
+      for (const call of mockQueue.mock.calls) {
+        expect(call[2]).toEqual(
+          expect.objectContaining({ deploymentId: 'deploy_123' })
+        );
+      }
     });
 
     it('should not call resolveLatestDeploymentId when a normal deploymentId is provided', async () => {

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -15,6 +15,7 @@ import {
   it,
   vi,
 } from 'vitest';
+import { runtimeLogger } from '../logger.js';
 import type { Run } from './run.js';
 import type { WorkflowFunction } from './start.js';
 import { start } from './start.js';
@@ -514,7 +515,11 @@ describe('start', () => {
       );
     });
 
-    it('should throw WorkflowRuntimeError when "latest" is used with a World that does not implement resolveLatestDeploymentId', async () => {
+    it('should warn and fall back to the current deployment ID when "latest" is used with a World that does not implement resolveLatestDeploymentId', async () => {
+      const warnSpy = vi
+        .spyOn(runtimeLogger, 'warn')
+        .mockImplementation(() => {});
+
       setWorld({
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
@@ -522,15 +527,35 @@ describe('start', () => {
         // No resolveLatestDeploymentId
       } as any);
 
-      await expect(
-        start(validWorkflow, [], { deploymentId: 'latest' })
-      ).rejects.toThrow(WorkflowRuntimeError);
+      // Should not throw — 'latest' is a no-op in worlds without atomic
+      // deployments.
+      await start(validWorkflow, [], { deploymentId: 'latest' });
 
-      await expect(
-        start(validWorkflow, [], { deploymentId: 'latest' })
-      ).rejects.toThrow(
-        "deploymentId 'latest' requires a World that implements resolveLatestDeploymentId()"
+      // It should warn that 'latest' had no effect in this world.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("deploymentId: 'latest' has no effect"),
+        expect.objectContaining({ currentDeploymentId: 'deploy_123' })
       );
+
+      // The run should fall back to the current deployment ID in both the
+      // run_created event and the queue call.
+      expect(mockEventsCreate).toHaveBeenCalledWith(
+        expect.stringMatching(/^wrun_/),
+        expect.objectContaining({
+          eventType: 'run_created',
+          eventData: expect.objectContaining({
+            deploymentId: 'deploy_123',
+          }),
+        }),
+        expect.anything()
+      );
+      expect(mockQueue).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({ deploymentId: 'deploy_123' })
+      );
+
+      warnSpy.mockRestore();
     });
 
     it('should not call resolveLatestDeploymentId when a normal deploymentId is provided', async () => {

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -40,6 +40,22 @@ const CROSS_DEPLOYMENT_CAPABILITY_PROBE_TIMEOUT_MS = 2_000;
 /** ULID generator for client-side runId generation */
 const ulid = monotonicFactory();
 
+// `deploymentId: 'latest'` is a no-op in Worlds without atomic deployments.
+// The warning that explains this only needs to fire once per process: a
+// workflow that hardcodes 'latest' for its Vercel deployment would otherwise
+// log it on every local/Postgres run, flooding tight dev loops.
+let hasWarnedLatestNoOp = false;
+
+/**
+ * Reset the `deploymentId: 'latest'` no-op warn-once guard. Test-only —
+ * exported so unit tests can exercise the warn path across `start()` calls.
+ *
+ * @internal
+ */
+export function _resetLatestNoOpWarnForTests(): void {
+  hasWarnedLatestNoOp = false;
+}
+
 export interface StartOptionsBase {
   /**
    * The world to use for the workflow run creation,
@@ -204,12 +220,16 @@ export async function start<TArgs extends unknown[], TResult>(
         if (world.resolveLatestDeploymentId) {
           deploymentId = await world.resolveLatestDeploymentId();
         } else {
-          runtimeLogger.warn(
-            "deploymentId: 'latest' has no effect in this world and was ignored. " +
-              'It is only supported by worlds with atomic deployments, such as Vercel. ' +
-              'The run will target the current deployment.',
-            { currentDeploymentId }
-          );
+          // Warn once per process — see hasWarnedLatestNoOp above.
+          if (!hasWarnedLatestNoOp) {
+            hasWarnedLatestNoOp = true;
+            runtimeLogger.warn(
+              "deploymentId: 'latest' has no effect in this world and was ignored. " +
+                'It is only supported by worlds with atomic deployments, such as Vercel. ' +
+                'The run will target the current deployment.',
+              { currentDeploymentId }
+            );
+          }
           deploymentId = currentDeploymentId;
         }
       }

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -83,7 +83,10 @@ export interface StartOptionsWithDeploymentId extends StartOptionsBase {
    *
    * Set to `'latest'` to automatically resolve the most recent deployment
    * for the current environment (same production target or git branch).
-   * This is currently a Vercel-specific feature.
+   * This is only meaningful in worlds with atomic, immutable deployments
+   * (currently Vercel). In other worlds (local dev, Postgres) there is no
+   * notion of multiple deployments to resolve between, so `'latest'` has no
+   * effect — a warning is logged and the run targets the current deployment.
    *
    * **Note:** When `deploymentId` is provided, the argument and return types become `unknown`
    * since there is no guarantee the types will be consistent across deployments.
@@ -190,13 +193,25 @@ export async function start<TArgs extends unknown[], TResult>(
       // When 'latest' is requested, resolve the actual latest deployment ID
       // for the current deployment's environment (same production target or
       // same git branch for preview deployments).
+      //
+      // Resolving 'latest' only means something in worlds with atomic,
+      // immutable deployments (e.g. Vercel), which implement
+      // resolveLatestDeploymentId(). Worlds without that concept (local dev,
+      // self-hosted Postgres) have nothing to resolve between, so rather than
+      // fail a run that works fine on Vercel, we warn and fall back to the
+      // current deployment — making 'latest' an effective no-op there.
       if (deploymentId === 'latest') {
-        if (!world.resolveLatestDeploymentId) {
-          throw new WorkflowRuntimeError(
-            "deploymentId 'latest' requires a World that implements resolveLatestDeploymentId()"
+        if (world.resolveLatestDeploymentId) {
+          deploymentId = await world.resolveLatestDeploymentId();
+        } else {
+          runtimeLogger.warn(
+            "deploymentId: 'latest' has no effect in this world and was ignored. " +
+              'It is only supported by worlds with atomic deployments, such as Vercel. ' +
+              'The run will target the current deployment.',
+            { currentDeploymentId }
           );
+          deploymentId = currentDeploymentId;
         }
-        deploymentId = await world.resolveLatestDeploymentId();
       }
 
       // Decide whether to write byte streams in the framed wire format.


### PR DESCRIPTION
## Summary

`start({ deploymentId: 'latest' })` previously **threw** a `WorkflowRuntimeError` in any World that doesn't implement `resolveLatestDeploymentId()` — i.e. local dev and Postgres. That meant a workflow which opts into `'latest'` to target the newest deployment on Vercel would **fail outright in local development**, even though there's nothing for it to do there.

Resolving `'latest'` only means something in worlds with atomic, immutable deployments (currently Vercel). Other worlds have no notion of multiple deployments to resolve between. So instead of throwing, the SDK now **logs a warning (once per process) and falls back to the current deployment**, making `'latest'` an effective no-op outside Vercel.

```
[workflow-sdk] deploymentId: 'latest' has no effect in this world and was ignored.
It is only supported by worlds with atomic deployments, such as Vercel.
The run will target the current deployment.
```

## Changes

- **`packages/core/src/runtime/start.ts`** — when `deploymentId === 'latest'` and the World has no `resolveLatestDeploymentId()`, warn via `runtimeLogger.warn` and fall back to `currentDeploymentId` instead of throwing. The warning is gated behind a once-per-process guard (`hasWarnedLatestNoOp`, mirroring the `warnOnce` pattern in `constants.ts`) so tight local/Postgres dev loops aren't flooded. Updated the `StartOptionsWithDeploymentId` JSDoc.
- **`packages/core/src/runtime/start.test.ts`** — replaced the *"should throw"* unit test with one asserting the warning is logged and the run falls back to the current deployment ID (in both the `run_created` event and the queue dispatch); added a test asserting the warning fires exactly once across repeated `'latest'` starts. Spies are now restored in `afterEach` via `vi.restoreAllMocks()` so a throwing assertion can't leak the `runtimeLogger.warn` spy into later tests.
- **`packages/core/e2e/e2e.test.ts`** — new test gated to non-Vercel worlds (`skipIf(WORKFLOW_VERCEL_ENV)`) that starts a workflow with `deploymentId: 'latest'` and asserts it completes — directly exercising the no-op against the real local/Postgres worlds. (This is the e2e coverage that was previously missing for this option.)
- **docs** — added a note to the `deploymentId: "latest"` section of both `v4` and `v5` `start.mdx` describing the no-op-with-warning behavior in non-Vercel worlds.

## Implementation note

The fallback assigns `deploymentId = currentDeploymentId` (rather than leaving the `'latest'` sentinel in place). This is deliberate: the downstream `if (deploymentId === currentDeploymentId)` gate then takes the **same-deployment fast path** — byte-stream framing + compression enabled, no cross-deployment health-probe round-trip — which is exactly right for local/Postgres, where `'latest'` semantically means "right here." (h/t @TooTallNate for calling this out.)

## Behavior matrix

| World | Before | After |
|-------|--------|-------|
| Vercel | resolves via API | resolves via API (unchanged) |
| local | ❌ throws | ⚠️ warns once, targets current deployment |
| Postgres | ❌ throws | ⚠️ warns once, targets current deployment |

## Testing

- `pnpm vitest run src/runtime/start.test.ts` → 28/28 pass (incl. warn+fallback and warn-once tests)
- `pnpm --filter @workflow/core typecheck` → clean
- New e2e test runs on non-Vercel matrix entries in CI.

## Docs Preview

| Page | v4 | v5 |
|------|----|----|
| `start` — Using `deploymentId: "latest"` | [/docs/…/start#using-deploymentid-latest](https://workflow-docs-git-pgp-deployment-id-latest.vercel.sh/docs/api-reference/workflow-api/start#using-deploymentid-latest) | [/v5/docs/…/start#using-deploymentid-latest](https://workflow-docs-git-pgp-deployment-id-latest.vercel.sh/v5/docs/api-reference/workflow-api/start#using-deploymentid-latest) |

_(Behind deployment protection — requires Vercel team access.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)