### PR TITLE
Fix Workflow loader source map warnings

### DIFF
--- a/.changeset/quiet-sourcemap-warnings.md
+++ b/.changeset/quiet-sourcemap-warnings.md
@@ -1,0 +1,5 @@
+---
+"@workflow/next": patch
+---
+
+Disable Workflow loader source-map emission for node_modules files to avoid noisy SWC input source-map warnings.

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -211,7 +211,8 @@ jobs:
         run: |
           DEV_TEST_CONFIG="$(jq -nc --arg name "$APP_NAME" '{name:$name,project:"workbench-\($name)-workflow",generatedStepPath:"app/.well-known/workflow/v1/flow/__step_registrations.js",generatedWorkflowPath:"app/.well-known/workflow/v1/flow/route.js",apiFilePath:"app/api/chat/route.ts",apiFileImportPath:"../../.."}')"
           export DEV_TEST_CONFIG
-          cd "workbench/$APP_NAME" && pnpm dev &
+          export DEV_SERVER_LOG_PATH="$GITHUB_WORKSPACE/dev-server-$APP_NAME-$WORLD_ID.log"
+          (cd "workbench/$APP_NAME" && pnpm dev 2>&1 | tee "$DEV_SERVER_LOG_PATH") &
           cd "$GITHUB_WORKSPACE"
           echo "Waiting for dev server to start..." && sleep 15
           pnpm vitest run packages/core/e2e/dev.test.ts --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts "--outputFile=e2e-community-$WORLD_ID-dev.json" || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -520,7 +520,8 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          cd "$WORKBENCH_APP_PATH" && pnpm dev &
+          export DEV_SERVER_LOG_PATH="$GITHUB_WORKSPACE/dev-server-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.log"
+          (cd "$WORKBENCH_APP_PATH" && pnpm dev 2>&1 | tee "$DEV_SERVER_LOG_PATH") &
           echo "starting tests in 10 seconds" && sleep 10
           pnpm vitest run packages/core/e2e/dev.test.ts; sleep 10
           pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
@@ -609,7 +610,8 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          cd "$WORKBENCH_APP_PATH" && pnpm start &
+          export PROD_SERVER_LOG_PATH="$GITHUB_WORKSPACE/prod-server-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.log"
+          (cd "$WORKBENCH_APP_PATH" && pnpm start 2>&1 | tee "$PROD_SERVER_LOG_PATH") &
           echo "starting tests in 10 seconds" && sleep 10
           pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
         env:
@@ -716,7 +718,8 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          cd "$WORKBENCH_APP_PATH" && pnpm start &
+          export PROD_SERVER_LOG_PATH="$GITHUB_WORKSPACE/prod-server-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.log"
+          (cd "$WORKBENCH_APP_PATH" && pnpm start 2>&1 | tee "$PROD_SERVER_LOG_PATH") &
           echo "starting tests in 10 seconds" && sleep 10
           pnpm run test:e2e --reporter=default --reporter=json --reporter=./packages/core/e2e/github-reporter.ts --outputFile=e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
         env:
@@ -781,6 +784,7 @@ jobs:
         run: |
           cd workbench/nextjs-turbopack
           $logFile = "$env:GITHUB_WORKSPACE/nextjs-server.log"
+          $env:DEV_SERVER_LOG_PATH = $logFile
           $job = Start-Job -ScriptBlock { Set-Location $using:PWD; pnpm dev *>&1 | Tee-Object -FilePath $using:logFile }
           Start-Sleep -Seconds 15
           cd ../..

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -16,6 +16,10 @@ export interface DevTestConfig {
   workflowsDir?: string;
 }
 
