### PR TITLE
[ai] Fix "missing text part" stream crash by repairing UI message framing

### DIFF
--- a/.changeset/repair-ui-message-stream-framing.md
+++ b/.changeset/repair-ui-message-stream-framing.md
@@ -1,0 +1,5 @@
+---
+'@workflow/ai': patch
+---
+
+`WorkflowChatTransport` now repairs UI message stream part framing, so duplicated or interleaved durable stream writes no longer crash the AI SDK consumer with `Received text-delta for missing text part`.

--- a/.changeset/repair-ui-message-stream-framing.md
+++ b/.changeset/repair-ui-message-stream-framing.md
@@ -1,5 +1,5 @@
 ---
-'@workflow/ai': patch
+'@workflow/ai': minor
 ---
 
 `WorkflowChatTransport` now repairs UI message stream part framing, so duplicated or interleaved durable stream writes no longer crash the AI SDK consumer with `Received text-delta for missing text part`.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,4 +2,5 @@
  * Re-export commonly used AI SDK types.
  */
 export type { ModelMessage } from 'ai';
+export { normalizeUIMessageStreamParts } from './normalize-ui-message-stream.js';
 export * from './workflow-chat-transport.js';

--- a/packages/ai/src/normalize-ui-message-stream.ts
+++ b/packages/ai/src/normalize-ui-message-stream.ts
@@ -1,0 +1,149 @@
+import type { UIMessageChunk } from 'ai';
+
+/**
+ * Tracks, for one part family (text or reasoning), which part ids are open or
+ * ended within the current step.
+ */
+interface PartFrameState {
+  /** A `*-start` was seen and not yet ended in the current step. */
+  open: Set<string>;
+  /** A part that was opened and ended in the current step. */
+  ended: Set<string>;
+}
+
+const newPartFrameState = (): PartFrameState => ({
+  open: new Set(),
+  ended: new Set(),
+});
+
+/**
+ * Repairs the framing for a single `*-start` / `*-delta` / `*-end` chunk
+ * against the running per-step state, yielding the chunks the consumer should
+ * see. Text and reasoning parts share this logic (`startType` differentiates
+ * the synthesized start chunk).
+ */
+function* repairPart(
+  kind: 'start' | 'delta' | 'end',
+  id: string,
+  chunk: UIMessageChunk,
+  state: PartFrameState,
+  startType: 'text-start' | 'reasoning-start'
+): Generator<UIMessageChunk> {
+  if (kind === 'start') {
+    // Drop a duplicate/replayed start for a part already framed this step.
+    if (state.open.has(id) || state.ended.has(id)) {
+      return;
+    }
+    state.open.add(id);
+    yield chunk;
+    return;
+  }
+
+  // delta / end: drop a re-delivered chunk for an already-ended part.
+  if (state.ended.has(id)) {
+    return;
+  }
+  // Synthesize the missing start for an orphaned delta/end.
+  if (!state.open.has(id)) {
+    state.open.add(id);
+    yield { type: startType, id } as UIMessageChunk;
+  }
+  if (kind === 'end') {
+    state.open.delete(id);
+    state.ended.add(id);
+  }
+  yield chunk;
+}
+
+/**
+ * Normalizes the part framing of a UI message stream so it is always
+ * well-formed for the AI SDK's stream consumer (`processUIMessageStream`,
+ * which backs `useChat`/`readUIMessageStream`).
+ *
+ * ## Why this exists
+ *
+ * The consumer maintains a map of "active" text/reasoning parts keyed by id.
+ * A `text-delta`/`text-end` for an id that has no open part is a fatal error
+ * (`Received text-delta for missing text part with ID "0" ...`) that kills the
+ * whole turn. Two properties of the durable streaming model make that error
+ * reachable:
+ *
+ * - A workflow run owns a single shared stream, and the consumer resets its
+ *   active-part maps on every `finish-step`. Multi-step turns reuse the same
+ *   part id (commonly `"0"`) in each step, so a single dropped or duplicated
+ *   `*-start` across a step boundary orphans the rest of that step's content.
+ * - The same stream is read across reconnects, and a stream-producing step can
+ *   run more than once (retry/redelivery, or the concurrent-worker duplication
+ *   tracked in vercel/workflow#2331 and #2039). Either can interleave or
+ *   duplicate chunks on the shared stream — e.g. a `finish-step` landing in the
+ *   middle of another execution's text part.
+ *
+ * Since the content is still flowing and only the framing is damaged, repairing
+ * the framing here degrades the worst case to "text begins slightly into the
+ * step" or "a duplicated tail is dropped" instead of a dead turn.
+ *
+ * ## What it does
+ *
+ * Mirrors the consumer's part-lifetime state machine, per part type, per step:
+ * - resets tracking on `finish-step` (exactly where the consumer resets);
+ * - synthesizes a missing `*-start` when an orphaned `*-delta`/`*-end` arrives;
+ * - drops a re-delivered `*-start`/`*-delta`/`*-end` for a part already
+ *   open or ended in the current step (reconnect/replay overlap).
+ *
+ * A well-formed stream passes through unchanged.
+ */
+export async function* normalizeUIMessageStreamParts(
+  source: AsyncIterable<UIMessageChunk>
+): AsyncGenerator<UIMessageChunk> {
+  const text = newPartFrameState();
+  const reasoning = newPartFrameState();
+
+  for await (const chunk of source) {
+    switch (chunk.type) {
+      case 'finish-step':
+        // The consumer clears its active-part maps here, so part ids may be
+        // legitimately reused in the next step. Reset to match.
+        text.open.clear();
+        text.ended.clear();
+        reasoning.open.clear();
+        reasoning.ended.clear();
+        yield chunk;
+        break;
+
+      case 'text-start':
+        yield* repairPart('start', chunk.id, chunk, text, 'text-start');
+        break;
+      case 'text-delta':
+        yield* repairPart('delta', chunk.id, chunk, text, 'text-start');
+        break;
+      case 'text-end':
+        yield* repairPart('end', chunk.id, chunk, text, 'text-start');
+        break;
+
+      case 'reasoning-start':
+        yield* repairPart(
+          'start',
+          chunk.id,
+          chunk,
+          reasoning,
+          'reasoning-start'
+        );
+        break;
+      case 'reasoning-delta':
+        yield* repairPart(
+          'delta',
+          chunk.id,
+          chunk,
+          reasoning,
+          'reasoning-start'
+        );
+        break;
+      case 'reasoning-end':
+        yield* repairPart('end', chunk.id, chunk, reasoning, 'reasoning-start');
+        break;
+
+      default:
+        yield chunk;
+    }
+  }
+}

