### PR TITLE
Events list timing (1/2): gap from previous event

### DIFF
--- a/.changeset/events-list-delta-timing.md
+++ b/.changeset/events-list-delta-timing.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Sidebar Events list now shows the time gap from the previous event (with the absolute timestamp on hover) instead of a bare wall-clock time.

--- a/packages/web-shared/src/components/sidebar/events-list.tsx
+++ b/packages/web-shared/src/components/sidebar/events-list.tsx
@@ -2,11 +2,14 @@
 
 import { EVENT_DATA_REF_FIELDS, type Event } from '@workflow/world';
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '../../lib/cn';
 import { hasEncryptedFields, isExpiredMarker } from '../../lib/hydration';
+import { formatEventGap } from '../../lib/utils';
 import { RunClickContext, StreamClickContext } from '../ui/data-inspector';
 import { ErrorCard } from '../ui/error-card';
 import { ErrorStackBlock, isStructuredError } from '../ui/error-stack-block';
 import { Skeleton } from '../ui/skeleton';
+import { TimestampTooltip } from '../ui/timestamp-tooltip';
 import { AttrSetEventBlock } from './attributes-block';
 import { CopyableDataBlock, EncryptedDataBlock } from './copyable-data-block';
 import { DetailCard } from './detail-card';
@@ -35,14 +38,36 @@ const DATA_EVENT_TYPES = new Set([
 ]);
 
 /**
+ * Inter-event gaps at or above this threshold are visually emphasized so long
+ * waits (sleeps, retries, queue backlog) stand out from the rapid
+ * created/started/completed bursts.
+ */
+const LARGE_GAP_MS = 60_000;
+
+/**
+ * Effective timestamp (ms) used to order events and compute the gap between
+ * consecutive rows. Prefers the client-side `occurredAt` when a world
+ * persists it, falling back to the server `createdAt`.
+ */
+function eventTimeMs(event: Event): number {
+  return new Date(event.occurredAt ?? event.createdAt).getTime();
+}
+
+/**
  * A single event row that can lazy-load its eventData when expanded.
  */
 function EventItem({
   event,
+  previousTimeMs,
   onLoadEventData,
   encryptionKey,
 }: {
   event: Event;
+  /**
+   * Effective timestamp (ms) of the preceding event in the list, or
+   * `undefined` for the first row (which anchors with an absolute time).
+   */
+  previousTimeMs?: number;
   onLoadEventData?: (
     correlationId: string,
     eventId: string
@@ -100,12 +125,22 @@ function EventItem({
     void loadEventData({ force: true });
   }, [encryptionKey, loadEventData]);
 
-  const createdAt = new Date(event.createdAt);
-  const createdAtTime = createdAt.toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-  });
+  const timeMs = eventTimeMs(event);
+  const isFirst = previousTimeMs === undefined;
+  // The first row anchors with an absolute time; later rows show the gap
+  // since the previous event so the time spent between steps is obvious and
+  // unambiguous across day boundaries (a long sleep reads "+26h", not a
+  // misleading bare clock time).
+  const deltaMs =
+    previousTimeMs === undefined ? 0 : Math.max(0, timeMs - previousTimeMs);
+  const isLargeGap = !isFirst && deltaMs >= LARGE_GAP_MS;
+  const rightLabel = isFirst
+    ? new Date(timeMs).toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
+      })
+    : formatEventGap(deltaMs);
 
   const displayPayload = isLoading ? loadedData : mergedDisplay;
 
