### PR TITLE
feat(web): add trace step shortcut helper

### DIFF
--- a/.changeset/all-chicken-enjoy.md
+++ b/.changeset/all-chicken-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@workflow/web-shared": patch
+"@workflow/web": patch
+---
+
+Add helper text that indicates keyboard shortcuts 

--- a/packages/web-shared/src/components/index.ts
+++ b/packages/web-shared/src/components/index.ts
@@ -33,6 +33,7 @@ export {
 } from './ui/data-inspector';
 export { DecryptButton } from './ui/decrypt-button';
 export { IconButton } from './ui/icon-button';
+export { Kbd } from './ui/kbd';
 export { LoadMoreButton } from './ui/load-more-button';
 export { MenuDropdown, type MenuDropdownOption } from './ui/menu-dropdown';
 export { Spinner } from './ui/spinner';

--- a/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.module.css
+++ b/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.module.css
@@ -1,0 +1,44 @@
+/* Two hints occupy the same grid cell so the container sizes to the wider one
+   and they can crossfade on top of each other. */
+.stack {
+  display: inline-grid;
+}
+
+.stack > * {
+  grid-area: 1 / 1;
+}
+
+/* CSS-driven crossfade: each hint is shown for half of the 16s cycle. The
+   second hint runs the same keyframe offset by half the cycle (negative delay)
+   so the two alternate. */
+.hint {
+  animation: trace-shortcut-hint 16s ease-in-out infinite;
+}
+
+.hintDelayed {
+  animation-delay: -8s;
+}
+
+@keyframes trace-shortcut-hint {
+  0% {
+    opacity: 0;
+  }
+  1% {
+    opacity: 1;
+  }
+  49% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hint {
+    animation: none;
+  }
+}

--- a/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.module.css
+++ b/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.module.css
@@ -1,39 +1,15 @@
-/* Two hints occupy the same grid cell so the container sizes to the wider one
-   and they can crossfade on top of each other. */
-.stack {
-  display: inline-grid;
-}
-
-.stack > * {
-  grid-area: 1 / 1;
-}
-
-/* CSS-driven crossfade: each hint is shown for half of the 16s cycle. The
-   second hint runs the same keyframe offset by half the cycle (negative delay)
-   so the two alternate. */
+/* Only one hint is in the DOM at a time; it is remounted on each rotation
+   (keyed by index in React) so this short fade-in plays as a crossfade. */
 .hint {
-  animation: trace-shortcut-hint 16s ease-in-out infinite;
+  animation: trace-shortcut-hint-fade 150ms ease-in-out;
 }
 
