### PR TITLE
feat(cli): print run deep links with `--url`, fix dashboard route

### DIFF
--- a/.changeset/cli-url-deep-link.md
+++ b/.changeset/cli-url-deep-link.md
@@ -1,0 +1,5 @@
+---
+'@workflow/cli': minor
+---
+
+Add a `--url` flag to `inspect`/`web` that prints the run's dashboard deep link to stdout and exits (no browser, no server), and fix the Vercel dashboard URL to use the current `…/workflows/runs/<id>?environment=<env>` route (respecting `--env`).

--- a/.github/scripts/aggregate-benchmarks.js
+++ b/.github/scripts/aggregate-benchmarks.js
@@ -138,7 +138,7 @@ function getObservabilityUrl(vercelMetadata, runId) {
   if (!teamSlug || !projectSlug) return null;
   // Always use 'preview' for PR benchmarks
   const env = environment === 'production' ? 'production' : 'preview';
-  return `https://vercel.com/${teamSlug}/${projectSlug}/observability/workflows/runs/${runId}?environment=${env}`;
+  return `https://vercel.com/${teamSlug}/${projectSlug}/workflows/runs/${runId}?environment=${env}`;
 }
 
 // Collect all benchmark data

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -186,7 +186,7 @@ function getObservabilityUrl(metadata, appName, testName) {
   if (!runInfo) return null;
 
   const env = vercel.environment === 'production' ? 'production' : 'preview';
-  return `https://vercel.com/${vercel.teamSlug}/${vercel.projectSlug}/observability/workflows/runs/${runInfo.runId}?environment=${env}`;
+  return `https://vercel.com/${vercel.teamSlug}/${vercel.projectSlug}/workflows/runs/${runInfo.runId}?environment=${env}`;
 }
 
 // Parse vitest JSON output

--- a/docs/content/docs/v4/observability/index.mdx
+++ b/docs/content/docs/v4/observability/index.mdx
@@ -42,6 +42,19 @@ npx workflow inspect runs --web
 
 ![Workflow SDK Web UI](/o11y-ui.png)
 
+To share a link to a specific run without opening a browser, use the `--url`
+flag. It prints the dashboard deep link to stdout and exits (no browser, no
+local server) — useful for scripts, PR comments, or automation. Add `--json` to
+get `{ "url": "..." }`.
+
+```bash
+# Print the deep-link URL for a run (no browser, no server)
+npx workflow inspect run <run_id> --url
+
+# Vercel runs: add the backend (and --env preview for preview deployments)
+npx workflow inspect run <run_id> --backend vercel --url
+```
+
 ## Backends
 
 The Workflow SDK CLI can inspect data from any [World](/docs/deploying). By default, it inspects data in your local development environment. For example, if you are using Next.js to develop workflows locally, the

--- a/docs/content/docs/v5/observability/index.mdx
+++ b/docs/content/docs/v5/observability/index.mdx
@@ -42,6 +42,19 @@ npx workflow inspect runs --web
 
 ![Workflow SDK Web UI](/o11y-ui.png)
 
+To share a link to a specific run without opening a browser, use the `--url`
+flag. It prints the dashboard deep link to stdout and exits (no browser, no
+local server) — useful for scripts, PR comments, or automation. Add `--json` to
+get `{ "url": "..." }`.
+
+```bash
+# Print the deep-link URL for a run (no browser, no server)
+npx workflow inspect run <run_id> --url
+
+# Vercel runs: add the backend (and --env preview for preview deployments)
+npx workflow inspect run <run_id> --backend vercel --url
+```
+
 ## Backends
 
 The Workflow SDK CLI can inspect data from any [World](/docs/deploying). By default, it inspects data in your local development environment. For example, if you are using Next.js to develop workflows locally, the

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -3,7 +3,7 @@ import { VERCEL_403_ERROR_MESSAGE } from '@workflow/errors';
 import { BaseCommand } from '../base.js';
 import { LOGGING_CONFIG, logger } from '../lib/config/log.js';
 import type { InspectCLIOptions } from '../lib/config/types.js';
