### PR TITLE
docs: deprecate DurableAgent and WorkflowChatTransport, point to AI SDK WorkflowAgent

### DIFF
--- a/docs/content/docs/v4/ai/chat-session-modeling.mdx
+++ b/docs/content/docs/v4/ai/chat-session-modeling.mdx
@@ -14,6 +14,10 @@ related:
   - /docs/api-reference/workflow/define-hook
 ---
 
+<Callout type="warn">
+The examples below use the deprecated `DurableAgent` API. For new agents, use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) and follow the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The session-modeling patterns here (single- vs multi-turn, hooks, stream reconnection) apply to either API.
+</Callout>
+
 Chat sessions in AI agents can be modeled at different layers of your architecture. The choice affects state ownership and how you handle interruptions and reconnections.
 
 While there are many ways to model chat sessions, the two most common categories are single-turn and multi-turn.
@@ -83,7 +87,7 @@ Chat messages need to be stored somewhere—typically a database. In this exampl
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai"; // [!code highlight]
+import { WorkflowChatTransport } from "@ai-sdk/workflow"; // [!code highlight]
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
 
@@ -338,7 +342,7 @@ A custom hook wraps `useChat` to manage the multi-turn session. It handles:
 
 import type { UIMessage, UIDataTypes, ChatStatus } from "ai";
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@ai-sdk/workflow";
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 
 const STORAGE_KEY = "workflow-run-id";
