### PR TITLE
[docs] use actual eve logo in OSS nav dropdown

### DIFF
--- a/docs/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve.tsx
+++ b/docs/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve.tsx
@@ -1,24 +1,36 @@
-import { cn } from '@/lib/utils';
-
 /**
- * eve wordmark + Beta badge. eve ships a text-based brand mark rather than an
- * SVG wordmark, so this mirrors its docs logo. `height` is accepted for parity
- * with the other product logos but does not drive sizing for this text mark.
+ * Temporary eve logo fallback.
+ *
+ * Hard-copied from `@vercel/geistcn-assets` (LogoEve). Uses `currentColor`
+ * so it adapts to light/dark themes without separate variants.
  */
 export function LogoEve({
+  height = 14,
   className,
 }: {
   height?: number;
   className?: string;
 }) {
+  const width = (169 / 53) * height;
   return (
-    <span className={cn('flex items-center gap-2', className)}>
-      <span className="font-semibold text-gray-1000 text-lg leading-none">
-        eve
-      </span>
-      <span className="rounded-full border border-blue-300 px-2 py-0.5 font-medium text-blue-700 text-xs leading-none">
-        Beta
-      </span>
-    </span>
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      height={height}
+      role="img"
+      viewBox="0 0 169 53"
+      width={width}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M169 8.47h-51.39L81.73 53H70.36L113 0H169zM169 44.51v8.47h-45.87V44.5zM45.87 52.98H0V44.5h45.87zM38.66 30.55H0v-8.47h38.66z"
+        fill="currentColor"
+      />
+      <path
+        d="M169 30.55h-38.66v-8.47H169zM75.52 8.47H0V0h75.52z"
+        fill="currentColor"
+      />
+    </svg>
   );
 }

--- a/docs/components/geistdocs/navbar-logo.tsx
+++ b/docs/components/geistdocs/navbar-logo.tsx
@@ -9,7 +9,6 @@ import { LogoChatSdk } from '@/components/geistcn-fallbacks/geistcn-assets/logos
 import { LogoEve } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve';
 import { LogoFlagsSdk } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-flags-sdk';
 import { LogoIconVercel } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-icon-vercel';
-import { LogoStreamdown } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-streamdown';
 import { LogoVercelOss } from '@/components/geistcn-fallbacks/geistcn-assets/logos/logo-vercel-oss';
 import {
   NavigationMenu,
@@ -26,12 +25,11 @@ const OSS_PRODUCT_LINKS: {
   logo: ComponentType<{ height: number }>;
   height: number;
 }[] = [
-  { href: 'https://eve.dev/docs', logo: LogoEve, height: 18 },
+  { href: 'https://eve.dev/docs', logo: LogoEve, height: 12 },
   { href: 'https://ai-sdk.dev/', logo: LogoAiSdk, height: 12 },
   { href: 'https://flags-sdk.dev/', logo: LogoFlagsSdk, height: 20 },
   { href: 'https://chat-sdk.dev/', logo: LogoChatSdk, height: 20 },
   { href: 'https://elements.ai-sdk.dev/', logo: LogoAiElements, height: 12 },
-  { href: 'https://streamdown.ai/', logo: LogoStreamdown, height: 17 },
 ];
 
 type NavbarLogoProps = {


### PR DESCRIPTION
Mirror of vercel/chat#641 for the workflow docs nav.

- Swap the text-based eve placeholder for the actual eve wordmark, hard-copied as an SVG from `@vercel/geistcn-assets` and themed via `currentColor`.
- Drop Streamdown and put AI Elements last