### PR TITLE
Left-align trace shortcut helper on the timeline

### DIFF
--- a/.changeset/trace-shortcut-helper-left-align.md
+++ b/.changeset/trace-shortcut-helper-left-align.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Left-align the trace shortcut helper at the start of the timeline column.

--- a/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/trace-shortcut-helper.tsx
@@ -86,7 +86,7 @@ export function TraceShortcutHelper({
   };
 
   return (
-    <div className="group absolute bottom-3 left-1/2 z-10 hidden h-8 max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-1 text-xs leading-none text-gray-900 md:inline-flex">
+    <div className="group absolute bottom-3 left-4 z-10 hidden h-8 max-w-[calc(100%-2rem)] items-center gap-1 text-xs leading-none text-gray-900 md:inline-flex">
       <span
         aria-live="polite"
         aria-atomic="true"

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -730,10 +730,6 @@ function NewTraceViewerContent({
               hoverFraction={hoverFraction}
               altHeld={altHeld}
             />
-            <TraceShortcutHelper
-              hasMultipleSpans={trace.spans.length > 1}
-              reducedMotion={reducedMotion}
-            />
           </div>
         </SplitPane>
         <div className="absolute right-3 bottom-3 z-[5] flex items-center border border-gray-alpha-400 rounded-md bg-background-100 shadow-sm overflow-hidden divide-x divide-gray-alpha-400">
@@ -843,6 +839,10 @@ function NewTraceViewerContent({
         </aside>
       ) : null}
 
+      <TraceShortcutHelper
+        hasMultipleSpans={trace.spans.length > 1}
+        reducedMotion={reducedMotion}
+      />
     </div>
   );
 }

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -730,6 +730,10 @@ function NewTraceViewerContent({
               hoverFraction={hoverFraction}
               altHeld={altHeld}
             />
+            <TraceShortcutHelper
+              hasMultipleSpans={trace.spans.length > 1}
+              reducedMotion={reducedMotion}
+            />
           </div>
         </SplitPane>
         <div className="absolute right-3 bottom-3 z-[5] flex items-center border border-gray-alpha-400 rounded-md bg-background-100 shadow-sm overflow-hidden divide-x divide-gray-alpha-400">
@@ -839,10 +843,6 @@ function NewTraceViewerContent({
         </aside>
       ) : null}
 
-      <TraceShortcutHelper
-        hasMultipleSpans={trace.spans.length > 1}
-        reducedMotion={reducedMotion}
-      />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Left-aligns the "Hold Option to see delta between spans" shortcut hint instead of centering it across the trace viewer.

## Changes

- Replace `left-1/2 -translate-x-1/2` centering with `left-4` on `TraceShortcutHelper`. No structural changes — the component stays where it was.

## Test plan

- [ ] Open a trace with multiple spans in the new trace viewer.
- [ ] Confirm the shortcut hint appears at the bottom-left rather than centered.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e5d6ead-2213-424d-8c21-4dcae33dde25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e5d6ead-2213-424d-8c21-4dcae33dde25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

