### PR TITLE
Preload workflow step bundle lazily

### DIFF
--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -73,6 +73,10 @@ export function createDevTests(config?: DevTestConfig) {
       path.dirname(generatedWorkflow),
       '__workflow_code.txt'
     );
+    const deferredStepBundlePath = path.join(
+      path.dirname(generatedWorkflow),
+      '__workflow_steps.js'
+    );
     const workflowManifestPath = path.join(
       appPath,
       'app/.well-known/workflow/v1/manifest.json'
@@ -636,12 +640,17 @@ ${apiFileContent}`
             // Package step sources are imported directly (not copied). Verify
             // the generated route imports the @workflow/ai package or
             // otherwise references `durable-agent` via its resolved path.
-            const generatedRouteContent =
-              (await readFileIfExists(generatedStep)) ??
-              (await readFileIfExists(generatedWorkflow));
-            if (!generatedRouteContent) {
+            const generatedRouteOutputs = [
+              await readFileIfExists(generatedStep),
+              await readFileIfExists(generatedWorkflow),
+              usesDeferredBuilder
+                ? await readFileIfExists(deferredStepBundlePath)
+                : null,
+            ].filter((output): output is string => output !== null);
+            if (generatedRouteOutputs.length === 0) {
               throw new Error('generated workflow outputs were not found');
             }
+            const generatedRouteContent = generatedRouteOutputs.join('\n');
             expect(
               generatedRouteContent.includes('@workflow/ai') ||
                 generatedRouteContent.includes('durable-agent')

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -49,6 +49,7 @@ async function runWorkflowHandlerWithEvents(
     createdEvents?: unknown[];
     queuedMessages?: unknown[];
     replayDivergence?: { eventId: string; count: number };
+    entrypointOptions?: Parameters<typeof workflowEntrypoint>[1];
   } = {}
 ) {
   const createdEvents = options.createdEvents ?? [];
@@ -115,7 +116,7 @@ async function runWorkflowHandlerWithEvents(
     getEncryptionKeyForRun: vi.fn(async () => undefined),
   } as any);
 
-  const handler = workflowEntrypoint(workflowCode);
+  const handler = workflowEntrypoint(workflowCode, options.entrypointOptions);
   await handler(new Request('https://example.test'));
 
   return createdEvents;
@@ -426,6 +427,43 @@ describe('workflowEntrypoint replay guards', () => {
       events
     );
 
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({ eventType: 'run_completed' })
+    );
+  });
+
+  it('does not fail a no-step replay when speculative step bundle preload rejects', async () => {
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_preload_no_step',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_preload_no_step',
+        undefined,
+        []
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const preloadStepBundle = vi.fn(async () => {
+      throw new Error('step bundle failed to load');
+    });
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      `async function workflow() {
+        return 'done';
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      [],
+      {
+        entrypointOptions: { preloadStepBundle },
+      }
+    );
+
+    expect(preloadStepBundle).toHaveBeenCalledTimes(1);
     expect(createdEvents).toContainEqual(
       expect.objectContaining({ eventType: 'run_completed' })
     );
@@ -950,6 +988,7 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
       queueName: string,
       message: any
     ) => Promise<{ messageId: null }>;
+    preloadStepBundle?: (order: string[]) => Promise<void> | void;
   }) {
     const workflowRun = await makeRunningRun(opts.runId);
     const order: string[] = [];
@@ -990,6 +1029,7 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
         return { event: recordEvent(data) };
       }
       if (data.eventType === 'step_started') {
+        order.push('step_started');
         // The inline step's lazy step_started creates the step on the fly:
         // record a synthetic step_created so replay observes it, then the
         // step_started, and return a running step so executeStep can run the
@@ -1077,7 +1117,11 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
       getEncryptionKeyForRun: vi.fn(async () => undefined),
     } as any);
 
