### PR TITLE
docs: clarify cross-deployment key resolution

### DIFF
--- a/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
@@ -35,18 +35,7 @@ Common causes, in rough order of likelihood:
 2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
 3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
 
-When custom observability code reads a run across deployments, load the run metadata first and pass its originating deployment to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
-
-```typescript lineNumbers
-import { getWorld } from "workflow/runtime";
-declare const runId: string; // @setup
-
-const world = await getWorld();
-const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(runId, {
-  deploymentId: run.deploymentId,
-});
-```
+When custom observability code reads a run across deployments, resolve the run and pass it to `getEncryptionKeyForRun(run)`. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
 
 ## What To Do
 

--- a/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
@@ -35,9 +35,20 @@ Common causes, in rough order of likelihood:
 2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
 3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
 
+When custom observability code reads a run across deployments, load the run metadata first and pass the run entity to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
+
+```typescript lineNumbers
+import { getWorld } from "workflow/runtime";
+declare const runId: string; // @setup
+
+const world = await getWorld();
+const run = await world.runs.get(runId, { resolveData: "none" });
+const key = await world.getEncryptionKeyForRun?.(run);
+```
+
 ## What To Do
 
-This error indicates an SDK or infrastructure problem — not a bug in your workflow code. Your workflow code does not need to change.
+In SDK-managed execution, this error indicates an SDK or infrastructure problem — not a bug in your workflow code. If it came from custom observability code, verify the key-resolution context above before reporting it.
 
 ### 1. Upgrade to the latest `workflow` package
 

--- a/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v4/errors/runtime-decryption-failed.mdx
@@ -35,7 +35,7 @@ Common causes, in rough order of likelihood:
 2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
 3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
 
-When custom observability code reads a run across deployments, load the run metadata first and pass the run entity to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
+When custom observability code reads a run across deployments, load the run metadata first and pass its originating deployment to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
 
 ```typescript lineNumbers
 import { getWorld } from "workflow/runtime";
@@ -43,7 +43,9 @@ declare const runId: string; // @setup
 
 const world = await getWorld();
 const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(run);
+const key = await world.getEncryptionKeyForRun?.(runId, {
+  deploymentId: run.deploymentId,
+});
 ```
 
 ## What To Do

--- a/docs/content/docs/v4/how-it-works/encryption.mdx
+++ b/docs/content/docs/v4/how-it-works/encryption.mdx
@@ -93,22 +93,7 @@ getEncryptionKeyForRun?(
 ): Promise<Uint8Array | undefined>;
 ```
 
-Use `getEncryptionKeyForRun(run)` when the run entity already exists. Use `getEncryptionKeyForRun(runId, context?)` in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
-
-<Callout type="warning">
-  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass its originating deployment as context:
-</Callout>
-
-```typescript lineNumbers
-import { getWorld } from "workflow/runtime";
-declare const runId: string; // @setup
-
-const world = await getWorld();
-const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(runId, {
-  deploymentId: run.deploymentId,
-});
-```
+Use `getEncryptionKeyForRun(run)` when the run entity already exists, especially when reading a run that may have been created by another deployment. The run carries its originating deployment context. Calling `getEncryptionKeyForRun(runId)` without context instead assumes the current deployment and can derive a different key. Use `getEncryptionKeyForRun(runId, context?)` only in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
 
 To add encryption support to a custom `World`:
 

--- a/docs/content/docs/v4/how-it-works/encryption.mdx
+++ b/docs/content/docs/v4/how-it-works/encryption.mdx
@@ -95,6 +95,19 @@ getEncryptionKeyForRun?(
 
 Use `getEncryptionKeyForRun(run)` when the run entity already exists. Use `getEncryptionKeyForRun(runId, context?)` in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
 
+<Callout type="warning">
+  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass the run entity instead:
+</Callout>
+
+```typescript lineNumbers
+import { getWorld } from "workflow/runtime";
+declare const runId: string; // @setup
+
+const world = await getWorld();
+const run = await world.runs.get(runId, { resolveData: "none" });
+const key = await world.getEncryptionKeyForRun?.(run);
+```
+
 To add encryption support to a custom `World`:
 
 1. Implement `getEncryptionKeyForRun()` on your `World` class, handling both call shapes

--- a/docs/content/docs/v4/how-it-works/encryption.mdx
+++ b/docs/content/docs/v4/how-it-works/encryption.mdx
@@ -96,7 +96,7 @@ getEncryptionKeyForRun?(
 Use `getEncryptionKeyForRun(run)` when the run entity already exists. Use `getEncryptionKeyForRun(runId, context?)` in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
 
 <Callout type="warning">
-  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass the run entity instead:
+  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass its originating deployment as context:
 </Callout>
 
 ```typescript lineNumbers