@@ -592,4 +596,4 @@ export async function POST(
 - [Building Durable AI Agents](/docs/ai) - Foundation guide for durable agents
 - [Message Queueing](/docs/ai/message-queueing) - Queueing messages during tool execution
 - [`defineHook()` API Reference](/docs/api-reference/workflow/define-hook) - Hook configuration options
-- [`DurableAgent` API Reference](/docs/api-reference/workflow-ai/durable-agent) - Full API documentation
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - AI SDK API for durable, resumable agents

--- a/docs/content/docs/v4/ai/defining-tools.mdx
+++ b/docs/content/docs/v4/ai/defining-tools.mdx
@@ -14,11 +14,11 @@ related:
 
 This page covers the details for some common patterns when defining tools for AI agents using Workflow SDK.
 
-Using DurableAgent, we model most tools as steps. These can be anything from a simple function call to a entire multi-day long workflow.
+Using WorkflowAgent, we model most tools as steps. These can be anything from a simple function call to a entire multi-day long workflow.
 
 ## Accessing message context in tools
 
-Just like in regular AI SDK tool definitions, tool in DurableAgent are called with a first argument of the tool's input parameters, and a second argument of the tool call context.
+Just like in regular AI SDK tool definitions, tool in WorkflowAgent are called with a first argument of the tool's input parameters, and a second argument of the tool call context.
 
 When you tool needs access to the full message history, you can access it via the `messages` property of the tool call context:
 

--- a/docs/content/docs/v4/ai/index.mdx
+++ b/docs/content/docs/v4/ai/index.mdx
@@ -93,7 +93,7 @@ Then modify your API endpoint to use the OpenAI provider:
 {/* @skip-typecheck: incomplete code sample */}
 ```typescript title="app/api/chat/route.ts" lineNumbers
 // ...
-import { openai } from "@workflow/ai/openai"; // [!code highlight]
+import { openai } from "@ai-sdk/openai"; // [!code highlight]
 
 export async function POST(req: Request) {
   // ...
@@ -233,7 +233,7 @@ Now that we have a basic agent using AI SDK, we can modify it to make it durable
 Add the Workflow SDK packages to your project:
 
 ```package-install
-npm i workflow @workflow/ai
+npm i workflow @ai-sdk/workflow
 ```
 
 and extend the Next.js config to transform your workflow code (see [Getting Started](/docs/getting-started/next) for more details).
@@ -259,18 +259,18 @@ Move the agent logic into a separate function, which will serve as our workflow 
 
 {/* @skip-typecheck: Shows two mutually exclusive model options */}
 ```typescript title="workflows/chat/workflow.ts" lineNumbers
-import { DurableAgent } from "@workflow/ai/agent"; // [!code highlight]
+import { WorkflowAgent, type ModelCallStreamPart } from "@ai-sdk/workflow"; // [!code highlight]
 import { getWritable } from "workflow"; // [!code highlight]
 import { tools } from "@/ai/tools";
-import { openai } from "@workflow/ai/openai";
-import type { ModelMessage, UIMessageChunk } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { convertToModelMessages, type UIMessage } from "ai";
 
-export async function chatWorkflow(messages: ModelMessage[]) {
+export async function chatWorkflow(messages: UIMessage[]) {
   "use workflow"; // [!code highlight]
 
-  const writable = getWritable<UIMessageChunk>(); // [!code highlight]
+  const writable = getWritable<ModelCallStreamPart>(); // [!code highlight]
 
-  const agent = new DurableAgent({ // [!code highlight]
+  const agent = new WorkflowAgent({ // [!code highlight]
 
     // If using AI Gateway, just specify the model name as a string:
     model: "bedrock/claude-4-5-haiku-20251001-v1", // [!code highlight]
@@ -282,8 +282,10 @@ export async function chatWorkflow(messages: ModelMessage[]) {
     tools: flightBookingTools,
   });
 
+  const modelMessages = await convertToModelMessages(messages); // [!code highlight]
+
   await agent.stream({ // [!code highlight]
-    messages,
+    messages: modelMessages,
     writable,
   });
 }
@@ -292,8 +294,9 @@ export async function chatWorkflow(messages: ModelMessage[]) {
 Key changes:
 
 - Add the `"use workflow"` directive to mark our Agent as a workflow function
-- Replaced `Agent` with [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) from `@workflow/ai/agent`. This ensures that all calls to the LLM are executed as "steps", and results are aggregated within the workflow context (see [Workflows and Steps](/docs/foundations/workflows-and-steps) for more details on how workflows/steps are defined).
-- Use [`getWritable()`](/docs/api-reference/workflow/get-writable) to get a stream for agent output. This stream is persistent, and API endpoints can read from a run's stream at any time.
+- Replace the in-memory agent with [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) from `@ai-sdk/workflow`. This runs the agent loop inside a workflow, persists state across step boundaries, and lets tool executions marked with `"use step"` retry automatically.
+- Convert AI SDK `UIMessage` values to model messages inside the workflow before calling `agent.stream()`.
+- Use [`getWritable()`](/docs/api-reference/workflow/get-writable) to get a stream for agent output. `WorkflowAgent` writes `ModelCallStreamPart` chunks to this persistent stream, and API endpoints can read from a run's stream at any time.
 </Step>
 
 <Step>
@@ -302,19 +305,18 @@ Key changes:
 Remove the agent call that we just extracted, and replace it with a call to `start()` to run the workflow:
 
 ```typescript title="app/api/chat/route.ts" lineNumbers
-import type { UIMessage } from "ai";
-import { convertToModelMessages, createUIMessageStreamResponse } from "ai";
+import { createModelCallToUIChunkTransform } from "@ai-sdk/workflow";
+import { createUIMessageStreamResponse, type UIMessage } from "ai";
 import { start } from "workflow/api";
 import { chatWorkflow } from "@/workflows/chat/workflow";
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
-  const modelMessages = await convertToModelMessages(messages);
 
-  const run = await start(chatWorkflow, [modelMessages]); // [!code highlight]
+  const run = await start(chatWorkflow, [messages]); // [!code highlight]
 
   return createUIMessageStreamResponse({
-    stream: run.readable, // [!code highlight]
+    stream: run.readable.pipeThrough(createModelCallToUIChunkTransform()), // [!code highlight]
   });
 }
 ```
@@ -322,7 +324,8 @@ export async function POST(req: Request) {
 Key changes:
 
 - Call `start()` to run the workflow function. This returns a `Run` object, which contains the run ID and the readable stream (see [Starting Workflows](/docs/foundations/starting-workflows) for more details on the `Run` object).
-- Pass the `writable` to `agent.stream()` instead of returning a stream directly, ensuring all the Agent output is written to to the run's stream.
+- Pass the `writable` to `agent.stream()` instead of returning a stream directly, ensuring all the Agent output is written to the run's stream.
+- Pipe the readable stream through `createModelCallToUIChunkTransform()` so the raw model-call chunks become AI SDK UI message chunks before they are returned to the client.
 
 </Step>
 
@@ -424,7 +427,7 @@ A complete example that includes all of the above, plus all of the "next steps" 
 ## Related Documentation
 
 - [Tools](/docs/ai/defining-tools) - Patterns for defining tools for your agent
-- [`DurableAgent` API Reference](/docs/api-reference/workflow-ai/durable-agent) - Full API documentation
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - AI SDK API for durable, resumable agents
 - [Workflows and Steps](/docs/foundations/workflows-and-steps) - Core concepts
 - [Streaming](/docs/foundations/streaming) - In-depth streaming guide
 - [Errors and Retries](/docs/foundations/errors-and-retries) - Error handling patterns

--- a/docs/content/docs/v4/ai/message-queueing.mdx
+++ b/docs/content/docs/v4/ai/message-queueing.mdx
@@ -13,7 +13,7 @@ related:
 
 When using [multi-turn workflows](/docs/ai/chat-session-modeling#multi-turn-workflows), messages typically arrive between agent turns. The workflow waits at a hook, receives a message, then starts a new turn. But sometimes you need to inject messages *during* an agent's turn, before tool calls complete or while the model is reasoning.
 
-`DurableAgent`'s `prepareStep` callback enables this by running before each step in the agent loop, giving you a chance to inject queued messages into the conversation. `prepareStep` also allows you to modify the model choice and existing messages mid-turn, see AI SDK's [prepareStep callback](https://ai-sdk.dev/docs/agents/loop-control#prepare-step) for more details.
+`WorkflowAgent`'s `prepareStep` callback enables this by running before each step in the agent loop, giving you a chance to inject queued messages into the conversation. `prepareStep` also allows you to modify the model choice and existing messages mid-turn, see AI SDK's [prepareStep callback](https://ai-sdk.dev/docs/agents/loop-control#prepare-step) for more details.
 
 ## When to Use This
 
@@ -52,20 +52,20 @@ interface PrepareStepResult {
 Once you have a [multi-turn workflow](/docs/ai/chat-session-modeling#multi-turn-workflows), you can combine a message queue with `prepareStep` to inject messages that arrive during processing:
 
 ```typescript title="workflows/chat/index.ts" lineNumbers
-import { DurableAgent } from "@workflow/ai/agent";
+import { WorkflowAgent, type ModelCallStreamPart } from "@ai-sdk/workflow";
 import { getWritable, getWorkflowMetadata } from "workflow";
 import { chatMessageHook } from "./hooks/chat-message";
 import { flightBookingTools, FLIGHT_ASSISTANT_PROMPT } from "./steps/tools";
-import type { UIMessageChunk, ModelMessage } from "ai";
+import type { ModelMessage } from "ai";
 
 export async function chat(initialMessages: ModelMessage[]) {
   "use workflow";
 
   const { workflowRunId: runId } = getWorkflowMetadata();
-  const writable = getWritable<UIMessageChunk>();
+  const writable = getWritable<ModelCallStreamPart>();
   const messageQueue: Array<{ role: "user"; content: string }> = []; // [!code highlight]
 
-  const agent = new DurableAgent({
+  const agent = new WorkflowAgent({
     model: "bedrock/claude-haiku-4-5-20251001-v1",
     instructions: FLIGHT_ASSISTANT_PROMPT,
     tools: flightBookingTools,
@@ -111,20 +111,20 @@ The `prepareStep` callback receives messages in `ModelMessage[]` format (with co
 You can also combine message queueing with the standard multi-turn pattern:
 
 ```typescript title="workflows/chat/index.ts" lineNumbers
-import { DurableAgent } from "@workflow/ai/agent";
+import { WorkflowAgent, type ModelCallStreamPart } from "@ai-sdk/workflow";
 import { getWritable, getWorkflowMetadata } from "workflow";
 import { chatMessageHook } from "./hooks/chat-message";
-import type { UIMessageChunk, ModelMessage } from "ai";
+import type { ModelMessage } from "ai";
 
 export async function chat(initialMessages: ModelMessage[]) {
   "use workflow";
 
   const { workflowRunId: runId } = getWorkflowMetadata();
-  const writable = getWritable<UIMessageChunk>();
+  const writable = getWritable<ModelCallStreamPart>();
   const messages: ModelMessage[] = [...initialMessages];
   const messageQueue: Array<{ role: "user"; content: string }> = [];
 
-  const agent = new DurableAgent({ /* ... */ });
+  const agent = new WorkflowAgent({ /* ... */ });
   const hook = chatMessageHook.create({ token: runId });
 
   while (true) {
@@ -173,5 +173,5 @@ export async function chat(initialMessages: ModelMessage[]) {
 
 - [Chat Session Modeling](/docs/ai/chat-session-modeling) - Single-turn vs multi-turn patterns
 - [Building Durable AI Agents](/docs/ai) - Complete guide to creating durable agents
-- [`DurableAgent` API Reference](/docs/api-reference/workflow-ai/durable-agent) - Full API documentation
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - AI SDK API for durable, resumable agents
 - [`defineHook()` API Reference](/docs/api-reference/workflow/define-hook) - Hook configuration options

--- a/docs/content/docs/v4/ai/resumable-streams.mdx
+++ b/docs/content/docs/v4/ai/resumable-streams.mdx
@@ -12,6 +12,10 @@ related:
   - /docs/api-reference/workflow-api/get-run
 ---
 
+<Callout type="warn">
+`WorkflowChatTransport` now ships in AI SDK as a 1:1 port — import it from `@ai-sdk/workflow` (the `@workflow/ai` export is deprecated). See [Resumable Streaming with `WorkflowChatTransport`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport) for the full reference.
+</Callout>
+
 When building chat interfaces, it's common to run into network interruptions, page refreshes, or serverless function timeouts, which can break the connection to an in-progress agent.
 
 Where a standard chat implementation would require the user to resend their message and wait for the entire response again, workflow runs are durable, and so are the streams attached to them. This means a stream can be resumed at any point, optionally only syncing the data that was missed since the last connection.
@@ -109,7 +113,7 @@ Replace the default transport in AI-SDK's `useChat` with [`WorkflowChatTransport
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai"; // [!code highlight]
+import { WorkflowChatTransport } from "@ai-sdk/workflow"; // [!code highlight]
 import { useMemo, useState } from "react";
 
 export default function ChatPage() {

--- a/docs/content/docs/v4/api-reference/workflow-ai/durable-agent.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-ai/durable-agent.mdx
@@ -1,59 +1,21 @@
 ---
 title: DurableAgent
-description: Create AI agents that maintain state, call tools, and handle interruptions gracefully.
+description: Deprecated DurableAgent API reference; use WorkflowAgent for new durable agents.
 type: reference
-summary: Use DurableAgent to build AI agents that maintain state across steps and survive interruptions.
+summary: "Deprecated: use AI SDK's WorkflowAgent instead of DurableAgent."
 prerequisites:
   - /docs/ai
 related:
   - /docs/ai/defining-tools
 ---
 
-The `DurableAgent` class enables you to create AI-powered agents that can maintain state across workflow steps, call tools, and gracefully handle interruptions and resumptions.
+<Callout type="warn">
+`DurableAgent` is deprecated. Use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) for new durable agents — see the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent).
+</Callout>
 
-Tool calls can be implemented as workflow steps for automatic retries, or as regular workflow-level logic utilizing core library features such as [`sleep()`](/docs/api-reference/workflow/sleep) and [Hooks](/docs/foundations/hooks).
+This reference is kept for existing applications that still import `DurableAgent` from `@workflow/ai/agent`. Do not use `DurableAgent` for new code.
 
-```typescript lineNumbers
-import { DurableAgent } from "@workflow/ai/agent";
-import { getWritable } from "workflow";
-import { z } from "zod";
-import type { UIMessageChunk } from "ai";
-
-async function getWeather({ city }: { city: string }) {
-  "use step";
-
-  return `Weather in ${city} is sunny`;
-}
-
-async function myAgent() {
-  "use workflow";
-
-  const agent = new DurableAgent({
-    model: "anthropic/claude-haiku-4.5",
-    instructions: "You are a helpful weather assistant.",
-    temperature: 0.7,
-    tools: {
-      getWeather: {
-        description: "Get weather for a city",
-        inputSchema: z.object({ city: z.string() }),
-        execute: getWeather,
-      },
-    },
-  });
-
-  // The agent will stream its output to the workflow
-  // run's default output stream
-  const writable = getWritable<UIMessageChunk>();
-
-  const result = await agent.stream({
-    messages: [{ role: "user", content: "How is the weather in San Francisco?" }],
-    writable,
-  });
-
-  // result contains messages, steps, and optional structured output
-  console.log(result.messages);
-}
-```
+For current examples and implementation guidance, see AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) docs. For legacy code, the API surface below documents the existing `DurableAgent` exports.
 
 ## API Signature
 

--- a/docs/content/docs/v4/api-reference/workflow-ai/index.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-ai/index.mdx
@@ -13,9 +13,9 @@ Helpers for integrating AI SDK for building AI-powered workflows.
 
 <Cards>
     <Card title="DurableAgent" href="/docs/api-reference/workflow-ai/durable-agent">
-      A class for building durable AI agents that maintain state across workflow steps and handle tool execution with automatic retries.
+      Deprecated — use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent). Reference kept for existing `@workflow/ai/agent` imports.
     </Card>
     <Card title="WorkflowChatTransport" href="/docs/api-reference/workflow-ai/workflow-chat-transport">
-      A drop-in transport for the AI SDK for automatic reconnection in interrupted streams.
+      Deprecated — use AI SDK's [`WorkflowChatTransport`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport) from `@ai-sdk/workflow`. Reference kept for existing `@workflow/ai` imports.
     </Card>
 </Cards>

--- a/docs/content/docs/v4/api-reference/workflow-ai/workflow-chat-transport.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-ai/workflow-chat-transport.mdx
@@ -9,6 +9,10 @@ related:
   - /docs/ai/resumable-streams
 ---
 
+<Callout type="warn">
+`WorkflowChatTransport` from `@workflow/ai` is deprecated. AI SDK ships a 1:1 port — use [`WorkflowChatTransport` from `@ai-sdk/workflow`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport) instead. This reference is kept for existing applications that still import it from `@workflow/ai`.
+</Callout>
+
 A chat transport implementation for the AI SDK that provides reliable message streaming with automatic reconnection to interrupted streams. This transport is a drop-in replacement for the default AI SDK transport, enabling seamless recovery from network issues, page refreshes, or Vercel Function timeouts.
 
 <Callout>
@@ -252,7 +256,7 @@ export default function ChatWithCustomConfig() {
 
 ## See Also
 
-- [DurableAgent](/docs/api-reference/workflow-ai/durable-agent) - Building durable AI agents within workflows
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - Building durable, resumable AI agents (replaces `DurableAgent`)
 - [AI SDK `useChat` Documentation](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) - Using `useChat` with custom transports
 - [Workflows and Steps](/docs/foundations/workflows-and-steps) - Understanding workflow fundamentals
 - ["flight-booking-app" Example](https://github.com/vercel/workflow-examples/tree/main/flight-booking-app) - An example application which uses `WorkflowChatTransport`

--- a/docs/content/docs/v4/cookbook/advanced/serializable-steps.mdx
+++ b/docs/content/docs/v4/cookbook/advanced/serializable-steps.mdx
@@ -63,6 +63,10 @@ The `DurableAgent` receives a function (`() => Promise<LanguageModel>`) instead 
 
 ## How `@workflow/ai` Uses This
 
+<Callout type="warn">
+`@workflow/ai`'s pre-wrapped providers and `DurableAgent` are deprecated. AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) resolves models from AI Gateway model strings (e.g. `"openai/gpt-4o"`), which usually removes the need for a model factory — see the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The serialization pattern on this page still applies to any non-serializable dependency you own (for example, cloud SDK clients).
+</Callout>
+
 The `@workflow/ai` package ships pre-wrapped providers for all major AI SDK backends. Each one follows the same pattern:
 
 ```typescript lineNumbers
@@ -143,5 +147,5 @@ async function uploadFile(
 
 - [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — marks a function for extraction and serialization
 - [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
-- [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — accepts a model factory for durable AI agent streaming
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) — AI SDK's durable agent (resolves models via AI Gateway strings; replaces `DurableAgent`)
 - [Custom class serialization](/docs/foundations/serialization#custom-class-serialization) — the companion pattern for classes you own (`WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE`)

--- a/docs/content/docs/v4/cookbook/agent-patterns/agent-cancellation.mdx
+++ b/docs/content/docs/v4/cookbook/agent-patterns/agent-cancellation.mdx
@@ -5,6 +5,10 @@ type: guide
 summary: Two patterns for cancelling a running agent — Hard Cancellation via getRun(runId).cancel() for forced termination, or Stop Signal via a hook + Promise.race for a clean exit with cleanup and final stream notification.
 ---
 
+<Callout type="warn">
+This recipe uses the deprecated `DurableAgent` API. For new agents, use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) and follow the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The cancellation patterns here (`run.cancel()`, stop-signal hook + `Promise.race`) apply to either API.
+</Callout>
+
 Cancel a running agent from the outside — for example, a "Stop" button in a chat UI, an admin cancellation endpoint, or a timeout fallback. Two patterns are available depending on whether you need the agent to exit cleanly or just need the run to stop: **Hard Cancellation** via `getRun(runId).cancel()` for immediate forced termination, or **Stop Signal** via a hook + `Promise.race` for a graceful exit that runs cleanup and notifies streaming clients before returning.
 
 ## When to use this
@@ -201,5 +205,5 @@ This is the same pattern used by the [Distributed Abort Controller](/cookbook/ad
 * [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook for the stop signal
 * [`getWorkflowMetadata()`](/docs/api-reference/workflow/get-workflow-metadata) — access the run ID for deterministic hook tokens
 * [`getWritable()`](/docs/api-reference/workflow/get-writable) — stream a stop notification to the client
-* [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — the agent that gets raced against the stop hook
+* [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) — AI SDK's durable agent that gets raced against the stop hook (replaces `DurableAgent`)
 * [`getRun()`](/docs/api-reference/workflow-api/get-run) — entry point for Hard Cancellation: `getRun(runId).cancel()`

--- a/docs/content/docs/v4/cookbook/agent-patterns/durable-agent.mdx
+++ b/docs/content/docs/v4/cookbook/agent-patterns/durable-agent.mdx
@@ -1,159 +1,18 @@
 ---
-title: Durable Agent
-description: Replace a stateless AI agent with a durable one that survives crashes, retries tool calls, and streams output.
+title: DurableAgent is now WorkflowAgent
+description: Use AI SDK v7's WorkflowAgent for durable, resumable AI agents.
 type: guide
-summary: Convert an AI SDK Agent into a DurableAgent backed by a workflow, with tools as retryable steps.
+summary: Build durable, resumable AI agents with AI SDK v7's WorkflowAgent.
 ---
 
-Use this pattern to make any AI SDK agent durable. The agent becomes a workflow, tools become steps, and the framework handles retries, streaming, and state persistence automatically.
+## WorkflowAgent from AI SDK v7
 
-## When to use this
+Use AI SDK v7's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) for new durable agent work. It replaces `DurableAgent` and keeps the current agent pattern in the AI SDK package.
 
-- Any AI agent with tool calls that should survive crashes and restarts
-- Agents where tool calls hit external APIs that need automatic retries
-- Long-running agent sessions where losing progress is unacceptable
-- Agents that need per-step observability in the workflow event log
+- Import `WorkflowAgent` from `@ai-sdk/workflow` and run it inside a `"use workflow"` function.
+- Stream `ModelCallStreamPart` chunks with `getWritable()`, then convert the run stream to UI message chunks with `createModelCallToUIChunkTransform()` in your route.
+- Mark tool `execute` functions with `"use step"` when they should run as durable workflow steps with retry and observability behavior.
 
-<Callout type="info">
-A durable agent run stays on the deployment that started it. For multi-turn agents that should pick up newer code between turns, see [Versioning](/docs/foundations/versioning) for patterns that start the next turn or next session run with `deploymentId: "latest"`.
+<Callout type="warn">
+`DurableAgent` is deprecated and remains documented for existing code only. See the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent), or the [`DurableAgent` API reference](/docs/api-reference/workflow-ai/durable-agent) while migrating.
 </Callout>
-
-## Pattern
-
-Replace `Agent` with `DurableAgent`, wrap the function in `"use workflow"`, mark each tool with `"use step"`, and stream output through `getWritable()`.
-
-### Workflow
-
-```typescript
-import { DurableAgent } from "@workflow/ai/agent";
-import { getWritable } from "workflow";
-import { z } from "zod";
-import type { ModelMessage, UIMessageChunk } from "ai";
-
-async function searchFlights({ from, to, date }: {
-  from: string;
-  to: string;
-  date: string;
-}) {
-  "use step"; // [!code highlight]
-  const res = await fetch(
-    `https://api.example.com/flights?from=${from}&to=${to}&date=${date}`
-  );
-  if (!res.ok) throw new Error(`Search failed: ${res.status}`);
-  return res.json();
-}
-
-async function bookFlight({ flightId, passenger }: {
-  flightId: string;
-  passenger: string;
-}) {
-  "use step"; // [!code highlight]
-  const res = await fetch("https://api.example.com/bookings", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ flightId, passenger }),
-  });
-  if (!res.ok) throw new Error(`Booking failed: ${res.status}`);
-  return res.json();
-}
-
-async function checkWeather({ city }: { city: string }) {
-  "use step"; // [!code highlight]
-  const res = await fetch(`https://api.weather.com/forecast?city=${city}`);
-  return res.json();
-}
-
-export async function flightAgent(messages: ModelMessage[]) {
-  "use workflow";
-
-  const agent = new DurableAgent({ // [!code highlight]
-    model: "anthropic/claude-haiku-4.5",
-    instructions: "You are a helpful flight booking assistant.",
-    tools: {
-      searchFlights: {
-        description: "Search for available flights between two airports",
-        inputSchema: z.object({
-          from: z.string().describe("Departure airport code"),
-          to: z.string().describe("Arrival airport code"),
-          date: z.string().describe("Travel date (YYYY-MM-DD)"),
-        }),
-        execute: searchFlights,
-      },
-      bookFlight: {
-        description: "Book a specific flight for a passenger",
-        inputSchema: z.object({
-          flightId: z.string().describe("Flight ID from search results"),
-          passenger: z.string().describe("Passenger full name"),
-        }),
-        execute: bookFlight,
-      },
-      checkWeather: {
-        description: "Check the weather forecast for a city",
-        inputSchema: z.object({
-          city: z.string().describe("City name"),
-        }),
-        execute: checkWeather,
-      },
-    },
-  });
-
-  const result = await agent.stream({ // [!code highlight]
-    messages,
-    writable: getWritable<UIMessageChunk>(), // [!code highlight]
-    maxSteps: 10,
-  });
-
-  return { messages: result.messages };
-}
-```
-
-### API route
-
-```typescript
-import type { UIMessage } from "ai";
-import { convertToModelMessages, createUIMessageStreamResponse } from "ai";
-import { start } from "workflow/api";
-import { flightAgent } from "@/app/workflows/flight-agent";
-
-export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json();
-  const modelMessages = await convertToModelMessages(messages); // [!code highlight]
-
-  const run = await start(flightAgent, [modelMessages]); // [!code highlight]
-
-  return createUIMessageStreamResponse({ // [!code highlight]
-    stream: run.readable,
-    headers: {
-      "x-workflow-run-id": run.runId,
-    },
-  });
-}
-```
-
-<Callout type="info">
-This route starts a new agent run for each request. If retried submissions should reconnect to the same agent run, store the returned `runId` behind an atomic conversation or request key before returning it. See [Run idempotency](/docs/foundations/idempotency#run-idempotency).
-</Callout>
-
-## How it works
-
-1. **DurableAgent wraps Agent** — same API as AI SDK's `Agent`, but backed by a workflow. If the process crashes, the agent resumes from the last completed step on replay.
-2. **Tools as steps** — each tool's `execute` function uses `"use step"`, giving it automatic retries, full Node.js access, and an entry in the workflow event log.
-3. **Streaming** — `getWritable<UIMessageChunk>()` streams the agent's output (text chunks, tool calls, tool results) to the client in real time via `createUIMessageStreamResponse`.
-4. **maxSteps** — limits the total number of LLM calls the agent can make, preventing runaway tool loops.
-
-## Adapting to your use case
-
-- **Change the model** — replace `"anthropic/claude-haiku-4.5"` with any AI Gateway model string (e.g. `"openai/gpt-4o"`, `"anthropic/claude-sonnet-4-5"`).
-- **Add tools** — define a new `"use step"` function with a Zod schema. Each tool automatically gets retries and persistence.
-- **Workflow-level tools** — if a tool needs workflow primitives like `sleep()` or `createHook()`, omit `"use step"` so it runs in the workflow context instead.
-- **Multi-turn** — pass `result.messages` plus new user messages to subsequent `agent.stream()` calls for multi-turn conversations.
-- **Client integration** — use `useChat()` from `@ai-sdk/react` with `WorkflowChatTransport` from `@workflow/ai` for a full chat UI with reconnection support.
-
-## Key APIs
-
-- [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
-- [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — declares step functions with retries and full Node.js access
-- [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — durable wrapper around AI SDK's Agent
-- [`getWritable()`](/docs/api-reference/workflow/get-writable) — streams agent output to the client
-- [`start()`](/docs/api-reference/workflow-api/start) — starts a workflow run from an API route
-- [Idempotency](/docs/foundations/idempotency) — deduplicate duplicate-sensitive starts and step side effects

--- a/docs/content/docs/v4/cookbook/agent-patterns/human-in-the-loop.mdx
+++ b/docs/content/docs/v4/cookbook/agent-patterns/human-in-the-loop.mdx
@@ -5,6 +5,10 @@ type: guide
 summary: Use defineHook with the tool call ID to suspend an agent for human approval, with an optional timeout.
 ---
 
+<Callout type="warn">
+This recipe uses the deprecated `DurableAgent` API. For new agents, use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) and follow the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The human-in-the-loop pattern here (hooks, `Promise.race`, approval gating) applies to either API.
+</Callout>
+
 Use this pattern when an AI agent needs human confirmation before performing a consequential action like booking, purchasing, or publishing. The workflow suspends without consuming resources until the human responds.
 
 ## When to use this
@@ -252,4 +256,4 @@ const approvalResult = messages
 - [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook with schema validation
 - [`sleep()`](/docs/api-reference/workflow/sleep) — durable timeout for approval expiry
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) — stream custom data parts from steps
-- [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — durable agent with tool definitions
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) — AI SDK's durable agent (replaces `DurableAgent`)

--- a/docs/content/docs/v4/cookbook/index.mdx
+++ b/docs/content/docs/v4/cookbook/index.mdx
@@ -8,7 +8,7 @@ A curated collection of workflow patterns with clean, copy-paste code examples f
 
 ## Agent Patterns
 
-- [**Durable Agent**](/cookbook/agent-patterns/durable-agent) — Replace a stateless AI agent with one that survives crashes and retries tool calls
+- [**WorkflowAgent**](/cookbook/agent-patterns/durable-agent) — Build durable, resumable AI agents with AI SDK's WorkflowAgent
 - [**Human-in-the-Loop**](/cookbook/agent-patterns/human-in-the-loop) — Pause an agent for human approval, then resume based on the decision
 - [**Agent Cancellation**](/cookbook/agent-patterns/agent-cancellation) — Stop a running agent immediately via `run.cancel()` or gracefully via a hook + `Promise.race`
 

--- a/docs/content/docs/v4/cookbook/integrations/ai-sdk.mdx
+++ b/docs/content/docs/v4/cookbook/integrations/ai-sdk.mdx
@@ -2,7 +2,7 @@
 title: AI SDK
 description: Use AI SDK's streamText directly inside durable workflows when you need the raw AI SDK API or a per-turn durability boundary.
 type: guide
-summary: Use streamText() inside a workflow when the durability boundary is an entire user turn, or when you need AI SDK APIs not exposed by DurableAgent. Individual tool calls and LLM calls inside a turn are not separately durable.
+summary: Use streamText() inside a workflow when the durability boundary is an entire user turn, or when you need AI SDK APIs not exposed by WorkflowAgent. Individual tool calls and LLM calls inside a turn are not separately durable.
 related:
   - /docs/ai
   - /docs/ai/chat-session-modeling
@@ -16,18 +16,18 @@ related:
 For the full AI SDK reference (providers, `streamText`, `generateObject`, `useChat`, tool calling, etc.) see the [AI SDK docs](https://ai-sdk.dev/docs). This page covers the Workflow-specific integration points.
 
 <Callout type="info">
-For most agent use cases, prefer [`DurableAgent`](/cookbook/agent-patterns/durable-agent), which implements the same agent loop as [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text), manages tool calling automatically, and runs tools at workflow scope — each tool can be marked `"use step"` for per-call durability and retries, or stay at workflow level to use primitives like `sleep()` and hooks. Use this page's raw `streamText()` pattern when you want the exact AI SDK API (for example `toUIMessageStream()`, `onChunk`, or `generateText`), or when the durability boundary should be an entire user turn in one step — accepting that tool calls inside that turn are not individually durable.
+For most agent use cases, prefer AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent), which implements the same agent loop as [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text), manages tool calling automatically, and runs tools at workflow scope — each tool can be marked `"use step"` for per-call durability and retries, or stay at workflow level to use primitives like `sleep()` and hooks. Use this page's raw `streamText()` pattern when you want the exact AI SDK API (for example `toUIMessageStream()`, `onChunk`, or `generateText`), or when the durability boundary should be an entire user turn in one step — accepting that tool calls inside that turn are not individually durable.
 </Callout>
 
 ## When to use streamText directly
 
-Use [`streamText()`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) instead of `DurableAgent` when you need:
+Use [`streamText()`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) instead of `WorkflowAgent` when you need:
 
-* **The raw AI SDK API** — `streamText().toUIMessageStream()`, `onChunk`, `smoothStream`, or other options that map directly to the [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) return value rather than `DurableAgent.stream()`
+* **The raw AI SDK API** — `streamText().toUIMessageStream()`, `onChunk`, `smoothStream`, or other options that map directly to the [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) return value rather than `WorkflowAgent.stream()`
 * **Per-turn durability** — wrap the entire agent response (model + tools) in a single `"use step"` function so one user turn is the atomic retry unit; useful when you want all tool calls inside a turn to re-execute together
-* **Custom multi-turn orchestration** — manual hook loops, per-turn stream slicing (`sliceUntilFinish`), or other workflow patterns shown below that don't map cleanly to `DurableAgent`
+* **Custom multi-turn orchestration** — manual hook loops, per-turn stream slicing (`sliceUntilFinish`), or other workflow patterns shown below that don't map cleanly to `WorkflowAgent`
 
-`DurableAgent` already supports `stopWhen`, `prepareStep`, `onStepFinish`, structured output (`experimental_output`), per-step model switching, and [provider options](https://ai-sdk.dev/docs/ai-sdk-core/provider-options). See the [DurableAgent reference](/docs/api-reference/workflow-ai/durable-agent).
+`WorkflowAgent` already supports `stopWhen`, `prepareStep`, lifecycle callbacks, structured output (`output`), per-step model switching, and [provider options](https://ai-sdk.dev/docs/ai-sdk-core/provider-options). See the [`WorkflowAgent` docs](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent).
 
 ## Multi-turn pattern
 
@@ -250,7 +250,7 @@ Store the `runId` in a ref and pass it in the body of every follow-up. `Workflow
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@ai-sdk/workflow";
 import { useMemo, useRef, useState } from "react";
 
 export function SupportChat() {
@@ -324,7 +324,7 @@ The consequences:
 **Mitigations:**
 
 - Make side-effectful tool implementations idempotent — dedupe server-side on a stable key (e.g. `orderId`, an `Idempotency-Key` header, etc.).
-- Or use [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent), which runs tools at workflow scope — each tool can be marked `"use step"` to become its own durable, retryable step, or stay at workflow level to use primitives like `sleep()` and hooks.
+- Or use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent), which runs tools at workflow scope — each tool can be marked `"use step"` to become its own durable, retryable step, or stay at workflow level to use primitives like `sleep()` and hooks.
 
 ### Snapshot `tailIndex` *before* resuming the hook
 
@@ -358,19 +358,19 @@ Clients can send a `runId` from a long-gone workflow (localStorage, back button,
 
 This example stores the `runId` after the first response. For strict one-session-per-thread behavior, use a deterministic hook token derived from the thread ID or conversation ID and route retries through the active hook. See [Idempotency](/docs/foundations/idempotency).
 
-## streamText vs DurableAgent
+## streamText vs WorkflowAgent
 
-| | `streamText()` (this pattern) | `DurableAgent` |
+| | `streamText()` (this pattern) | `WorkflowAgent` |
 |---|---|---|
 | **Tool loop** | AI SDK handles via `stopWhen` | Handles internally (AI SDK–compatible options) |
 | **LLM call durability** | Re-executes with the parent turn | Each LLM call is a durable step |
 | **Tool call durability** | Not individually durable — re-executes with the parent turn | Per tool — mark `"use step"` for a durable, retryable step, or keep at workflow level for `sleep()` / hooks |
 | **Stop conditions** | `stopWhen`, `prepareStep` | `stopWhen`, `prepareStep` |
-| **Structured output** | `Output.object()`, `Output.array()` | `experimental_output` (`Output.object()`, `Output.text()`) |
+| **Structured output** | `Output.object()`, `Output.array()` | `output` (`Output.object()`, `Output.text()`) |
 | **Step callbacks** | `onStepFinish`, `onChunk`, etc. | `onStepFinish`, `onFinish`, `onError`, `onAbort` (`onChunk` not available) |
 | **Setup** | Manual stream piping and turn slicing | Automatic |
 
-Use `DurableAgent` for most agent use cases. Use `streamText` when you need the raw AI SDK surface or a per-turn durability boundary.
+Use `WorkflowAgent` for most agent use cases. Use `streamText` when you need the raw AI SDK surface or a per-turn durability boundary.
 
 ## Key APIs
 

--- a/docs/content/docs/v4/foundations/streaming.mdx
+++ b/docs/content/docs/v4/foundations/streaming.mdx
@@ -345,28 +345,18 @@ export async function batchProcessingWorkflow(items: string[]) {
 }
 ```
 
-### Streaming AI Responses with `DurableAgent`
+### Streaming AI Responses with `WorkflowAgent`
 
-Stream AI-generated content using [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) from `@workflow/ai`. Tools can also emit progress updates to the same stream using [data chunks](https://ai-sdk.dev/docs/ai-sdk-ui/streaming-data#streaming-custom-data) with the [`UIMessageChunk`](https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol) type from the AI SDK:
+Stream AI-generated content using AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) from `@ai-sdk/workflow`. The agent writes `ModelCallStreamPart` chunks to the workflow stream, and route handlers convert them to UI message chunks with `createModelCallToUIChunkTransform()` before returning the response:
 
 ```typescript title="workflows/ai-assistant.ts" lineNumbers
-import { DurableAgent } from "@workflow/ai/agent";
+import { WorkflowAgent, type ModelCallStreamPart } from "@ai-sdk/workflow";
+import { tool } from "ai";
 import { getWritable } from "workflow";
 import { z } from "zod";
-import type { UIMessageChunk } from "ai";
 
 async function searchFlights({ query }: { query: string }) {
   "use step";
-
-  // Tools can emit progress updates to the stream
-  const writable = getWritable<UIMessageChunk>(); // [!code highlight]
-  const writer = writable.getWriter(); // [!code highlight]
-  await writer.write({ // [!code highlight]
-    type: "data-progress", // [!code highlight]
-    data: { message: `Searching flights for ${query}...` }, // [!code highlight]
-    transient: true, // [!code highlight]
-  }); // [!code highlight]
-  writer.releaseLock(); // [!code highlight]
 
   // ... search logic ...
   return { flights: [/* results */] };
@@ -375,27 +365,28 @@ async function searchFlights({ query }: { query: string }) {
 export async function aiAssistantWorkflow(userMessage: string) {
   "use workflow";
 
-  const agent = new DurableAgent({
+  const agent = new WorkflowAgent({
     model: "anthropic/claude-haiku-4.5",
-    system: "You are a helpful flight assistant.",
+    instructions: "You are a helpful flight assistant.",
     tools: {
-      searchFlights: {
+      searchFlights: tool({
         description: "Search for flights",
         inputSchema: z.object({ query: z.string() }),
         execute: searchFlights,
-      },
+      }),
     },
   });
 
   // LLM response will be streamed to the run's writable
   await agent.stream({
     messages: [{ role: "user", content: userMessage }],
-    writable: getWritable<UIMessageChunk>(), // [!code highlight]
+    writable: getWritable<ModelCallStreamPart>(), // [!code highlight]
   });
 }
 ```
 
 ```typescript title="app/api/ai-assistant/route.ts" lineNumbers
+import { createModelCallToUIChunkTransform } from "@ai-sdk/workflow";
 import { createUIMessageStreamResponse } from "ai";
 import { start } from "workflow/api";
 import { aiAssistantWorkflow } from "./workflows/ai";
@@ -406,13 +397,13 @@ export async function POST(request: Request) {
   const run = await start(aiAssistantWorkflow, [message]);
 
   return createUIMessageStreamResponse({
-    stream: run.readable,
+    stream: run.readable.pipeThrough(createModelCallToUIChunkTransform()), // [!code highlight]
   });
 }
 ```
 
 <Callout type="info">
-For a complete implementation, see the [flight booking example](https://github.com/vercel/workflow-examples/tree/main/flight-booking-app) which demonstrates streaming AI responses with tool progress updates.
+For the full agent API and migration notes, see the [`WorkflowAgent` documentation](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent).
 </Callout>
 
 ### Streaming Between Steps
@@ -594,7 +585,7 @@ Stream errors don't trigger automatic retries for the producer step. Design your
 - [`start()` API Reference](/docs/api-reference/workflow-api/start) - Start workflows and access the `Run` object
 - [`getRun()` API Reference](/docs/api-reference/workflow-api/get-run) - Retrieve runs and their streams later
 - [world.streams](/docs/api-reference/workflow-runtime/world/streams) - Low-level stream read/write/close via World SDK
-- [DurableAgent](/docs/api-reference/workflow-ai/durable-agent) - AI agents with built-in streaming support
+- [WorkflowAgent](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - AI agents with durable, resumable streaming support
 - [Errors and Retries](/docs/foundations/errors-and-retries) - Understanding error handling and retry behavior
 - [Serialization](/docs/foundations/serialization) - Understanding what data types can be passed in workflows
 - [Workflows and Steps](/docs/foundations/workflows-and-steps) - Core concepts of workflow execution

--- a/docs/content/docs/v5/ai/chat-session-modeling.mdx
+++ b/docs/content/docs/v5/ai/chat-session-modeling.mdx
@@ -14,6 +14,10 @@ related:
   - /docs/api-reference/workflow/define-hook
 ---
 
+<Callout type="warn">
+The examples below use the deprecated `DurableAgent` API. For new agents, use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) and follow the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The session-modeling patterns here (single- vs multi-turn, hooks, stream reconnection) apply to either API.
+</Callout>
+
 Chat sessions in AI agents can be modeled at different layers of your architecture. The choice affects state ownership and how you handle interruptions and reconnections.
 
 While there are many ways to model chat sessions, the two most common categories are single-turn and multi-turn.
@@ -83,7 +87,7 @@ Chat messages need to be stored somewhere—typically a database. In this exampl
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai"; // [!code highlight]
+import { WorkflowChatTransport } from "@ai-sdk/workflow"; // [!code highlight]
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
 
@@ -338,7 +342,7 @@ A custom hook wraps `useChat` to manage the multi-turn session. It handles:
 
 import type { UIMessage, UIDataTypes, ChatStatus } from "ai";
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@ai-sdk/workflow";
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 
 const STORAGE_KEY = "workflow-run-id";
@@ -592,4 +596,4 @@ export async function POST(
 - [Building Durable AI Agents](/docs/ai) - Foundation guide for durable agents
 - [Message Queueing](/docs/ai/message-queueing) - Queueing messages during tool execution
 - [`defineHook()` API Reference](/docs/api-reference/workflow/define-hook) - Hook configuration options
-- [`DurableAgent` API Reference](/docs/api-reference/workflow-ai/durable-agent) - Full API documentation
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - AI SDK API for durable, resumable agents

--- a/docs/content/docs/v5/ai/defining-tools.mdx
+++ b/docs/content/docs/v5/ai/defining-tools.mdx
@@ -14,11 +14,11 @@ related:
 
 This page covers the details for some common patterns when defining tools for AI agents using Workflow SDK.
 
-Using DurableAgent, we model most tools as steps. These can be anything from a simple function call to a entire multi-day long workflow.
+Using WorkflowAgent, we model most tools as steps. These can be anything from a simple function call to a entire multi-day long workflow.
 
 ## Accessing message context in tools
 
-Just like in regular AI SDK tool definitions, tool in DurableAgent are called with a first argument of the tool's input parameters, and a second argument of the tool call context.
+Just like in regular AI SDK tool definitions, tool in WorkflowAgent are called with a first argument of the tool's input parameters, and a second argument of the tool call context.
 
 When you tool needs access to the full message history, you can access it via the `messages` property of the tool call context:
 

--- a/docs/content/docs/v5/ai/message-queueing.mdx
+++ b/docs/content/docs/v5/ai/message-queueing.mdx
@@ -13,7 +13,7 @@ related:
 
 When using [multi-turn workflows](/docs/ai/chat-session-modeling#multi-turn-workflows), messages typically arrive between agent turns. The workflow waits at a hook, receives a message, then starts a new turn. But sometimes you need to inject messages *during* an agent's turn, before tool calls complete or while the model is reasoning.
 
-`DurableAgent`'s `prepareStep` callback enables this by running before each step in the agent loop, giving you a chance to inject queued messages into the conversation. `prepareStep` also allows you to modify the model choice and existing messages mid-turn, see AI SDK's [prepareStep callback](https://ai-sdk.dev/docs/agents/loop-control#prepare-step) for more details.
+`WorkflowAgent`'s `prepareStep` callback enables this by running before each step in the agent loop, giving you a chance to inject queued messages into the conversation. `prepareStep` also allows you to modify the model choice and existing messages mid-turn, see AI SDK's [prepareStep callback](https://ai-sdk.dev/docs/agents/loop-control#prepare-step) for more details.
 
 ## When to Use This
 
@@ -52,20 +52,20 @@ interface PrepareStepResult {
 Once you have a [multi-turn workflow](/docs/ai/chat-session-modeling#multi-turn-workflows), you can combine a message queue with `prepareStep` to inject messages that arrive during processing:
 
 ```typescript title="workflows/chat/index.ts" lineNumbers
-import { DurableAgent } from "@workflow/ai/agent";
+import { WorkflowAgent, type ModelCallStreamPart } from "@ai-sdk/workflow";
 import { getWritable, getWorkflowMetadata } from "workflow";
 import { chatMessageHook } from "./hooks/chat-message";
 import { flightBookingTools, FLIGHT_ASSISTANT_PROMPT } from "./steps/tools";
-import type { UIMessageChunk, ModelMessage } from "ai";
+import type { ModelMessage } from "ai";
 
 export async function chat(initialMessages: ModelMessage[]) {
   "use workflow";
 
   const { workflowRunId: runId } = getWorkflowMetadata();
-  const writable = getWritable<UIMessageChunk>();
+  const writable = getWritable<ModelCallStreamPart>();
   const messageQueue: Array<{ role: "user"; content: string }> = []; // [!code highlight]
 
-  const agent = new DurableAgent({
+  const agent = new WorkflowAgent({
     model: "bedrock/claude-haiku-4-5-20251001-v1",
     instructions: FLIGHT_ASSISTANT_PROMPT,
     tools: flightBookingTools,
@@ -111,20 +111,20 @@ The `prepareStep` callback receives messages in `ModelMessage[]` format (with co
 You can also combine message queueing with the standard multi-turn pattern:
 
 ```typescript title="workflows/chat/index.ts" lineNumbers
-import { DurableAgent } from "@workflow/ai/agent";
+import { WorkflowAgent, type ModelCallStreamPart } from "@ai-sdk/workflow";
 import { getWritable, getWorkflowMetadata } from "workflow";
 import { chatMessageHook } from "./hooks/chat-message";
-import type { UIMessageChunk, ModelMessage } from "ai";
+import type { ModelMessage } from "ai";
 
 export async function chat(initialMessages: ModelMessage[]) {
   "use workflow";
 
   const { workflowRunId: runId } = getWorkflowMetadata();
-  const writable = getWritable<UIMessageChunk>();
+  const writable = getWritable<ModelCallStreamPart>();
   const messages: ModelMessage[] = [...initialMessages];
   const messageQueue: Array<{ role: "user"; content: string }> = [];
 
-  const agent = new DurableAgent({ /* ... */ });
+  const agent = new WorkflowAgent({ /* ... */ });
   const hook = chatMessageHook.create({ token: runId });
 
   while (true) {
@@ -173,5 +173,5 @@ export async function chat(initialMessages: ModelMessage[]) {
 
 - [Chat Session Modeling](/docs/ai/chat-session-modeling) - Single-turn vs multi-turn patterns
 - [Building Durable AI Agents](/docs/ai) - Complete guide to creating durable agents
-- [`DurableAgent` API Reference](/docs/api-reference/workflow-ai/durable-agent) - Full API documentation
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - AI SDK API for durable, resumable agents
 - [`defineHook()` API Reference](/docs/api-reference/workflow/define-hook) - Hook configuration options

--- a/docs/content/docs/v5/ai/resumable-streams.mdx
+++ b/docs/content/docs/v5/ai/resumable-streams.mdx
@@ -12,6 +12,10 @@ related:
   - /docs/api-reference/workflow-api/get-run
 ---
 
+<Callout type="warn">
+`WorkflowChatTransport` now ships in AI SDK as a 1:1 port — import it from `@ai-sdk/workflow` (the `@workflow/ai` export is deprecated). See [Resumable Streaming with `WorkflowChatTransport`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport) for the full reference.
+</Callout>
+
 When building chat interfaces, it's common to run into network interruptions, page refreshes, or serverless function timeouts, which can break the connection to an in-progress agent.
 
 Where a standard chat implementation would require the user to resend their message and wait for the entire response again, workflow runs are durable, and so are the streams attached to them. This means a stream can be resumed at any point, optionally only syncing the data that was missed since the last connection.
@@ -109,7 +113,7 @@ Replace the default transport in AI-SDK's `useChat` with [`WorkflowChatTransport
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai"; // [!code highlight]
+import { WorkflowChatTransport } from "@ai-sdk/workflow"; // [!code highlight]
 import { useMemo, useState } from "react";
 
 export default function ChatPage() {

--- a/docs/content/docs/v5/api-reference/workflow-ai/durable-agent.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-ai/durable-agent.mdx
@@ -10,7 +10,7 @@ related:
 ---
 
 <Callout type="warn">
-`DurableAgent` is deprecated. Use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) for new durable agents and migration guidance.
+`DurableAgent` is deprecated. Use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) for new durable agents — see the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent).
 </Callout>
 
 This reference is kept for existing applications that still import `DurableAgent` from `@workflow/ai/agent`. Do not use `DurableAgent` for new code.

--- a/docs/content/docs/v5/api-reference/workflow-ai/index.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-ai/index.mdx
@@ -13,9 +13,9 @@ Helpers for integrating AI SDK for building AI-powered workflows.
 
 <Cards>
     <Card title="DurableAgent" href="/docs/api-reference/workflow-ai/durable-agent">
-      A class for building durable AI agents that maintain state across workflow steps and handle tool execution with automatic retries.
+      Deprecated — use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent). Reference kept for existing `@workflow/ai/agent` imports.
     </Card>
     <Card title="WorkflowChatTransport" href="/docs/api-reference/workflow-ai/workflow-chat-transport">
-      A drop-in transport for the AI SDK for automatic reconnection in interrupted streams.
+      Deprecated — use AI SDK's [`WorkflowChatTransport`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport) from `@ai-sdk/workflow`. Reference kept for existing `@workflow/ai` imports.
     </Card>
 </Cards>

--- a/docs/content/docs/v5/api-reference/workflow-ai/workflow-chat-transport.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-ai/workflow-chat-transport.mdx
@@ -9,6 +9,10 @@ related:
   - /docs/ai/resumable-streams
 ---
 
+<Callout type="warn">
+`WorkflowChatTransport` from `@workflow/ai` is deprecated. AI SDK ships a 1:1 port — use [`WorkflowChatTransport` from `@ai-sdk/workflow`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport) instead. This reference is kept for existing applications that still import it from `@workflow/ai`.
+</Callout>
+
 A chat transport implementation for the AI SDK that provides reliable message streaming with automatic reconnection to interrupted streams. This transport is a drop-in replacement for the default AI SDK transport, enabling seamless recovery from network issues, page refreshes, or Vercel Function timeouts.
 
 <Callout>
@@ -252,7 +256,7 @@ export default function ChatWithCustomConfig() {
 
 ## See Also
 
-- [DurableAgent](/docs/api-reference/workflow-ai/durable-agent) - Building durable AI agents within workflows
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - Building durable, resumable AI agents (replaces `DurableAgent`)
 - [AI SDK `useChat` Documentation](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) - Using `useChat` with custom transports
 - [Workflows and Steps](/docs/foundations/workflows-and-steps) - Understanding workflow fundamentals
 - ["flight-booking-app" Example](https://github.com/vercel/workflow-examples/tree/main/flight-booking-app) - An example application which uses `WorkflowChatTransport`

--- a/docs/content/docs/v5/cookbook/advanced/serializable-steps.mdx
+++ b/docs/content/docs/v5/cookbook/advanced/serializable-steps.mdx
@@ -63,6 +63,10 @@ The `DurableAgent` receives a function (`() => Promise<LanguageModel>`) instead 
 
 ## How `@workflow/ai` Uses This
 
+<Callout type="warn">
+`@workflow/ai`'s pre-wrapped providers and `DurableAgent` are deprecated. AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) resolves models from AI Gateway model strings (e.g. `"openai/gpt-4o"`), which usually removes the need for a model factory — see the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The serialization pattern on this page still applies to any non-serializable dependency you own (for example, cloud SDK clients).
+</Callout>
+
 The `@workflow/ai` package ships pre-wrapped providers for all major AI SDK backends. Each one follows the same pattern:
 
 ```typescript lineNumbers
@@ -143,5 +147,5 @@ async function uploadFile(
 
 - [`"use step"`](/docs/foundations/workflows-and-steps#step-functions) — marks a function for extraction and serialization
 - [`"use workflow"`](/docs/foundations/workflows-and-steps#workflow-functions) — declares the orchestrator function
-- [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — accepts a model factory for durable AI agent streaming
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) — AI SDK's durable agent (resolves models via AI Gateway strings; replaces `DurableAgent`)
 - [Custom class serialization](/docs/foundations/serialization#custom-class-serialization) — the companion pattern for classes you own (`WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE`)

--- a/docs/content/docs/v5/cookbook/agent-patterns/agent-cancellation.mdx
+++ b/docs/content/docs/v5/cookbook/agent-patterns/agent-cancellation.mdx
@@ -7,6 +7,10 @@ summary: Cancel a running agent cooperatively with AbortController. A stop hook 
 
 Cancel a running agent from the outside — for example, a "Stop" button in a chat UI, an admin cancellation endpoint, or a timeout fallback.
 
+<Callout type="warn">
+This recipe uses the deprecated `DurableAgent` API. For new agents, use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) and follow the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The cancellation patterns here (`run.cancel()`, stop-signal hook + `Promise.race`, `AbortController`) apply to either API.
+</Callout>
+
 ## Pattern
 
 Create an `AbortController` in the workflow and race the agent (passing its signal) against a stop hook. When the hook fires, `controller.abort()` is called — the signal propagates into the agent step and cancels the underlying model stream. Before returning, a `data-stopped` part is written to the stream so any streaming clients can render a clean end state.
@@ -153,4 +157,4 @@ export function StopButton({ runId }: { runId: string }) {
 * [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook for the stop signal
 * [`getWorkflowMetadata()`](/docs/api-reference/workflow/get-workflow-metadata) — access the run ID for deterministic hook tokens
 * [`getWritable()`](/docs/api-reference/workflow/get-writable) — stream output and the stop notification to the client
-* [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — the agent that respects the abort signal via its `signal` option
+* [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) — AI SDK's durable agent that respects the abort signal (replaces `DurableAgent`)

--- a/docs/content/docs/v5/cookbook/agent-patterns/durable-agent.mdx
+++ b/docs/content/docs/v5/cookbook/agent-patterns/durable-agent.mdx
@@ -7,12 +7,12 @@ summary: Build durable, resumable AI agents with AI SDK v7's WorkflowAgent.
 
 ## WorkflowAgent from AI SDK v7
 
-Use AI SDK v7's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) for new durable agent work. It replaces `DurableAgent` in v5 and keeps the current agent pattern in the AI SDK package.
+Use AI SDK v7's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) for new durable agent work. It replaces `DurableAgent` and keeps the current agent pattern in the AI SDK package.
 
 - Import `WorkflowAgent` from `@ai-sdk/workflow` and run it inside a `"use workflow"` function.
 - Stream `ModelCallStreamPart` chunks with `getWritable()`, then convert the run stream to UI message chunks with `createModelCallToUIChunkTransform()` in your route.
 - Mark tool `execute` functions with `"use step"` when they should run as durable workflow steps with retry and observability behavior.
 
 <Callout type="warn">
-`DurableAgent` is deprecated in v5 and remains documented for existing code only. Existing `DurableAgent` users can refer to the [`DurableAgent` API reference](/docs/api-reference/workflow-ai/durable-agent) while migrating.
+`DurableAgent` is deprecated and remains documented for existing code only. See the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent), or the [`DurableAgent` API reference](/docs/api-reference/workflow-ai/durable-agent) while migrating.
 </Callout>

--- a/docs/content/docs/v5/cookbook/agent-patterns/human-in-the-loop.mdx
+++ b/docs/content/docs/v5/cookbook/agent-patterns/human-in-the-loop.mdx
@@ -5,6 +5,10 @@ type: guide
 summary: Use defineHook with the tool call ID to suspend an agent for human approval, with an optional timeout.
 ---
 
+<Callout type="warn">
+This recipe uses the deprecated `DurableAgent` API. For new agents, use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) and follow the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent). The human-in-the-loop pattern here (hooks, `Promise.race`, approval gating) applies to either API.
+</Callout>
+
 Use this pattern when an AI agent needs human confirmation before performing a consequential action like booking, purchasing, or publishing. The workflow suspends without consuming resources until the human responds.
 
 ## When to use this
@@ -252,4 +256,4 @@ const approvalResult = messages
 - [`defineHook()`](/docs/api-reference/workflow/define-hook) — type-safe hook with schema validation
 - [`sleep()`](/docs/api-reference/workflow/sleep) — durable timeout for approval expiry
 - [`getWritable()`](/docs/api-reference/workflow/get-writable) — stream custom data parts from steps
-- [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent) — durable agent with tool definitions
+- [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) — AI SDK's durable agent (replaces `DurableAgent`)

--- a/docs/content/docs/v5/cookbook/integrations/ai-sdk.mdx
+++ b/docs/content/docs/v5/cookbook/integrations/ai-sdk.mdx
@@ -2,7 +2,7 @@
 title: AI SDK
 description: Use AI SDK's streamText directly inside durable workflows when you need the raw AI SDK API or a per-turn durability boundary.
 type: guide
-summary: Use streamText() inside a workflow when the durability boundary is an entire user turn, or when you need AI SDK APIs not exposed by DurableAgent. Individual tool calls and LLM calls inside a turn are not separately durable.
+summary: Use streamText() inside a workflow when the durability boundary is an entire user turn, or when you need AI SDK APIs not exposed by WorkflowAgent. Individual tool calls and LLM calls inside a turn are not separately durable.
 related:
   - /docs/ai
   - /docs/ai/chat-session-modeling
@@ -16,18 +16,18 @@ related:
 For the full AI SDK reference (providers, `streamText`, `generateObject`, `useChat`, tool calling, etc.) see the [AI SDK docs](https://ai-sdk.dev/docs). This page covers the Workflow-specific integration points.
 
 <Callout type="info">
-For most agent use cases, prefer [`DurableAgent`](/cookbook/agent-patterns/durable-agent), which implements the same agent loop as [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text), manages tool calling automatically, and runs tools at workflow scope — each tool can be marked `"use step"` for per-call durability and retries, or stay at workflow level to use primitives like `sleep()` and hooks. Use this page's raw `streamText()` pattern when you want the exact AI SDK API (for example `toUIMessageStream()`, `onChunk`, or `generateText`), or when the durability boundary should be an entire user turn in one step — accepting that tool calls inside that turn are not individually durable.
+For most agent use cases, prefer AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent), which implements the same agent loop as [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text), manages tool calling automatically, and runs tools at workflow scope — each tool can be marked `"use step"` for per-call durability and retries, or stay at workflow level to use primitives like `sleep()` and hooks. Use this page's raw `streamText()` pattern when you want the exact AI SDK API (for example `toUIMessageStream()`, `onChunk`, or `generateText`), or when the durability boundary should be an entire user turn in one step — accepting that tool calls inside that turn are not individually durable.
 </Callout>
 
 ## When to use streamText directly
 
-Use [`streamText()`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) instead of `DurableAgent` when you need:
+Use [`streamText()`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) instead of `WorkflowAgent` when you need:
 
-* **The raw AI SDK API** — `streamText().toUIMessageStream()`, `onChunk`, `smoothStream`, or other options that map directly to the [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) return value rather than `DurableAgent.stream()`
+* **The raw AI SDK API** — `streamText().toUIMessageStream()`, `onChunk`, `smoothStream`, or other options that map directly to the [`streamText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) return value rather than `WorkflowAgent.stream()`
 * **Per-turn durability** — wrap the entire agent response (model + tools) in a single `"use step"` function so one user turn is the atomic retry unit; useful when you want all tool calls inside a turn to re-execute together
-* **Custom multi-turn orchestration** — manual hook loops, per-turn stream slicing (`sliceUntilFinish`), or other workflow patterns shown below that don't map cleanly to `DurableAgent`
+* **Custom multi-turn orchestration** — manual hook loops, per-turn stream slicing (`sliceUntilFinish`), or other workflow patterns shown below that don't map cleanly to `WorkflowAgent`
 
-`DurableAgent` already supports `stopWhen`, `prepareStep`, `onStepFinish`, structured output (`experimental_output`), per-step model switching, and [provider options](https://ai-sdk.dev/docs/ai-sdk-core/provider-options). See the [DurableAgent reference](/docs/api-reference/workflow-ai/durable-agent).
+`WorkflowAgent` already supports `stopWhen`, `prepareStep`, lifecycle callbacks, structured output (`output`), per-step model switching, and [provider options](https://ai-sdk.dev/docs/ai-sdk-core/provider-options). See the [`WorkflowAgent` docs](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent).
 
 ## Multi-turn pattern
 
@@ -250,7 +250,7 @@ Store the `runId` in a ref and pass it in the body of every follow-up. `Workflow
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { WorkflowChatTransport } from "@workflow/ai";
+import { WorkflowChatTransport } from "@ai-sdk/workflow";
 import { useMemo, useRef, useState } from "react";
 
 export function SupportChat() {
@@ -324,7 +324,7 @@ The consequences:
 **Mitigations:**
 
 - Make side-effectful tool implementations idempotent — dedupe server-side on a stable key (e.g. `orderId`, an `Idempotency-Key` header, etc.).
-- Or use [`DurableAgent`](/docs/api-reference/workflow-ai/durable-agent), which runs tools at workflow scope — each tool can be marked `"use step"` to become its own durable, retryable step, or stay at workflow level to use primitives like `sleep()` and hooks.
+- Or use AI SDK's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent), which runs tools at workflow scope — each tool can be marked `"use step"` to become its own durable, retryable step, or stay at workflow level to use primitives like `sleep()` and hooks.
 
 ### Snapshot `tailIndex` *before* resuming the hook
 
@@ -358,19 +358,19 @@ Clients can send a `runId` from a long-gone workflow (localStorage, back button,
 
 This example stores the `runId` after the first response. For strict one-session-per-thread behavior, use a deterministic hook token derived from the thread ID or conversation ID and route retries through the active hook. See [Idempotency](/docs/foundations/idempotency).
 
-## streamText vs DurableAgent
+## streamText vs WorkflowAgent
 
-| | `streamText()` (this pattern) | `DurableAgent` |
+| | `streamText()` (this pattern) | `WorkflowAgent` |
 |---|---|---|
 | **Tool loop** | AI SDK handles via `stopWhen` | Handles internally (AI SDK–compatible options) |
 | **LLM call durability** | Re-executes with the parent turn | Each LLM call is a durable step |
 | **Tool call durability** | Not individually durable — re-executes with the parent turn | Per tool — mark `"use step"` for a durable, retryable step, or keep at workflow level for `sleep()` / hooks |
 | **Stop conditions** | `stopWhen`, `prepareStep` | `stopWhen`, `prepareStep` |
-| **Structured output** | `Output.object()`, `Output.array()` | `experimental_output` (`Output.object()`, `Output.text()`) |
+| **Structured output** | `Output.object()`, `Output.array()` | `output` (`Output.object()`, `Output.text()`) |
 | **Step callbacks** | `onStepFinish`, `onChunk`, etc. | `onStepFinish`, `onFinish`, `onError`, `onAbort` (`onChunk` not available) |
 | **Setup** | Manual stream piping and turn slicing | Automatic |
 
-Use `DurableAgent` for most agent use cases. Use `streamText` when you need the raw AI SDK surface or a per-turn durability boundary.
+Use `WorkflowAgent` for most agent use cases. Use `streamText` when you need the raw AI SDK surface or a per-turn durability boundary.
 
 ## Key APIs
 

--- a/docs/lib/cookbook-tree.ts
+++ b/docs/lib/cookbook-tree.ts
@@ -134,17 +134,10 @@ export const recipes: Record<string, Recipe> = {
   // Agent Patterns
   'durable-agent': {
     slug: 'durable-agent',
-    title: 'Durable Agent',
+    title: 'WorkflowAgent',
     description:
-      'Replace a stateless AI agent with a durable one that survives crashes, retries tool calls, and streams output.',
+      "Build durable, resumable AI agents with AI SDK's WorkflowAgent.",
     category: 'agent-patterns',
-    versionOverrides: {
-      v5: {
-        title: 'WorkflowAgent',
-        description:
-          "Build durable, resumable AI agents with AI SDK's WorkflowAgent.",
-      },
-    },
   },
   'human-in-the-loop': {
     slug: 'human-in-the-loop',


### PR DESCRIPTION
## What & why

`DurableAgent` (`@workflow/ai/agent`) and `WorkflowChatTransport` (`@workflow/ai`) are superseded by AI SDK v7's [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) and its built-in [`WorkflowChatTransport`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport) (`@ai-sdk/workflow`) — 1:1 ports. This steers all new readers to the AI SDK APIs and the [migration guide](https://ai-sdk.dev/v7/docs/agents/workflow-agent#migrating-from-durableagent), while keeping the API-reference pages live so existing imports aren't 404'd.

PR #2285 did this for **v5's 5 headline pages only**. This completes the sweep across **both v4 and v5**, adds `WorkflowChatTransport`, and adds the migration-guide link.

## Approach

- **API references kept + bannered** (full surface intact): `durable-agent` and `workflow-chat-transport` (v4 + v5), plus the `@workflow/ai` landing cards.
- **Headline guides fully converted to WorkflowAgent**: v4 `ai/index`, `foundations/streaming`, the cookbook recipe (now a WorkflowAgent stub) + cookbook index — brought to parity with v5.
- **Standard examples converted**: `ai/defining-tools`, `ai/message-queueing`; `cookbook/integrations/ai-sdk` reframed (`streamText` vs WorkflowAgent).
- **WorkflowChatTransport examples** repointed to `@ai-sdk/workflow`: `ai/resumable-streams`, `ai/chat-session-modeling`, `cookbook/integrations/ai-sdk`.
- **Convert + repoint (banner, keep legacy)** for recipes whose core mechanism streams **custom `UIMessageChunk` data parts** to the agent's run stream — `chat-session-modeling` (multi-turn markers), `human-in-the-loop` (approval parts), `agent-cancellation` (`data-stopped`), `serializable-steps` (`@workflow/ai` provider wrapping). That pattern does **not** map to WorkflowAgent's `ModelCallStreamPart` + route-transform model, and the AI SDK docs don't document an equivalent, so rather than publish an incorrect hybrid these keep their working DurableAgent examples behind a clear deprecation banner with links pointing to WorkflowAgent. **Flagging for reviewer judgment** — happy to attempt deeper rewrites if there's a supported WorkflowAgent pattern for custom data parts.
- **Nav**: cookbook `agent-patterns` recipe renamed to **WorkflowAgent** (base recipe in `cookbook-tree.ts`; the now-redundant v5 override is removed).

## Out of scope
- `skills/workflow/SKILL.md` still teaches DurableAgent — it's agent guidance (not user docs), not maintained on `stable`, and needs a skill version bump. Left for a follow-up; can include if wanted.

## Notes
- No changeset (docs-only; matches PR #2285 precedent).
- The local docs link checker (`pnpm lint:links`) couldn't run here — `bun` segfaults in this environment — so CI is the authoritative lint. Verified manually: Callout tags balanced, internal link targets exist, grep sweeps confirm the intended end state.

## Docs Preview

Preview deployment (`workflow-docs`, behind Vercel team auth):

| Page | v4 | v5 |
|---|---|---|
| AI overview | [/docs/ai](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/ai) | [/v5/docs/ai](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/ai) |
| Defining tools | [/docs/ai/defining-tools](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/ai/defining-tools) | [/v5/docs/ai/defining-tools](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/ai/defining-tools) |
| Message queueing | [/docs/ai/message-queueing](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/ai/message-queueing) | [/v5/docs/ai/message-queueing](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/ai/message-queueing) |
| Chat session modeling | [/docs/ai/chat-session-modeling](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/ai/chat-session-modeling) | [/v5/docs/ai/chat-session-modeling](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/ai/chat-session-modeling) |
| Resumable streams | [/docs/ai/resumable-streams](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/ai/resumable-streams) | [/v5/docs/ai/resumable-streams](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/ai/resumable-streams) |
| Streaming | [/docs/foundations/streaming](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/foundations/streaming) | [/v5/docs/foundations/streaming](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/foundations/streaming) |
| @workflow/ai reference | [/docs/api-reference/workflow-ai](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/api-reference/workflow-ai) | [/v5/docs/api-reference/workflow-ai](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/api-reference/workflow-ai) |
| DurableAgent reference | [/docs/api-reference/workflow-ai/durable-agent](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/api-reference/workflow-ai/durable-agent) | [/v5/docs/api-reference/workflow-ai/durable-agent](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/api-reference/workflow-ai/durable-agent) |
| WorkflowChatTransport reference | [/docs/api-reference/workflow-ai/workflow-chat-transport](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/docs/api-reference/workflow-ai/workflow-chat-transport) | [/v5/docs/api-reference/workflow-ai/workflow-chat-transport](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/docs/api-reference/workflow-ai/workflow-chat-transport) |
| Cookbook index | [/cookbook](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/cookbook) | [/v5/cookbook](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/cookbook) |
| Cookbook: WorkflowAgent recipe | [/cookbook/agent-patterns/durable-agent](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/cookbook/agent-patterns/durable-agent) | [/v5/cookbook/agent-patterns/durable-agent](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/cookbook/agent-patterns/durable-agent) |
| Cookbook: human-in-the-loop | [/cookbook/agent-patterns/human-in-the-loop](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/cookbook/agent-patterns/human-in-the-loop) | [/v5/cookbook/agent-patterns/human-in-the-loop](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/cookbook/agent-patterns/human-in-the-loop) |
| Cookbook: agent-cancellation | [/cookbook/agent-patterns/agent-cancellation](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/cookbook/agent-patterns/agent-cancellation) | [/v5/cookbook/agent-patterns/agent-cancellation](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/cookbook/agent-patterns/agent-cancellation) |
| Cookbook: serializable-steps | [/cookbook/advanced/serializable-steps](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/cookbook/advanced/serializable-steps) | [/v5/cookbook/advanced/serializable-steps](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/cookbook/advanced/serializable-steps) |
| Cookbook: AI SDK integration | [/cookbook/integrations/ai-sdk](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/cookbook/integrations/ai-sdk) | [/v5/cookbook/integrations/ai-sdk](https://workflow-docs-git-pgp-deprecate-durable-agent.vercel.sh/v5/cookbook/integrations/ai-sdk) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)