### PR TITLE
Fix discovery of dotted JS workflow imports

### DIFF
--- a/.changeset/friendly-step-files.md
+++ b/.changeset/friendly-step-files.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Fix fast workflow discovery for JS files imported through basenames like `./hello.step`.

--- a/packages/builders/src/fast-discovery.test.ts
+++ b/packages/builders/src/fast-discovery.test.ts
@@ -99,6 +99,33 @@ describe('fast workflow discovery', () => {
     );
   });
 
+  it('discovers relative JS imports whose basename includes .step', async () => {
+    const entryFile = join(testRoot, 'src', 'entry.ts');
+    const workflowFile = join(testRoot, 'src', 'hello.step.js');
+
+    writeFile(entryFile, `import './hello.step';\n`);
+    writeFile(
+      workflowFile,
+      `export async function run() {
+  'use workflow';
+  return 'ok';
+}
+`
+    );
+
+    const discovered = await createBuilder(testRoot).discoverEntriesPublic(
+      [entryFile],
+      join(testRoot, 'out')
+    );
+
+    expect(discovered.discoveredWorkflows).toEqual(
+      new Set([normalize(workflowFile)])
+    );
+    expect(parentHasChild(normalize(entryFile), normalize(workflowFile))).toBe(
+      true
+    );
+  });
+
   it('discovers workflow files reached through an imported package re-export', async () => {
     const entryFile = join(testRoot, 'src', 'entry.ts');
     const packageRoot = join(testRoot, 'node_modules', 'workflow-pkg');

--- a/packages/builders/src/fast-discovery.ts
+++ b/packages/builders/src/fast-discovery.ts
@@ -158,11 +158,11 @@ function shouldSkipFastDiscoveryImport(specifier: string): boolean {
   }
 
   const pathLikeSpecifier = stripImportSpecifierQuery(specifier);
-  if (
-    !pathLikeSpecifier.startsWith('.') &&
-    !isAbsolute(pathLikeSpecifier) &&
-    !pathLikeSpecifier.includes('/')
-  ) {
+  if (isRelativeOrAbsoluteSpecifier(pathLikeSpecifier)) {
+    return false;
+  }
+
+  if (!pathLikeSpecifier.includes('/')) {
     return false;
   }
 
@@ -634,11 +634,8 @@ export async function fastDiscoverEntries({
       ? strippedSpecifier
       : resolve(dirname(importer), strippedSpecifier);
     const extension = extname(basePath);
-    if (extension !== '') {
-      return FAST_DISCOVERY_SOURCE_EXTENSION_SET.has(extension) &&
-        (await fileExists(basePath))
-        ? normalizePath(basePath)
-        : null;
+    if (FAST_DISCOVERY_SOURCE_EXTENSION_SET.has(extension)) {
+      return (await fileExists(basePath)) ? normalizePath(basePath) : null;
     }
 
     for (const candidate of [


### PR DESCRIPTION
## Summary
- fix fast discovery resolving imports like `./hello.step` to JS/TS files such as `hello.step.js`
- add a regression test covering a discovered `use workflow` function behind that import shape
- add a patch changeset for `@workflow/builders`

## Tests
- `pnpm exec vitest run packages/builders/src/fast-discovery.test.ts -t "basename includes .step"`
- `pnpm exec vitest run packages/builders/src/fast-discovery.test.ts`
- `pnpm --filter @workflow/builders typecheck`
- `pnpm exec biome check packages/builders/src/fast-discovery.ts packages/builders/src/fast-discovery.test.ts .changeset/friendly-step-files.md`