### PR TITLE
[core] De-flake dev.test.ts cleanup hook timeout

### DIFF
--- a/.changeset/shy-turtles-decide.md
+++ b/.changeset/shy-turtles-decide.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: give the dev.test.ts cleanup hooks headroom over their bounded prewarm fetches so the local-dev lanes stop flaking on `Hook timed out in 10000ms`

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -38,6 +38,17 @@ export function createDevTests(config?: DevTestConfig) {
     );
   }
   describe('dev e2e', () => {
+    // Each prewarm/trigger fetch is hard-bounded by this so cleanup never hangs
+    // on a wedged dev server.
+    const PREWARM_FETCH_TIMEOUT_MS = 5_000;
+    // The afterEach cleanup can issue two *sequential* prewarms (before and
+    // after deleting an added file) while the dev server is mid-rebuild — the
+    // teardown of a test that added a workflow file and edited an import is
+    // exactly when both rebuild and respond slowly. Its budget must therefore
+    // exceed 2× PREWARM_FETCH_TIMEOUT_MS (plus file IO) with headroom, or it
+    // trips vitest's 10s default hook timeout. The bounded fetches mean this
+    // can't hang indefinitely, so a generous budget is safe.
+    const CLEANUP_HOOK_TIMEOUT_MS = PREWARM_FETCH_TIMEOUT_MS * 4;
     const appPath = getWorkbenchAppPath();
     const deploymentUrl = process.env.DEPLOYMENT_URL;
     const generatedStep = path.join(appPath, finalConfig.generatedStepPath);
@@ -92,7 +103,7 @@ export function createDevTests(config?: DevTestConfig) {
       }
 
       return fetch(new URL(pathname, deploymentUrl), {
-        signal: AbortSignal.timeout(5_000),
+        signal: AbortSignal.timeout(PREWARM_FETCH_TIMEOUT_MS),
       });
     };
 
@@ -115,7 +126,7 @@ export function createDevTests(config?: DevTestConfig) {
             workflowName,
             args,
           }),
-          signal: AbortSignal.timeout(5_000),
+          signal: AbortSignal.timeout(PREWARM_FETCH_TIMEOUT_MS),
         }
       );
 
@@ -171,7 +182,7 @@ export function createDevTests(config?: DevTestConfig) {
 
     beforeAll(async () => {
       await prewarm();
-    });
+    }, CLEANUP_HOOK_TIMEOUT_MS);
 
     afterEach(async () => {
       // Restore file contents before deleting any files. If a deletion races
@@ -190,7 +201,7 @@ export function createDevTests(config?: DevTestConfig) {
       await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
       await prewarm();
       restoreFiles.length = 0;
-    });
+    }, CLEANUP_HOOK_TIMEOUT_MS);
 
     test('should rebuild on workflow change', { timeout: 30_000 }, async () => {
       const workflowFile = path.join(appPath, workflowsDir, testWorkflowFile);


### PR DESCRIPTION
## Problem

The `E2E Local Dev Tests` lanes intermittently fail with:

```
FAIL packages/core/e2e/dev.test.ts > dev e2e > should rebuild on adding workflow file
Error: Hook timed out in 10000ms.
 ❯ packages/core/e2e/dev.test.ts:176:5   (the afterEach hook)
```

Most often on the webpack / eager-discovery (stable `lazyDiscovery disabled`) and Windows lanes. ([example run](https://github.com/vercel/workflow/actions/runs/27496928277/job/81272866892))

## Root cause

`should rebuild on adding workflow file` adds a workflow file **and** edits the api-file import. Its `afterEach` therefore takes the expensive cleanup path: it restores the api file and deletes the added workflow file — **both trigger dev-server rebuilds** — then runs **two sequential `prewarm()` calls**.

Each prewarm is `Promise.all([fetch('/'), fetch('/api/chat')])`, each fetch hard-bounded at 5s via `AbortSignal.timeout`. So the cleanup's worst case is ~2×5s of fetches plus file IO — right at vitest's **default 10s hook timeout**. The teardown runs precisely when the dev server is mid-rebuild (it's reverting the file add + import), so the prewarm fetches stall toward their 5s bound and the hook blows its 10s budget. The bounded fetches were added so cleanup "cannot hang," but the hook timeout was never raised above the sum of those bounds → marginal-by-construction → flaky.

This is independent of any product code — it reproduces on `main`/`stable` (the lane runs the repo's `dev.test.ts` against the stable SDK).

## Fix

Give the `beforeAll`/`afterEach` hooks an explicit budget of **4× the prewarm fetch bound (20s)**, derived from a single shared constant (no duplicated magic number, per repo test conventions):

```ts
const PREWARM_FETCH_TIMEOUT_MS = 5_000;
const CLEANUP_HOOK_TIMEOUT_MS = PREWARM_FETCH_TIMEOUT_MS * 4; // 20s
```

The fetches remain hard-bounded by `AbortSignal.timeout`, so the cleanup still can't hang indefinitely (worst case ≤ ~11s) — the hook just gets comfortable headroom over its bounded worst case. The two existing 5s fetch literals now reference the constant.

## Validation

A timing flake on a rebuild-bound dev server isn't deterministically reproducible locally, so this is validated by the bounded-work arithmetic: worst case ≈ 2×5s + file IO ≈ ≤11s, now under a 20s budget instead of the 10s default. CI exercises it on the affected lanes.