### PR TITLE
Stamp run IDs on world spans

### DIFF
--- a/.changeset/stamp-world-run-id-spans.md
+++ b/.changeset/stamp-world-run-id-spans.md
@@ -1,0 +1,6 @@
+---
+"@workflow/world-local": patch
+"@workflow/world-vercel": patch
+---
+
+Stamp run IDs on world storage telemetry spans.

--- a/.changeset/stamp-world-run-id-spans.md
+++ b/.changeset/stamp-world-run-id-spans.md
@@ -3,4 +3,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Stamp run IDs on world storage telemetry spans.
+Add run IDs on world storage telemetry spans.

--- a/packages/world-local/src/instrumentObject.test.ts
+++ b/packages/world-local/src/instrumentObject.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SpanCallback = (span?: {
+  setAttributes: (attributes: Record<string, unknown>) => void;
+}) => Promise<unknown>;
+
+const mocks = vi.hoisted(() => {
+  const span = { setAttributes: vi.fn() };
+  return {
+    span,
+    trace: vi.fn(async (_spanName: string, _opts: unknown, fn: SpanCallback) =>
+      fn(span)
+    ),
+    getSpanKind: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('./telemetry.js', () => ({
+  trace: mocks.trace,
+  getSpanKind: mocks.getSpanKind,
+  PeerService: (value: string) => ({ 'peer.service': value }),
+  RpcSystem: (value: string) => ({ 'rpc.system': value }),
+  RpcService: (value: string) => ({ 'rpc.service': value }),
+  RpcMethod: (value: string) => ({ 'rpc.method': value }),
+  WorkflowRunId: (value: string) => ({ 'workflow.run.id': value }),
+  StepId: (value: string) => ({ 'step.id': value }),
+}));
+
+import { instrumentObject } from './instrumentObject.js';
+
+describe('instrumentObject', () => {
+  beforeEach(() => {
+    mocks.span.setAttributes.mockClear();
+    mocks.trace.mockClear();
+  });
+
+  it('stamps runs.get spans with workflow.run.id from the run id argument', async () => {
+    const runs = instrumentObject('world.runs', {
+      get: vi.fn(async (runId: string) => ({ runId })),
+    });
+
+    await runs.get('wrun_test');
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({ 'workflow.run.id': 'wrun_test' })
+    );
+  });
+
+  it('stamps steps.get spans with workflow.run.id and step.id', async () => {
+    const steps = instrumentObject('world.steps', {
+      get: vi.fn(async () => ({ ok: true })),
+    });
+
+    await steps.get('wrun_test', 'step_test');
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'workflow.run.id': 'wrun_test',
+        'step.id': 'step_test',
+      })
+    );
+  });
+
+  it('stamps list spans with workflow.run.id from run-scoped params', async () => {
+    const events = instrumentObject('world.events', {
+      list: vi.fn(async () => ({ data: [] })),
+    });
+
+    await events.list({ runId: 'wrun_test' });
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({ 'workflow.run.id': 'wrun_test' })
+    );
+  });
+
+  it('stamps hook lookup spans with workflow.run.id from the result', async () => {
+    const hooks = instrumentObject('world.hooks', {
+      getByToken: vi.fn(async () => ({ runId: 'wrun_test' })),
+    });
+
+    await hooks.getByToken('hook_token');
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith({
+      'workflow.run.id': 'wrun_test',
+    });
+  });
+});

--- a/packages/world-local/src/instrumentObject.ts
+++ b/packages/world-local/src/instrumentObject.ts
@@ -3,12 +3,14 @@
  * This mirrors world-vercel's implementation for consistent observability.
  */
 import {
-  trace,
   getSpanKind,
   PeerService,
-  RpcSystem,
-  RpcService,
   RpcMethod,
+  RpcService,
+  RpcSystem,
+  StepId,
+  trace,
+  WorkflowRunId,
 } from './telemetry.js';
 
 /** Configuration for peer service attribution */
@@ -17,6 +19,20 @@ const WORLD_LOCAL_SERVICE = {
   rpcSystem: 'local',
   rpcService: 'world-local',
 };
