### PR TITLE
fix(sveltekit): production server crash from bundled TypeScript compiler

### DIFF
--- a/.changeset/fix-sveltekit-filename-chunk-patch.md
+++ b/.changeset/fix-sveltekit-filename-chunk-patch.md
@@ -1,0 +1,5 @@
+---
+"@workflow/sveltekit": patch
+---
+
+Fix the adapter-node server chunk patch skipping chunks whose only `__filename`/`__dirname` declarations are rollup-renamed (e.g. `__filename$1`), which crashed the production server at boot when a bundled CJS dependency (like the TypeScript compiler pulled in via cosmiconfig) referenced the bare identifier.

--- a/.changeset/fix-sveltekit-filename-chunk-patch.md
+++ b/.changeset/fix-sveltekit-filename-chunk-patch.md
@@ -1,5 +1,6 @@
 ---
 "@workflow/sveltekit": patch
+"@workflow/builders": patch
 ---
 
-Fix the adapter-node server chunk patch skipping chunks whose only `__filename`/`__dirname` declarations are rollup-renamed (e.g. `__filename$1`), which crashed the production server at boot when a bundled CJS dependency (like the TypeScript compiler pulled in via cosmiconfig) referenced the bare identifier.
+Fix the SvelteKit production server crashing at boot when a world package pulls cosmiconfig into the server bundle: alias the TypeScript compiler to a stub (bundling converts cosmiconfig's lazy `require('typescript')` into an eager evaluation, executing the entire compiler at boot and shrinking the server output by ~25MB once removed), and fix the adapter-node chunk patch skipping chunks whose only `__filename`/`__dirname` declarations are rollup-renamed (e.g. `__filename$1`) while a bundled CJS dependency references the bare identifier.

--- a/.changeset/fix-sveltekit-filename-chunk-patch.md
+++ b/.changeset/fix-sveltekit-filename-chunk-patch.md
@@ -3,4 +3,4 @@
 "@workflow/builders": patch
 ---
 
-Fix the SvelteKit production server crashing at boot when a world package pulls cosmiconfig into the server bundle: alias the TypeScript compiler to a stub (bundling converts cosmiconfig's lazy `require('typescript')` into an eager evaluation, executing the entire compiler at boot and shrinking the server output by ~25MB once removed), and fix the adapter-node chunk patch skipping chunks whose only `__filename`/`__dirname` declarations are rollup-renamed (e.g. `__filename$1`) while a bundled CJS dependency references the bare identifier.
+Fix SvelteKit production server crash at boot if a world package pulls cosmiconfig into the server bundle.

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './node-compat-banner.js';
 export { createNodeModuleErrorPlugin } from './node-module-esbuild-plugin.js';
 export { WORKFLOW_OPTIONAL_PG_NATIVE_ALIAS } from './optional-pg-native-alias.js';
+export { WORKFLOW_OPTIONAL_TYPESCRIPT_ALIAS } from './optional-typescript-alias.js';
 export {
   createPseudoPackagePlugin,
   PSEUDO_PACKAGES,

--- a/packages/builders/src/optional-typescript-alias.ts
+++ b/packages/builders/src/optional-typescript-alias.ts
@@ -1,0 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
+export const WORKFLOW_OPTIONAL_TYPESCRIPT_ALIAS = fileURLToPath(
+  new URL('./optional-typescript.js', import.meta.url)
+);

--- a/packages/builders/src/optional-typescript.ts
+++ b/packages/builders/src/optional-typescript.ts
@@ -1,0 +1,9 @@
+// Stub aliased in place of the `typescript` package in framework server
+// bundles. It is only reachable through cosmiconfig's TS-config loader
+// (via world packages -> graphile-worker), where `require('typescript')`
+// is lazy and never fires at runtime — but bundling converts it into an
+// eager top-level evaluation, pulling the entire compiler into the server
+// output and executing it at boot.
+const typescript = {};
+
+export default typescript;

--- a/packages/sveltekit/src/plugin.ts
+++ b/packages/sveltekit/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   WORKFLOW_NODE_COMPAT_BANNER,
   WORKFLOW_NODE_FILENAME_BANNER,
   WORKFLOW_OPTIONAL_PG_NATIVE_ALIAS,
+  WORKFLOW_OPTIONAL_TYPESCRIPT_ALIAS,
   WORKFLOW_WORLD_TARGET_MODULE,
 } from '@workflow/builders';
 import { workflowTransformPlugin } from '@workflow/rollup';
@@ -48,6 +49,7 @@ export function workflowPlugin(options: WorkflowPluginOptions = {}): Plugin[] {
             alias: {
               [WORKFLOW_WORLD_TARGET_MODULE]: workflowTargetWorldAlias,
               'pg-native': WORKFLOW_OPTIONAL_PG_NATIVE_ALIAS,
+              typescript: WORKFLOW_OPTIONAL_TYPESCRIPT_ALIAS,
             },
           },
         };

--- a/packages/sveltekit/src/plugin.ts
+++ b/packages/sveltekit/src/plugin.ts
@@ -143,9 +143,19 @@ function patchAdapterNodeServerChunks(cwd: string): void {
       // that already declares either identifier (const/let/var, e.g. a
       // CJS-interop shim) would produce a duplicate top-level declaration
       // and crash the server with a SyntaxError at startup.
-      const referencesFilename = /\b__(?:file|dir)name\b/.test(source);
+      //
+      // The `(?![\w$])` lookaheads matter: when adapter-node re-bundles the
+      // intermediate output, rollup renames colliding declarations to e.g.
+      // `__filename$1`. A bare `\b` boundary matches those ($ is not a word
+      // character), which made this skip chunks that declare only a RENAMED
+      // binding while still referencing the bare `__filename` (observed with
+      // the bundled `typescript` compiler pulled in via cosmiconfig — the
+      // server crashed at boot with "__filename is not defined").
+      const referencesFilename = /(?<![\w$])__(?:file|dir)name(?![\w$])/.test(
+        source
+      );
       const declaresOwnBinding =
-        /\b(?:const|let|var)\s+__(?:file|dir)name\b/.test(source);
+        /\b(?:const|let|var)\s+__(?:file|dir)name(?![\w$])/.test(source);
       if (!referencesFilename || declaresOwnBinding) {
         continue;
       }


### PR DESCRIPTION
### Description

Fixes the SvelteKit production node server crashing at boot on `main` (`ReferenceError: __filename is not defined` inside bundled TypeScript compiler code in `hooks.server-*.js`), a regression from the world-target injection change (#2752) adding a `@workflow/world-postgres` import to the workbench's `hooks.server.ts`.

Two fixes, both required:

1. **Keep the TypeScript compiler out of the server bundle.** `@workflow/world-postgres` → `graphile-worker` → `cosmiconfig`, whose TS-config loader has a `require('typescript')` that is lazy at runtime and never fires — but SvelteKit bundles the whole chain, and rollup's CJS conversion hoists it into an **eager top-level evaluation**, executing the entire compiler at boot. The `typescript` module is now aliased to a stub in the SvelteKit plugin, following the existing `pg-native` stub pattern. Server output shrinks from **36MB to 11MB**.
2. **Fix the adapter-node chunk patch heuristic.** `patchAdapterNodeServerChunks` exists to shim `__filename` for exactly such chunks, but its skip-check `/\b(const|let|var)\s+__filename\b/` also matches **rollup-renamed** declarations like `__filename$1` (`$` is not a regex word character), so it skipped the chunk while the bundled compiler referenced the bare identifier. Both regexes are now anchored with `(?![\w$])`. Kept as hardening for any other CJS dependency referencing `__filename`.

### How did you test your changes?

- Repro on `main`: `pnpm turbo build --filter @workflow/example-sveltekit` then `node workbench/sveltekit/build/index.js` → crashes at boot.
- With this PR: server boots, `/.well-known/workflow/v1/flow?__health` returns 200, a `start()` through `/api/signup` creates a run with clean queue deliveries (no `Queue message failed` retries in the server log).
- `rg requireTypescript build/server/chunks/` confirms the compiler is no longer bundled; `build/server` drops 36MB → 11MB.
- Unit tests, typecheck, and biome pass for `@workflow/sveltekit` and `@workflow/builders`.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
