### PR TITLE
fix(workbench): add @repo/* tsconfig alias to nitro-v2

### DIFF
--- a/workbench/nitro-v2/tsconfig.json
+++ b/workbench/nitro-v2/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@repo/*": ["../../*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
### Problem

Building `workbench/nitro-v2` with the Vercel preset fails on `main`:

```
../example/workflows/99_e2e.ts:67:106: ERROR: Could not resolve "@repo/lib/steps/paths-alias-test"
```

The workbench workflows are shared across apps (`nitro-v2/workflows` → `nitro-v3/workflows`, whose files are shared with `workbench/example`), and the shared `99_e2e.ts` imports `@repo/lib/steps/paths-alias-test`. `nitro-v2/tsconfig.json` was missing the `@repo/*` path alias that `nitro-v3/tsconfig.json` already has, so esbuild can't resolve the import during the workflow steps bundle.

This never showed in CI because nitro-v2 isn't built with the Vercel preset there; it surfaced while manually testing #2770 on the nitro-v2 app.

### Fix

Mirror nitro-v3's alias: `"@repo/*": ["../../*"]`.

### Verification

- Red on plain `main`: `NITRO_PRESET=vercel pnpm build` in `workbench/nitro-v2` fails with the resolve error above.
- Green with this one-line change: build completes, `flow.func`/webhook/manifest emitted (140 steps, 156 workflows compiled).
- Workbench-only change — no changeset needed (`pnpm changeset status` passes).