### PR TITLE
feat(docs): add eve and AI SDK to product switcher

### DIFF
--- a/docs/components/geistcn-fallbacks/geistcn-assets/logos/index.tsx
+++ b/docs/components/geistcn-fallbacks/geistcn-assets/logos/index.tsx
@@ -7,6 +7,7 @@
 export { LogoAiElements } from './logo-ai-elements';
 export { LogoAiSdk } from './logo-ai-sdk';
 export { LogoChatSdk } from './logo-chat-sdk';
+export { LogoEve } from './logo-eve';
 export { LogoFlagsSdk } from './logo-flags-sdk';
 export { LogoIconVercel } from './logo-icon-vercel';
 export { LogoStreamdown } from './logo-streamdown';

--- a/docs/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve.tsx
+++ b/docs/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * eve wordmark + Beta badge. eve ships a text-based brand mark rather than an
+ * SVG wordmark, so this mirrors its docs logo. `height` is accepted for parity
+ * with the other product logos but does not drive sizing for this text mark.
+ */
+export function LogoEve({
+  className,
+}: {
+  height?: number;
+  className?: string;
+}) {
+  return (
+    <span className={cn('flex items-center gap-2', className)}>
+      <span className="font-semibold text-gray-1000 text-lg leading-none">
+        eve
+      </span>
+      <span className="rounded-full border border-blue-300 px-2 py-0.5 font-medium text-blue-700 text-xs leading-none">
+        Beta
+      </span>
+    </span>
+  );
+}

--- a/docs/components/geistdocs/navbar-logo.tsx
+++ b/docs/components/geistdocs/navbar-logo.tsx
@@ -4,7 +4,9 @@ import Link from 'next/link';
 import type { ComponentType, ReactNode } from 'react';
 import { IconSlashForward } from '@/components/geistcn-fallbacks/geistcn-assets/icons/icon-slash-forward';
 import { LogoAiElements } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-ai-elements';
+import { LogoAiSdk } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-ai-sdk';
 import { LogoChatSdk } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-chat-sdk';
+import { LogoEve } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve';
 import { LogoFlagsSdk } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-flags-sdk';
 import { LogoIconVercel } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-icon-vercel';
 import { LogoStreamdown } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-streamdown';
@@ -24,6 +26,8 @@ const OSS_PRODUCT_LINKS: {
   logo: ComponentType<{ height: number }>;
   height: number;
 }[] = [
+  { href: 'https://eve.dev/docs', logo: LogoEve, height: 18 },
+  { href: 'https://ai-sdk.dev/', logo: LogoAiSdk, height: 12 },
   { href: 'https://flags-sdk.dev/', logo: LogoFlagsSdk, height: 20 },
   { href: 'https://chat-sdk.dev/', logo: LogoChatSdk, height: 20 },
   { href: 'https://elements.ai-sdk.dev/', logo: LogoAiElements, height: 12 },


### PR DESCRIPTION
Wire the existing AI SDK logo into the OSS product switcher (above Flags SDK) and add a new eve entry (text wordmark + Beta badge, linking to eve.dev/docs) above it at the top of the list.