-import { cliFlags } from '../lib/inspect/flags.js';
+import { cliFlags, urlFlag } from '../lib/inspect/flags.js';
 import {
   listEvents,
   listHooks,
@@ -17,7 +17,7 @@ import {
   showStream,
 } from '../lib/inspect/output.js';
 import { setupCliWorld } from '../lib/inspect/setup.js';
-import { launchWebUI } from '../lib/inspect/web.js';
+import { launchWebUI, printDeepLink } from '../lib/inspect/web.js';
 
 export default class Inspect extends BaseCommand {
   static description = 'Inspect runs, steps, streams, or events';
@@ -140,6 +140,7 @@ export default class Inspect extends BaseCommand {
       helpLabel: '--decrypt',
     }),
     ...cliFlags,
+    ...urlFlag,
   } as const;
 
   public async run(): Promise<void> {
@@ -156,6 +157,13 @@ export default class Inspect extends BaseCommand {
       }
 
       const id = args.id;
+
+      // Print-only deep link: resolve config and emit the URL, no browser/server.
+      if (flags.url) {
+        const actualResource = resource === 'web' ? 'run' : resource;
+        await printDeepLink(actualResource, id, flags, this.config.version);
+        return;
+      }
 
       // For web mode, allow config errors so we can open the web UI for configuration
       const isWebMode = flags.web || resource === 'web';

--- a/packages/cli/src/commands/web.ts
+++ b/packages/cli/src/commands/web.ts
@@ -2,9 +2,9 @@ import { Args } from '@oclif/core';
 import { VERCEL_403_ERROR_MESSAGE } from '@workflow/errors';
 import { BaseCommand } from '../base.js';
 import { LOGGING_CONFIG, logger } from '../lib/config/log.js';
-import { cliFlags } from '../lib/inspect/flags.js';
+import { cliFlags, urlFlag } from '../lib/inspect/flags.js';
 import { setupCliWorld } from '../lib/inspect/setup.js';
-import { launchWebUI } from '../lib/inspect/web.js';
+import { launchWebUI, printDeepLink } from '../lib/inspect/web.js';
 
 export default class Web extends BaseCommand {
   static description = 'Open the web UI to inspect workflow runs';
@@ -40,12 +40,19 @@ export default class Web extends BaseCommand {
 
   static flags = {
     ...cliFlags,
+    ...urlFlag,
   } as const;
 
   public async run(): Promise<void> {
     try {
       const { args, flags } = await this.parse(Web);
       const id = args.id;
+
+      // Print-only deep link: resolve config and emit the URL, no browser/server.
+      if (flags.url) {
+        await printDeepLink('run', id, flags, this.config.version);
+        process.exit(0);
+      }
 
       // Setup the CLI world to write env vars from flags
       // This ensures backend, authToken, team, project, etc. are properly set

--- a/packages/cli/src/lib/inspect/flags.ts
+++ b/packages/cli/src/lib/inspect/flags.ts
@@ -145,3 +145,19 @@ export const cliFlags = {
     helpLabel: '-i, --interactive',
   }),
 };
+
+/**
+ * Flag for printing a shareable deep-link URL instead of opening the web UI.
+ * Only relevant to commands that can open a dashboard (`inspect`, `web`), so it
+ * is exported separately rather than bundled into `cliFlags`.
+ */
+export const urlFlag = {
+  url: Flags.boolean({
+    description:
+      'Print the deep-link URL to the run/dashboard and exit (no browser, no server)',
+    required: false,
+    default: false,
+    helpGroup: 'Output',
+    helpLabel: '--url',
+  }),
+};

--- a/packages/cli/src/lib/inspect/vercel-api.test.ts
+++ b/packages/cli/src/lib/inspect/vercel-api.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { getVercelDashboardUrl } from './vercel-api.js';
+
+describe('getVercelDashboardUrl', () => {
+  it('builds a run deep link with the default (production) environment', () => {
+    expect(
+      getVercelDashboardUrl('my-team', 'my-project', 'run', 'wrun_123')
+    ).toBe(
+      'https://vercel.com/my-team/my-project/workflows/runs/wrun_123?environment=production'
+    );
+  });
+
+  it('respects the preview environment', () => {
+    expect(
+      getVercelDashboardUrl(
+        'my-team',
+        'my-project',
+        'run',
+        'wrun_123',
+        'preview'
+      )
+    ).toBe(
+      'https://vercel.com/my-team/my-project/workflows/runs/wrun_123?environment=preview'
+    );
+  });
+
+  it('never emits the legacy /observability segment', () => {
+    const url = getVercelDashboardUrl(
+      'my-team',
+      'my-project',
+      'run',
+      'wrun_123',
+      'preview'
+    );
+    expect(url).not.toContain('/observability');
+  });
+
+  it('builds an overview link when no id is provided', () => {
+    expect(getVercelDashboardUrl('my-team', 'my-project', 'run')).toBe(
+      'https://vercel.com/my-team/my-project/workflows?environment=production'
+    );
+  });
+
+  it('builds a resource-query link for non-run resources', () => {
+    expect(
+      getVercelDashboardUrl(
+        'my-team',
+        'my-project',
+        'step',
+        'step_456',
+        'preview'
+      )
+    ).toBe(
+      'https://vercel.com/my-team/my-project/workflows?stepId=step_456&environment=preview'
+    );
+  });
+});

--- a/packages/cli/src/lib/inspect/vercel-api.ts
+++ b/packages/cli/src/lib/inspect/vercel-api.ts
@@ -68,56 +68,28 @@ export async function fetchTeamInfo(
   }
 }
 
-// /**
-//  * Check if the Vercel dashboard workflows page is available
-//  */
-// export async function checkVercelDashboardAvailable(
-//   teamSlug: string,
-//   projectName: string,
-//   authToken: string
-// ): Promise<boolean> {
-//   try {
-//     const dashboardUrl = `https://vercel.com/${teamSlug}/${projectName}/ai/workflows`;
-//     logger.debug(`Checking Vercel dashboard availability: ${dashboardUrl}`);
-
-//     const response = await fetch(dashboardUrl, {
-//       method: 'HEAD',
-//       redirect: 'follow',
-//       headers: {
-//         Authorization: `Bearer ${authToken}`,
-//       },
-//     });
-
-//     // Consider 2xx and 3xx as success
-//     const isAvailable = response.status >= 200 && response.status < 400;
-//     logger.debug(
-//       `Dashboard check result: ${response.status} - ${isAvailable ? 'available' : 'not available'}`
-//     );
-
-//     return isAvailable;
-//   } catch (error) {
-//     logger.debug(`Error checking dashboard availability: ${error}`);
-//     return false;
-//   }
-// }
-
 /**
- * Get the Vercel dashboard URL for workflows
+ * Get the Vercel dashboard URL for workflows.
+ *
+ * Format: https://vercel.com/<teamSlug>/<projectSlug>/workflows/runs/<runId>?environment=<env>
+ * (the older `/observability/workflows` route is no longer used).
  */
 export function getVercelDashboardUrl(
   teamSlug: string,
   projectName: string,
   resource: string,
-  id?: string
+  id?: string,
+  environment = 'production'
 ): string {
-  let url = `https://vercel.com/${teamSlug}/${projectName}/observability/workflows`;
+  const base = `https://vercel.com/${teamSlug}/${projectName}/workflows`;
+  const env = `environment=${environment}`;
 
   // Add resource-specific path segments
   if (resource === 'run' && id) {
-    url += `/runs/${id}?environment=production`;
-  } else if (id) {
-    url += `?${resource}Id=${id}`;
+    return `${base}/runs/${id}?${env}`;
   }
-
-  return url;
+  if (id) {
+    return `${base}?${resource}Id=${id}&${env}`;
+  }
+  return `${base}?${env}`;
 }

--- a/packages/cli/src/lib/inspect/web.ts
+++ b/packages/cli/src/lib/inspect/web.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import open from 'open';
 import { logger } from '../config/log.js';
 import { getEnvVars } from './env.js';
+import { setupCliWorld } from './setup.js';
 import { getVercelDashboardUrl } from './vercel-api.js';
 
 export const getHostUrl = (webPort: number) => `http://localhost:${webPort}`;
@@ -48,7 +49,7 @@ async function startWebServer(webPort: number): Promise<boolean> {
  * The web UI reads world configuration from server-side environment variables.
  * Query params are only used for deep-linking to specific resources (resource/id, runId, etc.)
  */
-function buildWebUIUrl(
+export function buildWebUIUrl(
   hostUrl: string,
   resource: string,
   id: string | undefined,
@@ -118,7 +119,8 @@ export async function launchWebUI(
       teamSlug,
       projectName,
       resource,
-      id
+      id,
+      envVars.WORKFLOW_VERCEL_ENV || 'production'
     );
 
     if (disableBrowserOpen) {
@@ -187,5 +189,73 @@ export async function launchWebUI(
         resolve();
       }
     });
+  }
+}
+
+/**
+ * Build the deep-link URL for a resource without any side effects (no server,
+ * no browser). Picks the Vercel dashboard for a Vercel backend (unless
+ * `--localUi`), otherwise the local web UI deep link.
+ *
+ * Assumes env vars have already been resolved (e.g. via `setupCliWorld`).
+ */
+export function buildDeepLinkUrl(
+  resource: string,
+  id: string | undefined,
+  flags: Record<string, any>
+): string {
+  const envVars = getEnvVars();
+
+  const vercelBackendNames = ['vercel', '@workflow/world-vercel'];
+  const isVercelBackend = vercelBackendNames.includes(
+    envVars.WORKFLOW_TARGET_WORLD
+  );
+  const teamSlug = envVars.WORKFLOW_VERCEL_TEAM;
+  const projectName =
+    envVars.WORKFLOW_VERCEL_PROJECT_NAME || envVars.WORKFLOW_VERCEL_PROJECT;
+
+  // Use the Vercel dashboard when targeting Vercel (and not forced local).
+  if (isVercelBackend && !flags.localUi && teamSlug && projectName) {
+    return getVercelDashboardUrl(
+      teamSlug,
+      projectName,
+      resource,
+      id,
+      envVars.WORKFLOW_VERCEL_ENV || 'production'
+    );
+  }
+
+  // Fall back to the local web UI deep link.
+  const webPort = flags.webPort ?? 3456;
+  return buildWebUIUrl(getHostUrl(webPort), resource, id, flags);
+}
+
+/**
+ * Resolve and print a shareable deep-link URL to stdout, then return — without
+ * opening a browser or starting the local web server. Intended for scripting
+ * and agents that need the link rather than a rendered dashboard.
+ *
+ * Human-readable chatter (the startup box, info/debug logs) is routed to stderr
+ * so stdout contains only the URL (or `{ "url": "..." }` with `--json`).
+ */
+export async function printDeepLink(
+  resource: string,
+  id: string | undefined,
+  flags: Record<string, any>,
+  version: string
+): Promise<void> {
+  const wantsJson = Boolean(flags.json);
+
+  // Force JSON logging mode during setup so the startup box and any info/debug
+  // logs go to stderr, keeping stdout clean for the URL. We print the URL
+  // ourselves below, respecting the user's actual `--json` choice.
+  await setupCliWorld({ ...flags, json: true } as any, version, true);
+
+  const url = buildDeepLinkUrl(resource, id, flags);
+
+  if (wantsJson) {
+    process.stdout.write(`${JSON.stringify({ url }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${url}\n`);
   }
 }

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -224,7 +224,7 @@ function getDashboardUrl(runId: string): string | undefined {
   if (!projectSlug || !env) return undefined;
 
   const environment = env === 'production' ? 'production' : 'preview';
-  return `https://vercel.com/vercel-labs/${projectSlug}/observability/workflows/runs/${runId}?environment=${environment}`;
+  return `https://vercel.com/vercel-labs/${projectSlug}/workflows/runs/${runId}?environment=${environment}`;
 }
 
 function classifyFailure(errorCode: string | undefined): Outcome {

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -584,7 +584,7 @@ function getObservabilityDashboardUrl(runId: string): string | null {
   if (!projectSlug || !env) return null;
 
   const environment = env === 'production' ? 'production' : 'preview';
-  return `https://vercel.com/${teamSlug}/${projectSlug}/observability/workflows/runs/${runId}?environment=${environment}`;
+  return `https://vercel.com/${teamSlug}/${projectSlug}/workflows/runs/${runId}?environment=${environment}`;
 }
 
 /**

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -3,7 +3,7 @@ name: workflow
 description: Creates durable, resumable workflows using Vercel's Workflow SDK. Use when building workflows that need to survive restarts, pause for external events, retry on failure, or coordinate multi-step operations over time. Triggers on mentions of "workflow", "durable functions", "resumable", "workflow sdk", "queue", "event", "push", "subscribe", or step-based orchestration.
 metadata:
   author: Vercel Inc.
-  version: '1.9'
+  version: '1.10'
 ---
 
 ## *CRITICAL*: Always Use Correct `workflow` Documentation
@@ -524,9 +524,39 @@ npx workflow cancel <run_id> --backend vercel --project <project-name> --team <t
 # --env defaults to "production"; use --env preview for preview deployments
 ```
 
+### Deep-linking to a run (share a URL, no browser)
+
+Use `--url` to **print** the dashboard deep link and exit — no browser opens and
+no local server starts. This is the right tool when you need to hand a user a
+clickable link (PR comment, Slack message, debugging summary) rather than open a
+UI. (`--web` opens the dashboard; `--url` only prints the link.)
+
+```bash
+# Vercel run — prints the Vercel dashboard URL for the run
+npx workflow inspect run <run_id> --backend vercel --project <project> --team <team> --url
+npx workflow web <run_id> --backend vercel --project <project> --team <team> --env preview --url
+
+# Local run — prints the local web UI deep link
+npx workflow inspect run <run_id> --url
+
+# Machine-readable: --url --json prints { "url": "..." } to stdout
+npx workflow inspect run <run_id> --backend vercel --url --json
+```
+
+URL formats produced:
+
+- **Vercel:** `https://vercel.com/<team-slug>/<project-slug>/workflows/runs/<run_id>?environment=<production|preview>`
+  (`--env` selects the environment; defaults to `production`. Resolving the team
+  slug requires being logged in via `vercel login` with the project linked.)
+- **Local:** `http://localhost:<port>?resource=run&id=<run_id>` (port defaults
+  to `3456`; the link works while the `npx workflow web` server is running).
+
+stdout contains **only** the URL (or the JSON object) — all other output goes to
+stderr — so you can capture it directly, e.g. `URL=$(npx workflow web <run_id> --backend vercel --url)`.
+
 **Debugging tips:**
 - Use `--json` (`-j`) on any command for machine-readable output
-- Use `--web` to open the Vercel Observability dashboard in your browser
+- Use `--web` to open the Vercel Observability dashboard in your browser, or `--url` to just print the deep link
 - Use `--help` on any command for full usage details
 - Only import workflow APIs you actually use. Unused imports can cause 500 errors.
 

--- a/workbench/nextjs-turbopack/components/chat-client.tsx
+++ b/workbench/nextjs-turbopack/components/chat-client.tsx
@@ -1,19 +1,20 @@
 'use client';
 
-import type { ReactNode } from 'react';
-import { useState, useMemo, useCallback } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { WorkflowChatTransport } from '@workflow/ai';
+import type { UIMessage } from 'ai';
 import {
-  MessageSquare,
-  Cloud,
+  AlertTriangle,
   Calculator,
   CheckCircle2,
-  XCircle,
-  AlertTriangle,
-  ExternalLink,
+  Cloud,
   CopyIcon,
+  ExternalLink,
+  MessageSquare,
+  XCircle,
 } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   Conversation,
   ConversationContent,
@@ -22,25 +23,31 @@ import {
 } from '@/components/ai-elements/conversation';
 import {
   Message,
-  MessageActions,
   MessageAction,
+  MessageActions,
   MessageContent,
   MessageResponse,
 } from '@/components/ai-elements/message';
 import {
   PromptInput,
-  type PromptInputMessage,
   PromptInputBody,
   PromptInputFooter,
-  PromptInputTextarea,
-  PromptInputTools,
+  type PromptInputMessage,
   PromptInputSelect,
   PromptInputSelectContent,
   PromptInputSelectItem,
   PromptInputSelectTrigger,
   PromptInputSelectValue,
   PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputTools,
 } from '@/components/ai-elements/prompt-input';
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from '@/components/ai-elements/reasoning';
+import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion';
 import {
   Tool,
   ToolContent,
@@ -48,14 +55,7 @@ import {
   ToolInput,
   ToolOutput,
 } from '@/components/ai-elements/tool';
-import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from '@/components/ai-elements/reasoning';
 import { Spinner } from '@/components/ui/spinner';
-import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion';
-import type { UIMessage } from 'ai';
 
 const SUGGESTIONS = [
   "What's the weather in Tokyo?",
@@ -314,7 +314,7 @@ export function ChatClient() {
           const project = response.headers.get('x-workflow-project-slug');
           if (team && project) {
             setObservabilityBase(
-              `https://vercel.com/${team}/${project}/observability/workflows/runs`
+              `https://vercel.com/${team}/${project}/workflows/runs`
             );
           }
         },


### PR DESCRIPTION
## What & why

The workflow skill tells agents to open the observability dashboard (`--web`), but there was no way to **get the deep-link URL itself** — so an agent couldn't hand a user a clickable link in a PR comment, Slack message, or debugging summary. Two problems blocked this:

1. The CLI built the **old** dashboard route (`…/observability/workflows/runs/<id>?environment=production`) — the current route is `…/workflows/runs/<id>?environment=<env>`, and `environment` was hardcoded (ignored `--env`).
2. There was no clean "just give me the link" mode — `--web` always opens a browser, and `--noBrowser` is noisy and (for local) still boots the web server.

## Changes

- **`--url` flag** on `inspect` and `web`: resolves the deep link, prints it to **stdout**, and exits — no browser, no local server. All chatter goes to stderr, so stdout is exactly the URL (or `{ "url": "…" }` with `--json`). Captureable: `URL=$(npx workflow web <id> --backend vercel --url)`.
  - Vercel → `https://vercel.com/<team>/<project>/workflows/runs/<id>?environment=<production|preview>`
  - Local → `http://localhost:<port>?resource=run&id=<id>`
- **Fixed the Vercel dashboard URL** in `getVercelDashboardUrl` (single CLI source of truth): dropped the legacy `/observability` segment and threaded `--env` through. This also corrects what `--web`/`--noBrowser` open.
- Applied the same route fix to the e2e helpers, the two CI aggregation scripts, and the nextjs-turbopack workbench chat client.
- Documented deep-linking in the **workflow skill** (`SKILL.md`, version `1.9 → 1.10`) and the **v4/v5 observability docs**.

## Testing

- New `packages/cli/src/lib/inspect/vercel-api.test.ts` (5 tests) + existing `output.test.ts` (6) pass.
- CLI typechecks; full workspace build (27 packages) succeeds.
- Smoke-tested the built CLI for local, Vercel, and `--json` — correct new-format URLs, stdout verified clean via separated streams.

> Note: the `chat-client.tsx` diff also includes a pre-existing import reordering already present in the working tree; the substantive change there is the route fix.

## Docs Preview

| Page | v4 | v5 |
| --- | --- | --- |
| Observability → Web UI | [/docs/observability#web-ui](https://workflow-docs-git-pgp-workflow-skill-upgrade.vercel.sh/docs/observability#web-ui) | [/v5/docs/observability#web-ui](https://workflow-docs-git-pgp-workflow-skill-upgrade.vercel.sh/v5/docs/observability#web-ui) |

_(Behind deployment protection — requires Vercel team access.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
