### PR TITLE
DO NOT MERGE: revalidate windows unit flake (synchronous consume-drain)

### DIFF
--- a/.changeset/drain-consume-loop-synchronously.md
+++ b/.changeset/drain-consume-loop-synchronously.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Drain consecutively consumable replay events in a single synchronous pass instead of one `process.nextTick` per event, removing O(N) macrotask hops from replay.

--- a/packages/core/src/events-consumer.test.ts
+++ b/packages/core/src/events-consumer.test.ts
@@ -207,6 +207,41 @@ describe('EventsConsumer', () => {
       expect(consumer.callbacks).toHaveLength(0);
     });
 
+    it('should drain consecutively consumable events within a single tick', async () => {
+      // Optimization: when the consumers for a run of events are already
+      // registered (the common replay case), the consumer drains them all in
+      // one synchronous pass rather than paying one process.nextTick per
+      // event. A single tick is enough to fully advance the index here.
+      const events = [
+        createMockEvent({ id: 'event-1', sequence_number: 1 }),
+        createMockEvent({ id: 'event-2', sequence_number: 2 }),
+        createMockEvent({ id: 'event-3', sequence_number: 3 }),
+      ];
+      const consumer = new EventsConsumer(events, defaultOptions);
+      // A single long-lived consumer that consumes every real event (mirrors a
+      // step consumer walking step_created -> step_started -> step_completed)
+      // and returns NotConsumed once it reaches the end-of-events sentinel.
+      const callback = vi
+        .fn()
+        .mockImplementation((event: Event | null) =>
+          event === null
+            ? EventConsumerResult.NotConsumed
+            : EventConsumerResult.Consumed
+        );
+
+      consumer.subscribe(callback);
+      await waitForNextTick();
+
+      // Three real events consumed plus one call with the null sentinel, all
+      // within a single tick.
+      expect(callback).toHaveBeenCalledTimes(4);
+      expect(callback).toHaveBeenNthCalledWith(1, events[0]);
+      expect(callback).toHaveBeenNthCalledWith(2, events[1]);
+      expect(callback).toHaveBeenNthCalledWith(3, events[2]);
+      expect(callback).toHaveBeenNthCalledWith(4, null);
+      expect(consumer.eventIndex).toBe(3);
+    });
+
     it('should handle event index beyond events array length', async () => {
       const event = createMockEvent();
       const consumer = new EventsConsumer([event], defaultOptions);

--- a/packages/core/src/events-consumer.ts
+++ b/packages/core/src/events-consumer.ts
@@ -108,7 +108,41 @@ export class EventsConsumer {
   }
 
   private consume = () => {
-    const currentEvent = this.events[this.eventIndex] ?? null;
+    // Drain consecutively consumable events synchronously within a single
+    // pass instead of paying one `process.nextTick` per consumed event.
+    //
+    // Why this is safe: a callback only consumes an event using a consumer
+    // that is ALREADY registered (e.g. a long-lived step consumer walking
+    // `step_created` → `step_started` → `step_completed`, or the structural
+    // lifecycle consumer). New consumers are only ever registered by workflow
+    // VM body code that runs asynchronously off `ctx.promiseQueue` after a
+    // delivery `resolve()`; none of the callbacks here call `subscribe()`
+    // synchronously. So within one pass `this.callbacks` is mutated only by
+    // this loop (the `Finished` splice), and the next event's consumer is
+    // either already present (advance now) or not yet registered — in which
+    // case no callback consumes the event and we fall through to the
+    // cross-VM-safe deferred unconsumed-event check below, exactly as before.
+    while (true) {
+      const currentEvent = this.events[this.eventIndex] ?? null;
+      if (!this.consumeOne(currentEvent)) {
+        // No callback consumed the current event; handle the terminal case.
+        this.handleUnconsumed(currentEvent);
+        return;
+      }
+      // A real event was consumed — advance to the next in the same pass. A
+      // consumed `null` sentinel never returns true (see consumeOne), so the
+      // synchronous drain can't spin past the end of the log.
+    }
+  };
+
+  /**
+   * Offer `currentEvent` to each registered callback in turn. Returns true
+   * when a callback consumed a real (non-null) event and the drain should
+   * advance to the next event in the same synchronous pass; false otherwise
+   * (nothing consumed it, or the consumed event was the end-of-events
+   * sentinel).
+   */
+  private consumeOne(currentEvent: Event | null): boolean {
     for (let i = 0; i < this.callbacks.length; i++) {
       const callback = this.callbacks[i];
       let handled = EventConsumerResult.NotConsumed;
@@ -118,27 +152,30 @@ export class EventsConsumer {
         eventsLogger.error('EventConsumer callback threw an error', { error });
       }
       if (
-        handled === EventConsumerResult.Consumed ||
-        handled === EventConsumerResult.Finished
+        handled !== EventConsumerResult.Consumed &&
+        handled !== EventConsumerResult.Finished
       ) {
-        if (currentEvent !== null) {
-          this.notifyConsumedEvent(currentEvent);
-        }
-        // consumer handled this event, so increase the event index
-        this.eventIndex++;
-
-        // remove the callback if it has finished
-        if (handled === EventConsumerResult.Finished) {
-          this.callbacks.splice(i, 1);
-        }
-
-        // continue to the next event
-        process.nextTick(this.consume);
-        return;
+        continue;
       }
+      if (currentEvent !== null) {
+        this.notifyConsumedEvent(currentEvent);
+      }
+      // consumer handled this event, so increase the event index
+      this.eventIndex++;
+      // remove the callback if it has finished
+      if (handled === EventConsumerResult.Finished) {
+        this.callbacks.splice(i, 1);
+      }
+      // Continue draining only for real events. Real consumers return
+      // NotConsumed for the `null` sentinel, but guard against a pathological
+      // callback consuming it so the drain never spins past end-of-log.
+      return currentEvent !== null;
     }
+    return false;
+  }
 
-    // If we reach here, all callbacks returned NotConsumed.
+  private handleUnconsumed(currentEvent: Event | null) {
+    // All callbacks returned NotConsumed for the current event.
     // If the current event is non-null (a real event, not end-of-events),
     // schedule a deferred check. We chain onto the promiseQueue so that any
     // pending async work (e.g., deserialization/decryption that triggers
@@ -173,5 +210,5 @@ export class EventsConsumer {
           }, DEFERRED_CHECK_DELAY_MS);
         });
     }
