### PR TITLE
Fix trace detail panel Input/Output flicker (selection-driven state machine)

### DIFF
--- a/.changeset/fix-span-detail-flicker-state-machine.md
+++ b/.changeset/fix-span-detail-flicker-state-machine.md
@@ -1,0 +1,6 @@
+---
+'@workflow/web-shared': patch
+'@workflow/web': patch
+---
+
+Fix the run trace detail panel flickering its Input/Output sections when navigating between spans. Span detail is now driven by a single selection-derived state machine (`useSelectedSpanDetail`) whose loading state stays in phase with the selected span, replacing the fetch flag that lagged selection by a few renders.

--- a/packages/web-shared/README.md
+++ b/packages/web-shared/README.md
@@ -15,20 +15,15 @@ It comes with pre-styled UI components that accept data + callbacks:
 ```tsx
 import { WorkflowTraceViewer } from '@workflow/web-shared';
 
-export default function MyRunDetailView({
-  run,
-  steps,
-  hooks,
-  events,
-  onSpanSelect,
-}) {
+export default function MyRunDetailView({ run, events, fetchSpanDetail }) {
+  // `fetchSpanDetail(selection)` resolves a selected span's full
+  // input/output/metadata. The viewer owns the loading/ready/error state
+  // internally, so the host only supplies how to fetch.
   return (
     <WorkflowTraceViewer
       run={run}
-      steps={steps}
-      hooks={hooks}
       events={events}
-      onSpanSelect={onSpanSelect}
+      fetchSpanDetail={fetchSpanDetail}
     />
   );
 }

--- a/packages/web-shared/README.md
+++ b/packages/web-shared/README.md
@@ -16,9 +16,6 @@ It comes with pre-styled UI components that accept data + callbacks:
 import { WorkflowTraceViewer } from '@workflow/web-shared';
 
 export default function MyRunDetailView({ run, events, fetchSpanDetail }) {
-  // `fetchSpanDetail(selection)` resolves a selected span's full
-  // input/output/metadata. The viewer owns the loading/ready/error state
-  // internally, so the host only supplies how to fetch.
   return (
     <WorkflowTraceViewer
       run={run}

--- a/packages/web-shared/src/components/index.ts
+++ b/packages/web-shared/src/components/index.ts
@@ -13,18 +13,24 @@ export {
   ResolveHookModal,
   useHookActions,
 } from './hook-actions';
+export { TraceViewerSkeleton } from './new-trace-viewer/components/trace-viewer-skeleton';
 export { RunTraceView } from './run-trace-view';
 export { ConversationView } from './sidebar/conversation-view';
-export {
-  SidebarDataProvider,
-  type SidebarDataContextValue,
-} from './sidebar/sidebar-data-context';
 export type {
   SelectedSpanInfo,
   SpanSelectionInfo,
 } from './sidebar/entity-detail-panel';
+export {
+  type SidebarDataContextValue,
+  SidebarDataProvider,
+} from './sidebar/sidebar-data-context';
+export type {
+  DetailResource,
+  FetchSpanDetail,
+} from './sidebar/use-selected-span-detail';
 export { type StreamChunk, StreamViewer } from './stream-viewer';
 export type { Span, SpanEvent } from './trace-viewer/types';
+export { NewTraceViewer } from './trace-viewer-new';
 export {
   DataInspector,
   type DataInspectorProps,
@@ -38,5 +44,3 @@ export { LoadMoreButton } from './ui/load-more-button';
 export { MenuDropdown, type MenuDropdownOption } from './ui/menu-dropdown';
 export { Spinner } from './ui/spinner';
 export { WorkflowTraceViewer } from './workflow-trace-view';
-export { NewTraceViewer } from './trace-viewer-new';
-export { TraceViewerSkeleton } from './new-trace-viewer/components/trace-viewer-skeleton';

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -39,14 +39,14 @@ import {
   TooltipTrigger,
 } from '../ui/tooltip';
 import EventList from './components/event-list';
-import { TraceShortcutHelper } from './components/trace-shortcut-helper';
-import { ROW_HEIGHT_PX, scrollRowIntoView } from './components/use-row-window';
 import { SplitPane } from './components/split-pane';
 import {
   TIMELINE_PADDING_PX,
   Timeline,
   TimelineHeader,
 } from './components/timeline';
+import { TraceShortcutHelper } from './components/trace-shortcut-helper';
+import { ROW_HEIGHT_PX, scrollRowIntoView } from './components/use-row-window';
 import { ActiveSpanProvider, useActiveSpan } from './context';
 import { searchSpans } from './search';
 import type { TraceWithMeta } from './types';
@@ -822,10 +822,7 @@ function NewTraceViewerContent({
                 run={sidebar.run}
                 onStreamClick={sidebar.onStreamClick}
                 onRunClick={sidebar.onRunClick}
-                spanDetailData={sidebar.spanDetailData}
-                spanDetailError={sidebar.spanDetailError}
-                spanDetailLoading={sidebar.spanDetailLoading}
-                onSpanSelect={sidebar.onSpanSelect}
+                fetchSpanDetail={sidebar.fetchSpanDetail}
                 onWakeUpSleep={sidebar.onWakeUpSleep}
                 onLoadEventData={sidebar.onLoadEventData}
                 onResolveHook={sidebar.onResolveHook}

--- a/packages/web-shared/src/components/run-trace-view.tsx
+++ b/packages/web-shared/src/components/run-trace-view.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
+import type { Event, Hook, WorkflowRun } from '@workflow/world';
 import { AlertCircle } from 'lucide-react';
-import type { SpanSelectionInfo } from './sidebar/entity-detail-panel';
+import type { FetchSpanDetail } from './sidebar/use-selected-span-detail';
 import { WorkflowTraceViewer } from './workflow-trace-view';
 
 interface RunTraceViewProps {
@@ -10,9 +10,8 @@ interface RunTraceViewProps {
   events: Event[];
   isLoading?: boolean;
   error?: Error | null;
-  spanDetailData?: WorkflowRun | Step | Hook | Event | null;
-  spanDetailLoading?: boolean;
-  spanDetailError?: Error | null;
+  /** Loads the full detail (input/output/metadata) for the selected span. */
+  fetchSpanDetail: FetchSpanDetail;
   onWakeUpSleep?: (
     runId: string,
     correlationId: string
@@ -25,7 +24,6 @@ interface RunTraceViewProps {
   onCancelRun?: (runId: string) => Promise<void>;
   onStreamClick?: (streamId: string) => void;
   onRunClick?: (runId: string) => void;
-  onSpanSelect?: (info: SpanSelectionInfo) => void;
   onLoadMoreSpans?: () => void | Promise<void>;
   hasMoreSpans?: boolean;
   isLoadingMoreSpans?: boolean;
@@ -36,15 +34,12 @@ export function RunTraceView({
   events,
   isLoading,
   error,
-  spanDetailData,
-  spanDetailLoading,
-  spanDetailError,
+  fetchSpanDetail,
   onWakeUpSleep,
   onResolveHook,
   onCancelRun,
   onStreamClick,
   onRunClick,
-  onSpanSelect,
   onLoadMoreSpans,
   hasMoreSpans,
   isLoadingMoreSpans,
@@ -66,15 +61,12 @@ export function RunTraceView({
         events={events}
         run={run}
         isLoading={isLoading}
-        spanDetailData={spanDetailData}
-        spanDetailLoading={spanDetailLoading}
-        spanDetailError={spanDetailError}
+        fetchSpanDetail={fetchSpanDetail}
         onWakeUpSleep={onWakeUpSleep}
         onResolveHook={onResolveHook}
         onCancelRun={onCancelRun}
         onStreamClick={onStreamClick}
         onRunClick={onRunClick}
-        onSpanSelect={onSpanSelect}
         onLoadMoreSpans={onLoadMoreSpans}
         hasMoreSpans={hasMoreSpans}
         isLoadingMoreSpans={isLoadingMoreSpans}

--- a/packages/web-shared/src/components/run-trace-view.tsx
+++ b/packages/web-shared/src/components/run-trace-view.tsx
@@ -10,7 +10,6 @@ interface RunTraceViewProps {
   events: Event[];
   isLoading?: boolean;
   error?: Error | null;
-  /** Loads the full detail (input/output/metadata) for the selected span. */
   fetchSpanDetail: FetchSpanDetail;
   onWakeUpSleep?: (
     runId: string,

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -768,10 +768,13 @@ export const AttributePanel = ({
 
     if (resource === 'sleep') return present;
 
-    // During loading, ensure sections appear so their skeletons render
-    // in the correct position (above the events section).
-    const loadingDefaults = ['input', 'output'];
-    for (const key of loadingDefaults) {
+    // The span's inline data has no input/output — those load lazily. While
+    // `useSelectedSpanDetail` reports `loading` (a signal now kept in phase
+    // with the selection, so it can't drop out mid-navigation), render the
+    // Input/Output section placeholders in their natural position so they hold
+    // their place instead of vanishing and popping back in.
+    const loadingPlaceholders = ['input', 'output'];
+    for (const key of loadingPlaceholders) {
       if (!present.includes(key)) {
         present.push(key);
       }

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -768,11 +768,6 @@ export const AttributePanel = ({
 
     if (resource === 'sleep') return present;
 
-    // The span's inline data has no input/output — those load lazily. While
-    // `useSelectedSpanDetail` reports `loading` (a signal now kept in phase
-    // with the selection, so it can't drop out mid-navigation), render the
-    // Input/Output section placeholders in their natural position so they hold
-    // their place instead of vanishing and popping back in.
     const loadingPlaceholders = ['input', 'output'];
     for (const key of loadingPlaceholders) {
       if (!present.includes(key)) {

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -67,7 +67,6 @@ export function EntityDetailPanel({
   onStreamClick?: (streamId: string) => void;
   /** Callback when a run reference is clicked */
   onRunClick?: (runId: string) => void;
-  /** Loads the full detail (input/output/metadata) for the selected span. */
   fetchSpanDetail: FetchSpanDetail;
   /** Callback to wake up a pending sleep call. */
   onWakeUpSleep?: (
@@ -111,8 +110,6 @@ export function EntityDetailPanel({
   const rawEvents = selectedSpan?.rawEvents;
   const rawEventsLength = rawEvents?.length ?? 0;
 
-  // Selected span's detail (input/output/metadata) plus a loading status kept
-  // in phase with the selection. See useSelectedSpanDetail.
   const {
     status,
     resource,

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -111,10 +111,8 @@ export function EntityDetailPanel({
   const rawEvents = selectedSpan?.rawEvents;
   const rawEventsLength = rawEvents?.length ?? 0;
 
-  // Single source of truth for the selected span's detail: derives the
-  // selection, fetches its input/output/metadata directly, and exposes a
-  // status that stays in phase with the selection on every render. This is
-  // what keeps the Input/Output sections from flickering on navigation.
+  // Selected span's detail (input/output/metadata) plus a loading status kept
+  // in phase with the selection. See useSelectedSpanDetail.
   const {
     status,
     resource,

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
+import type { Event, Hook, WorkflowRun } from '@workflow/world';
 import clsx from 'clsx';
 import { Send, Zap } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useToast } from '../../lib/toast';
 import { DecryptClickContext } from '../ui/data-inspector';
 import { AttributePanel } from './attribute-panel';
@@ -11,19 +11,11 @@ import { EventsList } from './events-list';
 import { ResolveHookModal } from './resolve-hook-modal';
 import { useSidebarDataOptional } from './sidebar-data-context';
 import {
-  mergeSpanDetail,
-  spanDetailMatchesSelection,
-} from './span-detail-merge';
+  type FetchSpanDetail,
+  useSelectedSpanDetail,
+} from './use-selected-span-detail';
 
-// Type guards for runtime validation of span attribute data
-function isStep(data: unknown): data is Step {
-  return data !== null && typeof data === 'object' && 'stepId' in data;
-}
-
-function isWorkflowRun(data: unknown): data is WorkflowRun {
-  return data !== null && typeof data === 'object' && 'runId' in data;
-}
-
+// Type guard for runtime validation of span attribute data
 function isHook(data: unknown): data is Hook {
   return data !== null && typeof data === 'object' && 'hookId' in data;
 }
@@ -61,10 +53,7 @@ export function EntityDetailPanel({
   run,
   onStreamClick,
   onRunClick,
-  spanDetailData,
-  spanDetailError,
-  spanDetailLoading,
-  onSpanSelect,
+  fetchSpanDetail,
   onWakeUpSleep,
   onLoadEventData,
   onResolveHook,
@@ -78,14 +67,8 @@ export function EntityDetailPanel({
   onStreamClick?: (streamId: string) => void;
   /** Callback when a run reference is clicked */
   onRunClick?: (runId: string) => void;
-  /** Pre-fetched span detail data for the selected span. */
-  spanDetailData: WorkflowRun | Step | Hook | Event | null;
-  /** Error from external span detail fetch. */
-  spanDetailError?: Error | null;
-  /** Loading state from external span detail fetch. */
-  spanDetailLoading?: boolean;
-  /** Callback when a span is selected. Use this to fetch data externally and pass via spanDetailData. */
-  onSpanSelect: (info: SpanSelectionInfo) => void;
+  /** Loads the full detail (input/output/metadata) for the selected span. */
+  fetchSpanDetail: FetchSpanDetail;
   /** Callback to wake up a pending sleep call. */
   onWakeUpSleep?: (
     runId: string,
@@ -128,53 +111,19 @@ export function EntityDetailPanel({
   const rawEvents = selectedSpan?.rawEvents;
   const rawEventsLength = rawEvents?.length ?? 0;
 
-  // Determine resource type, ID, and runId from the selected span
-  const { resource, resourceId, runId } = useMemo(() => {
-    if (!selectedSpan) {
-      return { resource: undefined, resourceId: undefined, runId: undefined };
-    }
-
-    const res = selectedSpan.resource;
-    if (res === 'step' && isStep(data)) {
-      return { resource: 'step', resourceId: data.stepId, runId: data.runId };
-    }
-    if (res === 'run' && isWorkflowRun(data)) {
-      return { resource: 'run', resourceId: data.runId, runId: undefined };
-    }
-    if (res === 'hook' && isHook(data)) {
-      return { resource: 'hook', resourceId: data.hookId, runId: undefined };
-    }
-    if (res === 'sleep') {
-      const waitData = data as { runId?: string } | undefined;
-      return {
-        resource: 'sleep',
-        resourceId: selectedSpan.spanId,
-        runId: waitData?.runId,
-      };
-    }
-    return { resource: undefined, resourceId: undefined, runId: undefined };
-  }, [selectedSpan, data]);
-
-  // Notify parent when span selection changes.
-  // Use a ref for the callback so the effect only fires when the actual
-  // selection values change, not when the callback identity changes due to
-  // parent re-renders from polling.
-  const onSpanSelectRef = useRef(onSpanSelect);
-  onSpanSelectRef.current = onSpanSelect;
-
-  useEffect(() => {
-    if (
-      resource &&
-      resourceId &&
-      ['run', 'step', 'hook', 'sleep'].includes(resource)
-    ) {
-      onSpanSelectRef.current({
-        resource: resource as 'run' | 'step' | 'hook' | 'sleep',
-        resourceId,
-        runId,
-      });
-    }
-  }, [resource, resourceId, runId]);
+  // Single source of truth for the selected span's detail: derives the
+  // selection, fetches its input/output/metadata directly, and exposes a
+  // status that stays in phase with the selection on every render. This is
+  // what keeps the Input/Output sections from flickering on navigation.
+  const {
+    status,
+    resource,
+    resourceId,
+    displayData,
+    detail: matchedSpanDetailData,
+    error,
+  } = useSelectedSpanDetail(selectedSpan, fetchSpanDetail);
+  const loading = status === 'loading';
 
   // Check if this sleep is still pending and can be woken up
   const canWakeUp = useMemo(() => {
@@ -215,17 +164,6 @@ export function EntityDetailPanel({
     run.status,
     resolvedHookIds,
   ]);
-
-  const error = spanDetailError ?? undefined;
-  const loading = spanDetailLoading ?? false;
-
-  const matchedSpanDetailData = useMemo(
-    () =>
-      spanDetailMatchesSelection(spanDetailData, resource, resourceId)
-        ? spanDetailData
-        : null,
-    [spanDetailData, resource, resourceId]
-  );
 
   // Get the hook token for resolving (prefer fetched data, then hooks array fallback)
   const hookToken = useMemo(() => {
@@ -323,16 +261,6 @@ export function EntityDetailPanel({
       }
     },
     [onResolveHook, hookToken, resolvingHook, matchedSpanDetailData, data]
-  );
-
-  const displayData = useMemo(
-    () =>
-      mergeSpanDetail(data, matchedSpanDetailData) as
-        | WorkflowRun
-        | Step
-        | Hook
-        | Event,
-    [data, matchedSpanDetailData]
   );
 
   const moduleSpecifier = useMemo(() => {

--- a/packages/web-shared/src/components/sidebar/sidebar-data-context.tsx
+++ b/packages/web-shared/src/components/sidebar/sidebar-data-context.tsx
@@ -7,11 +7,6 @@ import type { FetchSpanDetail } from './use-selected-span-detail';
 export interface SidebarDataContextValue {
   run: WorkflowRun;
   events: Event[];
-  /**
-   * Loads the full detail (input/output/metadata) for a selected span. The
-   * trace viewer owns the loading/ready/error state internally (see
-   * `useSelectedSpanDetail`); the host only injects how to fetch.
-   */
   fetchSpanDetail: FetchSpanDetail;
   onStreamClick?: (streamId: string) => void;
   onRunClick?: (runId: string) => void;

--- a/packages/web-shared/src/components/sidebar/sidebar-data-context.tsx
+++ b/packages/web-shared/src/components/sidebar/sidebar-data-context.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { createContext, useContext, type ReactNode } from 'react';
-import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
-import type { SpanSelectionInfo } from './entity-detail-panel';
+import type { Event, Hook, WorkflowRun } from '@workflow/world';
+import { createContext, type ReactNode, useContext } from 'react';
+import type { FetchSpanDetail } from './use-selected-span-detail';
 
 export interface SidebarDataContextValue {
   run: WorkflowRun;
   events: Event[];
-  spanDetailData: WorkflowRun | Step | Hook | Event | null;
-  spanDetailError?: Error | null;
-  spanDetailLoading?: boolean;
-  onSpanSelect: (info: SpanSelectionInfo) => void;
+  /**
+   * Loads the full detail (input/output/metadata) for a selected span. The
+   * trace viewer owns the loading/ready/error state internally (see
+   * `useSelectedSpanDetail`); the host only injects how to fetch.
+   */
+  fetchSpanDetail: FetchSpanDetail;
   onStreamClick?: (streamId: string) => void;
   onRunClick?: (runId: string) => void;
   onWakeUpSleep?: (

--- a/packages/web-shared/src/components/sidebar/span-detail-merge.ts
+++ b/packages/web-shared/src/components/sidebar/span-detail-merge.ts
@@ -3,12 +3,6 @@ const hasField = (
   key: string
 ): value is Record<string, unknown> => key in value;
 
-/**
- * Resources whose input/output is loaded by a downstream fetch (the trace
- * strips those heavy fields from the span). Hooks are intentionally excluded:
- * their fetch is disabled and the panel renders them from inline span data, so
- * they are considered ready immediately.
- */
 const RESOURCES_WITH_FETCHED_DETAIL = new Set(['run', 'step', 'sleep']);
 
 export function resourceNeedsFetchedDetail(
@@ -21,23 +15,11 @@ export type SpanDetailStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 export interface SpanDetailView {
   status: SpanDetailStatus;
-  /** Inline span data merged with the matching fetched detail (if any). */
   displayData: Record<string, unknown>;
-  /** The fetched detail that matches the current selection, else null. */
   detail: unknown;
-  /** Error for the current selection, if the fetch failed. */
   error: Error | undefined;
 }
 
-/**
- * Derive the detail view-model for the selected span. `status` is a pure
- * function of (selection, fetched detail), so it can't lag the selection — the
- * panel reports `loading` from the first render after a new span is picked
- * until its matching detail arrives.
- *
- * `fetchedError` must already be scoped to the current selection by the caller
- * (a fetch error for a previously selected span must not surface here).
- */
 export function deriveSpanDetailView(args: {
   resource: string | undefined;
   resourceId: string | undefined;
@@ -71,7 +53,6 @@ export function deriveSpanDetailView(args: {
       error: fetchedError,
     };
   }
-  // Hooks have no fetch step — inline data is authoritative.
   if (!resourceNeedsFetchedDetail(resource)) {
     return {
       status: 'ready',

--- a/packages/web-shared/src/components/sidebar/span-detail-merge.ts
+++ b/packages/web-shared/src/components/sidebar/span-detail-merge.ts
@@ -4,6 +4,98 @@ const hasField = (
 ): value is Record<string, unknown> => key in value;
 
 /**
+ * Resources whose input/output is loaded by a downstream fetch (the trace
+ * strips those heavy fields from the span). Hooks are intentionally excluded:
+ * their fetch is disabled and the panel renders them from inline span data, so
+ * they are considered ready immediately.
+ */
+const RESOURCES_WITH_FETCHED_DETAIL = new Set(['run', 'step', 'sleep']);
+
+export function resourceNeedsFetchedDetail(
+  resource: string | undefined
+): boolean {
+  return resource !== undefined && RESOURCES_WITH_FETCHED_DETAIL.has(resource);
+}
+
+export type SpanDetailStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface SpanDetailView {
+  status: SpanDetailStatus;
+  /** Inline span data merged with the matching fetched detail (if any). */
+  displayData: Record<string, unknown>;
+  /** The fetched detail that matches the current selection, else null. */
+  detail: unknown;
+  /** Error for the current selection, if the fetch failed. */
+  error: Error | undefined;
+}
+
+/**
+ * Derive the detail view-model for the selected span from the synchronously
+ * known selection and whatever fetched detail we currently hold.
+ *
+ * Because the result is a pure function of (selection, fetched detail), the
+ * `status` can never lag the selection: the panel is `loading` from the first
+ * render after a new span is picked until its matching detail arrives. This is
+ * what removes the Input/Output flicker — previously the loading flag came from
+ * an async fetch hook several commits downstream of the selection.
+ *
+ * `fetchedError` must already be scoped to the current selection by the caller
+ * (a fetch error for a previously selected span must not surface here).
+ */
+export function deriveSpanDetailView(args: {
+  resource: string | undefined;
+  resourceId: string | undefined;
+  inlineData: unknown;
+  fetchedDetail: unknown;
+  fetchedError: Error | null;
+}): SpanDetailView {
+  const { resource, resourceId, inlineData, fetchedDetail, fetchedError } =
+    args;
+
+  const matchedDetail = spanDetailMatchesSelection(
+    fetchedDetail,
+    resource,
+    resourceId
+  )
+    ? fetchedDetail
+    : null;
+  const displayData = mergeSpanDetail(inlineData, matchedDetail) as Record<
+    string,
+    unknown
+  >;
+
+  if (!resource || !resourceId) {
+    return { status: 'idle', displayData, detail: null, error: undefined };
+  }
+  if (fetchedError) {
+    return {
+      status: 'error',
+      displayData,
+      detail: matchedDetail,
+      error: fetchedError,
+    };
+  }
+  // Hooks have no fetch step — inline data is authoritative.
+  if (!resourceNeedsFetchedDetail(resource)) {
+    return {
+      status: 'ready',
+      displayData,
+      detail: matchedDetail,
+      error: undefined,
+    };
+  }
+  if (matchedDetail !== null) {
+    return {
+      status: 'ready',
+      displayData,
+      detail: matchedDetail,
+      error: undefined,
+    };
+  }
+  return { status: 'loading', displayData, detail: null, error: undefined };
+}
+
+/**
  * Returns true when the fetched `detail` belongs to the current selection.
  * The fetch lags selection, so it can briefly hold a previously selected span
  * (even a different resource type); reject it before merging or its fields

--- a/packages/web-shared/src/components/sidebar/span-detail-merge.ts
+++ b/packages/web-shared/src/components/sidebar/span-detail-merge.ts
@@ -30,14 +30,10 @@ export interface SpanDetailView {
 }
 
 /**
- * Derive the detail view-model for the selected span from the synchronously
- * known selection and whatever fetched detail we currently hold.
- *
- * Because the result is a pure function of (selection, fetched detail), the
- * `status` can never lag the selection: the panel is `loading` from the first
- * render after a new span is picked until its matching detail arrives. This is
- * what removes the Input/Output flicker — previously the loading flag came from
- * an async fetch hook several commits downstream of the selection.
+ * Derive the detail view-model for the selected span. `status` is a pure
+ * function of (selection, fetched detail), so it can't lag the selection — the
+ * panel reports `loading` from the first render after a new span is picked
+ * until its matching detail arrives.
  *
  * `fetchedError` must already be scoped to the current selection by the caller
  * (a fetch error for a previously selected span must not surface here).

--- a/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
+++ b/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
@@ -1,0 +1,175 @@
+'use client';
+
+import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  SelectedSpanInfo,
+  SpanSelectionInfo,
+} from './entity-detail-panel';
+import {
+  deriveSpanDetailView,
+  resourceNeedsFetchedDetail,
+  type SpanDetailStatus,
+} from './span-detail-merge';
+
+export type DetailResource = WorkflowRun | Step | Hook | Event;
+
+/**
+ * Loads the full detail (input/output/metadata) for a selected span. Injected
+ * by the host app, which owns the RPC/hydration/encryption layer — see
+ * `fetchSpanDetailResource` in `@workflow/web`.
+ */
+export type FetchSpanDetail = (
+  selection: SpanSelectionInfo
+) => Promise<DetailResource>;
+
+/**
+ * Resolve a selected span to the `{ resource, resourceId, runId }` needed to
+ * fetch its detail. Returns null for spans we can't (or don't need to) resolve.
+ */
+function deriveSpanSelection(
+  selectedSpan: SelectedSpanInfo | null
+): SpanSelectionInfo | null {
+  if (!selectedSpan) return null;
+  const { resource, data } = selectedSpan;
+
+  if (
+    resource === 'step' &&
+    data &&
+    typeof data === 'object' &&
+    'stepId' in data
+  ) {
+    const step = data as Step;
+    return { resource: 'step', resourceId: step.stepId, runId: step.runId };
+  }
+  if (
+    resource === 'run' &&
+    data &&
+    typeof data === 'object' &&
+    'runId' in data
+  ) {
+    return { resource: 'run', resourceId: (data as WorkflowRun).runId };
+  }
+  if (
+    resource === 'hook' &&
+    data &&
+    typeof data === 'object' &&
+    'hookId' in data
+  ) {
+    return { resource: 'hook', resourceId: (data as Hook).hookId };
+  }
+  if (resource === 'sleep') {
+    if (!selectedSpan.spanId) return null;
+    const waitData = data as { runId?: string } | undefined;
+    return {
+      resource: 'sleep',
+      resourceId: selectedSpan.spanId,
+      runId: waitData?.runId,
+    };
+  }
+  return null;
+}
+
+export interface SelectedSpanDetailResult {
+  status: SpanDetailStatus;
+  resource: SpanSelectionInfo['resource'] | undefined;
+  resourceId: string | undefined;
+  runId: string | undefined;
+  /** Inline span data merged with the matching fetched detail. */
+  displayData: Record<string, unknown>;
+  /** The fetched detail matching the current selection, else null. */
+  detail: DetailResource | null;
+  /** Error for the current selection, if the fetch failed. */
+  error: Error | undefined;
+}
+
+/**
+ * Single source of truth for the selected span's detail. It derives the
+ * selection synchronously, fetches its detail directly (no notify-effect
+ * round-trip through the host page), and returns a view-model whose `status`
+ * is a pure function of (selection, fetched detail). Because `status` is
+ * computed synchronously from the current selection, the panel is `loading`
+ * from the first render after a new span is picked until its matching detail
+ * arrives — which is what removes the Input/Output flicker.
+ */
+export function useSelectedSpanDetail(
+  selectedSpan: SelectedSpanInfo | null,
+  fetchSpanDetail: FetchSpanDetail
+): SelectedSpanDetailResult {
+  const selection = useMemo(
+    () => deriveSpanSelection(selectedSpan),
+    [selectedSpan]
+  );
+  const resource = selection?.resource;
+  const resourceId = selection?.resourceId;
+  const runId = selection?.runId;
+  const selectionKey =
+    resource && resourceId ? `${resource}:${resourceId}` : null;
+  const needsFetch = resourceNeedsFetchedDetail(resource);
+
+  const [fetched, setFetched] = useState<{
+    detail: DetailResource | null;
+    error: Error | null;
+    errorKey: string | null;
+  }>({ detail: null, error: null, errorKey: null });
+
+  // Monotonic token so superseded / out-of-order responses are dropped. This
+  // is what lets us safely fetch directly off the selection: a slow response
+  // for a previously selected span can never overwrite the current one.
+  const tokenRef = useRef(0);
+  const selectionRef = useRef(selection);
+  selectionRef.current = selection;
+
+  useEffect(() => {
+    if (!selectionKey || !needsFetch) {
+      return;
+    }
+    const activeSelection = selectionRef.current;
+    if (!activeSelection) {
+      return;
+    }
+    const token = ++tokenRef.current;
+    fetchSpanDetail(activeSelection)
+      .then((detail) => {
+        if (tokenRef.current !== token) return;
+        setFetched({ detail, error: null, errorKey: null });
+      })
+      .catch((err: unknown) => {
+        if (tokenRef.current !== token) return;
+        setFetched({
+          detail: null,
+          error: err instanceof Error ? err : new Error(String(err)),
+          errorKey: selectionKey,
+        });
+      });
+    // `selectionKey` + `runId` capture the selection identity. `fetchSpanDetail`
+    // changes only when env / encryption key change (e.g. Decrypt), which
+    // should refetch while keeping prior data visible.
+  }, [selectionKey, runId, needsFetch, fetchSpanDetail]);
+
+  // Only surface an error that belongs to the current selection; a stale error
+  // from a previously selected span must not bleed into the new one.
+  const scopedError = fetched.errorKey === selectionKey ? fetched.error : null;
+
+  const view = useMemo(
+    () =>
+      deriveSpanDetailView({
+        resource,
+        resourceId,
+        inlineData: selectedSpan?.data,
+        fetchedDetail: fetched.detail,
+        fetchedError: scopedError,
+      }),
+    [resource, resourceId, selectedSpan?.data, fetched.detail, scopedError]
+  );
+
+  return {
+    status: view.status,
+    resource,
+    resourceId,
+    runId,
+    displayData: view.displayData,
+    detail: view.detail as DetailResource | null,
+    error: view.error,
+  };
+}

--- a/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
+++ b/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
@@ -84,13 +84,9 @@ export interface SelectedSpanDetailResult {
 }
 
 /**
- * Single source of truth for the selected span's detail. It derives the
- * selection synchronously, fetches its detail directly (no notify-effect
- * round-trip through the host page), and returns a view-model whose `status`
- * is a pure function of (selection, fetched detail). Because `status` is
- * computed synchronously from the current selection, the panel is `loading`
- * from the first render after a new span is picked until its matching detail
- * arrives — which is what removes the Input/Output flicker.
+ * Single source of truth for the selected span's detail: derives the selection
+ * synchronously and fetches its detail directly (no notify-effect round-trip
+ * through the host page), returning the `deriveSpanDetailView` view-model.
  */
 export function useSelectedSpanDetail(
   selectedSpan: SelectedSpanInfo | null,

--- a/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
+++ b/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
@@ -14,19 +14,10 @@ import {
 
 export type DetailResource = WorkflowRun | Step | Hook | Event;
 
-/**
- * Loads the full detail (input/output/metadata) for a selected span. Injected
- * by the host app, which owns the RPC/hydration/encryption layer — see
- * `fetchSpanDetailResource` in `@workflow/web`.
- */
 export type FetchSpanDetail = (
   selection: SpanSelectionInfo
 ) => Promise<DetailResource>;
 
-/**
- * Resolve a selected span to the `{ resource, resourceId, runId }` needed to
- * fetch its detail. Returns null for spans we can't (or don't need to) resolve.
- */
 function deriveSpanSelection(
   selectedSpan: SelectedSpanInfo | null
 ): SpanSelectionInfo | null {
@@ -75,19 +66,11 @@ export interface SelectedSpanDetailResult {
   resource: SpanSelectionInfo['resource'] | undefined;
   resourceId: string | undefined;
   runId: string | undefined;
-  /** Inline span data merged with the matching fetched detail. */
   displayData: Record<string, unknown>;
-  /** The fetched detail matching the current selection, else null. */
   detail: DetailResource | null;
-  /** Error for the current selection, if the fetch failed. */
   error: Error | undefined;
 }
 
-/**
- * Single source of truth for the selected span's detail: derives the selection
- * synchronously and fetches its detail directly (no notify-effect round-trip
- * through the host page), returning the `deriveSpanDetailView` view-model.
- */
 export function useSelectedSpanDetail(
   selectedSpan: SelectedSpanInfo | null,
   fetchSpanDetail: FetchSpanDetail
@@ -109,9 +92,6 @@ export function useSelectedSpanDetail(
     errorKey: string | null;
   }>({ detail: null, error: null, errorKey: null });
 
-  // Monotonic token so superseded / out-of-order responses are dropped. This
-  // is what lets us safely fetch directly off the selection: a slow response
-  // for a previously selected span can never overwrite the current one.
   const tokenRef = useRef(0);
   const selectionRef = useRef(selection);
   selectionRef.current = selection;
@@ -138,13 +118,8 @@ export function useSelectedSpanDetail(
           errorKey: selectionKey,
         });
       });
-    // `selectionKey` + `runId` capture the selection identity. `fetchSpanDetail`
-    // changes only when env / encryption key change (e.g. Decrypt), which
-    // should refetch while keeping prior data visible.
   }, [selectionKey, runId, needsFetch, fetchSpanDetail]);
 
-  // Only surface an error that belongs to the current selection; a stale error
-  // from a previously selected span must not bleed into the new one.
   const scopedError = fetched.errorKey === selectionKey ? fetched.error : null;
 
   const view = useMemo(

--- a/packages/web-shared/src/components/workflow-trace-view.tsx
+++ b/packages/web-shared/src/components/workflow-trace-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { parseStepName, parseWorkflowName } from '@workflow/utils/parse-name';
-import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
+import type { Event, Hook, WorkflowRun } from '@workflow/world';
 import {
   ChevronDown,
   ChevronUp,
@@ -29,6 +29,7 @@ import {
   type SpanSelectionInfo,
 } from './sidebar/entity-detail-panel';
 import { ResolveHookModal } from './sidebar/resolve-hook-modal';
+import type { FetchSpanDetail } from './sidebar/use-selected-span-detail';
 import {
   TraceViewerContextProvider,
   TraceViewerTimeline,
@@ -764,15 +765,12 @@ export const WorkflowTraceViewer = ({
   events,
   isLoading,
   error,
-  spanDetailData,
-  spanDetailLoading,
-  spanDetailError,
+  fetchSpanDetail,
   onWakeUpSleep,
   onResolveHook,
   onCancelRun,
   onStreamClick,
   onRunClick,
-  onSpanSelect,
   onLoadEventData,
   onLoadMoreSpans,
   hasMoreSpans = false,
@@ -785,9 +783,8 @@ export const WorkflowTraceViewer = ({
   events: Event[];
   isLoading?: boolean;
   error?: Error | null;
-  spanDetailData?: WorkflowRun | Step | Hook | Event | null;
-  spanDetailLoading?: boolean;
-  spanDetailError?: Error | null;
+  /** Loads the full detail (input/output/metadata) for the selected span. */
+  fetchSpanDetail: FetchSpanDetail;
   onWakeUpSleep?: (
     runId: string,
     correlationId: string
@@ -803,8 +800,6 @@ export const WorkflowTraceViewer = ({
   onStreamClick?: (streamId: string) => void;
   /** Callback when a run reference is clicked in the detail panel */
   onRunClick?: (runId: string) => void;
-  /** Callback when a span is selected. */
-  onSpanSelect?: (info: SpanSelectionInfo) => void;
   /** Callback to load event data for a specific event (lazy loading in sidebar) */
   onLoadEventData?: (
     correlationId: string,
@@ -855,13 +850,6 @@ export const WorkflowTraceViewer = ({
       });
     }
   }, [error, isLoading]);
-
-  const handleSpanSelect = useCallback(
-    (info: SpanSelectionInfo) => {
-      onSpanSelect?.(info);
-    },
-    [onSpanSelect]
-  );
 
   const handleSelectionChange = useCallback(
     (info: SelectedSpanInfo | null) => {
@@ -1158,10 +1146,7 @@ export const WorkflowTraceViewer = ({
                 run={run}
                 onStreamClick={onStreamClick}
                 onRunClick={onRunClick}
-                spanDetailData={spanDetailData ?? null}
-                spanDetailError={spanDetailError}
-                spanDetailLoading={spanDetailLoading}
-                onSpanSelect={handleSpanSelect}
+                fetchSpanDetail={fetchSpanDetail}
                 onWakeUpSleep={onWakeUpSleep}
                 onLoadEventData={onLoadEventData}
                 onResolveHook={onResolveHook}

--- a/packages/web-shared/src/components/workflow-trace-view.tsx
+++ b/packages/web-shared/src/components/workflow-trace-view.tsx
@@ -783,7 +783,6 @@ export const WorkflowTraceViewer = ({
   events: Event[];
   isLoading?: boolean;
   error?: Error | null;
-  /** Loads the full detail (input/output/metadata) for the selected span. */
   fetchSpanDetail: FetchSpanDetail;
   onWakeUpSleep?: (
     runId: string,

--- a/packages/web-shared/test/span-detail-merge.test.ts
+++ b/packages/web-shared/test/span-detail-merge.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  deriveSpanDetailView,
   mergeSpanDetail,
+  resourceNeedsFetchedDetail,
   spanDetailMatchesSelection,
 } from '../src/components/sidebar/span-detail-merge.js';
 
@@ -94,5 +96,109 @@ describe('spanDetailMatchesSelection', () => {
     expect(spanDetailMatchesSelection(null, 'step', 'step_a')).toBe(false);
     expect(spanDetailMatchesSelection(step, undefined, 'step_a')).toBe(false);
     expect(spanDetailMatchesSelection(step, 'step', undefined)).toBe(false);
+  });
+});
+
+describe('resourceNeedsFetchedDetail', () => {
+  it('is true for resources whose input/output loads lazily', () => {
+    expect(resourceNeedsFetchedDetail('run')).toBe(true);
+    expect(resourceNeedsFetchedDetail('step')).toBe(true);
+    expect(resourceNeedsFetchedDetail('sleep')).toBe(true);
+  });
+
+  it('is false for hooks (rendered from inline data) and unknowns', () => {
+    expect(resourceNeedsFetchedDetail('hook')).toBe(false);
+    expect(resourceNeedsFetchedDetail('event')).toBe(false);
+    expect(resourceNeedsFetchedDetail(undefined)).toBe(false);
+  });
+});
+
+describe('deriveSpanDetailView', () => {
+  const inlineStep = { stepId: 'step_a', runId: 'wrun_1', status: 'completed' };
+  const fetchedStep = {
+    stepId: 'step_a',
+    runId: 'wrun_1',
+    output: { ok: true },
+  };
+
+  it('is idle when nothing is selected', () => {
+    const view = deriveSpanDetailView({
+      resource: undefined,
+      resourceId: undefined,
+      inlineData: undefined,
+      fetchedDetail: null,
+      fetchedError: null,
+    });
+    expect(view.status).toBe('idle');
+  });
+
+  it('is loading right after selection, before the detail arrives', () => {
+    const view = deriveSpanDetailView({
+      resource: 'step',
+      resourceId: 'step_a',
+      inlineData: inlineStep,
+      fetchedDetail: null,
+      fetchedError: null,
+    });
+    expect(view.status).toBe('loading');
+    // Inline data shows immediately; the fetched output is not present yet.
+    expect(view.displayData.status).toBe('completed');
+    expect(view.displayData.output).toBeUndefined();
+  });
+
+  it('is ready once a matching detail arrives, merging input/output', () => {
+    const view = deriveSpanDetailView({
+      resource: 'step',
+      resourceId: 'step_a',
+      inlineData: inlineStep,
+      fetchedDetail: fetchedStep,
+      fetchedError: null,
+    });
+    expect(view.status).toBe('ready');
+    expect(view.detail).toBe(fetchedStep);
+    expect(view.displayData.output).toEqual({ ok: true });
+    // Inline status stays authoritative over the merged result.
+    expect(view.displayData.status).toBe('completed');
+  });
+
+  it('stays loading when the held detail belongs to a different span (stale)', () => {
+    // The detail for a previously selected step lingers for a frame after
+    // navigating to a new step — it must be rejected, not merged.
+    const view = deriveSpanDetailView({
+      resource: 'step',
+      resourceId: 'step_b',
+      inlineData: { stepId: 'step_b', runId: 'wrun_1' },
+      fetchedDetail: fetchedStep,
+      fetchedError: null,
+    });
+    expect(view.status).toBe('loading');
+    expect(view.detail).toBeNull();
+    expect(view.displayData.output).toBeUndefined();
+  });
+
+  it('is ready immediately for hooks (no fetch step)', () => {
+    const inlineHook = { hookId: 'hook_a', runId: 'wrun_1', token: 'tok' };
+    const view = deriveSpanDetailView({
+      resource: 'hook',
+      resourceId: 'hook_a',
+      inlineData: inlineHook,
+      fetchedDetail: null,
+      fetchedError: null,
+    });
+    expect(view.status).toBe('ready');
+    expect(view.displayData.token).toBe('tok');
+  });
+
+  it('surfaces an error for the current selection', () => {
+    const error = new Error('not found');
+    const view = deriveSpanDetailView({
+      resource: 'step',
+      resourceId: 'step_a',
+      inlineData: inlineStep,
+      fetchedDetail: null,
+      fetchedError: error,
+    });
+    expect(view.status).toBe('error');
+    expect(view.error).toBe(error);
   });
 });

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -373,10 +373,9 @@ export function RunDetailView({
     enabled: activeTab === 'events',
   });
 
-  // Loads a selected span's full detail on demand. The trace viewer owns the
-  // loading/ready/error state machine (useSelectedSpanDetail); here we only
-  // provide how to fetch. Closing over encryptionKey means clicking Decrypt
-  // re-runs the fetch for the open span with the key (prior data stays visible).
+  // How to load a selected span's full detail; the trace viewer owns the
+  // loading state. Closing over encryptionKey makes Decrypt re-fetch the open
+  // span with the key.
   const fetchSpanDetail = useCallback<FetchSpanDetail>(
     (selection) =>
       fetchSpanDetailResource(env, selection, {

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -373,9 +373,6 @@ export function RunDetailView({
     enabled: activeTab === 'events',
   });
 
-  // How to load a selected span's full detail; the trace viewer owns the
-  // loading state. Closing over encryptionKey makes Decrypt re-fetch the open
-  // span with the key.
   const fetchSpanDetail = useCallback<FetchSpanDetail>(
     (selection) =>
       fetchSpanDetailResource(env, selection, {
@@ -387,8 +384,6 @@ export function RunDetailView({
   const [isDecrypting, setIsDecrypting] = useState(false);
 
   const handleDecrypt = useCallback(async () => {
-    // The key is fetched once and reused; once present every selection (and a
-    // re-fetch of the open span) hydrates with it automatically.
     if (encryptionKey) {
       return;
     }

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -1,5 +1,5 @@
 import { parseWorkflowName } from '@workflow/utils/parse-name';
-import type { SpanSelectionInfo } from '@workflow/web-shared';
+import type { FetchSpanDetail } from '@workflow/web-shared';
 import {
   DecryptButton,
   ErrorBoundary,
@@ -56,10 +56,10 @@ import { fetchEvent, getEncryptionKeyForRun } from '~/lib/rpc-client';
 import type { EnvMap } from '~/lib/types';
 import {
   cancelRun,
+  fetchSpanDetailResource,
   recreateRun,
   resumeHook,
   unwrapServerActionResult,
-  useWorkflowResourceData,
   useWorkflowStreams,
   useWorkflowTraceViewerData,
   wakeUpRun,
@@ -373,34 +373,24 @@ export function RunDetailView({
     enabled: activeTab === 'events',
   });
 
-  const [spanSelection, setSpanSelection] = useState<SpanSelectionInfo | null>(
-    null
-  );
-  const {
-    data: spanDetailData,
-    loading: spanDetailLoading,
-    error: spanDetailError,
-    refresh: refreshSpanDetail,
-  } = useWorkflowResourceData(
-    env,
-    spanSelection?.resource ?? 'run',
-    spanSelection?.resourceId ?? '',
-    {
-      runId: spanSelection?.runId,
-      enabled: Boolean(
-        spanSelection?.resource &&
-          spanSelection?.resourceId &&
-          spanSelection.resource !== 'hook'
-      ),
-      encryptionKey: encryptionKey ?? undefined,
-    }
+  // Loads a selected span's full detail on demand. The trace viewer owns the
+  // loading/ready/error state machine (useSelectedSpanDetail); here we only
+  // provide how to fetch. Closing over encryptionKey means clicking Decrypt
+  // re-runs the fetch for the open span with the key (prior data stays visible).
+  const fetchSpanDetail = useCallback<FetchSpanDetail>(
+    (selection) =>
+      fetchSpanDetailResource(env, selection, {
+        encryptionKey: encryptionKey ?? undefined,
+      }),
+    [env, encryptionKey]
   );
 
   const [isDecrypting, setIsDecrypting] = useState(false);
 
   const handleDecrypt = useCallback(async () => {
+    // The key is fetched once and reused; once present every selection (and a
+    // re-fetch of the open span) hydrates with it automatically.
     if (encryptionKey) {
-      refreshSpanDetail();
       return;
     }
     setIsDecrypting(true);
@@ -419,20 +409,13 @@ export function RunDetailView({
     } finally {
       setIsDecrypting(false);
     }
-  }, [encryptionKey, env, runId, refreshSpanDetail]);
-
-  const handleSpanSelect = useCallback((info: SpanSelectionInfo) => {
-    setSpanSelection(info);
-  }, []);
+  }, [encryptionKey, env, runId]);
 
   const sidebarData = useMemo<SidebarDataContextValue>(
     () => ({
       run,
       events: allEvents ?? [],
-      spanDetailData: spanDetailData ?? null,
-      spanDetailError,
-      spanDetailLoading,
-      onSpanSelect: handleSpanSelect,
+      fetchSpanDetail,
       onStreamClick: handleStreamClick,
       onRunClick: handleRunRefClick,
       onWakeUpSleep: handleWakeUpSleep,
@@ -446,10 +429,7 @@ export function RunDetailView({
     [
       run,
       allEvents,
-      spanDetailData,
-      spanDetailError,
-      spanDetailLoading,
-      handleSpanSelect,
+      fetchSpanDetail,
       handleStreamClick,
       handleRunRefClick,
       handleWakeUpSleep,

--- a/packages/web/app/lib/client/hooks/use-resource-data.ts
+++ b/packages/web/app/lib/client/hooks/use-resource-data.ts
@@ -55,14 +55,6 @@ async function fetchResourceWithCorrelationId(
   return { data: resourceData, correlationId };
 }
 
-/**
- * Fetch the full detail (input/output/metadata, sleep resumeAt) for a selected
- * span's resource, hydrating — and decrypting when an `encryptionKey` is
- * provided. This is a plain async function with no React state, so it can be
- * injected into the trace viewer and driven directly by the current selection
- * (see `useSelectedSpanDetail` in `@workflow/web-shared`). `useWorkflowResourceData`
- * below is a thin stateful wrapper around it for callers that prefer a hook.
- */
 export async function fetchSpanDetailResource(
   env: EnvMap,
   selection: {

--- a/packages/web/app/lib/client/hooks/use-resource-data.ts
+++ b/packages/web/app/lib/client/hooks/use-resource-data.ts
@@ -7,7 +7,6 @@ import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   unwrapOrThrow,
-  unwrapServerActionResult,
   WorkflowWebAPIError,
 } from '~/lib/client/workflow-errors';
 import { fetchEvents, fetchHook, fetchRun, fetchStep } from '~/lib/rpc-client';
@@ -57,6 +56,72 @@ async function fetchResourceWithCorrelationId(
 }
 
 /**
+ * Fetch the full detail (input/output/metadata, sleep resumeAt) for a selected
+ * span's resource, hydrating — and decrypting when an `encryptionKey` is
+ * provided. This is a plain async function with no React state, so it can be
+ * injected into the trace viewer and driven directly by the current selection
+ * (see `useSelectedSpanDetail` in `@workflow/web-shared`). `useWorkflowResourceData`
+ * below is a thin stateful wrapper around it for callers that prefer a hook.
+ */
+export async function fetchSpanDetailResource(
+  env: EnvMap,
+  selection: {
+    resource: 'run' | 'step' | 'hook' | 'sleep';
+    resourceId: string;
+    runId?: string;
+  },
+  options: { encryptionKey?: Uint8Array } = {}
+): Promise<WorkflowRun | Step | Hook | Event> {
+  const { resource, resourceId, runId } = selection;
+  const { encryptionKey } = options;
+  const hydrate = async <T>(value: T): Promise<T> =>
+    encryptionKey
+      ? hydrateResourceIOWithKey(value, encryptionKey)
+      : hydrateResourceIO(value);
+
+  if (resource === 'hook') {
+    const result = await unwrapOrThrow(fetchHook(env, resourceId, 'all'));
+    return hydrate(result);
+  }
+
+  if (resource === 'sleep') {
+    if (!runId) {
+      throw new WorkflowWebAPIError(
+        'runId is required for loading sleep details',
+        { layer: 'client' }
+      );
+    }
+    const result = await unwrapOrThrow(
+      fetchEvents(env, runId, { sortOrder: 'asc', limit: 1000, withData: true })
+    );
+    const allEvents = (result.data as unknown as Event[]).map(
+      hydrateResourceIO
+    );
+    const waitEvents = await Promise.all(
+      allEvents.filter((e) => e.correlationId === resourceId).map(hydrate)
+    );
+    const data = waitEventsToWaitEntity(waitEvents);
+    if (data === null) {
+      throw new WorkflowWebAPIError(
+        `Failed to load ${resource} details: missing required event data`,
+        { layer: 'client' }
+      );
+    }
+    return data as unknown as Event;
+  }
+
+  const { data } = await fetchResourceWithCorrelationId(
+    env,
+    resource,
+    resourceId,
+    {
+      runId,
+    }
+  );
+  return hydrate(data);
+}
+
+/**
  * Returns (and keeps up-to-date) data inherent to a specific run/step/hook,
  * resolving input/output/metadata, AND loading all related events with full event data.
  */
@@ -81,15 +146,6 @@ export function useWorkflowResourceData(
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
 
-  // Hydrate a resource, decrypting if an encryption key is available
-  const hydrate = useCallback(
-    async <T>(resource: T): Promise<T> =>
-      encryptionKey
-        ? hydrateResourceIOWithKey(resource, encryptionKey)
-        : hydrateResourceIO(resource),
-    [encryptionKey]
-  );
-
   const prevSelectionRef = useRef('');
 
   const fetchData = useCallback(async () => {
@@ -108,95 +164,19 @@ export function useWorkflowResourceData(
     }
     setError(null);
     setLoading(true);
-    if (resource === 'hook') {
-      try {
-        const { error, result } = await unwrapServerActionResult(
-          fetchHook(env, resourceId, 'all')
-        );
-        if (error) {
-          setError(error);
-          return;
-        }
-        try {
-          setData(await hydrate(result));
-        } catch (hydrateError) {
-          setError(
-            hydrateError instanceof Error
-              ? hydrateError
-              : new Error(String(hydrateError))
-          );
-        }
-      } finally {
-        setLoading(false);
-      }
-      return;
-    }
-    if (resource === 'sleep') {
-      try {
-        if (!runId) {
-          setError(new Error('runId is required for loading sleep details'));
-          return;
-        }
-        const { error, result } = await unwrapServerActionResult(
-          fetchEvents(env, runId, {
-            sortOrder: 'asc',
-            limit: 1000,
-            withData: true,
-          })
-        );
-        if (error) {
-          setError(error);
-          return;
-        }
-        try {
-          const allEvents = (result.data as unknown as Event[]).map(
-            hydrateResourceIO
-          );
-          const waitEvents = await Promise.all(
-            allEvents.filter((e) => e.correlationId === resourceId).map(hydrate)
-          );
-          const data = waitEventsToWaitEntity(waitEvents);
-          if (data === null) {
-            setError(
-              new Error(
-                `Failed to load ${resource} details: missing required event data`
-              )
-            );
-            return;
-          }
-          setData(data as unknown as Hook | Event);
-        } catch (hydrateError) {
-          setError(
-            hydrateError instanceof Error
-              ? hydrateError
-              : new Error(String(hydrateError))
-          );
-        }
-      } finally {
-        setLoading(false);
-      }
-      return;
-    }
-    // Fetch resource with full data
     try {
-      const { data: resourceData } = await fetchResourceWithCorrelationId(
+      const result = await fetchSpanDetailResource(
         env,
-        resource,
-        resourceId,
-        { runId }
+        { resource, resourceId, runId },
+        { encryptionKey }
       );
-      setData(await hydrate(resourceData));
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        setError(error);
-      } else {
-        setError(new Error(String(error)));
-      }
-      return;
+      setData(result);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err : new Error(String(err)));
     } finally {
       setLoading(false);
     }
-  }, [env, resource, resourceId, runId, enabled, hydrate]);
+  }, [env, resource, resourceId, runId, enabled, encryptionKey]);
 
   // Initial load
   useEffect(() => {

--- a/packages/web/app/lib/workflow-api-client.ts
+++ b/packages/web/app/lib/workflow-api-client.ts
@@ -20,7 +20,10 @@ export {
   useWorkflowHooks,
   useWorkflowRuns,
 } from './client/hooks/use-paginated-list';
-export { useWorkflowResourceData } from './client/hooks/use-resource-data';
+export {
+  fetchSpanDetailResource,
+  useWorkflowResourceData,
+} from './client/hooks/use-resource-data';
 export { useWorkflowTraceViewerData } from './client/hooks/use-trace-viewer';
 export { useWorkflowStreams } from './client/hooks/use-workflow-streams';
 export {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The run trace **detail panel flickered its Input/Output sections** every time you navigated between spans (steps/spans).

**Root cause (structural).** The panel rendered from two sources that update on different React commits:

- The selected span (`selectedSpan.data`) updates synchronously on click, but the trace builder strips `input`/`output`, so it never carries I/O.
- The fetched detail that carries I/O came from a lagging chain: `EntityDetailPanel` effect → `onSpanSelect` → page `spanSelection` state → `useWorkflowResourceData` → back down via `SidebarDataContext`.

So for 1–2 commits right after selecting a span, the panel showed the new span with `isLoading === false` while the fetched detail still belonged to the previous span (correctly rejected). With nothing to render and loading false, the Input/Output sections rendered nothing — they **vanished**, then reappeared a couple commits later. That disappear/reappear is the flicker. Every existing guard (`spanDetailMatchesSelection`, timestamp-pinning, the `resolvedAttributes` force-defaults, `prevSelectionRef`) was compensating for these signals being out of phase.

**Fix.** Collapse the out-of-phase signals into a single selection-driven state machine:

- `fetchSpanDetailResource` (`@workflow/web`) — the run/step/hook/sleep fetch+hydrate core extracted out of `useWorkflowResourceData` as a plain async function (no React state). The hook now delegates to it.
- `useSelectedSpanDetail` (`@workflow/web-shared`) — derives the selection synchronously, fetches its detail directly (with a request-token to drop stale/out-of-order responses), and returns a `{ status, displayData, error }` view-model. `status` is a pure function of (selection, fetched detail) via `deriveSpanDetailView`, so it stays in phase with the selection on every render and the panel is `loading` from the first frame after a new span is picked until its matching detail arrives.

This is a **net simplification**: it removes the duplicate `spanSelection` state, the `onSpanSelect` notify-effect, four `SidebarDataContext` fields (`spanDetailData`/`spanDetailError`/`spanDetailLoading`/`onSpanSelect`, now a single injected `fetchSpanDetail`), and the scattered match/merge plumbing. The trace viewer's inbound contract shrinks to one `fetchSpanDetail` capability rather than mirroring transient async state back out to the host.

> A follow-up cleanup of the `AttributePanel` Input/Output loading placeholders is split into a separate stacked PR (#2642) to keep this one focused on the flicker fix.

### How did you test your changes?

- **Unit tests** (`packages/web-shared/test/span-detail-merge.test.ts`) for the pure deriver `deriveSpanDetailView` — idle / loading / ready / error, stale-detail rejection (the exact race that caused the vanish), hooks ready inline — plus `resourceNeedsFetchedDetail`.
- Existing `useWorkflowResourceData` tests still pass unchanged (the hook now delegates to the extracted `fetchSpanDetailResource`).
- `@workflow/web-shared` builds (`tsc`) cleanly; `tsc --noEmit` on `@workflow/web` is clean for all touched files; Biome reports zero errors on the changed files; full `web-shared` vitest suite is green (the only failures are the pre-existing `zstd-decoder` tests, which need a newer Node than this CI runner).
- **Manual browser verification** (navigating spans and rapid `j`/`k` in the run detail view to watch Input/Output stay stable) still needs an interactive browser session against a backend with runs — flagging for a reviewer to confirm visually.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR (`@workflow/web-shared` + `@workflow/web`, `patch`)
- [ ] 🔒 DCO sign-off passes — commits are not yet signed off (I avoided amending already-made commits); needs `--signoff`
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-094e0223-77e6-4e26-b6aa-999ad72e2085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-094e0223-77e6-4e26-b6aa-999ad72e2085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

