### PR TITLE
feat(web-shared): extend cn with custom tailwind-merge class groups

### DIFF
--- a/.changeset/extend-cn-tailwind-merge.md
+++ b/.changeset/extend-cn-tailwind-merge.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Extend `cn` with custom tailwind-merge class groups for the design-system typography and material utilities, and move it to its own `lib/cn` module.

--- a/packages/web-shared/src/components/new-trace-viewer/components/copy-button.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/copy-button.tsx
@@ -2,7 +2,7 @@
 
 import { Check, Copy } from 'lucide-react';
 import { type JSX, useEffect, useRef, useState } from 'react';
-import { cn } from '../../../lib/utils';
+import { cn } from '../../../lib/cn';
 
 interface CopyButtonProps {
   copyText: string;

--- a/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
@@ -1,6 +1,6 @@
 import { Circle } from 'lucide-react';
 import { useRef } from 'react';
-import { cn } from '../../../lib/utils';
+import { cn } from '../../../lib/cn';
 import type { Span } from '../types';
 import { formatDurationPrecise } from '../../trace-viewer/util/timing';
 import {

--- a/packages/web-shared/src/components/new-trace-viewer/components/middle-truncate/middle-truncate.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/middle-truncate/middle-truncate.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useRef } from 'react';
 import type { ClipboardEvent, ComponentPropsWithoutRef, JSX } from 'react';
-import { cn } from '../../../../lib/utils';
+import { cn } from '../../../../lib/cn';
 import {
   getMiddleTruncateCopyText,
   getMiddleTruncateCopyTextFromSelectionText,

--- a/packages/web-shared/src/components/new-trace-viewer/components/span-markers.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/span-markers.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, ArrowRight } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { cn } from '../../../lib/utils';
+import { cn } from '../../../lib/cn';
 import { TimestampTooltip } from '../../ui/timestamp-tooltip';
 import type { SpanMarker } from '../utils';
 

--- a/packages/web-shared/src/components/new-trace-viewer/components/split-pane.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/split-pane.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { cn } from '../../../lib/utils';
+import { cn } from '../../../lib/cn';
 
 const GUTTER_PX = 1;
 const MIN_PX = 50;

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { cn } from '../../../lib/utils';
+import { cn } from '../../../lib/cn';
 import {
   formatDuration,
   formatDurationPrecise,

--- a/packages/web-shared/src/components/sidebar/detail-card.tsx
+++ b/packages/web-shared/src/components/sidebar/detail-card.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 export function DetailCard({
   summary,

--- a/packages/web-shared/src/components/ui/alert.tsx
+++ b/packages/web-shared/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 const alertVariants = cva(
   'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4',

--- a/packages/web-shared/src/components/ui/button.tsx
+++ b/packages/web-shared/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 const buttonVariants = cva(
   [

--- a/packages/web-shared/src/components/ui/card.tsx
+++ b/packages/web-shared/src/components/ui/card.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/packages/web-shared/src/components/ui/context-card.tsx
+++ b/packages/web-shared/src/components/ui/context-card.tsx
@@ -14,7 +14,7 @@ import {
 import { createPortal } from 'react-dom';
 import useMeasure from 'react-use-measure';
 import { useReducedMotion } from '../../hooks/use-reduced-motion';
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 const INACTIVE_TIMEOUT_MS = 250;
 const ENTER_DELAY_MS = 0;

--- a/packages/web-shared/src/components/ui/error-card.tsx
+++ b/packages/web-shared/src/components/ui/error-card.tsx
@@ -2,7 +2,7 @@
 
 import { AlertCircle, ChevronDown } from 'lucide-react';
 import { useState } from 'react';
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 interface ErrorCardProps {
   /** Title shown in the header */

--- a/packages/web-shared/src/components/ui/icon-button.tsx
+++ b/packages/web-shared/src/components/ui/icon-button.tsx
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 const iconButtonVariants = cva(
   [

--- a/packages/web-shared/src/components/ui/kbd.tsx
+++ b/packages/web-shared/src/components/ui/kbd.tsx
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import type { ComponentProps, ReactNode } from 'react';
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 const kbdVariants = cva(
   'inline-flex items-center justify-center rounded px-1 text-center font-sans',

--- a/packages/web-shared/src/components/ui/skeleton.tsx
+++ b/packages/web-shared/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 function Skeleton({
   className,

--- a/packages/web-shared/src/components/ui/tooltip.tsx
+++ b/packages/web-shared/src/components/ui/tooltip.tsx
@@ -2,7 +2,7 @@
 
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import * as React from 'react';
-import { cn } from '../../lib/utils';
+import { cn } from '../../lib/cn';
 
 const TooltipProvider = TooltipPrimitive.Provider;
 

--- a/packages/web-shared/src/lib/cn.ts
+++ b/packages/web-shared/src/lib/cn.ts
@@ -1,0 +1,93 @@
+import { type ClassValue, clsx } from 'clsx';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+const twMergeConfig = {
+  extend: {
+    classGroups: {
+      'text-heading': [
+        {
+          'text-heading': [
+            '72',
+            '64',
+            '56',
+            '48',
+            '40',
+            '32',
+            '24',
+            '20',
+            '16',
+            '14',
+          ],
+        },
+      ],
+      'text-button': [
+        {
+          'text-button': ['16', '14', '12'],
+        },
+      ],
+      'text-label': [
+        {
+          'text-label': [
+            '20',
+            '18',
+            '16',
+            '14',
+            '14-mono',
+            '13',
+            '13-mono',
+            '12',
+            '12-mono',
+          ],
+        },
+      ],
+      'text-copy': [
+        {
+          'text-copy': ['24', '20', '18', '16', '14', '13', '13-mono'],
+        },
+      ],
+      material: [
+        {
+          material: [
+            'base',
+            'small',
+            'medium',
+            'large',
+            'tooltip',
+            'menu',
+            'modal',
+            'fullscreen',
+          ],
+        },
+      ],
+    },
+    // Make each category conflict with itself, so e.g. text-heading-32 overrides text-heading-24
+    conflictingClassGroups: {
+      'text-heading': ['text-heading'],
+      'text-button': ['text-button'],
+      'text-label': ['text-label'],
+      'text-copy': ['text-copy'],
+      material: ['material'],
+    },
+  },
+} as const;
+
+type CustomClassGroupIds =
+  | 'text-heading'
+  | 'text-button'
+  | 'text-label'
+  | 'text-copy'
+  | 'material';
+
+const customTwMerge = extendTailwindMerge<CustomClassGroupIds>(twMergeConfig);
+
+/**
+ * Merges Tailwind class names and resolves any conflicts using `clsx` with `tailwind-merge`.
+ *
+ * @param inputs - An array of class names to merge.
+ * @returns A string of merged and optimized class names.
+ */
+function cn(...classes: ClassValue[]) {
+  return customTwMerge(clsx(...classes));
+}
+
+export { cn };

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -1,11 +1,5 @@
 import type { Step } from '@workflow/world';
 import type { ModelMessage } from 'ai';
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
 
 const MS_IN_SECOND = 1000;
 const MS_IN_MINUTE = 60 * MS_IN_SECOND;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Teaches `tailwind-merge` about the design-system typography/material utilities (`text-heading-*`, `text-label-*`, `text-copy-*`, `text-button-*`, `material-*`) so that conflicting classes within those groups resolve correctly when merged via `cn`.

## Changes

- Add `packages/web-shared/src/lib/cn.ts` with an `extendTailwindMerge` config covering the custom class groups
- Move `cn` out of `lib/utils.ts` into its own `lib/cn` module and import it directly from there (no re-export indirection)
- Repoint the web-shared consumers' `cn` imports to `../lib/cn`

## Notes

- Split out from the metadata-panel-styling PR (#2604) to keep that one focused.

## Verification

- `pnpm --filter @workflow/web-shared typecheck` passes
- Each consumer file changes only its `cn` import line
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be0e4640-dbe6-4775-b71b-3343593ebe69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be0e4640-dbe6-4775-b71b-3343593ebe69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

