### PR TITLE
world-vercel: propagate x-vercel-tracing trace header through the queue

### DIFF
--- a/.changeset/world-vercel-trace-header-propagation.md
+++ b/.changeset/world-vercel-trace-header-propagation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Propagate the caller's Vercel trace-session JWT as an `x-vercel-tracing` header on every queue message, so backend flow-route invocations are collected in Vercel's tracing dashboard (not just client-initiated requests). The JWT is read from the `_vercel_tracing` cookie (browser-initiated `start()`) or the VQS-forwarded `x-vercel-tracing` header (server-to-server re-enqueue). Requires the matching VQS header-forwarding support (vercel/vqs-server#619) and the proxy's `ENABLE_TRACE_SESSION_HEADER`; no-ops when no request context or trace context is present.

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -17,6 +17,8 @@ const {
 
   const mockSend = vi.fn();
   const mockHandleCallback = vi.fn();
+  // Must be a regular function (not an arrow) — the queue constructs it with
+  // `new QueueClient(...)`, and arrow functions are not constructors.
   const MockQueueClient = vi.fn().mockImplementation(function () {
     return {
       send: mockSend,
@@ -37,6 +39,23 @@ vi.mock('@vercel/queue', () => ({
   DuplicateMessageError: MockDuplicateMessageError,
 }));
 
+// Stub the ambient Vercel request-context reader (the global key the runtime
+// registers and that getTraceCollectionHeaders reads). Lets tests simulate the
+// headers on the request that triggers the enqueue — a `_vercel_tracing` cookie
+// (browser start()) or a VQS-forwarded `x-vercel-tracing` header (re-enqueue).
+const REQUEST_CONTEXT_SYMBOL = Symbol.for('@vercel/request-context');
+function setRequestContextHeaders(headers: Record<string, string>): void {
+  (globalThis as Record<symbol, unknown>)[REQUEST_CONTEXT_SYMBOL] = {
+    get: () => ({ headers }),
+  };
+}
+function setRequestContextCookie(cookie: string | undefined): void {
+  setRequestContextHeaders(cookie ? { cookie } : {});
+}
+function clearRequestContext(): void {
+  delete (globalThis as Record<symbol, unknown>)[REQUEST_CONTEXT_SYMBOL];
+}
+
 vi.mock('./utils.js', () => ({
   getHttpUrl: vi
     .fn()
@@ -49,10 +68,14 @@ import { createQueue } from './queue.js';
 describe('createQueue', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no ambient request context. Individual tests opt in via
+    // setRequestContextCookie() to simulate an incoming `_vercel_tracing` cookie.
+    clearRequestContext();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    clearRequestContext();
   });
 
   describe('queue()', () => {
@@ -297,6 +320,102 @@ describe('createQueue', () => {
           'x-vercel-workflow-run-id': 'wrun_override',
           'x-custom-header': 'custom-value',
         });
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+    });
+
+    it('should attach x-vercel-tracing header from the _vercel_tracing cookie', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+      setRequestContextCookie('_vercel_tracing=jwt.trace.token');
+
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+
+      try {
+        const queue = createQueue();
+        await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc123' });
+
+        const sendOpts = mockSend.mock.calls[0][2];
+        expect(sendOpts.headers).toEqual(
+          expect.objectContaining({ 'x-vercel-tracing': 'jwt.trace.token' })
+        );
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+    });
+
+    it('should read x-vercel-tracing from an incoming forwarded header', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+      // No cookie — the delivery request carried the VQS-forwarded header,
+      // which the proxy reads directly as a fallback trace-session source.
+      setRequestContextHeaders({ 'x-vercel-tracing': 'jwt.trace.token' });
+
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+
+      try {
+        const queue = createQueue();
+        await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc123' });
+
+        const sendOpts = mockSend.mock.calls[0][2];
+        expect(sendOpts.headers).toEqual(
+          expect.objectContaining({ 'x-vercel-tracing': 'jwt.trace.token' })
+        );
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+    });
+
+    it('should parse _vercel_tracing from a multi-cookie header', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+      setRequestContextCookie(
+        'foo=bar; _vercel_tracing=jwt.trace.token; baz=qux'
+      );
+
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+
+      try {
+        const queue = createQueue();
+        await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc123' });
+
+        const sendOpts = mockSend.mock.calls[0][2];
+        expect(sendOpts.headers['x-vercel-tracing']).toBe('jwt.trace.token');
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+    });
+
+    it('should not attach x-vercel-tracing when no _vercel_tracing cookie is present', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+      setRequestContextCookie('other=value');
+
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+
+      try {
+        const queue = createQueue();
+        await queue.queue('__wkf_workflow_test', { runId: 'wrun_abc123' });
+
+        const sendOpts = mockSend.mock.calls[0][2];
+        expect(sendOpts.headers).not.toHaveProperty('x-vercel-tracing');
       } finally {
         if (originalEnv !== undefined) {
           process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
@@ -660,6 +779,30 @@ describe('createQueue', () => {
             'x-vercel-workflow-step-id': 'step_xyz789',
           }),
         })
+      );
+    });
+
+    it('should propagate x-vercel-tracing on delayed re-enqueue', async () => {
+      mockSend.mockResolvedValue({ messageId: 'new-msg-123' });
+      // The delivery request carried the VQS-forwarded x-vercel-tracing header;
+      // the re-enqueue runs inside that request context, so it re-attaches the
+      // trace header.
+      setRequestContextHeaders({ 'x-vercel-tracing': 'jwt.trace.token' });
+      const handler = setupHandler({ timeoutSeconds: 300 });
+
+      await handler(
+        {
+          payload: { runId: 'wrun_abc123' },
+          queueName: '__wkf_workflow_test',
+          deploymentId: 'dpl_original',
+        },
+        { messageId: 'msg-123', deliveryCount: 1, createdAt: new Date() }
+      );
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const sendOpts = mockSend.mock.calls[0][2];
+      expect(sendOpts.headers).toEqual(
+        expect.objectContaining({ 'x-vercel-tracing': 'jwt.trace.token' })
       );
     });
 

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -175,6 +175,80 @@ function getHeadersFromPayload(
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
+/**
+ * Producer header carrying the Vercel trace-collection JWT (a trace-session
+ * token). VQS forwards it verbatim to the flow-route delivery, and the Vercel
+ * proxy reads it directly as a trace-session JWT source — cookie preferred,
+ * this header as fallback (see vercel/proxy#23184) — so the queued flow-route
+ * invocation's trace is collected. This lets backend workflow invocations show
+ * up in the Vercel dashboard, not just client-initiated requests.
+ *
+ * Keep in sync with vqs-server `FORWARDED_HEADERS`.
+ */
+const TRACE_FORWARD_HEADER = 'x-vercel-tracing';
+
+/** Cookie name the Vercel proxy reads to decide whether to collect a trace. */
+const TRACE_COOKIE_NAME = '_vercel_tracing';
+
+/**
+ * Global key under which the Vercel runtime registers the per-request context
+ * reader. Reading it directly (rather than depending on `@vercel/functions`)
+ * mirrors how `@vercel/otel` accesses the ambient request — a stable contract
+ * that avoids coupling to that package's export surface.
+ */
+const REQUEST_CONTEXT_SYMBOL = Symbol.for('@vercel/request-context');
+
+interface VercelRequestContextReader {
+  get?: () => { headers?: Record<string, string | undefined> } | undefined;
+}
+
+/** Extract a single cookie value from a `Cookie` header string. */
+function parseCookie(cookieHeader: string, name: string): string | undefined {
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return part.slice(eq + 1).trim() || undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Reads the caller's trace-session JWT from the ambient Vercel request context
+ * and, when present, returns it as an `x-vercel-tracing` header so it rides the
+ * queue message to the next invocation. The JWT comes from the `_vercel_tracing`
+ * cookie (browser-initiated `start()`) or, failing that, the VQS-forwarded
+ * `x-vercel-tracing` header (server-to-server re-enqueue, where VQS forwards
+ * the header rather than a cookie) — cookie-preferred, mirroring the proxy.
+ * This runs inside the request context at every enqueue — the user's route at
+ * `start()`, and the flow-route handler on re-enqueues — so the trace context
+ * follows the run.
+ *
+ * Returns `{}` off-platform, when no request context/token is available, or if
+ * the global reader is missing — a safe no-op everywhere else.
+ */
+function getTraceCollectionHeaders(): Record<string, string> {
+  let headers: Record<string, string | undefined> | undefined;
+  try {
+    const reader = (globalThis as Record<symbol, unknown>)[
+      REQUEST_CONTEXT_SYMBOL
+    ] as VercelRequestContextReader | undefined;
+    headers = reader?.get?.()?.headers ?? undefined;
+  } catch {
+    return {};
+  }
+  if (!headers) return {};
+  // Prefer the `_vercel_tracing` cookie (browser-initiated start()); fall back
+  // to the VQS-forwarded x-vercel-tracing header (server-to-server re-enqueue,
+  // where VQS forwards the header rather than a cookie).
+  const token =
+    (headers.cookie
+      ? parseCookie(headers.cookie, TRACE_COOKIE_NAME)
+      : undefined) ?? headers[TRACE_FORWARD_HEADER];
+  return token ? { [TRACE_FORWARD_HEADER]: token } : {};
+}
+
 type QueueFunction = (
   queueName: ValidQueueName,
   payload: QueuePayload,
@@ -247,6 +321,7 @@ export function createQueue(config?: APIConfig): Queue {
         delaySeconds: opts?.delaySeconds,
         headers: {
           ...getHeadersFromPayload(payload),
+          ...getTraceCollectionHeaders(),
           ...opts?.headers,
         },
       });


### PR DESCRIPTION
## Summary

Makes **backend workflow flow-route invocations show up in the Vercel tracing dashboard**, not just client-initiated requests.

Vercel's proxy collects a request's trace from a signed trace-session JWT. Browser requests carry it in the `_vercel_tracing` cookie; the `.well-known/workflow/v1/flow` routes are invoked by **queue delivery** (server-to-server), so they carry no cookie and are never collected. As of **vercel/proxy#23184**, the proxy also accepts the JWT directly from an **`x-vercel-tracing` request header** (cookie preferred, header fallback), gated behind `ENABLE_TRACE_SESSION_HEADER`. This PR rides that header onto every queue message:

- `getTraceCollectionHeaders()` reads the trace JWT from the **ambient Vercel request context** (the global `Symbol.for('@vercel/request-context')` reader — the same source `@vercel/otel` uses): the `_vercel_tracing` **cookie** on a browser-initiated `start()`, or the VQS-forwarded **`x-vercel-tracing` header** on a server-to-server re-enqueue. It returns the JWT as an `x-vercel-tracing` header.
- The header is merged into every `client.send(...)` in the queue's `queue()` function — one call site that covers `start()` **and** every re-enqueue (including the handler's delayed re-enqueue).

Because the read is ambient, it works without any core/per-framework plumbing or a new dependency:
- at `start()` it runs in the user's route, where the cookie is present;
- on re-enqueue it runs inside the flow-route handler, whose incoming delivery request carries the VQS-forwarded `x-vercel-tracing` header.

The companion change **vercel/vqs-server#619** allowlists `x-vercel-tracing` and forwards it verbatim on delivery so the proxy collects it. Pair with `WORKFLOW_TRACE_MODE=continuous` (#2603) to read a whole run as one connected trace.

## Safety / graceful handling
- **No-op** when there's no request context, no trace JWT (cookie or header), or the global reader is missing (off-platform / local dev) — wrapped in try/catch.
- Additive and backward-compatible: until vqs-server#619 ships and the proxy flag is on, the extra `x-vercel-tracing` header is simply dropped/ignored.
- No new dependency; reads a stable global contract rather than coupling to `@vercel/functions`' export surface.

## Tests
`packages/world-vercel/src/queue.test.ts` — attaches the header from the `_vercel_tracing` cookie, parses it out of a multi-cookie header, reads it from a forwarded `x-vercel-tracing` header, omits the header when neither is present, and re-attaches it on delayed re-enqueue (via the forwarded header). Full world-vercel suite green; typecheck clean.

## Caveats
- End-to-end requires vqs-server#619 deployed to the production queue service and the proxy's `ENABLE_TRACE_SESSION_HEADER` enabled for the team.
- The trace JWT is hostname-scoped (`aud`) and ~15-min TTL — intended for short (<15 min) runs traced via the same deployment hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)