### PR TITLE
fix(deps): upgrade hono to 4.12.25 to resolve CVE-2026-54290

### DIFF
--- a/.changeset/bump-hono-cve-2026-54290.md
+++ b/.changeset/bump-hono-cve-2026-54290.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-testing': patch
+---
+
+Bump the `hono` dependency to 4.12.25 to resolve CVE-2026-54290 (GHSA-88fw-hqm2-52qc, CORS middleware reflects any origin with credentials when origin defaults to the wildcard).

--- a/packages/world-testing/package.json
+++ b/packages/world-testing/package.json
@@ -27,7 +27,7 @@
     "@workflow/core": "workspace:*",
     "@workflow/world": "workspace:*",
     "chalk": "5.6.2",
-    "hono": "4.12.21",
+    "hono": "4.12.25",
     "jsonlines": "0.1.1",
     "workflow": "workspace:*",
     "zod": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1450,7 +1450,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: 1.19.13
-        version: 1.19.13(hono@4.12.21)
+        version: 1.19.13(hono@4.12.25)
       '@workflow/cli':
         specifier: workspace:*
         version: link:../cli
@@ -1464,8 +1464,8 @@ importers:
         specifier: 5.6.2
         version: 5.6.2
       hono:
-        specifier: 4.12.21
-        version: 4.12.21
+        specifier: 4.12.25
+        version: 4.12.25
       jsonlines:
         specifier: 0.1.1
         version: 0.1.1
@@ -1797,8 +1797,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.116(zod@4.3.6)
       hono:
-        specifier: ^4.12.8
-        version: 4.12.9
+        specifier: ^4.12.25
+        version: 4.12.25
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
@@ -12496,12 +12496,8 @@ packages:
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
 
-  hono@4.12.21:
-    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -19278,9 +19274,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.13(hono@4.12.21)':
+  '@hono/node-server@1.19.13(hono@4.12.25)':
     dependencies:
-      hono: 4.12.21
+      hono: 4.12.25
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.3))':
     dependencies:
@@ -29734,9 +29730,7 @@ snapshots:
 
   hls.js@1.6.15: {}
 
-  hono@4.12.21: {}
-
-  hono@4.12.9: {}
+  hono@4.12.25: {}
 
   hookable@5.5.3: {}
 

--- a/workbench/hono/package.json
+++ b/workbench/hono/package.json
@@ -17,7 +17,7 @@
     "workflow": "workspace:*",
     "@workflow/ai": "workspace:*",
     "ai": "catalog:",
-    "hono": "^4.12.8",
+    "hono": "^4.12.25",
     "lodash.chunk": "^4.2.0",
     "nitro": "catalog:",
     "openai": "^6.6.0",


### PR DESCRIPTION
## Summary

`hono` <4.12.25 is vulnerable to [CVE-2026-54290](https://nvd.nist.gov/vuln/detail/CVE-2026-54290) ([GHSA-88fw-hqm2-52qc](https://github.com/honojs/hono/security/advisories/GHSA-88fw-hqm2-52qc), CVSS 7.1, High). With `credentials: true` and no explicit `origin` (the default wildcard), the CORS middleware reflects the request's `Origin` and sends `Access-Control-Allow-Credentials: true`, letting any site make credentialed cross-origin requests and read the responses.

Resolves Linear **VULN-11844** (Socket alert SOCKET-VERCEL-24943), which flagged `hono@4.12.21` in `packages/world-testing/package.json`.

## Changes

- **`packages/world-testing`**: `hono` `4.12.21` → `4.12.25` (the flagged manifest; this is a published package, so a `patch` changeset is included).
- **`workbench/hono`**: `hono` `^4.12.8` → `^4.12.25`, which clears the also-vulnerable `4.12.9` from the lockfile. This is a private example app (`@workflow/example-hono`, in the changeset ignore list), so no changeset is needed.

After the bump, no `hono` version `< 4.12.25` remains in `pnpm-lock.yaml`.

## Notes on exploitability

Neither app uses hono's CORS middleware (`grep` finds no `hono/cors` usage) — `world-testing` only imports the core `Hono` class — so neither was actually exploitable. The bump clears the vulnerable code from the dependency tree and the Socket alert regardless.

## Verification

- `pnpm install` resolves both manifests to `hono@4.12.25`; `@hono/node-server@1.19.13` peers `hono@4.12.25` with no peer warnings.
- `pnpm turbo build --filter=@workflow/world-testing` passes (includes `tsc` typecheck) — 23/23 tasks successful.
- `pnpm changeset status` lists `@workflow/world-testing` for a patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)