@@ -118,9 +153,16 @@ function EventItem({
           <span className="text-gray-1000 text-label-12 font-mono">
             {event.eventType}
           </span>
-          <span className="shrink-0 text-label-13 text-gray-900">
-            {createdAtTime}
-          </span>
+          <TimestampTooltip date={timeMs}>
+            <span
+              className={cn(
+                'shrink-0 text-label-13 tabular-nums',
+                isLargeGap ? 'text-gray-1000 font-medium' : 'text-gray-900'
+              )}
+            >
+              {rightLabel}
+            </span>
+          </TimestampTooltip>
         </div>
       }
       onToggle={
@@ -281,13 +323,9 @@ export function EventsList({
   /** When provided, signals that decryption is active (triggers re-load of expanded events) */
   encryptionKey?: Uint8Array;
 }) {
-  // Sort by createdAt
+  // Sort chronologically by effective event time (occurredAt ?? createdAt)
   const sortedEvents = useMemo(
-    () =>
-      [...events].sort(
-        (a, b) =>
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      ),
+    () => [...events].sort((a, b) => eventTimeMs(a) - eventTimeMs(b)),
     [events]
   );
 
@@ -315,10 +353,15 @@ export function EventsList({
             </div>
           ) : (
             <div className="flex flex-col -mx-4">
-              {sortedEvents.map((event) => (
+              {sortedEvents.map((event, index) => (
                 <EventItem
                   key={event.eventId}
                   event={event}
+                  previousTimeMs={
+                    index === 0
+                      ? undefined
+                      : eventTimeMs(sortedEvents[index - 1])
+                  }
                   onLoadEventData={onLoadEventData}
                   encryptionKey={encryptionKey}
                 />

--- a/packages/web-shared/src/lib/utils.ts
+++ b/packages/web-shared/src/lib/utils.ts
@@ -74,6 +74,18 @@ export function formatDuration(ms: number, compact = false): string {
   return parts.join(' ');
 }
 
+/**
+ * Formats the gap between two consecutive events as a signed, compact label
+ * (e.g. "+380ms", "+1m 30s", "+26h"). A zero gap renders as "+0ms" rather
+ * than the bare "0s" {@link formatDuration} would produce, so adjacent events
+ * that share a millisecond timestamp still read as a delta.
+ *
+ * @param deltaMs - Non-negative gap in milliseconds since the previous event.
+ */
+export function formatEventGap(deltaMs: number): string {
+  return deltaMs === 0 ? '+0ms' : `+${formatDuration(deltaMs, true)}`;
+}
+
 // Locale-aware formatter that always renders exactly two fraction digits.
 // Used for the seconds component of precise durations so values are never
 // snapped to a whole second (and thousands separators stay correct).

--- a/packages/web-shared/test/event-gap.test.ts
+++ b/packages/web-shared/test/event-gap.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { formatEventGap } from '../src/lib/utils.js';
+
+/**
+ * Tests for `formatEventGap`, the compact signed gap label shown between
+ * consecutive rows in the sidebar Events list. A zero gap is special-cased to
+ * "+0ms" (instead of the "0s" that `formatDuration` returns) so events that
+ * share a millisecond timestamp still read as a delta. Long gaps stay in
+ * hours (e.g. "+26h") rather than decomposing into days, matching the compact
+ * timeline-marker format.
+ */
+describe('formatEventGap', () => {
+  it('special-cases a zero gap', () => {
+    expect(formatEventGap(0)).toBe('+0ms');
+  });
+
+  it('formats sub-second gaps in milliseconds', () => {
+    expect(formatEventGap(1)).toBe('+1ms');
+    expect(formatEventGap(380)).toBe('+380ms');
+    expect(formatEventGap(999)).toBe('+999ms');
+  });
+
+  it('formats second- and minute-scale gaps', () => {
+    expect(formatEventGap(1000)).toBe('+1s');
+    expect(formatEventGap(45000)).toBe('+45s');
+    expect(formatEventGap(60000)).toBe('+1m');
+    expect(formatEventGap(90000)).toBe('+1m 30s');
+  });
+
+  it('keeps long gaps in hours instead of days', () => {
+    expect(formatEventGap(3600000)).toBe('+1h');
+    expect(formatEventGap(9000000)).toBe('+2h 30m');
+    expect(formatEventGap(93600000)).toBe('+26h');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The sidebar **Events** list currently shows each event's absolute wall-clock time (e.g. `3:47:18 PM`). That's hard to act on: it hides the day (misleading for runs that span midnight or sleep for a day), and it forces mental subtraction to answer the real question — *how long did each phase take?*

This PR (the **delta** approach) replaces the per-row clock time with the **gap since the previous event**, keeping the first row as an absolute anchor:

```
Events
step_created      7:47:18 PM     ← anchor (absolute; hover for full date)
step_started         +1s
step_completed       +1s
wait_created         +0ms
wait_completed       +26h         ← long sleep is obvious, not a misleading "9:47 AM"
```

- A long gap reads as `+26h` instead of an ambiguous bare clock time, so cross-day gaps and slow phases are immediately visible.
- The exact date/time is **not lost** — every row is wrapped in the existing `TimestampTooltip`, so hovering reveals the full UTC + local timestamp and relative ("x ago").
- Gaps `>= 60s` are visually emphasized (stronger color + weight) so sleeps / retries / queue backlog stand out from the rapid created -> started -> completed bursts.
- Ordering and gap math use `occurredAt ?? createdAt` (prefers true client time when a world persists it, falls back to stored time), with negative deltas clamped to 0.

New helper `formatEventGap()` in `lib/utils.ts` produces the compact `+...` label (`+0ms` for a zero gap so co-timestamped events still read as a delta; long gaps stay in hours rather than decomposing to days, matching the compact timeline-marker format).

> This is **1 of 2** sibling PRs exploring how to display event timing. The other (`c+ms/events-relative-time-ee1e`) takes the relative "x ago" approach. They are independent branches off `main` so they can be compared and chosen between.

Scope is limited to the sidebar `EventsList` (the component in the screenshot); the full Events tab table is unchanged.

### How did you test your changes?

- Added `packages/web-shared/test/event-gap.test.ts` covering `formatEventGap` (zero/sub-second/second/minute/hour and multi-day-as-hours). Passing.
- `pnpm --filter @workflow/web-shared typecheck` — passes.
- `pnpm --filter @workflow/web-shared build` (incl. workspace deps via turbo) — passes.
- Full `pnpm --filter @workflow/web-shared test` — all pass **except** the 2 pre-existing failures in `test/zstd-decoder.test.ts` (`zlib.zstdCompressSync is not a function`), which fail identically on a clean `main` in this Node 22.14 environment and are unrelated to this change.
- `biome check`: the changed files add **no** new diagnostics (`events-list.tsx` is clean; `utils.ts` shows only the pre-existing complexity warning on the untouched `formatDuration`). The package's overall error/warning counts are identical with and without this change.
- Visual confirmation in a preview/dev run is recommended (the list renders when selecting a span in the trace viewer sidebar) — not performed in this environment.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR (`@workflow/web-shared` patch)
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f10ab0d8-a437-400b-877c-055de251ee1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f10ab0d8-a437-400b-877c-055de251ee1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

