### PR TITLE
fix(world-postgres): defer loopback worker startup

### DIFF
--- a/.changeset/true-hands-grin.md
+++ b/.changeset/true-hands-grin.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-postgres": patch
+---
+
+Defer loopback worker startup

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -3,7 +3,12 @@ import { JsonTransport } from '@vercel/queue';
 import { getWorkflowPort } from '@workflow/utils/get-port';
 import { MessageId, parseQueueName, type QueuePayload } from '@workflow/world';
 import { createLocalWorld } from '@workflow/world-local';
-import { makeWorkerUtils, run, type WorkerUtils } from 'graphile-worker';
+import {
+  makeWorkerUtils,
+  type Runner,
+  run,
+  type WorkerUtils,
+} from 'graphile-worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { stepEntrypoint } from '../../core/dist/runtime/step-handler.js';
 import { MessageData } from './message.js';
@@ -55,7 +60,7 @@ describe('postgres queue http execution', () => {
 
     vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
     vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
-    vi.mocked(run).mockResolvedValue(runnerMock as any);
+    vi.mocked(run).mockResolvedValue(runnerMock as unknown as Runner);
     vi.mocked(createLocalWorld).mockReturnValue({
       createQueueHandler,
       close: localWorldClose,
@@ -138,13 +143,18 @@ describe('postgres queue http execution', () => {
       headers: Record<string, string | string[] | undefined>;
       body: string;
     }> = [];
-    const server = await startWorkflowHttpServer(requests);
-    vi.mocked(getWorkflowPort).mockResolvedValue(
-      Number(new URL(server.baseUrl).port)
-    );
+    const port = await getUnusedLoopbackPort();
+    vi.mocked(getWorkflowPort).mockResolvedValue(port);
 
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
     await queue.start();
+
+    expect(run).not.toHaveBeenCalled();
+
+    await startWorkflowHttpServer(requests, port);
+    await vi.waitFor(() => {
+      expect(run).toHaveBeenCalledTimes(1);
+    });
 
     const task = getTaskHandler('workflow_steps');
     const message = {
@@ -217,7 +227,7 @@ describe('postgres queue http execution', () => {
       return Response.json({ ok: true });
     });
     vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'http://localhost:3000';
+    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
 
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
     try {
@@ -282,7 +292,7 @@ describe('postgres queue http execution', () => {
       return Response.json({ ok: true });
     });
     vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'http://localhost:3000';
+    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
 
     const queue = buildQueue(
       { connectionString: 'postgres://test', namespace: 'custom' },
@@ -327,7 +337,7 @@ describe('postgres queue http execution', () => {
   it('does not require a runId for workflow health-check payloads', async () => {
     const fetchMock = vi.fn(async () => Response.json({ ok: true }));
     vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'http://localhost:3000';
+    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
 
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
     try {
@@ -342,7 +352,7 @@ describe('postgres queue http execution', () => {
       await expect(task(payload, {} as any)).resolves.toBeUndefined();
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:3000/.well-known/workflow/v1/flow',
+        'https://workflow.example.test/.well-known/workflow/v1/flow',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
@@ -477,12 +487,7 @@ async function startWorkflowHttpServer(
     headers: Record<string, string | string[] | undefined>;
     body: string;
   }>,
-  handler?: (req: {
-    method: string | undefined;
-    url: string | undefined;
-    headers: Record<string, string | string[] | undefined>;
-    body: string;
-  }) => Promise<Response> | Response
+  port = 0
 ) {
   const server = createServer(async (req, res) => {
     const body = await new Promise<string>((resolve, reject) => {
@@ -503,16 +508,6 @@ async function startWorkflowHttpServer(
     };
     requests.push(request);
 
-    if (handler) {
-      const response = await handler(request);
-      res.writeHead(
-        response.status,
-        Object.fromEntries(response.headers.entries())
-      );
-      res.end(await response.text());
-      return;
-    }
-
     if (req.method === 'POST' && req.url === '/.well-known/workflow/v1/step') {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
@@ -524,7 +519,7 @@ async function startWorkflowHttpServer(
   });
 
   await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
+    server.listen(port, '127.0.0.1', () => resolve());
     server.on('error', reject);
   });
 
@@ -537,4 +532,22 @@ async function startWorkflowHttpServer(
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
   };
+}
+
+async function getUnusedLoopbackPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+    server.on('error', reject);
+  });
+  const address = server.address();
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to reserve a loopback port');
+  }
+
+  return address.port;
 }

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -1,4 +1,6 @@
+import { connect } from 'node:net';
 import * as Stream from 'node:stream';
+import { setTimeout as sleep } from 'node:timers/promises';
 import type { Transport } from '@vercel/queue';
 import { getWorkflowPort } from '@workflow/utils/get-port';
 import {
@@ -62,6 +64,9 @@ type HttpExecutionResult =
       text: string;
       headers: Record<string, string>;
     };
+
+type RunnerStart = { controller: AbortController; promise: Promise<void> };
+type LoopbackTarget = { hosts: string[]; port: number };
 
 /**
  * The Postgres queue works by creating two job types in graphile-worker:
@@ -142,6 +147,8 @@ export function createQueue(
   >();
   let workerUtils: WorkerUtils | null = null;
   let runner: Runner | null = null;
+  let runnerStart: RunnerStart | null = null;
+  let closing = false;
   let startPromise: Promise<void> | null = null;
 
   function markMessageCompleted(idempotencyKey: string) {
@@ -204,7 +211,7 @@ export function createQueue(
     );
   }
 
-  async function resolveExecutionBaseUrl(): Promise<string> {
+  async function getExecutionBaseUrl(): Promise<string | undefined> {
     if (process.env.WORKFLOW_LOCAL_BASE_URL) {
       return process.env.WORKFLOW_LOCAL_BASE_URL;
     }
@@ -222,7 +229,104 @@ export function createQueue(
       return `http://localhost:${detectedPort}`;
     }
 
-    throw new Error('Unable to resolve base URL for workflow queue.');
+    return undefined;
+  }
+
+  function getLoopbackHosts(hostname: string): string[] {
+    if (hostname === 'localhost') {
+      return ['127.0.0.1', '::1'];
+    }
+    if (hostname === '[::1]') {
+      return ['::1'];
+    }
+    return hostname === '127.0.0.1' || hostname === '::1' ? [hostname] : [];
+  }
+
+  function getLoopbackTarget(baseUrl: string | undefined) {
+    if (!baseUrl) {
+      return undefined;
+    }
+
+    const url = new URL(baseUrl);
+    const hosts = getLoopbackHosts(url.hostname);
+    if (hosts.length === 0) {
+      return undefined;
+    }
+
+    return {
+      hosts,
+      port: Number(url.port || (url.protocol === 'https:' ? 443 : 80)),
+    };
+  }
+
+  async function canConnectToLoopbackTarget(
+    target: LoopbackTarget
+  ): Promise<boolean> {
+    for (const host of target.hosts) {
+      const reachable = await new Promise<boolean>((resolve) => {
+        const socket = connect({ host, port: target.port });
+        socket.unref();
+        const finish = (isReachable: boolean) => {
+          socket.destroy();
+          resolve(isReachable);
+        };
+
+        socket.setTimeout(200, () => finish(false));
+        socket.once('connect', () => finish(true));
+        socket.once('error', () => finish(false));
+      });
+
+      if (reachable) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async function startRunnerUnlessAborted(controller: AbortController) {
+    if (controller.signal.aborted) {
+      return;
+    }
+
+    await setupListeners();
+  }
+
+  async function waitForLoopbackAndStartRunner(
+    controller: AbortController,
+    target: LoopbackTarget
+  ) {
+    while (
+      !controller.signal.aborted &&
+      !(await canConnectToLoopbackTarget(target))
+    ) {
+      await sleep(50, undefined, {
+        ref: false,
+      });
+    }
+
+    await startRunnerUnlessAborted(controller);
+  }
+
+  function deferRunnerStart(
+    controller: AbortController,
+    target: LoopbackTarget
+  ) {
+    const promise = waitForLoopbackAndStartRunner(controller, target)
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          console.warn(
+            '[world-postgres] Failed to start Graphile Worker after local workflow executor became reachable:',
+            err
+          );
+        }
+      })
+      .finally(() => {
+        if (runnerStart?.promise === promise) {
+          runnerStart = null;
+        }
+      });
+    runnerStart = { controller, promise };
   }
 
   function getQueueRoute(queueName: ValidQueueName): 'flow' | 'step' {
@@ -249,7 +353,10 @@ export function createQueue(
       'x-vqs-message-id': messageId,
       'x-vqs-message-attempt': String(attempt),
     };
-    const baseUrl = await resolveExecutionBaseUrl();
+    const baseUrl = await getExecutionBaseUrl();
+    if (!baseUrl) {
+      throw new Error('Unable to resolve base URL for workflow queue.');
+    }
     const pathname = getQueueRoute(queueName);
 
     const response = await fetch(
@@ -329,7 +436,43 @@ export function createQueue(
     }
   }
 
+  async function startRunnerWhenExecutorIsReady(): Promise<void> {
+    if (closing || runner || runnerStart) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const promise = (async () => {
+      const target = getLoopbackTarget(await getExecutionBaseUrl());
+      if (!target) {
+        await startRunnerUnlessAborted(controller);
+        return;
+      }
+
+      if (await canConnectToLoopbackTarget(target)) {
+        await startRunnerUnlessAborted(controller);
+        return;
+      }
+
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      deferRunnerStart(controller, target);
+    })().finally(() => {
+      if (runnerStart?.promise === promise) {
+        runnerStart = null;
+      }
+    });
+    runnerStart = { controller, promise };
+    await promise;
+  }
+
   async function start(): Promise<void> {
+    if (closing) {
+      return;
+    }
+
     if (!startPromise) {
       startPromise = (async () => {
         try {
@@ -339,7 +482,7 @@ export function createQueue(
           });
           await workerUtils.migrate();
           await migratePgBossJobs(workerUtils);
-          await setupListeners();
+          await startRunnerWhenExecutorIsReady();
         } catch (err) {
           startPromise = null;
           throw err;
@@ -347,6 +490,9 @@ export function createQueue(
       })();
     }
     await startPromise;
+    if (!closing && !runner && !runnerStart) {
+      await startRunnerWhenExecutorIsReady();
+    }
   }
 
   const queue: Queue['queue'] = async (queue, message, opts) => {
@@ -519,6 +665,13 @@ export function createQueue(
     queue,
     start,
     async close() {
+      closing = true;
+      if (runnerStart) {
+        runnerStart.controller.abort();
+        await runnerStart.promise;
+        runnerStart = null;
+      }
+      await startPromise?.catch(() => {});
       if (runner) {
         await runner.stop();
         runner = null;


### PR DESCRIPTION
Fixes #2656.

## The Test

The regression test in [queue.test.ts (line 139)](/Users/nathancolosimo/Documents/workflow-fix-postgres-worker-start/packages/world-postgres/src/queue.test.ts:139) does this:

1. Gets an unused loopback port.
2. Mocks Workflow’s port detection to say: “the app will run on this port.”
3. Starts the Postgres queue.
4. Asserts Graphile Worker did not start yet, because the port is closed.
5. Starts a tiny HTTP server on that same port.
6. Waits until Graphile Worker starts.
7. Runs a fake step task.
8. Verifies the task POSTed to `/.well-known/workflow/v1/step`.
