### PR TITLE
fix(web): correct Geist tokens and context card styling in observability UI

### DIFF
--- a/.changeset/context-card-arrow-stroke.md
+++ b/.changeset/context-card-arrow-stroke.md
@@ -1,5 +1,0 @@
----
-'@workflow/web-shared': patch
----
-
-Make the context card arrow tip stroke use the theme-aware `--ds-gray-alpha-400` token so it matches the card border in both light and dark themes (previously hardcoded grays that relied on a `dark-theme` variant).

--- a/.changeset/context-card-arrow-stroke.md
+++ b/.changeset/context-card-arrow-stroke.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Make the context card arrow tip stroke use the theme-aware `--ds-gray-alpha-400` token so it matches the card border in both light and dark themes (previously hardcoded grays that relied on a `dark-theme` variant).

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Register the `dark-theme`/`light-theme` custom variants in the web app's global stylesheet so context card styling (e.g. the tooltip arrow stroke) resolves correctly in dark mode.

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -2,8 +2,4 @@
 '@workflow/web': patch
 ---
 
-Fix context card / timestamp tooltip styling in the observability UI:
-
-- Map the Geist `background` and `gray` (incl. `gray-alpha`) color scales to Tailwind tokens so utilities like `bg-background-100`, `text-gray-900`, and `text-gray-1000` resolve correctly instead of falling back to Tailwind's non-theme-aware defaults (or emitting no rule).
-- Correct the `--ds-*` neutral palette values, which had drifted to a Tailwind-neutral-style scale (e.g. dark `background-100` was pure black and dark `gray-900` was near-white). They now match the canonical Geist scale, so the card background and gray text render with the correct contrast in both themes.
-- Define the missing `--ds-shadow-tooltip` token so the context card renders its border + drop shadow (it previously fell back to a 1px ring the same color as the card background, making the border invisible).
+Fix context card / timestamp tooltip styling: map the Geist `background`/`gray` scales to Tailwind tokens, correct the drifted `--ds-*` neutral values to match the canonical Geist scale, and add the missing `--ds-shadow-tooltip` token.

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -2,4 +2,4 @@
 '@workflow/web': patch
 ---
 
-Fix context card / timestamp tooltip styling in the observability UI: register the `dark-theme`/`light-theme` custom variants and the missing Geist color tokens (`background-100`, `background-200`, `gray-1000`, `gray-alpha-400`) in the web app's global stylesheet so utilities like `bg-background-100` and `text-gray-1000` and the dark-mode arrow stroke resolve correctly.
+Fix context card / timestamp tooltip styling in the observability UI: register the `dark-theme`/`light-theme` custom variants and map the Geist `background` and `gray` (incl. `gray-alpha`) color scales to Tailwind tokens in the web app's global stylesheet. This makes `bg-background-100`, the theme-aware `gray` utilities (e.g. `text-gray-900`/`text-gray-1000`), and the dark-mode arrow stroke resolve correctly instead of falling back to Tailwind's non-theme-aware defaults (or emitting no rule).

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -1,5 +1,6 @@
 ---
 '@workflow/web': patch
+'@workflow/web-shared': patch
 ---
 
-Fix context card / timestamp tooltip styling: map the Geist `background`/`gray` scales to Tailwind tokens, correct the drifted `--ds-*` neutral values to match the canonical Geist scale, and add the missing `--ds-shadow-tooltip` token.
+Fix context card / timestamp tooltip styling: map the Geist `background`/`gray` scales to Tailwind tokens, correct the drifted `--ds-*` neutral values, add the missing `--ds-shadow-tooltip` token, and match the arrow stroke to the card border via `--ds-gray-alpha-400`.

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -4,6 +4,6 @@
 
 Fix context card / timestamp tooltip styling in the observability UI:
 
