### PR TITLE
cli: restore dynamic world loading for community backends

### DIFF
--- a/.changeset/cli-generic-world-backends.md
+++ b/.changeset/cli-generic-world-backends.md
@@ -1,0 +1,5 @@
+---
+'@workflow/cli': patch
+---
+
+Restore support for community world packages in CLI world initialization. Since static world-target injection, the CLI only constructed the vercel, local, and postgres worlds and threw "Unsupported workflow backend" for anything else. Backends other than vercel/local are now resolved from the user's project directory and loaded via their `createWorld()` export (the same approach as `@workflow/web`), so third-party worlds like `@workflow-worlds/*` work again with `workflow inspect`/`workflow web`.

--- a/.changeset/cli-generic-world-backends.md
+++ b/.changeset/cli-generic-world-backends.md
@@ -2,4 +2,4 @@
 '@workflow/cli': patch
 ---
 
-Restore support for community world packages in CLI world initialization. Since static world-target injection, the CLI only constructed the vercel, local, and postgres worlds and threw "Unsupported workflow backend" for anything else. Backends other than vercel/local are now resolved from the user's project directory and loaded via their `createWorld()` export (the same approach as `@workflow/web`), so third-party worlds like `@workflow-worlds/*` work again with `workflow inspect`/`workflow web`.
+Ensure the CLI can resolve community world packages if not statically injected. Fixes "Unsupported workflow backend" error.

--- a/packages/cli/src/lib/inspect/setup.ts
+++ b/packages/cli/src/lib/inspect/setup.ts
@@ -131,17 +131,13 @@ export const setupCliWorld = async (
         teamId: vercelEnvVars.teamId,
       },
     });
-  } else if (flags.backend === '@workflow/world-postgres') {
-    world = await createPostgresCliWorld();
   } else if (
     flags.backend === 'local' ||
     flags.backend === '@workflow/world-local'
   ) {
     world = createLocalWorld();
   } else {
-    throw new Error(
-      `Unsupported workflow backend for CLI world initialization: ${flags.backend}`
-    );
+    world = await createDynamicCliWorld(flags.backend);
   }
 
   // Store in the global cache so BaseCommand.finally() can find and close it.
@@ -149,13 +145,33 @@ export const setupCliWorld = async (
   return world;
 };
 
-async function createPostgresCliWorld(): Promise<World> {
-  const postgresWorldPackage = '@workflow/world-postgres';
-  const postgresWorldPath = createRequire(
-    join(process.cwd(), 'package.json')
-  ).resolve(postgresWorldPackage, { paths: [process.cwd()] });
-  const mod = (await import(pathToFileURL(postgresWorldPath).href)) as {
-    createWorld: () => World | Promise<World>;
+/**
+ * Construct a world from its package (e.g. `@workflow/world-postgres` or a
+ * community world), resolved from the user's project directory. The vercel
+ * and local worlds are direct dependencies and constructed explicitly above;
+ * every other backend is loaded dynamically so third-party worlds keep
+ * working without being dependencies of the CLI.
+ */
+async function createDynamicCliWorld(backendId: string): Promise<World> {
+  const cwd = process.cwd();
+  let worldPath: string;
+  try {
+    worldPath = createRequire(join(cwd, 'package.json')).resolve(backendId, {
+      paths: [cwd],
+    });
+  } catch {
+    throw new Error(
+      `Could not resolve workflow backend package "${backendId}" from "${cwd}". ` +
+        'Make sure the package is installed in your project.'
+    );
+  }
+  const mod = (await import(pathToFileURL(worldPath).href)) as {
+    createWorld?: () => World | Promise<World>;
   };
+  if (typeof mod.createWorld !== 'function') {
+    throw new Error(
+      `Workflow backend package "${backendId}" does not export createWorld().`
+    );
+  }
   return mod.createWorld();
 }

--- a/packages/cli/src/lib/inspect/setup.ts
+++ b/packages/cli/src/lib/inspect/setup.ts
@@ -167,11 +167,15 @@ async function createDynamicCliWorld(backendId: string): Promise<World> {
   }
   const mod = (await import(pathToFileURL(worldPath).href)) as {
     createWorld?: () => World | Promise<World>;
+    default?: { createWorld?: () => World | Promise<World> };
   };
-  if (typeof mod.createWorld !== 'function') {
+  // Fall back to default.createWorld for CJS packages whose named exports
+  // aren't statically detectable by cjs-module-lexer.
+  const createWorldFn = mod.createWorld ?? mod.default?.createWorld;
+  if (typeof createWorldFn !== 'function') {
     throw new Error(
       `Workflow backend package "${backendId}" does not export createWorld().`
     );
   }
-  return mod.createWorld();
+  return createWorldFn();
 }


### PR DESCRIPTION
## What changed

Follow-up to #2804, fixing the same class of #2752 regression on the CLI side.

Since #2752 moved world selection to static injection, `setupCliWorld` (`packages/cli/src/lib/inspect/setup.ts`) only constructs the vercel, local, and postgres worlds explicitly and throws for anything else:

> Unsupported workflow backend for CLI world initialization: @workflow-worlds/turso

Before #2752, any non-vercel backend fell through to the dynamic `createWorld()` loader in `@workflow/core/runtime`, so community worlds (`@workflow-worlds/turso`, `@workflow-worlds/mongodb`, `@workflow-worlds/redis`, `workflow-world-jazz`, …) worked with `workflow inspect` / `workflow web`. The `--backend` flag help still advertises `<your-package-name>`, and `@workflow/web` ships an env allowlist for these worlds — they're a supported configuration.

## Fix

Generalize the postgres-only dynamic path (`createPostgresCliWorld`) into `createDynamicCliWorld(backendId)`: any backend other than vercel/local is resolved from the user's project directory via `createRequire().resolve()` and loaded through its `createWorld()` export — the same construction `@workflow/web` uses after #2804 — with clear errors when the package isn't installed or doesn't export `createWorld()`.

The vercel, local, and postgres (`@workflow/world-postgres` resolves through the identical code it used before) paths are behaviorally unchanged.

## Validation

- `tsc --noEmit` on `@workflow/cli` — clean
- `biome check` on the changed file — only the pre-existing `setupCliWorld` complexity warning, present on `main`
- Smoke test against a fixture project: a fake `@workflow-worlds/fakeworld` package exporting `createWorld()` is resolved from the project's `node_modules` and constructed; a missing package produces `Could not resolve workflow backend package …`; a package without the export produces `… does not export createWorld()`

## Follow-up

This helper is now line-for-line the shape of `createWorldForBackend` in `@workflow/web` (#2804). Once both land, extracting a shared resolver (e.g. into `@workflow/utils`, guarded for Node-only usage) would keep them from drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)