-  };
+  }
 }

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -295,6 +295,18 @@ export function registerDeliveryBarrier(
  * if > 0, wait for promiseQueue → repeat. This handles the multi-round
  * delivery pattern where each hook payload delivery cycle appends new
  * async work to the promiseQueue.
+ *
+ * The initial `setTimeout(0)` macrotask is load-bearing and must NOT be
+ * downgraded to a microtask (`queueMicrotask`/`Promise.resolve().then`).
+ * `pendingDeliveries` only guards the host-side hydration window; between a
+ * delivery's `resolve()` and the workflow VM body running its continuation to
+ * register the next subscriber, `pendingDeliveries` is already 0 even though
+ * the VM is mid-reaction. Node does not guarantee a microtask scheduled in
+ * the host context settles after the cross-VM promise chain (resolve in host
+ * → workflow code in VM → subscribe back in host); the macrotask boundary
+ * gives that chain time to run, so the suspension does not preempt a sibling
+ * delivery still in flight. Empirically, replacing it with `queueMicrotask`
+ * breaks hook/sleep `Promise.race` ordering (CorruptedEventLogError).
  */
 export function scheduleWhenIdle(
   ctx: WorkflowOrchestratorContext,


### PR DESCRIPTION
Temporary branch to measure the Windows `Unit Tests (windows-latest)` failure rate of the synchronous consume-drain optimization (recovered from reverted b9c9e1928) vs main baseline. Re-validating whether the revert in #2473 was premature.

Do not merge.