### PR TITLE
Amend lazy discovery removal changeset

### DIFF
--- a/.changeset/remove-next-lazy-discovery.md
+++ b/.changeset/remove-next-lazy-discovery.md
@@ -1,5 +1,5 @@
 ---
-'@workflow/next': major
+'@workflow/next': minor
 '@workflow/builders': patch
 ---
 


### PR DESCRIPTION
To keep our builder packages on same major as core. 

x-ref: https://github.com/vercel/workflow/pull/2545