### PR TITLE
web: construct worlds explicitly instead of via static-injection stub

### DIFF
--- a/.changeset/web-local-world-static-injection.md
+++ b/.changeset/web-local-world-static-injection.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Fix `workflow web` for local and postgres backends after static world-target injection. The web server now constructs the local world directly and resolves other world packages from the inspected project, instead of calling the `createWorld()` static-injection stub (which throws when no build plugin aliased it).

--- a/packages/web/app/server/workflow-server-actions.server.ts
+++ b/packages/web/app/server/workflow-server-actions.server.ts
@@ -6,9 +6,10 @@
  */
 
 import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import * as workflowRunHelpers from '@workflow/core/runtime';
-import { createWorld } from '@workflow/core/runtime';
 import {
   type HealthCheckEndpoint,
   type HealthCheckResult,
@@ -27,6 +28,7 @@ import type {
   WorkflowRunStatus,
   World,
 } from '@workflow/world';
+import { createWorld as createLocalWorld } from '@workflow/world-local';
 import { createVercelWorld } from '@workflow/world-vercel';
 import type { HookListItem, HookTokenResult } from '~/lib/types';
 
@@ -473,9 +475,49 @@ async function getWorldFromEnv(userEnvMap: EnvMap): Promise<World> {
     return cachedWorld;
   }
 
-  const world = await createWorld();
+  const world = await createWorldForBackend(backendId);
   worldCache.set(cacheKey, world);
   return world;
+}
+
+/**
+ * Construct the world for the configured backend explicitly.
+ *
+ * `createWorld()` from `@workflow/core/runtime` is a static-injection stub:
+ * framework build plugins alias it to the selected world package when the
+ * user's app is built. The web UI selects its backend at runtime via env,
+ * so it must construct worlds directly (mirroring the CLI's world setup).
+ * The local world is a direct dependency; other world packages (e.g.
+ * `@workflow/world-postgres` or community worlds) are resolved from the
+ * inspected project's directory.
+ */
+async function createWorldForBackend(backendId: string): Promise<World> {
+  if (backendId === 'local' || backendId === '@workflow/world-local') {
+    return createLocalWorld();
+  }
+
+  const cwd = getObservabilityCwd();
+  let worldPath: string;
+  try {
+    worldPath = createRequire(path.join(cwd, 'package.json')).resolve(
+      backendId,
+      { paths: [cwd] }
+    );
+  } catch {
+    throw new Error(
+      `Could not resolve workflow backend package "${backendId}" from "${cwd}". ` +
+        'Make sure the package is installed in the inspected project.'
+    );
+  }
+  const mod = (await import(pathToFileURL(worldPath).href)) as {
+    createWorld?: () => World | Promise<World>;
+  };
+  if (typeof mod.createWorld !== 'function') {
+    throw new Error(
+      `Workflow backend package "${backendId}" does not export createWorld().`
+    );
+  }
+  return mod.createWorld();
 }
 
 /**

--- a/packages/web/app/server/workflow-server-actions.server.ts
+++ b/packages/web/app/server/workflow-server-actions.server.ts
@@ -511,13 +511,17 @@ async function createWorldForBackend(backendId: string): Promise<World> {
   }
   const mod = (await import(pathToFileURL(worldPath).href)) as {
     createWorld?: () => World | Promise<World>;
+    default?: { createWorld?: () => World | Promise<World> };
   };
-  if (typeof mod.createWorld !== 'function') {
+  // Fall back to default.createWorld for CJS packages whose named exports
+  // aren't statically detectable by cjs-module-lexer.
+  const createWorldFn = mod.createWorld ?? mod.default?.createWorld;
+  if (typeof createWorldFn !== 'function') {
     throw new Error(
       `Workflow backend package "${backendId}" does not export createWorld().`
     );
   }
-  return mod.createWorld();
+  return createWorldFn();
 }
 
 /**

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@workflow/world-local": "workspace:*",
     "express": "^5.2.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1037,6 +1037,9 @@ importers:
 
   packages/web:
     dependencies:
+      '@workflow/world-local':
+        specifier: workspace:*
+        version: link:../world-local
       express:
         specifier: ^5.2.1
         version: 5.2.1


### PR DESCRIPTION
## What changed

Fixes `workflow web` crashing for the local and postgres backends on latest main.

Since #2752, `createWorld()` from `@workflow/core/runtime` is a static-injection stub that throws unless a framework build plugin aliases `@workflow/core/runtime/world-target` to the selected world package at the host app's build time. The CLI was migrated to construct worlds explicitly (`packages/cli/src/lib/inspect/setup.ts`), but `@workflow/web`'s `getWorldFromEnv` still called the stub. Since the web UI selects its backend at *runtime* via env, no build plugin ever aliases its bundle, so every server action failed with:

> Workflow target world was not statically injected. Configure a Workflow builder/framework plugin so @workflow/core/runtime/world-target is aliased to the selected world package.

The Vercel backend was unaffected because that path constructs `createVercelWorld` directly.

## Fix

Mirror the CLI's approach in `getWorldFromEnv`:

- `local` / `@workflow/world-local` → import `createWorld` from `@workflow/world-local` directly (added as a dependency of `@workflow/web`)
- any other backend id (e.g. `@workflow/world-postgres`, community worlds) → resolve the package from the inspected project's directory (`WORKFLOW_OBSERVABILITY_CWD`) and call its `createWorld()`, preserving the pre-#2752 dynamic-selection behavior with a clear error when the package isn't installed

## Repro / validation

- Before: `workflow web` against a local-world project → every RPC returns the static-injection error.
- After: rebuilt `@workflow/web` and verified end-to-end against a local-world project (runs/steps/events/hooks list + detail + lazy hook-token fetch all working), and against the Vercel backend (unaffected path, still works).
- `pnpm exec vitest run app/server/workflow-server-actions.server.test.ts` — 3/3 pass
- `tsc --noEmit` on `@workflow/web` — 15 errors, identical to the pre-existing main baseline (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)