### PR TITLE
fix(web-shared): use solid gray for queued trace segment

### DIFF
--- a/.changeset/tame-coats-hug.md
+++ b/.changeset/tame-coats-hug.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Yse solid gray for queued trace segment

--- a/packages/web-shared/src/components/trace-viewer/trace-viewer.module.css
+++ b/packages/web-shared/src/components/trace-viewer/trace-viewer.module.css
@@ -1314,10 +1314,10 @@
 .segQueued {
   background: repeating-linear-gradient(
     45deg,
-    var(--ds-gray-alpha-200),
-    var(--ds-gray-alpha-200) 6px,
-    var(--ds-gray-alpha-100) 6px,
-    var(--ds-gray-alpha-100) 12px
+    var(--ds-gray-200),
+    var(--ds-gray-200) 6px,
+    var(--ds-gray-100) 6px,
+    var(--ds-gray-100) 12px
   );
 }
 


### PR DESCRIPTION
### Description

The "queued" span segment in the trace viewer used the alpha gray design tokens (`--ds-gray-alpha-200` / `--ds-gray-alpha-100`) for its hatched fill, which made the queued state look washed out / semi-transparent. This switches the hatch to the solid gray tokens (`--ds-gray-200` / `--ds-gray-100`) so the queued segment renders in normal gray.

Scope is limited to the `.segQueued` rule. The `retrying` and `waiting` segments still use the alpha gray hatch and were intentionally left unchanged.

### How did you test your changes?

Visual-only CSS change in `web-shared`. Verified the queued trace segment renders with solid gray instead of the washed-out alpha hatch in the observability trace viewer.