--- a/packages/ai/src/normalize-ui-message-stream.ts
+++ b/packages/ai/src/normalize-ui-message-stream.ts
@@ -91,6 +91,16 @@ function* repairPart(
  *   open or ended in the current step (reconnect/replay overlap).
  *
  * A well-formed stream passes through unchanged.
+ *
+ * ## Scope: text and reasoning only
+ *
+ * `tool-input-delta` raises the same class of fatal error (`Received
+ * tool-input-delta for missing tool call ...`), but tool parts are deliberately
+ * left untouched: the consumer does not reset its tool-call map on `finish-step`
+ * and tool-call ids are unique, so the step-boundary id-reuse orphaning that
+ * makes text/reasoning fragile does not apply to them. If a future duplication
+ * mode is found to orphan tool-input parts, extend the same machine to that
+ * family rather than special-casing it.
  */
 export async function* normalizeUIMessageStreamParts(
   source: AsyncIterable<UIMessageChunk>

--- a/packages/ai/src/workflow-chat-transport.stream-repair.test.ts
+++ b/packages/ai/src/workflow-chat-transport.stream-repair.test.ts
@@ -38,7 +38,7 @@ function fetchReturning(chunks: UIMessageChunk[]): typeof fetch {
 /**
  * Drives a transport-produced stream through the real AI SDK consumer
  * (the same state machine that backs `useChat`). Returns the final assembled
- * text and any framing error the consumer reported.
+ * text, reasoning, and any framing error the consumer reported.
  */
 async function consume(stream: ReadableStream<UIMessageChunk>) {
   let consumerError: Error | undefined;
@@ -51,11 +51,18 @@ async function consume(stream: ReadableStream<UIMessageChunk>) {
   })) {
     lastMessage = message;
   }
-  const text = (lastMessage?.parts ?? [])
+  const parts = lastMessage?.parts ?? [];
+  const text = parts
     .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
     .map((p) => p.text)
     .join('');
-  return { consumerError, text };
+  const reasoning = parts
+    .filter(
+      (p): p is { type: 'reasoning'; text: string } => p.type === 'reasoning'
+    )
+    .map((p) => p.text)
+    .join('');
+  return { consumerError, text, reasoning };
 }
 
 async function sendAndConsume(chunks: UIMessageChunk[]) {
@@ -149,5 +156,44 @@ describe('WorkflowChatTransport UI message stream repair (issue #2422)', () => {
     const { consumerError, text } = await sendAndConsume(WELL_FORMED);
     expect(consumerError).toBeUndefined();
     expect(text).toBe('onetwo');
+  });
+
+  // Reasoning parts have the same fragility as text (the consumer resets
+  // activeReasoningParts on finish-step and ids are reused), so the repair must
+  // cover them too. Drives the real consumer rather than asserting structurally.
+  const INTERLEAVED_REASONING: UIMessageChunk[] = [
+    { type: 'start', messageId: 'm1' },
+    { type: 'start-step' },
+    { type: 'reasoning-start', id: '0' },
+    { type: 'reasoning-delta', id: '0', delta: 'Think' },
+    // finish-step from a duplicated execution resets activeReasoningParts,
+    // orphaning the rest of id "0".
+    { type: 'finish-step' },
+    { type: 'reasoning-delta', id: '0', delta: 'ing...' },
+    { type: 'reasoning-end', id: '0' },
+    { type: 'finish' },
+  ];
+
+  it('demonstrates the raw interleaved reasoning stream is fatal to the consumer', async () => {
+    const raw = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        for (const chunk of INTERLEAVED_REASONING) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+    const { consumerError } = await consume(raw);
+    expect(consumerError?.message).toContain(
+      'Received reasoning-delta for missing reasoning part with ID "0"'
+    );
+  });
+
+  it('repairs an interleaved reasoning stream with no content lost', async () => {
+    const { consumerError, reasoning } = await sendAndConsume(
+      INTERLEAVED_REASONING
+    );
+    expect(consumerError).toBeUndefined();
+    expect(reasoning).toBe('Thinking...');
   });
 });

