### PR TITLE
[world-local] Fix resumeHook racing hook disposal being journaled after hook_disposed

### DIFF
--- a/.changeset/hook-claim-guarded-release.md
+++ b/.changeset/hook-claim-guarded-release.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Fix a stalled hook token claim release deleting the next claimant's live claim

--- a/.changeset/hook-received-after-dispose.md
+++ b/.changeset/hook-received-after-dispose.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Fix a `resumeHook` racing `hook.dispose()` being recorded after the disposal, which corrupted the receiving run's replay

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -2877,6 +2877,87 @@ describe('Storage', () => {
       );
       expect(hookDisposedEvents).toHaveLength(1);
     });
+
+    // Regression tests for #2781: a resume racing the hook's disposal must
+    // never be journaled after hook_disposed — once that order is in the
+    // log, every replay of the owning run diverges at the post-disposal
+    // hook_received and the run escalates to CorruptedEventLogError.
+    describe('hook_received vs. hook_disposed ordering (#2781)', () => {
+      it('should reject hook_received once disposal has committed, even while the hook entity still exists', async () => {
+        await createHook(storage, testRunId, {
+          hookId: 'hook_mid_teardown',
+          token: 'mid-teardown-token',
+        });
+
+        // Simulate a disposer mid-teardown (or crashed): the dispose lock
+        // is durably committed but the hook entity has not been deleted
+        // yet. The entity-existence check alone would accept the resume.
+        const lockPath = hookDisposeLockPath(testDir, 'hook_mid_teardown');
+        await fs.mkdir(path.dirname(lockPath), { recursive: true });
+        await fs.writeFile(lockPath, '');
+
+        await expect(
+          storage.events.create(testRunId, {
+            eventType: 'hook_received',
+            correlationId: 'hook_mid_teardown',
+            eventData: { payload: new Uint8Array([1]) },
+          })
+        ).rejects.toMatchObject({ name: 'HookNotFoundError' });
+
+        const events = await storage.events.list({
+          runId: testRunId,
+          pagination: {},
+        });
+        expect(
+          events.data.filter((e) => e.eventType === 'hook_received')
+        ).toHaveLength(0);
+      });
+
+      it('should never journal hook_received after hook_disposed when resume races disposal', async () => {
+        // Each round races one resume against the hook's disposal. Both
+        // outcomes are valid — the resume lands before the disposal, or it
+        // is rejected — but the journal must never contain hook_received
+        // ordered after hook_disposed for the same hook.
+        for (let round = 0; round < 20; round++) {
+          const hookId = `hook_race_2781_${round}`;
+          await createHook(storage, testRunId, {
+            hookId,
+            token: `race-2781-token-${round}`,
+          });
+
+          const [resume] = await Promise.allSettled([
+            storage.events.create(testRunId, {
+              eventType: 'hook_received',
+              correlationId: hookId,
+              eventData: { payload: new Uint8Array([round]) },
+            }),
+            disposeHook(storage, testRunId, hookId),
+          ]);
+
+          if (resume.status === 'rejected') {
+            expect((resume.reason as { name?: string }).name).toBe(
+              'HookNotFoundError'
+            );
+          }
+
+          const events = await storage.events.listByCorrelationId({
+            correlationId: hookId,
+            pagination: {},
+          });
+          const types = events.data.map((e) => e.eventType);
+          const disposedIndex = types.indexOf('hook_disposed');
+          expect(disposedIndex).toBeGreaterThan(-1);
+          expect(types.lastIndexOf('hook_received')).toBeLessThan(
+            disposedIndex
+          );
+          // A fulfilled resume must actually be in the log (before the
+          // disposal), a rejected one must not be journaled at all.
+          expect(types.filter((t) => t === 'hook_received')).toHaveLength(
+            resume.status === 'fulfilled' ? 1 : 0
+          );
+        }
+      });
+    });
   });
 
   describe('concurrent entity-creation races', () => {

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -2276,6 +2276,78 @@ describe('Storage', () => {
         expect(result.hook?.runId).toBe(run2.runId);
       });
 
+      // Regression tests for the #2779 follow-up: a releaser (hook_disposed
+      // handler or terminal-run cleanup) that stalls between reading the
+      // hook entity and deleting the claim can outlive a force-release of
+      // its stale claim — its deferred delete must not destroy the NEXT
+      // claimant's live claim. The claim file is rewritten manually to
+      // simulate the takeover happening during the stall.
+      it('hook_disposed should not release a token claim it no longer owns', async () => {
+        const token = 'stolen-claim-token';
+
+        await createHook(storage, testRunId, {
+          hookId: 'hook_old',
+          token,
+        });
+
+        // Simulate a force-release + re-claim by a new claimant while the
+        // disposer is stalled: the claim now points at (run2, hook_new).
+        const claimPath = path.join(
+          testDir,
+          'hooks',
+          'tokens',
+          `${hashToken(token)}.json`
+        );
+        const newClaim = {
+          token,
+          hookId: 'hook_new',
+          runId: 'wrun_someother_run',
+          eventId: 'evnt_00000000000000000000000001',
+        };
+        await fs.writeFile(claimPath, JSON.stringify(newClaim));
+
+        // The stalled disposer's release lands now — it must skip the
+        // deletion because the claim belongs to someone else.
+        await disposeHook(storage, testRunId, 'hook_old');
+
+        const claimAfter = JSON.parse(await fs.readFile(claimPath, 'utf8'));
+        expect(claimAfter).toEqual(newClaim);
+      });
+
+      it('terminal-run hook cleanup should not release a token claim it no longer owns', async () => {
+        const token = 'stolen-claim-token-terminal';
+
+        await createHook(storage, testRunId, {
+          hookId: 'hook_old',
+          token,
+        });
+
+        const claimPath = path.join(
+          testDir,
+          'hooks',
+          'tokens',
+          `${hashToken(token)}.json`
+        );
+        const newClaim = {
+          token,
+          hookId: 'hook_new',
+          runId: 'wrun_someother_run',
+          eventId: 'evnt_00000000000000000000000001',
+        };
+        await fs.writeFile(claimPath, JSON.stringify(newClaim));
+
+        // Completing the run triggers deleteAllHooksForRun, which reads
+        // hook_old's entity and releases its claim — it must skip the
+        // deletion because the claim belongs to someone else.
+        await updateRun(storage, testRunId, 'run_started');
+        await updateRun(storage, testRunId, 'run_completed', {
+          output: new Uint8Array(),
+        });
+
+        const claimAfter = JSON.parse(await fs.readFile(claimPath, 'utf8'));
+        expect(claimAfter).toEqual(newClaim);
+      });
+
       it('should enforce token uniqueness across different runs within the same project', async () => {
         // Create a second run
         const run2 = await createRun(storage, {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -61,6 +61,7 @@ import {
   hookRecoveryMarkerPath,
   isHookDisposalCommitted,
   monotonicUlid,
+  releaseHookTokenClaimIfOwnedBy,
 } from './helpers.js';
 import {
   deleteAllHooksForRun,
@@ -1980,19 +1981,23 @@ export function createEventsStorage(
             tag
           );
           if (existingHook) {
-            // Delete the token constraint file to free up the token
-            // for reuse, and delete this hook's recovery marker (if
+            // Release the token claim to free up the token for reuse —
+            // but only if it still points at this hook. A claimant that
+            // force-released this hook's stale claim (see
+            // `isHookTokenClaimReleasable`) may already hold a fresh
+            // claim for the token; deleting unconditionally here would
+            // destroy that live claim and transiently break token
+            // uniqueness. Also delete this hook's recovery marker (if
             // any) for disk hygiene. The marker's filename hash
             // includes `(token, runId, hookId)` so different
             // lifetimes never collide, but cleaning up reduces disk
             // leak for hooks that go through the recovery path.
-            const disposedConstraintPath = path.join(
+            await releaseHookTokenClaimIfOwnedBy(
               basedir,
-              'hooks',
-              'tokens',
-              `${hashToken(existingHook.token)}.json`
+              existingHook.token,
+              existingHook.runId,
+              existingHook.hookId
             );
-            await deleteJSON(disposedConstraintPath);
             await deleteJSON(
               hookRecoveryMarkerPath(
                 basedir,

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -629,7 +629,21 @@ export function createEventsStorage(
       // observe a claim with no matching hook entity — which the
       // crash-recovery path below would misinterpret as a prior crash
       // and incorrectly fall through to a second hook entity write.
-      if (data.eventType === 'hook_created' && runId && data.correlationId) {
+      //
+      // `hook_received` and `hook_disposed` share the same per-hook lock
+      // so a resume's "hook exists and is not disposed, then append"
+      // sequence is atomic with respect to the disposer's "write dispose
+      // lock, delete entity, then append" sequence. Without this, a
+      // resume that passed its existence check before the disposal began
+      // could append its `hook_received` AFTER `hook_disposed` — an
+      // ordering that is journaled durably and makes every subsequent
+      // replay of the owning run diverge at that event
+      // (https://github.com/vercel/workflow/issues/2781).
+      const isHookLifecycleEvent =
+        data.eventType === 'hook_created' ||
+        data.eventType === 'hook_received' ||
+        data.eventType === 'hook_disposed';
+      if (isHookLifecycleEvent && runId && data.correlationId) {
         const lockKey = tag
           ? `${runId}-${data.correlationId}.hook.${tag}`
           : `${runId}-${data.correlationId}.hook`;
@@ -975,6 +989,21 @@ export function createEventsStorage(
           hookEventsRequiringExistence.includes(data.eventType) &&
           data.correlationId
         ) {
+          // A resume must never be journaled after the hook's disposal.
+          // The disposer's durable order is: dispose lock → claim/entity
+          // delete → `hook_disposed` append, so the hook entity can still
+          // exist (or the disposer may have crashed mid-teardown) while
+          // disposal is already committed. Re-validate the dispose lock
+          // here — under the per-hook in-process lock taken above — so
+          // acceptance observes the same order replay will: once disposal
+          // has committed, the resume is rejected exactly like one that
+          // arrived after teardown finished.
+          if (
+            data.eventType === 'hook_received' &&
+            (await isHookDisposalCommitted(basedir, data.correlationId, tag))
+          ) {
+            throw new HookNotFoundError(data.correlationId);
+          }
           const existingHook = await readJSONWithFallback(
             basedir,
             'hooks',
@@ -2082,6 +2111,21 @@ export function createEventsStorage(
         // collision indicates a real bug and EntityConflictError is
         // also the right surface — same shape as step_created's
         // claim-file behavior.
+        // Last-instant re-validation for `hook_received` (see the acceptance
+        // check above). The per-hook in-process lock already serializes
+        // resume vs. dispose within one storage instance; this second check
+        // narrows the cross-instance window (independent lock maps, shared
+        // filesystem) to the single event write below, matching the
+        // module's convention that the on-disk lock file — not the
+        // in-process mutex — is the durable source of truth.
+        if (
+          data.eventType === 'hook_received' &&
+          data.correlationId &&
+          (await isHookDisposalCommitted(basedir, data.correlationId, tag))
+        ) {
+          throw new HookNotFoundError(data.correlationId);
+        }
+
         const compositeKey = `${effectiveRunId}-${eventId}`;
         const eventPath = taggedPath(basedir, 'events', compositeKey, tag);
         // Capture the serialized payload before the write's `await` so the

--- a/packages/world-local/src/storage/helpers.ts
+++ b/packages/world-local/src/storage/helpers.ts
@@ -53,6 +53,50 @@ export async function isHookDisposalCommitted(
 }
 
 /**
+ * Path of the exclusive-create claim file that reserves a hook token.
+ */
+export function hookTokenClaimPath(basedir: string, token: string): string {
+  return path.join(basedir, 'hooks', 'tokens', `${hashToken(token)}.json`);
+}
+
+/**
+ * Release (delete) a token claim only if it still points at the releasing
+ * hook's own `(runId, hookId)`.
+ *
+ * Both in-flight releasers — the `hook_disposed` handler and the
+ * terminal-run `deleteAllHooksForRun` cleanup — read the hook entity and
+ * then delete the claim file. Deleting unconditionally is unsafe across
+ * processes: a releaser that stalls between those two operations can
+ * outlive a force-release of its stale claim (see
+ * `isHookTokenClaimReleasable`) and then delete the NEXT claimant's live
+ * claim, transiently breaking token uniqueness. Re-reading the claim and
+ * matching its identity here shrinks that window from "a stall of any
+ * length" to the adjacent read/delete file ops.
+ *
+ * A claim that is missing, unreadable, or owned by someone else is left
+ * alone — if it is genuinely stale debris, the claimant-side force-release
+ * path reaps it.
+ */
+export async function releaseHookTokenClaimIfOwnedBy(
+  basedir: string,
+  token: string,
+  runId: string,
+  hookId: string
+): Promise<void> {
+  const claimPath = hookTokenClaimPath(basedir, token);
+  let claim: { runId?: unknown; hookId?: unknown };
+  try {
+    claim = JSON.parse(await fs.readFile(claimPath, 'utf8'));
+  } catch {
+    return;
+  }
+  if (claim.runId !== runId || claim.hookId !== hookId) {
+    return;
+  }
+  await fs.unlink(claimPath).catch(() => {});
+}
+
+/**
  * Compute the path of the recovery-marker sidecar for a specific
  * `(token, runId, hookId)` triple. Identity is encoded in the
  * filename hash so different token lifetimes (e.g. the same token

--- a/packages/world-local/src/storage/hooks-storage.ts
+++ b/packages/world-local/src/storage/hooks-storage.ts
@@ -36,6 +36,7 @@ import {
   hashToken,
   hookRecoveryMarkerPath,
   isHookDisposalCommitted,
+  releaseHookTokenClaimIfOwnedBy,
 } from './helpers.js';
 
 function isVisibleToTag(fileId: string, tag: string | undefined): boolean {
@@ -341,18 +342,22 @@ export async function deleteAllHooksForRun(
     const hookPath = path.join(hooksDir, `${file}.json`);
     const hook = await readJSON(hookPath, HookSchema);
     if (hook && hook.runId === runId) {
-      // Delete the token constraint file to free up the token, and
-      // delete the recovery marker (if any) for disk hygiene. The
+      // Release the token claim to free up the token — but only if it
+      // still points at this hook: a claimant may have force-released
+      // the terminal run's stale claim already (see
+      // `isHookTokenClaimReleasable`) and hold a fresh claim of its
+      // own, which an unconditional delete would destroy. Also delete
+      // the recovery marker (if any) for disk hygiene. The
       // marker's filename hash includes `(token, runId, hookId)` so
       // a leaked marker can never corrupt a different lifetime — but
       // cleaning it up here keeps the tokens/ directory from
       // accumulating recovered-hook sidecars over time.
-      const constraintPath = path.join(
-        hooksDir,
-        'tokens',
-        `${hashToken(hook.token)}.json`
+      await releaseHookTokenClaimIfOwnedBy(
+        basedir,
+        hook.token,
+        hook.runId,
+        hook.hookId
       );
-      await deleteJSON(constraintPath);
       await deleteJSON(
         hookRecoveryMarkerPath(basedir, hook.token, hook.runId, hook.hookId)
       );


### PR DESCRIPTION
Closes #2781. Also addresses the post-merge feedback on #2779 (guarded claim release).

### 1. `hook_received` journaled after `hook_disposed` (#2781)

A `hook_received` write only validated that the hook entity exists, and was not serialized against the `hook_disposed` write for the same hook. A resume that passed its existence check before the disposal began could be journaled **after** `hook_disposed` — once that order is in the log, every replay of the owning run diverges at the post-disposal `hook_received` and the run escalates to `CorruptedEventLogError`.

- `hook_received` and `hook_disposed` now share the per-hook in-process lock previously taken only by `hook_created`, making the resume's "validate, then append" atomic with the disposer's "dispose lock → entity delete → append" within a storage instance.
- The `hook_received` write re-validates the durable dispose lock from #2779 (at acceptance, and once more immediately before the event append, narrowing the cross-instance window to the single event write), rejecting with `HookNotFoundError` — the same surface as a resume that arrives after teardown finished. Acceptance now observes the same order replay will see.

### 2. Guarded token claim release (#2779 follow-up)

Both in-flight releasers (the `hook_disposed` handler and the terminal-run `deleteAllHooksForRun` cleanup) deleted the token claim file unconditionally after reading the hook entity. A releaser stalled between those operations could outlive a claimant force-releasing its stale claim, and its deferred delete would then destroy the new claimant's live claim — transiently breaking token uniqueness. Releasers now re-read the claim and delete it only if it still points at their own `(runId, hookId)`; a claim owned by someone else is left for the claimant-side force-release path to reap.

### Tests

- A deterministic mid-teardown acceptance test (dispose lock committed, hook entity still present) that fails without fix 1.
- A resume-vs-dispose race loop asserting `hook_received` is never journaled after `hook_disposed` and that a rejected resume leaves no event behind.
- Two claim-takeover tests (one per releaser) that rewrite the claim to a foreign `(runId, hookId)` and assert the release skips it; both fail without fix 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)