### PR TITLE
Thread occurredAt into web-shared entity details

### DIFF
--- a/.changeset/gentle-keys-occur.md
+++ b/.changeset/gentle-keys-occur.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Thread workflow event occurrence timestamps into derived observability entity data.

--- a/packages/web-shared/src/components/workflow-traces/trace-span-construction.ts
+++ b/packages/web-shared/src/components/workflow-traces/trace-span-construction.ts
@@ -29,6 +29,27 @@ const MARKER_EVENT_TYPES: Set<Event['eventType']> = new Set([
   'attr_set',
 ]);
 
+const findEventByType = (
+  events: Event[],
+  eventTypes: Event['eventType'][]
+): Event | undefined => {
+  for (const eventType of eventTypes) {
+    const event = events.find((e) => e.eventType === eventType);
+    if (event) return event;
+  }
+  return undefined;
+};
+
+const withOccurredAt = <T extends object>(
+  entity: T,
+  occurredAt: Event['occurredAt'] | undefined
+): T & { occurredAt?: Date } => {
+  if (!occurredAt || (entity as { occurredAt?: unknown }).occurredAt != null) {
+    return entity;
+  }
+  return { ...entity, occurredAt };
+};
+
 /**
  * Convert workflow events to span events
  * Only includes events that should be displayed as markers
@@ -60,6 +81,7 @@ export const waitEventsToWaitEntity = (
   waitId: string;
   runId: string;
   createdAt: Date;
+  occurredAt?: Date;
   resumeAt?: Date;
   completedAt?: Date;
 } | null => {
@@ -70,15 +92,18 @@ export const waitEventsToWaitEntity = (
   const completedEvent = events.find(
     (event) => event.eventType === 'wait_completed'
   );
-  return {
-    waitId: startEvent.correlationId,
-    runId: startEvent.runId,
-    createdAt: startEvent.createdAt,
-    resumeAt: startEvent.eventData?.resumeAt
-      ? new Date(startEvent.eventData.resumeAt)
-      : undefined,
-    completedAt: completedEvent?.createdAt,
-  };
+  return withOccurredAt(
+    {
+      waitId: startEvent.correlationId,
+      runId: startEvent.runId,
+      createdAt: startEvent.createdAt,
+      resumeAt: startEvent.eventData?.resumeAt
+        ? new Date(startEvent.eventData.resumeAt)
+        : undefined,
+      completedAt: completedEvent?.createdAt,
+    },
+    startEvent.occurredAt
+  );
 };
 
 /**
@@ -141,6 +166,7 @@ export const stepEventsToStepEntity = (
   attempt: number;
   createdAt: Date;
   updatedAt: Date;
+  occurredAt?: Date;
   startedAt?: Date;
   completedAt?: Date;
   specVersion?: number;
@@ -191,18 +217,24 @@ export const stepEventsToStepEntity = (
   if (attempt === 0) attempt = 1;
 
   const lastEvent = events[events.length - 1];
-  return {
-    stepId: anchorEvent.correlationId ?? '',
-    runId: anchorEvent.runId,
-    stepName: createdEvent?.eventData?.stepName ?? '',
-    status,
-    attempt,
-    createdAt: anchorEvent.createdAt,
-    updatedAt: lastEvent?.createdAt ?? anchorEvent.createdAt,
-    startedAt,
-    completedAt,
-    specVersion: anchorEvent.specVersion,
-  };
+  const occurrenceEvent =
+    findEventByType(events, ['step_created', 'step_started']) ?? anchorEvent;
+
+  return withOccurredAt(
+    {
+      stepId: anchorEvent.correlationId ?? '',
+      runId: anchorEvent.runId,
+      stepName: createdEvent?.eventData?.stepName ?? '',
+      status,
+      attempt,
+      createdAt: anchorEvent.createdAt,
+      updatedAt: lastEvent?.createdAt ?? anchorEvent.createdAt,
+      startedAt,
+      completedAt,
+      specVersion: anchorEvent.specVersion,
+    },
+    occurrenceEvent.occurredAt
+  );
 };
 
 /**
@@ -271,6 +303,7 @@ export const hookEventsToHookEntity = (
   runId: string;
   token?: string;
   createdAt: Date;
+  occurredAt?: Date;
   receivedCount: number;
   lastReceivedAt?: Date;
   disposedAt?: Date;
@@ -288,15 +321,18 @@ export const hookEventsToHookEntity = (
     (event) => event.eventType === 'hook_disposed'
   );
   const lastReceivedEvent = receivedEvents.at(-1);
-  return {
-    hookId: createdEvent.correlationId,
-    runId: createdEvent.runId,
-    token: createdEvent.eventData?.token,
-    createdAt: createdEvent.createdAt,
-    receivedCount: receivedEvents.length,
-    lastReceivedAt: lastReceivedEvent?.createdAt || undefined,
-    disposedAt: disposedEvents.at(-1)?.createdAt || undefined,
-  };
+  return withOccurredAt(
+    {
+      hookId: createdEvent.correlationId,
+      runId: createdEvent.runId,
+      token: createdEvent.eventData?.token,
+      createdAt: createdEvent.createdAt,
+      receivedCount: receivedEvents.length,
+      lastReceivedAt: lastReceivedEvent?.createdAt || undefined,
+      disposedAt: disposedEvents.at(-1)?.createdAt || undefined,
+    },
+    createdEvent.occurredAt
+  );
 };
 
 /**
@@ -346,9 +382,13 @@ export function runToSpan(
   // Only embed identification fields — not the full object with
   // input/output/error which may contain non-cloneable types.
   const { input: _i, output: _o, error: _e, ...runIdentity } = run;
+  const occurrenceEvent = findEventByType(runEvents, [
+    'run_created',
+    'run_started',
+  ]);
   const attributes = {
     resource: 'run' as const,
-    data: runIdentity,
+    data: withOccurredAt(runIdentity, occurrenceEvent?.occurredAt),
   };
 
   // Use createdAt as span start time, with activeStartTime for when execution began

--- a/packages/web-shared/src/lib/event-materialization.ts
+++ b/packages/web-shared/src/lib/event-materialization.ts
@@ -23,6 +23,7 @@ export interface MaterializedStep {
   status: StepStatus;
   attempt: number;
   createdAt: Date;
+  occurredAt?: Date;
   startedAt?: Date;
   completedAt?: Date;
   updatedAt: Date;
@@ -35,6 +36,7 @@ export interface MaterializedHook {
   runId: string;
   token?: string;
   createdAt: Date;
+  occurredAt?: Date;
   receivedCount: number;
   lastReceivedAt?: Date;
   disposedAt?: Date;
@@ -47,6 +49,7 @@ export interface MaterializedWait {
   runId: string;
   status: 'waiting' | 'completed';
   createdAt: Date;
+  occurredAt?: Date;
   resumeAt?: Date;
   completedAt?: Date;
   /** All events for this wait, in insertion order */
