### PR TITLE
Fix Next watcher with custom distDir

### DIFF
--- a/.changeset/fix-next-custom-distdir-watch.md
+++ b/.changeset/fix-next-custom-distdir-watch.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Ignore custom Next.js distDir output in the development workflow watcher.

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -50,6 +50,7 @@ export async function getNextBuilderEager(
   class NextBuilder extends BaseBuilderClass {
     protected declare config: BuilderNextConfig & {
       pageExtensions: NonNullable<ProjectNextConfig['pageExtensions']>;
+      distDir: string;
     };
 
     async build() {
@@ -171,10 +172,15 @@ export async function getNextBuilderEager(
           '/.well-known/workflow/',
         ];
         const normalizedGeneratedDir = workflowGeneratedDir.replace(/\\/g, '/');
+        const normalizedDistDir = normalizePath(this.config.distDir);
         ignoredPathFragments.push(normalizedGeneratedDir);
 
         const hasIgnoredPathFragment = (normalizedPath: string) => {
-          if (normalizedPath.startsWith(normalizedGeneratedDir)) {
+          if (
+            normalizedPath.startsWith(normalizedGeneratedDir) ||
+            normalizedPath === normalizedDistDir ||
+            normalizedPath.startsWith(`${normalizedDistDir}/`)
+          ) {
             return true;
           }
           for (const fragment of ignoredPathFragments) {


### PR DESCRIPTION
## Summary

Fixes #2809.

The eager Next builder's dev watcher already ignores hardcoded output directories such as `/.next/`, `/dist/`, and `/build/`. When a Next app configures a custom `distDir` such as `.next-dev`, that output directory was not ignored, so Next compiler output could be treated as a workflow source change and trigger a rebuild loop.

## Fix

Keep the existing watcher logic in place and add the configured `distDir` to the same local ignore check as the generated workflow directory.

## Validation

I first validated the temporary regression test passed, then removed it so we do not introduce a new `builder-eager` test file just for this.

Manual validation used `workbench/nextjs-webpack` with a temporary `distDir: '.next-dev'` in `next.config.ts`:

```bash
corepack pnpm@10.20.0 --filter workflow... build
corepack pnpm@10.20.0 --filter @workflow/ai... build
PORT=3211 WORKFLOW_DEV_HMR_LOGS=1 corepack pnpm@10.20.0 dev
curl -sS -o /tmp/workflow-next-webpack.out -w '%{http_code}\n' http://localhost:3211/
```

Observed result:

- initial workflow compile ran once
- app request returned `200`
- `.next-dev` was created
- no repeated `workflow dev hmr` rebuild messages appeared over two 30-second quiet windows after the page compile

Also verified:

```bash
corepack pnpm@10.20.0 --filter @workflow/next test
corepack pnpm@10.20.0 --filter @workflow/next build
corepack pnpm@10.20.0 exec biome check packages/next/src/builder-eager.ts .changeset/fix-next-custom-distdir-watch.md
```

`@workflow/next` tests passed: 4 files, 25 tests. Biome exits 0 with existing complexity warnings in the older watcher functions.
