### PR TITLE
chore: ignore workflow swc caches

### DIFF
--- a/packages/world-testing/.gitignore
+++ b/packages/world-testing/.gitignore
@@ -1,2 +1,3 @@
 .well-known
 .workflow-data
+/.swc

--- a/workbench/astro/.gitignore
+++ b/workbench/astro/.gitignore
@@ -25,3 +25,4 @@ pnpm-debug.log*
 
 # Workflow
 src/lib/_workflows.ts
+/.swc

--- a/workbench/example/.gitignore
+++ b/workbench/example/.gitignore
@@ -1,1 +1,2 @@
 manifest.js
+/.swc

--- a/workbench/express/.gitignore
+++ b/workbench/express/.gitignore
@@ -10,3 +10,4 @@ _workflows.ts
 
 # Nitro
 .output
+/.swc

--- a/workbench/fastify/.gitignore
+++ b/workbench/fastify/.gitignore
@@ -24,3 +24,4 @@ vite.config.ts.timestamp-*
 
 # Workflows
 _workflows.ts
+/.swc

--- a/workbench/hono/.gitignore
+++ b/workbench/hono/.gitignore
@@ -5,3 +5,4 @@ manifest.js
 .data
 .vercel
 _workflows.ts
+/.swc

--- a/workbench/nextjs-turbopack/.gitignore
+++ b/workbench/nextjs-turbopack/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 
 # workflow
 _workflows.ts
+/.swc

--- a/workbench/nextjs-webpack/.gitignore
+++ b/workbench/nextjs-webpack/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 
 # workflow
 _workflows.ts
+/.swc

--- a/workbench/nitro-v2/.gitignore
+++ b/workbench/nitro-v2/.gitignore
@@ -5,3 +5,4 @@ manifest.js
 .data
 .vercel
 _workflows.ts
+/.swc

--- a/workbench/nitro-v3/.gitignore
+++ b/workbench/nitro-v3/.gitignore
@@ -5,3 +5,4 @@ manifest.js
 .data
 .vercel
 _workflows.ts
+/.swc

--- a/workbench/nuxt/.gitignore
+++ b/workbench/nuxt/.gitignore
@@ -6,3 +6,4 @@ manifest.js
 .data
 .vercel
 _workflows.ts
+/.swc

--- a/workbench/sveltekit/.gitignore
+++ b/workbench/sveltekit/.gitignore
@@ -24,3 +24,4 @@ vite.config.ts.timestamp-*
 
 # Workflow
 src/lib/_workflows.ts
+/.swc

--- a/workbench/tanstack-start/.gitignore
+++ b/workbench/tanstack-start/.gitignore
@@ -10,3 +10,4 @@ dist
 .vercel
 _workflows.ts
 src/routeTree.gen.ts
+/.swc

--- a/workbench/vite/.gitignore
+++ b/workbench/vite/.gitignore
@@ -5,3 +5,4 @@ manifest.js
 .data
 .vercel
 _workflows.ts
+/.swc

--- a/workbench/vitest/.gitignore
+++ b/workbench/vitest/.gitignore
@@ -5,3 +5,4 @@
 # Test data
 .workflow-data/
 .workflow-vitest/
+/.swc


### PR DESCRIPTION
## Summary

- Add local `/.swc` ignores for workflow-building packages and workbenches.
- Keeps generated SWC/plugin cache directories out of dirty worktrees when builds run from each project directory.

yes this duplicates .swc, there are more complex fixes, but it has no effect and means no one needs to look at it every time it is regenerated multiple times per day

## Testing

- `pnpm build`
- `pnpm --filter './workbench/*' build`
- `pnpm changeset status --since=main` → no changeset needed
