### PR TITLE
fix(web-shared): use Unicode ellipsis character (…) in middle-truncate

### DIFF
--- a/.changeset/fix-middle-truncate-ellipsis.md
+++ b/.changeset/fix-middle-truncate-ellipsis.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Use Unicode ellipsis character (…) instead of three dots (...) in middle-truncate component.

--- a/packages/web-shared/src/components/new-trace-viewer/components/middle-truncate/truncate.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/components/middle-truncate/truncate.ts
@@ -1,4 +1,4 @@
-const ELLIPSIS = '...';
+const ELLIPSIS = '…';
 const MIN_START = 3;
 const MIN_END = 3;
 const MIN_KEPT = MIN_START + MIN_END;


### PR DESCRIPTION
## Summary

- Replace `'...'` (three ASCII dots) with `'…'` (U+2026 HORIZONTAL ELLIPSIS) in the middle-truncate `ELLIPSIS` constant
- Since `…` is a single character, the binary search measures slightly more accurately and allows a tiny bit more content to fit before truncating

🤖 Generated with [Claude Code](https://claude.com/claude-code)