### PR TITLE
Fix lazy Next workflow HMR

### DIFF
--- a/.changeset/lazy-discovery-hmr.md
+++ b/.changeset/lazy-discovery-hmr.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Rebuild deferred Next.js workflow entries when workflow modules recompile during dev.

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -41,6 +41,10 @@ export function createDevTests(config?: DevTestConfig) {
     // Each prewarm/trigger fetch is hard-bounded by this so cleanup never hangs
     // on a wedged dev server.
     const PREWARM_FETCH_TIMEOUT_MS = 5_000;
+    // Workflow requests can include Next's first compile of the API route and
+    // the deferred flow route. CI routinely exceeds 5s there even when the
+    // workflow itself is healthy, so keep those requests bounded separately.
+    const WORKFLOW_FETCH_TIMEOUT_MS = 30_000;
     // The afterEach cleanup can issue two *sequential* prewarms (before and
     // after deleting an added file) while the dev server is mid-rebuild — the
     // teardown of a test that added a workflow file and edited an import is
@@ -65,6 +69,10 @@ export function createDevTests(config?: DevTestConfig) {
       isNextLazyDiscoveryEnabledForTest() && usesNextFlowRoute;
     const usesNextEagerBuilder =
       !isNextLazyDiscoveryEnabledForTest() && usesNextFlowRoute;
+    const deferredWorkflowCodePath = path.join(
+      path.dirname(generatedWorkflow),
+      '__workflow_code.txt'
+    );
     const workflowManifestPath = path.join(
       appPath,
       'app/.well-known/workflow/v1/manifest.json'
@@ -94,6 +102,20 @@ export function createDevTests(config?: DevTestConfig) {
         }
         throw error;
       }
+    };
+    const readGeneratedWorkflowOutput = async (): Promise<string> => {
+      const outputs = [
+        await readFileIfExists(generatedWorkflow),
+        usesDeferredBuilder
+          ? await readFileIfExists(deferredWorkflowCodePath)
+          : null,
+      ].filter((output): output is string => output !== null);
+
+      if (outputs.length === 0) {
+        throw new Error('Generated workflow outputs were not found');
+      }
+
+      return outputs.join('\n');
     };
     const restoreFiles: Array<{ path: string; content: string }> = [];
 
@@ -126,7 +148,7 @@ export function createDevTests(config?: DevTestConfig) {
             workflowName,
             args,
           }),
-          signal: AbortSignal.timeout(PREWARM_FETCH_TIMEOUT_MS),
+          signal: AbortSignal.timeout(WORKFLOW_FETCH_TIMEOUT_MS),
         }
       );
 
@@ -135,6 +157,71 @@ export function createDevTests(config?: DevTestConfig) {
           `Failed to trigger workflow "${workflowName}": ${response.status}`
         );
       }
+    };
+
+    const triggerPagesWorkflowRun = async ({
+      workflowFile,
+      workflowFn,
+      args = [],
+    }: {
+      workflowFile: string;
+      workflowFn: string;
+      args?: unknown[];
+    }): Promise<string> => {
+      if (!deploymentUrl) {
+        throw new Error('DEPLOYMENT_URL is required to start a workflow');
+      }
+
+      const url = new URL('/api/trigger-pages', deploymentUrl);
+      url.searchParams.set('workflowFile', workflowFile);
+      url.searchParams.set('workflowFn', workflowFn);
+      if (args.length > 0) {
+        url.searchParams.set('args', args.map(String).join(','));
+      }
+
+      const response = await fetch(url, {
+        method: 'POST',
+        signal: AbortSignal.timeout(WORKFLOW_FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to trigger workflow "${workflowFn}" from "${workflowFile}": ${
+            response.status
+          } ${await response.text()}`
+        );
+      }
+
+      const result = (await response.json()) as { runId?: unknown };
+      if (typeof result.runId !== 'string') {
+        throw new Error(
+          `Workflow trigger response did not include a runId: ${JSON.stringify(
+            result
+          )}`
+        );
+      }
+      return result.runId;
+    };
+
+    const awaitPagesWorkflowRun = async (runId: string): Promise<unknown> => {
+      if (!deploymentUrl) {
+        throw new Error('DEPLOYMENT_URL is required to await a workflow');
+      }
+
+      const url = new URL('/api/trigger-pages', deploymentUrl);
+      url.searchParams.set('runId', runId);
+
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(WORKFLOW_FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to await workflow run "${runId}": ${
+            response.status
+          } ${await response.text()}`
+        );
+      }
+
+      return await response.json();
     };
 
     const prewarm = async () => {
@@ -223,7 +310,7 @@ export async function myNewWorkflow() {
       await pollUntil({
         description: 'generated workflow to include myNewWorkflow',
         check: async () => {
-          const workflowContent = await fs.readFile(generatedWorkflow, 'utf8');
+          const workflowContent = await readGeneratedWorkflowOutput();
           expect(workflowContent).toContain('myNewWorkflow');
         },
       });
@@ -267,6 +354,55 @@ export async function myNewStep() {
         },
       });
     });
