### PR TITLE
Remove SvelteKit prepare lifecycle hook

### DIFF
--- a/workbench/sveltekit/package.json
+++ b/workbench/sveltekit/package.json
@@ -10,7 +10,6 @@
     "dev": "vite dev",
     "build": "vite build",
     "start": "vite preview",
-    "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },


### PR DESCRIPTION
## Problem

SvelteKit 2.62+ loads the Vite config during `svelte-kit sync`. Because the workbench ran sync from `prepare`, `pnpm install` imported the Workflow plugin and started compilation before workspace build artifacts such as the SWC wasm were available, causing CI installs to hang.

## Solution

Remove the redundant `prepare` hook. SvelteKit still synchronizes during `dev` and `build`, and the `check` script runs `svelte-kit sync` explicitly.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --dir workbench/sveltekit check`
- `pnpm --dir workbench/sveltekit build`