### PR TITLE
perf(web): stop blocking run navigation on per-navigation server round-trips

### DIFF
--- a/.changeset/web-eliminate-blocking-nav-roundtrips.md
+++ b/.changeset/web-eliminate-blocking-nav-roundtrips.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Fix run/detail pages appearing to hang for seconds on navigation. React Router was making two blocking server round-trips before each client navigation could render — a lazy `/__manifest` route-discovery request and a root-loader `.data` request that needlessly re-fetched the static server config every time. These stall the whole page when the dashboard backend is remote or cold. Ship routes eagerly (`routeDiscovery: 'initial'`) and stop revalidating the root config loader on navigation (`shouldRevalidate`), so navigations render immediately and only the page's own data loads afterward.

--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -31,6 +31,17 @@ export async function loader() {
   return { serverConfig };
 }
 
+// The server config is derived from server-side env vars and is effectively
+// static for the lifetime of the server process. Without this, React Router
+// revalidates the root loader on every client navigation, issuing a blocking
+// `.data` round-trip to the (potentially remote/slow) dashboard backend before
+// the destination page can render — which makes the whole page appear to hang
+// for the duration of that request. Load the config once on the initial
+// document load and reuse it for all subsequent client navigations.
+export function shouldRevalidate() {
+  return false;
+}
+
 // Catch-all action: handles stray POST requests (e.g. from Radix UI dialogs
 // that render internal <form method="dialog"> elements).
 export async function action({ request }: { request: Request }) {

--- a/packages/web/react-router.config.ts
+++ b/packages/web/react-router.config.ts
@@ -19,4 +19,10 @@ export default {
   appDirectory: 'app',
   ssr: true,
   presets,
+  // Ship the full route manifest on the initial document load instead of
+  // lazily fetching it per navigation. This app has a handful of routes, so
+  // the manifest is tiny — and lazy discovery otherwise costs a blocking
+  // `/__manifest` round-trip on the first navigation to each route, which
+  // stalls the whole page when the dashboard backend is remote/slow.
+  routeDiscovery: { mode: 'initial' },
 } satisfies Config;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This is the actual cause of "the entire detail page doesn't load for a few seconds" (earlier attempts #2626 bundle size and #2627 events page-size were the wrong layer).

Using a headless-Chrome (CDP) harness I captured what happens on a client navigation from the runs list to a run detail page. **Before the destination page can render, React Router makes two blocking server round-trips:**

1. `GET /__manifest?paths=/run/…` — lazy route discovery ("fog of war").
2. `GET /run/:runId.data` — the **root loader** re-running `getPublicServerConfig()`, even though that config is derived from server env vars and never changes during the server's lifetime.

React Router keeps the *previous* page on screen until both resolve, so the whole page appears frozen for their combined duration. Locally that's ~2× RTT; against a remote or cold-started dashboard backend in production, each of these is easily a second or more — exactly the multi-second hang reported.

#### Fix

Two small config-level changes so navigations don't wait on the network at all:

- **`react-router.config.ts`** — `routeDiscovery: { mode: 'initial' }`. This app has a handful of routes; ship the whole manifest on the initial document load instead of fetching `/__manifest` per navigation.
- **`app/root.tsx`** — add `shouldRevalidate() { return false }`. The root loader still runs once on the initial document load (so SSR/first paint have the config), but it's no longer re-fetched via a blocking `.data` request on every client navigation.

With both routes loader-free and the root loader not revalidating, navigations carry no server data dependency, so React Router renders the destination immediately and the page's own client-side hooks load its data afterward (with the usual skeleton).

### How did you test your changes?

Headless-Chrome CDP harness, local-world `@workflow/web` production build, throttled to 150ms RTT / 1.5 Mbps (warm cache) to surface per-navigation round-trips:

| | Before | After |
| --- | --- | --- |
| home→run SPA nav, time-to-detail-shell | **~339 ms** | **~23 ms** |
| blocking `/__manifest` request | 154 ms | **gone** |
| blocking root-loader `/.data` request | 156 ms | **gone** |
| server requests blocking the nav | 2 | **0** (only cached route assets) |

The absence of the `/__manifest` request after the change confirms `routeDiscovery: 'initial'` is in effect. Full-page loads still SSR with the config (root loader runs on document load). `pnpm --filter @workflow/web exec vitest run app/root.test.tsx` → 4/4 pass.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR (`patch` for `@workflow/web`)
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e576c3e-71c1-4dfe-8b7e-24040283c4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e576c3e-71c1-4dfe-8b7e-24040283c4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