@@ -105,7 +105,9 @@ declare const runId: string; // @setup
 
 const world = await getWorld();
 const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(run);
+const key = await world.getEncryptionKeyForRun?.(runId, {
+  deploymentId: run.deploymentId,
+});
 ```
 
 To add encryption support to a custom `World`:

--- a/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
@@ -35,18 +35,7 @@ Common causes, in rough order of likelihood:
 2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
 3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
 
-When custom observability code reads a run across deployments, load the run metadata first and pass its originating deployment to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
-
-```typescript lineNumbers
-import { getWorld } from "workflow/runtime";
-declare const runId: string; // @setup
-
-const world = await getWorld();
-const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(runId, {
-  deploymentId: run.deploymentId,
-});
-```
+When custom observability code reads a run across deployments, resolve the run and pass it to `getEncryptionKeyForRun(run)`. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
 
 ## What To Do
 

--- a/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
@@ -35,9 +35,20 @@ Common causes, in rough order of likelihood:
 2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
 3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
 
+When custom observability code reads a run across deployments, load the run metadata first and pass the run entity to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
+
+```typescript lineNumbers
+import { getWorld } from "workflow/runtime";
+declare const runId: string; // @setup
+
+const world = await getWorld();
+const run = await world.runs.get(runId, { resolveData: "none" });
+const key = await world.getEncryptionKeyForRun?.(run);
+```
+
 ## What To Do
 
-This error indicates an SDK or infrastructure problem — not a bug in your workflow code. Your workflow code does not need to change.
+In SDK-managed execution, this error indicates an SDK or infrastructure problem — not a bug in your workflow code. If it came from custom observability code, verify the key-resolution context above before reporting it.
 
 ### 1. Upgrade to the latest `workflow` package
 

--- a/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
+++ b/docs/content/docs/v5/errors/runtime-decryption-failed.mdx
@@ -35,7 +35,7 @@ Common causes, in rough order of likelihood:
 2. **Key resolution mismatch.** The key used to decrypt is not the key that was used to encrypt — e.g. the run's `deploymentId` was not threaded through key resolution and the SDK fell back to the wrong deployment's key material.
 3. **Malformed encrypted envelope.** The envelope is too short to contain the GCM nonce (12 bytes) and auth tag (16 bytes), so decryption is rejected before it begins.
 
-When custom observability code reads a run across deployments, load the run metadata first and pass the run entity to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
+When custom observability code reads a run across deployments, load the run metadata first and pass its originating deployment to key resolution. Calling `getEncryptionKeyForRun(runId)` without context assumes the current deployment.
 
 ```typescript lineNumbers
 import { getWorld } from "workflow/runtime";
@@ -43,7 +43,9 @@ declare const runId: string; // @setup
 
 const world = await getWorld();
 const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(run);
+const key = await world.getEncryptionKeyForRun?.(runId, {
+  deploymentId: run.deploymentId,
+});
 ```
 
 ## What To Do

--- a/docs/content/docs/v5/how-it-works/encryption.mdx
+++ b/docs/content/docs/v5/how-it-works/encryption.mdx
@@ -93,22 +93,7 @@ getEncryptionKeyForRun?(
 ): Promise<Uint8Array | undefined>;
 ```
 
