### PR TITLE
[swc-plugin] Fix eager discovery for object property steps

### DIFF
--- a/.changeset/object-property-step-discovery.md
+++ b/.changeset/object-property-step-discovery.md
@@ -1,0 +1,5 @@
+---
+"@workflow/swc-plugin": patch
+---
+
+Fix detect mode discovery for object-property step handlers so eager builds register steps declared in callback objects.

--- a/packages/swc-plugin-workflow/transform/src/lib.rs
+++ b/packages/swc-plugin-workflow/transform/src/lib.rs
@@ -2156,6 +2156,27 @@ impl StepTransform {
         naming::format_name(prefix, &self.get_module_path(), &fn_name)
     }
 
+    fn record_object_property_step_metadata(&mut self, parent_var_name: &str, prop_key: &str) {
+        let step_id = self.create_object_property_id(
+            parent_var_name,
+            prop_key,
+            false,
+            self.current_workflow_function_name.as_deref(),
+        );
+        if self.object_property_workflow_conversions.iter().any(
+            |(parent, prop, existing_step_id)| {
+                parent == parent_var_name && prop == prop_key && existing_step_id == &step_id
+            },
+        ) {
+            return;
+        }
+        self.object_property_workflow_conversions.push((
+            parent_var_name.to_string(),
+            prop_key.to_string(),
+            step_id,
+        ));
+    }
+
     // Process object properties for step functions
     fn process_object_properties_for_step_functions(
         &mut self,
@@ -2185,6 +2206,14 @@ impl StepTransform {
                         };
 
                         if should_transform {
+                            if matches!(self.mode, TransformMode::Detect) {
+                                self.record_object_property_step_metadata(
+                                    parent_var_name,
+                                    &prop_key,
+                                );
+                                continue;
+                            }
+
                             // Process the transformation
                             match &mut *kv_prop.value {
                                 Expr::Arrow(arrow_expr) => {
@@ -2316,6 +2345,14 @@ impl StepTransform {
                         };
 
                         if self.has_use_step_directive(&method_prop.function.body) {
+                            if matches!(self.mode, TransformMode::Detect) {
+                                self.record_object_property_step_metadata(
+                                    parent_var_name,
+                                    &prop_key,
+                                );
+                                continue;
+                            }
+
                             // Remove the directive first
                             self.remove_use_step_directive(&mut method_prop.function.body);
 
@@ -2423,6 +2460,14 @@ impl StepTransform {
                                     .emit()
                             });
                         } else if has_step {
+                            if matches!(self.mode, TransformMode::Detect) {
+                                self.record_object_property_step_metadata(
+                                    parent_var_name,
+                                    &prop_key,
+                                );
+                                continue;
+                            }
+
                             // Getters don't need async validation (they can't be async syntactically)
 
                             // Remove the directive from the getter body
@@ -2551,13 +2596,6 @@ impl StepTransform {
         prop_key: &str,
         _span: swc_core::common::Span,
     ) {
-        let step_id = self.create_object_property_id(
-            parent_var_name,
-            prop_key,
-            false,
-            self.current_workflow_function_name.as_deref(),
-        );
-
         match self.mode {
             TransformMode::Step => {
                 // Replace with reference to hoisted variable so the stepId
@@ -2575,22 +2613,22 @@ impl StepTransform {
                     SyntaxContext::empty(),
                 ));
                 // Track for metadata generation
-                self.object_property_workflow_conversions.push((
-                    parent_var_name.to_string(),
-                    prop_key.to_string(),
-                    step_id,
-                ));
+                self.record_object_property_step_metadata(parent_var_name, prop_key);
             }
             TransformMode::Workflow => {
+                let step_id = self.create_object_property_id(
+                    parent_var_name,
+                    prop_key,
+                    false,
+                    self.current_workflow_function_name.as_deref(),
+                );
                 // Replace with initializer call
                 *kv_prop.value = self.create_step_initializer(&step_id);
-                self.object_property_workflow_conversions.push((
-                    parent_var_name.to_string(),
-                    prop_key.to_string(),
-                    step_id,
-                ));
+                self.record_object_property_step_metadata(parent_var_name, prop_key);
             }
-            TransformMode::Detect => {}
+            TransformMode::Detect => {
+                self.record_object_property_step_metadata(parent_var_name, prop_key);
+            }
         }
     }
 

--- a/packages/swc-plugin-workflow/transform/tests/fixture.rs
+++ b/packages/swc-plugin-workflow/transform/tests/fixture.rs
@@ -56,3 +56,24 @@ fn workflow_mode(input: PathBuf) {
         },
     );
 }
+
+#[testing::fixture("tests/fixture/object-property-step/input.js")]
+fn detect_mode_object_property_step(input: PathBuf) {
+    let detect_output = input.parent().unwrap().join("output-detect.js");
+    test_fixture(
+        syntax_for(&input),
+        &|_| {
+            visit_mut_pass(StepTransform::new(
+                TransformMode::Detect,
+                input.file_name().unwrap().to_string_lossy().to_string(),
+                None,
+            ))
+        },
+        &input,
+        &detect_output,
+        FixtureTestConfig {
+            module: Some(true),
+            ..Default::default()
+        },
+    );
+}

--- a/packages/swc-plugin-workflow/transform/tests/fixture/object-property-step/output-detect.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/object-property-step/output-detect.js
@@ -1,0 +1,38 @@
+import * as z from 'zod';
+import { tool } from 'ai';
+/**__internal_workflows{"steps":{"input.js":{"timeTool/execute":{"stepId":"step//./input//timeTool/execute"},"weatherTool/execute":{"stepId":"step//./input//weatherTool/execute"},"weatherTool2/execute":{"stepId":"step//./input//weatherTool2/execute"}}}}*/;
+export const weatherTool = tool({
+    description: 'Get the weather in a location',
+    inputSchema: z.object({
+        location: z.string().describe('The location to get the weather for')
+    }),
+    execute: async ({ location })=>{
+        "use step";
+        return {
+            location,
+            temperature: 72 + Math.floor(Math.random() * 21) - 10
+        };
+    }
+});
+export const timeTool = tool({
+    description: 'Get the current time',
+    execute: async function timeToolImpl() {
+        "use step";
+        return {
+            time: new Date().toISOString()
+        };
+    }
+});
+export const weatherTool2 = tool({
+    description: 'Get the weather in a location',
+    inputSchema: z.object({
+        location: z.string().describe('The location to get the weather for')
+    }),
+    async execute ({ location }) {
+        "use step";
+        return {
+            location,
+            temperature: 72 + Math.floor(Math.random() * 21) - 10
+        };
+    }
+});


### PR DESCRIPTION
## Summary
- record object-property step metadata during SWC detect mode without mutating the source
- dedupe object-property metadata entries when detect traversal visits the same export twice
- add a focused detect-mode fixture for object-property steps

## Root cause
Eager discovery relies on SWC detect mode to decide which files belong in the step registration bundle. Object-property handlers like `tool({ execute: async () => { 'use step' } })` were supported by step/workflow transforms, but detect mode emitted no step manifest entry, so eager builds skipped those files.

## Validation
- `cargo test -p swc_workflow`