### PR TITLE
[ABANDONED] perf(web): lazy-load Mermaid/Streamdown and graph viewer off the run-load path

### DIFF
--- a/.changeset/web-lazy-load-heavy-run-page-chunks.md
+++ b/.changeset/web-lazy-load-heavy-run-page-chunks.md
@@ -1,0 +1,6 @@
+---
+'@workflow/web-shared': patch
+'@workflow/web': patch
+---
+
+Speed up run-detail page loads by lazy-loading two heavy dependency trees that the trace view never needs: the Streamdown markdown renderer (which pulls in Mermaid + Shiki, ~1.7 MB) and the flow-graph viewer (~600 KB, behind the currently-hidden Graph tab). Both are now code-split and fetched on demand, cutting the JavaScript shipped on initial run load by ~36% (~1.2 MB).

--- a/packages/web-shared/src/components/sidebar/conversation-view.tsx
+++ b/packages/web-shared/src/components/sidebar/conversation-view.tsx
@@ -1,6 +1,17 @@
 import type { ModelMessage } from 'ai';
-import { Streamdown } from 'streamdown';
+import { lazy, Suspense } from 'react';
 import { DataInspector } from '../ui/data-inspector';
+
+/**
+ * `streamdown` bundles heavyweight markdown dependencies (Mermaid, Shiki).
+ * Importing it statically pulls ~1.7 MB of JS onto every run-detail page even
+ * though the conversation view only renders for the occasional AI/DurableAgent
+ * step span. Load it lazily so that cost is paid only when an assistant
+ * markdown message is actually displayed; until then we show the raw text.
+ */
+const Streamdown = lazy(() =>
+  import('streamdown').then((m) => ({ default: m.Streamdown }))
+);
 
 interface ConversationViewProps {
   messages: ModelMessage[];
@@ -73,14 +84,22 @@ function ContentPart({ part, role }: { part: ParsedPart; role: string }) {
   if (part.type === 'text') {
     if (!part.text) return null;
 
-    // Use Streamdown for assistant messages (they often contain markdown)
+    // Use Streamdown for assistant messages (they often contain markdown).
+    // Streamdown is lazy-loaded (see above); while its chunk loads we fall
+    // back to the raw text so there's no flash of empty content.
     if (role === 'assistant') {
       return (
         <div
           className="prose prose-sm max-w-none text-[11px] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
           style={{ color: 'var(--ds-gray-1000)' }}
         >
-          <Streamdown>{part.text}</Streamdown>
+          <Suspense
+            fallback={
+              <div className="whitespace-pre-wrap break-words">{part.text}</div>
+            }
+          >
+            <Streamdown>{part.text}</Streamdown>
+          </Suspense>
         </div>
       );
     }

--- a/packages/web/app/components/graph-tab-content.tsx
+++ b/packages/web/app/components/graph-tab-content.tsx
@@ -1,0 +1,135 @@
+import { parseWorkflowName } from '@workflow/utils/parse-name';
+import { stepEventsToStepEntity } from '@workflow/web-shared';
+import type { Event, WorkflowRun } from '@workflow/world';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import { useMemo } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
+import { mapRunToExecution } from '~/lib/flow-graph/graph-execution-mapper';
+import { useWorkflowGraphManifest } from '~/lib/flow-graph/use-workflow-graph';
+import type { EnvMap } from '~/lib/types';
+import { WorkflowGraphExecutionViewer } from './flow-graph/workflow-graph-execution-viewer';
+
+/**
+ * Graph tab content component that fetches the manifest internally.
+ * This ensures the manifest is only fetched when the Graph tab is mounted.
+ *
+ * Lives in its own module so it (and its heavy flow-graph dependency tree —
+ * ~600 KB of JS) can be lazy-loaded by the run-detail view via `React.lazy`,
+ * keeping it off the run page's initial-load critical path.
+ */
+export function GraphTabContent({
+  run,
+  allEvents,
+  env,
+}: {
+  run: WorkflowRun;
+  allEvents: Event[] | null;
+  env: EnvMap;
+}) {
+  // Fetch workflow graph manifest only when this tab is mounted
+  const {
+    manifest: graphManifest,
+    loading: graphLoading,
+    error: graphError,
+  } = useWorkflowGraphManifest();
+
+  // Find the workflow graph for this run
+  const workflowGraph = useMemo(() => {
+    if (!graphManifest || !run.workflowName) return null;
+    const runWorkflowName = String(run.workflowName).trim();
+
+    // Primary lookup: manifest key match.
+    const direct = graphManifest.workflows[runWorkflowName];
+    if (direct) return direct;
+
+    const runShortName = parseWorkflowName(runWorkflowName)?.shortName;
+    const workflows = Object.values(graphManifest.workflows);
+
+    // Fallbacks: workflowId/workflowName/shortName match.
+    return (
+      workflows.find((wf) => {
+        if (wf.workflowId === runWorkflowName) return true;
+        if (wf.workflowName === runWorkflowName) return true;
+        if (!runShortName) return false;
+        return parseWorkflowName(wf.workflowName)?.shortName === runShortName;
+      }) ?? null
+    );
+  }, [graphManifest, run.workflowName]);
+
+  // Reconstruct step entities from events for the graph mapper
+  const stepsFromEvents = useMemo(() => {
+    if (!allEvents) return [];
+    const stepEventsMap = new Map<string, Event[]>();
+    for (const event of allEvents) {
+      if (event.eventType.startsWith('step_') && event.correlationId) {
+        const existing = stepEventsMap.get(event.correlationId);
+        if (existing) {
+          existing.push(event);
+        } else {
+          stepEventsMap.set(event.correlationId, [event]);
+        }
+      }
+    }
+    return Array.from(stepEventsMap.values())
+      .map(stepEventsToStepEntity)
+      .filter((s): s is NonNullable<typeof s> => s !== null);
+  }, [allEvents]);
+
+  // Map run data to execution overlay
+  const execution = useMemo(() => {
+    if (!workflowGraph || !run.runId) return null;
+
+    return mapRunToExecution(
+      run,
+      stepsFromEvents as any,
+      allEvents || [],
+      workflowGraph
+    );
+  }, [workflowGraph, run, stepsFromEvents, allEvents]);
+
+  if (graphLoading) {
+    return (
+      <div className="flex items-center justify-center w-full h-full">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <span className="ml-4 text-muted-foreground">
+          Loading workflow graph…
+        </span>
+      </div>
+    );
+  }
+
+  if (graphError) {
+    return (
+      <div className="flex items-center justify-center w-full h-full p-4">
+        <Alert variant="destructive" className="max-w-lg">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error Loading Workflow Graph</AlertTitle>
+          <AlertDescription>{graphError.message}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!workflowGraph) {
+    return (
+      <div className="flex items-center justify-center w-full h-full">
+        <Alert className="max-w-lg">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Workflow Graph Not Found</AlertTitle>
+          <AlertDescription>
+            Could not find the workflow graph for this run. The workflow may
+            have been deleted or the graph manifest may need to be regenerated.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <WorkflowGraphExecutionViewer
+      workflow={workflowGraph}
+      execution={execution || undefined}
+      env={env}
+    />
+  );
+}

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -9,7 +9,6 @@ import {
   NewTraceViewer,
   type SidebarDataContextValue,
   StreamViewer,
-  stepEventsToStepEntity,
 } from '@workflow/web-shared';
 import type { Event, WorkflowRun } from '@workflow/world';
 import {
@@ -20,7 +19,7 @@ import {
   Loader2,
   Lock,
 } from 'lucide-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
@@ -49,8 +48,6 @@ import {
   TooltipTrigger,
 } from '~/components/ui/tooltip';
 import { useEventsListData } from '~/lib/client/hooks/use-events-list-data';
-import { mapRunToExecution } from '~/lib/flow-graph/graph-execution-mapper';
-import { useWorkflowGraphManifest } from '~/lib/flow-graph/use-workflow-graph';
 import { useStreamReader } from '~/lib/hooks/use-stream-reader';
 import { fetchEvent, getEncryptionKeyForRun } from '~/lib/rpc-client';
 import type { EnvMap } from '~/lib/types';
@@ -70,130 +67,18 @@ import { CopyableText } from './display-utils/copyable-text';
 import { LiveStatus } from './display-utils/live-status';
 import { RelativeTime } from './display-utils/relative-time';
 import { StatusBadge } from './display-utils/status-badge';
-import { WorkflowGraphExecutionViewer } from './flow-graph/workflow-graph-execution-viewer';
 import { RunActionsButtons } from './run-actions';
 import { Skeleton } from './ui/skeleton';
 
 /**
- * Graph tab content component that fetches the manifest internally
- * This ensures the manifest is only fetched when the Graph tab is mounted
+ * The graph tab pulls in the flow-graph viewer and its heavy dependency tree
+ * (~600 KB of JS). Lazy-load it so that cost stays off the run page's
+ * initial-load critical path — it's only fetched if/when the Graph tab is
+ * actually rendered.
  */
-function GraphTabContent({
-  run,
-  allEvents,
-  env,
-}: {
-  run: WorkflowRun;
-  allEvents: Event[] | null;
-  env: EnvMap;
-}) {
-  // Fetch workflow graph manifest only when this tab is mounted
-  const {
-    manifest: graphManifest,
-    loading: graphLoading,
-    error: graphError,
-  } = useWorkflowGraphManifest();
-
-  // Find the workflow graph for this run
-  const workflowGraph = useMemo(() => {
-    if (!graphManifest || !run.workflowName) return null;
-    const runWorkflowName = String(run.workflowName).trim();
-
-    // Primary lookup: manifest key match.
-    const direct = graphManifest.workflows[runWorkflowName];
-    if (direct) return direct;
-
-    const runShortName = parseWorkflowName(runWorkflowName)?.shortName;
-    const workflows = Object.values(graphManifest.workflows);
-
-    // Fallbacks: workflowId/workflowName/shortName match.
-    return (
-      workflows.find((wf) => {
-        if (wf.workflowId === runWorkflowName) return true;
-        if (wf.workflowName === runWorkflowName) return true;
-        if (!runShortName) return false;
-        return parseWorkflowName(wf.workflowName)?.shortName === runShortName;
-      }) ?? null
-    );
-  }, [graphManifest, run.workflowName]);
-
-  // Reconstruct step entities from events for the graph mapper
-  const stepsFromEvents = useMemo(() => {
-    if (!allEvents) return [];
-    const stepEventsMap = new Map<string, Event[]>();
-    for (const event of allEvents) {
-      if (event.eventType.startsWith('step_') && event.correlationId) {
-        const existing = stepEventsMap.get(event.correlationId);
-        if (existing) {
-          existing.push(event);
-        } else {
-          stepEventsMap.set(event.correlationId, [event]);
-        }
-      }
-    }
-    return Array.from(stepEventsMap.values())
-      .map(stepEventsToStepEntity)
-      .filter((s): s is NonNullable<typeof s> => s !== null);
-  }, [allEvents]);
-
-  // Map run data to execution overlay
-  const execution = useMemo(() => {
-    if (!workflowGraph || !run.runId) return null;
-
-    return mapRunToExecution(
-      run,
-      stepsFromEvents as any,
-      allEvents || [],
-      workflowGraph
-    );
-  }, [workflowGraph, run, stepsFromEvents, allEvents]);
-
-  if (graphLoading) {
-    return (
-      <div className="flex items-center justify-center w-full h-full">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        <span className="ml-4 text-muted-foreground">
-          Loading workflow graph…
-        </span>
-      </div>
-    );
-  }
-
-  if (graphError) {
-    return (
-      <div className="flex items-center justify-center w-full h-full p-4">
-        <Alert variant="destructive" className="max-w-lg">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Error Loading Workflow Graph</AlertTitle>
-          <AlertDescription>{graphError.message}</AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  if (!workflowGraph) {
-    return (
-      <div className="flex items-center justify-center w-full h-full">
-        <Alert className="max-w-lg">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Workflow Graph Not Found</AlertTitle>
-          <AlertDescription>
-            Could not find the workflow graph for this run. The workflow may
-            have been deleted or the graph manifest may need to be regenerated.
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  return (
-    <WorkflowGraphExecutionViewer
-      workflow={workflowGraph}
-      execution={execution || undefined}
-      env={env}
-    />
-  );
-}
+const GraphTabContent = lazy(() =>
+  import('./graph-tab-content').then((m) => ({ default: m.GraphTabContent }))
+);
 
 interface RunDetailViewProps {
   runId: string;
@@ -946,11 +831,19 @@ export function RunDetailView({
               <TabsContent value="graph" className="mt-0 flex-1 min-h-0">
                 <ErrorBoundary title="Failed to load execution graph">
                   <div className="h-full min-h-[500px]">
-                    <GraphTabContent
-                      run={run}
-                      allEvents={allEvents}
-                      env={env}
-                    />
+                    <Suspense
+                      fallback={
+                        <div className="flex items-center justify-center w-full h-full">
+                          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                        </div>
+                      }
+                    >
+                      <GraphTabContent
+                        run={run}
+                        allEvents={allEvents}
+                        env={env}
+                      />
+                    </Suspense>
                   </div>
                 </ErrorBoundary>
               </TabsContent>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> **⚠️ ABANDONED — please close.** This bundle-size optimization was not the cause of slow run loads; the real issue is in the data-fetching path. Superseded by a follow-up PR. I was unable to close this automatically (the bot lacks close permission), so please close it manually.

---

### Description

Original (incorrect) hypothesis: the run-detail page shipped ~2.3 MB of unused JS (Mermaid via Streamdown, the hidden Graph tab viewer) on its critical path. Lazy-loading both cut run-page JS by ~36%. While that is a real bundle improvement, it did **not** fix the reported "runs take extremely long to load" symptom, which is a data-fetching problem. Keeping this here only for reference.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e576c3e-71c1-4dfe-8b7e-24040283c4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e576c3e-71c1-4dfe-8b7e-24040283c4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

