### PR TITLE
[ai] Treat invalid Zod tool schemas as fatal user errors

### DIFF
--- a/.changeset/fix-ai-schema-user-error.md
+++ b/.changeset/fix-ai-schema-user-error.md
@@ -1,0 +1,5 @@
+---
+"@workflow/ai": patch
+---
+
+Treat invalid Zod tool schema definitions as fatal workflow user errors instead of retryable callback failures.

--- a/packages/ai/src/agent/durable-agent.test.ts
+++ b/packages/ai/src/agent/durable-agent.test.ts
@@ -283,6 +283,71 @@ describe('DurableAgent', () => {
       });
     });
 
+    it('should throw a fatal user error for invalid Zod tool schemas', async () => {
+      const execute = vi.fn(async () => 'never');
+      const tools: ToolSet = {
+        testTool: {
+          description: 'A test tool',
+          inputSchema: z.object({
+            event: { type: 'string' } as any,
+          }),
+          execute,
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new DurableAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockMessages: LanguageModelV3Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({
+          done: false,
+          value: {
+            toolCalls: [
+              {
+                toolCallId: 'test-call-id',
+                toolName: 'testTool',
+                input: '{"event":"created"}',
+              } as LanguageModelV3ToolCall,
+            ],
+            messages: mockMessages,
+          },
+        }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator
+      );
+
+      await expect(
+        agent.stream({
+          messages: [{ role: 'user', content: 'test' }],
+          writable: mockWritable,
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowAISchemaError',
+        fatal: true,
+        message: expect.stringContaining(
+          'Invalid inputSchema for tool "testTool"'
+        ),
+      });
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(mockIterator.next).toHaveBeenCalledTimes(1);
+    });
+
     it('should pass through LanguageModelV3ToolResultOutput directly', async () => {
       // Tool returns a pre-formatted content output (e.g., multimodal with images)
       const contentOutput = {

--- a/packages/ai/src/agent/durable-agent.ts
+++ b/packages/ai/src/agent/durable-agent.ts
@@ -28,6 +28,10 @@ import {
 import { convertToLanguageModelPrompt, standardizePrompt } from 'ai/internal';
 import { getErrorMessage } from '../get-error-message.js';
 import { safeParseToolCallInput } from './safe-parse-tool-call-input.js';
+import {
+  fatalSchemaDefinitionError,
+  isZodSchemaDefinitionError,
+} from './schema-error.js';
 import { streamTextIterator } from './stream-text-iterator.js';
 import { recordSpan, runInContext } from './telemetry.js';
 import type { CompatibleLanguageModel } from './types.js';
@@ -1600,7 +1604,18 @@ async function executeTool(
         `Client-side tools should be filtered before calling executeTool.`
     );
   }
-  const schema = asSchema(tool.inputSchema);
+  let schema: ReturnType<typeof asSchema>;
+  try {
+    schema = asSchema(tool.inputSchema);
+  } catch (error) {
+    if (isZodSchemaDefinitionError(error)) {
+      throw fatalSchemaDefinitionError(
+        error,
+        `Invalid inputSchema for tool "${toolCall.toolName}"`
+      );
+    }
+    throw error;
+  }
 
   let parsedInput: unknown;
   try {
@@ -1634,6 +1649,13 @@ async function executeTool(
     }
     parsedInput = input.value;
   } catch (parseError) {
+    if (isZodSchemaDefinitionError(parseError)) {
+      throw fatalSchemaDefinitionError(
+        parseError,
+        `Invalid inputSchema for tool "${toolCall.toolName}"`
+      );
+    }
+
     // Try to repair the tool call if a repair function is provided
     if (repairToolCall) {
       const repairedToolCall = await repairToolCall({

--- a/packages/ai/src/agent/schema-error.ts
+++ b/packages/ai/src/agent/schema-error.ts
@@ -1,0 +1,29 @@
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isZodSchemaDefinitionError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.startsWith('Invalid element at key "') &&
+    error.message.includes('expected a Zod schema')
+  );
+}
+
+export function fatalSchemaDefinitionError(
+  error: unknown,
+  context: string
+): Error {
+  const fatal = new Error(`${context}: ${getErrorMessage(error)}`, {
+    cause: error,
+  });
+  fatal.name = 'WorkflowAISchemaError';
+
+  Object.defineProperty(fatal, 'fatal', {
+    value: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  return fatal;
+}

--- a/packages/ai/src/agent/tools-to-model-tools.test.ts
+++ b/packages/ai/src/agent/tools-to-model-tools.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { tool } from 'ai';
+import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { toolsToModelTools } from './tools-to-model-tools.js';
 
@@ -24,6 +24,24 @@ describe('toolsToModelTools', () => {
     expect(result[0]).toHaveProperty('inputSchema');
     expect(result[0]).not.toHaveProperty('id');
     expect(result[0]).not.toHaveProperty('args');
+  });
+
+  it('throws a fatal user error for invalid Zod tool schemas', async () => {
+    const tools = {
+      broken: tool({
+        description: 'Broken schema',
+        inputSchema: z.object({
+          event: { type: 'string' } as any,
+        }),
+        execute: async () => 'never',
+      }),
+    };
+
+    await expect(toolsToModelTools(tools)).rejects.toMatchObject({
+      name: 'WorkflowAISchemaError',
+      fatal: true,
+      message: expect.stringContaining('Invalid inputSchema for tool "broken"'),
+    });
   });
 
   it('preserves provider tool type, id, and args', async () => {

--- a/packages/ai/src/agent/tools-to-model-tools.ts
+++ b/packages/ai/src/agent/tools-to-model-tools.ts
@@ -3,6 +3,40 @@ import type {
   LanguageModelV3ProviderTool,
 } from '@ai-sdk/provider';
 import { asSchema, type ToolSet } from 'ai';
+import {
+  fatalSchemaDefinitionError,
+  isZodSchemaDefinitionError,
+} from './schema-error.js';
+
+async function getSchemaDefinitionError(
+  schema: ReturnType<typeof asSchema>
+): Promise<unknown> {
+  try {
+    await schema.validate?.({});
+  } catch (error) {
+    if (isZodSchemaDefinitionError(error)) return error;
+  }
+}
+
+async function getInputJsonSchema(name: string, tool: ToolSet[string]) {
+  const schema = asSchema(tool.inputSchema);
+
+  try {
+    return await schema.jsonSchema;
+  } catch (error) {
+    const schemaDefinitionError = isZodSchemaDefinitionError(error)
+      ? error
+      : await getSchemaDefinitionError(schema);
+
+    if (schemaDefinitionError) {
+      throw fatalSchemaDefinitionError(
+        schemaDefinitionError,
+        `Invalid inputSchema for tool "${name}"`
+      );
+    }
+    throw error;
+  }
+}
 
 // Mirrors the tool→LanguageModelV3FunctionTool/LanguageModelV3ProviderTool
 // mapping in the core AI SDK's prepareToolsAndToolChoice
@@ -22,7 +56,7 @@ export async function toolsToModelTools(
             type: 'function' as const,
             name,
             description: tool.description,
-            inputSchema: await asSchema(tool.inputSchema).jsonSchema,
+            inputSchema: await getInputJsonSchema(name, tool),
             ...(tool.inputExamples != null
               ? { inputExamples: tool.inputExamples }
               : {}),


### PR DESCRIPTION
## What changed

- Treat invalid/incompatible Zod tool schema definitions in `@workflow/ai` as fatal workflow errors.
- Wrap the failure in a `WorkflowAISchemaError` with `fatal: true` so the runtime stops queue redelivery and fails the run as `USER_ERROR`.
- Apply this in both schema-to-model-tool conversion and local durable-agent tool execution.
- Add regressions for the model-tool serialization path and the durable agent execution path.
- Add a patch changeset for `@workflow/ai`.

## Why

The observed production failure is a deterministic Zod schema-definition error:

```txt
Invalid element at key "event": expected a Zod schema
```

That error happens when a Zod object shape contains something Zod cannot treat as a schema. Two concrete repros are:

```ts
// Plain object where Zod expects a Zod schema
z.object({
  event: { type: 'string' },
})
```

```ts
// Mixed incompatible Zod major versions
zod4.object({
  event: zod3.string(),
})
```

Queue redelivery cannot recover from either case because each callback replay reaches the same invalid `inputSchema`. The runtime already treats errors with `fatal: true` as non-retryable user-code/configuration failures, so this surfaces the underlying problem as `USER_ERROR` instead of eventually reporting `MAX_DELIVERIES_EXCEEDED`.

The fix is intentionally narrow: generic Zod internals are not enough by themselves. We only mark the failure fatal when Zod validation confirms the explicit schema-definition error above. That avoids treating unrelated Zod/version/internal failures as user errors.

## Related Zod Issue

This is different from #1901 / #1902. That issue was about Zod 4.4 treating `z.undefined()` properties as required in `@workflow/world` run schemas, with errors like:

```txt
run.output: expected nonoptional, received undefined
```

#1902 fixed that by changing those `z.undefined()` fields to `z.undefined().optional()` in `packages/world/src/runs.ts`. It was backported after `workflow@4.2.4` and first appears in stable `workflow@4.2.5`.

## Validation

- `pnpm --filter @workflow/ai test`
- `pnpm --filter @workflow/ai test src/agent/tools-to-model-tools.test.ts src/agent/durable-agent.test.ts`
- `pnpm --filter @workflow/ai build`
- `pnpm typecheck`
- `pnpm exec biome check packages/ai/src/agent/schema-error.ts packages/ai/src/agent/tools-to-model-tools.ts packages/ai/src/agent/durable-agent.ts packages/ai/src/agent/tools-to-model-tools.test.ts packages/ai/src/agent/durable-agent.test.ts .changeset/fix-ai-schema-user-error.md`

Note: full `pnpm lint` still fails on unrelated existing repo-wide Biome issues in generated/docs/GitHub files.
