### PR TITLE
perf(core): cache compiled workflow-bundle vm.Script across replays

### DIFF
--- a/.changeset/perf-cached-workflow-script.md
+++ b/.changeset/perf-cached-workflow-script.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Cache the compiled workflow-bundle `vm.Script` per process so replays reuse the compiled bundle instead of re-parsing it on every iteration.

--- a/packages/core/src/vm/script-cache.test.ts
+++ b/packages/core/src/vm/script-cache.test.ts
@@ -1,0 +1,94 @@
+import { runInContext } from 'node:vm';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createContext } from './index.js';
+import {
+  clearWorkflowScriptCache,
+  getCachedWorkflowScript,
+  runCachedWorkflowScript,
+} from './script-cache.js';
+
+const seed = 'script-cache seed';
+const fixedTimestamp = 1234567890000;
+
+const SAMPLE_BUNDLE = `
+globalThis.__private_workflows = new Map();
+globalThis.__private_workflows.set('my/workflow', async function workflow(name) {
+  return 'hello,' + name + ',' + Math.random() + ',' + Date.now();
+});
+`;
+
+describe('script-cache', () => {
+  afterEach(() => {
+    clearWorkflowScriptCache();
+  });
+
+  it('returns the same compiled Script for identical (code, filename)', () => {
+    const a = getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts');
+    const b = getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts');
+    expect(a).toBe(b);
+  });
+
+  it('returns distinct Scripts for the same code under different filenames', () => {
+    const a = getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts');
+    const b = getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/b.ts');
+    expect(a).not.toBe(b);
+  });
+
+  it('returns distinct Scripts for different code under the same filename', () => {
+    const a = getCachedWorkflowScript('1 + 1', 'workflows/a.ts');
+    const b = getCachedWorkflowScript('2 + 2', 'workflows/a.ts');
+    expect(a).not.toBe(b);
+  });
+
+  it('produces a byte-identical workflow result vs. uncached runInContext', async () => {
+    // Cached path: run the bundle then look up the workflow, mirroring
+    // runWorkflow's two-step evaluation.
+    const { context: cachedCtx } = createContext({ seed, fixedTimestamp });
+    runCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts', cachedCtx);
+    const cachedFn = runCachedWorkflowScript(
+      `globalThis.__private_workflows?.get('my/workflow')`,
+      'workflows/a.ts',
+      cachedCtx
+    );
+    expect(cachedFn).toBeTypeOf('function');
+    const cachedResult = await (cachedFn as (n: string) => Promise<string>)(
+      'world'
+    );
+
+    // Uncached path: the original combined-string approach.
+    const { context: plainCtx } = createContext({ seed, fixedTimestamp });
+    const plainFn = runInContext(
+      `${SAMPLE_BUNDLE}; globalThis.__private_workflows?.get('my/workflow')`,
+      plainCtx,
+      { filename: 'workflows/a.ts' }
+    );
+    const plainResult = await (plainFn as (n: string) => Promise<string>)(
+      'world'
+    );
+
+    expect(cachedResult).toEqual(plainResult);
+  });
+
+  it('reuses the compiled Script across multiple runs against fresh contexts', async () => {
+    const script = getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts');
+
+    const results: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const { context } = createContext({ seed, fixedTimestamp });
+      runCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts', context);
+      // The same cached Script object is used every iteration.
+      expect(getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts')).toBe(
+        script
+      );
+      const fn = runInContext(
+        `globalThis.__private_workflows?.get('my/workflow')`,
+        context
+      ) as (n: string) => Promise<string>;
+      results.push(await fn('world'));
+    }
+
+    // Deterministic context => identical results every run.
+    expect(results[0]).toEqual(results[1]);
+    expect(results[1]).toEqual(results[2]);
+  });
+});

--- a/packages/core/src/vm/script-cache.test.ts
+++ b/packages/core/src/vm/script-cache.test.ts
@@ -5,6 +5,7 @@ import {
   clearWorkflowScriptCache,
   getCachedWorkflowScript,
   runCachedWorkflowScript,
+  workflowScriptCacheSize,
 } from './script-cache.js';
 
 const seed = 'script-cache seed';
