### PR TITLE
Rename Postgres setup command

### DIFF
--- a/.changeset/soft-peas-speak.md
+++ b/.changeset/soft-peas-speak.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-postgres": patch
+---
+
+Rename the Postgres setup command to `bootstrap`.

--- a/docs/content/docs/v4/deploying/world/postgres-world.mdx
+++ b/docs/content/docs/v4/deploying/world/postgres-world.mdx
@@ -31,9 +31,41 @@ WORKFLOW_POSTGRES_URL="postgres://user:password@host:5432/database"
 
 Run the migration script to create the necessary tables in your database. Ensure `WORKFLOW_POSTGRES_URL` is set when running this command:
 
+<Tabs items={["npm", "pnpm", "Yarn", "Bun"]}>
+
+<Tab value="npm">
+
 ```bash
-npx workflow-postgres-setup
+npx --package=@workflow/world-postgres bootstrap
 ```
+
+</Tab>
+
+<Tab value="pnpm">
+
+```bash
+pnpm dlx --package @workflow/world-postgres bootstrap
+```
+
+</Tab>
+
+<Tab value="Yarn">
+
+```bash
+yarn dlx --package @workflow/world-postgres bootstrap
+```
+
+</Tab>
+
+<Tab value="Bun">
+
+```bash
+bunx --package @workflow/world-postgres bootstrap
+```
+
+</Tab>
+
+</Tabs>
 
 <Callout type="info">
 The migration is idempotent and can safely be run as a post-deployment lifecycle script.

--- a/docs/content/docs/v5/deploying/world/postgres-world.mdx
+++ b/docs/content/docs/v5/deploying/world/postgres-world.mdx
@@ -31,9 +31,41 @@ WORKFLOW_POSTGRES_URL="postgres://user:password@host:5432/database"
 
 Run the migration script to create the necessary tables in your database. Ensure `WORKFLOW_POSTGRES_URL` is set when running this command:
 
+<Tabs items={["npm", "pnpm", "Yarn", "Bun"]}>
+
+<Tab value="npm">
+
 ```bash
-npx workflow-postgres-setup
+npx --package=@workflow/world-postgres bootstrap
 ```
+
+</Tab>
+
+<Tab value="pnpm">
+
+```bash
+pnpm dlx --package @workflow/world-postgres bootstrap
+```
+
+</Tab>
+
+<Tab value="Yarn">
+
+```bash
+yarn dlx --package @workflow/world-postgres bootstrap
+```
+
+</Tab>
+
+<Tab value="Bun">
+
+```bash
+bunx --package @workflow/world-postgres bootstrap
+```
+
+</Tab>
+
+</Tabs>
 
 <Callout type="info">
 The migration is idempotent and can safely be run as a post-deployment lifecycle script.

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -98,9 +98,17 @@ This package uses PostgreSQL with the following components:
 The easiest way to set up your database is using the included CLI tool:
 
 ```bash
-pnpm exec workflow-postgres-setup
-# or
-npm exec workflow-postgres-setup
+# npm
+npx --package=@workflow/world-postgres bootstrap
+
+# pnpm
+pnpm dlx --package @workflow/world-postgres bootstrap
+
+# Yarn
+yarn dlx --package @workflow/world-postgres bootstrap
+
+# Bun
+bunx --package @workflow/world-postgres bootstrap
 ```
 
 The CLI automatically loads `.env` files and will use the connection string from:

--- a/packages/world-postgres/bin/setup-deprecated.js
+++ b/packages/world-postgres/bin/setup-deprecated.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+console.error(`The workflow-postgres-setup command has moved.
+
+Use one of these commands instead:
+
+  # npm
+  npx --package=@workflow/world-postgres bootstrap
+
+  # pnpm
+  pnpm dlx --package @workflow/world-postgres bootstrap
+
+  # Yarn
+  yarn dlx --package @workflow/world-postgres bootstrap
+
+  # Bun
+  bunx --package @workflow/world-postgres bootstrap
+`);
+
+process.exit(1);

--- a/packages/world-postgres/package.json
+++ b/packages/world-postgres/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "workflow-postgres-setup": "./bin/setup.js"
+    "bootstrap": "./bin/setup.js",
+    "workflow-postgres-setup": "./bin/setup-deprecated.js"
   },
   "files": [
     "dist",
@@ -37,7 +38,7 @@
     "./migrations/*.sql": "./src/drizzle/migrations/*.sql"
   },
   "scripts": {
-    "build": "tsc && chmod +x bin/setup.js",
+    "build": "tsc && chmod +x bin/setup.js bin/setup-deprecated.js",
     "dev": "tsc --watch",
     "clean": "tsc --build --clean && rm -rf dist",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- Rename the Postgres setup command to `bootstrap`
- Update docs and the package README to show npm, pnpm, Yarn, and Bun commands through `@workflow/world-postgres`
- Keep the old local `workflow-postgres-setup` bin as a migration message that exits before running setup
- Add a changeset for `@workflow/world-postgres`

## Docs Preview

| Page | Preview |
| --- | --- |
| v4 Postgres World | https://workflow-docs-git-codex-postgres-setup-command.vercel.sh/docs/deploying/world/postgres-world |
| v5 Postgres World | https://workflow-docs-git-codex-postgres-setup-command.vercel.sh/v5/docs/deploying/world/postgres-world |

## Testing

- `git diff --check`
- `node --check packages/world-postgres/bin/setup.js`
- `node --check packages/world-postgres/bin/setup-deprecated.js`
- `node packages/world-postgres/bin/setup-deprecated.js`
- `tsc -p packages/world-postgres/tsconfig.json`


