### PR TITLE
perf(web): paint trace from a small first events page instead of blocking on 500

### DIFF
--- a/.changeset/web-progressive-trace-event-load.md
+++ b/.changeset/web-progressive-trace-event-load.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Make run-detail trace loading paint faster: the trace render was blocked on fetching the first 500 events in a single `events.list` round-trip, which dominates run-load time over the network. We now fetch a small first page (100 events) to render immediately and fill the rest in the background, cutting time-to-first-trace roughly in half on a typical connection.

--- a/packages/web/app/lib/client/hooks/use-trace-viewer.ts
+++ b/packages/web/app/lib/client/hooks/use-trace-viewer.ts
@@ -7,8 +7,16 @@ import { fetchEvents, fetchRun } from '~/lib/rpc-client';
 import type { EnvMap } from '~/lib/types';
 
 const LIVE_POLL_LIMIT = 100;
-const INITIAL_PAGE_SIZE = 500;
-const LOAD_MORE_PAGE_SIZE = 100;
+// The trace render is gated on this first events page, so keep it small: a
+// run with hundreds of events otherwise blocks first paint on a large, slow
+// `events.list` round-trip (the dominant cost when loading a run over the
+// network). We paint the first page quickly, then keep filling in the
+// background (up to AUTO_LOAD_MAX_EVENTS) and on scroll — neither of which
+// blocks the initial render.
+const INITIAL_PAGE_SIZE = 100;
+// Background/scroll page size. Larger than the initial page so filling up to
+// AUTO_LOAD_MAX_EVENTS after first paint takes few round-trips.
+const LOAD_MORE_PAGE_SIZE = 200;
 const LIVE_UPDATE_INTERVAL_MS = 5000;
 const AUTO_LOAD_MAX_EVENTS = 500;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to the (now-abandoned) bundle-size PR #2626 — that was the wrong layer. This targets the **data-fetching critical path** of loading a run.

#### Root cause

When you open a run, the trace view renders only after `useWorkflowTraceViewerData` resolves its initial fetch, which requests **500 events in a single `events.list` round-trip** (`fetchRun` + `fetchEvents(limit: INITIAL_PAGE_SIZE)` in parallel). `fetchRun` is cheap, so first paint is gated on that one 500-event `events.list`. It's the dominant run-load cost over the network: against a 603-event run it's ~150 KB, and server-side it scales with the number of events fetched. The run header appears quickly (it only needs the run), but the trace area sits on a skeleton until the 500-event page returns.

I verified it is **not** the bundle (#2626 didn't help), **not** HTTP/2 (a controlled undici H1-vs-H2 streamed-response benchmark showed H2 reads are equal/faster), and **not** a client request storm (the load fires a small set of parallel requests). The long pole is simply this one large blocking fetch.

#### Fix

Render the trace from a small first page, then fill the rest in the background — the background auto-load + scroll-load machinery already exists, so first paint just no longer waits for all 500 events:

- `INITIAL_PAGE_SIZE` 500 → **100** (the only fetch that blocks first paint)
- `LOAD_MORE_PAGE_SIZE` 100 → **200** (so the background fill reaches the 500 cap in 2 requests, not 4)
- `AUTO_LOAD_MAX_EVENTS` unchanged (500) — the trace still ends up with the same spans, just loaded progressively and off the critical path.

### How did you test your changes?

Local-world `@workflow/web` production build, headless-Chrome (CDP) harness, against a real 603-event run (`twoHundredStepsWorkflow` workbench example):

| Metric | Before (500) | After (100 + bg) |
| --- | --- | --- |
| Blocking initial `events.list` payload | ~150 KB | **~30 KB** |
| Time-to-first-trace @ 150ms RTT / 1.5 Mbps (median of 5, warm cache) | **~1184 ms** | **~543 ms (≈2.2× faster)** |

- The remaining events still load (RPC trace confirms 100 + 200 + 200 = 500) via 2 non-blocking background fills, so the trace fills to the same span set. Rendering stays virtualized (unchanged).
- `pnpm --filter @workflow/web exec vitest run app/lib/client/hooks/use-trace-viewer.test.ts` → 8/8 pass.

> Note: this reduces the **client/SDK-side** contribution to run-load latency. If `events.list` is *also* slow server-side for very large runs (workflow-server query time), that lives outside this repo — but a smaller first page reduces both the bytes transferred and the server work on the path that gates first paint.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR (`patch` for `@workflow/web`)
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e576c3e-71c1-4dfe-8b7e-24040283c4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e576c3e-71c1-4dfe-8b7e-24040283c4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

