### PR TITLE
Trace /flow route initialization

### DIFF
--- a/.changeset/flow-route-init-traces.md
+++ b/.changeset/flow-route-init-traces.md
@@ -3,4 +3,4 @@
 '@workflow/builders': patch
 ---
 
-Add OpenTelemetry spans and generated-route module timing around `/flow` initialization.
+Add OpenTelemetry spans, turbo tagging, and generated-route module timing around `/flow` initialization.

--- a/.changeset/flow-route-init-traces.md
+++ b/.changeset/flow-route-init-traces.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Add OpenTelemetry spans around `/flow` route initialization and world loading.

--- a/.changeset/flow-route-init-traces.md
+++ b/.changeset/flow-route-init-traces.md
@@ -1,5 +1,6 @@
 ---
 '@workflow/core': patch
+'@workflow/builders': patch
 ---
 
-Add OpenTelemetry spans around `/flow` route initialization and world loading.
+Add OpenTelemetry spans and generated-route module timing around `/flow` initialization.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -24,8 +24,8 @@ import {
 import { createWorkflowEntrypointOptionsCode } from './constants.js';
 import { getEsbuildTsconfigOptions } from './esbuild-tsconfig.js';
 import {
-  fastDiscoverEntries,
   type DiscoveredEntries,
+  fastDiscoverEntries,
 } from './fast-discovery.js';
 import {
   getImportPath,
@@ -1425,8 +1425,11 @@ export const __steps_registered = true;
         }
       }
 
-      const workflowEntrypointOptionsCode =
-        createWorkflowEntrypointOptionsCode();
+      const workflowEntrypointOptionsCode = createWorkflowEntrypointOptionsCode(
+        {
+          routeModuleBodyStartedAt: 'workflowRouteModuleBodyStartedAt',
+        }
+      );
 
       const bundleFinal = async (interimBundle: string) => {
         const workflowBundleCode = interimBundle;
@@ -1435,6 +1438,7 @@ export const __steps_registered = true;
 /* eslint-disable */
 import { workflowEntrypoint } from 'workflow/runtime';
 
+const workflowRouteModuleBodyStartedAt = Date.now();
 const workflowCode = \`${workflowBundleCode.replace(/[\\`$]/g, '\\$&')}\`;
 
 export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode});`;
@@ -1613,14 +1617,18 @@ export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCo
     }
 
     // 3. Generate combined route file
-    const stepsRelativePath = './' + basename(stepsOutfile).replace(/\\/g, '/');
+    const stepsRelativePath = `./${basename(stepsOutfile).replace(/\\/g, '/')}`;
     const escapedVMCode = workflowVMCode.replace(/[\\`$]/g, '\\$&');
-    const workflowEntrypointOptionsCode = createWorkflowEntrypointOptionsCode();
+    const workflowEntrypointOptionsCode = createWorkflowEntrypointOptionsCode({
+      routeModuleBodyStartedAt: 'workflowRouteModuleBodyStartedAt',
+    });
 
     const combinedFunctionCode = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import { __steps_registered } from '${stepsRelativePath}';
 import { workflowEntrypoint } from 'workflow/runtime';
+
+const workflowRouteModuleBodyStartedAt = Date.now();
 
 // Prevent rollup from tree-shaking the steps side-effect import
 void __steps_registered;
@@ -1685,12 +1693,17 @@ export const POST = workflowEntrypoint(workflowCode${workflowEntrypointOptionsCo
     // Create a custom bundleFinal for watch mode that uses workflowEntrypoint
     const combinedBundleFinal = async (interimBundleText: string) => {
       const escaped = interimBundleText.replace(/[\\`$]/g, '\\$&');
