### PR TITLE
fix(nitro): reload steps during Vite HMR

### DIFF
--- a/.changeset/fresh-steps-hmr.md
+++ b/.changeset/fresh-steps-hmr.md
@@ -1,0 +1,5 @@
+---
+'@workflow/nitro': patch
+---
+
+Reload rebuilt step bundles during Vite development.

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { afterEach, beforeAll, describe, expect, test } from 'vitest';
-import { getWorkbenchAppPath } from './utils';
+import { afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { start } from '../src/runtime';
+import { getWorkbenchAppPath, getWorkflowMetadata, setupWorld } from './utils';
 
 export interface DevTestConfig {
   generatedStepPath: string;
@@ -258,6 +259,64 @@ export async function myNewStep() {
         },
       });
     });
+
+    test.runIf(process.env.APP_NAME === 'vite')(
+      'should execute updated step logic after HMR',
+      { timeout: 70_000 },
+      async () => {
+        assert(deploymentUrl);
+        setupWorld(deploymentUrl);
+
+        const workflowFile = path.join(appPath, workflowsDir, testWorkflowFile);
+        const content = await fs.readFile(workflowFile, 'utf8');
+        const before = 'before HMR';
+        const after = 'after HMR';
+        const fixture = `
+export async function hmrWorkflow() {
+  'use workflow';
+  return hmrStep();
+}
+
+async function hmrStep() {
+  'use step';
+  return '${before}';
+}
+`;
+
+        await fs.writeFile(workflowFile, content + fixture);
+        restoreFiles.push({ path: workflowFile, content });
+
+        await pollUntil({
+          description: 'generated step output to include the HMR fixture',
+          check: async () => {
+            expect(await fs.readFile(generatedStep, 'utf8')).toContain(before);
+          },
+        });
+
+        const workflow = await getWorkflowMetadata(
+          deploymentUrl,
+          `workflows/${testWorkflowFile}`,
+          'hmrWorkflow'
+        );
+        const runBefore = await start<[], string>(workflow, []);
+        expect(await runBefore.returnValue).toBe(before);
+
+        await fs.writeFile(
+          workflowFile,
+          (content + fixture).replace(before, after)
+        );
+
+        await pollUntil({
+          description: 'generated step output to include the HMR update',
+          check: async () => {
+            expect(await fs.readFile(generatedStep, 'utf8')).toContain(after);
+          },
+        });
+
+        const runAfter = await start<[], string>(workflow, []);
+        expect(await runAfter.returnValue).toBe(after);
+      }
+    );
 
     test(
       'should rebuild on adding workflow file',

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -1,5 +1,5 @@
-import { createRequire } from 'node:module';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WORKFLOW_QUEUE_TRIGGER } from '@workflow/builders';
 import { workflowTransformPlugin } from '@workflow/rollup';
@@ -413,7 +413,13 @@ function addDashboardHandler(nitro: Nitro) {
   }
 }
 
-function addVirtualHandler(nitro: Nitro, route: string, buildPath: string) {
+type VirtualHandlerPath = 'workflow/webhook.mjs' | 'workflow/workflows.mjs';
+
+function addVirtualHandler(
+  nitro: Nitro,
+  route: string,
+  buildPath: VirtualHandlerPath
+) {
   nitro.options.handlers.push({
     route,
     handler: `#${buildPath}`,
@@ -421,6 +427,13 @@ function addVirtualHandler(nitro: Nitro, route: string, buildPath: string) {
   const handlerImportPath = JSON.stringify(
     join(nitro.options.buildDir, buildPath)
   );
+  const stepsImportPath = JSON.stringify(
+    join(nitro.options.buildDir, 'workflow/steps.mjs')
+  );
+  const preloadSteps: Record<VirtualHandlerPath, string> = {
+    'workflow/webhook.mjs': '',
+    'workflow/workflows.mjs': `await import(/* @vite-ignore */ pathToFileURL(${stepsImportPath}).href + "?t=" + version);`,
+  };
 
   if (nitro.options.dev) {
     // Dev mode: load generated workflow bundles from disk at request time.
@@ -442,6 +455,7 @@ function addVirtualHandler(nitro: Nitro, route: string, buildPath: string) {
         if (version !== currentVersion) {
           currentVersion = version;
           currentImportPath = pathToFileURL(handlerPath).href + "?t=" + version;
+          ${preloadSteps[buildPath]}
         }
         return (await import(currentImportPath)).POST;
       }
@@ -465,6 +479,7 @@ function addVirtualHandler(nitro: Nitro, route: string, buildPath: string) {
         if (version !== currentVersion) {
           currentVersion = version;
           currentImportPath = pathToFileURL(handlerPath).href + "?t=" + version;
+          ${preloadSteps[buildPath]}
         }
         return (await import(currentImportPath)).POST;
       }


### PR DESCRIPTION
## Summary

- add a Vite dev integration test that executes a step before and after HMR
- preload the cache-busted generated step bundle before loading the rebuilt flow handler
- add a patch changeset for `@workflow/nitro`

Fixes #2350.

## TDD evidence

### RED

On latest `main` plus the regression test (`90060521`):

```text
FAIL should execute updated step logic after HMR
Expected: "after HMR"
Received: "before HMR"
```

The generated `steps.mjs` already contained the updated value, proving that rebuild detection worked and the running process retained the stale step module.

### GREEN

After the fix (`65e734de`):

```text
✓ packages/core/e2e/dev.test.ts (4 tests)
  ✓ should rebuild on workflow change
  ✓ should rebuild on step change
  ✓ should execute updated step logic after HMR
  ✓ should rebuild on adding workflow file
```

Additional validation:

```text
✓ packages/nitro/src/index.test.ts (23 tests)
✓ @workflow/nitro build
✓ changeset status --since=main
```
