### PR TITLE
fix(ai): recover @workflow/ai onto the 4.x stable line

### DIFF
--- a/.changeset/ai-4x-stable-recovery.md
+++ b/.changeset/ai-4x-stable-recovery.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+Re-release `@workflow/ai` on the 4.x stable line. Versions 5.0.0, 6.0.0, and 7.0.0 were published to the `latest` dist-tag in error: a changesets peer-dependency misconfiguration force-bumped a full major on every `workflow` minor release, even though `@workflow/ai` had no breaking changes. Those versions are deprecated — `^4` remains the correct stable range.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,6 +21,9 @@
   "access": "public",
   "baseBranch": "stable",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "docs",
     "tarballs",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workflow/ai",
-  "version": "7.0.0",
+  "version": "4.1.2",
   "description": "Workflow SDK compatible helper library for the AI SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Problem

`@workflow/ai` was accidentally published to the `latest` dist-tag as **5.0.0**, **6.0.0**, and **7.0.0** — full majors with no breaking changes, while the rest of the SDK is on 4.x stable. `latest` currently points at `7.0.0`.

### Root cause

`@workflow/ai` peer-depends on `workflow` (`"workflow": "workspace:^"`). Changesets force-bumps a package a full **major** whenever a peer dependency takes a `minor`/`major` bump, gated by `onlyUpdatePeerDependentsWhenOutOfRange` — which **defaults to `false`**. On `stable` (regular mode) three ordinary `workflow` minors dragged ai up a major each:

| stable release | `workflow` | `@workflow/ai` |
|---|---|---|
| #2203 | → 4.3.0 | 4.1.2 → **5.0.0** |
| #2221 | → 4.4.0 | → **6.0.0** |
| #2352 | → 4.5.0 | → **7.0.0** |

## What this PR does

1. **`.changeset/config.json`** — set `onlyUpdatePeerDependentsWhenOutOfRange: true`. ai now only majors when a new `workflow` version actually leaves its `^4` peer range (a real `workflow` major). Mirrors the `main` fix in #2439.
2. **`packages/ai/package.json`** — reset version `7.0.0` → `4.1.2`.
3. **changeset** — patch bump for `@workflow/ai`, so the Version Packages PR re-releases it as **4.1.3** on the 4.x line (carries the inline-sourcemaps packaging change that was trapped in 6.0.0). Merging that Version Packages PR repoints `latest → 4.1.3` automatically.

### Verification

`pnpm changeset status` on this branch (with the pending `workflow` minors still present):

```
Packages to be bumped at patch:
- @workflow/ai          ← was being dragged to major before this fix
Packages to be bumped at minor:
- @workflow/core
- workflow
NO packages to be bumped at major
```

## Manual npm follow-up (not done by this PR)

The bad versions are still on npm and can't be unpublished (~72k downloads/week; only 7.0.0 is even within the 72h window, and it's the current `latest`). After the **Version Packages** PR merges and publishes `4.1.3`:

```bash
# immediate stopgap if needed before 4.1.3 ships:
npm dist-tag add @workflow/ai@4.1.2 latest

# deprecate the mis-numbered majors (do after latest points to a 4.x):
npm deprecate "@workflow/ai@5.0.0" "Published in error (changeset peer-dep misconfig); a 4.x patch mislabeled as a major. Use @workflow/ai@^4 (stable) or @workflow/ai@beta (v5)."
npm deprecate "@workflow/ai@6.0.0" "<same>"
npm deprecate "@workflow/ai@7.0.0" "<same>"
```

## Forward note

`5.0.0`/`6.0.0`/`7.0.0` are burned on npm forever. When the v5 beta line graduates, `@workflow/ai` cannot publish `5.0.0` (already taken) — it must skip to the next free major (**8.0.0**), or `changeset publish` will fail.

## Notes for reviewer

- ai's `CHANGELOG.md` still has the `5.0.0`/`6.0.0`/`7.0.0` entries; the Version Packages PR will prepend `4.1.3` above them, so the ordering will look odd. Left intact intentionally (accurate record of what was published) — hand-clean if preferred.
- This supersedes any redundant config-only backport the bot opens for #2439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)