### PR TITLE
feat(world-local): event-first start-hook admission

### DIFF
--- a/.changeset/start-hook-world-local.md
+++ b/.changeset/start-hook-world-local.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-local": minor
+---
+
+Support experimental start-hook admission (event-first): `run_created` atomically claims the hook token, claims are retained for their TTL after hook disposal or run completion, and cancellation releases claims the workflow never materialized.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1863,6 +1863,43 @@ describe('e2e', () => {
     }
   );
 
+  // Postgres world support lands in the next PR of this stack; drop the
+  // WORKFLOW_TARGET_WORLD clause there.
+  test.skipIf(
+    !!process.env.WORKFLOW_VERCEL_ENV ||
+      process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  )(
+    'startHook rejects duplicate starts before hook materialization',
+    { timeout: 60_000 },
+    async () => {
+      const token = Math.random().toString(36).slice(2);
+      const workflow = await e2e('startHookWorkflow');
+      const startOptions = {
+        hook: {
+          token,
+          experimental_ttl: 60_000,
+        },
+      };
+
+      const run = await start(workflow, [token], startOptions);
+
+      const duplicateError = await start(workflow, [token], startOptions).catch(
+        (error: unknown) => error
+      );
+      expect(HookConflictError.is(duplicateError)).toBe(true);
+      assert(HookConflictError.is(duplicateError));
+      expect(duplicateError.conflictingRunId).toBe(run.runId);
+
+      const hook = await waitForHook(token, { runId: run.runId });
+      await resumeHook(hook, { message: 'accepted' });
+
+      await expect(run.returnValue).resolves.toEqual({
+        role: 'owner',
+        message: 'accepted',
+      });
+    }
+  );
+
   test('hookGetConflictWorkflow - awaiting hook.getConflict() registers hook without payload', async () => {
     const token = Math.random().toString(36).slice(2);
     const customData = Math.random().toString(36).slice(2);

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -17,7 +17,11 @@ import {
 import { initDataDir } from './init.js';
 import { instrumentObject } from './instrumentObject.js';
 import { createQueue, type DirectHandler } from './queue.js';
-import { hashToken, hookRecoveryMarkerPath } from './storage/helpers.js';
+import {
+  hookRecoveryMarkerPath,
+  hookTokenClaimPath,
+  readHookTokenClaim,
+} from './storage/helpers.js';
 import { createStorage } from './storage.js';
 import { createStreamer } from './streamer.js';
 
@@ -69,6 +73,7 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
   const recoverActiveRuns = mergedConfig.recoverActiveRuns ?? true;
   return {
     specVersion: SPEC_VERSION_CURRENT,
+    startHookAdmission: {},
     ...queue,
     ...storage,
     ...instrumentObject('world.streams', {
@@ -128,9 +133,7 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
               HookSchema
             );
             if (hook?.token) {
-              await deleteJSON(
-                path.join(hooksDir, 'tokens', `${hashToken(hook.token)}.json`)
-              );
+              await deleteJSON(hookTokenClaimPath(basedir, hook.token));
               await deleteJSON(
                 hookRecoveryMarkerPath(
                   basedir,
@@ -141,6 +144,29 @@ export function createLocalWorld(args?: Partial<Config>): LocalWorld {
               );
             }
           })
+        );
+        const tokensDir = path.join(hooksDir, 'tokens');
+        const tokenFiles = await fs.readdir(tokensDir).catch(() => []);
+        await Promise.all(
+          tokenFiles
+            .filter((tokenFile) => tokenFile.endsWith('.json'))
+            .map(async (tokenFile) => {
+              const claimPath = path.join(tokensDir, tokenFile);
+              const claim = await readHookTokenClaim(claimPath);
+              if (claim?.tag !== tag) return;
+
+              await deleteJSON(claimPath);
+              if (claim.token && claim.hookId) {
+                await deleteJSON(
+                  hookRecoveryMarkerPath(
+                    basedir,
+                    claim.token,
+                    claim.runId,
+                    claim.hookId
+                  )
+                );
+              }
+            })
         );
 
         // Delete tagged entity files across all directories

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -1,13 +1,21 @@
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { WorkflowWorldError } from '@workflow/errors';
+import {
+  EntityConflictError,
+  HookConflictError,
+  WorkflowWorldError,
+} from '@workflow/errors';
 import type { Event, Storage } from '@workflow/world';
 import { SPEC_VERSION_CURRENT, stripEventDataRefs } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { writeJSON } from './fs.js';
-import { hashToken } from './storage/helpers.js';
+import {
+  hashToken,
+  hookRecoveryMarkerPath,
+  hookTokenClaimLockPath,
+} from './storage/helpers.js';
 import { createStorage } from './storage.js';
 import {
   completeWait,
@@ -2116,6 +2124,729 @@ describe('Storage', () => {
           testRunId
         );
         expect(result.hook).toBeUndefined();
+      });
+
+      it('should reject duplicate start hook claims before hook materialization', async () => {
+        const token = 'start-claim-token';
+        const first = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        expect(first.run).toBeDefined();
+        const firstRun = first.run;
+        if (!firstRun) throw new Error('Expected run to be created');
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-123',
+              workflowName: 'test-workflow',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).rejects.toThrow(HookConflictError);
+
+        await expect(
+          storage.events.create(firstRun.runId, {
+            eventType: 'hook_created',
+            correlationId: 'hook_start',
+            eventData: { token },
+          })
+        ).resolves.toMatchObject({
+          event: { eventType: 'hook_created' },
+          hook: {
+            runId: firstRun.runId,
+            hookId: 'hook_start',
+            token,
+          },
+        });
+      });
+
+      it('should reserve start hook claims during resilient run_started bootstrap', async () => {
+        const token = 'resilient-start-claim-token';
+        const runId = `wrun_${monotonicFactory()()}`;
+
+        const started = await storage.events.create(runId, {
+          eventType: 'run_started',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+
+        expect(started.run?.runId).toBe(runId);
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-456',
+              workflowName: 'test-workflow-2',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).rejects.toThrow(HookConflictError);
+
+        await expect(
+          storage.events.create(runId, {
+            eventType: 'hook_created',
+            correlationId: 'hook_resilient_start',
+            eventData: { token },
+          })
+        ).resolves.toMatchObject({
+          event: { eventType: 'hook_created' },
+          hook: { runId, hookId: 'hook_resilient_start', token },
+        });
+      });
+
+      it('should materialize only one hook for a reserved start hook token', async () => {
+        const token = 'concurrent-start-claim-materialize-token';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        const run = started.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        const results = await Promise.all([
+          storage.events.create(run.runId, {
+            eventType: 'hook_created',
+            correlationId: 'hook_start_a',
+            eventData: { token },
+          }),
+          storage.events.create(run.runId, {
+            eventType: 'hook_created',
+            correlationId: 'hook_start_b',
+            eventData: { token },
+          }),
+        ]);
+
+        expect(results.map((result) => result.event.eventType).sort()).toEqual([
+          'hook_conflict',
+          'hook_created',
+        ]);
+        expect(results.filter((result) => result.hook).length).toBe(1);
+      });
+
+      it('should repair a same-run start hook retry when the run_created event is missing', async () => {
+        const token = 'same-run-start-claim-token';
+        const first = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        expect(first.run).toBeDefined();
+        const run = first.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        await fs.unlink(
+          path.join(
+            testDir,
+            'events',
+            `${run.runId}-${first.event.eventId}.json`
+          )
+        );
+
+        const retry = await storage.events.create(run.runId, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+
+        expect(retry.event.eventType).toBe('run_created');
+        expect(retry.event.eventId).toBe(first.event.eventId);
+        expect(retry.run?.runId).toBe(run.runId);
+      });
+
+      it('should recover a stale start hook materialization lock', async () => {
+        const token = 'stale-materialize-lock-token';
+        const first = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        expect(first.run).toBeDefined();
+        const run = first.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        const lockPath = hookTokenClaimLockPath(testDir, token);
+        await fs.mkdir(path.dirname(lockPath), { recursive: true });
+        await fs.writeFile(lockPath, '');
+        const stale = new Date(Date.now() - 60_000);
+        await fs.utimes(lockPath, stale, stale);
+
+        const result = await storage.events.create(run.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_stale_materialize',
+          eventData: { token },
+        });
+
+        expect(result.event.eventType).toBe('hook_created');
+        expect(result.hook?.hookId).toBe('hook_stale_materialize');
+      });
+
+      it('should not adopt or duplicate run_created when losing to a pre-existing hookless run', async () => {
+        const token = 'failed-run-create-start-claim-token';
+        const run = await createRun(storage, {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array(),
+        });
+
+        // A hook-carrying run_created for a runId that already exists
+        // (created without a start hook) is a divergent duplicate: it must
+        // conflict, and it must NOT append a second run_created event. Its
+        // claim stays behind and expires via TTL once the run is terminal.
+        await expect(
+          storage.events.create(run.runId, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-456',
+              workflowName: 'test-workflow-2',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).rejects.toThrow(EntityConflictError);
+
+        const runEvents = await storage.events.list({
+          runId: run.runId,
+          pagination: {},
+        });
+        expect(
+          runEvents.data.filter((e) => e.eventType === 'run_created')
+        ).toHaveLength(1);
+      });
+
+      it('should converge duplicate same-run hook-carrying run_created deliveries on one event', async () => {
+        const token = 'duplicate-run-create-start-claim-token';
+        const request = {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array(),
+          startHook: { token, ttlSeconds: 60 },
+        };
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: request,
+        });
+        const runId = started.run?.runId;
+        if (!runId) throw new Error('Expected run to be created');
+
+        // A duplicate delivery of the same run_created converges on the
+        // canonical event path and dedups instead of appending a second
+        // run_created or deleting the live claim.
+        await expect(
+          storage.events.create(runId, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: request,
+          })
+        ).rejects.toThrow(EntityConflictError);
+
+        const runEvents = await storage.events.list({
+          runId,
+          pagination: {},
+        });
+        expect(
+          runEvents.data.filter((e) => e.eventType === 'run_created')
+        ).toHaveLength(1);
+
+        // The claim survived the duplicate: another run still conflicts.
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-456',
+              workflowName: 'test-workflow-2',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).rejects.toThrow(HookConflictError);
+      });
+
+      it('should retain a disposed start hook claim until ttl expiry', async () => {
+        const token = 'disposed-start-claim-token';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        expect(started.run).toBeDefined();
+        const startedRun = started.run;
+        if (!startedRun) throw new Error('Expected run to be created');
+        const runId = startedRun.runId;
+
+        await storage.events.create(runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_start_disposed',
+          eventData: { token },
+        });
+        await storage.events.create(runId, {
+          eventType: 'hook_disposed',
+          correlationId: 'hook_start_disposed',
+        });
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-123',
+              workflowName: 'test-workflow',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).rejects.toThrow(HookConflictError);
+      });
+
+      it('should not materialize a retained start hook claim again', async () => {
+        const token = 'retained-start-claim-token';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        const run = started.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        await storage.events.create(run.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_start_retained',
+          eventData: { token },
+        });
+        await storage.events.create(run.runId, {
+          eventType: 'hook_disposed',
+          correlationId: 'hook_start_retained',
+        });
+
+        const result = await storage.events.create(run.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_start_retained_again',
+          eventData: { token },
+        });
+
+        expect(result.event.eventType).toBe('hook_conflict');
+        expect(result.hook).toBeUndefined();
+      });
+
+      it('should retain an unmaterialized start hook claim after run failure until ttl expiry', async () => {
+        const token = 'failed-unmaterialized-start-claim-token';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        const run = started.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        await storage.events.create(run.runId, {
+          eventType: 'run_started',
+        });
+        await storage.events.create(run.runId, {
+          eventType: 'run_failed',
+          eventData: { error: new Uint8Array() },
+        });
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-456',
+              workflowName: 'test-workflow-2',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).rejects.toThrow(HookConflictError);
+
+        const past = new Date(Date.now() - 2_000);
+        await writeJSON(
+          path.join(testDir, 'hooks', 'tokens', `${hashToken(token)}.json`),
+          {
+            token,
+            runId: run.runId,
+            ttlSeconds: 60,
+            createdAt: past,
+            expiresAt: past,
+          },
+          { overwrite: true }
+        );
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-789',
+              workflowName: 'test-workflow-3',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).resolves.toMatchObject({
+          event: { eventType: 'run_created' },
+          run: { workflowName: 'test-workflow-3' },
+        });
+      });
+
+      it('should release an unmaterialized start hook claim on cancellation', async () => {
+        const token = 'cancelled-unmaterialized-start-claim-token';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        });
+        const run = started.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        // Cancel the claim-owning run before it materialized a hook: the
+        // token must be immediately reusable (cancel-then-retry, including
+        // start()'s own cleanup when queueing fails after admission).
+        await storage.events.create(run.runId, {
+          eventType: 'run_cancelled',
+        });
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-456',
+              workflowName: 'test-workflow-2',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 60 },
+            },
+          })
+        ).resolves.toMatchObject({
+          event: { eventType: 'run_created' },
+          run: { workflowName: 'test-workflow-2' },
+        });
+      });
+
+      it("does not sweep another active run's expired claim at terminal cleanup", async () => {
+        const token = 'active-run-expired-claim-survives-sweep';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 1 },
+          },
+        });
+        const owner = started.run;
+        if (!owner) throw new Error('Expected run to be created');
+        await storage.events.create(owner.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_sweep_survivor',
+          eventData: { token },
+        });
+        await storage.events.create(owner.runId, {
+          eventType: 'hook_disposed',
+          correlationId: 'hook_sweep_survivor',
+        });
+        // Force the retained claim past its window while the owner run is
+        // still active.
+        const past = new Date(Date.now() - 2_000);
+        await writeJSON(
+          path.join(testDir, 'hooks', 'tokens', `${hashToken(token)}.json`),
+          {
+            token,
+            runId: owner.runId,
+            hookId: 'hook_sweep_survivor',
+            ttlSeconds: 1,
+            createdAt: past,
+            expiresAt: past,
+          },
+          { overwrite: true }
+        );
+
+        // An unrelated run reaching a terminal state triggers the tokens
+        // sweep — it must not GC the active owner's claim.
+        const bystander = await createRun(storage, {
+          deploymentId: 'deployment-456',
+          workflowName: 'test-workflow-2',
+          input: new Uint8Array(),
+        });
+        await storage.events.create(bystander.runId, {
+          eventType: 'run_started',
+        });
+        await storage.events.create(bystander.runId, {
+          eventType: 'run_completed',
+          eventData: { output: new Uint8Array() },
+        });
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-789',
+              workflowName: 'test-workflow-3',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 1 },
+            },
+          })
+        ).rejects.toThrow(HookConflictError);
+      });
+
+      it('should keep an expired disposed start hook claim while the run is active', async () => {
+        const token = 'active-expired-start-claim-token';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 1 },
+          },
+        });
+        expect(started.run).toBeDefined();
+        const run = started.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        await storage.events.create(run.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_start_expired_active',
+          eventData: { token },
+        });
+        await storage.events.create(run.runId, {
+          eventType: 'hook_disposed',
+          correlationId: 'hook_start_expired_active',
+        });
+
+        const past = new Date(Date.now() - 2_000);
+        await writeJSON(
+          path.join(testDir, 'hooks', 'tokens', `${hashToken(token)}.json`),
+          {
+            token,
+            runId: run.runId,
+            ttlSeconds: 1,
+            createdAt: past,
+            expiresAt: past,
+          },
+          { overwrite: true }
+        );
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-456',
+              workflowName: 'test-workflow-2',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 1 },
+            },
+          })
+        ).rejects.toThrow(HookConflictError);
+
+        await storage.events.create(run.runId, {
+          eventType: 'run_completed',
+          eventData: { output: new Uint8Array() },
+        });
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-789',
+              workflowName: 'test-workflow-3',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 1 },
+            },
+          })
+        ).resolves.toMatchObject({
+          event: { eventType: 'run_created' },
+          run: { workflowName: 'test-workflow-3' },
+        });
+      });
+
+      it('should allow an expired orphaned start hook claim to be reused', async () => {
+        const token = 'expired-orphaned-start-claim-token';
+        const past = new Date(Date.now() - 2_000);
+        await writeJSON(
+          path.join(testDir, 'hooks', 'tokens', `${hashToken(token)}.json`),
+          {
+            token,
+            runId: 'orphaned-start-run',
+            ttlSeconds: 1,
+            createdAt: past,
+          },
+          { overwrite: true }
+        );
+
+        await expect(
+          storage.events.create(null, {
+            eventType: 'run_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            eventData: {
+              deploymentId: 'deployment-123',
+              workflowName: 'test-workflow',
+              input: new Uint8Array(),
+              startHook: { token, ttlSeconds: 1 },
+            },
+          })
+        ).resolves.toMatchObject({
+          event: { eventType: 'run_created' },
+          run: { workflowName: 'test-workflow' },
+        });
+      });
+
+      it('should allow ordinary hook creation after a retained start hook claim expires', async () => {
+        const token = 'expired-retained-ordinary-hook-token';
+        const started = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 1 },
+          },
+        });
+        const run = started.run;
+        if (!run) throw new Error('Expected run to be created');
+
+        await storage.events.create(run.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_start_expired_reusable',
+          eventData: { token },
+        });
+        await storage.events.create(run.runId, {
+          eventType: 'hook_disposed',
+          correlationId: 'hook_start_expired_reusable',
+        });
+        await storage.events.create(run.runId, {
+          eventType: 'run_completed',
+          eventData: { output: new Uint8Array() },
+        });
+
+        const past = new Date(Date.now() - 2_000);
+        await writeJSON(
+          path.join(testDir, 'hooks', 'tokens', `${hashToken(token)}.json`),
+          {
+            token,
+            runId: run.runId,
+            hookId: 'hook_start_expired_reusable',
+            ttlSeconds: 1,
+            createdAt: past,
+            expiresAt: past,
+          },
+          { overwrite: true }
+        );
+
+        const nextRun = await createRun(storage, {
+          deploymentId: 'deployment-456',
+          workflowName: 'test-workflow-2',
+          input: new Uint8Array(),
+        });
+
+        await expect(
+          storage.events.create(nextRun.runId, {
+            eventType: 'hook_created',
+            correlationId: 'hook_after_retained_expired',
+            eventData: { token },
+          })
+        ).resolves.toMatchObject({
+          event: { eventType: 'hook_created' },
+          hook: {
+            runId: nextRun.runId,
+            hookId: 'hook_after_retained_expired',
+            token,
+          },
+        });
+      });
+
+      it('should ignore hook recovery markers when cleaning up start hook claims', async () => {
+        const run = await createRun(storage, {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array(),
+        });
+
+        await writeJSON(
+          hookRecoveryMarkerPath(
+            testDir,
+            'marker-token',
+            run.runId,
+            'hook_marker'
+          ),
+          { eventId: 'wevt_marker' },
+          { overwrite: true }
+        );
+
+        await expect(
+          updateRun(storage, run.runId, 'run_completed', {
+            output: new Uint8Array(),
+          })
+        ).resolves.toMatchObject({
+          status: 'completed',
+        });
       });
 
       it('should return hook_conflict event when the token claim cannot provide a run ID', async () => {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
   EntityConflictError,
+  HookConflictError,
   HookNotFoundError,
   RunExpiredError,
   RunNotSupportedError,
@@ -12,6 +13,7 @@ import {
 import type {
   Event,
   EventResult,
+  StartHook,
   Hook,
   SerializedData,
   Step,
@@ -30,7 +32,6 @@ import {
   requiresNewerWorld,
   SPEC_VERSION_CURRENT,
   StepSchema,
-  ulidToDate,
   validateAttributeChanges,
   validateUlidTimestamp,
   WaitSchema,
@@ -55,14 +56,20 @@ import {
 } from '../fs.js';
 import { stripEventDataRefs } from './filters.js';
 import {
+  canReuseExpiredStartClaim,
+  eventIdToDate,
   getObjectCreatedAt,
-  hashToken,
+  type HookTokenClaim,
   hookRecoveryMarkerPath,
+  hookTokenClaimPath,
   monotonicUlid,
+  readHookTokenClaim,
+  withTokenClaimLock,
 } from './helpers.js';
 import {
   deleteAllHooksForRun,
   rebuildLiveHookByTokenFromEventLog,
+  settleClaimForDisposedHook,
 } from './hooks-storage.js';
 import { handleLegacyEvent } from './legacy.js';
 import { withRunFileLock } from './runs-storage.js';
@@ -90,26 +97,6 @@ import { withRunFileLock } from './runs-storage.js';
 // but a shared filesystem), exactly matching the cross-process
 // semantics without spawning subprocesses.
 
-const HookTokenClaimSchema = z.object({
-  // The token-claim writer below has always persisted `hookId`, but
-  // this read schema previously omitted it, which is the bug fixed
-  // by https://github.com/vercel/workflow/issues/2283. `optional()`
-  // is defensive: any claim file that somehow lacks the field still
-  // parses (yielding `undefined`) and falls through to the cross-
-  // hook conflict branch, matching pre-fix behavior.
-  hookId: z.string().optional(),
-  runId: z.string(),
-  // `eventId` is the canonical hook_created event ID the claiming
-  // worker committed to publishing. Persisting it here turns the
-  // claim file into a durable convergence key for cross-worker /
-  // cross-process retries (see comment on the hook_created branch).
-  // `optional()` for backward compatibility: a legacy claim file
-  // written before this field existed falls through to the recovery-
-  // marker upgrade path, which atomically pins a canonical eventId
-  // via a sidecar marker (also a `writeExclusive`).
-  eventId: z.string().optional(),
-});
-
 /**
  * Sidecar recovery marker that pins a canonical `hook_created`
  * eventId for a legacy token claim — one written by a version of
@@ -131,17 +118,136 @@ const HookRecoveryMarkerSchema = z.object({
   eventId: z.string(),
 });
 
-async function readHookTokenClaim(
-  constraintPath: string
-): Promise<z.infer<typeof HookTokenClaimSchema> | null> {
-  try {
-    return await readJSON(constraintPath, HookTokenClaimSchema);
-  } catch (error) {
-    if (error instanceof SyntaxError || error instanceof z.ZodError) {
-      return null;
-    }
-    throw error;
+async function replaceExpiredStartClaim(
+  basedir: string,
+  tag: string | undefined,
+  token: string,
+  currentClaim: HookTokenClaim,
+  nextClaim: HookTokenClaim
+): Promise<boolean> {
+  // Cheap pre-check on the caller's snapshot: an unexpired claim can never
+  // be reclaimed, so skip the lock + re-reads entirely. The in-lock check
+  // below stays authoritative.
+  if (!(await canReuseExpiredStartClaim(basedir, tag, currentClaim))) {
+    return false;
   }
+  const replaced = await withTokenClaimLock(basedir, token, async () => {
+    const constraintPath = hookTokenClaimPath(basedir, token);
+    const latestClaim = await readHookTokenClaim(constraintPath);
+    if (
+      !latestClaim ||
+      !(await canReuseExpiredStartClaim(basedir, tag, latestClaim))
+    ) {
+      return false;
+    }
+    await writeJSON(constraintPath, nextClaim, { overwrite: true });
+    return true;
+  });
+  return replaced ?? false;
+}
+
+/**
+ * Binds an unmaterialized same-run start claim to a hook. Fails (returns
+ * false) when the claim is gone, owned by another run, already bound to a
+ * hook, or retained.
+ */
+async function materializeStartHookClaim(
+  basedir: string,
+  token: string,
+  nextClaim: HookTokenClaim
+): Promise<boolean> {
+  // Retry briefly on lock contention: reporting a contended lock as a lost
+  // materialization would make the caller's convergence read (which can
+  // observe the still-unmaterialized claim while the winner holds the
+  // lock) record a spurious self hook_conflict.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const materialized = await withTokenClaimLock(basedir, token, async () => {
+      const constraintPath = hookTokenClaimPath(basedir, token);
+      const latestClaim = await readHookTokenClaim(constraintPath);
+      if (
+        !latestClaim ||
+        latestClaim.runId !== nextClaim.runId ||
+        latestClaim.hookId !== undefined ||
+        latestClaim.expiresAt !== undefined
+      ) {
+        return false;
+      }
+      await writeJSON(constraintPath, nextClaim, { overwrite: true });
+      return true;
+    });
+    if (materialized !== undefined) return materialized;
+    await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+  }
+  return false;
+}
+
+/**
+ * Claims `token` for `runId`'s run_created event. Returns the canonical
+ * run_created eventId for the run: the caller's `eventId` when this call
+ * created (or reclaimed) the token, or the eventId recorded by a previous
+ * same-run attempt — every duplicate delivery converges on one event path,
+ * so the exclusive event publish downstream dedups instead of appending a
+ * second run_created. Throws HookConflictError when another run holds a
+ * live claim.
+ */
+async function claimStartHookToken(
+  basedir: string,
+  runId: string,
+  eventId: string,
+  startHook: StartHook,
+  tag?: string
+): Promise<string> {
+  const constraintPath = hookTokenClaimPath(basedir, startHook.token);
+  const nextClaim: HookTokenClaim = {
+    token: startHook.token,
+    runId,
+    ttlSeconds: startHook.ttlSeconds,
+    startEventId: eventId,
+    createdAt: new Date(),
+    tag,
+  };
+  const claimed = await writeExclusive(
+    constraintPath,
+    JSON.stringify(nextClaim)
+  );
+  if (claimed) return eventId;
+
+  const existingClaim = await readHookTokenClaim(constraintPath);
+  if (existingClaim?.runId === runId) {
+    return existingClaim.startEventId ?? eventId;
+  }
+  if (
+    existingClaim &&
+    (await replaceExpiredStartClaim(
+      basedir,
+      tag,
+      startHook.token,
+      existingClaim,
+      nextClaim
+    ))
+  ) {
+    return eventId;
+  }
+
+  // Do not throw from the (possibly stale) snapshot: the claim may have
+  // been reclaimed by another start or GC'd by terminal cleanup since the
+  // read above. Re-read and converge; if the token was freed entirely,
+  // retry the exclusive create once.
+  const currentClaim = await readHookTokenClaim(constraintPath);
+  if (!currentClaim) {
+    if (await writeExclusive(constraintPath, JSON.stringify(nextClaim))) {
+      return eventId;
+    }
+    const raced = await readHookTokenClaim(constraintPath);
+    if (raced?.runId === runId) {
+      return raced.startEventId ?? eventId;
+    }
+    throw new HookConflictError(startHook.token, raced?.runId);
+  }
+  if (currentClaim.runId === runId) {
+    return currentClaim.startEventId ?? eventId;
+  }
+  throw new HookConflictError(startHook.token, currentClaim.runId);
 }
 
 async function readHookRecoveryMarker(
@@ -662,6 +768,7 @@ export function createEventsStorage(
               executionContext?: Record<string, any>;
               attributes?: Record<string, string>;
               allowReservedAttributes?: true;
+              startHook?: StartHook;
             };
             if (
               runInputData.deploymentId &&
@@ -697,6 +804,20 @@ export function createEventsStorage(
                 createdAt: now,
                 updatedAt: now,
               };
+              // For start-hook runs, claimStartHookToken returns the
+              // canonical run_created eventId — duplicate deliveries of the
+              // same runId converge on one event path so the exclusive
+              // event write below dedups.
+              let runCreatedEventId = `evnt_${monotonicUlid()}`;
+              if (runInputData.startHook) {
+                runCreatedEventId = await claimStartHookToken(
+                  basedir,
+                  effectiveRunId,
+                  runCreatedEventId,
+                  runInputData.startHook,
+                  tag
+                );
+              }
               const runPath = taggedPath(basedir, 'runs', effectiveRunId, tag);
               const created = await writeExclusive(
                 runPath,
@@ -705,7 +826,6 @@ export function createEventsStorage(
 
               if (created) {
                 // We created the run — also write the run_created event.
-                const runCreatedEventId = `evnt_${monotonicUlid()}`;
                 const runCreatedEvent: Event = {
                   eventType: 'run_created',
                   runId: effectiveRunId,
@@ -720,13 +840,17 @@ export function createEventsStorage(
                     attributes: runInputData.attributes,
                     allowReservedAttributes:
                       runInputData.allowReservedAttributes,
+                    startHook: runInputData.startHook,
                   },
                 };
                 await storeEvent(runCreatedEvent);
                 currentRun = createdRun;
               } else {
                 // Run already exists (concurrent run_created won the
-                // race). Re-read it so downstream logic sees the real state.
+                // race). Re-read it so downstream logic sees the real
+                // state. Any start-hook claim stays: same-run attempts
+                // share the canonical event path, and a claim orphaned by
+                // a truly divergent writer expires via its TTL.
                 currentRun = await readJSONWithFallback(
                   basedir,
                   'runs',
@@ -1005,6 +1129,7 @@ export function createEventsStorage(
             executionContext?: Record<string, any>;
             attributes?: Record<string, string>;
             allowReservedAttributes?: true;
+            startHook?: StartHook;
           };
           validateAttributeChanges(
             Object.entries(runData.attributes ?? {}).map(([key, value]) => ({
@@ -1015,6 +1140,34 @@ export function createEventsStorage(
               allowReservedAttributes: runData.allowReservedAttributes === true,
             }
           );
+          // For start-hook runs, claimStartHookToken returns the canonical
+          // run_created eventId — duplicate deliveries converge on one
+          // event path so the exclusive event publish downstream dedups.
+          // `ownsStartHookClaim` records whether this call created the
+          // claim (canonical id === ours) or adopted a previous same-run
+          // attempt's.
+          let ownsStartHookClaim = false;
+          if (runData.startHook) {
+            const canonicalEventId = await claimStartHookToken(
+              basedir,
+              effectiveRunId,
+              eventId,
+              runData.startHook,
+              tag
+            );
+            ownsStartHookClaim = canonicalEventId === eventId;
+            if (!ownsStartHookClaim) {
+              // Rebuild the pending event around the adopted canonical id so
+              // the persisted event body always matches its file path — even
+              // when this writer goes on to win the run-entity write.
+              eventId = canonicalEventId;
+              event = {
+                ...event,
+                eventId,
+                createdAt: eventIdToDate(eventId) ?? now,
+              };
+            }
+          }
           run = {
             runId: effectiveRunId,
             deploymentId: runData.deploymentId,
@@ -1042,9 +1195,63 @@ export function createEventsStorage(
             JSON.stringify(run, jsonReplacer, 2)
           );
           if (!created) {
-            throw new EntityConflictError(
-              `Workflow run "${effectiveRunId}" already exists`
-            );
+            // Lost the run write to a concurrent same-run creation. For
+            // start-hook runs whose claim we share, converge on the winner:
+            // reuse the existing run and the canonical eventId, and let the
+            // exclusive event publish downstream dedup. The claim is left
+            // alone — same-run attempts share it, and a claim orphaned by a
+            // truly divergent writer expires via its TTL.
+            const startHook = runData.startHook;
+            const startHookClaim =
+              startHook && !ownsStartHookClaim
+                ? await readHookTokenClaim(
+                    hookTokenClaimPath(basedir, startHook.token)
+                  )
+                : null;
+            const existingRun =
+              startHook &&
+              !ownsStartHookClaim &&
+              startHookClaim?.runId === effectiveRunId &&
+              startHookClaim.startEventId
+                ? await readJSONWithFallback(
+                    basedir,
+                    'runs',
+                    effectiveRunId,
+                    WorkflowRunSchema,
+                    tag
+                  )
+                : null;
+
+            if (existingRun && startHook && startHookClaim?.startEventId) {
+              eventId = startHookClaim.startEventId;
+              event = {
+                eventType: 'run_created',
+                runId: effectiveRunId,
+                eventId,
+                createdAt: eventIdToDate(eventId) ?? now,
+                specVersion: effectiveSpecVersion,
+                eventData: {
+                  deploymentId: existingRun.deploymentId,
+                  workflowName: existingRun.workflowName,
+                  input: existingRun.input,
+                  executionContext: existingRun.executionContext,
+                  attributes: existingRun.attributes,
+                  ...(runData.allowReservedAttributes
+                    ? { allowReservedAttributes: true as const }
+                    : {}),
+                  startHook: {
+                    token: startHook.token,
+                    ttlSeconds:
+                      startHookClaim.ttlSeconds ?? startHook.ttlSeconds,
+                  },
+                },
+              };
+              run = existingRun;
+            } else {
+              throw new EntityConflictError(
+                `Workflow run "${effectiveRunId}" already exists`
+              );
+            }
           }
         } else if (data.eventType === 'run_started') {
           // Reuse currentRun from validation (already read above)
@@ -1108,7 +1315,7 @@ export function createEventsStorage(
               }
             );
             await Promise.all([
-              deleteAllHooksForRun(basedir, effectiveRunId),
+              deleteAllHooksForRun(basedir, effectiveRunId, { tag }),
               deleteAllWaitsForRun(basedir, effectiveRunId),
             ]);
           }
@@ -1146,7 +1353,7 @@ export function createEventsStorage(
               }
             );
             await Promise.all([
-              deleteAllHooksForRun(basedir, effectiveRunId),
+              deleteAllHooksForRun(basedir, effectiveRunId, { tag }),
               deleteAllWaitsForRun(basedir, effectiveRunId),
             ]);
           }
@@ -1176,7 +1383,10 @@ export function createEventsStorage(
               }
             );
             await Promise.all([
-              deleteAllHooksForRun(basedir, effectiveRunId),
+              deleteAllHooksForRun(basedir, effectiveRunId, {
+                releaseUnmaterializedClaims: true,
+                tag,
+              }),
               deleteAllWaitsForRun(basedir, effectiveRunId),
             ]);
           }
@@ -1557,12 +1767,7 @@ export function createEventsStorage(
 
           // Atomically claim the token using an exclusive-create constraint file.
           // This avoids the TOCTOU race of the previous read-all-then-check approach.
-          const constraintPath = path.join(
-            basedir,
-            'hooks',
-            'tokens',
-            `${hashToken(hookData.token)}.json`
-          );
+          const constraintPath = hookTokenClaimPath(basedir, hookData.token);
           // When the claim is absent, the event log is the only durable source
           // that can distinguish a first hook from a crash-lost token cache.
           if (!(await readHookTokenClaim(constraintPath))) {
@@ -1576,13 +1781,14 @@ export function createEventsStorage(
           // process retries can converge on a single canonical
           // `hook_created` event path. See the recovery comment
           // below.
-          const tokenClaimed = await writeExclusive(
+          let tokenClaimed = await writeExclusive(
             constraintPath,
             JSON.stringify({
               token: hookData.token,
               hookId: data.correlationId,
               runId: effectiveRunId,
               eventId,
+              tag,
             })
           );
 
@@ -1624,11 +1830,66 @@ export function createEventsStorage(
           let writeHookEntityWithOverwrite = false;
 
           if (!tokenClaimed) {
-            const existingClaim = await readHookTokenClaim(constraintPath);
+            let existingClaim = await readHookTokenClaim(constraintPath);
 
             if (
               existingClaim?.runId === effectiveRunId &&
-              existingClaim.hookId === data.correlationId
+              existingClaim.hookId === undefined &&
+              existingClaim.expiresAt === undefined
+            ) {
+              // Unmaterialized same-run start claim: bind it to this hook.
+              tokenClaimed = await materializeStartHookClaim(
+                basedir,
+                hookData.token,
+                {
+                  token: hookData.token,
+                  hookId: data.correlationId,
+                  runId: effectiveRunId,
+                  eventId,
+                  ttlSeconds: existingClaim.ttlSeconds,
+                  startEventId: existingClaim.startEventId,
+                  createdAt: existingClaim.createdAt,
+                  tag: existingClaim.tag,
+                }
+              );
+              if (!tokenClaimed) {
+                // Lost a concurrent materialize. Re-read so the dedup
+                // branch below sees the winner's claim — if the winner was
+                // a duplicate of this very (runId, hookId), this converges
+                // on its canonical eventId instead of emitting a spurious
+                // self-conflict.
+                existingClaim = await readHookTokenClaim(constraintPath);
+              }
+            }
+            // No expiry-shape gate here: retained claims carry an explicit
+            // expiresAt, but an expired *unmaterialized* orphan only has
+            // createdAt + ttlSeconds — replaceExpiredStartClaim derives
+            // both and refuses anything unexpired or still owned by an
+            // active run.
+            if (
+              !tokenClaimed &&
+              existingClaim &&
+              (await replaceExpiredStartClaim(
+                basedir,
+                tag,
+                hookData.token,
+                existingClaim,
+                {
+                  token: hookData.token,
+                  hookId: data.correlationId,
+                  runId: effectiveRunId,
+                  eventId,
+                }
+              ))
+            ) {
+              tokenClaimed = true;
+            }
+
+            if (
+              !tokenClaimed &&
+              existingClaim?.runId === effectiveRunId &&
+              existingClaim.hookId === data.correlationId &&
+              existingClaim.expiresAt === undefined
             ) {
               // Adopt a canonical eventId for the recovery write. The
               // outer event publish (`writeExclusive(eventPath)`)
@@ -1722,8 +1983,7 @@ export function createEventsStorage(
               // (a ULID) so two workers writing the same event
               // produce byte-identical content.
               eventId = canonicalEventId;
-              const canonicalCreatedAt =
-                ulidToDate(eventId.replace(/^evnt_/, '')) ?? now;
+              const canonicalCreatedAt = eventIdToDate(eventId) ?? now;
               event = {
                 ...data,
                 runId: effectiveRunId,
@@ -1732,7 +1992,7 @@ export function createEventsStorage(
                 specVersion: effectiveSpecVersion,
               };
               writeHookEntityWithOverwrite = true;
-            } else {
+            } else if (!tokenClaimed) {
               // Cross-hook / cross-run conflict: a different
               // (runId, hookId) holds this token. Create a
               // hook_conflict event so the workflow can fail
@@ -1844,19 +2104,10 @@ export function createEventsStorage(
             tag
           );
           if (existingHook) {
-            // Delete the token constraint file to free up the token
-            // for reuse, and delete this hook's recovery marker (if
-            // any) for disk hygiene. The marker's filename hash
-            // includes `(token, runId, hookId)` so different
-            // lifetimes never collide, but cleaning up reduces disk
-            // leak for hooks that go through the recovery path.
-            const disposedConstraintPath = path.join(
-              basedir,
-              'hooks',
-              'tokens',
-              `${hashToken(existingHook.token)}.json`
-            );
-            await deleteJSON(disposedConstraintPath);
+            // Normal hook disposal frees the token; start-hook claims carry
+            // ttlSeconds and are retained so duplicate starts remain fenced
+            // after the active hook entity is gone.
+            await settleClaimForDisposedHook(basedir, existingHook, now);
             await deleteJSON(
               hookRecoveryMarkerPath(
                 basedir,

--- a/packages/world-local/src/storage/helpers.ts
+++ b/packages/world-local/src/storage/helpers.ts
@@ -1,13 +1,98 @@
 import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
 import path from 'node:path';
+import {
+  isTerminalWorkflowRunStatus,
+  WorkflowRunSchema,
+} from '@workflow/world';
 import { monotonicFactory } from 'ulid';
-import { stripTag, ulidToDate } from '../fs.js';
+import { z } from 'zod';
+import {
+  readJSON,
+  readJSONWithFallback,
+  stripTag,
+  ulidToDate,
+  writeExclusive,
+} from '../fs.js';
 
 /**
  * Hash a hook token to produce a filesystem-safe constraint filename.
  */
 export function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * The token-claim constraint file: the single-owner record behind a hook
+ * token. A claim's lifecycle state is derived, not stored:
+ * - unmaterialized start claim: `startEventId` set, no `hookId`, no
+ *   `expiresAt` (reserved by `start()`, no hook entity yet)
+ * - materialized: `hookId` set, no `expiresAt` (live hook entity)
+ * - retained: `expiresAt` set (hook disposed / run finished; the token
+ *   stays fenced until `expiresAt`)
+ *
+ * Claims without `ttlSeconds` are plain `createHook` token guards with no
+ * retention window — they are deleted when the hook is disposed or the run
+ * reaches a terminal state.
+ */
+export const HookTokenClaimSchema = z.object({
+  token: z.string().optional(),
+  // The token-claim writer has always persisted `hookId`, but an older
+  // read schema omitted it, which is the bug fixed by
+  // https://github.com/vercel/workflow/issues/2283. `optional()` is
+  // defensive: any claim file that somehow lacks the field still parses
+  // (yielding `undefined`) and falls through to the cross-hook conflict
+  // branch, matching pre-fix behavior.
+  hookId: z.string().optional(),
+  runId: z.string(),
+  // `eventId` is the canonical hook_created event ID the claiming worker
+  // committed to publishing. Persisting it here turns the claim file into
+  // a durable convergence key for cross-worker / cross-process retries
+  // (see the hook_created branch in events-storage.ts). `optional()` for
+  // backward compatibility: a legacy claim file written before this field
+  // existed falls through to the recovery-marker upgrade path, which
+  // atomically pins a canonical eventId via a sidecar marker.
+  eventId: z.string().optional(),
+  ttlSeconds: z.number().int().positive().optional(),
+  // `startEventId` is the canonical run_created event ID for claims
+  // reserved by `start()` — the same convergence-key role `eventId` plays
+  // for hook_created.
+  startEventId: z.string().optional(),
+  createdAt: z.coerce.date().optional(),
+  expiresAt: z.coerce.date().optional(),
+  tag: z.string().optional(),
+});
+
+export type HookTokenClaim = z.infer<typeof HookTokenClaimSchema>;
+
+export function hookTokenClaimPath(basedir: string, token: string): string {
+  return path.join(basedir, 'hooks', 'tokens', `${hashToken(token)}.json`);
+}
+
+/**
+ * The single cross-process lock file guarding a token's claim writes (see
+ * `withTokenClaimLock` in events-storage.ts). Exported so tests can plant
+ * stale locks at the real path.
+ */
+export function hookTokenClaimLockPath(basedir: string, token: string): string {
+  return path.join(basedir, '.locks', 'hooks', `${hashToken(token)}.claim`);
+}
+
+/**
+ * Tolerant claim reader: malformed or partially-written claim files parse
+ * to `null` (treated as "no claim") instead of failing the caller.
+ */
+export async function readHookTokenClaim(
+  constraintPath: string
+): Promise<HookTokenClaim | null> {
+  try {
+    return await readJSON(constraintPath, HookTokenClaimSchema);
+  } catch (error) {
+    if (error instanceof SyntaxError || error instanceof z.ZodError) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -78,3 +163,92 @@ export const getObjectCreatedAt =
     const ulid = id.replace(replaceRegex, '');
     return ulidToDate(ulid);
   };
+
+/**
+ * The timestamp encoded in an event ID's ULID, or null when unparsable.
+ * Used to derive a deterministic `createdAt` when converging concurrent
+ * writers on a canonical event.
+ */
+export function eventIdToDate(eventId: string): Date | null {
+  return ulidToDate(eventId.replace(/^evnt_/, ''));
+}
+
+const START_HOOK_LOCK_STALE_MS = 30_000;
+
+/**
+ * Runs `fn` under THE exclusive cross-process file lock for a token's claim
+ * writes — one lock per token, shared by reclaim and materialize, so the two
+ * read-check-overwrite operations mutually exclude. Returns `undefined`
+ * (without running `fn`) when the lock is contended; callers treat that as
+ * a retryable failure and re-validate. Locks abandoned by a crashed holder
+ * (older than START_HOOK_LOCK_STALE_MS) are broken atomically via rename,
+ * so two breakers can never both enter, and the holder only removes a lock
+ * it still owns, so a stalled holder cannot free a breaker's lock.
+ */
+export async function withTokenClaimLock<T>(
+  basedir: string,
+  token: string,
+  fn: () => Promise<T>
+): Promise<T | undefined> {
+  const lockPath = hookTokenClaimLockPath(basedir, token);
+  const owner = monotonicUlid();
+  let locked = await writeExclusive(lockPath, owner);
+  if (!locked) {
+    const stat = await fs.stat(lockPath).catch(() => undefined);
+    if (stat && Date.now() - stat.mtimeMs > START_HOOK_LOCK_STALE_MS) {
+      const broken = await fs.rename(lockPath, `${lockPath}.${owner}`).then(
+        () => true,
+        () => false
+      );
+      if (broken) {
+        await fs.unlink(`${lockPath}.${owner}`).catch(() => {});
+        locked = await writeExclusive(lockPath, owner);
+      }
+    }
+  }
+  if (!locked) return undefined;
+
+  try {
+    return await fn();
+  } finally {
+    const current = await fs.readFile(lockPath, 'utf8').catch(() => undefined);
+    if (current === owner) {
+      await fs.unlink(lockPath).catch(() => {});
+    }
+  }
+}
+
+/**
+ * Whether a claim is dead and its token reclaimable. A claim with a
+ * retention window is dead once expired; a plain createHook guard (no
+ * `ttlSeconds`) has no window and dies with its run — this also self-heals
+ * guards leaked by a skipped cleanup. In both cases an active owning run
+ * keeps its token fenced.
+ */
+export async function canReuseExpiredStartClaim(
+  basedir: string,
+  tag: string | undefined,
+  claim: HookTokenClaim
+): Promise<boolean> {
+  if (claim.ttlSeconds) {
+    const expiresAt =
+      claim.expiresAt ??
+      (claim.createdAt
+        ? new Date(claim.createdAt.getTime() + claim.ttlSeconds * 1000)
+        : undefined);
+    // A TTL claim with no derivable expiry (malformed) is treated as live.
+    if (!expiresAt || expiresAt > new Date()) return false;
+  } else if (claim.expiresAt && claim.expiresAt > new Date()) {
+    return false;
+  }
+
+  const run = await readJSONWithFallback(
+    basedir,
+    'runs',
+    claim.runId,
+    WorkflowRunSchema,
+    claim.tag ?? tag
+  );
+  if (!run) return true;
+  return isTerminalWorkflowRunStatus(run.status);
+}

--- a/packages/world-local/src/storage/hooks-storage.ts
+++ b/packages/world-local/src/storage/hooks-storage.ts
@@ -30,9 +30,108 @@ import {
   readJSONWithFallback,
   taggedPath,
   writeExclusive,
+  writeJSON,
 } from '../fs.js';
 import { filterHookData } from './filters.js';
-import { hashToken, hookRecoveryMarkerPath } from './helpers.js';
+import {
+  canReuseExpiredStartClaim,
+  type HookTokenClaim,
+  hookRecoveryMarkerPath,
+  hookTokenClaimPath,
+  readHookTokenClaim,
+  withTokenClaimLock,
+} from './helpers.js';
+
+/**
+ * Transitions a TTL-carrying claim to retained: the token stays fenced
+ * until at least `hookCreatedAt + ttl` (falling back to the claim's own
+ * createdAt when no hook was ever created), never shrinking an existing
+ * retention window and never expiring before `now`.
+ */
+async function retainStartHookClaim(
+  constraintPath: string,
+  claim: HookTokenClaim,
+  now: Date,
+  hookCreatedAt?: Date
+): Promise<void> {
+  if (!claim.ttlSeconds) return;
+
+  const ttlBase = hookCreatedAt ?? claim.createdAt ?? now;
+  const expiresAt = new Date(
+    Math.max(
+      ttlBase.getTime() + claim.ttlSeconds * 1000,
+      claim.expiresAt?.getTime() ?? 0,
+      now.getTime()
+    )
+  );
+
+  await writeJSON(constraintPath, { ...claim, expiresAt }, { overwrite: true });
+}
+
+/**
+ * Settles a disposed hook's token claim: TTL-carrying claims are retained
+ * (duplicate starts stay fenced past disposal), plain createHook guards are
+ * deleted to free the token. Shared by hook_disposed and terminal-run
+ * cleanup.
+ */
+export async function settleClaimForDisposedHook(
+  basedir: string,
+  hook: Pick<Hook, 'token' | 'runId' | 'createdAt'>,
+  now: Date
+): Promise<string> {
+  const constraintPath = hookTokenClaimPath(basedir, hook.token);
+  // Settle under the claim lock and re-validate ownership: once a run is
+  // terminal, its expired claim becomes reclaimable, so an unguarded
+  // read-then-write here could clobber a fresh claim a new run just
+  // installed. Claims owned by another run are left alone. A contended
+  // lock skips the settle — the claim then expires via its
+  // createdAt + ttl fallback instead of the hookCreatedAt + ttl anchor.
+  // Bounded retry: a briefly contended lock must not skip the settle (a
+  // skipped plain-guard delete would fence the token until the owning run
+  // ends). If all attempts stay contended, canReuseExpiredStartClaim's
+  // run-liveness rule self-heals the leak once the owner is terminal.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const settled = await withTokenClaimLock(basedir, hook.token, async () => {
+      const claim = await readHookTokenClaim(constraintPath);
+      if (!claim || claim.runId !== hook.runId) return true;
+      if (claim.ttlSeconds) {
+        await retainStartHookClaim(
+          constraintPath,
+          { ...claim, token: hook.token },
+          now,
+          hook.createdAt
+        );
+      } else {
+        await deleteJSON(constraintPath);
+      }
+      return true;
+    });
+    if (settled) break;
+    await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+  }
+  return constraintPath;
+}
+
+/**
+ * Re-reads a token claim under its lock and acts only when `revalidate`
+ * still holds — the shared lock + re-validation discipline for claim writes
+ * (see settleClaimForDisposedHook). A contended lock skips the best-effort
+ * operation.
+ */
+async function withRevalidatedClaim(
+  basedir: string,
+  token: string,
+  constraintPath: string,
+  revalidate: (latest: HookTokenClaim) => boolean | Promise<boolean>,
+  act: (latest: HookTokenClaim) => Promise<void>
+): Promise<void> {
+  await withTokenClaimLock(basedir, token, async () => {
+    const latest = await readHookTokenClaim(constraintPath);
+    if (latest && (await revalidate(latest))) {
+      await act(latest);
+    }
+  });
+}
 
 function isVisibleToTag(fileId: string, tag: string | undefined): boolean {
   return tag ? isUntagged(fileId) || hasTag(fileId, tag) : isUntagged(fileId);
@@ -157,12 +256,7 @@ async function restoreHookCachesFromEvent(
 ): Promise<Hook> {
   const hook = hookFromCreatedEvent(event);
 
-  const claimPath = path.join(
-    basedir,
-    'hooks',
-    'tokens',
-    `${hashToken(hook.token)}.json`
-  );
+  const claimPath = hookTokenClaimPath(basedir, hook.token);
   await writeExclusive(
     claimPath,
     JSON.stringify({
@@ -170,6 +264,9 @@ async function restoreHookCachesFromEvent(
       hookId: hook.hookId,
       runId: hook.runId,
       eventId: event.eventId,
+      // Persisted so claim-liveness checks resolve the owning run in the
+      // right namespace (see canReuseExpiredStartClaim).
+      tag,
     })
   );
   await writeExclusive(
@@ -313,34 +410,109 @@ export function createHooksStorage(
 /**
  * Helper function to delete all hooks associated with a workflow run.
  * Called when a run reaches a terminal state.
+ *
+ * `releaseUnmaterializedClaims` (used for cancellation) additionally deletes
+ * start-hook claims the workflow never materialized into a hook, so
+ * cancel-then-retry — including `start()`'s own cleanup when queueing fails
+ * after admission — can reuse the token immediately.
  */
 export async function deleteAllHooksForRun(
   basedir: string,
-  runId: string
+  runId: string,
+  opts?: { releaseUnmaterializedClaims?: boolean; tag?: string }
 ): Promise<void> {
   const hooksDir = path.join(basedir, 'hooks');
   const files = await listJSONFiles(hooksDir);
+  const tokensDir = path.join(hooksDir, 'tokens');
+  const now = new Date();
 
+  // Settle claims through the run's hook entities (retain TTL claims, free
+  // plain guards), and delete the hooks + recovery markers. The marker's
+  // filename hash includes `(token, runId, hookId)` so a leaked marker can
+  // never corrupt a different lifetime — cleaning it up here keeps the
+  // tokens/ directory from accumulating recovered-hook sidecars over time.
+  const settledClaimPaths = new Set<string>();
   for (const file of files) {
     const hookPath = path.join(hooksDir, `${file}.json`);
     const hook = await readJSON(hookPath, HookSchema);
     if (hook && hook.runId === runId) {
-      // Delete the token constraint file to free up the token, and
-      // delete the recovery marker (if any) for disk hygiene. The
-      // marker's filename hash includes `(token, runId, hookId)` so
-      // a leaked marker can never corrupt a different lifetime — but
-      // cleaning it up here keeps the tokens/ directory from
-      // accumulating recovered-hook sidecars over time.
-      const constraintPath = path.join(
-        hooksDir,
-        'tokens',
-        `${hashToken(hook.token)}.json`
+      settledClaimPaths.add(
+        await settleClaimForDisposedHook(basedir, hook, now)
       );
-      await deleteJSON(constraintPath);
       await deleteJSON(
         hookRecoveryMarkerPath(basedir, hook.token, hook.runId, hook.hookId)
       );
       await deleteJSON(hookPath);
     }
   }
+
+  // Sweep the tokens directory for claims with no hook entity: this run's
+  // unmaterialized start claims (retain or, on cancellation, release), plus
+  // opportunistic GC of other runs' dead claims so the directory doesn't
+  // grow forever.
+  const tokenFiles = await listJSONFiles(tokensDir);
+  await Promise.all(
+    tokenFiles.map(async (file) => {
+      if (file.endsWith('.recovery')) return;
+      const constraintPath = path.join(tokensDir, `${file}.json`);
+      if (settledClaimPaths.has(constraintPath)) return;
+      const claim = await readHookTokenClaim(constraintPath);
+      if (!claim) return;
+      if (claim.runId !== runId) {
+        // A foreign claim with no retention window is settled by its own
+        // run's termination (and self-heals via lazy claim-time reclaim if
+        // that sweep was skipped) — checking it here would cost a run read
+        // per foreign plain guard on every terminal event.
+        if (!claim.token || (!claim.ttlSeconds && !claim.expiresAt)) return;
+        // A claim is dead only when expired AND its owning run is gone or
+        // terminal — an active run keeps its token fenced even past the
+        // TTL. Deletion re-validates under the claim lock so it cannot
+        // race a reclaim that just installed a fresh claim; a contended
+        // lock simply skips this best-effort GC.
+        if (await canReuseExpiredStartClaim(basedir, opts?.tag, claim)) {
+          await withRevalidatedClaim(
+            basedir,
+            claim.token,
+            constraintPath,
+            (latest) => canReuseExpiredStartClaim(basedir, opts?.tag, latest),
+            () => deleteJSON(constraintPath)
+          );
+        }
+        return;
+      }
+      if (!claim.token) return;
+      if (!claim.ttlSeconds) {
+        // A start claim without a retention TTL dies with its run — release
+        // it here instead of leaving debris for lazy reclaim.
+        await withRevalidatedClaim(
+          basedir,
+          claim.token,
+          constraintPath,
+          (latest) => latest.runId === runId && !latest.ttlSeconds,
+          () => deleteJSON(constraintPath)
+        );
+        return;
+      }
+      // Same lock + re-validation discipline as settleClaimForDisposedHook:
+      // this run is already terminal, so its expired claim may have been
+      // reclaimed by a new run between the read above and the write below.
+      await withRevalidatedClaim(
+        basedir,
+        claim.token,
+        constraintPath,
+        (latest) => latest.runId === runId && !!latest.ttlSeconds,
+        async (latest) => {
+          if (
+            opts?.releaseUnmaterializedClaims &&
+            latest.hookId === undefined &&
+            latest.expiresAt === undefined
+          ) {
+            await deleteJSON(constraintPath);
+          } else {
+            await retainStartHookClaim(constraintPath, latest, now);
+          }
+        }
+      );
+    })
+  );
 }

--- a/packages/world-local/src/storage/runs-storage.ts
+++ b/packages/world-local/src/storage/runs-storage.ts
@@ -10,8 +10,8 @@ import type {
   WorkflowRunWithoutData,
 } from '@workflow/world';
 import {
-  applyAttributeChanges,
   AttributeValidationError,
+  applyAttributeChanges,
   validateAttributeChanges,
   WorkflowRunSchema,
 } from '@workflow/world';

--- a/packages/world-local/src/tag.test.ts
+++ b/packages/world-local/src/tag.test.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { listJSONFiles, stripTag } from './fs.js';
 import { createStorage } from './storage.js';
@@ -268,6 +269,44 @@ describe('File tagging', () => {
       await world1.close?.();
     });
 
+    it('should not reclaim another tag active start hook claim after ttl', async () => {
+      const { createLocalWorld } = await import('./index.js');
+
+      const world0 = createLocalWorld({ dataDir: testDir, tag: 'vitest-0' });
+      const world1 = createLocalWorld({ dataDir: testDir, tag: 'vitest-1' });
+      await world0.start?.();
+
+      const token = 'cross-tag-active-start-hook-token';
+      await world0.events.create(null, {
+        eventType: 'run_created',
+        specVersion: SPEC_VERSION_CURRENT,
+        eventData: {
+          deploymentId: 'dep-1',
+          workflowName: 'wf-0',
+          input: new Uint8Array(),
+          startHook: { token, ttlSeconds: 1 },
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+      await expect(
+        world1.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'dep-2',
+            workflowName: 'wf-1',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 1 },
+          },
+        })
+      ).rejects.toThrow();
+
+      await world0.close?.();
+      await world1.close?.();
+    });
+
     it('should clear events, steps, hooks, and waits', async () => {
       const { createLocalWorld } = await import('./index.js');
 
@@ -348,6 +387,49 @@ describe('File tagging', () => {
 
       const constraintsAfter = await fs.readdir(tokensDir);
       expect(constraintsAfter).toHaveLength(0);
+
+      await world.close?.();
+    });
+
+    it('should clear unmaterialized start hook token claims', async () => {
+      const { createLocalWorld } = await import('./index.js');
+
+      const world = createLocalWorld({ dataDir: testDir, tag: 'vitest-0' });
+      await world.start?.();
+
+      const token = 'tagged-start-hook-token';
+      await world.events.create(null, {
+        eventType: 'run_created',
+        specVersion: SPEC_VERSION_CURRENT,
+        eventData: {
+          deploymentId: 'dep-1',
+          workflowName: 'start-hook-wf',
+          input: new Uint8Array(),
+          startHook: { token, ttlSeconds: 60 },
+        },
+      });
+
+      const tokensDir = path.join(testDir, 'hooks', 'tokens');
+      expect(await fs.readdir(tokensDir)).toHaveLength(1);
+
+      await world.clear();
+
+      expect(await fs.readdir(tokensDir)).toHaveLength(0);
+      await expect(
+        world.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'dep-2',
+            workflowName: 'start-hook-wf-2',
+            input: new Uint8Array(),
+            startHook: { token, ttlSeconds: 60 },
+          },
+        })
+      ).resolves.toMatchObject({
+        event: { eventType: 'run_created' },
+        run: { workflowName: 'start-hook-wf-2' },
+      });
 
       await world.close?.();
     });

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -778,6 +778,26 @@ export async function hookClaimOnlyMutexWorkflow(
   };
 }
 
+export async function startHookWorkflow(token: string) {
+  'use workflow';
+
+  using hook = createHook<{ message: string }>({ token });
+
+  const conflict = await hook.getConflict();
+  if (conflict) {
+    return {
+      role: 'duplicate' as const,
+      conflictRunId: conflict.runId,
+    };
+  }
+
+  const payload = await hook;
+  return {
+    role: 'owner' as const,
+    message: payload.message,
+  };
+}
+
 /**
  * "Adopt the owner's result" strategy: the duplicate run waits for the
  * active owner to finish and returns the owner's result, so callers


### PR DESCRIPTION
**Stack 2/4** · #2762 → this PR → #2764 → #2765

Implements **start-hook admission claims for `@workflow/world-local`** (filesystem dev world), on top of the core API PR. `start()` enqueues first; `run_created` (from the sync call or the queued message) claims the token.

- `run_created` atomically claims the token via an exclusive constraint-file write; duplicate deliveries of the same run converge on one canonical `run_created` event ID recorded in the claim, so the exclusive event publish dedups instead of appending twice.
- `createHook({ token })` inside the workflow materializes the reserved claim; a lost concurrent materialize converges instead of emitting a spurious self-`hook_conflict`.
- Disposal and run completion/failure retain TTL-carrying claims (`expiresAt = max(hookCreatedAt + ttl, prior window, now)`); **cancellation releases claims the workflow never materialized**, so cancel-then-retry (including `start()`'s own queue-failure cleanup) can reuse the token immediately.
- Expired claims whose run is terminal/missing are lazily reclaimable, and terminal-run cleanup opportunistically GCs expired claim debris so the tokens directory doesn't grow forever.
- Cross-process claim writes go through a single per-token lock with atomic (rename-based) stale-lock breaking.
- e2e: duplicate-start conflict test (skipped on the postgres CI lane until the next PR in the stack adds support there).

