### PR TITLE
clarify serverExternalPackages warning

### DIFF
--- a/.changeset/clear-server-external-warning.md
+++ b/.changeset/clear-server-external-warning.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Clarify that workflow packages removed from `serverExternalPackages` are still compiled during the build.

--- a/docs/content/docs/v4/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-next/with-workflow.mdx
@@ -31,8 +31,8 @@ export default withWorkflow(nextConfig, workflowConfig); // [!code highlight]
 If a package in `serverExternalPackages` contains workflow code (`"use step"`,
 `"use workflow"`, or serialization classes), `withWorkflow()` automatically
 removes it from `serverExternalPackages` for the current build and prints a
-warning. This ensures the package still gets transformed by the Workflow
-compiler. Remove that package from `serverExternalPackages` in your
+warning. Workflow still compiles the package so its directives are transformed.
+Remove that package from `serverExternalPackages` in your
 `next.config` to silence the warning.
 </Callout>
 

--- a/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx
@@ -31,8 +31,8 @@ export default withWorkflow(nextConfig, workflowConfig); // [!code highlight]
 If a package in `serverExternalPackages` contains workflow code (`"use step"`,
 `"use workflow"`, or serialization classes), `withWorkflow()` automatically
 removes it from `serverExternalPackages` for the current build and prints a
-warning. This ensures the package still gets transformed by the Workflow
-compiler. Remove that package from `serverExternalPackages` in your
+warning. Workflow still compiles the package so its directives are transformed.
+Remove that package from `serverExternalPackages` in your
 `next.config` to silence the warning.
 </Callout>
 

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -326,6 +326,7 @@ describe('withWorkflow builder config', () => {
       expect(warning).toContain('workflow-auto-remove-a');
       expect(warning).toContain('serverExternalPackages');
       expect(warning).toContain('removed');
+      expect(warning).toContain('compiling the packages anyway');
     } finally {
       warnSpy.mockRestore();
       process.chdir(originalCwd);

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -185,8 +185,8 @@ function warnAboutAutoRemovedServerExternalPackages(
     .join(', ');
 
   console.warn(
-    `\n⚠ Workflow removed ${packageDescriptions} from serverExternalPackages for this build.` +
-      `\n  These packages contain workflow code and must be transformed by the workflow compiler.` +
+    `\n⚠ Workflow found workflow code in serverExternalPackages: ${packageDescriptions}.` +
+      `\n  Workflow removed the affected entries from serverExternalPackages for this build and is compiling the packages anyway.` +
       `\n  Remove ${packageNames} from serverExternalPackages in next.config to silence this warning.\n`
   );
 }


### PR DESCRIPTION
## Summary
- Clarifies that packages removed from `serverExternalPackages` are still compiled by Workflow during the build.
- Updates the Next integration test and v4/v5 docs copy to match the warning.
- Adds a patch changeset for `@workflow/next`.

## Testing
- `pnpm vitest run packages/next/src/index.test.ts`
- `pnpm biome check \"packages/next/src/index.ts\" \"packages/next/src/index.test.ts\" \"docs/content/docs/v5/api-reference/workflow-next/with-workflow.mdx\" \"docs/content/docs/v4/api-reference/workflow-next/with-workflow.mdx\" \".changeset/clear-server-external-warning.md\"` (reports pre-existing cognitive-complexity warning in `packages/next/src/index.ts`)

## Docs Preview
| Page | v4 | v5 |
| --- | --- | --- |
| `withWorkflow` API reference | https://workflow-docs-git-clarify-server-external-warning.vercel.sh/docs/api-reference/workflow-next/with-workflow | https://workflow-docs-git-clarify-server-external-warning.vercel.sh/v5/docs/api-reference/workflow-next/with-workflow |