### PR TITLE
Send occurredAt with workflow events

### DIFF
--- a/.changeset/send-event-occurred-at.md
+++ b/.changeset/send-event-occurred-at.md
@@ -1,0 +1,7 @@
+---
+'@workflow/world': patch
+'@workflow/world-vercel': patch
+'@workflow/world-postgres': patch
+---
+
+Send optional client-side event occurrence timestamps through world event creation.

--- a/.changeset/send-event-occurred-at.md
+++ b/.changeset/send-event-occurred-at.md
@@ -2,6 +2,7 @@
 '@workflow/world': patch
 '@workflow/world-vercel': patch
 '@workflow/world-postgres': patch
+'@workflow/web-shared': patch
 ---
 
 Send optional client-side event occurrence timestamps through world event creation.

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -417,6 +417,7 @@ const attributeToDisplayFn: Record<
     return <RunAttributesCard attributes={value as Record<string, string>} />;
   },
   // Dates — wrapped with TimestampTooltip showing UTC/local + relative time
+  occurredAt: (_value: unknown) => null,
   createdAt: timestampWithTooltipOrNull,
   startedAt: timestampWithTooltipOrNull,
   updatedAt: (_value: unknown) => null,

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -136,7 +136,7 @@ export const events = schema.table(
     eventData: Cbor<unknown>()('payload_cbor'),
     specVersion: integer('spec_version'),
   } satisfies DrizzlishOfType<
