### PR TITLE
fix(world-vercel): retry idempotent event POSTs in-process to avoid step re-execution

### DIFF
--- a/.changeset/retry-idempotent-event-posts.md
+++ b/.changeset/retry-idempotent-event-posts.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Retry transient transport failures (e.g. `UND_ERR_REQ_RETRY`, `ECONNRESET`, socket timeouts, 5xx) in-process for idempotent-on-retry event POSTs, so a brief network blip after a step completes no longer re-executes the step. `step_started`, `step_retrying`, and `hook_received` are excluded as they are not safe to blindly retry.

--- a/packages/world-vercel/src/event-retry.test.ts
+++ b/packages/world-vercel/src/event-retry.test.ts
@@ -1,0 +1,213 @@
+import {
+  EntityConflictError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { EventTypeSchema } from '@workflow/world';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  EVENT_RETRY_ELIGIBILITY,
+  isRetryableEventPostError,
+  MAX_EVENT_POST_RETRIES,
+  withEventPostRetry,
+} from './event-retry.js';
+
+const transportErr = (code: string) =>
+  Object.assign(new Error(`transport ${code}`), { code });
+
+// undici `fetch` wraps low-level failures in a TypeError whose `cause` carries
+// the real code — the classifier must walk the cause chain.
+const fetchFailed = (code: string) =>
+  Object.assign(new TypeError('fetch failed'), {
+    cause: Object.assign(new Error('underlying'), { code }),
+  });
+
+describe('EVENT_RETRY_ELIGIBILITY', () => {
+  it('classifies every world event type (no gaps)', () => {
+    for (const type of EventTypeSchema.options) {
+      const policy = EVENT_RETRY_ELIGIBILITY[type];
+      expect(policy, `missing policy for ${type}`).toBeDefined();
+      expect(typeof policy.retryable).toBe('boolean');
+      expect(policy.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('marks idempotent-on-retry events retryable', () => {
+    for (const type of [
+      'run_created',
+      'run_started',
+      'run_completed',
+      'run_failed',
+      'run_cancelled',
+      'attr_set',
+      'step_created',
+      'step_completed',
+      'step_failed',
+      'wait_created',
+      'wait_completed',
+      'hook_created',
+      'hook_disposed',
+    ] as const) {
+      expect(EVENT_RETRY_ELIGIBILITY[type].retryable, type).toBe(true);
+    }
+  });
+
+  it('excludes events that are unsafe to blindly retry', () => {
+    // step_started double-increments attempt; step_retrying / hook_received
+    // append a duplicate event row; hook_conflict is server-originated.
+    for (const type of [
+      'step_started',
+      'step_retrying',
+      'hook_received',
+      'hook_conflict',
+    ] as const) {
+      expect(EVENT_RETRY_ELIGIBILITY[type].retryable, type).toBe(false);
+    }
+  });
+});
+
+describe('isRetryableEventPostError', () => {
+  it('retries transient 5xx', () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(
+        isRetryableEventPostError(new WorkflowWorldError('boom', { status }))
+      ).toBe(true);
+    }
+  });
+
+  it('does not retry 4xx definitive responses', () => {
+    for (const status of [400, 404]) {
+      expect(
+        isRetryableEventPostError(new WorkflowWorldError('nope', { status }))
+      ).toBe(false);
+    }
+  });
+
+  it('does not retry server-considered conflicts/terminal/too-early/throttle', () => {
+    expect(isRetryableEventPostError(new EntityConflictError('409'))).toBe(
+      false
+    );
+    expect(isRetryableEventPostError(new RunExpiredError('410'))).toBe(false);
+    expect(isRetryableEventPostError(new TooEarlyError('425'))).toBe(false);
+    expect(isRetryableEventPostError(new ThrottleError('429'))).toBe(false);
+  });
+
+  it('retries a body-parse failure (write may have landed)', () => {
+    expect(
+      isRetryableEventPostError(
+        new WorkflowWorldError('parse', { code: 'PARSE_ERROR' })
+      )
+    ).toBe(true);
+  });
+
+  it('retries raw transport errors by code', () => {
+    for (const code of [
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'UND_ERR_SOCKET',
+      'UND_ERR_REQ_RETRY',
+      'UND_ERR_HEADERS_TIMEOUT',
+    ]) {
+      expect(isRetryableEventPostError(transportErr(code)), code).toBe(true);
+    }
+  });
+
+  it('retries transport errors hidden under a `fetch failed` cause', () => {
+    expect(isRetryableEventPostError(fetchFailed('UND_ERR_SOCKET'))).toBe(true);
+  });
+
+  it('retries our own timeout (AbortError/TimeoutError name)', () => {
+    expect(
+      isRetryableEventPostError(
+        Object.assign(new Error('timed out'), { name: 'TimeoutError' })
+      )
+    ).toBe(true);
+  });
+
+  it('does not retry an unclassified error', () => {
+    expect(isRetryableEventPostError(new Error('something else'))).toBe(false);
+  });
+});
+
+describe('withEventPostRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a retryable event past a transient blip and returns the result', async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw transportErr('ECONNRESET');
+      return 'ok';
+    });
+
+    const p = withEventPostRetry(fn, 'step_completed');
+    await vi.runAllTimersAsync();
+
+    await expect(p).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a 409 that appears on a retry (original landed)', async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw transportErr('ECONNRESET');
+      // The first attempt actually landed; the retry observes the conflict.
+      throw new EntityConflictError('already completed');
+    });
+
+    const p = withEventPostRetry(fn, 'step_completed').catch((e) => e);
+    await vi.runAllTimersAsync();
+
+    const err = await p;
+    expect(EntityConflictError.is(err)).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after MAX_EVENT_POST_RETRIES and throws the last error', async () => {
+    const fn = vi.fn(async () => {
+      throw transportErr('ECONNRESET');
+    });
+
+    const p = withEventPostRetry(fn, 'step_completed').catch((e) => e);
+    await vi.runAllTimersAsync();
+
+    const err = await p;
+    expect((err as { code?: string }).code).toBe('ECONNRESET');
+    expect(fn).toHaveBeenCalledTimes(MAX_EVENT_POST_RETRIES + 1);
+  });
+
+  it('does not retry a definitive failure even for a retryable event', async () => {
+    const fn = vi.fn(async () => {
+      throw new WorkflowWorldError('bad request', { status: 400 });
+    });
+
+    await expect(withEventPostRetry(fn, 'step_completed')).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an excluded event (step_started — protects the attempt counter)', async () => {
+    const fn = vi.fn(async () => {
+      throw transportErr('ECONNRESET');
+    });
+
+    await expect(withEventPostRetry(fn, 'step_started')).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an excluded event (hook_received — avoids double-delivery)', async () => {
+    const fn = vi.fn(async () => {
+      throw transportErr('ECONNRESET');
+    });
+
+    await expect(withEventPostRetry(fn, 'hook_received')).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/world-vercel/src/event-retry.test.ts
+++ b/packages/world-vercel/src/event-retry.test.ts
@@ -118,12 +118,27 @@ describe('isRetryableEventPostError', () => {
     expect(isRetryableEventPostError(fetchFailed('UND_ERR_SOCKET'))).toBe(true);
   });
 
-  it('retries our own timeout (AbortError/TimeoutError name)', () => {
+  it('retries our own timeout (TimeoutError) but not an external abort (AbortError)', () => {
+    // Self-deadline via AbortSignal.timeout → TimeoutError → ambiguous, retry.
     expect(
       isRetryableEventPostError(
         Object.assign(new Error('timed out'), { name: 'TimeoutError' })
       )
     ).toBe(true);
+    // Caller-requested cancellation surfaces as AbortError → must NOT be retried.
+    expect(
+      isRetryableEventPostError(
+        Object.assign(new Error('aborted'), { name: 'AbortError' })
+      )
+    ).toBe(false);
+    // Also when wrapped by makeRequest as a WorkflowWorldError(cause).
+    expect(
+      isRetryableEventPostError(
+        new WorkflowWorldError('request aborted', {
+          cause: Object.assign(new Error('aborted'), { name: 'AbortError' }),
+        })
+      )
+    ).toBe(false);
   });
 
   it('does not retry an unclassified error', () => {

--- a/packages/world-vercel/src/event-retry.ts
+++ b/packages/world-vercel/src/event-retry.ts
@@ -12,10 +12,13 @@
  * idempotent *in outcome*: the entity handlers run before the event-log row is
  * inserted, and state transitions are conditional writes that exclude
  * already-terminal states. A retry whose original already landed therefore
- * throws before any row is written and surfaces as a 409 — which the SDK maps to
- * `EntityConflictError` and existing callers already handle (e.g. the step
- * executor swallows it as `{ type: 'skipped' }`). So retrying the POST is safe:
- * worst case we observe the 409 our own first attempt caused.
+ * throws before any row is written and surfaces as a 409 for most types — which
+ * the SDK maps to `EntityConflictError` and existing callers already handle (e.g.
+ * the step executor swallows it as `{ type: 'skipped' }`). The two non-conflict
+ * cases still resolve as plain success the caller already handles: `run_started`
+ * early-returns the running run and `attr_set` replays the existing event (both
+ * 200). So retrying the POST is safe: worst case we observe the outcome our own
+ * first attempt caused.
  *
  * This module retries the POST in-process for the event types that are provably
  * idempotent-on-retry, and leaves the rest at a single attempt. The three
@@ -169,8 +172,13 @@ const TRANSIENT_CODES = new Set([
   'UND_ERR_HEADERS_TIMEOUT',
   'UND_ERR_BODY_TIMEOUT',
   // Names (undici/Node surface these on the error or its cause).
+  // `TimeoutError` is our own per-request deadline (`AbortSignal.timeout` in
+  // makeRequest) — a genuinely ambiguous failure worth retrying. We deliberately
+  // do NOT include `AbortError`: that is how an external/caller-supplied
+  // cancellation surfaces (makeRequest composes the caller's signal via
+  // `AbortSignal.any`), and re-issuing a write the caller asked to cancel —
+  // stalling the abort by the full backoff budget — would be wrong.
   'TimeoutError',
-  'AbortError',
   'RequestRetryError',
 ]);
 
@@ -222,6 +230,33 @@ export function isRetryableEventPostError(err: unknown): boolean {
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+/** Gated like the rest of world-vercel's HTTP layer (`DEBUG=workflow:*`). Keeps
+ * in-process retries visible during a latency/outage investigation — otherwise a
+ * step that quietly rode out a blip and one that exhausted its retries and fell
+ * through to queue redelivery look identical in logs/traces. */
+const RETRY_DEBUG_ENABLED =
+  typeof process !== 'undefined' &&
+  typeof process.env.DEBUG === 'string' &&
+  (process.env.DEBUG.includes('workflow:') || process.env.DEBUG === '*');
+
+function logRetry(message: string, fields: Record<string, unknown>): void {
+  if (!RETRY_DEBUG_ENABLED) return;
+  const suffix = Object.entries(fields)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+  console.debug(`[workflow:world-vercel:event-retry] ${message} ${suffix}`);
+}
+
+/** A concise identifier for the failure, for the debug line above. */
+function errorMarker(err: unknown): string {
+  if (WorkflowWorldError.is(err)) {
+    return err.code ?? (err.status != null ? `status_${err.status}` : err.name);
+  }
+  return (
+    collectErrorMarkers(err)[0] ?? (err instanceof Error ? err.name : 'unknown')
+  );
+}
+
 /**
  * Run an event POST, retrying transient transport failures in-process when the
  * event type is idempotent-on-retry. Non-retryable event types and definitive
@@ -236,17 +271,33 @@ export async function withEventPostRetry<T>(
     try {
       return await fn();
     } catch (err) {
-      if (
-        !retryable ||
-        attempt >= MAX_EVENT_POST_RETRIES ||
-        !isRetryableEventPostError(err)
-      ) {
-        throw err;
+      const transient = retryable && isRetryableEventPostError(err);
+      if (transient && attempt < MAX_EVENT_POST_RETRIES) {
+        const backoff =
+          EVENT_POST_RETRY_BASE_MS * 2 ** attempt +
+          Math.floor(Math.random() * EVENT_POST_RETRY_JITTER_MS);
+        logRetry('retrying event POST after transient failure', {
+          eventType,
+          attempt: attempt + 1,
+          backoffMs: backoff,
+          error: errorMarker(err),
+        });
+        await sleep(backoff);
+        continue;
       }
-      const backoff =
-        EVENT_POST_RETRY_BASE_MS * 2 ** attempt +
-        Math.floor(Math.random() * EVENT_POST_RETRY_JITTER_MS);
-      await sleep(backoff);
+      // Out of retries on a still-transient failure: surface it so the queue
+      // redelivers (the worst-case fallthrough the in-process retry rode against).
+      if (transient) {
+        logRetry(
+          'exhausted in-process retries; surfacing for queue redelivery',
+          {
+            eventType,
+            attempts: attempt + 1,
+            error: errorMarker(err),
+          }
+        );
+      }
+      throw err;
     }
   }
 }

--- a/packages/world-vercel/src/event-retry.ts
+++ b/packages/world-vercel/src/event-retry.ts
@@ -1,0 +1,252 @@
+/**
+ * In-process retry for event POSTs.
+ *
+ * undici's `RetryAgent` never retries a POST (a non-idempotent method), so a
+ * trivially-recoverable transport blip — `UND_ERR_REQ_RETRY`, `ECONNRESET`, a
+ * socket/headers timeout, a transient 5xx — bubbles straight out of an event
+ * write. For a `step_completed`/`step_failed` write that means the queue message
+ * is not acked, it redelivers, the workflow replays, and the step's user code is
+ * re-executed with `attempt++` even though it already ran to completion once.
+ *
+ * That re-execution is avoidable, because workflow-server makes event writes
+ * idempotent *in outcome*: the entity handlers run before the event-log row is
+ * inserted, and state transitions are conditional writes that exclude
+ * already-terminal states. A retry whose original already landed therefore
+ * throws before any row is written and surfaces as a 409 — which the SDK maps to
+ * `EntityConflictError` and existing callers already handle (e.g. the step
+ * executor swallows it as `{ type: 'skipped' }`). So retrying the POST is safe:
+ * worst case we observe the 409 our own first attempt caused.
+ *
+ * This module retries the POST in-process for the event types that are provably
+ * idempotent-on-retry, and leaves the rest at a single attempt. The three
+ * excluded types are NOT safe to blindly retry:
+ *
+ *   - `step_started`  — its handler does an unconditional `attempt += 1` with a
+ *                       `.where()` that only excludes terminal states, so a
+ *                       retried start double-increments the attempt counter.
+ *   - `step_retrying` — re-applies `pending` (idempotent state) but its handler
+ *                       does NOT throw on a duplicate, so a retry appends a
+ *                       second event-log row.
+ *   - `hook_received` — has no server-side guard at all; a retry appends a
+ *                       duplicate row and can re-deliver the payload.
+ *
+ * Only transient/ambiguous transport failures are retried; definitive responses
+ * (409/410/425/429 and any other 4xx) surface immediately, exactly as before.
+ */
+
+import {
+  EntityConflictError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import type { EventTypeSchema } from '@workflow/world';
+import type { z } from 'zod';
+
+/** Every event type the world knows about (includes the server-only
+ * `hook_conflict`, which the SDK never POSTs). */
+type WorkflowEventType = z.infer<typeof EventTypeSchema>;
+
+export interface EventRetryPolicy {
+  /** Whether a failed POST of this event type may be retried in-process. */
+  retryable: boolean;
+  /** Why — kept in code so the validated classification is self-documenting. */
+  reason: string;
+}
+
+/**
+ * Validated per-event idempotency-on-retry classification, derived from reading
+ * every handler in workflow-server's event create path. `retryable: true` means
+ * a retry whose original already landed produces no duplicate event row and no
+ * double-applied state (it surfaces a 409 the SDK already handles).
+ *
+ * Declared `satisfies Record<WorkflowEventType, …>` so adding or removing a
+ * world event type without classifying it is a compile error.
+ */
+export const EVENT_RETRY_ELIGIBILITY = {
+  // Creates: conditional create → 409 EntityConflictError if it already exists.
+  run_created: {
+    retryable: true,
+    reason: 'conditional create → 409 if exists',
+  },
+  step_created: {
+    retryable: true,
+    reason: 'conditional create → 409 if exists',
+  },
+  wait_created: {
+    retryable: true,
+    reason: 'conditional create → 409 if exists',
+  },
+  hook_created: {
+    retryable: true,
+    reason: 'transactional token uniqueness → 409 if exists',
+  },
+  // Run start: early-returns if already running, writes no duplicate row.
+  run_started: {
+    retryable: true,
+    reason: 'early-returns if already running, no duplicate row',
+  },
+  // Terminal transitions: conditional `.where()` excludes terminal states →
+  // 409 before the event row is written.
+  run_completed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  run_failed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  run_cancelled: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  step_completed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  step_failed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  wait_completed: {
+    retryable: true,
+    reason: 'waiting-state guard → 409, no duplicate row',
+  },
+  hook_disposed: {
+    retryable: true,
+    reason: 'conditional delete (exists) → 409, no duplicate row',
+  },
+  // True idempotency via a correlationId constraint that reuses the eventId.
+  attr_set: {
+    retryable: true,
+    reason: 'correlationId constraint reuses eventId (idempotent replay)',
+  },
+  // NOT safe to retry — see the module comment.
+  step_started: {
+    retryable: false,
+    reason: 'unconditional attempt increment → a retry double-counts attempts',
+  },
+  step_retrying: {
+    retryable: false,
+    reason: 'no duplicate guard → a retry appends a second event row',
+  },
+  hook_received: {
+    retryable: false,
+    reason:
+      'no server guard → a retry duplicates the row / re-delivers payload',
+  },
+  // Server-originated; the SDK never POSTs it.
+  hook_conflict: {
+    retryable: false,
+    reason: 'server-originated; never POSTed by the SDK',
+  },
+} satisfies Record<WorkflowEventType, EventRetryPolicy>;
+
+/** Up to this many retries after the initial attempt (3 attempts total). */
+export const MAX_EVENT_POST_RETRIES = 2;
+/** Base backoff; doubles per attempt. Kept tiny — the goal is riding out a
+ * brief blip inline, not waiting out an outage (that falls through to the
+ * queue's redelivery). */
+export const EVENT_POST_RETRY_BASE_MS = 100;
+const EVENT_POST_RETRY_JITTER_MS = 50;
+
+/** Transient transport error codes/names worth retrying. Mirrors undici's
+ * default retryable `errorCodes` plus its timeout/retry codes. */
+const TRANSIENT_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'EHOSTDOWN',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'ETIMEDOUT',
+  'UND_ERR_SOCKET',
+  'UND_ERR_REQ_RETRY',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  // Names (undici/Node surface these on the error or its cause).
+  'TimeoutError',
+  'AbortError',
+  'RequestRetryError',
+]);
+
+/** Walk an error and its `cause` chain collecting `code`/`name` markers.
+ * `fetch()` (undici) wraps low-level failures in a `TypeError: fetch failed`
+ * whose `cause` carries the real `code`, so the chain must be inspected. */
+function collectErrorMarkers(err: unknown, depth = 0): string[] {
+  if (depth > 5 || err === null || typeof err !== 'object') return [];
+  const markers: string[] = [];
+  const e = err as { code?: unknown; name?: unknown; cause?: unknown };
+  if (typeof e.code === 'string') markers.push(e.code);
+  if (typeof e.name === 'string') markers.push(e.name);
+  if (e.cause) markers.push(...collectErrorMarkers(e.cause, depth + 1));
+  return markers;
+}
+
+/**
+ * Whether a failed event POST should be retried. Retries transient/ambiguous
+ * transport failures and transient 5xx; never retries a definitive response
+ * (409/410/425/429 and other 4xx), which surfaces immediately as today.
+ */
+export function isRetryableEventPostError(err: unknown): boolean {
+  // Definitive, server-considered outcomes — never retried in-process.
+  // (425/429 are intentionally left to the runtime's retry-after handling.)
+  if (
+    EntityConflictError.is(err) ||
+    RunExpiredError.is(err) ||
+    TooEarlyError.is(err) ||
+    ThrottleError.is(err)
+  ) {
+    return false;
+  }
+
+  if (WorkflowWorldError.is(err)) {
+    // Body parsed past the response but the write may have landed — safe to
+    // retry for eligible events (a landed original re-surfaces as 409).
+    if (err.code === 'PARSE_ERROR') return true;
+    if (typeof err.status === 'number') {
+      // Transient server errors; 4xx are definitive and not retried.
+      return err.status >= 500 && err.status <= 599;
+    }
+    // No status (e.g. a timeout wrapped by makeRequest) — fall through to the
+    // transport-marker check on the error/cause chain.
+  }
+
+  return collectErrorMarkers(err).some((m) => TRANSIENT_CODES.has(m));
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run an event POST, retrying transient transport failures in-process when the
+ * event type is idempotent-on-retry. Non-retryable event types and definitive
+ * responses run/throw on the first attempt, preserving existing behavior.
+ */
+export async function withEventPostRetry<T>(
+  fn: () => Promise<T>,
+  eventType: WorkflowEventType
+): Promise<T> {
+  const retryable = EVENT_RETRY_ELIGIBILITY[eventType]?.retryable ?? false;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (
+        !retryable ||
+        attempt >= MAX_EVENT_POST_RETRIES ||
+        !isRetryableEventPostError(err)
+      ) {
+        throw err;
+      }
+      const backoff =
+        EVENT_POST_RETRY_BASE_MS * 2 ** attempt +
+        Math.floor(Math.random() * EVENT_POST_RETRY_JITTER_MS);
+      await sleep(backoff);
+    }
+  }
+}

--- a/packages/world-vercel/src/events-retry.test.ts
+++ b/packages/world-vercel/src/events-retry.test.ts
@@ -1,0 +1,140 @@
+import {
+  EntityConflictError,
+  HookNotFoundError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Integration coverage for the retry seam in `createWorkflowRunEvent`: that
+// `data.eventType` is actually threaded into `withEventPostRetry`, and that the
+// existing 404 → HookNotFoundError mapping still fires *after* the retry loop.
+// The unit tests in event-retry.test.ts cover the retry logic in isolation; a
+// refactor that wrapped the wrong layer (or passed the wrong event type) would
+// keep those green but break here. We mock the v4 wire client so we can assert
+// attempt counts and error mapping without standing up a real transport.
+const { createV4Mock } = vi.hoisted(() => ({ createV4Mock: vi.fn() }));
+
+vi.mock('./events-v4.js', () => ({
+  createWorkflowRunEventV4: createV4Mock,
+  getEventV4: vi.fn(),
+  getWorkflowRunEventsV4: vi.fn(),
+  getEventsByCorrelationIdV4: vi.fn(),
+}));
+
+import { createWorkflowRunEvent } from './events.js';
+
+const RUN_ID = 'wrun_test';
+const CONFIG = { token: 'test-token' };
+
+const stepCompleted = () => ({
+  eventType: 'step_completed' as const,
+  correlationId: 'step_1',
+  specVersion: 2,
+  eventData: {
+    stepName: 's',
+    workflowName: 'w',
+    result: new Uint8Array(),
+  },
+});
+
+const v4Success = () => ({
+  eventId: 'evnt_1',
+  runId: RUN_ID,
+  createdAt: '2020-01-01T00:00:00.000Z',
+  body: {
+    event: {
+      eventId: 'evnt_1',
+      runId: RUN_ID,
+      eventType: 'step_completed',
+      correlationId: 'step_1',
+      specVersion: 2,
+      createdAt: '2020-01-01T00:00:00.000Z',
+      eventData: { stepName: 's', workflowName: 'w' },
+    },
+  },
+});
+
+describe('createWorkflowRunEvent retry wiring', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createV4Mock.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a transient 5xx on step_completed and then succeeds', async () => {
+    let calls = 0;
+    createV4Mock.mockImplementation(async () => {
+      calls++;
+      if (calls === 1) throw new WorkflowWorldError('boom', { status: 503 });
+      return v4Success();
+    });
+
+    const p = createWorkflowRunEvent(
+      RUN_ID,
+      stepCompleted(),
+      undefined,
+      CONFIG
+    );
+    await vi.runAllTimersAsync();
+
+    const result = await p;
+    expect(result.event).toBeDefined();
+    expect(createV4Mock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a retry-time 409 as EntityConflictError', async () => {
+    let calls = 0;
+    createV4Mock.mockImplementation(async () => {
+      calls++;
+      if (calls === 1) throw new WorkflowWorldError('boom', { status: 503 });
+      throw new EntityConflictError('already completed');
+    });
+
+    const p = createWorkflowRunEvent(
+      RUN_ID,
+      stepCompleted(),
+      undefined,
+      CONFIG
+    ).catch((e) => e);
+    await vi.runAllTimersAsync();
+
+    const err = await p;
+    expect(EntityConflictError.is(err)).toBe(true);
+    expect(createV4Mock).toHaveBeenCalledTimes(2);
+  });
+
+  it('still maps a hook_disposed 404 to HookNotFoundError, after the retry loop, without retrying', async () => {
+    createV4Mock.mockImplementation(async () => {
+      throw new WorkflowWorldError('not found', { status: 404 });
+    });
+
+    await expect(
+      createWorkflowRunEvent(
+        RUN_ID,
+        { eventType: 'hook_disposed', correlationId: 'hook_1', specVersion: 2 },
+        undefined,
+        CONFIG
+      )
+    ).rejects.toBeInstanceOf(HookNotFoundError);
+    // 404 is definitive → one attempt; the mapping wraps the retry loop.
+    expect(createV4Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an excluded event type (step_started) even on a 5xx', async () => {
+    createV4Mock.mockImplementation(async () => {
+      throw new WorkflowWorldError('boom', { status: 503 });
+    });
+
+    await expect(
+      createWorkflowRunEvent(
+        RUN_ID,
+        { eventType: 'step_started', correlationId: 'step_1', specVersion: 2 },
+        undefined,
+        CONFIG
+      )
+    ).rejects.toBeInstanceOf(WorkflowWorldError);
+    expect(createV4Mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -48,6 +48,7 @@ import {
   validateUlidTimestamp,
   type WorkflowRun,
 } from '@workflow/world';
+import { withEventPostRetry } from './event-retry.js';
 import {
   createWorkflowRunEventV4,
   type DecodedV4Event,
@@ -522,7 +523,17 @@ export async function createWorkflowRunEvent(
   config?: APIConfig
 ): Promise<EventResult> {
   try {
-    return await createWorkflowRunEventInner(id, data, params, config);
+    // Retry transient transport failures (UND_ERR_REQ_RETRY, ECONNRESET,
+    // socket/headers timeouts, transient 5xx) in-process for event types that
+    // are idempotent-on-retry. A write that landed but whose response was lost
+    // re-surfaces as a 409 the callers below already handle, so this avoids a
+    // needless step re-execution on the next queue delivery. Non-retryable
+    // types (step_started, step_retrying, hook_received) run once. See
+    // ./event-retry for the validated per-event classification.
+    return await withEventPostRetry(
+      () => createWorkflowRunEventInner(id, data, params, config),
+      data.eventType
+    );
   } catch (err) {
     // 404 on hook_disposed / hook_received → already-disposed hook.
     if (

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -526,8 +526,9 @@ export async function createWorkflowRunEvent(
     // Retry transient transport failures (UND_ERR_REQ_RETRY, ECONNRESET,
     // socket/headers timeouts, transient 5xx) in-process for event types that
     // are idempotent-on-retry. A write that landed but whose response was lost
-    // re-surfaces as a 409 the callers below already handle, so this avoids a
-    // needless step re-execution on the next queue delivery. Non-retryable
+    // re-surfaces as a 409 (or plain success for run_started/attr_set) the
+    // callers already handle, so this avoids a needless step re-execution on
+    // the next queue delivery. Non-retryable
     // types (step_started, step_retrying, hook_received) run once. See
     // ./event-retry for the validated per-event classification.
     return await withEventPostRetry(


### PR DESCRIPTION
## Problem

When a step's user code runs to completion (success or failure) but the subsequent `step_completed` / `step_failed` POST to workflow-server fails with anything other than a 409, the queue message isn't acked, it redelivers, the workflow replays, the step is still `running`, and the start patch re-runs the user's code with `attempt++` — **silently re-executing a step that already succeeded once.**

undici makes this worse: its `RetryAgent` never retries a POST (a non-idempotent method), so even a trivially-recoverable transport blip (`UND_ERR_REQ_RETRY`, `ECONNRESET`, a socket/headers timeout, a transient 5xx) bubbles straight into that re-execution path.

It *is* safe to retry, because workflow-server makes event writes idempotent **in outcome**: the entity handlers run **before** the event-log row is inserted, and state transitions are conditional writes that exclude already-terminal states. A retry whose original already landed therefore throws before any row is written and surfaces as a **409** for most types — which the SDK already maps to `EntityConflictError`, and which the step executor already swallows as `{ type: 'skipped' }`. The two non-conflict cases resolve as plain success the caller already handles: `run_started` early-returns the running run, and `attr_set` replays the existing event (both **200**).

## What this does

Adds a bounded, in-process retry around event POSTs in `@workflow/world-vercel`, gated to the event types that are provably idempotent-on-retry.

- **`src/event-retry.ts`** (new):
  - `EVENT_RETRY_ELIGIBILITY` — the validated per-event classification, `satisfies Record<WorkflowEventType, …>` so adding/removing a world event type without classifying it is a compile error. Each entry carries a `reason`.
  - `isRetryableEventPostError` — retries transient/ambiguous transport failures (`UND_ERR_*` socket/timeout codes, `ECONNRESET`/`ETIMEDOUT`/etc., `PARSE_ERROR`, 5xx, including undici's `cause`-wrapped variants); surfaces definitive responses (409/410/425/429 and other 4xx) immediately, exactly as before.
  - `withEventPostRetry` — bounded loop (3 attempts, ~100→300ms backoff with jitter); non-retryable event types run once.
- **`src/events.ts`** — wraps `createWorkflowRunEventInner` at the single `createWorkflowRunEvent` choke point (covers both the v4 and v1-compat POST paths). The existing 404→`HookNotFoundError` mapping is preserved.

Net effect: a transient blip after a step completes now retries the write in-process. If the original actually landed but the response was lost, the retry hits the server's conditional guard → 409 → existing `skipped` handling. **No re-execution, no `attempt++`.**

## Validated event-type idempotency (the classification, in code)

Derived by reading every handler in workflow-server's event-create path. "Safe to retry" = a retry whose original already landed produces no duplicate event row and no double-applied state.

| Event | Server guard | Retryable |
|---|---|---|
| `run_created` / `step_created` / `wait_created` / `hook_created` | conditional create → 409 | ✅ |
| `run_started` | early-returns if already running (no row) | ✅ |
| `run_completed` / `run_failed` / `run_cancelled` / `step_completed` / `step_failed` / `wait_completed` | terminal/waiting-state `.where()` → 409 | ✅ |
| `hook_disposed` | conditional delete (`exists`) → 409 | ✅ |
| `attr_set` | correlationId constraint (true idempotency) | ✅ |
| `step_started` | unconditional `attempt += 1` | ❌ a retry double-counts attempts |
| `step_retrying` | no duplicate guard | ❌ a retry appends a second event row |
| `hook_received` | none | ❌ a retry duplicates the row / re-delivers the payload |

## Relationship to #2666

Complementary. [#2666](https://github.com/vercel/workflow/pull/2666) moved the `step_completed` write out of the success try/catch so a persistence failure **redelivers** the queue message (an infrastructure error) instead of being misrecorded as a user `step_failed` / `step_retrying`. It still re-executes on redelivery; this PR avoids that redelivery — and the re-execution — for transient blips.

## Testing

- 17 new unit tests in `src/event-retry.test.ts` (classifier verdicts, retry/backoff behavior, excluded events run once, definitive errors not retried, exhaustion, eligibility-map exhaustiveness).
- Full `@workflow/world-vercel` suite green (190 tests); `tsc --noEmit` and biome clean.

## Follow-up (not in this PR)

Phase B: a durable "commit-only continuation" for the rarer case where the **process dies** after user code but before the commit lands (in-memory result lost, so in-process retry can't help) — carry the already-serialized result/error in an idempotency-keyed queue message and post the terminal event on delivery without re-running user code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
