### PR TITLE
fix(web): render restarted step segment as solid gray, not running stripes

### DIFF
--- a/packages/web-shared/src/components/new-trace-viewer/utils.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.ts
@@ -278,7 +278,7 @@ function computeStepSegmentsFromSpan(
             ? 'failed'
             : nextType === 'step_completed'
               ? 'succeeded'
-              : 'running';
+              : 'retrying';
         segments.push({
           startFraction: markFrac,
           endFraction: nextFrac,


### PR DESCRIPTION
## Summary

In the trace timeline (`new-trace-viewer`), each step bar is split into status segments. The animated blue diagonal "running" stripes are only drawn for segments whose status is `running` (or `received`).

When a step emits `step_started` twice in a row — a re-start with no `step_retrying`/`step_failed`/`step_completed` in between — the interval between the two starts fell into the `else` branch and was labeled `running`, so it rendered as the animated blue stripes. That implied active progress for what is really a superseded/abandoned attempt.

This changes that single case to `retrying`, which renders as a **solid gray** segment (no stripes). The other next-mark types are unaffected (`step_retrying`/`step_failed` → `failed`, `step_completed` → `succeeded`), so this only touches the started-twice case.

## Test plan

- [ ] Open a run whose step was started, then started again (with no retry/fail/complete in between) and confirm the interval between the two starts renders solid gray instead of animated blue stripes.
- [ ] Confirm normal steps (created → started → completed) still render green, and failed/retried steps are unchanged.

Made with [Cursor](https://cursor.com)