### PR TITLE
[world-vercel] Unify HTTP request handling into a shared core

### DIFF
--- a/.changeset/world-vercel-http-core.md
+++ b/.changeset/world-vercel-http-core.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Unify world-vercel HTTP request handling into a shared core and extend OTEL client spans + debug logging to the v4 events, stream, and Vercel-API request paths.

--- a/packages/world-vercel/src/encryption.ts
+++ b/packages/world-vercel/src/encryption.ts
@@ -11,10 +11,10 @@
  */
 
 import { webcrypto } from 'node:crypto';
-import { getVercelOidcToken } from '@vercel/oidc';
 import type { WorkflowRun, World } from '@workflow/world';
 import * as z from 'zod';
 import { getDispatcher } from './http-client.js';
+import { instrumentedFetch, resolveVercelApiToken } from './http-core.js';
 
 const KEY_BYTES = 32; // 256 bits = 32 bytes (AES-256)
 
@@ -101,14 +101,7 @@ export async function fetchRunKey(
     dispatcher?: unknown;
   }
 ): Promise<Uint8Array | undefined> {
-  // Authenticate via provided token (CLI/config), VERCEL_TOKEN env var
-  // (external tooling), or OIDC token (runtime) — in that order.
-  // OIDC is last to avoid an unnecessary network call when a token is
-  // already available (e.g. CLI or CI contexts).
-  const token =
-    options?.token ??
-    process.env.VERCEL_TOKEN ??
-    (await getVercelOidcToken().catch(() => null));
+  const token = await resolveVercelApiToken({ token: options?.token });
   if (!token) {
     throw new Error(
       'Cannot fetch run key: no OIDC token or VERCEL_TOKEN available'
@@ -119,30 +112,30 @@ export async function fetchRunKey(
   if (options?.teamId) {
     params.set('teamId', options.teamId);
   }
-  // 429/5xx retries are handled by the shared RetryAgent from getDispatcher()
-  const response = await fetch(
-    `https://api.vercel.com/v1/workflow/run-key/${deploymentId}?${params}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      // @ts-expect-error -- undici dispatcher is accepted by Node.js fetch but not in @types/node's RequestInit
-      dispatcher: getDispatcher({ dispatcher: options?.dispatcher }),
-    }
-  );
-
-  if (!response.ok) {
-    let body: string;
-    try {
-      body = await response.text();
-    } catch {
-      body = '<unable to read response body>';
-    }
-    throw new Error(
-      `Failed to fetch run key for ${runId} (deployment ${deploymentId}): HTTP ${response.status} ${response.statusText}${body ? ` — ${body}` : ''}`
-    );
-  }
+  // 429/5xx retries are handled by the shared RetryAgent from getDispatcher().
+  // instrumentedFetch adds the OTEL client span + DEBUG logging the v3/v4
+  // paths have.
+  const response = await instrumentedFetch({
+    method: 'GET',
+    url: `https://api.vercel.com/v1/workflow/run-key/${deploymentId}?${params}`,
+    headers: new Headers({ Authorization: `Bearer ${token}` }),
+    dispatcher: getDispatcher({ dispatcher: options?.dispatcher }),
+    peerService: 'vercel-api',
+    // Preserve the prior no-timeout behavior for this Vercel-API call; the
+    // shared RetryAgent still handles transient/5xx retries.
+    timeoutMs: null,
+    buildError: async (res) => {
+      let body: string;
+      try {
+        body = await res.text();
+      } catch {
+        body = '<unable to read response body>';
+      }
+      return new Error(
+        `Failed to fetch run key for ${runId} (deployment ${deploymentId}): HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`
+      );
+    },
+  });
 
   const data = await response.json();
   const result = z.object({ key: z.string().nullable() }).safeParse(data);

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -21,62 +21,62 @@
  * bytes — this module stays at the wire-bytes layer.
  */
 
-import {
-  EntityConflictError,
-  RunExpiredError,
-  ThrottleError,
-  TooEarlyError,
-  WorkflowWorldError,
-} from '@workflow/errors';
 import { decode } from 'cbor-x';
 import { decodeFrames, encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { getEventsDispatcher } from './http-client.js';
-import { injectTraceContextIntoHeaders } from './telemetry.js';
+import {
+  errorForResponse,
+  instrumentedFetch,
+  parseRetryAfter,
+} from './http-core.js';
 import { type APIConfig, getHttpConfig } from './utils.js';
 
 /**
- * Issue a v4 request through the global `fetch` — NOT undici's `request`.
+ * Issue an instrumented v4 request through the global `fetch` — NOT undici's
+ * `request`.
  *
  * Vercel's observability "outgoing requests" view instruments the global
  * `fetch`. Calling `undici.request()` directly bypasses that instrumentation,
  * so v4 event traffic disappeared from the log viewer while queue traffic
- * (which uses `fetch`) kept showing. Routing through `fetch` with the same
- * custom undici dispatcher restores visibility. The dispatcher itself does
- * not affect instrumentation — the v3 `makeRequest` path has always passed
- * one (see utils.ts) and stayed visible.
+ * (which uses `fetch`) kept showing. `instrumentedFetch` routes through the
+ * global `fetch` with the custom dispatcher, restoring visibility while also
+ * opening the OTEL client span, injecting trace context, setting the
+ * cache-bust header (see #618), and emitting `DEBUG` logs — the same envelope
+ * the v3 `makeRequest` path has always had.
  *
  * The events API uses its own HTTP/2-enabled dispatcher
  * (`getEventsDispatcher`): these reads/writes are plain request/response (or a
  * streamed LIST response) and benefit from multiplexing. The default dispatcher
  * stays on HTTP/1.1 because H2 deadlocks the queue's webhook respondWith
  * mechanism — see http-client.ts.
+ *
+ * No per-request timeout: a LIST response streams the full event-log page, which
+ * for a large run can legitimately take a while to drain — a whole-request
+ * deadline would abort it mid-stream.
  */
 async function fetchV4(
   url: string,
   init: { method: string; headers: Headers; body?: Uint8Array },
-  config: APIConfig | undefined
+  config: APIConfig | undefined,
+  opName: string
 ): Promise<Response> {
-  // Set a unique header per request to bypass Next.js fetch memoization /
-  // Data Cache. Routing through the global `fetch` (above) re-exposes these
-  // reads to that caching — without busting it, an identical event read could
-  // be served a stale or truncated cached page and silently drop events,
-  // breaking replay correctness. The v3 `makeRequest` path does the same.
-  // See: https://github.com/vercel/workflow/issues/618
-  init.headers.set('X-Request-Time', Date.now().toString());
-  // Explicitly propagate the active trace context (traceparent / tracestate /
-  // baggage) onto the outgoing request so workflow-server can parent its spans
-  // to this invocation — matching the v3 `makeRequest` path (see utils.ts).
-  // The custom undici dispatcher bypasses ambient auto-instrumentation, so
-  // without this v4 event traffic from the flow route would not propagate
-  // context to workflow-server. No-ops when no OTEL SDK is registered.
-  await injectTraceContextIntoHeaders(init.headers);
-  return fetch(url, {
+  return instrumentedFetch({
     method: init.method,
+    url,
     headers: init.headers,
     body: init.body,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
     dispatcher: getEventsDispatcher(config),
-  } as any);
+    timeoutMs: null,
+    logLabel: opName,
+    buildError: async (response) =>
+      errorFromV4Response(
+        response.status,
+        headersToRecord(response.headers),
+        await response.text(),
+        opName,
+        url
+      ),
+  });
 }
 
 /** Flatten a fetch `Headers` into the record shape throwForErrorResponse
@@ -230,27 +230,21 @@ function buildPostFrameMeta(
 }
 
 /**
- * Map a non-2xx response to the same typed-error contract the v3 client's
- * `makeRequest` used. The runtime branches on these types for core control
- * flow, so v4 must preserve every mapping:
- *
- *   - 409 → EntityConflictError (start() dedupe, terminal-state transitions)
- *   - 410 → RunExpiredError (runtime exits without retrying)
- *   - 425 → TooEarlyError + retryAfter (step retry pacing — see #1806 for
- *     what happens when a 425 degrades into an untyped error)
- *   - 429 → ThrottleError + retryAfter
- *   - anything else → WorkflowWorldError with `status` (the hook 404 →
- *     HookNotFoundError translation in events.ts keys off status === 404)
- *
- * Exported for unit tests.
+ * Build the typed error for a non-2xx v4 response. Reuses the shared
+ * `errorForResponse` status → error-type contract (409→EntityConflictError,
+ * 410→RunExpiredError, 425→TooEarlyError, 429→ThrottleError, else
+ * →WorkflowWorldError) so v3 and v4 stay in lockstep — only the message
+ * *string* is v4-specific (`v4 {opName} failed: HTTP …`, which the runtime and
+ * log tooling key on; the hook 404 → HookNotFoundError translation in events.ts
+ * keys off status === 404).
  */
-export function throwForErrorResponse(
+function errorFromV4Response(
   statusCode: number,
   responseHeaders: Record<string, string | string[] | undefined>,
   errorBody: string,
   opName: string,
   url: string
-): never {
+): Error {
   let message = `v4 ${opName} failed: HTTP ${statusCode}`;
   let code: string | undefined;
   try {
@@ -262,24 +256,30 @@ export function throwForErrorResponse(
     if (errorBody) message += ` ${errorBody}`;
   }
 
-  // Retry-After response header (seconds). Used by 425 and 429.
-  let retryAfter: number | undefined;
-  const retryAfterHeader = readHeader(responseHeaders, 'retry-after');
-  if (retryAfterHeader) {
-    const parsed = parseInt(retryAfterHeader, 10);
-    if (!Number.isNaN(parsed)) retryAfter = parsed;
-  }
+  const retryAfter = parseRetryAfter(
+    readHeader(responseHeaders, 'retry-after')
+  );
+  return errorForResponse(statusCode, message, { retryAfter, code, url });
+}
 
-  if (statusCode === 409) throw new EntityConflictError(message);
-  if (statusCode === 410) throw new RunExpiredError(message);
-  if (statusCode === 425) throw new TooEarlyError(message, { retryAfter });
-  if (statusCode === 429) throw new ThrottleError(message, { retryAfter });
-  throw new WorkflowWorldError(message, {
-    status: statusCode,
-    code,
-    url,
-    retryAfter,
-  });
+/**
+ * Throwing wrapper around `errorFromV4Response`. Exported for unit tests; the
+ * request paths throw via `instrumentedFetch`'s `buildError`.
+ */
+export function throwForErrorResponse(
+  statusCode: number,
+  responseHeaders: Record<string, string | string[] | undefined>,
+  errorBody: string,
+  opName: string,
+  url: string
+): never {
+  throw errorFromV4Response(
+    statusCode,
+    responseHeaders,
+    errorBody,
+    opName,
+    url
+  );
 }
 
 /**
@@ -314,18 +314,9 @@ export async function createWorkflowRunEventV4(
   const response = await fetchV4(
     url,
     { method: 'POST', headers, body: frame },
-    config
+    config,
+    'createEvent'
   );
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throwForErrorResponse(
-      response.status,
-      headersToRecord(response.headers),
-      errorBody,
-      'createEvent',
-      url
-    );
-  }
 
   const eventId = response.headers.get(V4_RESPONSE_HEADERS.eventId);
   const runId = response.headers.get(V4_RESPONSE_HEADERS.runId);
@@ -395,17 +386,12 @@ export async function getEventV4(
   const { baseUrl, headers } = await getHttpConfig(config);
 
   const url = `${baseUrl}/v4/runs/${encodeURIComponent(runId)}/events/${encodeURIComponent(eventId)}`;
-  const response = await fetchV4(url, { method: 'GET', headers }, config);
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throwForErrorResponse(
-      response.status,
-      headersToRecord(response.headers),
-      errorBody,
-      'getEvent',
-      url
-    );
-  }
+  const response = await fetchV4(
+    url,
+    { method: 'GET', headers },
+    config,
+    'getEvent'
+  );
   const contentType = response.headers.get('content-type');
   if (!contentType?.startsWith(V4_FRAME_CONTENT_TYPE)) {
     throw new Error(
@@ -488,17 +474,12 @@ async function consumeListFrameStream(
   config: APIConfig | undefined,
   opName: string
 ): Promise<ListEventsV4Result> {
-  const response = await fetchV4(url, { method: 'GET', headers }, config);
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throwForErrorResponse(
-      response.status,
-      headersToRecord(response.headers),
-      errorBody,
-      opName,
-      url
-    );
-  }
+  const response = await fetchV4(
+    url,
+    { method: 'GET', headers },
+    config,
+    opName
+  );
   const contentType = response.headers.get('content-type');
   if (!contentType?.startsWith(V4_FRAME_CONTENT_TYPE)) {
     throw new Error(

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -107,8 +107,16 @@ export function getStreamDispatcher(config?: APIConfig): unknown {
   return config?.dispatcher ?? getDefaultStreamDispatcher();
 }
 
+/** Build a shared undici RetryAgent wrapping an Agent with the given options. */
+function makeRetryDispatcher(
+  agentOptions: typeof DEFAULT_AGENT_OPTIONS | typeof EVENTS_AGENT_OPTIONS,
+  retryOptions: RetryHandler.RetryOptions
+): RetryAgent {
+  return new RetryAgent(new Agent(agentOptions), retryOptions);
+}
+
 /**
- * Returns a shared undici RetryAgent wrapping an Agent.
+ * Returns the shared default RetryAgent.
  *
  * - HTTP/1.1 (see DEFAULT_AGENT_OPTIONS)
  * - Connection pooling (up to 8 connections per origin)
@@ -116,12 +124,10 @@ export function getStreamDispatcher(config?: APIConfig): unknown {
  *   - Observes Retry-After header if received and lower than 30s
  */
 function getDefaultDispatcher(): RetryAgent {
-  if (!_dispatcher) {
-    _dispatcher = new RetryAgent(
-      new Agent(DEFAULT_AGENT_OPTIONS),
-      RETRY_AGENT_OPTIONS
-    );
-  }
+  _dispatcher ??= makeRetryDispatcher(
+    DEFAULT_AGENT_OPTIONS,
+    RETRY_AGENT_OPTIONS
+  );
   return _dispatcher;
 }
 
@@ -130,12 +136,10 @@ function getDefaultDispatcher(): RetryAgent {
  * pooling behavior as the default dispatcher, but with `allowH2` enabled.
  */
 function getDefaultEventsDispatcher(): RetryAgent {
-  if (!_eventsDispatcher) {
-    _eventsDispatcher = new RetryAgent(
-      new Agent(EVENTS_AGENT_OPTIONS),
-      RETRY_AGENT_OPTIONS
-    );
-  }
+  _eventsDispatcher ??= makeRetryDispatcher(
+    EVENTS_AGENT_OPTIONS,
+    RETRY_AGENT_OPTIONS
+  );
   return _eventsDispatcher;
 }
 
@@ -152,11 +156,9 @@ function getDefaultEventsDispatcher(): RetryAgent {
  * events agent's H2 / pooling options.
  */
 function getDefaultStreamDispatcher(): RetryAgent {
-  if (!_streamDispatcher) {
-    _streamDispatcher = new RetryAgent(
-      new Agent(EVENTS_AGENT_OPTIONS),
-      STREAM_RETRY_OPTIONS
-    );
-  }
+  _streamDispatcher ??= makeRetryDispatcher(
+    EVENTS_AGENT_OPTIONS,
+    STREAM_RETRY_OPTIONS
+  );
   return _streamDispatcher;
 }

--- a/packages/world-vercel/src/http-core.test.ts
+++ b/packages/world-vercel/src/http-core.test.ts
@@ -1,0 +1,125 @@
+import {
+  EntityConflictError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  errorForResponse,
+  formatVercelDiagnostics,
+  getVercelDiagnostics,
+  parseRetryAfter,
+  resolveVercelApiToken,
+} from './http-core.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn().mockRejectedValue(new Error('no OIDC')),
+}));
+
+describe('errorForResponse', () => {
+  // The runtime branches on these typed errors for core control flow, so the
+  // v3 and v4 paths must map status codes to the same types — this is the
+  // single source they both delegate to.
+  it('maps 409 to EntityConflictError', () => {
+    expect(errorForResponse(409, 'boom')).toBeInstanceOf(EntityConflictError);
+  });
+
+  it('maps 410 to RunExpiredError', () => {
+    expect(errorForResponse(410, 'boom')).toBeInstanceOf(RunExpiredError);
+  });
+
+  it('maps 425 to TooEarlyError carrying retryAfter', () => {
+    const err = errorForResponse(425, 'too early', { retryAfter: 7 });
+    expect(err).toBeInstanceOf(TooEarlyError);
+    expect((err as TooEarlyError).retryAfter).toBe(7);
+  });
+
+  it('maps 429 to ThrottleError carrying retryAfter', () => {
+    const err = errorForResponse(429, 'slow down', { retryAfter: 30 });
+    expect(err).toBeInstanceOf(ThrottleError);
+    expect((err as ThrottleError).retryAfter).toBe(30);
+  });
+
+  it('maps other statuses to WorkflowWorldError with status/code', () => {
+    const err = errorForResponse(404, 'not found', {
+      code: 'not_found',
+      url: 'http://x',
+    });
+    expect(err).toBeInstanceOf(WorkflowWorldError);
+    expect((err as WorkflowWorldError).status).toBe(404);
+    expect((err as WorkflowWorldError).code).toBe('not_found');
+    expect(err.message).toBe('not found');
+  });
+
+  it('treats 5xx as WorkflowWorldError (retryable, not a typed terminal)', () => {
+    const err = errorForResponse(503, 'unavailable');
+    expect(err).toBeInstanceOf(WorkflowWorldError);
+    expect((err as WorkflowWorldError).status).toBe(503);
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('parses integer seconds', () => {
+    expect(parseRetryAfter('30')).toBe(30);
+  });
+
+  it('returns undefined for missing or non-numeric values', () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+    expect(parseRetryAfter('')).toBeUndefined();
+    expect(parseRetryAfter('soon')).toBeUndefined();
+  });
+});
+
+describe('vercel diagnostics', () => {
+  function headers(init: Record<string, string>): Headers {
+    return new Headers(init);
+  }
+
+  it('extracts x-vercel-id and x-vercel-error when present', () => {
+    const h = headers({
+      'x-vercel-id': 'sfo1::abc',
+      'x-vercel-error': 'FUNCTION_INVOCATION_FAILED',
+    });
+    expect(getVercelDiagnostics(h)).toEqual([
+      'x-vercel-id=sfo1::abc',
+      'x-vercel-error=FUNCTION_INVOCATION_FAILED',
+    ]);
+    expect(formatVercelDiagnostics(h)).toBe(
+      ' (x-vercel-id=sfo1::abc; x-vercel-error=FUNCTION_INVOCATION_FAILED)'
+    );
+  });
+
+  it('skips absent headers and formats nothing when none present', () => {
+    const h = headers({ 'x-vercel-id': 'sfo1::abc' });
+    expect(getVercelDiagnostics(h)).toEqual(['x-vercel-id=sfo1::abc']);
+    expect(formatVercelDiagnostics(headers({}))).toBe('');
+  });
+});
+
+describe('resolveVercelApiToken', () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('prefers an explicit token over env and OIDC', async () => {
+    process.env = { ...originalEnv, VERCEL_TOKEN: 'env-token' };
+    expect(await resolveVercelApiToken({ token: 'explicit' })).toBe('explicit');
+  });
+
+  it('falls back to VERCEL_TOKEN when no explicit token', async () => {
+    process.env = { ...originalEnv, VERCEL_TOKEN: 'env-token' };
+    expect(await resolveVercelApiToken()).toBe('env-token');
+  });
+
+  it('falls back to null when OIDC is unavailable and no token/env', async () => {
+    process.env = { ...originalEnv };
+    delete process.env.VERCEL_TOKEN;
+    expect(await resolveVercelApiToken()).toBeNull();
+  });
+});

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -1,0 +1,377 @@
+/**
+ * Shared HTTP request core for the world-vercel adapter.
+ *
+ * Every outgoing request from world-vercel goes through one of a few
+ * higher-level clients — the v3 `makeRequest`, the v4 events client, the
+ * streamer, and the direct Vercel-API calls (run-key / resolve-deployment).
+ * They differ in how they shape the *body* (CBOR + schema, binary frames, raw
+ * chunks, JSON), but they share the same cross-cutting envelope: an OTEL client
+ * span, trace-context injection, a cache-bust header, a request timeout,
+ * `DEBUG` logging, x-vercel diagnostic headers, and the status → typed-error
+ * mapping the runtime branches on.
+ *
+ * This module is the single source of truth for that envelope. It depends only
+ * on `telemetry.js`, `@workflow/errors`, and `@vercel/oidc` so it can be
+ * imported by both `utils.ts` and `events-v4.ts` without an import cycle —
+ * dispatchers are passed in by the caller rather than imported here.
+ */
+
+import { getVercelOidcToken } from '@vercel/oidc';
+import {
+  EntityConflictError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import {
+  ErrorType,
+  getSpanKind,
+  HttpRequestMethod,
+  HttpResponseStatusCode,
+  injectTraceContextIntoHeaders,
+  PeerService,
+  RpcService,
+  RpcSystem,
+  ServerAddress,
+  ServerPort,
+  trace,
+  UrlFull,
+} from './telemetry.js';
+
+/**
+ * Per-request timeout for HTTP calls to workflow-server (in ms).
+ *
+ * Without this, a hung workflow-server response would keep the caller blocked
+ * until the platform's `maxDuration` SIGTERM — burning compute and defeating
+ * upstream timeout handlers (e.g. the replay timeout).
+ */
+export const REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Lightweight debug logger toggle for HTTP requests. Activated when the DEBUG
+ * env var contains "workflow:" or is "*".
+ *
+ * Note: this does not implement full `debug` module semantics (e.g.
+ * comma-separated globs, negation with `-`). It is a simple check sufficient
+ * for enabling HTTP-level debug output.
+ */
+export const HTTP_DEBUG_ENABLED =
+  typeof process !== 'undefined' &&
+  typeof process.env.DEBUG === 'string' &&
+  (process.env.DEBUG.includes('workflow:') || process.env.DEBUG === '*');
+
+/** Diagnostic response headers worth surfacing in logs and error messages. */
+const DIAGNOSTIC_HEADERS = ['x-vercel-id', 'x-vercel-error'] as const;
+
+/**
+ * Extract the Vercel diagnostic response headers (x-vercel-id /
+ * x-vercel-error) as `key=value` strings, skipping any that are absent.
+ */
+export function getVercelDiagnostics(headers: Headers): string[] {
+  return DIAGNOSTIC_HEADERS.flatMap((header) => {
+    const value = headers.get(header);
+    return value ? [`${header}=${value}`] : [];
+  });
+}
+
+/**
+ * Format the Vercel diagnostic headers as a ` (a=b; c=d)` suffix for error
+ * messages, or an empty string when none are present.
+ */
+export function formatVercelDiagnostics(headers: Headers): string {
+  const diagnostics = getVercelDiagnostics(headers);
+  return diagnostics.length > 0 ? ` (${diagnostics.join('; ')})` : '';
+}
+
+/**
+ * One-line request log, emitted only when HTTP debug is enabled. `label` is a
+ * short request identifier (an endpoint path or full URL).
+ */
+export function httpLog(
+  method: string,
+  label: string,
+  response: Response,
+  ms: number
+): void {
+  if (!HTTP_DEBUG_ENABLED) return;
+  const diagnostics = getVercelDiagnostics(response.headers);
+  const suffix = diagnostics.length > 0 ? `; ${diagnostics.join('; ')}` : '';
+  console.debug(
+    `[workflow:world-vercel:http] ${method} ${label} -> ${response.status} (${ms}ms${suffix})`
+  );
+}
+
+/**
+ * On a failed request with `DEBUG` set, print a copy-pasteable `curl` that
+ * reproduces it (authorization header stripped). Separate from
+ * HTTP_DEBUG_ENABLED so any DEBUG value opts in, matching the original v3
+ * behavior.
+ */
+export function logCurlRepro(
+  method: string,
+  url: string,
+  headers: Headers
+): void {
+  if (!process.env.DEBUG) return;
+  const stringifiedHeaders = Array.from(headers.entries())
+    .filter(([key]) => key.toLowerCase() !== 'authorization')
+    .map(([key, value]) => `-H "${key}: ${value}"`)
+    .join(' ');
+  console.error(
+    `Failed to fetch, reproduce with:\ncurl -X ${method} ${stringifiedHeaders} "${url}"`
+  );
+}
+
+/** Parse a `Retry-After` header value (seconds). Used by 425 and 429. */
+export function parseRetryAfter(
+  value: string | null | undefined
+): number | undefined {
+  if (!value) return undefined;
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Build the typed error for a non-2xx response. This is the single source of
+ * truth for the status → error-type contract the runtime branches on:
+ *
+ *   - 409 → EntityConflictError (start() dedupe, terminal-state transitions)
+ *   - 410 → RunExpiredError (runtime exits without retrying)
+ *   - 425 → TooEarlyError + retryAfter (step retry pacing — see #1806 for what
+ *     happens when a 425 degrades into an untyped error)
+ *   - 429 → ThrottleError + retryAfter
+ *   - anything else → WorkflowWorldError with `status` (the hook 404 →
+ *     HookNotFoundError translation in events.ts keys off status === 404)
+ *
+ * Returns the error rather than throwing so callers can `throw` it inside a
+ * span helper or pass it through a `buildError` callback.
+ */
+export function errorForResponse(
+  status: number,
+  message: string,
+  opts: { retryAfter?: number; code?: string; url?: string } = {}
+): Error {
+  const { retryAfter, code, url } = opts;
+  if (status === 409) return new EntityConflictError(message);
+  if (status === 410) return new RunExpiredError(message);
+  if (status === 425) return new TooEarlyError(message, { retryAfter });
+  if (status === 429) return new ThrottleError(message, { retryAfter });
+  return new WorkflowWorldError(message, { url, status, code, retryAfter });
+}
+
+/**
+ * Resolve the auth token for a direct Vercel-API call (run-key,
+ * resolve-deployment). Prefers an explicit token (CLI / config), then
+ * `VERCEL_TOKEN` (external tooling), then the per-request OIDC token (runtime).
+ * OIDC is last to avoid an unnecessary network call when a token is already
+ * available.
+ */
+export async function resolveVercelApiToken(opts?: {
+  token?: string;
+}): Promise<string | null> {
+  return (
+    opts?.token ??
+    process.env.VERCEL_TOKEN ??
+    (await getVercelOidcToken().catch(() => null))
+  );
+}
+
+/** Parse the server address/port from a URL for OTEL span attributes. */
+function parseServer(url: string): {
+  serverAddress?: string;
+  serverPort?: number;
+} {
+  try {
+    const parsed = new URL(url);
+    return {
+      serverAddress: parsed.hostname,
+      serverPort: parsed.port
+        ? parseInt(parsed.port, 10)
+        : parsed.protocol === 'https:'
+          ? 443
+          : 80,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Standard OTEL client-span attributes for an HTTP request. Shared by
+ * `instrumentedFetch` and the v3 `makeRequest` envelope so both report the
+ * same shape. `peerService` doubles as the rpc.service label (Datadog service
+ * maps); pass 'workflow-server' for backend calls and 'vercel-api' for direct
+ * api.vercel.com calls.
+ */
+export function httpClientSpanAttributes(args: {
+  method: string;
+  url: string;
+  peerService: string;
+}): Record<string, string | number> {
+  const { method, url, peerService } = args;
+  const { serverAddress, serverPort } = parseServer(url);
+  return {
+    ...HttpRequestMethod(method),
+    ...UrlFull(url),
+    ...(serverAddress ? ServerAddress(serverAddress) : {}),
+    ...(serverPort ? ServerPort(serverPort) : {}),
+    ...PeerService(peerService),
+    ...RpcSystem('http'),
+    ...RpcService(peerService),
+  };
+}
+
+export interface InstrumentedFetchOptions {
+  method: string;
+  url: string;
+  headers: Headers;
+  body?: Uint8Array | string;
+  /** Undici dispatcher (typed `unknown`; see APIConfig.dispatcher). */
+  dispatcher: unknown;
+  /**
+   * OTEL peer/rpc service label. 'workflow-server' for backend calls (default),
+   * 'vercel-api' for direct api.vercel.com calls.
+   */
+  peerService?: string;
+  /**
+   * Per-request timeout in ms. Defaults to REQUEST_TIMEOUT_MS. Pass `null` to
+   * disable (e.g. stream writes, which buffer arbitrarily large bodies).
+   */
+  timeoutMs?: number | null;
+  /** Optional caller abort signal, composed with the timeout. */
+  signal?: AbortSignal;
+  /** Inject W3C trace context onto the request headers. Default true. */
+  injectTraceContext?: boolean;
+  /** Set the X-Request-Time cache-bust header. Default true. */
+  cacheBust?: boolean;
+  /** Short label for logs (endpoint path). Defaults to the full URL. */
+  logLabel?: string;
+  /**
+   * Build the error to throw on a non-2xx response. Receives the raw Response
+   * so the caller can read its body in the right format and craft a path-
+   * specific message (the message *strings* legitimately differ per API
+   * version). May return an Error or throw directly. When omitted, a generic
+   * WorkflowWorldError is built from the status line + body text via
+   * `errorForResponse`.
+   */
+  buildError?: (response: Response) => Error | Promise<Error>;
+}
+
+/**
+ * Issue a single instrumented request through the global `fetch` (so Vercel's
+ * observability "outgoing requests" view picks it up) with a caller-supplied
+ * undici dispatcher.
+ *
+ * Handles the shared envelope — OTEL client span + attributes, trace-context
+ * injection, cache-bust header, timeout (mapping TimeoutError/AbortError to
+ * WorkflowWorldError), `DEBUG` logging, and the non-2xx error path (span error
+ * attribute + curl-repro + typed error). Returns the raw `Response` on success
+ * so the caller can consume the body in its own format.
+ */
+export async function instrumentedFetch(
+  opts: InstrumentedFetchOptions
+): Promise<Response> {
+  const {
+    method,
+    url,
+    headers,
+    body,
+    dispatcher,
+    peerService = 'workflow-server',
+    timeoutMs = REQUEST_TIMEOUT_MS,
+    signal: callerSignal,
+    injectTraceContext = true,
+    cacheBust = true,
+    logLabel,
+    buildError,
+  } = opts;
+  const label = logLabel ?? url;
+
+  return trace(
+    `http ${method}`,
+    { kind: await getSpanKind('CLIENT') },
+    async (span) => {
+      span?.setAttributes(
+        httpClientSpanAttributes({ method, url, peerService })
+      );
+
+      // Explicitly propagate trace context so the receiving server can parent
+      // its spans to this client span — the custom undici dispatcher bypasses
+      // ambient auto-instrumentation. No-ops when no OTEL SDK is registered.
+      if (injectTraceContext) await injectTraceContextIntoHeaders(headers);
+
+      // Unique header per attempt to bypass RSC/Next fetch memoization (and to
+      // avoid replaying a memoized truncated body). See:
+      // https://github.com/vercel/workflow/issues/618
+      if (cacheBust) headers.set('X-Request-Time', Date.now().toString());
+
+      const timeoutSignal =
+        timeoutMs != null ? AbortSignal.timeout(timeoutMs) : undefined;
+      const signal =
+        callerSignal && timeoutSignal
+          ? AbortSignal.any([callerSignal, timeoutSignal])
+          : (callerSignal ?? timeoutSignal);
+
+      const start = Date.now();
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method,
+          headers,
+          body,
+          signal,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+          dispatcher,
+        } as any);
+      } catch (error) {
+        const elapsed = Date.now() - start;
+        // AbortSignal.timeout() surfaces as a DOMException named 'TimeoutError'.
+        // Map to WorkflowWorldError so existing catch sites treat it like any
+        // other world transport failure.
+        if (
+          error instanceof Error &&
+          (error.name === 'TimeoutError' || error.name === 'AbortError')
+        ) {
+          const timeoutError = new WorkflowWorldError(
+            `${method} ${label} timed out after ${elapsed}ms`,
+            { url, cause: error }
+          );
+          span?.setAttributes({ ...ErrorType('TIMEOUT') });
+          span?.recordException?.(timeoutError);
+          throw timeoutError;
+        }
+        throw error;
+      }
+      const ms = Date.now() - start;
+
+      httpLog(method, label, response, ms);
+      span?.setAttributes({ ...HttpResponseStatusCode(response.status) });
+
+      if (!response.ok) {
+        span?.setAttributes({ ...ErrorType(`HTTP ${response.status}`) });
+        logCurlRepro(method, url, headers);
+        if (buildError) {
+          const error = await buildError(response);
+          span?.recordException?.(error);
+          throw error;
+        }
+        const text = await response.text().catch(() => '');
+        const error = errorForResponse(
+          response.status,
+          `${method} ${label} -> HTTP ${response.status}: ${response.statusText}${
+            text ? ` ${text}` : ''
+          }${formatVercelDiagnostics(response.headers)}`,
+          {
+            url,
+            retryAfter: parseRetryAfter(response.headers.get('Retry-After')),
+          }
+        );
+        span?.recordException?.(error);
+        throw error;
+      }
+
+      return response;
+    }
+  );
+}

--- a/packages/world-vercel/src/resolve-latest-deployment.test.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.test.ts
@@ -53,13 +53,10 @@ describe('createResolveLatestDeploymentId', () => {
     expect(result).toBe('dpl_latest_xyz789');
     expect(mockFetch).toHaveBeenCalledWith(
       'https://api.vercel.com/v1/workflow/resolve-latest-deployment/dpl_current_abc123',
-      expect.objectContaining({
-        method: 'GET',
-        headers: expect.objectContaining({
-          Authorization: 'Bearer test-token',
-        }),
-      })
+      expect.objectContaining({ method: 'GET' })
     );
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer test-token');
   });
 
   it('should throw when VERCEL_DEPLOYMENT_ID is not set', async () => {
@@ -112,12 +109,10 @@ describe('createResolveLatestDeploymentId', () => {
     expect(result).toBe('dpl_latest_from_env');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer env-token-123',
-        }),
-      })
+      expect.anything()
     );
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer env-token-123');
   });
 
   it('should use OIDC token when config token is absent and VERCEL_TOKEN is unset', async () => {
@@ -150,12 +145,10 @@ describe('createResolveLatestDeploymentId', () => {
     expect(result).toBe('dpl_latest_from_oidc');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer oidc-token-456',
-        }),
-      })
+      expect.anything()
     );
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer oidc-token-456');
   });
 
   it('should throw on non-ok HTTP response', async () => {

--- a/packages/world-vercel/src/resolve-latest-deployment.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.ts
@@ -6,9 +6,9 @@
  * deployments) as the provided current deployment.
  */
 
-import { getVercelOidcToken } from '@vercel/oidc';
 import * as z from 'zod';
 import { getDispatcher } from './http-client.js';
+import { instrumentedFetch, resolveVercelApiToken } from './http-core.js';
 import type { APIConfig } from './utils.js';
 
 const ResolveLatestDeploymentResponseSchema = z.object({
@@ -35,14 +35,7 @@ export function createResolveLatestDeploymentId(
       );
     }
 
-    // Authenticate via provided token (CLI/config), VERCEL_TOKEN env var
-    // (external tooling), or OIDC token (runtime) — in that order.
-    // OIDC is last to avoid an unnecessary network call when a token is
-    // already available (e.g. CLI or CI contexts).
-    const token =
-      config?.token ??
-      process.env.VERCEL_TOKEN ??
-      (await getVercelOidcToken().catch(() => null));
+    const token = await resolveVercelApiToken(config);
     if (!token) {
       throw new Error(
         'Cannot resolve latest deployment: no OIDC token or VERCEL_TOKEN available'
@@ -51,27 +44,30 @@ export function createResolveLatestDeploymentId(
 
     const url = `https://api.vercel.com/v1/workflow/resolve-latest-deployment/${encodeURIComponent(currentDeploymentId)}`;
 
-    // 429/5xx retries are handled by the shared RetryAgent from getDispatcher()
-    const response = await fetch(url, {
+    // 429/5xx retries are handled by the shared RetryAgent from getDispatcher().
+    // instrumentedFetch adds the OTEL client span + DEBUG logging the v3/v4
+    // paths have.
+    const response = await instrumentedFetch({
       method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      // @ts-expect-error -- undici dispatcher is accepted by Node.js fetch but not in @types/node's RequestInit
+      url,
+      headers: new Headers({ Authorization: `Bearer ${token}` }),
       dispatcher: getDispatcher(config),
+      peerService: 'vercel-api',
+      // Preserve the prior no-timeout behavior for this Vercel-API call; the
+      // shared RetryAgent still handles transient/5xx retries.
+      timeoutMs: null,
+      buildError: async (res) => {
+        let body: string;
+        try {
+          body = await res.text();
+        } catch {
+          body = '<unable to read response body>';
+        }
+        return new Error(
+          `Failed to resolve latest deployment for ${currentDeploymentId}: HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`
+        );
+      },
     });
-
-    if (!response.ok) {
-      let body: string;
-      try {
-        body = await response.text();
-      } catch {
-        body = '<unable to read response body>';
-      }
-      throw new Error(
-        `Failed to resolve latest deployment for ${currentDeploymentId}: HTTP ${response.status} ${response.statusText}${body ? ` — ${body}` : ''}`
-      );
-    }
 
     const data = await response.json();
     const result = ResolveLatestDeploymentResponseSchema.safeParse(data);

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -6,6 +6,7 @@ import type {
 } from '@workflow/world';
 import { z } from 'zod';
 import { getStreamDispatcher } from './http-client.js';
+import { getVercelDiagnostics, instrumentedFetch } from './http-core.js';
 import {
   type APIConfig,
   getHttpConfig,
@@ -19,17 +20,22 @@ import {
  */
 export const MAX_CHUNKS_PER_REQUEST = 1000;
 
-// Stream writes (the PUT write/close path) go through the H2 stream
-// dispatcher (see getStreamDispatcher): they send a fully-buffered body (or
-// none), so they benefit from H2 multiplexing without hitting the duplex
-// issues that keep the long-lived live-read (GET) on plain fetch. Because
-// stream appends aren't idempotent, that stream dispatcher uses a deliberately
-// narrowed retry policy (see STREAM_RETRY_OPTIONS): it retries only on
-// transient connection errors and HTTP 429 — both of which guarantee the chunk
-// was never persisted — and never on 5xx, so a retry can't duplicate an
-// already-applied write. Snapshot reads (chunks/info) go
-// through makeRequest (default H1 dispatcher); the live-read and list use
-// plain fetch().
+// All stream requests share the instrumented envelope (`instrumentedFetch`):
+// an OTEL client span, trace-context injection, `DEBUG` logging, and the
+// x-vercel diagnostic headers — the same coverage the v3/v4 paths have.
+//
+// Writes (the PUT write/close path) go through the H2 stream dispatcher (see
+// getStreamDispatcher): they send a fully-buffered body (or none), so they
+// benefit from H2 multiplexing without hitting the duplex issues that keep the
+// long-lived live-read (GET) on the global dispatcher. Because stream appends
+// aren't idempotent, that stream dispatcher uses a deliberately narrowed retry
+// policy (see STREAM_RETRY_OPTIONS): it retries only on transient connection
+// errors and HTTP 429 — both of which guarantee the chunk was never persisted —
+// and never on 5xx, so a retry can't duplicate an already-applied write.
+// Snapshot reads (chunks/info) go through makeRequest (default H1 dispatcher);
+// the live-read (GET) and list keep the global dispatcher (no custom retry) and
+// no request timeout — the live read is long-lived and a whole-request deadline
+// would truncate it.
 
 // Writes (PUT) and stream completion use the v2 stream endpoint.
 function getStreamUrl(name: string, runId: string, httpConfig: HttpConfig) {
@@ -58,13 +64,10 @@ function createStreamRequestError(
   response: Response,
   text: string
 ): Error {
-  const context = [`PUT ${url.origin}${url.pathname}`];
-  for (const header of ['x-vercel-id', 'x-vercel-error']) {
-    const value = response.headers.get(header);
-    if (value) {
-      context.push(`${header}=${value}`);
-    }
-  }
+  const context = [
+    `PUT ${url.origin}${url.pathname}`,
+    ...getVercelDiagnostics(response.headers),
+  ];
 
   return new Error(
     `Stream ${operation} failed: HTTP ${response.status} (${context.join('; ')}): ${text}`
@@ -144,17 +147,19 @@ export function createStreamer(config?: APIConfig): Streamer {
 
         const httpConfig = await getHttpConfig(config);
         const url = getStreamUrl(name, resolvedRunId, httpConfig);
-        const response = await fetch(url, {
+        const response = await instrumentedFetch({
           method: 'PUT',
+          url: url.toString(),
           body: chunk,
           headers: httpConfig.headers,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
           dispatcher: getStreamDispatcher(config),
-        } as any);
-        const text = await response.text();
-        if (!response.ok) {
-          throw createStreamRequestError('write', url, response, text);
-        }
+          timeoutMs: null,
+          logLabel: url.pathname,
+          buildError: async (res) =>
+            createStreamRequestError('write', url, res, await res.text()),
+        });
+        // Drain the (empty) response so undici can release the pooled connection.
+        await response.text();
       },
 
       async writeMulti(
@@ -184,17 +189,19 @@ export function createStreamer(config?: APIConfig): Streamer {
           const batch = chunks.slice(i, i + MAX_CHUNKS_PER_REQUEST);
           const body = encodeMultiChunks(batch);
           const url = getStreamUrl(name, resolvedRunId, httpConfig);
-          const response = await fetch(url, {
+          const response = await instrumentedFetch({
             method: 'PUT',
+            url: url.toString(),
             body,
             headers: httpConfig.headers,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
             dispatcher: getStreamDispatcher(config),
-          } as any);
-          const text = await response.text();
-          if (!response.ok) {
-            throw createStreamRequestError('write', url, response, text);
-          }
+            timeoutMs: null,
+            logLabel: url.pathname,
+            buildError: async (res) =>
+              createStreamRequestError('write', url, res, await res.text()),
+          });
+          // Drain so undici can release the pooled connection between pages.
+          await response.text();
         }
       },
 
@@ -205,16 +212,18 @@ export function createStreamer(config?: APIConfig): Streamer {
         const httpConfig = await getHttpConfig(config);
         httpConfig.headers.set('X-Stream-Done', 'true');
         const url = getStreamUrl(name, resolvedRunId, httpConfig);
-        const response = await fetch(url, {
+        const response = await instrumentedFetch({
           method: 'PUT',
+          url: url.toString(),
           headers: httpConfig.headers,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
           dispatcher: getStreamDispatcher(config),
-        } as any);
-        const text = await response.text();
-        if (!response.ok) {
-          throw createStreamRequestError('close', url, response, text);
-        }
+          timeoutMs: null,
+          logLabel: url.pathname,
+          buildError: async (res) =>
+            createStreamRequestError('close', url, res, await res.text()),
+        });
+        // Drain the (empty) response so undici can release the pooled connection.
+        await response.text();
       },
 
       async get(runId: string, name: string, startIndex?: number) {
@@ -223,12 +232,18 @@ export function createStreamer(config?: APIConfig): Streamer {
         if (typeof startIndex === 'number') {
           url.searchParams.set('startIndex', String(startIndex));
         }
-        const response = await fetch(url, {
+        // Live read: keep the global dispatcher and no request timeout so the
+        // long-lived, reconnecting read isn't truncated.
+        const response = await instrumentedFetch({
+          method: 'GET',
+          url: url.toString(),
           headers: httpConfig.headers,
+          dispatcher: undefined,
+          timeoutMs: null,
+          logLabel: url.pathname,
+          buildError: (res) =>
+            new Error(`Failed to fetch stream: ${res.status}`),
         });
-        if (!response.ok) {
-          throw new Error(`Failed to fetch stream: ${response.status}`);
-        }
         if (!response.body) {
           throw new Error('No response body for stream');
         }
@@ -270,12 +285,16 @@ export function createStreamer(config?: APIConfig): Streamer {
         const url = new URL(
           `${httpConfig.baseUrl}/v2/runs/${encodeURIComponent(runId)}/streams`
         );
-        const response = await fetch(url, {
+        const response = await instrumentedFetch({
+          method: 'GET',
+          url: url.toString(),
           headers: httpConfig.headers,
+          dispatcher: undefined,
+          timeoutMs: null,
+          logLabel: url.pathname,
+          buildError: (res) =>
+            new Error(`Failed to list streams: ${res.status}`),
         });
-        if (!response.ok) {
-          throw new Error(`Failed to list streams: ${response.status}`);
-        }
         return (await response.json()) as string[];
       },
     },

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -7,6 +7,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { encode } from 'cbor-x';
+import { MockAgent } from 'undici';
 import {
   afterAll,
   afterEach,
@@ -16,7 +17,6 @@ import {
   it,
   vi,
 } from 'vitest';
-import { MockAgent } from 'undici';
 import { z } from 'zod';
 import { getWorkflowRunEventsV4 } from './events-v4.js';
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
@@ -152,8 +152,62 @@ describe('v4 event requests (fetchV4) trace propagation', () => {
     const sent = new Headers(calledInit?.headers as HeadersInit);
     // Without the fetchV4 injection this header is absent and workflow-server
     // cannot parent its spans to the flow-route invocation.
-    expect(sent.get('traceparent')).toBe(`00-${traceId}-${spanId}-01`);
+    const traceparent = sent.get('traceparent');
+    expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    // The v4 path now opens its own `http GET` CLIENT span (a child of the
+    // flow-invocation span) and injects from inside it — matching the v3
+    // makeRequest path — so the server parents to the client span and the whole
+    // chain stays on one trace.
+    const clientSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'http GET');
+    expect(clientSpan).toBeDefined();
+    expect(clientSpan?.spanContext().traceId).toBe(traceId);
+    expect(clientSpan?.parentSpanId).toBe(spanId);
+    expect(traceparent).toBe(
+      `00-${traceId}-${clientSpan?.spanContext().spanId}-01`
+    );
     agent.assertNoPendingInterceptors();
     fetchSpy.mockRestore();
+  });
+});
+
+describe('streamer write trace propagation', () => {
+  it('injects traceparent on the outgoing stream write, parented to the client span', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { createStreamer } = await import('./streamer.js');
+    const streamer = createStreamer({ token: 'test-token' });
+
+    const tracer = otelTrace.getTracer('test');
+    let traceId = '';
+    let spanId = '';
+    await tracer.startActiveSpan('flow-invocation', async (span) => {
+      traceId = span.spanContext().traceId;
+      spanId = span.spanContext().spanId;
+      await streamer.streams.write('wrun_1', 'user', 'chunk');
+      span.end();
+    });
+
+    const calledInit = fetchMock.mock.calls[0][1];
+    const sent = new Headers(calledInit?.headers as HeadersInit);
+    const traceparent = sent.get('traceparent');
+    // Stream writes previously skipped trace-context injection; they now share
+    // the instrumented envelope, so workflow-server can correlate the write.
+    expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    const clientSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'http PUT');
+    expect(clientSpan).toBeDefined();
+    expect(clientSpan?.spanContext().traceId).toBe(traceId);
+    expect(clientSpan?.parentSpanId).toBe(spanId);
+    expect(traceparent).toBe(
+      `00-${traceId}-${clientSpan?.spanContext().spanId}-01`
+    );
   });
 });

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -1,75 +1,31 @@
 import os from 'node:os';
 import { inspect } from 'node:util';
 import { getVercelOidcToken } from '@vercel/oidc';
-import {
-  EntityConflictError,
-  RunExpiredError,
-  ThrottleError,
-  TooEarlyError,
-  WorkflowWorldError,
-} from '@workflow/errors';
+import { WorkflowWorldError } from '@workflow/errors';
 import type { SerializedData } from '@workflow/world';
 import { decode, encode } from 'cbor-x';
 import type { z } from 'zod';
 import { getDispatcher } from './http-client.js';
+import {
+  errorForResponse,
+  formatVercelDiagnostics,
+  HTTP_DEBUG_ENABLED,
+  httpClientSpanAttributes,
+  httpLog,
+  logCurlRepro,
+  parseRetryAfter,
+  REQUEST_TIMEOUT_MS,
+} from './http-core.js';
 
 import {
   ErrorType,
   getSpanKind,
-  HttpRequestMethod,
   HttpResponseStatusCode,
   injectTraceContextIntoHeaders,
-  PeerService,
-  RpcService,
-  RpcSystem,
-  ServerAddress,
-  ServerPort,
   trace,
-  UrlFull,
   WorldParseFormat,
 } from './telemetry.js';
 import { version } from './version.js';
-
-/**
- * Lightweight debug logger for HTTP requests. Activated when the DEBUG
- * env var contains "workflow:" or is "*".
- *
- * Note: this does not implement full `debug` module semantics (e.g.
- * comma-separated globs, negation with `-`). It is a simple check
- * sufficient for enabling HTTP-level debug output.
- */
-const HTTP_DEBUG_ENABLED =
-  typeof process !== 'undefined' &&
-  typeof process.env.DEBUG === 'string' &&
-  (process.env.DEBUG.includes('workflow:') || process.env.DEBUG === '*');
-
-function httpLog(
-  method: string,
-  endpoint: string,
-  response: Response,
-  ms: number
-): void {
-  if (HTTP_DEBUG_ENABLED) {
-    const responseContext = getResponseDiagnosticHeaders(response);
-    const diagnosticSuffix =
-      responseContext.length > 0 ? `; ${responseContext.join('; ')}` : '';
-    console.debug(
-      `[workflow:world-vercel:http] ${method} ${endpoint} -> ${response.status} (${ms}ms${diagnosticSuffix})`
-    );
-  }
-}
-
-function getResponseDiagnosticHeaders(response: Response): string[] {
-  return ['x-vercel-id', 'x-vercel-error'].flatMap((header) => {
-    const value = response.headers.get(header);
-    return value ? [`${header}=${value}`] : [];
-  });
-}
-
-function formatResponseDiagnostics(response: Response): string {
-  const headers = getResponseDiagnosticHeaders(response);
-  return headers.length > 0 ? ` (${headers.join('; ')})` : '';
-}
 
 /**
  * Inline workflow-server URL override. Must remain an empty string on
@@ -77,15 +33,6 @@ function formatResponseDiagnostics(response: Response): string {
  * Prefer `VERCEL_WORKFLOW_SERVER_URL` for deployment-time configuration.
  */
 const WORKFLOW_SERVER_URL_OVERRIDE = '';
-
-/**
- * Per-request timeout for HTTP calls to workflow-server (in ms).
- *
- * Without this, a hung workflow-server response would keep the caller
- * blocked until the platform's `maxDuration` SIGTERM — burning compute
- * and defeating upstream timeout handlers (e.g. the replay timeout).
- */
-const REQUEST_TIMEOUT_MS = 60_000;
 
 /**
  * HTTP methods that are safe to transparently re-issue inside the adapter.
@@ -305,21 +252,6 @@ export async function makeRequest<T>({
   const { baseUrl, headers } = await getHttpConfig(config);
   const url = `${baseUrl}${endpoint}`;
 
-  // Parse server address and port from URL for OTEL attributes
-  let serverAddress: string | undefined;
-  let serverPort: number | undefined;
-  try {
-    const parsedUrl = new URL(url);
-    serverAddress = parsedUrl.hostname;
-    serverPort = parsedUrl.port
-      ? parseInt(parsedUrl.port, 10)
-      : parsedUrl.protocol === 'https:'
-        ? 443
-        : 80;
-  } catch {
-    // URL parsing failed, skip these attributes
-  }
-
   // Standard OTEL span name for HTTP client: "{method}"
   // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
   return trace(
@@ -327,16 +259,13 @@ export async function makeRequest<T>({
     { kind: await getSpanKind('CLIENT') },
     async (span) => {
       // Set standard OTEL HTTP client attributes
-      span?.setAttributes({
-        ...HttpRequestMethod(method),
-        ...UrlFull(url),
-        ...(serverAddress && ServerAddress(serverAddress)),
-        ...(serverPort && ServerPort(serverPort)),
-        // Peer service for Datadog service maps
-        ...PeerService('workflow-server'),
-        ...RpcSystem('http'),
-        ...RpcService('workflow-server'),
-      });
+      span?.setAttributes(
+        httpClientSpanAttributes({
+          method,
+          url,
+          peerService: 'workflow-server',
+        })
+      );
 
       headers.set('Accept', 'application/cbor');
 
@@ -410,7 +339,7 @@ export async function makeRequest<T>({
         }
         const fetchMs = Date.now() - fetchStart;
 
-        responseDiagnostics = formatResponseDiagnostics(response);
+        responseDiagnostics = formatVercelDiagnostics(response.headers);
         httpLog(method, endpoint, response, fetchMs);
 
         span?.setAttributes({
@@ -422,64 +351,31 @@ export async function makeRequest<T>({
             await parseResponseBody(response)
               .then((r) => r.data as { message?: string; code?: string })
               .catch(() => ({}));
-          if (process.env.DEBUG) {
-            const stringifiedHeaders = Array.from(headers.entries())
-              .filter(([key]) => key.toLowerCase() !== 'authorization')
-              .map(([key, value]: [string, string]) => `-H "${key}: ${value}"`)
-              .join(' ');
-            console.error(
-              `Failed to fetch, reproduce with:\ncurl -X ${request.method} ${stringifiedHeaders} "${url}"`
-            );
-          }
+          logCurlRepro(request.method, url, headers);
 
-          // Parse Retry-After header (value is in seconds).
-          // Used by both 425 (TooEarlyError) and 429 (ThrottleError).
-          // Note: RetryAgent handles most 429 retries automatically, but this
-          // catches the case where retries are exhausted.
-          let retryAfter: number | undefined;
-          const retryAfterHeader = response.headers.get('Retry-After');
-          if (retryAfterHeader) {
-            const parsed = parseInt(retryAfterHeader, 10);
-            if (!Number.isNaN(parsed)) {
-              retryAfter = parsed;
-            }
-          }
+          // RetryAgent handles most 429 retries automatically, but this catches
+          // the case where retries are exhausted. Used by 425 and 429.
+          const retryAfter = parseRetryAfter(
+            response.headers.get('Retry-After')
+          );
 
           const defaultMessage =
             (errorData.message ||
               `${request.method} ${endpoint} -> HTTP ${response.status}: ${response.statusText}`) +
             responseDiagnostics;
 
-          // Map specific HTTP status codes to semantic error types
-          const throwWithTrace = (error: Error): never => {
-            span?.setAttributes({
-              ...ErrorType(errorData.code || `HTTP ${response.status}`),
-            });
-            span?.recordException?.(error);
-            throw error;
-          };
-
-          if (response.status === 409) {
-            throwWithTrace(new EntityConflictError(defaultMessage));
-          }
-          if (response.status === 410) {
-            throwWithTrace(new RunExpiredError(defaultMessage));
-          }
-          if (response.status === 425) {
-            throwWithTrace(new TooEarlyError(defaultMessage, { retryAfter }));
-          }
-          if (response.status === 429) {
-            throwWithTrace(new ThrottleError(defaultMessage, { retryAfter }));
-          }
-
-          throwWithTrace(
-            new WorkflowWorldError(defaultMessage, {
-              url,
-              status: response.status,
-              code: errorData.code,
-              retryAfter,
-            })
-          );
+          // Map the status to the typed error the runtime branches on (shared
+          // with the v4 path via errorForResponse).
+          const error = errorForResponse(response.status, defaultMessage, {
+            url,
+            code: errorData.code,
+            retryAfter,
+          });
+          span?.setAttributes({
+            ...ErrorType(errorData.code || `HTTP ${response.status}`),
+          });
+          span?.recordException?.(error);
+          throw error;
         }
 
         // Expose response headers to caller before consuming the body


### PR DESCRIPTION
## What

Follow-up to #2573. world-vercel had **five separate HTTP request paths**, each re-implementing the same cross-cutting concerns inconsistently. This collapses the duplication into one shared core (`http-core.ts`) and routes every path through it, so the v4 / stream / Vercel-API paths gain the OTEL client spans + `DEBUG` logging the v3 path already had.

### Before

| Path | OTEL span | DEBUG log | curl-repro | diag headers | typed errors | trace-ctx |
|---|---|---|---|---|---|---|
| v3 `makeRequest` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| v4 events | ❌ | ❌ | ❌ | ❌ | ✅ *(2nd copy)* | ✅ |
| stream write/close | ❌ | ❌ | ❌ | ✅ *(2nd copy)* | ❌ | ❌ |
| stream get/list | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
| Vercel API (run-key, resolve-deploy) | ❌ | ❌ | ❌ | ❌ | ❌ *(plain Error)* | ❌ |

The v4 events path — now the hottest path — had **no client span and no debug logging**.

## How

New `http-core.ts` is the single source of truth for the request envelope:

- **`errorForResponse`** — the status → typed-error map (409→`EntityConflictError`, 410→`RunExpiredError`, 425→`TooEarlyError`, 429→`ThrottleError`, else→`WorkflowWorldError`). Was implemented twice (v3 `makeRequest` + v4 `throwForErrorResponse`).
- **`getVercelDiagnostics` / `parseRetryAfter` / `httpLog` / `logCurlRepro`** — one copy each (were duplicated across `utils.ts` and `streamer.ts`).
- **`resolveVercelApiToken`** — shared `token → VERCEL_TOKEN → OIDC` precedence (was byte-identical in `encryption.ts` and `resolve-latest-deployment.ts`).
- **`instrumentedFetch`** — shared OTEL span + trace-context injection + cache-bust header + timeout + `DEBUG` logging + error envelope. The v4 events, stream, and Vercel-API paths now route through it.

Also: stream writes now inject W3C trace context (previously missing, contrary to the documented requirement that every world→server request must), and the three dispatcher singletons in `http-client.ts` collapse behind one `makeRetryDispatcher` factory.

## Behavior preserved

No behavior change beyond the added observability:
- Per-path **error-message strings** are unchanged (the v3/v4/stream message formats feed log tooling); only the type mapping, Retry-After parsing, and diagnostics are unified.
- The **non-idempotent stream retry policy** (transient + 429 only, never 5xx) is untouched.
- The **no-timeout semantics** of the v4 (streamed LIST), stream (large buffered writes / long-lived live read), and Vercel-API paths are preserved (`timeoutMs: null`); only the v3 path keeps its 60s timeout.

## Tests

- New `http-core.test.ts` (error mapping per status, `parseRetryAfter`, diagnostics, token precedence).
- Extended `trace-propagation.test.ts`: v4 now parents to its own `http GET` client span (matching v3), and a new case asserts stream writes inject `traceparent`.
- Full world-vercel suite green (187 tests); build + typecheck + lint clean.

## Changeset

`@workflow/world-vercel` patch — internal transport refactor + added observability, no API surface change.