### PR TITLE
Add .swc gitignore handling to builder

### DIFF
--- a/.changeset/swc-gitignore-builder.md
+++ b/.changeset/swc-gitignore-builder.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Add `.swc` to the builder's default gitignore handling.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -248,6 +248,7 @@ export abstract class BaseBuilder {
       '**/.workflow-data/**',
       '**/.workflow-vitest/**',
       '**/.well-known/workflow/**',
+      '**/.swc/**',
       '**/.svelte-kit/**',
       '**/.turbo/**',
       '**/.cache/**',
@@ -895,8 +896,7 @@ export abstract class BaseBuilder {
       })
     );
 
-    // Create .gitignore in .swc directory
-    await this.createSwcGitignore();
+    await this.ensureSwcIgnored();
 
     if (this.config.watch) {
       return { context: esbuildCtx, manifest: workflowManifest };
@@ -1125,8 +1125,7 @@ export abstract class BaseBuilder {
         );
       }
 
-      // Create .gitignore in .swc directory
-      await this.createSwcGitignore();
+      await this.ensureSwcIgnored();
 
       if (
         !interimBundle.outputFiles ||
@@ -1595,8 +1594,7 @@ export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCo
 
     this.logEsbuildMessages(clientResult, 'client library bundle');
 
-    // Create .gitignore in .swc directory
-    await this.createSwcGitignore();
+    await this.ensureSwcIgnored();
   }
 
   /**
@@ -1778,7 +1776,47 @@ export const OPTIONS = handler;`;
     await mkdir(dirname(filePath), { recursive: true });
   }
 
-  private async createSwcGitignore(): Promise<void> {
+  protected async ensureSwcIgnored(): Promise<void> {
+    await this.ensureProjectSwcGitignoreEntry();
+    await this.createSwcDirectoryGitignore();
+  }
+
+  private async ensureProjectSwcGitignoreEntry(): Promise<void> {
+    const gitignorePath = join(this.config.workingDir, '.gitignore');
+
+    try {
+      let content = '';
+      try {
+        content = await readFile(gitignorePath, 'utf-8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return;
+        }
+      }
+
+      const hasSwcEntry = content.split(/\r?\n/).some((line) => {
+        const trimmed = line.trim();
+        return (
+          trimmed === '.swc' ||
+          trimmed === '.swc/' ||
+          trimmed === '/.swc' ||
+          trimmed === '/.swc/'
+        );
+      });
+
+      if (hasSwcEntry) {
+        return;
+      }
+
+      const separator =
+        content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+      await writeFile(gitignorePath, `${content}${separator}/.swc\n`);
+    } catch {
+      // We're intentionally silently ignoring this error - updating .gitignore isn't critical
+    }
+  }
+
+  private async createSwcDirectoryGitignore(): Promise<void> {
     try {
       await writeFile(
         join(this.config.workingDir, '.swc', '.gitignore'),

--- a/packages/builders/src/get-input-files.test.ts
+++ b/packages/builders/src/get-input-files.test.ts
@@ -1,6 +1,7 @@
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -26,6 +27,10 @@ class TestBuilder extends BaseBuilder {
 
   public getDiagnosticsManifestPath(): string | undefined {
     return super.getDiagnosticsManifestPath();
+  }
+
+  public ensureSwcIgnored(): Promise<void> {
+    return super.ensureSwcIgnored();
   }
 }
 
@@ -112,6 +117,7 @@ describe('getInputFiles', () => {
     writeFile(srcDir, '.workflow-data/state.ts');
     writeFile(srcDir, '.workflow-vitest/workflows.mjs');
     writeFile(srcDir, '.well-known/workflow/route.ts');
+    writeFile(srcDir, '.swc/cache/plugin-output.ts');
     writeFile(srcDir, '.turbo/cache/build.ts');
     writeFile(srcDir, '.cache/babel/plugin.js');
     writeFile(srcDir, '.yarn/releases/yarn.cjs');
@@ -148,6 +154,9 @@ describe('getInputFiles', () => {
       normalize(join(srcDir, '.well-known/workflow/route.ts'))
     );
     expect(files).not.toContain(
+      normalize(join(srcDir, '.swc/cache/plugin-output.ts'))
+    );
+    expect(files).not.toContain(
       normalize(join(srcDir, '.turbo/cache/build.ts'))
     );
     expect(files).not.toContain(
@@ -179,6 +188,47 @@ describe('getInputFiles', () => {
     expect(files).toContain(normalize(join(srcDir, '.api/handler.mts')));
     expect(files).toContain(normalize(join(srcDir, '.api/utils.js')));
     expect(files).toContain(normalize(join(srcDir, '.api/config.cjs')));
+  });
+});
+
+describe('ensureSwcIgnored', () => {
+  let testRoot: string;
+
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(realTmpdir, 'swc-gitignore-'));
+  });
+
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('adds .swc to the project .gitignore once', async () => {
+    writeFile(testRoot, '.gitignore', 'node_modules\n');
+
+    const builder = createBuilder(testRoot, ['src']);
+
+    await builder.ensureSwcIgnored();
+    await builder.ensureSwcIgnored();
+
+    const gitignore = readFileSync(join(testRoot, '.gitignore'), 'utf-8');
+    const swcEntries = gitignore
+      .split(/\r?\n/)
+      .filter((line) => line.trim() === '/.swc');
+
+    expect(gitignore).toBe('node_modules\n/.swc\n');
+    expect(swcEntries).toHaveLength(1);
+  });
+
+  it('preserves existing .swc gitignore variants', async () => {
+    writeFile(testRoot, '.gitignore', 'node_modules\n.swc/\n');
+
+    const builder = createBuilder(testRoot, ['src']);
+
+    await builder.ensureSwcIgnored();
+
+    expect(readFileSync(join(testRoot, '.gitignore'), 'utf-8')).toBe(
+      'node_modules\n.swc/\n'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add .swc to the builder's default source discovery ignores
- ensure workflow builds add /.swc to the project .gitignore when missing
- cover the ignore behavior with focused builder tests

x-ref: [slack thread](https://vercel.slack.com/archives/C09G3EQAL84/p1781529612082689)

## Tests
- pnpm exec vitest run packages/builders/src/get-input-files.test.ts
- pnpm --dir packages/builders typecheck