-.hintDelayed {
-  animation-delay: -8s;
-}
-
-@keyframes trace-shortcut-hint {
-  0% {
+@keyframes trace-shortcut-hint-fade {
+  from {
     opacity: 0;
   }
-  1% {
+  to {
     opacity: 1;
-  }
-  49% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 0;
   }
 }
 

--- a/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
@@ -61,20 +61,13 @@ export function TraceShortcutHelper({
   hasMultipleSpans: boolean;
   reducedMotion: boolean;
 }) {
-  // Start hidden so SSR markup matches the first client render, then reveal
-  // once we can read the persisted dismissal count.
   const [visible, setVisible] = useState(false);
-  // Index of the hint currently shown (0 = Alt hint, 1 = J/K hint). Only one
-  // hint is in the DOM at a time so the container width tracks the visible
-  // text and the dismiss button always hugs it.
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
     setVisible(readDismissals() < DISMISSAL_LIMIT);
   }, []);
 
-  // Rotate between the two hints. The interval lives here (not tied to props)
-  // so parent re-renders from trace-viewer interactions never restart it.
   useEffect(() => {
     if (reducedMotion) return;
     const id = setInterval(() => {
@@ -88,9 +81,7 @@ export function TraceShortcutHelper({
   const dismiss = () => {
     try {
       window.localStorage.setItem(DISMISSALS_KEY, String(readDismissals() + 1));
-    } catch {
-      // Ignore storage failures — dismissal just won't persist.
-    }
+    } catch {}
     setVisible(false);
   };
 
@@ -104,9 +95,6 @@ export function TraceShortcutHelper({
         {reducedMotion ? (
           <AltHint />
         ) : (
-          // Keying by index remounts the node on each rotation so the CSS
-          // fade-in plays. Only one hint is ever in the DOM, so the width
-          // matches the visible text and the dismiss button hugs it.
           <span
             key={index}
             className={`inline-flex items-center ${styles.hint}`}

--- a/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Kbd } from '../../ui/kbd';
+import styles from './trace-shortcut-helper.module.css';
+
+const DISMISSALS_KEY = 'workflow-step-shortcut-helper-dismissals';
+const DISMISSAL_LIMIT = 3;
+
+function getAltKeyLabel(): 'Alt' | 'Option' {
+  if (typeof navigator === 'undefined') return 'Alt';
+  return navigator.platform.toLowerCase().includes('mac') ? 'Option' : 'Alt';
+}
+
+function readDismissals(): number {
+  try {
+    const dismissals = Number.parseInt(
+      window.localStorage.getItem(DISMISSALS_KEY) ?? '0',
+      10
+    );
+    return Number.isNaN(dismissals) ? 0 : dismissals;
+  } catch {
+    return 0;
+  }
+}
+
+function AltHint() {
+  return (
+    <>
+      Hold
+      <Kbd variant="outline" size="compact" className="mx-1">
+        {getAltKeyLabel()}
+      </Kbd>
+      to show span deltas
+    </>
+  );
+}
+
+function NavHint() {
+  return (
+    <>
+      Use
+      <Kbd variant="outline" size="compact" className="ml-1">
+        J
+      </Kbd>
+      <span className="mx-1">/</span>
+      <Kbd variant="outline" size="compact" className="mr-1">
+        K
+      </Kbd>
+      to move between spans
+    </>
+  );
+}
+
+export function TraceShortcutHelper({
+  hasMultipleSpans,
+  reducedMotion,
+}: {
+  hasMultipleSpans: boolean;
+  reducedMotion: boolean;
+}) {
+  // Start hidden so SSR markup matches the first client render, then reveal
+  // once we can read the persisted dismissal count.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(readDismissals() < DISMISSAL_LIMIT);
+  }, []);
+
+  if (!visible || !hasMultipleSpans) return null;
+
+  const dismiss = () => {
+    try {
+      window.localStorage.setItem(DISMISSALS_KEY, String(readDismissals() + 1));
+    } catch {
+      // Ignore storage failures — dismissal just won't persist.
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div className="group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground">
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        className={
+          reducedMotion
+            ? 'inline-flex items-center whitespace-nowrap'
+            : `${styles.stack} whitespace-nowrap`
+        }
+      >
+        {reducedMotion ? (
+          <AltHint />
+        ) : (
+          // Both hints are always rendered with stable classes so the CSS
+          // crossfade keeps running uninterrupted across trace-viewer
+          // interactions and never restarts.
+          <>
+            <span className={`inline-flex items-center ${styles.hint}`}>
+              <AltHint />
+            </span>
+            <span
+              className={`inline-flex items-center ${styles.hint} ${styles.hintDelayed}`}
+            >
+              <NavHint />
+            </span>
+          </>
+        )}
+      </span>
+      <button
+        type="button"
+        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+        onClick={dismiss}
+        aria-label="Dismiss trace shortcuts helper"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
@@ -7,6 +7,7 @@ import styles from './trace-shortcut-helper.module.css';
 
 const DISMISSALS_KEY = 'workflow-step-shortcut-helper-dismissals';
 const DISMISSAL_LIMIT = 3;
+const HINT_ROTATION_MS = 8000;
 
 function getAltKeyLabel(): 'Alt' | 'Option' {
   if (typeof navigator === 'undefined') return 'Alt';
@@ -32,7 +33,7 @@ function AltHint() {
       <Kbd variant="outline" size="compact" className="mx-1">
         {getAltKeyLabel()}
       </Kbd>
-      to show span deltas
+      to see delta between spans
     </>
   );
 }
@@ -63,10 +64,24 @@ export function TraceShortcutHelper({
   // Start hidden so SSR markup matches the first client render, then reveal
   // once we can read the persisted dismissal count.
   const [visible, setVisible] = useState(false);
+  // Index of the hint currently shown (0 = Alt hint, 1 = J/K hint). Only one
+  // hint is in the DOM at a time so the container width tracks the visible
+  // text and the dismiss button always hugs it.
+  const [index, setIndex] = useState(0);
 
   useEffect(() => {
     setVisible(readDismissals() < DISMISSAL_LIMIT);
   }, []);
+
+  // Rotate between the two hints. The interval lives here (not tied to props)
+  // so parent re-renders from trace-viewer interactions never restart it.
+  useEffect(() => {
+    if (reducedMotion) return;
+    const id = setInterval(() => {
+      setIndex((i) => (i === 0 ? 1 : 0));
+    }, HINT_ROTATION_MS);
+    return () => clearInterval(id);
+  }, [reducedMotion]);
 
   if (!visible || !hasMultipleSpans) return null;
 
@@ -80,32 +95,24 @@ export function TraceShortcutHelper({
   };
 
   return (
-    <div className="group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground">
+    <div className="group absolute bottom-3 left-1/2 z-10 hidden h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground md:inline-flex">
       <span
         aria-live="polite"
         aria-atomic="true"
-        className={
-          reducedMotion
-            ? 'inline-flex items-center whitespace-nowrap'
-            : `${styles.stack} whitespace-nowrap`
-        }
+        className="inline-flex items-center whitespace-nowrap"
       >
         {reducedMotion ? (
           <AltHint />
         ) : (
-          // Both hints are always rendered with stable classes so the CSS
-          // crossfade keeps running uninterrupted across trace-viewer
-          // interactions and never restarts.
-          <>
-            <span className={`inline-flex items-center ${styles.hint}`}>
-              <AltHint />
-            </span>
-            <span
-              className={`inline-flex items-center ${styles.hint} ${styles.hintDelayed}`}
-            >
-              <NavHint />
-            </span>
-          </>
+          // Keying by index remounts the node on each rotation so the CSS
+          // fade-in plays. Only one hint is ever in the DOM, so the width
+          // matches the visible text and the dismiss button hugs it.
+          <span
+            key={index}
+            className={`inline-flex items-center ${styles.hint}`}
+          >
+            {index === 0 ? <AltHint /> : <NavHint />}
+          </span>
         )}
       </span>
       <button

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -61,6 +61,18 @@ interface NewTraceViewerProps {
 const MIN_VIEWPORT_MS = 0.001;
 
 const ZOOM_DEBOUNCE_MS = 150;
+const TRACE_SHORTCUT_HELPER_DISMISSALS_KEY =
+  'workflow-step-shortcut-helper-dismissals';
+const TRACE_SHORTCUT_HELPER_DISMISSAL_LIMIT = 3;
+const TRACE_SHORTCUT_HELPER_ROTATION_MS = 8000;
+const TRACE_SHORTCUT_HELPER_ANIMATION_MS = 150;
+const TRACE_SHORTCUT_HINT_IDS = {
+  spanDeltas: 'span-deltas',
+  spanNavigation: 'span-navigation',
+} as const;
+
+type TraceShortcutHintId =
+  (typeof TRACE_SHORTCUT_HINT_IDS)[keyof typeof TRACE_SHORTCUT_HINT_IDS];
 
 interface Viewport {
   start: number;
@@ -163,6 +175,188 @@ function useSelectedSpanInfo(): SelectedSpanInfo | null {
       rawEvents,
     };
   }, [activeSpan, sidebar]);
+}
+
+function getAltKeyLabel(): 'Alt' | 'Option' {
+  if (typeof navigator === 'undefined') return 'Alt';
+  return navigator.platform.toLowerCase().includes('mac') ? 'Option' : 'Alt';
+}
+
+function readTraceShortcutHelperDismissals() {
+  try {
+    const dismissals = Number.parseInt(
+      window.localStorage.getItem(TRACE_SHORTCUT_HELPER_DISMISSALS_KEY) ?? '0',
+      10
+    );
+    return Number.isNaN(dismissals) ? 0 : dismissals;
+  } catch {
+    return 0;
+  }
+}
+
+function writeTraceShortcutHelperDismissals(dismissals: number) {
+  try {
+    window.localStorage.setItem(
+      TRACE_SHORTCUT_HELPER_DISMISSALS_KEY,
+      String(dismissals)
+    );
+  } catch {
+    return;
+  }
+}
+
+function TraceShortcutHint({ hintId }: { hintId: TraceShortcutHintId }) {
+  if (hintId === TRACE_SHORTCUT_HINT_IDS.spanDeltas) {
+    return (
+      <>
+        Hold
+        <Kbd variant="outline" size="compact" className="mx-1">
+          {getAltKeyLabel()}
+        </Kbd>
+        to show duration deltas between spans
+      </>
+    );
+  }
+
+  return (
+    <>
+      Use
+      <Kbd variant="outline" size="compact" className="ml-1">
+        J
+      </Kbd>
+      <span className="mx-1">/</span>
+      <Kbd variant="outline" size="compact" className="mr-1">
+        K
+      </Kbd>
+      to move between spans
+    </>
+  );
+}
+
+function TraceShortcutHelper({
+  hasMultipleSpans,
+  canNavigateSpans,
+  reducedMotion,
+}: {
+  hasMultipleSpans: boolean;
+  canNavigateSpans: boolean;
+  reducedMotion: boolean;
+}) {
+  const [visible, setVisible] = useState(false);
+  const [activeHintId, setActiveHintId] = useState<TraceShortcutHintId>(
+    TRACE_SHORTCUT_HINT_IDS.spanDeltas
+  );
+  const [hintVisible, setHintVisible] = useState(true);
+  const [dismissing, setDismissing] = useState(false);
+
+  const availableHintIds = useMemo<TraceShortcutHintId[]>(() => {
+    if (!canNavigateSpans) return [TRACE_SHORTCUT_HINT_IDS.spanDeltas];
+    return [
+      TRACE_SHORTCUT_HINT_IDS.spanDeltas,
+      TRACE_SHORTCUT_HINT_IDS.spanNavigation,
+    ];
+  }, [canNavigateSpans]);
+
+  const resolvedActiveHintId = availableHintIds.includes(activeHintId)
+    ? activeHintId
+    : TRACE_SHORTCUT_HINT_IDS.spanDeltas;
+
+  useEffect(() => {
+    if (activeHintId !== resolvedActiveHintId) {
+      setActiveHintId(resolvedActiveHintId);
+    }
+  }, [activeHintId, resolvedActiveHintId]);
+
+  useEffect(() => {
+    const dismissals = readTraceShortcutHelperDismissals();
+    setVisible(dismissals < TRACE_SHORTCUT_HELPER_DISMISSAL_LIMIT);
+  }, []);
+
+  const dismiss = useCallback(() => {
+    const nextDismissals = readTraceShortcutHelperDismissals() + 1;
+    writeTraceShortcutHelperDismissals(nextDismissals);
+
+    if (reducedMotion) {
+      setVisible(false);
+      return;
+    }
+
+    setDismissing(true);
+    window.setTimeout(() => {
+      setVisible(false);
+      setDismissing(false);
+    }, TRACE_SHORTCUT_HELPER_ANIMATION_MS);
+  }, [reducedMotion]);
+
+  useEffect(() => {
+    if (
+      !visible ||
+      dismissing ||
+      reducedMotion ||
+      availableHintIds.length < 2
+    ) {
+      return;
+    }
+
+    let swapTimeoutId: number | undefined;
+    const rotationTimeoutId = window.setTimeout(() => {
+      setHintVisible(false);
+      swapTimeoutId = window.setTimeout(() => {
+        setActiveHintId((currentHintId) => {
+          const currentIndex = availableHintIds.indexOf(currentHintId);
+          const nextIndex =
+            currentIndex === -1
+              ? 0
+              : (currentIndex + 1) % availableHintIds.length;
+          return (
+            availableHintIds[nextIndex] ?? TRACE_SHORTCUT_HINT_IDS.spanDeltas
+          );
+        });
+        setHintVisible(true);
+      }, TRACE_SHORTCUT_HELPER_ANIMATION_MS);
+    }, TRACE_SHORTCUT_HELPER_ROTATION_MS);
+
+    return () => {
+      window.clearTimeout(rotationTimeoutId);
+      if (swapTimeoutId !== undefined) {
+        window.clearTimeout(swapTimeoutId);
+      }
+    };
+  }, [
+    availableHintIds,
+    dismissing,
+    reducedMotion,
+    resolvedActiveHintId,
+    visible,
+  ]);
+
+  if (!visible || !hasMultipleSpans) return null;
+
+  return (
+    <div
+      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+        dismissing ? 'opacity-0' : 'opacity-100'
+      }`}
+    >
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        className={`inline-flex items-center whitespace-nowrap transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+          hintVisible ? 'opacity-100' : 'opacity-0'
+        }`}
+      >
+        <TraceShortcutHint hintId={resolvedActiveHintId} />
+      </span>
+      <button
+        type="button"
+        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+        onClick={dismiss}
+        aria-label="Dismiss trace shortcuts helper"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -460,7 +654,6 @@ function NewTraceViewerContent({
       if (e.key === 'Escape') {
         handleClearActiveSpan();
       } else if (e.key === 'Alt') {
-        e.preventDefault();
         setAltHeld(true);
       } else if (e.key === 'j' || e.key === 'k') {
         handleSidebarNavKey(e);
@@ -758,6 +951,11 @@ function NewTraceViewerContent({
             <ZoomIn className="w-4 h-4" />
           </IconButton>
         </div>
+        <TraceShortcutHelper
+          hasMultipleSpans={trace.spans.length > 1}
+          canNavigateSpans={Boolean(activeSpanId && (prevSpanId || nextSpanId))}
+          reducedMotion={reducedMotion}
+        />
       </div>
 
       {/* Detail panel */}

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -39,6 +39,7 @@ import {
   TooltipTrigger,
 } from '../ui/tooltip';
 import EventList from './components/event-list';
+import { TraceShortcutHelper } from './components/trace-shortcut-helper';
 import { ROW_HEIGHT_PX, scrollRowIntoView } from './components/use-row-window';
 import { SplitPane } from './components/split-pane';
 import {
@@ -61,18 +62,6 @@ interface NewTraceViewerProps {
 const MIN_VIEWPORT_MS = 0.001;
 
 const ZOOM_DEBOUNCE_MS = 150;
-const TRACE_SHORTCUT_HELPER_DISMISSALS_KEY =
-  'workflow-step-shortcut-helper-dismissals';
-const TRACE_SHORTCUT_HELPER_DISMISSAL_LIMIT = 3;
-const TRACE_SHORTCUT_HELPER_ROTATION_MS = 8000;
-const TRACE_SHORTCUT_HELPER_ANIMATION_MS = 150;
-const TRACE_SHORTCUT_HINT_IDS = {
-  spanDeltas: 'span-deltas',
-  spanNavigation: 'span-navigation',
-} as const;
-
-type TraceShortcutHintId =
-  (typeof TRACE_SHORTCUT_HINT_IDS)[keyof typeof TRACE_SHORTCUT_HINT_IDS];
 
 interface Viewport {
   start: number;
@@ -175,188 +164,6 @@ function useSelectedSpanInfo(): SelectedSpanInfo | null {
       rawEvents,
     };
   }, [activeSpan, sidebar]);
-}
-
-function getAltKeyLabel(): 'Alt' | 'Option' {
-  if (typeof navigator === 'undefined') return 'Alt';
-  return navigator.platform.toLowerCase().includes('mac') ? 'Option' : 'Alt';
-}
-
-function readTraceShortcutHelperDismissals() {
-  try {
-    const dismissals = Number.parseInt(
-      window.localStorage.getItem(TRACE_SHORTCUT_HELPER_DISMISSALS_KEY) ?? '0',
-      10
-    );
-    return Number.isNaN(dismissals) ? 0 : dismissals;
-  } catch {
-    return 0;
-  }
-}
-
-function writeTraceShortcutHelperDismissals(dismissals: number) {
-  try {
-    window.localStorage.setItem(
-      TRACE_SHORTCUT_HELPER_DISMISSALS_KEY,
-      String(dismissals)
-    );
-  } catch {
-    return;
-  }
-}
-
-function TraceShortcutHint({ hintId }: { hintId: TraceShortcutHintId }) {
-  if (hintId === TRACE_SHORTCUT_HINT_IDS.spanDeltas) {
-    return (
-      <>
-        Hold
-        <Kbd variant="outline" size="compact" className="mx-1">
-          {getAltKeyLabel()}
-        </Kbd>
-        to show duration deltas between spans
-      </>
-    );
-  }
-
-  return (
-    <>
-      Use
-      <Kbd variant="outline" size="compact" className="ml-1">
-        J
-      </Kbd>
-      <span className="mx-1">/</span>
-      <Kbd variant="outline" size="compact" className="mr-1">
-        K
-      </Kbd>
-      to move between spans
-    </>
-  );
-}
-
-function TraceShortcutHelper({
-  hasMultipleSpans,
-  canNavigateSpans,
-  reducedMotion,
-}: {
-  hasMultipleSpans: boolean;
-  canNavigateSpans: boolean;
-  reducedMotion: boolean;
-}) {
-  const [visible, setVisible] = useState(false);
-  const [activeHintId, setActiveHintId] = useState<TraceShortcutHintId>(
-    TRACE_SHORTCUT_HINT_IDS.spanDeltas
-  );
-  const [hintVisible, setHintVisible] = useState(true);
-  const [dismissing, setDismissing] = useState(false);
-
-  const availableHintIds = useMemo<TraceShortcutHintId[]>(() => {
-    if (!canNavigateSpans) return [TRACE_SHORTCUT_HINT_IDS.spanDeltas];
-    return [
-      TRACE_SHORTCUT_HINT_IDS.spanDeltas,
-      TRACE_SHORTCUT_HINT_IDS.spanNavigation,
-    ];
-  }, [canNavigateSpans]);
-
-  const resolvedActiveHintId = availableHintIds.includes(activeHintId)
-    ? activeHintId
-    : TRACE_SHORTCUT_HINT_IDS.spanDeltas;
-
-  useEffect(() => {
-    if (activeHintId !== resolvedActiveHintId) {
-      setActiveHintId(resolvedActiveHintId);
-    }
-  }, [activeHintId, resolvedActiveHintId]);
-
-  useEffect(() => {
-    const dismissals = readTraceShortcutHelperDismissals();
-    setVisible(dismissals < TRACE_SHORTCUT_HELPER_DISMISSAL_LIMIT);
-  }, []);
-
-  const dismiss = useCallback(() => {
-    const nextDismissals = readTraceShortcutHelperDismissals() + 1;
-    writeTraceShortcutHelperDismissals(nextDismissals);
-
-    if (reducedMotion) {
-      setVisible(false);
-      return;
-    }
-
-    setDismissing(true);
-    window.setTimeout(() => {
-      setVisible(false);
-      setDismissing(false);
-    }, TRACE_SHORTCUT_HELPER_ANIMATION_MS);
-  }, [reducedMotion]);
-
-  useEffect(() => {
-    if (
-      !visible ||
-      dismissing ||
-      reducedMotion ||
-      availableHintIds.length < 2
-    ) {
-      return;
-    }
-
-    let swapTimeoutId: number | undefined;
-    const rotationTimeoutId = window.setTimeout(() => {
-      setHintVisible(false);
-      swapTimeoutId = window.setTimeout(() => {
-        setActiveHintId((currentHintId) => {
-          const currentIndex = availableHintIds.indexOf(currentHintId);
-          const nextIndex =
-            currentIndex === -1
-              ? 0
-              : (currentIndex + 1) % availableHintIds.length;
-          return (
-            availableHintIds[nextIndex] ?? TRACE_SHORTCUT_HINT_IDS.spanDeltas
-          );
-        });
-        setHintVisible(true);
-      }, TRACE_SHORTCUT_HELPER_ANIMATION_MS);
-    }, TRACE_SHORTCUT_HELPER_ROTATION_MS);
-
-    return () => {
-      window.clearTimeout(rotationTimeoutId);
-      if (swapTimeoutId !== undefined) {
-        window.clearTimeout(swapTimeoutId);
-      }
-    };
-  }, [
-    availableHintIds,
-    dismissing,
-    reducedMotion,
-    resolvedActiveHintId,
-    visible,
-  ]);
-
-  if (!visible || !hasMultipleSpans) return null;
-
-  return (
-    <div
-      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
-        dismissing ? 'opacity-0' : 'opacity-100'
-      }`}
-    >
-      <span
-        aria-live="polite"
-        aria-atomic="true"
-        className={`inline-flex items-center whitespace-nowrap transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
-          hintVisible ? 'opacity-100' : 'opacity-0'
-        }`}
-      >
-        <TraceShortcutHint hintId={resolvedActiveHintId} />
-      </span>
-      <button
-        type="button"
-        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
-        onClick={dismiss}
-        aria-label="Dismiss trace shortcuts helper"
-      >
-        <X className="h-3 w-3" />
-      </button>
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -841,7 +648,7 @@ function NewTraceViewerContent({
     <div
       data-pane="pane-root"
       data-has-detail={activeSpan ? '' : undefined}
-      className="grid w-full h-full max-h-full grid-cols-[minmax(100px,1fr)] data-[has-detail]:grid-cols-[minmax(100px,1fr)_clamp(280px,360px,100%)]"
+      className="relative grid w-full h-full max-h-full grid-cols-[minmax(100px,1fr)] data-[has-detail]:grid-cols-[minmax(100px,1fr)_clamp(280px,360px,100%)]"
     >
       <div
         id="trace-parent"
@@ -951,11 +758,6 @@ function NewTraceViewerContent({
             <ZoomIn className="w-4 h-4" />
           </IconButton>
         </div>
-        <TraceShortcutHelper
-          hasMultipleSpans={trace.spans.length > 1}
-          canNavigateSpans={Boolean(activeSpanId && (prevSpanId || nextSpanId))}
-          reducedMotion={reducedMotion}
-        />
       </div>
 
       {/* Detail panel */}
@@ -1036,6 +838,13 @@ function NewTraceViewerContent({
           </div>
         </aside>
       ) : null}
+
+      {/* Centered relative to the whole viewer (timeline + detail panel) so it
+          doesn't shift when the detail panel opens or closes. */}
+      <TraceShortcutHelper
+        hasMultipleSpans={trace.spans.length > 1}
+        reducedMotion={reducedMotion}
+      />
     </div>
   );
 }

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -839,8 +839,6 @@ function NewTraceViewerContent({
         </aside>
       ) : null}
 
-      {/* Centered relative to the whole viewer (timeline + detail panel) so it
-          doesn't shift when the detail panel opens or closes. */}
       <TraceShortcutHelper
         hasMultipleSpans={trace.spans.length > 1}
         reducedMotion={reducedMotion}

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -683,9 +683,9 @@ function NewTraceViewerContent({
                   onClick={() => setSearchQuery('')}
                   className="-mr-2 hidden h-full max-w-full shrink-0 cursor-pointer items-center rounded-r-md border-0 bg-transparent px-2.5 font-inherit text-base text-gray-900 no-underline transition-colors duration-150 ease-in hover:text-gray-1000 focus-visible:-outline-offset-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--ds-focus-color)] min-[961px]:flex"
                 >
-                  <kbd className="inline-flex h-5 min-h-5 min-w-5 items-center justify-center rounded border border-gray-alpha-400 bg-background-100 px-1 font-sans text-[13px] font-medium leading-[1.7em] text-gray-900">
+                  <Kbd variant="outline" size="search">
                     Esc
-                  </kbd>
+                  </Kbd>
                 </button>
               )}
             </div>

--- a/packages/web-shared/src/components/ui/kbd.tsx
+++ b/packages/web-shared/src/components/ui/kbd.tsx
@@ -1,21 +1,43 @@
-import type { ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactNode } from 'react';
 import { cn } from '../../lib/utils';
+
+const kbdVariants = cva(
+  'inline-flex items-center justify-center rounded px-1 text-center font-sans',
+  {
+    variants: {
+      variant: {
+        subtle: 'bg-background-100/20',
+        outline:
+          'border border-gray-alpha-400 bg-background-100 font-medium text-gray-900',
+      },
+      size: {
+        default: 'h-5 min-w-5 text-xs leading-none',
+        compact: 'h-4 min-h-4 min-w-4 text-[11px] leading-none',
+        search: 'h-5 min-h-5 min-w-5 text-[13px] leading-[1.7em]',
+      },
+    },
+    defaultVariants: {
+      variant: 'subtle',
+      size: 'default',
+    },
+  }
+);
+
+type KbdProps = ComponentProps<'kbd'> & VariantProps<typeof kbdVariants>;
 
 export function Kbd({
   children,
   className,
-}: {
-  children: ReactNode;
-  className?: string;
-}): ReactNode {
+  variant,
+  size,
+  ...props
+}: KbdProps): ReactNode {
   return (
-    <kbd
-      className={cn(
-        'inline-flex h-5 min-w-5 items-center justify-center rounded bg-background-100/20 px-1 text-center font-sans text-xs leading-none',
-        className
-      )}
-    >
+    <kbd className={cn(kbdVariants({ variant, size }), className)} {...props}>
       {children}
     </kbd>
   );
 }
+
+export { kbdVariants };

--- a/packages/web-shared/src/components/ui/kbd.tsx
+++ b/packages/web-shared/src/components/ui/kbd.tsx
@@ -34,7 +34,7 @@ export function Kbd({
   ...props
 }: KbdProps): ReactNode {
   return (
-    <kbd className={cn(kbdVariants({ variant, size }), className)} {...props}>
+    <kbd className={cn(kbdVariants({ variant, size, className }))} {...props}>
       {children}
     </kbd>
   );

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -208,8 +208,6 @@ const STEP_SHORTCUT_HELPER_DISMISSALS_KEY =
   'workflow-step-shortcut-helper-dismissals';
 const STEP_SHORTCUT_HELPER_DISMISSAL_LIMIT = 3;
 const STEP_SHORTCUT_HELPER_ROTATION_MS = 8000;
-const STEP_SHORTCUT_KEY_CLASS_NAME =
-  'h-4 min-h-4 min-w-4 border border-gray-alpha-400 bg-background-100 px-1 text-[11px] font-medium leading-none text-gray-900';
 
 function readStepShortcutHelperDismissals() {
   try {
@@ -264,27 +262,33 @@ function StepShortcutHelperToast() {
   const activeHint = activeHintIndex % 2;
 
   return (
-    <div className="group absolute bottom-4 left-1/2 z-10 inline-flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs text-muted-foreground">
-      <span className="whitespace-nowrap">
+    <div className="group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs leading-none text-muted-foreground">
+      <span className="inline-flex items-center whitespace-nowrap">
         {activeHint === 0 ? (
           <>
             Press{' '}
-            <Kbd className={STEP_SHORTCUT_KEY_CLASS_NAME}>Alt</Kbd>{' '}
+            <Kbd variant="outline" size="compact">
+              Alt
+            </Kbd>{' '}
             to see delta between steps
           </>
         ) : (
           <>
             Press{' '}
-            <Kbd className={STEP_SHORTCUT_KEY_CLASS_NAME}>J</Kbd>
+            <Kbd variant="outline" size="compact">
+              J
+            </Kbd>
             /
-            <Kbd className={STEP_SHORTCUT_KEY_CLASS_NAME}>K</Kbd>{' '}
+            <Kbd variant="outline" size="compact">
+              K
+            </Kbd>{' '}
             to navigate through steps
           </>
         )}
       </span>
       <button
         type="button"
-        className="rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
         onClick={dismiss}
         aria-label="Dismiss step shortcuts helper"
       >

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -16,11 +16,13 @@ import {
   AlertCircle,
   GitBranch,
   HelpCircle,
+  Keyboard,
   List,
   Loader2,
   Lock,
+  X,
 } from 'lucide-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
@@ -201,6 +203,73 @@ interface RunDetailViewProps {
 }
 
 type Tab = 'trace' | 'graph' | 'streams' | 'events';
+
+const STEP_SHORTCUT_HELPER_DISMISSALS_KEY =
+  'workflow-step-shortcut-helper-dismissals';
+const STEP_SHORTCUT_HELPER_DISMISSAL_LIMIT = 3;
+
+function readStepShortcutHelperDismissals() {
+  try {
+    return Number.parseInt(
+      window.localStorage.getItem(STEP_SHORTCUT_HELPER_DISMISSALS_KEY) ?? '0',
+      10
+    );
+  } catch {
+    return 0;
+  }
+}
+
+function StepShortcutHelperToast() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissals = readStepShortcutHelperDismissals();
+    setVisible(
+      Number.isNaN(dismissals) ||
+        dismissals < STEP_SHORTCUT_HELPER_DISMISSAL_LIMIT
+    );
+  }, []);
+
+  const dismiss = useCallback(() => {
+    const currentDismissals = readStepShortcutHelperDismissals();
+    const nextDismissals =
+      (Number.isNaN(currentDismissals) ? 0 : currentDismissals) + 1;
+    try {
+      window.localStorage.setItem(
+        STEP_SHORTCUT_HELPER_DISMISSALS_KEY,
+        String(nextDismissals)
+      );
+    } catch {
+      // The toast can still be dismissed for this render if storage is blocked.
+    }
+    setVisible(false);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-lg border bg-background px-4 py-3 text-sm shadow-lg">
+      <div className="flex items-start gap-3">
+        <Keyboard className="mt-0.5 h-4 w-4 text-muted-foreground" />
+        <div className="space-y-1">
+          <div className="font-medium">Step shortcuts</div>
+          <div className="text-muted-foreground">
+            Press Alt to see the delta between steps. Press J/K to navigate
+            through steps.
+          </div>
+        </div>
+        <button
+          type="button"
+          className="-mr-1 -mt-1 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          onClick={dismiss}
+          aria-label="Dismiss step shortcuts helper"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export function RunDetailView({
   runId,
@@ -784,7 +853,7 @@ export function RunDetailView({
 
             <TabsContent value="trace" className="mt-0 flex-1 min-h-0">
               <ErrorBoundary title="Failed to load trace viewer">
-                <div className="h-full -mx-6 bg-background-100 border-t border-gray-alpha-400 overflow-hidden">
+                <div className="relative h-full -mx-6 bg-background-100 border-t border-gray-alpha-400 overflow-hidden">
                   <NewTraceViewer
                     run={run}
                     events={allEvents ?? []}
@@ -794,6 +863,7 @@ export function RunDetailView({
                     hasMore={hasMoreTraceData}
                     isLoadingMore={isLoadingMoreTraceData}
                   />
+                  <StepShortcutHelperToast />
                 </div>
               </ErrorBoundary>
             </TabsContent>

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -225,10 +225,10 @@ function StepShortcutHint({ hint }: { hint: number }) {
   if (hint === 0) {
     return (
       <>
-        Hold{' '}
-        <Kbd variant="outline" size="compact">
+        Hold
+        <Kbd variant="outline" size="compact" className="mx-1">
           Alt
-        </Kbd>{' '}
+        </Kbd>
         to show delta between steps
       </>
     );
@@ -236,14 +236,14 @@ function StepShortcutHint({ hint }: { hint: number }) {
 
   return (
     <>
-      Use{' '}
-      <Kbd variant="outline" size="compact">
+      Use
+      <Kbd variant="outline" size="compact" className="ml-1">
         J
       </Kbd>
-      {' / '}
-      <Kbd variant="outline" size="compact">
+      <span className="mx-1">/</span>
+      <Kbd variant="outline" size="compact" className="mr-1">
         K
-      </Kbd>{' '}
+      </Kbd>
       to move between steps
     </>
   );

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -6,7 +6,6 @@ import {
   EventListView,
   hydrateResourceIO,
   hydrateResourceIOWithKey,
-  Kbd,
   NewTraceViewer,
   type SidebarDataContextValue,
   StreamViewer,
@@ -20,9 +19,8 @@ import {
   List,
   Loader2,
   Lock,
-  X,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
@@ -203,156 +201,6 @@ interface RunDetailViewProps {
 }
 
 type Tab = 'trace' | 'graph' | 'streams' | 'events';
-
-const STEP_SHORTCUT_HELPER_DISMISSALS_KEY =
-  'workflow-step-shortcut-helper-dismissals';
-const STEP_SHORTCUT_HELPER_DISMISSAL_LIMIT = 3;
-const STEP_SHORTCUT_HELPER_ROTATION_MS = 8000;
-const STEP_SHORTCUT_HELPER_ANIMATION_MS = 200;
-
-function readStepShortcutHelperDismissals() {
-  try {
-    return Number.parseInt(
-      window.localStorage.getItem(STEP_SHORTCUT_HELPER_DISMISSALS_KEY) ?? '0',
-      10
-    );
-  } catch {
-    return 0;
-  }
-}
-
-function StepShortcutHint({ hint }: { hint: number }) {
-  if (hint === 0) {
-    return (
-      <>
-        Hold
-        <Kbd variant="outline" size="compact" className="mx-1">
-          Alt
-        </Kbd>
-        to show delta between steps
-      </>
-    );
-  }
-
-  return (
-    <>
-      Use
-      <Kbd variant="outline" size="compact" className="ml-1">
-        J
-      </Kbd>
-      <span className="mx-1">/</span>
-      <Kbd variant="outline" size="compact" className="mr-1">
-        K
-      </Kbd>
-      to move between steps
-    </>
-  );
-}
-
-function StepShortcutHelperToast() {
-  const [visible, setVisible] = useState(false);
-  const [activeHint, setActiveHint] = useState(0);
-  const [previousHint, setPreviousHint] = useState<number | null>(null);
-  const [hintAnimating, setHintAnimating] = useState(false);
-  const [dismissing, setDismissing] = useState(false);
-
-  useEffect(() => {
-    const dismissals = readStepShortcutHelperDismissals();
-    setVisible(
-      Number.isNaN(dismissals) ||
-        dismissals < STEP_SHORTCUT_HELPER_DISMISSAL_LIMIT
-    );
-  }, []);
-
-  const dismiss = useCallback(() => {
-    const currentDismissals = readStepShortcutHelperDismissals();
-    const nextDismissals =
-      (Number.isNaN(currentDismissals) ? 0 : currentDismissals) + 1;
-    try {
-      window.localStorage.setItem(
-        STEP_SHORTCUT_HELPER_DISMISSALS_KEY,
-        String(nextDismissals)
-      );
-    } catch {
-      // The toast can still be dismissed for this render if storage is blocked.
-    }
-    setDismissing(true);
-    window.setTimeout(() => {
-      setVisible(false);
-      setDismissing(false);
-    }, STEP_SHORTCUT_HELPER_ANIMATION_MS);
-  }, []);
-
-  useEffect(() => {
-    if (!visible || dismissing) return;
-
-    const timeoutId = window.setTimeout(() => {
-      setPreviousHint(activeHint);
-      setActiveHint(activeHint === 0 ? 1 : 0);
-    }, STEP_SHORTCUT_HELPER_ROTATION_MS);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [activeHint, dismissing, visible]);
-
-  useEffect(() => {
-    if (previousHint === null) return;
-
-    setHintAnimating(false);
-    const animationFrameId = window.requestAnimationFrame(() => {
-      setHintAnimating(true);
-    });
-    const timeoutId = window.setTimeout(() => {
-      setPreviousHint(null);
-      setHintAnimating(false);
-    }, STEP_SHORTCUT_HELPER_ANIMATION_MS);
-
-    return () => {
-      window.cancelAnimationFrame(animationFrameId);
-      window.clearTimeout(timeoutId);
-    };
-  }, [previousHint]);
-
-  if (!visible) return null;
-
-  return (
-    <div
-      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
-        dismissing
-          ? '-translate-y-1 opacity-0'
-          : 'translate-y-0 opacity-100'
-      }`}
-    >
-      <span className="relative grid h-5 items-center overflow-hidden whitespace-nowrap">
-        {previousHint !== null ? (
-          <span
-            className={`col-start-1 row-start-1 inline-flex items-center transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
-              hintAnimating ? '-translate-y-2 opacity-0' : 'translate-y-0 opacity-100'
-            }`}
-          >
-            <StepShortcutHint hint={previousHint} />
-          </span>
-        ) : null}
-        <span
-          className={`col-start-1 row-start-1 inline-flex items-center transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
-            previousHint !== null && !hintAnimating
-              ? 'translate-y-2 opacity-0'
-              : 'translate-y-0 opacity-100'
-          }`}
-        >
-          <StepShortcutHint hint={activeHint} />
-        </span>
-      </span>
-      <button
-        type="button"
-        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
-        onClick={dismiss}
-        aria-label="Dismiss step shortcuts helper"
-      >
-        <X className="h-3 w-3" />
-      </button>
-    </div>
-  );
-}
 
 export function RunDetailView({
   runId,
@@ -946,7 +794,6 @@ export function RunDetailView({
                     hasMore={hasMoreTraceData}
                     isLoadingMore={isLoadingMoreTraceData}
                   />
-                  <StepShortcutHelperToast />
                 </div>
               </ErrorBoundary>
             </TabsContent>

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -316,17 +316,17 @@ function StepShortcutHelperToast() {
 
   return (
     <div
-      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs leading-none text-muted-foreground transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
         dismissing
           ? '-translate-y-1 opacity-0'
           : 'translate-y-0 opacity-100'
       }`}
     >
-      <span className="relative grid items-center overflow-hidden whitespace-nowrap">
+      <span className="relative grid h-5 items-center overflow-hidden whitespace-nowrap">
         {previousHint !== null ? (
           <span
             className={`col-start-1 row-start-1 inline-flex items-center transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
-              hintAnimating ? '-translate-y-1 opacity-0' : 'translate-y-0 opacity-100'
+              hintAnimating ? '-translate-y-2 opacity-0' : 'translate-y-0 opacity-100'
             }`}
           >
             <StepShortcutHint hint={previousHint} />
@@ -335,7 +335,7 @@ function StepShortcutHelperToast() {
         <span
           className={`col-start-1 row-start-1 inline-flex items-center transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
             previousHint !== null && !hintAnimating
-              ? 'translate-y-1 opacity-0'
+              ? 'translate-y-2 opacity-0'
               : 'translate-y-0 opacity-100'
           }`}
         >

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -16,7 +16,6 @@ import {
   AlertCircle,
   GitBranch,
   HelpCircle,
-  Keyboard,
   List,
   Loader2,
   Lock,
@@ -221,6 +220,7 @@ function readStepShortcutHelperDismissals() {
 
 function StepShortcutHelperToast() {
   const [visible, setVisible] = useState(false);
+  const [activeHintIndex, setActiveHintIndex] = useState(0);
 
   useEffect(() => {
     const dismissals = readStepShortcutHelperDismissals();
@@ -245,28 +245,53 @@ function StepShortcutHelperToast() {
     setVisible(false);
   }, []);
 
+  useEffect(() => {
+    if (!visible) return;
+
+    const intervalId = window.setInterval(() => {
+      setActiveHintIndex((index) => index + 1);
+    }, 4000);
+
+    return () => window.clearInterval(intervalId);
+  }, [visible]);
+
   if (!visible) return null;
 
+  const activeHint = activeHintIndex % 2;
+
   return (
-    <div className="absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-lg border bg-background px-4 py-3 text-sm shadow-lg">
-      <div className="flex items-start gap-3">
-        <Keyboard className="mt-0.5 h-4 w-4 text-muted-foreground" />
-        <div className="space-y-1">
-          <div className="font-medium">Step shortcuts</div>
-          <div className="text-muted-foreground">
-            Press Alt to see the delta between steps. Press J/K to navigate
-            through steps.
-          </div>
-        </div>
-        <button
-          type="button"
-          className="-mr-1 -mt-1 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-          onClick={dismiss}
-          aria-label="Dismiss step shortcuts helper"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
+    <div className="group absolute bottom-4 left-1/2 z-10 inline-flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-sm text-muted-foreground">
+      <span className="whitespace-nowrap">
+        {activeHint === 0 ? (
+          <>
+            Press{' '}
+            <kbd className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-foreground">
+              Alt
+            </kbd>{' '}
+            to see delta between steps
+          </>
+        ) : (
+          <>
+            Press{' '}
+            <kbd className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-foreground">
+              J
+            </kbd>
+            /
+            <kbd className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-foreground">
+              K
+            </kbd>{' '}
+            to navigate through steps
+          </>
+        )}
+      </span>
+      <button
+        type="button"
+        className="rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+        onClick={dismiss}
+        aria-label="Dismiss step shortcuts helper"
+      >
+        <X className="h-3 w-3" />
+      </button>
     </div>
   );
 }

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -240,7 +240,7 @@ function StepShortcutHint({ hint }: { hint: number }) {
       <Kbd variant="outline" size="compact">
         J
       </Kbd>
-      /
+      {' / '}
       <Kbd variant="outline" size="compact">
         K
       </Kbd>{' '}
@@ -251,8 +251,9 @@ function StepShortcutHint({ hint }: { hint: number }) {
 
 function StepShortcutHelperToast() {
   const [visible, setVisible] = useState(false);
-  const [activeHintIndex, setActiveHintIndex] = useState(0);
-  const [exitingHint, setExitingHint] = useState<number | null>(null);
+  const [activeHint, setActiveHint] = useState(0);
+  const [previousHint, setPreviousHint] = useState<number | null>(null);
+  const [hintAnimating, setHintAnimating] = useState(false);
   const [dismissing, setDismissing] = useState(false);
 
   useEffect(() => {
@@ -285,46 +286,58 @@ function StepShortcutHelperToast() {
   useEffect(() => {
     if (!visible || dismissing) return;
 
-    const activeHint = activeHintIndex % 2;
     const timeoutId = window.setTimeout(() => {
-      setExitingHint(activeHint);
-      setActiveHintIndex((index) => index + 1);
+      setPreviousHint(activeHint);
+      setActiveHint(activeHint === 0 ? 1 : 0);
     }, STEP_SHORTCUT_HELPER_ROTATION_MS);
 
     return () => window.clearTimeout(timeoutId);
-  }, [activeHintIndex, dismissing, visible]);
+  }, [activeHint, dismissing, visible]);
 
   useEffect(() => {
-    if (exitingHint === null) return;
+    if (previousHint === null) return;
 
+    setHintAnimating(false);
+    const animationFrameId = window.requestAnimationFrame(() => {
+      setHintAnimating(true);
+    });
     const timeoutId = window.setTimeout(() => {
-      setExitingHint(null);
+      setPreviousHint(null);
+      setHintAnimating(false);
     }, STEP_SHORTCUT_HELPER_ANIMATION_MS);
 
-    return () => window.clearTimeout(timeoutId);
-  }, [exitingHint]);
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [previousHint]);
 
   if (!visible) return null;
 
-  const activeHint = activeHintIndex % 2;
-
   return (
     <div
-      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs leading-none text-muted-foreground motion-reduce:animate-none ${
+      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs leading-none text-muted-foreground transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
         dismissing
-          ? 'animate-out fade-out slide-out-to-top-1 duration-150 ease-out'
-          : 'animate-in fade-in slide-in-from-bottom-1 duration-200 ease-out'
+          ? '-translate-y-1 opacity-0'
+          : 'translate-y-0 opacity-100'
       }`}
     >
-      <span className="grid items-center whitespace-nowrap">
-        {exitingHint !== null ? (
-          <span className="col-start-1 row-start-1 inline-flex items-center animate-out fade-out slide-out-to-top-1 duration-150 ease-out motion-reduce:animate-none">
-            <StepShortcutHint hint={exitingHint} />
+      <span className="relative grid items-center overflow-hidden whitespace-nowrap">
+        {previousHint !== null ? (
+          <span
+            className={`col-start-1 row-start-1 inline-flex items-center transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+              hintAnimating ? '-translate-y-1 opacity-0' : 'translate-y-0 opacity-100'
+            }`}
+          >
+            <StepShortcutHint hint={previousHint} />
           </span>
         ) : null}
         <span
-          key={activeHintIndex}
-          className="col-start-1 row-start-1 inline-flex items-center animate-in fade-in slide-in-from-bottom-1 duration-200 ease-out motion-reduce:animate-none"
+          className={`col-start-1 row-start-1 inline-flex items-center transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+            previousHint !== null && !hintAnimating
+              ? 'translate-y-1 opacity-0'
+              : 'translate-y-0 opacity-100'
+          }`}
         >
           <StepShortcutHint hint={activeHint} />
         </span>

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -6,6 +6,7 @@ import {
   EventListView,
   hydrateResourceIO,
   hydrateResourceIOWithKey,
+  Kbd,
   NewTraceViewer,
   type SidebarDataContextValue,
   StreamViewer,
@@ -206,6 +207,9 @@ type Tab = 'trace' | 'graph' | 'streams' | 'events';
 const STEP_SHORTCUT_HELPER_DISMISSALS_KEY =
   'workflow-step-shortcut-helper-dismissals';
 const STEP_SHORTCUT_HELPER_DISMISSAL_LIMIT = 3;
+const STEP_SHORTCUT_HELPER_ROTATION_MS = 8000;
+const STEP_SHORTCUT_KEY_CLASS_NAME =
+  'h-4 min-h-4 min-w-4 border border-gray-alpha-400 bg-background-100 px-1 text-[11px] font-medium leading-none text-gray-900';
 
 function readStepShortcutHelperDismissals() {
   try {
@@ -250,7 +254,7 @@ function StepShortcutHelperToast() {
 
     const intervalId = window.setInterval(() => {
       setActiveHintIndex((index) => index + 1);
-    }, 4000);
+    }, STEP_SHORTCUT_HELPER_ROTATION_MS);
 
     return () => window.clearInterval(intervalId);
   }, [visible]);
@@ -260,26 +264,20 @@ function StepShortcutHelperToast() {
   const activeHint = activeHintIndex % 2;
 
   return (
-    <div className="group absolute bottom-4 left-1/2 z-10 inline-flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-sm text-muted-foreground">
+    <div className="group absolute bottom-4 left-1/2 z-10 inline-flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs text-muted-foreground">
       <span className="whitespace-nowrap">
         {activeHint === 0 ? (
           <>
             Press{' '}
-            <kbd className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-foreground">
-              Alt
-            </kbd>{' '}
+            <Kbd className={STEP_SHORTCUT_KEY_CLASS_NAME}>Alt</Kbd>{' '}
             to see delta between steps
           </>
         ) : (
           <>
             Press{' '}
-            <kbd className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-foreground">
-              J
-            </kbd>
+            <Kbd className={STEP_SHORTCUT_KEY_CLASS_NAME}>J</Kbd>
             /
-            <kbd className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-foreground">
-              K
-            </kbd>{' '}
+            <Kbd className={STEP_SHORTCUT_KEY_CLASS_NAME}>K</Kbd>{' '}
             to navigate through steps
           </>
         )}

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -155,7 +155,7 @@ function GraphTabContent({
       <div className="flex items-center justify-center w-full h-full">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         <span className="ml-4 text-muted-foreground">
-          Loading workflow graph...
+          Loading workflow graph…
         </span>
       </div>
     );
@@ -208,6 +208,7 @@ const STEP_SHORTCUT_HELPER_DISMISSALS_KEY =
   'workflow-step-shortcut-helper-dismissals';
 const STEP_SHORTCUT_HELPER_DISMISSAL_LIMIT = 3;
 const STEP_SHORTCUT_HELPER_ROTATION_MS = 8000;
+const STEP_SHORTCUT_HELPER_ANIMATION_MS = 200;
 
 function readStepShortcutHelperDismissals() {
   try {
@@ -220,9 +221,39 @@ function readStepShortcutHelperDismissals() {
   }
 }
 
+function StepShortcutHint({ hint }: { hint: number }) {
+  if (hint === 0) {
+    return (
+      <>
+        Hold{' '}
+        <Kbd variant="outline" size="compact">
+          Alt
+        </Kbd>{' '}
+        to show delta between steps
+      </>
+    );
+  }
+
+  return (
+    <>
+      Use{' '}
+      <Kbd variant="outline" size="compact">
+        J
+      </Kbd>
+      /
+      <Kbd variant="outline" size="compact">
+        K
+      </Kbd>{' '}
+      to move between steps
+    </>
+  );
+}
+
 function StepShortcutHelperToast() {
   const [visible, setVisible] = useState(false);
   const [activeHintIndex, setActiveHintIndex] = useState(0);
+  const [exitingHint, setExitingHint] = useState<number | null>(null);
+  const [dismissing, setDismissing] = useState(false);
 
   useEffect(() => {
     const dismissals = readStepShortcutHelperDismissals();
@@ -244,47 +275,59 @@ function StepShortcutHelperToast() {
     } catch {
       // The toast can still be dismissed for this render if storage is blocked.
     }
-    setVisible(false);
+    setDismissing(true);
+    window.setTimeout(() => {
+      setVisible(false);
+      setDismissing(false);
+    }, STEP_SHORTCUT_HELPER_ANIMATION_MS);
   }, []);
 
   useEffect(() => {
-    if (!visible) return;
+    if (!visible || dismissing) return;
 
-    const intervalId = window.setInterval(() => {
+    const activeHint = activeHintIndex % 2;
+    const timeoutId = window.setTimeout(() => {
+      setExitingHint(activeHint);
       setActiveHintIndex((index) => index + 1);
     }, STEP_SHORTCUT_HELPER_ROTATION_MS);
 
-    return () => window.clearInterval(intervalId);
-  }, [visible]);
+    return () => window.clearTimeout(timeoutId);
+  }, [activeHintIndex, dismissing, visible]);
+
+  useEffect(() => {
+    if (exitingHint === null) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setExitingHint(null);
+    }, STEP_SHORTCUT_HELPER_ANIMATION_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [exitingHint]);
 
   if (!visible) return null;
 
   const activeHint = activeHintIndex % 2;
 
   return (
-    <div className="group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs leading-none text-muted-foreground">
-      <span className="inline-flex items-center whitespace-nowrap">
-        {activeHint === 0 ? (
-          <>
-            Press{' '}
-            <Kbd variant="outline" size="compact">
-              Alt
-            </Kbd>{' '}
-            to see delta between steps
-          </>
-        ) : (
-          <>
-            Press{' '}
-            <Kbd variant="outline" size="compact">
-              J
-            </Kbd>
-            /
-            <Kbd variant="outline" size="compact">
-              K
-            </Kbd>{' '}
-            to navigate through steps
-          </>
-        )}
+    <div
+      className={`group absolute bottom-3 left-1/2 z-10 inline-flex h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1.5 text-xs leading-none text-muted-foreground motion-reduce:animate-none ${
+        dismissing
+          ? 'animate-out fade-out slide-out-to-top-1 duration-150 ease-out'
+          : 'animate-in fade-in slide-in-from-bottom-1 duration-200 ease-out'
+      }`}
+    >
+      <span className="grid items-center whitespace-nowrap">
+        {exitingHint !== null ? (
+          <span className="col-start-1 row-start-1 inline-flex items-center animate-out fade-out slide-out-to-top-1 duration-150 ease-out motion-reduce:animate-none">
+            <StepShortcutHint hint={exitingHint} />
+          </span>
+        ) : null}
+        <span
+          key={activeHintIndex}
+          className="col-start-1 row-start-1 inline-flex items-center animate-in fade-in slide-in-from-bottom-1 duration-200 ease-out motion-reduce:animate-none"
+        >
+          <StepShortcutHint hint={activeHint} />
+        </span>
       </span>
       <button
         type="button"
@@ -584,7 +627,7 @@ export function RunDetailView({
       await cancelRun(env, runId);
       // Trigger a refresh of the data
       await update();
-      toast.success('Run cancelled successfully');
+      toast.success('Run cancelled');
     } catch (err) {
       console.error('Failed to cancel run:', err);
       toast.error('Failed to cancel run', {
@@ -608,7 +651,7 @@ export function RunDetailView({
       setShowRerunDialog(false);
       // Start a new run with the same workflow and input arguments
       const newRunId = await recreateRun(env, run.runId);
-      toast.success('New run started successfully', {
+      toast.success('New run started', {
         description: `Run ID: ${newRunId}`,
       });
       // Navigate to the new run


### PR DESCRIPTION
### Description

Adds a dismissible helper toast to the trace viewer that teaches the step shortcuts:

- Press Alt to see the delta between steps.
- Press J/K to navigate through steps.

The helper stores dismissals in localStorage and stops appearing after three dismissals.

### How did you test your changes?

Not run: `pnpm exec biome check packages/web/app/components/run-detail-view.tsx` could not find `biome` because dependencies are not installed in this worktree.

### PR Checklist - Required to merge

- [ ] 📦 `pnpm changeset` was run to create a changelog for this PR
  - Use the correct semver bump type: `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete