### PR TITLE
test(core): de-flake sleep/stepWinsRace e2e wall-clock bounds

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -752,17 +752,27 @@ describe('e2e', () => {
   test('sleepWinsRaceWorkflow', { timeout: 60_000 }, async () => {
     const run = await start(await e2e('sleepWinsRaceWorkflow'), []);
     const returnValue = await run.returnValue;
+    // The real invariant: the 1s sleep wins the race against the 10s step.
     expect(returnValue.winner).toBe('sleep');
-    // Sleep is 1s; step would take 10s. Should resolve in ~1s, well under 5s.
-    expect(returnValue.durationMs).toBeLessThan(5_000);
+    // durationMs is only a guard that we didn't block on the 10s losing step.
+    // The fast branch is ~1s, but on preview it carries queue round-trips,
+    // cold starts, and replay overhead (observed up to ~5.1s in CI), so a 5s
+    // bound flakes. 8s stays comfortably below the 10s loser — proving the
+    // step did not win — while leaving generous headroom for that jitter.
+    expect(returnValue.durationMs).toBeLessThan(8_000);
   });
 
   test('stepWinsRaceWorkflow', { timeout: 60_000 }, async () => {
     const run = await start(await e2e('stepWinsRaceWorkflow'), []);
     const returnValue = await run.returnValue;
+    // The real invariant: the 1s step wins the race against the 10s sleep.
     expect(returnValue.winner).toBe('step');
-    // Step is 1s; sleep would take 10s. Should resolve in ~1s, well under 5s.
-    expect(returnValue.durationMs).toBeLessThan(5_000);
+    // durationMs is only a guard that we didn't block on the 10s losing sleep.
+    // The fast branch is ~1s, but on preview it carries queue round-trips,
+    // cold starts, and replay overhead, so the previous 5s bound was brittle.
+    // 8s stays comfortably below the 10s loser — proving the sleep did not win
+    // — while leaving generous headroom for that jitter.
+    expect(returnValue.durationMs).toBeLessThan(8_000);
   });
 
   test('nullByteWorkflow', { timeout: 60_000 }, async () => {


### PR DESCRIPTION
## Problem

The `sleepWinsRaceWorkflow` e2e test (`packages/core/e2e/e2e.test.ts`) intermittently fails in CI at **~5110ms**, just over its hard `expect(returnValue.durationMs).toBeLessThan(5_000)` wall-clock bound.

## Root cause

The workflow runs a `Promise.race` between a **1s** `sleep` and a **10s** step (`delayMsStep(10_000, 'step')`), and the sleep is expected to win:

```ts
const winner = await Promise.race([
  delayMsStep(10_000, 'step'),
  sleep('1s').then(() => 'sleep'),
]);
return { winner, durationMs: endTime - startTime };
```

The meaningful invariant is the **race outcome** — `winner === 'sleep'` — which the test already asserts. The `durationMs < 5000` check is only a secondary guard that we didn't block on the losing 10s branch. But it's an *absolute wall-clock bound* on a fast branch whose ~1s logical duration accrues preview-environment overhead (cold starts, VQS queue round-trips, replay), which intermittently pushes total elapsed time just past 5s. That makes 5000ms a brittle threshold, not a meaningful one.

## Fix

- Keep the real invariant (`winner === 'sleep'` / `winner === 'step'`) as the primary assertion.
- Widen the `durationMs` guard from `< 5_000` to `< 8_000` for both `sleepWinsRaceWorkflow` and its sibling `stepWinsRaceWorkflow` (same structure, same fragility).
- 8s is **not** an arbitrary bump: the losing branch in each test is **10s**, so an 8s ceiling still proves the slow branch did not win (≥2s clear of the loser) while leaving ~3s of headroom over the observed ~5.1s flake. The threshold is justified in an inline comment, mirroring the generous-bound pattern already used by `parallelSleepWorkflow` above (`< 25_000` for a ~10s-sequential worst case).

This reduces flakiness without weakening coverage — the test still fails loudly if the slow branch ever wins.

## Verification

Run in an isolated worktree off `origin/main`:

- `pnpm build` (turbo, 27/27 tasks) — green
- `pnpm typecheck` (turbo, 40/40 tasks incl. `packages/core`) — green
- `pnpm lint` (biome) — no new diagnostics on the changed lines (pre-existing warnings elsewhere in the file are untouched)

Not run locally: the full e2e suite (`test:e2e`) requires a deployed preview/`DEPLOYMENT_URL` environment and cannot execute on a workstation, so the runtime behavior of the widened bound was not exercised here — only static checks were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)