### PR TITLE
Add workflow trace timing breakdown

### DIFF
--- a/.changeset/trace-timing-breakdown.md
+++ b/.changeset/trace-timing-breakdown.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Add optional workflow span timing breakdown metadata and sidebar rendering.

--- a/packages/web-shared/src/components/index.ts
+++ b/packages/web-shared/src/components/index.ts
@@ -1,3 +1,10 @@
+export type {
+  WorkflowQueuedTiming,
+  WorkflowSpanTiming,
+  WorkflowSpanTimingAttempt,
+  WorkflowSpanTimingMap,
+  WorkflowTimingTimeValue,
+} from '../lib/workflow-span-timing';
 export { ErrorBoundary } from './error-boundary';
 export { EventListView } from './event-list-view';
 export type {

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -58,6 +58,7 @@ interface NewTraceViewerProps {
   onLoadMore?: () => void | Promise<void>;
   hasMore?: boolean;
   isLoadingMore?: boolean;
+  showWorkflowTimingBreakdown?: boolean;
 }
 
 const MIN_VIEWPORT_MS = 0.001;
@@ -177,6 +178,7 @@ export function NewTraceViewer({
   onLoadMore,
   hasMore,
   isLoadingMore,
+  showWorkflowTimingBreakdown = false,
 }: NewTraceViewerProps): ReactNode {
   return (
     <TooltipProvider delayDuration={300}>
@@ -186,6 +188,7 @@ export function NewTraceViewer({
           onLoadMore={onLoadMore}
           hasMore={hasMore}
           isLoadingMore={isLoadingMore}
+          showWorkflowTimingBreakdown={showWorkflowTimingBreakdown}
         />
       </ActiveSpanProvider>
     </TooltipProvider>
@@ -197,6 +200,7 @@ function NewTraceViewerContent({
   onLoadMore,
   hasMore,
   isLoadingMore,
+  showWorkflowTimingBreakdown = false,
 }: NewTraceViewerProps): ReactNode {
   const { activeSpan, activeSpanId, setActiveSpan, clearActiveSpan } =
     useActiveSpan();
@@ -835,6 +839,7 @@ function NewTraceViewerContent({
                 showSeparateEventOccurrenceTimestamps={
                   sidebar.showSeparateEventOccurrenceTimestamps
                 }
+                showWorkflowTimingBreakdown={showWorkflowTimingBreakdown}
               />
             </ErrorBoundary>
           </div>

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -22,6 +22,7 @@ import {
 import { useLoadMoreOnScroll } from '../../hooks/use-load-more-on-scroll';
 import { useReducedMotion } from '../../hooks/use-reduced-motion';
 import { filterSpanRawEvents } from '../../lib/trace-builder';
+import { getWorkflowSpanTiming } from '../../lib/workflow-span-timing';
 import { ErrorBoundary } from '../error-boundary';
 import {
   EntityDetailPanel,
@@ -161,6 +162,7 @@ function useSelectedSpanInfo(): SelectedSpanInfo | null {
       data: activeSpan.attributes?.data,
       resource,
       spanId: activeSpan.spanId,
+      timing: getWorkflowSpanTiming(activeSpan.attributes),
       rawEvents,
     };
   }, [activeSpan, sidebar]);

--- a/packages/web-shared/src/components/run-trace-view.tsx
+++ b/packages/web-shared/src/components/run-trace-view.tsx
@@ -2,6 +2,7 @@
 
 import type { Event, Hook, WorkflowRun } from '@workflow/world';
 import { AlertCircle } from 'lucide-react';
+import type { WorkflowSpanTimingMap } from '../lib/workflow-span-timing';
 import type { FetchSpanDetail } from './sidebar/use-selected-span-detail';
 import { WorkflowTraceViewer } from './workflow-trace-view';
 
@@ -27,6 +28,7 @@ interface RunTraceViewProps {
   hasMoreSpans?: boolean;
   isLoadingMoreSpans?: boolean;
   showSeparateEventOccurrenceTimestamps?: boolean;
+  spanTimings?: WorkflowSpanTimingMap;
 }
 
 export function RunTraceView({
@@ -44,6 +46,7 @@ export function RunTraceView({
   hasMoreSpans,
   isLoadingMoreSpans,
   showSeparateEventOccurrenceTimestamps,
+  spanTimings,
 }: RunTraceViewProps) {
   if (error && !run) {
     return (
@@ -74,6 +77,7 @@ export function RunTraceView({
         showSeparateEventOccurrenceTimestamps={
           showSeparateEventOccurrenceTimestamps
         }
+        spanTimings={spanTimings}
       />
     </div>
   );

--- a/packages/web-shared/src/components/run-trace-view.tsx
+++ b/packages/web-shared/src/components/run-trace-view.tsx
@@ -28,6 +28,7 @@ interface RunTraceViewProps {
   hasMoreSpans?: boolean;
   isLoadingMoreSpans?: boolean;
   showSeparateEventOccurrenceTimestamps?: boolean;
+  showWorkflowTimingBreakdown?: boolean;
   spanTimings?: WorkflowSpanTimingMap;
 }
 
@@ -46,6 +47,7 @@ export function RunTraceView({
   hasMoreSpans,
   isLoadingMoreSpans,
   showSeparateEventOccurrenceTimestamps,
+  showWorkflowTimingBreakdown = false,
   spanTimings,
 }: RunTraceViewProps) {
   if (error && !run) {
@@ -77,6 +79,7 @@ export function RunTraceView({
         showSeparateEventOccurrenceTimestamps={
           showSeparateEventOccurrenceTimestamps
         }
+        showWorkflowTimingBreakdown={showWorkflowTimingBreakdown}
         spanTimings={spanTimings}
       />
     </div>

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -750,6 +750,7 @@ export const AttributePanel = ({
   isDecrypting = false,
   resource,
   workflowTiming,
+  showWorkflowTimingBreakdown = false,
 }: {
   data: Record<string, unknown>;
   moduleSpecifier?: string;
@@ -768,6 +769,8 @@ export const AttributePanel = ({
   resource?: string;
   /** Log-derived timing data for the selected workflow run or step span. */
   workflowTiming?: WorkflowSpanTiming;
+  /** Show log-derived cold start, module init, and workflow overhead timing rows. */
+  showWorkflowTimingBreakdown?: boolean;
 }) => {
   // Extract workflowCoreVersion from executionContext for display
   const displayData = useMemo(() => {
@@ -861,8 +864,10 @@ export const AttributePanel = ({
       }
     : outerDecryptCtx;
   const hasCompletedAttribute = orderedBasicAttributes.includes('completedAt');
+  const shouldShowWorkflowTiming =
+    showWorkflowTimingBreakdown && Boolean(workflowTiming);
   const showMetadata =
-    visibleBasicAttributes.length > 0 || Boolean(workflowTiming);
+    visibleBasicAttributes.length > 0 || shouldShowWorkflowTiming;
 
   return (
     <ContextCardProvider>
@@ -895,16 +900,17 @@ export const AttributePanel = ({
                                 : undefined
                             }
                           />
-                          {attribute === 'completedAt' && (
-                            <WorkflowTimingBreakdown
-                              resource={resource}
-                              timing={workflowTiming}
-                            />
-                          )}
+                          {attribute === 'completedAt' &&
+                            shouldShowWorkflowTiming && (
+                              <WorkflowTimingBreakdown
+                                resource={resource}
+                                timing={workflowTiming}
+                              />
+                            )}
                         </Fragment>
                       );
                     })}
-                    {!hasCompletedAttribute && (
+                    {!hasCompletedAttribute && shouldShowWorkflowTiming && (
                       <WorkflowTimingBreakdown
                         resource={resource}
                         timing={workflowTiming}

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -4,10 +4,18 @@ import { parseStepName, parseWorkflowName } from '@workflow/utils/parse-name';
 import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
 import type { ModelMessage } from 'ai';
 import { format } from 'date-fns';
-import type { KeyboardEvent, ReactNode } from 'react';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import {
+  Fragment,
+  type KeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import { isEncryptedMarker, isExpiredMarker } from '../../lib/hydration';
 import { extractConversation, isDoStreamStep } from '../../lib/utils';
+import type { WorkflowSpanTiming } from '../../lib/workflow-span-timing';
 import {
   Collapsible,
   CollapsibleContent,
@@ -31,6 +39,7 @@ import {
 } from './attributes-block';
 import { ConversationView } from './conversation-view';
 import { CopyableDataBlock, EncryptedDataBlock } from './copyable-data-block';
+import { WorkflowTimingBreakdown } from './workflow-timing-breakdown';
 
 /**
  * Tab button for conversation/JSON toggle
@@ -740,6 +749,7 @@ export const AttributePanel = ({
   onDecrypt,
   isDecrypting = false,
   resource,
+  workflowTiming,
 }: {
   data: Record<string, unknown>;
   moduleSpecifier?: string;
@@ -756,6 +766,8 @@ export const AttributePanel = ({
   isDecrypting?: boolean;
   /** Resource type of the selected span — used to show targeted loading skeletons. */
   resource?: string;
+  /** Log-derived timing data for the selected workflow run or step span. */
+  workflowTiming?: WorkflowSpanTiming;
 }) => {
   // Extract workflowCoreVersion from executionContext for display
   const displayData = useMemo(() => {
@@ -848,13 +860,16 @@ export const AttributePanel = ({
         hasEncryptedData: outerDecryptCtx?.hasEncryptedData,
       }
     : outerDecryptCtx;
+  const hasCompletedAttribute = orderedBasicAttributes.includes('completedAt');
+  const showMetadata =
+    visibleBasicAttributes.length > 0 || Boolean(workflowTiming);
 
   return (
     <ContextCardProvider>
       <RunClickContext.Provider value={onRunClick}>
         <StreamClickContext.Provider value={onStreamClick}>
           <DecryptClickContext.Provider value={decryptValue}>
-            {visibleBasicAttributes.length > 0 && (
+            {showMetadata && (
               <CollapsibleRoot defaultOpen>
                 <CollapsibleTrigger>Metadata</CollapsibleTrigger>
                 <CollapsibleContent className="mt-0 mb-2">
@@ -870,16 +885,31 @@ export const AttributePanel = ({
                       const label = getAttributeDisplayName(attribute);
 
                       return (
-                        <DetailMonoKeyValueRow
-                          key={attribute}
-                          label={label}
-                          value={displayValue}
-                          copyText={
-                            isCopyableBasicAttribute ? displayValue : undefined
-                          }
-                        />
+                        <Fragment key={attribute}>
+                          <DetailMonoKeyValueRow
+                            label={label}
+                            value={displayValue}
+                            copyText={
+                              isCopyableBasicAttribute
+                                ? displayValue
+                                : undefined
+                            }
+                          />
+                          {attribute === 'completedAt' && (
+                            <WorkflowTimingBreakdown
+                              resource={resource}
+                              timing={workflowTiming}
+                            />
+                          )}
+                        </Fragment>
                       );
                     })}
+                    {!hasCompletedAttribute && (
+                      <WorkflowTimingBreakdown
+                        resource={resource}
+                        timing={workflowTiming}
+                      />
+                    )}
                     {isLoading &&
                       resource === 'sleep' &&
                       !displayData.resumeAt && (

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { Send, Zap } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useToast } from '../../lib/toast';
+import type { WorkflowSpanTiming } from '../../lib/workflow-span-timing';
 import { DecryptClickContext } from '../ui/data-inspector';
 import { AttributePanel } from './attribute-panel';
 import { EventsList } from './events-list';
@@ -14,6 +15,7 @@ import {
   type FetchSpanDetail,
   useSelectedSpanDetail,
 } from './use-selected-span-detail';
+import { WorkflowTimingBreakdown } from './workflow-timing-breakdown';
 
 // Type guard for runtime validation of span attribute data
 function isHook(data: unknown): data is Hook {
@@ -27,6 +29,7 @@ export type SpanSelectionInfo = {
   resource: 'run' | 'step' | 'hook' | 'sleep';
   resourceId: string;
   runId?: string;
+  spanId?: string;
 };
 
 /**
@@ -39,6 +42,8 @@ export interface SelectedSpanInfo {
   resource?: string;
   /** The span ID (correlationId for filtering events) */
   spanId?: string;
+  /** Optional log-derived timing data for run and step invocations. */
+  timing?: WorkflowSpanTiming;
   /** Raw correlated events from the store (NOT from the trace worker pipeline) */
   rawEvents?: Event[];
 }
@@ -368,6 +373,11 @@ export function EntityDetailPanel({
             onDecrypt={onDecrypt}
             isDecrypting={isDecrypting}
             resource={resource}
+          />
+
+          <WorkflowTimingBreakdown
+            resource={resource}
+            timing={selectedSpan.timing}
           />
 
           {rawEvents && (

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -66,6 +66,7 @@ export function EntityDetailPanel({
   isDecrypting = false,
   selectedSpan,
   showSeparateEventOccurrenceTimestamps = false,
+  showWorkflowTimingBreakdown = false,
 }: {
   run: WorkflowRun;
   /** Callback when a stream reference is clicked */
@@ -99,6 +100,8 @@ export function EntityDetailPanel({
   selectedSpan: SelectedSpanInfo | null;
   /** Show occurredAt separately instead of folding it into the Created timestamp. */
   showSeparateEventOccurrenceTimestamps?: boolean;
+  /** Show log-derived cold start, module init, and workflow overhead timing rows. */
+  showWorkflowTimingBreakdown?: boolean;
 }): React.JSX.Element | null {
   const toast = useToast();
   const [stoppingSleep, setStoppingSleep] = useState(false);
@@ -373,6 +376,7 @@ export function EntityDetailPanel({
             isDecrypting={isDecrypting}
             resource={resource}
             workflowTiming={selectedSpan.timing}
+            showWorkflowTimingBreakdown={showWorkflowTimingBreakdown}
           />
 
           {rawEvents && (

--- a/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/entity-detail-panel.tsx
@@ -15,7 +15,6 @@ import {
   type FetchSpanDetail,
   useSelectedSpanDetail,
 } from './use-selected-span-detail';
-import { WorkflowTimingBreakdown } from './workflow-timing-breakdown';
 
 // Type guard for runtime validation of span attribute data
 function isHook(data: unknown): data is Hook {
@@ -373,11 +372,7 @@ export function EntityDetailPanel({
             onDecrypt={onDecrypt}
             isDecrypting={isDecrypting}
             resource={resource}
-          />
-
-          <WorkflowTimingBreakdown
-            resource={resource}
-            timing={selectedSpan.timing}
+            workflowTiming={selectedSpan.timing}
           />
 
           {rawEvents && (

--- a/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
+++ b/packages/web-shared/src/components/sidebar/use-selected-span-detail.ts
@@ -31,7 +31,12 @@ function deriveSpanSelection(
     'stepId' in data
   ) {
     const step = data as Step;
-    return { resource: 'step', resourceId: step.stepId, runId: step.runId };
+    return {
+      resource: 'step',
+      resourceId: step.stepId,
+      runId: step.runId,
+      spanId: selectedSpan.spanId,
+    };
   }
   if (
     resource === 'run' &&
@@ -39,7 +44,11 @@ function deriveSpanSelection(
     typeof data === 'object' &&
     'runId' in data
   ) {
-    return { resource: 'run', resourceId: (data as WorkflowRun).runId };
+    return {
+      resource: 'run',
+      resourceId: (data as WorkflowRun).runId,
+      spanId: selectedSpan.spanId,
+    };
   }
   if (
     resource === 'hook' &&
@@ -47,7 +56,11 @@ function deriveSpanSelection(
     typeof data === 'object' &&
     'hookId' in data
   ) {
-    return { resource: 'hook', resourceId: (data as Hook).hookId };
+    return {
+      resource: 'hook',
+      resourceId: (data as Hook).hookId,
+      spanId: selectedSpan.spanId,
+    };
   }
   if (resource === 'sleep') {
     if (!selectedSpan.spanId) return null;
@@ -56,6 +69,7 @@ function deriveSpanSelection(
       resource: 'sleep',
       resourceId: selectedSpan.spanId,
       runId: waitData?.runId,
+      spanId: selectedSpan.spanId,
     };
   }
   return null;
@@ -83,7 +97,9 @@ export function useSelectedSpanDetail(
   const resourceId = selection?.resourceId;
   const runId = selection?.runId;
   const selectionKey =
-    resource && resourceId ? `${resource}:${resourceId}` : null;
+    resource && resourceId
+      ? `${resource}:${resourceId}:${selection?.spanId ?? ''}`
+      : null;
   const needsFetch = resourceNeedsFetchedDetail(resource);
 
   const [fetched, setFetched] = useState<{

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -34,15 +34,14 @@ function TimingRow({
   label,
   description,
   value,
+  fallback = 'None',
 }: {
   label: string;
   description: string;
   value: number | undefined;
+  fallback?: string;
 }) {
   const formatted = formatDuration(value);
-  if (!formatted) {
-    return null;
-  }
 
   return (
     <div className="flex min-h-8 items-center justify-between gap-4 border-t border-gray-alpha-400 first:border-t-0">
@@ -53,8 +52,12 @@ function TimingRow({
         <span className="truncate">{label}</span>
         <Info aria-hidden className="h-3 w-3 shrink-0 text-gray-700" />
       </span>
-      <span className="shrink-0 text-label-13 font-medium tabular-nums text-gray-1000">
-        {formatted}
+      <span
+        className={`shrink-0 text-label-13 font-medium tabular-nums ${
+          formatted ? 'text-gray-1000' : 'text-gray-900'
+        }`}
+      >
+        {formatted ?? fallback}
       </span>
     </div>
   );

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -12,8 +12,8 @@ import { DetailCard } from './detail-card';
 
 const TIMING_LABELS = {
   coldStart: {
-    label: 'Cold Start',
-    description: 'Time Fluid spent starting a new VM for this invocation.',
+    label: 'Cold VM Start',
+    description: 'Time Fluid spent starting a cold VM for this invocation.',
   },
   moduleInit: {
     label: 'Module Init',

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -10,11 +10,6 @@ import {
   type WorkflowSpanTiming,
   type WorkflowSpanTimingAttempt,
 } from '../../lib/workflow-span-timing';
-import {
-  CollapsibleContent,
-  CollapsibleRoot,
-  CollapsibleTrigger,
-} from '../ui/collapsible';
 import { Skeleton } from '../ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 
@@ -30,7 +25,8 @@ const TIMING_LABELS = {
   },
   workflowOverhead: {
     label: 'Workflow Overhead',
-    description: 'Duration of the first Workflow API request.',
+    description:
+      'Remaining time between creation and start after cold start and module initialization.',
   },
 };
 
@@ -246,26 +242,24 @@ export function WorkflowTimingBreakdown({
     : false;
 
   return (
-    <CollapsibleRoot>
-      <CollapsibleTrigger>Queued</CollapsibleTrigger>
-      <CollapsibleContent className="mb-4">
-        <div className="space-y-3">
-          {isLoading ? <TimingRowsSkeleton /> : null}
-          {!isLoading &&
-            breakdowns.map(({ attempt, breakdown, index }) => {
-              return (
-                <div key={`${attemptLabel(attempt, index)}-${index}`}>
-                  {showAttemptLabels ? (
-                    <div className="mb-2 text-label-13 text-gray-900">
-                      {attemptLabel(attempt, index)}
-                    </div>
-                  ) : null}
-                  <TimingRows breakdown={breakdown} />
+    <>
+      {isLoading ? <TimingRowsSkeleton /> : null}
+      {!isLoading &&
+        breakdowns.map(({ attempt, breakdown, index }) => {
+          return (
+            <div
+              className="flex flex-col"
+              key={`${attemptLabel(attempt, index)}-${index}`}
+            >
+              {showAttemptLabels ? (
+                <div className="-mx-1.5 px-1.5 pb-0.5 pt-2 text-label-12 text-gray-700">
+                  {attemptLabel(attempt, index)}
                 </div>
-              );
-            })}
-        </div>
-      </CollapsibleContent>
-    </CollapsibleRoot>
+              ) : null}
+              <TimingRows breakdown={breakdown} />
+            </div>
+          );
+        })}
+    </>
   );
 }

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -8,6 +8,7 @@ import {
   type WorkflowSpanTiming,
   type WorkflowSpanTimingAttempt,
 } from '../../lib/workflow-span-timing';
+import { Skeleton } from '../ui/skeleton';
 import { DetailCard } from './detail-card';
 
 const TIMING_LABELS = {
@@ -109,6 +110,26 @@ function TimingRows({
   );
 }
 
+function TimingRowsSkeleton() {
+  return (
+    <div className="rounded-md border border-gray-alpha-400 bg-background-200 px-3 py-1">
+      {[
+        TIMING_LABELS.coldStart.label,
+        TIMING_LABELS.moduleInit.label,
+        TIMING_LABELS.workflowOverhead.label,
+      ].map((label) => (
+        <div
+          className="flex min-h-8 items-center justify-between gap-4 border-t border-gray-alpha-400 first:border-t-0"
+          key={label}
+        >
+          <span className="text-label-13 text-gray-900">{label}</span>
+          <Skeleton className="h-4 w-14" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function WorkflowTimingBreakdown({
   timing,
   resource,
@@ -116,11 +137,21 @@ export function WorkflowTimingBreakdown({
   timing?: WorkflowSpanTiming;
   resource?: string;
 }) {
-  if (!timing || (resource !== 'run' && resource !== 'step')) {
+  if (resource !== 'run' && resource !== 'step') {
     return null;
   }
 
-  const attempts = timing.attempts?.length ? timing.attempts : [timing];
+  const isLoading = Boolean(timing?.isLoading);
+
+  if (!timing && !isLoading) {
+    return null;
+  }
+
+  const attempts = timing?.attempts?.length
+    ? timing.attempts
+    : timing
+      ? [timing]
+      : [];
   const breakdowns = attempts
     .map((attempt, index) => ({
       attempt,
@@ -137,60 +168,37 @@ export function WorkflowTimingBreakdown({
       } => item.breakdown !== null
     );
 
-  if (breakdowns.length === 0) {
+  if (breakdowns.length === 0 && !isLoading) {
     return null;
   }
 
-  const showAttemptLabels = hasRepeatedAttemptLabel(
-    timing,
-    breakdowns.map((item) => item.breakdown)
-  );
-  const summaryDuration =
-    breakdowns.length === 1
-      ? formatDuration(
-          breakdowns[0].breakdown.firstWorkflowRequestStartOffsetMs ??
-            breakdowns[0].breakdown.queuedDurationMs
-        )
-      : null;
+  const showAttemptLabels = timing
+    ? hasRepeatedAttemptLabel(
+        timing,
+        breakdowns.map((item) => item.breakdown)
+      )
+    : false;
 
   return (
     <DetailCard
       contentClassName="mb-4"
-      defaultOpen
-      summary={
-        <span className="flex min-w-0 flex-1 items-center justify-between gap-3">
-          <span className="truncate">Queued</span>
-          {summaryDuration ? (
-            <span className="shrink-0 text-label-13 font-normal tabular-nums text-gray-900">
-              {summaryDuration}
-            </span>
-          ) : null}
-        </span>
-      }
+      summary={<span className="min-w-0 flex-1 truncate">Queued</span>}
     >
       <div className="space-y-3">
-        {breakdowns.map(({ attempt, breakdown, index }) => {
-          const attemptStartOffset = formatDuration(
-            breakdown.firstWorkflowRequestStartOffsetMs
-          );
-          return (
-            <div key={`${attemptLabel(attempt, index)}-${index}`}>
-              {showAttemptLabels ? (
-                <div className="mb-2 flex items-center justify-between gap-3 text-label-13 text-gray-900">
-                  <span className="truncate">
+        {isLoading ? <TimingRowsSkeleton /> : null}
+        {!isLoading &&
+          breakdowns.map(({ attempt, breakdown, index }) => {
+            return (
+              <div key={`${attemptLabel(attempt, index)}-${index}`}>
+                {showAttemptLabels ? (
+                  <div className="mb-2 text-label-13 text-gray-900">
                     {attemptLabel(attempt, index)}
-                  </span>
-                  {attemptStartOffset ? (
-                    <span className="shrink-0 tabular-nums">
-                      {attemptStartOffset}
-                    </span>
-                  ) : null}
-                </div>
-              ) : null}
-              <TimingRows breakdown={breakdown} />
-            </div>
-          );
-        })}
+                  </div>
+                ) : null}
+                <TimingRows breakdown={breakdown} />
+              </div>
+            );
+          })}
       </div>
     </DetailCard>
   );

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -12,7 +12,7 @@ import { DetailCard } from './detail-card';
 
 const TIMING_LABELS = {
   coldStart: {
-    label: 'Cold VM Start',
+    label: 'Cold start',
     description: 'Time Fluid spent starting a cold VM for this invocation.',
   },
   moduleInit: {

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -2,6 +2,7 @@
 
 import { Info } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { cn } from '../../lib/cn';
 import { formatDurationPrecise } from '../../lib/utils';
 import {
   type DerivedWorkflowTimingBreakdown,
@@ -9,9 +10,13 @@ import {
   type WorkflowSpanTiming,
   type WorkflowSpanTimingAttempt,
 } from '../../lib/workflow-span-timing';
+import {
+  CollapsibleContent,
+  CollapsibleRoot,
+  CollapsibleTrigger,
+} from '../ui/collapsible';
 import { Skeleton } from '../ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-import { DetailCard } from './detail-card';
 
 const TIMING_LABELS = {
   coldStart: {
@@ -32,6 +37,8 @@ const TIMING_LABELS = {
 const MODULE_INIT_WARNING_THRESHOLD_MS = 50;
 const MODULE_INIT_WARNING_DESCRIPTION =
   'Module loading took over 50ms. Move expensive imports or startup work out of module scope, or lazy-load them before making Workflow requests.';
+const timingRowClassName =
+  'px-1.5 hover:bg-gray-100 flex justify-between gap-3 -mx-1.5 py-0.5 rounded items-center';
 
 function formatDuration(value: number | undefined): string | null {
   return value === undefined ? null : formatDurationPrecise(value);
@@ -102,16 +109,17 @@ function TimingRow({
   const formatted = formatDuration(value);
 
   return (
-    <div className="flex min-h-8 items-center justify-between gap-4 border-t border-gray-alpha-400 first:border-t-0">
-      <span className="inline-flex min-w-0 items-center gap-1.5 text-label-13 text-gray-900">
+    <div className={timingRowClassName}>
+      <span className="flex min-w-0 items-center gap-1.5 truncate text-label-13 text-gray-900">
         <span className="truncate">{label}</span>
         <TimingInfoTooltip description={description} label={label} />
         {badge}
       </span>
       <span
-        className={`shrink-0 text-label-13 font-medium tabular-nums ${
+        className={cn(
+          'max-w-[60%] shrink-0 truncate text-right text-copy-13 tabular-nums',
           formatted ? 'text-gray-1000' : 'text-gray-900'
-        }`}
+        )}
       >
         {formatted ?? fallback}
       </span>
@@ -145,7 +153,7 @@ function TimingRows({
   breakdown: DerivedWorkflowTimingBreakdown;
 }) {
   return (
-    <div className="rounded-md border border-gray-alpha-400 bg-background-200 px-3 py-1">
+    <div className="flex flex-col">
       <TimingRow
         description={TIMING_LABELS.coldStart.description}
         label={TIMING_LABELS.coldStart.label}
@@ -173,16 +181,13 @@ function TimingRows({
 
 function TimingRowsSkeleton() {
   return (
-    <div className="rounded-md border border-gray-alpha-400 bg-background-200 px-3 py-1">
+    <div className="flex flex-col">
       {[
         TIMING_LABELS.coldStart.label,
         TIMING_LABELS.moduleInit.label,
         TIMING_LABELS.workflowOverhead.label,
       ].map((label) => (
-        <div
-          className="flex min-h-8 items-center justify-between gap-4 border-t border-gray-alpha-400 first:border-t-0"
-          key={label}
-        >
+        <div className={timingRowClassName} key={label}>
           <span className="text-label-13 text-gray-900">{label}</span>
           <Skeleton className="h-4 w-14" />
         </div>
@@ -241,26 +246,26 @@ export function WorkflowTimingBreakdown({
     : false;
 
   return (
-    <DetailCard
-      contentClassName="mb-4"
-      summary={<span className="min-w-0 flex-1 truncate">Queued</span>}
-    >
-      <div className="space-y-3">
-        {isLoading ? <TimingRowsSkeleton /> : null}
-        {!isLoading &&
-          breakdowns.map(({ attempt, breakdown, index }) => {
-            return (
-              <div key={`${attemptLabel(attempt, index)}-${index}`}>
-                {showAttemptLabels ? (
-                  <div className="mb-2 text-label-13 text-gray-900">
-                    {attemptLabel(attempt, index)}
-                  </div>
-                ) : null}
-                <TimingRows breakdown={breakdown} />
-              </div>
-            );
-          })}
-      </div>
-    </DetailCard>
+    <CollapsibleRoot>
+      <CollapsibleTrigger>Queued</CollapsibleTrigger>
+      <CollapsibleContent className="mb-4">
+        <div className="space-y-3">
+          {isLoading ? <TimingRowsSkeleton /> : null}
+          {!isLoading &&
+            breakdowns.map(({ attempt, breakdown, index }) => {
+              return (
+                <div key={`${attemptLabel(attempt, index)}-${index}`}>
+                  {showAttemptLabels ? (
+                    <div className="mb-2 text-label-13 text-gray-900">
+                      {attemptLabel(attempt, index)}
+                    </div>
+                  ) : null}
+                  <TimingRows breakdown={breakdown} />
+                </div>
+              );
+            })}
+        </div>
+      </CollapsibleContent>
+    </CollapsibleRoot>
   );
 }

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Info } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { formatDurationPrecise } from '../../lib/utils';
 import {
   type DerivedWorkflowTimingBreakdown,
@@ -14,12 +15,12 @@ import { DetailCard } from './detail-card';
 const TIMING_LABELS = {
   coldStart: {
     label: 'Cold start',
-    description: 'Time Fluid spent starting a cold VM for this invocation.',
+    description: 'Fluid Compute function cold start time.',
   },
   moduleInit: {
     label: 'Module Init',
     description:
-      'Time before the first Workflow API request that was not cold start.',
+      'Time it took to load the function module before the first Workflow request was made.',
   },
   workflowOverhead: {
     label: 'Workflow Overhead',
@@ -27,19 +28,39 @@ const TIMING_LABELS = {
   },
 };
 
+const MODULE_INIT_WARNING_THRESHOLD_MS = 50;
+
 function formatDuration(value: number | undefined): string | null {
   return value === undefined ? null : formatDurationPrecise(value);
+}
+
+function ModuleInitWarningBadge() {
+  return (
+    <span
+      className="shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium leading-none"
+      style={{
+        borderColor: 'var(--ds-red-400)',
+        backgroundColor: 'var(--ds-red-100)',
+        color: 'var(--ds-red-900)',
+      }}
+      title="Module loading took over 50ms. Check module-level imports and initialization code."
+    >
+      Check code
+    </span>
+  );
 }
 
 function TimingRow({
   label,
   description,
   value,
+  badge,
   fallback = 'None',
 }: {
   label: string;
   description: string;
   value: number | undefined;
+  badge?: ReactNode;
   fallback?: string;
 }) {
   const formatted = formatDuration(value);
@@ -52,6 +73,7 @@ function TimingRow({
       >
         <span className="truncate">{label}</span>
         <Info aria-hidden className="h-3 w-3 shrink-0 text-gray-700" />
+        {badge}
       </span>
       <span
         className={`shrink-0 text-label-13 font-medium tabular-nums ${
@@ -97,6 +119,12 @@ function TimingRows({
         value={breakdown.coldStartDurationMs}
       />
       <TimingRow
+        badge={
+          breakdown.moduleInitDurationMs !== undefined &&
+          breakdown.moduleInitDurationMs > MODULE_INIT_WARNING_THRESHOLD_MS ? (
+            <ModuleInitWarningBadge />
+          ) : undefined
+        }
         description={TIMING_LABELS.moduleInit.description}
         label={TIMING_LABELS.moduleInit.label}
         value={breakdown.moduleInitDurationMs}

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -10,6 +10,7 @@ import {
   type WorkflowSpanTimingAttempt,
 } from '../../lib/workflow-span-timing';
 import { Skeleton } from '../ui/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { DetailCard } from './detail-card';
 
 const TIMING_LABELS = {
@@ -29,24 +30,59 @@ const TIMING_LABELS = {
 };
 
 const MODULE_INIT_WARNING_THRESHOLD_MS = 50;
+const MODULE_INIT_WARNING_DESCRIPTION =
+  'Module loading took over 50ms. Move expensive imports or startup work out of module scope, or lazy-load them before making Workflow requests.';
 
 function formatDuration(value: number | undefined): string | null {
   return value === undefined ? null : formatDurationPrecise(value);
 }
 
+function TimingInfoTooltip({
+  label,
+  description,
+}: {
+  label: string;
+  description: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          aria-label={`${label} timing info`}
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-gray-700 transition-colors hover:text-gray-1000 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
+          type="button"
+        >
+          <Info aria-hidden className="h-3 w-3" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs text-left">
+        {description}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function ModuleInitWarningBadge() {
   return (
-    <span
-      className="shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium leading-none"
-      style={{
-        borderColor: 'var(--ds-red-400)',
-        backgroundColor: 'var(--ds-red-100)',
-        color: 'var(--ds-red-900)',
-      }}
-      title="Module loading took over 50ms. Check module-level imports and initialization code."
-    >
-      Check code
-    </span>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          aria-label="High module init timing"
+          className="shrink-0 cursor-help rounded-sm border px-1.5 py-0.5 text-[10px] font-medium leading-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-900"
+          style={{
+            borderColor: 'var(--ds-red-400)',
+            backgroundColor: 'var(--ds-red-100)',
+            color: 'var(--ds-red-900)',
+          }}
+          type="button"
+        >
+          High
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs text-left">
+        {MODULE_INIT_WARNING_DESCRIPTION}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -67,12 +103,9 @@ function TimingRow({
 
   return (
     <div className="flex min-h-8 items-center justify-between gap-4 border-t border-gray-alpha-400 first:border-t-0">
-      <span
-        className="inline-flex min-w-0 items-center gap-1.5 text-label-13 text-gray-900"
-        title={description}
-      >
+      <span className="inline-flex min-w-0 items-center gap-1.5 text-label-13 text-gray-900">
         <span className="truncate">{label}</span>
-        <Info aria-hidden className="h-3 w-3 shrink-0 text-gray-700" />
+        <TimingInfoTooltip description={description} label={label} />
         {badge}
       </span>
       <span

--- a/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
+++ b/packages/web-shared/src/components/sidebar/workflow-timing-breakdown.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { Info } from 'lucide-react';
+import { formatDurationPrecise } from '../../lib/utils';
+import {
+  type DerivedWorkflowTimingBreakdown,
+  deriveWorkflowTimingBreakdown,
+  type WorkflowSpanTiming,
+  type WorkflowSpanTimingAttempt,
+} from '../../lib/workflow-span-timing';
+import { DetailCard } from './detail-card';
+
+const TIMING_LABELS = {
+  coldStart: {
+    label: 'Cold Start',
+    description: 'Time Fluid spent starting a new VM for this invocation.',
+  },
+  moduleInit: {
+    label: 'Module Init',
+    description:
+      'Time before the first Workflow API request that was not cold start.',
+  },
+  workflowOverhead: {
+    label: 'Workflow Overhead',
+    description: 'Duration of the first Workflow API request.',
+  },
+};
+
+function formatDuration(value: number | undefined): string | null {
+  return value === undefined ? null : formatDurationPrecise(value);
+}
+
+function TimingRow({
+  label,
+  description,
+  value,
+}: {
+  label: string;
+  description: string;
+  value: number | undefined;
+}) {
+  const formatted = formatDuration(value);
+  if (!formatted) {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-8 items-center justify-between gap-4 border-t border-gray-alpha-400 first:border-t-0">
+      <span
+        className="inline-flex min-w-0 items-center gap-1.5 text-label-13 text-gray-900"
+        title={description}
+      >
+        <span className="truncate">{label}</span>
+        <Info aria-hidden className="h-3 w-3 shrink-0 text-gray-700" />
+      </span>
+      <span className="shrink-0 text-label-13 font-medium tabular-nums text-gray-1000">
+        {formatted}
+      </span>
+    </div>
+  );
+}
+
+function hasRepeatedAttemptLabel(
+  timing: WorkflowSpanTiming,
+  breakdowns: DerivedWorkflowTimingBreakdown[]
+) {
+  return Boolean(timing.attempts?.length) && breakdowns.length > 1;
+}
+
+function attemptLabel(
+  attempt: WorkflowSpanTimingAttempt | WorkflowSpanTiming,
+  index: number
+) {
+  if ('label' in attempt && attempt.label) {
+    return attempt.label;
+  }
+  if ('attempt' in attempt && typeof attempt.attempt === 'number') {
+    return `Attempt ${attempt.attempt}`;
+  }
+  return `Attempt ${index + 1}`;
+}
+
+function TimingRows({
+  breakdown,
+}: {
+  breakdown: DerivedWorkflowTimingBreakdown;
+}) {
+  return (
+    <div className="rounded-md border border-gray-alpha-400 bg-background-200 px-3 py-1">
+      <TimingRow
+        description={TIMING_LABELS.coldStart.description}
+        label={TIMING_LABELS.coldStart.label}
+        value={breakdown.coldStartDurationMs}
+      />
+      <TimingRow
+        description={TIMING_LABELS.moduleInit.description}
+        label={TIMING_LABELS.moduleInit.label}
+        value={breakdown.moduleInitDurationMs}
+      />
+      <TimingRow
+        description={TIMING_LABELS.workflowOverhead.description}
+        label={TIMING_LABELS.workflowOverhead.label}
+        value={breakdown.workflowOverheadDurationMs}
+      />
+    </div>
+  );
+}
+
+export function WorkflowTimingBreakdown({
+  timing,
+  resource,
+}: {
+  timing?: WorkflowSpanTiming;
+  resource?: string;
+}) {
+  if (!timing || (resource !== 'run' && resource !== 'step')) {
+    return null;
+  }
+
+  const attempts = timing.attempts?.length ? timing.attempts : [timing];
+  const breakdowns = attempts
+    .map((attempt, index) => ({
+      attempt,
+      index,
+      breakdown: deriveWorkflowTimingBreakdown(attempt),
+    }))
+    .filter(
+      (
+        item
+      ): item is {
+        attempt: WorkflowSpanTimingAttempt | WorkflowSpanTiming;
+        index: number;
+        breakdown: DerivedWorkflowTimingBreakdown;
+      } => item.breakdown !== null
+    );
+
+  if (breakdowns.length === 0) {
+    return null;
+  }
+
+  const showAttemptLabels = hasRepeatedAttemptLabel(
+    timing,
+    breakdowns.map((item) => item.breakdown)
+  );
+  const summaryDuration =
+    breakdowns.length === 1
+      ? formatDuration(
+          breakdowns[0].breakdown.firstWorkflowRequestStartOffsetMs ??
+            breakdowns[0].breakdown.queuedDurationMs
+        )
+      : null;
+
+  return (
+    <DetailCard
+      contentClassName="mb-4"
+      defaultOpen
+      summary={
+        <span className="flex min-w-0 flex-1 items-center justify-between gap-3">
+          <span className="truncate">Queued</span>
+          {summaryDuration ? (
+            <span className="shrink-0 text-label-13 font-normal tabular-nums text-gray-900">
+              {summaryDuration}
+            </span>
+          ) : null}
+        </span>
+      }
+    >
+      <div className="space-y-3">
+        {breakdowns.map(({ attempt, breakdown, index }) => {
+          const attemptStartOffset = formatDuration(
+            breakdown.firstWorkflowRequestStartOffsetMs
+          );
+          return (
+            <div key={`${attemptLabel(attempt, index)}-${index}`}>
+              {showAttemptLabels ? (
+                <div className="mb-2 flex items-center justify-between gap-3 text-label-13 text-gray-900">
+                  <span className="truncate">
+                    {attemptLabel(attempt, index)}
+                  </span>
+                  {attemptStartOffset ? (
+                    <span className="shrink-0 tabular-nums">
+                      {attemptStartOffset}
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
+              <TimingRows breakdown={breakdown} />
+            </div>
+          );
+        })}
+      </div>
+    </DetailCard>
+  );
+}

--- a/packages/web-shared/src/components/trace-viewer-new.tsx
+++ b/packages/web-shared/src/components/trace-viewer-new.tsx
@@ -21,6 +21,7 @@ const NewTraceViewer = ({
   hasMore,
   isLoadingMore,
   loading = false,
+  showWorkflowTimingBreakdown = false,
   spanTimings,
 }: {
   run: WorkflowRun;
@@ -30,6 +31,7 @@ const NewTraceViewer = ({
   hasMore?: boolean;
   isLoadingMore?: boolean;
   loading?: boolean;
+  showWorkflowTimingBreakdown?: boolean;
   spanTimings?: WorkflowSpanTimingMap;
 }) => {
   const trace: TraceWithMeta | undefined = useMemo(() => {
@@ -55,6 +57,7 @@ const NewTraceViewer = ({
           onLoadMore={onLoadMore}
           hasMore={hasMore}
           isLoadingMore={isLoadingMore}
+          showWorkflowTimingBreakdown={showWorkflowTimingBreakdown}
         />
       </div>
     </SidebarDataProvider>

--- a/packages/web-shared/src/components/trace-viewer-new.tsx
+++ b/packages/web-shared/src/components/trace-viewer-new.tsx
@@ -2,6 +2,10 @@ import type { WorkflowRun } from '@workflow/core/runtime';
 import type { Event } from '@workflow/world';
 import { useMemo } from 'react';
 import { buildTrace, type TraceWithMeta } from '../lib/trace-builder';
+import {
+  type WorkflowSpanTimingMap,
+  withWorkflowSpanTimings,
+} from '../lib/workflow-span-timing';
 import { TraceViewerSkeleton } from './new-trace-viewer/components/trace-viewer-skeleton';
 import { NewTraceViewer as NewTraceViewerComponent } from './new-trace-viewer/trace-viewer';
 import {
@@ -17,6 +21,7 @@ const NewTraceViewer = ({
   hasMore,
   isLoadingMore,
   loading = false,
+  spanTimings,
 }: {
   run: WorkflowRun;
   events: Event[];
@@ -25,14 +30,18 @@ const NewTraceViewer = ({
   hasMore?: boolean;
   isLoadingMore?: boolean;
   loading?: boolean;
+  spanTimings?: WorkflowSpanTimingMap;
 }) => {
   const trace: TraceWithMeta | undefined = useMemo(() => {
     if (!run?.runId) {
       return undefined;
     }
-    return buildTrace(run, events, new Date());
+    return withWorkflowSpanTimings(
+      buildTrace(run, events, new Date()),
+      spanTimings
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `new Date()` is intentionally not a dep
-  }, [run, events]);
+  }, [run, events, spanTimings]);
 
   if (!trace || (loading && events.length === 0)) {
     return <TraceViewerSkeleton />;

--- a/packages/web-shared/src/components/trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/trace-viewer/trace-viewer.tsx
@@ -173,9 +173,12 @@ export function TraceViewerTimeline({
       for (const [id, newNode] of Object.entries(newSpanMap)) {
         const oldNode = oldSpanMap[id];
         if (oldNode) {
+          const attributesChanged =
+            oldNode.span.attributes !== newNode.span.attributes;
           if (
             oldNode.endTime !== newNode.endTime ||
-            oldNode.duration !== newNode.duration
+            oldNode.duration !== newNode.duration ||
+            attributesChanged
           ) {
             oldNode.endTime = newNode.endTime;
             oldNode.duration = newNode.duration;

--- a/packages/web-shared/src/components/workflow-trace-view.tsx
+++ b/packages/web-shared/src/components/workflow-trace-view.tsx
@@ -22,6 +22,11 @@ import {
   filterSpanRawEvents,
   type TraceWithMeta,
 } from '../lib/trace-builder';
+import {
+  getWorkflowSpanTiming,
+  type WorkflowSpanTimingMap,
+  withWorkflowSpanTimings,
+} from '../lib/workflow-span-timing';
 import { ErrorBoundary } from './error-boundary';
 import {
   EntityDetailPanel,
@@ -620,18 +625,33 @@ function SelectionBridge({
   const { selected } = state;
   const onSelectionChangeRef = useRef(onSelectionChange);
   onSelectionChangeRef.current = onSelectionChange;
-  const prevSpanIdRef = useRef<string | undefined>(undefined);
+  const prevSelectionRef = useRef<{
+    spanId: string | undefined;
+    timing: ReturnType<typeof getWorkflowSpanTiming>;
+  }>({ spanId: undefined, timing: undefined });
 
   useEffect(() => {
     const currentSpanId = selected?.span.spanId;
-    if (currentSpanId === prevSpanIdRef.current) return;
-    prevSpanIdRef.current = currentSpanId;
+    const currentTiming = selected
+      ? getWorkflowSpanTiming(selected.span.attributes)
+      : undefined;
+    if (
+      currentSpanId === prevSelectionRef.current.spanId &&
+      currentTiming === prevSelectionRef.current.timing
+    ) {
+      return;
+    }
+    prevSelectionRef.current = {
+      spanId: currentSpanId,
+      timing: currentTiming,
+    };
 
     if (selected) {
       onSelectionChangeRef.current({
         data: selected.span.attributes?.data,
         resource: selected.span.attributes?.resource as string | undefined,
         spanId: selected.span.spanId,
+        timing: currentTiming,
       });
     } else {
       onSelectionChangeRef.current(null);
@@ -779,6 +799,7 @@ export const WorkflowTraceViewer = ({
   onDecrypt,
   isDecrypting = false,
   showSeparateEventOccurrenceTimestamps = false,
+  spanTimings,
 }: {
   run: WorkflowRun;
   events: Event[];
@@ -819,6 +840,8 @@ export const WorkflowTraceViewer = ({
   isDecrypting?: boolean;
   /** Show occurredAt separately instead of folding it into the Created timestamp. */
   showSeparateEventOccurrenceTimestamps?: boolean;
+  /** Optional log-derived timing data keyed by trace span ID. */
+  spanTimings?: WorkflowSpanTimingMap;
 }) => {
   const toast = useToast();
   const [selectedSpan, setSelectedSpan] = useState<SelectedSpanInfo | null>(
@@ -839,9 +862,12 @@ export const WorkflowTraceViewer = ({
     if (!run?.runId) {
       return undefined;
     }
-    return buildTrace(run, events, new Date());
+    return withWorkflowSpanTimings(
+      buildTrace(run, events, new Date()),
+      spanTimings
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `new Date()` is intentionally not a dep; useLiveTick handles live growth
-  }, [run, events]);
+  }, [run, events, spanTimings]);
   const trace = traceWithMeta;
 
   useEffect(() => {

--- a/packages/web-shared/src/components/workflow-trace-view.tsx
+++ b/packages/web-shared/src/components/workflow-trace-view.tsx
@@ -799,6 +799,7 @@ export const WorkflowTraceViewer = ({
   onDecrypt,
   isDecrypting = false,
   showSeparateEventOccurrenceTimestamps = false,
+  showWorkflowTimingBreakdown = false,
   spanTimings,
 }: {
   run: WorkflowRun;
@@ -840,6 +841,8 @@ export const WorkflowTraceViewer = ({
   isDecrypting?: boolean;
   /** Show occurredAt separately instead of folding it into the Created timestamp. */
   showSeparateEventOccurrenceTimestamps?: boolean;
+  /** Show log-derived cold start, module init, and workflow overhead timing rows. */
+  showWorkflowTimingBreakdown?: boolean;
   /** Optional log-derived timing data keyed by trace span ID. */
   spanTimings?: WorkflowSpanTimingMap;
 }) => {
@@ -1185,6 +1188,7 @@ export const WorkflowTraceViewer = ({
                 showSeparateEventOccurrenceTimestamps={
                   showSeparateEventOccurrenceTimestamps
                 }
+                showWorkflowTimingBreakdown={showWorkflowTimingBreakdown}
               />
             </ErrorBoundary>
           </div>

--- a/packages/web-shared/src/lib/workflow-span-timing.ts
+++ b/packages/web-shared/src/lib/workflow-span-timing.ts
@@ -6,6 +6,8 @@ export const WORKFLOW_SPAN_TIMING_ATTRIBUTE = 'workflowTiming';
 export type WorkflowTimingTimeValue = Date | number | string;
 
 export interface WorkflowQueuedTiming {
+  /** Whether timing data is currently being fetched for this span. */
+  isLoading?: boolean;
   /** Vercel request id for the function invocation that produced this timing. */
   requestId?: string;
   /** Timestamp for the start of the function invocation. */

--- a/packages/web-shared/src/lib/workflow-span-timing.ts
+++ b/packages/web-shared/src/lib/workflow-span-timing.ts
@@ -1,0 +1,207 @@
+import type { Span } from '../components/trace-viewer/types';
+import type { TraceWithMeta } from './trace-builder';
+
+export const WORKFLOW_SPAN_TIMING_ATTRIBUTE = 'workflowTiming';
+
+export type WorkflowTimingTimeValue = Date | number | string;
+
+export interface WorkflowQueuedTiming {
+  /** Vercel request id for the function invocation that produced this timing. */
+  requestId?: string;
+  /** Timestamp for the start of the function invocation. */
+  invocationStartedAt?: WorkflowTimingTimeValue;
+  /** Timestamp for the first Workflow API request made by this invocation. */
+  firstWorkflowRequestStartedAt?: WorkflowTimingTimeValue;
+  /** Milliseconds from invocation start to the first Workflow API request. */
+  firstWorkflowRequestStartOffsetMs?: number;
+  /** Fluid VM cold-start duration, when the invocation was cold. */
+  coldStartDurationMs?: number;
+  /** Function start type reported by Fluid, e.g. "cold". */
+  functionStartType?: string;
+  /**
+   * Time spent before the first Workflow API request that is not accounted for
+   * by VM cold start, usually module imports and user initialization.
+   */
+  moduleInitDurationMs?: number;
+  /** Duration of the first Workflow API request. */
+  workflowOverheadDurationMs?: number;
+  /** Alias for workflowOverheadDurationMs used by logs request metrics. */
+  firstWorkflowRequestDurationMs?: number;
+  /** Total queued/pre-execution duration, when known directly. */
+  queuedDurationMs?: number;
+}
+
+export interface WorkflowSpanTimingAttempt extends WorkflowQueuedTiming {
+  attempt?: number;
+  label?: string;
+}
+
+export interface WorkflowSpanTiming extends WorkflowQueuedTiming {
+  attempts?: WorkflowSpanTimingAttempt[];
+}
+
+export type WorkflowSpanTimingMap = Record<
+  string,
+  WorkflowSpanTiming | undefined
+>;
+
+export interface DerivedWorkflowTimingBreakdown {
+  requestId?: string;
+  label?: string;
+  attempt?: number;
+  functionStartType?: string;
+  coldStartDurationMs?: number;
+  moduleInitDurationMs?: number;
+  workflowOverheadDurationMs?: number;
+  firstWorkflowRequestStartOffsetMs?: number;
+  queuedDurationMs?: number;
+}
+
+function finiteDuration(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return value;
+}
+
+function timeValueToMs(value: WorkflowTimingTimeValue | undefined) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isFinite(ms) ? ms : undefined;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function durationBetween(
+  start: WorkflowTimingTimeValue | undefined,
+  end: WorkflowTimingTimeValue | undefined
+) {
+  const startMs = timeValueToMs(start);
+  const endMs = timeValueToMs(end);
+  if (startMs === undefined || endMs === undefined || endMs < startMs) {
+    return undefined;
+  }
+  return endMs - startMs;
+}
+
+function isColdStart(
+  functionStartType: string | undefined,
+  coldStartDurationMs: number | undefined
+) {
+  return (
+    coldStartDurationMs !== undefined &&
+    (coldStartDurationMs > 0 || functionStartType?.toLowerCase() === 'cold')
+  );
+}
+
+export function deriveWorkflowTimingBreakdown(
+  timing: WorkflowQueuedTiming | undefined
+): DerivedWorkflowTimingBreakdown | null {
+  if (!timing) {
+    return null;
+  }
+
+  const workflowOverheadDurationMs =
+    finiteDuration(timing.workflowOverheadDurationMs) ??
+    finiteDuration(timing.firstWorkflowRequestDurationMs);
+  const queuedDurationMs = finiteDuration(timing.queuedDurationMs);
+  const firstWorkflowRequestStartOffsetMs =
+    finiteDuration(timing.firstWorkflowRequestStartOffsetMs) ??
+    durationBetween(
+      timing.invocationStartedAt,
+      timing.firstWorkflowRequestStartedAt
+    ) ??
+    (queuedDurationMs !== undefined && workflowOverheadDurationMs !== undefined
+      ? Math.max(0, queuedDurationMs - workflowOverheadDurationMs)
+      : undefined);
+
+  const coldStartDurationCandidate = finiteDuration(timing.coldStartDurationMs);
+  const coldStartDurationMs = isColdStart(
+    timing.functionStartType,
+    coldStartDurationCandidate
+  )
+    ? coldStartDurationCandidate
+    : undefined;
+
+  const moduleInitDurationMs =
+    finiteDuration(timing.moduleInitDurationMs) ??
+    (firstWorkflowRequestStartOffsetMs !== undefined
+      ? Math.max(
+          0,
+          firstWorkflowRequestStartOffsetMs - (coldStartDurationMs ?? 0)
+        )
+      : undefined);
+
+  const derivedQueuedDurationMs =
+    queuedDurationMs ??
+    (firstWorkflowRequestStartOffsetMs !== undefined &&
+    workflowOverheadDurationMs !== undefined
+      ? firstWorkflowRequestStartOffsetMs + workflowOverheadDurationMs
+      : firstWorkflowRequestStartOffsetMs);
+
+  const hasAnyTiming =
+    coldStartDurationMs !== undefined ||
+    moduleInitDurationMs !== undefined ||
+    workflowOverheadDurationMs !== undefined ||
+    firstWorkflowRequestStartOffsetMs !== undefined ||
+    derivedQueuedDurationMs !== undefined;
+
+  if (!hasAnyTiming) {
+    return null;
+  }
+
+  return {
+    requestId: timing.requestId,
+    functionStartType: timing.functionStartType,
+    coldStartDurationMs,
+    moduleInitDurationMs,
+    workflowOverheadDurationMs,
+    firstWorkflowRequestStartOffsetMs,
+    queuedDurationMs: derivedQueuedDurationMs,
+  };
+}
+
+export function getWorkflowSpanTiming(
+  attributes: Record<string, unknown> | undefined
+): WorkflowSpanTiming | undefined {
+  const value = attributes?.[WORKFLOW_SPAN_TIMING_ATTRIBUTE];
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  return value as WorkflowSpanTiming;
+}
+
+export function withWorkflowSpanTimings(
+  trace: TraceWithMeta,
+  spanTimings: WorkflowSpanTimingMap | undefined
+): TraceWithMeta {
+  if (!spanTimings) {
+    return trace;
+  }
+
+  let changed = false;
+  const spans: Span[] = trace.spans.map((span) => {
+    const timing = spanTimings[span.spanId];
+    if (!timing) {
+      return span;
+    }
+
+    changed = true;
+    return {
+      ...span,
+      attributes: {
+        ...span.attributes,
+        [WORKFLOW_SPAN_TIMING_ATTRIBUTE]: timing,
+      },
+    };
+  });
+
+  return changed ? { ...trace, spans } : trace;
+}

--- a/packages/web-shared/src/lib/workflow-span-timing.ts
+++ b/packages/web-shared/src/lib/workflow-span-timing.ts
@@ -25,9 +25,9 @@ export interface WorkflowQueuedTiming {
    * by VM cold start, usually module imports and user initialization.
    */
   moduleInitDurationMs?: number;
-  /** Duration of the first Workflow API request. */
+  /** Precomputed/fallback Workflow overhead duration. */
   workflowOverheadDurationMs?: number;
-  /** Alias for workflowOverheadDurationMs used by logs request metrics. */
+  /** Duration of the first Workflow API request, used as a fallback. */
   firstWorkflowRequestDurationMs?: number;
   /** Total queued/pre-execution duration, when known directly. */
   queuedDurationMs?: number;
@@ -103,6 +103,73 @@ function isColdStart(
   );
 }
 
+function deriveFirstWorkflowRequestStartOffset(
+  timing: WorkflowQueuedTiming,
+  queuedDurationMs: number | undefined,
+  rawWorkflowRequestDurationMs: number | undefined
+) {
+  const explicitOffset = finiteDuration(
+    timing.firstWorkflowRequestStartOffsetMs
+  );
+  if (explicitOffset !== undefined) {
+    return explicitOffset;
+  }
+
+  const timestampOffset = durationBetween(
+    timing.invocationStartedAt,
+    timing.firstWorkflowRequestStartedAt
+  );
+  if (timestampOffset !== undefined) {
+    return timestampOffset;
+  }
+
+  if (
+    queuedDurationMs === undefined ||
+    rawWorkflowRequestDurationMs === undefined
+  ) {
+    return undefined;
+  }
+
+  return Math.max(0, queuedDurationMs - rawWorkflowRequestDurationMs);
+}
+
+function deriveModuleInitDuration(
+  timing: WorkflowQueuedTiming,
+  firstWorkflowRequestStartOffsetMs: number | undefined,
+  coldStartDurationMs: number | undefined
+) {
+  const explicitModuleInitDurationMs = finiteDuration(
+    timing.moduleInitDurationMs
+  );
+  if (explicitModuleInitDurationMs !== undefined) {
+    return explicitModuleInitDurationMs;
+  }
+  if (firstWorkflowRequestStartOffsetMs === undefined) {
+    return undefined;
+  }
+
+  return Math.max(
+    0,
+    firstWorkflowRequestStartOffsetMs - (coldStartDurationMs ?? 0)
+  );
+}
+
+function deriveWorkflowOverheadDuration(
+  queuedDurationMs: number | undefined,
+  coldStartDurationMs: number | undefined,
+  moduleInitDurationMs: number | undefined,
+  fallbackDurationMs: number | undefined
+) {
+  if (queuedDurationMs === undefined || moduleInitDurationMs === undefined) {
+    return fallbackDurationMs;
+  }
+
+  return Math.max(
+    0,
+    queuedDurationMs - (coldStartDurationMs ?? 0) - moduleInitDurationMs
+  );
+}
+
 export function deriveWorkflowTimingBreakdown(
   timing: WorkflowQueuedTiming | undefined
 ): DerivedWorkflowTimingBreakdown | null {
@@ -110,20 +177,10 @@ export function deriveWorkflowTimingBreakdown(
     return null;
   }
 
-  const workflowOverheadDurationMs =
+  const rawWorkflowRequestDurationMs =
     finiteDuration(timing.workflowOverheadDurationMs) ??
     finiteDuration(timing.firstWorkflowRequestDurationMs);
   const queuedDurationMs = finiteDuration(timing.queuedDurationMs);
-  const firstWorkflowRequestStartOffsetMs =
-    finiteDuration(timing.firstWorkflowRequestStartOffsetMs) ??
-    durationBetween(
-      timing.invocationStartedAt,
-      timing.firstWorkflowRequestStartedAt
-    ) ??
-    (queuedDurationMs !== undefined && workflowOverheadDurationMs !== undefined
-      ? Math.max(0, queuedDurationMs - workflowOverheadDurationMs)
-      : undefined);
-
   const coldStartDurationCandidate = finiteDuration(timing.coldStartDurationMs);
   const coldStartDurationMs = isColdStart(
     timing.functionStartType,
@@ -131,15 +188,23 @@ export function deriveWorkflowTimingBreakdown(
   )
     ? coldStartDurationCandidate
     : undefined;
-
-  const moduleInitDurationMs =
-    finiteDuration(timing.moduleInitDurationMs) ??
-    (firstWorkflowRequestStartOffsetMs !== undefined
-      ? Math.max(
-          0,
-          firstWorkflowRequestStartOffsetMs - (coldStartDurationMs ?? 0)
-        )
-      : undefined);
+  const firstWorkflowRequestStartOffsetMs =
+    deriveFirstWorkflowRequestStartOffset(
+      timing,
+      queuedDurationMs,
+      rawWorkflowRequestDurationMs
+    );
+  const moduleInitDurationMs = deriveModuleInitDuration(
+    timing,
+    firstWorkflowRequestStartOffsetMs,
+    coldStartDurationMs
+  );
+  const workflowOverheadDurationMs = deriveWorkflowOverheadDuration(
+    queuedDurationMs,
+    coldStartDurationMs,
+    moduleInitDurationMs,
+    rawWorkflowRequestDurationMs
+  );
 
   const derivedQueuedDurationMs =
     queuedDurationMs ??

--- a/packages/web-shared/test/workflow-span-timing.test.ts
+++ b/packages/web-shared/test/workflow-span-timing.test.ts
@@ -39,4 +39,23 @@ describe('deriveWorkflowTimingBreakdown', () => {
       })
     );
   });
+
+  it('derives workflow overhead from queued duration, cold start, and module init', () => {
+    const breakdown = deriveWorkflowTimingBreakdown({
+      functionStartType: 'cold',
+      queuedDurationMs: 2135,
+      firstWorkflowRequestStartOffsetMs: 1903,
+      coldStartDurationMs: 459,
+      firstWorkflowRequestDurationMs: 999,
+    });
+
+    expect(breakdown).toEqual(
+      expect.objectContaining({
+        coldStartDurationMs: 459,
+        moduleInitDurationMs: 1444,
+        workflowOverheadDurationMs: 232,
+        queuedDurationMs: 2135,
+      })
+    );
+  });
 });

--- a/packages/web-shared/test/workflow-span-timing.test.ts
+++ b/packages/web-shared/test/workflow-span-timing.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { deriveWorkflowTimingBreakdown } from '../src/lib/workflow-span-timing';
+
+describe('deriveWorkflowTimingBreakdown', () => {
+  it('splits first workflow request delay into cold start and module init', () => {
+    const breakdown = deriveWorkflowTimingBreakdown({
+      functionStartType: 'cold',
+      firstWorkflowRequestStartOffsetMs: 1903,
+      coldStartDurationMs: 459,
+      workflowOverheadDurationMs: 232,
+    });
+
+    expect(breakdown).toEqual(
+      expect.objectContaining({
+        firstWorkflowRequestStartOffsetMs: 1903,
+        coldStartDurationMs: 459,
+        moduleInitDurationMs: 1444,
+        workflowOverheadDurationMs: 232,
+        queuedDurationMs: 2135,
+      })
+    );
+  });
+
+  it('can derive the first request offset from queued duration and overhead', () => {
+    const breakdown = deriveWorkflowTimingBreakdown({
+      functionStartType: 'cold',
+      queuedDurationMs: 2135,
+      coldStartDurationMs: 459,
+      firstWorkflowRequestDurationMs: 232,
+    });
+
+    expect(breakdown).toEqual(
+      expect.objectContaining({
+        firstWorkflowRequestStartOffsetMs: 1903,
+        coldStartDurationMs: 459,
+        moduleInitDurationMs: 1444,
+        workflowOverheadDurationMs: 232,
+        queuedDurationMs: 2135,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add optional workflow span timing metadata for trace viewers
- render cold start, module init, and workflow overhead in run/step detail panels
- expose selected span IDs so front can lazily hydrate timing per selected span
- add tests for timing derivation

## Why
Front can combine workflow observability, request logs, and outbound fetch metrics to explain queued time before a workflow run or step starts. web-shared should render that breakdown without owning front-specific data fetching.

## Tarballs
- `@workflow/web-shared@5.0.0-beta.24-454ba29`: https://workflow-tarballs-qjd1vxptg.labs.vercel.dev/workflow-web-shared.tgz
- Catalog: https://workflow-tarballs-git-kk-workflow-trace-timing-breakdown.labs.vercel.dev/catalog.json

## Checks
- `node_modules/.bin/tsc --noEmit -p packages/web-shared/tsconfig.json`
- `../../node_modules/.bin/vitest run test/workflow-span-timing.test.ts` from `packages/web-shared`
- `node_modules/.bin/biome check --write ...` on touched files (completed with existing warnings; no fixes applied)

## CI note
Tarballs deployment and Tarballs Preview Smoke Checks passed. Ubuntu unit tests currently fail in `@workflow/ai` (`workflow-chat-transport.test.ts`), outside this PR’s touched web-shared files.