### PR TITLE
test(web-shared): add unit tests for CopyableDataBlock JSON viewer

### DIFF
--- a/.changeset/copyable-data-block-tests.md
+++ b/.changeset/copyable-data-block-tests.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Export `serializeForClipboard` from the copyable data block and add unit tests covering its clipboard serialization and the `CopyableDataBlock`/`EncryptedDataBlock` rendering.

--- a/packages/web-shared/src/components/sidebar/copyable-data-block.tsx
+++ b/packages/web-shared/src/components/sidebar/copyable-data-block.tsx
@@ -44,7 +44,7 @@ export function EncryptedDataBlock() {
   );
 }
 
-const serializeForClipboard = (value: unknown): string => {
+export const serializeForClipboard = (value: unknown): string => {
   if (typeof value === 'string') return value;
   if (
     typeof value === 'number' ||

--- a/packages/web-shared/test/copyable-data-block.test.ts
+++ b/packages/web-shared/test/copyable-data-block.test.ts
@@ -1,0 +1,142 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  CopyableDataBlock,
+  EncryptedDataBlock,
+  serializeForClipboard,
+} from '../src/components/sidebar/copyable-data-block.js';
+import {
+  DecryptClickContext,
+  type DecryptClickContextValue,
+} from '../src/components/ui/data-inspector.js';
+
+/**
+ * `serializeForClipboard` is the helper behind the copy button on the JSON-style
+ * data viewer (`CopyableDataBlock`). It decides what text lands on the clipboard
+ * when a user copies a step's input/output/error payload, so these tests pin the
+ * formatting contract: strings stay verbatim, primitives stringify, and objects
+ * become pretty-printed JSON with a defensive fallback for un-serializable values.
+ */
+describe('serializeForClipboard', () => {
+  it('returns strings verbatim without quoting them', () => {
+    expect(serializeForClipboard('hello world')).toBe('hello world');
+    // Strings that happen to be JSON must not be double-encoded.
+    expect(serializeForClipboard('{"a":1}')).toBe('{"a":1}');
+    expect(serializeForClipboard('')).toBe('');
+  });
+
+  it('stringifies numeric, boolean, and null primitives', () => {
+    expect(serializeForClipboard(42)).toBe('42');
+    expect(serializeForClipboard(0)).toBe('0');
+    expect(serializeForClipboard(-1.5)).toBe('-1.5');
+    expect(serializeForClipboard(Number.NaN)).toBe('NaN');
+    expect(serializeForClipboard(true)).toBe('true');
+    expect(serializeForClipboard(false)).toBe('false');
+    expect(serializeForClipboard(null)).toBe('null');
+  });
+
+  it('pretty-prints objects as two-space-indented JSON', () => {
+    const value = { input: 'x', count: 2, nested: { ok: true } };
+    expect(serializeForClipboard(value)).toBe(JSON.stringify(value, null, 2));
+    // Sanity-check the formatting is actually multi-line and indented.
+    expect(serializeForClipboard(value)).toContain('\n  "input": "x"');
+  });
+
+  it('pretty-prints arrays as two-space-indented JSON', () => {
+    const value = [1, 'two', { three: 3 }];
+    expect(serializeForClipboard(value)).toBe(JSON.stringify(value, null, 2));
+  });
+
+  it('falls back to String() when JSON.stringify throws (circular refs)', () => {
+    const circular: Record<string, unknown> = { name: 'loop' };
+    circular.self = circular;
+
+    expect(serializeForClipboard(circular)).toBe('[object Object]');
+  });
+
+  it('falls back to String() for BigInt values JSON cannot encode', () => {
+    expect(serializeForClipboard(10n)).toBe('10');
+  });
+
+  it('passes undefined through (JSON.stringify yields no string)', () => {
+    // Documents the current behavior: undefined is neither a handled primitive
+    // nor JSON-serializable, so the helper returns undefined as-is.
+    expect(serializeForClipboard(undefined)).toBeUndefined();
+  });
+});
+
+describe('CopyableDataBlock', () => {
+  it('renders a labelled copy button for the data viewer', () => {
+    const markup = renderToStaticMarkup(
+      createElement(CopyableDataBlock, { data: { input: 'value' } })
+    );
+
+    expect(markup).toContain('aria-label="Copy data"');
+  });
+
+  it('renders without throwing for a variety of payload shapes', () => {
+    const payloads: unknown[] = [
+      'a plain string',
+      1234,
+      null,
+      { nested: { deeply: [1, 2, 3] } },
+      [{ id: 'a' }, { id: 'b' }],
+    ];
+
+    for (const data of payloads) {
+      expect(() =>
+        renderToStaticMarkup(createElement(CopyableDataBlock, { data }))
+      ).not.toThrow();
+    }
+  });
+});
+
+describe('EncryptedDataBlock', () => {
+  it('shows a static Encrypted badge when no decrypt context is provided', () => {
+    const markup = renderToStaticMarkup(createElement(EncryptedDataBlock));
+
+    expect(markup).toContain('Encrypted');
+    // The blurred placeholder previews the encrypted shape to the user.
+    expect(markup).toContain('[encrypted]');
+    expect(markup).not.toContain('Decrypt');
+  });
+
+  it('renders an enabled Decrypt button when a decrypt context is present', () => {
+    const ctx: DecryptClickContextValue = {
+      onDecrypt: () => {},
+      isDecrypting: false,
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(
+        DecryptClickContext.Provider,
+        { value: ctx },
+        createElement(EncryptedDataBlock)
+      )
+    );
+
+    expect(markup).toContain('Decrypt');
+    // The `disabled:`-prefixed Tailwind classes are always present, so assert on
+    // the actual `disabled` attribute instead of a loose substring match.
+    expect(markup).not.toContain('disabled=""');
+  });
+
+  it('disables the Decrypt button while decryption is in progress', () => {
+    const ctx: DecryptClickContextValue = {
+      onDecrypt: () => {},
+      isDecrypting: true,
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(
+        DecryptClickContext.Provider,
+        { value: ctx },
+        createElement(EncryptedDataBlock)
+      )
+    );
+
+    expect(markup).toContain('Decrypt');
+    expect(markup).toContain('disabled=""');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds unit test coverage for the copyable JSON-style data viewer in `@workflow/web-shared` — `CopyableDataBlock` (the bordered data block with a copy-to-clipboard button over a `DataInspector` tree) and its sibling `EncryptedDataBlock`.

The core logic worth pinning is `serializeForClipboard`, which decides what text lands on the clipboard when a user copies a step's input/output/error payload. It was a private helper, so it's now exported to be testable directly.

## Changes

- `packages/web-shared/src/components/sidebar/copyable-data-block.tsx`: export `serializeForClipboard` (no behavior change).
- `packages/web-shared/test/copyable-data-block.test.ts`: new test file (12 tests).

## Test coverage

`serializeForClipboard`:
- strings returned verbatim (no double-encoding of JSON-looking strings, empty string)
- numeric / boolean / `null` primitives stringified (incl. `0`, `NaN`)
- objects and arrays pretty-printed as 2-space-indented JSON
- fallback to `String()` when `JSON.stringify` throws (circular refs, `BigInt`)
- `undefined` passthrough (documents current behavior)

Rendering (via `react-dom/server`, matching the package's existing test style — no jsdom):
- `CopyableDataBlock` renders a labelled copy button and doesn't throw across varied payload shapes
- `EncryptedDataBlock` shows a static "Encrypted" badge with no decrypt context, an enabled "Decrypt" button when a context is present, and a disabled button while decrypting

## Verification

- `pnpm vitest run test/copyable-data-block.test.ts` → 12/12 pass
- `pnpm typecheck` → clean
- Biome check on the changed files → clean

Note: pre-existing `zstd-decoder.test.ts` failures and package-wide Biome findings are unrelated to this change (the zstd failure is a Node `zlib.zstdCompressSync` availability issue in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d2ce083-076d-4684-bc47-b57f50550803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d2ce083-076d-4684-bc47-b57f50550803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