-Use `getEncryptionKeyForRun(run)` when the run entity already exists. Use `getEncryptionKeyForRun(runId, context?)` in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
-
-<Callout type="warning">
-  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass its originating deployment as context:
-</Callout>
-
-```typescript lineNumbers
-import { getWorld } from "workflow/runtime";
-declare const runId: string; // @setup
-
-const world = await getWorld();
-const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(runId, {
-  deploymentId: run.deploymentId,
-});
-```
+Use `getEncryptionKeyForRun(run)` when the run entity already exists, especially when reading a run that may have been created by another deployment. The run carries its originating deployment context. Calling `getEncryptionKeyForRun(runId)` without context instead assumes the current deployment and can derive a different key. Use `getEncryptionKeyForRun(runId, context?)` only in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
 
 To add encryption support to a custom `World`:
 

--- a/docs/content/docs/v5/how-it-works/encryption.mdx
+++ b/docs/content/docs/v5/how-it-works/encryption.mdx
@@ -95,6 +95,19 @@ getEncryptionKeyForRun?(
 
 Use `getEncryptionKeyForRun(run)` when the run entity already exists. Use `getEncryptionKeyForRun(runId, context?)` in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
 
+<Callout type="warning">
+  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass the run entity instead:
+</Callout>
+
+```typescript lineNumbers
+import { getWorld } from "workflow/runtime";
+declare const runId: string; // @setup
+
+const world = await getWorld();
+const run = await world.runs.get(runId, { resolveData: "none" });
+const key = await world.getEncryptionKeyForRun?.(run);
+```
+
 To add encryption support to a custom `World`:
 
 1. Implement `getEncryptionKeyForRun()` on your `World` class, handling both call shapes

--- a/docs/content/docs/v5/how-it-works/encryption.mdx
+++ b/docs/content/docs/v5/how-it-works/encryption.mdx
@@ -96,7 +96,7 @@ getEncryptionKeyForRun?(
 Use `getEncryptionKeyForRun(run)` when the run entity already exists. Use `getEncryptionKeyForRun(runId, context?)` in runtime paths like `start()` where the run has not been created yet but the world may still need context such as `deploymentId`.
 
 <Callout type="warning">
-  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass the run entity instead:
+  When reading an existing run that may have been created by another deployment, do not call `getEncryptionKeyForRun(runId)` without context. Omitting the context tells the World to assume the current deployment, which can derive a different key. Load the run without resolving its encrypted data and pass its originating deployment as context:
 </Callout>
 
 ```typescript lineNumbers
@@ -105,7 +105,9 @@ declare const runId: string; // @setup
 
 const world = await getWorld();
 const run = await world.runs.get(runId, { resolveData: "none" });
-const key = await world.getEncryptionKeyForRun?.(run);
+const key = await world.getEncryptionKeyForRun?.(runId, {
+  deploymentId: run.deploymentId,
+});
 ```
 
 To add encryption support to a custom `World`:


### PR DESCRIPTION
## Summary

- document that `getEncryptionKeyForRun(runId)` assumes the current deployment when no context is provided
- show how custom observability readers can load run metadata with `resolveData: "none"` and pass the full run entity
- add the same recovery guidance to the runtime decryption error page

Closes #2245.

## Validation

- targeted documentation sample type-check: 8 passed
- `git diff --check`

## Docs Preview

| Page | v4 | v5 |
| --- | --- | --- |
| Encryption | [Preview](https://workflow-docs-git-codex-docs-cross-deployment-encryption.vercel.sh/docs/how-it-works/encryption#custom-world-implementations) | [Preview](https://workflow-docs-git-codex-docs-cross-deployment-encryption.vercel.sh/v5/docs/how-it-works/encryption#custom-world-implementations) |
| Runtime decryption failed | [Preview](https://workflow-docs-git-codex-docs-cross-deployment-encryption.vercel.sh/docs/errors/runtime-decryption-failed#why-this-happens) | [Preview](https://workflow-docs-git-codex-docs-cross-deployment-encryption.vercel.sh/v5/docs/errors/runtime-decryption-failed#why-this-happens) |
