### PR TITLE
ci: run multi-worker exactly-once test in e2e-restart-recovery (postgres)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -970,6 +970,10 @@ jobs:
       WORKFLOW_PUBLIC_MANIFEST: '1'
       APP_NAME: nextjs-turbopack
       RESTART_RECOVERY_TEST: '1'
+      # Enable the multi-worker exactly-once guarantee test (postgres only: it
+      # needs a shared DB + graphile-worker pool). The local matrix entry skips
+      # it via its own world gate.
+      MULTIWORKER_RECOVERY_TEST: ${{ matrix.world == 'postgres' && '1' || '' }}
       DEPLOYMENT_URL: 'http://localhost:3000'
       # Empty for the local matrix entry -> resolveWorkflowTargetWorld() falls
       # back to the local world.


### PR DESCRIPTION
Stacked on #2544.

## What

Enables `MULTIWORKER_RECOVERY_TEST=1` on the **postgres** entry of the `e2e-restart-recovery` job so the multi-worker exactly-once guarantee test (added in #2544, currently gated off CI) runs in CI.

## The test it wires up

`packages/core/e2e/restart-recovery.test.ts` → *"a worker booting does not re-run a step already executing on another worker"*:

1. Worker **B** runs a workflow whose only work is one long step (`sideEffectStepWorkflow`); the step records each execution of its body to a shared side-effect log.
2. Worker **A** boots while the step is still in flight on B — its startup wiring (`ensureWorldStarted → reenqueueActiveRuns`) re-drives **all** active runs, including this healthy one.
3. The test counts how many times the step body actually ran.

It asserts the step body executes **exactly once** — proving boot-time recovery does not duplicately execute a step that's healthily in-flight on another worker (the `correlationId` idempotency key + the step's terminal-state guard hold even when another worker re-enqueues the run).

## Why postgres-only

The duplicate-execution concern only applies to a shared DB + graphile-worker pool. The local matrix entry skips the test via its own world gate (`WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'`), so this only affects the postgres entry.

## Verification

Run locally against a postgres container:
```
Re-enqueued 1 active run(s) on startup   ← worker A re-drove the in-flight run
step body executed 1 time(s)             ← exactly-once
```
Test passes, VITEST EXIT 0 (robust process-group + lsof teardown so the worker exits cleanly). Adds ~25s + a second server to the postgres entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)