### PR TITLE
Fix middle truncation on detail panel

### DIFF
--- a/.changeset/breezy-regions-leave.md
+++ b/.changeset/breezy-regions-leave.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Fix middle truncation on detail panel

--- a/packages/web-shared/src/components/sidebar/attributes-block.tsx
+++ b/packages/web-shared/src/components/sidebar/attributes-block.tsx
@@ -21,7 +21,7 @@ function isReservedAttributeKey(key: string): boolean {
 }
 
 const rowValueVariants = cva(
-  'max-w-[60%] truncate text-right text-copy-13 text-gray-1000',
+  'min-w-0 flex-1 truncate text-right text-copy-13 text-gray-1000',
   {
     variants: {
       variant: {
@@ -36,7 +36,7 @@ const rowValueVariants = cva(
 );
 
 const rowCopyValueVariants = cva(
-  'flex min-w-0 max-w-[60%] items-center justify-end gap-1 text-copy-13 text-gray-1000',
+  'flex min-w-0 flex-1 items-center justify-end gap-1 text-copy-13 text-gray-1000',
   {
     variants: {
       variant: {


### PR DESCRIPTION
Currently, module and ID are default middle truncated even if there's a lot of space on the detail panel. This fix makes it dynamic, allowing the text to be fully visible if there's enoguh space. 