+
+const RUN_ID_ARG_INDEX_BY_METHOD: Record<string, number> = {
+  'world.runs.get': 0,
+  'world.runs.experimentalSetAttributes': 0,
+  'world.steps.get': 0,
+  'world.events.create': 0,
+  'world.events.get': 0,
+};
+
+const RUN_ID_PARAM_METHODS = new Set([
+  'world.steps.list',
+  'world.events.list',
+  'world.hooks.list',
+]);
 
 /**
  * Extracts the event type from arguments for events.create calls.
@@ -30,6 +46,68 @@ function extractEventType(args: unknown[]): string | undefined {
     }
   }
   return undefined;
+}
+
+function getStringArg(args: unknown[], index: number): string | undefined {
+  return typeof args[index] === 'string' ? args[index] : undefined;
+}
+
+function getRunIdFromParams(params: unknown): string | undefined {
+  if (typeof params !== 'object' || params === null) {
+    return undefined;
+  }
+  const runId = (params as Record<string, unknown>).runId;
+  return typeof runId === 'string' ? runId : undefined;
+}
+
+function getRunIdFromResult(result: unknown): string | undefined {
+  if (typeof result !== 'object' || result === null) {
+    return undefined;
+  }
+
+  const record = result as Record<string, unknown>;
+  if (typeof record.runId === 'string') {
+    return record.runId;
+  }
+
+  for (const key of ['run', 'step', 'hook', 'wait']) {
+    const entity = record[key];
+    if (typeof entity === 'object' && entity !== null) {
+      const runId = (entity as Record<string, unknown>).runId;
+      if (typeof runId === 'string') {
+        return runId;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function extractWorkflowAttributes(
+  prefix: string,
+  methodName: string,
+  args: unknown[]
+): Record<string, string> {
+  const methodKey = `${prefix}.${methodName}`;
+  const attributes: Record<string, string> = {};
+
+  const runIdArgIndex = RUN_ID_ARG_INDEX_BY_METHOD[methodKey];
+  const runId =
+    runIdArgIndex === undefined
+      ? RUN_ID_PARAM_METHODS.has(methodKey)
+        ? getRunIdFromParams(args[0])
+        : undefined
+      : getStringArg(args, runIdArgIndex);
+  if (runId) {
+    Object.assign(attributes, WorkflowRunId(runId));
+  }
+
+  if (methodKey === 'world.steps.get') {
+    const stepId = getStringArg(args, 1);
+    if (stepId) Object.assign(attributes, StepId(stepId));
+  }
+
+  return attributes;
 }
 
 /**
@@ -68,8 +146,14 @@ export function instrumentObject<T extends object>(prefix: string, o: T): T {
               ...RpcSystem(WORLD_LOCAL_SERVICE.rpcSystem),
               ...RpcService(WORLD_LOCAL_SERVICE.rpcService),
               ...RpcMethod(spanName),
+              ...extractWorkflowAttributes(prefix, methodName, args),
             });
-            return f(...args);
+            const result = await f(...args);
+            const resultRunId = getRunIdFromResult(result);
+            if (resultRunId) {
+              span?.setAttributes(WorkflowRunId(resultRunId));
+            }
+            return result;
           }
         );
       };

--- a/packages/world-local/src/telemetry.ts
+++ b/packages/world-local/src/telemetry.ts
@@ -100,3 +100,9 @@ export const RpcService = SemanticConvention<string>('rpc.service');
 
 /** RPC method name (standard OTEL: rpc.method) */
 export const RpcMethod = SemanticConvention<string>('rpc.method');
+
+/** Unique identifier for a specific workflow run instance */
+export const WorkflowRunId = SemanticConvention<string>('workflow.run.id');
+
+/** Unique identifier for the step instance */
+export const StepId = SemanticConvention<string>('step.id');

