### PR TITLE
Prevent peer dependency-only major bumps (backport #2437)

### DIFF
--- a/.changeset/avoid-peer-major-bumps.md
+++ b/.changeset/avoid-peer-major-bumps.md
@@ -1,0 +1,4 @@
+---
+---
+
+Only major-bump peer dependents when updated workspace peer ranges fall out of range, and block release publishes that contain package major version upgrades outside the branch's release major.

--- a/.github/scripts/check-release-major.js
+++ b/.github/scripts/check-release-major.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseMajor(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  return match ? Number(match[1]) : null;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function matchesIgnorePattern(name, pattern) {
+  if (!pattern.includes('*')) {
+    return name === pattern;
+  }
+
+  const regex = new RegExp(
+    `^${pattern.split('*').map(escapeRegExp).join('.*')}$`
+  );
+  return regex.test(name);
+}
+
+function isIgnoredPackage(name, ignorePatterns) {
+  return ignorePatterns.some((pattern) => matchesIgnorePattern(name, pattern));
+}
+
+function findPackagesOutsideReleaseMajor({
+  packages,
+  releaseVersion,
+  ignorePatterns = [],
+}) {
+  const mismatches = [];
+
+  for (const pkg of packages) {
+    if (pkg.private || isIgnoredPackage(pkg.name, ignorePatterns)) {
+      continue;
+    }
+
+    const major = parseMajor(pkg.version);
+    if (major === releaseVersion) {
+      continue;
+    }
+
+    mismatches.push({
+      name: pkg.name,
+      path: pkg.path,
+      version: pkg.version,
+    });
+  }
+
+  return mismatches.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function readPackageJson(filePath, rootDir) {
+  const packageJson = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const relativePath = path
+    .relative(rootDir, filePath)
+    .split(path.sep)
+    .join('/');
+
+  return {
+    name: packageJson.name ?? relativePath,
+    path: relativePath,
+    private: packageJson.private === true,
+    version: packageJson.version,
+  };
+}
+
+function readWorkspacePackages(rootDir = process.cwd()) {
+  const packagesDir = path.join(rootDir, 'packages');
+
+  return fs
+    .readdirSync(packagesDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => path.join(packagesDir, dirent.name, 'package.json'))
+    .filter((packageJsonPath) => fs.existsSync(packageJsonPath))
+    .map((packageJsonPath) => readPackageJson(packageJsonPath, rootDir));
+}
+
+function readChangesetIgnorePatterns(rootDir = process.cwd()) {
+  const configPath = path.join(rootDir, '.changeset', 'config.json');
+  if (!fs.existsSync(configPath)) {
+    return [];
+  }
+
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  return Array.isArray(config.ignore) ? config.ignore : [];
+}
+
+function renderMarkdownSummary({ mismatches, releaseVersion }) {
+  if (mismatches.length === 0) {
+    return `### Major Version Guard\n\nAll public workspace package versions match release major \`${releaseVersion}\`.\n`;
+  }
+
+  const rows = mismatches
+    .map(
+      (mismatch) =>
+        `| \`${mismatch.name}\` | \`${mismatch.version}\` | \`${mismatch.path}\` |`
+    )
+    .join('\n');
+
+  return [
+    '### Major Version Guard',
+    '',
+    `Failing because these public workspace package versions do not match release major \`${releaseVersion}\`.`,
+    '',
+    '| Package | Version | Path |',
+    '| --- | --- | --- |',
+    rows,
+    '',
+  ].join('\n');
+}
+
+function writeStepSummary(markdown) {
+  if (!process.env.GITHUB_STEP_SUMMARY) {
+    return;
+  }
+
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown);
+}
+
+function parseArgs(argv) {
+  const [releaseVersionArg] = argv;
+  if (argv.length > 1) {
+    throw new Error(
+      'Usage: check-release-major.js [release-version]\nSet RELEASE_VERSION when no argument is provided.'
+    );
+  }
+
+  const releaseVersion = Number(
+    releaseVersionArg ?? process.env.RELEASE_VERSION
+  );
+  if (!Number.isInteger(releaseVersion) || releaseVersion < 0) {
+    throw new Error(
+      'RELEASE_VERSION must be set to a non-negative integer release major.'
+    );
+  }
+
+  return { releaseVersion };
+}
+
+function main() {
+  const { releaseVersion } = parseArgs(process.argv.slice(2));
+  const mismatches = findPackagesOutsideReleaseMajor({
+    ignorePatterns: readChangesetIgnorePatterns(),
+    packages: readWorkspacePackages(),
+    releaseVersion,
+  });
+  const summary = renderMarkdownSummary({ mismatches, releaseVersion });
+
+  process.stdout.write(summary);
+  writeStepSummary(summary);
+
+  if (mismatches.length > 0) {
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  findPackagesOutsideReleaseMajor,
+  isIgnoredPackage,
+  parseArgs,
+  parseMajor,
+  renderMarkdownSummary,
+  readChangesetIgnorePatterns,
+  readWorkspacePackages,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/.github/scripts/check-release-major.test.js
+++ b/.github/scripts/check-release-major.test.js
@@ -1,0 +1,115 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const {
+  findPackagesOutsideReleaseMajor,
+  isIgnoredPackage,
+  parseArgs,
+  parseMajor,
+  renderMarkdownSummary,
+} = require('./check-release-major.js');
+
+test('parseMajor reads stable and prerelease versions', () => {
+  assert.strictEqual(parseMajor('4.5.0'), 4);
+  assert.strictEqual(parseMajor('5.0.0-beta.17'), 5);
+  assert.strictEqual(parseMajor('not-semver'), null);
+});
+
+test('isIgnoredPackage supports exact names and wildcard patterns', () => {
+  assert.strictEqual(
+    isIgnoredPackage('@workflow/docs-typecheck', [
+      '@workflow/docs-typecheck',
+      '@workflow/example-*',
+    ]),
+    true
+  );
+  assert.strictEqual(
+    isIgnoredPackage('@workflow/example-nextjs', ['@workflow/example-*']),
+    true
+  );
+  assert.strictEqual(
+    isIgnoredPackage('@workflow/ai', ['@workflow/example-*']),
+    false
+  );
+});
+
+test('findPackagesOutsideReleaseMajor flags packages outside the configured release version', () => {
+  const packages = [
+    {
+      name: '@workflow/ai',
+      path: 'packages/ai/package.json',
+      version: '7.0.0',
+    },
+    {
+      name: '@workflow/core',
+      path: 'packages/core/package.json',
+      version: '5.0.0',
+    },
+    {
+      name: 'workflow',
+      path: 'packages/workflow/package.json',
+      version: '5.0.0-beta.17',
+    },
+    {
+      name: '@workflow/internal',
+      path: 'packages/internal/package.json',
+      private: true,
+      version: '7.0.0',
+    },
+    {
+      name: '@workflow/example-nextjs',
+      path: 'packages/example-nextjs/package.json',
+      version: '7.0.0',
+    },
+  ];
+
+  assert.deepStrictEqual(
+    findPackagesOutsideReleaseMajor({
+      ignorePatterns: ['@workflow/example-*'],
+      packages,
+      releaseVersion: 5,
+    }),
+    [
+      {
+        name: '@workflow/ai',
+        path: 'packages/ai/package.json',
+        version: '7.0.0',
+      },
+    ]
+  );
+});
+
+test('renderMarkdownSummary names the configured release version when blocked', () => {
+  const summary = renderMarkdownSummary({
+    releaseVersion: 5,
+    mismatches: [
+      {
+        name: '@workflow/ai',
+        path: 'packages/ai/package.json',
+        version: '7.0.0',
+      },
+    ],
+  });
+
+  assert.match(summary, /release major `5`/);
+  assert.match(summary, /@workflow\/ai/);
+  assert.match(summary, /Failing/);
+});
+
+test('parseArgs reads release version from argv or environment', () => {
+  assert.deepStrictEqual(parseArgs(['5']), {
+    releaseVersion: 5,
+  });
+
+  const oldReleaseVersion = process.env.RELEASE_VERSION;
+  process.env.RELEASE_VERSION = '4';
+  assert.deepStrictEqual(parseArgs([]), {
+    releaseVersion: 4,
+  });
+
+  if (oldReleaseVersion === undefined) {
+    delete process.env.RELEASE_VERSION;
+  } else {
+    process.env.RELEASE_VERSION = oldReleaseVersion;
+  }
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      # Stable is the v4 release line. Main sets this to 5; future version
+      # branches should update it to their release major.
+      RELEASE_VERSION: 4
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -47,6 +50,9 @@ jobs:
           node-version: 24.x
           cache: "pnpm"
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Check package release major
+        run: node .github/scripts/check-release-major.js "$RELEASE_VERSION"
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workflow/nest",
-  "version": "0.0.10",
+  "version": "4.0.11",
   "description": "NestJS integration for Workflow SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Backport of #2437 to the `stable` (v4) release line.

## Summary

- Add a publish-time release-major guard (`.github/scripts/check-release-major.js` + unit tests) that reads `packages/*/package.json`, skips private and Changesets-ignored packages, and fails if any public workspace package has a major version outside the branch's release major.
- Wire it into `.github/workflows/release.yml` before dependency installation, gated on `RELEASE_VERSION: 4` (main uses `5`).

## Stable-specific deviation from #2437

The upstream PR said only `RELEASE_VERSION` needed changing for the backport, but stable had one package out of the v4 line: `@workflow/nest` was `0.0.10` (it skipped straight to `5.0.0-beta` on main and never had a 4.x release). A literal backport would have failed the guard on the next stable release.

Per the chosen approach, `@workflow/nest` is realigned to `4.0.11`, matching the current patch level of the sibling stable framework integrations (next/nuxt/vitest) and joining the v4 line. `4.0.11` has never been published for nest, so there's no npm conflict. Changesets can't express a `0.0.10 → 4.x` jump (a 0.x major bump only reaches `1.0.0`), so this is a direct `package.json` version edit.

The `.changeset/config.json` `onlyUpdatePeerDependentsWhenOutOfRange` option from #2437 was already present on stable, so it's not part of this diff.

## Validation

- `node --test .github/scripts/check-release-major.test.js` — all pass
- `node .github/scripts/check-release-major.js 4` — passes on the stable tree after the nest realignment
- `node .github/scripts/check-release-major.js 5` — fails as expected
- `pnpm exec biome check` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)