@@ -58,6 +61,16 @@ export interface MaterializedEntities {
   hooks: MaterializedHook[];
   waits: MaterializedWait[];
 }
+
+const withOccurredAt = <T extends object>(
+  entity: T,
+  occurredAt: Event['occurredAt'] | undefined
+): T & { occurredAt?: Date } => {
+  if (!occurredAt || (entity as { occurredAt?: unknown }).occurredAt != null) {
+    return entity;
+  }
+  return { ...entity, occurredAt };
+};
 
 // ---------------------------------------------------------------------------
 // Helper: group events by correlationId prefix
@@ -133,21 +146,26 @@ export function materializeSteps(events: Event[]): MaterializedStep[] {
       }
     }
 
-    steps.push({
-      stepId: correlationId,
-      runId: created.runId,
-      stepName:
-        created.eventType === 'step_created'
-          ? (created.eventData?.stepName ?? correlationId)
-          : correlationId,
-      status,
-      attempt,
-      createdAt: created.createdAt,
-      startedAt,
-      completedAt,
-      updatedAt,
-      events: stepEvents,
-    });
+    steps.push(
+      withOccurredAt(
+        {
+          stepId: correlationId,
+          runId: created.runId,
+          stepName:
+            created.eventType === 'step_created'
+              ? (created.eventData?.stepName ?? correlationId)
+              : correlationId,
+          status,
+          attempt,
+          createdAt: created.createdAt,
+          startedAt,
+          completedAt,
+          updatedAt,
+          events: stepEvents,
+        },
+        created.occurredAt
+      )
+    );
   }
 
   return steps;