-    Cborized<Event & { eventData?: undefined }, 'eventData'>
+    Cborized<Omit<Event, 'occurredAt'> & { eventData?: undefined }, 'eventData'>
   >,
   (tb) => [
     index().on(tb.runId),

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -103,6 +103,8 @@ export interface CreateEventV4Input {
   specVersion: number;
   correlationId?: string;
   vercelId?: string;
+  /** Client-side time at which the event occurred. */
+  occurredAt?: Date;
   remoteRefBehavior?: 'resolve' | 'lazy';
   deploymentId?: string;
   workflowName?: string;
@@ -192,6 +194,7 @@ function buildPostFrameMeta(
   if (input.correlationId !== undefined)
     meta.correlationId = input.correlationId;
   if (input.vercelId !== undefined) meta.vercelId = input.vercelId;
+  if (input.occurredAt !== undefined) meta.occurredAt = input.occurredAt;
   if (input.remoteRefBehavior !== undefined) {
     meta.remoteRefBehavior = input.remoteRefBehavior;
   }
@@ -352,6 +355,7 @@ export interface DecodedV4Event {
   eventType: string;
   correlationId?: string;
   createdAt: Date | string;
+  occurredAt?: Date | string;
   specVersion?: number;
   eventData?: Record<string, unknown>;
 }

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -1,5 +1,5 @@
 import type { AnyEventRequest } from '@workflow/world';
-import { encode } from 'cbor-x';
+import { decode, encode } from 'cbor-x';
 import { MockAgent } from 'undici';
 import { describe, expect, it } from 'vitest';
 import {
@@ -15,6 +15,19 @@ function mockAgent() {
   const agent = new MockAgent();
   agent.disableNetConnect();
   return agent;
+}
+
+function decodePostedMeta(rawBody: unknown): Record<string, unknown> {
+  const bytes =
+    typeof rawBody === 'string'
+      ? new TextEncoder().encode(rawBody)
+      : new Uint8Array(rawBody as ArrayBufferLike);
+  const metaLen = new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength
+  ).getUint32(0, false);
+  return decode(bytes.subarray(4, 4 + metaLen)) as Record<string, unknown>;
 }
 
 /**
@@ -215,6 +228,52 @@ describe('splitEventDataForV4 attribute fields', () => {
 });
 
 describe('createWorkflowRunEvent response coercion', () => {
+  it('sends occurredAt in the v4 frame meta', async () => {
+    const agent = mockAgent();
+    const occurredAt = new Date('2026-06-10T00:00:03.000Z');
+    let capturedMeta: Record<string, unknown> | undefined;
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/run_started',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          capturedMeta = decodePostedMeta(opts.body);
+          return encode({
+            run: {
+              runId: 'wrun_1',
+              status: 'running',
+              startedAt: new Date('2026-06-10T00:00:04.000Z'),
+            },
+          });
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:04.000Z',
+          },
+        }
+      );
+
+    await createWorkflowRunEvent(
+      'wrun_1',
+      { eventType: 'run_started', specVersion: 2 } as AnyEventRequest,
+      { occurredAt },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(capturedMeta?.occurredAt).toBeInstanceOf(Date);
+    expect((capturedMeta?.occurredAt as Date).getTime()).toBe(
+      occurredAt.getTime()
+    );
+    agent.assertNoPendingInterceptors();
+  });
+
   it('coerces ISO-string dates in the returned event and preloaded events', async () => {
     // Persisted events store nested eventData dates as ISO strings
     // (the backend's entity layer converts Date → toISOString on write with
@@ -242,6 +301,7 @@ describe('createWorkflowRunEvent response coercion', () => {
             runId: 'wrun_1',
             eventType: 'run_started',
             createdAt: '2026-06-10T00:00:01.000Z',
+            occurredAt: '2026-06-10T00:00:00.500Z',
             eventData: {},
           },
           events: [
@@ -251,6 +311,7 @@ describe('createWorkflowRunEvent response coercion', () => {
               eventType: 'wait_created',
               correlationId: 'wait_1',
               createdAt: '2026-06-10T00:00:02.000Z',
+              occurredAt: '2026-06-10T00:00:01.500Z',
               specVersion: 2,
               eventData: { resumeAt: '2026-06-10T01:00:00.000Z' },
             },
@@ -275,11 +336,14 @@ describe('createWorkflowRunEvent response coercion', () => {
     );
 
     expect(result.event?.createdAt).toBeInstanceOf(Date);
+    expect(result.event?.occurredAt).toBeInstanceOf(Date);
     const preloaded = result.events?.[0] as {
       createdAt: Date;
+      occurredAt: Date;
       eventData: { resumeAt: Date };
     };
     expect(preloaded.createdAt).toBeInstanceOf(Date);
+    expect(preloaded.occurredAt).toBeInstanceOf(Date);
     expect(preloaded.eventData.resumeAt).toBeInstanceOf(Date);
     expect(preloaded.eventData.resumeAt.getTime()).toBe(
       new Date('2026-06-10T01:00:00.000Z').getTime()

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -433,6 +433,14 @@ function buildEventFromV4(
       decoded.createdAt instanceof Date
         ? decoded.createdAt
         : new Date(decoded.createdAt),
+    ...(decoded.occurredAt !== undefined
+      ? {
+          occurredAt:
+            decoded.occurredAt instanceof Date
+              ? decoded.occurredAt
+              : new Date(decoded.occurredAt),
+        }
+      : {}),
     ...(decoded.correlationId ? { correlationId: decoded.correlationId } : {}),
     eventData,
     ...(decoded.specVersion !== undefined
@@ -598,6 +606,7 @@ async function createWorkflowRunEventInner(
       specVersion: data.specVersion ?? 2,
       ...(data.correlationId ? { correlationId: data.correlationId } : {}),
       ...(params?.requestId ? { vercelId: params.requestId } : {}),
+      occurredAt: params?.occurredAt ?? new Date(),
       // Opt-in inline-delta: forward the cursor the runtime held before
       // this write so the server can return the authoritative event-log
       // delta on the response (events/cursor/hasMore), letting the inline

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -414,6 +414,7 @@ export const EventSchema = AllEventsSchema.and(
     runId: z.string(),
     eventId: z.string(),
     createdAt: z.coerce.date(),
+    occurredAt: z.coerce.date().optional(),
     specVersion: z.number().optional(),
   })
 );
@@ -449,6 +450,12 @@ export interface CreateEventParams {
   resolveData?: ResolveData;
   /** Request ID (x-vercel-id when on Vercel) for correlating request logs with workflow events. */
   requestId?: string;
+  /**
+   * Timestamp for when the event occurred on the client side. Worlds that
+   * support this can persist it separately from `createdAt`, which represents
+   * when the backing service accepted or stored the event.
+   */
+  occurredAt?: Date;
   /**
    * Inline-delta optimization (opt-in). When set, the World MAY return,
    * on the resulting {@link EventResult}, the first page of events written


### PR DESCRIPTION
## Summary
- add optional occurredAt metadata to the shared world event creation contract and event schema
- send occurredAt through world-vercel v4 event frame metadata, defaulting to the client-side post time
- preserve occurredAt on returned v4 events and keep world-postgres schema typing compatible until it persists the field

## Validation
- pnpm --filter @workflow/world build
- pnpm --filter @workflow/world-vercel test -- events.test.ts
- pnpm --filter @workflow/world-vercel typecheck
- pnpm --filter @workflow/world-postgres typecheck
- pnpm biome check .changeset/send-event-occurred-at.md packages/world/src/events.ts packages/world-vercel/src/events-v4.ts packages/world-vercel/src/events.ts packages/world-vercel/src/events.test.ts packages/world-postgres/src/drizzle/schema.ts
- pnpm changeset status --since=origin/main