### PR TITLE
Propagate trace context to vercel-workflow.com in workbench instrumentation

### DIFF
--- a/workbench/example/instrumentation.ts
+++ b/workbench/example/instrumentation.ts
@@ -6,12 +6,13 @@ registerOTel({
     fetch: {
       // By default @vercel/otel only propagates W3C trace context to Vercel
       // deployment URLs, so outgoing requests to the workflow-server
-      // (vercel-workflow.com) get a client span with no `traceparent` header —
-      // which breaks the trace link to workflow-server's spans in APM.
-      // Explicitly propagate context to the workflow-server domain so traces
-      // stay correlated end to end.
+      // (vercel-workflow.com) and the Vercel Queue Service
+      // (*.vercel-queue.com) get a client span with no `traceparent` header —
+      // which breaks the trace link to those services' spans in APM.
+      // Explicitly propagate context to both domains so traces stay
+      // correlated end to end.
       // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
-      propagateContextUrls: [/vercel-workflow\.com/],
+      propagateContextUrls: [/vercel-workflow\.com/, /vercel-queue\.com/],
     },
   },
 });

--- a/workbench/example/instrumentation.ts
+++ b/workbench/example/instrumentation.ts
@@ -1,3 +1,17 @@
 import { registerOTel } from '@vercel/otel';
 
-registerOTel({ serviceName: 'example-workflow' });
+registerOTel({
+  serviceName: 'example-workflow',
+  instrumentationConfig: {
+    fetch: {
+      // By default @vercel/otel only propagates W3C trace context to Vercel
+      // deployment URLs, so outgoing requests to the workflow-server
+      // (vercel-workflow.com) get a client span with no `traceparent` header —
+      // which breaks the trace link to workflow-server's spans in APM.
+      // Explicitly propagate context to the workflow-server domain so traces
+      // stay correlated end to end.
+      // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
+      propagateContextUrls: [/vercel-workflow\.com/],
+    },
+  },
+});

--- a/workbench/nextjs-turbopack/instrumentation.ts
+++ b/workbench/nextjs-turbopack/instrumentation.ts
@@ -1,0 +1,19 @@
+import { registerOTel } from '@vercel/otel';
+
+export function register() {
+  registerOTel({
+    serviceName: 'nextjs-turbopack',
+    instrumentationConfig: {
+      fetch: {
+        // By default @vercel/otel only propagates W3C trace context to Vercel
+        // deployment URLs, so outgoing requests to the workflow-server
+        // (vercel-workflow.com) get a client span with no `traceparent` header
+        // — which breaks the trace link to workflow-server's spans in APM.
+        // Explicitly propagate context to the workflow-server domain so traces
+        // stay correlated end to end.
+        // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
+        propagateContextUrls: [/vercel-workflow\.com/],
+      },
+    },
+  });
+}

--- a/workbench/nextjs-turbopack/instrumentation.ts
+++ b/workbench/nextjs-turbopack/instrumentation.ts
@@ -7,12 +7,13 @@ export function register() {
       fetch: {
         // By default @vercel/otel only propagates W3C trace context to Vercel
         // deployment URLs, so outgoing requests to the workflow-server
-        // (vercel-workflow.com) get a client span with no `traceparent` header
-        // — which breaks the trace link to workflow-server's spans in APM.
-        // Explicitly propagate context to the workflow-server domain so traces
-        // stay correlated end to end.
+        // (vercel-workflow.com) and the Vercel Queue Service
+        // (*.vercel-queue.com) get a client span with no `traceparent` header
+        // — which breaks the trace link to those services' spans in APM.
+        // Explicitly propagate context to both domains so traces stay
+        // correlated end to end.
         // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
-        propagateContextUrls: [/vercel-workflow\.com/],
+        propagateContextUrls: [/vercel-workflow\.com/, /vercel-queue\.com/],
       },
     },
   });

--- a/workbench/nextjs-webpack/instrumentation.ts
+++ b/workbench/nextjs-webpack/instrumentation.ts
@@ -1,0 +1,19 @@
+import { registerOTel } from '@vercel/otel';
+
+export function register() {
+  registerOTel({
+    serviceName: 'nextjs-webpack',
+    instrumentationConfig: {
+      fetch: {
+        // By default @vercel/otel only propagates W3C trace context to Vercel
+        // deployment URLs, so outgoing requests to the workflow-server
+        // (vercel-workflow.com) get a client span with no `traceparent` header
+        // — which breaks the trace link to workflow-server's spans in APM.
+        // Explicitly propagate context to the workflow-server domain so traces
+        // stay correlated end to end.
+        // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
+        propagateContextUrls: [/vercel-workflow\.com/],
+      },
+    },
+  });
+}

