### PR TITLE
[RFC] Reject empty-string hook tokens in createHook()

### DIFF
--- a/.changeset/reject-empty-hook-token.md
+++ b/.changeset/reject-empty-hook-token.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Reject an explicit empty-string `token` in `createHook()`. Omit the option (or pass `undefined`) to get a randomly generated token, or pass a non-empty string.

--- a/packages/core/src/create-hook.ts
+++ b/packages/core/src/create-hook.ts
@@ -132,7 +132,9 @@ export interface HookOptions {
    * tokens are always randomly generated to prevent unauthorized access
    * to the public webhook endpoint.
    *
-   * If not provided, a randomly generated token will be assigned.
+   * If provided, the token must be a non-empty string; passing an empty
+   * string throws. If not provided (or `undefined`), a randomly generated
+   * token will be assigned.
    *
    * @example
    *

--- a/packages/core/src/workflow/hook.test.ts
+++ b/packages/core/src/workflow/hook.test.ts
@@ -1172,6 +1172,33 @@ describe('createCreateHook', () => {
       expect(queueItem.isWebhook).toBe(true);
     }
   });
+
+  it('should throw when an empty string token is provided', () => {
+    const ctx = setupWorkflowContext([]);
+    const createHook = createCreateHook(ctx);
+
+    expect(() => createHook({ token: '' })).toThrow(
+      '`createHook()` was called with an empty string token. Pass a non-empty token, or omit the `token` option to use a randomly generated one.'
+    );
+
+    // The rejected hook must not be registered in the invocations queue.
+    expect(ctx.invocationsQueue.size).toBe(0);
+  });
+
+  it('should auto-generate a non-empty token when none is provided', () => {
+    const ctx = setupWorkflowContext([]);
+    const createHook = createCreateHook(ctx);
+    const hook = createHook();
+
+    expect(hook.token).toBeTruthy();
+    expect(hook.token.length).toBeGreaterThan(0);
+
+    const queueItem = ctx.invocationsQueue.values().next().value;
+    expect(queueItem?.type).toBe('hook');
+    if (queueItem?.type === 'hook') {
+      expect(queueItem.token).toBe(hook.token);
+    }
+  });
 });
 
 describe('createWebhook', () => {

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -57,6 +57,18 @@ function createConflictingRun(
 
 export function createCreateHook(ctx: WorkflowOrchestratorContext) {
   return function createHookImpl<T = any>(options: HookOptions = {}): Hook<T> {
+    // Reject an explicit empty-string token. A token must either be omitted
+    // (or `undefined`/`null`) to get a randomly generated one, or be an
+    // explicit non-empty string. An empty string is almost always an
+    // accidental value (e.g. an unset variable) and would otherwise slip
+    // through the `??` below — which only falls back for nullish values — and
+    // be used as a meaningless, non-deterministic token.
+    if (options.token === '') {
+      throw new Error(
+        '`createHook()` was called with an empty string token. Pass a non-empty token, or omit the `token` option to use a randomly generated one.'
+      );
+    }
+
     // Generate hook ID and token
     const correlationId = `hook_${ctx.generateUlid()}`;
     const token = options.token ?? ctx.generateNanoid();


### PR DESCRIPTION
## Summary

`createHook()` builds its token with `options.token ?? ctx.generateNanoid()`. Because `??` only falls back for nullish values, an explicit empty string (`createHook({ token: '' })`) was accepted verbatim and used as the hook's real token — a meaningless, non-deterministic value that defeats the purpose of caller-supplied tokens (deterministic identity, dedup, conflict detection). It's also an easy accidental value (e.g. `token: someVar` where `someVar` is an unset/empty string).

This change makes `createHook()` **fail at validation** when given an empty-string token:

- `token: ''` → throws a clear, actionable `Error`.
- `token` omitted / `undefined` / `null` → unchanged: a random token is generated.
- A non-empty string token → unchanged.

This mirrors the existing input-validation precedent right next door in `createWebhook()`, which throws synchronously when handed a disallowed `token` option.

## Changes

- `packages/core/src/workflow/hook.ts` — throw when `options.token === ''` in `createHookImpl`, before the token is generated/enqueued. The internal abort-controller hook writes to the invocations queue directly and does not go through this path, so internal callers are unaffected.
- `packages/core/src/create-hook.ts` — clarify the `HookOptions.token` JSDoc: must be a non-empty string if provided.
- `packages/core/src/workflow/hook.test.ts` — add tests that an empty-string token throws (and is not enqueued), and that omitting the token still auto-generates a non-empty one.

## Notes / scope

- **Empty string only**, not whitespace-only — matches the "non-empty" requirement literally without surprising callers who use spaces intentionally.
- **Did not** tighten the world-level `HookSchema` zod (`packages/world/src/hooks.ts`) to `.min(1)`. That schema validates persisted/replayed events; any run that already recorded an empty token from this bug would start failing to parse. Guarding at `createHook()` stops new bad tokens without that replay risk.

## Test plan

- `pnpm vitest run src/workflow/hook.test.ts` in `packages/core` — 37 passed (incl. 2 new).
- `pnpm typecheck` in `packages/core` — clean (after building workspace deps).
- Biome: no new findings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)