### PR TITLE
Fix Postgres step lifecycle event ordering

### DIFF
--- a/.changeset/postgres-step-ordering.md
+++ b/.changeset/postgres-step-ordering.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Fix Postgres step lifecycle event ordering so a late concurrent step_started is no longer logged after step_completed.

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -72,8 +72,9 @@ export function createDevTests(config?: DevTestConfig) {
     );
     // Next canary webpack can queue Workflow rediscovery behind route
     // compilation long enough that the default budget races test cleanup.
-    const hmrRediscoveryTimeoutMs = finalConfig.canary ? 120_000 : 50_000;
-    const flowRouteHmrFuzzTimeoutMs = finalConfig.canary ? 360_000 : 240_000;
+    const hmrRediscoveryTimeoutMs = finalConfig.canary ? 180_000 : 50_000;
+    const hmrTestTimeoutMs = finalConfig.canary ? 210_000 : 70_000;
+    const flowRouteHmrFuzzTimeoutMs = finalConfig.canary ? 480_000 : 240_000;
     const readManifestStepFunctionNames = async (): Promise<string[]> => {
       const manifestJson = await fs.readFile(workflowManifestPath, 'utf8');
       const manifest = JSON.parse(manifestJson) as {
@@ -340,7 +341,7 @@ export function createDevTests(config?: DevTestConfig) {
 
     test.runIf(shouldRunNextFlowRouteHmrTests)(
       'should not rebuild workflows on Next page body-only change',
-      { timeout: 70_000 },
+      { timeout: hmrTestTimeoutMs },
       async () => {
         await waitForHmrReady();
 
@@ -364,7 +365,7 @@ export function createDevTests(config?: DevTestConfig) {
 
     test.runIf(shouldRunNextFlowRouteHmrTests)(
       'should rediscover workflows on Next page directive change',
-      { timeout: 70_000 },
+      { timeout: hmrTestTimeoutMs },
       async () => {
         await waitForHmrReady();
 
@@ -447,79 +448,83 @@ export async function hmrPageWorkflow() {
       }
     );
 
-    test('should rebuild on workflow change', { timeout: 70_000 }, async () => {
-      if (usesNextFlowRoute) {
-        await waitForHmrReady();
-      }
+    test(
+      'should rebuild on workflow change',
+      { timeout: hmrTestTimeoutMs },
+      async () => {
+        if (usesNextFlowRoute) {
+          await waitForHmrReady();
+        }
 
-      let workflowFile = path.join(appPath, workflowsDir, testWorkflowFile);
-      let content = await fs.readFile(workflowFile, 'utf8');
+        let workflowFile = path.join(appPath, workflowsDir, testWorkflowFile);
+        let content = await fs.readFile(workflowFile, 'utf8');
 
-      if (usesNextFlowRoute) {
-        workflowFile = path.join(
-          appPath,
-          workflowsDir,
-          'dev-test-workflow-change.ts'
-        );
-        const apiFile = path.join(appPath, finalConfig.apiFilePath);
-        const apiFileContent = await fs.readFile(apiFile, 'utf8');
-        restoreFiles.push({ path: apiFile, content: apiFileContent });
-        restoreFiles.push({ path: workflowFile, content: '' });
+        if (usesNextFlowRoute) {
+          workflowFile = path.join(
+            appPath,
+            workflowsDir,
+            'dev-test-workflow-change.ts'
+          );
+          const apiFile = path.join(appPath, finalConfig.apiFilePath);
+          const apiFileContent = await fs.readFile(apiFile, 'utf8');
+          restoreFiles.push({ path: apiFile, content: apiFileContent });
+          restoreFiles.push({ path: workflowFile, content: '' });
 
-        content = `export async function devTestWorkflowChangeBase() {
+          content = `export async function devTestWorkflowChangeBase() {
   'use workflow';
   return 'base';
 }
 `;
-        await fs.writeFile(workflowFile, content);
-        await fs.writeFile(
-          apiFile,
-          `import '${finalConfig.apiFileImportPath}/${workflowsDir}/dev-test-workflow-change';
+          await fs.writeFile(workflowFile, content);
+          await fs.writeFile(
+            apiFile,
+            `import '${finalConfig.apiFileImportPath}/${workflowsDir}/dev-test-workflow-change';
 ${apiFileContent}`
-        );
-        await pollUntil({
-          description: 'workflow-change fixture to appear in manifest',
-          timeoutMs: 50_000,
-          check: async () => {
-            await prewarm();
-            expect(await readManifestWorkflowFunctionNames()).toContain(
-              'devTestWorkflowChangeBase'
-            );
-          },
-        });
-      }
+          );
+          await pollUntil({
+            description: 'workflow-change fixture to appear in manifest',
+            timeoutMs: 50_000,
+            check: async () => {
+              await prewarm();
+              expect(await readManifestWorkflowFunctionNames()).toContain(
+                'devTestWorkflowChangeBase'
+              );
+            },
+          });
+        }
 
-      await fs.writeFile(
-        workflowFile,
-        `${content}
+        await fs.writeFile(
+          workflowFile,
+          `${content}
 
 export async function myNewWorkflow() {
   'use workflow'
   return 'hello world'
 }
 `
-      );
-      if (!usesNextFlowRoute) {
-        restoreFiles.push({ path: workflowFile, content });
+        );
+        if (!usesNextFlowRoute) {
+          restoreFiles.push({ path: workflowFile, content });
+        }
+
+        await pollUntil({
+          description: 'generated workflow to include myNewWorkflow',
+          timeoutMs: usesNextFlowRoute ? 50_000 : 25_000,
+          check: async () => {
+            if (usesNextFlowRoute) {
+              await prewarm();
+              const manifestFunctionNames =
+                await readManifestWorkflowFunctionNames();
+              expect(manifestFunctionNames).toContain('myNewWorkflow');
+              return;
+            }
+
+            const workflowContent = await readGeneratedWorkflowOutput();
+            expect(workflowContent).toContain('myNewWorkflow');
+          },
+        });
       }
-
-      await pollUntil({
-        description: 'generated workflow to include myNewWorkflow',
-        timeoutMs: usesNextFlowRoute ? 50_000 : 25_000,
-        check: async () => {
-          if (usesNextFlowRoute) {
-            await prewarm();
-            const manifestFunctionNames =
-              await readManifestWorkflowFunctionNames();
-            expect(manifestFunctionNames).toContain('myNewWorkflow');
-            return;
-          }
-
-          const workflowContent = await readGeneratedWorkflowOutput();
-          expect(workflowContent).toContain('myNewWorkflow');
-        },
-      });
-    });
+    );
 
     test.runIf(!usesNextFlowRoute)(
       'should rebuild on step change',
@@ -670,7 +675,7 @@ async function hmrStep() {
 
     test(
       'should rebuild on adding workflow file',
-      { timeout: 60_000 },
+      { timeout: hmrTestTimeoutMs },
       async () => {
         if (usesNextFlowRoute) {
           await waitForHmrReady();

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -664,26 +664,9 @@ describe('e2e', () => {
     expect(returnValue[2].body).toBe('{"message":"three"}');
   });
 
-  // Skipped on world-postgres: the same-tick replay pattern this test
-  // stresses also surfaces a SEPARATE, pre-existing world-postgres bug
-  // — the step entity UPDATE and the event INSERT are not atomic, so a
-  // late concurrent `step_started` can pass the non-terminal
-  // conditional UPDATE before `step_completed` commits but append its
-  // event after it, producing a duplicate `step_started` after
-  // `step_completed` in the log and a `CorruptedEventLogError` on
-  // replay. That is a step-lifecycle ordering bug, not the hook
-  // self-conflict fixed by this PR (the postgres log in the failing CI
-  // run shows duplicate `hook_created` inserts were correctly rejected
-  // by `workflow_events_entity_creation_unique`). Tracked separately
-  // in https://github.com/vercel/workflow/issues/2331 — re-enable on
-  // postgres when that lands. The deterministic unit tests in
-  // `world-local` and `world-postgres` cover the hook idempotency
-  // invariant on both worlds regardless.
-  const isPostgresWorld =
-    !!process.env.WORKFLOW_TARGET_WORLD?.includes('postgres');
-  test.skipIf(isPostgresWorld)(
+  test(
     'parallelStepsThenWebhookWorkflow - no hook_conflict from same-tick replay race',
-    { timeout: 120_000 },
+    { timeout: 180_000 },
     async () => {
       // Regression test for https://github.com/vercel/workflow/issues/1665
       // and https://github.com/vercel/workflow/issues/2283.

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -393,7 +393,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
 
   return {
     async create(runId, data, params): Promise<EventResult> {
-      const eventId = `wevt_${ulid()}`;
+      let eventId: string | undefined;
+      const getEventId = () => (eventId ??= `wevt_${ulid()}`);
 
       // For run_created events, use client-provided runId or generate one server-side
       let effectiveRunId: string;
@@ -568,7 +569,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
           return handleLegacyEventPostgres(
             drizzle,
             effectiveRunId,
-            eventId,
+            getEventId(),
             data,
             currentRun,
             params
@@ -618,7 +619,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             .insert(Schema.events)
             .values({
               runId: effectiveRunId,
-              eventId,
+              eventId: getEventId(),
               correlationId: data.correlationId,
               eventType: data.eventType,
               eventData: 'eventData' in data ? data.eventData : undefined,
@@ -626,7 +627,12 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             })
             .returning({ createdAt: Schema.events.createdAt });
 
-          const result = { ...data, ...value, runId: effectiveRunId, eventId };
+          const result = {
+            ...data,
+            ...value,
+            runId: effectiveRunId,
+            eventId: getEventId(),
+          };
           const parsed = EventSchema.parse(result);
           const resolveData = params?.resolveData ?? 'all';
           return {
@@ -1070,6 +1076,30 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         run = deserializeRunError(compact(runValue));
       }
 
+      // Strip eventData from run_started — it belongs on run_created only.
+      // For step_started on the lazy-start path, strip only the step `input`
+      // (it belongs on the synthetic step_created written below); `stepName`
+      // is preserved for the client replay consumer's step-name divergence
+      // check.
+      let storedEventData: unknown;
+      if (data.eventType === 'run_started') {
+        storedEventData = undefined;
+      } else if ('eventData' in data && data.eventData) {
+        if (
+          data.eventType === 'step_started' &&
+          'input' in (data.eventData as Record<string, unknown>)
+        ) {
+          const { input: _strippedInput, ...rest } = data.eventData as {
+            input?: unknown;
+          } & Record<string, unknown>;
+          storedEventData = rest;
+        } else {
+          storedEventData = data.eventData;
+        }
+      } else {
+        storedEventData = undefined;
+      }
+
       // Handle step_created event: create step entity
       if (data.eventType === 'step_created') {
         const eventData = (data as any).eventData as {
@@ -1095,133 +1125,130 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         }
       }
 
-      // Handle step_started event: increment attempt, set status to 'running'
-      // Sets startedAt (maps to startedAt) only on first start
-      // Uses conditional UPDATE to prevent re-starting a step that has already
-      // reached a terminal state (completed/failed). Without this guard a
-      // concurrent step_started could revert a completed step back to 'running',
-      // allowing a duplicate execution that corrupts the event log.
-      if (data.eventType === 'step_started') {
-        // Lazy step start: no prior step_created exists, but this step_started
-        // carries the step-creation data. Create the step entity and write a
-        // synthetic step_created event (so replay still observes a
-        // step_created) before the start UPDATE below. Mirrors the resilient
-        // run_started path. Idempotency/ownership is enforced by
-        // onConflictDoNothing() on both the step row (PK runId+stepId) and the
-        // step_created event row (the workflow_events_entity_creation_unique
-        // partial index): a concurrent step_created (or lazy step_started)
-        // simply no-ops here, and the start UPDATE below then operates on the
-        // winner's step.
-        if (lazyStepStart && !validatedStep) {
-          const lazyData = (data as any).eventData as {
-            stepName: string;
-            input: any;
-          };
-          // Atomic create-claim: onConflictDoNothing + .returning() tells us
-          // whether THIS call inserted the step (winner) or a concurrent
-          // handler already created it (loser, empty result). The claim is the
-          // exactly-once ownership gate — only the winner runs the body inline.
-          const inserted = await drizzle
-            .insert(Schema.steps)
-            .values({
-              runId: effectiveRunId,
-              stepId: data.correlationId!,
-              stepName: lazyData.stepName,
-              input: lazyData.input as SerializedContent,
-              status: 'pending',
-              attempt: 0,
-              specVersion: effectiveSpecVersion,
-            })
-            .onConflictDoNothing()
-            .returning({ stepId: Schema.steps.stepId });
+      let value: { createdAt: Date } | undefined;
 
-          if (inserted.length === 0) {
-            // A concurrent handler won the create. Throw EntityConflictError so
-            // the runtime's executeStep maps this to `skipped` and the loser
-            // does not start or run the step — preserving the same exactly-once
-            // ownership guarantee the separate step_created claim provides.
-            throw new EntityConflictError(
-              `Step "${data.correlationId}" already created`
+      if (data.eventType === 'step_started') {
+        value = await drizzle.transaction(async (tx) => {
+          if (lazyStepStart && !validatedStep) {
+            const lazyData = (data as any).eventData as {
+              stepName: string;
+              input: any;
+            };
+            const [inserted] = await tx
+              .insert(Schema.steps)
+              .values({
+                runId: effectiveRunId,
+                stepId: data.correlationId!,
+                stepName: lazyData.stepName,
+                input: lazyData.input as SerializedContent,
+                status: 'pending',
+                attempt: 0,
+                specVersion: effectiveSpecVersion,
+              })
+              .onConflictDoNothing()
+              .returning({ stepId: Schema.steps.stepId });
+
+            if (!inserted) {
+              throw new EntityConflictError(
+                `Step "${data.correlationId}" already created`
+              );
+            }
+
+            const stepCreatedEventId = `wevt_${ulid()}`;
+            await tx
+              .insert(events)
+              .values({
+                runId: effectiveRunId,
+                eventId: stepCreatedEventId,
+                correlationId: data.correlationId,
+                eventType: 'step_created',
+                eventData: {
+                  stepName: lazyData.stepName,
+                  input: lazyData.input,
+                },
+                specVersion: effectiveSpecVersion,
+              })
+              .onConflictDoNothing();
+            stepCreatedLazily = true;
+          }
+
+          if (
+            validatedStep?.retryAfter &&
+            validatedStep.retryAfter.getTime() > Date.now()
+          ) {
+            throw new TooEarlyError(
+              `Cannot start step "${data.correlationId}": retryAfter timestamp has not been reached yet`,
+              {
+                retryAfter: Math.ceil(
+                  (validatedStep.retryAfter.getTime() - Date.now()) / 1000
+                ),
+              }
             );
           }
 
-          // Synthetic step_created event — earlier ULID than the step_started
-          // event written later in this function, so replay sees created
-          // before started. onConflictDoNothing dedupes against a concurrent
-          // real step_created via the entity-creation unique index.
-          const stepCreatedEventId = `wevt_${ulid()}`;
-          await drizzle
+          const [stepValue] = await tx
+            .update(Schema.steps)
+            .set({
+              status: 'running',
+              attempt: sql`${Schema.steps.attempt} + 1`,
+              startedAt: sql`COALESCE(${Schema.steps.startedAt}, ${now.toISOString()})`,
+              retryAfter: null,
+            })
+            .where(
+              and(
+                eq(Schema.steps.runId, effectiveRunId),
+                eq(Schema.steps.stepId, data.correlationId!),
+                notInArray(Schema.steps.status, terminalStepStatuses)
+              )
+            )
+            .returning();
+
+          if (stepValue) {
+            step = deserializeStepError(compact(stepValue));
+          } else {
+            const [existing] = await tx
+              .select({ status: Schema.steps.status })
+              .from(Schema.steps)
+              .where(
+                and(
+                  eq(Schema.steps.runId, effectiveRunId),
+                  eq(Schema.steps.stepId, data.correlationId!)
+                )
+              )
+              .limit(1);
+            if (!existing) {
+              throw new WorkflowWorldError(
+                `Step "${data.correlationId}" not found`
+              );
+            }
+            if (isStepTerminal(existing.status)) {
+              throw new EntityConflictError(
+                `Cannot modify step in terminal state "${existing.status}"`
+              );
+            }
+          }
+
+          const stepStartedEventId = `wevt_${ulid()}`;
+          eventId = stepStartedEventId;
+          const [eventValue] = await tx
             .insert(events)
             .values({
               runId: effectiveRunId,
-              eventId: stepCreatedEventId,
+              eventId: stepStartedEventId,
               correlationId: data.correlationId,
-              eventType: 'step_created',
-              eventData: {
-                stepName: lazyData.stepName,
-                input: lazyData.input,
-              },
+              eventType: data.eventType,
+              eventData: storedEventData,
               specVersion: effectiveSpecVersion,
             })
-            .onConflictDoNothing();
-          stepCreatedLazily = true;
-        }
+            .returning({ createdAt: events.createdAt });
 
-        // Check if retryAfter timestamp hasn't been reached yet
-        if (
-          validatedStep?.retryAfter &&
-          validatedStep.retryAfter.getTime() > Date.now()
-        ) {
-          throw new TooEarlyError(
-            `Cannot start step "${data.correlationId}": retryAfter timestamp has not been reached yet`,
-            {
-              retryAfter: Math.ceil(
-                (validatedStep.retryAfter.getTime() - Date.now()) / 1000
-              ),
-            }
-          );
-        }
-
-        const [stepValue] = await drizzle
-          .update(Schema.steps)
-          .set({
-            status: 'running',
-            // Increment attempt counter using SQL
-            attempt: sql`${Schema.steps.attempt} + 1`,
-            // Only set startedAt on first start — use COALESCE so concurrent
-            // step_started calls can't clobber the original timestamp.
-            startedAt: sql`COALESCE(${Schema.steps.startedAt}, ${now.toISOString()})`,
-            // Always clear retryAfter now that the step has started
-            retryAfter: null,
-          })
-          .where(
-            and(
-              eq(Schema.steps.runId, effectiveRunId),
-              eq(Schema.steps.stepId, data.correlationId!),
-              // Only update if not already in terminal state (prevents TOCTOU race)
-              notInArray(Schema.steps.status, terminalStepStatuses)
-            )
-          )
-          .returning();
-        if (stepValue) {
-          step = deserializeStepError(compact(stepValue));
-        } else {
-          // Step not updated - check if it exists and why
-          const [existing] = await getStepForValidation.execute({
-            runId: effectiveRunId,
-            stepId: data.correlationId!,
-          });
-          if (!existing) {
-            throw new WorkflowWorldError(
-              `Step "${data.correlationId}" not found`
-            );
-          }
-          if (isStepTerminal(existing.status)) {
+          if (!eventValue) {
             throw new EntityConflictError(
-              `Cannot modify step in terminal state "${existing.status}"`
+              `Event ${stepStartedEventId} could not be created`
             );
           }
-        }
+          return eventValue;
+        });
       }
 
       // Handle step_completed event: update step status
@@ -1424,12 +1451,13 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
               token: eventData.token,
               conflictingRunId: existingHook.runId,
             };
+            const conflictEventId = getEventId();
 
             const [conflictValue] = await drizzle
               .insert(events)
               .values({
                 runId: effectiveRunId,
-                eventId,
+                eventId: conflictEventId,
                 correlationId: data.correlationId,
                 eventType: 'hook_conflict',
                 eventData: conflictEventData,
@@ -1439,7 +1467,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
 
             if (!conflictValue) {
               throw new EntityConflictError(
-                `Event ${eventId} could not be created`
+                `Event ${conflictEventId} could not be created`
               );
             }
 
@@ -1449,7 +1477,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
               eventData: conflictEventData,
               ...conflictValue,
               runId: effectiveRunId,
-              eventId,
+              eventId: conflictEventId,
             };
             const parsedConflict = EventSchema.parse(conflictResult);
             const resolveData = params?.resolveData ?? 'all';
@@ -1581,43 +1609,20 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         }
       }
 
-      // Strip eventData from run_started — it belongs on run_created only.
-      // For step_started on the lazy-start path, strip only the step `input`
-      // (it belongs on the synthetic step_created written above); `stepName`
-      // is preserved for the client replay consumer's step-name divergence
-      // check.
-      let storedEventData: unknown;
-      if (data.eventType === 'run_started') {
-        storedEventData = undefined;
-      } else if ('eventData' in data && data.eventData) {
-        if (
-          data.eventType === 'step_started' &&
-          'input' in (data.eventData as Record<string, unknown>)
-        ) {
-          const { input: _strippedInput, ...rest } = data.eventData as {
-            input?: unknown;
-          } & Record<string, unknown>;
-          storedEventData = rest;
-        } else {
-          storedEventData = data.eventData;
-        }
-      } else {
-        storedEventData = undefined;
-      }
-
-      let value: { createdAt: Date } | undefined;
       try {
-        [value] = await drizzle
-          .insert(events)
-          .values({
-            runId: effectiveRunId,
-            eventId,
-            correlationId: data.correlationId,
-            eventType: data.eventType,
-            eventData: storedEventData,
-            specVersion: effectiveSpecVersion,
-          })
-          .returning({ createdAt: events.createdAt });
+        if (!value) {
+          [value] = await drizzle
+            .insert(events)
+            .values({
+              runId: effectiveRunId,
+              eventId: getEventId(),
+              correlationId: data.correlationId,
+              eventType: data.eventType,
+              eventData: storedEventData,
+              specVersion: effectiveSpecVersion,
+            })
+            .returning({ createdAt: events.createdAt });
+        }
       } catch (err) {
         // Translate unique-violation on the correlated-event partial index
         // (workflow_events_entity_creation_unique) into EntityConflictError
@@ -1655,13 +1660,15 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         throw err;
       }
       if (!value) {
-        throw new EntityConflictError(`Event ${eventId} could not be created`);
+        throw new EntityConflictError(
+          `Event ${getEventId()} could not be created`
+        );
       }
       const result = {
         ...data,
         ...value,
         runId: effectiveRunId,
-        eventId,
+        eventId: getEventId(),
         ...(storedEventData !== undefined
           ? { eventData: storedEventData }
           : {}),

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -1127,8 +1127,17 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
 
       let value: { createdAt: Date } | undefined;
 
+      // Handle step_started event: increment attempt and set the step to
+      // running, then write the matching event log entry in the same
+      // transaction. The guarded UPDATE takes the step row lock; keeping the
+      // event INSERT behind that lock prevents a late step_started from being
+      // ordered after a concurrent terminal event that already won the row.
       if (data.eventType === 'step_started') {
         value = await drizzle.transaction(async (tx) => {
+          // Lazy step start: no prior step_created exists, but this
+          // step_started carries the step-creation data. The step INSERT is
+          // the ownership claim: only the caller that inserts the row gets to
+          // run the step body inline.
           if (lazyStepStart && !validatedStep) {
             const lazyData = (data as any).eventData as {
               stepName: string;
@@ -1154,6 +1163,10 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
               );
             }
 
+            // Replay still needs to observe step_created before
+            // step_started. Because this synthetic event is in the same
+            // transaction as the lazy step row and step_started event, we
+            // cannot leave behind only one side of that materialization.
             const stepCreatedEventId = `wevt_${ulid()}`;
             await tx
               .insert(events)
@@ -1172,6 +1185,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             stepCreatedLazily = true;
           }
 
+          // Retried steps may be scheduled for later. Keep this check inside
+          // the transaction so the step_started write cannot slip past it.
           if (
             validatedStep?.retryAfter &&
             validatedStep.retryAfter.getTime() > Date.now()
@@ -1186,11 +1201,16 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             );
           }
 
+          // The terminal-state guard is part of the UPDATE, not just the
+          // earlier validation read. That closes the race where another
+          // writer completes/fails the step between validation and start.
           const [stepValue] = await tx
             .update(Schema.steps)
             .set({
               status: 'running',
               attempt: sql`${Schema.steps.attempt} + 1`,
+              // Preserve the original first-start timestamp across retries or
+              // overlapping starts.
               startedAt: sql`COALESCE(${Schema.steps.startedAt}, ${now.toISOString()})`,
               retryAfter: null,
             })
@@ -1228,6 +1248,10 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             }
           }
 
+          // Allocate the step_started ULID only after the guarded step UPDATE
+          // has acquired and passed the row lock. Without a sequence, this is
+          // the local ordering guarantee we can provide: a writer blocked on
+          // the step row will not carry an older event id into a later insert.
           const stepStartedEventId = `wevt_${ulid()}`;
           eventId = stepStartedEventId;
           const [eventValue] = await tx

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -4,6 +4,7 @@ import type { Hook, Step, WorkflowRun } from '@workflow/world';
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { encode } from 'cbor-x';
 import { Pool } from 'pg';
+import { decodeTime } from 'ulid';
 import {
   afterAll,
   beforeAll,
@@ -700,6 +701,49 @@ describe('Storage (Postgres integration)', () => {
         expect(updated.status).toBe('running');
         expect(updated.startedAt).toBeInstanceOf(Date);
         expect(updated.attempt).toBe(1); // Incremented by step_started
+      });
+
+      it('allocates the step_started event id after the guarded step update', async () => {
+        const stepId = 'step-start-lock';
+        await createStep(events, testRunId, {
+          stepId,
+          stepName: 'test-step',
+          input: new Uint8Array([1]),
+        });
+
+        const lockPool = new Pool({
+          connectionString: container.getConnectionUri(),
+          max: 1,
+        });
+        const client = await lockPool.connect();
+
+        try {
+          await client.query('BEGIN');
+          await client.query(
+            'SELECT 1 FROM workflow.workflow_steps WHERE run_id = $1 AND step_id = $2 FOR UPDATE',
+            [testRunId, stepId]
+          );
+
+          const started = events.create(testRunId, {
+            eventType: 'step_started',
+            correlationId: stepId,
+          });
+
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          const releasedAt = Date.now();
+          await client.query('COMMIT');
+
+          const result = await started;
+          if (!result.event) {
+            throw new Error('Expected step_started event');
+          }
+          expect(
+            decodeTime(result.event.eventId.slice('wevt_'.length))
+          ).toBeGreaterThanOrEqual(releasedAt);
+        } finally {
+          client.release();
+          await lockPool.end();
+        }
       });
 
       it('should update step status to completed via step_completed event', async () => {


### PR DESCRIPTION
## Summary

Fixes #2331 by writing the Postgres `step_started` step update and matching `workflow_events` insert in one transaction. The `step_started` event id is allocated after the guarded `workflow_steps` update has acquired the row lock, so a blocked writer does not carry an older ULID into a later event insert.

No schema migration or sequence is included.

Also gives Next canary local-dev HMR tests more time to rediscover workflow changes. The previous head's functional checks passed, but a canary local-dev HMR job flaked; the bumped timeout keeps the test-level timeout aligned with the canary HMR wait budget.

## Limitations

This still uses ULID wall-clock ordering, not a database monotonic sequence. The transaction serializes lifecycle writers that contend on the same step row, which is the issue here, and shrinks the old ordering window from the whole blocked DB-write span down to event-id generation after the row-lock-protected update.

For the same step, the remaining caveat is not that two full transactions must complete within one millisecond. It is that transaction A generates its ULID before it commits, then transaction B can generate its ULID after A commits and B's blocked row update returns. If both generation calls land in the same millisecond, cross-process ULID random suffix ordering is still not a commit-order guarantee. This is a much narrower caveat than the previous DB-call-duration race, but a database sequence would be the stronger primitive if we later need global event ordering.

## Testing

- `./node_modules/.bin/biome check --diagnostic-level=error packages/world-postgres/src/storage.ts packages/world-postgres/test/storage.test.ts`
- `./node_modules/.bin/biome check --diagnostic-level=error packages/core/e2e/dev.test.ts`
- `./node_modules/.bin/tsc --noEmit -p packages/world-postgres/tsconfig.json`
- `cd packages/world-postgres && ../../node_modules/.bin/vitest run test/storage.test.ts -t "allocates the step_started event id after the guarded step update"`
- `cd packages/world-postgres && ../../node_modules/.bin/vitest run test/storage.test.ts`
- `cd packages/world-postgres && ../../node_modules/.bin/vitest run test/storage.test.ts src/reenqueue.test.ts src/util.test.ts src/queue.test.ts`
- `pnpm --filter @workflow/world-postgres build`

Note: `./node_modules/.bin/tsc --noEmit -p packages/core/tsconfig.json` currently fails on unrelated `packages/core/src/runtime/start.ts` `specVersion` typing errors.
