### PR TITLE
feat(core): experimental start-hook admission for start()

### DIFF
--- a/.changeset/start-hook-core-api.md
+++ b/.changeset/start-hook-core-api.md
@@ -1,0 +1,11 @@
+---
+"workflow": minor
+"@workflow/core": minor
+"@workflow/errors": minor
+"@workflow/world": minor
+"@workflow/web-shared": patch
+"@workflow/cli": patch
+"@workflow/world-vercel": patch
+---
+
+Add the experimental `hook` option to `start()`. Worlds that declare `startHookAdmission` reserve the hook token atomically with queue-first run admission: duplicate starts throw `HookConflictError`, and a queued run whose admission cannot be confirmed throws the new `WorkflowStartError`. Without `experimental_ttl` the token is released when the run ends. Queue failures on every `start()` path are now surfaced as `WorkflowStartError` (stage `queue`) instead of raw transport errors.

--- a/docs/content/docs/v5/api-reference/workflow-api/start.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-api/start.mdx
@@ -56,10 +56,11 @@ Learn more about [`WorkflowReadableStreamOptions`](/docs/api-reference/workflow-
 * In v5, `start()` can also be called directly from a workflow function to spawn a child run or continue work in a new run. See [Workflow Composition](/cookbook/common-patterns/workflow-composition) and [Versioning](/docs/foundations/versioning).
 * This is different from calling workflow functions directly, which is the typical pattern in Next.js applications.
 * The function returns immediately after enqueuing the workflow - it doesn't wait for the workflow to complete.
-* Each call to `start()` creates a new workflow run. If retried requests must route to one active workflow, have the workflow create a deterministic hook token and use [`getHookByToken()`](/docs/api-reference/workflow-api/get-hook-by-token) to reuse an already-registered active hook. The lookup is not atomic with `start()`, so concurrent callers can still create extra runs before the hook is registered; handle that race inside the workflow by checking `await hook.getConflict()` before duplicate-sensitive work — on a conflict it resolves with the run that owns the token, so the duplicate can return the active owner to the caller. If duplicates must be rejected before a workflow body runs, keep a durable request record until native atomic start-and-hook registration exists. See [Idempotency](/docs/foundations/idempotency#run-idempotency).
+* Each call to `start()` creates a new workflow run unless you opt into an idempotency mechanism. The stable pattern is to have the workflow create a deterministic hook token and use [`getHookByToken()`](/docs/api-reference/workflow-api/get-hook-by-token) to reuse an already-registered active hook. The lookup is not atomic with `start()`, so concurrent callers can still create extra runs before the hook is registered; handle that race inside the workflow by checking `await hook.getConflict()` before duplicate-sensitive work. If duplicates must be rejected before duplicate workflow code can run, use the experimental `hook` start option in a supporting World. See [Idempotency](/docs/foundations/idempotency#run-idempotency).
 * All arguments must be [serializable](/docs/foundations/serialization).
 * When `deploymentId` is provided, the argument types and return type become `unknown` since there is no guarantee the workflow function's types will be consistent across different deployments.
 * `attributes` seeds plaintext run metadata as part of creation and requires a World implementing spec version 4 or later. Keys that start with `$` are reserved for framework and library code; framework-level callers can pass `allowReservedAttributes: true` to seed reserved keys, with the same semantics as the [`experimental_setAttributes`](/docs/api-reference/workflow/experimental-set-attributes) option of the same name.
+* `hook` (experimental) reserves a deterministic hook token as part of start admission in Worlds that support it. Admission is queue-first: the run is enqueued, then admitted — duplicate starts throw [`HookConflictError`](/docs/api-reference/workflow-errors/hook-conflict-error), and a queued run whose admission cannot be confirmed throws [`WorkflowStartError`](/docs/api-reference/workflow-errors/workflow-start-error). Turbo mode is disabled for the first invocation of a start-hook run, and Worlds may cap the TTL and token size. Without `experimental_ttl`, the token is released when the hook is disposed or the run ends; with it, the token stays fenced for the TTL. See [Run idempotency](/docs/foundations/idempotency#atomic-start-hook-idempotency).
 
 <Callout type="info">
 If `start()` throws `'start' received an invalid workflow function. Ensure the Workflow Development Kit is configured correctly and the function includes a 'use workflow' directive.`, the passed function was not transformed as a workflow. The two most common causes are a missing `"use workflow"` directive or missing framework integration. See [start-invalid-workflow-function](/docs/errors/start-invalid-workflow-function).
@@ -86,6 +87,29 @@ const run = await start(myWorkflow, ["arg1", "arg2"], { // [!code highlight]
   deploymentId: "custom-deployment-id", // [!code highlight]
   attributes: { source: "checkout" } // [!code highlight]
 }); // [!code highlight]
+```
+
+### With the `hook` option
+
+Use the experimental `hook` option when duplicate starts must be rejected before duplicate workflow code can run. The workflow should still create the same hook token and check `hook.getConflict()` so the queued invocation can materialize the reserved hook and so non-supporting Worlds have the same in-workflow guard.
+
+```typescript
+import { start } from "workflow/api";
+import { processOrder } from "./workflows/process-order";
+
+try {
+  const run = await start(processOrder, ["order_123"], {
+    hook: {
+      token: "order:order_123",
+      experimental_ttl: "30 days",
+    },
+  });
+  console.log("Started run", run.runId);
+} catch (error) {
+  // HookConflictError means another active or retained run owns the token.
+  // WorkflowStartError means the run may already be queued; inspect error.runId.
+  throw error;
+}
 ```
 
 ### Using `deploymentId: "latest"`

--- a/docs/content/docs/v5/api-reference/workflow-errors/index.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-errors/index.mdx
@@ -51,6 +51,9 @@ All errors extend [`WorkflowError`](/docs/api-reference/workflow-errors/workflow
     <Card href="/docs/api-reference/workflow-errors/workflow-runtime-error" title="WorkflowRuntimeError">
         Thrown when the workflow runtime encounters an execution error, such as serialization failures or timeouts.
     </Card>
+    <Card href="/docs/api-reference/workflow-errors/workflow-start-error" title="WorkflowStartError">
+        Thrown when start() cannot synchronously confirm queueing or start-hook admission.
+    </Card>
     <Card href="/docs/api-reference/workflow-errors/run-expired-error" title="RunExpiredError">
         Thrown when a workflow run has expired and can no longer be operated on.
     </Card>

--- a/docs/content/docs/v5/api-reference/workflow-errors/workflow-start-error.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-errors/workflow-start-error.mdx
@@ -1,0 +1,76 @@
+---
+title: WorkflowStartError
+description: Thrown when start() cannot synchronously confirm queueing or start-hook admission.
+type: reference
+summary: Catch WorkflowStartError when a start call may have queued a run but could not confirm admission.
+related:
+  - /docs/api-reference/workflow-api/start
+  - /docs/foundations/idempotency
+---
+
+`WorkflowStartError` is thrown by [`start()`](/docs/api-reference/workflow-api/start) when the SDK cannot synchronously confirm a run started successfully. It carries the generated `runId` so callers can inspect the run, poll later, or retry the start call.
+
+Every `start()` call can throw it when enqueueing fails (`stage: 'queue'`) — the queue may or may not have accepted the message. With the experimental `hook` option, admission is queue-first, so a queued run whose admission cannot be confirmed also surfaces as `WorkflowStartError` (`stage: 'admission'`); the original run may still start later, and retrying the same request can then return a [`HookConflictError`](/docs/api-reference/workflow-errors/hook-conflict-error) if the original run wins the token claim.
+
+```typescript lineNumbers
+import { start } from "workflow/api";
+import { WorkflowStartError } from "workflow/errors";
+import { processOrder } from "./workflows/process-order";
+
+try {
+  await start(processOrder, ["order_123"], {
+    hook: {
+      token: "order:order_123",
+      experimental_ttl: "30 days",
+    },
+  });
+} catch (error) {
+  if (WorkflowStartError.is(error)) { // [!code highlight]
+    console.log("Run may already be queued:", error.runId);
+  }
+}
+```
+
+## API Signature
+
+### Properties
+
+<TSDoc
+definition={`
+interface WorkflowStartError {
+  /** The generated workflow run ID. */
+  runId: string;
+  /** The phase that failed: queue send or admission confirmation. */
+  stage: "queue" | "admission";
+  /** Whether the queue accepted the message, when known. */
+  queued: true | "unknown";
+  /** Whether retrying the start call is expected to be safe/useful. */
+  retryable: boolean;
+  /** HTTP status code from the world backend, if available. */
+  status?: number;
+  /** Machine-readable error code, if available. */
+  code?: string;
+  /** Request URL from the world backend, if available. */
+  url?: string;
+  /** Retry-After value in seconds, present on 429 and 425 responses. */
+  retryAfter?: number;
+  /** The error message. */
+  message: string;
+}
+export default WorkflowStartError;`}
+/>
+
+### Static Methods
+
+#### `WorkflowStartError.is(value)`
+
+Type-safe check for `WorkflowStartError` instances.
+
+```typescript
+import { WorkflowStartError } from "workflow/errors"
+declare const error: unknown; // @setup
+
+if (WorkflowStartError.is(error)) {
+  // error is typed as WorkflowStartError
+}
+```

--- a/docs/content/docs/v5/foundations/idempotency.mdx
+++ b/docs/content/docs/v5/foundations/idempotency.mdx
@@ -146,10 +146,79 @@ export async function POST(request: Request) {
 ```
 
 <Callout type="warn">
-This avoids creating a new run only after the first run has registered its hook. Because `start()` returns before the run body executes and calls `createHook()`, two concurrent requests can both observe "no hook yet" and each call `start()`. The race is resolved inside the workflow body, where the losing run observes `getConflict()` resolving with the active owner and returns without doing duplicate-sensitive work — and the route detects it by comparing the resumed hook's `runId` against the run it just started, without waiting for either run to finish. A native API for atomically starting a run and registering a hook is in the works. Until then, model recovery inside the workflow by checking `hook.getConflict()`.
+This avoids creating a new run only after the first run has registered its hook. Because `start()` returns before the run body executes and calls `createHook()`, two concurrent requests can both observe "no hook yet" and each call `start()`. The race is resolved inside the workflow body, where the losing run observes `getConflict()` resolving with the active owner and returns without doing duplicate-sensitive work — and the route detects it by comparing the resumed hook's `runId` against the run it just started, without waiting for either run to finish. If duplicates must be rejected before duplicate workflow code can run, use experimental start-hook admission in a supporting World.
 </Callout>
 
 This is active-run coordination. When the workflow completes and disposes the hook, the token can be used again. If a duplicate request after completion must return the original result instead of starting fresh work, persist that completed result under the same domain key.
+
+### Atomic start-hook idempotency
+
+`start()` can reserve the same hook token at admission time with the experimental `hook` option. In supporting Worlds, the run and hook-token claim are admitted atomically. Admission is queue-first: the queue message is accepted first (so a crash can never orphan a claimed token — the queued message can complete admission itself), turbo mode is disabled for that start, and the backend claim decides whether this run owns the token.
+
+```typescript lineNumbers
+import { start } from "workflow/api";
+import { HookConflictError, WorkflowStartError } from "workflow/errors";
+import { processOrder } from "./workflows/process-order";
+
+export async function POST(request: Request) {
+  const { orderId } = await request.json();
+  const token = `order:${orderId}`;
+
+  try {
+    const run = await start(processOrder, [orderId], {
+      hook: {
+        token,
+        experimental_ttl: "30 days",
+      },
+    });
+
+    return Response.json({ runId: run.runId, reused: false });
+  } catch (error) {
+    if (HookConflictError.is(error)) {
+      return Response.json({
+        runId: error.conflictingRunId,
+        reused: true,
+      });
+    }
+
+    if (WorkflowStartError.is(error)) {
+      // The queue may already have accepted this run. Keep error.runId so
+      // callers can poll it or retry the start call.
+      return Response.json(
+        { runId: error.runId, queued: error.queued },
+        { status: 202 }
+      );
+    }
+
+    throw error;
+  }
+}
+```
+
+The workflow should still create the same hook token and check `hook.getConflict()`. That materializes the reserved hook for the owning run and keeps the workflow body correct in Worlds that do not support atomic admission.
+
+```typescript lineNumbers
+import { createHook } from "workflow";
+
+type OrderRequest = { confirmed: boolean };
+
+export async function processOrder(orderId: string) {
+  "use workflow";
+
+  using request = createHook<OrderRequest>({
+    token: `order:${orderId}`,
+  });
+
+  const conflict = await request.getConflict();
+  if (conflict) {
+    return { status: "duplicate" as const, runId: conflict.runId };
+  }
+
+  // Continue with the owning run.
+}
+```
+
+`experimental_ttl` is optional: without it, the token is released as soon as the hook is disposed or the run reaches a terminal state — duplicate starts are fenced only while the run is active. With a TTL, the claim is retained until at least the later of hook creation plus TTL and run completion, so duplicates keep being rejected for the retention window. Cancelling a run before it has created its hook always releases the claim immediately, so an explicit cancel-then-retry can reuse the token without waiting out the TTL. Worlds may cap `experimental_ttl` and the token byte length; values above a cap fail with a world contract error before queueing, and cross-deployment starts fail before queueing unless the target deployment reports support for queued start-hook handling.
 
 ### Conflict-handling strategies
 

--- a/packages/cli/src/lib/inspect/hydration.ts
+++ b/packages/cli/src/lib/inspect/hydration.ts
@@ -159,6 +159,7 @@ const ERROR_REVIVER_KEYS = [
   'SyntaxError',
   'TypeError',
   'URIError',
+  'WorkflowStartError',
 ] as const;
 
 /**

--- a/packages/core/src/capabilities.test.ts
+++ b/packages/core/src/capabilities.test.ts
@@ -103,4 +103,21 @@ describe('getRunCapabilities', () => {
       expect(getRunCapabilities(version).framedByteStreams).toBe(true);
     });
   });
+
+  describe('startHookLoserAck', () => {
+    it('is false when version is missing or invalid', () => {
+      expect(getRunCapabilities(undefined).startHookLoserAck).toBe(false);
+      expect(getRunCapabilities('not-a-version').startHookLoserAck).toBe(false);
+    });
+
+    it('is false before the loser-ack cutoff', () => {
+      // beta.26 was published from main without loser-ack handling.
+      expect(getRunCapabilities('5.0.0-beta.26').startHookLoserAck).toBe(false);
+    });
+
+    it('is true at and after the loser-ack cutoff', () => {
+      expect(getRunCapabilities('5.0.0-beta.27').startHookLoserAck).toBe(true);
+      expect(getRunCapabilities('5.0.0').startHookLoserAck).toBe(true);
+    });
+  });
 });

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -31,6 +31,7 @@
  * - `gzip` (gzip payload compression): added in `5.0.0-beta.18`
  * - `zstd` (zstd payload compression, preferred codec): added in `5.0.0-beta.18`
  *   alongside gzip — they co-ship, so any run that can read one can read both.
+ * - `startHookLoserAck` (queued start-hook loser handling): added in `5.0.0-beta.27`
  */
 
 import semver from 'semver';
@@ -59,6 +60,13 @@ export interface RunCapabilities {
    * raw bytes (the legacy format) for compatibility with older runs.
    */
   framedByteStreams: boolean;
+
+  /**
+   * Whether the target workflow handler safely handles a queued start-hook
+   * run that LOST its token claim: turbo is disabled and `HookConflictError`
+   * during `run_started` is acknowledged without running user workflow code.
+   */
+  startHookLoserAck: boolean;
 }
 
 /**
@@ -96,7 +104,18 @@ const CAPABILITY_VERSION_TABLE: ReadonlyArray<{
   // to the next beta. A too-low cutoff makes new producers write framed bytes to
   // consumers that cannot unframe them (silent corruption); too-high merely
   // delays the optimization (safe).
-}> = [{ capability: 'framedByteStreams', minVersion: '5.0.0-beta.15' }];
+}> = [
+  { capability: 'framedByteStreams', minVersion: '5.0.0-beta.15' },
+  // beta.26 was published from main WITHOUT this change, so the cutoff must
+  // point past it. TODO(release): bump again if another "Version Packages
+  // (beta)" PR merges before this change ships. A too-low cutoff runs user
+  // workflow code on a lost claim (unsafe); too-high merely rejects
+  // cross-deployment start-hook starts (safe).
+  {
+    capability: 'startHookLoserAck',
+    minVersion: '5.0.0-beta.27',
+  },
+];
 
 /**
  * The set of formats supported by all specVersion 2 runs, regardless of
@@ -123,6 +142,7 @@ export function getRunCapabilities(
     return {
       supportedFormats: BASELINE_FORMATS,
       framedByteStreams: false,
+      startHookLoserAck: false,
     };
   }
 
@@ -137,6 +157,7 @@ export function getRunCapabilities(
   const result: RunCapabilities = {
     supportedFormats: formats,
     framedByteStreams: false,
+    startHookLoserAck: false,
   };
 
   for (const { capability, minVersion } of CAPABILITY_VERSION_TABLE) {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,4 +1,5 @@
 import {
+  HookConflictError,
   RUN_ERROR_CODES,
   ThrottleError,
   WorkflowWorldError,
@@ -1479,13 +1480,14 @@ describe('workflowEntrypoint turbo mode', () => {
       return r;
     }${xform('workflow')}`;
 
-  async function makeRunInput(runId: string) {
+  async function makeRunInput(runId: string, extra?: Record<string, unknown>) {
     return {
       input: await dehydrateWorkflowArguments([], runId, undefined, []),
       deploymentId: 'test-deployment',
       workflowName: 'workflow',
       specVersion: SPEC_VERSION_CURRENT,
       executionContext: {},
+      ...extra,
     };
   }
 
@@ -1499,7 +1501,9 @@ describe('workflowEntrypoint turbo mode', () => {
     runId: string;
     attempt: number;
     source: string;
+    runInput?: Awaited<ReturnType<typeof makeRunInput>>;
     runStartedGate?: Promise<void>;
+    runStartedError?: unknown;
   }) {
     const { runId, attempt, source } = opts;
     const order = turboOrder;
@@ -1530,6 +1534,7 @@ describe('workflowEntrypoint turbo mode', () => {
     const eventsCreate = vi.fn(async (_runId: string, data: any) => {
       if (data.eventType === 'run_started') {
         if (opts.runStartedGate) await opts.runStartedGate;
+        if (opts.runStartedError) throw opts.runStartedError;
         order.push('run_started_resolved');
         return { run: runEntity, events: [] as Event[] };
       }
@@ -1573,7 +1578,7 @@ describe('workflowEntrypoint turbo mode', () => {
               {
                 runId,
                 requestedAt: new Date('2024-01-01T00:00:00.000Z'),
-                runInput: await makeRunInput(runId),
+                runInput: opts.runInput ?? (await makeRunInput(runId)),
               },
               {
                 requestId: 'req_turbo',
@@ -1672,6 +1677,69 @@ describe('workflowEntrypoint turbo mode', () => {
     expect(order.indexOf('run_started_resolved')).toBeLessThan(
       order.indexOf('body')
     );
+  });
+
+  it('does not turbo when runInput carries an experimental start hook', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const runId = 'wrun_start_hook_no_turbo';
+    const { handlerPromise, order, eventsCreate } = await driveTurbo({
+      runId,
+      attempt: 1,
+      source: oneStepWorkflow,
+      runInput: await makeRunInput(runId, {
+        startHook: { token: 'order:123', ttlSeconds: 60 },
+      }),
+      runStartedGate: gate,
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(
+          eventsCreate.mock.calls.some(
+            (c) => (c[1] as any).eventType === 'run_started'
+          )
+        ).toBe(true),
+      { timeout: 15_000 }
+    );
+    expect(order).not.toContain('body');
+    expect(order).not.toContain('run_started_resolved');
+
+    release();
+    const res = await handlerPromise;
+    expect(res.status).toBe(204);
+    expect(order.indexOf('run_started_resolved')).toBeLessThan(
+      order.indexOf('body')
+    );
+    const runStarted = eventsCreate.mock.calls.find(
+      (c) => (c[1] as any).eventType === 'run_started'
+    );
+    expect((runStarted?.[2] as any)?.skipPreload).toBeUndefined();
+  });
+
+  it('acknowledges queued start-hook losers without running workflow code', async () => {
+    const runId = 'wrun_start_hook_loser';
+    const { handlerPromise, order, eventsCreate } = await driveTurbo({
+      runId,
+      attempt: 1,
+      source: oneStepWorkflow,
+      runInput: await makeRunInput(runId, {
+        startHook: { token: 'order:123', ttlSeconds: 60 },
+      }),
+      runStartedError: new HookConflictError('order:123', 'wrun_winner'),
+    });
+
+    const res = await handlerPromise;
+    expect(res.status).toBe(204);
+    expect(order).not.toContain('body');
+    expect(order).not.toContain('step_started_called');
+    expect(
+      eventsCreate.mock.calls.some(
+        (c) => (c[1] as any).eventType === 'run_failed'
+      )
+    ).toBe(false);
   });
 
   it('asks the World to skip the run_started preload only under turbo', async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3,6 +3,7 @@ import {
   CorruptedEventLogError,
   EntityConflictError,
   FatalError,
+  HookConflictError,
   ReplayDivergenceError,
   RUN_ERROR_CODES,
   type RunErrorCode,
@@ -542,6 +543,7 @@ export function workflowEntrypoint(
                   const turbo =
                     isTurboEnabled() &&
                     runInput !== undefined &&
+                    runInput.startHook === undefined &&
                     metadata.attempt === 1 &&
                     incomingStepId === undefined &&
                     !replayDivergence;
@@ -770,6 +772,7 @@ export function workflowEntrypoint(
                               workflowName: runInput.workflowName,
                               executionContext: runInput.executionContext,
                               attributes: runInput.attributes,
+                              startHook: runInput.startHook,
                               allowReservedAttributes:
                                 runInput.allowReservedAttributes,
                             },
@@ -883,6 +886,16 @@ export function workflowEntrypoint(
                           );
                         }
                       } catch (err) {
+                        if (runInput?.startHook && HookConflictError.is(err)) {
+                          runtimeLogger.info(
+                            'Start-hook claim lost during setup, skipping queued run',
+                            {
+                              workflowRunId: runId,
+                              message: err.message,
+                            }
+                          );
+                          return;
+                        }
                         // Run was concurrently completed/failed/cancelled
                         if (
                           EntityConflictError.is(err) ||

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -1,9 +1,19 @@
-import { WorkflowRuntimeError, WorkflowWorldError } from '@workflow/errors';
+import { waitUntil } from '@vercel/functions';
+import {
+  EntityConflictError,
+  HookConflictError,
+  RUN_ERROR_CODES,
+  WorkflowRuntimeError,
+  WorkflowStartError,
+  WorkflowWorldError,
+} from '@workflow/errors';
 import {
   SPEC_VERSION_CURRENT,
+  type StartHookAdmissionCaps,
   SPEC_VERSION_LEGACY,
   SPEC_VERSION_SUPPORTS_ATTRIBUTES,
   SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+  SPEC_VERSION_SUPPORTS_EVENT_SOURCING,
 } from '@workflow/world';
 import {
   afterEach,
@@ -88,6 +98,10 @@ describe('start', () => {
   describe('specVersion', () => {
     let mockEventsCreate: ReturnType<typeof vi.fn>;
     let mockQueue: ReturnType<typeof vi.fn>;
+    const queueFirstStartHookAdmission: StartHookAdmissionCaps = {
+      maxTtlSeconds: 30 * 24 * 60 * 60,
+      maxTokenBytes: 255,
+    };
 
     beforeEach(() => {
       mockEventsCreate = vi.fn().mockImplementation((runId) => {
@@ -106,9 +120,20 @@ describe('start', () => {
     });
 
     afterEach(() => {
+      vi.useRealTimers();
       setWorld(undefined);
       vi.clearAllMocks();
     });
+
+    function setQueueFirstWorld(specVersion = SPEC_VERSION_CURRENT) {
+      setWorld({
+        specVersion,
+        startHookAdmission: queueFirstStartHookAdmission,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+    }
 
     it('rejects worlds that do not declare a specVersion', async () => {
       const validWorkflow = Object.assign(() => Promise.resolve('result'), {
@@ -259,6 +284,454 @@ describe('start', () => {
       expect(mockQueue.mock.calls[0]?.[1].runInput).not.toHaveProperty(
         'allowReservedAttributes'
       );
+    });
+
+    it('seeds start hook data on run_created and the resilient run input', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      // Worlds without caps declare an empty admission object.
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        startHookAdmission: {},
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+
+      await start(validWorkflow, [], {
+        hook: {
+          token: 'order:123',
+          experimental_ttl: '30 days',
+        },
+      });
+
+      expect(mockEventsCreate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          eventData: expect.objectContaining({
+            startHook: {
+              token: 'order:123',
+              ttlSeconds: 30 * 24 * 60 * 60,
+            },
+          }),
+        }),
+        expect.anything()
+      );
+      expect(mockQueue.mock.calls[0]?.[1].runInput.startHook).toEqual({
+        token: 'order:123',
+        ttlSeconds: 30 * 24 * 60 * 60,
+      });
+
+      vi.useRealTimers();
+    });
+
+    it('omits ttlSeconds when experimental_ttl is not provided (token released at run end)', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setQueueFirstWorld();
+
+      await start(validWorkflow, [], {
+        hook: { token: 'order:123' },
+      });
+
+      expect(mockEventsCreate.mock.calls[0]?.[1].eventData.startHook).toEqual({
+        token: 'order:123',
+      });
+      expect(mockQueue.mock.calls[0]?.[1].runInput.startHook).toEqual({
+        token: 'order:123',
+      });
+    });
+
+    it('rejects empty start hook tokens', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: '',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toThrow(/token must be a non-empty string/);
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
+    });
+
+    it('queues before admitting experimental start hooks in queue-first worlds', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setQueueFirstWorld();
+
+      const run = await start(validWorkflow, [], {
+        hook: {
+          token: 'order:123',
+          experimental_ttl: '30 days',
+        },
+      });
+
+      expect(run.runId).toBe(mockEventsCreate.mock.calls[0]?.[0]);
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+      expect(mockEventsCreate).toHaveBeenCalledTimes(1);
+      expect(mockQueue.mock.calls[0]?.[1].runInput.startHook).toEqual({
+        token: 'order:123',
+        ttlSeconds: 30 * 24 * 60 * 60,
+      });
+      expect(mockEventsCreate.mock.calls[0]?.[1].eventData).toEqual(
+        expect.objectContaining({
+          startHook: {
+            token: 'order:123',
+            ttlSeconds: 30 * 24 * 60 * 60,
+          },
+        })
+      );
+      expect(mockQueue.mock.calls[0]?.[2]).not.toHaveProperty('idempotencyKey');
+      expect(mockQueue.mock.invocationCallOrder[0]).toBeLessThan(
+        mockEventsCreate.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('throws WorkflowStartError without admission when queue-first enqueue fails', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      const queueError = new WorkflowWorldError('queue unavailable', {
+        status: 503,
+      });
+      mockQueue.mockRejectedValueOnce(queueError);
+      setQueueFirstWorld();
+
+      const startPromise = start(validWorkflow, [], {
+        hook: {
+          token: 'order:123',
+          experimental_ttl: '30 days',
+        },
+      });
+
+      await expect(startPromise).rejects.toBeInstanceOf(WorkflowStartError);
+      await expect(startPromise).rejects.toMatchObject({
+        name: 'WorkflowStartError',
+        stage: 'queue',
+        queued: 'unknown',
+        retryable: true,
+        status: 503,
+        cause: queueError,
+      });
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+    });
+
+    it('throws WorkflowStartError when queue-first admission cannot be confirmed', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      const admissionError = new WorkflowWorldError('response lost', {
+        status: 500,
+      });
+      mockEventsCreate.mockRejectedValueOnce(admissionError);
+      setQueueFirstWorld();
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowStartError',
+        stage: 'admission',
+        queued: true,
+        retryable: true,
+        status: 500,
+        cause: admissionError,
+      });
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('wraps transient queue-first admission world errors after queueing', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      const admissionError = new WorkflowWorldError('service unavailable', {
+        status: 503,
+      });
+      mockEventsCreate.mockRejectedValueOnce(admissionError);
+      setQueueFirstWorld();
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowStartError',
+        stage: 'admission',
+        queued: true,
+        retryable: true,
+        status: 503,
+        cause: admissionError,
+      });
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('wraps non-retryable queue-first admission world errors after queueing', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      const admissionError = new WorkflowWorldError('forbidden', {
+        status: 403,
+      });
+      mockEventsCreate.mockRejectedValueOnce(admissionError);
+      setQueueFirstWorld();
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowStartError',
+        stage: 'admission',
+        queued: true,
+        retryable: false,
+        status: 403,
+        cause: admissionError,
+      });
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('wraps unknown queue-first admission failures after queueing', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      const admissionError = new TypeError('socket closed');
+      mockEventsCreate.mockRejectedValueOnce(admissionError);
+      setQueueFirstWorld();
+      const waitUntilCalls = vi.mocked(waitUntil).mock.calls.length;
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowStartError',
+        stage: 'admission',
+        queued: true,
+        retryable: false,
+        cause: admissionError,
+      });
+      await vi.waitFor(() =>
+        expect(vi.mocked(waitUntil).mock.calls.length).toBeGreaterThan(
+          waitUntilCalls
+        )
+      );
+    });
+
+    it('wraps durability-probe failures after a post-enqueue admission conflict', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      const probeError = new WorkflowWorldError('list unavailable', {
+        status: 503,
+      });
+      mockEventsCreate.mockRejectedValueOnce(
+        new EntityConflictError('Run already exists')
+      );
+      const mockEventsList = vi.fn().mockRejectedValue(probeError);
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        startHookAdmission: queueFirstStartHookAdmission,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate, list: mockEventsList },
+        queue: mockQueue,
+      } as any);
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowStartError',
+        stage: 'admission',
+        queued: true,
+        retryable: true,
+        cause: probeError,
+      });
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('still surfaces HookConflictError after queue-first enqueue', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      mockEventsCreate.mockRejectedValueOnce(
+        new HookConflictError('order:123', 'wrun_conflicting')
+      );
+      setQueueFirstWorld();
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toThrow(HookConflictError);
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+      expect(mockQueue.mock.invocationCallOrder[0]).toBeLessThan(
+        mockEventsCreate.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('rejects experimental start hook TTLs above the world cap before queueing', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setQueueFirstWorld();
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '31 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowWorldError',
+        code: RUN_ERROR_CODES.WORLD_CONTRACT_ERROR,
+      });
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects queue-first start hooks with oversized tokens before queueing', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setQueueFirstWorld();
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'x'.repeat(256),
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowWorldError',
+        code: RUN_ERROR_CODES.WORLD_CONTRACT_ERROR,
+      });
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects queue-first start hooks without runInput queue transport before queueing', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setQueueFirstWorld();
+
+      // Worlds must match the runtime spec version, so a pre-CBOR-transport
+      // run can only come from an explicit opts.specVersion override.
+      await expect(
+        start(validWorkflow, [], {
+          specVersion: SPEC_VERSION_SUPPORTS_EVENT_SOURCING,
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowWorldError',
+        code: RUN_ERROR_CODES.WORLD_CONTRACT_ERROR,
+      });
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects queue-first start hooks when the target deployment lacks runtime support', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        startHookAdmission: queueFirstStartHookAdmission,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_current'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+        streams: {
+          get: vi.fn().mockResolvedValue(
+            new Response(
+              JSON.stringify({
+                healthy: true,
+                workflowCoreVersion: '5.0.0-beta.25',
+              })
+            ).body
+          ),
+        },
+      } as any);
+
+      await expect(
+        start(validWorkflow, [], {
+          deploymentId: 'deploy_old',
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkflowWorldError',
+        code: RUN_ERROR_CODES.WORLD_CONTRACT_ERROR,
+      });
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+      expect(mockQueue.mock.calls[0]?.[0]).toContain('health_check');
+    });
+
+    it('rejects experimental start hooks when the world has not opted in', async () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+
+      await expect(
+        start(validWorkflow, [], {
+          hook: {
+            token: 'order:123',
+            experimental_ttl: '30 days',
+          },
+        })
+      ).rejects.toThrow(/supports experimental start-hook admission/);
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+      expect(mockQueue).not.toHaveBeenCalled();
     });
 
     it('rejects initial attributes for pre-v4 runs', async () => {
@@ -732,13 +1205,12 @@ describe('start', () => {
       );
     });
 
-    it('should throw when queue fails even if events.create succeeds', async () => {
+    it('wraps queue failures in WorkflowStartError even if events.create succeeds', async () => {
       const mockEventsCreate = vi.fn().mockResolvedValue({
         run: { runId: 'wrun_test', status: 'pending' },
       });
-      const mockQueue = vi
-        .fn()
-        .mockRejectedValue(new Error('Queue unavailable'));
+      const queueError = new Error('Queue unavailable');
+      const mockQueue = vi.fn().mockRejectedValue(queueError);
 
       setWorld({
         specVersion: SPEC_VERSION_CURRENT,
@@ -747,9 +1219,13 @@ describe('start', () => {
         queue: mockQueue,
       });
 
-      await expect(start(validWorkflow, [])).rejects.toThrow(
-        'Queue unavailable'
-      );
+      await expect(start(validWorkflow, [])).rejects.toMatchObject({
+        name: 'WorkflowStartError',
+        stage: 'queue',
+        queued: 'unknown',
+        cause: queueError,
+        runId: expect.stringMatching(/^wrun_/),
+      });
     });
 
     it('should throw when events.create fails with a non-retryable error (e.g. 400)', async () => {

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -1,4 +1,12 @@
-import { EntityConflictError, WorkflowRuntimeError } from '@workflow/errors';
+import {
+  EntityConflictError,
+  HookConflictError,
+  RUN_ERROR_CODES,
+  WorkflowRuntimeError,
+  WorkflowStartError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { parseDurationToDate } from '@workflow/utils';
 import { workflowDisplayName } from '@workflow/utils/parse-name';
 import type { WorkflowInvokePayload, World } from '@workflow/world';
 import {
@@ -7,6 +15,7 @@ import {
   SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
   SPEC_VERSION_SUPPORTS_COMPRESSION,
 } from '@workflow/world';
+import type { StringValue } from 'ms';
 import { monotonicFactory } from 'ulid';
 import { normalizeAttributeChanges } from '../attribute-changes.js';
 import { getRunCapabilities } from '../capabilities.js';
@@ -37,6 +46,7 @@ import { assertWorldSupportsRuntimeProtocol } from './world-compatibility.js';
  * deployments don't recognize the health check at all.
  */
 const CROSS_DEPLOYMENT_CAPABILITY_PROBE_TIMEOUT_MS = 2_000;
+const textEncoder = new TextEncoder();
 
 /** ULID generator for client-side runId generation */
 const ulid = monotonicFactory();
@@ -55,6 +65,89 @@ let hasWarnedLatestNoOp = false;
  */
 export function _resetLatestNoOpWarnForTests(): void {
   hasWarnedLatestNoOp = false;
+}
+
+interface StartHookOptions {
+  token: string;
+  /**
+   * How long the token stays fenced after the hook is disposed or the run
+   * completes/fails, so duplicate starts keep being rejected. Without it,
+   * the token is released as soon as the hook is disposed or the run
+   * reaches a terminal state (cancellation always releases a token whose
+   * hook was never created).
+   */
+  experimental_ttl?: StringValue | number;
+}
+
+function normalizeStartHookOptions(hook: StartHookOptions): {
+  token: string;
+  ttlSeconds?: number;
+} {
+  if (!hook.token) {
+    throw new WorkflowRuntimeError('hook.token must be a non-empty string.');
+  }
+  if (hook.experimental_ttl === undefined) {
+    return { token: hook.token };
+  }
+
+  const ttlMilliseconds =
+    parseDurationToDate(hook.experimental_ttl).getTime() - Date.now();
+  if (!Number.isFinite(ttlMilliseconds) || ttlMilliseconds <= 0) {
+    throw new WorkflowRuntimeError(
+      'hook.experimental_ttl must be a positive duration.'
+    );
+  }
+
+  return {
+    token: hook.token,
+    ttlSeconds: Math.max(1, Math.floor(ttlMilliseconds / 1000)),
+  };
+}
+
+async function hasDurableRunCreatedEvent(
+  world: World,
+  runId: string
+): Promise<boolean> {
+  const page = await world.events.list({
+    runId,
+    pagination: { limit: 1, sortOrder: 'asc' },
+    resolveData: 'none',
+  });
+  return page.data.some((event) => event.eventType === 'run_created');
+}
+
+function getRunCreatedResult(
+  result: Awaited<ReturnType<World['events']['create']>>,
+  expectedRunId?: string
+) {
+  if (!result.run) {
+    throw new WorkflowRuntimeError(
+      "Missing 'run' in server response for 'run_created' event"
+    );
+  }
+  if (expectedRunId !== undefined && result.run.runId !== expectedRunId) {
+    throw new WorkflowRuntimeError(
+      `Server returned different runId than requested: expected ${expectedRunId}, got ${result.run.runId}`
+    );
+  }
+  return result.run;
+}
+
+function isWorkflowWorldError(error: unknown): error is WorkflowWorldError {
+  // `.is()` alone misses subclasses (their `name` differs, e.g.
+  // ThrottleError); `instanceof` alone misses cross-realm base instances.
+  // World code runs in the host realm, so together they cover both.
+  return error instanceof WorkflowWorldError || WorkflowWorldError.is(error);
+}
+
+function getWorkflowWorldErrorDetails(error: unknown) {
+  if (!isWorkflowWorldError(error)) return {};
+  return {
+    status: error.status,
+    url: error.url,
+    code: error.code,
+    retryAfter: error.retryAfter,
+  };
 }
 
 export interface StartOptionsBase {
@@ -89,6 +182,16 @@ export interface StartOptionsBase {
    * the `experimental_setAttributes` option of the same name.
    */
   allowReservedAttributes?: boolean;
+
+  /**
+   * EXPERIMENTAL: atomically reserve a hook token as part of run admission.
+   *
+   * If another active or retained run already owns the token, `start()`
+   * throws `HookConflictError`. In queue-first Worlds the queue may already
+   * have accepted the losing run before the conflict is observed; that
+   * queued invocation exits without running user workflow code.
+   */
+  hook?: StartHookOptions;
 }
 
 export interface StartOptionsWithDeploymentId extends StartOptionsBase {
@@ -250,12 +353,15 @@ export async function start<TArgs extends unknown[], TResult>(
       // mocks) can't service health checks, so we skip the probe for them.
       let framedByteStreams: boolean;
       let targetSupportsCompression: boolean;
+      let targetSupportsStartHookAdmission: boolean;
       if (deploymentId === currentDeploymentId) {
         framedByteStreams = true;
         targetSupportsCompression = true;
+        targetSupportsStartHookAdmission = true;
       } else if (typeof world.streams?.get !== 'function') {
         framedByteStreams = false;
         targetSupportsCompression = false;
+        targetSupportsStartHookAdmission = false;
       } else {
         const probe = await healthCheck(world, 'workflow', {
           deploymentId,
@@ -266,9 +372,28 @@ export async function start<TArgs extends unknown[], TResult>(
         targetSupportsCompression = capabilities.supportedFormats.has(
           SerializationFormat.GZIP
         );
+        targetSupportsStartHookAdmission = capabilities.startHookLoserAck;
       }
 
       const ops: Promise<void>[] = [];
+      let opsFlushScheduled = false;
+      const scheduleOpsFlush = () => {
+        if (opsFlushScheduled) return;
+        opsFlushScheduled = true;
+        // These argument-stream ops are flushed in the background; the promise
+        // handed to waitUntil must never reject (an unconsumed waitUntil
+        // rejection crashes the process as unhandledRejection), so unexpected
+        // failures are logged instead.
+        safeWaitUntil(Promise.all(ops), (err) => {
+          runtimeLogger.warn(
+            'Background flush of workflow argument streams failed',
+            {
+              workflowRunId: runId,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          );
+        });
+      };
 
       // Generate runId client-side so we have it before serialization
       // (required for future E2E encryption where runId is part of the encryption context)
@@ -281,6 +406,54 @@ export async function start<TArgs extends unknown[], TResult>(
       // itself has already been checked against this runtime's spec version.
       const specVersion = opts.specVersion ?? world.specVersion;
       const v1Compat = isLegacySpecVersion(specVersion);
+      const startHook = opts.hook
+        ? normalizeStartHookOptions(opts.hook)
+        : undefined;
+      const startHookAdmission = world.startHookAdmission;
+      if (startHook) {
+        if (v1Compat) {
+          throw new WorkflowRuntimeError(
+            'The start() hook option requires an event-sourced World.'
+          );
+        }
+        if (startHookAdmission === undefined) {
+          throw new WorkflowRuntimeError(
+            'The start() hook option requires a World that supports experimental start-hook admission.'
+          );
+        }
+        const contractError = (message: string) =>
+          new WorkflowWorldError(message, {
+            code: RUN_ERROR_CODES.WORLD_CONTRACT_ERROR,
+          });
+        if (!targetSupportsStartHookAdmission) {
+          throw contractError(
+            'The start() hook option requires a target deployment that supports queue-first start-hook admission.'
+          );
+        }
+        if (
+          startHookAdmission.maxTtlSeconds !== undefined &&
+          startHook.ttlSeconds !== undefined &&
+          startHook.ttlSeconds > startHookAdmission.maxTtlSeconds
+        ) {
+          throw contractError(
+            `hook.experimental_ttl exceeds this World's maximum of ${startHookAdmission.maxTtlSeconds} seconds.`
+          );
+        }
+        if (
+          startHookAdmission.maxTokenBytes !== undefined &&
+          textEncoder.encode(startHook.token).byteLength >
+            startHookAdmission.maxTokenBytes
+        ) {
+          throw contractError(
+            `hook.token exceeds this World's maximum of ${startHookAdmission.maxTokenBytes} bytes.`
+          );
+        }
+        if (specVersion < SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT) {
+          throw contractError(
+            'The start() hook option requires a spec version that supports runInput queue transport.'
+          );
+        }
+      }
       const allowReservedAttributes = opts.allowReservedAttributes === true;
       let attributes: Record<string, string> | undefined;
       if (opts.attributes && Object.keys(opts.attributes).length > 0) {
@@ -318,6 +491,7 @@ export async function start<TArgs extends unknown[], TResult>(
               : {}),
           }
         : {};
+      const startHookSeed = startHook ? { startHook } : {};
 
       // Resolve encryption key for the new run. The runId has already been
       // generated above (client-generated ULID) and will be used for both
@@ -358,115 +532,173 @@ export async function start<TArgs extends unknown[], TResult>(
         features: { encryption: !!encryptionKey },
       };
 
-      // Call events.create (run_created) and queue in parallel.
-      // If events.create fails with 429/5xx, the run was still accepted
-      // via the queue and creation will be re-tried async by the runtime.
-      const [runCreatedResult, queueResult] = await Promise.allSettled([
-        world.events.create(
-          runId,
-          {
-            eventType: 'run_created',
-            specVersion,
-            eventData: {
-              deploymentId: deploymentId,
-              workflowName: workflowName,
-              input: workflowArguments,
-              executionContext,
-              ...attributeSeed,
-            },
-          },
-          { v1Compat }
-        ),
-        world.queue(
-          getWorkflowQueueName(workflowName),
+      const runCreatedEvent = {
+        eventType: 'run_created' as const,
+        specVersion,
+        eventData: {
+          deploymentId: deploymentId,
+          workflowName: workflowName,
+          input: workflowArguments,
+          executionContext,
+          ...attributeSeed,
+          ...startHookSeed,
+        },
+      };
+      const queuePayload = {
+        runId,
+        traceCarrier,
+        ...(specVersion >= SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT
+          ? {
+              runInput: {
+                input: workflowArguments,
+                deploymentId,
+                workflowName,
+                specVersion,
+                executionContext,
+                ...attributeSeed,
+                ...startHookSeed,
+              },
+            }
+          : {}),
+      } satisfies WorkflowInvokePayload;
+
+      const createRunEvent = () =>
+        world.events.create(runId, runCreatedEvent, { v1Compat });
+      const enqueueRun = () =>
+        world.queue(getWorkflowQueueName(workflowName), queuePayload, {
+          deploymentId,
+          specVersion,
+        });
+      const wrapQueueError = (error: unknown) =>
+        new WorkflowStartError(
+          `Workflow start failed while enqueueing run "${runId}". The queue may have accepted the message; inspect this run ID or retry the start call.`,
           {
             runId,
-            traceCarrier,
-            ...(specVersion >= SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT
-              ? {
-                  runInput: {
-                    input: workflowArguments,
-                    deploymentId,
-                    workflowName,
-                    specVersion,
-                    executionContext,
-                    ...attributeSeed,
-                  },
-                }
-              : {}),
-          } satisfies WorkflowInvokePayload,
-          {
-            deploymentId,
-            specVersion,
-          }
-        ),
-      ]);
-
-      // Queue failure is always fatal — the run was not enqueued
-      if (queueResult.status === 'rejected') {
-        throw queueResult.reason;
-      }
-
-      // Handle events.create result
-      let resilientStart = false;
-      if (runCreatedResult.status === 'rejected') {
-        const err = runCreatedResult.reason;
-        if (EntityConflictError.is(err)) {
-          // 409: The run already exists. This can happen in extreme cases where
-          // the run creation call gets a cold start or other slowdown, and the queue
-          // + run_started call completes faster. We expect this to be <=1% of cases.
-          // In this case, we can safely return.
-        } else if (isRetryableWorldError(err)) {
-          // 429 (ThrottleError), 5xx, and transient transport failures
-          // (TRANSPORT/TIMEOUT) are retryable — the run was accepted via the
-          // queue and creation will be re-tried by the runtime when it calls
-          // run_started.
-          resilientStart = true;
-          runtimeLogger.warn(
-            'Run creation event failed, but the run was accepted via the queue. ' +
-              'The run_created event will be re-tried async by the runtime.',
-            { workflowRunId: runId, error: err.message }
-          );
-        } else {
-          throw err;
-        }
-      } else {
-        const result = runCreatedResult.value;
-        // Assert that the run was created
-        if (!result.run) {
-          throw new WorkflowRuntimeError(
-            "Missing 'run' in server response for 'run_created' event"
-          );
-        }
-
-        // Verify server accepted our runId
-        if (!v1Compat && result.run.runId !== runId) {
-          throw new WorkflowRuntimeError(
-            `Server returned different runId than requested: expected ${runId}, got ${result.run.runId}`
-          );
-        }
-      }
-
-      // These argument-stream ops are flushed in the background; the promise
-      // handed to waitUntil must never reject (an unconsumed waitUntil
-      // rejection crashes the process as unhandledRejection), so unexpected
-      // failures are logged instead.
-      safeWaitUntil(Promise.all(ops), (err) => {
-        runtimeLogger.warn(
-          'Background flush of workflow argument streams failed',
-          {
-            workflowRunId: runId,
-            error: err instanceof Error ? err.message : String(err),
+            stage: 'queue',
+            retryable: isRetryableWorldError(error),
+            cause: error,
+            ...getWorkflowWorldErrorDetails(error),
           }
         );
-      });
+      const wrapAdmissionError = (error: unknown) =>
+        new WorkflowStartError(
+          `Workflow run "${runId}" was queued, but start-hook admission could not be confirmed. Inspect this run ID or retry the start call; a retry may conflict if the queued run starts successfully.`,
+          {
+            runId,
+            stage: 'admission',
+            retryable: isRetryableWorldError(error),
+            cause: error,
+            ...getWorkflowWorldErrorDetails(error),
+          }
+        );
+
+      let resilientStart = false;
+      let createdRunForSpan:
+        | NonNullable<Awaited<ReturnType<typeof world.events.create>>['run']>
+        | undefined;
+      // The finally guarantees the argument-stream ops flush is scheduled on
+      // every admission exit path — success or throw. An unflushed rejected
+      // ops promise would crash the process as an unhandledRejection.
+      try {
+        if (startHook) {
+          // Queue-first admission: enqueue, then create run_created (which
+          // claims the token). A crash after the enqueue cannot orphan the
+          // claim — the queued message bootstraps admission itself via the
+          // resilient run_started path, and a queued run that loses its
+          // claim acknowledges without running user code.
+          try {
+            await enqueueRun();
+          } catch (error) {
+            throw wrapQueueError(error);
+          }
+
+          try {
+            createdRunForSpan = getRunCreatedResult(
+              await createRunEvent(),
+              runId
+            );
+          } catch (error) {
+            if (HookConflictError.is(error)) {
+              throw error;
+            }
+            if (!EntityConflictError.is(error)) {
+              throw wrapAdmissionError(error);
+            }
+            // The durability probe is itself a world call; if it fails,
+            // surface the same post-enqueue WorkflowStartError contract
+            // instead of leaking a raw world error (the run may already
+            // be queued either way).
+            let runCreatedDurable: boolean;
+            try {
+              runCreatedDurable = await hasDurableRunCreatedEvent(world, runId);
+            } catch (probeError) {
+              throw wrapAdmissionError(probeError);
+            }
+            if (!runCreatedDurable) {
+              throw error;
+            }
+            resilientStart = true;
+            runtimeLogger.warn(
+              'Run creation conflicted after start-hook queue acceptance, but the run_created event is durable.',
+              { workflowRunId: runId, error: error.message }
+            );
+          }
+        } else {
+          // Call events.create (run_created) and queue in parallel.
+          // If events.create fails with 429/5xx, the run was still accepted
+          // via the queue and creation will be re-tried async by the runtime.
+          const [runCreatedResult, queueResult] = await Promise.allSettled([
+            createRunEvent(),
+            enqueueRun(),
+          ]);
+
+          // Queue failure is fatal. It is surfaced as WorkflowStartError
+          // (stage 'queue') because the outcome is ambiguous: the queue may
+          // have accepted the message before failing, and the parallel
+          // run_created may have succeeded — carry the runId so callers can
+          // inspect or retry.
+          if (queueResult.status === 'rejected') {
+            throw wrapQueueError(queueResult.reason);
+          }
+
+          // Handle events.create result
+          if (runCreatedResult.status === 'rejected') {
+            const err = runCreatedResult.reason;
+            if (EntityConflictError.is(err)) {
+              // 409: The run already exists. This can happen in extreme cases where
+              // the run creation call gets a cold start or other slowdown, and the queue
+              // + run_started call completes faster. We expect this to be <=1% of cases.
+              // In this case, we can safely return.
+            } else if (isRetryableWorldError(err)) {
+              // 429 (ThrottleError), 5xx, and transient transport failures
+              // (TRANSPORT/TIMEOUT) are retryable — the run was accepted via
+              // the queue and creation will be re-tried by the runtime when it
+              // calls run_started.
+              resilientStart = true;
+              runtimeLogger.warn(
+                'Run creation event failed, but the run was accepted via the queue. ' +
+                  'The run_created event will be re-tried async by the runtime.',
+                { workflowRunId: runId, error: err.message }
+              );
+            } else {
+              throw err;
+            }
+          } else {
+            createdRunForSpan = getRunCreatedResult(
+              runCreatedResult.value,
+              v1Compat ? undefined : runId
+            );
+          }
+        }
+      } finally {
+        scheduleOpsFlush();
+      }
 
       span?.setAttributes({
         ...Attribute.WorkflowRunId(runId),
         ...Attribute.DeploymentId(deploymentId),
-        ...(runCreatedResult.status === 'fulfilled' &&
-        runCreatedResult.value.run
-          ? Attribute.WorkflowRunStatus(runCreatedResult.value.run.status)
+        ...(createdRunForSpan
+          ? Attribute.WorkflowRunStatus(createdRunForSpan.status)
           : {}),
       });
 

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -5,6 +5,7 @@ import {
   HookConflictError,
   RetryableError,
   RuntimeDecryptionError,
+  WorkflowStartError,
 } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
@@ -2667,7 +2668,7 @@ describe('step function serialization', () => {
     const stepId = 'step//workflows/test.ts//addNumbers';
 
     // Create a VM context like the workflow runner does
-    const { context, globalThis: vmGlobalThis } = createContext({
+    const { globalThis: vmGlobalThis } = createContext({
       seed: 'test',
       fixedTimestamp: 1714857600000,
     });
@@ -2729,7 +2730,7 @@ describe('step function serialization', () => {
     const stepId = 'step//workflows/test.ts//missingUseStep';
 
     // Create a VM context WITHOUT setting up WORKFLOW_USE_STEP
-    const { context, globalThis: vmGlobalThis } = createContext({
+    const { globalThis: vmGlobalThis } = createContext({
       seed: 'test',
       fixedTimestamp: 1714857600000,
     });
@@ -3980,6 +3981,46 @@ describe('Workflow error serialization', () => {
       (serialized as Uint8Array).subarray(4)
     );
     expect(str).toContain('["HookConflictError",');
+    expect(str).not.toContain('["Error",');
+    expect(str).not.toContain('Instance');
+  });
+
+  it('should round-trip WorkflowStartError preserving recovery fields', async () => {
+    const error = new WorkflowStartError('queued but not admitted', {
+      runId: 'wrun_queued',
+      stage: 'admission',
+      retryable: true,
+      status: 408,
+      retryAfter: 2,
+    });
+    const hydrated = (await roundTrip(error)) as WorkflowStartError;
+
+    expect(hydrated).toBeInstanceOf(WorkflowStartError);
+    expect(WorkflowStartError.is(hydrated)).toBe(true);
+    expect(hydrated.runId).toBe('wrun_queued');
+    expect(hydrated.stage).toBe('admission');
+    expect(hydrated.queued).toBe(true);
+    expect(hydrated.retryable).toBe(true);
+    expect(hydrated.status).toBe(408);
+    expect(hydrated.retryAfter).toBe(2);
+  });
+
+  it('should serialize WorkflowStartError using its dedicated reducer key', async () => {
+    const error = new WorkflowStartError('queue response lost', {
+      runId: 'wrun_unknown',
+      stage: 'queue',
+      retryable: true,
+    });
+    const serialized = await dehydrateStepReturnValue(
+      error,
+      mockRunId,
+      noEncryptionKey
+    );
+    const str = new TextDecoder().decode(
+      (serialized as Uint8Array).subarray(4)
+    );
+
+    expect(str).toContain('["WorkflowStartError",');
     expect(str).not.toContain('["Error",');
     expect(str).not.toContain('Instance');
   });
@@ -5561,7 +5602,7 @@ describe('isEncrypted', () => {
 // ============================================================================
 
 describe('AbortController serialization', () => {
-  const { context, globalThis: vmGlobalThis } = createContext({
+  const { globalThis: vmGlobalThis } = createContext({
     seed: 'test-abort-serde',
     fixedTimestamp: 1714857600000,
   });

--- a/packages/core/src/serialization/reducers/common.ts
+++ b/packages/core/src/serialization/reducers/common.ts
@@ -15,6 +15,7 @@ import {
   HookConflictError,
   RetryableError,
   RuntimeDecryptionError,
+  WorkflowStartError,
 } from '@workflow/errors';
 import type { Reducers, Revivers, SerializableSpecial } from '../types.js';
 
@@ -228,6 +229,24 @@ export function getCommonReducers(
       }
       return reduced;
     },
+    WorkflowStartError: (value) => {
+      const base = reduceNamedErrorSubclassBase('WorkflowStartError', value);
+      if (!base) return false;
+      const error = value as WorkflowStartError;
+      const reduced: SerializableSpecial['WorkflowStartError'] = {
+        ...base,
+        runId: error.runId,
+        stage: error.stage,
+        retryable: error.retryable,
+      };
+      if (error.status !== undefined) reduced.status = error.status;
+      if (error.url !== undefined) reduced.url = error.url;
+      if (error.code !== undefined) reduced.code = error.code;
+      if (error.retryAfter !== undefined) {
+        reduced.retryAfter = error.retryAfter;
+      }
+      return reduced;
+    },
     RangeError: makeErrorSubclassReducer('RangeError'),
     ReferenceError: makeErrorSubclassReducer('ReferenceError'),
     // RetryableError carries an extra `retryAfter` Date that we serialize as
@@ -407,6 +426,24 @@ export function getCommonRevivers(
       if ('cause' in value) {
         (error as Error & { cause?: unknown }).cause = value.cause;
       }
+      return error;
+    },
+    WorkflowStartError: (value) => {
+      const Ctor =
+        ((global as Record<symbol, unknown>)[
+          Symbol.for('@workflow/errors//WorkflowStartError')
+        ] as typeof WorkflowStartError | undefined) ?? WorkflowStartError;
+      const error = new Ctor(value.message, {
+        runId: value.runId,
+        stage: value.stage,
+        retryable: value.retryable,
+        status: value.status,
+        url: value.url,
+        code: value.code,
+        retryAfter: value.retryAfter,
+        ...('cause' in value ? { cause: value.cause } : {}),
+      });
+      if (value.stack !== undefined) error.stack = value.stack;
       return error;
     },
     RangeError: makeErrorSubclassReviver(global, 'RangeError'),

--- a/packages/core/src/serialization/types.ts
+++ b/packages/core/src/serialization/types.ts
@@ -2,7 +2,10 @@
  * Shared types for the serialization system.
  */
 
-import type { RuntimeDecryptionErrorContext } from '@workflow/errors';
+import type {
+  RuntimeDecryptionErrorContext,
+  WorkflowStartErrorOptions,
+} from '@workflow/errors';
 
 // ---- Format Prefix ----
 
@@ -83,6 +86,12 @@ export interface SerializableSpecial {
     // TODO: Make this required when HookConflictError.conflictingRunId is required.
     conflictingRunId?: string;
   };
+  // `queued` is derived from `stage` by the constructor, so only the
+  // constructor options are serialized.
+  WorkflowStartError: {
+    message: string;
+    stack?: string;
+  } & WorkflowStartErrorOptions;
   Int8Array: string; // base64 string
   Int16Array: string; // base64 string
   Int32Array: string; // base64 string

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -54,9 +54,9 @@ function appendFramedDetails(
     const head = isLast ? '╰▶ ' : '├▶ ';
     const cont = isLast ? '   ' : '│  ';
     const text = `${detail.label}: ${detail.value}`;
-    text
-      .split('\n')
-      .forEach((line, i) => lines.push(`${i === 0 ? head : cont}${line}`));
+    text.split('\n').forEach((line, i) => {
+      lines.push(`${i === 0 ? head : cont}${line}`);
+    });
   });
   return lines.join('\n');
 }
@@ -184,6 +184,57 @@ export class WorkflowWorldError extends WorkflowError {
 
   static is(value: unknown): value is WorkflowWorldError {
     return isError(value) && value.name === 'WorkflowWorldError';
+  }
+}
+
+/**
+ * The `start()` phase a `WorkflowStartError` failed in. `queue` means the
+ * enqueue call itself failed (the queue may or may not have accepted the
+ * message); `admission` means the message was queued but admission could not
+ * be confirmed.
+ */
+export type WorkflowStartStage = 'queue' | 'admission';
+
+export interface WorkflowStartErrorOptions {
+  runId: string;
+  /** The phase that failed. */
+  stage: WorkflowStartStage;
+  retryable: boolean;
+  status?: number;
+  url?: string;
+  code?: string;
+  retryAfter?: number;
+  cause?: unknown;
+}
+
+/**
+ * Thrown when `start()` cannot synchronously confirm whether a workflow run was
+ * fully admitted. The error carries the client-generated run ID so callers can
+ * inspect or retry the run when the queue may already have accepted it.
+ */
+export class WorkflowStartError extends WorkflowWorldError {
+  readonly runId: string;
+  readonly stage: WorkflowStartStage;
+  /** Whether the queue accepted the message — derived from `stage`. */
+  readonly queued: true | 'unknown';
+  readonly retryable: boolean;
+
+  constructor(message: string, options: WorkflowStartErrorOptions) {
+    super(message, options);
+    this.name = 'WorkflowStartError';
+    this.runId = options.runId;
+    this.stage = options.stage;
+    this.queued = WorkflowStartError.queuedFromStage(options.stage);
+    this.retryable = options.retryable;
+  }
+
+  /** Whether the queue accepted the message, derived from the failed stage. */
+  static queuedFromStage(stage: WorkflowStartStage): true | 'unknown' {
+    return stage === 'queue' ? 'unknown' : true;
+  }
+
+  static is(value: unknown): value is WorkflowStartError {
+    return isError(value) && value.name === 'WorkflowStartError';
   }
 }
 
@@ -914,7 +965,8 @@ export { RUN_ERROR_CODES, type RunErrorCode } from './error-codes.js';
 // Cross-realm class registration
 // ---------------------------------------------------------------------------
 //
-// `FatalError`, `RetryableError`, and `HookConflictError` are not built-ins, so different realms
+// `FatalError`, `RetryableError`, `HookConflictError`, and
+// `WorkflowStartError` are not built-ins, so different realms
 // (e.g. the workflow VM context vs. the host context that runs the queue
 // handler) bundle and load their own copies of this module — meaning each
 // realm has its own distinct class identity. Cross-realm `instanceof` fails
@@ -932,6 +984,9 @@ const FATAL_ERROR_KEY = Symbol.for('@workflow/errors//FatalError');
 const RETRYABLE_ERROR_KEY = Symbol.for('@workflow/errors//RetryableError');
 const HOOK_CONFLICT_ERROR_KEY = Symbol.for(
   '@workflow/errors//HookConflictError'
+);
+const WORKFLOW_START_ERROR_KEY = Symbol.for(
+  '@workflow/errors//WorkflowStartError'
 );
 const RUNTIME_DECRYPTION_ERROR_KEY = Symbol.for(
   '@workflow/errors//RuntimeDecryptionError'
@@ -957,6 +1012,14 @@ if (typeof globalThis !== 'undefined') {
   if (!Object.hasOwn(globalThis, HOOK_CONFLICT_ERROR_KEY)) {
     Object.defineProperty(globalThis, HOOK_CONFLICT_ERROR_KEY, {
       value: HookConflictError,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+  if (!Object.hasOwn(globalThis, WORKFLOW_START_ERROR_KEY)) {
+    Object.defineProperty(globalThis, WORKFLOW_START_ERROR_KEY, {
+      value: WorkflowStartError,
       writable: false,
       enumerable: false,
       configurable: false,

--- a/packages/web-shared/src/lib/hydration.ts
+++ b/packages/web-shared/src/lib/hydration.ts
@@ -16,6 +16,7 @@ import {
   type Revivers,
   serializedInstanceToRef,
 } from '@workflow/core/serialization-format';
+import { WorkflowStartError } from '@workflow/errors';
 import { EVENT_DATA_REF_FIELDS } from '@workflow/world';
 
 const V4_EXTRA_EVENT_DATA_REF_FIELDS: Record<string, string[]> = {
@@ -150,7 +151,7 @@ export function getWebRevivers(): Revivers {
     // `packages/core/src/serialization/reducers/common.ts`) emits a tagged
     // entry for each built-in Error subclass plus the workflow-specific
     // `FatalError` / `RetryableError` / `HookConflictError` /
-    // `RuntimeDecryptionError` and `AggregateError`. Without
+    // `WorkflowStartError` / `RuntimeDecryptionError` and `AggregateError`. Without
     // matching revivers here, `devalue.unflatten` throws "Unknown type X"
     // — which surfaces in the web o11y UI as "Failed to load resource
     // details: Unknown type FatalError".
@@ -209,6 +210,30 @@ export function getWebRevivers(): Revivers {
       if (value.conflictingRunId !== undefined) {
         error.conflictingRunId = value.conflictingRunId;
       }
+      if (value.stack !== undefined) error.stack = value.stack;
+      return error;
+    },
+    WorkflowStartError: (value) => {
+      const opts = 'cause' in value ? { cause: value.cause } : undefined;
+      const error = new Error(value.message, opts) as Error & {
+        runId?: string;
+        stage?: string;
+        queued?: true | 'unknown';
+        retryable?: boolean;
+        status?: number;
+        url?: string;
+        code?: string;
+        retryAfter?: number;
+      };
+      error.name = 'WorkflowStartError';
+      error.runId = value.runId;
+      error.stage = value.stage;
+      error.queued = WorkflowStartError.queuedFromStage(value.stage);
+      error.retryable = value.retryable;
+      if (value.status !== undefined) error.status = value.status;
+      if (value.url !== undefined) error.url = value.url;
+      if (value.code !== undefined) error.code = value.code;
+      if (value.retryAfter !== undefined) error.retryAfter = value.retryAfter;
       if (value.stack !== undefined) error.stack = value.stack;
       return error;
     },

--- a/packages/web-shared/test/hydration.test.ts
+++ b/packages/web-shared/test/hydration.test.ts
@@ -4,7 +4,11 @@ import {
   dehydrateStepReturnValue,
 } from '@workflow/core/serialization';
 import { hydrateData } from '@workflow/core/serialization-format';
-import { FatalError, RetryableError } from '@workflow/errors';
+import {
+  FatalError,
+  RetryableError,
+  WorkflowStartError,
+} from '@workflow/errors';
 import { describe, expect, it } from 'vitest';
 import {
   getWebRevivers,
@@ -121,6 +125,34 @@ describe('getWebRevivers — error family', () => {
     expect(revived.message).toContain('already in use');
     expect(revived.token).toBe('approval-token');
     expect(revived.conflictingRunId).toBe('wrun_conflicting');
+  });
+
+  it('hydrates a WorkflowStartError with recovery details preserved', async () => {
+    const revived = await roundTrip<
+      Error & {
+        runId?: string;
+        stage?: string;
+        queued?: true | 'unknown';
+        retryable?: boolean;
+        status?: number;
+      }
+    >(
+      new WorkflowStartError('admission uncertain', {
+        runId: 'wrun_queued',
+        stage: 'admission',
+        retryable: false,
+        status: 403,
+      })
+    );
+
+    expect(revived).toBeInstanceOf(Error);
+    expect(revived.name).toBe('WorkflowStartError');
+    expect(revived.message).toBe('admission uncertain');
+    expect(revived.runId).toBe('wrun_queued');
+    expect(revived.stage).toBe('admission');
+    expect(revived.queued).toBe(true);
+    expect(revived.retryable).toBe(false);
+    expect(revived.status).toBe(403);
   });
 
   it('hydrates a RetryableError with retryAfter as a Date', async () => {

--- a/packages/web-shared/test/serializable-revivers.test.ts
+++ b/packages/web-shared/test/serializable-revivers.test.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { hydrateData } from '@workflow/core/serialization-format';
-import { getCLIRevivers } from '../../cli/src/lib/inspect/hydration.js';
-import { getWebRevivers } from '../src/lib/hydration.js';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
+import { getCLIRevivers } from '../../cli/src/lib/inspect/hydration.js';
+import { getWebRevivers } from '../src/lib/hydration.js';
 
 const SERIALIZABLE_TYPES_PATH = fileURLToPath(
   new URL('../../core/src/serialization/types.ts', import.meta.url)
@@ -99,6 +99,21 @@ const SERIALIZABLE_PAYLOADS: Record<string, unknown[]> = {
     'Hook token "approval-token" is already in use by another workflow (run "wrun_conflicting")',
     'approval-token',
     'wrun_conflicting',
+  ],
+  WorkflowStartError: [
+    ['WorkflowStartError', 1],
+    {
+      message: 2,
+      runId: 3,
+      stage: 4,
+      retryable: 5,
+      status: 6,
+    },
+    'Workflow run "wrun_queued" was queued, but start-hook admission could not be confirmed.',
+    'wrun_queued',
+    'admission',
+    false,
+    403,
   ],
   Instance: [
     ['Instance', 1],

--- a/packages/workflow/src/internal/errors.ts
+++ b/packages/workflow/src/internal/errors.ts
@@ -14,5 +14,6 @@ export {
   WorkflowRunNotCompletedError,
   WorkflowRunNotFoundError,
   WorkflowRuntimeError,
+  WorkflowStartError,
   WorkflowWorldError,
 } from '@workflow/errors';

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -15,6 +15,19 @@ import {
 } from './events-v4.js';
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 
+function decodePostedMeta(rawBody: unknown): Record<string, unknown> {
+  const bytes =
+    typeof rawBody === 'string'
+      ? new TextEncoder().encode(rawBody)
+      : new Uint8Array(rawBody as ArrayBufferLike);
+  const metaLen = new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength
+  ).getUint32(0, false);
+  return decode(bytes.subarray(4, 4 + metaLen)) as Record<string, unknown>;
+}
+
 /**
  * The v4 client must preserve the typed-error contract of the v3
  * `makeRequest` path — the workflow runtime branches on these types
@@ -349,24 +362,7 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
     const agent = new MockAgent();
     agent.disableNetConnect();
 
-    // Decode the posted frame's CBOR meta block:
-    //   u32_be(meta_len) || cbor_meta || u32_be(body_len) || body
     let capturedMeta: Record<string, unknown> | undefined;
-    const captureMeta = (rawBody: unknown) => {
-      const bytes =
-        typeof rawBody === 'string'
-          ? new TextEncoder().encode(rawBody)
-          : new Uint8Array(rawBody as ArrayBufferLike);
-      const metaLen = new DataView(
-        bytes.buffer,
-        bytes.byteOffset,
-        bytes.byteLength
-      ).getUint32(0, false);
-      capturedMeta = decode(bytes.subarray(4, 4 + metaLen)) as Record<
-        string,
-        unknown
-      >;
-    };
 
     agent
       .get(origin)
@@ -377,7 +373,7 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
       .reply(
         200,
         (opts: { body?: unknown }) => {
-          captureMeta(opts.body);
+          capturedMeta = decodePostedMeta(opts.body);
           return encode({ run: { runId: 'wrun_1', status: 'running' } });
         },
         {
@@ -401,6 +397,50 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
 
     expect(capturedMeta?.eventType).toBe('run_started');
     expect(capturedMeta?.skipPreload).toBe(true);
+    agent.assertNoPendingInterceptors();
+  });
+
+  it('forwards startHook in the frame meta', async () => {
+    const origin = 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    let capturedMeta: Record<string, unknown> | undefined;
+    const startHook = { token: 'order:123', ttlSeconds: 60 };
+
+    agent
+      .get(origin)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/run_created',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          capturedMeta = decodePostedMeta(opts.body);
+          return encode({ run: { runId: 'wrun_1', status: 'pending' } });
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+          },
+        }
+      );
+
+    await createWorkflowRunEventV4(
+      {
+        runId: 'wrun_1',
+        eventType: 'run_created',
+        specVersion: 5,
+        startHook: startHook,
+      },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(capturedMeta?.eventType).toBe('run_created');
+    expect(capturedMeta?.startHook).toEqual(startHook);
     agent.assertNoPendingInterceptors();
   });
 

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -21,6 +21,7 @@
  * bytes — this module stays at the wire-bytes layer.
  */
 
+import type { StartHook } from '@workflow/world';
 import { decode } from 'cbor-x';
 import { decodeFrames, encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { getEventsDispatcher } from './http-client.js';
@@ -136,6 +137,9 @@ export interface CreateEventV4Input {
    *  resilient-start path). Validated server-side against the attribute
    *  key/value/count caps. */
   attributes?: Record<string, string>;
+  /** Experimental start-hook token claim carried by run_created and the
+   *  resilient-start run_started fallback. */
+  startHook?: StartHook;
   /** attr_set's attribute change list ({key, value|null} entries). */
   changes?: Array<Record<string, unknown>>;
   /** attr_set's writer provenance ({type:'workflow'} or
@@ -219,6 +223,9 @@ function buildPostFrameMeta(
     meta.executionContext = input.executionContext;
   }
   if (input.attributes !== undefined) meta.attributes = input.attributes;
+  if (input.startHook !== undefined) {
+    meta.startHook = input.startHook;
+  }
   if (input.changes !== undefined) meta.changes = input.changes;
   if (input.writer !== undefined) meta.writer = input.writer;
   if (input.allowReservedAttributes !== undefined) {

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -177,6 +177,34 @@ describe('splitEventDataForV4 attribute fields', () => {
     expect(meta.attributes).toEqual({ sourceAtStart: 'api' });
   });
 
+  it('carries experimental start hooks on run_created and resilient-start run_started', () => {
+    const startHook = { token: 'order:123', ttlSeconds: 60 };
+
+    const created = splitEventDataForV4({
+      eventType: 'run_created',
+      specVersion: 4,
+      eventData: {
+        deploymentId: 'dpl_1',
+        workflowName: 'wf',
+        input: new TextEncoder().encode('[]'),
+        startHook: startHook,
+      },
+    } as AnyEventRequest);
+    const started = splitEventDataForV4({
+      eventType: 'run_started',
+      specVersion: 4,
+      eventData: {
+        input: new TextEncoder().encode('[]'),
+        deploymentId: 'dpl_1',
+        workflowName: 'wf',
+        startHook: startHook,
+      },
+    } as AnyEventRequest);
+
+    expect(created.meta.startHook).toEqual(startHook);
+    expect(started.meta.startHook).toEqual(startHook);
+  });
+
   it('lifts workflowName into the frame meta on outcome events (step_completed/step_created), keeping the payload in the body', () => {
     // The backend keys payload refs by workflow name; carrying it in the
     // frame meta lets the v4 POST handler skip the per-step run lookup.

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -40,6 +40,7 @@ import {
   type EventResult,
   EventSchema,
   EventTypeSchema,
+  type StartHook,
   type GetEventParams,
   type ListEventsByCorrelationIdParams,
   type ListEventsParams,
@@ -184,6 +185,8 @@ interface SplitEventData {
     executionContext?: Record<string, unknown>;
     /** Initial run attributes (run_created / resilient-start run_started). */
     attributes?: Record<string, string>;
+    /** Experimental start-hook token claim (run_created / resilient start). */
+    startHook?: StartHook;
     /** attr_set change list, included verbatim in frame meta. */
     changes?: Array<Record<string, unknown>>;
     /** attr_set writer provenance, included verbatim in frame meta. */
@@ -215,6 +218,7 @@ type MetaSourceField =
   | 'errorCode'
   | 'executionContext'
   | 'attributes'
+  | 'startHook'
   | 'changes'
   | 'writer'
   | 'allowReservedAttributes';
@@ -330,6 +334,13 @@ export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
     typeof eventData.attributes === 'object'
   ) {
     meta.attributes = eventData.attributes as Record<string, string>;
+  }
+  if (
+    eventData.startHook !== undefined &&
+    eventData.startHook !== null &&
+    typeof eventData.startHook === 'object'
+  ) {
+    meta.startHook = eventData.startHook as StartHook;
   }
   if (Array.isArray(eventData.changes)) {
     meta.changes = eventData.changes as Array<Record<string, unknown>>;

--- a/packages/world/src/attributes.test.ts
+++ b/packages/world/src/attributes.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-  applyAttributeChanges,
   ATTRIBUTE_KEY_MAX_LENGTH,
   ATTRIBUTE_MAX_PER_RUN,
   AttributeValidationError,
+  applyAttributeChanges,
   validateAttributeChanges,
   validateAttributeKey,
   validateAttributeValue,

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -290,6 +290,26 @@ const AttrSetEventSchema = BaseEventSchema.extend({
   }),
 });
 
+/**
+ * Start-hook claim data: `start()` reserves `token` atomically with run
+ * admission, fencing duplicate starts for `ttlSeconds` past hook creation /
+ * run completion. Rides on `run_created` (and the resilient-start
+ * `run_started` fallback + queue runInput) so every admission path validates
+ * the same shape.
+ */
+export const StartHookSchema = z.object({
+  token: z.string().min(1),
+  /**
+   * Retention window (seconds past hook creation / run completion) during
+   * which the token stays fenced. Absent = no retention: the claim is
+   * released when the hook is disposed or the run reaches a terminal
+   * state, like a plain `createHook` token guard.
+   */
+  ttlSeconds: z.number().int().positive().optional(),
+});
+
+export type StartHook = z.infer<typeof StartHookSchema>;
+
 // =============================================================================
 // Run lifecycle events
 // =============================================================================
@@ -307,6 +327,7 @@ const RunCreatedEventSchema = BaseEventSchema.extend({
     executionContext: z.record(z.string(), z.any()).optional(),
     attributes: z.record(z.string(), z.string()).optional(),
     allowReservedAttributes: z.literal(true).optional(),
+    startHook: StartHookSchema.optional(),
   }),
 });
 
@@ -329,6 +350,7 @@ const RunStartedEventSchema = BaseEventSchema.extend({
       executionContext: z.record(z.string(), z.any()).optional(),
       attributes: z.record(z.string(), z.string()).optional(),
       allowReservedAttributes: z.literal(true).optional(),
+      startHook: StartHookSchema.optional(),
     })
     .optional(),
 });

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -272,6 +272,15 @@ export interface Storage {
 }
 
 /**
+ * Optional caps a World places on start-hook admission claims. See
+ * `World.startHookAdmission`.
+ */
+export interface StartHookAdmissionCaps {
+  maxTtlSeconds?: number;
+  maxTokenBytes?: number;
+}
+
+/**
  * The "World" interface represents how Workflows are able to communicate with the outside world.
  */
 export interface World extends Queue, Streamer, Storage {
@@ -292,6 +301,17 @@ export interface World extends Queue, Streamer, Storage {
    * `SPEC_VERSION_CURRENT` before they create or replay runs.
    */
   specVersion: number;
+
+  /**
+   * Declares that this World atomically reserves
+   * `run_created.eventData.startHook` tokens with run
+   * admission. Admission is queue-first: `start()` enqueues the run (the
+   * queued message can bootstrap admission itself via the resilient
+   * `run_started` path, so a crash cannot orphan a claimed token), then
+   * creates `run_created`, which claims the token. Optional caps bound the
+   * claim's TTL and token size.
+   */
+  startHookAdmission?: StartHookAdmissionCaps;
 
   /**
    * Whether calling `process.exit(1)` from a queue handler is observed by

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -1,4 +1,5 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
+import { StartHookSchema } from './events.js';
 
 export type QueueKind = 'workflow' | 'step';
 
@@ -115,6 +116,8 @@ export const RunInputSchema = z.object({
   executionContext: z.record(z.string(), z.any()).optional(),
   /** Initial plaintext run attributes, for resilient run creation. */
   attributes: z.record(z.string(), z.string()).optional(),
+  /** Start-hook claim data, for resilient run creation. */
+  startHook: StartHookSchema.optional(),
   /**
    * Permits reserved `$`-prefixed keys in `attributes`, mirrored from the
    * `start()` option so resilient run creation validates the same way as

--- a/packages/world/src/recovery.ts
+++ b/packages/world/src/recovery.ts
@@ -1,6 +1,5 @@
-import type { Queue } from './queue.js';
 import type { Storage } from './interfaces.js';
-import type { ValidQueueName } from './queue.js';
+import type { Queue, ValidQueueName } from './queue.js';
 
 /**
  * Re-enqueue all active (pending/running) workflow runs so they resume


### PR DESCRIPTION
**Stack 1/4** · this PR → #2763 → #2764 → #2765 · Replaces the monolithic #2684

Adds the experimental `hook` option to `start()` (refs #2376, gaps 1 and 2): Worlds that declare `startHookAdmission` reserve the hook token **atomically with run admission**, so duplicate starts are rejected before any duplicate workflow code can run.

```ts
const run = await start(processOrder, [orderId], {
  hook: {
    token: `order:${orderId}`,
    experimental_ttl: '30 days',
  },
});
```

### What's in this PR
- `start()` option + validation. Admission is **queue-first everywhere**: enqueue → admission (`run_created` claims the token). A crash after the enqueue cannot orphan a claimed token — the queued message bootstraps admission itself via the resilient `run_started` path. Admission failures after the enqueue surface as the new **`WorkflowStartError`** (`runId` / `stage` / `queued` / `retryable`); `HookConflictError` passes through.
- `experimental_ttl` is **optional**: without it, the token is released when the hook is disposed or the run ends (plain-guard semantics); with it, the token stays fenced for the TTL past hook creation / run completion.
- Queue failures on the **default** (non-hook) `start()` path are now also typed as `WorkflowStartError` (stage `queue`) instead of leaking raw transport errors — the create/queue parallelism is unchanged.
- Runtime handling for queued runs that **lost** their claim: acknowledged without running user code; turbo mode disabled for start-hook runs. Gated cross-deployment by the new `startHookLoserAck` capability (cutoff `5.0.0-beta.27`).
- `@workflow/world`: `World.startHookAdmission` declaration, `StartHook` schema/type on `run_created` / resilient-start `run_started` / queue `runInput` (embedded directly in the queue runInput schema).
- `WorkflowStartError` serialization end-to-end (core reducers/revivers, web-shared + CLI hydration).
- world-vercel **v4 wire routing only** for the new eventData field — its compile-time wire-contract exhaustiveness guard requires schema fields to be routed in the same change. Vercel admission behavior lands in PR 4.
- Docs: Idempotency foundations section, `start()` API notes, `WorkflowStartError` reference page.

No World in this PR implements admission yet — using the option against an unsupporting World throws a clear error. Implementations land in the stacked follow-ups.

### Docs Preview
Preview links will resolve once the docs deployment builds for this branch: `/v5/docs/foundations/idempotency#atomic-start-hook-idempotency`, `/v5/docs/api-reference/workflow-api/start`, `/v5/docs/api-reference/workflow-errors/workflow-start-error`.