@@ -174,19 +192,24 @@ export function materializeHooks(events: Event[]): MaterializedHook[] {
     const disposed = hookEvents.find((e) => e.eventType === 'hook_disposed');
     const lastReceived = receivedEvents.at(-1);
 
-    hooks.push({
-      hookId: correlationId,
-      runId: created.runId,
-      token:
-        created.eventType === 'hook_created'
-          ? created.eventData?.token
-          : undefined,
-      createdAt: created.createdAt,
-      receivedCount: receivedEvents.length,
-      lastReceivedAt: lastReceived?.createdAt,
-      disposedAt: disposed?.createdAt,
-      events: hookEvents,
-    });
+    hooks.push(
+      withOccurredAt(
+        {
+          hookId: correlationId,
+          runId: created.runId,
+          token:
+            created.eventType === 'hook_created'
+              ? created.eventData?.token
+              : undefined,
+          createdAt: created.createdAt,
+          receivedCount: receivedEvents.length,
+          lastReceivedAt: lastReceived?.createdAt,
+          disposedAt: disposed?.createdAt,
+          events: hookEvents,
+        },
+        created.occurredAt
+      )
+    );
   }
 
   return hooks;
@@ -209,18 +232,23 @@ export function materializeWaits(events: Event[]): MaterializedWait[] {
 
     const completed = waitEvents.find((e) => e.eventType === 'wait_completed');
 
-    waits.push({
-      waitId: correlationId,
-      runId: created.runId,
-      status: completed ? 'completed' : 'waiting',
-      createdAt: created.createdAt,
-      resumeAt:
-        created.eventType === 'wait_created'
-          ? created.eventData?.resumeAt
-          : undefined,
-      completedAt: completed?.createdAt,
-      events: waitEvents,
-    });
+    waits.push(
+      withOccurredAt(
+        {
+          waitId: correlationId,
+          runId: created.runId,
+          status: completed ? 'completed' : 'waiting',
+          createdAt: created.createdAt,
+          resumeAt:
+            created.eventType === 'wait_created'
+              ? created.eventData?.resumeAt
+              : undefined,
+          completedAt: completed?.createdAt,
+          events: waitEvents,
+        },
+        created.occurredAt
+      )
+    );
   }
 
   return waits;

