### PR TITLE
fix(ai): continue DurableAgent tool loops

### DIFF
--- a/.changeset/durable-agent-tool-stop-detection.md
+++ b/.changeset/durable-agent-tool-stop-detection.md
@@ -1,0 +1,5 @@
+---
+'@workflow/ai': patch
+---
+
+Continue DurableAgent tool loops whenever a model step contains tool calls, regardless of the reported finish reason.

--- a/packages/ai/src/agent/stream-text-iterator.ts
+++ b/packages/ai/src/agent/stream-text-iterator.ts
@@ -331,7 +331,7 @@ export async function* streamTextIterator({
         // Normalize finishReason - AI SDK v6 returns { unified, raw }, v5 returns a string
         const finishReason = normalizeFinishReason(raw.rawFinishReason);
 
-        if (finishReason === 'tool-calls') {
+        if (finishReason === 'tool-calls' || toolCalls.length > 0) {
           lastStepWasToolCalls = true;
 
           // Build reasoning content parts from the step result.


### PR DESCRIPTION
## Summary
- Treat any DurableAgent step with collected tool calls as a tool-call step, even if the provider reports a non-tool finish reason.
- Add a patch changeset for `@workflow/ai`.

Fixes #1387.

## Testing
- `PATH="/Users/nathancolosimo/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/nathancolosimo/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH" HUSKY=0 pnpm --dir packages/ai exec vitest run src/agent/stream-text-iterator.test.ts`