+const SOURCE_MAP_WARNING = 'failed to read input source map';
+const SOURCE_MAP_FIXTURE_PACKAGE = 'workflow-sourcemap-warning-fixture';
+const SOURCE_MAP_COMMENT = '//# sourceMapping' + 'URL=index.js.map';
+
 function getConfigFromEnv(): DevTestConfig | null {
   const envConfig = process.env.DEV_TEST_CONFIG;
   if (envConfig) {
@@ -110,6 +114,7 @@ export function createDevTests(config?: DevTestConfig) {
       return outputs.join('\n');
     };
     const restoreFiles: Array<{ path: string; content: string }> = [];
+    const restoreDirectories: string[] = [];
 
     const fetchWithTimeout = (pathname: string) => {
       if (!deploymentUrl) {
@@ -183,8 +188,14 @@ export function createDevTests(config?: DevTestConfig) {
         await prewarm();
       }
       await Promise.all(toDelete.map((item) => fs.unlink(item.path)));
+      await Promise.all(
+        restoreDirectories.map((dir) =>
+          fs.rm(dir, { recursive: true, force: true })
+        )
+      );
       await prewarm();
       restoreFiles.length = 0;
+      restoreDirectories.length = 0;
     }, CLEANUP_HOOK_TIMEOUT_MS);
 
     test('should rebuild on workflow change', { timeout: 70_000 }, async () => {
@@ -373,6 +384,106 @@ ${apiFileContent}`
             expect(workflowContent).toContain('newWorkflowFile');
           },
         });
+      }
+    );
+
+    test.runIf(process.env.APP_NAME === 'nextjs-turbopack')(
+      'should not log source map warnings for workflow node_modules imports',
+      { timeout: 70_000 },
+      async () => {
+        const packageDir = path.join(
+          appPath,
+          'node_modules',
+          SOURCE_MAP_FIXTURE_PACKAGE
+        );
+        const packageJsonPath = path.join(packageDir, 'package.json');
+        const packageIndexPath = path.join(packageDir, 'index.js');
+        const workflowFile = path.join(
+          appPath,
+          workflowsDir,
+          'source-map-warning-fixture.ts'
+        );
+        const apiFile = path.join(appPath, finalConfig.apiFilePath);
+        const apiFileContent = await fs.readFile(apiFile, 'utf8');
+
+        await fs.mkdir(packageDir, { recursive: true });
+        restoreDirectories.push(packageDir);
+        await fs.writeFile(
+          packageJsonPath,
+          JSON.stringify(
+            {
+              name: SOURCE_MAP_FIXTURE_PACKAGE,
+              version: '0.0.0',
+              type: 'module',
+              main: './index.js',
+              types: './index.d.ts',
+            },
+            null,
+            2
+          )
+        );
+        await fs.writeFile(
+          packageIndexPath,
+          `export const sourceMapWarningFixtureValue = Symbol.for('workflow-serialize').description ?? 'workflow-serialize';
+${SOURCE_MAP_COMMENT}
+`
+        );
+        await fs.writeFile(
+          path.join(packageDir, 'index.d.ts'),
+          `export declare const sourceMapWarningFixtureValue: string;
+`
+        );
+        await fs.writeFile(
+          workflowFile,
+          `import { sourceMapWarningFixtureValue } from '${SOURCE_MAP_FIXTURE_PACKAGE}';
+
+async function readSourceMapWarningFixture() {
+  'use step';
+  return sourceMapWarningFixtureValue;
+}
+
+export async function sourceMapWarningFixtureWorkflow() {
+  'use workflow';
+  return readSourceMapWarningFixture();
+}
+`
+        );
+        restoreFiles.push({ path: workflowFile, content: '' });
+        restoreFiles.push({ path: apiFile, content: apiFileContent });
+
+        await fs.writeFile(
+          apiFile,
+          `import '${finalConfig.apiFileImportPath}/${workflowsDir}/source-map-warning-fixture';
+${apiFileContent}`
+        );
+
+        await pollUntil({
+          description:
+            'generated workflow to include sourceMapWarningFixtureWorkflow',
+          timeoutMs: 50_000,
+          check: async () => {
+            if (usesNextFlowRoute) {
+              const manifestFunctionNames =
+                await readManifestWorkflowFunctionNames();
+              expect(manifestFunctionNames).toContain(
+                'sourceMapWarningFixtureWorkflow'
+              );
+              return;
+            }
+
+            await fetchWithTimeout('/api/chat');
+            const workflowContent = await readGeneratedWorkflowOutput();
+            expect(workflowContent).toContain(
+              'sourceMapWarningFixtureWorkflow'
+            );
+          },
+        });
+
+        const devServerLogPath = process.env.DEV_SERVER_LOG_PATH;
+        if (devServerLogPath) {
+          const log = await fs.readFile(devServerLogPath, 'utf8');
+          expect(log).not.toContain(SOURCE_MAP_WARNING);
+        }
       }
     );
   });

--- a/packages/core/e2e/local-build.test.ts
+++ b/packages/core/e2e/local-build.test.ts
@@ -89,6 +89,81 @@ const DIAGNOSTICS_MANIFEST_PATHS: Record<string, string> = {
   'nextjs-turbopack': '.next/diagnostics/workflows-manifest.json',
 };
 
+const SOURCE_MAP_WARNING = 'failed to read input source map';
+const SOURCE_MAP_FIXTURE_PACKAGE = 'workflow-sourcemap-warning-fixture';
+const SOURCE_MAP_COMMENT = '//# sourceMapping' + 'URL=index.js.map';
+
+async function writeFileWithParents(
+  filePath: string,
+  content: string
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+async function setupNextSourceMapWarningFixture(
+  appPath: string
+): Promise<() => Promise<void>> {
+  const packageDir = path.join(
+    appPath,
+    'node_modules',
+    SOURCE_MAP_FIXTURE_PACKAGE
+  );
+  const workflowPath = path.join(
+    appPath,
+    'workflows',
+    'source-map-warning-fixture.ts'
+  );
+
+  await writeFileWithParents(
+    path.join(packageDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: SOURCE_MAP_FIXTURE_PACKAGE,
+        version: '0.0.0',
+        type: 'module',
+        main: './index.js',
+        types: './index.d.ts',
+      },
+      null,
+      2
+    )
+  );
+  await writeFileWithParents(
+    path.join(packageDir, 'index.js'),
+    `export const sourceMapWarningFixtureValue = Symbol.for('workflow-serialize').description ?? 'workflow-serialize';
+${SOURCE_MAP_COMMENT}
+`
+  );
+  await writeFileWithParents(
+    path.join(packageDir, 'index.d.ts'),
+    `export declare const sourceMapWarningFixtureValue: string;
+`
+  );
+  await writeFileWithParents(
+    workflowPath,
+    `import { sourceMapWarningFixtureValue } from '${SOURCE_MAP_FIXTURE_PACKAGE}';
+
+async function readSourceMapWarningFixture() {
+  'use step';
+  return sourceMapWarningFixtureValue;
+}
+
+export async function sourceMapWarningFixtureWorkflow() {
+  'use workflow';
+  return readSourceMapWarningFixture();
+}
+`
+  );
+
+  return async () => {
+    await Promise.all([
+      fs.rm(packageDir, { recursive: true, force: true }),
+      fs.rm(workflowPath, { force: true }),
+    ]);
+  };
+}
+
 describe.each([
   'example',
   'nextjs-webpack',
@@ -110,20 +185,35 @@ describe.each([
       return;
     }
 
-    const result = await runCommandWithLiveOutput(
-      'pnpm',
-      ['build'],
-      getWorkbenchAppPath(project)
-    );
+    const appPath = getWorkbenchAppPath(project);
+    const cleanup =
+      project === 'nextjs-turbopack'
+        ? await setupNextSourceMapWarningFixture(appPath)
+        : async () => {};
+    const preserveFixtureForBuiltOutput =
+      project === 'nextjs-turbopack' && process.env.CI === 'true';
+
+    let result: CommandResult;
+    try {
+      result = await runCommandWithLiveOutput('pnpm', ['build'], appPath);
+    } finally {
+      // CI starts the just-built app in the same prepared workbench path after
+      // this test. Turbopack production bundles can retain references to the
+      // fixture package/source, so keep them available until the job ends.
+      if (!preserveFixtureForBuiltOutput) {
+        await cleanup();
+      }
+    }
 
     expect(result.output).not.toContain('Error:');
+    expect(result.output).not.toContain(SOURCE_MAP_WARNING);
 
     const diagnosticsManifestPath = usesVercelWorld()
       ? '.vercel/output/diagnostics/workflows-manifest.json'
       : DIAGNOSTICS_MANIFEST_PATHS[project];
     if (diagnosticsManifestPath) {
       const resolvedDiagnosticsManifestPath = path.join(
-        getWorkbenchAppPath(project),
+        appPath,
         diagnosticsManifestPath
       );
       await fs.access(resolvedDiagnosticsManifestPath);
@@ -133,7 +223,7 @@ describe.each([
     const esmBundlePath = ESM_STEP_BUNDLE_PROJECTS[project];
     if (esmBundlePath) {
       const bundleContent = await readFileIfExists(
-        path.join(getWorkbenchAppPath(project), esmBundlePath)
+        path.join(appPath, esmBundlePath)
       );
       expect(bundleContent).not.toBeNull();
       // ESM output should NOT contain CJS polyfill

--- a/packages/next/src/loader.test.ts
+++ b/packages/next/src/loader.test.ts
@@ -1,0 +1,52 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getLoaderSourceMapOptions } from './loader.js';
+
+describe('getLoaderSourceMapOptions', () => {
+  it('emits source maps for app files and uses the upstream source map', () => {
+    const upstreamMap = { version: 3, sources: ['input.ts'], mappings: '' };
+
+    expect(
+      getLoaderSourceMapOptions(
+        join(process.cwd(), 'app', 'workflow.ts'),
+        upstreamMap
+      )
+    ).toEqual({
+      inputSourceMap: upstreamMap,
+      sourceMaps: true,
+      inlineSourcesContent: true,
+    });
+  });
+
+  it('disables implicit input source map loading when app files have no upstream map', () => {
+    expect(
+      getLoaderSourceMapOptions(join(process.cwd(), 'app', 'workflow.ts'), null)
+    ).toEqual({
+      inputSourceMap: false,
+      sourceMaps: true,
+      inlineSourcesContent: true,
+    });
+  });
+
+  it('does not emit source maps for node_modules files', () => {
+    expect(
+      getLoaderSourceMapOptions(
+        join(
+          process.cwd(),
+          'node_modules',
+          '.pnpm',
+          'pkg@1.0.0',
+          'node_modules',
+          'pkg',
+          'dist',
+          'index.js'
+        ),
+        { version: 3, sources: ['index.js'], mappings: '' }
+      )
+    ).toEqual({
+      inputSourceMap: false,
+      sourceMaps: false,
+      inlineSourcesContent: false,
+    });
+  });
+});

--- a/packages/next/src/loader.ts
+++ b/packages/next/src/loader.ts
@@ -196,6 +196,19 @@ async function getRelativeFilenameForSwc(
   return relativeFilename;
 }
 
+function isNodeModulesPath(filename: string): boolean {
+  return /(?:^|[/\\])node_modules(?:[/\\]|$)/.test(filename);
+}
+
+export function getLoaderSourceMapOptions(filename: string, sourceMap: any) {
+  const shouldEmitSourceMaps = !isNodeModulesPath(filename);
+  return {
+    inputSourceMap: shouldEmitSourceMaps ? (sourceMap ?? false) : false,
+    sourceMaps: shouldEmitSourceMaps,
+    inlineSourcesContent: shouldEmitSourceMaps,
+  };
+}
+
 // This loader applies the "use workflow"/"use step" transform.
 // All files use step mode; the SWC plugin decides per-function whether
 // to emit workflow or step bindings based on the source's directives.
@@ -292,9 +305,7 @@ export default function workflowLoader(
         },
       },
       minify: false,
-      inputSourceMap: sourceMap,
-      sourceMaps: true,
-      inlineSourcesContent: true,
+      ...getLoaderSourceMapOptions(filename, sourceMap),
     });
 
     let transformedMap = sourceMap;


### PR DESCRIPTION
## Summary
- disable workflow loader source map emission for transformed node_modules files while keeping app code source maps enabled
- add unit coverage for the loader source map options
- add build/dev e2e regression coverage for the missing input source map warning
- capture prod server logs in local prod/postgres CI for easier route failure diagnosis

Refs https://github.com/vercel/next.js/issues/95255

## Testing
- Not run locally per request; relying on CI.