### PR TITLE
Display occurredAt in trace details

### DIFF
--- a/.changeset/display-occurred-at.md
+++ b/.changeset/display-occurred-at.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Show event occurrence timestamps in the trace detail panel when present.

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -218,6 +218,7 @@ type AttributeKey =
   | keyof WorkflowRun
   | keyof Hook
   | keyof Event
+  | 'occurredAt'
   | 'moduleSpecifier'
   | 'eventData'
   | 'resumeAt'
@@ -252,6 +253,7 @@ const attributeOrder: AttributeKey[] = [
   'projectId',
   'environment',
   'executionContext',
+  'occurredAt',
   'createdAt',
   'startedAt',
   'updatedAt',
@@ -292,6 +294,7 @@ const attributeDisplayNames: Partial<Record<AttributeKey, string>> = {
   deploymentId: 'Deployment ID',
   specVersion: 'Spec Version',
   workflowCoreVersion: '@workflow/core version',
+  occurredAt: 'Occurred',
   createdAt: 'Created',
   startedAt: 'Started',
   updatedAt: 'Updated',
@@ -417,6 +420,7 @@ const attributeToDisplayFn: Record<
     return <RunAttributesCard attributes={value as Record<string, string>} />;
   },
   // Dates — wrapped with TimestampTooltip showing UTC/local + relative time
+  occurredAt: timestampWithTooltipOrNull,
   createdAt: timestampWithTooltipOrNull,
   startedAt: timestampWithTooltipOrNull,
   updatedAt: (_value: unknown) => null,


### PR DESCRIPTION
## Summary
- show an optional Occurred timestamp row in the trace detail panel when occurredAt is present
- order Occurred immediately above Created and render it with the same timestamp tooltip formatting
- add a web-shared changeset; the fixed web/web-shared group picks up @workflow/web as well

## Validation
- pnpm biome check packages/web-shared/src/components/sidebar/attribute-panel.tsx (passes with existing warnings in this file)
- pnpm --filter @workflow/web-shared exec vitest run test/span-detail-merge.test.ts
- pnpm changeset status --since=origin/main

## Notes
- pnpm --filter @workflow/web-shared typecheck is blocked in this local checkout by missing/stale dependencies: @radix-ui/react-slot, react-use-measure, @tootallnate/zstd-wasm, and @workflow/core/serialization-format registerZstdDecoder.
- pnpm --filter @workflow/web-shared test -- span-detail-merge.test.ts invokes the package test script and runs the broader suite; it hits the same missing dependency blockers in unrelated tests.
