### PR TITLE
otel(world-vercel): inject trace context on v4 event requests

### DIFF
--- a/.changeset/v4-trace-propagation.md
+++ b/.changeset/v4-trace-propagation.md
@@ -2,4 +2,4 @@
 '@workflow/world-vercel': patch
 ---
 
-Propagate W3C trace context (`traceparent` / `tracestate` / `baggage`) on v4 event requests. The v4 event path (`createEvent` / `getEvent` / `listEvents`) routes through `fetchV4`, which bypasses the `makeRequest` path where trace-context injection lives — so v4 event traffic from the flow route did not propagate context to workflow-server, and workflow-server spans could not join the invocation's trace (while v2/v3 reads/writes did). `fetchV4` now injects the active context, matching `makeRequest`. No-op when no OpenTelemetry SDK is registered.
+Inject W3C trace context (`traceparent`/`tracestate`/`baggage`) on v4 event requests, which previously bypassed it via `fetchV4` — restoring workflow-server span correlation for traffic from the flow route. No-op when no OpenTelemetry SDK is registered.

--- a/.changeset/v4-trace-propagation.md
+++ b/.changeset/v4-trace-propagation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Propagate W3C trace context (`traceparent` / `tracestate` / `baggage`) on v4 event requests. The v4 event path (`createEvent` / `getEvent` / `listEvents`) routes through `fetchV4`, which bypasses the `makeRequest` path where trace-context injection lives — so v4 event traffic from the flow route did not propagate context to workflow-server, and workflow-server spans could not join the invocation's trace (while v2/v3 reads/writes did). `fetchV4` now injects the active context, matching `makeRequest`. No-op when no OpenTelemetry SDK is registered.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,3 +289,8 @@ The `executionContext` field on workflow runs is a flexible JSONB/CBOR object th
 
 ### Observability Data Hydration
 `packages/core/src/observability.ts` contains `hydrateResourceIO` which strips certain fields (like `executionContext`) before UI display. If you need to display data from stripped fields, extract it before the stripping occurs.
