### PR TITLE
[world-local] Scope untagged startup recovery to untagged runs

### DIFF
--- a/.changeset/world-local-untagged-recovery-filter.md
+++ b/.changeset/world-local-untagged-recovery-filter.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Scope untagged startup recovery to untagged runs so a dev server no longer re-enqueues tagged runs (e.g. left behind by the vitest harness in a shared data directory), which previously failed `run_started` with "did not return the run entity".

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -166,6 +166,19 @@ export function hasTag(fileId: string, tag: string): boolean {
 }
 
 /**
+ * Check whether a fileId carries no tag suffix at all.
+ * `wrun_ABC` → true, `wrun_ABC.vitest-0` → false.
+ *
+ * An untagged world's reads (`readJSONWithFallback`) can only resolve untagged
+ * files, so when it lists entities for recovery it must skip files tagged by
+ * other worlds (e.g. the vitest harness) sharing the same data directory —
+ * otherwise it would re-enqueue runs it cannot subsequently read back.
+ */
+export function isUntagged(fileId: string): boolean {
+  return !TAG_PATTERN.test(fileId);
+}
+
+/**
  * Build the file path for an entity, with optional tag embedded in the filename.
  * `taggedPath('/data', 'runs', 'wrun_ABC', 'vitest-0')` → `/data/runs/wrun_ABC.vitest-0.json`
  * `taggedPath('/data', 'runs', 'wrun_ABC')` → `/data/runs/wrun_ABC.json`

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -9,6 +9,7 @@ import {
   clearCreatedFilesCache,
   deleteJSON,
   hasTag,
+  isUntagged,
   listTaggedFiles,
   listTaggedFilesByExtension,
   readJSON,
@@ -78,16 +79,24 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
       if (!recoverActiveRuns) {
         return;
       }
-      const recoveryRuns = tag
-        ? {
-            ...storage.runs,
-            list: ((params) =>
-              storage.runs.list({
-                ...params,
-                fileIdFilter: (fileId) => hasTag(fileId, tag),
-              })) as typeof storage.runs.list,
-          }
-        : storage.runs;
+      // Scope recovery to this world's own files. A tagged world recovers only
+      // its tag; an untagged world recovers only untagged files. Without the
+      // untagged filter, an untagged dev server sharing the data directory with
+      // the vitest harness would list tagged runs (list enumerates every file)
+      // and re-enqueue them, but run_started's tagged-or-untagged read can't
+      // resolve a foreign tag — yielding "did not return the run entity" 500s
+      // on startup until the message exhausts its deliveries.
+      const fileIdFilter = tag
+        ? (fileId: string) => hasTag(fileId, tag)
+        : isUntagged;
+      const recoveryRuns = {
+        ...storage.runs,
+        list: ((params) =>
+          storage.runs.list({
+            ...params,
+            fileIdFilter,
+          })) as typeof storage.runs.list,
+      };
       await reenqueueActiveRuns(recoveryRuns, queue.queue, 'world-local');
     },
     async close() {

--- a/packages/world-local/src/reenqueue.test.ts
+++ b/packages/world-local/src/reenqueue.test.ts
@@ -160,6 +160,49 @@ describe('re-enqueue active runs on start', () => {
     await restartedWorld0.close();
   });
 
+  it('untagged recovery skips tagged runs sharing the data dir', async () => {
+    // A vitest harness (tagged world) leaves an active run in the shared
+    // data directory. createRun leaves the run in `pending`, which recovery
+    // would otherwise pick up.
+    const taggedWorld = createLocalWorld({ dataDir, tag: 'vitest-0' });
+    const taggedRun = await createRun(taggedWorld, {
+      deploymentId: 'dpl_1',
+      workflowName: 'taggedWorkflow',
+      input: new Uint8Array([1]),
+    });
+    await taggedWorld.close();
+
+    // An untagged run that recovery SHOULD pick up, to prove the filter
+    // isn't simply dropping everything.
+    const untaggedWorld = createLocalWorld({ dataDir });
+    const untaggedRun = await createRun(untaggedWorld, {
+      deploymentId: 'dpl_1',
+      workflowName: 'untaggedWorkflow',
+      input: new Uint8Array([2]),
+    });
+    await untaggedWorld.close();
+
+    // A normal dev server boots untagged on the same data dir.
+    const devWorld = createLocalWorld({ dataDir });
+    const receivedRunIds: string[] = [];
+    devWorld.registerHandler('__wkf_workflow_', async (req) => {
+      const body = await req.json();
+      receivedRunIds.push(body.runId);
+      return Response.json({ ok: true });
+    });
+
+    await devWorld.start();
+
+    await vi.waitFor(() => {
+      expect(receivedRunIds).toEqual([untaggedRun.runId]);
+    });
+    // The tagged run must never be re-enqueued: the untagged world cannot read
+    // it back, so run_started would fail with "did not return the run entity".
+    expect(receivedRunIds).not.toContain(taggedRun.runId);
+
+    await devWorld.close();
+  });
+
   it('keeps tag filtering when recovery paginates across multiple pages', async () => {
     const world0 = createLocalWorld({ dataDir, tag: 'vitest-0' });
     const world1 = createLocalWorld({ dataDir, tag: 'vitest-1' });


### PR DESCRIPTION
## Problem

Using Workflow SDK locally with `world-local`, users can hit a startup error storm:

```
[workflow-sdk] Fatal runtime error during workflow setup
  code   RUNTIME_ERROR
  error  Event creation for 'run_started' did not return the run entity for run "wrun_…"
 POST /.well-known/workflow/v1/flow 500
```

### Root cause

`createLocalWorld` defaults `recoverActiveRuns: true`, so `world.start()` (on every dev-server boot) calls `reenqueueActiveRuns`, which lists active runs and re-enqueues them with **no `runInput`**.

`runs.list` enumerates **every** `*.json` file in the `runs` directory and keys each by the `runId` *inside* the file — including tag-suffixed files like `wrun_X.vitest-0.json`. But reads go through `readJSONWithFallback`, which only resolves `{id}.{tag}.json` (own tag) then untagged `{id}.json`.

So an **untagged** world (a normal `pnpm dev`) sharing the default `.workflow-data` directory with the vitest harness — which writes tagged files there "so runs are visible to the observability dashboard" — recovers leftover **tagged** runs it cannot read back. Since the re-enqueued message carries no `runInput`, the resilient-start path can't recreate the run either, and `run_started` returns no run entity → `RUNTIME_ERROR` 500, retried until the message exhausts its deliveries (hence "multiple times").

Tagged worlds already guarded against this with `fileIdFilter: (fileId) => hasTag(fileId, tag)`. The untagged path had no symmetric guard.

## Fix

Give the untagged recovery path the symmetric filter via a new `isUntagged` predicate, so each world only recovers files it can actually read back:

- tagged world → recover only its own tag (unchanged)
- untagged world → recover only untagged files (new)

## Test

Added `untagged recovery skips tagged runs sharing the data dir` to `reenqueue.test.ts`: a tagged (vitest-style) active run + an untagged active run share a data dir; an untagged dev boot must recover only the untagged run. Verified the test **fails** on the old code (the tagged run gets re-enqueued) and passes with the fix. Full `@workflow/world-local` suite (412 tests) passes.
