### PR TITLE
fix(next): discover root entrypoints

### DIFF
--- a/.changeset/tidy-badgers-build.md
+++ b/.changeset/tidy-badgers-build.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Discover workflows imported by Next.js instrumentation, middleware, and proxy entrypoints.

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -1,7 +1,11 @@
 import { constants } from 'node:fs';
 import { access, copyFile, mkdir, stat, writeFile } from 'node:fs/promises';
-import { extname, join, resolve } from 'node:path';
-import type { WorkflowManifest } from '@workflow/builders';
+import { extname, join, relative, resolve } from 'node:path';
+import type {
+  NextConfig as BuilderNextConfig,
+  WorkflowManifest,
+} from '@workflow/builders';
+import type { NextConfig as ProjectNextConfig } from 'next';
 import Watchpack from 'watchpack';
 
 let CachedNextBuilderEager: any;
@@ -23,6 +27,10 @@ export async function getNextBuilderEager() {
   )) as typeof import('@workflow/builders');
 
   class NextBuilder extends BaseBuilderClass {
+    protected declare config: BuilderNextConfig & {
+      pageExtensions: NonNullable<ProjectNextConfig['pageExtensions']>;
+    };
+
     async build() {
       const outputDir = await this.findAppDirectory();
       const workflowGeneratedDir = join(outputDir, '.well-known/workflow/v1');
@@ -387,21 +395,30 @@ export async function getNextBuilderEager() {
 
     protected async getInputFiles(): Promise<string[]> {
       const inputFiles = await super.getInputFiles();
-      return inputFiles.filter((item) => {
-        // Match App Router entrypoints: route.ts, page.ts, layout.ts in app/ or src/app/ directories
-        // Matches: /app/page.ts, /app/dashboard/page.ts, /src/app/route.ts, etc.
-        if (
-          item.match(
-            /(^|.*[/\\])(app|src[/\\]app)([/\\](route|page|layout)\.|[/\\].*[/\\](route|page|layout)\.)/
+      return inputFiles.filter((file) => {
+        const entry = relative(this.config.workingDir, file).replaceAll(
+          '\\',
+          '/'
+        );
+
+        // Match App Router route, page, and layout entrypoints in app/ or src/app/.
+        if (/^(?:app|src\/app)\/(?:.*\/)?(?:route|page|layout)\./.test(entry)) {
+          return true;
+        }
+
+        // Match every Pages Router entrypoint in pages/ or src/pages/.
+        if (/^(?:pages|src\/pages)\//.test(entry)) {
+          return true;
+        }
+
+        // Match Next.js root entrypoints at the project root or under src/.
+        return ['instrumentation', 'middleware', 'proxy'].some((name) =>
+          this.config.pageExtensions.some(
+            (extension) =>
+              entry === `${name}.${extension}` ||
+              entry === `src/${name}.${extension}`
           )
-        ) {
-          return true;
-        }
-        // Match Pages Router entrypoints: files in pages/ or src/pages/
-        if (item.match(/[/\\](pages|src[/\\]pages)[/\\]/)) {
-          return true;
-        }
-        return false;
+        );
       });
     }
 

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -98,6 +98,7 @@ describe('withWorkflow builder config', () => {
   it('uses outputFileTracingRoot for tracing without changing module specifier root', async () => {
     const config = withWorkflow({
       outputFileTracingRoot: '/repo',
+      pageExtensions: ['page.ts'],
     });
 
     await config('phase-production-build', {
@@ -108,6 +109,8 @@ describe('withWorkflow builder config', () => {
     expect(buildMock).toHaveBeenCalledOnce();
     expect(builderConfigs).toHaveLength(1);
     expect(builderConfigs[0]).toMatchObject({
+      dirs: ['.'],
+      pageExtensions: ['page.ts'],
       projectRoot: '/repo',
       moduleSpecifierRoot: process.cwd(),
       workingDir: process.cwd(),

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -455,8 +455,14 @@ export function withWorkflow(
           const NextBuilder = await getNextBuilder(nextVersion);
           return new NextBuilder({
             watch: shouldWatch,
-            // discover workflows from pages/app entries
-            dirs: ['pages', 'app', 'src/pages', 'src/app'],
+            // getInputFiles filters the project to Next.js entrypoints
+            dirs: ['.'],
+            pageExtensions: nextConfig.pageExtensions ?? [
+              'tsx',
+              'ts',
+              'jsx',
+              'js',
+            ],
             projectRoot: nextConfig.outputFileTracingRoot,
             moduleSpecifierRoot: process.cwd(),
             workingDir: process.cwd(),


### PR DESCRIPTION
## Summary

- discover workflows imported from exact Next.js `instrumentation`, `middleware`, and `proxy` entrypoints at the project root or under `src`
- honor configured `pageExtensions` when identifying those root entrypoints
- keep the existing App Router and Pages Router entrypoint filtering
- scan the project once so root entrypoints are available to the filter

Replaces #1846.
Fixes #1845.

## Testing

- `pnpm --filter @workflow/next... build`
- `vitest run packages/next/src/index.test.ts`
- `tsc -p packages/next/tsconfig.json`