### PR TITLE
[world-local] Retry transport-level queue delivery failures

### DIFF
--- a/.changeset/world-local-retry-transport-failures.md
+++ b/.changeset/world-local-retry-transport-failures.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Retry local queue deliveries that fail at the transport (e.g. `fetch failed` / `ETIMEDOUT` when the dev server is saturated by many parallel steps) instead of dropping the message, so steps no longer get stuck never-started under high local concurrency.

--- a/packages/world-local/src/queue.test.ts
+++ b/packages/world-local/src/queue.test.ts
@@ -344,3 +344,87 @@ describe('queue delaySeconds', () => {
     expect(mockSetTimeout).not.toHaveBeenCalled();
   });
 });
+
+/** undici's shape for a saturated-local-server connect timeout. */
+function fetchFailedTimeout(): TypeError {
+  const err = new TypeError('fetch failed');
+  (err as TypeError & { cause?: unknown }).cause = new AggregateError(
+    [
+      Object.assign(new Error('connect ETIMEDOUT ::1:3000'), {
+        code: 'ETIMEDOUT',
+      }),
+    ],
+    ''
+  );
+  return err;
+}
+
+describe('transport-level delivery failures are retried (regression)', () => {
+  let localQueue: ReturnType<typeof createQueue>;
+
+  beforeEach(() => {
+    localQueue = createQueue({ baseUrl: 'http://localhost:3000' });
+  });
+
+  afterEach(async () => {
+    await localQueue.close();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('retries an HTTP 500 and recovers (control: non-ok response path)', async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls++;
+        if (calls < 3) return new Response('boom', { status: 500 });
+        return Response.json({ ok: true }, { status: 200 });
+      })
+    );
+
+    await localQueue.queue('__wkf_step_test' as any, stepPayload);
+
+    await vi.waitFor(() => expect(calls).toBe(3));
+  });
+
+  it('retries a "fetch failed"/ETIMEDOUT transport throw instead of dropping it', async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls++;
+        if (calls < 3) throw fetchFailedTimeout();
+        return Response.json({ ok: true }, { status: 200 });
+      })
+    );
+
+    await localQueue.queue('__wkf_step_test' as any, stepPayload);
+
+    // Before the fix this stayed at 1 (the throw escaped the retry loop and the
+    // message was dropped); now it retries until the transient timeout clears.
+    await vi.waitFor(() => expect(calls).toBe(3));
+  });
+
+  it('does NOT advance the handler delivery attempt across transport failures', async () => {
+    // The handler counts x-vqs-message-attempt against MAX_QUEUE_DELIVERIES, so
+    // a burst of transport timeouts must not inflate it: the first delivery that
+    // actually reaches the handler must arrive as attempt 1.
+    const attempts: number[] = [];
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { headers: Record<string, string> }) => {
+        calls++;
+        if (calls < 4) throw fetchFailedTimeout();
+        attempts.push(Number(init.headers['x-vqs-message-attempt']));
+        return Response.json({ ok: true }, { status: 200 });
+      })
+    );
+
+    await localQueue.queue('__wkf_step_test' as any, stepPayload);
+
+    await vi.waitFor(() => expect(attempts.length).toBe(1));
+    expect(attempts[0]).toBe(1);
+  });
+});

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -189,43 +189,88 @@ export function createQueue(config: Partial<Config>): LocalQueue {
       // The actual max delivery enforcement happens in the workflow/step handlers
       // (at MAX_QUEUE_DELIVERIES = 48), so this just needs to be comfortably higher.
       const MAX_LOCAL_SAFETY_LIMIT = 256;
+      // Number of times the message has actually reached a handler (returned
+      // ok, a timeoutSeconds re-delivery, or an HTTP error response). This —
+      // not the loop counter — is the attempt the handler sees via
+      // `x-vqs-message-attempt`, which it counts against MAX_QUEUE_DELIVERIES.
+      // Transport-level failures (below) never reach the handler, so they must
+      // not advance this, or a burst of "fetch failed"/ETIMEDOUT timeouts under
+      // local load would exhaust the handler's delivery budget before its first
+      // real execution.
+      let delivery = 0;
       try {
-        for (let attempt = 0; attempt < MAX_LOCAL_SAFETY_LIMIT; attempt++) {
+        for (let loop = 0; loop < MAX_LOCAL_SAFETY_LIMIT; loop++) {
           const headers: Record<string, string> = {
             ...opts?.headers,
             'content-type': 'application/json',
             'x-vqs-queue-name': queueName,
             'x-vqs-message-id': messageId,
-            'x-vqs-message-attempt': String(attempt + 1),
+            'x-vqs-message-attempt': String(delivery + 1),
           };
           const directHandler = directHandlers.get(prefix);
           let response: Response;
 
-          if (directHandler) {
-            const req = new Request(
-              `http://localhost/.well-known/workflow/v1/${pathname}`,
+          try {
+            if (directHandler) {
+              const req = new Request(
+                `http://localhost/.well-known/workflow/v1/${pathname}`,
+                {
+                  method: 'POST',
+                  headers,
+                  body,
+                }
+              );
+              response = await directHandler(req);
+            } else {
+              const baseUrl = await resolveBaseUrl(config);
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici v7 dispatcher types don't match @types/node's RequestInit
+              response = await fetch(
+                `${baseUrl}/.well-known/workflow/v1/${pathname}`,
+                {
+                  method: 'POST',
+                  duplex: 'half',
+                  dispatcher: httpAgent,
+                  headers,
+                  body,
+                } as any
+              );
+            }
+          } catch (err) {
+            // The delivery never reached the handler: undici threw before a
+            // response. Under heavy local concurrency the single-process dev
+            // server can't accept every connection, so undici reports
+            // `TypeError: fetch failed` with an ETIMEDOUT/ECONNRESET cause.
+            // These are transient — back off and retry the *same* delivery
+            // rather than dropping the message (which would leave the step
+            // never started, with no retry). Two failures are not retryable:
+            //  - shutdown: close() aborted the agent / the backoff sleep.
+            //  - a detached-ArrayBuffer proxy misconfig, which never succeeds —
+            //    rethrow so the outer catch surfaces the actionable guidance.
+            const name = (err as { name?: string } | undefined)?.name;
+            if (
+              closeSignal.aborted ||
+              name === 'AbortError' ||
+              name === 'ResponseAborted'
+            ) {
+              return;
+            }
+            if (isDetachedArrayBufferQueueError(err)) throw err;
+
+            console.error(
+              `[world-local] Queue delivery failed at the transport (loop ${loop + 1}), retrying`,
               {
-                method: 'POST',
-                headers,
-                body,
+                queueName,
+                messageId,
+                ...(runId && { runId }),
+                ...(stepId && { stepId }),
+                error: String(err),
               }
             );
-            response = await directHandler(req);
-          } else {
-            const baseUrl = await resolveBaseUrl(config);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici v7 dispatcher types don't match @types/node's RequestInit
-            response = await fetch(
-              `${baseUrl}/.well-known/workflow/v1/${pathname}`,
-              {
-                method: 'POST',
-                duplex: 'half',
-                dispatcher: httpAgent,
-                headers,
-                body,
-              } as any
-            );
+            await setTimeout(5000, undefined, { signal: closeSignal });
+            continue;
           }
 
+          delivery++;
           const text = await response.text();
 
           if (response.ok) {
@@ -251,7 +296,7 @@ export function createQueue(config: Partial<Config>): LocalQueue {
           }
 
           console.error(
-            `[world-local] Queue message failed (attempt ${attempt + 1}, HTTP ${response.status})`,
+            `[world-local] Queue message failed (attempt ${delivery}, HTTP ${response.status})`,
             {
               queueName,
               messageId,


### PR DESCRIPTION
## Problem

When many steps run in parallel under `world-local` (e.g. a workflow that fans out hundreds of `"use step"` calls via `Promise.all`), the local queue dispatches each delivery as a `fetch()` to the single-process dev server. Under that load the server can't accept every connection, so undici raises `TypeError: fetch failed` with an `AggregateError [ETIMEDOUT]` (or `ECONNRESET`) cause — `localhost` is dual-stack, so both `::1` and `127.0.0.1` connect attempts time out and get aggregated.

The delivery loop only retried **non-ok HTTP responses**. A thrown `fetch()` escaped the loop entirely, landed in the outer `.catch()` (logging `[local world] Queue operation failed:`), and the message was **silently dropped** — the step never started and was never retried. An HTTP 500 got up to 256 retries; a transport timeout got zero.

## Fix

Wrap the dispatch in a try/catch and treat a transport-level throw like a failed delivery: back off 5s and retry the **same** message instead of dropping it. Two cases stay non-retryable:

- shutdown (`close()` aborted the agent / backoff sleep),
- the detached-ArrayBuffer proxy misconfiguration (rethrown so the outer catch keeps surfacing its actionable guidance).

The handler delivery attempt (`x-vqs-message-attempt`, which the step/flow handlers count against `MAX_QUEUE_DELIVERIES = 48`) is now tracked separately from the loop counter, so a burst of transport timeouts can't inflate it and exhaust the handler's delivery budget before its first real execution.

## Tests

Added regression tests in `queue.test.ts`:
- a `fetch failed`/ETIMEDOUT throw is retried until it clears (was dropped at 1 call before),
- an HTTP 500 control still retries (unchanged),
- transport failures do not advance the handler delivery attempt (first real delivery arrives as attempt 1).

All existing `world-local` queue tests, including the detached-ArrayBuffer guidance test, still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)