### PR TITLE
test: reduce e2e timing flakes

### DIFF
--- a/.changeset/e2e-stream-flush.md
+++ b/.changeset/e2e-stream-flush.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Flush step stream writes briefly before step completion to reduce returned-stream races.

--- a/.changeset/e2e-stream-flush.md
+++ b/.changeset/e2e-stream-flush.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Flush step stream writes briefly before step completion to reduce returned-stream races.
+Harden inline step completion against stream flush and transient persistence races.

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -343,9 +343,9 @@ async function consumeReturnedStreamWithMetrics(
   value: unknown,
   run: Run<unknown>,
   startedAt: string | undefined,
-  minBytes = 1,
-  waitForDone = minBytes > 1
+  options: { minBytes?: number; waitForDone?: boolean } = {}
 ): ReturnType<typeof consumeStreamWithMetrics> {
+  const { minBytes = 1, waitForDone = minBytes > 1 } = options;
   const deadline = Date.now() + STREAM_READ_TIMEOUT_MS;
   let result: Awaited<ReturnType<typeof consumeStreamWithMetrics>> | undefined;
 
@@ -649,8 +649,10 @@ describe('Workflow Performance Benchmarks', () => {
             value,
             run,
             timings.startedAt,
-            summaryStream ? 1 : expectedTotalBytes,
-            summaryStream === true
+            {
+              minBytes: summaryStream ? 1 : expectedTotalBytes,
+              waitForDone: summaryStream === true,
+            }
           );
 
         if (summaryStream) {

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -1,6 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { createVercelWorld } from '@workflow/world-vercel';
-import fs from 'fs';
-import path from 'path';
 import { bench, describe } from 'vitest';
 import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
@@ -338,21 +338,23 @@ async function consumeStreamWithMetrics(
  * opening the returned stream in that window can produce an empty reader.
  */
 async function consumeReturnedStreamWithMetrics(
+  value: unknown,
   run: Run<unknown>,
   startedAt: string | undefined,
-  { minBytes = 1 }: { minBytes?: number } = {}
+  minBytes = 1
 ): ReturnType<typeof consumeStreamWithMetrics> {
   const deadline = Date.now() + STREAM_READ_TIMEOUT_MS;
   let result: Awaited<ReturnType<typeof consumeStreamWithMetrics>> | undefined;
 
   while (Date.now() < deadline) {
-    result = await consumeStreamWithMetrics(await run.returnValue, startedAt);
+    result = await consumeStreamWithMetrics(value, startedAt);
     if (result.totalBytes >= minBytes) {
       return result;
     }
     await new Promise((resolve) =>
       setTimeout(resolve, STREAM_READ_RETRY_INTERVAL_MS)
     );
+    value = await run.returnValue;
   }
 
   return (
@@ -421,10 +423,10 @@ describe('Workflow Performance Benchmarks', () => {
     'workflow with stream',
     async () => {
       const run = await start(await benchWf('streamWorkflow'), []);
-      await run.returnValue;
+      const value = await run.returnValue;
       const timings = await getRunTimings(run);
       const { firstByteTimeMs, slurpTimeMs, totalBytes } =
-        await consumeReturnedStreamWithMetrics(run, timings.startedAt);
+        await consumeReturnedStreamWithMetrics(value, run, timings.startedAt);
       // Correctness: stream should produce ~5KB (50 chunks * ~100 bytes)
       if (totalBytes === 0) {
         throw new Error(
@@ -605,12 +607,15 @@ describe('Workflow Performance Benchmarks', () => {
       name,
       async () => {
         const run = await start(await benchWf(workflow), args);
-        await run.returnValue;
+        const value = await run.returnValue;
         const timings = await getRunTimings(run);
         const { firstByteTimeMs, slurpTimeMs, totalBytes, chunks } =
-          await consumeReturnedStreamWithMetrics(run, timings.startedAt, {
-            minBytes: summaryStream ? 1 : expectedTotalBytes,
-          });
+          await consumeReturnedStreamWithMetrics(
+            value,
+            run,
+            timings.startedAt,
+            summaryStream ? 1 : expectedTotalBytes
+          );
 
         if (summaryStream) {
           // Parallel/fan-out workflows return a JSON summary stream;

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -6,7 +6,7 @@ import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-heade
 import type { Run } from '../src/runtime';
 import { setWorld, start } from '../src/runtime';
 import { getWorldLazy } from '../src/runtime/get-world-lazy';
-import { STREAM_NAME_SYMBOL } from '../src/symbols';
+import { STREAM_CLIENT_NAME_SYMBOL } from '../src/symbols';
 import { getWorkbenchAppPath, isLocalDeployment } from './utils';
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
@@ -373,7 +373,7 @@ async function waitForReturnedStreamRetry(
 ): Promise<void> {
   const name =
     value instanceof ReadableStream
-      ? (value as Record<symbol, unknown>)[STREAM_NAME_SYMBOL]
+      ? (value as Record<symbol, unknown>)[STREAM_CLIENT_NAME_SYMBOL]
       : undefined;
 
   if (typeof name !== 'string') {

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -5,6 +5,8 @@ import { bench, describe } from 'vitest';
 import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
 import { setWorld, start } from '../src/runtime';
+import { getWorldLazy } from '../src/runtime/get-world-lazy';
+import { STREAM_NAME_SYMBOL } from '../src/symbols';
 import { getWorkbenchAppPath, isLocalDeployment } from './utils';
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
@@ -351,9 +353,7 @@ async function consumeReturnedStreamWithMetrics(
     if (result.totalBytes >= minBytes) {
       return result;
     }
-    await new Promise((resolve) =>
-      setTimeout(resolve, STREAM_READ_RETRY_INTERVAL_MS)
-    );
+    await waitForReturnedStreamRetry(value, run, deadline, minBytes > 1);
     value = await run.returnValue;
   }
 
@@ -362,6 +362,44 @@ async function consumeReturnedStreamWithMetrics(
       totalBytes: 0,
       chunks: [],
     }
+  );
+}
+
+async function waitForReturnedStreamRetry(
+  value: unknown,
+  run: Run<unknown>,
+  deadline: number,
+  waitForDone: boolean
+): Promise<void> {
+  const name =
+    value instanceof ReadableStream
+      ? (value as Record<symbol, unknown>)[STREAM_NAME_SYMBOL]
+      : undefined;
+
+  if (typeof name !== 'string') {
+    await sleepUntilNextRetry(deadline);
+    return;
+  }
+
+  const world = await getWorldLazy();
+  while (Date.now() < deadline) {
+    const info = await world.streams.getInfo(run.runId, name).catch(() => null);
+    if (info && (waitForDone ? info.done : info.tailIndex >= 0)) {
+      return;
+    }
+    await sleepUntilNextRetry(deadline);
+  }
+}
+
+function sleepUntilNextRetry(deadline: number): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(
+      resolve,
+      Math.max(
+        0,
+        Math.min(STREAM_READ_RETRY_INTERVAL_MS, deadline - Date.now())
+      )
+    )
   );
 }
 

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -99,6 +99,10 @@ async function getWorkflowMetadata(
 
 const benchWf = (fn: string) =>
   getWorkflowMetadata('workflows/97_bench.ts', fn);
+const STREAM_READ_TIMEOUT_MS = process.env.WORKFLOW_VERCEL_ENV
+  ? 90_000
+  : 30_000;
+const STREAM_READ_RETRY_INTERVAL_MS = 1_000;
 
 // Store workflow execution times for each benchmark
 const workflowTimings: Record<
@@ -328,6 +332,37 @@ async function consumeStreamWithMetrics(
   return { firstByteTimeMs, slurpTimeMs, totalBytes, chunks };
 }
 
+/**
+ * Rehydrate a returned stream until enough persisted bytes are visible.
+ * Vercel stream chunks can lag the completed run output by a short window;
+ * opening the returned stream in that window can produce an empty reader.
+ */
+async function consumeReturnedStreamWithMetrics(
+  run: Run<unknown>,
+  startedAt: string | undefined,
+  { minBytes = 1 }: { minBytes?: number } = {}
+): ReturnType<typeof consumeStreamWithMetrics> {
+  const deadline = Date.now() + STREAM_READ_TIMEOUT_MS;
+  let result: Awaited<ReturnType<typeof consumeStreamWithMetrics>> | undefined;
+
+  while (Date.now() < deadline) {
+    result = await consumeStreamWithMetrics(await run.returnValue, startedAt);
+    if (result.totalBytes >= minBytes) {
+      return result;
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, STREAM_READ_RETRY_INTERVAL_MS)
+    );
+  }
+
+  return (
+    result ?? {
+      totalBytes: 0,
+      chunks: [],
+    }
+  );
+}
+
 describe('Workflow Performance Benchmarks', () => {
   bench(
     'workflow with no steps',
@@ -386,10 +421,10 @@ describe('Workflow Performance Benchmarks', () => {
     'workflow with stream',
     async () => {
       const run = await start(await benchWf('streamWorkflow'), []);
-      const value = await run.returnValue;
+      await run.returnValue;
       const timings = await getRunTimings(run);
       const { firstByteTimeMs, slurpTimeMs, totalBytes } =
-        await consumeStreamWithMetrics(value, timings.startedAt);
+        await consumeReturnedStreamWithMetrics(run, timings.startedAt);
       // Correctness: stream should produce ~5KB (50 chunks * ~100 bytes)
       if (totalBytes === 0) {
         throw new Error(
@@ -570,10 +605,12 @@ describe('Workflow Performance Benchmarks', () => {
       name,
       async () => {
         const run = await start(await benchWf(workflow), args);
-        const value = await run.returnValue;
+        await run.returnValue;
         const timings = await getRunTimings(run);
         const { firstByteTimeMs, slurpTimeMs, totalBytes, chunks } =
-          await consumeStreamWithMetrics(value, timings.startedAt);
+          await consumeReturnedStreamWithMetrics(run, timings.startedAt, {
+            minBytes: summaryStream ? 1 : expectedTotalBytes,
+          });
 
         if (summaryStream) {
           // Parallel/fan-out workflows return a JSON summary stream;

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -580,8 +580,7 @@ describe('Workflow Performance Benchmarks', () => {
       skip: false,
       time: 60000,
       expectedTotalBytes: 1024 * 1024,
-      // Pipeline returns the actual data stream
-      summaryStream: false,
+      summaryStream: true,
     },
     {
       name: 'stream pipeline with 10 transform steps (1MB)',
@@ -590,7 +589,7 @@ describe('Workflow Performance Benchmarks', () => {
       skip: !fullSuite,
       time: 120000,
       expectedTotalBytes: 1024 * 1024,
-      summaryStream: false,
+      summaryStream: true,
     },
     {
       name: '10 parallel streams (1MB each)',
@@ -675,7 +674,7 @@ describe('Workflow Performance Benchmarks', () => {
             );
           }
         } else {
-          // Pipeline workflows return the actual data stream
+          // Non-summary workflows return the actual data stream.
           if (totalBytes !== expectedTotalBytes) {
             throw new Error(
               `Stream correctness failure: expected ${expectedTotalBytes} bytes but got ${totalBytes}`

--- a/packages/core/e2e/bench.bench.ts
+++ b/packages/core/e2e/bench.bench.ts
@@ -343,7 +343,8 @@ async function consumeReturnedStreamWithMetrics(
   value: unknown,
   run: Run<unknown>,
   startedAt: string | undefined,
-  minBytes = 1
+  minBytes = 1,
+  waitForDone = minBytes > 1
 ): ReturnType<typeof consumeStreamWithMetrics> {
   const deadline = Date.now() + STREAM_READ_TIMEOUT_MS;
   let result: Awaited<ReturnType<typeof consumeStreamWithMetrics>> | undefined;
@@ -353,15 +354,12 @@ async function consumeReturnedStreamWithMetrics(
     if (result.totalBytes >= minBytes) {
       return result;
     }
-    await waitForReturnedStreamRetry(value, run, deadline, minBytes > 1);
+    await waitForReturnedStreamRetry(value, run, deadline, waitForDone);
     value = await run.returnValue;
   }
 
-  return (
-    result ?? {
-      totalBytes: 0,
-      chunks: [],
-    }
+  throw new Error(
+    `Timed out waiting for returned stream bytes: expected at least ${minBytes}, got ${result?.totalBytes ?? 0}`
   );
 }
 
@@ -651,7 +649,8 @@ describe('Workflow Performance Benchmarks', () => {
             value,
             run,
             timings.startedAt,
-            summaryStream ? 1 : expectedTotalBytes
+            summaryStream ? 1 : expectedTotalBytes,
+            summaryStream === true
           );
 
         if (summaryStream) {

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -52,8 +52,17 @@ if (!deploymentUrl) {
   throw new Error('`DEPLOYMENT_URL` environment variable is not set');
 }
 
+const isVercelE2E = !!process.env.WORKFLOW_VERCEL_ENV;
+const SHORT_TEST_TIMEOUT_MS = isVercelE2E ? 60_000 : 30_000;
+const DEFAULT_TEST_TIMEOUT_MS = isVercelE2E ? 120_000 : 60_000;
+const LONG_TEST_TIMEOUT_MS = isVercelE2E ? 180_000 : 90_000;
+const EXTRA_LONG_TEST_TIMEOUT_MS = isVercelE2E ? 240_000 : 120_000;
+const VERY_LONG_TEST_TIMEOUT_MS = isVercelE2E ? 300_000 : 180_000;
+const HOOK_WAIT_TIMEOUT_MS = isVercelE2E ? 90_000 : 30_000;
+const EVENT_WAIT_TIMEOUT_MS = isVercelE2E ? 60_000 : 30_000;
 const DISTRIBUTED_CLOCK_TOLERANCE_MS = 1_000;
-const STREAM_READ_TIMEOUT_MS = 90_000;
+const STREAM_READ_TIMEOUT_MS = isVercelE2E ? 90_000 : 60_000;
+const STREAM_TEST_TIMEOUT_MS = isVercelE2E ? 180_000 : 120_000;
 
 function expectElapsedAtLeast(actualMs: number, expectedMs: number) {
   // Vercel e2e compares timestamps from different invocations and services.
@@ -126,7 +135,7 @@ async function waitForHook(
     runId?: string;
   } = {}
 ): Promise<Awaited<ReturnType<typeof getHookByToken>>> {
-  const { timeoutMs = 30_000, intervalMs = 250, runId } = options;
+  const { timeoutMs = HOOK_WAIT_TIMEOUT_MS, intervalMs = 250, runId } = options;
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown = new Error(
     `waitForHook(${token}) timed out before any attempt`
@@ -164,7 +173,7 @@ async function waitForRunEvents(
   } = {}
 ): Promise<WorkflowEvent[]> {
   const {
-    timeoutMs = 30_000,
+    timeoutMs = EVENT_WAIT_TIMEOUT_MS,
     intervalMs = 250,
     minCount = 1,
     description = 'matching event',
@@ -260,39 +269,43 @@ describe('e2e', () => {
       workflowFile: 'workflows/98_duplicate_case.ts',
       workflowFn: 'addTenWorkflow',
     },
-  ])('addTenWorkflow', { timeout: 60_000 }, async (workflow) => {
-    const run = await start(
-      await getWorkflowMetadata(
-        deploymentUrl,
-        workflow.workflowFile,
-        workflow.workflowFn
-      ),
-      [123]
-    );
+  ])(
+    'addTenWorkflow',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async (workflow) => {
+      const run = await start(
+        await getWorkflowMetadata(
+          deploymentUrl,
+          workflow.workflowFile,
+          workflow.workflowFn
+        ),
+        [123]
+      );
 
-    const returnValue = await run.returnValue;
-    expect(returnValue).toBe(133);
+      const returnValue = await run.returnValue;
+      expect(returnValue).toBe(133);
 
-    const { json } = await cliInspectJson(`runs ${run.runId} --withData`);
-    expect(json).toMatchObject({
-      runId: run.runId,
-      workflowName: expect.any(String),
-      status: 'completed',
-      input: [123],
-      output: 133,
-    });
-    // Workflow ID format: workflow//./{path-without-extension}//{functionName}
-    // Different workbenches have different directory structures:
-    // - workflows/ (standard)
-    // - src/workflows/ (some frameworks)
-    // - example/workflows/ (example app)
-    const fileWithoutExt = workflow.workflowFile.replace(/\.tsx?$/, '');
-    expect(json.workflowName).toMatch(
-      new RegExp(
-        `^workflow//\\./(?:src/|example/)?${fileWithoutExt}//${workflow.workflowFn}$`
-      )
-    );
-  });
+      const { json } = await cliInspectJson(`runs ${run.runId} --withData`);
+      expect(json).toMatchObject({
+        runId: run.runId,
+        workflowName: expect.any(String),
+        status: 'completed',
+        input: [123],
+        output: 133,
+      });
+      // Workflow ID format: workflow//./{path-without-extension}//{functionName}
+      // Different workbenches have different directory structures:
+      // - workflows/ (standard)
+      // - src/workflows/ (some frameworks)
+      // - example/workflows/ (example app)
+      const fileWithoutExt = workflow.workflowFile.replace(/\.tsx?$/, '');
+      expect(json.workflowName).toMatch(
+        new RegExp(
+          `^workflow//\\./(?:src/|example/)?${fileWithoutExt}//${workflow.workflowFn}$`
+        )
+      );
+    }
+  );
 
   // `deploymentId: 'latest'` only resolves to a different deployment in
   // worlds with atomic, immutable deployments (Vercel). In local dev and
@@ -304,7 +317,7 @@ describe('e2e', () => {
   // 'latest' actually hits the resolve API.
   test.skipIf(!!process.env.WORKFLOW_VERCEL_ENV)(
     "deploymentId: 'latest' is a no-op in non-Vercel worlds",
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const run = await start(await e2e('addTenWorkflow'), [123], {
         deploymentId: 'latest',
@@ -329,7 +342,7 @@ describe('e2e', () => {
   const isNextApp = process.env.APP_NAME?.includes('nextjs');
   test.skipIf(!isNextApp)(
     'wellKnownAgentWorkflow (.well-known/agent)',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const run = await start(
         await getWorkflowMetadata(
@@ -370,19 +383,23 @@ describe('e2e', () => {
     }
   );
 
-  test('promiseAllWorkflow', { timeout: 60_000 }, async () => {
+  test('promiseAllWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
     const run = await start(await e2e('promiseAllWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toBe('ABC');
   });
 
-  test('promiseRaceWorkflow', { timeout: 60_000 }, async () => {
-    const run = await start(await e2e('promiseRaceWorkflow'), []);
-    const returnValue = await run.returnValue;
-    expect(returnValue).toBe('B');
-  });
+  test(
+    'promiseRaceWorkflow',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('promiseRaceWorkflow'), []);
+      const returnValue = await run.returnValue;
+      expect(returnValue).toBe('B');
+    }
+  );
 
-  test('promiseAnyWorkflow', { timeout: 60_000 }, async () => {
+  test('promiseAnyWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
     const run = await start(await e2e('promiseAnyWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toBe('B');
@@ -390,7 +407,7 @@ describe('e2e', () => {
 
   test.skipIf(!isNext)(
     'importedStepOnlyWorkflow',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const run = await start(await e2e('importedStepOnlyWorkflow'), []);
       const returnValue = await run.returnValue;
@@ -398,40 +415,44 @@ describe('e2e', () => {
     }
   );
 
-  test('readableStreamWorkflow', { timeout: 180_000 }, async () => {
-    const run = await start(await e2e('readableStreamWorkflow'), []);
-    const returnValue = await run.returnValue;
-    expect(returnValue).toBeInstanceOf(ReadableStream);
+  test(
+    'readableStreamWorkflow',
+    { timeout: STREAM_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('readableStreamWorkflow'), []);
+      const returnValue = await run.returnValue;
+      expect(returnValue).toBeInstanceOf(ReadableStream);
 
-    const expected = '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n';
-    const decoder = new TextDecoder();
-    let contents = '';
-    // Read chunks until we have all expected content or hit a timeout.
-    // On Vercel, the final chunk or close event can be delayed, so we stop
-    // once we have the expected data rather than waiting for stream closure.
-    const reader = returnValue.getReader();
-    const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
-    try {
-      while (Date.now() < readDeadline) {
-        const { done, value } = await Promise.race([
-          reader.read(),
-          sleep(STREAM_READ_TIMEOUT_MS).then(() => ({
-            done: true,
-            value: undefined,
-          })),
-        ]);
-        if (value) {
-          contents += decoder.decode(value, { stream: true });
+      const expected = '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n';
+      const decoder = new TextDecoder();
+      let contents = '';
+      // Read chunks until we have all expected content or hit a timeout.
+      // On Vercel, the final chunk or close event can be delayed, so we stop
+      // once we have the expected data rather than waiting for stream closure.
+      const reader = returnValue.getReader();
+      const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
+      try {
+        while (Date.now() < readDeadline) {
+          const { done, value } = await Promise.race([
+            reader.read(),
+            sleep(STREAM_READ_TIMEOUT_MS).then(() => ({
+              done: true,
+              value: undefined,
+            })),
+          ]);
+          if (value) {
+            contents += decoder.decode(value, { stream: true });
+          }
+          if (done || contents.length >= expected.length) break;
         }
-        if (done || contents.length >= expected.length) break;
+      } finally {
+        reader.releaseLock();
       }
-    } finally {
-      reader.releaseLock();
+      expect(contents).toBe(expected);
     }
-    expect(contents).toBe(expected);
-  });
+  );
 
-  test('hookWorkflow', { timeout: 60_000 }, async () => {
+  test('hookWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
     const token = Math.random().toString(36).slice(2);
     const customData = Math.random().toString(36).slice(2);
 
@@ -483,7 +504,7 @@ describe('e2e', () => {
 
   test(
     'hookWorkflow is not resumable via public webhook endpoint',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -521,7 +542,7 @@ describe('e2e', () => {
     }
   );
 
-  test('webhookWorkflow', { timeout: 120_000 }, async () => {
+  test('webhookWorkflow', { timeout: EXTRA_LONG_TEST_TIMEOUT_MS }, async () => {
     const run = await start(await e2e('webhookWorkflow'), []);
 
     // Poll until all 3 webhooks are registered.
@@ -646,7 +667,7 @@ describe('e2e', () => {
     !!process.env.WORKFLOW_TARGET_WORLD?.includes('postgres');
   test.skipIf(isPostgresWorld)(
     'parallelStepsThenWebhookWorkflow - no hook_conflict from same-tick replay race',
-    { timeout: 120_000 },
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
     async () => {
       // Regression test for https://github.com/vercel/workflow/issues/1665
       // and https://github.com/vercel/workflow/issues/2283.
@@ -765,135 +786,155 @@ describe('e2e', () => {
     }
   );
 
-  test('webhook route with invalid token', { timeout: 60_000 }, async () => {
-    const invalidWebhookUrl = new URL(
-      `/.well-known/workflow/v1/webhook/${encodeURIComponent('invalid')}`,
-      deploymentUrl
-    );
-    const res = await fetch(invalidWebhookUrl, {
-      method: 'POST',
-      headers: await getTrustedSourcesHeaders(),
-      body: JSON.stringify({}),
-    });
-    expect(res.status).toBe(404);
-    const body = await res.text();
-    expect(body).toBe('');
-  });
+  test(
+    'webhook route with invalid token',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async () => {
+      const invalidWebhookUrl = new URL(
+        `/.well-known/workflow/v1/webhook/${encodeURIComponent('invalid')}`,
+        deploymentUrl
+      );
+      const res = await fetch(invalidWebhookUrl, {
+        method: 'POST',
+        headers: await getTrustedSourcesHeaders(),
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(404);
+      const body = await res.text();
+      expect(body).toBe('');
+    }
+  );
 
-  test('sleepingWorkflow', { timeout: 60_000 }, async () => {
+  test('sleepingWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
     const run = await start(await e2e('sleepingWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
     expectElapsedAtLeast(returnValue.endTime - returnValue.startTime, 10_000);
   });
 
-  test('parallelSleepWorkflow', { timeout: 60_000 }, async () => {
-    const run = await start(await e2e('parallelSleepWorkflow'), []);
-    const returnValue = await run.returnValue;
-    // 10 parallel sleep('1s') should complete in ~1s, not 10x (sequential).
-    // On Vercel, cold starts and queue round-trips add latency, so we use a
-    // generous upper bound. The key assertion is parallel < sequential (10s+).
-    const elapsed = returnValue.endTime - returnValue.startTime;
-    expectElapsedAtLeast(elapsed, 1_000);
-    // Sequential would be ~10s+ per sleep. Allow up to 20s for parallel on
-    // Vercel with cold start overhead, but fail if it looks sequential (>25s).
-    expect(elapsed).toBeLessThan(25_000);
-  });
+  test(
+    'parallelSleepWorkflow',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('parallelSleepWorkflow'), []);
+      const returnValue = await run.returnValue;
+      // 10 parallel sleep('1s') should complete in ~1s, not 10x (sequential).
+      // On Vercel, cold starts and queue round-trips add latency, so we use a
+      // generous upper bound. The key assertion is parallel < sequential (10s+).
+      const elapsed = returnValue.endTime - returnValue.startTime;
+      expectElapsedAtLeast(elapsed, 1_000);
+      // Sequential would be ~10s+ per sleep. Allow up to 20s for parallel on
+      // Vercel with cold start overhead, but fail if it looks sequential (>25s).
+      expect(elapsed).toBeLessThan(25_000);
+    }
+  );
 
-  test('sleepWinsRaceWorkflow', { timeout: 60_000 }, async () => {
-    const run = await start(await e2e('sleepWinsRaceWorkflow'), []);
-    const returnValue = await run.returnValue;
-    expect(returnValue.winner).toBe('sleep');
-    // Sleep is 1s; step would take 10s. Keep this below the losing branch
-    // without depending on exact remote queue/cold-start overhead.
-    expect(returnValue.durationMs).toBeLessThan(9_000);
-  });
+  test(
+    'sleepWinsRaceWorkflow',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('sleepWinsRaceWorkflow'), []);
+      const returnValue = await run.returnValue;
+      expect(returnValue.winner).toBe('sleep');
+      // Sleep is 1s; step would take 10s. Keep this below the losing branch
+      // without depending on exact remote queue/cold-start overhead.
+      expect(returnValue.durationMs).toBeLessThan(9_000);
+    }
+  );
 
-  test('stepWinsRaceWorkflow', { timeout: 60_000 }, async () => {
-    const run = await start(await e2e('stepWinsRaceWorkflow'), []);
-    const returnValue = await run.returnValue;
-    expect(returnValue.winner).toBe('step');
-    // Step is 1s; sleep would take 10s. Keep this below the losing branch
-    // without depending on exact remote queue/cold-start overhead.
-    expect(returnValue.durationMs).toBeLessThan(9_000);
-  });
+  test(
+    'stepWinsRaceWorkflow',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('stepWinsRaceWorkflow'), []);
+      const returnValue = await run.returnValue;
+      expect(returnValue.winner).toBe('step');
+      // Step is 1s; sleep would take 10s. Keep this below the losing branch
+      // without depending on exact remote queue/cold-start overhead.
+      expect(returnValue.durationMs).toBeLessThan(9_000);
+    }
+  );
 
-  test('nullByteWorkflow', { timeout: 60_000 }, async () => {
+  test('nullByteWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
     const run = await start(await e2e('nullByteWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toBe('null byte \0');
   });
 
-  test('workflowAndStepMetadataWorkflow', { timeout: 60_000 }, async () => {
-    const run = await start(await e2e('workflowAndStepMetadataWorkflow'), []);
-    const returnValue = await run.returnValue;
+  test(
+    'workflowAndStepMetadataWorkflow',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('workflowAndStepMetadataWorkflow'), []);
+      const returnValue = await run.returnValue;
 
-    expect(returnValue).toHaveProperty('workflowMetadata');
-    expect(returnValue).toHaveProperty('stepMetadata');
-    expect(returnValue).toHaveProperty('innerWorkflowMetadata');
+      expect(returnValue).toHaveProperty('workflowMetadata');
+      expect(returnValue).toHaveProperty('stepMetadata');
+      expect(returnValue).toHaveProperty('innerWorkflowMetadata');
 
-    // workflow and context
+      // workflow and context
 
-    expect(returnValue.workflowMetadata).toStrictEqual(
-      returnValue.innerWorkflowMetadata
-    );
+      expect(returnValue.workflowMetadata).toStrictEqual(
+        returnValue.innerWorkflowMetadata
+      );
 
-    // workflow context should have workflowName and stepMetadata shouldn't
-    expect(typeof returnValue.workflowMetadata.workflowName).toBe('string');
-    expect(returnValue.workflowMetadata.workflowName).toBe(
-      returnValue.innerWorkflowMetadata.workflowName
-    );
-    expect(returnValue.stepMetadata.workflowName).toBeUndefined();
+      // workflow context should have workflowName and stepMetadata shouldn't
+      expect(typeof returnValue.workflowMetadata.workflowName).toBe('string');
+      expect(returnValue.workflowMetadata.workflowName).toBe(
+        returnValue.innerWorkflowMetadata.workflowName
+      );
+      expect(returnValue.stepMetadata.workflowName).toBeUndefined();
 
-    // workflow context should have workflowRunId and stepMetadata shouldn't
-    expect(returnValue.workflowMetadata.workflowRunId).toBe(run.runId);
-    expect(returnValue.innerWorkflowMetadata.workflowRunId).toBe(run.runId);
-    expect(returnValue.stepMetadata.workflowRunId).toBeUndefined();
+      // workflow context should have workflowRunId and stepMetadata shouldn't
+      expect(returnValue.workflowMetadata.workflowRunId).toBe(run.runId);
+      expect(returnValue.innerWorkflowMetadata.workflowRunId).toBe(run.runId);
+      expect(returnValue.stepMetadata.workflowRunId).toBeUndefined();
 
-    // workflow context should have workflowStartedAt and stepMetadata shouldn't
-    // Note: workflowStartedAt may be a Date object (when using run.returnValue directly)
-    // or a string (when serialized through JSON via HTTP)
-    expect(returnValue.workflowMetadata.workflowStartedAt).toBeDefined();
-    expect(returnValue.innerWorkflowMetadata.workflowStartedAt).toBeDefined();
-    expect(String(returnValue.innerWorkflowMetadata.workflowStartedAt)).toBe(
-      String(returnValue.workflowMetadata.workflowStartedAt)
-    );
-    expect(returnValue.stepMetadata.workflowStartedAt).toBeUndefined();
+      // workflow context should have workflowStartedAt and stepMetadata shouldn't
+      // Note: workflowStartedAt may be a Date object (when using run.returnValue directly)
+      // or a string (when serialized through JSON via HTTP)
+      expect(returnValue.workflowMetadata.workflowStartedAt).toBeDefined();
+      expect(returnValue.innerWorkflowMetadata.workflowStartedAt).toBeDefined();
+      expect(String(returnValue.innerWorkflowMetadata.workflowStartedAt)).toBe(
+        String(returnValue.workflowMetadata.workflowStartedAt)
+      );
+      expect(returnValue.stepMetadata.workflowStartedAt).toBeUndefined();
 
-    // workflow context should have url and stepMetadata shouldn't
-    expect(typeof returnValue.workflowMetadata.url).toBe('string');
-    expect(typeof returnValue.innerWorkflowMetadata.url).toBe('string');
-    expect(returnValue.innerWorkflowMetadata.url).toBe(
-      returnValue.workflowMetadata.url
-    );
-    expect(returnValue.stepMetadata.url).toBeUndefined();
+      // workflow context should have url and stepMetadata shouldn't
+      expect(typeof returnValue.workflowMetadata.url).toBe('string');
+      expect(typeof returnValue.innerWorkflowMetadata.url).toBe('string');
+      expect(returnValue.innerWorkflowMetadata.url).toBe(
+        returnValue.workflowMetadata.url
+      );
+      expect(returnValue.stepMetadata.url).toBeUndefined();
 
-    // workflow context should have features and stepMetadata shouldn't
-    expect(returnValue.workflowMetadata.features).toBeDefined();
-    expect(typeof returnValue.workflowMetadata.features.encryption).toBe(
-      'boolean'
-    );
-    expect(returnValue.innerWorkflowMetadata.features).toStrictEqual(
-      returnValue.workflowMetadata.features
-    );
-    expect(returnValue.stepMetadata.features).toBeUndefined();
+      // workflow context should have features and stepMetadata shouldn't
+      expect(returnValue.workflowMetadata.features).toBeDefined();
+      expect(typeof returnValue.workflowMetadata.features.encryption).toBe(
+        'boolean'
+      );
+      expect(returnValue.innerWorkflowMetadata.features).toStrictEqual(
+        returnValue.workflowMetadata.features
+      );
+      expect(returnValue.stepMetadata.features).toBeUndefined();
 
-    // workflow context shouldn't have stepId, stepStartedAt, or attempt
-    expect(returnValue.workflowMetadata.stepId).toBeUndefined();
-    expect(returnValue.workflowMetadata.stepStartedAt).toBeUndefined();
-    expect(returnValue.workflowMetadata.attempt).toBeUndefined();
+      // workflow context shouldn't have stepId, stepStartedAt, or attempt
+      expect(returnValue.workflowMetadata.stepId).toBeUndefined();
+      expect(returnValue.workflowMetadata.stepStartedAt).toBeUndefined();
+      expect(returnValue.workflowMetadata.attempt).toBeUndefined();
 
-    // step context
+      // step context
 
-    // stepName should be a string
-    expect(typeof returnValue.stepMetadata.stepName).toBe('string');
+      // stepName should be a string
+      expect(typeof returnValue.stepMetadata.stepName).toBe('string');
 
-    // Attempt should be atleast 1
-    expect(returnValue.stepMetadata.attempt).toBeGreaterThanOrEqual(1);
+      // Attempt should be atleast 1
+      expect(returnValue.stepMetadata.attempt).toBeGreaterThanOrEqual(1);
 
-    // stepStartedAt should be a Date or date string
-    expect(returnValue.stepMetadata.stepStartedAt).toBeDefined();
-  });
+      // stepStartedAt should be a Date or date string
+      expect(returnValue.stepMetadata.stepStartedAt).toBeDefined();
+    }
+  );
 
   // outputStreamWorkflow writes 2 chunks to the default stream:
   //   chunk 0: binary "Hello, world!"
@@ -937,7 +978,7 @@ describe('e2e', () => {
     ] as const;
 
     for (const tc of startIndexCases) {
-      test(tc.name, { timeout: 60_000 }, async () => {
+      test(tc.name, { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
 
         if (tc.waitForCompletion) {
@@ -989,7 +1030,7 @@ describe('e2e', () => {
     test(
       'getTailIndex returns correct index after stream completes',
       {
-        timeout: 60_000,
+        timeout: DEFAULT_TEST_TIMEOUT_MS,
       },
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
@@ -1006,7 +1047,7 @@ describe('e2e', () => {
     test(
       'getTailIndex returns -1 before any chunks are written',
       {
-        timeout: 60_000,
+        timeout: DEFAULT_TEST_TIMEOUT_MS,
       },
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
@@ -1023,7 +1064,7 @@ describe('e2e', () => {
     test(
       'getChunks returns same content as reading the stream',
       {
-        timeout: 60_000,
+        timeout: DEFAULT_TEST_TIMEOUT_MS,
       },
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
@@ -1065,7 +1106,7 @@ describe('e2e', () => {
 
   test(
     'outputStreamInsideStepWorkflow - getWritable() called inside step functions',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const run = await start(await e2e('outputStreamInsideStepWorkflow'), []);
       const reader = run.getReadable().getReader();
@@ -1112,40 +1153,44 @@ describe('e2e', () => {
   // Extended, CJK, emoji, RTL) round-trip end-to-end as bytes that decode
   // back to the original strings — the same property that the web inspector
   // relies on to render decoded text for typed-array stream chunks.
-  test('utf8StreamWorkflow', { timeout: 120_000 }, async () => {
-    const run = await start(await e2e('utf8StreamWorkflow'), []);
-    const reader = run.getReadable().getReader();
+  test(
+    'utf8StreamWorkflow',
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('utf8StreamWorkflow'), []);
+      const reader = run.getReadable().getReader();
 
-    // `fatal: true` makes the decoder throw on any invalid UTF-8 sequence,
-    // so a successful decode is itself a round-trip assertion.
-    const decoder = new TextDecoder('utf-8', { fatal: true });
+      // `fatal: true` makes the decoder throw on any invalid UTF-8 sequence,
+      // so a successful decode is itself a round-trip assertion.
+      const decoder = new TextDecoder('utf-8', { fatal: true });
 
-    const expectedTexts = [
-      'Hello, world!',
-      'Café — naïve résumé',
-      '你好，世界！🌍✨',
-      'مرحبا بالعالم',
-    ];
+      const expectedTexts = [
+        'Hello, world!',
+        'Café — naïve résumé',
+        '你好，世界！🌍✨',
+        'مرحبا بالعالم',
+      ];
 
-    for (const expected of expectedTexts) {
-      const { value } = await reader.read();
-      assert(value);
-      assert(value instanceof Uint8Array);
-      expect(decoder.decode(value)).toBe(expected);
+      for (const expected of expectedTexts) {
+        const { value } = await reader.read();
+        assert(value);
+        assert(value instanceof Uint8Array);
+        expect(decoder.decode(value)).toBe(expected);
+      }
+
+      // Final chunk: UTF-8 encoded JSON document. The web inspector also
+      // re-parses decoded text as JSON when possible, so we exercise that
+      // shape here too.
+      const expectedJson = { greeting: '안녕하세요', emoji: '🎉' };
+      const { value: jsonValue } = await reader.read();
+      assert(jsonValue);
+      assert(jsonValue instanceof Uint8Array);
+      expect(JSON.parse(decoder.decode(jsonValue))).toEqual(expectedJson);
+
+      expect((await reader.read()).done).toBe(true);
+      expect(await run.returnValue).toEqual('done');
     }
-
-    // Final chunk: UTF-8 encoded JSON document. The web inspector also
-    // re-parses decoded text as JSON when possible, so we exercise that
-    // shape here too.
-    const expectedJson = { greeting: '안녕하세요', emoji: '🎉' };
-    const { value: jsonValue } = await reader.read();
-    assert(jsonValue);
-    assert(jsonValue instanceof Uint8Array);
-    expect(JSON.parse(decoder.decode(jsonValue))).toEqual(expectedJson);
-
-    expect((await reader.read()).done).toBe(true);
-    expect(await run.returnValue).toEqual('done');
-  });
+  );
 
   // A WritableStream passed as a workflow argument to start() should
   // land raw bytes on the parent's output stream when the child step
@@ -1159,39 +1204,43 @@ describe('e2e', () => {
   test.each([
     'writableForwardedFromWorkflowWorkflow',
     'writableForwardedFromStepWorkflow',
-  ] as const)('%s', { timeout: 120_000 }, async (workflowName) => {
-    const payload = `hello-from-child-${Date.now()}\n`;
-    const run = await start(await e2e(workflowName), [payload]);
+  ] as const)(
+    '%s',
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    async (workflowName) => {
+      const payload = `hello-from-child-${Date.now()}\n`;
+      const run = await start(await e2e(workflowName), [payload]);
 
-    const reader = run.getReadable().getReader();
-    // `fatal: true` makes the decoder throw on any invalid UTF-8
-    // sequence, so a successful decode is itself a round-trip
-    // assertion that the bytes survived intact.
-    const decoder = new TextDecoder('utf-8', { fatal: true });
+      const reader = run.getReadable().getReader();
+      // `fatal: true` makes the decoder throw on any invalid UTF-8
+      // sequence, so a successful decode is itself a round-trip
+      // assertion that the bytes survived intact.
+      const decoder = new TextDecoder('utf-8', { fatal: true });
 
-    // The child step performs exactly one write of `payload` as
-    // UTF-8 bytes, so we should receive a single chunk containing
-    // exactly those bytes before the stream closes.
-    const { value, done } = await reader.read();
-    expect(done).toBeFalsy();
-    assert(value);
-    assert(value instanceof Uint8Array);
+      // The child step performs exactly one write of `payload` as
+      // UTF-8 bytes, so we should receive a single chunk containing
+      // exactly those bytes before the stream closes.
+      const { value, done } = await reader.read();
+      expect(done).toBeFalsy();
+      assert(value);
+      assert(value instanceof Uint8Array);
 
-    const expectedBytes = new TextEncoder().encode(payload);
-    expect(value.byteLength).toBe(expectedBytes.byteLength);
-    expect(decoder.decode(value)).toBe(payload);
+      const expectedBytes = new TextEncoder().encode(payload);
+      expect(value.byteLength).toBe(expectedBytes.byteLength);
+      expect(decoder.decode(value)).toBe(payload);
 
-    // Default stream should close cleanly after the parent closes its
-    // writable.
-    expect((await reader.read()).done).toBe(true);
+      // Default stream should close cleanly after the parent closes its
+      // writable.
+      expect((await reader.read()).done).toBe(true);
 
-    const returnValue = await run.returnValue;
-    expect(returnValue).toMatchObject({
-      childRunId: expect.stringMatching(/^wrun_/),
-    });
-  });
+      const returnValue = await run.returnValue;
+      expect(returnValue).toMatchObject({
+        childRunId: expect.stringMatching(/^wrun_/),
+      });
+    }
+  );
 
-  test('fetchWorkflow', { timeout: 60_000 }, async () => {
+  test('fetchWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
     const run = await start(await e2e('fetchWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toMatchObject({
@@ -1202,12 +1251,16 @@ describe('e2e', () => {
     });
   });
 
-  test('promiseRaceStressTestWorkflow', { timeout: 60_000 }, async () => {
-    const run = await start(await e2e('promiseRaceStressTestWorkflow'), []);
-    const returnValue = await run.returnValue;
-    // Completion order can vary across worlds and scheduling environments.
-    expect([...returnValue].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
-  });
+  test(
+    'promiseRaceStressTestWorkflow',
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    async () => {
+      const run = await start(await e2e('promiseRaceStressTestWorkflow'), []);
+      const returnValue = await run.returnValue;
+      // Completion order can vary across worlds and scheduling environments.
+      expect([...returnValue].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
+    }
+  );
 
   // ==================== ERROR HANDLING TESTS ====================
   describe('error handling', () => {
@@ -1215,7 +1268,7 @@ describe('e2e', () => {
       describe('workflow errors', () => {
         test(
           'nested function calls preserve message and stack trace',
-          { timeout: 60_000 },
+          { timeout: DEFAULT_TEST_TIMEOUT_MS },
           async () => {
             const run = await start(await e2e('errorWorkflowNested'), []);
             const error = await run.returnValue.catch((e: unknown) => e);
@@ -1250,7 +1303,7 @@ describe('e2e', () => {
 
         test(
           'cross-file imports preserve message and stack trace',
-          { timeout: 60_000 },
+          { timeout: DEFAULT_TEST_TIMEOUT_MS },
           async () => {
             const run = await start(await e2e('errorWorkflowCrossFile'), []);
             const error = await run.returnValue.catch((e: unknown) => e);
@@ -1281,7 +1334,7 @@ describe('e2e', () => {
       describe('step errors', () => {
         test(
           'basic step error preserves message and stack trace',
-          { timeout: 60_000 },
+          { timeout: DEFAULT_TEST_TIMEOUT_MS },
           async () => {
             const run = await start(await e2e('errorStepBasic'), []);
             const result = await run.returnValue;
@@ -1337,7 +1390,7 @@ describe('e2e', () => {
 
         test(
           'cross-file step error preserves message and function names in stack',
-          { timeout: 60_000 },
+          { timeout: DEFAULT_TEST_TIMEOUT_MS },
           async () => {
             const run = await start(await e2e('errorStepCrossFile'), []);
             const result = await run.returnValue;
@@ -1398,7 +1451,7 @@ describe('e2e', () => {
     describe('retry behavior', () => {
       test(
         'regular Error retries until success',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           const run = await start(await e2e('errorRetrySuccess'), []);
           const result = await run.returnValue;
@@ -1418,7 +1471,7 @@ describe('e2e', () => {
 
       test(
         'FatalError fails immediately without retries',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           const run = await start(await e2e('errorRetryFatal'), []);
           const error = await run.returnValue.catch((e: unknown) => e);
@@ -1444,7 +1497,7 @@ describe('e2e', () => {
 
       test(
         'RetryableError respects custom retryAfter delay',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           const run = await start(await e2e('errorRetryCustomDelay'), []);
           const result = await run.returnValue;
@@ -1454,19 +1507,23 @@ describe('e2e', () => {
         }
       );
 
-      test('maxRetries=0 disables retries', { timeout: 60_000 }, async () => {
-        const run = await start(await e2e('errorRetryDisabled'), []);
-        const result = await run.returnValue;
+      test(
+        'maxRetries=0 disables retries',
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        async () => {
+          const run = await start(await e2e('errorRetryDisabled'), []);
+          const result = await run.returnValue;
 
-        expect(result.failed).toBe(true);
-        expect(result.attempt).toBe(1);
-      });
+          expect(result.failed).toBe(true);
+          expect(result.attempt).toBe(1);
+        }
+      );
     });
 
     describe('catchability', () => {
       test(
         'FatalError can be caught and detected with FatalError.is()',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           const run = await start(await e2e('errorFatalCatchable'), []);
           const result = await run.returnValue;
@@ -1482,7 +1539,7 @@ describe('e2e', () => {
 
       test(
         'step throw round-trips FatalError with cause chain to workflow catch',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           // A step throws a FatalError whose `.cause` is a TypeError. The
           // workflow catches the rejection and inspects the hydrated value.
@@ -1514,7 +1571,7 @@ describe('e2e', () => {
 
       test(
         'workflow throw round-trips FatalError + cause through run_failed event',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           // A workflow itself throws a FatalError with a RangeError cause.
           // Verifies that run_failed events go through the new
@@ -1561,7 +1618,7 @@ describe('e2e', () => {
 
       test(
         'workflow throw of a non-Error value round-trips verbatim as cause',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           // Workflows may throw any JS value. Verify a plain object thrown
           // from a workflow surfaces verbatim as WorkflowRunFailedError.cause
@@ -1589,7 +1646,7 @@ describe('e2e', () => {
 
       test(
         'step throw of a non-Error value preserves it as cause on the wrapping FatalError',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           // Steps may also throw any JS value. Non-Error throws aren't
           // recognized as `FatalError` (they have no `name === 'FatalError'`)
@@ -1627,7 +1684,7 @@ describe('e2e', () => {
     describe('not registered', () => {
       test(
         'WorkflowNotRegisteredError fails the run when workflow does not exist',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           // Start a run with a workflowId that doesn't exist in the deployment bundle.
           // This simulates starting a run against a deployment that doesn't have the workflow.
@@ -1652,7 +1709,7 @@ describe('e2e', () => {
 
       test(
         'StepNotRegisteredError fails the step but workflow can catch it',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           const run = await start(await e2e('stepNotRegisteredCatchable'), []);
           const result = await run.returnValue;
@@ -1678,7 +1735,7 @@ describe('e2e', () => {
 
       test(
         'StepNotRegisteredError fails the run when not caught in workflow',
-        { timeout: 60_000 },
+        { timeout: DEFAULT_TEST_TIMEOUT_MS },
         async () => {
           const run = await start(await e2e('stepNotRegisteredUncaught'), []);
           const error = await run.returnValue.catch((e: unknown) => e);
@@ -1695,7 +1752,7 @@ describe('e2e', () => {
 
   test(
     'stepDirectCallWorkflow - calling step functions directly outside workflow context',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Call the API route that directly calls a step function (no workflow context)
       const url = new URL('/api/test-direct-step-call', deploymentUrl);
@@ -1725,7 +1782,7 @@ describe('e2e', () => {
 
   test(
     'hookCleanupTestWorkflow - hook token reuse after workflow completion',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1787,7 +1844,7 @@ describe('e2e', () => {
 
   test(
     'concurrent hook token conflict - two workflows cannot use the same hook token simultaneously',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1886,7 +1943,7 @@ describe('e2e', () => {
     },
   ])(
     '$workflow - hook.getConflict() does not block step execution',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async ({ workflow, hookGetConflictTestData }) => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1917,7 +1974,7 @@ describe('e2e', () => {
 
   test(
     'hookGetConflictThenStepParallelWorkflow - hook.getConflict() continuation step runs alongside other steps',
-    { timeout: 90_000 },
+    { timeout: LONG_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1949,7 +2006,7 @@ describe('e2e', () => {
 
   test(
     'hookGetConflictWorkflow - hook.getConflict() resolves with the conflicting run when token is already registered',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1998,7 +2055,7 @@ describe('e2e', () => {
 
   test(
     'hookClaimOnlyMutexWorkflow - hook works as a pure run mutex without payload data',
-    { timeout: 90_000 },
+    { timeout: LONG_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2062,7 +2119,7 @@ describe('e2e', () => {
 
   test(
     'hookAdoptOwnerResultWorkflow - duplicate adopts the owner result via conflict.returnValue',
-    { timeout: 120_000 },
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2123,7 +2180,7 @@ describe('e2e', () => {
 
   test(
     'hookSignalOwnerWorkflow - duplicate forwards its payload to the owner via resumeHook',
-    { timeout: 90_000 },
+    { timeout: LONG_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2157,7 +2214,7 @@ describe('e2e', () => {
 
   test(
     'hookSupersedeOwnerWorkflow - duplicate cancels the owner and claims the released token',
-    { timeout: 90_000 },
+    { timeout: LONG_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2171,7 +2228,10 @@ describe('e2e', () => {
       const run2 = await start(await e2e('hookSupersedeOwnerWorkflow'), [
         token,
       ]);
-      await waitForHook(token, { runId: run2.runId, timeoutMs: 60_000 });
+      await waitForHook(token, {
+        runId: run2.runId,
+        timeoutMs: HOOK_WAIT_TIMEOUT_MS,
+      });
 
       // The superseded owner ends up cancelled — assert via both the
       // rejected returnValue (also prevents an unhandled rejection from
@@ -2193,7 +2253,7 @@ describe('e2e', () => {
 
   test(
     'resume-or-start route pattern - resumeHook retried after start() reaches the new run',
-    { timeout: 90_000 },
+    { timeout: LONG_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2238,7 +2298,7 @@ describe('e2e', () => {
 
   test(
     'hookDisposeTestWorkflow - hook token reuse after explicit disposal while workflow still running',
-    { timeout: 90_000 },
+    { timeout: LONG_TEST_TIMEOUT_MS },
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -2329,7 +2389,7 @@ describe('e2e', () => {
 
   test(
     'stepFunctionPassingWorkflow - step function references can be passed as arguments (without closure vars)',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This workflow passes a step function reference to another step
       // The receiving step calls the passed function and returns the result
@@ -2361,7 +2421,7 @@ describe('e2e', () => {
 
   test(
     'stepFunctionWithClosureWorkflow - step function with closure variables passed as argument',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This workflow creates a nested step function with closure variables,
       // then passes it to another step which invokes it.
@@ -2386,7 +2446,7 @@ describe('e2e', () => {
 
   test(
     'closureVariableWorkflow - nested step functions with closure variables',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This workflow uses a nested step function that references closure variables
       // from the parent workflow scope (multiplier, prefix, baseValue)
@@ -2400,7 +2460,7 @@ describe('e2e', () => {
 
   test(
     'spawnWorkflowFromStepWorkflow - spawning a child workflow using start() inside a step',
-    { timeout: 120_000 },
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
     async () => {
       // This workflow spawns another workflow using start() inside a step function
       // This is the recommended pattern for spawning workflows from within workflows
@@ -2445,7 +2505,7 @@ describe('e2e', () => {
 
   test(
     'runClassSerializationWorkflow - Run instances serialize across workflow/step boundaries',
-    { timeout: 120_000 },
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
     async () => {
       const inputValue = 21;
       const run = await start(await e2e('runClassSerializationWorkflow'), [
@@ -2484,7 +2544,7 @@ describe('e2e', () => {
 
   test(
     'startFromWorkflow - calling start() directly inside a workflow function with hook communication',
-    { timeout: 120_000 },
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
     async () => {
       const inputValue = 42;
       const run = await start(await e2e('startFromWorkflow'), [inputValue]);
@@ -2506,7 +2566,7 @@ describe('e2e', () => {
 
   test(
     'fibonacciWorkflow - recursive workflow composition via start()',
-    { timeout: 180_000 },
+    { timeout: VERY_LONG_TEST_TIMEOUT_MS },
     async () => {
       // fib(6) = 8, spawns a tree of child workflow runs
       const run = await start(await e2e('fibonacciWorkflow'), [6]);
@@ -2522,7 +2582,7 @@ describe('e2e', () => {
   // bypasses protection by sending messages through the Queue infrastructure.
   test.skipIf(!isLocalDeployment())(
     'health check endpoint (HTTP) - workflow endpoint responds to __health query parameter',
-    { timeout: 30_000 },
+    { timeout: SHORT_TEST_TIMEOUT_MS },
     async () => {
       // NOTE: This tests the HTTP-based health check using the `?__health` query parameter.
       // This approach requires direct HTTP access and works when running locally (for port detection)
@@ -2558,7 +2618,7 @@ describe('e2e', () => {
 
   test(
     'health check (queue-based) - workflow endpoint responds to health check messages',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Tests the queue-based health check using healthCheck() directly.
       // This bypasses Vercel Deployment Protection by sending messages
@@ -2579,7 +2639,7 @@ describe('e2e', () => {
 
   test(
     'health check (CLI) - workflow health command reports healthy endpoints',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // NOTE: This tests the `workflow health` CLI command which uses the
       // queue-based health check under the hood. The CLI provides a convenient
@@ -2602,7 +2662,7 @@ describe('e2e', () => {
 
   test(
     'pathsAliasWorkflow - TypeScript path aliases resolve correctly',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This workflow uses a step that calls a helper function imported via @repo/* path alias
       // which resolves to a file outside the workbench directory (../../lib/steps/paths-alias-test.ts)
@@ -2626,7 +2686,7 @@ describe('e2e', () => {
 
   test(
     'Calculator.calculate - static workflow method using static step methods from another class',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Calculator.calculate(5, 3) should:
       // 1. MathService.add(5, 3) = 8
@@ -2648,7 +2708,7 @@ describe('e2e', () => {
 
   test(
     'AllInOneService.processNumber - static workflow method using sibling static step methods',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // AllInOneService.processNumber(10) should:
       // 1. AllInOneService.double(10) = 20
@@ -2671,7 +2731,7 @@ describe('e2e', () => {
 
   test(
     'ChainableService.processWithThis - static step methods using `this` to reference the class',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // ChainableService.processWithThis(5) should:
       // - ChainableService.multiplyByClassValue(5) uses `this.multiplier` (10) -> 5 * 10 = 50
@@ -2705,7 +2765,7 @@ describe('e2e', () => {
 
   test(
     'thisSerializationWorkflow - step function invoked with .call() and .apply()',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // thisSerializationWorkflow(10) should:
       // 1. multiplyByFactor.call({ factor: 2 }, 10) = 20
@@ -2728,7 +2788,7 @@ describe('e2e', () => {
 
   test(
     'customSerializationWorkflow - custom class serialization with WORKFLOW_SERIALIZE/WORKFLOW_DESERIALIZE',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This workflow tests custom serialization of user-defined class instances.
       // The Point class uses WORKFLOW_SERIALIZE and WORKFLOW_DESERIALIZE symbols
@@ -2765,7 +2825,7 @@ describe('e2e', () => {
 
   test(
     'instanceMethodStepWorkflow - instance methods with "use step" directive',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This workflow tests instance methods marked with "use step".
       // The Counter class has custom serialization so the `this` context
@@ -2860,7 +2920,7 @@ describe('e2e', () => {
 
   test(
     'crossContextSerdeWorkflow - classes defined in step code are deserializable in workflow context',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This is a critical test for the cross-context class registration feature.
       //
@@ -2913,7 +2973,7 @@ describe('e2e', () => {
 
   test(
     'errorSubclassRoundTripWorkflow - first-class Error subclasses survive every serialization boundary',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Round-trips one instance of each Error subclass that has a dedicated
       // reducer/reviver pair (built-in subclasses + FatalError/RetryableError
@@ -3028,7 +3088,7 @@ describe('e2e', () => {
 
   test(
     'stepFunctionAsStartArgWorkflow - step function reference passed as start() argument',
-    { timeout: 120_000 },
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
     async () => {
       // This test verifies that step function references can be:
       // 1. Serialized in the client bundle (the SWC plugin sets stepId property on the function)
@@ -3093,7 +3153,7 @@ describe('e2e', () => {
   // ==================== CANCEL TESTS ====================
   test(
     'cancelRun - cancelling a running workflow',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Start a long-running workflow with a 30s sleep to provide a wide
       // window for the cancel to arrive while the workflow is still running.
@@ -3126,7 +3186,7 @@ describe('e2e', () => {
 
   test(
     'cancelRun via CLI - cancelling a running workflow',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Start a long-running workflow with a 30s sleep to provide a wide
       // window for the cancel to arrive while the workflow is still running.
@@ -3162,22 +3222,26 @@ describe('e2e', () => {
     process.env.APP_NAME === 'nextjs-webpack';
 
   describe.skipIf(!isNextJsApp)('pages router', () => {
-    test('addTenWorkflow via pages router', { timeout: 60_000 }, async () => {
-      const run = await startWorkflowViaHttp(
-        {
-          workflowFile: 'workflows/99_e2e.ts',
-          workflowFn: 'addTenWorkflow',
-        },
-        [123],
-        '/api/trigger-pages'
-      );
-      const returnValue = await run.returnValue;
-      expect(returnValue).toBe(133);
-    });
+    test(
+      'addTenWorkflow via pages router',
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      async () => {
+        const run = await startWorkflowViaHttp(
+          {
+            workflowFile: 'workflows/99_e2e.ts',
+            workflowFn: 'addTenWorkflow',
+          },
+          [123],
+          '/api/trigger-pages'
+        );
+        const returnValue = await run.returnValue;
+        expect(returnValue).toBe(133);
+      }
+    );
 
     test(
       'promiseAllWorkflow via pages router',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await startWorkflowViaHttp(
           'promiseAllWorkflow',
@@ -3189,21 +3253,28 @@ describe('e2e', () => {
       }
     );
 
-    test('sleepingWorkflow via pages router', { timeout: 60_000 }, async () => {
-      const run = await startWorkflowViaHttp(
-        'sleepingWorkflow',
-        [],
-        '/api/trigger-pages'
-      );
-      const returnValue = await run.returnValue;
-      expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
-      expectElapsedAtLeast(returnValue.endTime - returnValue.startTime, 10_000);
-    });
+    test(
+      'sleepingWorkflow via pages router',
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      async () => {
+        const run = await startWorkflowViaHttp(
+          'sleepingWorkflow',
+          [],
+          '/api/trigger-pages'
+        );
+        const returnValue = await run.returnValue;
+        expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
+        expectElapsedAtLeast(
+          returnValue.endTime - returnValue.startTime,
+          10_000
+        );
+      }
+    );
   });
 
   test(
     'hookWithSleepWorkflow - hook payloads delivered correctly with concurrent sleep',
-    { timeout: 90_000 },
+    { timeout: LONG_TEST_TIMEOUT_MS },
     async () => {
       // Regression test: when a hook and sleep run concurrently, multiple
       // hook_received events should all be processed even though the sleep
@@ -3262,7 +3333,7 @@ describe('e2e', () => {
 
   test(
     'hookWithSleepFinalStepWorkflow - step only on final payload',
-    { timeout: 120_000 },
+    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
     async () => {
       // Regression test for the v0chat incident. Mirrors the production
       // shape: a hook + fire-and-forget sleep, where the step runs only
@@ -3304,7 +3375,7 @@ describe('e2e', () => {
 
   test(
     'sleepInLoopWorkflow - sleep inside loop with steps actually delays each iteration',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const run = await start(await e2e('sleepInLoopWorkflow'), []);
       const returnValue = await run.returnValue;
@@ -3322,7 +3393,7 @@ describe('e2e', () => {
 
   test(
     'sleepWithSequentialStepsWorkflow - sequential steps work with concurrent sleep (control)',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Control test: proves that void sleep('1d').then() does NOT break
       // sequential step execution. Steps have per-event consumption so the
@@ -3348,7 +3419,7 @@ describe('e2e', () => {
   describe('AbortController', () => {
     test(
       'abortTimeoutWorkflow: timeout cancels long-running step',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortTimeoutWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3383,7 +3454,7 @@ describe('e2e', () => {
 
     test(
       'abortParallelWorkflow: abort cancels all parallel steps',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortParallelWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3398,7 +3469,7 @@ describe('e2e', () => {
 
     test(
       'abortFromStepWorkflow: step abort cancels an in-flight sibling step',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortFromStepWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3419,7 +3490,7 @@ describe('e2e', () => {
 
     test(
       'abortAlreadyAbortedWorkflow: pre-aborted signal seen by step',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortAlreadyAbortedWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3433,7 +3504,7 @@ describe('e2e', () => {
 
     test(
       'abortReasonWorkflow: abort reason preserved across boundaries',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortReasonWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3447,7 +3518,7 @@ describe('e2e', () => {
 
     test(
       'abortAfterCompletionWorkflow: abort after step completes is a no-op',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortAfterCompletionWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3461,7 +3532,7 @@ describe('e2e', () => {
 
     test(
       'abortViaHookWorkflow: external hook triggers abort on in-flight step',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const token = Math.random().toString(36).slice(2);
         const run = await start(await e2e('abortViaHookWorkflow'), [token]);
@@ -3481,7 +3552,7 @@ describe('e2e', () => {
 
     test(
       'abortExternalSignalWorkflow: signal passed as workflow input',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         // Pass a pre-aborted AbortController to the workflow.
         // The workflow receives the signal and passes it to a step.
@@ -3501,7 +3572,7 @@ describe('e2e', () => {
 
     test(
       'abortExternalSignalInFlightWorkflow: external abort fires mid-flight, propagates to nested steps',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         // Source controller starts NOT aborted. The serialization-time
         // listener attached during start() must write the cancellation packet
@@ -3542,7 +3613,7 @@ describe('e2e', () => {
 
     test(
       'abortAnyInWorkflowWorkflow: AbortSignal.any composes signals inside the workflow VM',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortAnyInWorkflowWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3560,7 +3631,7 @@ describe('e2e', () => {
 
     test(
       'abortAnyInStepWorkflow: AbortSignal.any inside a step composes deserialized signals',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortAnyInStepWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3578,7 +3649,7 @@ describe('e2e', () => {
 
     test(
       'abortSurvivesReplayWorkflow: controller state consistent across replay',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortSurvivesReplayWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3593,7 +3664,7 @@ describe('e2e', () => {
 
     test(
       'abortThrowIfAbortedWorkflow: throwIfAborted causes FatalError, no retries',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortThrowIfAbortedWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3607,7 +3678,7 @@ describe('e2e', () => {
 
     test(
       'abortReasonTypesWorkflow: various abort reason types propagate correctly',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortReasonTypesWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3630,7 +3701,7 @@ describe('e2e', () => {
 
     test(
       'abortFetchUncaughtWorkflow: uncaught fetch AbortError is FatalError, no retries',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortFetchUncaughtWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3650,7 +3721,7 @@ describe('e2e', () => {
 
     test(
       'abortFetchInFlightWorkflow: aborting cancels an in-flight fetch',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         // The workflow kicks off a fetch against a slow endpoint, races it
         // against a 2s sleep, and aborts when the sleep wins. The fetch must
@@ -3676,7 +3747,7 @@ describe('e2e', () => {
 
     test(
       'abortVoidSleepTimeoutWorkflow: documented `void sleep().then(abort)` pattern works',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         // Validates the simplified timeout pattern documented on the
         // abort-signal-timeout-in-workflow error page:
@@ -3702,7 +3773,7 @@ describe('e2e', () => {
 
     test(
       'abortDeterministicBranchWorkflow: if-check takes same path on first-run and replay',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('abortDeterministicBranchWorkflow'),
@@ -3721,7 +3792,7 @@ describe('e2e', () => {
 
     test(
       'abortListenerWorkflow: signal.addEventListener fires on the deserialized step signal',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(await e2e('abortListenerWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3737,7 +3808,7 @@ describe('e2e', () => {
 
     test(
       'abortThrowIfAbortedMidFlightWorkflow: throwIfAborted in a polling loop bails when abort fires',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('abortThrowIfAbortedMidFlightWorkflow'),
@@ -3756,7 +3827,7 @@ describe('e2e', () => {
 
     test(
       'abortDeterministicBranchFromStepWorkflow: branches stay consistent when abort comes from a step',
-      { timeout: 60_000 },
+      { timeout: DEFAULT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('abortDeterministicBranchFromStepWorkflow'),
@@ -3815,7 +3886,7 @@ describe('e2e', () => {
     } of orderingVariants) {
       test(
         `abortHookOrderingWorkflow [${variant}]: ${description}`,
-        { timeout: 90_000 },
+        { timeout: LONG_TEST_TIMEOUT_MS },
         async () => {
           const token = `ordering-${variant}-${Math.random().toString(36).slice(2)}`;
           const run = await start(await e2e('abortHookOrderingWorkflow'), [
@@ -3859,7 +3930,7 @@ describe('e2e', () => {
 
   test(
     'importMetaUrlWorkflow - import.meta.url is available in step bundles',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const run = await start(await e2e('importMetaUrlWorkflow'), []);
       const returnValue = await run.returnValue;
@@ -3873,7 +3944,7 @@ describe('e2e', () => {
 
   test(
     'metadataFromHelperWorkflow - getWorkflowMetadata/getStepMetadata work from module-level helper (#1577)',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const run = await start(await e2e('metadataFromHelperWorkflow'), [
         'smoke-test',
@@ -3895,7 +3966,7 @@ describe('e2e', () => {
   // over the queue boundary.
   test(
     'resilient start: addTenWorkflow completes when run_created returns 500',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // Get the real world and wrap it so the first events.create call
       // (run_created) throws a 500 server error. The queue should still
@@ -3940,7 +4011,7 @@ describe('e2e', () => {
 
   test(
     'getterStepWorkflow - getter functions with "use step" directive',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       // This workflow tests getter functions marked with "use step".
       // The Sensor class has custom serialization so the `this` context
@@ -3978,7 +4049,7 @@ describe('e2e', () => {
   // ============================================================
   test(
     'distributedAbortController - manual abort triggers signal',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const controllerId = `test-abort-${Math.random().toString(36).slice(2)}`;
 
@@ -4014,7 +4085,7 @@ describe('e2e', () => {
 
   test(
     'distributedAbortController - TTL expiration triggers signal',
-    { timeout: 30_000 },
+    { timeout: SHORT_TEST_TIMEOUT_MS },
     async () => {
       const controllerId = `test-expire-${Math.random().toString(36).slice(2)}`;
 
@@ -4042,7 +4113,7 @@ describe('e2e', () => {
 
   test(
     'distributedAbortController - reconnect to existing controller',
-    { timeout: 60_000 },
+    { timeout: DEFAULT_TEST_TIMEOUT_MS },
     async () => {
       const controllerId = `test-reconnect-${Math.random().toString(36).slice(2)}`;
       const token = `distributed-abort:${controllerId}`;
@@ -4077,7 +4148,7 @@ describe('e2e', () => {
   describe('experimental_setAttributes', () => {
     test(
       'start: initial attributes are seeded on run creation',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesWorkflow'),
@@ -4097,7 +4168,7 @@ describe('e2e', () => {
 
     test(
       'start: reserved-prefix initial attributes are seeded with allowReservedAttributes',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesWorkflow'),
@@ -4124,7 +4195,7 @@ describe('e2e', () => {
 
     test(
       'experimentalSetAttributesWorkflow: workflow-body calls append native attr_set events and merge correctly',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesWorkflow'),
@@ -4152,7 +4223,7 @@ describe('e2e', () => {
 
     test(
       'experimentalSetAttributesInsideStepWorkflow: step-body calls append attributed native events',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesInsideStepWorkflow'),
@@ -4182,7 +4253,7 @@ describe('e2e', () => {
 
     test(
       'fire-and-forget: void experimental_setAttributes lands without awaiting',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesFireAndForgetWorkflow'),
@@ -4200,7 +4271,7 @@ describe('e2e', () => {
 
     test(
       'Promise.all of disjoint-key writes: every key lands',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesParallelWorkflow'),
@@ -4220,7 +4291,7 @@ describe('e2e', () => {
 
     test(
       'workflow throws after awaited setAttributes: attribute still persists on the failed run',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesThrowsAfterWorkflow'),
@@ -4247,7 +4318,7 @@ describe('e2e', () => {
 
     test(
       'validation DX: invalid writes throw catchable FatalErrors naming rule and limit',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesValidationWorkflow'),
@@ -4285,7 +4356,7 @@ describe('e2e', () => {
 
     test(
       'start: invalid initial attributes are rejected before a run is created',
-      { timeout: 30_000 },
+      { timeout: SHORT_TEST_TIMEOUT_MS },
       async () => {
         const workflow = await e2e('experimentalSetAttributesWorkflow');
         await expect(

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -52,6 +52,16 @@ if (!deploymentUrl) {
   throw new Error('`DEPLOYMENT_URL` environment variable is not set');
 }
 
+const DISTRIBUTED_CLOCK_TOLERANCE_MS = 1_000;
+
+function expectElapsedAtLeast(actualMs: number, expectedMs: number) {
+  // Vercel e2e compares timestamps from different invocations and services.
+  // Allow clock skew while still catching immediate or default-delay resumes.
+  expect(actualMs).toBeGreaterThanOrEqual(
+    Math.max(0, expectedMs - DISTRIBUTED_CLOCK_TOLERANCE_MS)
+  );
+}
+
 /**
  * Tracked wrapper around start() that automatically registers runs
  * for diagnostics on test failure and observability metadata collection.
@@ -95,6 +105,10 @@ function writeE2EMetadata() {
 const e2e = (fn: string) =>
   getWorkflowMetadata(deploymentUrl, 'workflows/99_e2e.ts', fn);
 
+type WorkflowEvent = Awaited<
+  ReturnType<World['events']['list']>
+>['data'][number];
+
 /**
  * Polls `getHookByToken(token)` until it resolves or the timeout is hit.
  * Replaces fixed `setTimeout(N)` waits in hook tests, which are flaky on
@@ -136,6 +150,40 @@ async function waitForHook(
     await sleep(intervalMs);
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function waitForRunEvents(
+  runId: string,
+  predicate: (event: WorkflowEvent) => boolean,
+  options: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    minCount?: number;
+    description?: string;
+  } = {}
+): Promise<WorkflowEvent[]> {
+  const {
+    timeoutMs = 30_000,
+    intervalMs = 250,
+    minCount = 1,
+    description = 'matching event',
+  } = options;
+  const world = await getWorld();
+  const deadline = Date.now() + timeoutMs;
+  let latestMatches: WorkflowEvent[] = [];
+
+  while (Date.now() < deadline) {
+    const { data: events } = await world.events.list({ runId });
+    latestMatches = events.filter(predicate);
+    if (latestMatches.length >= minCount) {
+      return latestMatches;
+    }
+    await sleep(intervalMs);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${minCount} ${description} for run ${runId}; saw ${latestMatches.length}`
+  );
 }
 
 /**
@@ -733,7 +781,7 @@ describe('e2e', () => {
     const run = await start(await e2e('sleepingWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
-    expect(returnValue.endTime - returnValue.startTime).toBeGreaterThan(9999);
+    expectElapsedAtLeast(returnValue.endTime - returnValue.startTime, 10_000);
   });
 
   test('parallelSleepWorkflow', { timeout: 60_000 }, async () => {
@@ -743,7 +791,7 @@ describe('e2e', () => {
     // On Vercel, cold starts and queue round-trips add latency, so we use a
     // generous upper bound. The key assertion is parallel < sequential (10s+).
     const elapsed = returnValue.endTime - returnValue.startTime;
-    expect(elapsed).toBeGreaterThan(999);
+    expectElapsedAtLeast(elapsed, 1_000);
     // Sequential would be ~10s+ per sleep. Allow up to 20s for parallel on
     // Vercel with cold start overhead, but fail if it looks sequential (>25s).
     expect(elapsed).toBeLessThan(25_000);
@@ -753,16 +801,18 @@ describe('e2e', () => {
     const run = await start(await e2e('sleepWinsRaceWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue.winner).toBe('sleep');
-    // Sleep is 1s; step would take 10s. Should resolve in ~1s, well under 5s.
-    expect(returnValue.durationMs).toBeLessThan(5_000);
+    // Sleep is 1s; step would take 10s. Keep this below the losing branch
+    // without depending on exact remote queue/cold-start overhead.
+    expect(returnValue.durationMs).toBeLessThan(9_000);
   });
 
   test('stepWinsRaceWorkflow', { timeout: 60_000 }, async () => {
     const run = await start(await e2e('stepWinsRaceWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue.winner).toBe('step');
-    // Step is 1s; sleep would take 10s. Should resolve in ~1s, well under 5s.
-    expect(returnValue.durationMs).toBeLessThan(5_000);
+    // Step is 1s; sleep would take 10s. Keep this below the losing branch
+    // without depending on exact remote queue/cold-start overhead.
+    expect(returnValue.durationMs).toBeLessThan(9_000);
   });
 
   test('nullByteWorkflow', { timeout: 60_000 }, async () => {
@@ -1397,7 +1447,7 @@ describe('e2e', () => {
           const result = await run.returnValue;
 
           expect(result.attempt).toBe(2);
-          expect(result.duration).toBeGreaterThan(10_000);
+          expectElapsedAtLeast(result.duration, 10_000);
         }
       );
 
@@ -1883,7 +1933,6 @@ describe('e2e', () => {
 
       const { stepAResult, stepBResult } = returnValue;
       const stepADuration = stepAResult.endedAt - stepAResult.startedAt;
-      const stepStartDelta = stepBResult.startedAt - stepAResult.startedAt;
 
       expect(stepAResult.label).toBe('A');
       expect(stepBResult.label).toBe('B');
@@ -1892,10 +1941,6 @@ describe('e2e', () => {
         stepBResult.startedAt,
         'stepB should start before stepA finishes, proving hook.getConflict() can continue independently of other steps'
       ).toBeLessThan(stepAResult.endedAt);
-      expect(
-        stepStartDelta,
-        'stepB should start roughly alongside stepA instead of only after stepA finishes'
-      ).toBeLessThan(8_000);
     }
   );
 
@@ -3051,8 +3096,14 @@ describe('e2e', () => {
       // window for the cancel to arrive while the workflow is still running.
       const run = await start(await e2e('sleepingWorkflow'), [30_000]);
 
-      // Wait for the workflow to start and enter the sleep
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      // Wait for the workflow to start and enter the sleep.
+      await waitForRunEvents(
+        run.runId,
+        (event) => event.eventType === 'wait_created',
+        {
+          description: 'wait_created event',
+        }
+      );
 
       // Cancel the run using the core runtime cancelRun function.
       // This exercises the same cancelRun code path that the CLI uses
@@ -3078,8 +3129,14 @@ describe('e2e', () => {
       // window for the cancel to arrive while the workflow is still running.
       const run = await start(await e2e('sleepingWorkflow'), [30_000]);
 
-      // Wait for the workflow to start and enter the sleep
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      // Wait for the workflow to start and enter the sleep.
+      await waitForRunEvents(
+        run.runId,
+        (event) => event.eventType === 'wait_created',
+        {
+          description: 'wait_created event',
+        }
+      );
 
       // Cancel the run via the CLI command. This tests the full CLI code path
       // including World.close() which ensures the process exits cleanly.
@@ -3137,7 +3194,7 @@ describe('e2e', () => {
       );
       const returnValue = await run.returnValue;
       expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
-      expect(returnValue.endTime - returnValue.startTime).toBeGreaterThan(9999);
+      expectElapsedAtLeast(returnValue.endTime - returnValue.startTime, 10_000);
     });
   });
 
@@ -3159,13 +3216,23 @@ describe('e2e', () => {
       expect(hook.runId).toBe(run.runId);
       await resumeHook(hook, { type: 'subscribe', id: 1 });
 
-      // Wait for the first payload to be processed (step must complete)
-      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      await waitForRunEvents(
+        run.runId,
+        (event) => event.eventType === 'step_completed',
+        { description: 'step_completed event after first hook payload' }
+      );
 
       hook = await getHookByToken(token);
       await resumeHook(hook, { type: 'subscribe', id: 2 });
 
-      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      await waitForRunEvents(
+        run.runId,
+        (event) => event.eventType === 'step_completed',
+        {
+          minCount: 2,
+          description: 'step_completed events after second hook payload',
+        }
+      );
 
       hook = await getHookByToken(token);
       await resumeHook(hook, { type: 'done', done: true });
@@ -3205,19 +3272,20 @@ describe('e2e', () => {
         token,
       ]);
 
-      // Wait for the hook to register.
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-
-      let hook = await getHookByToken(token);
+      let hook = await waitForHook(token, { runId: run.runId });
       expect(hook.runId).toBe(run.runId);
       await resumeHook(hook, { type: 'msg', id: 1 });
 
       // Let the workflow replay and suspend before the next payload so the
       // final event log contains two `hook_received` entries before any
       // `step_created` — the exact replay shape from production.
-      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      await waitForRunEvents(
+        run.runId,
+        (event) => event.eventType === 'hook_received',
+        { description: 'hook_received event after first payload' }
+      );
 
-      hook = await getHookByToken(token);
+      hook = await waitForHook(token, { runId: run.runId });
       await resumeHook(hook, { type: 'final', id: 2, done: true });
 
       const returnValue = await run.returnValue;
@@ -3243,9 +3311,9 @@ describe('e2e', () => {
       expect(returnValue.timestamps).toHaveLength(3);
       const delta1 = returnValue.timestamps[1] - returnValue.timestamps[0];
       const delta2 = returnValue.timestamps[2] - returnValue.timestamps[1];
-      expect(delta1).toBeGreaterThan(2_500);
-      expect(delta2).toBeGreaterThan(2_500);
-      expect(returnValue.totalElapsed).toBeGreaterThan(5_000);
+      expectElapsedAtLeast(delta1, 3_000);
+      expectElapsedAtLeast(delta2, 3_000);
+      expectElapsedAtLeast(returnValue.totalElapsed, 6_000);
     }
   );
 
@@ -3993,10 +4061,6 @@ describe('e2e', () => {
       // Abort the controller
       await resumeHook(token, { reason: 'Test complete' });
 
-      // Workflow should still be running (grace period), so hook should still be findable
-      await sleep(1_000);
-      const _hookAfterAbort = await getHookByToken(token).catch(() => null);
-      // Hook may or may not be disposed depending on timing, but run should complete
       const returnValue = await run1.returnValue;
       expect(returnValue.aborted).toBe(true);
       expect(returnValue.reason).toBe('Test complete');

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1211,18 +1211,39 @@ describe('e2e', () => {
       const payload = `hello-from-child-${Date.now()}\n`;
       const run = await start(await e2e(workflowName), [payload]);
 
-      const reader = run.getReadable().getReader();
+      const returnValue = await run.returnValue;
       // `fatal: true` makes the decoder throw on any invalid UTF-8
       // sequence, so a successful decode is itself a round-trip
       // assertion that the bytes survived intact.
       const decoder = new TextDecoder('utf-8', { fatal: true });
+      const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
+      let reader: ReadableStreamDefaultReader<unknown> | undefined;
+      let value: unknown;
 
       // The child step performs exactly one write of `payload` as
       // UTF-8 bytes, so we should receive a single chunk containing
-      // exactly those bytes before the stream closes.
-      const { value, done } = await reader.read();
-      expect(done).toBeFalsy();
-      assert(value);
+      // exactly those bytes before the stream closes. On distributed
+      // Vercel runs, the run can complete just before the readable
+      // endpoint sees the forwarded stream chunk, so reopen until the
+      // persisted output is visible.
+      while (Date.now() < readDeadline) {
+        reader = run.getReadable().getReader();
+        const result = await reader.read();
+
+        if (!result.done && result.value) {
+          value = result.value;
+          break;
+        }
+
+        reader.releaseLock();
+        reader = undefined;
+        await sleep(1_000);
+      }
+
+      assert(
+        value,
+        `Timed out waiting for forwarded writable chunk from ${workflowName}`
+      );
       assert(value instanceof Uint8Array);
 
       const expectedBytes = new TextEncoder().encode(payload);
@@ -1231,9 +1252,10 @@ describe('e2e', () => {
 
       // Default stream should close cleanly after the parent closes its
       // writable.
+      assert(reader, 'Expected an open reader for forwarded writable stream');
       expect((await reader.read()).done).toBe(true);
+      reader.releaseLock();
 
-      const returnValue = await run.returnValue;
       expect(returnValue).toMatchObject({
         childRunId: expect.stringMatching(/^wrun_/),
       });

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -53,6 +53,7 @@ if (!deploymentUrl) {
 }
 
 const DISTRIBUTED_CLOCK_TOLERANCE_MS = 1_000;
+const STREAM_READ_TIMEOUT_MS = 90_000;
 
 function expectElapsedAtLeast(actualMs: number, expectedMs: number) {
   // Vercel e2e compares timestamps from different invocations and services.
@@ -397,7 +398,7 @@ describe('e2e', () => {
     }
   );
 
-  test('readableStreamWorkflow', { timeout: 120_000 }, async () => {
+  test('readableStreamWorkflow', { timeout: 180_000 }, async () => {
     const run = await start(await e2e('readableStreamWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toBeInstanceOf(ReadableStream);
@@ -406,16 +407,18 @@ describe('e2e', () => {
     const decoder = new TextDecoder();
     let contents = '';
     // Read chunks until we have all expected content or hit a timeout.
-    // On Vercel, the stream close event can be delayed even after all
-    // chunks are delivered, so we stop once we have the expected data
-    // rather than waiting for the stream to end.
+    // On Vercel, the final chunk or close event can be delayed, so we stop
+    // once we have the expected data rather than waiting for stream closure.
     const reader = returnValue.getReader();
-    const readDeadline = Date.now() + 60_000;
+    const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
     try {
       while (Date.now() < readDeadline) {
         const { done, value } = await Promise.race([
           reader.read(),
-          sleep(30_000).then(() => ({ done: true, value: undefined })),
+          sleep(STREAM_READ_TIMEOUT_MS).then(() => ({
+            done: true,
+            value: undefined,
+          })),
         ]);
         if (value) {
           contents += decoder.decode(value, { stream: true });

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2225,7 +2225,7 @@ describe('e2e', () => {
       const run2 = await start(await e2e('hookSupersedeOwnerWorkflow'), [
         token,
       ]);
-      await waitForHook(token, {
+      const run2Hook = await waitForHook(token, {
         runId: run2.runId,
         timeoutMs: HOOK_WAIT_TIMEOUT_MS,
       });
@@ -2239,7 +2239,7 @@ describe('e2e', () => {
       expect(run1Data.status).toBe('cancelled');
 
       // The new owner receives payloads on the reclaimed token.
-      await resumeHook(token, { message: 'post-supersede' });
+      await resumeHook(run2Hook, { message: 'post-supersede' });
       const run2Result = await run2.returnValue;
       expect(run2Result).toMatchObject({
         role: 'owner',

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -87,14 +87,15 @@ async function readWithDeadline<T>(
     return { done: true, value: undefined, timedOut: true };
   }
   let timeout: ReturnType<typeof setTimeout> | undefined;
+  const readPromise = reader.read().then(
+    (result): DeadlineReadResult<T> => ({
+      ...result,
+      timedOut: false,
+    })
+  );
   try {
-    return await Promise.race<DeadlineReadResult<T>>([
-      reader.read().then(
-        (result): DeadlineReadResult<T> => ({
-          ...result,
-          timedOut: false,
-        })
-      ),
+    const result = await Promise.race<DeadlineReadResult<T>>([
+      readPromise,
       new Promise<DeadlineReadResult<T>>((resolve) => {
         timeout = setTimeout(() => {
           resolve({ done: true, value: undefined, timedOut: true });
@@ -102,6 +103,11 @@ async function readWithDeadline<T>(
         (timeout as { unref?: () => void }).unref?.();
       }),
     ]);
+    if (result.timedOut) {
+      await reader.cancel().catch(() => {});
+      await readPromise.catch(() => {});
+    }
+    return result;
   } finally {
     if (timeout) clearTimeout(timeout);
   }
@@ -215,22 +221,38 @@ async function waitForRunEvents(
   } = options;
   const world = await getWorld();
   const deadline = Date.now() + timeoutMs;
-  let latestMatches: WorkflowEvent[] = [];
+  const matches: WorkflowEvent[] = [];
+  const seenEventIds = new Set<string>();
+  let cursor: string | undefined;
 
   while (Date.now() < deadline) {
-    const { data: events } = await world.events.list({
+    const page = await world.events.list({
       runId,
       resolveData: 'none',
+      pagination: {
+        sortOrder: 'asc',
+        cursor,
+      },
     });
-    latestMatches = events.filter(predicate);
-    if (latestMatches.length >= minCount) {
-      return latestMatches;
+    for (const event of page.data) {
+      if (seenEventIds.has(event.eventId)) continue;
+      seenEventIds.add(event.eventId);
+      if (predicate(event)) matches.push(event);
+    }
+    if (matches.length >= minCount) {
+      return matches;
+    }
+    if (page.cursor) {
+      cursor = page.cursor;
+    }
+    if (page.hasMore) {
+      continue;
     }
     await sleep(intervalMs);
   }
 
   throw new Error(
-    `Timed out waiting for ${minCount} ${description} for run ${runId}; saw ${latestMatches.length}`
+    `Timed out waiting for ${minCount} ${description} for run ${runId}; saw ${matches.length}`
   );
 }
 
@@ -1236,13 +1258,16 @@ describe('e2e', () => {
     // Default stream should close cleanly after the parent closes its
     // writable.
     assert(reader, 'Expected an open reader for forwarded writable stream');
-    const closeResult = await readWithDeadline(
-      reader,
-      Date.now() + STREAM_READ_TIMEOUT_MS
-    );
-    expect(closeResult.timedOut).toBe(false);
-    expect(closeResult.done).toBe(true);
-    reader.releaseLock();
+    try {
+      const closeResult = await readWithDeadline(
+        reader,
+        Date.now() + STREAM_READ_TIMEOUT_MS
+      );
+      expect(closeResult.timedOut).toBe(false);
+      expect(closeResult.done).toBe(true);
+    } finally {
+      reader.releaseLock();
+    }
 
     expect(returnValue).toMatchObject({
       childRunId: expect.stringMatching(/^wrun_/),

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -53,16 +53,18 @@ if (!deploymentUrl) {
 }
 
 const isVercelE2E = !!process.env.WORKFLOW_VERCEL_ENV;
-const SHORT_TEST_TIMEOUT_MS = isVercelE2E ? 60_000 : 30_000;
-const DEFAULT_TEST_TIMEOUT_MS = isVercelE2E ? 120_000 : 60_000;
-const LONG_TEST_TIMEOUT_MS = isVercelE2E ? 180_000 : 90_000;
-const EXTRA_LONG_TEST_TIMEOUT_MS = isVercelE2E ? 240_000 : 120_000;
-const VERY_LONG_TEST_TIMEOUT_MS = isVercelE2E ? 300_000 : 180_000;
+const TO = {
+  short: { timeout: isVercelE2E ? 60_000 : 30_000 },
+  default: { timeout: isVercelE2E ? 120_000 : 60_000 },
+  long: { timeout: isVercelE2E ? 180_000 : 90_000 },
+  extraLong: { timeout: isVercelE2E ? 240_000 : 120_000 },
+  veryLong: { timeout: isVercelE2E ? 300_000 : 180_000 },
+  stream: { timeout: isVercelE2E ? 180_000 : 120_000 },
+} as const;
 const HOOK_WAIT_TIMEOUT_MS = isVercelE2E ? 90_000 : 30_000;
 const EVENT_WAIT_TIMEOUT_MS = isVercelE2E ? 60_000 : 30_000;
-const DISTRIBUTED_CLOCK_TOLERANCE_MS = 1_000;
+const DISTRIBUTED_CLOCK_TOLERANCE_MS = isVercelE2E ? 1_000 : 0;
 const STREAM_READ_TIMEOUT_MS = isVercelE2E ? 90_000 : 60_000;
-const STREAM_TEST_TIMEOUT_MS = isVercelE2E ? 180_000 : 120_000;
 
 function expectElapsedAtLeast(actualMs: number, expectedMs: number) {
   // Vercel e2e compares timestamps from different invocations and services.
@@ -70,6 +72,39 @@ function expectElapsedAtLeast(actualMs: number, expectedMs: number) {
   expect(actualMs).toBeGreaterThanOrEqual(
     Math.max(0, expectedMs - DISTRIBUTED_CLOCK_TOLERANCE_MS)
   );
+}
+
+type DeadlineReadResult<T> = ReadableStreamReadResult<T> & {
+  timedOut: boolean;
+};
+
+async function readWithDeadline<T>(
+  reader: ReadableStreamDefaultReader<T>,
+  deadline: number
+): Promise<DeadlineReadResult<T>> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    return { done: true, value: undefined, timedOut: true };
+  }
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race<DeadlineReadResult<T>>([
+      reader.read().then(
+        (result): DeadlineReadResult<T> => ({
+          ...result,
+          timedOut: false,
+        })
+      ),
+      new Promise<DeadlineReadResult<T>>((resolve) => {
+        timeout = setTimeout(() => {
+          resolve({ done: true, value: undefined, timedOut: true });
+        }, remainingMs);
+        (timeout as { unref?: () => void }).unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 /**
@@ -183,7 +218,10 @@ async function waitForRunEvents(
   let latestMatches: WorkflowEvent[] = [];
 
   while (Date.now() < deadline) {
-    const { data: events } = await world.events.list({ runId });
+    const { data: events } = await world.events.list({
+      runId,
+      resolveData: 'none',
+    });
     latestMatches = events.filter(predicate);
     if (latestMatches.length >= minCount) {
       return latestMatches;
@@ -269,43 +307,39 @@ describe('e2e', () => {
       workflowFile: 'workflows/98_duplicate_case.ts',
       workflowFn: 'addTenWorkflow',
     },
-  ])(
-    'addTenWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async (workflow) => {
-      const run = await start(
-        await getWorkflowMetadata(
-          deploymentUrl,
-          workflow.workflowFile,
-          workflow.workflowFn
-        ),
-        [123]
-      );
+  ])('addTenWorkflow', TO.default, async (workflow) => {
+    const run = await start(
+      await getWorkflowMetadata(
+        deploymentUrl,
+        workflow.workflowFile,
+        workflow.workflowFn
+      ),
+      [123]
+    );
 
-      const returnValue = await run.returnValue;
-      expect(returnValue).toBe(133);
+    const returnValue = await run.returnValue;
+    expect(returnValue).toBe(133);
 
-      const { json } = await cliInspectJson(`runs ${run.runId} --withData`);
-      expect(json).toMatchObject({
-        runId: run.runId,
-        workflowName: expect.any(String),
-        status: 'completed',
-        input: [123],
-        output: 133,
-      });
-      // Workflow ID format: workflow//./{path-without-extension}//{functionName}
-      // Different workbenches have different directory structures:
-      // - workflows/ (standard)
-      // - src/workflows/ (some frameworks)
-      // - example/workflows/ (example app)
-      const fileWithoutExt = workflow.workflowFile.replace(/\.tsx?$/, '');
-      expect(json.workflowName).toMatch(
-        new RegExp(
-          `^workflow//\\./(?:src/|example/)?${fileWithoutExt}//${workflow.workflowFn}$`
-        )
-      );
-    }
-  );
+    const { json } = await cliInspectJson(`runs ${run.runId} --withData`);
+    expect(json).toMatchObject({
+      runId: run.runId,
+      workflowName: expect.any(String),
+      status: 'completed',
+      input: [123],
+      output: 133,
+    });
+    // Workflow ID format: workflow//./{path-without-extension}//{functionName}
+    // Different workbenches have different directory structures:
+    // - workflows/ (standard)
+    // - src/workflows/ (some frameworks)
+    // - example/workflows/ (example app)
+    const fileWithoutExt = workflow.workflowFile.replace(/\.tsx?$/, '');
+    expect(json.workflowName).toMatch(
+      new RegExp(
+        `^workflow//\\./(?:src/|example/)?${fileWithoutExt}//${workflow.workflowFn}$`
+      )
+    );
+  });
 
   // `deploymentId: 'latest'` only resolves to a different deployment in
   // worlds with atomic, immutable deployments (Vercel). In local dev and
@@ -317,7 +351,7 @@ describe('e2e', () => {
   // 'latest' actually hits the resolve API.
   test.skipIf(!!process.env.WORKFLOW_VERCEL_ENV)(
     "deploymentId: 'latest' is a no-op in non-Vercel worlds",
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const run = await start(await e2e('addTenWorkflow'), [123], {
         deploymentId: 'latest',
@@ -342,7 +376,7 @@ describe('e2e', () => {
   const isNextApp = process.env.APP_NAME?.includes('nextjs');
   test.skipIf(!isNextApp)(
     'wellKnownAgentWorkflow (.well-known/agent)',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const run = await start(
         await getWorkflowMetadata(
@@ -383,76 +417,58 @@ describe('e2e', () => {
     }
   );
 
-  test('promiseAllWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
+  test('promiseAllWorkflow', TO.default, async () => {
     const run = await start(await e2e('promiseAllWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toBe('ABC');
   });
 
-  test(
-    'promiseRaceWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('promiseRaceWorkflow'), []);
-      const returnValue = await run.returnValue;
-      expect(returnValue).toBe('B');
-    }
-  );
+  test('promiseRaceWorkflow', TO.default, async () => {
+    const run = await start(await e2e('promiseRaceWorkflow'), []);
+    const returnValue = await run.returnValue;
+    expect(returnValue).toBe('B');
+  });
 
-  test('promiseAnyWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
+  test('promiseAnyWorkflow', TO.default, async () => {
     const run = await start(await e2e('promiseAnyWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toBe('B');
   });
 
-  test.skipIf(!isNext)(
-    'importedStepOnlyWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('importedStepOnlyWorkflow'), []);
-      const returnValue = await run.returnValue;
-      expect(returnValue).toBe('imported-step-only-ok');
-    }
-  );
+  test.skipIf(!isNext)('importedStepOnlyWorkflow', TO.default, async () => {
+    const run = await start(await e2e('importedStepOnlyWorkflow'), []);
+    const returnValue = await run.returnValue;
+    expect(returnValue).toBe('imported-step-only-ok');
+  });
 
-  test(
-    'readableStreamWorkflow',
-    { timeout: STREAM_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('readableStreamWorkflow'), []);
-      const returnValue = await run.returnValue;
-      expect(returnValue).toBeInstanceOf(ReadableStream);
+  test('readableStreamWorkflow', TO.stream, async () => {
+    const run = await start(await e2e('readableStreamWorkflow'), []);
+    const returnValue = await run.returnValue;
+    expect(returnValue).toBeInstanceOf(ReadableStream);
 
-      const expected = '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n';
-      const decoder = new TextDecoder();
-      let contents = '';
-      // Read chunks until we have all expected content or hit a timeout.
-      // On Vercel, the final chunk or close event can be delayed, so we stop
-      // once we have the expected data rather than waiting for stream closure.
-      const reader = returnValue.getReader();
-      const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
-      try {
-        while (Date.now() < readDeadline) {
-          const { done, value } = await Promise.race([
-            reader.read(),
-            sleep(STREAM_READ_TIMEOUT_MS).then(() => ({
-              done: true,
-              value: undefined,
-            })),
-          ]);
-          if (value) {
-            contents += decoder.decode(value, { stream: true });
-          }
-          if (done || contents.length >= expected.length) break;
+    const expected = '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n';
+    const decoder = new TextDecoder();
+    let contents = '';
+    // Read chunks until we have all expected content or hit a timeout.
+    // On Vercel, the final chunk or close event can be delayed, so we stop
+    // once we have the expected data rather than waiting for stream closure.
+    const reader = returnValue.getReader();
+    const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
+    try {
+      while (Date.now() < readDeadline) {
+        const { done, value } = await readWithDeadline(reader, readDeadline);
+        if (value) {
+          contents += decoder.decode(value, { stream: true });
         }
-      } finally {
-        reader.releaseLock();
+        if (done || contents.length >= expected.length) break;
       }
-      expect(contents).toBe(expected);
+    } finally {
+      reader.releaseLock();
     }
-  );
+    expect(contents).toBe(expected);
+  });
 
-  test('hookWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
+  test('hookWorkflow', TO.default, async () => {
     const token = Math.random().toString(36).slice(2);
     const customData = Math.random().toString(36).slice(2);
 
@@ -504,7 +520,7 @@ describe('e2e', () => {
 
   test(
     'hookWorkflow is not resumable via public webhook endpoint',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -542,7 +558,7 @@ describe('e2e', () => {
     }
   );
 
-  test('webhookWorkflow', { timeout: EXTRA_LONG_TEST_TIMEOUT_MS }, async () => {
+  test('webhookWorkflow', TO.extraLong, async () => {
     const run = await start(await e2e('webhookWorkflow'), []);
 
     // Poll until all 3 webhooks are registered.
@@ -667,7 +683,7 @@ describe('e2e', () => {
     !!process.env.WORKFLOW_TARGET_WORLD?.includes('postgres');
   test.skipIf(isPostgresWorld)(
     'parallelStepsThenWebhookWorkflow - no hook_conflict from same-tick replay race',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    TO.extraLong,
     async () => {
       // Regression test for https://github.com/vercel/workflow/issues/1665
       // and https://github.com/vercel/workflow/issues/2283.
@@ -786,155 +802,135 @@ describe('e2e', () => {
     }
   );
 
-  test(
-    'webhook route with invalid token',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const invalidWebhookUrl = new URL(
-        `/.well-known/workflow/v1/webhook/${encodeURIComponent('invalid')}`,
-        deploymentUrl
-      );
-      const res = await fetch(invalidWebhookUrl, {
-        method: 'POST',
-        headers: await getTrustedSourcesHeaders(),
-        body: JSON.stringify({}),
-      });
-      expect(res.status).toBe(404);
-      const body = await res.text();
-      expect(body).toBe('');
-    }
-  );
+  test('webhook route with invalid token', TO.default, async () => {
+    const invalidWebhookUrl = new URL(
+      `/.well-known/workflow/v1/webhook/${encodeURIComponent('invalid')}`,
+      deploymentUrl
+    );
+    const res = await fetch(invalidWebhookUrl, {
+      method: 'POST',
+      headers: await getTrustedSourcesHeaders(),
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    expect(body).toBe('');
+  });
 
-  test('sleepingWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
+  test('sleepingWorkflow', TO.default, async () => {
     const run = await start(await e2e('sleepingWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
     expectElapsedAtLeast(returnValue.endTime - returnValue.startTime, 10_000);
   });
 
-  test(
-    'parallelSleepWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('parallelSleepWorkflow'), []);
-      const returnValue = await run.returnValue;
-      // 10 parallel sleep('1s') should complete in ~1s, not 10x (sequential).
-      // On Vercel, cold starts and queue round-trips add latency, so we use a
-      // generous upper bound. The key assertion is parallel < sequential (10s+).
-      const elapsed = returnValue.endTime - returnValue.startTime;
-      expectElapsedAtLeast(elapsed, 1_000);
-      // Sequential would be ~10s+ per sleep. Allow up to 20s for parallel on
-      // Vercel with cold start overhead, but fail if it looks sequential (>25s).
-      expect(elapsed).toBeLessThan(25_000);
-    }
-  );
+  test('parallelSleepWorkflow', TO.default, async () => {
+    const run = await start(await e2e('parallelSleepWorkflow'), []);
+    const returnValue = await run.returnValue;
+    // 10 parallel sleep('1s') should complete in ~1s, not 10x (sequential).
+    // On Vercel, cold starts and queue round-trips add latency, so we use a
+    // generous upper bound. The key assertion is parallel < sequential (10s+).
+    const elapsed = returnValue.endTime - returnValue.startTime;
+    expect(elapsed).toBeGreaterThanOrEqual(500);
+    // Sequential would be ~10s+ per sleep. Allow up to 20s for parallel on
+    // Vercel with cold start overhead, but fail if it looks sequential (>25s).
+    expect(elapsed).toBeLessThan(25_000);
+  });
 
-  test(
-    'sleepWinsRaceWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('sleepWinsRaceWorkflow'), []);
-      const returnValue = await run.returnValue;
-      expect(returnValue.winner).toBe('sleep');
-      // Sleep is 1s; step would take 10s. Keep this below the losing branch
-      // without depending on exact remote queue/cold-start overhead.
-      expect(returnValue.durationMs).toBeLessThan(9_000);
-    }
-  );
+  test('sleepWinsRaceWorkflow', TO.default, async () => {
+    const run = await start(await e2e('sleepWinsRaceWorkflow'), []);
+    const returnValue = await run.returnValue;
+    expect(returnValue.winner).toBe('sleep');
+    // Sleep is 1s; step would take 10s. Keep this below the losing branch
+    // without depending on exact remote queue/cold-start overhead.
+    expect(returnValue.durationMs).toBeLessThan(9_000);
+  });
 
-  test(
-    'stepWinsRaceWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('stepWinsRaceWorkflow'), []);
-      const returnValue = await run.returnValue;
-      expect(returnValue.winner).toBe('step');
-      // Step is 1s; sleep would take 10s. Keep this below the losing branch
-      // without depending on exact remote queue/cold-start overhead.
-      expect(returnValue.durationMs).toBeLessThan(9_000);
-    }
-  );
+  test('stepWinsRaceWorkflow', TO.default, async () => {
+    const run = await start(await e2e('stepWinsRaceWorkflow'), []);
+    const returnValue = await run.returnValue;
+    expect(returnValue.winner).toBe('step');
+    // Step is 1s; sleep would take 10s. Keep this below the losing branch
+    // without depending on exact remote queue/cold-start overhead.
+    expect(returnValue.durationMs).toBeLessThan(9_000);
+  });
 
-  test('nullByteWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
+  test('nullByteWorkflow', TO.default, async () => {
     const run = await start(await e2e('nullByteWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toBe('null byte \0');
   });
 
-  test(
-    'workflowAndStepMetadataWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('workflowAndStepMetadataWorkflow'), []);
-      const returnValue = await run.returnValue;
+  test('workflowAndStepMetadataWorkflow', TO.default, async () => {
+    const run = await start(await e2e('workflowAndStepMetadataWorkflow'), []);
+    const returnValue = await run.returnValue;
 
-      expect(returnValue).toHaveProperty('workflowMetadata');
-      expect(returnValue).toHaveProperty('stepMetadata');
-      expect(returnValue).toHaveProperty('innerWorkflowMetadata');
+    expect(returnValue).toHaveProperty('workflowMetadata');
+    expect(returnValue).toHaveProperty('stepMetadata');
+    expect(returnValue).toHaveProperty('innerWorkflowMetadata');
 
-      // workflow and context
+    // workflow and context
 
-      expect(returnValue.workflowMetadata).toStrictEqual(
-        returnValue.innerWorkflowMetadata
-      );
+    expect(returnValue.workflowMetadata).toStrictEqual(
+      returnValue.innerWorkflowMetadata
+    );
 
-      // workflow context should have workflowName and stepMetadata shouldn't
-      expect(typeof returnValue.workflowMetadata.workflowName).toBe('string');
-      expect(returnValue.workflowMetadata.workflowName).toBe(
-        returnValue.innerWorkflowMetadata.workflowName
-      );
-      expect(returnValue.stepMetadata.workflowName).toBeUndefined();
+    // workflow context should have workflowName and stepMetadata shouldn't
+    expect(typeof returnValue.workflowMetadata.workflowName).toBe('string');
+    expect(returnValue.workflowMetadata.workflowName).toBe(
+      returnValue.innerWorkflowMetadata.workflowName
+    );
+    expect(returnValue.stepMetadata.workflowName).toBeUndefined();
 
-      // workflow context should have workflowRunId and stepMetadata shouldn't
-      expect(returnValue.workflowMetadata.workflowRunId).toBe(run.runId);
-      expect(returnValue.innerWorkflowMetadata.workflowRunId).toBe(run.runId);
-      expect(returnValue.stepMetadata.workflowRunId).toBeUndefined();
+    // workflow context should have workflowRunId and stepMetadata shouldn't
+    expect(returnValue.workflowMetadata.workflowRunId).toBe(run.runId);
+    expect(returnValue.innerWorkflowMetadata.workflowRunId).toBe(run.runId);
+    expect(returnValue.stepMetadata.workflowRunId).toBeUndefined();
 
-      // workflow context should have workflowStartedAt and stepMetadata shouldn't
-      // Note: workflowStartedAt may be a Date object (when using run.returnValue directly)
-      // or a string (when serialized through JSON via HTTP)
-      expect(returnValue.workflowMetadata.workflowStartedAt).toBeDefined();
-      expect(returnValue.innerWorkflowMetadata.workflowStartedAt).toBeDefined();
-      expect(String(returnValue.innerWorkflowMetadata.workflowStartedAt)).toBe(
-        String(returnValue.workflowMetadata.workflowStartedAt)
-      );
-      expect(returnValue.stepMetadata.workflowStartedAt).toBeUndefined();
+    // workflow context should have workflowStartedAt and stepMetadata shouldn't
+    // Note: workflowStartedAt may be a Date object (when using run.returnValue directly)
+    // or a string (when serialized through JSON via HTTP)
+    expect(returnValue.workflowMetadata.workflowStartedAt).toBeDefined();
+    expect(returnValue.innerWorkflowMetadata.workflowStartedAt).toBeDefined();
+    expect(String(returnValue.innerWorkflowMetadata.workflowStartedAt)).toBe(
+      String(returnValue.workflowMetadata.workflowStartedAt)
+    );
+    expect(returnValue.stepMetadata.workflowStartedAt).toBeUndefined();
 
-      // workflow context should have url and stepMetadata shouldn't
-      expect(typeof returnValue.workflowMetadata.url).toBe('string');
-      expect(typeof returnValue.innerWorkflowMetadata.url).toBe('string');
-      expect(returnValue.innerWorkflowMetadata.url).toBe(
-        returnValue.workflowMetadata.url
-      );
-      expect(returnValue.stepMetadata.url).toBeUndefined();
+    // workflow context should have url and stepMetadata shouldn't
+    expect(typeof returnValue.workflowMetadata.url).toBe('string');
+    expect(typeof returnValue.innerWorkflowMetadata.url).toBe('string');
+    expect(returnValue.innerWorkflowMetadata.url).toBe(
+      returnValue.workflowMetadata.url
+    );
+    expect(returnValue.stepMetadata.url).toBeUndefined();
 
-      // workflow context should have features and stepMetadata shouldn't
-      expect(returnValue.workflowMetadata.features).toBeDefined();
-      expect(typeof returnValue.workflowMetadata.features.encryption).toBe(
-        'boolean'
-      );
-      expect(returnValue.innerWorkflowMetadata.features).toStrictEqual(
-        returnValue.workflowMetadata.features
-      );
-      expect(returnValue.stepMetadata.features).toBeUndefined();
+    // workflow context should have features and stepMetadata shouldn't
+    expect(returnValue.workflowMetadata.features).toBeDefined();
+    expect(typeof returnValue.workflowMetadata.features.encryption).toBe(
+      'boolean'
+    );
+    expect(returnValue.innerWorkflowMetadata.features).toStrictEqual(
+      returnValue.workflowMetadata.features
+    );
+    expect(returnValue.stepMetadata.features).toBeUndefined();
 
-      // workflow context shouldn't have stepId, stepStartedAt, or attempt
-      expect(returnValue.workflowMetadata.stepId).toBeUndefined();
-      expect(returnValue.workflowMetadata.stepStartedAt).toBeUndefined();
-      expect(returnValue.workflowMetadata.attempt).toBeUndefined();
+    // workflow context shouldn't have stepId, stepStartedAt, or attempt
+    expect(returnValue.workflowMetadata.stepId).toBeUndefined();
+    expect(returnValue.workflowMetadata.stepStartedAt).toBeUndefined();
+    expect(returnValue.workflowMetadata.attempt).toBeUndefined();
 
-      // step context
+    // step context
 
-      // stepName should be a string
-      expect(typeof returnValue.stepMetadata.stepName).toBe('string');
+    // stepName should be a string
+    expect(typeof returnValue.stepMetadata.stepName).toBe('string');
 
-      // Attempt should be atleast 1
-      expect(returnValue.stepMetadata.attempt).toBeGreaterThanOrEqual(1);
+    // Attempt should be atleast 1
+    expect(returnValue.stepMetadata.attempt).toBeGreaterThanOrEqual(1);
 
-      // stepStartedAt should be a Date or date string
-      expect(returnValue.stepMetadata.stepStartedAt).toBeDefined();
-    }
-  );
+    // stepStartedAt should be a Date or date string
+    expect(returnValue.stepMetadata.stepStartedAt).toBeDefined();
+  });
 
   // outputStreamWorkflow writes 2 chunks to the default stream:
   //   chunk 0: binary "Hello, world!"
@@ -978,7 +974,7 @@ describe('e2e', () => {
     ] as const;
 
     for (const tc of startIndexCases) {
-      test(tc.name, { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
+      test(tc.name, TO.default, async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
 
         if (tc.waitForCompletion) {
@@ -1029,9 +1025,7 @@ describe('e2e', () => {
   describe('outputStreamWorkflow - getTailIndex and getChunks', () => {
     test(
       'getTailIndex returns correct index after stream completes',
-      {
-        timeout: DEFAULT_TEST_TIMEOUT_MS,
-      },
+      TO.default,
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
         await run.returnValue;
@@ -1046,9 +1040,7 @@ describe('e2e', () => {
 
     test(
       'getTailIndex returns -1 before any chunks are written',
-      {
-        timeout: DEFAULT_TEST_TIMEOUT_MS,
-      },
+      TO.default,
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
 
@@ -1063,9 +1055,7 @@ describe('e2e', () => {
 
     test(
       'getChunks returns same content as reading the stream',
-      {
-        timeout: DEFAULT_TEST_TIMEOUT_MS,
-      },
+      TO.default,
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
         await run.returnValue;
@@ -1106,7 +1096,7 @@ describe('e2e', () => {
 
   test(
     'outputStreamInsideStepWorkflow - getWritable() called inside step functions',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const run = await start(await e2e('outputStreamInsideStepWorkflow'), []);
       const reader = run.getReadable().getReader();
@@ -1153,44 +1143,40 @@ describe('e2e', () => {
   // Extended, CJK, emoji, RTL) round-trip end-to-end as bytes that decode
   // back to the original strings — the same property that the web inspector
   // relies on to render decoded text for typed-array stream chunks.
-  test(
-    'utf8StreamWorkflow',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('utf8StreamWorkflow'), []);
-      const reader = run.getReadable().getReader();
+  test('utf8StreamWorkflow', TO.extraLong, async () => {
+    const run = await start(await e2e('utf8StreamWorkflow'), []);
+    const reader = run.getReadable().getReader();
 
-      // `fatal: true` makes the decoder throw on any invalid UTF-8 sequence,
-      // so a successful decode is itself a round-trip assertion.
-      const decoder = new TextDecoder('utf-8', { fatal: true });
+    // `fatal: true` makes the decoder throw on any invalid UTF-8 sequence,
+    // so a successful decode is itself a round-trip assertion.
+    const decoder = new TextDecoder('utf-8', { fatal: true });
 
-      const expectedTexts = [
-        'Hello, world!',
-        'Café — naïve résumé',
-        '你好，世界！🌍✨',
-        'مرحبا بالعالم',
-      ];
+    const expectedTexts = [
+      'Hello, world!',
+      'Café — naïve résumé',
+      '你好，世界！🌍✨',
+      'مرحبا بالعالم',
+    ];
 
-      for (const expected of expectedTexts) {
-        const { value } = await reader.read();
-        assert(value);
-        assert(value instanceof Uint8Array);
-        expect(decoder.decode(value)).toBe(expected);
-      }
-
-      // Final chunk: UTF-8 encoded JSON document. The web inspector also
-      // re-parses decoded text as JSON when possible, so we exercise that
-      // shape here too.
-      const expectedJson = { greeting: '안녕하세요', emoji: '🎉' };
-      const { value: jsonValue } = await reader.read();
-      assert(jsonValue);
-      assert(jsonValue instanceof Uint8Array);
-      expect(JSON.parse(decoder.decode(jsonValue))).toEqual(expectedJson);
-
-      expect((await reader.read()).done).toBe(true);
-      expect(await run.returnValue).toEqual('done');
+    for (const expected of expectedTexts) {
+      const { value } = await reader.read();
+      assert(value);
+      assert(value instanceof Uint8Array);
+      expect(decoder.decode(value)).toBe(expected);
     }
-  );
+
+    // Final chunk: UTF-8 encoded JSON document. The web inspector also
+    // re-parses decoded text as JSON when possible, so we exercise that
+    // shape here too.
+    const expectedJson = { greeting: '안녕하세요', emoji: '🎉' };
+    const { value: jsonValue } = await reader.read();
+    assert(jsonValue);
+    assert(jsonValue instanceof Uint8Array);
+    expect(JSON.parse(decoder.decode(jsonValue))).toEqual(expectedJson);
+
+    expect((await reader.read()).done).toBe(true);
+    expect(await run.returnValue).toEqual('done');
+  });
 
   // A WritableStream passed as a workflow argument to start() should
   // land raw bytes on the parent's output stream when the child step
@@ -1204,65 +1190,66 @@ describe('e2e', () => {
   test.each([
     'writableForwardedFromWorkflowWorkflow',
     'writableForwardedFromStepWorkflow',
-  ] as const)(
-    '%s',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
-    async (workflowName) => {
-      const payload = `hello-from-child-${Date.now()}\n`;
-      const run = await start(await e2e(workflowName), [payload]);
+  ] as const)('%s', TO.extraLong, async (workflowName) => {
+    const payload = `hello-from-child-${Date.now()}\n`;
+    const run = await start(await e2e(workflowName), [payload]);
 
-      const returnValue = await run.returnValue;
-      // `fatal: true` makes the decoder throw on any invalid UTF-8
-      // sequence, so a successful decode is itself a round-trip
-      // assertion that the bytes survived intact.
-      const decoder = new TextDecoder('utf-8', { fatal: true });
-      const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
-      let reader: ReadableStreamDefaultReader<unknown> | undefined;
-      let value: unknown;
+    const returnValue = await run.returnValue;
+    // `fatal: true` makes the decoder throw on any invalid UTF-8
+    // sequence, so a successful decode is itself a round-trip
+    // assertion that the bytes survived intact.
+    const decoder = new TextDecoder('utf-8', { fatal: true });
+    const readDeadline = Date.now() + STREAM_READ_TIMEOUT_MS;
+    let reader: ReadableStreamDefaultReader<unknown> | undefined;
+    let value: unknown;
 
-      // The child step performs exactly one write of `payload` as
-      // UTF-8 bytes, so we should receive a single chunk containing
-      // exactly those bytes before the stream closes. On distributed
-      // Vercel runs, the run can complete just before the readable
-      // endpoint sees the forwarded stream chunk, so reopen until the
-      // persisted output is visible.
-      while (Date.now() < readDeadline) {
-        reader = run.getReadable().getReader();
-        const result = await reader.read();
+    // The child step performs exactly one write of `payload` as
+    // UTF-8 bytes, so we should receive a single chunk containing
+    // exactly those bytes before the stream closes. On distributed
+    // Vercel runs, the run can complete just before the readable
+    // endpoint sees the forwarded stream chunk, so reopen until the
+    // persisted output is visible.
+    while (Date.now() < readDeadline) {
+      reader = run.getReadable().getReader();
+      const result = await readWithDeadline(reader, readDeadline);
 
-        if (!result.done && result.value) {
-          value = result.value;
-          break;
-        }
-
-        reader.releaseLock();
-        reader = undefined;
-        await sleep(1_000);
+      if (!result.done && result.value) {
+        value = result.value;
+        break;
       }
 
-      assert(
-        value,
-        `Timed out waiting for forwarded writable chunk from ${workflowName}`
-      );
-      assert(value instanceof Uint8Array);
-
-      const expectedBytes = new TextEncoder().encode(payload);
-      expect(value.byteLength).toBe(expectedBytes.byteLength);
-      expect(decoder.decode(value)).toBe(payload);
-
-      // Default stream should close cleanly after the parent closes its
-      // writable.
-      assert(reader, 'Expected an open reader for forwarded writable stream');
-      expect((await reader.read()).done).toBe(true);
       reader.releaseLock();
-
-      expect(returnValue).toMatchObject({
-        childRunId: expect.stringMatching(/^wrun_/),
-      });
+      reader = undefined;
+      await sleep(1_000);
     }
-  );
 
-  test('fetchWorkflow', { timeout: DEFAULT_TEST_TIMEOUT_MS }, async () => {
+    assert(
+      value,
+      `Timed out waiting for forwarded writable chunk from ${workflowName}`
+    );
+    assert(value instanceof Uint8Array);
+
+    const expectedBytes = new TextEncoder().encode(payload);
+    expect(value.byteLength).toBe(expectedBytes.byteLength);
+    expect(decoder.decode(value)).toBe(payload);
+
+    // Default stream should close cleanly after the parent closes its
+    // writable.
+    assert(reader, 'Expected an open reader for forwarded writable stream');
+    const closeResult = await readWithDeadline(
+      reader,
+      Date.now() + STREAM_READ_TIMEOUT_MS
+    );
+    expect(closeResult.timedOut).toBe(false);
+    expect(closeResult.done).toBe(true);
+    reader.releaseLock();
+
+    expect(returnValue).toMatchObject({
+      childRunId: expect.stringMatching(/^wrun_/),
+    });
+  });
+
+  test('fetchWorkflow', TO.default, async () => {
     const run = await start(await e2e('fetchWorkflow'), []);
     const returnValue = await run.returnValue;
     expect(returnValue).toMatchObject({
@@ -1273,16 +1260,12 @@ describe('e2e', () => {
     });
   });
 
-  test(
-    'promiseRaceStressTestWorkflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      const run = await start(await e2e('promiseRaceStressTestWorkflow'), []);
-      const returnValue = await run.returnValue;
-      // Completion order can vary across worlds and scheduling environments.
-      expect([...returnValue].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
-    }
-  );
+  test('promiseRaceStressTestWorkflow', TO.default, async () => {
+    const run = await start(await e2e('promiseRaceStressTestWorkflow'), []);
+    const returnValue = await run.returnValue;
+    // Completion order can vary across worlds and scheduling environments.
+    expect([...returnValue].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
+  });
 
   // ==================== ERROR HANDLING TESTS ====================
   describe('error handling', () => {
@@ -1290,7 +1273,7 @@ describe('e2e', () => {
       describe('workflow errors', () => {
         test(
           'nested function calls preserve message and stack trace',
-          { timeout: DEFAULT_TEST_TIMEOUT_MS },
+          TO.default,
           async () => {
             const run = await start(await e2e('errorWorkflowNested'), []);
             const error = await run.returnValue.catch((e: unknown) => e);
@@ -1325,7 +1308,7 @@ describe('e2e', () => {
 
         test(
           'cross-file imports preserve message and stack trace',
-          { timeout: DEFAULT_TEST_TIMEOUT_MS },
+          TO.default,
           async () => {
             const run = await start(await e2e('errorWorkflowCrossFile'), []);
             const error = await run.returnValue.catch((e: unknown) => e);
@@ -1356,7 +1339,7 @@ describe('e2e', () => {
       describe('step errors', () => {
         test(
           'basic step error preserves message and stack trace',
-          { timeout: DEFAULT_TEST_TIMEOUT_MS },
+          TO.default,
           async () => {
             const run = await start(await e2e('errorStepBasic'), []);
             const result = await run.returnValue;
@@ -1412,7 +1395,7 @@ describe('e2e', () => {
 
         test(
           'cross-file step error preserves message and function names in stack',
-          { timeout: DEFAULT_TEST_TIMEOUT_MS },
+          TO.default,
           async () => {
             const run = await start(await e2e('errorStepCrossFile'), []);
             const result = await run.returnValue;
@@ -1471,29 +1454,25 @@ describe('e2e', () => {
     });
 
     describe('retry behavior', () => {
-      test(
-        'regular Error retries until success',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
-        async () => {
-          const run = await start(await e2e('errorRetrySuccess'), []);
-          const result = await run.returnValue;
+      test('regular Error retries until success', TO.default, async () => {
+        const run = await start(await e2e('errorRetrySuccess'), []);
+        const result = await run.returnValue;
 
-          expect(result.finalAttempt).toBe(3);
+        expect(result.finalAttempt).toBe(3);
 
-          const { json: steps } = await cliInspectJson(
-            `steps --runId ${run.runId}`
-          );
-          const step = steps.find((s: any) =>
-            s.stepName.includes('retryUntilAttempt3')
-          );
-          expect(step.status).toBe('completed');
-          expect(step.attempt).toBe(3);
-        }
-      );
+        const { json: steps } = await cliInspectJson(
+          `steps --runId ${run.runId}`
+        );
+        const step = steps.find((s: any) =>
+          s.stepName.includes('retryUntilAttempt3')
+        );
+        expect(step.status).toBe('completed');
+        expect(step.attempt).toBe(3);
+      });
 
       test(
         'FatalError fails immediately without retries',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           const run = await start(await e2e('errorRetryFatal'), []);
           const error = await run.returnValue.catch((e: unknown) => e);
@@ -1519,7 +1498,7 @@ describe('e2e', () => {
 
       test(
         'RetryableError respects custom retryAfter delay',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           const run = await start(await e2e('errorRetryCustomDelay'), []);
           const result = await run.returnValue;
@@ -1529,23 +1508,19 @@ describe('e2e', () => {
         }
       );
 
-      test(
-        'maxRetries=0 disables retries',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
-        async () => {
-          const run = await start(await e2e('errorRetryDisabled'), []);
-          const result = await run.returnValue;
+      test('maxRetries=0 disables retries', TO.default, async () => {
+        const run = await start(await e2e('errorRetryDisabled'), []);
+        const result = await run.returnValue;
 
-          expect(result.failed).toBe(true);
-          expect(result.attempt).toBe(1);
-        }
-      );
+        expect(result.failed).toBe(true);
+        expect(result.attempt).toBe(1);
+      });
     });
 
     describe('catchability', () => {
       test(
         'FatalError can be caught and detected with FatalError.is()',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           const run = await start(await e2e('errorFatalCatchable'), []);
           const result = await run.returnValue;
@@ -1561,7 +1536,7 @@ describe('e2e', () => {
 
       test(
         'step throw round-trips FatalError with cause chain to workflow catch',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           // A step throws a FatalError whose `.cause` is a TypeError. The
           // workflow catches the rejection and inspects the hydrated value.
@@ -1593,7 +1568,7 @@ describe('e2e', () => {
 
       test(
         'workflow throw round-trips FatalError + cause through run_failed event',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           // A workflow itself throws a FatalError with a RangeError cause.
           // Verifies that run_failed events go through the new
@@ -1640,7 +1615,7 @@ describe('e2e', () => {
 
       test(
         'workflow throw of a non-Error value round-trips verbatim as cause',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           // Workflows may throw any JS value. Verify a plain object thrown
           // from a workflow surfaces verbatim as WorkflowRunFailedError.cause
@@ -1668,7 +1643,7 @@ describe('e2e', () => {
 
       test(
         'step throw of a non-Error value preserves it as cause on the wrapping FatalError',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           // Steps may also throw any JS value. Non-Error throws aren't
           // recognized as `FatalError` (they have no `name === 'FatalError'`)
@@ -1706,7 +1681,7 @@ describe('e2e', () => {
     describe('not registered', () => {
       test(
         'WorkflowNotRegisteredError fails the run when workflow does not exist',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           // Start a run with a workflowId that doesn't exist in the deployment bundle.
           // This simulates starting a run against a deployment that doesn't have the workflow.
@@ -1731,7 +1706,7 @@ describe('e2e', () => {
 
       test(
         'StepNotRegisteredError fails the step but workflow can catch it',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           const run = await start(await e2e('stepNotRegisteredCatchable'), []);
           const result = await run.returnValue;
@@ -1757,7 +1732,7 @@ describe('e2e', () => {
 
       test(
         'StepNotRegisteredError fails the run when not caught in workflow',
-        { timeout: DEFAULT_TEST_TIMEOUT_MS },
+        TO.default,
         async () => {
           const run = await start(await e2e('stepNotRegisteredUncaught'), []);
           const error = await run.returnValue.catch((e: unknown) => e);
@@ -1774,7 +1749,7 @@ describe('e2e', () => {
 
   test(
     'stepDirectCallWorkflow - calling step functions directly outside workflow context',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // Call the API route that directly calls a step function (no workflow context)
       const url = new URL('/api/test-direct-step-call', deploymentUrl);
@@ -1804,7 +1779,7 @@ describe('e2e', () => {
 
   test(
     'hookCleanupTestWorkflow - hook token reuse after workflow completion',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1866,7 +1841,7 @@ describe('e2e', () => {
 
   test(
     'concurrent hook token conflict - two workflows cannot use the same hook token simultaneously',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1965,7 +1940,7 @@ describe('e2e', () => {
     },
   ])(
     '$workflow - hook.getConflict() does not block step execution',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async ({ workflow, hookGetConflictTestData }) => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -1996,7 +1971,7 @@ describe('e2e', () => {
 
   test(
     'hookGetConflictThenStepParallelWorkflow - hook.getConflict() continuation step runs alongside other steps',
-    { timeout: LONG_TEST_TIMEOUT_MS },
+    TO.long,
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -2028,7 +2003,7 @@ describe('e2e', () => {
 
   test(
     'hookGetConflictWorkflow - hook.getConflict() resolves with the conflicting run when token is already registered',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -2077,7 +2052,7 @@ describe('e2e', () => {
 
   test(
     'hookClaimOnlyMutexWorkflow - hook works as a pure run mutex without payload data',
-    { timeout: LONG_TEST_TIMEOUT_MS },
+    TO.long,
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2141,7 +2116,7 @@ describe('e2e', () => {
 
   test(
     'hookAdoptOwnerResultWorkflow - duplicate adopts the owner result via conflict.returnValue',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    TO.extraLong,
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2202,7 +2177,7 @@ describe('e2e', () => {
 
   test(
     'hookSignalOwnerWorkflow - duplicate forwards its payload to the owner via resumeHook',
-    { timeout: LONG_TEST_TIMEOUT_MS },
+    TO.long,
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2236,7 +2211,7 @@ describe('e2e', () => {
 
   test(
     'hookSupersedeOwnerWorkflow - duplicate cancels the owner and claims the released token',
-    { timeout: LONG_TEST_TIMEOUT_MS },
+    TO.long,
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2275,7 +2250,7 @@ describe('e2e', () => {
 
   test(
     'resume-or-start route pattern - resumeHook retried after start() reaches the new run',
-    { timeout: LONG_TEST_TIMEOUT_MS },
+    TO.long,
     async () => {
       const token = Math.random().toString(36).slice(2);
 
@@ -2320,7 +2295,7 @@ describe('e2e', () => {
 
   test(
     'hookDisposeTestWorkflow - hook token reuse after explicit disposal while workflow still running',
-    { timeout: LONG_TEST_TIMEOUT_MS },
+    TO.long,
     async () => {
       const token = Math.random().toString(36).slice(2);
       const customData = Math.random().toString(36).slice(2);
@@ -2411,7 +2386,7 @@ describe('e2e', () => {
 
   test(
     'stepFunctionPassingWorkflow - step function references can be passed as arguments (without closure vars)',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This workflow passes a step function reference to another step
       // The receiving step calls the passed function and returns the result
@@ -2443,7 +2418,7 @@ describe('e2e', () => {
 
   test(
     'stepFunctionWithClosureWorkflow - step function with closure variables passed as argument',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This workflow creates a nested step function with closure variables,
       // then passes it to another step which invokes it.
@@ -2468,7 +2443,7 @@ describe('e2e', () => {
 
   test(
     'closureVariableWorkflow - nested step functions with closure variables',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This workflow uses a nested step function that references closure variables
       // from the parent workflow scope (multiplier, prefix, baseValue)
@@ -2482,7 +2457,7 @@ describe('e2e', () => {
 
   test(
     'spawnWorkflowFromStepWorkflow - spawning a child workflow using start() inside a step',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    TO.extraLong,
     async () => {
       // This workflow spawns another workflow using start() inside a step function
       // This is the recommended pattern for spawning workflows from within workflows
@@ -2527,7 +2502,7 @@ describe('e2e', () => {
 
   test(
     'runClassSerializationWorkflow - Run instances serialize across workflow/step boundaries',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    TO.extraLong,
     async () => {
       const inputValue = 21;
       const run = await start(await e2e('runClassSerializationWorkflow'), [
@@ -2566,7 +2541,7 @@ describe('e2e', () => {
 
   test(
     'startFromWorkflow - calling start() directly inside a workflow function with hook communication',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    TO.extraLong,
     async () => {
       const inputValue = 42;
       const run = await start(await e2e('startFromWorkflow'), [inputValue]);
@@ -2588,7 +2563,7 @@ describe('e2e', () => {
 
   test(
     'fibonacciWorkflow - recursive workflow composition via start()',
-    { timeout: VERY_LONG_TEST_TIMEOUT_MS },
+    TO.veryLong,
     async () => {
       // fib(6) = 8, spawns a tree of child workflow runs
       const run = await start(await e2e('fibonacciWorkflow'), [6]);
@@ -2604,7 +2579,7 @@ describe('e2e', () => {
   // bypasses protection by sending messages through the Queue infrastructure.
   test.skipIf(!isLocalDeployment())(
     'health check endpoint (HTTP) - workflow endpoint responds to __health query parameter',
-    { timeout: SHORT_TEST_TIMEOUT_MS },
+    TO.short,
     async () => {
       // NOTE: This tests the HTTP-based health check using the `?__health` query parameter.
       // This approach requires direct HTTP access and works when running locally (for port detection)
@@ -2640,7 +2615,7 @@ describe('e2e', () => {
 
   test(
     'health check (queue-based) - workflow endpoint responds to health check messages',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // Tests the queue-based health check using healthCheck() directly.
       // This bypasses Vercel Deployment Protection by sending messages
@@ -2661,7 +2636,7 @@ describe('e2e', () => {
 
   test(
     'health check (CLI) - workflow health command reports healthy endpoints',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // NOTE: This tests the `workflow health` CLI command which uses the
       // queue-based health check under the hood. The CLI provides a convenient
@@ -2684,7 +2659,7 @@ describe('e2e', () => {
 
   test(
     'pathsAliasWorkflow - TypeScript path aliases resolve correctly',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This workflow uses a step that calls a helper function imported via @repo/* path alias
       // which resolves to a file outside the workbench directory (../../lib/steps/paths-alias-test.ts)
@@ -2708,7 +2683,7 @@ describe('e2e', () => {
 
   test(
     'Calculator.calculate - static workflow method using static step methods from another class',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // Calculator.calculate(5, 3) should:
       // 1. MathService.add(5, 3) = 8
@@ -2730,7 +2705,7 @@ describe('e2e', () => {
 
   test(
     'AllInOneService.processNumber - static workflow method using sibling static step methods',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // AllInOneService.processNumber(10) should:
       // 1. AllInOneService.double(10) = 20
@@ -2753,7 +2728,7 @@ describe('e2e', () => {
 
   test(
     'ChainableService.processWithThis - static step methods using `this` to reference the class',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // ChainableService.processWithThis(5) should:
       // - ChainableService.multiplyByClassValue(5) uses `this.multiplier` (10) -> 5 * 10 = 50
@@ -2787,7 +2762,7 @@ describe('e2e', () => {
 
   test(
     'thisSerializationWorkflow - step function invoked with .call() and .apply()',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // thisSerializationWorkflow(10) should:
       // 1. multiplyByFactor.call({ factor: 2 }, 10) = 20
@@ -2810,7 +2785,7 @@ describe('e2e', () => {
 
   test(
     'customSerializationWorkflow - custom class serialization with WORKFLOW_SERIALIZE/WORKFLOW_DESERIALIZE',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This workflow tests custom serialization of user-defined class instances.
       // The Point class uses WORKFLOW_SERIALIZE and WORKFLOW_DESERIALIZE symbols
@@ -2847,7 +2822,7 @@ describe('e2e', () => {
 
   test(
     'instanceMethodStepWorkflow - instance methods with "use step" directive',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This workflow tests instance methods marked with "use step".
       // The Counter class has custom serialization so the `this` context
@@ -2942,7 +2917,7 @@ describe('e2e', () => {
 
   test(
     'crossContextSerdeWorkflow - classes defined in step code are deserializable in workflow context',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This is a critical test for the cross-context class registration feature.
       //
@@ -2995,7 +2970,7 @@ describe('e2e', () => {
 
   test(
     'errorSubclassRoundTripWorkflow - first-class Error subclasses survive every serialization boundary',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // Round-trips one instance of each Error subclass that has a dedicated
       // reducer/reviver pair (built-in subclasses + FatalError/RetryableError
@@ -3110,7 +3085,7 @@ describe('e2e', () => {
 
   test(
     'stepFunctionAsStartArgWorkflow - step function reference passed as start() argument',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    TO.extraLong,
     async () => {
       // This test verifies that step function references can be:
       // 1. Serialized in the client bundle (the SWC plugin sets stepId property on the function)
@@ -3173,42 +3148,38 @@ describe('e2e', () => {
   );
 
   // ==================== CANCEL TESTS ====================
-  test(
-    'cancelRun - cancelling a running workflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
-    async () => {
-      // Start a long-running workflow with a 30s sleep to provide a wide
-      // window for the cancel to arrive while the workflow is still running.
-      const run = await start(await e2e('sleepingWorkflow'), [30_000]);
+  test('cancelRun - cancelling a running workflow', TO.default, async () => {
+    // Start a long-running workflow with a 30s sleep to provide a wide
+    // window for the cancel to arrive while the workflow is still running.
+    const run = await start(await e2e('sleepingWorkflow'), [30_000]);
 
-      // Wait for the workflow to start and enter the sleep.
-      await waitForRunEvents(
-        run.runId,
-        (event) => event.eventType === 'wait_created',
-        {
-          description: 'wait_created event',
-        }
-      );
+    // Wait for the workflow to start and enter the sleep.
+    await waitForRunEvents(
+      run.runId,
+      (event) => event.eventType === 'wait_created',
+      {
+        description: 'wait_created event',
+      }
+    );
 
-      // Cancel the run using the core runtime cancelRun function.
-      // This exercises the same cancelRun code path that the CLI uses
-      // (the CLI delegates directly to this function).
-      const { cancelRun } = await import('../src/runtime');
-      await cancelRun(await getWorld(), run.runId);
+    // Cancel the run using the core runtime cancelRun function.
+    // This exercises the same cancelRun code path that the CLI uses
+    // (the CLI delegates directly to this function).
+    const { cancelRun } = await import('../src/runtime');
+    await cancelRun(await getWorld(), run.runId);
 
-      // Verify the run was cancelled - returnValue should throw WorkflowRunCancelledError
-      const error = await run.returnValue.catch((e: unknown) => e);
-      expect(WorkflowRunCancelledError.is(error)).toBe(true);
+    // Verify the run was cancelled - returnValue should throw WorkflowRunCancelledError
+    const error = await run.returnValue.catch((e: unknown) => e);
+    expect(WorkflowRunCancelledError.is(error)).toBe(true);
 
-      // Verify the run status is 'cancelled' via CLI inspect
-      const { json: runData } = await cliInspectJson(`runs ${run.runId}`);
-      expect(runData.status).toBe('cancelled');
-    }
-  );
+    // Verify the run status is 'cancelled' via CLI inspect
+    const { json: runData } = await cliInspectJson(`runs ${run.runId}`);
+    expect(runData.status).toBe('cancelled');
+  });
 
   test(
     'cancelRun via CLI - cancelling a running workflow',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // Start a long-running workflow with a 30s sleep to provide a wide
       // window for the cancel to arrive while the workflow is still running.
@@ -3244,59 +3215,44 @@ describe('e2e', () => {
     process.env.APP_NAME === 'nextjs-webpack';
 
   describe.skipIf(!isNextJsApp)('pages router', () => {
-    test(
-      'addTenWorkflow via pages router',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
-      async () => {
-        const run = await startWorkflowViaHttp(
-          {
-            workflowFile: 'workflows/99_e2e.ts',
-            workflowFn: 'addTenWorkflow',
-          },
-          [123],
-          '/api/trigger-pages'
-        );
-        const returnValue = await run.returnValue;
-        expect(returnValue).toBe(133);
-      }
-    );
+    test('addTenWorkflow via pages router', TO.default, async () => {
+      const run = await startWorkflowViaHttp(
+        {
+          workflowFile: 'workflows/99_e2e.ts',
+          workflowFn: 'addTenWorkflow',
+        },
+        [123],
+        '/api/trigger-pages'
+      );
+      const returnValue = await run.returnValue;
+      expect(returnValue).toBe(133);
+    });
 
-    test(
-      'promiseAllWorkflow via pages router',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
-      async () => {
-        const run = await startWorkflowViaHttp(
-          'promiseAllWorkflow',
-          [],
-          '/api/trigger-pages'
-        );
-        const returnValue = await run.returnValue;
-        expect(returnValue).toBe('ABC');
-      }
-    );
+    test('promiseAllWorkflow via pages router', TO.default, async () => {
+      const run = await startWorkflowViaHttp(
+        'promiseAllWorkflow',
+        [],
+        '/api/trigger-pages'
+      );
+      const returnValue = await run.returnValue;
+      expect(returnValue).toBe('ABC');
+    });
 
-    test(
-      'sleepingWorkflow via pages router',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
-      async () => {
-        const run = await startWorkflowViaHttp(
-          'sleepingWorkflow',
-          [],
-          '/api/trigger-pages'
-        );
-        const returnValue = await run.returnValue;
-        expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
-        expectElapsedAtLeast(
-          returnValue.endTime - returnValue.startTime,
-          10_000
-        );
-      }
-    );
+    test('sleepingWorkflow via pages router', TO.default, async () => {
+      const run = await startWorkflowViaHttp(
+        'sleepingWorkflow',
+        [],
+        '/api/trigger-pages'
+      );
+      const returnValue = await run.returnValue;
+      expect(returnValue.startTime).toBeLessThan(returnValue.endTime);
+      expectElapsedAtLeast(returnValue.endTime - returnValue.startTime, 10_000);
+    });
   });
 
   test(
     'hookWithSleepWorkflow - hook payloads delivered correctly with concurrent sleep',
-    { timeout: LONG_TEST_TIMEOUT_MS },
+    TO.long,
     async () => {
       // Regression test: when a hook and sleep run concurrently, multiple
       // hook_received events should all be processed even though the sleep
@@ -3355,7 +3311,7 @@ describe('e2e', () => {
 
   test(
     'hookWithSleepFinalStepWorkflow - step only on final payload',
-    { timeout: EXTRA_LONG_TEST_TIMEOUT_MS },
+    TO.extraLong,
     async () => {
       // Regression test for the v0chat incident. Mirrors the production
       // shape: a hook + fire-and-forget sleep, where the step runs only
@@ -3397,7 +3353,7 @@ describe('e2e', () => {
 
   test(
     'sleepInLoopWorkflow - sleep inside loop with steps actually delays each iteration',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const run = await start(await e2e('sleepInLoopWorkflow'), []);
       const returnValue = await run.returnValue;
@@ -3415,7 +3371,7 @@ describe('e2e', () => {
 
   test(
     'sleepWithSequentialStepsWorkflow - sequential steps work with concurrent sleep (control)',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // Control test: proves that void sleep('1d').then() does NOT break
       // sequential step execution. Steps have per-event consumption so the
@@ -3441,7 +3397,7 @@ describe('e2e', () => {
   describe('AbortController', () => {
     test(
       'abortTimeoutWorkflow: timeout cancels long-running step',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortTimeoutWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3476,7 +3432,7 @@ describe('e2e', () => {
 
     test(
       'abortParallelWorkflow: abort cancels all parallel steps',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortParallelWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3491,7 +3447,7 @@ describe('e2e', () => {
 
     test(
       'abortFromStepWorkflow: step abort cancels an in-flight sibling step',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortFromStepWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3512,7 +3468,7 @@ describe('e2e', () => {
 
     test(
       'abortAlreadyAbortedWorkflow: pre-aborted signal seen by step',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortAlreadyAbortedWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3526,7 +3482,7 @@ describe('e2e', () => {
 
     test(
       'abortReasonWorkflow: abort reason preserved across boundaries',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortReasonWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3540,7 +3496,7 @@ describe('e2e', () => {
 
     test(
       'abortAfterCompletionWorkflow: abort after step completes is a no-op',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortAfterCompletionWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3554,7 +3510,7 @@ describe('e2e', () => {
 
     test(
       'abortViaHookWorkflow: external hook triggers abort on in-flight step',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const token = Math.random().toString(36).slice(2);
         const run = await start(await e2e('abortViaHookWorkflow'), [token]);
@@ -3574,7 +3530,7 @@ describe('e2e', () => {
 
     test(
       'abortExternalSignalWorkflow: signal passed as workflow input',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         // Pass a pre-aborted AbortController to the workflow.
         // The workflow receives the signal and passes it to a step.
@@ -3594,7 +3550,7 @@ describe('e2e', () => {
 
     test(
       'abortExternalSignalInFlightWorkflow: external abort fires mid-flight, propagates to nested steps',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         // Source controller starts NOT aborted. The serialization-time
         // listener attached during start() must write the cancellation packet
@@ -3635,7 +3591,7 @@ describe('e2e', () => {
 
     test(
       'abortAnyInWorkflowWorkflow: AbortSignal.any composes signals inside the workflow VM',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortAnyInWorkflowWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3653,7 +3609,7 @@ describe('e2e', () => {
 
     test(
       'abortAnyInStepWorkflow: AbortSignal.any inside a step composes deserialized signals',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortAnyInStepWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3671,7 +3627,7 @@ describe('e2e', () => {
 
     test(
       'abortSurvivesReplayWorkflow: controller state consistent across replay',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortSurvivesReplayWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3686,7 +3642,7 @@ describe('e2e', () => {
 
     test(
       'abortThrowIfAbortedWorkflow: throwIfAborted causes FatalError, no retries',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortThrowIfAbortedWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3700,7 +3656,7 @@ describe('e2e', () => {
 
     test(
       'abortReasonTypesWorkflow: various abort reason types propagate correctly',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortReasonTypesWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3723,7 +3679,7 @@ describe('e2e', () => {
 
     test(
       'abortFetchUncaughtWorkflow: uncaught fetch AbortError is FatalError, no retries',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortFetchUncaughtWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3743,7 +3699,7 @@ describe('e2e', () => {
 
     test(
       'abortFetchInFlightWorkflow: aborting cancels an in-flight fetch',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         // The workflow kicks off a fetch against a slow endpoint, races it
         // against a 2s sleep, and aborts when the sleep wins. The fetch must
@@ -3769,7 +3725,7 @@ describe('e2e', () => {
 
     test(
       'abortVoidSleepTimeoutWorkflow: documented `void sleep().then(abort)` pattern works',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         // Validates the simplified timeout pattern documented on the
         // abort-signal-timeout-in-workflow error page:
@@ -3795,7 +3751,7 @@ describe('e2e', () => {
 
     test(
       'abortDeterministicBranchWorkflow: if-check takes same path on first-run and replay',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(
           await e2e('abortDeterministicBranchWorkflow'),
@@ -3814,7 +3770,7 @@ describe('e2e', () => {
 
     test(
       'abortListenerWorkflow: signal.addEventListener fires on the deserialized step signal',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(await e2e('abortListenerWorkflow'), []);
         const returnValue = await run.returnValue;
@@ -3830,7 +3786,7 @@ describe('e2e', () => {
 
     test(
       'abortThrowIfAbortedMidFlightWorkflow: throwIfAborted in a polling loop bails when abort fires',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(
           await e2e('abortThrowIfAbortedMidFlightWorkflow'),
@@ -3849,7 +3805,7 @@ describe('e2e', () => {
 
     test(
       'abortDeterministicBranchFromStepWorkflow: branches stay consistent when abort comes from a step',
-      { timeout: DEFAULT_TEST_TIMEOUT_MS },
+      TO.default,
       async () => {
         const run = await start(
           await e2e('abortDeterministicBranchFromStepWorkflow'),
@@ -3908,7 +3864,7 @@ describe('e2e', () => {
     } of orderingVariants) {
       test(
         `abortHookOrderingWorkflow [${variant}]: ${description}`,
-        { timeout: LONG_TEST_TIMEOUT_MS },
+        TO.long,
         async () => {
           const token = `ordering-${variant}-${Math.random().toString(36).slice(2)}`;
           const run = await start(await e2e('abortHookOrderingWorkflow'), [
@@ -3952,7 +3908,7 @@ describe('e2e', () => {
 
   test(
     'importMetaUrlWorkflow - import.meta.url is available in step bundles',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const run = await start(await e2e('importMetaUrlWorkflow'), []);
       const returnValue = await run.returnValue;
@@ -3966,7 +3922,7 @@ describe('e2e', () => {
 
   test(
     'metadataFromHelperWorkflow - getWorkflowMetadata/getStepMetadata work from module-level helper (#1577)',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const run = await start(await e2e('metadataFromHelperWorkflow'), [
         'smoke-test',
@@ -3988,7 +3944,7 @@ describe('e2e', () => {
   // over the queue boundary.
   test(
     'resilient start: addTenWorkflow completes when run_created returns 500',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // Get the real world and wrap it so the first events.create call
       // (run_created) throws a 500 server error. The queue should still
@@ -4033,7 +3989,7 @@ describe('e2e', () => {
 
   test(
     'getterStepWorkflow - getter functions with "use step" directive',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       // This workflow tests getter functions marked with "use step".
       // The Sensor class has custom serialization so the `this` context
@@ -4071,7 +4027,7 @@ describe('e2e', () => {
   // ============================================================
   test(
     'distributedAbortController - manual abort triggers signal',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const controllerId = `test-abort-${Math.random().toString(36).slice(2)}`;
 
@@ -4107,7 +4063,7 @@ describe('e2e', () => {
 
   test(
     'distributedAbortController - TTL expiration triggers signal',
-    { timeout: SHORT_TEST_TIMEOUT_MS },
+    TO.short,
     async () => {
       const controllerId = `test-expire-${Math.random().toString(36).slice(2)}`;
 
@@ -4135,7 +4091,7 @@ describe('e2e', () => {
 
   test(
     'distributedAbortController - reconnect to existing controller',
-    { timeout: DEFAULT_TEST_TIMEOUT_MS },
+    TO.default,
     async () => {
       const controllerId = `test-reconnect-${Math.random().toString(36).slice(2)}`;
       const token = `distributed-abort:${controllerId}`;
@@ -4170,7 +4126,7 @@ describe('e2e', () => {
   describe('experimental_setAttributes', () => {
     test(
       'start: initial attributes are seeded on run creation',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesWorkflow'),
@@ -4190,7 +4146,7 @@ describe('e2e', () => {
 
     test(
       'start: reserved-prefix initial attributes are seeded with allowReservedAttributes',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesWorkflow'),
@@ -4217,7 +4173,7 @@ describe('e2e', () => {
 
     test(
       'experimentalSetAttributesWorkflow: workflow-body calls append native attr_set events and merge correctly',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesWorkflow'),
@@ -4245,7 +4201,7 @@ describe('e2e', () => {
 
     test(
       'experimentalSetAttributesInsideStepWorkflow: step-body calls append attributed native events',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesInsideStepWorkflow'),
@@ -4275,7 +4231,7 @@ describe('e2e', () => {
 
     test(
       'fire-and-forget: void experimental_setAttributes lands without awaiting',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesFireAndForgetWorkflow'),
@@ -4293,7 +4249,7 @@ describe('e2e', () => {
 
     test(
       'Promise.all of disjoint-key writes: every key lands',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesParallelWorkflow'),
@@ -4313,7 +4269,7 @@ describe('e2e', () => {
 
     test(
       'workflow throws after awaited setAttributes: attribute still persists on the failed run',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesThrowsAfterWorkflow'),
@@ -4340,7 +4296,7 @@ describe('e2e', () => {
 
     test(
       'validation DX: invalid writes throw catchable FatalErrors naming rule and limit',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const run = await start(
           await e2e('experimentalSetAttributesValidationWorkflow'),
@@ -4378,7 +4334,7 @@ describe('e2e', () => {
 
     test(
       'start: invalid initial attributes are rejected before a run is created',
-      { timeout: SHORT_TEST_TIMEOUT_MS },
+      TO.short,
       async () => {
         const workflow = await e2e('experimentalSetAttributesWorkflow');
         await expect(

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -39,7 +39,7 @@ import {
 } from './constants.js';
 import { getPortLazy } from './get-port-lazy.js';
 import { memoizeEncryptionKey } from './helpers.js';
-import { safeWaitUntil } from './wait-until.js';
+import { waitForBackgroundOps } from './wait-until.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
 
@@ -627,33 +627,20 @@ export async function executeStep(
       // across steps), waitUntil handles the rest.
       let opsSettled = true;
       if (ops.length > 0) {
-        const opsPromise = Promise.all(ops);
         // The race below surfaces failures inline when ops settle quickly;
-        // if the 500ms timeout wins, the failure is only observed here. The
+        // if the 500ms timeout wins, waitUntil keeps the work alive. The
         // promise handed to waitUntil must never reject (an unconsumed
-        // waitUntil rejection crashes the process as unhandledRejection),
-        // so unexpected failures are logged instead.
-        safeWaitUntil(opsPromise, (err) => {
-          runtimeLogger.warn('Background flush of step stream ops failed', {
-            workflowRunId,
-            stepId,
-            error: err instanceof Error ? err.message : String(err),
-          });
+        // waitUntil rejection crashes the process as unhandledRejection), so
+        // unexpected failures are logged instead.
+        opsSettled = await waitForBackgroundOps(Promise.all(ops), {
+          onError: (err) => {
+            runtimeLogger.warn('Background flush of step stream ops failed', {
+              workflowRunId,
+              stepId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          },
         });
-        opsSettled = await Promise.race([
-          opsPromise.then(
-            () => true as const,
-            (err) => {
-              // Ignore expected client disconnect errors (e.g., browser
-              // refresh during streaming)
-              const isAbortError =
-                err?.name === 'AbortError' || err?.name === 'ResponseAborted';
-              if (isAbortError) return true as const;
-              throw err;
-            }
-          ),
-          new Promise<false>((r) => setTimeout(() => r(false), 500)),
-        ]);
       }
 
       // Optimistic start: the body ran before `step_started` was confirmed.

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -449,6 +449,7 @@ export async function executeStep(
     });
 
     let result: unknown;
+    let propagateStepCompletedError = false;
 
     // Check max retries AFTER step_started (attempt was just incremented).
     // Only enforce when the step has a previous error — this distinguishes
@@ -707,6 +708,7 @@ export async function executeStep(
             stepCompleted409 = true;
             return undefined;
           }
+          propagateStepCompletedError = true;
           throw err;
         });
 
@@ -737,6 +739,8 @@ export async function executeStep(
       // and queue a continuation so waitUntil can flush them.
       return { type: 'completed', hasPendingOps: !opsSettled, inlineDelta };
     } catch (err: unknown) {
+      if (propagateStepCompletedError && !RunExpiredError.is(err)) throw err;
+
       // Optimistic start: the body threw before `step_started` was confirmed.
       // Reconcile first — if we lost the create-claim (or the run is
       // gone/throttled) the body error is moot; discard it and don't write a

--- a/packages/core/src/runtime/step-handler.test.ts
+++ b/packages/core/src/runtime/step-handler.test.ts
@@ -1,6 +1,7 @@
 import {
   EntityConflictError,
   FatalError,
+  RunExpiredError,
   ThrottleError,
   WorkflowWorldError,
 } from '@workflow/errors';
@@ -283,7 +284,6 @@ describe('step-handler 409 handling', () => {
   describe('step_completed 409', () => {
     it('should warn and return when step_completed gets a 409', async () => {
       // step_started succeeds, step function succeeds, step_completed returns 409
-      let callCount = 0;
       mockEventsCreate.mockImplementation(
         (_runId: string, event: { eventType: string }) => {
           if (event.eventType === 'step_started') {
@@ -299,7 +299,6 @@ describe('step-handler 409 handling', () => {
             });
           }
           if (event.eventType === 'step_completed') {
-            callCount++;
             return Promise.reject(
               new EntityConflictError(
                 'Cannot complete step because it is already completed'
@@ -537,7 +536,7 @@ describe('step-handler 409 handling', () => {
           event.eventType === 'step_started'
       );
       expect(startedCall).toBeDefined();
-      expect(startedCall![2]).toEqual(
+      expect(startedCall?.[2]).toEqual(
         expect.objectContaining({ requestId: 'iad1::req-abc' })
       );
     });
@@ -553,7 +552,7 @@ describe('step-handler 409 handling', () => {
           event.eventType === 'step_completed'
       );
       expect(completedCall).toBeDefined();
-      expect(completedCall![2]).toEqual(
+      expect(completedCall?.[2]).toEqual(
         expect.objectContaining({ requestId: 'iad1::req-abc' })
       );
     });
@@ -566,7 +565,7 @@ describe('step-handler 409 handling', () => {
           event.eventType === 'step_started'
       );
       expect(startedCall).toBeDefined();
-      expect(startedCall![2]).toEqual(
+      expect(startedCall?.[2]).toEqual(
         expect.objectContaining({ requestId: undefined })
       );
     });
@@ -647,7 +646,7 @@ describe('step-handler max deliveries', () => {
   });
 
   it('should not trigger max deliveries check when under limit', async () => {
-    const result = await capturedHandler(createMessage(), {
+    await capturedHandler(createMessage(), {
       ...createMetadata('myStep'),
       attempt: MAX_QUEUE_DELIVERIES,
     });
@@ -1175,6 +1174,74 @@ describe('executeStep inline-delta threading', () => {
     if (result.type !== 'completed') throw new Error('unreachable');
     expect(result.inlineDelta).toBeUndefined();
   });
+
+  it('rethrows step_completed write failures without recording a step failure', async () => {
+    const completionError = new Error('fetch failed');
+    mockEventsCreate.mockImplementation(
+      (_runId: string, event: { eventType: string }) => {
+        if (event.eventType === 'step_started') {
+          return Promise.resolve({
+            step: {
+              stepId: 'step_abc',
+              status: 'running',
+              attempt: 1,
+              startedAt: new Date(),
+              input: [],
+            },
+            event: {},
+          });
+        }
+        if (event.eventType === 'step_completed') {
+          return Promise.reject(completionError);
+        }
+        return Promise.resolve({ event: {} });
+      }
+    );
+
+    const world = await getWorld();
+    await expect(
+      executeStep({ world: world as never, ...baseParams })
+    ).rejects.toBe(completionError);
+
+    expect(
+      mockEventsCreate.mock.calls.map(
+        ([, event]) => (event as { eventType: string }).eventType
+      )
+    ).toEqual(['step_started', 'step_completed']);
+  });
+
+  it('treats a RunExpiredError from step_completed as gone', async () => {
+    mockEventsCreate.mockImplementation(
+      (_runId: string, event: { eventType: string }) => {
+        if (event.eventType === 'step_started') {
+          return Promise.resolve({
+            step: {
+              stepId: 'step_abc',
+              status: 'running',
+              attempt: 1,
+              startedAt: new Date(),
+              input: [],
+            },
+            event: {},
+          });
+        }
+        if (event.eventType === 'step_completed') {
+          return Promise.reject(new RunExpiredError('run already completed'));
+        }
+        return Promise.resolve({ event: {} });
+      }
+    );
+
+    const world = await getWorld();
+    const result = await executeStep({ world: world as never, ...baseParams });
+
+    expect(result).toEqual({ type: 'gone' });
+    expect(
+      mockEventsCreate.mock.calls.map(
+        ([, event]) => (event as { eventType: string }).eventType
+      )
+    ).toEqual(['step_started', 'step_completed']);
+  });
 });
 
 describe('executeStep optimistic inline start', () => {
@@ -1213,7 +1280,7 @@ describe('executeStep optimistic inline start', () => {
   it('sends step_started carrying the input and completes (when enabled)', async () => {
     mockEventsCreate
       .mockReset()
-      .mockImplementation((_runId: string, event: { eventType: string }) =>
+      .mockImplementation((_runId: string, _event: { eventType: string }) =>
         Promise.resolve({ event: {} })
       );
 

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -1081,16 +1081,27 @@ function createStepHandler(namespace?: string) {
             // resilient to the below code not executing on a failed step.
             // (Dehydration already happened above and is accounted for in the
             // userCodeFailed path.)
-            // These stream ops are flushed in the background; the promise
-            // handed to waitUntil must never reject (an unconsumed waitUntil
-            // rejection crashes the process as unhandledRejection), so
-            // unexpected failures are logged instead.
-            safeWaitUntil(Promise.all(ops), (err) => {
-              stepRuntimeLogger.warn(
-                'Background flush of step stream ops failed',
-                { error: err instanceof Error ? err.message : String(err) }
-              );
-            });
+            if (ops.length > 0) {
+              const opsPromise = Promise.all(ops);
+              // Match inline step execution: surface quick stream flush failures
+              // before step_completed, but leave slow/open streams to waitUntil.
+              safeWaitUntil(opsPromise, (err) => {
+                stepRuntimeLogger.warn(
+                  'Background flush of step stream ops failed',
+                  { error: err instanceof Error ? err.message : String(err) }
+                );
+              });
+              await Promise.race([
+                opsPromise.catch((err) => {
+                  const isAbortError =
+                    err?.name === 'AbortError' ||
+                    err?.name === 'ResponseAborted';
+                  if (isAbortError) return;
+                  throw err;
+                }),
+                new Promise<void>((resolve) => setTimeout(resolve, 500)),
+              ]);
+            }
 
             // Run step_completed and trace serialization concurrently;
             // the trace carrier is used in the final queueMessage call below

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -57,7 +57,7 @@ import {
   queueMessage,
   withHealthCheck,
 } from './helpers.js';
-import { safeWaitUntil } from './wait-until.js';
+import { waitForBackgroundOps } from './wait-until.js';
 import { getWorld, getWorldHandlers, type WorldHandlers } from './world.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
@@ -1082,25 +1082,16 @@ function createStepHandler(namespace?: string) {
             // (Dehydration already happened above and is accounted for in the
             // userCodeFailed path.)
             if (ops.length > 0) {
-              const opsPromise = Promise.all(ops);
               // Match inline step execution: surface quick stream flush failures
               // before step_completed, but leave slow/open streams to waitUntil.
-              safeWaitUntil(opsPromise, (err) => {
-                stepRuntimeLogger.warn(
-                  'Background flush of step stream ops failed',
-                  { error: err instanceof Error ? err.message : String(err) }
-                );
+              await waitForBackgroundOps(Promise.all(ops), {
+                onError: (err) => {
+                  stepRuntimeLogger.warn(
+                    'Background flush of step stream ops failed',
+                    { error: err instanceof Error ? err.message : String(err) }
+                  );
+                },
               });
-              await Promise.race([
-                opsPromise.catch((err) => {
-                  const isAbortError =
-                    err?.name === 'AbortError' ||
-                    err?.name === 'ResponseAborted';
-                  if (isAbortError) return;
-                  throw err;
-                }),
-                new Promise<void>((resolve) => setTimeout(resolve, 500)),
-              ]);
             }
 
             // Run step_completed and trace serialization concurrently;

--- a/packages/core/src/runtime/wait-until.test.ts
+++ b/packages/core/src/runtime/wait-until.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { safeWaitUntil } from './wait-until';
+import {
+  isExpectedClientDisconnectError,
+  safeWaitUntil,
+  waitForBackgroundOps,
+} from './wait-until';
 
 describe('safeWaitUntil', () => {
   it('invokes onError for unexpected rejections instead of letting the promise reject', async () => {
@@ -30,5 +34,46 @@ describe('safeWaitUntil', () => {
     safeWaitUntil(Promise.resolve('ok'), onError);
     await new Promise((resolve) => setImmediate(resolve));
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('identifies expected client-disconnect errors', () => {
+    const abortError = new Error('client disconnected');
+    abortError.name = 'AbortError';
+    const responseAborted = new Error('response aborted');
+    responseAborted.name = 'ResponseAborted';
+
+    expect(isExpectedClientDisconnectError(abortError)).toBe(true);
+    expect(isExpectedClientDisconnectError(responseAborted)).toBe(true);
+    expect(isExpectedClientDisconnectError(new Error('boom'))).toBe(false);
+    expect(isExpectedClientDisconnectError(undefined)).toBe(false);
+  });
+});
+
+describe('waitForBackgroundOps', () => {
+  it('returns true when work settles inside the timeout', async () => {
+    const onError = vi.fn();
+    await expect(
+      waitForBackgroundOps(Promise.resolve('ok'), { onError, timeoutMs: 50 })
+    ).resolves.toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('returns false when work is still pending after the timeout', async () => {
+    const onError = vi.fn();
+    await expect(
+      waitForBackgroundOps(new Promise(() => {}), { onError, timeoutMs: 1 })
+    ).resolves.toBe(false);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('surfaces quick unexpected failures while keeping waitUntil safe', async () => {
+    const onError = vi.fn();
+    const err = new Error('boom');
+
+    await expect(
+      waitForBackgroundOps(Promise.reject(err), { onError, timeoutMs: 50 })
+    ).rejects.toBe(err);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(onError).toHaveBeenCalledWith(err);
   });
 });

--- a/packages/core/src/runtime/wait-until.ts
+++ b/packages/core/src/runtime/wait-until.ts
@@ -4,6 +4,14 @@ export function waitUntil(promise: Promise<unknown>): void {
   });
 }
 
+export function isExpectedClientDisconnectError(err: unknown): boolean {
+  const name =
+    typeof err === 'object' && err !== null && 'name' in err
+      ? (err as { name?: unknown }).name
+      : undefined;
+  return name === 'AbortError' || name === 'ResponseAborted';
+}
+
 /**
  * Schedule a background promise via `waitUntil`, guaranteeing that the
  * promise handed to `waitUntil` can never reject. Nothing consumes a
@@ -20,9 +28,7 @@ export function safeWaitUntil(
 ): void {
   waitUntil(
     promise.catch((err) => {
-      const isAbortError =
-        err?.name === 'AbortError' || err?.name === 'ResponseAborted';
-      if (!isAbortError) {
+      if (!isExpectedClientDisconnectError(err)) {
         try {
           onError(err);
         } catch {
@@ -31,6 +37,40 @@ export function safeWaitUntil(
       }
     })
   );
+}
+
+/**
+ * Schedule a background promise and wait a short window for quick success or
+ * failure. Returns false when the timeout wins so callers can queue a
+ * continuation while `waitUntil` keeps the background work alive.
+ */
+export async function waitForBackgroundOps(
+  promise: Promise<unknown>,
+  {
+    onError,
+    timeoutMs = 500,
+  }: { onError: (err: unknown) => void; timeoutMs?: number }
+): Promise<boolean> {
+  safeWaitUntil(promise, onError);
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true as const,
+        (err) => {
+          if (isExpectedClientDisconnectError(err)) return true as const;
+          throw err;
+        }
+      ),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 /**

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -2189,7 +2189,7 @@ describe('step arguments', () => {
     });
     const world = makeMockWorld();
     world.streams.write.mockImplementation((_runId, name) => {
-      if (name === 'strm_manual_webhook_response') {
+      if (name === webhookResponseStreamName) {
         return writeGate;
       }
       return Promise.resolve();

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -36,6 +36,7 @@ import {
   maybeEncrypt,
   SerializationFormat,
 } from './serialization.js';
+import type { StepContext } from './step/context-storage.js';
 import {
   ABORT_HOOK_TOKEN,
   ABORT_READER_CANCEL,
@@ -44,6 +45,7 @@ import {
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
+  WEBHOOK_RESPONSE_WRITABLE,
 } from './symbols.js';
 import { createContext } from './vm/index.js';
 
@@ -2029,6 +2031,109 @@ describe('step arguments', () => {
       // packages/core/src/serialization/errors.ts.
       `Ensure you're passing workflow serializable types. Check the serialization docs to see what's serializable: https://workflow-sdk.dev/docs/foundations/serialization`
     );
+  });
+
+  it('waits for manual webhook response streams to flush before respondWith resolves', async () => {
+    const { contextStorage } = await import('./step/context-storage.js');
+    const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
+
+    let resolveWrite!: () => void;
+    const writeGate = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    const world = makeMockWorld();
+    world.streams.write.mockImplementation((_runId, name) => {
+      if (name === 'strm_manual_webhook_response') {
+        return writeGate;
+      }
+      return Promise.resolve();
+    });
+    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+
+    try {
+      const responseWritable = new WritableStream();
+      Object.defineProperty(responseWritable, STREAM_NAME_SYMBOL, {
+        value: 'strm_manual_webhook_response',
+        writable: false,
+      });
+      Object.defineProperty(responseWritable, STREAM_SERVER_RUN_ID_SYMBOL, {
+        value: mockRunId,
+        writable: false,
+      });
+
+      const request = new Request('https://example.com/webhook', {
+        method: 'POST',
+      });
+      (request as any)[WEBHOOK_RESPONSE_WRITABLE] = responseWritable;
+
+      const serialized = await dehydrateStepArguments(
+        request,
+        mockRunId,
+        noEncryptionKey,
+        globalThis
+      );
+      const ops: Promise<void>[] = [];
+      const hydrated = (await hydrateStepArguments(
+        serialized,
+        mockRunId,
+        noEncryptionKey,
+        ops,
+        globalThis
+      )) as Request & { respondWith(response: Response): Promise<void> };
+
+      const preCompletionOps: Promise<void>[] = [];
+      const stepContext: StepContext = {
+        stepMetadata: {
+          stepName: 'sendWebhookResponse',
+          stepId: 'step_manual_webhook_response',
+          stepStartedAt: new Date(),
+          attempt: 1,
+        },
+        workflowMetadata: {
+          workflowName: 'webhookWorkflow',
+          workflowRunId: mockRunId,
+          workflowStartedAt: new Date(),
+          url: 'https://example.com',
+          features: { encryption: false },
+        },
+        ops,
+        preCompletionOps,
+        encryptionKey: undefined,
+      };
+
+      let responded = false;
+      const respondPromise = contextStorage
+        .run(stepContext, () =>
+          hydrated.respondWith(new Response('Hello from webhook!'))
+        )
+        .then(() => {
+          responded = true;
+        });
+
+      await vi.waitFor(() => {
+        expect(world.streams.write).toHaveBeenCalledWith(
+          mockRunId,
+          'strm_manual_webhook_response',
+          expect.any(Uint8Array)
+        );
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(responded).toBe(false);
+      expect(preCompletionOps).toHaveLength(1);
+
+      resolveWrite();
+      await respondPromise;
+      await Promise.all(preCompletionOps);
+
+      expect(responded).toBe(true);
+      expect(world.streams.close).toHaveBeenCalledWith(
+        mockRunId,
+        'strm_manual_webhook_response'
+      );
+    } finally {
+      vi.mocked(getWorldLazy).mockImplementation(() => makeMockWorld() as any);
+    }
   });
 });
 

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -42,9 +42,11 @@ import {
   ABORT_READER_CANCEL,
   ABORT_STREAM_NAME,
   STABLE_ULID,
+  STREAM_FRAMING_SYMBOL,
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
+  STREAM_TYPE_SYMBOL,
   WEBHOOK_RESPONSE_WRITABLE,
 } from './symbols.js';
 import { createContext } from './vm/index.js';
@@ -686,6 +688,50 @@ describe('workflow arguments', () => {
     expect(hydrated).toBeInstanceOf(OurReadableStream);
     const streamName = hydrated[STREAM_NAME_SYMBOL];
     expect(streamName).toMatch(/^strm_[0-9A-Z]{26}$/);
+  });
+
+  it('preserves returned ReadableStream metadata for external hydration', async () => {
+    const ops: Promise<void>[] = [];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const stepSerialized = await dehydrateStepReturnValue(
+      stream,
+      mockRunId,
+      noEncryptionKey,
+      ops,
+      globalThis,
+      false,
+      true
+    );
+    const workflowHandle = await hydrateStepReturnValue(
+      stepSerialized,
+      mockRunId,
+      noEncryptionKey
+    );
+    const workflowSerialized = await dehydrateWorkflowReturnValue(
+      workflowHandle,
+      mockRunId,
+      noEncryptionKey
+    );
+    const hydrated = await hydrateWorkflowReturnValue(
+      workflowSerialized,
+      mockRunId,
+      noEncryptionKey
+    );
+
+    expect(hydrated[STREAM_NAME_SYMBOL]).toBe(
+      workflowHandle[STREAM_NAME_SYMBOL]
+    );
+    expect(hydrated[STREAM_TYPE_SYMBOL]).toBe(
+      workflowHandle[STREAM_TYPE_SYMBOL]
+    );
+    expect(hydrated[STREAM_FRAMING_SYMBOL]).toBe(
+      workflowHandle[STREAM_FRAMING_SYMBOL]
+    );
+    await Promise.all(ops);
   });
 
   it('should work with Headers', async () => {

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -2011,6 +2011,75 @@ describe('workflow return value', () => {
 });
 
 describe('step arguments', () => {
+  const webhookResponseStreamName = 'strm_manual_webhook_response';
+
+  async function hydrateManualWebhookRequest(world = makeMockWorld()) {
+    const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
+    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+
+    const responseWritable = new WritableStream();
+    Object.defineProperty(responseWritable, STREAM_NAME_SYMBOL, {
+      value: webhookResponseStreamName,
+      writable: false,
+    });
+    Object.defineProperty(responseWritable, STREAM_SERVER_RUN_ID_SYMBOL, {
+      value: mockRunId,
+      writable: false,
+    });
+
+    const request = new Request('https://example.com/webhook', {
+      method: 'POST',
+    });
+    (request as any)[WEBHOOK_RESPONSE_WRITABLE] = responseWritable;
+
+    const serialized = await dehydrateStepArguments(
+      request,
+      mockRunId,
+      noEncryptionKey,
+      globalThis
+    );
+    const ops: Promise<void>[] = [];
+    const hydrated = (await hydrateStepArguments(
+      serialized,
+      mockRunId,
+      noEncryptionKey,
+      ops,
+      globalThis
+    )) as Request & { respondWith(response: Response): Promise<void> };
+
+    const preCompletionOps: Promise<void>[] = [];
+    const stepContext: StepContext = {
+      stepMetadata: {
+        stepName: 'sendWebhookResponse',
+        stepId: 'step_manual_webhook_response',
+        stepStartedAt: new Date(),
+        attempt: 1,
+      },
+      workflowMetadata: {
+        workflowName: 'webhookWorkflow',
+        workflowRunId: mockRunId,
+        workflowStartedAt: new Date(),
+        url: 'https://example.com',
+        features: { encryption: false },
+      },
+      ops,
+      preCompletionOps,
+      encryptionKey: undefined,
+    };
+
+    return {
+      hydrated,
+      ops,
+      preCompletionOps,
+      resetWorld: () =>
+        vi
+          .mocked(getWorldLazy)
+          .mockImplementation(() => makeMockWorld() as any),
+      stepContext,
+      world,
+    };
+  }
+
   it('should throw error for an unsupported type', async () => {
     class Foo {}
     let err: WorkflowRuntimeError | undefined;
@@ -2035,7 +2104,6 @@ describe('step arguments', () => {
 
   it('waits for manual webhook response streams to flush before respondWith resolves', async () => {
     const { contextStorage } = await import('./step/context-storage.js');
-    const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
 
     let resolveWrite!: () => void;
     const writeGate = new Promise<void>((resolve) => {
@@ -2048,58 +2116,14 @@ describe('step arguments', () => {
       }
       return Promise.resolve();
     });
-    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+    const { hydrated, preCompletionOps, resetWorld, stepContext } =
+      await hydrateManualWebhookRequest(world);
 
     try {
-      const responseWritable = new WritableStream();
-      Object.defineProperty(responseWritable, STREAM_NAME_SYMBOL, {
-        value: 'strm_manual_webhook_response',
-        writable: false,
-      });
-      Object.defineProperty(responseWritable, STREAM_SERVER_RUN_ID_SYMBOL, {
-        value: mockRunId,
-        writable: false,
-      });
-
-      const request = new Request('https://example.com/webhook', {
-        method: 'POST',
-      });
-      (request as any)[WEBHOOK_RESPONSE_WRITABLE] = responseWritable;
-
-      const serialized = await dehydrateStepArguments(
-        request,
-        mockRunId,
-        noEncryptionKey,
-        globalThis
-      );
-      const ops: Promise<void>[] = [];
-      const hydrated = (await hydrateStepArguments(
-        serialized,
-        mockRunId,
-        noEncryptionKey,
-        ops,
-        globalThis
-      )) as Request & { respondWith(response: Response): Promise<void> };
-
-      const preCompletionOps: Promise<void>[] = [];
-      const stepContext: StepContext = {
-        stepMetadata: {
-          stepName: 'sendWebhookResponse',
-          stepId: 'step_manual_webhook_response',
-          stepStartedAt: new Date(),
-          attempt: 1,
-        },
-        workflowMetadata: {
-          workflowName: 'webhookWorkflow',
-          workflowRunId: mockRunId,
-          workflowStartedAt: new Date(),
-          url: 'https://example.com',
-          features: { encryption: false },
-        },
-        ops,
-        preCompletionOps,
-        encryptionKey: undefined,
-      };
+      // Let the writable lock poller observe the idle stream before the
+      // response is written. respondWith must still wait for this specific
+      // write/close, not for a stale idle-state promise.
+      await new Promise((resolve) => setTimeout(resolve, 30));
 
       let responded = false;
       const respondPromise = contextStorage
@@ -2113,7 +2137,7 @@ describe('step arguments', () => {
       await vi.waitFor(() => {
         expect(world.streams.write).toHaveBeenCalledWith(
           mockRunId,
-          'strm_manual_webhook_response',
+          webhookResponseStreamName,
           expect.any(Uint8Array)
         );
       });
@@ -2129,10 +2153,54 @@ describe('step arguments', () => {
       expect(responded).toBe(true);
       expect(world.streams.close).toHaveBeenCalledWith(
         mockRunId,
-        'strm_manual_webhook_response'
+        webhookResponseStreamName
       );
     } finally {
-      vi.mocked(getWorldLazy).mockImplementation(() => makeMockWorld() as any);
+      resetWorld();
+    }
+  });
+
+  it('rejects manual webhook respondWith when response stream write fails', async () => {
+    const { contextStorage } = await import('./step/context-storage.js');
+
+    const streamError = new Error('manual webhook response write failed');
+    let rejectWrite!: (reason?: unknown) => void;
+    const writeFailure = new Promise<void>((_resolve, reject) => {
+      rejectWrite = reject;
+    });
+    writeFailure.catch(() => {});
+    const world = makeMockWorld();
+    world.streams.write.mockImplementation((_runId, name) => {
+      if (name === webhookResponseStreamName) {
+        return writeFailure;
+      }
+      return Promise.resolve();
+    });
+    const { hydrated, ops, preCompletionOps, resetWorld, stepContext } =
+      await hydrateManualWebhookRequest(world);
+    const opsDone = Promise.all(ops).catch(() => undefined);
+
+    try {
+      const respondPromise = contextStorage.run(stepContext, () =>
+        hydrated.respondWith(new Response('Hello from webhook!'))
+      );
+
+      await vi.waitFor(() => {
+        expect(world.streams.write).toHaveBeenCalledWith(
+          mockRunId,
+          webhookResponseStreamName,
+          expect.any(Uint8Array)
+        );
+      });
+      rejectWrite(streamError);
+
+      await expect(respondPromise).rejects.toThrow(streamError.message);
+
+      expect(preCompletionOps).toHaveLength(1);
+      await expect(Promise.all(preCompletionOps)).resolves.toEqual([undefined]);
+      await opsDone;
+    } finally {
+      resetWorld();
     }
   });
 });
@@ -2772,7 +2840,7 @@ describe('step function serialization', () => {
     const stepId = 'step//workflows/test.ts//addNumbers';
 
     // Create a VM context like the workflow runner does
-    const { context, globalThis: vmGlobalThis } = createContext({
+    const { globalThis: vmGlobalThis } = createContext({
       seed: 'test',
       fixedTimestamp: 1714857600000,
     });
@@ -2834,7 +2902,7 @@ describe('step function serialization', () => {
     const stepId = 'step//workflows/test.ts//missingUseStep';
 
     // Create a VM context WITHOUT setting up WORKFLOW_USE_STEP
-    const { context, globalThis: vmGlobalThis } = createContext({
+    const { globalThis: vmGlobalThis } = createContext({
       seed: 'test',
       fixedTimestamp: 1714857600000,
     });
@@ -5666,7 +5734,7 @@ describe('isEncrypted', () => {
 // ============================================================================
 
 describe('AbortController serialization', () => {
-  const { context, globalThis: vmGlobalThis } = createContext({
+  const { globalThis: vmGlobalThis } = createContext({
     seed: 'test-abort-serde',
     fixedTimestamp: 1714857600000,
   });

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -42,11 +42,10 @@ import {
   ABORT_READER_CANCEL,
   ABORT_STREAM_NAME,
   STABLE_ULID,
-  STREAM_FRAMING_SYMBOL,
+  STREAM_CLIENT_NAME_SYMBOL,
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
-  STREAM_TYPE_SYMBOL,
   WEBHOOK_RESPONSE_WRITABLE,
 } from './symbols.js';
 import { createContext } from './vm/index.js';
@@ -722,16 +721,49 @@ describe('workflow arguments', () => {
       noEncryptionKey
     );
 
-    expect(hydrated[STREAM_NAME_SYMBOL]).toBe(
+    expect(hydrated[STREAM_CLIENT_NAME_SYMBOL]).toBe(
       workflowHandle[STREAM_NAME_SYMBOL]
     );
-    expect(hydrated[STREAM_TYPE_SYMBOL]).toBe(
-      workflowHandle[STREAM_TYPE_SYMBOL]
-    );
-    expect(hydrated[STREAM_FRAMING_SYMBOL]).toBe(
-      workflowHandle[STREAM_FRAMING_SYMBOL]
-    );
+    expect(hydrated[STREAM_NAME_SYMBOL]).toBeUndefined();
     await Promise.all(ops);
+  });
+
+  it('does not tag step-hydrated ReadableStreams as reusable handles', async () => {
+    const ops: Promise<void>[] = [];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const stepSerialized = await dehydrateStepReturnValue(
+      stream,
+      mockRunId,
+      noEncryptionKey,
+      ops,
+      globalThis,
+      false,
+      true
+    );
+    const workflowHandle = await hydrateStepReturnValue(
+      stepSerialized,
+      mockRunId,
+      noEncryptionKey
+    );
+    const stepArgs = await dehydrateStepArguments(
+      workflowHandle,
+      mockRunId,
+      noEncryptionKey
+    );
+    const stepOps: Promise<void>[] = [];
+    const hydrated = await hydrateStepArguments(
+      stepArgs,
+      mockRunId,
+      noEncryptionKey,
+      stepOps
+    );
+
+    expect(hydrated[STREAM_NAME_SYMBOL]).toBeUndefined();
+    await Promise.all([...ops, ...stepOps]);
   });
 
   it('should work with Headers', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -943,6 +943,25 @@ import type {
   SerializableSpecial,
 } from './serialization/types.js';
 
+function tagReadableStreamHandle<T extends ReadableStream>(
+  stream: T,
+  value: Extract<SerializableSpecial['ReadableStream'], { name: string }>
+): T {
+  Object.defineProperty(stream, STREAM_NAME_SYMBOL, {
+    value: value.name,
+    writable: false,
+  });
+  Object.defineProperty(stream, STREAM_TYPE_SYMBOL, {
+    value: value.type,
+    writable: false,
+  });
+  Object.defineProperty(stream, STREAM_FRAMING_SYMBOL, {
+    value: value.framing,
+    writable: false,
+  });
+  return stream;
+}
+
 // ---- Composed reducers ----
 // Composes modular reducers (common, class, step-function) with
 // mode-specific Request/Response/Stream reducers below.
@@ -1968,7 +1987,7 @@ export function getExternalRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(userReadable, state);
 
-        return userReadable;
+        return tagReadableStreamHandle(userReadable, value);
       } else {
         // Non-byte streams carry length-prefixed frames, so we can count
         // completed frames and transparently reconnect when the server
@@ -1993,7 +2012,7 @@ export function getExternalRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(transform.readable, state);
 
-        return transform.readable;
+        return tagReadableStreamHandle(transform.readable, value);
       }
     },
     WritableStream: (value) => {
@@ -2383,7 +2402,7 @@ function getStepRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(userReadable, state);
 
-        return userReadable;
+        return tagReadableStreamHandle(userReadable, value);
       } else {
         const transform = getDeserializeStream(
           getStepRevivers(global, ops, runId, cryptoKey, deploymentId),
@@ -2400,7 +2419,7 @@ function getStepRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(transform.readable, state);
 
-        return transform.readable;
+        return tagReadableStreamHandle(transform.readable, value);
       }
     },
     WritableStream: (value) => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -75,6 +75,7 @@ import {
   ABORT_STREAM_NAME,
   BODY_INIT_SYMBOL,
   STABLE_ULID,
+  STREAM_CLIENT_NAME_SYMBOL,
   STREAM_FLUSH_PROMISE_SYMBOL,
   STREAM_FRAMING_SYMBOL,
   STREAM_NAME_SYMBOL,
@@ -943,20 +944,12 @@ import type {
   SerializableSpecial,
 } from './serialization/types.js';
 
-function tagReadableStreamHandle<T extends ReadableStream>(
+function tagExternalReadableStream<T extends ReadableStream>(
   stream: T,
   value: Extract<SerializableSpecial['ReadableStream'], { name: string }>
 ): T {
-  Object.defineProperty(stream, STREAM_NAME_SYMBOL, {
+  Object.defineProperty(stream, STREAM_CLIENT_NAME_SYMBOL, {
     value: value.name,
-    writable: false,
-  });
-  Object.defineProperty(stream, STREAM_TYPE_SYMBOL, {
-    value: value.type,
-    writable: false,
-  });
-  Object.defineProperty(stream, STREAM_FRAMING_SYMBOL, {
-    value: value.framing,
     writable: false,
   });
   return stream;
@@ -1987,7 +1980,7 @@ export function getExternalRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(userReadable, state);
 
-        return tagReadableStreamHandle(userReadable, value);
+        return tagExternalReadableStream(userReadable, value);
       } else {
         // Non-byte streams carry length-prefixed frames, so we can count
         // completed frames and transparently reconnect when the server
@@ -2012,7 +2005,7 @@ export function getExternalRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(transform.readable, state);
 
-        return tagReadableStreamHandle(transform.readable, value);
+        return tagExternalReadableStream(transform.readable, value);
       }
     },
     WritableStream: (value) => {
@@ -2402,7 +2395,7 @@ function getStepRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(userReadable, state);
 
-        return tagReadableStreamHandle(userReadable, value);
+        return userReadable;
       } else {
         const transform = getDeserializeStream(
           getStepRevivers(global, ops, runId, cryptoKey, deploymentId),
@@ -2419,7 +2412,7 @@ function getStepRevivers(
         // Start polling to detect when user releases lock
         pollReadableLock(transform.readable, state);
 
-        return tagReadableStreamHandle(transform.readable, value);
+        return transform.readable;
       }
     },
     WritableStream: (value) => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -75,6 +75,7 @@ import {
   ABORT_STREAM_NAME,
   BODY_INIT_SYMBOL,
   STABLE_ULID,
+  STREAM_FLUSH_PROMISE_SYMBOL,
   STREAM_FRAMING_SYMBOL,
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
@@ -1036,6 +1037,10 @@ type AbortSignalLike = AbortInternals & {
 };
 
 type AbortHolder = AbortInternals & { signal?: AbortInternals };
+
+type FlushableWritableStream<T> = WritableStream<T> & {
+  [STREAM_FLUSH_PROMISE_SYMBOL]?: Promise<void>;
+};
 
 /**
  * Shared logic for AbortController/AbortSignal reducers in external and step
@@ -2040,6 +2045,10 @@ export function getExternalRevivers(
           }
         );
       }
+      Object.defineProperty(serialize.writable, STREAM_FLUSH_PROMISE_SYMBOL, {
+        value: state.promise,
+        writable: false,
+      });
 
       return serialize.writable;
     },
@@ -2309,9 +2318,30 @@ function getStepRevivers(
       if (value.signal) copyAbortInternals(value.signal, request.signal);
       if (responseWritable) {
         request.respondWith = async (response: Response) => {
-          const writer = responseWritable.getWriter();
-          await writer.write(response);
-          await writer.close();
+          const ctx = contextStorage.getStore();
+          const responseFlush = (
+            responseWritable as FlushableWritableStream<Response>
+          )[STREAM_FLUSH_PROMISE_SYMBOL];
+          const responseWrite = (async () => {
+            const writer = responseWritable.getWriter();
+            await writer.write(response);
+            await writer.close();
+            if (responseFlush) {
+              await responseFlush.catch(() => {
+                // Best-effort response stream write. Awaiting this before
+                // step completion preserves ordering when it succeeds, but
+                // the hook/request machinery owns retries and diagnostics.
+              });
+            }
+          })();
+          if (ctx) {
+            ctx.preCompletionOps.push(
+              responseWrite.catch(() => {
+                // Preserve the StepContext.preCompletionOps no-reject contract.
+              })
+            );
+          }
+          await responseWrite;
         };
       }
       return request;
@@ -2449,6 +2479,10 @@ function getStepRevivers(
           }
         );
       }
+      Object.defineProperty(serialize.writable, STREAM_FLUSH_PROMISE_SYMBOL, {
+        value: state.promise,
+        writable: false,
+      });
 
       return serialize.writable;
     },

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1033,7 +1033,7 @@ type AbortInternals = {
 type AbortSignalLike = AbortInternals & {
   aborted: boolean;
   reason?: unknown;
-  addEventListener?: Function;
+  addEventListener?: AbortSignal['addEventListener'];
 };
 
 type AbortHolder = AbortInternals & { signal?: AbortInternals };
@@ -2020,7 +2020,12 @@ export function getExternalRevivers(
       ops.push(state.promise);
 
       // Start the flushable pipe in the background
-      flushablePipe(serialize.readable, serverWritable, state).catch(() => {
+      const pipePromise = flushablePipe(
+        serialize.readable,
+        serverWritable,
+        state
+      );
+      pipePromise.catch(() => {
         // Errors are handled via state.reject
       });
 
@@ -2046,7 +2051,7 @@ export function getExternalRevivers(
         );
       }
       Object.defineProperty(serialize.writable, STREAM_FLUSH_PROMISE_SYMBOL, {
-        value: state.promise,
+        value: pipePromise,
         writable: false,
       });
 
@@ -2324,23 +2329,12 @@ function getStepRevivers(
           )[STREAM_FLUSH_PROMISE_SYMBOL];
           const responseWrite = (async () => {
             const writer = responseWritable.getWriter();
+            writer.closed.catch(() => {});
             await writer.write(response);
             await writer.close();
-            if (responseFlush) {
-              await responseFlush.catch(() => {
-                // Best-effort response stream write. Awaiting this before
-                // step completion preserves ordering when it succeeds, but
-                // the hook/request machinery owns retries and diagnostics.
-              });
-            }
+            await responseFlush;
           })();
-          if (ctx) {
-            ctx.preCompletionOps.push(
-              responseWrite.catch(() => {
-                // Preserve the StepContext.preCompletionOps no-reject contract.
-              })
-            );
-          }
+          ctx?.preCompletionOps.push(responseWrite.catch(() => {}));
           await responseWrite;
         };
       }
@@ -2448,7 +2442,12 @@ function getStepRevivers(
       ops.push(state.promise);
 
       // Start the flushable pipe in the background
-      flushablePipe(serialize.readable, serverWritable, state).catch(() => {
+      const pipePromise = flushablePipe(
+        serialize.readable,
+        serverWritable,
+        state
+      );
+      pipePromise.catch(() => {
         // Errors are handled via state.reject
       });
 
@@ -2480,7 +2479,7 @@ function getStepRevivers(
         );
       }
       Object.defineProperty(serialize.writable, STREAM_FLUSH_PROMISE_SYMBOL, {
-        value: state.promise,
+        value: pipePromise,
         writable: false,
       });
 

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -34,6 +34,15 @@ export const STREAM_SERVER_RUN_ID_SYMBOL = Symbol.for(
 export const STREAM_SERVER_DEPLOYMENT_ID_SYMBOL = Symbol.for(
   'WORKFLOW_STREAM_SERVER_DEPLOYMENT_ID'
 );
+/**
+ * Stamped on user-visible stream handles revived from server-backed writable
+ * descriptors. Awaiting this promise waits for that handle's background pipe
+ * to flush/close, without tying callers to unrelated stream ops in the same
+ * step.
+ */
+export const STREAM_FLUSH_PROMISE_SYMBOL = Symbol.for(
+  'WORKFLOW_STREAM_FLUSH_PROMISE'
+);
 export const BODY_INIT_SYMBOL = Symbol.for('BODY_INIT');
 export const WEBHOOK_RESPONSE_WRITABLE = Symbol.for(
   'WEBHOOK_RESPONSE_WRITABLE'

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -9,9 +9,17 @@ export const STREAM_NAME_SYMBOL = Symbol.for('WORKFLOW_STREAM_NAME');
 export const STREAM_TYPE_SYMBOL = Symbol.for('WORKFLOW_STREAM_TYPE');
 export const STREAM_FRAMING_SYMBOL = Symbol.for('WORKFLOW_STREAM_FRAMING');
 /**
- * Stamped on real stream handles (for example, the user-visible
- * `serialize.writable` returned from a step-side reviver or step-context
- * `getWritable()`) to
+ * Stamped on externally hydrated readable streams for diagnostics and retry
+ * helpers. Keep this distinct from `STREAM_NAME_SYMBOL`: reducers use that
+ * symbol as a durable-handle fast path, which would be incorrect for a client
+ * stream that may have already been consumed.
+ */
+export const STREAM_CLIENT_NAME_SYMBOL = Symbol.for(
+  'WORKFLOW_STREAM_CLIENT_NAME'
+);
+/**
+ * Stamped on a real `WritableStream` (the user-visible `serialize.writable`
+ * returned from a step-side reviver or step-context `getWritable()`) to
  * record the `runId` of the workflow run that owns the underlying server
  * stream. Used together with `STREAM_NAME_SYMBOL`.
  *

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -9,8 +9,9 @@ export const STREAM_NAME_SYMBOL = Symbol.for('WORKFLOW_STREAM_NAME');
 export const STREAM_TYPE_SYMBOL = Symbol.for('WORKFLOW_STREAM_TYPE');
 export const STREAM_FRAMING_SYMBOL = Symbol.for('WORKFLOW_STREAM_FRAMING');
 /**
- * Stamped on a real `WritableStream` (the user-visible `serialize.writable`
- * returned from a step-side reviver or step-context `getWritable()`) to
+ * Stamped on real stream handles (for example, the user-visible
+ * `serialize.writable` returned from a step-side reviver or step-context
+ * `getWritable()`) to
  * record the `runId` of the workflow run that owns the underlying server
  * stream. Used together with `STREAM_NAME_SYMBOL`.
  *

--- a/packages/world-testing/src/inline-batches-debug.mts
+++ b/packages/world-testing/src/inline-batches-debug.mts
@@ -1,5 +1,5 @@
-import { expect, test, vi } from 'vitest';
 import { hydrateWorkflowReturnValue } from '@workflow/core/serialization';
+import { expect, test, vi } from 'vitest';
 import { createFetcher, startServer } from './util.mjs';
 
 /**
@@ -13,7 +13,7 @@ import { createFetcher, startServer } from './util.mjs';
  *   - unconsumed-event skips
  *
  * Not part of the default suite; run with:
- *   pnpm vitest run packages/world-testing/test/inline-batches-debug.test.ts
+ *   WORKFLOW_INLINE_BATCHES_DEBUG=1 pnpm vitest run packages/world-testing/test/inline-batches-debug.test.ts
  */
 export function inlineBatchesDebug(world: string) {
   test(

--- a/packages/world-testing/test/inline-batches-debug.test.ts
+++ b/packages/world-testing/test/inline-batches-debug.test.ts
@@ -1,3 +1,10 @@
+import { test } from 'vitest';
 import { inlineBatchesDebug } from '../src/inline-batches-debug.mjs';
 
-inlineBatchesDebug('local');
+if (process.env.WORKFLOW_INLINE_BATCHES_DEBUG === '1') {
+  inlineBatchesDebug('local');
+} else {
+  test.skip(
+    'three batches of five parallel steps — report V2 handler behavior'
+  );
+}

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -271,8 +271,14 @@ async function consumeAndVerifyStreams(
   // Return a summary stream so the bench harness can measure TTFB/slurp
   const encoder = new TextEncoder();
   const summary = JSON.stringify({ totalBytes, streamCount: streams.length });
+  let sent = false;
   return new ReadableStream<Uint8Array>({
-    start(controller) {
+    pull(controller) {
+      if (sent) {
+        controller.close();
+        return;
+      }
+      sent = true;
       controller.enqueue(encoder.encode(summary));
       controller.close();
     },

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -280,7 +280,6 @@ async function consumeAndVerifyStreams(
 }
 
 // Workflow 1: Pipeline — generate 1 stream, pipe through N XOR transform steps
-// Returns the final transformed stream (same size as input)
 export async function streamPipelineWorkflow(
   steps: number,
   totalBytes: number
@@ -290,7 +289,7 @@ export async function streamPipelineWorkflow(
   for (let i = 0; i < steps; i++) {
     stream = await transformStreamXor(stream, (i + 1) % 256);
   }
-  return stream;
+  return await consumeAndVerifyStreams(totalBytes, stream);
 }
 
 // Workflow 2: N steps generate streams in parallel, one step consumes + verifies all

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -378,17 +378,21 @@ export async function outputStreamInsideStepWorkflow() {
 
 //////////////////////////////////////////////////////////
 
-async function stepWriteUtf8Text(writable: WritableStream, text: string) {
+async function stepWriteUtf8Sequence(writable: WritableStream) {
   'use step';
   const writer = writable.getWriter();
-  await writer.write(new TextEncoder().encode(text));
-  writer.releaseLock();
-}
-
-async function stepWriteUtf8Json(writable: WritableStream, value: unknown) {
-  'use step';
-  const writer = writable.getWriter();
-  await writer.write(new TextEncoder().encode(JSON.stringify(value)));
+  const encoder = new TextEncoder();
+  for (const text of [
+    'Hello, world!',
+    'Café — naïve résumé',
+    '你好，世界！🌍✨',
+    'مرحبا بالعالم',
+  ]) {
+    await writer.write(encoder.encode(text));
+  }
+  await writer.write(
+    encoder.encode(JSON.stringify({ greeting: '안녕하세요', emoji: '🎉' }))
+  );
   writer.releaseLock();
 }
 
@@ -400,11 +404,7 @@ export async function utf8StreamWorkflow() {
   'use workflow';
   const writable = getWritable();
   await sleep('1s');
-  await stepWriteUtf8Text(writable, 'Hello, world!');
-  await stepWriteUtf8Text(writable, 'Café — naïve résumé');
-  await stepWriteUtf8Text(writable, '你好，世界！🌍✨');
-  await stepWriteUtf8Text(writable, 'مرحبا بالعالم');
-  await stepWriteUtf8Json(writable, { greeting: '안녕하세요', emoji: '🎉' });
+  await stepWriteUtf8Sequence(writable);
   await stepCloseOutputStream(writable);
   return 'done';
 }
@@ -847,7 +847,7 @@ export async function hookSignalOwnerWorkflow(token: string, message: string) {
 export async function hookSupersedeOwnerWorkflow(token: string) {
   'use workflow';
 
-  for (let attempt = 0; attempt < 5; attempt++) {
+  for (let attempt = 0; attempt < 10; attempt++) {
     using hook = createHook<{ message: string }>({ token });
 
     const conflict = await hook.getConflict();
@@ -861,6 +861,7 @@ export async function hookSupersedeOwnerWorkflow(token: string) {
     }
 
     await conflict.cancel();
+    await sleep('1s');
   }
 
   throw new Error(`Could not claim ${token} after cancelling the owner`);


### PR DESCRIPTION
Draft: experimenting with less flaky PR runs.

Changes:
- Add skew-aware elapsed-time assertions for distributed Vercel e2e timestamp comparisons.
- Loosen race timing checks so they still prove the 10s losing branch did not win.
- Replace fixed sleeps in hook/cancel tests with event polling.
- Give readable stream e2e more room for delayed final chunks/close on Vercel.
- Add environment-aware e2e timeout budgets so local runs stay tight while Vercel prod runs have enough room for slow hook/event/run API calls under load.
- Remove one redundant scheduler-speed assertion and one dead wait.

Validation so far: install, Biome check, dependency builds, core typecheck, and CI monitoring. I am rerunning full e2e/check workflows after passes to verify this is consistently green, not just lucky.