### PR TITLE
Fix world-postgres enum schemas

### DIFF
--- a/.changeset/fix-postgres-workflow-enums.md
+++ b/.changeset/fix-postgres-workflow-enums.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': minor
+---
+
+Move Workflow Postgres enum types into the workflow schema.

--- a/packages/world-postgres/src/drizzle/migrations/0015_move_enums_to_workflow_schema.sql
+++ b/packages/world-postgres/src/drizzle/migrations/0015_move_enums_to_workflow_schema.sql
@@ -1,0 +1,75 @@
+DO $$
+DECLARE
+  enum_name text;
+  public_enum regtype;
+  workflow_enum regtype;
+  is_used_by_workflow_columns boolean;
+  has_dependents_outside_workflow_tables boolean;
+BEGIN
+  FOREACH enum_name IN ARRAY ARRAY['status', 'step_status', 'wait_status'] LOOP
+    public_enum := to_regtype(format('public.%I', enum_name));
+    workflow_enum := to_regtype(format('workflow.%I', enum_name));
+
+    -- Nothing to migrate when the legacy public enum does not exist, or when
+    -- the enum has already been moved to the workflow schema.
+    IF public_enum IS NULL OR workflow_enum IS NOT NULL THEN
+      CONTINUE;
+    END IF;
+
+    -- Only move enums that are actually used by workflow table columns.
+    -- pg_depend has an index on referenced objects, so this lookup is based
+    -- on the enum type OID instead of scanning user data or workflow rows.
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_depend dependency
+      JOIN pg_class dependent_table
+        ON dependency.classid = 'pg_class'::regclass AND dependency.objid = dependent_table.oid
+      JOIN pg_namespace dependent_table_schema
+        ON dependent_table_schema.oid = dependent_table.relnamespace
+      WHERE dependency.refclassid = 'pg_type'::regclass
+        AND dependency.refobjid = public_enum::oid
+        AND dependency.objsubid > 0
+        AND dependency.deptype != 'i'
+        AND dependent_table_schema.nspname = 'workflow'
+    ) INTO is_used_by_workflow_columns;
+
+    IF NOT is_used_by_workflow_columns THEN
+      CONTINUE;
+    END IF;
+
+    /*
+      pg_depend is Postgres' dependency graph.
+
+      We use it here as a safety check before moving the enum object itself.
+      A normal workflow-owned enum has only workflow table-column dependents,
+      so ALTER TYPE ... SET SCHEMA is a fast metadata change.
+
+      If anything outside workflow tables also depends on this enum, moving it
+      would silently rename that user's public enum to workflow.<enum_name>.
+      In that case, leave the enum in public, warn, and continue so this cleanup
+      migration does not block later migrations.
+    */
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_depend dependency
+      LEFT JOIN pg_class dependent_table
+        ON dependency.classid = 'pg_class'::regclass AND dependency.objid = dependent_table.oid
+      LEFT JOIN pg_namespace dependent_table_schema
+        ON dependent_table_schema.oid = dependent_table.relnamespace
+      WHERE dependency.refclassid = 'pg_type'::regclass
+        AND dependency.refobjid = public_enum::oid
+        AND dependency.deptype != 'i'
+        AND NOT (
+          dependency.classid = 'pg_class'::regclass
+          AND dependent_table_schema.nspname = 'workflow'
+        )
+    ) INTO has_dependents_outside_workflow_tables;
+
+    IF has_dependents_outside_workflow_tables THEN
+      RAISE WARNING 'Skipping move of public.% to workflow schema because objects outside workflow tables depend on it', enum_name;
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('ALTER TYPE public.%I SET SCHEMA workflow', enum_name);
+  END LOOP;
+END $$;

--- a/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
+++ b/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1780185600000,
       "tag": "0014_add_attr_set_event_unique_index",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1782691200000,
+      "tag": "0015_move_enums_to_workflow_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -17,7 +17,6 @@ import {
   integer,
   /** @deprecated: use Cbor instead */
   jsonb,
-  pgEnum,
   pgSchema,
   primaryKey,
   text,
@@ -27,21 +26,23 @@ import {
 } from 'drizzle-orm/pg-core';
 import { Cbor, type Cborized } from './cbor.js';
 
+export const schema = pgSchema('workflow');
+
 function mustBeMoreThanOne<T>(t: T[]) {
   return t as [T, ...T[]];
 }
 
-export const workflowRunStatus = pgEnum(
+export const workflowRunStatus = schema.enum(
   'status',
   mustBeMoreThanOne(WorkflowRunStatusSchema.options)
 );
 
-export const stepStatus = pgEnum(
+export const stepStatus = schema.enum(
   'step_status',
   mustBeMoreThanOne(StepStatusSchema.options)
 );
 
-export const waitStatus = pgEnum(
+export const waitStatus = schema.enum(
   'wait_status',
   mustBeMoreThanOne(WaitStatusSchema.options)
 );
@@ -60,8 +61,6 @@ type DrizzlishOfType<T extends object> = {
  * Sadly we do `any[]` right now
  */
 export type SerializedContent = any[];
-
-export const schema = pgSchema('workflow');
 
 export const runs = schema.table(
   'workflow_runs',


### PR DESCRIPTION
Fixes #1808.

## Summary
- define world-postgres Drizzle enums under the `workflow` schema
- add a migration entry that moves legacy Workflow-owned enum types from `public` to `workflow`
- keep historical migrations/snapshots unchanged; already-applied production migrations are not rewritten

## Migration safety
- verified against Postgres 15 with 1,000,000 `workflow_runs` rows and 1,000,000 `workflow_events` rows
- the guarded `ALTER TYPE ... SET SCHEMA` migration completed in low single-digit milliseconds
- enum type OIDs were preserved, so existing Workflow columns keep pointing at the same types
- `workflow_runs`, `workflow_steps`, `workflow_waits`, and `workflow_events` relfilenodes were unchanged, confirming no table rewrite
- running the migration a second time no-ops when the enum types are already in `workflow`
- if a legacy `public` enum is shared by non-Workflow objects, the migration warns, skips that enum, and continues so future migrations are not blocked; automatically splitting a shared enum would require altering Workflow columns and can rewrite/lock large tables, so that case should be handled manually if needed

## Tests
- `tsc -p packages/world-postgres/tsconfig.json --noEmit --pretty false`
- `vitest run` from `packages/world-postgres` (5 files, 137 tests)
- `biome check packages/world-postgres/src/drizzle/schema.ts .changeset/fix-postgres-workflow-enums.md`
- `git diff --check`
- targeted Postgres 15 migration probe for million-row metadata-only move and shared-enum warn/skip behavior