--- a/packages/world-vercel/src/instrumentObject.test.ts
+++ b/packages/world-vercel/src/instrumentObject.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SpanCallback = (span?: {
+  setAttributes: (attributes: Record<string, unknown>) => void;
+}) => Promise<unknown>;
+
+const mocks = vi.hoisted(() => {
+  const span = { setAttributes: vi.fn() };
+  return {
+    span,
+    trace: vi.fn(async (_spanName: string, _opts: unknown, fn: SpanCallback) =>
+      fn(span)
+    ),
+    getSpanKind: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('./telemetry.js', () => ({
+  trace: mocks.trace,
+  getSpanKind: mocks.getSpanKind,
+  PeerService: (value: string) => ({ 'peer.service': value }),
+  RpcSystem: (value: string) => ({ 'rpc.system': value }),
+  RpcService: (value: string) => ({ 'rpc.service': value }),
+  RpcMethod: (value: string) => ({ 'rpc.method': value }),
+  WorkflowRunId: (value: string) => ({ 'workflow.run.id': value }),
+  StepId: (value: string) => ({ 'step.id': value }),
+}));
+
+import { instrumentObject } from './instrumentObject.js';
+
+describe('instrumentObject', () => {
+  beforeEach(() => {
+    mocks.span.setAttributes.mockClear();
+    mocks.trace.mockClear();
+  });
+
+  it('stamps runs.get spans with workflow.run.id from the run id argument', async () => {
+    const runs = instrumentObject('world.runs', {
+      get: vi.fn(async (runId: string) => ({ runId })),
+    });
+
+    await runs.get('wrun_test');
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({ 'workflow.run.id': 'wrun_test' })
+    );
+  });
+
+  it('stamps steps.get spans with workflow.run.id and step.id', async () => {
+    const steps = instrumentObject('world.steps', {
+      get: vi.fn(async () => ({ ok: true })),
+    });
+
+    await steps.get('wrun_test', 'step_test');
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'workflow.run.id': 'wrun_test',
+        'step.id': 'step_test',
+      })
+    );
+  });
+
+  it('stamps list spans with workflow.run.id from run-scoped params', async () => {
+    const events = instrumentObject('world.events', {
+      list: vi.fn(async () => ({ data: [] })),
+    });
+
+    await events.list({ runId: 'wrun_test' });
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({ 'workflow.run.id': 'wrun_test' })
+    );
+  });
+
+  it('stamps hook lookup spans with workflow.run.id from the result', async () => {
+    const hooks = instrumentObject('world.hooks', {
+      getByToken: vi.fn(async () => ({ runId: 'wrun_test' })),
+    });
+
+    await hooks.getByToken('hook_token');
+
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith({
+      'workflow.run.id': 'wrun_test',
+    });
+  });
+});

--- a/packages/world-vercel/src/instrumentObject.ts
+++ b/packages/world-vercel/src/instrumentObject.ts
@@ -3,12 +3,14 @@
  * This is a minimal version for world-vercel to avoid circular dependencies with @workflow/core.
  */
 import {
-  trace,
   getSpanKind,
   PeerService,
-  RpcSystem,
-  RpcService,
   RpcMethod,
+  RpcService,
+  RpcSystem,
+  StepId,
+  trace,
+  WorkflowRunId,
 } from './telemetry.js';
 
 /** Configuration for peer service attribution */
@@ -17,6 +19,20 @@ const WORKFLOW_SERVER_SERVICE = {
   rpcSystem: 'http',
   rpcService: 'workflow-server',
 };
