### PR TITLE
Remove shadow from off-screen marker indicator button

### DIFF
--- a/.changeset/quiet-marker-shadow.md
+++ b/.changeset/quiet-marker-shadow.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Remove the drop shadow from the off-screen marker indicator button in the trace viewer.

--- a/packages/web-shared/src/components/new-trace-viewer/components/span-markers.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/span-markers.tsx
@@ -153,7 +153,7 @@ export function OffscreenMarkerIndicator({
         onReveal?.(targetMs);
       }}
       className={cn(
-        'pointer-events-auto absolute top-1/2 z-20 flex h-6 -translate-y-1/2 cursor-pointer items-center rounded-[0.25rem] border border-gray-alpha-400 bg-background-100 shadow-sm hover:bg-gray-100',
+        'pointer-events-auto absolute top-1/2 z-20 flex h-6 -translate-y-1/2 cursor-pointer items-center rounded-[0.25rem] border border-gray-alpha-400 bg-background-100 hover:bg-gray-100',
         direction === 'right' ? 'right-0 pl-1.5' : 'left-0 pr-1.5'
       )}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `shadow-sm` drop shadow from the off-screen marker indicator button (`OffscreenMarkerIndicator`) in the new trace viewer. This is the small arrow + tick glyph pinned to the edge of a span bar when markers scroll out of view while zoomed in.

The button keeps its border, rounded corners, and hover background — only the drop shadow is removed.

## Changes

- `packages/web-shared/src/components/new-trace-viewer/components/span-markers.tsx`: drop `shadow-sm` from the indicator button's className.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edccca36-73c5-4ff8-a409-7a40f511cb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edccca36-73c5-4ff8-a409-7a40f511cb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