-- Register the `dark-theme`/`light-theme` custom variants and map the Geist `background` and `gray` (incl. `gray-alpha`) color scales to Tailwind tokens so utilities like `bg-background-100`, `text-gray-900`, `text-gray-1000`, and the dark-mode arrow stroke resolve correctly instead of falling back to Tailwind's non-theme-aware defaults (or emitting no rule).
+- Map the Geist `background` and `gray` (incl. `gray-alpha`) color scales to Tailwind tokens so utilities like `bg-background-100`, `text-gray-900`, and `text-gray-1000` resolve correctly instead of falling back to Tailwind's non-theme-aware defaults (or emitting no rule).
 - Correct the `--ds-*` neutral palette values, which had drifted to a Tailwind-neutral-style scale (e.g. dark `background-100` was pure black and dark `gray-900` was near-white). They now match the canonical Geist scale, so the card background and gray text render with the correct contrast in both themes.
 - Define the missing `--ds-shadow-tooltip` token so the context card renders its border + drop shadow (it previously fell back to a 1px ring the same color as the card background, making the border invisible).

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -2,4 +2,7 @@
 '@workflow/web': patch
 ---
 
-Fix context card / timestamp tooltip styling in the observability UI: register the `dark-theme`/`light-theme` custom variants and map the Geist `background` and `gray` (incl. `gray-alpha`) color scales to Tailwind tokens in the web app's global stylesheet. This makes `bg-background-100`, the theme-aware `gray` utilities (e.g. `text-gray-900`/`text-gray-1000`), and the dark-mode arrow stroke resolve correctly instead of falling back to Tailwind's non-theme-aware defaults (or emitting no rule).
+Fix context card / timestamp tooltip styling in the observability UI:
+
+- Register the `dark-theme`/`light-theme` custom variants and map the Geist `background` and `gray` (incl. `gray-alpha`) color scales to Tailwind tokens so utilities like `bg-background-100`, `text-gray-900`, `text-gray-1000`, and the dark-mode arrow stroke resolve correctly instead of falling back to Tailwind's non-theme-aware defaults (or emitting no rule).
+- Correct the `--ds-*` neutral palette values, which had drifted to a Tailwind-neutral-style scale (e.g. dark `background-100` was pure black and dark `gray-900` was near-white). They now match the canonical Geist scale, so the card background and gray text render with the correct contrast in both themes.

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -6,3 +6,4 @@ Fix context card / timestamp tooltip styling in the observability UI:
 
 - Register the `dark-theme`/`light-theme` custom variants and map the Geist `background` and `gray` (incl. `gray-alpha`) color scales to Tailwind tokens so utilities like `bg-background-100`, `text-gray-900`, `text-gray-1000`, and the dark-mode arrow stroke resolve correctly instead of falling back to Tailwind's non-theme-aware defaults (or emitting no rule).
 - Correct the `--ds-*` neutral palette values, which had drifted to a Tailwind-neutral-style scale (e.g. dark `background-100` was pure black and dark `gray-900` was near-white). They now match the canonical Geist scale, so the card background and gray text render with the correct contrast in both themes.
+- Define the missing `--ds-shadow-tooltip` token so the context card renders its border + drop shadow (it previously fell back to a 1px ring the same color as the card background, making the border invisible).

--- a/.changeset/web-theme-variants.md
+++ b/.changeset/web-theme-variants.md
@@ -2,4 +2,4 @@
 '@workflow/web': patch
 ---
 
-Register the `dark-theme`/`light-theme` custom variants in the web app's global stylesheet so context card styling (e.g. the tooltip arrow stroke) resolves correctly in dark mode.
+Fix context card / timestamp tooltip styling in the observability UI: register the `dark-theme`/`light-theme` custom variants and the missing Geist color tokens (`background-100`, `background-200`, `gray-1000`, `gray-alpha-400`) in the web app's global stylesheet so utilities like `bg-background-100` and `text-gray-1000` and the dark-mode arrow stroke resolve correctly.