+
+const RUN_ID_ARG_INDEX_BY_METHOD: Record<string, number> = {
+  'world.runs.get': 0,
+  'world.runs.experimentalSetAttributes': 0,
+  'world.steps.get': 0,
+  'world.events.create': 0,
+  'world.events.get': 0,
+};
+
+const RUN_ID_PARAM_METHODS = new Set([
+  'world.steps.list',
+  'world.events.list',
+  'world.hooks.list',
+]);
 
 /**
  * Extracts the event type from arguments for events.create calls.
@@ -30,6 +46,68 @@ function extractEventType(args: unknown[]): string | undefined {
     }
   }
   return undefined;
+}
+
+function getStringArg(args: unknown[], index: number): string | undefined {
+  return typeof args[index] === 'string' ? args[index] : undefined;
+}
+
+function getRunIdFromParams(params: unknown): string | undefined {
+  if (typeof params !== 'object' || params === null) {
+    return undefined;
+  }
+  const runId = (params as Record<string, unknown>).runId;
+  return typeof runId === 'string' ? runId : undefined;
+}
+
+function getRunIdFromResult(result: unknown): string | undefined {
+  if (typeof result !== 'object' || result === null) {
+    return undefined;
+  }
+
+  const record = result as Record<string, unknown>;
+  if (typeof record.runId === 'string') {
+    return record.runId;
+  }
+
+  for (const key of ['run', 'step', 'hook', 'wait']) {
+    const entity = record[key];
+    if (typeof entity === 'object' && entity !== null) {
+      const runId = (entity as Record<string, unknown>).runId;
+      if (typeof runId === 'string') {
+        return runId;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function extractWorkflowAttributes(
+  prefix: string,
+  methodName: string,
+  args: unknown[]
+): Record<string, string> {
+  const methodKey = `${prefix}.${methodName}`;
+  const attributes: Record<string, string> = {};
+
+  const runIdArgIndex = RUN_ID_ARG_INDEX_BY_METHOD[methodKey];
+  const runId =
+    runIdArgIndex === undefined
+      ? RUN_ID_PARAM_METHODS.has(methodKey)
+        ? getRunIdFromParams(args[0])
+        : undefined
+      : getStringArg(args, runIdArgIndex);
+  if (runId) {
+    Object.assign(attributes, WorkflowRunId(runId));
+  }
+
+  if (methodKey === 'world.steps.get') {
+    const stepId = getStringArg(args, 1);
+    if (stepId) Object.assign(attributes, StepId(stepId));
+  }
+
+  return attributes;
 }
 
 /**
@@ -68,8 +146,14 @@ export function instrumentObject<T extends object>(prefix: string, o: T): T {
               ...RpcSystem(WORKFLOW_SERVER_SERVICE.rpcSystem),
               ...RpcService(WORKFLOW_SERVER_SERVICE.rpcService),
               ...RpcMethod(spanName),
+              ...extractWorkflowAttributes(prefix, methodName, args),
             });
-            return f(...args);
+            const result = await f(...args);
+            const resultRunId = getRunIdFromResult(result);
+            if (resultRunId) {
+              span?.setAttributes(WorkflowRunId(resultRunId));
+            }
+            return result;
           }
         );
       };

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -156,3 +156,9 @@ export const RpcService = SemanticConvention<string>('rpc.service');
 
 /** RPC method name (standard OTEL: rpc.method) */
 export const RpcMethod = SemanticConvention<string>('rpc.method');
+
+/** Unique identifier for a specific workflow run instance */
+export const WorkflowRunId = SemanticConvention<string>('workflow.run.id');
+
+/** Unique identifier for the step instance */
+export const StepId = SemanticConvention<string>('step.id');


### PR DESCRIPTION
## Summary
- stamp `workflow.run.id` on run-scoped world storage spans in `world-local` and `world-vercel`
- stamp `step.id` on `world.steps.get` spans
- add focused instrumentation tests and a changeset

## Validation
- `pnpm exec biome check packages/world-local/src/instrumentObject.ts packages/world-local/src/telemetry.ts packages/world-local/src/instrumentObject.test.ts packages/world-vercel/src/instrumentObject.ts packages/world-vercel/src/telemetry.ts packages/world-vercel/src/instrumentObject.test.ts`
- `pnpm --filter @workflow/world-local exec vitest run src/instrumentObject.test.ts`
- `pnpm --filter @workflow/world-vercel exec vitest run src/instrumentObject.test.ts`
- `pnpm --filter @workflow/world-vercel test`

## Notes
- `pnpm --filter @workflow/world-local test` currently fails on the existing `attr_set` storage test: `Storage > concurrent entity-creation races > should reject duplicate correlated workflow attr_set events`.
- Package typecheck is blocked by existing `attr_set` / package export drift on `origin/main`.
