### PR TITLE
fix(web-shared): animate trace viewer zoom with a composited transform

### DIFF
--- a/.changeset/trace-viewer-zoom-transform.md
+++ b/.changeset/trace-viewer-zoom-transform.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Animate the new trace viewer's zoom/pan transitions with a single composited transform on the timeline instead of re-rendering every bar each frame, fixing span-click lag on large traces.

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -680,21 +680,49 @@ export function Timeline({
       className="relative h-full overflow-hidden"
       style={{ minHeight: spans.length * ROW_HEIGHT_PX }}
     >
+      {/*
+        Zoom layer: gridlines + bars share one transform so a zoom/pan tween is
+        a single composited transform instead of a per-frame re-render. Origin
+        sits at the content's left edge (past the timeline padding) to match the
+        affine math in `useAnimatedViewport`, which drives this element's
+        `transform` imperatively (located via the `data-zoom-layer` marker).
+      */}
       <div
-        aria-hidden
-        className="absolute inset-y-0 pointer-events-none"
-        style={TIMELINE_INSET_STYLE}
+        data-zoom-layer
+        className="absolute inset-0"
+        style={{ transformOrigin: `${TIMELINE_PADDING_PX}px 0` }}
       >
-        {markers.map((marker) =>
-          // Skip the "0s" origin marker since the left edge already implies it.
-          Math.abs(marker.value) > 0.000001 ? (
-            <div
-              key={String(marker.value)}
-              className="absolute top-0 bottom-0 w-px bg-gray-alpha-300"
-              style={{ left: `${marker.position * 100}%` }}
+        <div
+          aria-hidden
+          className="absolute inset-y-0 pointer-events-none"
+          style={TIMELINE_INSET_STYLE}
+        >
+          {markers.map((marker) =>
+            // Skip the "0s" origin marker since the left edge already implies it.
+            Math.abs(marker.value) > 0.000001 ? (
+              <div
+                key={String(marker.value)}
+                className="absolute top-0 bottom-0 w-px bg-gray-alpha-300"
+                style={{ left: `${marker.position * 100}%` }}
+              />
+            ) : null
+          )}
+        </div>
+        <div style={{ transform: `translateY(${start * ROW_HEIGHT_PX}px)` }}>
+          {spans.slice(start, end).map((span) => (
+            <TimelineBar
+              key={span.spanId}
+              span={span}
+              viewStart={viewStart}
+              viewDuration={viewDuration}
+              containerWidth={timelineWidth}
+              isSelected={selectedId === span.spanId}
+              isDimmed={isSpanDimmedBySearch(span.spanId, searchResult)}
+              onSelect={onSelect}
+              onRevealTime={onRevealTime}
             />
-          ) : null
-        )}
+          ))}
+        </div>
       </div>
       {hoverFraction != null && (
         <div
@@ -707,21 +735,6 @@ export function Timeline({
           />
         </div>
       )}
-      <div style={{ transform: `translateY(${start * ROW_HEIGHT_PX}px)` }}>
-        {spans.slice(start, end).map((span) => (
-          <TimelineBar
-            key={span.spanId}
-            span={span}
-            viewStart={viewStart}
-            viewDuration={viewDuration}
-            containerWidth={timelineWidth}
-            isSelected={selectedId === span.spanId}
-            isDimmed={isSpanDimmedBySearch(span.spanId, searchResult)}
-            onSelect={onSelect}
-            onRevealTime={onRevealTime}
-          />
-        ))}
-      </div>
       {altHeld && (
         <div
           aria-hidden

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -12,9 +12,11 @@ import {
 } from 'lucide-react';
 import {
   type ReactNode,
+  type RefObject,
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -68,73 +70,166 @@ interface Viewport {
   end: number;
 }
 
-function useAnimatedViewport(initial: Viewport) {
+const ZOOM_ANIM_MS = 150;
+
+/**
+ * Drives the timeline viewport, animating zoom/pan transitions as a single
+ * GPU-composited transform on the timeline's "zoom layer" instead of a
+ * `setState`-per-frame tween.
+ *
+ * The committed `viewport` jumps straight to the target (one render, so bars
+ * and gridlines reconcile exactly once per zoom). The visual transition is then
+ * performed by seeding the layer with the inverse transform that maps the
+ * freshly-rendered target back onto the currently-displayed view, and tweening
+ * that transform to identity. Because the timeline maps time→x linearly, the
+ * mapping is a 1-D affine transform `X' = a·X + b` (with `transform-origin` at
+ * the content's left edge):
+ *
+ *   a = toDuration / fromDuration            (scaleX)
+ *   b = (W / fromDuration) · (toStart − fromStart)   (translateX, px)
+ *
+ * where `W` is the content width in px. This collapses ~9 full-timeline
+ * re-renders per zoom into a single render + a compositor animation.
+ *
+ * `rootRef` is the timeline's outer wrapper; the layer we transform is found
+ * within it via its `data-zoom-layer` marker, so `Timeline` owns the element
+ * and needs no extra prop.
+ */
+function useAnimatedViewport(
+  initial: Viewport,
+  rootRef: RefObject<HTMLElement | null>
+) {
   const [viewport, setViewportState] = useState<Viewport>(initial);
-  const animRef = useRef<{
-    raf: number;
-    from: Viewport;
-    to: Viewport;
-    start: number;
-  } | null>(null);
-  const currentRef = useRef(initial);
-  currentRef.current = viewport;
+
+  // The viewport currently *displayed*. During a transition this tracks the
+  // interpolated value (the committed `viewport` is already at the target);
+  // used as the `from` when a new animation interrupts a running one.
+  const visualRef = useRef<Viewport>(initial);
+
+  // Set by `animateTo` to request a tween; consumed once by the layout effect
+  // after the target viewport has been committed to the DOM.
+  const pendingFromRef = useRef<Viewport | null>(null);
+  const rafRef = useRef(0);
   const reducedMotion = useReducedMotion();
 
-  const cancel = useCallback(() => {
-    if (animRef.current) {
-      cancelAnimationFrame(animRef.current.raf);
-      animRef.current = null;
+  // The layer whose `transform` we drive imperatively. `transform` is NOT a
+  // React-managed style on that element, so re-renders never clobber it.
+  const getZoomLayer = useCallback(
+    () =>
+      rootRef.current?.querySelector<HTMLElement>('[data-zoom-layer]') ?? null,
+    [rootRef]
+  );
+
+  const stopRaf = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = 0;
     }
   }, []);
 
-  const animateTo = useCallback(
-    (target: Viewport) => {
-      cancel();
-
-      if (reducedMotion) {
-        currentRef.current = target;
-        setViewportState(target);
-        return;
-      }
-
-      const from = currentRef.current;
-      const anim = { raf: 0, from, to: target, start: performance.now() };
-
-      const tick = () => {
-        const t = Math.min((performance.now() - anim.start) / 150, 1);
-        const e = 1 - (1 - t) * (1 - t);
-        setViewportState({
-          start: anim.from.start + (anim.to.start - anim.from.start) * e,
-          end: anim.from.end + (anim.to.end - anim.from.end) * e,
-        });
-        if (t < 1) anim.raf = requestAnimationFrame(tick);
-        else animRef.current = null;
-      };
-
-      animRef.current = anim;
-      anim.raf = requestAnimationFrame(tick);
-    },
-    [cancel, reducedMotion]
-  );
+  const clearTransform = useCallback(() => {
+    const el = getZoomLayer();
+    if (el) {
+      el.style.transform = '';
+      el.style.willChange = '';
+    }
+  }, [getZoomLayer]);
 
   const setViewport = useCallback(
     (update: Viewport | ((prev: Viewport) => Viewport)) => {
-      cancel();
-      if (typeof update === 'function') {
-        setViewportState((prev) => {
-          const next = update(prev);
-          currentRef.current = next;
-          return next;
-        });
-      } else {
-        currentRef.current = update;
-        setViewportState(update);
-      }
+      stopRaf();
+      pendingFromRef.current = null;
+      clearTransform();
+      setViewportState((prev) => {
+        const next = typeof update === 'function' ? update(prev) : update;
+        visualRef.current = next;
+        return next;
+      });
     },
-    [cancel]
+    [stopRaf, clearTransform]
   );
 
-  useEffect(() => cancel, [cancel]);
+  const animateTo = useCallback(
+    (target: Viewport) => {
+      stopRaf();
+      if (reducedMotion) {
+        pendingFromRef.current = null;
+        clearTransform();
+        visualRef.current = target;
+        setViewportState(target);
+        return;
+      }
+      // Commit the target now (a single render); the layout effect maps the
+      // freshly-painted target back to the current visual viewport and tweens
+      // the transform to identity.
+      pendingFromRef.current = visualRef.current;
+      setViewportState(target);
+    },
+    [stopRaf, clearTransform, reducedMotion]
+  );
+
+  // After the target viewport commits, before paint: seed the inverse transform
+  // (no visible flash) and tween it to identity. Runs on every viewport change
+  // but no-ops unless `animateTo` requested a transition.
+  useLayoutEffect(() => {
+    const from = pendingFromRef.current;
+    pendingFromRef.current = null;
+    const to = viewport;
+    const el = getZoomLayer();
+    if (!from || !el) {
+      visualRef.current = to;
+      return;
+    }
+
+    const contentWidth = el.clientWidth - TIMELINE_PADDING_PX * 2;
+    const fromDuration = from.end - from.start;
+    const toDuration = to.end - to.start;
+    if (contentWidth <= 0 || fromDuration <= 0 || toDuration <= 0) {
+      clearTransform();
+      visualRef.current = to;
+      return;
+    }
+
+    const scaleFrom = toDuration / fromDuration;
+    const translateFrom =
+      (contentWidth / fromDuration) * (to.start - from.start);
+
+    // Nothing meaningful to animate — snap to the target.
+    if (Math.abs(scaleFrom - 1) < 1e-4 && Math.abs(translateFrom) < 0.5) {
+      clearTransform();
+      visualRef.current = to;
+      return;
+    }
+
+    el.style.willChange = 'transform';
+    el.style.transform = `translateX(${translateFrom}px) scaleX(${scaleFrom})`;
+
+    const startedAt = performance.now();
+    const tick = () => {
+      const t = Math.min((performance.now() - startedAt) / ZOOM_ANIM_MS, 1);
+      const e = 1 - (1 - t) * (1 - t);
+      const scale = scaleFrom + (1 - scaleFrom) * e;
+      const translate = translateFrom * (1 - e);
+      el.style.transform = `translateX(${translate}px) scaleX(${scale})`;
+      visualRef.current = {
+        start: from.start + (to.start - from.start) * e,
+        end: from.end + (to.end - from.end) * e,
+      };
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        rafRef.current = 0;
+        el.style.transform = '';
+        el.style.willChange = '';
+        visualRef.current = to;
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+
+    return stopRaf;
+  }, [viewport, stopRaf, clearTransform, getZoomLayer]);
+
+  useEffect(() => stopRaf, [stopRaf]);
 
   return { viewport, setViewport, animateTo };
 }
@@ -223,10 +318,17 @@ function NewTraceViewerContent({
     rootRef: scrollContainerRef,
   });
 
-  const { viewport, setViewport, animateTo } = useAnimatedViewport({
-    start: root.startTime,
-    end: root.startTime + root.duration,
-  });
+  // Wrapper around the timeline; the zoom-transform layer lives within it and
+  // is located via its `data-zoom-layer` marker.
+  const timelineRef = useRef<HTMLDivElement>(null);
+
+  const { viewport, setViewport, animateTo } = useAnimatedViewport(
+    {
+      start: root.startTime,
+      end: root.startTime + root.duration,
+    },
+    timelineRef
+  );
 
   const prevRootRef = useRef<Viewport>({
     start: root.startTime,
@@ -481,7 +583,6 @@ function NewTraceViewerContent({
     };
   }, [handleClearActiveSpan]);
 
-  const timelineRef = useRef<HTMLDivElement>(null);
   const [hoverFraction, setHoverFraction] = useState<number | null>(null);
 
   const hoverInfo = useMemo(() => {


### PR DESCRIPTION
## Problem

The new trace viewer is laggy when **clicking a span** on the timeline — specifically on Vercel `front` **preview** deploys, in **Chrome** (fine in local dev, fine on Safari, fine in production). Same data via the dev bridge, so it's not data volume.

## Root cause

Clicking a span calls `focusViewportOnSpan` → `animateTo`, a 150ms rAF zoom tween that called `setViewportState` **every frame**. `viewStart`/`viewDuration` are memo keys on every `TimelineBar`, so all ~30 windowed rows re-rendered and recomputed geometry/segments/markers ~9× per click (~270 renders + ~1000 `useMemo` recomputes). That re-render storm is tolerable in dev and on Safari, but front's **preview-only `next build --profile`** wraps every render in profiler instrumentation, which tips Chrome into dropped frames. (Confirmed not React DevTools — reproduced in incognito.)

## Fix (Option A: transform-based viewport tween)

Commit the target viewport **once** (a single render, so bars/gridlines reconcile once per zoom), then perform the visual transition as a single **GPU-composited transform** on a new "zoom layer" wrapping the gridlines + bars. The timeline maps time→x linearly, so the old→new view is a 1-D affine map applied with `transform-origin` at the content's left edge:

- `scaleX = toDuration / fromDuration`
- `translateX = (W / fromDuration) · (toStart − fromStart)` px

The inverse map is seeded in a `useLayoutEffect` (pre-paint, no flash) and tweened to identity via rAF writing only `transform`. Collapses ~9 full-timeline re-renders per zoom into **one render + a compositor animation**. Interrupts (rapid J/K, reset mid-tween) resume from the live visual viewport; `prefers-reduced-motion` snaps as before.

The zoom layer is located via a `data-zoom-layer` marker, so `Timeline` needs no extra prop.

## Notes
- No public API change.
- Mid-tween, bar mode/labels are computed at the target so they're visually approximate during the 150ms but exact at rest — inherent to transform tweens, unnoticeable at this duration.
- Follow-ups (separate PR, if profiling shows residual cost): `startTransition` on selection + defer the detail-panel data-inspector; composited swap for the stripe animation.

## Test plan
- `pnpm --filter @workflow/web-shared typecheck` ✅, `test` ✅ (97), `build` ✅
- Manual: click span (zoom-to), double-click reset, off-screen marker reveal, wheel-zoom interrupt mid-tween, reduced-motion. Verify React Profiler commit count per click drops from dozens → ~2.