+
+### Trace context propagation (world-vercel HTTP requests)
+Every outgoing HTTP request from `@workflow/world-vercel` to workflow-server (or the queue) MUST explicitly inject W3C trace context so the server can parent its spans to the caller and traces stay correlated end to end. Call `injectTraceContextIntoHeaders(headers)` (from `packages/world-vercel/src/telemetry.ts`) on the outgoing headers, inside the client span when one exists — `makeRequest` in `utils.ts` is the reference implementation. It is a no-op when no OpenTelemetry SDK is registered.
+
+Do **not** rely on ambient OpenTelemetry auto-instrumentation to do this: world-vercel's request paths use custom undici dispatchers / `global fetch`, which auto-instrumentation does not reliably hook. When you add a new request path or API version (e.g. a future v5 events API), wire the injection in the same place you build the request headers. The v4 events path (`fetchV4` in `events-v4.ts`) regressed cross-service correlation precisely by routing around `makeRequest` and skipping this step — workflow-server spans stopped joining the flow-route invocation trace until the injection was added back. Cover new paths with a test in `trace-propagation.test.ts`.

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -31,6 +31,7 @@ import {
 import { decode } from 'cbor-x';
 import { decodeFrames, encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { getDispatcher } from './http-client.js';
+import { injectTraceContextIntoHeaders } from './telemetry.js';
 import { type APIConfig, getHttpConfig } from './utils.js';
 
 /**
@@ -56,6 +57,13 @@ async function fetchV4(
   // breaking replay correctness. The v3 `makeRequest` path does the same.
   // See: https://github.com/vercel/workflow/issues/618
   init.headers.set('X-Request-Time', Date.now().toString());
+  // Explicitly propagate the active trace context (traceparent / tracestate /
+  // baggage) onto the outgoing request so workflow-server can parent its spans
+  // to this invocation — matching the v3 `makeRequest` path (see utils.ts).
+  // The custom undici dispatcher bypasses ambient auto-instrumentation, so
+  // without this v4 event traffic from the flow route would not propagate
+  // context to workflow-server. No-ops when no OTEL SDK is registered.
+  await injectTraceContextIntoHeaders(init.headers);
   return fetch(url, {
     method: init.method,
     headers: init.headers,

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -16,7 +16,10 @@ import {
   it,
   vi,
 } from 'vitest';
+import { MockAgent } from 'undici';
 import { z } from 'zod';
+import { getWorkflowRunEventsV4 } from './events-v4.js';
+import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { injectTraceContextIntoHeaders } from './telemetry.js';
 import { makeRequest } from './utils.js';
 
@@ -111,5 +114,46 @@ describe('makeRequest trace propagation', () => {
     expect(traceparent).toBe(
       `00-${clientSpan?.spanContext().traceId}-${clientSpan?.spanContext().spanId}-01`
     );
+  });
+});
+
+describe('v4 event requests (fetchV4) trace propagation', () => {
+  it('sends traceparent on the outgoing v4 request, propagating the active context to workflow-server', async () => {
+    const origin = 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+    agent
+      .get(origin)
+      .intercept({ path: '/api/v4/runs/wrun_1/events', method: 'GET' })
+      .reply(200, encodeFrame({ _end: 1 }, new Uint8Array(0)), {
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+
+    // Spy passes through to the real fetch (MockAgent intercepts at the
+    // dispatcher layer) so we can read the headers fetchV4 actually sent.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const tracer = otelTrace.getTracer('test');
+    let traceId = '';
+    let spanId = '';
+    await tracer.startActiveSpan('flow-invocation', async (span) => {
+      traceId = span.spanContext().traceId;
+      spanId = span.spanContext().spanId;
+      await getWorkflowRunEventsV4(
+        'wrun_1',
+        {},
+        { token: 'test-token', dispatcher: agent }
+      );
+      span.end();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledInit = fetchSpy.mock.calls[0][1];
+    const sent = new Headers(calledInit?.headers as HeadersInit);
+    // Without the fetchV4 injection this header is absent and workflow-server
+    // cannot parent its spans to the flow-route invocation.
+    expect(sent.get('traceparent')).toBe(`00-${traceId}-${spanId}-01`);
+    agent.assertNoPendingInterceptors();
+    fetchSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

v4 event requests don't propagate W3C trace context to workflow-server, so workflow-server spans never join the `/flow` execution trace — while v2/v3 calls do. This restores propagation for v4.

## Root cause

The explicit trace-context injection added for cross-service correlation lives in `world-vercel`'s `makeRequest` (the v2/v3 path):

```js
// utils.ts — runs inside the `http <method>` client span
await injectTraceContextIntoHeaders(headers);
```

The v4 event path (`createWorkflowRunEventV4` / `getEventV4` / `getWorkflowRunEventsV4`) was routed through a separate `fetchV4` → global `fetch` helper (to keep v4 traffic visible in Vercel's outgoing-requests view). `fetchV4` builds headers from `getHttpConfig` (auth/UA only), sets `X-Request-Time`, and calls `fetch(...)` with a **custom undici dispatcher** — it never calls `injectTraceContextIntoHeaders`, and the custom dispatcher means ambient undici auto-instrumentation can't be relied on for injection either.

Net effect, observable in traces:

- **Start-site request** (`/api/run/...` → run-status reads via `GET /api/v2/runs/:runId`) goes through `makeRequest` → `traceparent` injected → workflow-server's server span **joins** the trace. ✓
- **Inside the `/flow` route** (event writes via `POST /api/v4/runs/.../events`) goes through `fetchV4` → **no** `traceparent` → workflow-server starts a fresh root and **never joins** the invocation trace. ✗

This is not sampling — the v4 requests genuinely carry no trace context.

## Fix

Inject the active trace context in `fetchV4`, the single choke point for all v4 create/get/list requests, mirroring `makeRequest`:

```js
init.headers.set('X-Request-Time', Date.now().toString());
await injectTraceContextIntoHeaders(init.headers);   // ← added
return fetch(url, { method, headers: init.headers, body, dispatcher: getDispatcher(config) });
```

Now workflow-server joins the `/flow` execution trace the same way it joins the start-site trace. No-op when no OpenTelemetry SDK is registered.

## Guardrail

Adds a note to `AGENTS.md` (Architecture Notes → "Trace context propagation") requiring every new `@workflow/world-vercel` HTTP path to call `injectTraceContextIntoHeaders` and cover it in `trace-propagation.test.ts`, citing this v4 regression — so a future v5 events API doesn't repeat it.

## Testing

- New test in `trace-propagation.test.ts`: drives `getWorkflowRunEventsV4` inside an active span (MockAgent + real `fetch` spy, W3C propagator registered) and asserts the outgoing v4 request carries `traceparent` matching the active span. Fails without the injection.
- `@workflow/world-vercel`: full suite 163 passed; build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

