### PR TITLE
fix(web-shared): keep trace viewer span-select zoom smooth on large traces

### DIFF
--- a/.changeset/trace-viewer-zoom-render-isolation.md
+++ b/.changeset/trace-viewer-zoom-render-isolation.md
@@ -2,4 +2,4 @@
 '@workflow/web-shared': patch
 ---
 
-Fix trace viewer lag when selecting/zooming a span. Timeline marker tooltips now share a single `ContextCardProvider` instead of each tick self-mounting its own portal/observer/listener, the detail panel and event list no longer re-render on every frame of the click-to-zoom animation, and the per-frame span-gap pass is skipped unless the Alt-key delta overlay is active.
+Fix the trace viewer click-to-zoom animation jumping/stuttering on large traces. The easing clock now starts on the first animation frame (so a heavy detail-panel mount can't make the zoom skip ahead), the panel opens as a low-priority transition so it doesn't block the animation, and the panel/event list/marker tooltips no longer do redundant work on every animation frame.

--- a/.changeset/trace-viewer-zoom-render-isolation.md
+++ b/.changeset/trace-viewer-zoom-render-isolation.md
@@ -2,4 +2,4 @@
 '@workflow/web-shared': patch
 ---
 
-Fix trace viewer lag when selecting a span: the detail panel and event list no longer re-render on every frame of the click-to-zoom animation.
+Fix trace viewer lag when selecting a span: the detail panel and event list no longer re-render on every frame of the click-to-zoom animation, and the per-frame span-gap pass is skipped unless the Alt-key delta overlay is active.

--- a/.changeset/trace-viewer-zoom-render-isolation.md
+++ b/.changeset/trace-viewer-zoom-render-isolation.md
@@ -2,4 +2,4 @@
 '@workflow/web-shared': patch
 ---
 
-Fix trace viewer lag when selecting a span: the detail panel and event list no longer re-render on every frame of the click-to-zoom animation, and the per-frame span-gap pass is skipped unless the Alt-key delta overlay is active.
+Fix trace viewer lag when selecting/zooming a span. Timeline marker tooltips now share a single `ContextCardProvider` instead of each tick self-mounting its own portal/observer/listener, the detail panel and event list no longer re-render on every frame of the click-to-zoom animation, and the per-frame span-gap pass is skipped unless the Alt-key delta overlay is active.

--- a/.changeset/trace-viewer-zoom-render-isolation.md
+++ b/.changeset/trace-viewer-zoom-render-isolation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Fix trace viewer lag when selecting a span: the detail panel and event list no longer re-render on every frame of the click-to-zoom animation.

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -23,6 +23,7 @@ import type {
   OffscreenMarkers,
   Segment,
   SegmentStatus,
+  SpanGap,
   TimeMarker,
 } from '../utils';
 import {
@@ -49,6 +50,9 @@ import { ROW_HEIGHT_PX, useRowWindow } from './use-row-window';
 const TINY_BAR_BOX_SIZE_PX = 24;
 const TINY_BAR_WIDTH_PX = 4;
 export const TIMELINE_PADDING_PX = 16;
+
+/** Stable empty reference so the gaps memo doesn't churn when Alt isn't held. */
+const EMPTY_GAPS: SpanGap[] = [];
 
 const SEGMENT_CLASSES: Record<SegmentStatus, string> = {
   queued: 'bg-gray-400 border border-gray-500',
@@ -669,9 +673,13 @@ export function Timeline({
     return () => ro.disconnect();
   }, []);
 
+  // Only needed for the Alt-key delta overlay. Gating on `altHeld` keeps this
+  // O(spans) pass off the zoom/pan animation path — `viewStart`/`viewEnd` change
+  // on every frame, so without the guard this recomputes over the whole trace
+  // each frame even though nothing consumes it unless Alt is held.
   const gaps = useMemo(
-    () => computeSpanGaps(spans, viewStart, viewEnd),
-    [spans, viewStart, viewEnd]
+    () => (altHeld ? computeSpanGaps(spans, viewStart, viewEnd) : EMPTY_GAPS),
+    [altHeld, spans, viewStart, viewEnd]
   );
 
   return (

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -29,6 +29,7 @@ import {
 } from '../sidebar/entity-detail-panel';
 import { useSidebarData } from '../sidebar/sidebar-data-context';
 import { formatDuration, getHighResInMs } from '../trace-viewer/util/timing';
+import { ContextCardProvider } from '../ui/context-card';
 import { IconButton } from '../ui/icon-button';
 import { Kbd } from '../ui/kbd';
 import { Spinner } from '../ui/spinner';
@@ -178,14 +179,21 @@ export function NewTraceViewer({
 }: NewTraceViewerProps): ReactNode {
   return (
     <TooltipProvider delayDuration={300}>
-      <ActiveSpanProvider spans={trace.spans}>
-        <NewTraceViewerContent
-          trace={trace}
-          onLoadMore={onLoadMore}
-          hasMore={hasMore}
-          isLoadingMore={isLoadingMore}
-        />
-      </ActiveSpanProvider>
+      {/* One shared provider for every timeline-marker TimestampTooltip. Without
+          it, each marker tick self-mounts its own ContextCardProvider — a
+          full-screen portal + ResizeObserver + document scroll listener — and
+          those mount/unmount in bulk as bars cross the tiny↔full threshold on
+          each zoom frame. Sharing one provider is the design's intended usage. */}
+      <ContextCardProvider>
+        <ActiveSpanProvider spans={trace.spans}>
+          <NewTraceViewerContent
+            trace={trace}
+            onLoadMore={onLoadMore}
+            hasMore={hasMore}
+            isLoadingMore={isLoadingMore}
+          />
+        </ActiveSpanProvider>
+      </ContextCardProvider>
     </TooltipProvider>
   );
 }

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -644,6 +644,116 @@ function NewTraceViewerContent({
   nextSpanIdRef.current = nextSpanId;
   navigateToSpanRef.current = navigateToSpan;
 
+  // The viewport animation (`animateTo`) updates `viewport` state ~60×/sec,
+  // re-rendering this component on every frame. The event list and the detail
+  // panel don't depend on the viewport, so we memoize them into stable element
+  // references — React bails out of reconciling a child subtree when its
+  // element is referentially identical across renders. Without this, selecting
+  // a span re-reconciles the entire (recursive) detail-panel JSON tree on every
+  // zoom frame, which is what made the click-to-zoom feel janky.
+  const eventList = useMemo(
+    () => (
+      <EventList
+        spans={trace.spans}
+        activeSpanId={activeSpanId}
+        searchResult={searchResult}
+        onSelectSpan={handleSelectSpan}
+      />
+    ),
+    [trace.spans, activeSpanId, searchResult, handleSelectSpan]
+  );
+
+  const detailPanel = useMemo(() => {
+    if (!activeSpan) return null;
+    return (
+      <aside className="flex flex-col h-full max-h-full bg-background-100 border-l border-gray-alpha-400 overflow-auto">
+        {/* Panel header */}
+        <div className="flex items-center justify-between gap-2 shrink-0 px-4 pt-3 pb-3">
+          <span className="text-label-14 font-medium text-gray-1000 truncate block">
+            {selectedSpanName}
+          </span>
+          <div className="flex items-center gap-0.5 shrink-0">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton
+                  aria-label="Navigate up"
+                  aria-keyshortcuts="K"
+                  onClick={handleSelectPrevSpan}
+                  disabled={!prevSpanId}
+                >
+                  <ChevronUp className="w-4 h-4" />
+                </IconButton>
+              </TooltipTrigger>
+              {prevSpanId ? (
+                <TooltipContent>
+                  Navigate up
+                  <Kbd>K</Kbd>
+                </TooltipContent>
+              ) : null}
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconButton
+                  aria-label="Navigate down"
+                  aria-keyshortcuts="J"
+                  onClick={handleSelectNextSpan}
+                  disabled={!nextSpanId}
+                >
+                  <ChevronDown className="w-4 h-4" />
+                </IconButton>
+              </TooltipTrigger>
+              {nextSpanId ? (
+                <TooltipContent>
+                  Navigate down
+                  <Kbd>J</Kbd>
+                </TooltipContent>
+              ) : null}
+            </Tooltip>
+            <div aria-hidden className="w-px h-4 bg-gray-alpha-400 mx-1" />
+            <IconButton
+              aria-label="Close span details"
+              aria-keyshortcuts="Escape"
+              onClick={handleClearActiveSpan}
+            >
+              <X className="w-4 h-4" />
+            </IconButton>
+          </div>
+        </div>
+        {/* Panel body */}
+        <div className="flex-1 overflow-y-auto">
+          <ErrorBoundary>
+            <EntityDetailPanel
+              run={sidebar.run}
+              onStreamClick={sidebar.onStreamClick}
+              onRunClick={sidebar.onRunClick}
+              spanDetailData={sidebar.spanDetailData}
+              spanDetailError={sidebar.spanDetailError}
+              spanDetailLoading={sidebar.spanDetailLoading}
+              onSpanSelect={sidebar.onSpanSelect}
+              onWakeUpSleep={sidebar.onWakeUpSleep}
+              onLoadEventData={sidebar.onLoadEventData}
+              onResolveHook={sidebar.onResolveHook}
+              encryptionKey={sidebar.encryptionKey}
+              onDecrypt={sidebar.onDecrypt}
+              isDecrypting={sidebar.isDecrypting}
+              selectedSpan={selectedSpan}
+            />
+          </ErrorBoundary>
+        </div>
+      </aside>
+    );
+  }, [
+    activeSpan,
+    selectedSpanName,
+    handleSelectPrevSpan,
+    prevSpanId,
+    handleSelectNextSpan,
+    nextSpanId,
+    handleClearActiveSpan,
+    sidebar,
+    selectedSpan,
+  ]);
+
   return (
     <div
       data-pane="pane-root"
@@ -695,12 +805,7 @@ function NewTraceViewerContent({
           }
         >
           <div className="block overflow-visible">
-            <EventList
-              spans={trace.spans}
-              activeSpanId={activeSpanId}
-              searchResult={searchResult}
-              onSelectSpan={handleSelectSpan}
-            />
+            {eventList}
             <div ref={loadMoreSentinelRef} className="flex justify-center">
               {isLoadingMore ? (
                 <div className="flex items-center justify-center gap-2 py-3 text-sm text-gray-800">
@@ -761,83 +866,7 @@ function NewTraceViewerContent({
       </div>
 
       {/* Detail panel */}
-      {activeSpan ? (
-        <aside className="flex flex-col h-full max-h-full bg-background-100 border-l border-gray-alpha-400 overflow-auto">
-          {/* Panel header */}
-          <div className="flex items-center justify-between gap-2 shrink-0 px-4 pt-3 pb-3">
-            <span className="text-label-14 font-medium text-gray-1000 truncate block">
-              {selectedSpanName}
-            </span>
-            <div className="flex items-center gap-0.5 shrink-0">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <IconButton
-                    aria-label="Navigate up"
-                    aria-keyshortcuts="K"
-                    onClick={handleSelectPrevSpan}
-                    disabled={!prevSpanId}
-                  >
-                    <ChevronUp className="w-4 h-4" />
-                  </IconButton>
-                </TooltipTrigger>
-                {prevSpanId ? (
-                  <TooltipContent>
-                    Navigate up
-                    <Kbd>K</Kbd>
-                  </TooltipContent>
-                ) : null}
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <IconButton
-                    aria-label="Navigate down"
-                    aria-keyshortcuts="J"
-                    onClick={handleSelectNextSpan}
-                    disabled={!nextSpanId}
-                  >
-                    <ChevronDown className="w-4 h-4" />
-                  </IconButton>
-                </TooltipTrigger>
-                {nextSpanId ? (
-                  <TooltipContent>
-                    Navigate down
-                    <Kbd>J</Kbd>
-                  </TooltipContent>
-                ) : null}
-              </Tooltip>
-              <div aria-hidden className="w-px h-4 bg-gray-alpha-400 mx-1" />
-              <IconButton
-                aria-label="Close span details"
-                aria-keyshortcuts="Escape"
-                onClick={handleClearActiveSpan}
-              >
-                <X className="w-4 h-4" />
-              </IconButton>
-            </div>
-          </div>
-          {/* Panel body */}
-          <div className="flex-1 overflow-y-auto">
-            <ErrorBoundary>
-              <EntityDetailPanel
-                run={sidebar.run}
-                onStreamClick={sidebar.onStreamClick}
-                onRunClick={sidebar.onRunClick}
-                spanDetailData={sidebar.spanDetailData}
-                spanDetailError={sidebar.spanDetailError}
-                spanDetailLoading={sidebar.spanDetailLoading}
-                onSpanSelect={sidebar.onSpanSelect}
-                onWakeUpSleep={sidebar.onWakeUpSleep}
-                onLoadEventData={sidebar.onLoadEventData}
-                onResolveHook={sidebar.onResolveHook}
-                encryptionKey={sidebar.encryptionKey}
-                onDecrypt={sidebar.onDecrypt}
-                isDecrypting={sidebar.isDecrypting}
-                selectedSpan={selectedSpan}
-              />
-            </ErrorBoundary>
-          </div>
-        </aside>
-      ) : null}
+      {detailPanel}
 
       <TraceShortcutHelper
         hasMultipleSpans={trace.spans.length > 1}

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import {
   type ReactNode,
+  startTransition,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -99,10 +100,19 @@ function useAnimatedViewport(initial: Viewport) {
       }
 
       const from = currentRef.current;
-      const anim = { raf: 0, from, to: target, start: performance.now() };
+      // Anchor the easing clock to the first delivered frame, not to call time.
+      // Selecting a span mounts the detail panel in the same tick, and on large
+      // production traces that synchronous render can delay the first animation
+      // frame by tens/hundreds of ms. With a call-time clock, that delay makes
+      // the zoom skip ahead — or jump straight to the end — which reads exactly
+      // like "the animation broke / reduced motion is on". Starting the clock on
+      // the first frame keeps the zoom smooth no matter how late it begins.
+      const anim = { raf: 0, from, to: target, start: 0 };
 
       const tick = () => {
-        const t = Math.min((performance.now() - anim.start) / 150, 1);
+        const now = performance.now();
+        if (anim.start === 0) anim.start = now;
+        const t = Math.min((now - anim.start) / 150, 1);
         const e = 1 - (1 - t) * (1 - t);
         setViewportState({
           start: anim.from.start + (anim.to.start - anim.from.start) * e,
@@ -420,8 +430,16 @@ function NewTraceViewerContent({
         clearActiveSpan();
         return;
       }
-      setActiveSpan(spanId);
+      // Start the zoom first (urgent), then open the detail panel as a
+      // low-priority transition. On large production traces the panel's first
+      // render is heavy; as an urgent update it blocks the animation's opening
+      // frames (the zoom then jumps instead of easing). As a transition, React
+      // keeps the rAF-driven viewport updates responsive and renders the panel
+      // without blocking them.
       focusViewportOnSpan(spanId);
+      startTransition(() => {
+        setActiveSpan(spanId);
+      });
     },
     [
       cancelPendingZoom,


### PR DESCRIPTION
### Description

Fixes the trace viewer click-to-zoom animation feeling broken / "like reduced motion is on" — it jumps to the end instead of easing. Reproduces on production (Vercel Front) but not locally, and only on **click** (wheel/scrollbar zoom is smooth).

#### Root cause

Two zoom paths behave differently:

- **Wheel/scrollbar zoom** updates `viewport` directly, once per event → always smooth.
- **Click-to-zoom** runs `animateTo` (a `requestAnimationFrame` easing loop) **and mounts the detail panel in the same React commit**.

`animateTo` captured its easing clock at call time (`start: performance.now()`), then each frame computed `t = (performance.now() - start) / 150`. On a production-sized trace, mounting/rendering the detail panel (real step input/output) blocks the main thread for tens-to-hundreds of ms **before the first animation frame runs**. Because the clock started at call time, by the first frame `t` is already most of (or all of) the 150ms — so the zoom **skips straight to the end**. That's the "animation broke / reduced motion" feel.

This is why it's invisible locally (panel data is tiny → first frame on time) and why wheel zoom is fine (never touches the panel). It's also independent of the #2434 JSON-viewer reskin, which isn't deployed yet.

#### Fixes (all @workflow/web-shared)

1. **Anchor the easing clock to the first delivered frame**, not call time — a late first frame no longer makes the zoom skip ahead.
2. **Open the detail panel as a low-priority startTransition** on span select, so its heavy first render can't block the animation's opening frames.

Supporting per-frame work reductions:
3. Memoize the event list and detail-panel aside so viewport-only re-renders skip them.
4. Share one ContextCardProvider for timeline marker tooltips instead of each tick self-mounting its own portal/observer/listener.
5. Gate computeSpanGaps on altHeld so that O(spans) pass stays off the animation path.

#### Narrowing

The wheel-vs-click contrast proved the per-frame timeline render (bars/markers/gaps) isn't the bottleneck — wheel re-renders all of that and stays smooth. The click-only cost is the panel, and the visible "jump" is the call-time easing clock. Fixes 1–2 target that directly; 3–5 are defensive.

### How did you test your changes?

- `pnpm typecheck` and `pnpm vitest run test/new-trace-viewer-search.test.ts` pass for @workflow/web-shared.
- Mechanism verified against the easing math: with a call-time clock a >=150ms pre-first-frame block sets t=1 immediately (instant jump); anchoring to the first frame removes that.
- Recommend a final check on a marker/payload-heavy production-scale run (or preview build) since the symptom is data-size dependent and doesn't show on local fixtures.

### PR Checklist - Required to merge

- [x] pnpm changeset (patch for @workflow/web-shared)
- [ ] DCO sign-off — commits not yet signed off; git rebase --signoff main (or amend) + force-push before merging.
- [ ] Ping @vercel/workflow once ready