### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,3 +294,22 @@ The `executionContext` field on workflow runs is a flexible JSONB/CBOR object th
 Every outgoing HTTP request from `@workflow/world-vercel` to workflow-server (or the queue) MUST explicitly inject W3C trace context so the server can parent its spans to the caller and traces stay correlated end to end. Call `injectTraceContextIntoHeaders(headers)` (from `packages/world-vercel/src/telemetry.ts`) on the outgoing headers, inside the client span when one exists — `makeRequest` in `utils.ts` is the reference implementation. It is a no-op when no OpenTelemetry SDK is registered.
 
 Do **not** rely on ambient OpenTelemetry auto-instrumentation to do this: world-vercel's request paths use custom undici dispatchers / `global fetch`, which auto-instrumentation does not reliably hook. When you add a new request path or API version (e.g. a future v5 events API), wire the injection in the same place you build the request headers. The v4 events path (`fetchV4` in `events-v4.ts`) regressed cross-service correlation precisely by routing around `makeRequest` and skipping this step — workflow-server spans stopped joining the flow-route invocation trace until the injection was added back. Cover new paths with a test in `trace-propagation.test.ts`.
+
+## Cursor Cloud specific instructions
+
+The VM snapshot already has dependencies installed (`pnpm install` runs automatically on startup) and a Rust toolchain configured. This section captures only non-obvious, durable caveats — see the `## Development Commands` section above for the standard build/test/lint/dev commands.
+
+### Build before running anything downstream
+`pnpm build` (root) builds only `packages/*`, and the workbench apps consume the packages' compiled `dist` output via `workspace:*`. You must run `pnpm build` at least once before starting a workbench dev server or running e2e tests, and rebuild any package you change. This is already noted in the changesets guidance above; it applies to the dev environment too.
+
+### Rust is required to build the SWC plugin
+`@workflow/swc-plugin` (`packages/swc-plugin-workflow`) compiles a WASM binary from Rust during `pnpm build`. The Rust workspace requires **edition 2024 / Rust ≥ 1.87** (`Cargo.toml` pins `rust-version = "1.87"`) and the `wasm32-unknown-unknown` target. The snapshot's default toolchain (`rustup default stable`) and the wasm target are already set up. If a future toolchain reset leaves the default at an older Rust (e.g. 1.83), `pnpm build` fails with `feature 'edition2024' is required`; fix with `rustup default stable` (must resolve to ≥ 1.87) and `rustup target add wasm32-unknown-unknown`. There is no committed prebuilt `.wasm`, so this build step is mandatory. The first WASM build takes ~1 minute (LTO release build); subsequent builds are Turbo-cached.
+
+### Local development uses the filesystem "world" — no database needed
+With `WORKFLOW_TARGET_WORLD` unset and no `VERCEL_DEPLOYMENT_ID`, the runtime defaults to the local filesystem world (`@workflow/world-local`). The `workbench/nextjs-turbopack` dev server therefore runs workflows end-to-end with no Postgres/Vercel setup. Postgres/Vercel worlds are optional and only needed to exercise those specific backends.
+
+### `pnpm lint` is not a clean gate
+`pnpm lint` (`biome check`) currently reports many pre-existing diagnostics (e.g. `noNonNullAssertion`, `useImportType`) across source and generated dirs, and it is **not** run by CI — the `Lint` workflow (`.github/workflows/lint.yml`) only checks for test overrides, runs `.github/scripts` unit tests, and validates docs links. Do not expect a clean `biome check`; use `pnpm format` / targeted `biome check <path>` when tidying code you touch.
+
+### Quick end-to-end smoke test
+The `nextjs-turbopack` app exposes `POST /api/workflows/start` (`{ "workflowName": "...", "args": [...] }`, returns an `X-Workflow-Run-Id` header) and `POST /api/workflows/await` (`{ "runId": "..." }`). The home page (`http://localhost:3000`) also has a Workflows tab to trigger any workflow and watch it complete. Deterministic workflows for smoke tests: `addTenWorkflow` (`[123]` → `133`), `simple` (`[42]` → `57`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the Cloud Agent development environment for this repo and documents the non-obvious setup caveats discovered along the way. The only code change is an additive `## Cursor Cloud specific instructions` section in `AGENTS.md`.

## Environment setup

- **Update script** (runs on VM startup): `pnpm install` — minimal and idempotent. Rust toolchain and package builds are intentionally left out of the update script (documented in AGENTS.md instead).
- **Rust caveat**: `@workflow/swc-plugin` compiles a WASM binary needing Rust ≥ 1.87 (edition 2024) + `wasm32-unknown-unknown`. The VM default was 1.83, so it was updated via `rustup default stable` (1.96.1) + `rustup target add wasm32-unknown-unknown`. There is no committed prebuilt `.wasm`, so `pnpm build` is mandatory before running downstream apps/e2e.
- Local dev uses the filesystem "world" — no database required.

## Verification

- ✅ `pnpm install`
- ✅ `pnpm build` (27 packages, including the Rust→WASM SWC plugin)
- ✅ `pnpm typecheck` (40 tasks)
- ⚠️ `pnpm lint` (`biome check`) runs but reports pre-existing findings; not part of CI gating in `.github/workflows/lint.yml`
- ✅ `pnpm vitest run` core unit tests (283 passed)
- ✅ `nextjs-turbopack` dev server on port 3000; ran `addTenWorkflow([123]) → 133` via HTTP and `simple([42]) → 57` via the browser UI
- ✅ e2e subset `sleepingWorkflow` against the local dev server

Demo of running the `simple` workflow end-to-end through the web UI (completes with result `57`):

[workflow_sdk_run_simple_workflow_demo.mp4](https://cursor.com/agents/bc-21a19d18-2355-415e-9afa-46d3d9c09c51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow_sdk_run_simple_workflow_demo.mp4)

[simple workflow completed with result 57](https://cursor.com/agents/bc-21a19d18-2355-415e-9afa-46d3d9c09c51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkflow_simple_completed_result_57.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21a19d18-2355-415e-9afa-46d3d9c09c51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21a19d18-2355-415e-9afa-46d3d9c09c51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

