### PR TITLE
[core] Fix turbo-mode step-body writes racing run_started

### DIFF
--- a/.changeset/turbo-setattr-run-ready.md
+++ b/.changeset/turbo-setattr-run-ready.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix a turbo-mode race where `experimental_setAttributes` called from a step body could be written before the workflow run was created.

--- a/.changeset/turbo-setattr-run-ready.md
+++ b/.changeset/turbo-setattr-run-ready.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Fix a turbo-mode race where `experimental_setAttributes` called from a step body could be written before the workflow run was created.
+Fix a turbo-mode race where step-body writes (`experimental_setAttributes` and stream writes via `getWritable`) could reach the server before the workflow run was created.

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -588,6 +588,13 @@ export async function executeStep(
             preCompletionOps,
             closureVars: hydratedInput.closureVars,
             encryptionKey,
+            // Turbo optimistic start runs this body before `run_started` is
+            // durable. Expose the barrier so a direct step-body world write
+            // (e.g. `experimental_setAttributes`) can order itself after the
+            // run exists. Undefined on the await path (run already durable).
+            runReadyBarrier: optimisticStart
+              ? params.runReadyBarrier
+              : undefined,
           },
           () => stepFn.apply(thisVal, args)
         );

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -615,7 +615,11 @@ export async function executeStep(
           globalThis,
           false,
           false,
-          compression
+          compression,
+          // Turbo optimistic start: a returned stream is piped to the server
+          // after the body but within this same op flush, so gate its first
+          // write on the run-ready barrier. Undefined on the await path.
+          optimisticStart ? params.runReadyBarrier : undefined
         );
         const durationMs = Date.now() - startTime;
         dehydrateSpan?.setAttributes({

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -795,7 +795,16 @@ export function createReconnectingFramedStream(
 const STREAM_FLUSH_INTERVAL_MS = 10;
 
 export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
-  constructor(runId: string, name: string) {
+  /**
+   * @param runReadyBarrier Turbo mode only: a promise that resolves once the
+   * backgrounded `run_started` has landed. When the step body runs
+   * optimistically (before `run_started` is durable), the first chunk write to
+   * a brand-new stream would otherwise reach the World before the run exists
+   * and be rejected as run-not-found. Awaiting this once before the first
+   * flush/close orders the write after the run's creation. `undefined` outside
+   * turbo and on the await path, where the run was already durable.
+   */
+  constructor(runId: string, name: string, runReadyBarrier?: Promise<unknown>) {
     if (typeof runId !== 'string') {
       throw new WorkflowRuntimeError(
         `"runId" must be a string, got "${typeof runId}"`
@@ -805,6 +814,22 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
       throw new WorkflowRuntimeError(`"name" is required, got "${name}"`);
     }
     const worldPromise = getWorldLazy();
+
+    // Hold the first server write until the run exists (turbo optimistic
+    // start). Awaited once, then cleared so later flushes pay nothing. The
+    // rejection is swallowed for ordering only: if `run_started` truly failed
+    // the run does not exist, so the write below surfaces the real error.
+    let pendingRunReady: Promise<unknown> | undefined = runReadyBarrier;
+    const ensureRunReady = async (): Promise<void> => {
+      if (pendingRunReady) {
+        try {
+          await pendingRunReady;
+        } catch {
+          // intentional: ordering barrier only — see above.
+        }
+        pendingRunReady = undefined;
+      }
+    };
 
     // Buffering state for batched writes
     // Encryption/decryption is handled at the framing level by
@@ -821,6 +846,10 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
       }
 
       if (buffer.length === 0) return;
+
+      // Order the first server write after the run exists (turbo optimistic
+      // start); a no-op on every later flush and outside turbo.
+      await ensureRunReady();
 
       // Copy chunks to flush, but don't clear buffer until write succeeds
       // This prevents data loss if the write operation fails
@@ -902,6 +931,10 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
 
         // Flush any remaining buffered chunks
         await flush();
+
+        // A close with an empty buffer skips flush()'s write (and its barrier),
+        // but can itself be the first write to a brand-new stream — gate it too.
+        await ensureRunReady();
 
         const world = await worldPromise;
         await world.streams.close(runId, name);

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1440,7 +1440,12 @@ function getStepReducers(
   ops: Promise<void>[],
   runId: string,
   cryptoKey: EncryptionKeyParam,
-  framedByteStreams = false
+  framedByteStreams = false,
+  // Turbo optimistic start: a returned `ReadableStream` is piped to the server
+  // after the body but within the same op flush, so its first chunk can race
+  // `run_started`. Thread the run-ready barrier into the sink so that write
+  // orders after the run exists. Undefined outside turbo / on the await path.
+  runReadyBarrier?: Promise<unknown>
 ): Partial<Reducers> {
   return {
     ...getAllBaseReducers(global),
@@ -1476,7 +1481,11 @@ function getStepReducers(
         type = getStreamType(value);
         framing = type === 'bytes' && framedByteStreams ? 'framed-v1' : framing;
 
-        const writable = new WorkflowServerWritableStream(runId, name);
+        const writable = new WorkflowServerWritableStream(
+          runId,
+          name,
+          runReadyBarrier
+        );
         if (type === 'bytes') {
           if (framing === 'framed-v1') {
             ops.push(
@@ -1495,7 +1504,8 @@ function getStepReducers(
                     ops,
                     runId,
                     cryptoKey,
-                    framedByteStreams
+                    framedByteStreams,
+                    runReadyBarrier
                   ),
                   cryptoKey
                 )
@@ -2759,12 +2769,23 @@ export async function dehydrateStepReturnValue(
   global: Record<string, any> = globalThis,
   v1Compat = false,
   framedByteStreams = false,
-  compression = false
+  compression = false,
+  // Turbo optimistic start: order the first chunk of a returned stream after
+  // the backgrounded `run_started`. Threaded into the step reducers' stream
+  // sink. Undefined outside turbo / on the await path.
+  runReadyBarrier?: Promise<unknown>
 ): Promise<Uint8Array | unknown> {
   if (v1Compat) {
     const str = stringify(
       value,
-      getStepReducers(global, ops, runId, key, framedByteStreams)
+      getStepReducers(
+        global,
+        ops,
+        runId,
+        key,
+        framedByteStreams,
+        runReadyBarrier
+      )
     );
     return revive(str);
   }
@@ -2773,7 +2794,14 @@ export async function dehydrateStepReturnValue(
     const result = await stepModule.serialize(value, key, {
       global,
       extraReducers: getStreamAndRequestReducers(
-        getStepReducers(global, ops, runId, key, framedByteStreams)
+        getStepReducers(
+          global,
+          ops,
+          runId,
+          key,
+          framedByteStreams,
+          runReadyBarrier
+        )
       ),
       compression,
       compressionStats,

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1211,7 +1211,13 @@ export function getExternalReducers(
   ops: Promise<void>[],
   runId: string,
   cryptoKey: EncryptionKeyParam,
-  framedByteStreams = false
+  framedByteStreams = false,
+  // Turbo optimistic start: a nested `ReadableStream` found while serializing
+  // is piped to its own server stream independently of the outer sink, so its
+  // first chunk can race `run_started`. Thread the run-ready barrier into that
+  // sink so the write orders after the run exists. Undefined outside turbo /
+  // on the await path.
+  runReadyBarrier?: Promise<unknown>
 ): Partial<Reducers> {
   return {
     ...getAllBaseReducers(global),
@@ -1233,7 +1239,11 @@ export function getExternalReducers(
       const name = `strm_${streamId}`;
       const type = getStreamType(value);
 
-      const writable = new WorkflowServerWritableStream(runId, name);
+      const writable = new WorkflowServerWritableStream(
+        runId,
+        name,
+        runReadyBarrier
+      );
       if (type === 'bytes') {
         if (framedByteStreams) {
           ops.push(value.pipeThrough(getByteFramingStream()).pipeTo(writable));
@@ -1250,7 +1260,8 @@ export function getExternalReducers(
                   ops,
                   runId,
                   cryptoKey,
-                  framedByteStreams
+                  framedByteStreams,
+                  runReadyBarrier
                 ),
                 cryptoKey
               )

--- a/packages/core/src/set-attributes.test.ts
+++ b/packages/core/src/set-attributes.test.ts
@@ -110,6 +110,58 @@ describe('experimental_setAttributes (host-side)', () => {
     );
   });
 
+  it('waits for runReadyBarrier before posting the event (turbo optimistic start)', async () => {
+    const order: string[] = [];
+    const create = vi.fn().mockImplementation(async () => {
+      order.push('create');
+      return {};
+    });
+    globals[WORLD_CACHE] = {
+      events: { create },
+    };
+
+    let releaseBarrier!: () => void;
+    const runReadyBarrier = new Promise<void>((resolve) => {
+      releaseBarrier = () => {
+        order.push('barrier');
+        resolve();
+      };
+    });
+
+    const call = contextStorage.run({ ...stepContext(), runReadyBarrier }, () =>
+      experimental_setAttributes({ phase: 'ready' })
+    );
+
+    // The body ran before run_started is durable: the write must not fire yet.
+    await Promise.resolve();
+    expect(create).not.toHaveBeenCalled();
+
+    releaseBarrier();
+    await call;
+
+    // The attr_set create lands strictly after the run-ready barrier resolves.
+    expect(order).toEqual(['barrier', 'create']);
+  });
+
+  it('still posts when the runReadyBarrier rejects (write surfaces the real error)', async () => {
+    const create = vi.fn().mockResolvedValue({});
+    globals[WORLD_CACHE] = {
+      events: { create },
+    };
+
+    const runReadyBarrier = Promise.reject(new Error('run_started failed'));
+    // Pre-attach a catch so the rejection never surfaces as unhandled.
+    runReadyBarrier.catch(() => {});
+
+    await contextStorage.run({ ...stepContext(), runReadyBarrier }, () =>
+      experimental_setAttributes({ phase: 'ready' })
+    );
+
+    // Barrier rejection is swallowed for ordering only — the write still fires
+    // and would surface a genuine run-not-found error from the World itself.
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects validation errors before posting from a step', async () => {
     const create = vi.fn();
     globals[WORLD_CACHE] = {

--- a/packages/core/src/set-attributes.ts
+++ b/packages/core/src/set-attributes.ts
@@ -32,6 +32,20 @@ export async function experimental_setAttributes(
   const changes = normalizeAttributeChanges(attrs, options);
   if (changes.length === 0) return;
 
+  // Turbo optimistic start runs the step body before the backgrounded
+  // `run_started` is durable. Order this `attr_set` after the run exists so it
+  // never reaches the World before the run does (which would be rejected as
+  // run-not-found). A no-op outside turbo (barrier undefined) and on the await
+  // path. The rejection is swallowed for ordering only: if `run_started` truly
+  // failed the run does not exist, so the create below surfaces the real error.
+  if (store.runReadyBarrier) {
+    try {
+      await store.runReadyBarrier;
+    } catch {
+      // intentional: ordering barrier only — see above.
+    }
+  }
+
   const world = await getWorldLazy();
   await world.events.create(runId, {
     eventType: 'attr_set',

--- a/packages/core/src/step/context-storage.ts
+++ b/packages/core/src/step/context-storage.ts
@@ -53,6 +53,16 @@ export type StepContext = {
   closureVars?: Record<string, any>;
   encryptionKey?: CryptoKey;
   writables?: Map<string, CachedWritable>;
+  /**
+   * Turbo mode only: a promise that resolves once the backgrounded
+   * `run_started` has landed (the run exists). Set when the step body runs
+   * optimistically — before `run_started`/`step_started` are confirmed — so a
+   * direct step-body world write (e.g. `experimental_setAttributes`, which
+   * resolves to a host-side `attr_set` create) can gate on it and never race
+   * ahead of the run's creation. `undefined` outside turbo and on the await
+   * path, where `run_started` was already durable before the body ran.
+   */
+  runReadyBarrier?: Promise<unknown>;
 };
 
 /**

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -78,7 +78,18 @@ export function getWritable<W = any>(
   // version skew protection) is on this same SDK version, so byte-stream
   // framing is always safe here.
   const serialize = getSerializeStream(
-    getExternalReducers(globalThis, ctx.ops, runId, ctx.encryptionKey, true),
+    // In turbo optimistic start the body runs before `run_started` is durable.
+    // Thread the run-ready barrier so that a nested ReadableStream written into
+    // this writable is piped to its own server stream only after the run
+    // exists. Undefined outside turbo / on the await path.
+    getExternalReducers(
+      globalThis,
+      ctx.ops,
+      runId,
+      ctx.encryptionKey,
+      true,
+      ctx.runReadyBarrier
+    ),
     ctx.encryptionKey
   );
 

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -86,7 +86,14 @@ export function getWritable<W = any>(
   // their writer lock, not only when the stream is explicitly closed.
   // Without this, Vercel functions hang until the runtime timeout because
   // .pipeTo() only resolves on stream close.
-  const serverWritable = new WorkflowServerWritableStream(runId, name);
+  // In turbo optimistic start the body runs before `run_started` is durable;
+  // pass the run-ready barrier so the first server write orders after the run
+  // exists. Undefined outside turbo / on the await path (run already durable).
+  const serverWritable = new WorkflowServerWritableStream(
+    runId,
+    name,
+    ctx.runReadyBarrier
+  );
   const state = createFlushableState();
   ctx.ops.push(state.promise);
 

--- a/packages/core/src/writable-stream.test.ts
+++ b/packages/core/src/writable-stream.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { WorkflowServerWritableStream } from './serialization.js';
 import { setWorld } from './runtime/world.js';
+import { WorkflowServerWritableStream } from './serialization.js';
 
 describe('WorkflowServerWritableStream', () => {
   let mockStreams: {
@@ -292,6 +292,115 @@ describe('WorkflowServerWritableStream', () => {
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
 
       await writer.close();
+    });
+  });
+
+  describe('runReadyBarrier (turbo optimistic start)', () => {
+    it('holds the first server write until the run-ready barrier resolves', async () => {
+      const order: string[] = [];
+      mockStreams.write.mockImplementation(async () => {
+        order.push('write');
+      });
+
+      let releaseBarrier!: () => void;
+      const runReadyBarrier = new Promise<void>((resolve) => {
+        releaseBarrier = () => {
+          order.push('barrier');
+          resolve();
+        };
+      });
+
+      const stream = new WorkflowServerWritableStream(
+        'run-123',
+        'test-stream',
+        runReadyBarrier
+      );
+      const writer = stream.getWriter();
+      const writePromise = writer.write(new Uint8Array([1, 2, 3]));
+
+      // The body wrote a chunk before run_started is durable: the flush timer
+      // may fire, but the server write must not happen until the run exists.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(mockStreams.write).not.toHaveBeenCalled();
+
+      releaseBarrier();
+      await writePromise;
+
+      // The chunk reaches the server strictly after the barrier resolves.
+      expect(order).toEqual(['barrier', 'write']);
+
+      await writer.close();
+    });
+
+    it('only awaits the barrier once — later flushes are not gated', async () => {
+      const runReadyBarrier = Promise.resolve();
+      const stream = new WorkflowServerWritableStream(
+        'run-123',
+        'test-stream',
+        runReadyBarrier
+      );
+      const writer = stream.getWriter();
+
+      await writer.write(new Uint8Array([1]));
+      await writer.write(new Uint8Array([2]));
+      await writer.write(new Uint8Array([3]));
+
+      expect(mockStreams.write).toHaveBeenCalledTimes(3);
+
+      await writer.close();
+    });
+
+    it('still writes when the barrier rejects (write surfaces the real error)', async () => {
+      const runReadyBarrier = Promise.reject(new Error('run_started failed'));
+      runReadyBarrier.catch(() => {});
+
+      const stream = new WorkflowServerWritableStream(
+        'run-123',
+        'test-stream',
+        runReadyBarrier
+      );
+      const writer = stream.getWriter();
+
+      await writer.write(new Uint8Array([1, 2, 3]));
+
+      // Barrier rejection is swallowed for ordering only — the write still
+      // fires and would surface a genuine run-not-found error from the World.
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+
+      await writer.close();
+    });
+
+    it('gates a close that is itself the first write to a new stream', async () => {
+      const order: string[] = [];
+      mockStreams.close.mockImplementation(async () => {
+        order.push('close');
+      });
+
+      let releaseBarrier!: () => void;
+      const runReadyBarrier = new Promise<void>((resolve) => {
+        releaseBarrier = () => {
+          order.push('barrier');
+          resolve();
+        };
+      });
+
+      const stream = new WorkflowServerWritableStream(
+        'run-123',
+        'test-stream',
+        runReadyBarrier
+      );
+      const writer = stream.getWriter();
+
+      // Close with no chunks written: flush() short-circuits on the empty
+      // buffer, so close() must apply the barrier itself.
+      const closePromise = writer.close();
+      await new Promise((r) => setTimeout(r, 30));
+      expect(mockStreams.close).not.toHaveBeenCalled();
+
+      releaseBarrier();
+      await closePromise;
+
+      expect(order).toEqual(['barrier', 'close']);
     });
   });
 });

--- a/packages/core/src/writable-stream.test.ts
+++ b/packages/core/src/writable-stream.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setWorld } from './runtime/world.js';
-import { WorkflowServerWritableStream } from './serialization.js';
+import {
+  dehydrateStepReturnValue,
+  WorkflowServerWritableStream,
+} from './serialization.js';
 
 describe('WorkflowServerWritableStream', () => {
   let mockStreams: {
@@ -368,6 +371,57 @@ describe('WorkflowServerWritableStream', () => {
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
 
       await writer.close();
+    });
+
+    it('gates the first write of a stream RETURNED from a turbo first step', async () => {
+      // Regression: getWritable()/setAttributes are gated while the step
+      // context is active, but a step that *returns* a fresh ReadableStream
+      // is serialized after the body via dehydrateStepReturnValue(), whose
+      // sink must also wait for run_started before the first chunk lands.
+      const order: string[] = [];
+      mockStreams.write.mockImplementation(async () => {
+        order.push('write');
+      });
+
+      let releaseBarrier!: () => void;
+      const runReadyBarrier = new Promise<void>((resolve) => {
+        releaseBarrier = () => {
+          order.push('barrier');
+          resolve();
+        };
+      });
+
+      const returned = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+
+      const ops: Promise<unknown>[] = [];
+      await dehydrateStepReturnValue(
+        returned,
+        'run-123',
+        undefined, // encryption key
+        ops,
+        globalThis,
+        false, // v1Compat
+        false, // framedByteStreams
+        false, // compression
+        runReadyBarrier
+      );
+
+      // The pipe is queued but must not have written before the run exists.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(mockStreams.write).not.toHaveBeenCalled();
+
+      releaseBarrier();
+      await Promise.all(ops);
+
+      // The returned stream's first chunk reaches the server only after the
+      // run-ready barrier resolves.
+      expect(order[0]).toBe('barrier');
+      expect(mockStreams.write).toHaveBeenCalled();
     });
 
     it('gates a close that is itself the first write to a new stream', async () => {


### PR DESCRIPTION
## Problem

In turbo mode the first step's body runs **optimistically** — before the backgrounded `run_started` event is durable. Direct step-body world writes had no ordering gate, so they could reach the server **before the run existed**. Two such paths:

1. **`experimental_setAttributes`** (host-side) wrote its `attr_set` event directly.
2. **`getWritable()` stream writes** flushed chunks directly. The first chunk of a brand-new stream requires the run to exist (the World does a run lookup on stream creation), so an early write could be rejected as run-not-found — failing the step, or silently dropping the chunk if the rejection lands after the step's op-flush timeout.

The workflow-side `experimental_setAttributes` path (a `"use workflow"` body) was already gated on the run-ready barrier in the suspension handler. Only the **step-body** paths were unguarded. (Step-initiated aborts write directly too, but they require a pre-existing hook, which disables turbo's forced optimistic start — so they can't race.)

## Fix

Thread the run-ready barrier through the step execution context and await it before the first direct step-body write:

- `step/context-storage.ts` — add `runReadyBarrier?: Promise<unknown>` to `StepContext`.
- `runtime/step-executor.ts` — populate it only on the optimistic-start path; `undefined` on the await path (run already durable).
- `set-attributes.ts` — `await` the barrier before the `attr_set` create.
- `serialization.ts` (`WorkflowServerWritableStream`) — accept the barrier; await it once before the first flush write **and** before `close` (a close with an empty buffer can itself be the first write to a new stream).
- `step/writable-stream.ts` — pass `ctx.runReadyBarrier` into the stream.

In every case the rejection is swallowed for ordering only — a genuinely failed `run_started` then surfaces the real error from the write itself, mirroring the workflow-side `ensureRunReady` behavior. All gates are no-ops outside turbo and on the await path.

## Tests

- `set-attributes.test.ts` — the `attr_set` write fires strictly after the barrier resolves; a rejecting barrier still writes.
- `writable-stream.test.ts` — the first server write/close waits for the barrier; later flushes aren't re-gated; a rejecting barrier still writes.

Typecheck + `step-handler` / `set-attributes` / `serialization` / `writable-stream` / `flushable-stream` suites pass. (world-local has no run-existence check on stream writes, so the stream race is Vercel-only; the unit tests gate against a fake World that models the server contract.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)