--- a/packages/web-shared/test/trace-builder-occurred-at.test.ts
+++ b/packages/web-shared/test/trace-builder-occurred-at.test.ts
@@ -1,0 +1,112 @@
+import type { Event, WorkflowRun } from '@workflow/world';
+import { describe, expect, it } from 'vitest';
+import { materializeAll } from '../src/lib/event-materialization.js';
+import { buildTrace } from '../src/lib/trace-builder.js';
+
+const BASE_TIME = new Date('2026-03-16T00:00:00Z');
+
+function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  return {
+    runId: 'wrun_occurred_at_test',
+    deploymentId: 'dep_1',
+    workflowName: 'occurred-at-workflow',
+    specVersion: 2,
+    input: {},
+    createdAt: BASE_TIME,
+    updatedAt: BASE_TIME,
+    startedAt: BASE_TIME,
+    completedAt: undefined,
+    status: 'running',
+    output: undefined,
+    error: undefined,
+    executionContext: {},
+    expiredAt: undefined,
+    ...overrides,
+  } as WorkflowRun;
+}
+
+describe('trace builder occurredAt data', () => {
+  it('threads lifecycle event occurredAt into span and materialized entity data', () => {
+    const run = makeRun();
+    const runOccurredAt = new Date(BASE_TIME.getTime() + 50);
+    const stepOccurredAt = new Date(BASE_TIME.getTime() + 1_050);
+    const hookOccurredAt = new Date(BASE_TIME.getTime() + 2_050);
+    const waitOccurredAt = new Date(BASE_TIME.getTime() + 3_050);
+    const events = [
+      {
+        eventId: 'evnt_run_created',
+        runId: run.runId,
+        eventType: 'run_created',
+        createdAt: BASE_TIME,
+        occurredAt: runOccurredAt,
+        specVersion: 2,
+        eventData: {
+          deploymentId: 'dep_1',
+          workflowName: run.workflowName,
+          input: {},
+        },
+      },
+      {
+        eventId: 'evnt_step_created',
+        runId: run.runId,
+        eventType: 'step_created',
+        correlationId: 'step_1',
+        createdAt: new Date(BASE_TIME.getTime() + 1_000),
+        occurredAt: stepOccurredAt,
+        specVersion: 2,
+        eventData: { stepName: 'add', input: {} },
+      },
+      {
+        eventId: 'evnt_step_started',
+        runId: run.runId,
+        eventType: 'step_started',
+        correlationId: 'step_1',
+        createdAt: new Date(BASE_TIME.getTime() + 1_100),
+        specVersion: 2,
+      },
+      {
+        eventId: 'evnt_hook_created',
+        runId: run.runId,
+        eventType: 'hook_created',
+        correlationId: 'hook_1',
+        createdAt: new Date(BASE_TIME.getTime() + 2_000),
+        occurredAt: hookOccurredAt,
+        specVersion: 2,
+        eventData: { token: 'approve' },
+      },
+      {
+        eventId: 'evnt_wait_created',
+        runId: run.runId,
+        eventType: 'wait_created',
+        correlationId: 'wait_1',
+        createdAt: new Date(BASE_TIME.getTime() + 3_000),
+        occurredAt: waitOccurredAt,
+        specVersion: 2,
+        eventData: {
+          resumeAt: new Date(BASE_TIME.getTime() + 60_000),
+        },
+      },
+    ] as Event[];
+
+    const trace = buildTrace(
+      run,
+      events,
+      new Date(BASE_TIME.getTime() + 10_000)
+    );
+    const dataFor = (resource: string) => {
+      const span = trace.spans.find((s) => s.attributes.resource === resource);
+      expect(span).toBeDefined();
+      return span?.attributes.data as { occurredAt?: Date } | undefined;
+    };
+
+    expect(dataFor('run')?.occurredAt).toEqual(runOccurredAt);
+    expect(dataFor('step')?.occurredAt).toEqual(stepOccurredAt);
+    expect(dataFor('hook')?.occurredAt).toEqual(hookOccurredAt);
+    expect(dataFor('sleep')?.occurredAt).toEqual(waitOccurredAt);
+
+    const materialized = materializeAll(events);
+    expect(materialized.steps[0]?.occurredAt).toEqual(stepOccurredAt);
+    expect(materialized.hooks[0]?.occurredAt).toEqual(hookOccurredAt);
+    expect(materialized.waits[0]?.occurredAt).toEqual(waitOccurredAt);
+  });
+});


### PR DESCRIPTION
## Summary
- Threads workflow event `occurredAt` into the derived run, step, hook, and sleep detail data used by the trace viewer sidebar.
- Adds `occurredAt` to exported materialized step, hook, and wait entities.
- Adds a focused regression test and a patch changeset for `@workflow/web-shared`.

## Why
`@workflow/web-shared` already renders the `Occurred` row when detail data contains `occurredAt`, but the trace builder was dropping that field while deriving entity data from raw events. This keeps the fix in the package so front can consume it from the next beta instead of carrying a local adapter.

## Tests
- `pnpm exec biome check packages/web-shared/src/components/workflow-traces/trace-span-construction.ts packages/web-shared/src/lib/event-materialization.ts packages/web-shared/test/trace-builder-occurred-at.test.ts`
- `pnpm --filter @workflow/web-shared test -- trace-builder-occurred-at.test.ts`
- `pnpm --filter @workflow/web-shared typecheck`
- `git diff --check`
