### PR TITLE
feat(world-vercel): send x-vercel-queue-region on proxy-mode queue sends

### DIFF
--- a/.changeset/world-vercel-proxy-queue-region.md
+++ b/.changeset/world-vercel-proxy-queue-region.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": patch
+---
+
+Send the `x-vercel-queue-region` header on proxy-mode queue sends so the api.vercel.com workflow proxy forwards them to the region's VQS dataplane host, giving token/proxy clients parity with the direct in-function path (which already dials the regional host). Direct sends are unchanged.

--- a/.changeset/world-vercel-proxy-queue-region.md
+++ b/.changeset/world-vercel-proxy-queue-region.md
@@ -2,4 +2,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Send the `x-vercel-queue-region` header on proxy-mode queue sends so the api.vercel.com workflow proxy forwards them to the region's VQS dataplane host, giving token/proxy clients parity with the direct in-function path (which already dials the regional host). Direct sends are unchanged.
+Send the `x-vercel-queue-region` header on proxy-mode queue sends so they route to the region's VQS dataplane host like direct in-function sends do.

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -62,9 +62,7 @@ describe('createQueue', () => {
   describe('proxy region header', () => {
     it('sends x-vercel-queue-region when using the api.vercel.com proxy', async () => {
       // `./utils.js` is module-mocked with `usingProxy: false`; flip it to
-      // proxy mode for this construction. The proxy's fixed resolveBaseUrl
-      // discards the region, so it must ride along as a header for
-      // regional VQS routing (vercel/api#79056).
+      // proxy mode for this construction.
       vi.mocked(getHttpUrl).mockReturnValueOnce({
         baseUrl: 'https://api.vercel.com/v1/workflow',
         usingProxy: true,

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -48,6 +48,7 @@ vi.mock('./utils.js', () => ({
 }));
 
 import { createQueue } from './queue.js';
+import { getHttpUrl } from './utils.js';
 
 describe('createQueue', () => {
   beforeEach(() => {
@@ -56,6 +57,71 @@ describe('createQueue', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('proxy region header', () => {
+    it('sends x-vercel-queue-region when using the api.vercel.com proxy', async () => {
+      // `./utils.js` is module-mocked with `usingProxy: false`; flip it to
+      // proxy mode for this construction. The proxy's fixed resolveBaseUrl
+      // discards the region, so it must ride along as a header for
+      // regional VQS routing (vercel/api#79056).
+      vi.mocked(getHttpUrl).mockReturnValueOnce({
+        baseUrl: 'https://api.vercel.com/v1/workflow',
+        usingProxy: true,
+      });
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+      try {
+        const queue = createQueue({
+          token: 'test-token',
+          projectConfig: { projectId: 'prj_123', teamId: 'team_456' },
+        });
+        await queue.queue('__wkf_workflow_test', { runId: 'run-123' });
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+
+      const ctorCalls = (
+        MockQueueClient as unknown as { mock: { calls: unknown[][] } }
+      ).mock.calls;
+      const ctorArg = ctorCalls[ctorCalls.length - 1][0] as {
+        region?: string;
+        headers?: Record<string, string>;
+      };
+      expect(ctorArg.headers?.['x-vercel-queue-region']).toBe(ctorArg.region);
+      expect(ctorArg.headers?.['x-vercel-queue-region']).toBeDefined();
+    });
+
+    it('does not send x-vercel-queue-region on the direct (non-proxy) path', async () => {
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+      try {
+        const queue = createQueue();
+        await queue.queue('__wkf_workflow_test', { runId: 'run-123' });
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+
+      const ctorCalls = (
+        MockQueueClient as unknown as { mock: { calls: unknown[][] } }
+      ).mock.calls;
+      const ctorArg = ctorCalls[ctorCalls.length - 1][0] as {
+        headers?: Record<string, string>;
+      };
+      // Direct sends dial `<region>.vercel-queue.com` via the SDK's own
+      // base-URL resolution; the header is proxy-only.
+      expect(ctorArg.headers?.['x-vercel-queue-region']).toBeUndefined();
+    });
   });
 
   describe('queue()', () => {

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -212,7 +212,19 @@ export function createQueue(config?: APIConfig): Queue {
       resolveBaseUrl: () => new URL(`${baseUrl}/queues-proxy`),
       token: config?.token,
     }),
-    headers: Object.fromEntries(headers.entries()),
+    headers: {
+      ...Object.fromEntries(headers.entries()),
+      // When sending through the api.vercel.com proxy, the fixed
+      // `resolveBaseUrl` above replaces the queue SDK's own
+      // region -> `<region>.vercel-queue.com` base-URL resolution, so
+      // the region the client was constructed with must travel as a
+      // header instead: the proxy forwards the send to that region's
+      // VQS dataplane host when `x-vercel-queue-region` is present
+      // (vercel/api#79056). This gives token/proxy clients parity with
+      // the direct in-function path, where the SDK itself dials the
+      // regional host.
+      ...(usingProxy && { 'x-vercel-queue-region': region }),
+    },
   };
 
   const queue: QueueFunction = async (

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -214,15 +214,8 @@ export function createQueue(config?: APIConfig): Queue {
     }),
     headers: {
       ...Object.fromEntries(headers.entries()),
-      // When sending through the api.vercel.com proxy, the fixed
-      // `resolveBaseUrl` above replaces the queue SDK's own
-      // region -> `<region>.vercel-queue.com` base-URL resolution, so
-      // the region the client was constructed with must travel as a
-      // header instead: the proxy forwards the send to that region's
-      // VQS dataplane host when `x-vercel-queue-region` is present
-      // (vercel/api#79056). This gives token/proxy clients parity with
-      // the direct in-function path, where the SDK itself dials the
-      // regional host.
+      // The proxy's fixed base URL bypasses the SDK's regional host
+      // resolution, so the region travels as a header instead.
       ...(usingProxy && { 'x-vercel-queue-region': region }),
     },
   };


### PR DESCRIPTION
Based on `main` — mergeable ahead of #1981.

## Problem

Token/proxy clients (CLI, dashboards, external scripts) send queue messages through api.vercel.com's `/v1/workflow` proxy, where the fixed `resolveBaseUrl` override replaces the queue SDK's own `region → <region>.vercel-queue.com` base-URL resolution. Every proxied send therefore lands on the region-less VQS host — while the direct in-function path already dials the regional host (`iad1.vercel-queue.com` today). Surfaced during the multi-region e2e work on #1981.

## Change

The proxy now forwards sends to the region's VQS dataplane when `x-vercel-queue-region` is present. This PR sets that header on every **proxy-mode** send, carrying the region the `QueueClient` is constructed with. Direct (in-function) sends are unchanged.

**Today** that region is the static `'iad1'`, so the observable effect on main is proxied sends moving from `vercel-queue.com` → `iad1.vercel-queue.com` (parity with the direct path). **When #1981 lands**, per-send region resolution (`opts.region` → run-ID tag → `VERCEL_REGION` → `iad1`) feeds the same construction, and the header automatically becomes region-aware — this PR is the transport mechanism, not the policy.

## Tests

- Proxy-mode construction carries the header matching the client's region (the suite's `./utils.js` module mock pins `usingProxy: false`, so the test flips it via `mockReturnValueOnce`)
- Direct-path construction doesn't send the header
- world-vercel suite: 225/225 on main, build clean