@@ -16,6 +17,25 @@ globalThis.__private_workflows.set('my/workflow', async function workflow(name) 
   return 'hello,' + name + ',' + Math.random() + ',' + Date.now();
 });
 `;
+
+/**
+ * Builds a realistic multi-workflow bundle: many registered workflow functions
+ * (the production shape) with a distinguishing `marker` baked in so two bundles
+ * built with different markers are genuinely different code (not the trivial
+ * `1 + 1` / `2 + 2` strings). Each workflow returns a value derived from the
+ * marker so a mis-served Script would produce a detectably wrong result.
+ */
+function buildBundle(marker: string, workflowCount = 12): string {
+  const defs: string[] = [];
+  for (let i = 0; i < workflowCount; i++) {
+    defs.push(
+      `globalThis.__private_workflows.set('app/workflow-${i}', async function workflow${i}(name) {\n` +
+        `  return '${marker}:' + ${i} + ':' + name + ':' + Math.random();\n` +
+        `});`
+    );
+  }
+  return `globalThis.__private_workflows = new Map();\n${defs.join('\n')}\n`;
+}
 
 describe('script-cache', () => {
   afterEach(() => {
@@ -90,5 +110,93 @@ describe('script-cache', () => {
     // Deterministic context => identical results every run.
     expect(results[0]).toEqual(results[1]);
     expect(results[1]).toEqual(results[2]);
+  });
+
+  it('bounds the bundle cache and evicts least-recently-used bundles', () => {
+    // Insert far more distinct bundles than any sane cap, simulating a long
+    // dev/watch session where every edit produces a new bundle string. The
+    // cache must NOT grow monotonically with edit count.
+    const editCount = 100;
+    const filename = 'workflows/a.ts';
+    for (let i = 0; i < editCount; i++) {
+      getCachedWorkflowScript(buildBundle(`edit-${i}`), filename);
+    }
+
+    const size = workflowScriptCacheSize();
+    expect(size).toBeGreaterThan(0);
+    // Bounded well below the number of edits — the whole point of the LRU.
+    expect(size).toBeLessThan(editCount);
+
+    // The cache still serves correctly after heavy churn: the most-recently
+    // inserted bundle is retained and repeated lookups return the same Script.
+    const latest = buildBundle(`edit-${editCount - 1}`);
+    expect(getCachedWorkflowScript(latest, filename)).toBe(
+      getCachedWorkflowScript(latest, filename)
+    );
+  });
+
+  it('keeps the most-recently-used bundle and evicts the stale one', () => {
+    const filename = 'workflows/a.ts';
+    // Seed an "old" bundle, then keep it hot by re-touching it while many
+    // unrelated bundles churn through. LRU must NOT evict the bundle we keep
+    // using, even though it was inserted first.
+    const hot = buildBundle('hot');
+    const hotScript = getCachedWorkflowScript(hot, filename);
+
+    for (let i = 0; i < 50; i++) {
+      getCachedWorkflowScript(buildBundle(`cold-${i}`), filename);
+      // Re-access the hot bundle so it stays most-recently-used.
+      expect(getCachedWorkflowScript(hot, filename)).toBe(hotScript);
+    }
+
+    // After all that churn the hot bundle is still the *same* cached Script —
+    // proving LRU recency (touch-on-access), not mere insertion order, governs
+    // eviction.
+    expect(getCachedWorkflowScript(hot, filename)).toBe(hotScript);
+  });
+
+  it('never returns the wrong Script across realistic multi-workflow bundles', async () => {
+    // Two genuinely different bundles (production-shape: many workflows each),
+    // distinguished by their marker, plus two filenames. Every distinct
+    // (code, filename) must map to its own Script, and running each must
+    // produce results derived from its own marker — never another bundle's.
+    const bundleX = buildBundle('bundle-X');
+    const bundleY = buildBundle('bundle-Y');
+    const fileA = 'workflows/a.ts';
+    const fileB = 'workflows/b.ts';
+
+    const xa = getCachedWorkflowScript(bundleX, fileA);
+    const xb = getCachedWorkflowScript(bundleX, fileB);
+    const ya = getCachedWorkflowScript(bundleY, fileA);
+    const yb = getCachedWorkflowScript(bundleY, fileB);
+
+    // All four (code, filename) combinations are distinct Script objects.
+    const scripts = [xa, xb, ya, yb];
+    for (let i = 0; i < scripts.length; i++) {
+      for (let j = i + 1; j < scripts.length; j++) {
+        expect(scripts[i]).not.toBe(scripts[j]);
+      }
+    }
+
+    // Same (code, filename) is stable across lookups.
+    expect(getCachedWorkflowScript(bundleX, fileA)).toBe(xa);
+    expect(getCachedWorkflowScript(bundleY, fileB)).toBe(yb);
+
+    // Running each bundle yields its OWN marker, confirming no cross-wiring.
+    const { context: ctxX } = createContext({ seed, fixedTimestamp });
+    runCachedWorkflowScript(bundleX, fileA, ctxX);
+    const fnX = runInContext(
+      `globalThis.__private_workflows?.get('app/workflow-3')`,
+      ctxX
+    ) as (n: string) => Promise<string>;
+    expect(await fnX('z')).toContain('bundle-X:3:z');
+
+    const { context: ctxY } = createContext({ seed, fixedTimestamp });
+    runCachedWorkflowScript(bundleY, fileA, ctxY);
+    const fnY = runInContext(
+      `globalThis.__private_workflows?.get('app/workflow-3')`,
+      ctxY
+    ) as (n: string) => Promise<string>;
+    expect(await fnY('z')).toContain('bundle-Y:3:z');
   });
 });

--- a/packages/core/src/vm/script-cache.ts
+++ b/packages/core/src/vm/script-cache.ts
@@ -1,0 +1,86 @@
+import { type Context, Script } from 'node:vm';
+
+/**
+ * Module-level cache of compiled workflow-bundle `vm.Script` objects.
+ *
+ * Why this exists
+ * ---------------
+ * Replaying a workflow re-evaluates the workflow bundle against a fresh VM
+ * context on every iteration of the inline replay loop (see
+ * `runWorkflow` in `../workflow.ts`). The bundle is a single string that
+ * contains every workflow function in the app and registers them on
+ * `globalThis.__private_workflows`. Previously each replay called
+ * `vm.runInContext(workflowCode, context, { filename })`, which RE-PARSES and
+ * RE-COMPILES the entire bundle every time — O(N) full re-parses for a
+ * sequential workflow of N steps, plus the same parse cost repeated across
+ * every invocation in the process.
+ *
+ * Compilation is a pure function of `(code, filename)`: a `vm.Script` carries
+ * no realm/context state — it is only bound to a context at `runInContext`
+ * time. So a single compiled `Script` can be reused across replays AND across
+ * workflow invocations in the same process without affecting determinism: the
+ * produced workflow function and any thrown errors are byte-identical to the
+ * previous re-parse-every-time behaviour.
+ *
+ * Keying
+ * ------
+ * Keyed by `code` then `filename`. The `filename` is part of the key because
+ * it is baked into the compiled script's source attribution and surfaces in
+ * stack traces (and is consumed by `remapErrorStack` at runtime). Two
+ * workflows in the same bundle share the same `code` but can have different
+ * `filename`s, so they must not share a compiled `Script`. The number of
+ * distinct `(code, filename)` pairs in a process is bounded by
+ * (bundle versions) × (workflow names) and is small in practice.
+ *
+ * We use a nested Map (code -> filename -> Script) so that swapping the bundle
+ * (e.g. a new deployment/hot-reload producing a different `code`) lets the old
+ * code string and all its per-filename scripts become unreachable together.
+ */
+const scriptCache = new Map<string, Map<string, Script>>();
+
+/**
+ * Returns a compiled `vm.Script` for the given workflow bundle code and
+ * filename, compiling and caching it on first use. Subsequent calls with the
+ * same `(code, filename)` return the cached `Script`.
+ *
+ * The returned `Script` is not yet bound to any context; the caller runs it
+ * against a specific VM context via `script.runInContext(context)`. This is
+ * equivalent to `vm.runInContext(code, context, { filename })` but skips the
+ * recompile.
+ */
+export function getCachedWorkflowScript(
+  code: string,
+  filename: string
+): Script {
+  let byFilename = scriptCache.get(code);
+  if (byFilename === undefined) {
+    byFilename = new Map<string, Script>();
+    scriptCache.set(code, byFilename);
+  }
+  let script = byFilename.get(filename);
+  if (script === undefined) {
+    script = new Script(code, { filename });
+    byFilename.set(filename, script);
+  }
+  return script;
+}
+
+/**
+ * Runs the cached workflow-bundle `Script` against `context`. Compiles and
+ * caches the `Script` on first use for the given `(code, filename)`.
+ */
+export function runCachedWorkflowScript(
+  code: string,
+  filename: string,
+  context: Context
+): unknown {
+  return getCachedWorkflowScript(code, filename).runInContext(context);
+}
+
+/**
+ * Clears the compiled-script cache. Intended for tests that want to assert
+ * compile-vs-cache behaviour in isolation; not used on the hot path.
+ */
+export function clearWorkflowScriptCache(): void {
+  scriptCache.clear();
+}

--- a/packages/core/src/vm/script-cache.ts
+++ b/packages/core/src/vm/script-cache.ts
@@ -19,24 +19,74 @@ import { type Context, Script } from 'node:vm';
  * no realm/context state — it is only bound to a context at `runInContext`
  * time. So a single compiled `Script` can be reused across replays AND across
  * workflow invocations in the same process without affecting determinism: the
- * produced workflow function and any thrown errors are byte-identical to the
- * previous re-parse-every-time behaviour.
+ * produced workflow function is identical to the previous re-parse-every-time
+ * behaviour, with identical `filename` source attribution (see the precise
+ * claim — and its one caveat — in `runWorkflow`).
  *
  * Keying
  * ------
- * Keyed by `code` then `filename`. The `filename` is part of the key because
- * it is baked into the compiled script's source attribution and surfaces in
- * stack traces (and is consumed by `remapErrorStack` at runtime). Two
- * workflows in the same bundle share the same `code` but can have different
- * `filename`s, so they must not share a compiled `Script`. The number of
- * distinct `(code, filename)` pairs in a process is bounded by
- * (bundle versions) × (workflow names) and is small in practice.
+ * Keyed by `code` then `filename`. The `filename` is part of the key on
+ * purpose, NOT as a dedupe key: it is baked into the compiled script's source
+ * attribution and surfaces in stack traces, where `remapErrorStack` keys on it
+ * to map frames back to the user's source. Two workflows in the same bundle
+ * share the same `code` but have different `filename`s, so they intentionally
+ * compile to distinct `Script`s — collapsing them onto a single shared `Script`
+ * would misattribute one workflow's stack frames to another file. The cost of
+ * keeping them distinct is that the whole bundle is compiled once per distinct
+ * `filename` (not once per bundle); in practice that is bounded by the number
+ * of source files that define a workflow, and because V8 lazily compiles
+ * function bodies the duplicated work is the (cheap) top-level parse, not full
+ * per-workflow codegen.
  *
- * We use a nested Map (code -> filename -> Script) so that swapping the bundle
- * (e.g. a new deployment/hot-reload producing a different `code`) lets the old
- * code string and all its per-filename scripts become unreachable together.
+ * We use a nested Map (code -> filename -> Script) so that evicting a bundle
+ * (e.g. a new deployment/hot-reload producing a different `code`) drops the old
+ * code string and all of its per-filename scripts together.
+ *
+ * Bounding
+ * --------
+ * The top-level (`code`-keyed) map is an insertion-ordered LRU capped at
+ * `MAX_BUNDLES` entries. In production this bound is never reached: a
+ * deployment is its own process serving exactly one build-time bundle literal
+ * (skew protection runs old versions as separate processes), so there is a
+ * single `code` key for the process lifetime. The bound exists for dev/watch
+ * mode, where the dev route re-reads `workflowCode` from disk and re-invokes
+ * the entrypoint on every edit — each edit produces a NEW bundle string, which
+ * without a bound would pin every historical version forever (~0.8MB per edit,
+ * growing monotonically with edit count). The dev path only ever needs the
+ * latest bundle, so an LRU that keeps the few most-recent bundles and evicts
+ * the rest preserves the pre-cache GC behaviour while still serving the
+ * steady-state single-bundle case for free. The per-`filename` inner map is not
+ * separately bounded: it is naturally bounded by the (small) number of workflow
+ * source files in a bundle and is dropped wholesale when its parent `code`
+ * entry is evicted.
  */
 const scriptCache = new Map<string, Map<string, Script>>();
+
+/**
+ * Max number of distinct bundle (`code`) versions to retain. One is enough for
+ * production; a handful covers pathological dev hot-reload / repeated-rebuild
+ * churn within a single long-lived process (e.g. a watch session or a test
+ * file) without unbounded growth. Kept deliberately small — there is no value
+ * in retaining stale bundles, only a memory cost.
+ */
+const MAX_BUNDLES = 8;
+
+/**
+ * Looks up the per-filename map for `code`, marking it most-recently-used.
+ * Relies on `Map` preserving insertion order: deleting and re-inserting an
+ * existing key moves it to the end (newest), so the first key is always the
+ * least-recently-used eviction candidate.
+ */
+function touchBundle(code: string): Map<string, Script> | undefined {
+  const byFilename = scriptCache.get(code);
+  if (byFilename === undefined) {
+    return undefined;
+  }
+  // Move to the most-recently-used position (end of insertion order).
+  scriptCache.delete(code);
+  scriptCache.set(code, byFilename);
+  return byFilename;
+}
 
 /**
  * Returns a compiled `vm.Script` for the given workflow bundle code and
@@ -52,10 +102,19 @@ export function getCachedWorkflowScript(
   code: string,
   filename: string
 ): Script {
-  let byFilename = scriptCache.get(code);
+  let byFilename = touchBundle(code);
   if (byFilename === undefined) {
     byFilename = new Map<string, Script>();
     scriptCache.set(code, byFilename);
+    // Evict the least-recently-used bundle(s) when over the cap. New bundles
+    // are appended at the end, so the oldest live at the front.
+    while (scriptCache.size > MAX_BUNDLES) {
+      const oldest = scriptCache.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      scriptCache.delete(oldest);
+    }
   }
   let script = byFilename.get(filename);
   if (script === undefined) {
@@ -83,4 +142,12 @@ export function runCachedWorkflowScript(
  */
 export function clearWorkflowScriptCache(): void {
   scriptCache.clear();
+}
+
+/**
+ * Number of distinct bundle (`code`) versions currently retained. Exposed for
+ * tests asserting the LRU bound; not used on the hot path.
+ */
+export function workflowScriptCacheSize(): number {
+  return scriptCache.size;
 }

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -1,4 +1,3 @@
-import { runInContext } from 'node:vm';
 import {
   ERROR_SLUGS,
   ReplayDivergenceError,
@@ -38,6 +37,7 @@ import * as Attribute from './telemetry/semantic-conventions.js';
 import { trace } from './telemetry.js';
 import { getWorkflowRunStreamId } from './util.js';
 import { createContext } from './vm/index.js';
+import { runCachedWorkflowScript } from './vm/script-cache.js';
 import {
   createAbortSignalStatics,
   createCreateAbortController,
@@ -769,10 +769,23 @@ export async function runWorkflow(
     const parsedName = parseWorkflowName(workflowRun.workflowName);
     const filename = parsedName?.moduleSpecifier || workflowRun.workflowName;
 
-    const workflowFn = runInContext(
-      `${workflowCode}; globalThis.__private_workflows?.get(${JSON.stringify(workflowRun.workflowName)})`,
-      context,
-      { filename }
+    // Evaluate the workflow bundle against the fresh context using a
+    // process-wide cache of the compiled `vm.Script`. The bundle is the same
+    // string for every replay and every invocation in this process, and
+    // compilation is a pure function of `(code, filename)`, so reusing the
+    // compiled Script across replays is determinism-safe: it produces a
+    // byte-identical result to re-parsing the bundle every time, but skips the
+    // (expensive) re-parse. Evaluating the bundle registers every workflow on
+    // `globalThis.__private_workflows`; the trailing lookup expression then
+    // retrieves the requested workflow function. The lookup is evaluated as a
+    // separate cached Script under the same `filename` so its source
+    // attribution (and thus stack traces) match the previous combined-string
+    // behaviour.
+    runCachedWorkflowScript(workflowCode, filename, context);
+    const workflowFn = runCachedWorkflowScript(
+      `globalThis.__private_workflows?.get(${JSON.stringify(workflowRun.workflowName)})`,
+      filename,
+      context
     );
 
     if (typeof workflowFn !== 'function') {

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -42,11 +42,11 @@ import {
   createAbortSignalStatics,
   createCreateAbortController,
 } from './workflow/abort-controller.js';
+import { createSetAttributes } from './workflow/attribute-dispatcher.js';
 import type { WorkflowMetadata } from './workflow/get-workflow-metadata.js';
 import { WORKFLOW_CONTEXT_SYMBOL } from './workflow/get-workflow-metadata.js';
 import { createCreateHook } from './workflow/hook.js';
 import { createSleep } from './workflow/sleep.js';
-import { createSetAttributes } from './workflow/attribute-dispatcher.js';
 
 /**
  * Drain pending queue items at workflow completion (success or failure).
@@ -773,14 +773,20 @@ export async function runWorkflow(
     // process-wide cache of the compiled `vm.Script`. The bundle is the same
     // string for every replay and every invocation in this process, and
     // compilation is a pure function of `(code, filename)`, so reusing the
-    // compiled Script across replays is determinism-safe: it produces a
-    // byte-identical result to re-parsing the bundle every time, but skips the
-    // (expensive) re-parse. Evaluating the bundle registers every workflow on
+    // compiled Script across replays is determinism-safe: it produces the same
+    // workflow function and the same `filename` source attribution as
+    // re-parsing the bundle every time, but skips the (expensive) re-parse.
+    // Evaluating the bundle registers every workflow on
     // `globalThis.__private_workflows`; the trailing lookup expression then
     // retrieves the requested workflow function. The lookup is evaluated as a
-    // separate cached Script under the same `filename` so its source
-    // attribution (and thus stack traces) match the previous combined-string
-    // behaviour.
+    // separate cached Script under the same `filename`, so error stack frames
+    // still attribute to the workflow's source file (`remapErrorStack` keys on
+    // `filename`). The one behavioural difference from the previous
+    // single-combined-string approach is the *line number* of an error thrown
+    // by the lookup expression itself: it now reports line 1 of the lookup
+    // Script rather than the line just past the end of the bundle. That path
+    // is rare (it requires the lookup `?.get(...)` expression to throw) and
+    // does not affect the workflow function or replay determinism.
     runCachedWorkflowScript(workflowCode, filename, context);
     const workflowFn = runCachedWorkflowScript(
       `globalThis.__private_workflows?.get(${JSON.stringify(workflowRun.workflowName)})`,


### PR DESCRIPTION
## Summary

This is performance optimization work targeting the inline replay loop's hot path (`packages/core/src/runtime.ts` → `runWorkflow` → re-parse the workflow bundle every replay).

**Part A (shipped):** cache the compiled workflow-bundle `vm.Script` per process so replays reuse the compiled bundle instead of re-parsing the bundle string on every iteration.

**Part B (deferred to design writeup, see below):** a reusable VM that resumes the already-advanced workflow instead of re-creating the realm and replaying from the top. Not shipped because it cannot be proven deterministic within the current test contract — details and a proposed safe path are below.

This PR is marked **draft** because Part B is a writeup, not code. The Part A change is complete and ready to review on its own.

## Part A: compiled `vm.Script` cache

### The cost being attacked

Each iteration of the inline replay loop calls `runWorkflow`, which previously did:

```ts
const workflowFn = runInContext(
  `${workflowCode}; globalThis.__private_workflows?.get("name")`,
  context,
  { filename }
);
```

`vm.runInContext(string, ...)` **re-parses and re-compiles the entire bundle string every time**. The bundle contains *every* workflow definition in the app and registers them on `globalThis.__private_workflows`. The production shape is "many workflows in the bundle, one called per replay" — so the uncached path re-scans every definition on every replay, while only the single called workflow actually needs compiling.

### The change

- New module `packages/core/src/vm/script-cache.ts`: a process-wide cache of compiled `vm.Script` objects, keyed by `(workflowCode, filename)` (nested `Map<code, Map<filename, Script>>`).
- `runWorkflow` now runs the cached compiled bundle `Script` against the fresh context, then a separate cached lookup `Script` to retrieve the workflow function.

### Determinism & isolation safety analysis

- **A `vm.Script` carries no realm/context state.** Compilation is a pure function of `(code, filename)`; the script is only bound to a context at `runInContext` time. Reusing it produces the **same workflow function and the same `filename` source attribution** as re-parsing every time — it just skips the parse. (More precise than the original "byte-identical including thrown errors" wording: splitting the old single combined `${code}; ...get(name)` string into two separate `Script`s preserves `filename` attribution, but the *line number* of an error thrown by the lookup expression shifts from "just past the end of the bundle" to line 1 of the lookup Script. That path is rare — it requires the `?.get(...)` lookup itself to throw — and doesn't affect the workflow function or replay determinism.) The full `workflow.test.ts` replay suite (79 tests) and the e2e step/sleep suites pass unchanged.
- **`filename` is part of the cache key** because it is baked into the compiled script's source attribution and surfaces in stack traces (consumed by `remapErrorStack` in the runtime). Two workflows in the same bundle share `code` but can have different `filename`s, so they intentionally compile to distinct `Script`s — collapsing them would misattribute one workflow's stack frames to another file. This means the whole bundle is compiled once per distinct `filename` rather than once per bundle; that's bounded by the number of source files defining a workflow, and V8's lazy body compilation keeps the duplicated work to the cheap top-level parse.
- **Isolation across concurrent runs is preserved.** The cache holds *immutable, stateless* compiled `Script`s. Each run still gets its own fresh `vm.Context` from `createContext` (unchanged). Nothing mutable is shared between runs.
- **The cache is bounded (LRU, cap = 8 bundle versions).** Production never reaches the bound — a deployment is its own process serving one build-time bundle literal, so there's a single `code` key for the process lifetime. The bound exists for dev/watch mode: the dev route re-reads `workflowCode` on every edit, producing a new bundle string each time, which without a bound would pin every historical version (~0.8MB/edit, monotonic). The top-level `code`-keyed map is an insertion-ordered LRU (touch-on-access); evicting a `code` entry drops it and all of its per-`filename` scripts together, restoring the pre-cache GC behaviour while still serving the steady-state single-bundle case for free.

### Benchmark (per replay iteration, production shape: many workflows, one called)

| App size | Bundle | uncached | cached | saved/replay | % |
|---|---|---|---|---|---|
| typical (50 workflows) | 61KB | 0.232ms | 0.152ms | 0.080ms | 34% |
| large (155 workflows) | 254KB | 0.468ms | 0.192ms | 0.276ms | 59% |
| xl (400 workflows) | 821KB | 1.194ms | 0.236ms | 0.958ms | 80% |

Savings scale with bundle size and **multiply by replay count** (a sequential N-step workflow replays ~N+1 times). For a large-app 20-step workflow that's ~5.8ms/run; for the xl app ~20ms/run. This is a real but modest win.

**Honest caveats:**
- V8 **lazily compiles** function bodies, so the savings come from not re-scanning *un-called* workflow definitions — not from the called function (which V8 compiles per-context in both paths).
- A V8 **code cache** (`Script.createCachedData()` / `new Script(code, { cachedData })`) gave **no additional benefit** in measurement, because the lazily-compiled-and-called-once bodies don't benefit from cached bytecode. So a **build-time precompile is not worth pursuing** — the runtime `Script` cache captures the available win.
- The benchmark uses synthetic bundles of representative shape/size; it took several iterations to measure correctly (early measurements that didn't invoke the workflow function understated the win).

### Where the real cost actually is

Profiling the per-replay path shows the dominant costs are **not** the bundle parse:

| Cost per replay iteration | Time |
|---|---|
| Bundle parse (what Part A caches) | up to ~1ms on a large bundle, scales with size |
| `createContext` realm + global setup | ~0.29ms |
| **Body re-execution of all N prior steps** | grows O(N) per iteration → **O(N²) total** |

The realm-creation and O(N²) body re-execution costs require **Part B**.

## Part B: reusable VM (design writeup — not shipped)

> Goal: instead of creating a whole new realm and replaying from the top each iteration, keep the workflow VM + its in-flight promises alive and resolve them as new events arrive, so the body resumes rather than re-runs.

### What would have to change

The current model is **abandon-and-replay**:
1. The workflow body runs in the VM. Each `await step()` registers a callback on the `EventsConsumer` and returns a pending promise.
2. When the consumer reaches end-of-events with an unfulfilled step, the step callback calls `onWorkflowError(new WorkflowSuspension(...))`, which rejects `workflowDiscontinuation`. That wins the `Promise.race` in `runWorkflow`, so it returns — **the VM, its context, and all pending in-VM promises and async frames are abandoned (GC'd).**
3. The runtime executes the step, appends `step_completed`, loops, and calls `runWorkflow` **fresh**: new realm, body re-executed from the top, replaying the entire event log to reconstruct local variable state.

A resumable model would instead **suspend-and-resume**: treat end-of-events as a *pause* (don't reject), keep the `stepA()` promise pending, and when `step_completed` arrives, append it to the **same** `EventsConsumer`'s `events` array and re-run `consume()` to resolve that promise — letting the already-running body continue naturally to `stepB`. The `EventsConsumer` already supports incremental consumption (`events` held by reference, `eventIndex` advances, `subscribe()` re-triggers `consume()`), so the building block exists; the blocker is the runtime loop tearing down the VM rather than feeding new events back into the live consumer.

### Why it is NOT shipped (risks that can't be discharged here)

1. **Determinism-via-fresh-realm is load-bearing in the test contract.** `createContext` re-seeds `Math.random` (seedrandom) and re-pins `Date.now` to `startedAt` on every replay, then advances the clock deterministically as events are consumed. The entire suite asserts replay-from-top reproduces identical results. A resume model keeps the RNG counter and timestamp *advancing* across the pause — which is actually correct for a true resume, but it produces results that are only *equivalent* to replay if the body never observes realm state that replay would have reset. Any path that implicitly relies on the per-replay reset would diverge silently.
2. **Global mutation across the pause becomes observable.** User workflow code runs in the shared realm. In abandon-and-replay, each replay gets a pristine realm so global mutations are wiped and re-applied identically. In a reused VM, e.g. `globalThis.counter = (globalThis.counter ?? 0) + 1` at body scope accumulates across resumes — a behavior change. The replay model "hides" certain non-determinism by re-running; resume exposes it.
3. **It only helps within a single invocation.** On Vercel, after a real suspension the next step is queued and typically runs on a *different* instance with no shared memory — so the VM cannot be reused across invocations at all. Reuse only applies to the inline loop *within one function invocation* (bounded by `WORKFLOW_V2_TIMEOUT_MS`). That is the hot path the task targets, but it bounds the achievable win and means the fallback (replay) must remain fully correct anyway.
4. **Memory & leak surface.** Keeping VMs + pending promise chains alive lengthens GC lifetimes and risks leaking abandoned consumers if a run errors mid-resume.

### Proposed safe path (future work)

- Gate resume behind a conservative guard: only attempt it within a single inline-loop invocation, only for runs whose workflow body provably touches no realm/global state beyond the sanctioned deterministic primitives (hard to prove statically — likely needs an opt-in or a compiler signal).
- Keep abandon-and-replay as the always-correct fallback; resume is a fast-path that must produce identical event-log writes or bail to replay.
- Add differential tests that run the same event log through both replay and resume and assert byte-identical event output before enabling resume anywhere.
- Separately, the cheaper realm-reuse idea (reset RNG/Date on a kept context instead of building a new realm) is lower-risk than full promise-resume and could be evaluated independently.

## Verification

- `pnpm build` (all packages) — green
- `cd packages/core && pnpm test` — **1241 passed** (incl. the 79-test `workflow.test.ts` replay suite and new `script-cache.test.ts`)
- `tsc --noEmit` on `@workflow/core` — clean
- biome lint on changed files — clean (2 pre-existing complexity warnings in `workflow.ts` are unrelated)
- nextjs-turbopack e2e (local dev server): `sleeping` (2) + `step` (40) — **all passed**, covering multi-iteration replay, inline step execution, retries, error cause chains, closure vars, abort propagation, sleep-in-loops, and cross-context serialization.

## What's deferred

- Part B (reusable/resumable VM) — captured as the design writeup above.
- Build-time precompile / V8 code cache — investigated, no measurable benefit, not pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

