### PR TITLE
perf(core): build-time V8 code cache for workflow bundles

### DIFF
--- a/.changeset/workflow-vm-compile-cache.md
+++ b/.changeset/workflow-vm-compile-cache.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/builders': patch
+'@workflow/next': patch
+---
+
+Ship a build-time V8 code cache alongside large workflow bundles so a cold serverless instance skips parsing the bundle on its first replay, cutting time-to-first-step.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -14,7 +14,10 @@ import {
   applySwcTransform,
   type WorkflowManifest,
 } from './apply-swc-transform.js';
-import { createWorkflowEntrypointOptionsCode } from './constants.js';
+import {
+  createWorkflowEntrypointArgs,
+  createWorkflowEntrypointOptionsCode,
+} from './constants.js';
 import { createDiscoverEntriesPlugin } from './discover-entries-esbuild-plugin.js';
 import { getEsbuildTsconfigOptions } from './esbuild-tsconfig.js';
 import {
@@ -1182,19 +1185,18 @@ export abstract class BaseBuilder {
         }
       }
 
-      const workflowEntrypointOptionsCode =
-        createWorkflowEntrypointOptionsCode();
-
       const bundleFinal = async (interimBundle: string) => {
         const workflowBundleCode = interimBundle;
+        const { cachedDataDecl, secondArg } =
+          createWorkflowEntrypointArgs(workflowBundleCode);
 
         const workflowFunctionCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${workflowBundleCode.replace(/[\\`$]/g, '\\$&')}\`;
-
-export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
+${cachedDataDecl}
+export const POST = workflowEntrypoint(workflowCode${secondArg});`;
 
         // we skip the final bundling step for Next.js so it can bundle itself
         if (!bundleFinalOutput) {
@@ -1373,7 +1375,8 @@ export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCo
     // 3. Generate combined route file
     const stepsRelativePath = './' + basename(stepsOutfile).replace(/\\/g, '/');
     const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
-    const workflowEntrypointOptionsCode = createWorkflowEntrypointOptionsCode();
+    const { cachedDataDecl, secondArg } =
+      createWorkflowEntrypointArgs(workflowVMCode);
 
     const combinedFunctionCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
@@ -1384,8 +1387,8 @@ import { workflowEntrypoint } from 'workflow/runtime';
 void __steps_registered;
 
 const workflowCode = \`${escapedVMCode}\`;
-
-export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
+${cachedDataDecl}
+export const POST = workflowEntrypoint(workflowCode${secondArg});`;
 
     if (!bundleFinalOutput) {
       // Write directly (Next.js will bundle)

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -1,8 +1,21 @@
+import { Script } from 'node:vm';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  createWorkflowEntrypointArgs,
   createWorkflowEntrypointOptionsCode,
   createWorkflowQueueTrigger,
 } from './constants.js';
+
+// A bundle comfortably over the 256KB code-cache threshold.
+function largeBundle(): string {
+  const lines: string[] = ['globalThis.__private_workflows = new Map();'];
+  for (let i = 0; i < 8000; i++) {
+    lines.push(
+      `globalThis.__private_workflows.set('app/wf-${i}', async function wf${i}(a){ return a*${i}+${i}; });`
+    );
+  }
+  return lines.join('\n');
+}
 
 describe('createWorkflowQueueTrigger', () => {
   afterEach(() => {
@@ -47,5 +60,56 @@ describe('createWorkflowEntrypointOptionsCode', () => {
     expect(createWorkflowEntrypointOptionsCode()).toBe(
       ', { namespace: "custom" }'
     );
+  });
+});
+
+describe('createWorkflowEntrypointArgs', () => {
+  afterEach(() => {
+    delete process.env.WORKFLOW_QUEUE_NAMESPACE;
+    delete process.env.WORKFLOW_DISABLE_BUNDLE_CODE_CACHE;
+  });
+
+  it('omits the code cache for small bundles', () => {
+    const { cachedDataDecl, secondArg } = createWorkflowEntrypointArgs(
+      'const workflowCode = 1;'
+    );
+    expect(cachedDataDecl).toBe('');
+    expect(secondArg).toBe('');
+  });
+
+  it('emits a usable code cache for large bundles', () => {
+    const bundle = largeBundle();
+    const { cachedDataDecl, secondArg } = createWorkflowEntrypointArgs(bundle);
+
+    expect(cachedDataDecl).toMatch(
+      /^const __workflowCodeCachedData = ".+";\n$/
+    );
+    expect(secondArg).toBe(', { cachedData: __workflowCodeCachedData }');
+
+    // The emitted base64 must be a V8 code cache that the runtime accepts for
+    // the same source — proving the producer/consumer contract round-trips.
+    const match = cachedDataDecl.match(/"([^"]+)"/);
+    expect(match).not.toBeNull();
+    const cachedData = Buffer.from(match?.[1] ?? '', 'base64');
+    const script = new Script(bundle, { filename: 'rt.js', cachedData });
+    expect(script.cachedDataRejected).toBe(false);
+  });
+
+  it('combines namespace and code cache', () => {
+    const { secondArg } = createWorkflowEntrypointArgs(largeBundle(), {
+      namespace: 'custom',
+    });
+    expect(secondArg).toBe(
+      ', { namespace: "custom", cachedData: __workflowCodeCachedData }'
+    );
+  });
+
+  it('respects WORKFLOW_DISABLE_BUNDLE_CODE_CACHE', () => {
+    process.env.WORKFLOW_DISABLE_BUNDLE_CODE_CACHE = '1';
+    const { cachedDataDecl, secondArg } = createWorkflowEntrypointArgs(
+      largeBundle()
+    );
+    expect(cachedDataDecl).toBe('');
+    expect(secondArg).toBe('');
   });
 });

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -1,3 +1,5 @@
+import { Script } from 'node:vm';
+
 const QUEUE_NAMESPACE_PATTERN = /^[a-z][a-z0-9]*$/;
 
 function resolveQueueNamespace(namespace?: string): string | undefined {
@@ -65,6 +67,76 @@ export function createWorkflowEntrypointOptionsCode(options?: {
   getQueueTopicPrefix('workflow', namespace);
 
   return `, { namespace: ${JSON.stringify(namespace)} }`;
+}
+
+/**
+ * Variable name a generated route uses to hold the build-time V8 code cache.
+ */
+const WORKFLOW_CODE_CACHED_DATA_VAR = '__workflowCodeCachedData';
+
+/**
+ * Bundles below this size parse in ~1ms, so embedding a base64 code cache
+ * (which roughly doubles the route's source size) is not worth it. Above it,
+ * the cold-instance parse — the dominant first-replay cost — grows ~linearly
+ * (~30ms/MB), and the cache skips it.
+ */
+const MIN_CODE_CACHE_BYTES = 256 * 1024;
+
+/**
+ * Builds the trailing pieces a generated flow route needs to hand a build-time
+ * V8 code cache to `workflowEntrypoint`:
+ *  - `cachedDataDecl`: a `const __workflowCodeCachedData = "<base64>";` line to
+ *    emit right after `const workflowCode = ...` (empty when no cache).
+ *  - `secondArg`: the full `, { namespace, cachedData }` argument string.
+ *
+ * The cache (`Script.createCachedData()`) lets a fresh serverless instance skip
+ * parsing the bundle on its first replay. Skipped for small bundles and when
+ * `WORKFLOW_DISABLE_BUNDLE_CODE_CACHE=1`. Generation failure degrades silently
+ * to no cache; at runtime V8 also validates the blob and falls back to a full
+ * parse on any mismatch, so this is never a correctness risk.
+ *
+ * Only for production (bundle-embedded) routes — dev/watch routes that read the
+ * bundle from disk should keep using `createWorkflowEntrypointOptionsCode`.
+ */
+export function createWorkflowEntrypointArgs(
+  workflowCode: string,
+  options?: { namespace?: string }
+): { cachedDataDecl: string; secondArg: string } {
+  const namespace = resolveQueueNamespace(options?.namespace);
+  if (namespace) {
+    // Reuse prefix construction for namespace validation.
+    getQueueTopicPrefix('workflow', namespace);
+  }
+
+  let cachedDataB64 = '';
+  if (
+    process.env.WORKFLOW_DISABLE_BUNDLE_CODE_CACHE !== '1' &&
+    workflowCode.length >= MIN_CODE_CACHE_BYTES
+  ) {
+    try {
+      const script = new Script(workflowCode, {
+        filename: 'workflow-bundle.js',
+      });
+      cachedDataB64 = script.createCachedData().toString('base64');
+    } catch {
+      cachedDataB64 = '';
+    }
+  }
+
+  const entries: string[] = [];
+  if (namespace) {
+    entries.push(`namespace: ${JSON.stringify(namespace)}`);
+  }
+  if (cachedDataB64) {
+    entries.push(`cachedData: ${WORKFLOW_CODE_CACHED_DATA_VAR}`);
+  }
+
+  return {
+    cachedDataDecl: cachedDataB64
+      ? `const ${WORKFLOW_CODE_CACHED_DATA_VAR} = ${JSON.stringify(cachedDataB64)};\n`
+      : '',
+    secondArg: entries.length ? `, { ${entries.join(', ')} }` : '',
+  };
 }
 
 /**

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -10,6 +10,7 @@ export {
   getDecoratorOptionsForDirectoryWithConfigPath,
 } from './config-helpers.js';
 export {
+  createWorkflowEntrypointArgs,
   createWorkflowEntrypointOptionsCode,
   createWorkflowQueueTrigger,
   WORKFLOW_QUEUE_TRIGGER,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -282,10 +282,18 @@ function hasOpenHookOrWait(events: Event[]): boolean {
  */
 export function workflowEntrypoint(
   workflowCode: string,
-  options?: { namespace?: string }
+  options?: { namespace?: string; cachedData?: string }
 ): (req: Request) => Promise<Response> {
   const NO_INLINE_REPLAY_AFTER_MS =
     Number(process.env.WORKFLOW_V2_TIMEOUT_MS) || 120_000;
+
+  // Decode the build-time V8 code cache (base64) once per process. Passed to
+  // every replay so the first bundle compile in a fresh process can skip
+  // parsing (see `runWorkflow` / `getCachedWorkflowScript`). Undefined when the
+  // build emitted no cache (e.g. dev, or a bundle below the size threshold).
+  const workflowCodeCachedData = options?.cachedData
+    ? Buffer.from(options.cachedData, 'base64')
+    : undefined;
 
   const namespace = resolveQueueNamespace(options?.namespace);
   const workflowPrefix = getQueueTopicPrefix('workflow', namespace);
@@ -1074,7 +1082,8 @@ export function workflowEntrypoint(
                         workflowCode,
                         workflowRun,
                         events,
-                        encryptionKey
+                        encryptionKey,
+                        workflowCodeCachedData
                       );
                       runtimeLogger.debug('Workflow replay completed', {
                         workflowRunId: runId,

--- a/packages/core/src/vm/script-cache.test.ts
+++ b/packages/core/src/vm/script-cache.test.ts
@@ -199,4 +199,61 @@ describe('script-cache', () => {
     ) as (n: string) => Promise<string>;
     expect(await fnY('z')).toContain('bundle-Y:3:z');
   });
+
+  describe('build-time code cache (cachedData)', () => {
+    it('accepts a matching code cache and still produces the right workflow', async () => {
+      const bundle = buildBundle('cached-ok');
+      // Build-time step: compile once and capture the V8 code cache.
+      const { Script } = await import('node:vm');
+      const cachedData = new Script(bundle, {
+        filename: 'build.js',
+      }).createCachedData();
+
+      // Runtime: compiling with the cache must not reject it...
+      const script = getCachedWorkflowScript(bundle, 'app/file.js', cachedData);
+      expect(script.cachedDataRejected).toBe(false);
+
+      // ...and the workflow it registers still runs correctly.
+      const { context } = createContext({ seed, fixedTimestamp });
+      script.runInContext(context);
+      const fn = runInContext(
+        `globalThis.__private_workflows?.get('app/workflow-5')`,
+        context
+      ) as (n: string) => Promise<string>;
+      expect(await fn('q')).toContain('cached-ok:5:q');
+    });
+
+    it('falls back to a full parse when the code cache is corrupt', async () => {
+      const bundle = buildBundle('cached-corrupt');
+      const corrupt = Buffer.from('not a real v8 code cache blob');
+
+      // A rejected cache must not throw and must still compile correctly.
+      const script = getCachedWorkflowScript(bundle, 'app/file.js', corrupt);
+      expect(script.cachedDataRejected).toBe(true);
+
+      const { context } = createContext({ seed, fixedTimestamp });
+      script.runInContext(context);
+      const fn = runInContext(
+        `globalThis.__private_workflows?.get('app/workflow-2')`,
+        context
+      ) as (n: string) => Promise<string>;
+      expect(await fn('q')).toContain('cached-corrupt:2:q');
+    });
+
+    it('is independent of filename: a cache built under one filename is accepted under another', async () => {
+      const bundle = buildBundle('cached-fname');
+      const { Script } = await import('node:vm');
+      const cachedData = new Script(bundle, {
+        filename: 'workflow//./a//wfA',
+      }).createCachedData();
+
+      // Runtime compiles under a different per-workflow filename.
+      const script = getCachedWorkflowScript(
+        bundle,
+        'workflow//./b//wfB',
+        cachedData
+      );
+      expect(script.cachedDataRejected).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/vm/script-cache.ts
+++ b/packages/core/src/vm/script-cache.ts
@@ -1,4 +1,5 @@
 import { type Context, Script } from 'node:vm';
+import { runtimeLogger as scriptCacheLogger } from '../logger.js';
 
 /**
  * Module-level cache of compiled workflow-bundle `vm.Script` objects.
@@ -100,7 +101,8 @@ function touchBundle(code: string): Map<string, Script> | undefined {
  */
 export function getCachedWorkflowScript(
   code: string,
-  filename: string
+  filename: string,
+  cachedData?: Buffer
 ): Script {
   let byFilename = touchBundle(code);
   if (byFilename === undefined) {
@@ -118,7 +120,26 @@ export function getCachedWorkflowScript(
   }
   let script = byFilename.get(filename);
   if (script === undefined) {
-    script = new Script(code, { filename });
+    // `cachedData` (a V8 code cache produced at build time via
+    // `Script.createCachedData()`) lets V8 skip parsing the bundle on the first
+    // compile in this process — the dominant cost on a cold serverless instance
+    // for large bundles. The in-process cache above only helps subsequent
+    // replays in the *same* process; the code cache helps the very first one.
+    // V8 validates the blob against its version/flags and the source; on any
+    // mismatch it sets `cachedDataRejected` and transparently falls back to a
+    // full parse, so a stale or wrong-Node-version blob is never a correctness
+    // risk — only a missed optimization. `cachedData` is independent of
+    // `filename`, so a single build-time blob is valid for every per-workflow
+    // filename the bundle is compiled under.
+    script = cachedData
+      ? new Script(code, { filename, cachedData })
+      : new Script(code, { filename });
+    if (cachedData && script.cachedDataRejected) {
+      scriptCacheLogger.debug(
+        'Workflow bundle code cache rejected; falling back to full parse',
+        { filename }
+      );
+    }
     byFilename.set(filename, script);
   }
   return script;
@@ -126,14 +147,18 @@ export function getCachedWorkflowScript(
 
 /**
  * Runs the cached workflow-bundle `Script` against `context`. Compiles and
- * caches the `Script` on first use for the given `(code, filename)`.
+ * caches the `Script` on first use for the given `(code, filename)`. When
+ * `cachedData` is provided, it is used to skip parsing on the first compile.
  */
 export function runCachedWorkflowScript(
   code: string,
   filename: string,
-  context: Context
+  context: Context,
+  cachedData?: Buffer
 ): unknown {
-  return getCachedWorkflowScript(code, filename).runInContext(context);
+  return getCachedWorkflowScript(code, filename, cachedData).runInContext(
+    context
+  );
 }
 
 /**

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -124,7 +124,11 @@ export async function runWorkflow(
   workflowCode: string,
   workflowRun: WorkflowRun,
   events: Event[],
-  encryptionKey: CryptoKey | undefined
+  encryptionKey: CryptoKey | undefined,
+  // Optional V8 code cache for `workflowCode`, produced at build time. Lets the
+  // first compile in a fresh process skip parsing the bundle (see
+  // `getCachedWorkflowScript`). Omitted in dev / when no cache was emitted.
+  workflowCodeCachedData?: Buffer
 ): Promise<Uint8Array | unknown> {
   return trace(`workflow.run ${workflowRun.workflowName}`, async (span) => {
     span?.setAttributes({
@@ -787,7 +791,12 @@ export async function runWorkflow(
     // Script rather than the line just past the end of the bundle. That path
     // is rare (it requires the lookup `?.get(...)` expression to throw) and
     // does not affect the workflow function or replay determinism.
-    runCachedWorkflowScript(workflowCode, filename, context);
+    runCachedWorkflowScript(
+      workflowCode,
+      filename,
+      context,
+      workflowCodeCachedData
+    );
     const workflowFn = runCachedWorkflowScript(
       `globalThis.__private_workflows?.get(${JSON.stringify(workflowRun.workflowName)})`,
       filename,

--- a/packages/next/src/builder-deferred.ts
+++ b/packages/next/src/builder-deferred.ts
@@ -53,6 +53,7 @@ export async function getNextBuilderDeferred() {
   const {
     BaseBuilder: BaseBuilderClass,
     WORKFLOW_QUEUE_TRIGGER,
+    createWorkflowEntrypointArgs,
     createWorkflowEntrypointOptionsCode,
     detectWorkflowPatterns,
     applySwcTransform,
@@ -686,6 +687,8 @@ export async function POST(req) {
   return (await getWorkflowHandler())(req);
 }`;
       } else {
+        const { cachedDataDecl, secondArg } =
+          createWorkflowEntrypointArgs(workflowVMCode);
         routeCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import 'workflow/internal/builtins';
@@ -693,8 +696,8 @@ ${stepImports}
 import { workflowEntrypoint } from 'workflow/runtime';
 
 const workflowCode = \`${escapedVMCode}\`;
-
-export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
+${cachedDataDecl}
+export const POST = workflowEntrypoint(workflowCode${secondArg});`;
       }
 
       await this.writeFileIfChanged(flowOutfile, routeCode);


### PR DESCRIPTION
> **Status: draft / not mergeable as-is.** The build-time win is real (7× faster cold parse) but the *delivery* mechanism in this PR — embedding the V8 code cache as base64 in the generated route — bloats the route and breaks some bundlers. See **Why this is parked** and the **Comparison with #2524** below.

## Summary

On a cold serverless instance, a workflow's **first** replay must parse the entire workflow bundle before it can reach the first step. The in-process `vm.Script` cache from #2471 only helps *subsequent* replays in the **same** process — the cold first replay still pays a full parse, which grows ~linearly with bundle size (~30ms/MB) and dominates time-to-first-step for large bundles.

This PR ships a **build-time V8 code cache** (`Script.createCachedData()`) so V8 can skip parsing on that first compile:

- **Producer** (`@workflow/builders`, `@workflow/next`): for bundles over a size threshold, compile the bundle at build time and emit the cache as base64 in the generated flow route, handed to `workflowEntrypoint` via a `cachedData` option.
- **Consumer** (`@workflow/core`): `getCachedWorkflowScript` compiles with `cachedData`; V8 validates it and falls back to a full parse on any mismatch (`cachedDataRejected`), so a stale blob is never a correctness risk.

### Measured win (fresh-process parse, no in-process cache)

| bundle | cold `new Script` | with `cachedData` | saved |
|---|---|---|---|
| 2 MB | 33.9 ms | 4.85 ms | ~7× / −29 ms |
| 8 MB | 147 ms | 20.7 ms | ~7× / −126 ms |

This is genuinely different from #2471, which evaluated `createCachedData()` and saw "no benefit" — but only at ≤821KB **and in-process**, where V8's internal compile cache already hides re-parse. At realistic sizes, fresh-process, the win is large. `cachedData` is also filename-independent (verified), so one build-time blob is valid for every per-workflow filename the bundle is compiled under.

## Why this is parked

The **delivery** mechanism — embedding the cache as base64 in the route source — is not viable. The blob is roughly bundle-sized, so it ~doubles an already-large route. Measured on the 155-workflow example workbench:

| | generated route size |
|---|---|
| without this change | 10.33 MB |
| with this change | **16.77 MB** (+6.4 MB / +62%) |

esbuild (standalone / Build Output API) tolerates 16 MB, but in CI:
- **nuxt** build → `FATAL ERROR: JavaScript heap out of memory` (the bundler choking on the giant string literal);
- **Turbopack** build → `TurbopackInternalError: failed to receive message / unexpected end of file` (worker IPC crash passing the oversized route).

No size threshold fixes this: the cache scales *with* the bundle, so it's largest exactly where the parse win matters most and where it can least be afforded. Embedding-in-source is the wrong transport.

## Comparison with #2524

#2524 (*precompile workflow `vm.Script` at module init*) targets the **same cold-TTFB problem on a different axis**, and ships safely:

| | this PR (#2523) | #2524 |
|---|---|---|
| **Approach** | Reduce the parse *cost* (persisted V8 code cache) | Move *when* the parse happens — off the replay critical path |
| **Mechanism** | Embed ~bundle-sized base64; runtime compiles with it | Inline a small `workflowFilenames` array; `workflowEntrypoint` precompiles the `Script` at module-init so the first replay is a cache hit |
| **Route size impact** | +6.4 MB on the example (10.3 → 16.7 MB) | a few hundred bytes |
| **Build impact** | Breaks nuxt (OOM) + Turbopack (IPC crash) | None |
| **Effect on cold parse** | Reduces it ~7× | Doesn't reduce it; relocates it from the first replay to module-init |

They are **complementary, not duplicates**. #2524 removes the parse from the replay window (and pays it once, regardless of replay count); this PR would make that parse itself cheap. The right composition is: land #2524, and *if* cold-start boot parse still matters afterward, reduce it with a code cache — but delivered **file-based** (a sibling `.cache` read at runtime via fs, surviving each framework's function file-tracing), never embedded in source.

The reusable, harmless part of this PR is the **runtime consumer** (`getCachedWorkflowScript` / `runWorkflow` / `workflowEntrypoint` accept optional `cachedData`, with `cachedDataRejected` fallback). The producer (embed) is the part to discard or rework.

## Recommendation

Prefer **#2524** for the immediate cold-TTFB win. This PR should either be **closed** (superseded by #2524 for the "earlier" win; embed delivery unviable) or **repurposed** into a follow-up that delivers `cachedData` via a file-based transport, stacked on top of #2524 — only if measurement after #2524 shows boot-time parse is still worth attacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