--- a/packages/ai/src/workflow-chat-transport.stream-repair.test.ts
+++ b/packages/ai/src/workflow-chat-transport.stream-repair.test.ts
@@ -1,0 +1,153 @@
+import {
+  JsonToSseTransformStream,
+  readUIMessageStream,
+  type UIMessage,
+  type UIMessageChunk,
+} from 'ai';
+import { describe, expect, it } from 'vitest';
+import { WorkflowChatTransport } from './workflow-chat-transport.js';
+
+/**
+ * Builds a mock `fetch` whose response body is the given UIMessageChunks
+ * encoded as the JSON/SSE event stream the transport expects, with the
+ * `x-workflow-run-id` header the transport requires.
+ */
+function fetchReturning(chunks: UIMessageChunk[]): typeof fetch {
+  return (async () => {
+    const body = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    })
+      .pipeThrough(new JsonToSseTransformStream())
+      .pipeThrough(new TextEncoderStream());
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'content-type': 'text/event-stream',
+        'x-workflow-run-id': 'wrun_test',
+      },
+    });
+  }) as unknown as typeof fetch;
+}
+
+/**
+ * Drives a transport-produced stream through the real AI SDK consumer
+ * (the same state machine that backs `useChat`). Returns the final assembled
+ * text and any framing error the consumer reported.
+ */
+async function consume(stream: ReadableStream<UIMessageChunk>) {
+  let consumerError: Error | undefined;
+  let lastMessage: UIMessage | undefined;
+  for await (const message of readUIMessageStream({
+    stream,
+    onError: (error) => {
+      consumerError = error as Error;
+    },
+  })) {
+    lastMessage = message;
+  }
+  const text = (lastMessage?.parts ?? [])
+    .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+    .map((p) => p.text)
+    .join('');
+  return { consumerError, text };
+}
+
+async function sendAndConsume(chunks: UIMessageChunk[]) {
+  const transport = new WorkflowChatTransport({
+    fetch: fetchReturning(chunks),
+  });
+  const stream = await transport.sendMessages({
+    trigger: 'submit-message',
+    chatId: 'chat_test',
+    messages: [],
+  });
+  return consume(stream);
+}
+
+// A duplicated/interleaved execution of the stream-producing step lands a
+// `finish-step` in the middle of a text part that reuses id "0", orphaning the
+// rest of the part. This is the exact shape behind
+// "Received text-delta for missing text part with ID 0" (vercel/workflow#2422).
+const INTERLEAVED: UIMessageChunk[] = [
+  { type: 'start', messageId: 'm1' },
+  { type: 'start-step' },
+  { type: 'text-start', id: '0' },
+  { type: 'text-delta', id: '0', delta: 'Hello' },
+  // finish-step from a second/duplicated execution resets the consumer's
+  // active text parts, closing id "0" prematurely.
+  { type: 'finish-step' },
+  { type: 'text-delta', id: '0', delta: ' world' },
+  { type: 'text-end', id: '0' },
+  { type: 'finish' },
+];
+
+describe('WorkflowChatTransport UI message stream repair (issue #2422)', () => {
+  it('demonstrates the raw interleaved stream is fatal to the AI SDK consumer', async () => {
+    // Sanity check on the unrepaired stream: prove the chunk shape really does
+    // trigger the reported error, so the repair test below is meaningful.
+    const raw = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        for (const chunk of INTERLEAVED) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+    const { consumerError } = await consume(raw);
+    expect(consumerError?.message).toContain(
+      'Received text-delta for missing text part with ID "0"'
+    );
+  });
+
+  it('repairs an interleaved stream so the consumer does not fail the turn', async () => {
+    const { consumerError, text } = await sendAndConsume(INTERLEAVED);
+    expect(consumerError).toBeUndefined();
+    // No content is lost — the orphaned delta is re-framed rather than dropped.
+    expect(text).toBe('Hello world');
+  });
+
+  it('drops a re-delivered (reconnect/replay) duplicate tail without erroring', async () => {
+    const DUPLICATED: UIMessageChunk[] = [
+      { type: 'start', messageId: 'm1' },
+      { type: 'start-step' },
+      { type: 'text-start', id: '0' },
+      { type: 'text-delta', id: '0', delta: 'Hello world' },
+      { type: 'text-end', id: '0' },
+      // Replayed copy of the same already-ended part (no finish-step between).
+      { type: 'text-start', id: '0' },
+      { type: 'text-delta', id: '0', delta: 'Hello world' },
+      { type: 'text-end', id: '0' },
+      { type: 'finish' },
+    ];
+    const { consumerError, text } = await sendAndConsume(DUPLICATED);
+    expect(consumerError).toBeUndefined();
+    expect(text).toBe('Hello world');
+  });
+
+  it('passes a well-formed multi-step stream through unchanged', async () => {
+    const WELL_FORMED: UIMessageChunk[] = [
+      { type: 'start', messageId: 'm1' },
+      { type: 'start-step' },
+      { type: 'text-start', id: '0' },
+      { type: 'text-delta', id: '0', delta: 'one' },
+      { type: 'text-end', id: '0' },
+      { type: 'finish-step' },
+      // Second step legitimately reuses id "0" after the consumer reset.
+      { type: 'start-step' },
+      { type: 'text-start', id: '0' },
+      { type: 'text-delta', id: '0', delta: 'two' },
+      { type: 'text-end', id: '0' },
+      { type: 'finish-step' },
+      { type: 'finish' },
+    ];
+    const { consumerError, text } = await sendAndConsume(WELL_FORMED);
+    expect(consumerError).toBeUndefined();
+    expect(text).toBe('onetwo');
+  });
+});

