### PR TITLE
[web] Fix HTTP/2 in bundled server build so observability reads work

### DIFF
--- a/.changeset/web-h2-noderequire.md
+++ b/.changeset/web-h2-noderequire.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Fix run and event observability pages hanging (~16s) and showing no data in the bundled server build, caused by HTTP/2 requests failing to reach `node:http2`.

--- a/packages/web/vite-plugin-node-require.test.ts
+++ b/packages/web/vite-plugin-node-require.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { build, type Plugin, type Rollup } from 'vite';
+import { describe, expect, test } from 'vitest';
+import { nodeRequireBanner } from './vite-plugin-node-require';
+
+// A virtual entry so the build needs no real files on disk. The body is
+// irrelevant — we only care about the banner the plugin prepends to the chunk.
+function virtualEntry(): Plugin {
+  const id = 'virtual:entry';
+  const resolved = `\0${id}`;
+  return {
+    name: 'test:virtual-entry',
+    resolveId(source) {
+      return source === id ? resolved : null;
+    },
+    load(thisId) {
+      return thisId === resolved ? 'export const ok = true;' : null;
+    },
+  };
+}
+
+async function buildChunkCode(opts: {
+  ssr: boolean;
+  withPlugin: boolean;
+}): Promise<string> {
+  const result = (await build({
+    logLevel: 'silent',
+    configFile: false,
+    build: {
+      ssr: opts.ssr,
+      write: false,
+      minify: false,
+      rollupOptions: { input: 'virtual:entry' },
+    },
+    plugins: [
+      virtualEntry(),
+      ...(opts.withPlugin ? [nodeRequireBanner()] : []),
+    ],
+  })) as Rollup.RollupOutput;
+  const chunk = result.output.find((o) => o.type === 'chunk');
+  if (!chunk || chunk.type !== 'chunk') throw new Error('no chunk emitted');
+  return chunk.code;
+}
+
+describe('nodeRequireBanner', () => {
+  // The load-bearing assertion: without this banner, bundled undici's lazy
+  // `require('node:http2')` finds no `require` in the ESM server bundle, falls
+  // back to a stub with no `http2.connect`, and every HTTP/2 request (the v4
+  // events API + stream writes) breaks — silently degrading observability
+  // reads. See vite-plugin-node-require.ts for the full mechanism.
+  test('injects the global-require shim into the SSR server build', async () => {
+    // rollup may re-quote / reflow the banner, so assert on its semantic parts
+    // rather than the exact source string.
+    const code = await buildChunkCode({ ssr: true, withPlugin: true });
+    expect(code).toContain('__wkfCreateRequire');
+    expect(code).toContain('globalThis.require');
+    expect(code).toMatch(/createRequire[\s\S]*from ['"]node:module['"]/);
+  });
+
+  test('does not inject the shim into the client/browser build', async () => {
+    const code = await buildChunkCode({ ssr: false, withPlugin: true });
+    expect(code).not.toContain('__wkfCreateRequire');
+  });
+
+  test('the SSR build has no shim without the plugin (guards the assertion)', async () => {
+    const code = await buildChunkCode({ ssr: true, withPlugin: false });
+    expect(code).not.toContain('__wkfCreateRequire');
+  });
+});

--- a/packages/web/vite-plugin-node-require.ts
+++ b/packages/web/vite-plugin-node-require.ts
@@ -1,0 +1,56 @@
+import type { Plugin, Rollup } from 'vite';
+
+// The web server build sets `ssr.noExternal: true` (see vite.config.ts), which
+// bundles every dependency — including the world adapters and their `undici` —
+// into the ESM server output. undici loads most node: builtins as ESM imports,
+// but pulls in `node:http2` lazily via a bare `require('node:http2')` inside a
+// try/catch. The bundler leaves that `require` un-wired, so in the ESM bundle
+// there is no `require` in scope: the call throws, undici swallows it and falls
+// back to a stub whose `http2.connect` is undefined. That silently breaks every
+// HTTP/2 request — and world-vercel's events API + stream writes run over H2 —
+// so the observability reads (fetchEvents, etc.) hang on a failing H2
+// connection, retry with backoff for ~16s, then return empty.
+//
+// Prepend a `createRequire`-backed global `require` to the server chunks so the
+// real `node:http2` resolves. This mirrors the same fix the @workflow/sveltekit
+// and @workflow/nitro plugins apply for their bundled server builds.
+export const NODE_REQUIRE_BANNER =
+  "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
+
+/** Prepend NODE_REQUIRE_BANNER to an existing rollup `banner` option, which may
+ *  be absent, a string, or a per-chunk function. */
+function prependBanner(
+  existing: Rollup.OutputOptions['banner']
+): Rollup.OutputOptions['banner'] {
+  if (existing == null) return NODE_REQUIRE_BANNER;
+  if (typeof existing === 'function') {
+    return async (chunk) => `${NODE_REQUIRE_BANNER}\n${await existing(chunk)}`;
+  }
+  return `${NODE_REQUIRE_BANNER}\n${existing}`;
+}
+
+/**
+ * Vite plugin that installs a working global `require` at the top of every
+ * server chunk so bundled `undici` can reach `node:http2` (and HTTP/2 works).
+ *
+ * Gated to the SSR production build: a `node:module` import would break the
+ * client/browser bundle, and dev (`react-router dev`) loads dependencies
+ * natively via Vite's SSR runner where a real `require` already exists. The
+ * `typeof require === 'undefined'` guard keeps it a safe no-op in any CJS chunk,
+ * and `node:module` is always available in the Node server runtime.
+ */
+export function nodeRequireBanner(): Plugin {
+  return {
+    name: 'workflow-web:node-require-banner',
+    configResolved(config) {
+      if (config.command !== 'build' || !config.build?.ssr) return;
+      const rollupOptions = config.build.rollupOptions;
+      rollupOptions.output ??= {};
+      const output = rollupOptions.output;
+      const outputs = Array.isArray(output) ? output : [output];
+      for (const o of outputs) {
+        o.banner = prependBanner(o.banner);
+      }
+    },
+  };
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,6 +1,7 @@
 import { reactRouter } from '@react-router/dev/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
+import { nodeRequireBanner } from './vite-plugin-node-require';
 
 // When `true`, we're building the `packages/web` project for deployment to
 // Vercel itself (as opposed to local development, publishing to npm, or being
@@ -38,7 +39,7 @@ export default defineConfig(({ command, isSsrBuild }) => ({
     noExternal: command === 'build' ? true : undefined,
     external: isVercelWebDeployment ? undefined : ['express'],
   },
-  plugins: [tailwindcss(), reactRouter()],
+  plugins: [tailwindcss(), reactRouter(), nodeRequireBanner()],
   resolve: {
     // Ensure all workspace packages resolve React from the same location
     // to prevent duplicate React instances (which cause "Invalid hook call"


### PR DESCRIPTION
## Problem

After #2573 enabled HTTP/2 for the world-vercel **v4 events API** and **stream writes**, the deployed `workflow-web` observability app broke: the run-detail page took **~16s** (was ~1s), the trace viewer showed **no steps**, and the events list returned **no results**. The single slow RPC was `fetchEvents`.

### Root cause

`packages/web` is a React Router v7 + Vite app whose server build sets `ssr.noExternal: true`, bundling every dependency — including the world adapters and their **undici** — into the ESM server output.

undici loads most `node:` builtins as ESM imports, but pulls in `node:http2` lazily via a bare `require('node:http2')` inside a try/catch. In an ESM bundle there is no `require` in scope, so the call throws, undici swallows it and falls back to a **stub whose `http2.connect` is `undefined`** — breaking every HTTP/2 request.

Since #2573, `workflow-web`'s events reads use the H2 events dispatcher, so each request can't establish its H2 connection. undici's `RetryAgent` retries with exponential backoff (≈ 0.5 + 1 + 2 + 4 + 8 = **15.5s**, matching the observed ~16s), then fails; the UI degrades to empty states.

#2573 added this exact fix to **@workflow/sveltekit** and **@workflow/nitro** (the `*-h2-noderequire` changesets), but `workflow-web` — the same Vite-bundled-undici profile — never got it.

## Fix

Prepend a `createRequire`-backed `globalThis.require` banner to the SSR server chunks so the real `node:http2` resolves. Identical mechanism and banner string to the sveltekit/nitro plugins. Gated to the SSR production build (`config.command === 'build' && config.build.ssr`); a no-op in the client bundle and in dev (where deps load natively).

This also fixes the **self-hosted** `@workflow/web` (`node server.js`), whose build path bundles undici the same way.

## Verification

- `WORKFLOW_WEB_VERCEL_BUILD=1 pnpm build` → banner present in all 11 server chunks, including the one bundling undici.
- New `vite-plugin-node-require.test.ts` runs a real in-memory Vite SSR build and asserts the shim is injected into the server chunk, absent from the client build, and absent without the plugin (guards the assertion).
- Full `packages/web` suite green (79 tests).

## Note on regression coverage

There is currently **no CI e2e against the deployed `workflow-web`** — the e2e-vercel-prod matrix only covers workbench apps, exercised from a plain Node test runner where undici uses native (non-bundled) `node:http2`, so H2 works there and this class of bug is invisible. The unit test here guards against accidental removal of the banner; a deployed-web e2e lane (waiting on the `workflow-web` preview and driving an `fetchEvents` RPC over H2) would be the gold-standard follow-up — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)