### PR TITLE
Fail fast on incompatible workflow worlds

### DIFF
--- a/docs/content/docs/v5/deploying/world/postgres-world.mdx
+++ b/docs/content/docs/v5/deploying/world/postgres-world.mdx
@@ -22,6 +22,15 @@ Install the Postgres World package in your workflow project:
 @workflow/world-postgres
 ```
 
+<Callout type="info">
+Use the same release channel for `workflow` and `@workflow/world-postgres`. If
+your app uses a beta or other prerelease Workflow version, install the matching
+prerelease Postgres World package, such as
+`npm install @workflow/world-postgres@beta`. Mismatched versions fail before
+starting a run with an error that says the runtime requires a World with a
+matching spec version.
+</Callout>
+
 Configure the required environment variables to use the world and point it to your PostgreSQL database:
 
 ```bash title=".env"

--- a/packages/core/src/byte-stream-framing.test.ts
+++ b/packages/core/src/byte-stream-framing.test.ts
@@ -1,4 +1,4 @@
-import type { World } from '@workflow/world';
+import { SPEC_VERSION_CURRENT, type World } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setWorld } from './runtime/world.js';
 import {
@@ -267,6 +267,7 @@ function makeMockWorld(): World {
   );
 
   return {
+    specVersion: SPEC_VERSION_CURRENT,
     streams: {
       write,
       writeMulti: vi.fn(

--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -1,4 +1,4 @@
-import type { World } from '@workflow/world';
+import { SPEC_VERSION_CURRENT, type World } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./version.js', () => ({ version: '0.0.0-test' }));
@@ -79,6 +79,7 @@ function makeWorldWithScriptedStreams(
 ): { world: World; calls: number[] } {
   const calls: number[] = [];
   const world = {
+    specVersion: SPEC_VERSION_CURRENT,
     streams: {
       get: vi.fn(async (_runId: string, _name: string, startIndex?: number) => {
         const idx = startIndex ?? 0;
@@ -185,6 +186,7 @@ describe('createReconnectingFramedStream', () => {
     const calls: number[] = [];
     let reopenAttempts = 0;
     const world = {
+      specVersion: SPEC_VERSION_CURRENT,
       streams: {
         get: vi.fn(
           async (_runId: string, _name: string, startIndex?: number) => {
@@ -321,7 +323,10 @@ describe('createReconnectingFramedStream', () => {
           { kind: 'close' },
         ])
     );
-    const world = { streams: { get: getSpy } } as unknown as World;
+    const world = {
+      specVersion: SPEC_VERSION_CURRENT,
+      streams: { get: getSpy },
+    } as unknown as World;
     setWorld(world);
 
     const stream = createReconnectingFramedStream('run-abc', 'my-stream', 3);
@@ -336,6 +341,7 @@ describe('createReconnectingFramedStream', () => {
     // forever.
     const calls: number[] = [];
     const world = {
+      specVersion: SPEC_VERSION_CURRENT,
       streams: {
         get: vi.fn(
           async (_runId: string, _name: string, startIndex?: number) => {
@@ -369,6 +375,7 @@ describe('createReconnectingFramedStream', () => {
     const lastIndex = FRAMED_STREAM_MAX_RECONNECTS + 5;
     const calls: number[] = [];
     const world = {
+      specVersion: SPEC_VERSION_CURRENT,
       streams: {
         get: vi.fn(
           async (_runId: string, _name: string, startIndex?: number) => {
@@ -407,6 +414,7 @@ describe('createReconnectingFramedStream', () => {
     // guards against a misbehaving backend turning reconnect into a hang.
     let calls = 0;
     const world = {
+      specVersion: SPEC_VERSION_CURRENT,
       streams: {
         get: vi.fn(async () => {
           calls++;

--- a/packages/core/src/runtime/get-world-lazy.ts
+++ b/packages/core/src/runtime/get-world-lazy.ts
@@ -29,16 +29,27 @@
  */
 
 import type { World } from '@workflow/world';
+import { assertWorldSupportsRuntimeProtocol } from './world-compatibility.js';
 
 const WorldCacheKey = Symbol.for('@workflow/world//cache');
 const WorldCachePromiseKey = Symbol.for('@workflow/world//cachePromise');
 const GetWorldFnKey = Symbol.for('@workflow/world//getWorldFn');
 
+type GlobalWorldCache = typeof globalThis & {
+  [WorldCacheKey]?: World;
+  [WorldCachePromiseKey]?: Promise<World>;
+  [GetWorldFnKey]?: () => Promise<World>;
+};
+
 export async function getWorldLazy(): Promise<World> {
-  const g = globalThis as any;
-  if (g[WorldCacheKey]) return g[WorldCacheKey];
+  const g = globalThis as GlobalWorldCache;
+  if (g[WorldCacheKey]) {
+    assertWorldSupportsRuntimeProtocol(g[WorldCacheKey]);
+    return g[WorldCacheKey];
+  }
   if (g[WorldCachePromiseKey]) {
     g[WorldCacheKey] = await g[WorldCachePromiseKey];
+    assertWorldSupportsRuntimeProtocol(g[WorldCacheKey]);
     return g[WorldCacheKey];
   }
   // If world.ts is statically present in this bundle, it has registered
@@ -46,8 +57,12 @@ export async function getWorldLazy(): Promise<World> {
   // import fallback, which doesn't survive Next.js inlining get-world-lazy
   // into a route bundle (the relative './world.js' resolves against the
   // bundled location, where no sibling world.js exists).
-  const getWorldFn = g[GetWorldFnKey] as (() => Promise<World>) | undefined;
-  if (getWorldFn) return getWorldFn();
+  const getWorldFn = g[GetWorldFnKey];
+  if (getWorldFn) {
+    const world = await getWorldFn();
+    assertWorldSupportsRuntimeProtocol(world);
+    return world;
+  }
   // Last resort: dynamic import for environments where world.ts wasn't
   // bundled but is reachable as a sibling module on disk. The specifier is
   // built at runtime so esbuild can't trace it into the step bundle.

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -6,7 +6,7 @@ import {
   WorkflowWorldError,
 } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
-import type { Event, World } from '@workflow/world';
+import { type Event, SPEC_VERSION_CURRENT, type World } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Mock version module to avoid missing generated file
@@ -47,6 +47,7 @@ function createMockWorld(
   const events = overrides.events ?? [];
 
   return {
+    specVersion: SPEC_VERSION_CURRENT,
     runs: {
       get: vi.fn().mockResolvedValue(run),
     },
@@ -322,6 +323,7 @@ describe('Run.returnValue when run.status === "failed"', () => {
 
   function makeFailedRunWorld(error: Uint8Array, errorCode?: string): World {
     return {
+      specVersion: SPEC_VERSION_CURRENT,
       runs: {
         get: vi.fn().mockResolvedValue({
           runId: 'wrun_failed',

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -4,7 +4,6 @@ import {
   SPEC_VERSION_LEGACY,
   SPEC_VERSION_SUPPORTS_ATTRIBUTES,
   SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
-  SPEC_VERSION_SUPPORTS_EVENT_SOURCING,
 } from '@workflow/world';
 import {
   afterEach,
@@ -99,10 +98,11 @@ describe('start', () => {
       mockQueue = vi.fn().mockResolvedValue(undefined);
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
     });
 
     afterEach(() => {
@@ -110,34 +110,28 @@ describe('start', () => {
       vi.clearAllMocks();
     });
 
-    it('should use world.specVersion when available, falling back to SPEC_VERSION_SUPPORTS_EVENT_SOURCING', async () => {
+    it('rejects worlds that do not declare a specVersion', async () => {
       const validWorkflow = Object.assign(() => Promise.resolve('result'), {
         workflowId: 'test-workflow',
       });
 
-      // Mock world without specVersion → falls back to safe baseline (v2)
-      await start(validWorkflow, []);
-
-      expect(mockEventsCreate).toHaveBeenCalledWith(
-        expect.stringMatching(/^wrun_/),
-        expect.objectContaining({
-          eventType: 'run_created',
-          specVersion: SPEC_VERSION_SUPPORTS_EVENT_SOURCING,
-        }),
-        expect.objectContaining({
-          v1Compat: false,
-        })
-      );
-
-      vi.clearAllMocks();
-
-      // Mock world with specVersion 3 → uses it
       setWorld({
-        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
       } as any);
+
+      await expect(start(validWorkflow, [])).rejects.toThrow(
+        'requires a World with matching spec version'
+      );
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
+    });
+
+    it('uses world.specVersion when available', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
 
       await start(validWorkflow, []);
 
@@ -151,6 +145,44 @@ describe('start', () => {
           v1Compat: false,
         })
       );
+    });
+
+    it('rejects worlds whose declared specVersion is older than the runtime', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+
+      setWorld({
+        specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+
+      await expect(start(validWorkflow, [])).rejects.toThrow(
+        'requires a World with matching spec version'
+      );
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects worlds whose declared specVersion is newer than the runtime', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT + 1,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+
+      await expect(start(validWorkflow, [])).rejects.toThrow(
+        'requires a World with matching spec version'
+      );
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
     });
 
     it('should use provided specVersion when passed in options', async () => {
@@ -196,13 +228,16 @@ describe('start', () => {
         workflowId: 'test-workflow',
       });
       setWorld({
-        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
-      await start(validWorkflow, [], { attributes: { tenant: 't1' } });
+      await start(validWorkflow, [], {
+        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        attributes: { tenant: 't1' },
+      });
 
       expect(mockEventsCreate).toHaveBeenCalledWith(
         expect.any(String),
@@ -244,11 +279,11 @@ describe('start', () => {
         workflowId: 'test-workflow',
       });
       setWorld({
-        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       await expect(
         start(validWorkflow, [], {
@@ -263,11 +298,11 @@ describe('start', () => {
         workflowId: 'test-workflow',
       });
       setWorld({
-        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       await expect(
         start(validWorkflow, [], { attributes: { $system: 'x' } })
@@ -280,11 +315,11 @@ describe('start', () => {
         workflowId: 'test-workflow',
       });
       setWorld({
-        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       await start(validWorkflow, [], {
         attributes: { $rootRunId: 'wrun_root', tenant: 't1' },
@@ -318,11 +353,11 @@ describe('start', () => {
         workflowId: 'test-workflow',
       });
       setWorld({
-        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       await expect(
         start(validWorkflow, [], {
@@ -338,11 +373,11 @@ describe('start', () => {
         workflowId: 'test-workflow',
       });
       setWorld({
-        specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       await expect(
         start(validWorkflow, [], {
@@ -381,11 +416,12 @@ describe('start', () => {
       mockGetEncryptionKeyForRun = vi.fn().mockResolvedValue(undefined);
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_resolved'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
         getEncryptionKeyForRun: mockGetEncryptionKeyForRun,
-      } as any);
+      });
     });
 
     afterEach(() => {
@@ -461,11 +497,12 @@ describe('start', () => {
         .mockResolvedValue('dpl_resolved_abc123');
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
         resolveLatestDeploymentId: mockResolveLatest,
-      } as any);
+      });
 
       await start(validWorkflow, [], { deploymentId: 'latest' });
 
@@ -498,12 +535,13 @@ describe('start', () => {
       const mockGetEncryptionKeyForRun = vi.fn();
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
         resolveLatestDeploymentId: mockResolveLatest,
         getEncryptionKeyForRun: mockGetEncryptionKeyForRun,
-      } as any);
+      });
 
       await start(validWorkflow, [], { deploymentId: 'latest' });
 
@@ -528,11 +566,12 @@ describe('start', () => {
         .mockImplementation(() => {});
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
         // No resolveLatestDeploymentId
-      } as any);
+      });
 
       // Should not throw — 'latest' is a no-op in worlds without atomic
       // deployments.
@@ -569,11 +608,12 @@ describe('start', () => {
         .mockImplementation(() => {});
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
         // No resolveLatestDeploymentId
-      } as any);
+      });
 
       // Multiple runs that all hit the no-op path...
       await start(validWorkflow, [], { deploymentId: 'latest' });
@@ -598,11 +638,12 @@ describe('start', () => {
         .mockResolvedValue('dpl_resolved_abc123');
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
         resolveLatestDeploymentId: mockResolveLatest,
-      } as any);
+      });
 
       await start(validWorkflow, [], { deploymentId: 'dpl_specific_456' });
 
@@ -626,11 +667,12 @@ describe('start', () => {
         .mockResolvedValue('dpl_resolved_abc123');
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('dpl_default_789'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
         resolveLatestDeploymentId: mockResolveLatest,
-      } as any);
+      });
 
       await start(validWorkflow, []);
 
@@ -667,15 +709,16 @@ describe('start', () => {
       const mockEventsCreate = vi.fn().mockRejectedValue(serverError);
 
       setWorld({
-        // World declares specVersion 3 to enable CBOR queue transport + runInput
-        specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       // start() should NOT throw — the queue was still dispatched
-      const run = await start(validWorkflow, [42]);
+      const run = await start(validWorkflow, [42], {
+        specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+      });
       expect(run.runId).toMatch(/^wrun_/);
 
       // Queue should have been called with runInput
@@ -698,10 +741,11 @@ describe('start', () => {
         .mockRejectedValue(new Error('Queue unavailable'));
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       await expect(start(validWorkflow, [])).rejects.toThrow(
         'Queue unavailable'
@@ -716,10 +760,11 @@ describe('start', () => {
       const mockQueue = vi.fn().mockResolvedValue({ messageId: null });
 
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
         events: { create: mockEventsCreate },
         queue: mockQueue,
-      } as any);
+      });
 
       await expect(start(validWorkflow, [])).rejects.toThrow('Bad Request');
     });

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -6,7 +6,6 @@ import {
   SPEC_VERSION_SUPPORTS_ATTRIBUTES,
   SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
   SPEC_VERSION_SUPPORTS_COMPRESSION,
-  SPEC_VERSION_SUPPORTS_EVENT_SOURCING,
 } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 import { normalizeAttributeChanges } from '../attribute-changes.js';
@@ -26,6 +25,7 @@ import { getWorldLazy } from './get-world-lazy.js';
 import { getWorkflowQueueName, healthCheck } from './helpers.js';
 import { Run } from './run.js';
 import { safeWaitUntil, waitedUntil } from './wait-until.js';
+import { assertWorldSupportsRuntimeProtocol } from './world-compatibility.js';
 
 /**
  * Timeout for the cross-deployment capability probe done before
@@ -204,7 +204,8 @@ export async function start<TArgs extends unknown[], TResult>(
         ...Attribute.WorkflowArgumentsCount(args.length),
       });
 
-      const world = opts?.world ?? (await getWorldLazy());
+      const world = opts.world ?? (await getWorldLazy());
+      assertWorldSupportsRuntimeProtocol(world);
       const currentDeploymentId = await world.getDeploymentId();
       let deploymentId = opts.deploymentId ?? currentDeploymentId;
 
@@ -276,14 +277,9 @@ export async function start<TArgs extends unknown[], TResult>(
       // Serialize current trace context to propagate across queue boundary
       const traceCarrier = await serializeTraceCarrier();
 
-      // Use world-declared specVersion when available (our worlds set this),
-      // otherwise fall back to the safe baseline that community worlds handle.
-      // Community worlds built against older @workflow/world reject runs with
-      // specVersion > their SPEC_VERSION_CURRENT via requiresNewerWorld().
-      const specVersion =
-        opts.specVersion ??
-        world.specVersion ??
-        SPEC_VERSION_SUPPORTS_EVENT_SOURCING;
+      // Default new runs to the configured world's spec version. The world
+      // itself has already been checked against this runtime's spec version.
+      const specVersion = opts.specVersion ?? world.specVersion;
       const v1Compat = isLegacySpecVersion(specVersion);
       const allowReservedAttributes = opts.allowReservedAttributes === true;
       let attributes: Record<string, string> | undefined;

--- a/packages/core/src/runtime/world-compatibility.ts
+++ b/packages/core/src/runtime/world-compatibility.ts
@@ -1,0 +1,20 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
+import type { World } from '@workflow/world';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
+
+type WorldSpecVersionMetadata = Pick<World, 'specVersion'>;
+
+export function assertWorldSupportsRuntimeProtocol(
+  world: WorldSpecVersionMetadata
+): void {
+  if (world.specVersion === SPEC_VERSION_CURRENT) {
+    return;
+  }
+
+  const supportedVersion = world.specVersion ?? 'none';
+  throw new WorkflowRuntimeError(
+    `This Workflow runtime requires a World with matching spec version ${SPEC_VERSION_CURRENT}, ` +
+      `but the configured World declares spec version ${supportedVersion}. ` +
+      'Install a World package version compatible with the current Workflow runtime.'
+  );
+}

--- a/packages/core/src/runtime/world-init.test.ts
+++ b/packages/core/src/runtime/world-init.test.ts
@@ -1,3 +1,4 @@
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Re-declare the symbols here (mirrors world.ts and get-world-lazy.ts)
@@ -52,10 +53,8 @@ describe('world-init', () => {
       const { getWorldLazy } = await import('./get-world-lazy.js');
 
       // Replace the registration with a sentinel-returning function so we can
-      // prove which branch getWorldLazy used. Using a Symbol means a real
-      // World instance from `world.ts`'s `getWorld()` (returned by the
-      // production registration) can't accidentally satisfy this assertion.
-      const sentinel = Symbol('sentinel-world');
+      // prove which branch getWorldLazy used.
+      const sentinel = { specVersion: SPEC_VERSION_CURRENT };
       g[GetWorldFnKey] = async () => sentinel as unknown;
 
       const result = await getWorldLazy();

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -7,6 +7,7 @@ import {
 import type { World } from '@workflow/world';
 import { createLocalWorld } from '@workflow/world-local';
 import { createVercelWorld } from '@workflow/world-vercel';
+import { assertWorldSupportsRuntimeProtocol } from './world-compatibility.js';
 
 function getRuntimeRequire() {
   // Resolve from the app root (process.cwd()) so custom world packages
@@ -174,6 +175,7 @@ export type WorldHandlers = Pick<World, 'createQueueHandler' | 'specVersion'>;
  */
 export const getWorldHandlers = async (): Promise<WorldHandlers> => {
   if (globalSymbols[StubbedWorldCache]) {
+    assertWorldSupportsRuntimeProtocol(globalSymbols[StubbedWorldCache]);
     return globalSymbols[StubbedWorldCache];
   }
   // Store the promise immediately to prevent race conditions with concurrent calls.
@@ -185,6 +187,7 @@ export const getWorldHandlers = async (): Promise<WorldHandlers> => {
     });
   }
   const _world = await globalSymbols[StubbedWorldCachePromise];
+  assertWorldSupportsRuntimeProtocol(_world);
   globalSymbols[StubbedWorldCache] = _world;
   return {
     createQueueHandler: _world.createQueueHandler,
@@ -194,6 +197,7 @@ export const getWorldHandlers = async (): Promise<WorldHandlers> => {
 
 export const getWorld = async (): Promise<World> => {
   if (globalSymbols[WorldCache]) {
+    assertWorldSupportsRuntimeProtocol(globalSymbols[WorldCache]);
     return globalSymbols[WorldCache];
   }
   // Store the promise immediately to prevent race conditions with concurrent calls.
@@ -205,6 +209,7 @@ export const getWorld = async (): Promise<World> => {
     });
   }
   globalSymbols[WorldCache] = await globalSymbols[WorldCachePromise];
+  assertWorldSupportsRuntimeProtocol(globalSymbols[WorldCache]);
   return globalSymbols[WorldCache];
 };
 

--- a/packages/core/src/set-attributes.test.ts
+++ b/packages/core/src/set-attributes.test.ts
@@ -1,4 +1,5 @@
 import { FatalError } from '@workflow/errors';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { experimental_setAttributes } from './set-attributes.js';
 import { contextStorage, type StepContext } from './step/context-storage.js';
@@ -61,6 +62,7 @@ describe('experimental_setAttributes (host-side)', () => {
   it('posts normalized changes as a native event when called from a step', async () => {
     const create = vi.fn().mockResolvedValue({});
     globals[WORLD_CACHE] = {
+      specVersion: SPEC_VERSION_CURRENT,
       name: 'test-world',
       events: { create },
     };
@@ -87,6 +89,7 @@ describe('experimental_setAttributes (host-side)', () => {
   it('forwards allowReservedAttributes for step-side reserved namespace writes', async () => {
     const create = vi.fn().mockResolvedValue({});
     globals[WORLD_CACHE] = {
+      specVersion: SPEC_VERSION_CURRENT,
       events: { create },
     };
 
@@ -117,6 +120,7 @@ describe('experimental_setAttributes (host-side)', () => {
       return {};
     });
     globals[WORLD_CACHE] = {
+      specVersion: SPEC_VERSION_CURRENT,
       events: { create },
     };
 
@@ -146,6 +150,7 @@ describe('experimental_setAttributes (host-side)', () => {
   it('still posts when the runReadyBarrier rejects (write surfaces the real error)', async () => {
     const create = vi.fn().mockResolvedValue({});
     globals[WORLD_CACHE] = {
+      specVersion: SPEC_VERSION_CURRENT,
       events: { create },
     };
 
@@ -165,6 +170,7 @@ describe('experimental_setAttributes (host-side)', () => {
   it('rejects validation errors before posting from a step', async () => {
     const create = vi.fn();
     globals[WORLD_CACHE] = {
+      specVersion: SPEC_VERSION_CURRENT,
       events: { create },
     };
 

--- a/packages/core/src/step/writable-stream.test.ts
+++ b/packages/core/src/step/writable-stream.test.ts
@@ -1,3 +1,4 @@
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LOCK_POLL_INTERVAL_MS } from '../flushable-stream.js';
 import { setWorld } from '../runtime/world.js';
@@ -32,6 +33,7 @@ describe('step-level getWritable', () => {
   beforeEach(() => {
     writeCalls = [];
     const mockWorld = {
+      specVersion: SPEC_VERSION_CURRENT,
       streams: {
         write: vi.fn(
           async (_runId: string, _name: string, chunk: Uint8Array) => {

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -1,6 +1,7 @@
 import { types } from 'node:util';
 import { HookConflictError, WorkflowRuntimeError } from '@workflow/errors';
 import type { Event, WorkflowRun } from '@workflow/world';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 import { DEFERRED_CHECK_DELAY_MS } from './events-consumer.js';
@@ -5486,6 +5487,7 @@ describe('runWorkflow', () => {
         event: { eventType: 'hook_created' as const },
       }));
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         events: { create },
         streams: { write: vi.fn(), close: vi.fn() },
       } as any);
@@ -5533,6 +5535,7 @@ describe('runWorkflow', () => {
         event: { eventType: 'wait_created' as const },
       }));
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         events: { create },
         streams: { write: vi.fn(), close: vi.fn() },
       } as any);
@@ -5572,6 +5575,7 @@ describe('runWorkflow', () => {
         event: { eventType: 'hook_created' as const },
       }));
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         events: { create },
         streams: { write: vi.fn(), close: vi.fn() },
       } as any);
@@ -5601,6 +5605,7 @@ describe('runWorkflow', () => {
         event: { eventType: 'hook_created' as const },
       }));
       setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
         events: { create },
         streams: { write: vi.fn(), close: vi.fn() },
       } as any);

--- a/packages/core/src/writable-stream.test.ts
+++ b/packages/core/src/writable-stream.test.ts
@@ -1,3 +1,4 @@
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setWorld } from './runtime/world.js';
 import {
@@ -12,6 +13,7 @@ describe('WorkflowServerWritableStream', () => {
     close: ReturnType<typeof vi.fn>;
   };
   let mockWorld: {
+    specVersion: typeof SPEC_VERSION_CURRENT;
     streams: typeof mockStreams;
     streamFlushIntervalMs?: number;
   };
@@ -23,7 +25,7 @@ describe('WorkflowServerWritableStream', () => {
       close: vi.fn().mockResolvedValue(undefined),
     };
 
-    mockWorld = { streams: mockStreams };
+    mockWorld = { specVersion: SPEC_VERSION_CURRENT, streams: mockStreams };
 
     setWorld(mockWorld as any);
   });

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -275,15 +275,12 @@ export interface Storage {
  */
 export interface World extends Queue, Streamer, Storage {
   /**
-   * The highest spec version this World supports.
+   * The Workflow protocol spec version this World implements.
    *
-   * When set, `start()` creates runs at this version so world-specific
-   * features (e.g., CBOR queue transport) are enabled automatically.
-   * When omitted, runs default to `SPEC_VERSION_SUPPORTS_EVENT_SOURCING` (2),
-   * the safe baseline that all worlds — including community worlds on
-   * older @workflow/world versions — are expected to handle.
+   * Current runtimes require this to exactly match their
+   * `SPEC_VERSION_CURRENT` before they create or replay runs.
    */
-  specVersion?: number;
+  specVersion: number;
 
   /**
    * Whether calling `process.exit(1)` from a queue handler is observed by


### PR DESCRIPTION
Closes #2638

## Summary
- require configured Worlds to declare the same specVersion as the runtime
- make World.specVersion required and update its JSDoc for the strict equality contract
- reject missing, older, and newer world specVersion values before runtime work starts
- document matching the Postgres World release channel for v5 self-hosting

## Docs Preview
| Page | Preview |
| --- | --- |
| Postgres World (v5) | https://workflow-docs-git-nathanc-align-world-runtime-versions.vercel.sh/v5/docs/deploying/world/postgres-world |

## Tests
- pnpm --filter @workflow/core... build
- pnpm vitest run src
- focused affected Vitest files
- biome check / git diff --check
- changed MDX page compiles
- temporary mismatch harness with @workflow/world-postgres@4.2.0 throws the expected WorkflowRuntimeError
- autoreview clean