### PR TITLE
Derive Hook type from HookSchema

### DIFF
--- a/.changeset/derive-hook-type.md
+++ b/.changeset/derive-hook-type.md
@@ -1,5 +1,0 @@
----
-'@workflow/world': patch
----
-
-Derive the public Hook type from its schema so they stay synchronized.

--- a/.changeset/derive-hook-type.md
+++ b/.changeset/derive-hook-type.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world': patch
+---
+
+Derive the public Hook type from its schema so they stay synchronized.

--- a/packages/world/src/hooks.ts
+++ b/packages/world/src/hooks.ts
@@ -33,30 +33,7 @@ export const HookSchema = z.object({
  * - specVersion >= 2: Uint8Array (binary devalue format)
  * - specVersion 1: unknown (legacy JSON format)
  */
-export type Hook = z.infer<typeof HookSchema> & {
-  /** The unique identifier of the workflow run this hook belongs to. */
-  runId: string;
-  /** The unique identifier of this hook within the workflow run. */
-  hookId: string;
-  /** The secret token used to reference this hook. */
-  token: string;
-  /** The owner ID (team or user) that owns this hook. */
-  ownerId: string;
-  /** The project ID this hook belongs to. */
-  projectId: string;
-  /** The environment (e.g., "production", "preview", "development") where this hook was created. */
-  environment: string;
-  /** Optional metadata associated with the hook, set when the hook was created. */
-  metadata?: SerializedData;
-  /** The timestamp when this hook was created. */
-  createdAt: Date;
-  /** The spec version when this hook was created. */
-  specVersion?: number;
-  /** Whether this hook is resumable via the public webhook endpoint. undefined = legacy (treated as true for backwards compat). */
-  isWebhook?: boolean;
-  /** Whether this hook is a system-managed hook (e.g., for abort signals). */
-  isSystem?: boolean;
-};
+export type Hook = z.infer<typeof HookSchema>;
 
 // Request types
 export interface CreateHookRequest {


### PR DESCRIPTION
## Summary

- derive the public `Hook` type directly from `HookSchema`
- remove the duplicated field declaration so the schema remains the single source of truth

Follow-up to #2790.

## Test plan

- `pnpm --filter @workflow/world build`
- typecheck `world-local`, `world-postgres`, `world-vercel`, and `web-shared`
- `pnpm vitest run src/storage.test.ts -t hook` in `packages/world-local`