### PR TITLE
Emit workflowName on per-step events to drop a backend run lookup

### DIFF
--- a/.changeset/outcome-event-workflowname.md
+++ b/.changeset/outcome-event-workflowname.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world': patch
+'@workflow/core': patch
+---
+
+Emit `workflowName` on per-step events (`step_created`, `step_completed`, and lazy-start `step_started`) so the Vercel backend can build payload ref keys without an extra run lookup on each step, reducing inter-step latency.

--- a/.changeset/outcome-event-workflowname.md
+++ b/.changeset/outcome-event-workflowname.md
@@ -3,4 +3,4 @@
 '@workflow/core': patch
 ---
 
-Emit `workflowName` on per-step events (`step_created`, `step_completed`, and lazy-start `step_started`) so the Vercel backend can build payload ref keys without an extra run lookup on each step, reducing inter-step latency.
+Emit `workflowName` on per-step events (`step_created`, `step_completed`, and lazy-start `step_started`) so Worlds can access it without additional queries

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -204,7 +204,9 @@ export async function executeStep(
             eventType: 'step_started',
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: stepId,
-            eventData: { stepName, input: params.lazyStepInput },
+            // workflowName lets the backend key the lazy-start input ref
+            // without re-reading the run.
+            eventData: { stepName, workflowName, input: params.lazyStepInput },
           });
         } catch (startErr) {
           if (EntityConflictError.is(startErr)) {
@@ -546,6 +548,9 @@ export async function executeStep(
             correlationId: stepId,
             eventData: {
               stepName,
+              // Lets the backend build the payload ref key without re-reading
+              // the run on this per-step write (it's keyed by workflow name).
+              workflowName,
               result: result as Uint8Array,
             },
           },

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -267,7 +267,7 @@ export async function executeStep(
         correlationId: stepId,
         eventData:
           params.lazyStepInput !== undefined
-            ? { stepName, input: params.lazyStepInput }
+            ? { stepName, workflowName, input: params.lazyStepInput }
             : { stepName },
       });
 

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -204,8 +204,6 @@ export async function executeStep(
             eventType: 'step_started',
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: stepId,
-            // workflowName lets the backend key the lazy-start input ref
-            // without re-reading the run.
             eventData: { stepName, workflowName, input: params.lazyStepInput },
           });
         } catch (startErr) {
@@ -548,8 +546,6 @@ export async function executeStep(
             correlationId: stepId,
             eventData: {
               stepName,
-              // Lets the backend build the payload ref key without re-reading
-              // the run on this per-step write (it's keyed by workflow name).
               workflowName,
               result: result as Uint8Array,
             },

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -442,6 +442,9 @@ export async function handleSuspension({
             correlationId: queueItem.correlationId,
             eventData: {
               stepName: queueItem.stepName,
+              // Lets the backend build the payload ref key without re-reading
+              // the run on this per-step write (it's keyed by workflow name).
+              workflowName: run.workflowName,
               input: dehydratedInput as SerializedData,
             },
           };

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -442,8 +442,6 @@ export async function handleSuspension({
             correlationId: queueItem.correlationId,
             eventData: {
               stepName: queueItem.stepName,
-              // Lets the backend build the payload ref key without re-reading
-              // the run on this per-step write (it's keyed by workflow name).
               workflowName: run.workflowName,
               input: dehydratedInput as SerializedData,
             },

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -194,6 +194,23 @@ describe('splitEventDataForV4 attribute fields', () => {
     } as AnyEventRequest);
     expect(created.meta.workflowName).toBe('wf');
     expect(created.payload).toBeInstanceOf(Uint8Array);
+
+    // The lazy inline start is the motivating hot-path event: it writes the
+    // step `input` payload ref on the sequential path, so it must carry
+    // workflowName to spare the backend the per-step run lookup.
+    const started = splitEventDataForV4({
+      eventType: 'step_started',
+      correlationId: 'step_3',
+      specVersion: 4,
+      eventData: {
+        stepName: 's',
+        workflowName: 'wf',
+        input: new TextEncoder().encode('[]'),
+      },
+    } as AnyEventRequest);
+    expect(started.meta.workflowName).toBe('wf');
+    expect(started.payload).toBeInstanceOf(Uint8Array);
+    expect(started.meta.input).toBeUndefined();
   });
 });
 

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -163,6 +163,38 @@ describe('splitEventDataForV4 attribute fields', () => {
 
     expect(meta.attributes).toEqual({ sourceAtStart: 'api' });
   });
+
+  it('lifts workflowName into the frame meta on outcome events (step_completed/step_created), keeping the payload in the body', () => {
+    // The backend keys payload refs by workflow name; carrying it in the
+    // frame meta lets the v4 POST handler skip the per-step run lookup.
+    const completed = splitEventDataForV4({
+      eventType: 'step_completed',
+      correlationId: 'step_1',
+      specVersion: 4,
+      eventData: {
+        stepName: 's',
+        workflowName: 'wf',
+        result: new TextEncoder().encode('"ok"'),
+      },
+    } as AnyEventRequest);
+    expect(completed.meta.workflowName).toBe('wf');
+    // The result still travels as the opaque body, not in meta.
+    expect(completed.payload).toBeInstanceOf(Uint8Array);
+    expect(completed.meta.result).toBeUndefined();
+
+    const created = splitEventDataForV4({
+      eventType: 'step_created',
+      correlationId: 'step_2',
+      specVersion: 4,
+      eventData: {
+        stepName: 's',
+        workflowName: 'wf',
+        input: new TextEncoder().encode('[]'),
+      },
+    } as AnyEventRequest);
+    expect(created.meta.workflowName).toBe('wf');
+    expect(created.payload).toBeInstanceOf(Uint8Array);
+  });
 });
 
 describe('createWorkflowRunEvent response coercion', () => {

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -100,6 +100,10 @@ const StepCompletedEventSchema = BaseEventSchema.extend({
   correlationId: z.string(),
   eventData: z.object({
     stepName: z.string().optional(),
+    // Carried so a backend that keys payload refs by workflow name can build
+    // the key without an extra run lookup on this hot per-step write.
+    // Optional: older runtimes omit it and the backend falls back to a read.
+    workflowName: z.string().optional(),
     result: SerializedDataSchema,
   }),
 });
@@ -152,6 +156,9 @@ const StepStartedEventSchema = BaseEventSchema.extend({
     .object({
       stepName: z.string().optional(),
       attempt: z.number().optional(),
+      // Carried on the lazy-start path (where `input` is present) so the
+      // backend can build the payload ref key without re-reading the run.
+      workflowName: z.string().optional(),
       // Lazy-start: the dehydrated step input, present only when this
       // step_started is also responsible for creating the step.
       input: SerializedDataSchema.optional(),
@@ -168,6 +175,7 @@ const StepCreatedEventSchema = BaseEventSchema.extend({
   correlationId: z.string(),
   eventData: z.object({
     stepName: z.string(),
+    workflowName: z.string().optional(),
     input: SerializedDataSchema,
   }),
 });


### PR DESCRIPTION
Investigating a ~50ms-per-step inter-step latency regression (SDK 5.0.0-beta.15 → beta.19), I traced it (endpoint metrics + APM traces) to the v4 **event-write** path. The v4 payload ref key embeds the workflow name, so on per-step events that don't carry `workflowName` in their frame meta — `step_completed`, `step_created`, and the lazy-start `step_started` — the backend falls back to a per-event run lookup to resolve it. That's roughly two extra reads per step boundary on the hot sequential-step path.

## Change

Carry `workflowName` in those events' `eventData`:
- `@workflow/world`: add optional `workflowName` to the `step_completed` / `step_created` / `step_started` event schemas (additive, optional).
- `@workflow/core`: populate it at the emit sites (`step-executor` for `step_completed` and lazy `step_started`; `suspension-handler` for `step_created`) — the runtime already knows the workflow name.
- `world-vercel`: no change needed — its existing `splitEventDataForV4` already lifts `eventData.workflowName` into the v4 frame meta, and the wire-contract exhaustiveness guard is satisfied (`workflowName` was already a meta field).

The backend can then build the ref key directly, skipping the run lookup. Fully backward-compatible: the field is optional (older runtimes unaffected), and older backends ignore it. Pairs with the backend change that also de-duplicates the read when it does occur, so older clients benefit too.