### PR TITLE
Show pending runs as gray animated stripes in trace viewer

### DIFF
--- a/.changeset/pending-trace-viewer-gray-indicator.md
+++ b/.changeset/pending-trace-viewer-gray-indicator.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Show pending runs with gray animated stripes instead of the blue running indicator in the new trace viewer.

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.module.css
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.module.css
@@ -1,9 +1,15 @@
-.runningStripes {
+.runningStripes,
+.pendingStripes {
   position: absolute;
   inset: 0;
   pointer-events: none;
   border-radius: 0.25rem;
   opacity: 0.5;
+  background-size: 11.314px 11.314px;
+  animation: running-stripes 0.6s linear infinite;
+}
+
+.runningStripes {
   background-image: repeating-linear-gradient(
     45deg,
     var(--ds-blue-500) 0,
@@ -11,8 +17,16 @@
     transparent 1.5px,
     transparent 8px
   );
-  background-size: 11.314px 11.314px;
-  animation: running-stripes 0.6s linear infinite;
+}
+
+.pendingStripes {
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--ds-gray-500) 0,
+    var(--ds-gray-500) 1.5px,
+    transparent 1.5px,
+    transparent 8px
+  );
 }
 
 @keyframes running-stripes {
@@ -25,7 +39,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .runningStripes {
+  .runningStripes,
+  .pendingStripes {
     animation: none;
   }
 }

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -52,6 +52,7 @@ export const TIMELINE_PADDING_PX = 16;
 
 const SEGMENT_CLASSES: Record<SegmentStatus, string> = {
   queued: 'bg-gray-400 border border-gray-500',
+  pending: 'bg-gray-200 border border-gray-500',
   retrying: 'bg-gray-400 border border-gray-500',
   waiting: 'bg-gray-200 border border-gray-500',
   running: 'bg-blue-200 border border-blue-500',
@@ -67,13 +68,21 @@ const TIMELINE_INSET_STYLE: CSSProperties = {
   right: TIMELINE_PADDING_PX,
 };
 
-const ACTIVE_SEGMENT_STATUSES: ReadonlySet<SegmentStatus> = new Set([
+const STRIPED_SEGMENT_STATUSES: ReadonlySet<SegmentStatus> = new Set([
+  'pending',
   'running',
   'received',
 ]);
 
-function RunningStripes(): ReactNode {
-  return <div aria-hidden className={styles.runningStripes} />;
+function AnimatedStripes({ status }: { status: SegmentStatus }): ReactNode {
+  return (
+    <div
+      aria-hidden
+      className={
+        status === 'pending' ? styles.pendingStripes : styles.runningStripes
+      }
+    />
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -348,8 +357,8 @@ function SegmentBar({
               minWidth: 1,
             }}
           >
-            {ACTIVE_SEGMENT_STATUSES.has(seg.status) ? (
-              <RunningStripes />
+            {STRIPED_SEGMENT_STATUSES.has(seg.status) ? (
+              <AnimatedStripes status={seg.status} />
             ) : null}
             {showLabel ? <DurationLabel label={label} /> : null}
           </div>

--- a/packages/web-shared/src/components/new-trace-viewer/utils.test.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.test.ts
@@ -58,6 +58,38 @@ function hookSpan(opts: {
   };
 }
 
+describe('computeSpanSegments (run)', () => {
+  function runSpan(status: string): Span {
+    return {
+      name: 'run',
+      kind: 0,
+      resource: 'run',
+      library: { name: 'workflow' },
+      spanId: 'run-1',
+      status: { code: 1 },
+      traceFlags: 0,
+      attributes: { data: { status } },
+      links: [],
+      events: [{ name: 'run_created', timestamp: ts(0), attributes: {} }],
+      startTime: ts(0),
+      endTime: ts(100_000),
+      duration: ts(100_000),
+    };
+  }
+
+  it('maps pending runs to a pending segment (not running)', () => {
+    expect(computeSpanSegments(runSpan('pending'))).toEqual([
+      { startFraction: 0, endFraction: 1, status: 'pending' },
+    ]);
+  });
+
+  it('maps running runs to a running segment', () => {
+    expect(computeSpanSegments(runSpan('running'))).toEqual([
+      { startFraction: 0, endFraction: 1, status: 'running' },
+    ]);
+  });
+});
+
 describe('computeSpanSegments (hook)', () => {
   it('renders a single waiting segment for a hook resumed many times but not disposed', () => {
     const span = hookSpan({

--- a/packages/web-shared/src/components/new-trace-viewer/utils.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.ts
@@ -184,6 +184,7 @@ export function getResourceColor(resource: string): {
 
 export type SegmentStatus =
   | 'queued'
+  | 'pending'
   | 'running'
   | 'completed'
   | 'failed'
@@ -349,7 +350,8 @@ function computeSleepSegmentsFromSpan(
 
 function runSegmentStatus(runStatus: string | undefined): SegmentStatus {
   if (runStatus === 'failed') return 'failed';
-  if (runStatus === 'running' || runStatus === 'pending') return 'running';
+  if (runStatus === 'pending') return 'pending';
+  if (runStatus === 'running') return 'running';
   return 'completed';
 }
 


### PR DESCRIPTION
## Summary
- Add a distinct `pending` segment status for workflow runs in the new trace viewer
- Render pending segments with gray styling and the same animated stripe overlay used for running segments
- Keep running/received segments blue with blue stripes

## Test plan
- [x] `pnpm vitest run packages/web-shared/src/components/new-trace-viewer/utils.test.ts`
- [ ] Start local observability UI against a workbench with `WORKFLOW_LOCAL_QUEUE_CONCURRENCY=1`
- [ ] Trigger a long-running workflow, then a second workflow, and confirm the pending run shows gray stripes (not blue)


Made with [Cursor](https://cursor.com)