--- a/packages/web-shared/src/components/ui/context-card.tsx
+++ b/packages/web-shared/src/components/ui/context-card.tsx
@@ -274,7 +274,7 @@ export function ContextCardProvider({
               >
                 <div
                   className={cn(
-                    'absolute bg-background-100 bg-clip-padding rounded-[6px] overflow-visible pointer-events-none z-[1000000] shadow-[var(--ds-shadow-tooltip),0_0_0_1px_var(--ds-background-100)] w-fit [--context-card-tip-stroke:#DBDBDB] dark-theme:[--context-card-tip-stroke:#252525]',
+                    'absolute bg-background-100 bg-clip-padding rounded-[6px] overflow-visible pointer-events-none z-[1000000] shadow-[var(--ds-shadow-tooltip),0_0_0_1px_var(--ds-background-100)] w-fit [--context-card-tip-stroke:var(--ds-gray-alpha-400)]',
                     skipTransition
                       ? '!transition-none'
                       : 'transition-[transform,width,height] duration-250 ease-[easing-function:cubic-bezier(0.29,0.31,0.05,0.96)] will-change-[transform,width,height] motion-reduce:!transition-none'

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -4,9 +4,6 @@
 @source "../../web-shared/src";
 @source "./components";
 
-@custom-variant dark-theme (&:where(.dark-theme, .dark-theme *, .dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
-@custom-variant light-theme (&:where(.light-theme, .light-theme *, .light, .light *));
-
 /* Geist fonts — referenced directly from the "geist" npm package. */
 /* Vite resolves these at build time and bundles them into the output. */
 @font-face {

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -4,12 +4,6 @@
 @source "../../web-shared/src";
 @source "./components";
 
-/*
- * Theme variants used by @workflow/web-shared components (e.g. the context
- * card arrow stroke). These mirror the declarations in
- * @workflow/web-shared/styles.css, which this app does not import, so the
- * `dark-theme:`/`light-theme:` variants compile here too.
- */
 @custom-variant dark-theme (&:where(.dark-theme, .dark-theme *, .dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
 @custom-variant light-theme (&:where(.light-theme, .light-theme *, .light, .light *));
 
@@ -72,12 +66,6 @@
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
 
-  /*
-   * Geist design system tokens used by @workflow/web-shared components that
-   * have no Tailwind default equivalent (e.g. the context card background and
-   * the highest-contrast gray). Without these, utilities like
-   * `bg-background-100` and `text-gray-1000` emit no rule.
-   */
   --color-background-100: var(--ds-background-100);
   --color-background-200: var(--ds-background-200);
   --color-gray-1000: var(--ds-gray-1000);

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -139,16 +139,16 @@
   --ds-background-200: rgb(250 250 250);
 
   /* Gray Scale */
-  --ds-gray-100: rgb(250 250 250);
-  --ds-gray-200: rgb(245 245 245);
-  --ds-gray-300: rgb(229 229 229);
-  --ds-gray-400: rgb(212 212 212);
-  --ds-gray-500: rgb(163 163 163);
-  --ds-gray-600: rgb(115 115 115);
-  --ds-gray-700: rgb(82 82 82);
-  --ds-gray-800: rgb(64 64 64);
-  --ds-gray-900: rgb(23 23 23);
-  --ds-gray-1000: rgb(0 0 0);
+  --ds-gray-100: hsl(0, 0%, 95%);
+  --ds-gray-200: hsl(0, 0%, 92%);
+  --ds-gray-300: hsl(0, 0%, 90%);
+  --ds-gray-400: hsl(0, 0%, 92%);
+  --ds-gray-500: hsl(0, 0%, 79%);
+  --ds-gray-600: hsl(0, 0%, 66%);
+  --ds-gray-700: hsl(0, 0%, 56%);
+  --ds-gray-800: hsl(0, 0%, 49%);
+  --ds-gray-900: hsl(0, 0%, 40%);
+  --ds-gray-1000: hsl(0, 0%, 9%);
 
   /* Gray Alpha */
   --ds-gray-alpha-100: rgba(0, 0, 0, 0.05);
@@ -292,20 +292,20 @@
 
   /* Geist Design System Colors - Dark Mode */
   /* Backgrounds */
-  --ds-background-100: rgb(0 0 0);
-  --ds-background-200: rgb(10 10 10);
+  --ds-background-100: hsl(0, 0%, 7%);
+  --ds-background-200: hsl(0, 0%, 10%);
 
   /* Gray Scale */
-  --ds-gray-100: rgb(17 17 17);
-  --ds-gray-200: rgb(23 23 23);
-  --ds-gray-300: rgb(41 41 41);
-  --ds-gray-400: rgb(64 64 64);
-  --ds-gray-500: rgb(115 115 115);
-  --ds-gray-600: rgb(163 163 163);
-  --ds-gray-700: rgb(212 212 212);
-  --ds-gray-800: rgb(229 229 229);
-  --ds-gray-900: rgb(245 245 245);
-  --ds-gray-1000: rgb(255 255 255);
+  --ds-gray-100: hsl(0, 0%, 11%);
+  --ds-gray-200: hsl(0, 0%, 14%);
+  --ds-gray-300: hsl(0, 0%, 17%);
+  --ds-gray-400: hsl(0, 0%, 14%);
+  --ds-gray-500: hsl(0, 0%, 23%);
+  --ds-gray-600: hsl(0, 0%, 34%);
+  --ds-gray-700: hsl(0, 0%, 44%);
+  --ds-gray-800: hsl(0, 0%, 51%);
+  --ds-gray-900: hsl(0, 0%, 63%);
+  --ds-gray-1000: hsl(0, 0%, 93%);
 
   /* Gray Alpha - Dark Mode */
   --ds-gray-alpha-100: rgba(255, 255, 255, 0.06);
@@ -450,18 +450,18 @@
     --node-bg-conditional: #7f1d1d;
 
     /* Geist Design System Colors - Dark Mode (same as .dark) */
-    --ds-background-100: rgb(0 0 0);
-    --ds-background-200: rgb(10 10 10);
-    --ds-gray-100: rgb(17 17 17);
-    --ds-gray-200: rgb(23 23 23);
-    --ds-gray-300: rgb(41 41 41);
-    --ds-gray-400: rgb(64 64 64);
-    --ds-gray-500: rgb(115 115 115);
-    --ds-gray-600: rgb(163 163 163);
-    --ds-gray-700: rgb(212 212 212);
-    --ds-gray-800: rgb(229 229 229);
-    --ds-gray-900: rgb(245 245 245);
-    --ds-gray-1000: rgb(255 255 255);
+    --ds-background-100: hsl(0, 0%, 7%);
+    --ds-background-200: hsl(0, 0%, 10%);
+    --ds-gray-100: hsl(0, 0%, 11%);
+    --ds-gray-200: hsl(0, 0%, 14%);
+    --ds-gray-300: hsl(0, 0%, 17%);
+    --ds-gray-400: hsl(0, 0%, 14%);
+    --ds-gray-500: hsl(0, 0%, 23%);
+    --ds-gray-600: hsl(0, 0%, 34%);
+    --ds-gray-700: hsl(0, 0%, 44%);
+    --ds-gray-800: hsl(0, 0%, 51%);
+    --ds-gray-900: hsl(0, 0%, 63%);
+    --ds-gray-1000: hsl(0, 0%, 93%);
     --ds-gray-alpha-100: rgba(255, 255, 255, 0.06);
     --ds-gray-alpha-200: rgba(255, 255, 255, 0.09);
     --ds-gray-alpha-400: rgba(255, 255, 255, 0.14);

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -71,6 +71,18 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+
+  /*
+   * Geist design system tokens used by @workflow/web-shared components that
+   * have no Tailwind default equivalent (e.g. the context card background and
+   * the highest-contrast gray). Without these, utilities like
+   * `bg-background-100` and `text-gray-1000` emit no rule.
+   */
+  --color-background-100: var(--ds-background-100);
+  --color-background-200: var(--ds-background-200);
+  --color-gray-1000: var(--ds-gray-1000);
+  --color-gray-alpha-400: var(--ds-gray-alpha-400);
+
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -68,8 +68,21 @@
 
   --color-background-100: var(--ds-background-100);
   --color-background-200: var(--ds-background-200);
+  --color-gray-100: var(--ds-gray-100);
+  --color-gray-200: var(--ds-gray-200);
+  --color-gray-300: var(--ds-gray-300);
+  --color-gray-400: var(--ds-gray-400);
+  --color-gray-500: var(--ds-gray-500);
+  --color-gray-600: var(--ds-gray-600);
+  --color-gray-700: var(--ds-gray-700);
+  --color-gray-800: var(--ds-gray-800);
+  --color-gray-900: var(--ds-gray-900);
   --color-gray-1000: var(--ds-gray-1000);
+  --color-gray-alpha-100: var(--ds-gray-alpha-100);
+  --color-gray-alpha-200: var(--ds-gray-alpha-200);
   --color-gray-alpha-400: var(--ds-gray-alpha-400);
+  --color-gray-alpha-700: var(--ds-gray-alpha-700);
+  --color-gray-alpha-1000: var(--ds-gray-alpha-1000);
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -4,6 +4,15 @@
 @source "../../web-shared/src";
 @source "./components";
 
+/*
+ * Theme variants used by @workflow/web-shared components (e.g. the context
+ * card arrow stroke). These mirror the declarations in
+ * @workflow/web-shared/styles.css, which this app does not import, so the
+ * `dark-theme:`/`light-theme:` variants compile here too.
+ */
+@custom-variant dark-theme (&:where(.dark-theme, .dark-theme *, .dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
+@custom-variant light-theme (&:where(.light-theme, .light-theme *, .light, .light *));
+
 /* Geist fonts — referenced directly from the "geist" npm package. */
 /* Vite resolves these at build time and bundles them into the output. */
 @font-face {

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -239,6 +239,9 @@
   --ds-shadow-small: 0 0 0 1px rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.05), 0 12px 24px rgba(0, 0, 0, 0.05);
   --ds-shadow-medium: 0 0 0 1px rgba(0, 0, 0, 0.07), 0 4px 8px rgba(0, 0, 0, 0.07), 0 24px 48px rgba(0, 0, 0, 0.07);
   --ds-shadow-large: 0 0 0 1px rgba(0, 0, 0, 0.07), 0 8px 16px rgba(0, 0, 0, 0.10), 0 48px 96px rgba(0, 0, 0, 0.10);
+  --ds-shadow-tooltip:
+    0 0 0 1px rgba(0, 0, 0, 0.08), 0px 1px 1px rgba(0, 0, 0, 0.02),
+    0px 4px 8px rgba(0, 0, 0, 0.04), 0 0 0 1px var(--ds-background-200);
   --ds-shadow-menu: var(--ds-shadow-medium);
 
   /* Legacy aliases used by trace-viewer.module.css */
@@ -396,6 +399,9 @@
   --ds-shadow-small: 0 0 0 1px rgba(255, 255, 255, 0.07), 0 2px 4px rgba(0, 0, 0, 0.3), 0 12px 24px rgba(0, 0, 0, 0.3);
   --ds-shadow-medium: 0 0 0 1px rgba(255, 255, 255, 0.07), 0 4px 8px rgba(0, 0, 0, 0.4), 0 24px 48px rgba(0, 0, 0, 0.4);
   --ds-shadow-large: 0 0 0 1px rgba(255, 255, 255, 0.07), 0 8px 16px rgba(0, 0, 0, 0.5), 0 48px 96px rgba(0, 0, 0, 0.5);
+  --ds-shadow-tooltip:
+    0 0 0 1px rgba(255, 255, 255, 0.145), 0px 1px 1px rgba(0, 0, 0, 0.02),
+    0px 4px 8px rgba(0, 0, 0, 0.04), 0 0 0 1px var(--ds-background-200);
   --ds-shadow-menu: var(--ds-shadow-medium);
 
   /* Legacy aliases used by trace-viewer.module.css */
@@ -534,6 +540,9 @@
     --ds-shadow-small: 0 0 0 1px rgba(255, 255, 255, 0.07), 0 2px 4px rgba(0, 0, 0, 0.3), 0 12px 24px rgba(0, 0, 0, 0.3);
     --ds-shadow-medium: 0 0 0 1px rgba(255, 255, 255, 0.07), 0 4px 8px rgba(0, 0, 0, 0.4), 0 24px 48px rgba(0, 0, 0, 0.4);
     --ds-shadow-large: 0 0 0 1px rgba(255, 255, 255, 0.07), 0 8px 16px rgba(0, 0, 0, 0.5), 0 48px 96px rgba(0, 0, 0, 0.5);
+    --ds-shadow-tooltip:
+      0 0 0 1px rgba(255, 255, 255, 0.145), 0px 1px 1px rgba(0, 0, 0, 0.02),
+      0px 4px 8px rgba(0, 0, 0, 0.04), 0 0 0 1px var(--ds-background-200);
     --ds-shadow-menu: var(--ds-shadow-medium);
     --geist-background: var(--ds-background-100);
     --accents-2: var(--ds-gray-300);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `RelativeTimeCard` / `TimestampTooltip` context card (in `@workflow/web-shared`) rendered incorrectly in the `@workflow/web` observability UI: no card background, a pure-black card that blended into the page, wrong gray shades, a missing border/shadow, and an arrow tip whose outline didn't match the card border.

Root causes:

1. **Missing tokens (`packages/web/app/globals.css`).** The component uses Geist tokens declared only in `@workflow/web-shared/styles.css`, which the `web` app doesn't import. So `bg-background-100`, `text-gray-1000`, and `border-gray-alpha-400` emitted **no rule**, and other `gray` utilities fell back to Tailwind's non-theme-aware defaults.
2. **Wrong `--ds-*` values.** The hand-maintained Geist palette had drifted to a Tailwind-`neutral`-style scale (dark `background-100` pure black instead of `hsl(0,0%,7%)`; dark `gray-900` near-white instead of `hsl(0,0%,63%)`).
3. **Missing `--ds-shadow-tooltip`.** The card's `shadow-[var(--ds-shadow-tooltip),…]` fell back to a 1px ring colored `--ds-background-100` — the same color as the card in dark mode → invisible border.
4. **Arrow stroke mismatch (`context-card.tsx`).** The arrow tip used hardcoded `#DBDBDB`/`#252525` (gated on a `dark-theme` variant) which didn't match the card border.

## Fix

In `packages/web/app/globals.css`:

1. Map the Geist `background` and full `gray` scales (incl. `gray-alpha`) to Tailwind tokens in `@theme inline`, pointing at the theme-aware `--ds-*` variables.
2. Correct the `--ds-*` neutral palette values (light `:root`, `.dark`, `prefers-color-scheme: dark`) to the canonical Geist scale used by `vercel/front` (sourced from `@workflow/web-shared/styles.css`).
3. Define the canonical `--ds-shadow-tooltip` token in all three blocks so the card shows its border + drop shadow.

In `packages/web-shared/src/components/ui/context-card.tsx`:

4. Point the arrow tip stroke at `var(--ds-gray-alpha-400)` — the exact color of the card border (the first layer of `--ds-shadow-tooltip` is `rgba(0,0,0,0.08)` light / `rgba(255,255,255,0.145)` dark; `--ds-gray-alpha-400` is `rgba(0,0,0,0.08)` / `rgba(255,255,255,0.14)`). This makes the arrow outline match the border in both themes and removes the need for the `dark-theme` custom variant.

Accent palettes (`blue`/`red`/`green`/`purple`/`pink`/`teal`/`amber`) are intentionally left on Tailwind's defaults for the utility classes, since the codebase uses Tailwind-only shades there (e.g. `red-50`, `red-950`).

## Verification

`pnpm --filter @workflow/web-shared build && pnpm --filter @workflow/web build` — compiled CSS now resolves to canonical theme-aware Geist values, e.g. in dark mode:

```
--ds-background-100:#121212               (was #000)
--ds-gray-900:#a1a1a1                      (was #f5f5f5)
--ds-shadow-tooltip:0 0 0 1px #ffffff25,…  (previously undefined)
.bg-background-100{background-color:var(--ds-background-100)}
.text-gray-900{color:var(--ds-gray-900)}
context-card-tip-stroke:var(--ds-gray-alpha-400)   (matches the card border)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bb2501f-ada9-474a-abac-96c6a735ac73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bb2501f-ada9-474a-abac-96c6a735ac73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