-      const workflowEntrypointOptionsCode =
-        createWorkflowEntrypointOptionsCode();
+      const workflowEntrypointOptionsCode = createWorkflowEntrypointOptionsCode(
+        {
+          routeModuleBodyStartedAt: 'workflowRouteModuleBodyStartedAt',
+        }
+      );
       const code = `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import { __steps_registered } from '${stepsRelativePath}';
 import { workflowEntrypoint } from 'workflow/runtime';
+
+const workflowRouteModuleBodyStartedAt = Date.now();
 
 void __steps_registered;
 

--- a/packages/builders/src/constants.test.ts
+++ b/packages/builders/src/constants.test.ts
@@ -48,4 +48,15 @@ describe('createWorkflowEntrypointOptionsCode', () => {
       ', { namespace: "custom" }'
     );
   });
+
+  it('inlines route module timing with namespace options', () => {
+    expect(
+      createWorkflowEntrypointOptionsCode({
+        namespace: 'custom',
+        routeModuleBodyStartedAt: 'workflowRouteModuleBodyStartedAt',
+      })
+    ).toBe(
+      ', { namespace: "custom", routeModuleBodyStartedAt: workflowRouteModuleBodyStartedAt }'
+    );
+  });
 });

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -54,6 +54,7 @@ export function createWorkflowQueueTrigger(options?: { namespace?: string }) {
  */
 export function createWorkflowEntrypointOptionsCode(options?: {
   namespace?: string;
+  /** Raw code identifier/expression emitted into generated route files, not data. */
   routeModuleBodyStartedAt?: string;
 }) {
   const namespace = resolveQueueNamespace(options?.namespace);

--- a/packages/builders/src/constants.ts
+++ b/packages/builders/src/constants.ts
@@ -54,17 +54,28 @@ export function createWorkflowQueueTrigger(options?: { namespace?: string }) {
  */
 export function createWorkflowEntrypointOptionsCode(options?: {
   namespace?: string;
+  routeModuleBodyStartedAt?: string;
 }) {
   const namespace = resolveQueueNamespace(options?.namespace);
+  const fields: string[] = [];
 
-  if (!namespace) {
+  if (namespace) {
+    // Reuse prefix construction for namespace validation.
+    getQueueTopicPrefix('workflow', namespace);
+    fields.push(`namespace: ${JSON.stringify(namespace)}`);
+  }
+
+  if (options?.routeModuleBodyStartedAt) {
+    fields.push(
+      `routeModuleBodyStartedAt: ${options.routeModuleBodyStartedAt}`
+    );
+  }
+
+  if (fields.length === 0) {
     return '';
   }
 
-  // Reuse prefix construction for namespace validation.
-  getQueueTopicPrefix('workflow', namespace);
-
-  return `, { namespace: ${JSON.stringify(namespace)} }`;
+  return `, { ${fields.join(', ')} }`;
 }
 
 /**

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -98,7 +98,7 @@ async function makeRunningRun(runId: string): Promise<WorkflowRun> {
  * Drives the workflow queue handler once with the given trace carrier,
  * inside an active "delivery" span (simulating the span the platform/queue
  * consumer creates around the delivery request). Returns the finished
- * WORKFLOW_V2 span, the delivery span, and all queued messages.
+ * route and WORKFLOW_V2 spans, the delivery span, and all queued messages.
  */
 async function driveHandler(opts: {
   runId: string;
@@ -183,8 +183,28 @@ async function driveHandler(opts: {
   const workflowSpan = exporter
     .getFinishedSpans()
     .find((s) => s.name === 'workflow.execute workflow');
+  const routeSpan = exporter
+    .getFinishedSpans()
+    .find((s) => s.name === 'workflow.route.flow');
+  const routeInitSpan = exporter
+    .getFinishedSpans()
+    .find((s) => s.name === 'workflow.route.init');
+  const getWorldHandlersSpan = exporter
+    .getFinishedSpans()
+    .find((s) => s.name === 'workflow.route.get_world_handlers');
+  const getWorldSpan = exporter
+    .getFinishedSpans()
+    .find((s) => s.name === 'workflow.route.get_world');
 
-  return { workflowSpan, deliverySpan, queuedMessages };
+  return {
+    workflowSpan,
+    routeSpan,
+    routeInitSpan,
+    getWorldHandlersSpan,
+    getWorldSpan,
+    deliverySpan,
+    queuedMessages,
+  };
 }
 
 function linkTraceIds(span: ReadableSpan | undefined): string[] {
@@ -221,17 +241,43 @@ describe('getWorkflowTraceMode', () => {
 });
 
 describe('workflowEntrypoint trace modes', () => {
-  it('linked (default): nests under the delivery context with a link to the run-origin context', async () => {
-    const { workflowSpan, deliverySpan } = await driveHandler({
+  it('linked (default): nests under the flow route context with a link to the run-origin context', async () => {
+    const {
+      workflowSpan,
+      routeSpan,
+      routeInitSpan,
+      getWorldHandlersSpan,
+      getWorldSpan,
+      deliverySpan,
+    } = await driveHandler({
       runId: 'wrun_trace_linked',
       workflowCode: simpleWorkflow,
       traceCarrier: ORIGIN_CARRIER,
     });
 
+    expect(routeSpan).toBeDefined();
+    expect(routeSpan?.parentSpanId).toBe(deliverySpan.spanContext().spanId);
+    expect(routeSpan?.attributes['workflow.route.type']).toBe('flow');
+    expect(routeSpan?.attributes['workflow.route.handler_cached']).toBe(false);
+    expect(routeSpan?.attributes['workflow.route.invocation_count']).toBe(1);
+    expect(routeSpan?.attributes['http.route']).toBe(
+      '/.well-known/workflow/v1/flow'
+    );
+    expect(routeSpan?.attributes['http.response.status_code']).toBe(204);
+
+    expect(routeInitSpan).toBeDefined();
+    expect(routeInitSpan?.parentSpanId).toBe(routeSpan?.spanContext().spanId);
+    expect(getWorldHandlersSpan).toBeDefined();
+    expect(getWorldHandlersSpan?.parentSpanId).toBe(
+      routeInitSpan?.spanContext().spanId
+    );
+    expect(getWorldSpan).toBeDefined();
+    expect(getWorldSpan?.parentSpanId).toBe(routeSpan?.spanContext().spanId);
+
     expect(workflowSpan).toBeDefined();
-    // Child of the local delivery (flow-route) span — same trace, so one
+    // Child of the local /flow route span — same trace, so one
     // invocation is a single bounded trace rather than a new root.
-    expect(workflowSpan?.parentSpanId).toBe(deliverySpan.spanContext().spanId);
+    expect(workflowSpan?.parentSpanId).toBe(routeSpan?.spanContext().spanId);
     expect(workflowSpan?.spanContext().traceId).toBe(
       deliverySpan.spanContext().traceId
     );
@@ -254,32 +300,119 @@ describe('workflowEntrypoint trace modes', () => {
   });
 
   it('linked: treats an empty trace carrier ({}) like an absent one', async () => {
-    const { workflowSpan, deliverySpan } = await driveHandler({
+    const { workflowSpan, routeSpan } = await driveHandler({
       runId: 'wrun_trace_linked_empty_carrier',
       workflowCode: simpleWorkflow,
       traceCarrier: {},
     });
 
     expect(workflowSpan).toBeDefined();
-    // Still nested under the delivery context...
-    expect(workflowSpan?.parentSpanId).toBe(deliverySpan.spanContext().spanId);
+    // Still nested under the local /flow route context...
+    expect(workflowSpan?.parentSpanId).toBe(routeSpan?.spanContext().spanId);
     // ...but no run-origin link is derived from `{}`.
     expect(workflowSpan?.links ?? []).toHaveLength(0);
     // An empty carrier does not count as propagated trace context.
     expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(false);
   });
 
-  it('linked: without an incoming carrier, nests under the delivery context with no links', async () => {
-    const { workflowSpan, deliverySpan } = await driveHandler({
+  it('linked: without an incoming carrier, nests under the flow route context with no links', async () => {
+    const { workflowSpan, routeSpan } = await driveHandler({
       runId: 'wrun_trace_linked_no_carrier',
       workflowCode: simpleWorkflow,
       traceCarrier: undefined,
     });
 
     expect(workflowSpan).toBeDefined();
-    expect(workflowSpan?.parentSpanId).toBe(deliverySpan.spanContext().spanId);
+    expect(workflowSpan?.parentSpanId).toBe(routeSpan?.spanContext().spanId);
     expect(workflowSpan?.links ?? []).toHaveLength(0);
     expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(false);
+  });
+
+  it('traces route initialization only on the first flow request', async () => {
+    const workflowRun = await makeRunningRun('wrun_trace_route_cache');
+
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      createQueueHandler: vi.fn(
+        (
+          _prefix: string,
+          handler: (message: unknown, metadata: unknown) => Promise<unknown>
+        ) => {
+          return async () => {
+            await handler(
+              {
+                runId: workflowRun.runId,
+                requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+              },
+              {
+                requestId: 'req_test',
+                attempt: 1,
+                queueName: '__wkf_workflow_workflow',
+                messageId: 'msg_test',
+              }
+            );
+            return new Response(null, { status: 204 });
+          };
+        }
+      ),
+      events: {
+        create: vi.fn(async (_runId: string, data: any) => {
+          if (data.eventType === 'run_started') {
+            return { run: workflowRun, events: [] as Event[] };
+          }
+          return {
+            event: {
+              eventId: `event-${Math.random()}`,
+              runId: workflowRun.runId,
+              createdAt: new Date(),
+              ...data,
+            },
+          };
+        }),
+        list: vi.fn(async () => ({
+          data: [] as Event[],
+          hasMore: false,
+          cursor: 'cursor_test',
+        })),
+      },
+      runs: {
+        get: vi.fn(async () => workflowRun),
+      },
+      queue: vi.fn(async () => ({ messageId: null })),
+      getEncryptionKeyForRun: vi.fn(async () => undefined),
+    } as any);
+
+    const handler = workflowEntrypoint(simpleWorkflow);
+    const tracer = otelTrace.getTracer('test');
+    await tracer.startActiveSpan('queue delivery', async (span) => {
+      try {
+        await handler(new Request('https://example.test'));
+        await handler(new Request('https://example.test'));
+      } finally {
+        span.end();
+      }
+    });
+
+    const spans = exporter.getFinishedSpans();
+    const routeSpans = spans.filter((s) => s.name === 'workflow.route.flow');
+    const routeInitSpans = spans.filter(
+      (s) => s.name === 'workflow.route.init'
+    );
+
+    expect(routeSpans).toHaveLength(2);
+    expect(routeInitSpans).toHaveLength(1);
+    expect(routeSpans[0]?.attributes['workflow.route.handler_cached']).toBe(
+      false
+    );
+    expect(routeSpans[0]?.attributes['workflow.route.invocation_count']).toBe(
+      1
+    );
+    expect(routeSpans[1]?.attributes['workflow.route.handler_cached']).toBe(
+      true
+    );
+    expect(routeSpans[1]?.attributes['workflow.route.invocation_count']).toBe(
+      2
+    );
   });
 
   it('continuous: preserves the legacy shape — parented to the run-origin context with a delivery link', async () => {

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -104,6 +104,7 @@ async function driveHandler(opts: {
   runId: string;
   workflowCode: string;
   traceCarrier?: Record<string, string>;
+  routeModuleBodyStartedAt?: number;
 }) {
   const workflowRun = await makeRunningRun(opts.runId);
   const queuedMessages: any[] = [];
@@ -165,7 +166,12 @@ async function driveHandler(opts: {
     getEncryptionKeyForRun: vi.fn(async () => undefined),
   } as any);
 
-  const handler = workflowEntrypoint(opts.workflowCode);
+  const handler = workflowEntrypoint(
+    opts.workflowCode,
+    opts.routeModuleBodyStartedAt === undefined
+      ? undefined
+      : { routeModuleBodyStartedAt: opts.routeModuleBodyStartedAt }
+  );
 
   // Invoke inside an active "delivery" span so linkToCurrentContext()
   // observes a live delivery context, as it would in production.
@@ -253,6 +259,7 @@ describe('workflowEntrypoint trace modes', () => {
       runId: 'wrun_trace_linked',
       workflowCode: simpleWorkflow,
       traceCarrier: ORIGIN_CARRIER,
+      routeModuleBodyStartedAt: Date.now(),
     });
 
     expect(routeSpan).toBeDefined();
@@ -260,6 +267,10 @@ describe('workflowEntrypoint trace modes', () => {
     expect(routeSpan?.attributes['workflow.route.type']).toBe('flow');
     expect(routeSpan?.attributes['workflow.route.handler_cached']).toBe(false);
     expect(routeSpan?.attributes['workflow.route.invocation_count']).toBe(1);
+    const moduleBodyInitMs =
+      routeSpan?.attributes['workflow.route.module_body_init_ms'];
+    expect(typeof moduleBodyInitMs).toBe('number');
+    expect(moduleBodyInitMs as number).toBeGreaterThanOrEqual(0);
     expect(routeSpan?.attributes['http.route']).toBe(
       '/.well-known/workflow/v1/flow'
     );
@@ -293,6 +304,13 @@ describe('workflowEntrypoint trace modes', () => {
 
     expect(workflowSpan?.attributes['workflow.trace.mode']).toBe('linked');
     expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(true);
+    const runStartedCreateEvent = workflowSpan?.events.find(
+      (e) => e.name === 'workflow.run_started.create.start'
+    );
+    expect(runStartedCreateEvent).toBeDefined();
+    expect(
+      runStartedCreateEvent?.attributes['workflow.run_started.skip_preload']
+    ).toBe(false);
 
     // Queue-delivered invocation spans use the CONSUMER kind, matching
     // queue-delivered step.execute spans.

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -304,6 +304,7 @@ describe('workflowEntrypoint trace modes', () => {
 
     expect(workflowSpan?.attributes['workflow.trace.mode']).toBe('linked');
     expect(workflowSpan?.attributes['workflow.trace.propagated']).toBe(true);
+    expect(workflowSpan?.attributes['workflow.turbo']).toBe(false);
     const runStartedCreateEvent = workflowSpan?.events.find(
       (e) => e.name === 'workflow.run_started.create.start'
     );

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -461,7 +461,9 @@ export function workflowEntrypoint(
           return await withWorkflowBaggage(
             { workflowRunId: runId, workflowName },
             async () => {
-              const world = await getWorld();
+              const world = await trace('workflow.route.get_world', async () =>
+                getWorld()
+              );
               return trace(
                 `workflow.execute ${workflowDisplayName(workflowName)}`,
                 { kind: spanKind, links: spanLinks },
@@ -2012,10 +2014,48 @@ export function workflowEntrypoint(
     );
 
   let cachedHandler: ((req: Request) => Promise<Response>) | undefined;
+  let invocationCount = 0;
+  const entrypointCreatedAt = Date.now();
+
   return withHealthCheck(async (req) => {
-    if (!cachedHandler) {
-      cachedHandler = handler(await getWorldHandlers());
-    }
-    return cachedHandler(req);
+    invocationCount += 1;
+    const handlerCached = cachedHandler !== undefined;
+    const spanKind = await getSpanKind('SERVER');
+
+    return trace(
+      'workflow.route.flow',
+      {
+        kind: spanKind,
+        attributes: {
+          ...Attribute.WorkflowRouteType('flow'),
+          ...Attribute.WorkflowRouteHandlerCached(handlerCached),
+          ...Attribute.WorkflowRouteInvocationCount(invocationCount),
+          ...Attribute.WorkflowRouteEntrypointAgeMs(
+            Date.now() - entrypointCreatedAt
+          ),
+          ...Attribute.HttpRequestMethod(req.method),
+          ...Attribute.HttpRoute('/.well-known/workflow/v1/flow'),
+        },
+      },
+      async (span) => {
+        if (!cachedHandler) {
+          cachedHandler = await trace('workflow.route.init', async () => {
+            const worldHandlers = await trace(
+              'workflow.route.get_world_handlers',
+              async () => getWorldHandlers()
+            );
+            return handler(worldHandlers);
+          });
+        }
+
+        const response = await cachedHandler(req);
+        if (response instanceof Response) {
+          span?.setAttributes(
+            Attribute.HttpResponseStatusCode(response.status)
+          );
+        }
+        return response;
+      }
+    );
   });
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -538,6 +538,7 @@ export function workflowEntrypoint(
                     metadata.attempt === 1 &&
                     incomingStepId === undefined &&
                     !replayDivergence;
+                  span?.setAttributes(Attribute.WorkflowTurbo(turbo));
 
                   // Turbo mode only: resolves once the backgrounded
                   // `run_started` has landed (or rejects if it failed). Threaded

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -287,7 +287,7 @@ function hasOpenHookOrWait(events: Event[]): boolean {
  */
 export function workflowEntrypoint(
   workflowCode: string,
-  options?: { namespace?: string }
+  options?: { namespace?: string; routeModuleBodyStartedAt?: number }
 ): (req: Request) => Promise<Response> {
   const NO_INLINE_REPLAY_AFTER_MS =
     Number(process.env.WORKFLOW_V2_TIMEOUT_MS) || 120_000;
@@ -768,6 +768,13 @@ export function workflowEntrypoint(
                           }
                         : {}),
                     };
+                    const recordRunStartedCreateStart = (
+                      skipPreload: boolean
+                    ) => {
+                      span?.addEvent('workflow.run_started.create.start', {
+                        'workflow.run_started.skip_preload': skipPreload,
+                      });
+                    };
 
                     if (turbo && runInput) {
                       // Turbo: background `run_started` and synthesize the run
@@ -778,6 +785,7 @@ export function workflowEntrypoint(
                       // barrier is consumed by every downstream write (suspension
                       // handler, optimistic step_started, terminal run writes) so
                       // nothing is written before the run exists.
+                      recordRunStartedCreateStart(true);
                       const startedPromise = world.events.create(
                         runId,
                         runStartedEvent,
@@ -837,6 +845,7 @@ export function workflowEntrypoint(
                       });
                     } else {
                       try {
+                        recordRunStartedCreateStart(false);
                         const result = await world.events.create(
                           runId,
                           runStartedEvent,
@@ -2016,6 +2025,10 @@ export function workflowEntrypoint(
   let cachedHandler: ((req: Request) => Promise<Response>) | undefined;
   let invocationCount = 0;
   const entrypointCreatedAt = Date.now();
+  const routeModuleBodyInitMs =
+    typeof options?.routeModuleBodyStartedAt === 'number'
+      ? entrypointCreatedAt - options.routeModuleBodyStartedAt
+      : undefined;
 
   return withHealthCheck(async (req) => {
     invocationCount += 1;
@@ -2033,6 +2046,9 @@ export function workflowEntrypoint(
           ...Attribute.WorkflowRouteEntrypointAgeMs(
             Date.now() - entrypointCreatedAt
           ),
+          ...(routeModuleBodyInitMs === undefined
+            ? {}
+            : Attribute.WorkflowRouteModuleBodyInitMs(routeModuleBodyInitMs)),
           ...Attribute.HttpRequestMethod(req.method),
           ...Attribute.HttpRoute('/.well-known/workflow/v1/flow'),
         },

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -97,6 +97,9 @@ export const WorkflowTraceMode = SemanticConvention<'linked' | 'continuous'>(
   'workflow.trace.mode'
 );
 
+/** Whether this workflow invocation is using the turbo first-delivery path */
+export const WorkflowTurbo = SemanticConvention<boolean>('workflow.turbo');
+
 /** Name of the error that caused workflow failure */
 export const WorkflowErrorName = SemanticConvention<string>(
   'workflow.error.name'
@@ -153,9 +156,6 @@ export const WorkflowRouteEntrypointAgeMs = SemanticConvention<number>(
 export const WorkflowRouteModuleBodyInitMs = SemanticConvention<number>(
   'workflow.route.module_body_init_ms'
 );
-
-/** Route pattern for the request */
-export const HttpRoute = SemanticConvention<string>('http.route');
 
 // Step attributes
 
@@ -290,6 +290,9 @@ export const WorkflowSuspensionWaitCount = SemanticConvention<number>(
 export const HttpRequestMethod = SemanticConvention<string>(
   'http.request.method'
 );
+
+/** Route pattern for the request (standard OTEL: http.route) */
+export const HttpRoute = SemanticConvention<string>('http.route');
 
 /** Full URL of the request (standard OTEL: url.full) */
 export const UrlFull = SemanticConvention<string>('url.full');

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -127,6 +127,31 @@ export const WorkflowWaitsCreated = SemanticConvention<number>(
   'workflow.waits.created'
 );
 
+// Route attributes
+
+/** The workflow runtime route being handled */
+export const WorkflowRouteType = SemanticConvention<'flow' | 'step'>(
+  'workflow.route.type'
+);
+
+/** Whether this route invocation reused an already-created request handler */
+export const WorkflowRouteHandlerCached = SemanticConvention<boolean>(
+  'workflow.route.handler_cached'
+);
+
+/** Number of times this in-memory route handler has been invoked */
+export const WorkflowRouteInvocationCount = SemanticConvention<number>(
+  'workflow.route.invocation_count'
+);
+
+/** Time since this route entrypoint was constructed, in milliseconds */
+export const WorkflowRouteEntrypointAgeMs = SemanticConvention<number>(
+  'workflow.route.entrypoint_age_ms'
+);
+
+/** Route pattern for the request */
+export const HttpRoute = SemanticConvention<string>('http.route');
+
 // Step attributes
 
 /** Name of the step function being executed */

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -149,6 +149,11 @@ export const WorkflowRouteEntrypointAgeMs = SemanticConvention<number>(
   'workflow.route.entrypoint_age_ms'
 );
 
+/** Time spent evaluating the generated route module body before creating the entrypoint */
+export const WorkflowRouteModuleBodyInitMs = SemanticConvention<number>(
+  'workflow.route.module_body_init_ms'
+);
+
 /** Route pattern for the request */
 export const HttpRoute = SemanticConvention<string>('http.route');
 


### PR DESCRIPTION
## Summary

This instruments the Workflow SDK `/flow` route path so we can explain delay before the route makes its first workflow-server `run_started` POST.

## Instrumentation contract

### `workflow.route.flow`

New server span around each generated `/flow` route request.

Attributes:

- `workflow.route.type`: currently `flow`
- `workflow.route.handler_cached`: whether this invocation reused the in-memory route handler
- `workflow.route.invocation_count`: per-process invocation count for this route entrypoint
- `workflow.route.entrypoint_age_ms`: milliseconds since `workflowEntrypoint()` constructed this route entrypoint
- `workflow.route.module_body_init_ms`: process-level milliseconds from the generated route module-body timestamp to `workflowEntrypoint()` construction, when generated routes provide the timestamp
- `http.request.method`: request method
- `http.route`: `/.well-known/workflow/v1/flow`
- `http.response.status_code`: response status when the handler returns a `Response`

### `workflow.route.init`

New child span under `workflow.route.flow`, emitted when the route creates the cached queue handler.

Use this to separate first-hit handler construction from normal warm-route request handling. Under concurrent cold requests, more than one request can observe an empty cache and emit `workflow.route.init`; that is pre-existing harmless last-write-wins behavior.

### `workflow.route.get_world_handlers`

New child span under `workflow.route.init` around `getWorldHandlers()`.

Use this to identify latency from loading/creating the world handler layer during route setup.

### `workflow.route.get_world`

New child span under `workflow.route.flow`, emitted for each workflow invocation before `workflow.execute`.

Use this to identify latency from resolving the per-invocation world before SDK runtime work posts `run_started`.

### `workflow.execute <workflowName>`

Existing workflow execution span. This PR adds:

Attributes:

- `workflow.turbo`: whether this invocation is using the turbo first-delivery path

Span events:

- `workflow.run_started.create.start`: emitted immediately before `world.events.create(... run_started ...)`, i.e. right before the first workflow-server `run_started` POST begins

Event attributes:

- `workflow.run_started.skip_preload`: whether the `run_started` create call is using the turbo `skipPreload` path

## Reading the signal

- Gap from `workflow.route.flow` start to `workflow.run_started.create.start`: SDK/runtime work before the first workflow-server `run_started` POST begins.
- Large `workflow.route.module_body_init_ms`: generated route module body work after static imports, before the SDK route handler is created. This value is computed once per route entrypoint and emitted on every request from that in-memory entrypoint.
- Near-zero `workflow.route.entrypoint_age_ms`: the route entrypoint was just created for this request, so this request hit a cold SDK route instance.
- `workflow.route.handler_cached=false` plus `workflow.route.init`: the request paid route handler creation. Sequentially this happens once per warm instance; concurrent cold requests may briefly produce more than one init span.
- `workflow.route.handler_cached=true`: route handler was already created; delay is not from handler construction.
- `workflow.turbo=true`: this invocation is the turbo first-delivery path. `workflow.run_started.skip_preload=true` is the finer-grained marker for the associated `run_started` create call.

Static ESM import evaluation still happens before generated route body code can run, so this does not directly measure the entire import graph. It gives us the earliest SDK-controlled marker in the generated `/flow` module, plus the exact pre-`run_started` marker inside the SDK handler.

## Testing

- `PATH=/Users/karthikkalyanaraman/.nvm/versions/node/v24.13.1/bin:$PATH pnpm exec vitest run packages/core/src/runtime-trace-mode.test.ts packages/builders/src/constants.test.ts`
- `PATH=/Users/karthikkalyanaraman/.nvm/versions/node/v24.13.1/bin:$PATH pnpm --filter @workflow/core typecheck`
- `PATH=/Users/karthikkalyanaraman/.nvm/versions/node/v24.13.1/bin:$PATH pnpm --filter @workflow/builders typecheck`
- `PATH=/Users/karthikkalyanaraman/.nvm/versions/node/v24.13.1/bin:$PATH pnpm exec biome check .changeset/flow-route-init-traces.md packages/builders/src/base-builder.ts packages/builders/src/constants.ts packages/builders/src/constants.test.ts packages/core/src/runtime.ts packages/core/src/runtime-trace-mode.test.ts packages/core/src/telemetry/semantic-conventions.ts` (exit 0; reports existing complexity/unused-suppression warnings)
- Previous full `@workflow/core` suite under Node 24: all 1322 tests passed, but Vitest exited 1 due an existing pending-fetch shutdown error; `packages/core/src/abort-controller-step.test.ts` passed by itself.
