### PR TITLE
[ai] Fix main: reconnect test stale after merge collision

### DIFF
--- a/.changeset/wet-comics-tell.md
+++ b/.changeset/wet-comics-tell.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update a `WorkflowChatTransport` reconnect test whose expectation predated the always-on UI-message framing normalizer; no runtime change.

--- a/packages/ai/src/workflow-chat-transport.test.ts
+++ b/packages/ai/src/workflow-chat-transport.test.ts
@@ -705,8 +705,12 @@ describe('WorkflowChatTransport', () => {
         // Default initialStartIndex = 0 → filter inactive.
       });
 
-      // Even orphan-looking deltas should pass through unchanged because the
-      // caller didn't ask for a tail-only resume.
+      // Orphan-looking deltas are NOT dropped because the caller didn't ask for
+      // a tail-only resume. The framing normalizer still runs on every reconnect
+      // stream (it repairs damaged framing to keep the AI SDK consumer alive),
+      // so the orphan reasoning-delta survives and gets a synthesized
+      // reasoning-start prepended — rather than being silently discarded the way
+      // the negative-resume orphan filter would.
       mockFetch.mockResolvedValueOnce({
         ok: true,
         headers: new Headers(),
@@ -717,9 +721,20 @@ describe('WorkflowChatTransport', () => {
       });
 
       const stream = await transport.reconnectToStream({ chatId: 'test-chat' });
-      const chunks = (await collect(stream!)) as Array<{ type: string }>;
+      const chunks = (await collect(stream!)) as Array<{
+        type: string;
+        id?: string;
+      }>;
 
-      expect(chunks.map((c) => c.type)).toEqual(['reasoning-delta', 'finish']);
+      // If the drop filter had activated, the delta would be gone entirely
+      // (`['finish']`). It surviving — repaired, not dropped — proves the filter
+      // stayed inactive for the non-negative resume.
+      expect(chunks.map((c) => c.type)).toEqual([
+        'reasoning-start',
+        'reasoning-delta',
+        'finish',
+      ]);
+      expect(chunks[0].id).toBe('reasoning-0');
       expect(warnSpy).not.toHaveBeenCalled();
 
       warnSpy.mockRestore();


### PR DESCRIPTION
## Summary

`main`'s `Tests` workflow is currently red. The unit test `WorkflowChatTransport > orphan UI chunk filter on negative startIndex resume > does not activate the filter for non-negative startIndex` (added by #2082) fails on `main`.

This is a **cross-PR interaction**, not a regression in either PR alone:

- **#2082** added an orphan-**drop** filter that only activates on negative (tail-only) reconnects, plus a test asserting that for a non-negative resume an orphan `reasoning-delta` passes through *unchanged* (`['reasoning-delta', 'finish']`).
- **#2537** made the UI-message framing **normalizer** run on *every* reconnect stream. It **repairs** an orphan `reasoning-delta` by synthesizing a `reasoning-start` ahead of it, so the output is now `['reasoning-start', 'reasoning-delta', 'finish']`.

Both PRs were green independently; merged together on `main` the stale assertion fails.

## The repair is correct — only the test is stale

Synthesizing the missing `reasoning-start` is exactly what keeps the AI SDK consumer (`processUIMessageStream`) from the fatal *"Received reasoning-delta for missing reasoning part"* error that #2537 set out to fix. Letting a raw orphan delta through would reintroduce that crash, so the runtime behavior on `main` is already right.

## Change

Test-only. Updates the #2082 test to expect the repaired framing and adds an explicit assertion that the delta **survives** — which is what proves the orphan-drop filter stayed inactive for the non-negative resume (had it activated, the delta would be dropped entirely, leaving `['finish']`). Also asserts the synthesized start carries the original part id.

## Test plan

- [x] `pnpm --filter @workflow/ai test` — 201 pass (was 1 failing on `main`)
- [x] `workflow-chat-transport.test.ts` — 23/23 pass

Empty changeset: no npm-published runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)