### PR TITLE
[world] Make @workflow/world own its Zod dependency

### DIFF
--- a/.changeset/world-zod-dependency.md
+++ b/.changeset/world-zod-dependency.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world': patch
+---
+
+Declare Zod as a runtime dependency so exported schemas are built with the package's own Zod version instead of the consuming application's peer.

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -23,9 +23,7 @@
     "clean": "tsc --build --clean && rm -rf dist"
   },
   "dependencies": {
-    "ulid": "catalog:"
-  },
-  "peerDependencies": {
+    "ulid": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,6 +1331,9 @@ importers:
       ulid:
         specifier: 'catalog:'
         version: 3.0.1
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1338,9 +1341,6 @@ importers:
       '@workflow/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      zod:
-        specifier: 'catalog:'
-        version: 4.3.6
 
   packages/world-local:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ catalogs:
       specifier: ^4.0.18
       version: 4.0.18
     zod:
-      specifier: 4.3.6
+      specifier: ~4.3.6
       version: 4.3.6
 
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   ulid: ~3.0.1
   undici: 7.28.0
   vitest: ^4.0.18
-  zod: 4.3.6
+  zod: ~4.3.6
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary

- Move Zod from a peer dependency to a runtime dependency of `@workflow/world`.
- Update the lockfile and add a patch changeset for the packaging fix.

## Why

`@workflow/world` exports Zod schemas such as `EventSchema`, and `@workflow/world-vercel` composes those schemas into response validators. If `@workflow/world` resolves a consuming application's incompatible Zod version, those validators can fail locally after a successful workflow-server response with errors like `Invalid element at key "event": expected a Zod schema`.

Owning the Zod runtime dependency keeps exported schemas on the package's expected Zod version instead of depending on the application install.

## Validation

- `pnpm exec tsc -p packages/world/tsconfig.json --noEmit`
- `pnpm exec biome check packages/world/package.json .changeset/world-zod-dependency.md`

Note: repo-wide `pnpm lint` currently fails on unrelated existing generated/docs/benchmark diagnostics.