+
+    test.skipIf(!usesDeferredBuilder)(
+      'should execute updated workflow logic after HMR without restart',
+      { timeout: 120_000 },
+      async () => {
+        const workflowFileName = '98_duplicate_case.ts';
+        const workflowFile = path.join(appPath, workflowsDir, workflowFileName);
+        const workflowFileKey = `workflows/${workflowFileName}`;
+        const workflowFn = 'addTenWorkflow';
+        const content = await fs.readFile(workflowFile, 'utf8');
+        const originalLine = '  const b = await add(a, 3);';
+        const updatedLine = '  const b = await add(a, 30);';
+
+        if (!content.includes(originalLine)) {
+          throw new Error(
+            `Expected ${workflowFile} to contain ${JSON.stringify(
+              originalLine
+            )}`
+          );
+        }
+
+        const baselineRunId = await triggerPagesWorkflowRun({
+          workflowFile: workflowFileKey,
+          workflowFn,
+          args: [100],
+        });
+        await expect(awaitPagesWorkflowRun(baselineRunId)).resolves.toBe(110);
+
+        await fs.writeFile(
+          workflowFile,
+          content.replace(originalLine, updatedLine)
+        );
+        restoreFiles.push({ path: workflowFile, content });
+
+        await pollUntil({
+          description:
+            'updated workflow logic to be used by the deferred flow route',
+          timeoutMs: 75_000,
+          check: async () => {
+            const runId = await triggerPagesWorkflowRun({
+              workflowFile: workflowFileKey,
+              workflowFn,
+              args: [100],
+            });
+            await expect(awaitPagesWorkflowRun(runId)).resolves.toBe(137);
+          },
+        });
+      }
+    );
 
     test.skipIf(!usesDeferredBuilder)(
       'should rebuild on imported step dependency change',
@@ -371,10 +507,7 @@ ${apiFileContent}`
             }
 
             await fetchWithTimeout('/api/chat');
-            const workflowContent = await fs.readFile(
-              generatedWorkflow,
-              'utf8'
-            );
+            const workflowContent = await readGeneratedWorkflowOutput();
             expect(workflowContent).toContain('newWorkflowFile');
           },
         });
@@ -444,24 +577,13 @@ ${apiFileContent}`
 
         // Tear down in-test (rather than relying on afterEach) so we can wait
         // for the deferred builder to drop the discovered step from the
-        // manifest before the next test file runs. The generated flow route
-        // holds a literal `import '../workflows/discovered-via-workflow-step.ts'`
-        // that is only pruned when the deferred builder rebuilds and
-        // `filterExistingFiles` excludes the now-missing source. On Windows
-        // the rebuild can lag behind the deletion, leaving the bundle
-        // unable to compile and breaking every step request in subsequent
-        // tests (which all share the same dev server).
+        // manifest before the next test file runs. Rewrite the temporary
+        // sources to inert modules before deleting them; otherwise the rebuild
+        // can race with deletion and get stuck on an ENOENT from the SWC
+        // transform while the generated route still imports the old files.
         await fs.writeFile(apiFile, apiFileContent);
-        await fs.unlink(workflowFile);
-        await fs.unlink(stepFile);
-        for (const trackedPath of [apiFile, workflowFile, stepFile]) {
-          const idx = restoreFiles.findIndex(
-            (item) => item.path === trackedPath
-          );
-          if (idx !== -1) {
-            restoreFiles.splice(idx, 1);
-          }
-        }
+        await fs.writeFile(workflowFile, 'export const removed = true;\n');
+        await fs.writeFile(stepFile, 'export const removed = true;\n');
         await pollUntil({
           description:
             'manifest.json to drop discoveredViaWorkflowStep after cleanup',
@@ -474,6 +596,16 @@ ${apiFileContent}`
             );
           },
         });
+        await fs.unlink(workflowFile);
+        await fs.unlink(stepFile);
+        for (const trackedPath of [apiFile, workflowFile, stepFile]) {
+          const idx = restoreFiles.findIndex(
+            (item) => item.path === trackedPath
+          );
+          if (idx !== -1) {
+            restoreFiles.splice(idx, 1);
+          }
+        }
       }
     );
 

--- a/packages/next/src/builder-deferred.test.ts
+++ b/packages/next/src/builder-deferred.test.ts
@@ -92,6 +92,60 @@ describe('NextDeferredBuilder', () => {
     expect(routeCode).not.toContain('__step_registrations');
   });
 
+  it('loads workflow code from disk for dev deferred flow routes', async () => {
+    const workingDir = await mkdtemp(join(tmpdir(), 'workflow-next-deferred-'));
+    tempDirs.push(workingDir);
+    vi.stubGlobal('eval', (source: string) => {
+      if (source === 'import("@workflow/builders")') {
+        return import('@workflow/builders');
+      }
+      return originalEval(source);
+    });
+
+    const NextDeferredBuilder = await getNextBuilderDeferred();
+    const builder = new NextDeferredBuilder({
+      dirs: [],
+      workingDir,
+      buildTarget: 'next',
+      workflowsBundlePath: '',
+      stepsBundlePath: '',
+      webhookBundlePath: '',
+      watch: true,
+    }) as any;
+
+    const workflowCode = 'globalThis.__private_workflows = new Map();';
+    const workflowFile = join(workingDir, 'workflows/example.ts');
+    const routeDir = join(workingDir, 'app/.well-known/workflow/v1/flow');
+    const flowOutfile = join(routeDir, 'route.js.temp');
+
+    builder.createWorkflowsBundle = vi.fn(async () => ({
+      interimBundleText: workflowCode,
+      manifest: { workflows: {}, classes: {} },
+    }));
+    builder.createDeferredStepManifest = vi.fn(async () => ({}));
+
+    await builder.createDeferredFlowRoute({
+      inputFiles: [workflowFile],
+      flowOutfile,
+      discoveredEntries: {
+        discoveredSteps: new Set(),
+        discoveredWorkflows: new Set([workflowFile]),
+        discoveredSerdeFiles: new Set(),
+      },
+    });
+
+    const routeCode = await readFile(flowOutfile, 'utf8');
+    expect(routeCode).toContain(
+      "import { readFile, stat } from 'node:fs/promises';"
+    );
+    expect(routeCode).toContain('async function getWorkflowHandler()');
+    expect(routeCode).toContain('export async function POST(req)');
+    expect(routeCode).not.toContain('const workflowCode = `');
+    await expect(
+      readFile(join(routeDir, '__workflow_code.txt'), 'utf8')
+    ).resolves.toBe(workflowCode);
+  });
+
   it('imports workspace package step sources from dist output outside packages directories', async () => {
     const workingDir = await mkdtemp(join(tmpdir(), 'workflow-next-deferred-'));
     tempDirs.push(workingDir);

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -32,6 +32,7 @@ import {
 
 const ROUTE_STUB_FILE_MARKER = 'WORKFLOW_ROUTE_STUB_FILE';
 const ROUTE_STUB_MARKER_SCAN_BYTES = 4 * 1024;
+const DEV_WORKFLOW_CODE_FILENAME = '__workflow_code.txt';
 
 let CachedNextBuilderDeferred: any;
 
@@ -651,7 +652,41 @@ export async function getNextBuilderDeferred() {
       const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
       const workflowEntrypointOptionsCode =
         createWorkflowEntrypointOptionsCode();
-      const routeCode = `// biome-ignore-all lint: generated file
+      let routeCode: string;
+
+      if (this.config.watch) {
+        const workflowCodePath = join(
+          dirname(flowOutfile),
+          DEV_WORKFLOW_CODE_FILENAME
+        );
+        await this.writeFileIfChanged(workflowCodePath, workflowVMCode);
+        routeCode = `// biome-ignore-all lint: generated file
+/* eslint-disable */
+import 'workflow/internal/builtins';
+${stepImports}
+import { readFile, stat } from 'node:fs/promises';
+import { workflowEntrypoint } from 'workflow/runtime';
+
+const workflowCodePath = ${JSON.stringify(workflowCodePath)};
+let cachedWorkflowHandler;
+let cachedWorkflowCodeSignature;
+
+async function getWorkflowHandler() {
+  const workflowCodeStats = await stat(workflowCodePath);
+  const workflowCodeSignature = \`\${workflowCodeStats.size}:\${workflowCodeStats.mtimeMs}\`;
+  if (!cachedWorkflowHandler || cachedWorkflowCodeSignature !== workflowCodeSignature) {
+    const workflowCode = await readFile(workflowCodePath, 'utf8');
+    cachedWorkflowHandler = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});
+    cachedWorkflowCodeSignature = workflowCodeSignature;
+  }
+  return cachedWorkflowHandler;
+}
+
+export async function POST(req) {
+  return (await getWorkflowHandler())(req);
+}`;
+      } else {
+        routeCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import 'workflow/internal/builtins';
 ${stepImports}
@@ -660,6 +695,7 @@ import { workflowEntrypoint } from 'workflow/runtime';
 const workflowCode = \`${escapedVMCode}\`;
 
 export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
+      }
 
       await this.writeFileIfChanged(flowOutfile, routeCode);
 
@@ -857,6 +893,7 @@ export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCo
         join(flowRouteDir, 'route.js.temp'),
         join(flowRouteDir, 'route.js.temp.debug.json'),
         join(flowRouteDir, 'route.js.debug.json'),
+        join(flowRouteDir, DEV_WORKFLOW_CODE_FILENAME),
         join(flowRouteDir, '__step_registrations.route.js.temp'),
         join(flowRouteDir, '__step_registrations.route.js.temp.debug.json'),
         // V2: clean up stale V1 step route directory

--- a/packages/next/src/loader.test.ts
+++ b/packages/next/src/loader.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { shouldNotifySocketForDiscoveredPattern } from './loader.js';
+
+describe('workflow loader discovery notifications', () => {
+  it('notifies for unchanged files that still contain workflow patterns', () => {
+    expect(
+      shouldNotifySocketForDiscoveredPattern(false, {
+        hasWorkflow: true,
+        hasStep: false,
+        hasSerde: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldNotifySocketForDiscoveredPattern(false, {
+        hasWorkflow: false,
+        hasStep: true,
+        hasSerde: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldNotifySocketForDiscoveredPattern(false, {
+        hasWorkflow: false,
+        hasStep: false,
+        hasSerde: true,
+      })
+    ).toBe(true);
+  });
+
+  it('only notifies for plain files when pattern state changed', () => {
+    const plainPatternState = {
+      hasWorkflow: false,
+      hasStep: false,
+      hasSerde: false,
+    };
+
+    expect(
+      shouldNotifySocketForDiscoveredPattern(false, plainPatternState)
+    ).toBe(false);
+    expect(
+      shouldNotifySocketForDiscoveredPattern(true, plainPatternState)
+    ).toBe(true);
+  });
+});

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -37,6 +37,18 @@ const discoveredPatternStateByFilePath = new Map<
   DiscoveredPatternState
 >();
 
+export function shouldNotifySocketForDiscoveredPattern(
+  patternStateChanged: boolean,
+  patternState: DiscoveredPatternState
+): boolean {
+  return (
+    patternStateChanged ||
+    patternState.hasWorkflow ||
+    patternState.hasStep ||
+    patternState.hasSerde
+  );
+}
+
 // Cache socket connection to avoid reconnecting on every file.
 let socketClientPromise: Promise<Socket | null> | null = null;
 let socketClient: Socket | null = null;
@@ -704,7 +716,9 @@ export default function workflowLoader(
       filename,
       nextPatternState
     );
-    if (shouldNotify) {
+    if (
+      shouldNotifySocketForDiscoveredPattern(shouldNotify, nextPatternState)
+    ) {
       await notifySocketServer(
         filename,
         nextPatternState.hasWorkflow,


### PR DESCRIPTION
## Summary
- re-notify the deferred builder when workflow modules recompile with unchanged directive state, so logic-only edits in `"use workflow"` files trigger lazy discovery updates
- in Next dev lazy mode, keep the generated flow route stable and load workflow code from a sidecar file keyed by `size:mtimeMs`, avoiding stale route-module caching after HMR
- add unit coverage for same-pattern workflow notifications and deferred dev flow-route sidecar loading
- add a lazy Next dev HMR e2e that verifies updated workflow logic executes end-to-end without restarting the dev server
- harden the dev e2e assertions and cleanup for lazy deferred outputs, including sidecar-aware generated-code checks and race-free temporary workflow cleanup

x-ref: [slack thread](https://vercel.slack.com/archives/C09G3EQAL84/p1781504829085249?thread_ts=1781504677.670589&cid=C09G3EQAL84)

## Tests
- `pnpm --filter @workflow/next build`
- `pnpm exec vitest run packages/next/src/loader.test.ts packages/next/src/builder-deferred.test.ts packages/next/src/index.test.ts`
- `pnpm exec biome check packages/core/e2e/dev.test.ts`
- `APP_NAME=nextjs-turbopack WORKBENCH_APP_PATH=/Users/jj/dev/workflow/workbench/nextjs-turbopack DEPLOYMENT_URL=http://localhost:3000 WORKFLOW_NEXT_LAZY_DISCOVERY=1 WORKFLOW_PUBLIC_MANIFEST=1 DEV_TEST_CONFIG='{"name":"nextjs-turbopack","generatedStepPath":"app/.well-known/workflow/v1/flow/__step_registrations.js","generatedWorkflowPath":"app/.well-known/workflow/v1/flow/route.js","apiFilePath":"app/api/chat/route.ts","apiFileImportPath":"../../..","lazyDiscovery":true}' pnpm exec vitest run packages/core/e2e/dev.test.ts`
