### PR TITLE
[core] Gate turbo end-of-run drain writes on the run-ready barrier

### DIFF
--- a/.changeset/turbo-drain-hook-run-ready.md
+++ b/.changeset/turbo-drain-hook-run-ready.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix a turbo-mode race where a fire-and-forget hook, wait, or attribute created by a workflow that completes synchronously could be written to the server before the run was created.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1247,7 +1247,12 @@ export function workflowEntrypoint(
                         workflowRun,
                         events,
                         encryptionKey,
-                        stepHydrationCache
+                        stepHydrationCache,
+                        // Turbo: the end-of-run drain inside runWorkflow commits
+                        // fire-and-forget `*_created` events before the terminal
+                        // `awaitRunReady()` below, so gate those writes on the
+                        // backgrounded run_started too. Undefined outside turbo.
+                        runReadyBarrier
                       );
                       runtimeLogger.debug('Workflow replay completed', {
                         workflowRunId: runId,

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -5445,6 +5445,14 @@ describe('runWorkflow', () => {
         return 'done';
       }`;
 
+    // `void sleep(...)` is the wait equivalent: it enqueues a wait_created the
+    // workflow never awaits, drained the same way as the hook above.
+    const FIRE_AND_FORGET_WAIT = `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+      async function workflow() {
+        void sleep('1d');
+        return 'done';
+      }`;
+
     async function makeRun(): Promise<WorkflowRun> {
       const ops: Promise<any>[] = [];
       return {
@@ -5512,6 +5520,50 @@ describe('runWorkflow', () => {
       expect(create).toHaveBeenCalledTimes(1);
       expect(create.mock.calls[0][1]).toMatchObject({
         eventType: 'hook_created',
+      });
+    });
+
+    it('does not write wait_created until the runReadyBarrier resolves', async () => {
+      let releaseBarrier: () => void = () => {};
+      const runReadyBarrier = new Promise<void>((resolve) => {
+        releaseBarrier = resolve;
+      });
+
+      const create = vi.fn(async () => ({
+        event: { eventType: 'wait_created' as const },
+      }));
+      setWorld({
+        events: { create },
+        streams: { write: vi.fn(), close: vi.fn() },
+      } as any);
+
+      const runPromise = runWorkflow(
+        `${FIRE_AND_FORGET_WAIT}${getWorkflowTransformCode('workflow')}`,
+        await makeRun(),
+        [],
+        noEncryptionKey,
+        undefined,
+        runReadyBarrier
+      ).then(() => 'completed' as const);
+
+      // Same gating as the hook case: a fire-and-forget wait drained at
+      // completion must not write wait_created before the backgrounded
+      // run_started lands.
+      const winner = await Promise.race([
+        runPromise,
+        new Promise<'pending'>((resolve) =>
+          setTimeout(() => resolve('pending'), 250)
+        ),
+      ]);
+      expect(winner).toBe('pending');
+      expect(create).not.toHaveBeenCalled();
+
+      releaseBarrier();
+      expect(await runPromise).toBe('completed');
+
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(create.mock.calls[0][1]).toMatchObject({
+        eventType: 'wait_created',
       });
     });
 

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -2,9 +2,10 @@ import { types } from 'node:util';
 import { HookConflictError, WorkflowRuntimeError } from '@workflow/errors';
 import type { Event, WorkflowRun } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
-import { assert, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 import { DEFERRED_CHECK_DELAY_MS } from './events-consumer.js';
 import type { WorkflowSuspension } from './global.js';
+import { setWorld } from './runtime/world.js';
 import {
   dehydrateStepReturnValue,
   dehydrateWorkflowArguments,
@@ -5430,4 +5431,138 @@ describe('runWorkflow', () => {
       spy.mockRestore();
     }
   }, 30_000);
+
+  describe('turbo: end-of-run drain gates writes on runReadyBarrier', () => {
+    // A workflow that creates a fire-and-forget hook and then returns
+    // synchronously never suspends, so its `hook_created` event is committed by
+    // the end-of-run drain inside runWorkflow — *before* the runtime's terminal
+    // `awaitRunReady()`. In turbo (`run_started` backgrounded), that write must
+    // still be ordered after the run exists, so runWorkflow threads the barrier
+    // into the drain. These tests pin that gating.
+    const FIRE_AND_FORGET_HOOK = `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+      async function workflow() {
+        createHook({ token: 'fire-and-forget' });
+        return 'done';
+      }`;
+
+    async function makeRun(): Promise<WorkflowRun> {
+      const ops: Promise<any>[] = [];
+      return {
+        runId: 'wrun_drain_turbo',
+        workflowName: 'workflow',
+        status: 'running',
+        input: await dehydrateWorkflowArguments(
+          [],
+          'wrun_drain_turbo',
+          noEncryptionKey,
+          ops
+        ),
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+        startedAt: new Date('2024-01-01T00:00:00.000Z'),
+        deploymentId: 'test-deployment',
+      };
+    }
+
+    afterEach(() => {
+      setWorld(undefined);
+    });
+
+    it('does not write hook_created until the runReadyBarrier resolves', async () => {
+      let releaseBarrier: () => void = () => {};
+      const runReadyBarrier = new Promise<void>((resolve) => {
+        releaseBarrier = resolve;
+      });
+
+      const create = vi.fn(async () => ({
+        event: { eventType: 'hook_created' as const },
+      }));
+      setWorld({
+        events: { create },
+        streams: { write: vi.fn(), close: vi.fn() },
+      } as any);
+
+      const runPromise = runWorkflow(
+        `${FIRE_AND_FORGET_HOOK}${getWorkflowTransformCode('workflow')}`,
+        await makeRun(),
+        [],
+        noEncryptionKey,
+        undefined,
+        runReadyBarrier
+      ).then(() => 'completed' as const);
+
+      // The body returns synchronously, but the drain's hook_created write — and
+      // therefore runWorkflow's own completion — must stay blocked behind the
+      // still-pending backgrounded run_started. A fixed-time race (not a fixed
+      // wait-then-assert) makes this robust to VM setup latency: the window only
+      // has to exceed the drain's own work, never a calibrated guess at it.
+      const winner = await Promise.race([
+        runPromise,
+        new Promise<'pending'>((resolve) =>
+          setTimeout(() => resolve('pending'), 250)
+        ),
+      ]);
+      expect(winner).toBe('pending');
+      expect(create).not.toHaveBeenCalled();
+
+      // Once run_started lands, the drain proceeds and runWorkflow resolves.
+      releaseBarrier();
+      expect(await runPromise).toBe('completed');
+
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(create.mock.calls[0][1]).toMatchObject({
+        eventType: 'hook_created',
+      });
+    });
+
+    it('still writes hook_created when the runReadyBarrier rejects (ordering only)', async () => {
+      const create = vi.fn(async () => ({
+        event: { eventType: 'hook_created' as const },
+      }));
+      setWorld({
+        events: { create },
+        streams: { write: vi.fn(), close: vi.fn() },
+      } as any);
+
+      // A rejected barrier is swallowed for ordering: if run_started truly
+      // failed, the run does not exist and the write itself surfaces the error.
+      const rejected = Promise.reject(new Error('run_started failed'));
+      rejected.catch(() => {});
+
+      await runWorkflow(
+        `${FIRE_AND_FORGET_HOOK}${getWorkflowTransformCode('workflow')}`,
+        await makeRun(),
+        [],
+        noEncryptionKey,
+        undefined,
+        rejected
+      );
+
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(create.mock.calls[0][1]).toMatchObject({
+        eventType: 'hook_created',
+      });
+    });
+
+    it('writes hook_created without blocking when no barrier (non-turbo)', async () => {
+      const create = vi.fn(async () => ({
+        event: { eventType: 'hook_created' as const },
+      }));
+      setWorld({
+        events: { create },
+        streams: { write: vi.fn(), close: vi.fn() },
+      } as any);
+
+      // No barrier (the await path already awaited run_started up front): the
+      // drain writes immediately.
+      await runWorkflow(
+        `${FIRE_AND_FORGET_HOOK}${getWorkflowTransformCode('workflow')}`,
+        await makeRun(),
+        [],
+        noEncryptionKey
+      );
+
+      expect(create).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -84,7 +84,17 @@ async function drainPendingQueueItems(
   pendingQueue: Map<string, QueueItem>,
   vmGlobalThis: typeof globalThis,
   workflowRun: WorkflowRun,
-  outcome: 'completed' | 'failed'
+  outcome: 'completed' | 'failed',
+  /**
+   * Turbo mode only: resolves once the backgrounded `run_started` has landed.
+   * The drain runs at workflow completion *inside* `runWorkflow`, before the
+   * caller's terminal `awaitRunReady()` — so a workflow that creates a
+   * fire-and-forget hook (or wait/attribute) and then returns synchronously
+   * would otherwise have its `*_created` write race ahead of `run_started`.
+   * Threading the barrier into the suspension handler gates those writes the
+   * same way the normal suspension path is gated. Undefined outside turbo.
+   */
+  runReadyBarrier?: Promise<unknown>
 ): Promise<void> {
   if (pendingQueue.size === 0) return;
   // Implicitly dispose any abort hooks (system hooks) that are still alive at
@@ -110,6 +120,7 @@ async function drainPendingQueueItems(
       suspension: synthesized,
       world,
       run: workflowRun,
+      runReadyBarrier,
     });
   } catch (err) {
     runtimeLogger.warn(
@@ -134,7 +145,14 @@ export async function runWorkflow(
    * step results to turn O(N²) replay hydration into O(N). Omitted by callers
    * that replay only once (then there is nothing to reuse).
    */
-  stepHydrationCache?: StepHydrationCache
+  stepHydrationCache?: StepHydrationCache,
+  /**
+   * Turbo mode only: resolves once the backgrounded `run_started` has landed.
+   * Threaded into the end-of-run drain so fire-and-forget `*_created` writes
+   * committed at workflow completion order after the run's creation. Undefined
+   * outside turbo, where `run_started` is awaited up front.
+   */
+  runReadyBarrier?: Promise<unknown>
 ): Promise<Uint8Array | unknown> {
   return trace(`workflow.run ${workflowRun.workflowName}`, async (span) => {
     span?.setAttributes({
@@ -885,7 +903,8 @@ export async function runWorkflow(
         workflowContext.invocationsQueue,
         vmGlobalThis,
         workflowRun,
-        'completed'
+        'completed',
+        runReadyBarrier
       );
 
       return dehydrated;
@@ -901,7 +920,8 @@ export async function runWorkflow(
         workflowContext.invocationsQueue,
         vmGlobalThis,
         workflowRun,
-        'failed'
+        'failed',
+        runReadyBarrier
       );
 
       throw err;


### PR DESCRIPTION
## Problem

Turbo mode backgrounds `run_started` and runs the workflow body optimistically before it is durable, gating every downstream write on a run-ready barrier so nothing reaches the server before the run exists. The awaited-hook path is already gated (the suspension handler threads the barrier).

But a workflow that creates a **fire-and-forget** hook (or wait/attribute) and then **returns synchronously** never suspends. Its `*_created` event is instead committed by the end-of-run drain *inside* `runWorkflow` — which runs **before** the runtime's terminal `awaitRunReady()`. In turbo, that write could race ahead of the still-in-flight `run_started` and hit the server before the run is created.

```ts
async function wf() {
  "use workflow";
  createHook({ token: orderId }); // never awaited
  return "done";                  // completes synchronously → drained, ungated
}
```

## Fix

Thread the run-ready barrier through `runWorkflow` into `drainPendingQueueItems` → `handleSuspension`, so the drain's writes are gated exactly like the normal suspension path. No-op outside turbo (barrier `undefined`), and a barrier rejection is swallowed for ordering only (a genuinely failed `run_started` surfaces via the subsequent write).

## Test

Added regression tests in `workflow.test.ts` that run a fire-and-forget-hook and a fire-and-forget-wait (`void sleep(...)`) workflow through `runWorkflow` with a pending barrier and assert (via a fixed-time race, robust to VM-setup latency) that `runWorkflow` cannot complete and the `hook_created`/`wait_created` write is withheld until the barrier resolves. Both verified to fail without the threading. `attr_set` is gated by the same path. Also covers the barrier-rejection (writes anyway) and no-barrier (non-turbo, writes immediately) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
