### PR TITLE
Bump undici to 7.28.0

### DIFF
--- a/.changeset/bump-undici-7-28.md
+++ b/.changeset/bump-undici-7-28.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-local': patch
+'@workflow/world-vercel': patch
+---
+
+Update `undici` to 7.28.0.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ~3.0.1
       version: 3.0.1
     undici:
-      specifier: 7.26.0
-      version: 7.26.0
+      specifier: 7.28.0
+      version: 7.28.0
     vitest:
       specifier: ^4.0.18
       version: 4.0.18
@@ -1364,7 +1364,7 @@ importers:
         version: 3.0.1
       undici:
         specifier: 'catalog:'
-        version: 7.26.0
+        version: 7.28.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1511,7 +1511,7 @@ importers:
         version: 1.6.0
       undici:
         specifier: 'catalog:'
-        version: 7.26.0
+        version: 7.28.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -16679,8 +16679,8 @@ packages:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.26.0:
-    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -35616,7 +35616,7 @@ snapshots:
 
   undici@7.22.0: {}
 
-  undici@7.26.0: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   semver: 7.7.4
   typescript: ^5.9.3
   ulid: ~3.0.1
-  undici: 7.26.0
+  undici: 7.28.0
   vitest: ^4.0.18
   zod: 4.3.6
 


### PR DESCRIPTION
## Summary
- Bump the workspace catalog for undici to 7.28.0.
- Refresh the lockfile entries for @workflow/world-local and @workflow/world-vercel.
- Add a patch changeset for the published world packages.

## Verification
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm --filter @workflow/world-local... --filter @workflow/world-vercel... build
- pnpm --filter @workflow/world-local typecheck
- pnpm --filter @workflow/world-vercel typecheck
- Filtered pnpm audit confirms the direct Workflow undici findings are cleared; one unrelated workbench/tanstack-start transitive undici@7.22.0 finding remains.