### PR TITLE
Fail closed for deferred workflow route stubs

### DIFF
--- a/.changeset/fail-closed-deferred-workflow-stubs.md
+++ b/.changeset/fail-closed-deferred-workflow-stubs.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Fail builds instead of compiling deferred workflow route stubs when lazy discovery does not generate the real route.

--- a/packages/next/src/loader.test.ts
+++ b/packages/next/src/loader.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { shouldNotifySocketForDiscoveredPattern } from './loader.js';
+import {
+  resolveDeferredWorkflowRouteStubSource,
+  shouldNotifySocketForDiscoveredPattern,
+} from './loader.js';
 
 describe('workflow loader discovery notifications', () => {
   it('notifies for unchanged files that still contain workflow patterns', () => {
@@ -39,5 +42,62 @@ describe('workflow loader discovery notifications', () => {
     expect(
       shouldNotifySocketForDiscoveredPattern(true, plainPatternState)
     ).toBe(true);
+  });
+});
+
+describe('deferred workflow route stubs', () => {
+  it('returns the generated route after the deferred build completes', async () => {
+    await expect(
+      resolveDeferredWorkflowRouteStubSource({
+        filename: '/app/.well-known/workflow/v1/flow/route.js',
+        sourceMap: 'source-map',
+        waitForDeferredBuild: async () => {},
+        readGeneratedRoute: async () => 'export async function POST() {}',
+      })
+    ).resolves.toEqual({
+      code: 'export async function POST() {}',
+      map: 'source-map',
+    });
+  });
+
+  it('throws instead of returning stub output when the deferred build fails', async () => {
+    const cause = new Error('Timed out waiting for deferred route build');
+
+    await expect(
+      resolveDeferredWorkflowRouteStubSource({
+        filename: '/app/.well-known/workflow/v1/flow/route.js',
+        sourceMap: undefined,
+        waitForDeferredBuild: async () => {
+          throw cause;
+        },
+        readGeneratedRoute: async () =>
+          '// WORKFLOW_ROUTE_STUB_FILE\nexport const __workflowRouteStub = true;',
+      })
+    ).rejects.toThrow('Refusing to compile the route stub');
+  });
+
+  it('throws when the deferred build leaves the generated route as a stub', async () => {
+    let thrownError: unknown;
+
+    try {
+      await resolveDeferredWorkflowRouteStubSource({
+        filename: '/app/.well-known/workflow/v1/flow/route.js',
+        sourceMap: undefined,
+        waitForDeferredBuild: async () => {},
+        readGeneratedRoute: async () =>
+          '// WORKFLOW_ROUTE_STUB_FILE\nexport const __workflowRouteStub = true;',
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect((thrownError as Error).message).toContain(
+      'Refusing to compile the route stub'
+    );
+    expect((thrownError as { cause?: unknown }).cause).toBeInstanceOf(Error);
+    expect(((thrownError as { cause?: Error }).cause as Error).message).toBe(
+      'Deferred route build completed, but the generated route file is still the workflow route stub.'
+    );
   });
 });

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -412,6 +412,48 @@ function isWorkflowRouteStubSource(source: string): boolean {
   return source.includes(ROUTE_STUB_FILE_MARKER);
 }
 
+function createDeferredRouteStubBuildError(
+  filename: string,
+  cause: unknown
+): Error {
+  const error = new Error(
+    [
+      `[workflow] Failed to generate deferred workflow route for ${filename}.`,
+      'Refusing to compile the route stub because it does not export POST and would return 405 to workflow callbacks.',
+      'Retry the build, or disable lazy discovery with WORKFLOW_NEXT_LAZY_DISCOVERY=0 or withWorkflow(..., { workflows: { lazyDiscovery: false } }).',
+    ].join('\n')
+  );
+  if (cause !== undefined) {
+    (error as { cause?: unknown }).cause = cause;
+  }
+  return error;
+}
+
+export async function resolveDeferredWorkflowRouteStubSource({
+  filename,
+  sourceMap,
+  waitForDeferredBuild,
+  readGeneratedRoute,
+}: {
+  filename: string;
+  sourceMap: any;
+  waitForDeferredBuild: () => Promise<void>;
+  readGeneratedRoute: () => Promise<string>;
+}): Promise<{ code: string; map: any }> {
+  try {
+    await waitForDeferredBuild();
+    const refreshedSource = await readGeneratedRoute();
+    if (!isWorkflowRouteStubSource(refreshedSource)) {
+      return { code: refreshedSource, map: sourceMap };
+    }
+    throw new Error(
+      'Deferred route build completed, but the generated route file is still the workflow route stub.'
+    );
+  } catch (error) {
+    throw createDeferredRouteStubBuildError(filename, error);
+  }
+}
+
 async function createSocketConnection(
   socketCredentials: SocketCredentials,
   timeoutMs = 1_000
@@ -687,18 +729,12 @@ export default function workflowLoader(
         process.env.WORKFLOW_NEXT_LAZY_DISCOVERY === '1' &&
         isWorkflowRouteStubSource(normalizedSource)
       ) {
-        try {
-          await ensureDeferredRouteStubBuildAndWait();
-          const refreshedSource = await readFile(filename, 'utf8');
-          if (!isWorkflowRouteStubSource(refreshedSource)) {
-            return { code: refreshedSource, map: sourceMap };
-          }
-        } catch (error) {
-          console.warn(
-            `[workflow] Failed waiting for deferred route build for ${filename}, using stub output`,
-            error
-          );
-        }
+        return resolveDeferredWorkflowRouteStubSource({
+          filename,
+          sourceMap,
+          waitForDeferredBuild: ensureDeferredRouteStubBuildAndWait,
+          readGeneratedRoute: () => readFile(filename, 'utf8'),
+        });
       }
       return { code: normalizedSource, map: sourceMap };
     }


### PR DESCRIPTION
## Summary

Fail closed when a lazy Next workflow route is still the generated stub after deferred route generation.

## Why

Production investigation found a deployment where `/.well-known/workflow/v1/flow` compiled the Workflow route stub instead of the generated route. That stub has no `POST` export, so queue callback POSTs received 405s and workflow runs were created but never progressed.

Previously the loader logged a warning and returned the stub if waiting for the deferred build failed, or if the refreshed route file was still a stub. This PR turns that into a build-time error with remediation text, so affected deployments fail before shipping a callback route that cannot handle POST.

The stub intentionally does not grow a placeholder `POST` export: it does not contain the workflow VM bundle, manifest, or step side-effect imports needed to execute callbacks. Returning a synthetic handler would only replace the 405 with another runtime failure, while still leaving runs unable to progress.

## Validation

- `pnpm vitest run packages/next/src/loader.test.ts`
- `git diff --check`
- `pnpm biome check packages/next/src/loader.ts packages/next/src/loader.test.ts .changeset/fail-closed-deferred-workflow-stubs.md`
- Attempted `pnpm --filter @workflow/next build`, but latest `origin/main` currently fails in `packages/next/src/builder-deferred.ts` with pre-existing `moduleSpecifierRoot` / `applySwcTransform` type errors unrelated to this change.

Note: local commands warn because this shell is running Node 25 while the repo supports Node 18/20/22/24.