-    const handler = workflowEntrypoint(stepWithSleepWorkflow);
+    const handler = workflowEntrypoint(stepWithSleepWorkflow, {
+      preloadStepBundle: opts.preloadStepBundle
+        ? () => opts.preloadStepBundle?.(order)
+        : undefined,
+    });
     // Push the ack sentinel the moment the handler resolves — i.e. right
     // before @vercel/queue would delete (ack) the orchestrator message.
     const handlerPromise = handler(new Request('https://example.test')).then(
@@ -1157,6 +1201,46 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
     await handlerPromise;
     expect(order.indexOf('queue_dispatch_done')).toBeLessThan(
       order.indexOf('ack')
+    );
+  });
+
+  it('preloads the step bundle in parallel and waits before inline step execution', async () => {
+    let releasePreload!: () => void;
+    const preloadGate = new Promise<void>((resolve) => {
+      releasePreload = resolve;
+    });
+
+    const { handlerPromise, order } = await driveHandler({
+      runId: 'wrun_preload_before_inline_step',
+      queueImpl: async () => ({ messageId: null }),
+      preloadStepBundle: async (order) => {
+        order.push('preload_start');
+        await preloadGate;
+        order.push('preload_done');
+      },
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(order).toContain('preload_start');
+      },
+      { timeout: 15_000 }
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).not.toContain('step_started');
+
+    releasePreload();
+    const res = (await handlerPromise) as Response;
+    expect(res.status).toBe(204);
+
+    expect(order).toContain('preload_done');
+    expect(order).toContain('step_started');
+    expect(order.indexOf('preload_start')).toBeLessThan(
+      order.indexOf('preload_done')
+    );
+    expect(order.indexOf('preload_done')).toBeLessThan(
+      order.indexOf('step_started')
     );
   });
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -282,7 +282,10 @@ function hasOpenHookOrWait(events: Event[]): boolean {
  */
 export function workflowEntrypoint(
   workflowCode: string,
-  options?: { namespace?: string }
+  options?: {
+    namespace?: string;
+    preloadStepBundle?: () => Promise<void> | void;
+  }
 ): (req: Request) => Promise<Response> {
   const NO_INLINE_REPLAY_AFTER_MS =
     Number(process.env.WORKFLOW_V2_TIMEOUT_MS) || 120_000;
@@ -327,6 +330,22 @@ export function workflowEntrypoint(
           : undefined;
         const { requestId } = metadata;
         const workflowName = metadata.queueName.slice(workflowPrefix.length);
+        let stepBundlePreload: Promise<void> | undefined;
+        const startStepBundlePreload = () => {
+          if (!options?.preloadStepBundle) {
+            return Promise.resolve();
+          }
+
+          stepBundlePreload ??= Promise.resolve()
+            .then(() => options.preloadStepBundle?.())
+            .then(() => undefined);
+          // The preload is speculative. Surface failures only if this request
+          // actually reaches a step execution path and awaits the promise.
+          stepBundlePreload.catch(() => {});
+          return stepBundlePreload;
+        };
+        const ensureStepBundleLoaded = () =>
+          stepBundlePreload ?? startStepBundlePreload();
 
         // --- Max delivery check ---
         // Enforce max delivery limit before any infrastructure calls.
@@ -390,6 +409,10 @@ export function workflowEntrypoint(
             );
           }
           return;
+        }
+
+        if (incomingStepId && incomingStepName) {
+          startStepBundlePreload();
         }
 
         // --- Trace correlation mode ---
@@ -527,6 +550,7 @@ export function workflowEntrypoint(
                       replayBudget.pause();
                       let stepResult: Awaited<ReturnType<typeof executeStep>>;
                       try {
+                        await ensureStepBundleLoaded();
                         stepResult = await executeStep({
                           world,
                           workflowRunId: runId,
@@ -704,6 +728,7 @@ export function workflowEntrypoint(
                           `Workflow run "${runId}" has no "startedAt" timestamp`
                         );
                       }
+                      startStepBundlePreload();
                     } catch (err) {
                       // Run was concurrently completed/failed/cancelled
                       if (
@@ -1423,6 +1448,7 @@ export function workflowEntrypoint(
                         replayBudget.pause();
                         let stepResult: Awaited<ReturnType<typeof executeStep>>;
                         try {
+                          await ensureStepBundleLoaded();
                           stepResult = await executeStep({
                             world,
                             workflowRunId: runId,

--- a/packages/next/src/builder-deferred.test.ts
+++ b/packages/next/src/builder-deferred.test.ts
@@ -80,16 +80,25 @@ describe('NextDeferredBuilder', () => {
     });
 
     const routeCode = await readFile(flowOutfile, 'utf8');
+    const stepBundleCode = await readFile(
+      join(routeDir, '__workflow_steps.js'),
+      'utf8'
+    );
     const expectedStepImport = relative(routeDir, workflowFile).replace(
       /\\/g,
       '/'
     );
-    expect(routeCode).toContain("import 'workflow/internal/builtins';");
-    expect(routeCode).toContain(`import "${expectedStepImport}";`);
+    expect(routeCode).not.toContain("import 'workflow/internal/builtins';");
+    expect(routeCode).not.toContain(`import "${expectedStepImport}";`);
     expect(routeCode).toContain(
       "import { workflowEntrypoint } from 'workflow/runtime';"
     );
-    expect(routeCode).not.toContain('__step_registrations');
+    expect(routeCode).toContain('function preloadStepBundle()');
+    expect(routeCode).toContain('import("./__workflow_steps.js")');
+    expect(routeCode).toContain('preloadStepBundle,');
+    expect(stepBundleCode).toContain("import 'workflow/internal/builtins';");
+    expect(stepBundleCode).toContain(`import "${expectedStepImport}";`);
+    expect(stepBundleCode).toContain('export const __steps_registered = true;');
   });
 
   it('loads workflow code from disk for dev deferred flow routes', async () => {
@@ -135,10 +144,15 @@ describe('NextDeferredBuilder', () => {
     });
 
     const routeCode = await readFile(flowOutfile, 'utf8');
+    await expect(
+      readFile(join(routeDir, '__workflow_steps.js'), 'utf8')
+    ).resolves.toContain("import 'workflow/internal/builtins';");
     expect(routeCode).toContain(
       "import { readFile, stat } from 'node:fs/promises';"
     );
     expect(routeCode).toContain('async function getWorkflowHandler()');
+    expect(routeCode).toContain('function preloadStepBundle()');
+    expect(routeCode).toContain('import("./__workflow_steps.js")');
     expect(routeCode).toContain('export async function POST(req)');
     expect(routeCode).not.toContain('const workflowCode = `');
     await expect(

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -33,6 +33,7 @@ import {
 const ROUTE_STUB_FILE_MARKER = 'WORKFLOW_ROUTE_STUB_FILE';
 const ROUTE_STUB_MARKER_SCAN_BYTES = 4 * 1024;
 const DEV_WORKFLOW_CODE_FILENAME = '__workflow_code.txt';
+const DEFERRED_STEP_BUNDLE_FILENAME = '__workflow_steps.js';
 
 let CachedNextBuilderDeferred: any;
 
@@ -647,11 +648,28 @@ export async function getNextBuilderDeferred() {
         stepAndSerdeFiles,
         dirname(flowOutfile)
       );
+      const stepBundlePath = join(
+        dirname(flowOutfile),
+        DEFERRED_STEP_BUNDLE_FILENAME
+      );
+      await this.writeFileIfChanged(
+        stepBundlePath,
+        `// biome-ignore-all lint: generated file
+/* eslint-disable */
+import 'workflow/internal/builtins';
+${stepImports}
+
+export const __steps_registered = true;`
+      );
       const stepManifest =
         await this.createDeferredStepManifest(stepAndSerdeFiles);
       const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
       const workflowEntrypointOptionsCode =
         createWorkflowEntrypointOptionsCode();
+      const workflowEntrypointOptionsObjectCode = workflowEntrypointOptionsCode
+        ? workflowEntrypointOptionsCode.replace(/^,\s*/, '')
+        : '{}';
+      const stepBundleImportPath = `./${DEFERRED_STEP_BUNDLE_FILENAME}`;
       let routeCode: string;
 
       if (this.config.watch) {
@@ -662,21 +680,28 @@ export async function getNextBuilderDeferred() {
         await this.writeFileIfChanged(workflowCodePath, workflowVMCode);
         routeCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
-import 'workflow/internal/builtins';
-${stepImports}
 import { readFile, stat } from 'node:fs/promises';
 import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCodePath = ${JSON.stringify(workflowCodePath)};
 let cachedWorkflowHandler;
 let cachedWorkflowCodeSignature;
+let stepBundlePromise;
+
+function preloadStepBundle() {
+  stepBundlePromise ??= import(${JSON.stringify(stepBundleImportPath)}).then(() => undefined);
+  return stepBundlePromise;
+}
 
 async function getWorkflowHandler() {
   const workflowCodeStats = await stat(workflowCodePath);
   const workflowCodeSignature = \`\${workflowCodeStats.size}:\${workflowCodeStats.mtimeMs}\`;
   if (!cachedWorkflowHandler || cachedWorkflowCodeSignature !== workflowCodeSignature) {
     const workflowCode = await readFile(workflowCodePath, 'utf8');
-    cachedWorkflowHandler = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});
+    cachedWorkflowHandler = workflowEntrypoint(workflowCode, {
+      ...${workflowEntrypointOptionsObjectCode},
+      preloadStepBundle,
+    });
     cachedWorkflowCodeSignature = workflowCodeSignature;
   }
   return cachedWorkflowHandler;
@@ -688,13 +713,20 @@ export async function POST(req) {
       } else {
         routeCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
-import 'workflow/internal/builtins';
-${stepImports}
 import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${escapedVMCode}\`;
+let stepBundlePromise;
 
-export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
+function preloadStepBundle() {
+  stepBundlePromise ??= import(${JSON.stringify(stepBundleImportPath)}).then(() => undefined);
+  return stepBundlePromise;
+}
+
+export const POST = workflowEntrypoint(workflowCode, {
+  ...${workflowEntrypointOptionsObjectCode},
+  preloadStepBundle,
+});`;
       }
 
       await this.writeFileIfChanged(flowOutfile, routeCode);


### PR DESCRIPTION
## Summary
- Split deferred Next workflow flow routes so step registrations live in a sibling `__workflow_steps.js` module instead of top-level flow route imports.
- Add a `preloadStepBundle` runtime hook that starts step bundle loading after `run_started` or immediately for background step deliveries, then awaits it only before step execution.
- Cover no-step replay preload failures and inline-step preload ordering in runtime tests, plus generated route shape in deferred builder tests.

## Testing
- `pnpm vitest run packages/core/src/runtime.test.ts`
- `pnpm vitest run packages/next/src/builder-deferred.test.ts`
- `git diff --check`

## Notes
- Attempted `pnpm --filter @workflow/core typecheck` and `pnpm --filter @workflow/next build`; both currently fail on existing unrelated TypeScript issues in `step-executor.ts` and older `builder-deferred.ts` call sites.