### PR TITLE
fix(ai): ignore intentional stream aborts

### DIFF
--- a/.changeset/silent-abort-streams.md
+++ b/.changeset/silent-abort-streams.md
@@ -1,0 +1,5 @@
+---
+'@workflow/ai': patch
+---
+
+Suppress chat transport console errors for intentional AbortError stream closes.

--- a/packages/ai/src/workflow-chat-transport.ts
+++ b/packages/ai/src/workflow-chat-transport.ts
@@ -30,6 +30,16 @@ export interface ReconnectToStreamOptions {
   startIndex?: number;
 }
 
+function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
+  return (
+    abortSignal?.aborted === true ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      error.name === 'AbortError')
+  );
+}
+
 type OnChatSendMessage<UI_MESSAGE extends UIMessage> = (
   response: Response,
   options: SendMessagesOptions<UI_MESSAGE>
@@ -261,6 +271,9 @@ export class WorkflowChatTransport<UI_MESSAGE extends UIMessage>
         }
       }
     } catch (error) {
+      if (isAbortError(error, abortSignal)) {
+        return;
+      }
       console.error('Error in chat POST stream', error);
     }
 
@@ -400,6 +413,9 @@ export class WorkflowChatTransport<UI_MESSAGE extends UIMessage>
         // Reset consecutive error count only after successful stream parsing
         consecutiveErrors = 0;
       } catch (error) {
+        if (isAbortError(error, options.abortSignal)) {
+          return;
+        }
         console.error('Error in chat GET reconnectToStream', error);
         consecutiveErrors++;
 


### PR DESCRIPTION
## Summary
- suppress chat transport console errors for intentional AbortError stream closes in the POST and GET reconnect paths
- return cleanly instead of counting intentional aborts toward reconnect failures
- include an @workflow/ai patch changeset

Based on #1992 by @EfeDurmaz16, rebased onto latest main. This intentionally omits the unneeded added regression tests from that PR.

Closes #1971.

## Testing
- `pnpm dlx pnpm@10.20.0 --filter @workflow/ai exec vitest run src/workflow-chat-transport.test.ts`
- `pnpm dlx pnpm@10.20.0 --filter @workflow/ai build`
- `pnpm dlx pnpm@10.20.0 exec biome check packages/ai/src/workflow-chat-transport.ts .changeset/silent-abort-streams.md` (passes with existing complexity warnings in `workflow-chat-transport.ts`)