### PR TITLE
[core] Fix hook token reuse after dispose() (same-run and cross-run)

### DIFF
--- a/.changeset/hook-token-claim-release.md
+++ b/.changeset/hook-token-claim-release.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Fix hook token claims of disposed hooks and finished runs not being released to the next claimant

--- a/.changeset/hook-token-reuse-after-dispose.md
+++ b/.changeset/hook-token-reuse-after-dispose.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix `createHook()` conflicting with the run's own disposed hook when a token is reused after `dispose()` within the same run

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -144,9 +144,15 @@ async function waitForHook(
     timeoutMs?: number;
     intervalMs?: number;
     runId?: string;
+    excludeHookId?: string;
   } = {}
 ): Promise<Awaited<ReturnType<typeof getHookByToken>>> {
-  const { timeoutMs = 30_000, intervalMs = 250, runId } = options;
+  const {
+    timeoutMs = 30_000,
+    intervalMs = 250,
+    runId,
+    excludeHookId,
+  } = options;
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown = new Error(
     `waitForHook(${token}) timed out before any attempt`
@@ -161,6 +167,12 @@ async function waitForHook(
       if (runId && hook.runId !== runId) {
         lastError = new Error(
           `waitForHook(${token}) saw runId=${hook.runId}, expected ${runId}`
+        );
+      } else if (excludeHookId && hook.hookId === excludeHookId) {
+        // Same-run token-reuse tests wait for the NEXT hook on the token;
+        // keep polling while the lookup still resolves to the prior hook.
+        lastError = new Error(
+          `waitForHook(${token}) still sees hookId=${hook.hookId}`
         );
       } else {
         return hook;
@@ -2347,6 +2359,42 @@ describe('e2e', () => {
 
       const { json: run2Data } = await cliInspectJson(`runs ${run2.runId}`);
       expect(run2Data.status).toBe('completed');
+    }
+  );
+
+  // Regression test for #2777: recreating a hook with the same token after
+  // dispose() within a single run must not conflict with the run's own
+  // disposed hook.
+  test(
+    'hookTokenReuseLoopWorkflow - same run recreates a hook with the same token after dispose()',
+    { timeout: 90_000 },
+    async () => {
+      const token = Math.random().toString(36).slice(2);
+      const rounds = 3;
+
+      const run = await start(await e2e('hookTokenReuseLoopWorkflow'), [
+        token,
+        rounds,
+      ]);
+
+      let previousHookId: string | undefined;
+      for (let round = 0; round < rounds; round++) {
+        const hook = await waitForHook(token, {
+          runId: run.runId,
+          excludeHookId: previousHookId,
+        });
+        previousHookId = hook.hookId;
+        await resumeHook(hook, { message: `round-${round}` });
+      }
+
+      const result = await run.returnValue;
+      expect(result).toEqual({
+        received: ['round-0', 'round-1', 'round-2'],
+        conflictRound: null,
+      });
+
+      const { json: runData } = await cliInspectJson(`runs ${run.runId}`);
+      expect(runData.status).toBe('completed');
     }
   );
 

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -247,4 +247,116 @@ describe('handleSuspension', () => {
     expect(result.hasAwaitedHookCreation).toBe(false);
     expect(result.timeoutSeconds).toBeUndefined();
   });
+
+  // Regression test for #2777: a dispose() of an earlier hook must be
+  // flushed before a later same-token hook's creation is validated, or the
+  // new hook records a spurious hook_conflict against the run's own
+  // disposed hook.
+  it('flushes a prior hook disposal before validating a same-token recreation', async () => {
+    const eventsCreate = vi.fn(async (_runId, event) => ({ event }));
+    const world = createWorld(eventsCreate);
+    const pending = new Map([
+      [
+        'hook_old',
+        {
+          type: 'hook' as const,
+          correlationId: 'hook_old',
+          token: 'reused-token',
+          hasCreatedEvent: true,
+          disposed: true,
+        },
+      ],
+      [
+        'hook_new',
+        {
+          type: 'hook' as const,
+          correlationId: 'hook_new',
+          token: 'reused-token',
+          hasConflictAwaiter: true,
+        },
+      ],
+    ]);
+
+    const result = await handleSuspension({
+      suspension: new WorkflowSuspension(pending, globalThis),
+      world,
+      run,
+    });
+
+    const hookCalls = eventsCreate.mock.calls.map(([, event]) => ({
+      eventType: event.eventType,
+      correlationId: event.correlationId,
+    }));
+    expect(hookCalls).toEqual([
+      { eventType: 'hook_disposed', correlationId: 'hook_old' },
+      { eventType: 'hook_created', correlationId: 'hook_new' },
+    ]);
+    expect(result.hasHookConflict).toBe(false);
+    expect(result.hasAwaitedHookCreation).toBe(true);
+  });
+
+  it('creates a hook before disposing it when both happen within one suspension', async () => {
+    const eventsCreate = vi.fn(async (_runId, event) => ({ event }));
+    const world = createWorld(eventsCreate);
+    const pending = new Map([
+      [
+        'hook_ephemeral',
+        {
+          type: 'hook' as const,
+          correlationId: 'hook_ephemeral',
+          token: 'ephemeral-token',
+          disposed: true,
+        },
+      ],
+    ]);
+
+    await handleSuspension({
+      suspension: new WorkflowSuspension(pending, globalThis),
+      world,
+      run,
+    });
+
+    const hookCalls = eventsCreate.mock.calls.map(([, event]) => ({
+      eventType: event.eventType,
+      correlationId: event.correlationId,
+    }));
+    expect(hookCalls).toEqual([
+      { eventType: 'hook_created', correlationId: 'hook_ephemeral' },
+      { eventType: 'hook_disposed', correlationId: 'hook_ephemeral' },
+    ]);
+  });
+
+  it('does not dispose a hook whose creation conflicted', async () => {
+    const eventsCreate = vi.fn(async (_runId, event) => {
+      if (event.eventType === 'hook_created') {
+        return { event: { eventType: 'hook_conflict' } };
+      }
+      return { event };
+    });
+    const world = createWorld(eventsCreate);
+    const pending = new Map([
+      [
+        'hook_contended',
+        {
+          type: 'hook' as const,
+          correlationId: 'hook_contended',
+          token: 'contended-token',
+          disposed: true,
+        },
+      ],
+    ]);
+
+    const result = await handleSuspension({
+      suspension: new WorkflowSuspension(pending, globalThis),
+      world,
+      run,
+    });
+
+    expect(result.hasHookConflict).toBe(true);
+    expect(
+      eventsCreate.mock.calls.some(
+        ([, event]) => event.eventType === 'hook_disposed'
+      )
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -216,11 +216,30 @@ export async function handleSuspension({
     (item): item is AttributeInvocationQueueItem => item.type === 'attribute'
   );
 
-  // Split hooks by what actions they need
   const hooksNeedingCreation = allHookItems.filter(
     (item) => !item.hasCreatedEvent
   );
-  const hooksNeedingDisposal = allHookItems.filter((item) => item.disposed);
+
+  // Group hook items that need work by token, preserving queue-insertion
+  // (workflow code) order within each token. Operations on one token must
+  // apply in code order: a dispose() of an earlier hook releases the token
+  // before a later same-token hook's creation is validated — otherwise the
+  // new hook records a spurious hook_conflict against the run's own
+  // disposed hook — while a hook created and disposed within the same
+  // suspension is still created before it is disposed. Different tokens
+  // have no claim interaction, so token groups are processed in parallel.
+  const hookItemsByToken = new Map<string, HookInvocationQueueItem[]>();
+  for (const item of allHookItems) {
+    if (item.hasCreatedEvent && !item.disposed) {
+      continue; // already committed and still live — nothing to do
+    }
+    const group = hookItemsByToken.get(item.token);
+    if (group) {
+      group.push(item);
+    } else {
+      hookItemsByToken.set(item.token, [item]);
+    }
+  }
 
   // Resolve encryption key for this run
   const rawKey = await world.getEncryptionKeyForRun?.(run);
@@ -231,107 +250,105 @@ export async function handleSuspension({
   const compression =
     (run.specVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION;
 
-  // Build and process hook_created events (same as V1)
-  const hookEvents = await Promise.all(
-    hooksNeedingCreation.map(async (queueItem) => {
-      const hookMetadata: SerializedData | undefined =
-        typeof queueItem.metadata === 'undefined'
-          ? undefined
-          : ((await dehydrateStepArguments(
-              queueItem.metadata,
-              runId,
-              encryptionKey,
-              suspension.globalThis,
-              false,
-              compression
-            )) as SerializedData);
-      return {
-        queueItem,
-        hookEvent: {
-          eventType: 'hook_created' as const,
-          specVersion: SPEC_VERSION_CURRENT,
+  async function disposeHook(
+    queueItem: HookInvocationQueueItem
+  ): Promise<void> {
+    const hookDisposedEvent: CreateEventRequest = {
+      eventType: 'hook_disposed' as const,
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: queueItem.correlationId,
+      eventData: {
+        token: queueItem.token,
+      },
+    };
+    try {
+      await world.events.create(runId, hookDisposedEvent, { requestId });
+    } catch (err) {
+      if (EntityConflictError.is(err)) {
+        // Hook was already disposed by a concurrent invocation — safe to skip
+        runtimeLogger.info(
+          'Hook already disposed, skipping duplicate disposal',
+          {
+            workflowRunId: runId,
+            correlationId: queueItem.correlationId,
+            message: err.message,
+          }
+        );
+      } else if (RunExpiredError.is(err)) {
+        runtimeLogger.info(
+          'Workflow run already completed, skipping hook disposal',
+          {
+            workflowRunId: runId,
+            correlationId: queueItem.correlationId,
+            message: err.message,
+          }
+        );
+      } else if (HookNotFoundError.is(err)) {
+        // Hook may have already been disposed or never created
+        runtimeLogger.info('Hook not found for disposal, continuing', {
+          workflowRunId: runId,
           correlationId: queueItem.correlationId,
-          eventData: {
-            token: queueItem.token,
-            metadata: hookMetadata,
-            isWebhook: queueItem.isWebhook ?? false,
-            ...(queueItem.isSystem && { isSystem: true }),
-          },
-        },
-      };
-    })
-  );
+          message: err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
+  }
 
   // Process hooks first to prevent race conditions with webhook receivers.
-  // All hook creations run in parallel.
   // Track any hook conflicts that occur — these are returned to the caller
   // so the V2 handler can re-invoke immediately.
   let hasHookConflict = false;
   let hasAwaitedHookCreation = false;
 
-  if (hookEvents.length > 0) {
-    await ensureRunReady();
-    const results = await Promise.all(
-      hookEvents.map(({ hookEvent, queueItem }) =>
-        createHookEvent({
-          world,
-          runId,
-          hookEvent,
-          queueItem,
-          requestId,
-        })
-      )
-    );
-    hasHookConflict = results.some((result) => result.hasHookConflict);
-    hasAwaitedHookCreation = results.some(
-      (result) => result.hasAwaitedHookCreation
-    );
-  }
-
-  // Process hook disposals — these release hook tokens for reuse by other workflows.
-  if (hooksNeedingDisposal.length > 0) {
+  if (hookItemsByToken.size > 0) {
     await ensureRunReady();
     await Promise.all(
-      hooksNeedingDisposal.map(async (queueItem) => {
-        const hookDisposedEvent: CreateEventRequest = {
-          eventType: 'hook_disposed' as const,
-          specVersion: SPEC_VERSION_CURRENT,
-          correlationId: queueItem.correlationId,
-          eventData: {
-            token: queueItem.token,
-          },
-        };
-        try {
-          await world.events.create(runId, hookDisposedEvent, { requestId });
-        } catch (err) {
-          if (EntityConflictError.is(err)) {
-            // Hook was already disposed by a concurrent invocation — safe to skip
-            runtimeLogger.info(
-              'Hook already disposed, skipping duplicate disposal',
-              {
-                workflowRunId: runId,
-                correlationId: queueItem.correlationId,
-                message: err.message,
-              }
-            );
-          } else if (RunExpiredError.is(err)) {
-            runtimeLogger.info(
-              'Workflow run already completed, skipping hook disposal',
-              {
-                workflowRunId: runId,
-                correlationId: queueItem.correlationId,
-                message: err.message,
-              }
-            );
-          } else if (HookNotFoundError.is(err)) {
-            // Hook may have already been disposed or never created
-            runtimeLogger.info('Hook not found for disposal, continuing', {
-              workflowRunId: runId,
+      [...hookItemsByToken.values()].map(async (items) => {
+        for (const queueItem of items) {
+          let creationConflicted = false;
+
+          if (!queueItem.hasCreatedEvent) {
+            const hookMetadata: SerializedData | undefined =
+              typeof queueItem.metadata === 'undefined'
+                ? undefined
+                : ((await dehydrateStepArguments(
+                    queueItem.metadata,
+                    runId,
+                    encryptionKey,
+                    suspension.globalThis,
+                    false,
+                    compression
+                  )) as SerializedData);
+            const hookEvent: CreateEventRequest = {
+              eventType: 'hook_created' as const,
+              specVersion: SPEC_VERSION_CURRENT,
               correlationId: queueItem.correlationId,
-              message: err.message,
+              eventData: {
+                token: queueItem.token,
+                metadata: hookMetadata,
+                isWebhook: queueItem.isWebhook ?? false,
+                ...(queueItem.isSystem && { isSystem: true }),
+              },
+            };
+            const result = await createHookEvent({
+              world,
+              runId,
+              hookEvent,
+              queueItem,
+              requestId,
             });
-          } else {
-            throw err;
+            hasHookConflict ||= result.hasHookConflict;
+            hasAwaitedHookCreation ||= result.hasAwaitedHookCreation;
+            creationConflicted = result.hasHookConflict;
+          }
+
+          // Dispose after creation for hooks born and disposed within this
+          // batch. A hook whose creation conflicted was never created, so
+          // there is nothing to dispose.
+          if (queueItem.disposed && !creationConflicted) {
+            await disposeHook(queueItem);
           }
         }
       })
@@ -654,7 +671,7 @@ export async function handleSuspension({
     hasHookConflict,
     hasAwaitedHookCreation,
     hasAttributeEvents: attributeItems.length > 0,
-    hasHookEvents: hookEvents.length > 0,
+    hasHookEvents: hooksNeedingCreation.length > 0,
   };
 }
 

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -7,7 +7,7 @@ import { SPEC_VERSION_CURRENT, stripEventDataRefs } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { writeJSON } from './fs.js';
-import { hashToken } from './storage/helpers.js';
+import { hashToken, hookDisposeLockPath } from './storage/helpers.js';
 import { createStorage } from './storage.js';
 import {
   completeWait,
@@ -2195,6 +2195,85 @@ describe('Storage', () => {
 
         expect(hook2.token).toBe(token);
         expect(hook2.hookId).toBe('hook_2');
+      });
+
+      // Regression test for #2778: a claim whose owning run is terminal can
+      // never become live again — a new claimant must treat it as vacant
+      // instead of recording a hook_conflict against a finished run. The
+      // claim file is rewritten manually to simulate the window where the
+      // run-completion cleanup has not deleted it yet (or crashed).
+      it('should treat a token claim owned by a terminal run as vacant', async () => {
+        const token = 'terminal-owner-token';
+
+        await createHook(storage, testRunId, {
+          hookId: 'hook_1',
+          token,
+        });
+        await updateRun(storage, testRunId, 'run_started');
+        await updateRun(storage, testRunId, 'run_completed', {
+          output: new Uint8Array(),
+        });
+
+        // Simulate the stale claim surviving the terminal-run cleanup
+        await fs.writeFile(
+          path.join(testDir, 'hooks', 'tokens', `${hashToken(token)}.json`),
+          JSON.stringify({
+            token,
+            hookId: 'hook_1',
+            runId: testRunId,
+            eventId: 'evnt_00000000000000000000000000',
+          })
+        );
+
+        const run2 = await createRun(storage, {
+          deploymentId: 'deployment-456',
+          workflowName: 'another-workflow',
+          input: new Uint8Array(),
+        });
+
+        const result = await storage.events.create(run2.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_2',
+          eventData: { token },
+        });
+
+        expect(result.event.eventType).toBe('hook_created');
+        expect(result.hook?.runId).toBe(run2.runId);
+      });
+
+      // Regression test for #2778: the hook_disposed handler commits the
+      // disposal (dispose lock) before deleting the token claim, so a new
+      // claimant can observe the claim of a hook whose disposal is already
+      // committed. It must treat that claim as vacant — and the event-log
+      // rebuild must not resurrect the half-torn-down hook.
+      it('should treat a token claim of a dispose-committed hook as vacant', async () => {
+        const token = 'disposed-owner-token';
+
+        await createHook(storage, testRunId, {
+          hookId: 'hook_1',
+          token,
+        });
+
+        // Simulate a disposer that crashed right after committing the
+        // dispose lock, before deleting the claim and hook entity.
+        const lockPath = hookDisposeLockPath(testDir, 'hook_1');
+        await fs.mkdir(path.dirname(lockPath), { recursive: true });
+        await fs.writeFile(lockPath, '');
+
+        const run2 = await createRun(storage, {
+          deploymentId: 'deployment-456',
+          workflowName: 'another-workflow',
+          input: new Uint8Array(),
+        });
+
+        const result = await storage.events.create(run2.runId, {
+          eventType: 'hook_created',
+          correlationId: 'hook_2',
+          eventData: { token },
+        });
+
+        expect(result.event.eventType).toBe('hook_created');
+        expect(result.hook?.runId).toBe(run2.runId);
       });
 
       it('should enforce token uniqueness across different runs within the same project', async () => {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -57,7 +57,9 @@ import { stripEventDataRefs } from './filters.js';
 import {
   getObjectCreatedAt,
   hashToken,
+  hookDisposeLockPath,
   hookRecoveryMarkerPath,
+  isHookDisposalCommitted,
   monotonicUlid,
 } from './helpers.js';
 import {
@@ -142,6 +144,46 @@ async function readHookTokenClaim(
     }
     throw error;
   }
+}
+
+/**
+ * Whether a token claim held by another `(runId, hookId)` can never become
+ * live again and may therefore be released by a new claimant:
+ *
+ *   - the claimed hook's disposal is committed (its dispose lock exists —
+ *     the durable release of the claim file just hasn't landed yet, or was
+ *     lost to a crash between the lock write and the claim delete), or
+ *   - the owning run is terminal (the run-completion cleanup releases all
+ *     of the run's claims, but a claimant can observe the claim in the
+ *     window before that cleanup lands — or the cleanup crashed), or
+ *   - the owning run does not exist (a claim can only be written during a
+ *     suspension of an existing run, so an ownerless claim is debris).
+ *
+ * A claim from a mid-creation writer is never releasable: its owning run
+ * exists and is non-terminal, and its dispose lock does not exist.
+ */
+async function isHookTokenClaimReleasable(
+  basedir: string,
+  claim: z.infer<typeof HookTokenClaimSchema>,
+  tag?: string
+): Promise<boolean> {
+  if (
+    claim.hookId &&
+    (await isHookDisposalCommitted(basedir, claim.hookId, tag))
+  ) {
+    return true;
+  }
+  const owningRun = await readJSONWithFallback(
+    basedir,
+    'runs',
+    claim.runId,
+    WorkflowRunSchema,
+    tag
+  );
+  if (!owningRun) {
+    return true;
+  }
+  return isTerminalWorkflowRunStatus(owningRun.status);
 }
 
 async function readHookRecoveryMarker(
@@ -1563,28 +1605,95 @@ export function createEventsStorage(
             'tokens',
             `${hashToken(hookData.token)}.json`
           );
-          // When the claim is absent, the event log is the only durable source
-          // that can distinguish a first hook from a crash-lost token cache.
-          if (!(await readHookTokenClaim(constraintPath))) {
-            await rebuildLiveHookByTokenFromEventLog(
-              basedir,
-              hookData.token,
-              tag
-            );
-          }
           // Persist `eventId` in the claim so concurrent / cross-
           // process retries can converge on a single canonical
           // `hook_created` event path. See the recovery comment
           // below.
-          const tokenClaimed = await writeExclusive(
-            constraintPath,
-            JSON.stringify({
-              token: hookData.token,
-              hookId: data.correlationId,
-              runId: effectiveRunId,
-              eventId,
-            })
-          );
+          const claimContent = JSON.stringify({
+            token: hookData.token,
+            hookId: data.correlationId,
+            runId: effectiveRunId,
+            eventId,
+          });
+
+          // Bounded claim loop. A same-token claim can be observed in the
+          // short window where its release is already committed but the
+          // claim file itself is still on disk (or was just deleted):
+          //
+          //   - the claim vanished between the exclusive-create attempt
+          //     and the ownership read → retry immediately;
+          //   - the claim is held by a disposed hook or a terminal/missing
+          //     run (`isHookTokenClaimReleasable`) → wait briefly for the
+          //     in-flight releaser (the hook_disposed handler or the
+          //     run-completion cleanup) to delete it, then reclaim; if it
+          //     never does (the releaser crashed after committing its
+          //     dispose lock / terminal status), release the stale claim
+          //     ourselves and reclaim.
+          //
+          // Without this, a run claiming a token right after the previous
+          // owner disposed it records a durable, spurious hook_conflict
+          // (issue #2778). A genuinely live claim exits the loop on the
+          // first iteration and falls through to the dedup / conflict
+          // handling below.
+          let tokenClaimed = false;
+          let existingClaim: z.infer<typeof HookTokenClaimSchema> | null = null;
+          let releasableObservations = 0;
+          for (let attempt = 0; attempt < 10; attempt++) {
+            // When the claim is absent, the event log is the only durable
+            // source that can distinguish a first hook from a crash-lost
+            // token cache.
+            if (!(await readHookTokenClaim(constraintPath))) {
+              await rebuildLiveHookByTokenFromEventLog(
+                basedir,
+                hookData.token,
+                tag
+              );
+            }
+            tokenClaimed = await writeExclusive(constraintPath, claimContent);
+            if (tokenClaimed) break;
+
+            existingClaim = await readHookTokenClaim(constraintPath);
+            if (!existingClaim) {
+              continue;
+            }
+            if (
+              existingClaim.runId === effectiveRunId &&
+              existingClaim.hookId === data.correlationId
+            ) {
+              // Our own prior claim — dedup-recovery handling below.
+              break;
+            }
+            if (
+              !(await isHookTokenClaimReleasable(basedir, existingClaim, tag))
+            ) {
+              // Genuinely live claim — conflict handling below.
+              break;
+            }
+            releasableObservations++;
+            if (releasableObservations < 3) {
+              // Give the in-flight releaser a moment to delete the claim.
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            } else {
+              // The releaser is not coming. Release the stale claim and
+              // the hook entity it points at, mirroring the hook_disposed
+              // cleanup.
+              await deleteJSON(constraintPath);
+              if (existingClaim.hookId) {
+                await deleteJSON(
+                  taggedPath(basedir, 'hooks', existingClaim.hookId, tag)
+                );
+                await deleteJSON(
+                  hookRecoveryMarkerPath(
+                    basedir,
+                    hookData.token,
+                    existingClaim.runId,
+                    existingClaim.hookId
+                  )
+                );
+              }
+            }
+            existingClaim = null;
+          }
 
           // Recovery shape: the durable record of a successful hook
           // creation is the `hook_created` event in the event log. The
@@ -1624,8 +1733,6 @@ export function createEventsStorage(
           let writeHookEntityWithOverwrite = false;
 
           if (!tokenClaimed) {
-            const existingClaim = await readHookTokenClaim(constraintPath);
-
             if (
               existingClaim?.runId === effectiveRunId &&
               existingClaim.hookId === data.correlationId
@@ -1814,14 +1921,14 @@ export function createEventsStorage(
           // hook_disposed: Deletes hook entity, rejects duplicates.
           // Uses writeExclusive on a lock file to atomically prevent concurrent
           // invocations from both disposing the same hook (TOCTOU race).
-          const hookLockName = tag
-            ? `${data.correlationId}.disposed.${tag}`
-            : `${data.correlationId}.disposed`;
-          const lockPath = resolveWithinBase(
+          // The lock doubles as the durable disposal marker consulted by the
+          // hook_created claim path and the event-log rebuild (see
+          // `isHookDisposalCommitted`), which is why it must be written
+          // before any of the destructive deletes below.
+          const lockPath = hookDisposeLockPath(
             basedir,
-            '.locks',
-            'hooks',
-            hookLockName
+            data.correlationId,
+            tag
           );
           const claimed = await writeExclusive(lockPath, '');
           if (!claimed) {

--- a/packages/world-local/src/storage/helpers.ts
+++ b/packages/world-local/src/storage/helpers.ts
@@ -1,13 +1,55 @@
 import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { monotonicFactory } from 'ulid';
-import { stripTag, ulidToDate } from '../fs.js';
+import { resolveWithinBase, stripTag, ulidToDate } from '../fs.js';
 
 /**
  * Hash a hook token to produce a filesystem-safe constraint filename.
  */
 export function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Path of the exclusive-create lock file that commits a hook's disposal.
+ * The `hook_disposed` handler writes this lock BEFORE deleting the token
+ * claim and hook entity (and before appending the event to the log), so
+ * its existence is the earliest durable evidence that the hook can never
+ * be live again.
+ */
+export function hookDisposeLockPath(
+  basedir: string,
+  hookId: string,
+  tag?: string
+): string {
+  const name = tag ? `${hookId}.disposed.${tag}` : `${hookId}.disposed`;
+  return resolveWithinBase(basedir, '.locks', 'hooks', name);
+}
+
+/**
+ * Whether a hook's disposal has been committed (its dispose lock exists).
+ * Mirrors event visibility for tagged worlds: an untagged lock is visible
+ * to every tag, a tagged lock only to its own tag.
+ */
+export async function isHookDisposalCommitted(
+  basedir: string,
+  hookId: string,
+  tag?: string
+): Promise<boolean> {
+  const candidates = [hookDisposeLockPath(basedir, hookId)];
+  if (tag) {
+    candidates.push(hookDisposeLockPath(basedir, hookId, tag));
+  }
+  for (const lockPath of candidates) {
+    try {
+      await fs.access(lockPath);
+      return true;
+    } catch {
+      // lock not present at this path
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/world-local/src/storage/hooks-storage.ts
+++ b/packages/world-local/src/storage/hooks-storage.ts
@@ -32,7 +32,11 @@ import {
   writeExclusive,
 } from '../fs.js';
 import { filterHookData } from './filters.js';
-import { hashToken, hookRecoveryMarkerPath } from './helpers.js';
+import {
+  hashToken,
+  hookRecoveryMarkerPath,
+  isHookDisposalCommitted,
+} from './helpers.js';
 
 function isVisibleToTag(fileId: string, tag: string | undefined): boolean {
   return tag ? isUntagged(fileId) || hasTag(fileId, tag) : isUntagged(fileId);
@@ -144,6 +148,18 @@ async function findLiveHookCreatedEvent(
   }
 
   if (liveEvent && (await isTerminalRunCache(basedir, liveEvent.runId, tag))) {
+    return null;
+  }
+
+  // A committed disposal (dispose lock on disk) closes the hook even when
+  // its `hook_disposed` event has not landed in the log yet — the disposer
+  // writes the lock, releases the token claim and hook entity, and only
+  // then appends the event. Rebuilding the caches from the log in that
+  // window would resurrect a claim for a hook that is being torn down.
+  if (
+    liveEvent &&
+    (await isHookDisposalCommitted(basedir, liveEvent.correlationId, tag))
+  ) {
     return null;
   }
 

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -911,6 +911,39 @@ export async function hookDisposeTestWorkflow(
 
 //////////////////////////////////////////////////////////
 
+/**
+ * Workflow for testing same-run hook token recreation: each iteration
+ * recreates a hook with the same token after disposing the previous one.
+ *
+ * Regression workflow for issue #2777 — the disposal must be flushed
+ * before the next hook's creation is validated, otherwise the second
+ * round records a spurious conflict against the run's own disposed hook.
+ */
+export async function hookTokenReuseLoopWorkflow(
+  token: string,
+  rounds: number
+) {
+  'use workflow';
+
+  const received: string[] = [];
+  for (let round = 0; round < rounds; round++) {
+    const hook = createHook<{ message: string }>({ token });
+
+    const conflict = await hook.getConflict();
+    if (conflict) {
+      return { received, conflictRound: round };
+    }
+
+    const payload = await hook;
+    received.push(payload.message);
+    hook.dispose();
+  }
+
+  return { received, conflictRound: null };
+}
+
+//////////////////////////////////////////////////////////
+
 export async function stepFunctionPassingWorkflow() {
   'use workflow';
   // Pass a step function reference to another step (without closure vars)

--- a/workbench/vitest/test/hook-token-reuse.test.ts
+++ b/workbench/vitest/test/hook-token-reuse.test.ts
@@ -1,0 +1,55 @@
+import { waitForHook } from '@workflow/vitest';
+import { describe, expect, it } from 'vitest';
+import type { Run } from 'workflow/api';
+import { resumeHook, start } from 'workflow/api';
+import {
+  claimTokenOnceWorkflow,
+  reuseHookTokenWorkflow,
+} from '../workflows/hook-token-reuse.js';
+
+describe('hook token reuse after dispose', () => {
+  // Issue #2777: dispose() followed by createHook() with the same token in
+  // the same run must not conflict with the run's own disposed hook.
+  it('same run can recreate a hook with the same token after dispose()', async () => {
+    const token = `same-run-reuse-${Math.random().toString(36).slice(2)}`;
+    const rounds = 3;
+    const run = await start(reuseHookTokenWorkflow, [token, rounds]);
+
+    for (let round = 0; round < rounds; round++) {
+      const settled = await Promise.race([
+        waitForHook(run, { token }).then(() => 'hook' as const),
+        run.returnValue.then((value) => ({ value })),
+      ]);
+      expect(settled, `round ${round} should register a hook`).toBe('hook');
+      await resumeHook(token, { n: round });
+    }
+
+    await expect(run.returnValue).resolves.toBe('ok');
+  }, 60_000);
+
+  // Issue #2778: when run A disposes its hook and completes, run B claiming
+  // the same token immediately afterwards must not conflict against run A.
+  it('next run can claim the token right after the previous run disposed it', async () => {
+    const token = `handoff-reuse-${Math.random().toString(36).slice(2)}`;
+    const rounds = 5;
+    const runs: Run<typeof claimTokenOnceWorkflow>[] = [];
+
+    for (let round = 0; round < rounds; round++) {
+      const run = await start(claimTokenOnceWorkflow, [token]);
+      runs.push(run);
+
+      const settled = await Promise.race([
+        waitForHook(run, { token }).then(() => 'hook' as const),
+        run.returnValue.then((value) => ({ value })),
+      ]);
+      expect(settled, `round ${round} should register a hook`).toBe('hook');
+
+      // Resume the hook and immediately start the next claimant without
+      // waiting for this run to settle (the "fast handoff" timing).
+      await resumeHook(token, { n: round });
+    }
+
+    const results = await Promise.all(runs.map((run) => run.returnValue));
+    expect(results).toEqual(Array(rounds).fill('ok'));
+  }, 60_000);
+});

--- a/workbench/vitest/workflows/hook-token-reuse.ts
+++ b/workbench/vitest/workflows/hook-token-reuse.ts
@@ -1,0 +1,43 @@
+import { createHook } from 'workflow';
+
+/**
+ * Regression workflow for issue #2777: recreating a hook with the same
+ * token after dispose() within a single run must not self-conflict.
+ */
+export async function reuseHookTokenWorkflow(token: string, rounds: number) {
+  'use workflow';
+
+  for (let round = 0; round < rounds; round++) {
+    const hook = createHook<{ n: number }>({ token });
+
+    const conflict = await hook.getConflict();
+    if (conflict !== null) {
+      return `conflict-round-${round}:${conflict.runId}`;
+    }
+
+    await hook;
+    hook.dispose();
+  }
+
+  return 'ok';
+}
+
+/**
+ * Regression workflow for issue #2778: a run that claims a token, receives
+ * one payload, disposes, and completes must release the token claim so the
+ * next run can immediately claim the same token.
+ */
+export async function claimTokenOnceWorkflow(token: string) {
+  'use workflow';
+
+  const hook = createHook<{ n: number }>({ token });
+
+  const conflict = await hook.getConflict();
+  if (conflict !== null) {
+    return `conflict:${conflict.runId}`;
+  }
+
+  await hook;
+  hook.dispose();
+  return 'ok';
+}


### PR DESCRIPTION
Closes #2777, closes #2778.

## Problem

Reusing a hook token after `hook.dispose()` deterministically or intermittently failed with a spurious `HookConflictError` naming an already-disposed hook:

- **Same run (#2777):** the suspension handler processed all `hook_created` events before any `hook_disposed`, so recreating a hook with the same token after `dispose()` was validated while the disposed hook still held the token claim — the first reuse always self-conflicted.
- **Cross-run handoff (#2778, world-local):** the token claim is released as a separate effect from the disposal / run completion, so a fast next-run claimant could observe the stale claim (or catch the release mid-flight and record a conflict with `conflictingRunId: undefined`). The event-log rebuild could also resurrect a claim for a hook whose teardown was in progress.

## Fix

- **`@workflow/core`:** `handleSuspension` now processes hook operations grouped per token, in workflow-code order: a dispose of an earlier hook flushes before a later same-token hook's creation is validated, while a hook created and disposed within one suspension is still created first. Different tokens keep processing in parallel, and hooks still process before steps/waits.
- **`@workflow/world-local`:** the `hook_created` token claim runs in a short bounded loop — it retries when the observed claim vanished mid-check, and treats a claim as vacant when its hook's disposal is committed (dispose lock exists) or its owning run is terminal/missing, releasing the stale claim if the in-flight releaser never finishes. The event-log rebuild (`rebuildLiveHookByTokenFromEventLog` / `hooks.get*`) no longer considers a hook live once its dispose lock exists. Live claims still conflict exactly as before.