### PR TITLE
fix(ts-plugin): allow direct workflow composition

### DIFF
--- a/.changeset/quiet-workflows-join.md
+++ b/.changeset/quiet-workflows-join.md
@@ -1,0 +1,5 @@
+---
+"@workflow/typescript-plugin": patch
+---
+
+Stop warning on direct workflow calls from workflow code, where direct-await composition is valid.

--- a/packages/typescript-plugin/src/completions.ts
+++ b/packages/typescript-plugin/src/completions.ts
@@ -1,5 +1,5 @@
 import type ts from 'typescript/lib/tsserverlibrary';
-import { getDirective, WORKFLOW_HOOKS } from './utils';
+import { getDirective, isDirectiveFunctionLike, WORKFLOW_HOOKS } from './utils';
 
 export function enhanceCompletions(
   fileName: string,
@@ -20,7 +20,7 @@ export function enhanceCompletions(
   const enclosingFunction = findEnclosingFunction(node, tsLib);
   if (!enclosingFunction) return prior;
 
-  const directive = getDirective(enclosingFunction, sourceFile, tsLib);
+  const directive = getDirective(enclosingFunction, tsLib);
 
   // If we're in a workflow function, add workflow hooks to completions
   if (directive === 'use workflow') {
@@ -64,11 +64,7 @@ function findEnclosingFunction(
 ): ts.FunctionLikeDeclaration | undefined {
   let current: ts.Node | undefined = node;
   while (current) {
-    if (
-      tsLib.isFunctionDeclaration(current) ||
-      tsLib.isArrowFunction(current) ||
-      tsLib.isFunctionExpression(current)
-    ) {
+    if (isDirectiveFunctionLike(current, tsLib)) {
       return current;
     }
     current = current.parent;

--- a/packages/typescript-plugin/src/diagnostics.test.ts
+++ b/packages/typescript-plugin/src/diagnostics.test.ts
@@ -786,7 +786,7 @@ describe('getCustomDiagnostics', () => {
   });
 
   describe('Error 9009: Direct workflow function invocation', () => {
-    it('warns when calling workflow function directly from another workflow', () => {
+    it('does not warn when calling workflow function directly from another workflow', () => {
       const source = `
         export async function myWorkflow() {
           'use workflow';
@@ -803,10 +803,60 @@ describe('getCustomDiagnostics', () => {
       const { program } = createTestProgram(source);
       const diagnostics = getCustomDiagnostics('test.ts', program, ts);
 
-      expectDiagnostic(diagnostics, {
-        code: 9009,
-        messageIncludes: 'start()',
-      });
+      expectNoDiagnostic(diagnostics, 9009);
+    });
+
+    it('does not warn when calling imported workflow function from another workflow', () => {
+      const { program } = createTestProgram(
+        [
+          {
+            fileName: 'child.ts',
+            source: `
+              export async function childWorkflow() {
+                'use workflow';
+                return 123;
+              }
+            `,
+          },
+          {
+            fileName: 'parent.ts',
+            source: `
+              import { childWorkflow } from './child';
+
+              export async function parentWorkflow() {
+                'use workflow';
+                return await childWorkflow();
+              }
+            `,
+          },
+        ],
+        'parent.ts'
+      );
+
+      const diagnostics = getCustomDiagnostics('parent.ts', program, ts);
+
+      expectNoDiagnostic(diagnostics, 9009);
+    });
+
+    it('does not warn when static workflow method calls workflow function directly', () => {
+      const source = `
+        export async function childWorkflow() {
+          'use workflow';
+          return 123;
+        }
+
+        class ParentWorkflow {
+          static async run() {
+            'use workflow';
+            return await childWorkflow();
+          }
+        }
+      `;
+
+      const { program } = createTestProgram(source);
+      const diagnostics = getCustomDiagnostics('test.ts', program, ts);
+
+      expectNoDiagnostic(diagnostics, 9009);
     });
 
     it('warns when calling workflow function directly from API route', () => {
@@ -841,6 +891,59 @@ describe('getCustomDiagnostics', () => {
         export async function regularFunction() {
           const result = await myWorkflow();
           return result;
+        }
+      `;
+
+      const { program } = createTestProgram(source);
+      const diagnostics = getCustomDiagnostics('test.ts', program, ts);
+
+      expectDiagnostic(diagnostics, {
+        code: 9009,
+        messageIncludes: 'workflow/api',
+      });
+    });
+
+    it('warns when calling workflow function directly from step function', () => {
+      const source = `
+        export async function myWorkflow() {
+          'use workflow';
+          return 123;
+        }
+
+        export async function myStep() {
+          'use step';
+          const result = await myWorkflow();
+          return result;
+        }
+      `;
+
+      const { program } = createTestProgram(source);
+      const diagnostics = getCustomDiagnostics('test.ts', program, ts);
+
+      expectDiagnostic(diagnostics, {
+        code: 9009,
+        messageIncludes: 'workflow/api',
+      });
+    });
+
+    it('warns when calling workflow function directly from step getter nested in a workflow', () => {
+      const source = `
+        export async function childWorkflow() {
+          'use workflow';
+          return 123;
+        }
+
+        export async function parentWorkflow() {
+          'use workflow';
+
+          class Sensor {
+            get reading() {
+              'use step';
+              return childWorkflow();
+            }
+          }
+
+          return await new Sensor().reading;
         }
       `;
 

--- a/packages/typescript-plugin/src/diagnostics.ts
+++ b/packages/typescript-plugin/src/diagnostics.ts
@@ -3,6 +3,7 @@ import {
   getDirective,
   getDirectiveTypo,
   isAsyncFunction,
+  isDirectiveFunctionLike,
 } from './utils';
 
 const BUILTIN_MODULES = new Set<string>();
@@ -47,7 +48,7 @@ export function getCustomDiagnostics(
   const typeChecker = program.getTypeChecker();
 
   // Track function declarations with "use workflow" directive
-  const workflowFunctions = new Map<string, FunctionLikeDeclaration>();
+  const workflowFunctions = new Set<string>();
 
   function addTypoError(node: Node, typo: string, expected: string) {
     const formattedTypo = `'${typo}'`;
@@ -83,9 +84,7 @@ export function getCustomDiagnostics(
 
     // Check if this is the first statement in a function body
     const isFunctionBody =
-      (ts.isFunctionDeclaration(blockParent) ||
-        ts.isArrowFunction(blockParent) ||
-        ts.isFunctionExpression(blockParent)) &&
+      isDirectiveFunctionLike(blockParent, ts) &&
       block.statements[0] === parent;
 
     if (!isFunctionBody) {
@@ -103,19 +102,14 @@ export function getCustomDiagnostics(
     checkDirectiveStringLiteral(node);
 
     // Check function declarations for workflow/step directives
-    if (
-      ts.isFunctionDeclaration(node) ||
-      ts.isArrowFunction(node) ||
-      ts.isFunctionExpression(node)
-    ) {
-      const directive = getDirective(node, sourceFile, ts);
+    if (isDirectiveFunctionLike(node, ts)) {
+      const directive = getDirective(node, ts);
 
       if (directive === 'use workflow') {
         checkWorkflowFunction(node);
         // Track workflow functions by name (for function declarations)
         if (ts.isFunctionDeclaration(node) && node.name) {
-          const functionName = node.name.text;
-          workflowFunctions.set(functionName, node);
+          workflowFunctions.add(node.name.text);
         }
       }
     }
@@ -395,103 +389,87 @@ export function getCustomDiagnostics(
     }
   }
 
-  // Second pass: check all calls in the file for direct workflow function invocations
-  function checkAllCallsForDirectWorkflowInvocation(node: Node) {
-    if (ts.isCallExpression(node)) {
-      if (ts.isIdentifier(node.expression)) {
-        const functionName = node.expression.text;
+  function addDirectWorkflowInvocationDiagnostic(node: CallExpression) {
+    diagnostics.push({
+      file: sourceFile,
+      start: node.getStart(),
+      length: node.getWidth(),
+      messageText: `Workflow functions should not be invoked directly. Use the \`start()\` function from 'workflow/api' to invoke this workflow.`,
+      category: ts.DiagnosticCategory.Warning,
+      code: 9009,
+    });
+  }
 
-        // First check: is it a locally-defined workflow function?
-        if (workflowFunctions.has(functionName)) {
-          diagnostics.push({
-            file: sourceFile,
-            start: node.getStart(),
-            length: node.getWidth(),
-            messageText: `Workflow functions should not be invoked directly. Use the \`start()\` function from 'workflow/api' to invoke this workflow.`,
-            category: ts.DiagnosticCategory.Warning,
-            code: 9009,
-          });
-        } else {
-          // Second check: is it an imported workflow function?
-          let symbolToCheck = typeChecker.getSymbolAtLocation(node.expression);
+  function declarationHasWorkflowDirective(decl: Node): boolean {
+    if (isDirectiveFunctionLike(decl, ts)) {
+      return getDirective(decl, ts) === 'use workflow';
+    }
 
-          // If this is an alias (e.g., from an import), resolve to the actual symbol
-          if (symbolToCheck && symbolToCheck.flags & ts.SymbolFlags.Alias) {
-            const aliasedSymbol = typeChecker.getAliasedSymbol(symbolToCheck);
-            if (aliasedSymbol && aliasedSymbol !== symbolToCheck) {
-              symbolToCheck = aliasedSymbol;
-            }
-          }
+    if (
+      ts.isVariableDeclaration(decl) &&
+      decl.initializer &&
+      isDirectiveFunctionLike(decl.initializer, ts)
+    ) {
+      return getDirective(decl.initializer, ts) === 'use workflow';
+    }
 
-          const declarations = symbolToCheck?.getDeclarations();
-          if (declarations && declarations.length > 0) {
-            for (const decl of declarations) {
-              if (!decl) continue;
+    return false;
+  }
 
-              // Check function declarations directly
-              if (
-                ts.isFunctionDeclaration(decl) ||
-                ts.isArrowFunction(decl) ||
-                ts.isFunctionExpression(decl)
-              ) {
-                // Get the source file from the declaration itself
-                const declSourceFile = decl.getSourceFile?.();
-                if (!declSourceFile) continue;
+  function isDirectWorkflowInvocation(node: CallExpression): boolean {
+    if (!ts.isIdentifier(node.expression)) {
+      return false;
+    }
 
-                const directive = getDirective(
-                  decl as FunctionLikeDeclaration,
-                  declSourceFile,
-                  ts
-                );
+    // First check: is it a locally-defined workflow function?
+    if (workflowFunctions.has(node.expression.text)) {
+      return true;
+    }
 
-                if (directive === 'use workflow') {
-                  diagnostics.push({
-                    file: sourceFile,
-                    start: node.getStart(),
-                    length: node.getWidth(),
-                    messageText: `Workflow functions should not be invoked directly. Use the \`start()\` function from 'workflow/api' to invoke this workflow.`,
-                    category: ts.DiagnosticCategory.Warning,
-                    code: 9009,
-                  });
-                  break;
-                }
-              }
-              // Check variable declarations (e.g., const myWorkflow = async () => { 'use workflow'; })
-              else if (ts.isVariableDeclaration(decl)) {
-                const init = decl.initializer;
-                if (
-                  init &&
-                  (ts.isArrowFunction(init) || ts.isFunctionExpression(init))
-                ) {
-                  const declSourceFile = decl.getSourceFile?.();
-                  if (!declSourceFile) continue;
+    // Second check: is it an imported workflow function?
+    let symbolToCheck = typeChecker.getSymbolAtLocation(node.expression);
 
-                  const directive = getDirective(
-                    init as FunctionLikeDeclaration,
-                    declSourceFile,
-                    ts
-                  );
-
-                  if (directive === 'use workflow') {
-                    diagnostics.push({
-                      file: sourceFile,
-                      start: node.getStart(),
-                      length: node.getWidth(),
-                      messageText: `Workflow functions should not be invoked directly. Use the \`start()\` function from 'workflow/api' to invoke this workflow.`,
-                      category: ts.DiagnosticCategory.Warning,
-                      code: 9009,
-                    });
-                    break;
-                  }
-                }
-              }
-            }
-          }
-        }
+    if (symbolToCheck?.flags & ts.SymbolFlags.Alias) {
+      const aliasedSymbol = typeChecker.getAliasedSymbol(symbolToCheck);
+      if (aliasedSymbol !== symbolToCheck) {
+        symbolToCheck = aliasedSymbol;
       }
     }
 
-    ts.forEachChild(node, checkAllCallsForDirectWorkflowInvocation);
+    return (
+      symbolToCheck?.getDeclarations()?.some(declarationHasWorkflowDirective) ??
+      false
+    );
+  }
+
+  // Second pass: check all calls in the file for direct workflow function invocations
+  function checkAllCallsForDirectWorkflowInvocation(
+    node: Node,
+    allowDirectWorkflowInvocation = false
+  ) {
+    if (isDirectiveFunctionLike(node, ts)) {
+      const directive = getDirective(node, ts);
+      if (directive === 'use workflow') {
+        allowDirectWorkflowInvocation = true;
+      } else if (directive === 'use step') {
+        allowDirectWorkflowInvocation = false;
+      }
+    }
+
+    if (
+      !allowDirectWorkflowInvocation &&
+      ts.isCallExpression(node) &&
+      isDirectWorkflowInvocation(node)
+    ) {
+      addDirectWorkflowInvocationDiagnostic(node);
+    }
+
+    ts.forEachChild(node, (child) =>
+      checkAllCallsForDirectWorkflowInvocation(
+        child,
+        allowDirectWorkflowInvocation
+      )
+    );
   }
 
   visit(sourceFile);

--- a/packages/typescript-plugin/src/hover.ts
+++ b/packages/typescript-plugin/src/hover.ts
@@ -1,5 +1,5 @@
 import type { Program, QuickInfo } from 'typescript/lib/tsserverlibrary';
-import { getDirective } from './utils';
+import { getDirective, isDirectiveFunctionLike } from './utils';
 
 type TypeScriptLib = typeof import('typescript/lib/tsserverlibrary');
 
@@ -56,14 +56,7 @@ export function getHoverInfo(
   }
 
   const blockParent = grandParent.parent;
-  if (
-    !blockParent ||
-    !(
-      ts.isFunctionDeclaration(blockParent) ||
-      ts.isArrowFunction(blockParent) ||
-      ts.isFunctionExpression(blockParent)
-    )
-  ) {
+  if (!blockParent || !isDirectiveFunctionLike(blockParent, ts)) {
     return undefined;
   }
 
@@ -73,7 +66,7 @@ export function getHoverInfo(
   }
 
   // Get the parent function to determine directive type
-  const directive = getDirective(blockParent, sourceFile, ts);
+  const directive = getDirective(blockParent, ts);
   if (!directive) {
     return undefined;
   }

--- a/packages/typescript-plugin/src/utils.test.ts
+++ b/packages/typescript-plugin/src/utils.test.ts
@@ -1,7 +1,30 @@
 import ts from 'typescript/lib/tsserverlibrary';
 import { describe, expect, it } from 'vitest';
 import { createTestProgram } from './test-helpers';
-import { findFunctionCalls, getDirective, isAsyncFunction } from './utils';
+import {
+  findFunctionCalls,
+  getDirective,
+  isAsyncFunction,
+  isDirectiveFunctionLike,
+} from './utils';
+
+function getFirstMethod(source: string): ts.MethodDeclaration {
+  const { sourceFile } = createTestProgram(source);
+  let method: ts.MethodDeclaration | undefined;
+
+  function visit(node: ts.Node) {
+    if (ts.isMethodDeclaration(node)) {
+      method = node;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sourceFile, visit);
+
+  if (!method) {
+    throw new Error('Expected source to contain a method declaration');
+  }
+  return method;
+}
 
 describe('getDirective', () => {
   it('returns "use workflow" for workflow functions', () => {
@@ -12,12 +35,12 @@ describe('getDirective', () => {
       }
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let result: string | null = null;
     ts.forEachChild(sourceFile, (node) => {
       if (ts.isFunctionDeclaration(node)) {
-        result = getDirective(node, sourceFile, ts);
+        result = getDirective(node, ts);
       }
     });
 
@@ -32,12 +55,12 @@ describe('getDirective', () => {
       }
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let result: string | null = null;
     ts.forEachChild(sourceFile, (node) => {
       if (ts.isFunctionDeclaration(node)) {
-        result = getDirective(node, sourceFile, ts);
+        result = getDirective(node, ts);
       }
     });
 
@@ -51,12 +74,12 @@ describe('getDirective', () => {
       }
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let result: string | null = null;
     ts.forEachChild(sourceFile, (node) => {
       if (ts.isFunctionDeclaration(node)) {
-        result = getDirective(node, sourceFile, ts);
+        result = getDirective(node, ts);
       }
     });
 
@@ -71,12 +94,12 @@ describe('getDirective', () => {
       }
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let result: string | null = null;
     ts.forEachChild(sourceFile, (node) => {
       if (ts.isFunctionDeclaration(node)) {
-        result = getDirective(node, sourceFile, ts);
+        result = getDirective(node, ts);
       }
     });
 
@@ -91,18 +114,46 @@ describe('getDirective', () => {
       };
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let result: string | null = null;
     function visit(node: ts.Node) {
       if (ts.isArrowFunction(node)) {
-        result = getDirective(node, sourceFile, ts);
+        result = getDirective(node, ts);
       }
       ts.forEachChild(node, visit);
     }
     ts.forEachChild(sourceFile, visit);
 
     expect(result).toBe('use workflow');
+  });
+
+  it('handles method declarations', () => {
+    const source = `
+      class JobRunner {
+        static async run() {
+          'use workflow';
+          return 123;
+        }
+      }
+    `;
+
+    expect(getDirective(getFirstMethod(source), ts)).toBe('use workflow');
+  });
+});
+
+describe('isDirectiveFunctionLike', () => {
+  it('returns true for function-like nodes that can carry directives', () => {
+    const source = `
+      class JobRunner {
+        static async run() {
+          'use workflow';
+          return 123;
+        }
+      }
+    `;
+
+    expect(isDirectiveFunctionLike(getFirstMethod(source), ts)).toBe(true);
   });
 });
 
@@ -200,7 +251,7 @@ describe('findFunctionCalls', () => {
       }
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let calls: ts.CallExpression[] = [];
     ts.forEachChild(sourceFile, (node) => {
@@ -221,7 +272,7 @@ describe('findFunctionCalls', () => {
       }
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let calls: ts.CallExpression[] = [];
     ts.forEachChild(sourceFile, (node) => {
@@ -242,7 +293,7 @@ describe('findFunctionCalls', () => {
       }
     `;
 
-    const { program, sourceFile } = createTestProgram(source);
+    const { sourceFile } = createTestProgram(source);
 
     let calls: ts.CallExpression[] = [];
     ts.forEachChild(sourceFile, (node) => {

--- a/packages/typescript-plugin/src/utils.ts
+++ b/packages/typescript-plugin/src/utils.ts
@@ -61,7 +61,6 @@ export function detectSimilarStrings(a: string, b: string): boolean {
  */
 export function getDirective(
   node: FunctionLikeDeclaration,
-  _sourceFile: SourceFile,
   ts: TypeScriptLib
 ): 'use workflow' | 'use step' | null {
   if (!node.body || !ts.isBlock(node.body)) {
@@ -84,6 +83,19 @@ export function getDirective(
   }
 
   return null;
+}
+
+export function isDirectiveFunctionLike(
+  node: Node,
+  ts: TypeScriptLib
+): node is FunctionLikeDeclaration {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isFunctionExpression(node)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1234.

- suppress TypeScript plugin diagnostic 9009 when a workflow directly calls another workflow from workflow context
- keep diagnostic 9009 for workflow calls from non-workflow contexts, including step functions
- share directive-capable function detection so static workflow methods are handled consistently

## Verification

- `pnpm dlx pnpm@10.20.0 --filter @workflow/typescript-plugin test`
- `pnpm dlx pnpm@10.20.0 --filter @workflow/typescript-plugin typecheck`
- `pnpm dlx pnpm@10.20.0 --filter @workflow/typescript-plugin build`
- `pnpm dlx pnpm@10.20.0 --filter @workflow/vitest-workbench exec vitest run test/cookbook-common.test.ts`
- `pnpm dlx pnpm@10.20.0 exec biome check packages/typescript-plugin/src/diagnostics.ts packages/typescript-plugin/src/diagnostics.test.ts packages/typescript-plugin/src/utils.ts packages/typescript-plugin/src/utils.test.ts packages/typescript-plugin/src/completions.ts packages/typescript-plugin/src/hover.ts .changeset/quiet-workflows-join.md` (exits 0; reports existing complexity warnings in `diagnostics.ts`)
