### PR TITLE
Fix graph extraction for annotated step proxies

### DIFF
--- a/.changeset/fix-graph-manifest-generation.md
+++ b/.changeset/fix-graph-manifest-generation.md
@@ -1,0 +1,5 @@
+---
+"@workflow/builders": patch
+---
+
+Fix workflow graph extraction when transformed step proxies include pure annotations.

--- a/packages/builders/src/workflows-extractor.test.ts
+++ b/packages/builders/src/workflows-extractor.test.ts
@@ -45,4 +45,40 @@ describe('extractWorkflowGraphs', () => {
     });
     expect(consoleError).not.toHaveBeenCalled();
   });
+
+  it('extracts step nodes when step proxies include pure annotations', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'workflow-builders-'));
+    const bundlePath = join(tempDir, 'workflow-bundle.js');
+
+    await writeFile(
+      bundlePath,
+      [
+        'var stepOne = globalThis[/* @__PURE__ */ Symbol.for("WORKFLOW_USE_STEP")]("step//./input.ts//stepOne");',
+        'async function testWorkflow(input) {',
+        '  const output = await stepOne(input);',
+        '  return output;',
+        '}',
+        'testWorkflow.workflowId = "workflow//./input.ts//testWorkflow";',
+      ].join('\n')
+    );
+
+    await expect(extractWorkflowGraphs(bundlePath)).resolves.toEqual({
+      './input.ts': {
+        testWorkflow: expect.objectContaining({
+          workflowId: 'workflow//./input.ts//testWorkflow',
+          graph: expect.objectContaining({
+            nodes: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'step',
+                data: expect.objectContaining({
+                  label: 'stepOne',
+                  stepId: 'step//./input.ts//stepOne',
+                }),
+              }),
+            ]),
+          }),
+        }),
+      },
+    });
+  });
 });

--- a/packages/builders/src/workflows-extractor.ts
+++ b/packages/builders/src/workflows-extractor.ts
@@ -304,7 +304,7 @@ function extractStepDeclarations(
   const stepDeclarations = new Map<string, { stepId: string }>();
 
   const stepPattern =
-    /var (\w+) = globalThis\[Symbol\.for\("WORKFLOW_USE_STEP"\)\]\("([^"]+)"\)/g;
+    /var (\w+) = globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\("WORKFLOW_USE_STEP"\)\]\("([^"]+)"\)/g;
 
   const lines = bundleCode.split('\n');
   for (const line of lines) {


### PR DESCRIPTION
## Summary
- Allow workflow graph step declaration extraction to tolerate pure annotations inside `globalThis[...]` step proxies.
- Add a regression test for the transformed `/* @__PURE__ */ Symbol.for("WORKFLOW_USE_STEP")` shape.
- Add a patch changeset for `@workflow/builders`.

Closes #1746

## Verification
- `pnpm exec vitest run packages/builders/src/workflows-extractor.test.ts`
- `pnpm --filter @workflow/builders test`
- `pnpm turbo run build --filter='@workflow/builders...'`
- `pnpm changeset status --since=origin/main`
- `pnpm exec biome check packages/builders/src/workflows-extractor.ts packages/builders/src/workflows-extractor.test.ts .changeset/fix-graph-manifest-generation.md`

## Auto Review
- `autoreview --mode branch --base origin/main --reviewers codex:gpt-5.5:xhigh` clean: no accepted/actionable findings.
- `autoreview --mode branch --base origin/main --reviewers claude:opus:xhigh` clean: no accepted/actionable findings.

Note: the literal `claude:opus-4.8:xhigh` model string was attempted twice and the Claude CLI returned 404/not available both times; the local CLI documents `opus` as the supported Opus alias.