### PR TITLE
fix(core): bump payload-compression cutoff to 5.0.0-beta.18

### DIFF
--- a/.changeset/fix-compression-cutoff-beta18.md
+++ b/.changeset/fix-compression-cutoff-beta18.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix the payload-compression capability cutoff: gzip/zstd are gated on `5.0.0-beta.18` (the first published version containing the compression read path) instead of `5.0.0-beta.16`. The previous cutoff would let a producer write compressed payloads to a beta.16/beta.17 target that cannot decode them.

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -28,8 +28,8 @@
  *   Commit: 7618ac36 "Wire AES-GCM encryption into serialization layer (#1251)"
  *   https://github.com/vercel/workflow/commit/7618ac36
  * - `framedByteStreams` (wire-level chunk framing for byte streams): added in `5.0.0-beta.15`
- * - `gzip` (gzip payload compression): added in `5.0.0-beta.16`
- * - `zstd` (zstd payload compression, preferred codec): added in `5.0.0-beta.16`
+ * - `gzip` (gzip payload compression): added in `5.0.0-beta.18`
+ * - `zstd` (zstd payload compression, preferred codec): added in `5.0.0-beta.18`
  *   alongside gzip — they co-ship, so any run that can read one can read both.
  */
 
@@ -77,8 +77,8 @@ const FORMAT_VERSION_TABLE: ReadonlyArray<{
   // compressed payloads to consumers that cannot decompress them; too-high
   // merely delays the optimization (safe). gzip and zstd ship together, so
   // they share a min version — a run that can read one can read both.
-  { format: SerializationFormat.GZIP, minVersion: '5.0.0-beta.16' },
-  { format: SerializationFormat.ZSTD, minVersion: '5.0.0-beta.16' },
+  { format: SerializationFormat.GZIP, minVersion: '5.0.0-beta.18' },
+  { format: SerializationFormat.ZSTD, minVersion: '5.0.0-beta.18' },
   // Future entries:
   // { format: SerializationFormat.CBOR, minVersion: '5.x.y' },
   // { format: SerializationFormat.ENCRYPTED_V2, minVersion: '5.x.y' },

--- a/packages/core/src/serialization/compression.test.ts
+++ b/packages/core/src/serialization/compression.test.ts
@@ -441,14 +441,29 @@ describe('run capabilities for compression codecs', () => {
     SerializationFormat.GZIP,
     SerializationFormat.ZSTD,
   ] as const) {
-    it(`supports ${fmt} for core versions >= 5.0.0-beta.16`, () => {
-      expect(
-        getRunCapabilities('5.0.0-beta.16').supportedFormats.has(fmt)
-      ).toBe(true);
+    it(`supports ${fmt} for core versions >= 5.0.0-beta.18`, () => {
+      for (const version of [
+        '5.0.0-beta.18',
+        '5.0.0-beta.19',
+        '5.0.0',
+        '6.0.0',
+      ])
+        expect(getRunCapabilities(version).supportedFormats.has(fmt)).toBe(
+          true
+        );
     });
 
     it(`does not support ${fmt} for older core versions`, () => {
-      for (const version of ['5.0.0-beta.15', '4.2.1', '4.0.0']) {
+      // beta.16 and beta.17 were published before compression shipped, so a
+      // producer must treat those targets as compression-incapable — writing
+      // a codec they cannot decode is the silent-corruption failure mode.
+      for (const version of [
+        '5.0.0-beta.17',
+        '5.0.0-beta.16',
+        '5.0.0-beta.15',
+        '4.2.1',
+        '4.0.0',
+      ]) {
         expect(getRunCapabilities(version).supportedFormats.has(fmt)).toBe(
           false
         );


### PR DESCRIPTION
## Summary

Follow-up to #2394 (payload compression), which auto-merged. The `FORMAT_VERSION_TABLE` cutoff for `gzip`/`zstd` is one beta too low and would cause silent replay corruption once compression ships.

## The bug

#2394 gates both compression codecs on `minVersion: '5.0.0-beta.16'`. But:

- `workflow@5.0.0-beta.16` — tagged 2026-06-15 (`Version Packages #2390`)
- `workflow@5.0.0-beta.17` — tagged 2026-06-15 (`Version Packages #2428`)
- #2394 merged 2026-06-16 → `git merge-base --is-ancestor 5f0b84521 workflow@5.0.0-beta.17` reports **NOT** an ancestor

Neither published beta contains the compression read path. The next published version is **beta.18** (pending `Version Packages #2451`), which is the first that can decode these payloads.

With the cutoff at beta.16, `getRunCapabilities()` reports a target running beta.16 or beta.17 as compression-capable. A cross-deployment `start()` / `resumeHook()` to such a target — or a resilient-start capability probe resolving to one — would then write zstd/gzip payloads the target cannot decode: a `ReferenceError`-class failure at replay, silent until it bites. This is exactly the `TODO(release)` hazard noted on those lines, and the same cutoff-lag class of bug that hit byte-stream framing (#1853) twice.

## Fix

- Bump the `GZIP` and `ZSTD` `FORMAT_VERSION_TABLE` entries (and the doc-comment changelog lines) from `5.0.0-beta.16` → `5.0.0-beta.18`.
- Extend the capability test to assert beta.16 **and** beta.17 are treated as compression-incapable (the corruption-prevention boundary), and that beta.18+ are capable.

No data is corrupted in the wild yet — compression doesn't activate until a published SDK writes it, i.e. beta.18 — but this must land in the same release that first enables compression.

## Testing

- `pnpm --filter @workflow/core test` → compression suite green (34 tests)