### PR TITLE
Use text-gray-900 for trace shortcut helper text

### DIFF
--- a/.changeset/trace-shortcut-helper-text-color.md
+++ b/.changeset/trace-shortcut-helper-text-color.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Use text-gray-900 for trace shortcut helper text.

--- a/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
@@ -86,7 +86,7 @@ export function TraceShortcutHelper({
   };
 
   return (
-    <div className="group absolute bottom-3 left-1/2 z-10 hidden h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-muted-foreground md:inline-flex">
+    <div className="group absolute bottom-3 left-1/2 z-10 hidden h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-gray-900 md:inline-flex">
       <span
         aria-live="polite"
         aria-atomic="true"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the trace shortcut helper bar text color from `text-muted-foreground` to `text-gray-900` for better contrast/readability.

**Changed file:** `packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79ae0d42-883d-4845-ad8a-b630319dc51a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79ae0d42-883d-4845-ad8a-b630319dc51a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