--- a/packages/ai/src/workflow-chat-transport.ts
+++ b/packages/ai/src/workflow-chat-transport.ts
@@ -9,6 +9,7 @@ import {
   uiMessageChunkSchema,
 } from 'ai';
 import { getErrorMessage } from './get-error-message.js';
+import { normalizeUIMessageStreamParts } from './normalize-ui-message-stream.js';
 import { iteratorToStream, streamToIterator } from './stream-iterator.js';
 
 export interface SendMessagesOptions<UI_MESSAGE extends UIMessage> {
@@ -182,9 +183,12 @@ export class WorkflowChatTransport<UI_MESSAGE extends UIMessage>
   async sendMessages(
     options: SendMessagesOptions<UI_MESSAGE> & ChatRequestOptions
   ): Promise<ReadableStream<UIMessageChunk>> {
-    return iteratorToStream(this.sendMessagesIterator(options), {
-      signal: options.abortSignal,
-    });
+    return iteratorToStream(
+      normalizeUIMessageStreamParts(this.sendMessagesIterator(options)),
+      {
+        signal: options.abortSignal,
+      }
+    );
   }
 
   private async *sendMessagesIterator(
@@ -289,7 +293,9 @@ export class WorkflowChatTransport<UI_MESSAGE extends UIMessage>
   async reconnectToStream(
     options: ReconnectToStreamOptions & ChatRequestOptions
   ): Promise<ReadableStream<UIMessageChunk> | null> {
-    const it = this.reconnectToStreamIterator(options);
+    const it = normalizeUIMessageStreamParts(
+      this.reconnectToStreamIterator(options)
+    );
     return iteratorToStream(it, { signal: options.abortSignal });
   }
 


### PR DESCRIPTION
Closes #2422

## Problem

A workflow run owns a **single shared UI message stream**, and the AI SDK's stream consumer (`processUIMessageStream`, backing `useChat`/`readUIMessageStream`) **resets its active text/reasoning part maps on every `finish-step`**. Multi-step turns reuse the same part id (commonly `"0"`) in each step. So if a `text-start` is dropped or a `finish-step` lands in the middle of a text part, the consumer hits a `text-delta`/`text-end` for an id it has no open part for and throws:

```
Received text-delta for missing text part with ID "0". Ensure a "text-start" chunk is sent before any "text-delta" chunks.
```

…which kills the whole turn.

That malformed framing is reachable whenever a stream-producing step's output is **duplicated or interleaved** on the shared stream — e.g. step retry/redelivery, reconnect/replay overlap, or the concurrent-worker duplication tracked in #2331 / #2039 (a `finish-step` from one execution landing inside another's text part).

## Fix

`WorkflowChatTransport` now passes the stream it hands to the AI SDK through `normalizeUIMessageStreamParts`, which mirrors the consumer's per-step part-lifetime state machine:

- resets tracking on `finish-step` (exactly where the consumer resets);
- **synthesizes a missing `*-start`** when an orphaned `*-delta`/`*-end` arrives;
- **drops a re-delivered** `*-start`/`*-delta`/`*-end` for a part already open/ended in the current step (reconnect/replay overlap).

It wraps the *output* of the send/reconnect iterators, so the reconnect `chunkIndex`/`gotFinish` accounting is untouched. A well-formed stream passes through unchanged; the worst case degrades to "text begins slightly into the step" or "a duplicated tail is dropped" instead of a dead turn. Applies to both text and reasoning parts.

This addresses the client-visible symptom for all `WorkflowChatTransport` consumers regardless of the upstream duplication cause. The underlying server-side duplicate-execution races (#2331, #2039) are separate and remain tracked there.

## Tests

`packages/ai/src/workflow-chat-transport.stream-repair.test.ts` drives the **real** transport (mock `fetch` returning chunks via the AI SDK's own `JsonToSseTransformStream`) into the **real** `readUIMessageStream` consumer:

- proves the raw interleaved stream reproduces the exact `missing text part` error;
- proves the transport now repairs it with **no content lost** (`"Hello world"`);
- proves a reconnect/replay duplicate tail is dropped without erroring;
- proves a well-formed multi-step stream (id `"0"` reused across steps) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Ported to `@ai-sdk/workflow`:** vercel/ai#16433