--- a/workbench/nextjs-webpack/instrumentation.ts
+++ b/workbench/nextjs-webpack/instrumentation.ts
@@ -7,12 +7,13 @@ export function register() {
       fetch: {
         // By default @vercel/otel only propagates W3C trace context to Vercel
         // deployment URLs, so outgoing requests to the workflow-server
-        // (vercel-workflow.com) get a client span with no `traceparent` header
-        // — which breaks the trace link to workflow-server's spans in APM.
-        // Explicitly propagate context to the workflow-server domain so traces
-        // stay correlated end to end.
+        // (vercel-workflow.com) and the Vercel Queue Service
+        // (*.vercel-queue.com) get a client span with no `traceparent` header
+        // — which breaks the trace link to those services' spans in APM.
+        // Explicitly propagate context to both domains so traces stay
+        // correlated end to end.
         // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
-        propagateContextUrls: [/vercel-workflow\.com/],
+        propagateContextUrls: [/vercel-workflow\.com/, /vercel-queue\.com/],
       },
     },
   });

--- a/workbench/sveltekit/src/hooks.server.ts
+++ b/workbench/sveltekit/src/hooks.server.ts
@@ -7,12 +7,13 @@ registerOTel({
     fetch: {
       // By default @vercel/otel only propagates W3C trace context to Vercel
       // deployment URLs, so outgoing requests to the workflow-server
-      // (vercel-workflow.com) get a client span with no `traceparent` header —
-      // which breaks the trace link to workflow-server's spans in APM.
-      // Explicitly propagate context to the workflow-server domain so traces
-      // stay correlated end to end.
+      // (vercel-workflow.com) and the Vercel Queue Service
+      // (*.vercel-queue.com) get a client span with no `traceparent` header —
+      // which breaks the trace link to those services' spans in APM.
+      // Explicitly propagate context to both domains so traces stay
+      // correlated end to end.
       // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
-      propagateContextUrls: [/vercel-workflow\.com/],
+      propagateContextUrls: [/vercel-workflow\.com/, /vercel-queue\.com/],
     },
   },
 });

--- a/workbench/sveltekit/src/hooks.server.ts
+++ b/workbench/sveltekit/src/hooks.server.ts
@@ -1,4 +1,21 @@
 import type { ServerInit } from '@sveltejs/kit';
+import { registerOTel } from '@vercel/otel';
+
+registerOTel({
+  serviceName: 'example-sveltekit',
+  instrumentationConfig: {
+    fetch: {
+      // By default @vercel/otel only propagates W3C trace context to Vercel
+      // deployment URLs, so outgoing requests to the workflow-server
+      // (vercel-workflow.com) get a client span with no `traceparent` header —
+      // which breaks the trace link to workflow-server's spans in APM.
+      // Explicitly propagate context to the workflow-server domain so traces
+      // stay correlated end to end.
+      // https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation
+      propagateContextUrls: [/vercel-workflow\.com/],
+    },
+  },
+});
 
 export const init: ServerInit = async () => {
   // Start the Postgres World


### PR DESCRIPTION
## Summary

`@vercel/otel` propagates W3C trace context **only to Vercel deployment URLs by default** (confirmed in both the package's `FetchInstrumentationConfig` type docs and its compiled `shouldPropagate` matcher). As a result, every outgoing request from a workbench app to the workflow-server backends got a client span but **no `traceparent` header**, so their spans never joined the workbench's invocation trace in APM. Two backends are affected:

- **workflow-server** — `https://vercel-workflow.com`
- **Vercel Queue Service** — regional `*.vercel-queue.com` subdomains (e.g. `iad1.vercel-queue.com`), used by `@vercel/queue` when not routing through the queues proxy

This adds `instrumentationConfig.fetch.propagateContextUrls: [/vercel-workflow\.com/, /vercel-queue\.com/]` to every workbench that uses `@vercel/otel`:

| Workbench | Change | Placement |
|---|---|---|
| `example` | edit existing `instrumentation.ts` | top-level `registerOTel` |
| `nextjs-turbopack` | **new** `instrumentation.ts` | repo root, `export function register()` (no `src/`) |
| `nextjs-webpack` | **new** `instrumentation.ts` | repo root, `export function register()` |
| `sveltekit` | edit `src/hooks.server.ts` | top-level `registerOTel`, before the existing `init` hook |

`nextjs-turbopack`, `nextjs-webpack`, and `sveltekit` already declared `@vercel/otel` as a dependency but weren't registering it anywhere — they now do, in addition to the propagation fix.

## Why regex matchers

The matcher does `url.toString().startsWith(matcher)` for strings against the **full** URL, so a bare `'vercel-workflow.com'` would not match `https://vercel-workflow.com/...`. Regexes match the host wherever it appears, and `/vercel-queue\.com/` covers every regional subdomain. Default propagation still covers deployment/branch/`VERCEL_URL` hosts (including the `/queues-proxy` path on the deployment's own host), so only the two backend domains are added.

This complements the manual `injectTraceContextIntoHeaders` in `@workflow/world-vercel` (which covers world-vercel's custom-dispatcher paths that auto-instrumentation can't reliably hook); this PR covers the standard `fetch` paths that `@vercel/otel` does hook.

## Notes

- No changeset: all four packages are in `.changeset/config.json`'s `ignore` list.
- Docs reference: https://vercel.com/docs/tracing/instrumentation#configuring-context-propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)