### PR TITLE
docs: derive section landing-page cards from the page tree + lint drift

### DIFF
--- a/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -3,11 +3,10 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
-import { rewriteCookbookUrl } from '@/lib/geistdocs/cookbook-source';
 import { AgentTraces } from '@/components/custom/agent-traces';
 import { FluidComputeCallout } from '@/components/custom/fluid-compute-callout';
-import { PreviewInstallServer } from '@/components/preview-install-server';
 import { AskAI } from '@/components/geistdocs/ask-ai';
+import { AutoCards } from '@/components/geistdocs/auto-cards';
 import { CopyPage } from '@/components/geistdocs/copy-page';
 import {
   DocsBody,
@@ -21,10 +20,15 @@ import { getMDXComponents } from '@/components/geistdocs/mdx-components';
 import { MobileDocsBar } from '@/components/geistdocs/mobile-docs-bar';
 import { OpenInChat } from '@/components/geistdocs/open-in-chat';
 import { ScrollTop } from '@/components/geistdocs/scroll-top';
+import { PreviewInstallServer } from '@/components/preview-install-server';
 import * as AccordionComponents from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
+import { rewriteCookbookUrl } from '@/lib/geistdocs/cookbook-source';
+import { resolveSectionChildren } from '@/lib/geistdocs/section-children';
 import { getLLMText, getPageImage, source } from '@/lib/geistdocs/source';
+import { getDocsTreeForVersion } from '@/lib/geistdocs/version-source';
+import { LATEST_VERSION } from '@/lib/geistdocs/versions';
 import { TSDoc } from '@/lib/tsdoc';
 
 // No-op component for world MDX files rendered outside /worlds/ context
@@ -46,7 +50,11 @@ const Page = async ({ params }: PageProps<'/[lang]/docs/[[...slug]]'>) => {
     notFound();
   }
 
-  const markdown = await getLLMText(page);
+  // v4's sidebar tree is already in the `/docs/...` URL space (no version
+  // rewrite), so the same tree drives both the rendered cards and the markdown
+  // export expansion in getLLMText.
+  const tree = getDocsTreeForVersion(lang, LATEST_VERSION);
+  const markdown = await getLLMText(page, tree);
   const MDX = page.data.body;
 
   return (
@@ -78,6 +86,9 @@ const Page = async ({ params }: PageProps<'/[lang]/docs/[[...slug]]'>) => {
             a: createRelativeLink(source, page),
 
             // Add your custom components here
+            AutoCards: () => (
+              <AutoCards items={resolveSectionChildren(tree, page.url)} />
+            ),
             AgentTraces,
             FluidComputeCallout,
             Badge,

--- a/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
@@ -1,7 +1,10 @@
 import { generateNotFoundMarkdown } from '@vercel/agent-readability';
-import { rewriteCookbookUrlsInText } from '@/lib/geistdocs/cookbook-source';
-import { getLLMText, source } from '@/lib/geistdocs/source';
+import {
+  getDocsTreeWithoutCookbook,
+  rewriteCookbookUrlsInText,
+} from '@/lib/geistdocs/cookbook-source';
 import { i18n } from '@/lib/geistdocs/i18n';
+import { getLLMText, source } from '@/lib/geistdocs/source';
 
 export const revalidate = false;
 
@@ -25,7 +28,7 @@ export async function GET(
   const sitemapPath =
     lang === i18n.defaultLanguage ? '/sitemap.md' : `/${lang}/sitemap.md`;
 
-  const text = await getLLMText(page);
+  const text = await getLLMText(page, getDocsTreeWithoutCookbook(lang, 'v4'));
 
   return new Response(
     rewriteCookbookUrlsInText(text) +

--- a/docs/app/[lang]/llms.txt/route.ts
+++ b/docs/app/[lang]/llms.txt/route.ts
@@ -1,5 +1,8 @@
 import type { NextRequest } from 'next/server';
-import { rewriteCookbookUrlsInText } from '@/lib/geistdocs/cookbook-source';
+import {
+  getDocsTreeWithoutCookbook,
+  rewriteCookbookUrlsInText,
+} from '@/lib/geistdocs/cookbook-source';
 import { getLLMText, source } from '@/lib/geistdocs/source';
 
 export const revalidate = false;
@@ -9,7 +12,8 @@ export const GET = async (
   { params }: RouteContext<'/[lang]/llms.txt'>
 ) => {
   const { lang } = await params;
-  const scan = source.getPages(lang).map(getLLMText);
+  const tree = getDocsTreeWithoutCookbook(lang, 'v4');
+  const scan = source.getPages(lang).map((page) => getLLMText(page, tree));
   const scanned = await Promise.all(scan);
 
   return new Response(rewriteCookbookUrlsInText(scanned.join('\n\n')), {

--- a/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import type { ComponentProps } from 'react';
 import { AgentTraces } from '@/components/custom/agent-traces';
 import { FluidComputeCallout } from '@/components/custom/fluid-compute-callout';
 import { AskAI } from '@/components/geistdocs/ask-ai';
+import { AutoCards } from '@/components/geistdocs/auto-cards';
 import { CopyPage } from '@/components/geistdocs/copy-page';
 import {
   DocsBody,
@@ -25,13 +26,21 @@ import { PreviewInstallServer } from '@/components/preview-install-server';
 import * as AccordionComponents from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import { rewriteCookbookUrl } from '@/lib/geistdocs/cookbook-source';
+import {
+  getDocsTreeWithoutCookbook,
+  rewriteCookbookUrl,
+} from '@/lib/geistdocs/cookbook-source';
+import { resolveSectionChildren } from '@/lib/geistdocs/section-children';
 import {
   getLLMText,
   getPageImage,
   source,
   v5Source,
 } from '@/lib/geistdocs/source';
+import {
+  getDocsTreeForVersion,
+  PRE_RELEASE_VERSION,
+} from '@/lib/geistdocs/version-source';
 import { TSDoc } from '@/lib/tsdoc';
 
 const WorldTestingPerformanceNoop = () => null;
@@ -50,7 +59,15 @@ const Page = async ({ params }: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
     notFound();
   }
 
-  const markdown = await getLLMText(page);
+  // Cards render in the v5 URL space (`/v5/docs/...`), matching the sidebar tree
+  // so hrefs don't escape to the v4 route. The markdown export, however, mirrors
+  // the page's own `/docs/...` URL space, so it uses the raw (un-rewritten) tree.
+  const cardsTree = getDocsTreeForVersion(lang, PRE_RELEASE_VERSION);
+  const sectionUrl = `${PRE_RELEASE_VERSION.prefix}${page.url}`;
+  const markdown = await getLLMText(
+    page,
+    getDocsTreeWithoutCookbook(lang, 'v5')
+  );
   const MDX = page.data.body;
 
   // Inline MDX links use /docs/... paths (matching the source baseUrl). When
@@ -100,6 +117,11 @@ const Page = async ({ params }: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
           components={getMDXComponents({
             a: v5Link,
             Card: V5Card,
+            AutoCards: () => (
+              <AutoCards
+                items={resolveSectionChildren(cardsTree, sectionUrl)}
+              />
+            ),
             AgentTraces,
             FluidComputeCallout,
             Badge,

--- a/docs/components/geistdocs/auto-cards.tsx
+++ b/docs/components/geistdocs/auto-cards.tsx
@@ -1,0 +1,27 @@
+import { Card, Cards } from 'fumadocs-ui/components/card';
+import type { SectionChild } from '@/lib/geistdocs/section-children';
+
+/**
+ * Renders a card grid for a section landing page from children resolved off the
+ * fumadocs page tree (see `resolveSectionChildren`). Because the list is derived
+ * from `meta.json` + page frontmatter rather than hand-written, the cards can
+ * never drift from the sidebar navigation.
+ *
+ * The `items` are bound per-request in the docs route handlers, where the active
+ * version's page tree and the current page URL are known.
+ */
+export function AutoCards({ items }: { items: SectionChild[] }) {
+  return (
+    <Cards>
+      {items.map((item) => (
+        <Card
+          key={item.url}
+          href={item.url}
+          title={item.title}
+          description={item.description}
+          icon={item.icon}
+        />
+      ))}
+    </Cards>
+  );
+}

--- a/docs/content/docs/v4/ai/index.mdx
+++ b/docs/content/docs/v4/ai/index.mdx
@@ -3,6 +3,7 @@ title: Building Durable AI Agents
 description: Build AI agents that survive crashes, scale across requests, and maintain state with durable LLM tool-call loops.
 type: overview
 summary: Convert a basic AI chat app into a durable, resumable agent using Workflow SDK.
+manualCards: true
 related:
   - /docs/foundations/workflows-and-steps
   - /docs/foundations/streaming

--- a/docs/content/docs/v4/deploying/index.mdx
+++ b/docs/content/docs/v4/deploying/index.mdx
@@ -4,6 +4,7 @@ icon: Rocket
 description: Deploy workflows locally, on Vercel, or anywhere using pluggable World adapters.
 type: overview
 summary: Learn how to deploy workflows to different environments using World adapters.
+manualCards: true
 related:
   - /docs/deploying/world/local-world
   - /docs/deploying/world/postgres-world

--- a/docs/content/docs/v4/errors/index.mdx
+++ b/docs/content/docs/v4/errors/index.mdx
@@ -9,50 +9,7 @@ related:
 
 Fix common mistakes when creating and executing workflows in the **Workflow SDK**.
 
-<Cards>
-    <Card href="/docs/errors/fetch-in-workflow" title="fetch-in-workflow">
-        Learn how to use fetch in workflow functions.
-    </Card>
-    <Card href="/docs/errors/hook-conflict" title="hook-conflict">
-        Learn how to handle hook token conflicts between workflows.
-    </Card>
-    <Card href="/docs/errors/node-js-module-in-workflow" title="node-js-module-in-workflow">
-        Learn how to use Node.js modules in workflows.
-    </Card>
-    <Card href="/docs/errors/serialization-failed" title="serialization-failed">
-        Learn how to handle serialization failures in workflows.
-    </Card>
-    <Card href="/docs/errors/start-invalid-workflow-function" title="start-invalid-workflow-function">
-        Learn how to start an invalid workflow function.
-    </Card>
-    <Card href="/docs/errors/timeout-in-workflow" title="timeout-in-workflow">
-        Learn how to handle timing delays in workflow functions.
-    </Card>
-    <Card href="/docs/errors/webhook-invalid-respond-with-value" title="webhook-invalid-respond-with-value">
-        Learn how to use the correct `respondWith` values for webhooks.
-    </Card>
-    <Card href="/docs/errors/webhook-response-not-sent" title="webhook-response-not-sent">
-        Learn how to send responses when using manual webhook response mode.
-    </Card>
-    <Card href="/docs/errors/corrupted-event-log" title="corrupted-event-log">
-        Learn how to handle corrupted or invalid event logs.
-    </Card>
-    <Card href="/docs/errors/replay-divergence" title="replay-divergence">
-        Learn how workflow replay divergence is recovered automatically.
-    </Card>
-    <Card href="/docs/errors/step-not-registered" title="step-not-registered">
-        Resolve step not registered errors caused by deployment mismatches.
-    </Card>
-    <Card href="/docs/errors/step-executed-multiple-times" title="Step executed multiple times">
-        Diagnose duplicate step_started events from function crashes, timeouts, or OOMs.
-    </Card>
-    <Card href="/docs/errors/workflow-not-registered" title="workflow-not-registered">
-        Resolve workflow not registered errors caused by deployment mismatches.
-    </Card>
-    <Card href="/docs/errors/runtime-decryption-failed" title="runtime-decryption-failed">
-        Resolve runtime decryption failures from the SDK's encryption layer.
-    </Card>
-</Cards>
+<AutoCards />
 
 ## Learn More
 

--- a/docs/content/docs/v4/foundations/index.mdx
+++ b/docs/content/docs/v4/foundations/index.mdx
@@ -10,29 +10,4 @@ related:
 
 Workflow programming can be a slight shift from how you traditionally write real-world applications. Learning the foundations now will go a long way toward helping you use workflows effectively.
 
-<Cards>
-    <Card href="/docs/foundations/workflows-and-steps" title="Workflows and Steps">
-        Learn about the building blocks of durability
-    </Card>
-    <Card href="/docs/foundations/starting-workflows" title="Starting Workflows">
-        Trigger workflows and track their execution using the `start()` function.
-    </Card>
-    <Card href="/docs/foundations/errors-and-retries" title="Errors & Retrying">
-        Types of errors and how retrying work in workflows.
-    </Card>
-    <Card href="/docs/foundations/hooks" title="Webhooks (and hooks)">
-        Respond to external events in your workflow using hooks and webhooks.
-    </Card>
-    <Card href="/docs/foundations/streaming" title="Streaming">
-        Stream data in real-time to clients without waiting for the workflow to complete.
-    </Card>
-    <Card href="/docs/foundations/serialization" title="Serialization">
-        Understand which types can be passed between workflow and step functions.
-    </Card>
-    <Card href="/docs/foundations/idempotency" title="Idempotency">
-        Prevent duplicate side effects when retrying operations.
-    </Card>
-    <Card href="/docs/foundations/versioning" title="Versioning">
-        Understand how runs stay pinned to deployments and when to opt in to newer code.
-    </Card>
-</Cards>
+<AutoCards />

--- a/docs/content/docs/v4/foundations/meta.json
+++ b/docs/content/docs/v4/foundations/meta.json
@@ -6,7 +6,6 @@
     "errors-and-retries",
     "hooks",
     "streaming",
-    "cancellation",
     "serialization",
     "idempotency",
     "versioning"

--- a/docs/content/docs/v4/how-it-works/meta.json
+++ b/docs/content/docs/v4/how-it-works/meta.json
@@ -5,8 +5,7 @@
     "code-transform",
     "framework-integrations",
     "event-sourcing",
-    "encryption",
-    "cancellation"
+    "encryption"
   ],
   "defaultOpen": false
 }

--- a/docs/content/docs/v4/internal/meta.json
+++ b/docs/content/docs/v4/internal/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Internal",
-  "pages": ["index", "serializable-abort-controller"],
+  "pages": ["index"],
   "defaultOpen": false
 }

--- a/docs/content/docs/v4/meta.json
+++ b/docs/content/docs/v4/meta.json
@@ -1,6 +1,5 @@
 {
   "pages": [
-    "introduction",
     "---",
     "getting-started",
     "foundations",

--- a/docs/content/docs/v5/ai/index.mdx
+++ b/docs/content/docs/v5/ai/index.mdx
@@ -3,6 +3,7 @@ title: Building Durable AI Agents
 description: Build AI agents that survive crashes, scale across requests, and maintain state with durable LLM tool-call loops.
 type: overview
 summary: Convert a basic AI chat app into a durable, resumable agent using Workflow SDK.
+manualCards: true
 related:
   - /docs/foundations/workflows-and-steps
   - /docs/foundations/streaming

--- a/docs/content/docs/v5/deploying/index.mdx
+++ b/docs/content/docs/v5/deploying/index.mdx
@@ -4,6 +4,7 @@ icon: Rocket
 description: Deploy workflows locally, on Vercel, or anywhere using pluggable World adapters.
 type: overview
 summary: Learn how to deploy workflows to different environments using World adapters.
+manualCards: true
 related:
   - /docs/deploying/world/local-world
   - /docs/deploying/world/postgres-world

--- a/docs/content/docs/v5/errors/index.mdx
+++ b/docs/content/docs/v5/errors/index.mdx
@@ -9,50 +9,7 @@ related:
 
 Fix common mistakes when creating and executing workflows in the **Workflow SDK**.
 
-<Cards>
-    <Card href="/docs/errors/fetch-in-workflow" title="fetch-in-workflow">
-        Learn how to use fetch in workflow functions.
-    </Card>
-    <Card href="/docs/errors/hook-conflict" title="hook-conflict">
-        Learn how to handle hook token conflicts between workflows.
-    </Card>
-    <Card href="/docs/errors/node-js-module-in-workflow" title="node-js-module-in-workflow">
-        Learn how to use Node.js modules in workflows.
-    </Card>
-    <Card href="/docs/errors/serialization-failed" title="serialization-failed">
-        Learn how to handle serialization failures in workflows.
-    </Card>
-    <Card href="/docs/errors/start-invalid-workflow-function" title="start-invalid-workflow-function">
-        Learn how to start an invalid workflow function.
-    </Card>
-    <Card href="/docs/errors/timeout-in-workflow" title="timeout-in-workflow">
-        Learn how to handle timing delays in workflow functions.
-    </Card>
-    <Card href="/docs/errors/webhook-invalid-respond-with-value" title="webhook-invalid-respond-with-value">
-        Learn how to use the correct `respondWith` values for webhooks.
-    </Card>
-    <Card href="/docs/errors/webhook-response-not-sent" title="webhook-response-not-sent">
-        Learn how to send responses when using manual webhook response mode.
-    </Card>
-    <Card href="/docs/errors/corrupted-event-log" title="corrupted-event-log">
-        Learn how to handle corrupted or invalid event logs.
-    </Card>
-    <Card href="/docs/errors/replay-divergence" title="replay-divergence">
-        Learn how workflow replay divergence is recovered automatically.
-    </Card>
-    <Card href="/docs/errors/step-not-registered" title="step-not-registered">
-        Resolve step not registered errors caused by deployment mismatches.
-    </Card>
-    <Card href="/docs/errors/step-executed-multiple-times" title="Step executed multiple times">
-        Diagnose duplicate step_started events from function crashes, timeouts, or OOMs.
-    </Card>
-    <Card href="/docs/errors/workflow-not-registered" title="workflow-not-registered">
-        Resolve workflow not registered errors caused by deployment mismatches.
-    </Card>
-    <Card href="/docs/errors/runtime-decryption-failed" title="runtime-decryption-failed">
-        Resolve runtime decryption failures from the SDK's encryption layer.
-    </Card>
-</Cards>
+<AutoCards />
 
 ## Learn More
 

--- a/docs/content/docs/v5/foundations/index.mdx
+++ b/docs/content/docs/v5/foundations/index.mdx
@@ -10,29 +10,4 @@ related:
 
 Workflow programming can be a slight shift from how you traditionally write real-world applications. Learning the foundations now will go a long way toward helping you use workflows effectively.
 
-<Cards>
-    <Card href="/docs/foundations/workflows-and-steps" title="Workflows and Steps">
-        Learn about the building blocks of durability
-    </Card>
-    <Card href="/docs/foundations/starting-workflows" title="Starting Workflows">
-        Trigger workflows and track their execution using the `start()` function.
-    </Card>
-    <Card href="/docs/foundations/errors-and-retries" title="Errors & Retrying">
-        Types of errors and how retrying work in workflows.
-    </Card>
-    <Card href="/docs/foundations/hooks" title="Webhooks (and hooks)">
-        Respond to external events in your workflow using hooks and webhooks.
-    </Card>
-    <Card href="/docs/foundations/streaming" title="Streaming">
-        Stream data in real-time to clients without waiting for the workflow to complete.
-    </Card>
-    <Card href="/docs/foundations/serialization" title="Serialization">
-        Understand which types can be passed between workflow and step functions.
-    </Card>
-    <Card href="/docs/foundations/idempotency" title="Idempotency">
-        Prevent duplicate side effects when retrying operations.
-    </Card>
-    <Card href="/docs/foundations/versioning" title="Versioning">
-        Understand how runs stay pinned to deployments and when to opt in to newer code.
-    </Card>
-</Cards>
+<AutoCards />

--- a/docs/content/docs/v5/meta.json
+++ b/docs/content/docs/v5/meta.json
@@ -1,6 +1,5 @@
 {
   "pages": [
-    "introduction",
     "---",
     "getting-started",
     "foundations",

--- a/docs/content/docs/v5/observability/index.mdx
+++ b/docs/content/docs/v5/observability/index.mdx
@@ -79,11 +79,4 @@ When deployed to Vercel, workflow data is [encrypted end-to-end](/docs/how-it-wo
 
 ## More Observability Features
 
-<Cards>
-    <Card href="/docs/observability/tracing" title="Tracing">
-        Distributed tracing with OpenTelemetry for workflow runs, steps, and queue deliveries.
-    </Card>
-    <Card href="/docs/observability/attributes" title="Attributes">
-        Attach experimental metadata to workflow runs for observability.
-    </Card>
-</Cards>
+<AutoCards />

--- a/docs/lib/geistdocs/section-children.ts
+++ b/docs/lib/geistdocs/section-children.ts
@@ -1,0 +1,66 @@
+import type { Folder, Node, Root } from 'fumadocs-core/page-tree';
+import type { ReactNode } from 'react';
+
+export interface SectionChild {
+  title: ReactNode;
+  url: string;
+  description?: ReactNode;
+  icon?: ReactNode;
+}
+
+/**
+ * Find the folder whose index page is served at `sectionUrl` (e.g. the
+ * `foundations` folder for `/docs/foundations`). Searches the tree recursively
+ * so it works regardless of nesting depth.
+ */
+function findSectionFolder(
+  nodes: Node[],
+  sectionUrl: string
+): Folder | undefined {
+  for (const node of nodes) {
+    if (node.type !== 'folder') continue;
+    if (node.index?.url === sectionUrl) return node;
+    const nested = findSectionFolder(node.children, sectionUrl);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the child pages of a section's landing page directly from the
+ * fumadocs page tree — the same tree that builds the sidebar (driven by
+ * `meta.json` + page frontmatter). This is the single source of truth shared by
+ * the `<AutoCards />` component, the markdown export in `getLLMText`, and the
+ * docs lint, so the card grid can never drift from the navigation.
+ *
+ * Children are returned in navigation order. Both leaf pages and sub-folders
+ * (which surface via their own index page) become cards; separators and
+ * index-less folders are skipped.
+ */
+export function resolveSectionChildren(
+  tree: Root,
+  sectionUrl: string
+): SectionChild[] {
+  const folder = findSectionFolder(tree.children, sectionUrl);
+  if (!folder) return [];
+
+  const children: SectionChild[] = [];
+  for (const child of folder.children) {
+    if (child.type === 'page') {
+      children.push({
+        title: child.name,
+        url: child.url,
+        description: child.description,
+        icon: child.icon,
+      });
+    } else if (child.type === 'folder' && child.index) {
+      children.push({
+        title: child.index.name ?? child.name,
+        url: child.index.url,
+        description: child.index.description ?? child.description,
+        icon: child.index.icon ?? child.icon,
+      });
+    }
+  }
+  return children;
+}

--- a/docs/lib/geistdocs/source.ts
+++ b/docs/lib/geistdocs/source.ts
@@ -1,8 +1,10 @@
+import type { Root } from 'fumadocs-core/page-tree';
 import { type InferPageType, loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 import { v4docs, v5docs } from '@/.source/server';
 import { basePath } from '@/geistdocs';
 import { i18n } from './i18n';
+import { resolveSectionChildren } from './section-children';
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
@@ -30,8 +32,44 @@ export const getPageImage = (page: InferPageType<typeof source>) => {
   };
 };
 
-export const getLLMText = async (page: InferPageType<typeof source>) => {
-  const processed = await page.data.getText('processed');
+// Matches the `<AutoCards />` placeholder (self-closing or paired) so the
+// markdown export can substitute the rendered card list. The component itself
+// only renders in the React tree, so without this the agent-facing markdown
+// (llms.txt, .md routes, copy-page) would lose every child link.
+const AUTO_CARDS_RE = /<AutoCards\b[^>]*?(?:\/>|>[\s\S]*?<\/AutoCards>)/g;
+
+const asText = (value: unknown): string =>
+  typeof value === 'string' ? value : '';
+
+/**
+ * Render the `<Cards>`/`<Card>` JSX a section landing page would have contained
+ * by hand, derived from the page tree. Matching the existing serialized format
+ * keeps the markdown export consistent across converted and unconverted pages.
+ */
+function renderAutoCardsMarkdown(tree: Root, sectionUrl: string): string {
+  const cards = resolveSectionChildren(tree, sectionUrl)
+    .map((child) => {
+      const title = asText(child.title);
+      const description = asText(child.description);
+      const open = `<Card href="${child.url}" title="${title}">`;
+      return description ? `${open}${description}</Card>` : `${open}</Card>`;
+    })
+    .join('\n');
+  return `<Cards>\n${cards}\n</Cards>`;
+}
+
+export const getLLMText = async (
+  page: InferPageType<typeof source>,
+  tree?: Root
+) => {
+  let processed = await page.data.getText('processed');
+  if (tree) {
+    // `.replace` is a no-op when there's no placeholder, and the replacer only
+    // walks the tree on an actual match.
+    processed = processed.replace(AUTO_CARDS_RE, () =>
+      renderAutoCardsMarkdown(tree, page.url)
+    );
+  }
   const { title, description, product, type, summary, prerequisites, related } =
     page.data;
 

--- a/docs/scripts/lint.ts
+++ b/docs/scripts/lint.ts
@@ -1,13 +1,18 @@
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Folder, Node, Root } from 'fumadocs-core/page-tree';
 import GithubSlugger from 'github-slugger';
 import {
   type FileObject,
   printErrors,
   validateFiles,
 } from 'next-validate-link';
-import { rewriteCookbookUrl } from '../lib/geistdocs/cookbook-source';
+import {
+  getDocsTreeWithoutCookbook,
+  rewriteCookbookUrl,
+} from '../lib/geistdocs/cookbook-source';
+import { resolveSectionChildren } from '../lib/geistdocs/section-children';
 import { source, v5Source } from '../lib/geistdocs/source';
 import { getWorldIds } from '../lib/worlds-data';
 import nextConfig from '../next.config';
@@ -311,6 +316,188 @@ async function checkLinks() {
   }
 
   await checkStaticAppLinks();
+  checkSectionCards(v4Pages, v5Pages);
+  await checkMetaEntriesResolve();
+}
+
+/**
+ * Enforce that every section landing page accounts for all of its navigation
+ * children. A page passes if it either:
+ *   - renders `<AutoCards />` (cards are derived from the tree — drift is
+ *     structurally impossible), or
+ *   - declares `manualCards: true` in frontmatter (intentionally curated), or
+ *   - has a `<Card href>` for every child page in the section.
+ *
+ * The existing link validation already covers the reverse direction (cards that
+ * point at pages which don't exist), so together the two checks keep the card
+ * grid and the sidebar in lockstep.
+ */
+function sectionMissingCards(
+  folder: Folder,
+  tree: Root,
+  rawByUrl: Map<string, LoadedPage>
+): { sourcePath: string; missing: string[] } | null {
+  const sectionUrl = folder.index?.url;
+  if (!sectionUrl) return null;
+
+  const expected = resolveSectionChildren(tree, sectionUrl).map((c) =>
+    normalizePathname(c.url)
+  );
+  if (expected.length === 0) return null;
+
+  const loaded = rawByUrl.get(sectionUrl);
+  if (!loaded) return null;
+  const { raw, page } = loaded;
+
+  // Drift is impossible (AutoCards) or intentionally owned by the author.
+  if (/<AutoCards\b/.test(raw) || hasManualCardsFlag(raw)) return null;
+
+  const carded = new Set(
+    getCardHrefs(raw).map((href) => normalizePathname(href))
+  );
+  const missing = expected.filter((url) => !carded.has(url));
+  return missing.length > 0 ? { sourcePath: page.absolutePath, missing } : null;
+}
+
+function checkSectionCards(v4Pages: LoadedPage[], v5Pages: LoadedPage[]) {
+  const errors: { sourcePath: string; missing: string[] }[] = [];
+  for (const [pages, version] of [
+    [v4Pages, 'v4'],
+    [v5Pages, 'v5'],
+  ] as const) {
+    const tree = getDocsTreeWithoutCookbook('en', version);
+    const rawByUrl = new Map(pages.map((p) => [p.page.url, p]));
+    for (const folder of collectSectionFolders(tree.children)) {
+      const result = sectionMissingCards(folder, tree, rawByUrl);
+      if (result) errors.push(result);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(
+      '\nSection landing pages missing cards for navigation children:'
+    );
+    for (const error of errors) {
+      console.error(`- ${error.sourcePath}: ${error.missing.join(', ')}`);
+    }
+    console.error(
+      '  Fix by using <AutoCards /> (recommended), adding the missing <Card> ' +
+        'entries, or setting `manualCards: true` if the page is intentionally curated.'
+    );
+    process.exitCode = 1;
+  }
+}
+
+/** Recursively collect folders that have an index page (section landing pages). */
+function collectSectionFolders(nodes: Node[]): Folder[] {
+  const folders: Folder[] = [];
+  for (const node of nodes) {
+    if (node.type !== 'folder') continue;
+    if (node.index) folders.push(node);
+    folders.push(...collectSectionFolders(node.children));
+  }
+  return folders;
+}
+
+function getCardHrefs(raw: string): string[] {
+  const hrefs: string[] = [];
+  const pattern = /<Card\b[^>]*?\bhref="([^"]+)"/g;
+  let match = pattern.exec(raw);
+  while (match !== null) {
+    hrefs.push(match[1].split('#')[0]);
+    match = pattern.exec(raw);
+  }
+  return hrefs;
+}
+
+function hasManualCardsFlag(raw: string): boolean {
+  const frontmatter = raw.match(/^---\n([\s\S]*?)\n---/)?.[1];
+  return frontmatter ? /^manualCards:\s*true\s*$/m.test(frontmatter) : false;
+}
+
+/**
+ * Validate that every plain-slug `pages` entry in a `meta.json` resolves to a
+ * real page file or sub-folder. Catches dangling navigation entries (e.g. a
+ * `cancellation` entry with no `cancellation.mdx`). Fumadocs control tokens
+ * (`...rest`, `---separators---`, `[label](url)` links, `!exclude`) are skipped.
+ */
+// Fumadocs control tokens that don't reference a page: rest globs, separators,
+// external links, and exclusions.
+function isMetaControlToken(entry: string): boolean {
+  return (
+    entry === 'index' ||
+    entry.startsWith('...') ||
+    entry.startsWith('---') ||
+    entry.startsWith('[') ||
+    entry.startsWith('!')
+  );
+}
+
+async function metaEntryResolves(dir: string, entry: string): Promise<boolean> {
+  return (
+    (await pathExists(join(dir, `${entry}.mdx`))) ||
+    (await pathExists(join(dir, `${entry}.md`))) ||
+    (await pathExists(join(dir, entry)))
+  );
+}
+
+async function unresolvedMetaEntries(metaPath: string): Promise<string[]> {
+  let pages: unknown;
+  try {
+    pages = JSON.parse(await readFile(metaPath, 'utf8')).pages;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(pages)) return [];
+
+  const dir = metaPath.slice(0, metaPath.lastIndexOf('/'));
+  const unresolved: string[] = [];
+  for (const entry of pages) {
+    if (typeof entry !== 'string' || isMetaControlToken(entry)) continue;
+    if (!(await metaEntryResolves(dir, entry))) unresolved.push(entry);
+  }
+  return unresolved;
+}
+
+async function checkMetaEntriesResolve() {
+  const errors: { sourcePath: string; entry: string }[] = [];
+  const contentRoot = join(DOCS_DIR, 'content/docs');
+
+  for (const metaPath of await findFiles(contentRoot, 'meta.json')) {
+    for (const entry of await unresolvedMetaEntries(metaPath)) {
+      errors.push({ sourcePath: metaPath, entry });
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('\nmeta.json entries with no matching page or folder:');
+    for (const error of errors) {
+      console.error(`- ${error.sourcePath} -> "${error.entry}"`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+async function findFiles(dir: string, name: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await findFiles(full, name)));
+    } else if (entry.name === name) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function checkStaticAppLinks() {

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -38,6 +38,11 @@ const docsSchema = frontmatterSchema.extend({
     .optional(),
   summary: z.string().optional(),
   keywords: z.array(z.string()).optional(),
+  // Opt a section landing page out of the card↔nav completeness lint when its
+  // `<Cards>` grid is intentionally curated (e.g. links outside the section or
+  // deliberately omits children). Exhaustive list pages should use `<AutoCards />`
+  // instead, which derives cards from the page tree and can never drift.
+  manualCards: z.boolean().optional(),
 });
 
 // You can customise Zod schemas for frontmatter and `meta.json` here


### PR DESCRIPTION
## Problem

Section landing pages (e.g. `foundations/index.mdx`) render a `<Cards>` grid that's supposed to link to every page in that section. That grid was **hand-written**, so it drifted from the two other representations of the same list:

1. `meta.json` `pages` — the **sidebar nav**
2. the actual `.mdx` files on disk
3. the hand-written `<Cards>` in `index.mdx`

Concrete drift this fixes: `v5/foundations` was missing `cancellation`; `v5/errors` was missing `abort-signal-timeout-in-workflow`; and several `meta.json` entries pointed at pages that don't exist.

## Approach (single source of truth + lint)

Hybrid: derive cards from the fumadocs page tree where possible, and lint-enforce parity everywhere else.

- **`resolveSectionChildren(tree, url)`** (`lib/geistdocs/section-children.ts`) — walks the page tree (built from `meta.json` + frontmatter) and returns a section's children in nav order. Handles both leaf pages and sub-folders (`folder.index`). This one function is the shared source of truth.
- **`<AutoCards />`** (`components/geistdocs/auto-cards.tsx`) — renders the card grid from those children. Bound per-route in both docs routes so hrefs land in the right URL space (`/docs/...` for v4, `/v5/docs/...` for v5).
- **`getLLMText` expands `<AutoCards/>`** into `<Card>` JSX in the markdown export, so `llms.txt` / `.md` / copy-page keep the child links (a bare `<AutoCards/>` tag would otherwise strip them from agent-facing markdown).
- **`manualCards: true`** frontmatter opt-out (`source.config.ts`) for pages whose grid is intentionally curated (links outside the section, custom layout, deliberate omissions).
- **Two lint checks** in `scripts/lint.ts` (already CI-gated via `lint.yml`):
  - `checkSectionCards` — every section index must use `<AutoCards/>`, set `manualCards: true`, or have a `<Card>` for every nav child.
  - `checkMetaEntriesResolve` — every plain-slug `meta.json` entry must resolve to a real page/folder.

## Authoring model going forward

- **Exhaustive list** → `<AutoCards />` (drift-proof; card text comes from each child's frontmatter `title`/`description`).
- **Curated / partial** → keep hand-written `<Cards>` + `manualCards: true`.
- **Hand-written but should stay complete** (e.g. getting-started's framework logos, grouped api-reference) → leave as-is; the lint fails if a nav child loses its card.

## Content changes

- Converted to `<AutoCards/>`: `foundations` and `errors` (both had real drift), v5 `observability`.
- Marked `manualCards: true`: `deploying` (links `/worlds`, omits the `world/` subfolder), `ai` (tutorial with a curated next-steps grid).
- Removed dangling nav entries surfaced by the new meta check: v4 `cancellation` (foundations + how-it-works), root `introduction` (v4 + v5 — vestigial; `/docs` redirects to `/docs/getting-started`), v4/internal `serializable-abort-controller` (v5-only page).

> Note on `ai/index`: treated as curated (kept its 4-item grid) rather than auto-listing all AI pages, since it's a tutorial. If those extra pages should appear there, switch it to `<AutoCards/>` and drop the flag.

## Verification

- `bun ./scripts/lint.ts` (the docs CI gate) passes; both new checks were confirmed to **fail** on injected drift (removed card / re-added dangling entry).
- Full build: **690/690 static pages**, all turbo tasks successful.
- Runtime: v5 foundations cards now include `cancellation` in `/v5/docs/...`; errors lists all 15; markdown export expands `<AutoCards/>` to real card links.
- Biome-clean on all changed files. No changeset needed (docs-only).

## Docs Preview

Pages whose card grid changed (behind Vercel deployment protection — requires team access):

| Page | v4 | v5 |
| --- | --- | --- |
| Foundations | [/docs/foundations](https://workflow-docs-git-pgp-docs-nit.vercel.sh/docs/foundations) | [/v5/docs/foundations](https://workflow-docs-git-pgp-docs-nit.vercel.sh/v5/docs/foundations) |
| Errors | [/docs/errors](https://workflow-docs-git-pgp-docs-nit.vercel.sh/docs/errors) | [/v5/docs/errors](https://workflow-docs-git-pgp-docs-nit.vercel.sh/v5/docs/errors) |
| Observability | — | [/v5/docs/observability](https://workflow-docs-git-pgp-docs-nit.vercel.sh/v5/docs/observability) |


🤖 Generated with [Claude Code](https://claude.com/claude-code)
