### PR TITLE
[core/world/world-vercel] Report TTFS/STSO latency telemetry on step terminal events

### DIFF
--- a/.changeset/attr-inprocess-replay.md
+++ b/.changeset/attr-inprocess-replay.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+`experimental_setAttributes` now resolves via an in-process replay instead of a queue re-invocation, removing a delivery round-trip before subsequent steps.

--- a/.changeset/olive-lions-measure.md
+++ b/.changeset/olive-lions-measure.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'@workflow/world': minor
+'@workflow/world-vercel': minor
+---
+
+Report time-to-first-step and step-to-step overhead latency telemetry on step completion events.

--- a/docs/content/docs/v5/changelog/lazy-event-creation.md
+++ b/docs/content/docs/v5/changelog/lazy-event-creation.md
@@ -69,7 +69,7 @@ This intersects with the inline-delta optimization. The delta returned on the `s
 
 ### Pre-emption by attributes / hook conflicts
 
-When `attr_set` events or a hook conflict force an immediate re-invocation, the handler returns *before* the dispatch loop. The deferred step is therefore **neither created nor queued** on that pass; it is recreated and run on the re-invocation (where it is still a lazy candidate).
+When `attr_set` events force an immediate in-process replay, or a hook conflict forces a re-invocation, the handler skips the dispatch loop for that pass. The deferred step is therefore **neither created nor queued** on that pass; it is recreated and run on the following replay (where it is still a lazy candidate).
 
 This is a small behavioral improvement: previously the eager `step_created` left an orphan "created but never started" event when a step lost an attribute/hook race (e.g. `Promise.race([setAttributes(), step()])` where the attribute write wins and completes the run). With deferral, a step that loses the race is never created at all — less event-log garbage.
 

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   SPEC_VERSION_CURRENT,
   type WorkflowRun,
 } from '@workflow/world';
+import { ulid } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { registerStepFunction } from './private.js';
 import { REPLAY_DIVERGENCE_MAX_RETRIES } from './runtime/constants.js';
@@ -1721,5 +1722,222 @@ describe('workflowEntrypoint turbo mode', () => {
     expect(order.indexOf('step_started_called')).toBeLessThan(
       order.indexOf('body')
     );
+  });
+});
+
+describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
+  const ORIG_TURBO = process.env.WORKFLOW_TURBO;
+
+  beforeEach(() => {
+    delete process.env.WORKFLOW_TURBO;
+  });
+  afterEach(() => {
+    if (ORIG_TURBO === undefined) delete process.env.WORKFLOW_TURBO;
+    else process.env.WORKFLOW_TURBO = ORIG_TURBO;
+    setWorld(undefined);
+    vi.clearAllMocks();
+    waitUntilPromises.length = 0;
+  });
+
+  registerStepFunction('latStepOne', async () => undefined);
+  registerStepFunction('latStepTwo', async () => undefined);
+
+  const latXform = (name: string) =>
+    `;globalThis.__private_workflows = new Map();
+     globalThis.__private_workflows.set(${JSON.stringify(name)}, ${name});`;
+
+  const twoStepWorkflow = `const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("latStepOne");
+    const s2 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("latStepTwo");
+    async function workflow() { await s1(); return await s2(); }${latXform('workflow')}`;
+
+  // The first step races a long sleep: the suspension that schedules the
+  // step also creates a wait, which must disqualify the measurement.
+  const stepRacingSleepWorkflow = `const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("latStepOne");
+    const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+    async function workflow() {
+      const [r] = await Promise.all([s1(), sleep('1h')]);
+      return r;
+    }${latXform('workflow')}`;
+
+  /** Backdated `wrun_` ULID so a real TTFS (≈ backdateMs) is computable. */
+  function makeLatencyRunId(backdateMs: number): string {
+    return `wrun_${ulid(Date.now() - backdateMs)}`;
+  }
+
+  async function driveLatency(opts: {
+    runId: string;
+    source: string;
+    attempt?: number;
+  }) {
+    const { runId, source } = opts;
+    const durable: Event[] = [];
+    let seq = 0;
+    const rec = (data: any): Event => {
+      seq += 1;
+      const e = {
+        eventId: `e-${seq}`,
+        runId,
+        createdAt: new Date(),
+        ...data,
+      } as Event;
+      durable.push(e);
+      return e;
+    };
+    const runEntity: WorkflowRun = {
+      runId,
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments([], runId, undefined, []),
+      createdAt: new Date(Date.now() - 60_000),
+      updatedAt: new Date(),
+      startedAt: new Date(),
+      deploymentId: 'test-deployment',
+    };
+
+    const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+      if (data.eventType === 'run_started') {
+        return { run: runEntity, events: [] as Event[] };
+      }
+      if (data.eventType === 'step_started') {
+        const d = data.eventData as { stepName?: string; input?: unknown };
+        if (d?.input !== undefined) {
+          rec({
+            eventType: 'step_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            correlationId: data.correlationId,
+            eventData: { stepName: d.stepName, input: d.input },
+          });
+        }
+        return {
+          event: rec(data),
+          step: {
+            runId,
+            stepId: data.correlationId,
+            stepName: d?.stepName,
+            status: 'running' as const,
+            attempt: 1,
+            input: d?.input,
+            startedAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          ...(d?.input !== undefined ? { stepCreated: true } : {}),
+        };
+      }
+      return { event: rec(data) };
+    });
+
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      createQueueHandler: vi.fn(
+        (_p: string, handler: (m: unknown, md: unknown) => Promise<unknown>) =>
+          async () => {
+            await handler(
+              {
+                runId,
+                requestedAt: new Date(),
+                runInput: {
+                  input: await dehydrateWorkflowArguments(
+                    [],
+                    runId,
+                    undefined,
+                    []
+                  ),
+                  deploymentId: 'test-deployment',
+                  workflowName: 'workflow',
+                  specVersion: SPEC_VERSION_CURRENT,
+                  executionContext: {},
+                },
+              },
+              {
+                requestId: 'req_latency',
+                attempt: opts.attempt ?? 1,
+                queueName: '__wkf_workflow_workflow',
+                messageId: 'msg_latency',
+              }
+            );
+            return new Response(null, { status: 204 });
+          }
+      ),
+      events: {
+        create: eventsCreate,
+        list: vi.fn(async () => ({
+          data: [...durable],
+          hasMore: false,
+          cursor: 'cursor_latency',
+        })),
+      },
+      runs: { get: vi.fn(async () => runEntity) },
+      queue: vi.fn(async () => ({ messageId: null })),
+      getEncryptionKeyForRun: vi.fn(async () => undefined),
+    } as any);
+
+    const res = (await workflowEntrypoint(source)(
+      new Request('https://example.test')
+    )) as Response;
+    expect(res.status).toBe(204);
+
+    const stepCompleted = eventsCreate.mock.calls
+      .map((c) => c[1] as any)
+      .filter((d) => d.eventType === 'step_completed');
+    return { stepCompleted };
+  }
+
+  it('attaches ttfs to the first step and stso to the next back-to-back step (turbo)', async () => {
+    const backdateMs = 5_000;
+    const before = Date.now();
+    const { stepCompleted } = await driveLatency({
+      runId: makeLatencyRunId(backdateMs),
+      source: twoStepWorkflow,
+    });
+    const elapsed = Date.now() - before;
+    expect(stepCompleted).toHaveLength(2);
+
+    const [first, second] = stepCompleted;
+    // First step: TTFS anchored at the run-id ULID timestamp, no STSO.
+    expect(first.eventData.ttfs).toBeGreaterThanOrEqual(backdateMs);
+    expect(first.eventData.ttfs).toBeLessThanOrEqual(backdateMs + elapsed);
+    expect(first.eventData.stso).toBeUndefined();
+    expect(first.eventData.optimizations).toEqual([
+      'turbo',
+      'lazyStepStart',
+      'optimisticStart',
+    ]);
+
+    // Second step ran back-to-back with the first: STSO only, and far
+    // smaller than the TTFS anchor distance (it measures the scheduling
+    // gap, not run age).
+    expect(second.eventData.ttfs).toBeUndefined();
+    expect(second.eventData.stso).toBeGreaterThanOrEqual(0);
+    expect(second.eventData.stso).toBeLessThanOrEqual(elapsed);
+    expect(second.eventData.optimizations).toEqual([
+      'turbo',
+      'lazyStepStart',
+      'optimisticStart',
+    ]);
+  });
+
+  it('still reports ttfs without turbo (redelivery), minus turbo-only optimization flags', async () => {
+    const backdateMs = 5_000;
+    const { stepCompleted } = await driveLatency({
+      runId: makeLatencyRunId(backdateMs),
+      source: twoStepWorkflow,
+      attempt: 2, // redelivery → turbo off, awaited run_started path
+    });
+    expect(stepCompleted).toHaveLength(2);
+    const [first] = stepCompleted;
+    expect(first.eventData.ttfs).toBeGreaterThanOrEqual(backdateMs);
+    expect(first.eventData.optimizations).toEqual(['lazyStepStart']);
+  });
+
+  it('reports nothing when the first step is scheduled alongside a wait', async () => {
+    const { stepCompleted } = await driveLatency({
+      runId: makeLatencyRunId(5_000),
+      source: stepRacingSleepWorkflow,
+    });
+    expect(stepCompleted).toHaveLength(1);
+    expect(stepCompleted[0].eventData.ttfs).toBeUndefined();
+    expect(stepCompleted[0].eventData.stso).toBeUndefined();
+    expect(stepCompleted[0].eventData.optimizations).toBeUndefined();
   });
 });

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -54,6 +54,14 @@ async function runWorkflowHandlerWithEvents(
     createdEvents?: unknown[];
     queuedMessages?: unknown[];
     replayDivergence?: { eventId: string; count: number };
+    /**
+     * Make created events visible to subsequent events.list calls (appended
+     * to `events`), like a real World. Needed for flows where the handler
+     * makes in-process progress over its own writes (e.g. an attr_set
+     * resolved by the next replay iteration). Off by default so tests that
+     * pin the log's contents keep full control.
+     */
+    dynamicEventLog?: boolean;
   } = {}
 ) {
   const createdEvents = options.createdEvents ?? [];
@@ -67,14 +75,16 @@ async function runWorkflowHandlerWithEvents(
       };
     }
 
-    return {
-      event: {
-        eventId: `event-${createdEvents.length}`,
-        runId: workflowRun.runId,
-        createdAt: new Date(),
-        ...data,
-      },
+    const event = {
+      eventId: `event-${createdEvents.length}`,
+      runId: workflowRun.runId,
+      createdAt: new Date(),
+      ...data,
     };
+    if (options.dynamicEventLog) {
+      events.push(event as Event);
+    }
+    return { event };
   });
 
   setWorld({
@@ -719,55 +729,36 @@ describe('workflowEntrypoint replay guards', () => {
         return "attribute won";
       }${getWorkflowTransformCode('workflow')}`;
 
-    const firstAttemptEvents: any[] = [];
-    const firstAttemptMessages: unknown[] = [];
+    const createdEvents: any[] = [];
+    const queuedMessages: unknown[] = [];
     await runWorkflowHandlerWithEvents(workflowCode, workflowRun, [], {
-      createdEvents: firstAttemptEvents,
-      queuedMessages: firstAttemptMessages,
+      createdEvents,
+      queuedMessages,
+      dynamicEventLog: true,
     });
 
-    expect(firstAttemptEvents).toContainEqual(
+    expect(createdEvents).toContainEqual(
       expect.objectContaining({ eventType: 'attr_set' })
     );
-    // Under lazy inline start the step that loses the attribute race is NOT
-    // eagerly created: its step_created is deferred for a lazy step_started
-    // that never fires, because the attr_set event triggers an immediate
-    // re-invocation before any step executes. So no step_created is written on
-    // this attempt — strictly less event-log garbage than the eager model,
-    // and correct because the step loses the race and is abandoned on replay.
-    expect(firstAttemptEvents).not.toContainEqual(
-      expect.objectContaining({ eventType: 'step_created' })
-    );
-    expect(firstAttemptMessages).toEqual([]);
-
-    const replayEvents = firstAttemptEvents
-      .filter(
-        (event) =>
-          event.eventType === 'attr_set' || event.eventType === 'step_created'
-      )
-      .map((event, index) => ({
-        ...event,
-        eventId: `event-${index}`,
-        runId: workflowRun.runId,
-        createdAt: new Date('2024-01-01T00:00:01.000Z'),
-      })) as Event[];
-    const replayCreatedEvents: unknown[] = [];
-    const replayQueuedMessages: unknown[] = [];
-
-    await runWorkflowHandlerWithEvents(
-      workflowCode,
-      workflowRun,
-      replayEvents,
-      {
-        createdEvents: replayCreatedEvents,
-        queuedMessages: replayQueuedMessages,
-      }
-    );
-
-    expect(replayCreatedEvents).toContainEqual(
+    // The attr_set suspension skips step processing and resolves through an
+    // in-process replay, where the durable attribute event wins the race —
+    // so the run completes within this same delivery, with no queue
+    // interaction.
+    expect(createdEvents).toContainEqual(
       expect.objectContaining({ eventType: 'run_completed' })
     );
-    expect(replayQueuedMessages).toEqual([]);
+    expect(queuedMessages).toEqual([]);
+    // Under lazy inline start the step that loses the attribute race is NOT
+    // eagerly created: its step_created is deferred for a lazy step_started
+    // that never fires, because the attribute-resolving replay decides the
+    // race before any step executes. So the losing step leaves no events at
+    // all — strictly less event-log garbage than the eager model.
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'step_created' })
+    );
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'step_started' })
+    );
   });
 
   it('fails the run when the World rejects an attr_set event as invalid', async () => {
@@ -1797,6 +1788,7 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
       startedAt: new Date(),
       deploymentId: 'test-deployment',
     };
+    const queued: unknown[] = [];
 
     const eventsCreate = vi.fn(async (_runId: string, data: any) => {
       if (data.eventType === 'run_started') {
@@ -1877,7 +1869,10 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
         })),
       },
       runs: { get: vi.fn(async () => runEntity) },
-      queue: vi.fn(async () => ({ messageId: null })),
+      queue: vi.fn(async (_queueName: string, message: unknown) => {
+        queued.push(message);
+        return { messageId: null };
+      }),
       getEncryptionKeyForRun: vi.fn(async () => undefined),
     } as any);
 
@@ -1889,7 +1884,7 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     const stepCompleted = eventsCreate.mock.calls
       .map((c) => c[1] as any)
       .filter((d) => d.eventType === 'step_completed');
-    return { stepCompleted, eventsCreate };
+    return { stepCompleted, eventsCreate, queued };
   }
 
   it('attaches ttfs to the first step and stso to the next back-to-back step (turbo)', async () => {
@@ -1950,45 +1945,74 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     expect(stepCompleted[0].eventData.optimizations).toBeUndefined();
   });
 
-  it('reports ttfs across a pre-step setAttributes, ending the measurement at the attr write', async () => {
-    // A workflow-body setAttributes before the first step: the attribute
-    // suspension re-invokes through the queue before any step runs (see the
-    // hasAttributeEvents branch in the orchestrator), so the first step
-    // executes in a LATER invocation whose log already holds the attr_set.
-    // TTFS must still be reported, anchored run-creation → the attr write
-    // (the setAttributes call's duration — including the queue hop — is
-    // subtracted by ending the measurement there).
-    const attrThenStepWorkflow = `const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("latStepOne");
-      const setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
-      async function workflow() {
-        await setAttributes([{ key: "k", value: "v" }]);
-        return await s1();
-      }${latXform('workflow')}`;
+  const attrThenStepWorkflow = `const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("latStepOne");
+    const setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
+    async function workflow() {
+      await setAttributes([{ key: "k", value: "v" }]);
+      return await s1();
+    }${latXform('workflow')}`;
 
+  it('reports ttfs across a pre-step setAttributes, resolved in-process without a re-invoke', async () => {
+    // A workflow-body setAttributes before the first step resolves through
+    // an in-process replay: the same delivery commits attr_set, replays, and
+    // runs the step — no queue interaction. TTFS ends at the attr write, so
+    // the setAttributes call's duration is subtracted; here that detour is
+    // milliseconds, keeping ttfs ≈ the run's ULID backdate.
+    const backdateMs = 10_000;
+    const before = Date.now();
+    const first = await driveLatency({
+      runId: makeLatencyRunId(backdateMs),
+      source: attrThenStepWorkflow,
+    });
+    const elapsed = Date.now() - before;
+
+    // Everything happened in this one delivery: attr committed, step run,
+    // and nothing was enqueued (no re-invoke, no step dispatch).
+    const attrCreates = first.eventsCreate.mock.calls
+      .map((c) => c[1] as any)
+      .filter((d) => d.eventType === 'attr_set');
+    expect(attrCreates).toHaveLength(1);
+    expect(first.stepCompleted).toHaveLength(1);
+    expect(first.queued).toEqual([]);
+
+    const { ttfs, stso, optimizations } = first.stepCompleted[0].eventData;
+    expect(ttfs).toBeGreaterThanOrEqual(backdateMs);
+    expect(ttfs).toBeLessThanOrEqual(backdateMs + elapsed);
+    expect(stso).toBeUndefined();
+    // The attr detour does not end turbo: no resume invocation source
+    // exists, so the forced-optimistic fast path stays engaged.
+    expect(optimizations).toEqual([
+      'turbo',
+      'lazyStepStart',
+      'optimisticStart',
+    ]);
+  });
+
+  it('reports ttfs when a redelivery lands after a committed pre-step attr_set, ending the measurement at the attr write', async () => {
     // Both measurement endpoints are values this test controls (the run-id
     // ULID timestamp and the crafted attr occurredAt), so the expected ttfs
     // is exact — no wall-clock slack that a slow CI runner could exceed.
     const runCreatedAtMs = Date.now() - 10_000;
     const runId = `wrun_${ulid(runCreatedAtMs)}`;
 
-    // Invocation 1 (first delivery): commits attr_set and re-invokes —
-    // no step may run yet.
-    const first = await driveLatency({ runId, source: attrThenStepWorkflow });
-    expect(first.stepCompleted).toHaveLength(0);
-    const attrCreates = first.eventsCreate.mock.calls
+    // Harvest a replay-consumable attr_set by driving the workflow once:
+    // its correlationId is a deterministic replay ULID, so only an event
+    // captured from a real drive of the SAME run id resolves the
+    // setAttributes call on the next drive's replay.
+    const harvest = await driveLatency({
+      runId,
+      source: attrThenStepWorkflow,
+    });
+    const attrCreates = harvest.eventsCreate.mock.calls
       .map((c) => c[1] as any)
       .filter((d) => d.eventType === 'attr_set');
     expect(attrCreates).toHaveLength(1);
-    expect(
-      first.eventsCreate.mock.calls.some(
-        (c) => (c[1] as any).eventType === 'step_started'
-      )
-    ).toBe(false);
 
-    // Invocation 2 (queue continuation, no runInput): replays over the
-    // durable attr_set — stamped as written 7s after run creation — and runs
-    // the step. The measurement must end at the attr write: exactly 7s, NOT
-    // the full wall-clock distance to now (10s+).
+    // Simulate a redelivery landing after the attr_set was committed but
+    // before the first step ran: a fresh world seeded with only the attr
+    // event, stamped as written 7s after run creation. The measurement must
+    // end at the attr write: exactly 7s, NOT the full wall-clock distance
+    // to now (10s+).
     const attrOccurredAt = new Date(runCreatedAtMs + 7_000);
     const attrEvent = {
       ...attrCreates[0],
@@ -1998,14 +2022,14 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
       occurredAt: attrOccurredAt,
     } as Event;
 
-    const second = await driveLatency({
+    const redelivery = await driveLatency({
       runId,
       source: attrThenStepWorkflow,
       seedEvents: [attrEvent],
       withRunInput: false,
     });
-    expect(second.stepCompleted).toHaveLength(1);
-    const { ttfs, stso, optimizations } = second.stepCompleted[0].eventData;
+    expect(redelivery.stepCompleted).toHaveLength(1);
+    const { ttfs, stso, optimizations } = redelivery.stepCompleted[0].eventData;
     // ULID time encoding is millisecond-exact, so this is deterministic.
     expect(ttfs).toBe(+attrOccurredAt - runCreatedAtMs);
     expect(stso).toBeUndefined();

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1768,10 +1768,14 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     runId: string;
     source: string;
     attempt?: number;
+    /** Pre-existing durable log (an earlier invocation's writes). */
+    seedEvents?: Event[];
+    /** false simulates a queue continuation delivery (no runInput → no turbo). */
+    withRunInput?: boolean;
   }) {
     const { runId, source } = opts;
-    const durable: Event[] = [];
-    let seq = 0;
+    const durable: Event[] = [...(opts.seedEvents ?? [])];
+    let seq = durable.length;
     const rec = (data: any): Event => {
       seq += 1;
       const e = {
@@ -1796,7 +1800,8 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
 
     const eventsCreate = vi.fn(async (_runId: string, data: any) => {
       if (data.eventType === 'run_started') {
-        return { run: runEntity, events: [] as Event[] };
+        // Preload mirrors the real server: the durable log as of now.
+        return { run: runEntity, events: [...durable] };
       }
       if (data.eventType === 'step_started') {
         const d = data.eventData as { stepName?: string; input?: unknown };
@@ -1836,18 +1841,22 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
               {
                 runId,
                 requestedAt: new Date(),
-                runInput: {
-                  input: await dehydrateWorkflowArguments(
-                    [],
-                    runId,
-                    undefined,
-                    []
-                  ),
-                  deploymentId: 'test-deployment',
-                  workflowName: 'workflow',
-                  specVersion: SPEC_VERSION_CURRENT,
-                  executionContext: {},
-                },
+                ...(opts.withRunInput === false
+                  ? {}
+                  : {
+                      runInput: {
+                        input: await dehydrateWorkflowArguments(
+                          [],
+                          runId,
+                          undefined,
+                          []
+                        ),
+                        deploymentId: 'test-deployment',
+                        workflowName: 'workflow',
+                        specVersion: SPEC_VERSION_CURRENT,
+                        executionContext: {},
+                      },
+                    }),
               },
               {
                 requestId: 'req_latency',
@@ -1880,7 +1889,7 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     const stepCompleted = eventsCreate.mock.calls
       .map((c) => c[1] as any)
       .filter((d) => d.eventType === 'step_completed');
-    return { stepCompleted };
+    return { stepCompleted, eventsCreate };
   }
 
   it('attaches ttfs to the first step and stso to the next back-to-back step (turbo)', async () => {
@@ -1939,5 +1948,66 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     expect(stepCompleted[0].eventData.ttfs).toBeUndefined();
     expect(stepCompleted[0].eventData.stso).toBeUndefined();
     expect(stepCompleted[0].eventData.optimizations).toBeUndefined();
+  });
+
+  it('reports ttfs across a pre-step setAttributes, ending the measurement at the attr write', async () => {
+    // A workflow-body setAttributes before the first step: the attribute
+    // suspension re-invokes through the queue before any step runs (see the
+    // hasAttributeEvents branch in the orchestrator), so the first step
+    // executes in a LATER invocation whose log already holds the attr_set.
+    // TTFS must still be reported, anchored run-creation → the attr write
+    // (the setAttributes call's duration — including the queue hop — is
+    // subtracted by ending the measurement there).
+    const attrThenStepWorkflow = `const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("latStepOne");
+      const setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
+      async function workflow() {
+        await setAttributes([{ key: "k", value: "v" }]);
+        return await s1();
+      }${latXform('workflow')}`;
+
+    const runBackdateMs = 10_000;
+    const runId = makeLatencyRunId(runBackdateMs);
+
+    // Invocation 1 (first delivery): commits attr_set and re-invokes —
+    // no step may run yet.
+    const first = await driveLatency({ runId, source: attrThenStepWorkflow });
+    expect(first.stepCompleted).toHaveLength(0);
+    const attrCreates = first.eventsCreate.mock.calls
+      .map((c) => c[1] as any)
+      .filter((d) => d.eventType === 'attr_set');
+    expect(attrCreates).toHaveLength(1);
+    expect(
+      first.eventsCreate.mock.calls.some(
+        (c) => (c[1] as any).eventType === 'step_started'
+      )
+    ).toBe(false);
+
+    // Invocation 2 (queue continuation, no runInput): replays over the
+    // durable attr_set — stamped as written 7s after run creation — and runs
+    // the step. The measurement must end at the attr write: ~7s, NOT the
+    // full wall-clock distance to now (~10s+).
+    const attrWriteBackdateMs = 3_000;
+    const attrEvent = {
+      ...attrCreates[0],
+      eventId: 'e-attr-1',
+      runId,
+      createdAt: new Date(Date.now() - attrWriteBackdateMs),
+      occurredAt: new Date(Date.now() - attrWriteBackdateMs),
+    } as Event;
+
+    const second = await driveLatency({
+      runId,
+      source: attrThenStepWorkflow,
+      seedEvents: [attrEvent],
+      withRunInput: false,
+    });
+    expect(second.stepCompleted).toHaveLength(1);
+    const { ttfs, stso, optimizations } = second.stepCompleted[0].eventData;
+    const expectedTtfs = runBackdateMs - attrWriteBackdateMs;
+    expect(ttfs).toBeGreaterThanOrEqual(expectedTtfs - 100);
+    expect(ttfs).toBeLessThanOrEqual(expectedTtfs + 1_000);
+    expect(stso).toBeUndefined();
+    // Continuation delivery is not turbo.
+    expect(optimizations).toEqual(['lazyStepStart']);
   });
 });

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1965,8 +1965,11 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
         return await s1();
       }${latXform('workflow')}`;
 
-    const runBackdateMs = 10_000;
-    const runId = makeLatencyRunId(runBackdateMs);
+    // Both measurement endpoints are values this test controls (the run-id
+    // ULID timestamp and the crafted attr occurredAt), so the expected ttfs
+    // is exact — no wall-clock slack that a slow CI runner could exceed.
+    const runCreatedAtMs = Date.now() - 10_000;
+    const runId = `wrun_${ulid(runCreatedAtMs)}`;
 
     // Invocation 1 (first delivery): commits attr_set and re-invokes —
     // no step may run yet.
@@ -1984,15 +1987,15 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
 
     // Invocation 2 (queue continuation, no runInput): replays over the
     // durable attr_set — stamped as written 7s after run creation — and runs
-    // the step. The measurement must end at the attr write: ~7s, NOT the
-    // full wall-clock distance to now (~10s+).
-    const attrWriteBackdateMs = 3_000;
+    // the step. The measurement must end at the attr write: exactly 7s, NOT
+    // the full wall-clock distance to now (10s+).
+    const attrOccurredAt = new Date(runCreatedAtMs + 7_000);
     const attrEvent = {
       ...attrCreates[0],
       eventId: 'e-attr-1',
       runId,
-      createdAt: new Date(Date.now() - attrWriteBackdateMs),
-      occurredAt: new Date(Date.now() - attrWriteBackdateMs),
+      createdAt: attrOccurredAt,
+      occurredAt: attrOccurredAt,
     } as Event;
 
     const second = await driveLatency({
@@ -2003,9 +2006,8 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     });
     expect(second.stepCompleted).toHaveLength(1);
     const { ttfs, stso, optimizations } = second.stepCompleted[0].eventData;
-    const expectedTtfs = runBackdateMs - attrWriteBackdateMs;
-    expect(ttfs).toBeGreaterThanOrEqual(expectedTtfs - 100);
-    expect(ttfs).toBeLessThanOrEqual(expectedTtfs + 1_000);
+    // ULID time encoding is millisecond-exact, so this is deterministic.
+    expect(ttfs).toBe(+attrOccurredAt - runCreatedAtMs);
     expect(stso).toBeUndefined();
     // Continuation delivery is not turbo.
     expect(optimizations).toEqual(['lazyStepStart']);

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -51,7 +51,9 @@ import {
   handleReplayBudgetExhausted,
   ReplayBudget,
 } from './runtime/replay-budget.js';
+import { runIdCreatedAt } from './runtime/run-id-time.js';
 import { executeStep } from './runtime/step-executor.js';
+import { computeStepLatencyTracking } from './runtime/step-latency.js';
 import { handleSuspension } from './runtime/suspension-handler.js';
 import { getWaitContinuationDispatch } from './runtime/wait-continuation.js';
 import {
@@ -533,6 +535,19 @@ export function workflowEntrypoint(
                   let workflowStartedAt = -1;
                   let preloadedEvents: Event[] | undefined;
                   let preloadedEventsCursor: string | null | undefined;
+
+                  // Latency telemetry (TTFS) state — see runtime/step-latency.ts.
+                  // Whether this invocation's FIRST event snapshot contained
+                  // nothing beyond run_created/run_started: anything else was
+                  // written by an earlier invocation, whose contribution to
+                  // time-to-first-step (including the queue hop back here)
+                  // cannot be measured wall-clock, so TTFS is not reported.
+                  // Set once, on the first iteration's loaded snapshot.
+                  let invocationStartedClean: boolean | undefined;
+                  // Wall-clock ms spent committing hook_created events before
+                  // the first step ran, accumulated across suspension passes
+                  // and subtracted from TTFS.
+                  let preStepBlockingMs = 0;
 
                   // Turbo mode fast-paths the very first delivery of the very
                   // first invocation, where it is provably safe to: background
@@ -1238,6 +1253,16 @@ export function workflowEntrypoint(
                       // Update cache reference (may have been set for first time)
                       cachedEvents = events;
 
+                      // Latency telemetry: judge TTFS eligibility against the
+                      // invocation's first snapshot. Waits completed above
+                      // would already disqualify via the event-type check, so
+                      // evaluating after the wait pass is equivalent.
+                      invocationStartedClean ??= events.every(
+                        (e) =>
+                          e.eventType === 'run_created' ||
+                          e.eventType === 'run_started'
+                      );
+
                       // Snapshot the cursor as it stands for this iteration's
                       // event log, before any inline writes (step_created via
                       // handleSuspension, step_started/step_completed via
@@ -1417,6 +1442,7 @@ export function workflowEntrypoint(
                           });
                           return;
                         }
+                        preStepBlockingMs += suspensionResult.hookCreationMs;
                         runtimeLogger.debug('Suspension handled', {
                           workflowRunId: runId,
                           suspensionMs: Date.now() - suspensionStart,
@@ -1652,13 +1678,38 @@ export function workflowEntrypoint(
                         // bounded by the platform's function maxDuration, not the
                         // replay timeout — so the budget check at the top of the
                         // next loop iteration doesn't charge the step bodies.
+                        // Latency telemetry: decide whether this batch's first
+                        // step qualifies for TTFS/STSO measurement. Only the
+                        // batch's first step carries the tracking so a
+                        // parallel batch emits one sample per scheduling gap,
+                        // not one per sibling. Turbo's synthesized run
+                        // snapshot has a local-clock createdAt, so under
+                        // turbo only the run-id ULID timestamp is trusted.
+                        const latencyTracking = computeStepLatencyTracking({
+                          events: cachedEvents ?? [],
+                          invocationStartedClean:
+                            invocationStartedClean === true,
+                          runCreatedAtMs:
+                            runIdCreatedAt(runId) ??
+                            (turbo ? undefined : +workflowRun.createdAt),
+                          preStepBlockingMs,
+                          // This suspension's own hook/wait writes are not in
+                          // cachedEvents yet, so report them explicitly.
+                          suspensionHasWaits:
+                            err.waitCount > 0 ||
+                            suspensionResult.waitTimeout !== undefined,
+                          suspensionCreatedHooks:
+                            err.hookCount > 0 || suspensionResult.hasHookEvents,
+                          turbo,
+                        });
+
                         replayBudget.pause();
                         let stepResults: Awaited<
                           ReturnType<typeof executeStep>
                         >[];
                         try {
                           stepResults = await Promise.all(
-                            lazyInlineSteps.map((s) =>
+                            lazyInlineSteps.map((s, stepIndex) =>
                               executeStep({
                                 world,
                                 workflowRunId: runId,
@@ -1678,6 +1729,9 @@ export function workflowEntrypoint(
                                 // are undefined/false outside turbo.
                                 forceOptimisticStart,
                                 runReadyBarrier,
+                                ...(stepIndex === 0 && latencyTracking
+                                  ? { latencyTracking }
+                                  : {}),
                                 ...(requestInlineDelta && preInlineWriteCursor
                                   ? {
                                       inlineDeltaSinceCursor:

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -548,6 +548,13 @@ export function workflowEntrypoint(
                   // the first step ran, accumulated across suspension passes
                   // and subtracted from TTFS.
                   let preStepBlockingMs = 0;
+                  // Snapshot of the accumulator as of the suspension that
+                  // wrote the run's first attr_set (whose hook phase ran
+                  // before its attr writes). When a pre-step setAttributes
+                  // ends the TTFS measurement at the attr write, only hook
+                  // time from BEFORE that point may be subtracted — later
+                  // hook writes fall outside the measured window.
+                  let preStepBlockingBeforeAttrMs: number | undefined;
 
                   // Turbo mode fast-paths the very first delivery of the very
                   // first invocation, where it is provably safe to: background
@@ -559,8 +566,11 @@ export function workflowEntrypoint(
                   // delivery; `incomingStepId` would mark a background-step
                   // invocation and `replayDivergence` a recovery replay — both
                   // ineligible. The single-handler guarantee that makes forced
-                  // optimistic start safe ends once a hook/wait/attr is created,
-                  // so turbo exits at that point (see `forceOptimisticStart`).
+                  // optimistic start safe ends once a hook or wait is created
+                  // (they introduce resume invocations), so turbo exits at that
+                  // point (see `forceOptimisticStart`). Workflow attribute
+                  // writes introduce no such invocation source — they resolve
+                  // via an in-process replay and don't end turbo.
                   const turbo =
                     isTurboEnabled() &&
                     runInput !== undefined &&
@@ -600,7 +610,7 @@ export function workflowEntrypoint(
                   // (e.g. graphile-worker) a reschedule comes back as delivery
                   // attempt 1 — so turbo re-engages, skips the event-log load
                   // again, replays against an empty log, never observes the
-                  // hook/attr event this invocation just wrote, and re-suspends
+                  // hook event this invocation just wrote, and re-suspends
                   // forever (the run wedges). Under turbo we instead enqueue an
                   // explicit continuation that carries NO `runInput`, so the
                   // next delivery is a normal (non-turbo) load-and-replay that
@@ -1257,11 +1267,10 @@ export function workflowEntrypoint(
                       // invocation's first snapshot. Waits completed above
                       // would already disqualify via the event-type check, so
                       // evaluating after the wait pass is equivalent.
-                      // attr_set is permitted: an attribute suspension
-                      // re-invokes before steps run, so the invocation that
-                      // executes the first step loads the attr events — the
-                      // detour is subtracted via preStepAttrStartMs (see
-                      // runtime/step-latency.ts).
+                      // attr_set is permitted: a redelivery can land after a
+                      // committed pre-step attr_set, and the detour it marks
+                      // is subtracted via preStepAttrStartMs regardless of
+                      // which invocation wrote it (see runtime/step-latency.ts).
                       invocationStartedClean ??= events.every(
                         (e) =>
                           e.eventType === 'run_created' ||
@@ -1449,6 +1458,12 @@ export function workflowEntrypoint(
                           return;
                         }
                         preStepBlockingMs += suspensionResult.hookCreationMs;
+                        if (
+                          suspensionResult.hasAttributeEvents &&
+                          preStepBlockingBeforeAttrMs === undefined
+                        ) {
+                          preStepBlockingBeforeAttrMs = preStepBlockingMs;
+                        }
                         runtimeLogger.debug('Suspension handled', {
                           workflowRunId: runId,
                           suspensionMs: Date.now() - suspensionStart,
@@ -1466,13 +1481,22 @@ export function workflowEntrypoint(
                           return await reinvoke(0);
                         }
 
-                        // Native workflow attribute events are resolved through
-                        // replay. Re-invoke before processing pending steps:
-                        // in Promise.race([setAttributes(), step()]), the
-                        // durable attribute event can win without executing
-                        // the losing step.
+                        // Native workflow attribute events are resolved
+                        // through replay: the next loop iteration reloads the
+                        // log (now holding the just-committed attr_set) and
+                        // replays, resolving the setAttributes promise. Skip
+                        // step processing for this pass so that replay decides
+                        // races first — in Promise.race([setAttributes(),
+                        // step()]), the durable attribute event must be able
+                        // to win without executing the losing step. The replay
+                        // happens in-process rather than via a queue
+                        // re-invocation: unlike hooks and waits, an attr_set
+                        // introduces no out-of-band invocation source that the
+                        // handler would need to yield the message for, so
+                        // paying a delivery round-trip here would only add
+                        // latency before the workflow's next step.
                         if (suspensionResult.hasAttributeEvents) {
-                          return await reinvoke(0);
+                          continue;
                         }
 
                         const pendingSteps = suspensionResult.pendingSteps;
@@ -1652,14 +1676,17 @@ export function workflowEntrypoint(
 
                         // Turbo mode forces optimistic inline start for this
                         // batch — but only while the run is still "clean" (a pure
-                        // step suspension). The moment a hook or wait (or attr) is
+                        // step suspension). The moment a hook or wait is
                         // created, later resume/parallel invocations become
                         // possible, so the single-handler guarantee that makes
                         // forced optimistic start safe no longer holds — turbo
                         // exits and the steps take the normal (env-gated)
-                        // await-then-run path. The hook-conflict / attr cases
-                        // already returned early above and the awaited-hook case
-                        // emptied lazyInlineSteps; the checks below are defensive.
+                        // await-then-run path. The hook-conflict case already
+                        // returned early above, the attr case continued into a
+                        // fresh replay (so a batch-scheduling suspension never
+                        // carries attr events), and the awaited-hook case
+                        // emptied lazyInlineSteps; the checks below are
+                        // defensive.
                         //
                         // The `suspensionResult.*` flags only reflect what THIS
                         // batch created, so they do not catch a hook/wait opened
@@ -1699,6 +1726,7 @@ export function workflowEntrypoint(
                             runIdCreatedAt(runId) ??
                             (turbo ? undefined : +workflowRun.createdAt),
                           preStepBlockingMs,
+                          preStepBlockingBeforeAttrMs,
                           // This suspension's own hook/wait writes are not in
                           // cachedEvents yet, so report them explicitly.
                           suspensionHasWaits:

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1257,10 +1257,16 @@ export function workflowEntrypoint(
                       // invocation's first snapshot. Waits completed above
                       // would already disqualify via the event-type check, so
                       // evaluating after the wait pass is equivalent.
+                      // attr_set is permitted: an attribute suspension
+                      // re-invokes before steps run, so the invocation that
+                      // executes the first step loads the attr events — the
+                      // detour is subtracted via preStepAttrStartMs (see
+                      // runtime/step-latency.ts).
                       invocationStartedClean ??= events.every(
                         (e) =>
                           e.eventType === 'run_created' ||
-                          e.eventType === 'run_started'
+                          e.eventType === 'run_started' ||
+                          e.eventType === 'attr_set'
                       );
 
                       // Snapshot the cursor as it stands for this iteration's

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -611,6 +611,21 @@ export async function executeStep(
         lazyStepStart: params.lazyStepInput !== undefined,
         optimisticStart,
       });
+      if (latencyEventData) {
+        // Mirror the latency telemetry onto the step span so traces show
+        // TTFS/STSO alongside the flame graph, not just Datadog metrics.
+        span?.setAttributes({
+          ...(latencyEventData.ttfs !== undefined
+            ? Attribute.StepTtfsMs(latencyEventData.ttfs)
+            : {}),
+          ...(latencyEventData.stso !== undefined
+            ? Attribute.StepStsoMs(latencyEventData.stso)
+            : {}),
+          ...Attribute.StepLatencyOptimizations(
+            latencyEventData.optimizations ?? []
+          ),
+        });
+      }
       try {
         result = await trace('step.execute', {}, async () => {
           return await contextStorage.run(

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -44,6 +44,11 @@ import {
 } from './constants.js';
 import { getPortLazy } from './get-port-lazy.js';
 import { memoizeEncryptionKey } from './helpers.js';
+import {
+  computeStepLatencyEventData,
+  type StepLatencyEventData,
+  type StepLatencyTracking,
+} from './step-latency.js';
 import { safeWaitUntil } from './wait-until.js';
 
 const DEFAULT_STEP_MAX_RETRIES = 3;
@@ -124,6 +129,15 @@ export interface StepExecutorParams {
    * outside turbo, where `run_started` was already awaited up front.
    */
   runReadyBarrier?: Promise<unknown>;
+  /**
+   * Latency telemetry (TTFS / STSO): eligibility and anchor timestamps decided
+   * by the orchestrator. When set, this executor computes the final values
+   * against the wall clock taken immediately before user code runs and
+   * attaches them to the step's terminal event. Set only for the first step of
+   * an inline batch, and only on first-attempt executions that qualify — see
+   * runtime/step-latency.ts.
+   */
+  latencyTracking?: StepLatencyTracking;
 }
 
 /**
@@ -531,6 +545,11 @@ export async function executeStep(
     const ops: Promise<void>[] = [];
     let opsSettled = true;
 
+    // Latency telemetry to attach to this step's terminal event. Computed
+    // right before user code runs; declared here so the failure path (the
+    // catch below) can attach it to step_failed too.
+    let latencyEventData: StepLatencyEventData | undefined;
+
     try {
       const attempt = step.attempt;
 
@@ -585,6 +604,13 @@ export async function executeStep(
       let userCodeFailed = false;
 
       const executionStartTime = Date.now();
+      latencyEventData = computeStepLatencyEventData({
+        tracking: params.latencyTracking,
+        stepCodeStartedAtMs: executionStartTime,
+        attempt,
+        lazyStepStart: params.lazyStepInput !== undefined,
+        optimisticStart,
+      });
       try {
         result = await trace('step.execute', {}, async () => {
           return await contextStorage.run(
@@ -816,6 +842,7 @@ export async function executeStep(
                 globalThis,
                 compression
               ),
+              ...latencyEventData,
             },
           });
         } catch (stepFailErr) {
@@ -884,6 +911,7 @@ export async function executeStep(
                 globalThis,
                 compression
               ),
+              ...latencyEventData,
             },
           });
         } catch (stepFailErr) {
@@ -995,6 +1023,7 @@ export async function executeStep(
             stepName,
             workflowName,
             result: result as Uint8Array,
+            ...latencyEventData,
           },
         },
         params.inlineDeltaSinceCursor !== undefined

--- a/packages/core/src/runtime/step-latency.test.ts
+++ b/packages/core/src/runtime/step-latency.test.ts
@@ -59,7 +59,6 @@ describe('computeStepLatencyTracking', () => {
     'hook_received',
     'wait_created',
     'wait_completed',
-    'attr_set',
     'step_created',
     'step_started',
     'step_retrying',
@@ -82,6 +81,42 @@ describe('computeStepLatencyTracking', () => {
       preStepBlockingMs: 42,
       turbo: false,
     });
+  });
+
+  it('keeps TTFS eligible across a pre-step attr_set, ending the measurement at the first attr write', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [
+        makeEvent('run_started'),
+        makeEvent('attr_set', {
+          createdAt: new Date(3_100),
+          occurredAt: new Date(3_000),
+        }),
+        makeEvent('attr_set', {
+          createdAt: new Date(4_000),
+          occurredAt: new Date(3_900),
+        }),
+      ],
+    });
+    expect(tracking).toEqual({
+      ttfsAnchorMs: 1_000,
+      preStepBlockingMs: 0,
+      // Earliest attr write wins; occurredAt preferred over createdAt.
+      preStepAttrStartMs: 3_000,
+      turbo: false,
+    });
+  });
+
+  it('disqualifies TTFS when both a hook_created and an attr_set precede the step (hook time unmeasurable across the attr re-invoke)', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [
+        makeEvent('run_started'),
+        makeEvent('hook_created'),
+        makeEvent('attr_set', { occurredAt: new Date(3_000) }),
+      ],
+    });
+    expect(tracking).toBeUndefined();
   });
 
   it('disqualifies TTFS when the invocation did not start clean (events written by an earlier invocation)', () => {
@@ -171,6 +206,23 @@ describe('computeStepLatencyEventData', () => {
       ttfs: 800,
       optimizations: ['turbo', 'lazyStepStart', 'optimisticStart'],
     });
+  });
+
+  it('ends ttfs at the pre-step attr write instead of the step code start', () => {
+    const data = computeStepLatencyEventData({
+      tracking: {
+        ttfsAnchorMs: 1_000,
+        preStepBlockingMs: 0,
+        preStepAttrStartMs: 3_000,
+        turbo: false,
+      },
+      // Includes the setAttributes re-invoke round-trip — must be excluded.
+      stepCodeStartedAtMs: 60_000,
+      attempt: 1,
+      lazyStepStart: true,
+      optimisticStart: false,
+    });
+    expect(data).toEqual({ ttfs: 2_000, optimizations: ['lazyStepStart'] });
   });
 
   it('computes stso against the previous step terminal timestamp', () => {

--- a/packages/core/src/runtime/step-latency.test.ts
+++ b/packages/core/src/runtime/step-latency.test.ts
@@ -236,21 +236,24 @@ describe('computeStepLatencyEventData', () => {
     });
   });
 
-  it('ends ttfs at the pre-step attr write instead of the step code start', () => {
+  it('ends ttfs at the pre-step attr write instead of the step code start, still subtracting pre-attr hook time', () => {
     const data = computeStepLatencyEventData({
       tracking: {
         ttfsAnchorMs: 1_000,
-        preStepBlockingMs: 0,
+        // Hook time from before the attr write (computeStepLatencyTracking
+        // guarantees this excludes post-attr hook writes) — inside the
+        // measured window, so it must still be subtracted.
+        preStepBlockingMs: 40,
         preStepAttrStartMs: 3_000,
         turbo: false,
       },
-      // Includes the setAttributes re-invoke round-trip — must be excluded.
+      // Includes the setAttributes detour — must be excluded.
       stepCodeStartedAtMs: 60_000,
       attempt: 1,
       lazyStepStart: true,
       optimisticStart: false,
     });
-    expect(data).toEqual({ ttfs: 2_000, optimizations: ['lazyStepStart'] });
+    expect(data).toEqual({ ttfs: 1_960, optimizations: ['lazyStepStart'] });
   });
 
   it('computes stso against the previous step terminal timestamp', () => {

--- a/packages/core/src/runtime/step-latency.test.ts
+++ b/packages/core/src/runtime/step-latency.test.ts
@@ -1,0 +1,224 @@
+import type { Event } from '@workflow/world';
+import { describe, expect, it } from 'vitest';
+import {
+  computeStepLatencyEventData,
+  computeStepLatencyTracking,
+} from './step-latency.js';
+
+const RUN_ID = 'wrun_test';
+
+function makeEvent(
+  eventType: Event['eventType'],
+  overrides: { createdAt?: Date; occurredAt?: Date } = {}
+): Event {
+  return {
+    eventId: `e-${Math.random().toString(36).slice(2)}`,
+    runId: RUN_ID,
+    eventType,
+    createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
+    ...(overrides.occurredAt ? { occurredAt: overrides.occurredAt } : {}),
+  } as Event;
+}
+
+const BASE = {
+  invocationStartedClean: true,
+  runCreatedAtMs: 1_000,
+  preStepBlockingMs: 0,
+  suspensionHasWaits: false,
+  suspensionCreatedHooks: false,
+  turbo: false,
+};
+
+describe('computeStepLatencyTracking', () => {
+  it('marks TTFS-eligible on a clean first-step log (run events only)', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('run_created'), makeEvent('run_started')],
+    });
+    expect(tracking).toEqual({
+      ttfsAnchorMs: 1_000,
+      preStepBlockingMs: 0,
+      turbo: false,
+    });
+  });
+
+  it('marks TTFS-eligible on an empty log (turbo skip-preload)', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [],
+      turbo: true,
+    });
+    expect(tracking).toEqual({
+      ttfsAnchorMs: 1_000,
+      preStepBlockingMs: 0,
+      turbo: true,
+    });
+  });
+
+  it.each([
+    'hook_received',
+    'wait_created',
+    'wait_completed',
+    'attr_set',
+    'step_created',
+    'step_started',
+    'step_retrying',
+  ] as const)('disqualifies TTFS when a %s event precedes the step', (type) => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('run_started'), makeEvent(type)],
+    });
+    expect(tracking?.ttfsAnchorMs).toBeUndefined();
+  });
+
+  it('keeps TTFS eligible when only a hook_created precedes the step (its write time is subtracted instead)', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('run_started'), makeEvent('hook_created')],
+      preStepBlockingMs: 42,
+    });
+    expect(tracking).toEqual({
+      ttfsAnchorMs: 1_000,
+      preStepBlockingMs: 42,
+      turbo: false,
+    });
+  });
+
+  it('disqualifies TTFS when the invocation did not start clean (events written by an earlier invocation)', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('run_started')],
+      invocationStartedClean: false,
+    });
+    expect(tracking).toBeUndefined();
+  });
+
+  it('disqualifies TTFS when run creation time is unrecoverable', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('run_started')],
+      runCreatedAtMs: undefined,
+    });
+    expect(tracking).toBeUndefined();
+  });
+
+  it('disqualifies TTFS when this suspension also created a wait', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('run_started')],
+      suspensionHasWaits: true,
+    });
+    expect(tracking).toBeUndefined();
+  });
+
+  it('marks STSO-eligible when the last event is a step terminal, preferring occurredAt', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [
+        makeEvent('run_started'),
+        makeEvent('step_started'),
+        makeEvent('step_completed', {
+          createdAt: new Date(5_000),
+          occurredAt: new Date(4_500),
+        }),
+      ],
+    });
+    // step events disqualify TTFS but qualify STSO.
+    expect(tracking).toEqual({ prevStepEndMs: 4_500, turbo: false });
+  });
+
+  it('falls back to createdAt for STSO when occurredAt is absent', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('step_failed', { createdAt: new Date(5_000) })],
+    });
+    expect(tracking).toEqual({ prevStepEndMs: 5_000, turbo: false });
+  });
+
+  it('does not mark STSO when the last event is not a step terminal', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('step_completed'), makeEvent('hook_received')],
+      invocationStartedClean: false,
+    });
+    expect(tracking).toBeUndefined();
+  });
+
+  it.each([
+    ['waits', { suspensionHasWaits: true, suspensionCreatedHooks: false }],
+    ['hooks', { suspensionHasWaits: false, suspensionCreatedHooks: true }],
+  ])('does not mark STSO when this suspension also created %s', (_label, overrides) => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [makeEvent('step_completed')],
+      invocationStartedClean: false,
+      ...overrides,
+    });
+    expect(tracking).toBeUndefined();
+  });
+});
+
+describe('computeStepLatencyEventData', () => {
+  it('computes ttfs minus pre-step blocking time and reports optimizations', () => {
+    const data = computeStepLatencyEventData({
+      tracking: { ttfsAnchorMs: 1_000, preStepBlockingMs: 200, turbo: true },
+      stepCodeStartedAtMs: 2_000,
+      attempt: 1,
+      lazyStepStart: true,
+      optimisticStart: true,
+    });
+    expect(data).toEqual({
+      ttfs: 800,
+      optimizations: ['turbo', 'lazyStepStart', 'optimisticStart'],
+    });
+  });
+
+  it('computes stso against the previous step terminal timestamp', () => {
+    const data = computeStepLatencyEventData({
+      tracking: { prevStepEndMs: 1_500, turbo: false },
+      stepCodeStartedAtMs: 2_000,
+      attempt: 1,
+      lazyStepStart: true,
+      optimisticStart: false,
+    });
+    expect(data).toEqual({ stso: 500, optimizations: ['lazyStepStart'] });
+  });
+
+  it('clamps negative durations (cross-machine clock skew) to zero', () => {
+    const data = computeStepLatencyEventData({
+      tracking: {
+        ttfsAnchorMs: 5_000,
+        preStepBlockingMs: 0,
+        prevStepEndMs: 5_000,
+        turbo: false,
+      },
+      stepCodeStartedAtMs: 4_000,
+      attempt: 1,
+      lazyStepStart: false,
+      optimisticStart: false,
+    });
+    expect(data).toEqual({ ttfs: 0, stso: 0, optimizations: [] });
+  });
+
+  it('reports nothing on a retry attempt', () => {
+    const data = computeStepLatencyEventData({
+      tracking: { ttfsAnchorMs: 1_000, preStepBlockingMs: 0, turbo: false },
+      stepCodeStartedAtMs: 2_000,
+      attempt: 2,
+      lazyStepStart: false,
+      optimisticStart: false,
+    });
+    expect(data).toBeUndefined();
+  });
+
+  it('reports nothing without tracking', () => {
+    const data = computeStepLatencyEventData({
+      tracking: undefined,
+      stepCodeStartedAtMs: 2_000,
+      attempt: 1,
+      lazyStepStart: true,
+      optimisticStart: true,
+    });
+    expect(data).toBeUndefined();
+  });
+});

--- a/packages/core/src/runtime/step-latency.test.ts
+++ b/packages/core/src/runtime/step-latency.test.ts
@@ -24,6 +24,7 @@ const BASE = {
   invocationStartedClean: true,
   runCreatedAtMs: 1_000,
   preStepBlockingMs: 0,
+  preStepBlockingBeforeAttrMs: undefined,
   suspensionHasWaits: false,
   suspensionCreatedHooks: false,
   turbo: false,
@@ -107,7 +108,7 @@ describe('computeStepLatencyTracking', () => {
     });
   });
 
-  it('disqualifies TTFS when both a hook_created and an attr_set precede the step (hook time unmeasurable across the attr re-invoke)', () => {
+  it('subtracts only pre-attr hook time when a hook and an attr both precede the step', () => {
     const tracking = computeStepLatencyTracking({
       ...BASE,
       events: [
@@ -115,8 +116,35 @@ describe('computeStepLatencyTracking', () => {
         makeEvent('hook_created'),
         makeEvent('attr_set', { occurredAt: new Date(3_000) }),
       ],
+      // Live accumulator includes a hook written AFTER the attr suspension —
+      // outside the attr-anchored measurement window.
+      preStepBlockingMs: 90,
+      preStepBlockingBeforeAttrMs: 40,
     });
-    expect(tracking).toBeUndefined();
+    expect(tracking).toEqual({
+      ttfsAnchorMs: 1_000,
+      preStepBlockingMs: 40,
+      preStepAttrStartMs: 3_000,
+      turbo: false,
+    });
+  });
+
+  it('subtracts no hook time when the attr_set came from a redelivery snapshot (no pre-attr snapshot)', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [
+        makeEvent('run_started'),
+        makeEvent('attr_set', { occurredAt: new Date(3_000) }),
+      ],
+      preStepBlockingMs: 90,
+      preStepBlockingBeforeAttrMs: undefined,
+    });
+    expect(tracking).toEqual({
+      ttfsAnchorMs: 1_000,
+      preStepBlockingMs: 0,
+      preStepAttrStartMs: 3_000,
+      turbo: false,
+    });
   });
 
   it('disqualifies TTFS when the invocation did not start clean (events written by an earlier invocation)', () => {

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -33,11 +33,11 @@ export interface StepLatencyTracking {
    * `occurredAt`, falling back to `createdAt`). When present, the TTFS
    * measurement ENDS here instead of at the step's code start: a
    * workflow-body `experimental_setAttributes` before the first step
-   * resolves through an immediate re-invoke (see the `hasAttributeEvents`
-   * branch in runtime.ts), so everything from this write until the step body
-   * runs is the duration of the setAttributes call — which is subtracted by
-   * ending the measurement at the point where the step would otherwise have
-   * been scheduled.
+   * resolves through an extra replay (see the `hasAttributeEvents` branch in
+   * runtime.ts), so everything from this write until the step body runs is
+   * the duration of the setAttributes call — which is subtracted by ending
+   * the measurement at the point where the step would otherwise have been
+   * scheduled.
    */
   preStepAttrStartMs?: number;
   /**
@@ -72,9 +72,8 @@ export interface StepLatencyEventData {
  *   commits in the same invocation, whose measured duration is subtracted via
  *   {@link StepLatencyTracking.preStepBlockingMs}.
  * - `attr_set` (workflow-body `experimental_setAttributes`): resolves through
- *   an immediate re-invoke before steps run, so its duration spans
- *   invocations. Subtracted by ending the measurement at the first attr
- *   write's timestamp instead — see
+ *   an extra replay before steps run. Subtracted by ending the measurement at
+ *   the first attr write's timestamp instead — see
  *   {@link StepLatencyTracking.preStepAttrStartMs}.
  */
 const TTFS_DISQUALIFYING_EVENT_TYPES: ReadonlySet<Event['eventType']> = new Set(
@@ -105,15 +104,25 @@ export function computeStepLatencyTracking(params: {
    * run_created/run_started/attr_set. Pre-existing hook events were written
    * by an earlier invocation, so the time they added (including the queue
    * hop back to this invocation) is unmeasurable and disqualifies TTFS.
-   * attr_set is permitted: an attribute suspension re-invokes before steps
-   * run, so the invocation that executes the first step legitimately loads
-   * the attr events — their detour is subtracted via `preStepAttrStartMs`.
+   * attr_set is permitted: a redelivery can land after a committed pre-step
+   * attr_set, and the detour it marks is subtracted via `preStepAttrStartMs`
+   * regardless of which invocation wrote it.
    */
   invocationStartedClean: boolean;
   /** Epoch ms of run creation, if recoverable. Absent disqualifies TTFS. */
   runCreatedAtMs: number | undefined;
   /** See {@link StepLatencyTracking.preStepBlockingMs}. */
   preStepBlockingMs: number;
+  /**
+   * The accumulator's value as of the suspension that wrote the run's first
+   * attr_set (its hook phase runs before its attr writes). When the
+   * measurement ends at the attr write, only hook time from before that
+   * point may be subtracted — later hook writes fall outside the measured
+   * window. Undefined when no attr suspension happened in this invocation
+   * (e.g. the attr_set was loaded from a redelivery's snapshot, where no
+   * same-invocation hook time precedes it).
+   */
+  preStepBlockingBeforeAttrMs: number | undefined;
   /**
    * Whether the suspension that scheduled this batch also created waits.
    * Those `wait_created` writes are not in `events` yet (they were committed
@@ -139,28 +148,18 @@ export function computeStepLatencyTracking(params: {
     !params.suspensionHasWaits;
   let preStepAttrStartMs: number | undefined;
   if (ttfsEligible) {
-    let sawHookCreated = false;
     for (const event of events) {
       if (TTFS_DISQUALIFYING_EVENT_TYPES.has(event.eventType)) {
         ttfsEligible = false;
         break;
       }
-      if (event.eventType === 'hook_created') {
-        sawHookCreated = true;
-      } else if (event.eventType === 'attr_set') {
+      if (event.eventType === 'attr_set') {
         const attrStartMs = +(event.occurredAt ?? event.createdAt);
         preStepAttrStartMs =
           preStepAttrStartMs === undefined
             ? attrStartMs
             : Math.min(preStepAttrStartMs, attrStartMs);
       }
-    }
-    // Hooks before an attr detour were committed by an EARLIER invocation
-    // (the attr re-invoke moved the first step to this one), so their write
-    // time is not in this invocation's preStepBlockingMs accumulator and
-    // would contaminate the measurement — disqualify the combination.
-    if (sawHookCreated && preStepAttrStartMs !== undefined) {
-      ttfsEligible = false;
     }
   }
 
@@ -188,7 +187,12 @@ export function computeStepLatencyTracking(params: {
     ...(ttfsEligible
       ? {
           ttfsAnchorMs: params.runCreatedAtMs,
-          preStepBlockingMs: params.preStepBlockingMs,
+          // When the measurement ends at the first attr write, only hook
+          // time from before that point is inside the measured window.
+          preStepBlockingMs:
+            preStepAttrStartMs !== undefined
+              ? (params.preStepBlockingBeforeAttrMs ?? 0)
+              : params.preStepBlockingMs,
           ...(preStepAttrStartMs !== undefined ? { preStepAttrStartMs } : {}),
         }
       : {}),

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -226,13 +226,18 @@ export function computeStepLatencyEventData(params: {
   // write instead of the step's code start — the remainder is the duration
   // of the setAttributes call (resolved via re-invoke), which is subtracted
   // rather than disqualifying the sample.
+  const attrDetour = tracking.preStepAttrStartMs !== undefined;
   const ttfsEndMs = tracking.preStepAttrStartMs ?? params.stepCodeStartedAtMs;
+  // `preStepBlockingMs` measures hook writes committed by the invocation that
+  // schedules the first step. In an attr detour the measurement window ends
+  // at the first attr write (in an EARLIER invocation), so any hook writes
+  // this invocation reports happened strictly AFTER the window closed —
+  // subtracting them would contaminate the metric. Only subtract when there
+  // is no attr detour and the hook writes fall inside the window.
+  const preStepBlockingMs = attrDetour ? 0 : (tracking.preStepBlockingMs ?? 0);
   const ttfs =
     tracking.ttfsAnchorMs !== undefined
-      ? Math.max(
-          0,
-          ttfsEndMs - tracking.ttfsAnchorMs - (tracking.preStepBlockingMs ?? 0)
-        )
+      ? Math.max(0, ttfsEndMs - tracking.ttfsAnchorMs - preStepBlockingMs)
       : undefined;
   const stso =
     tracking.prevStepEndMs !== undefined

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -29,6 +29,18 @@ export interface StepLatencyTracking {
    */
   preStepBlockingMs?: number;
   /**
+   * Epoch ms the first pre-step `attr_set` write began (its client-stamped
+   * `occurredAt`, falling back to `createdAt`). When present, the TTFS
+   * measurement ENDS here instead of at the step's code start: a
+   * workflow-body `experimental_setAttributes` before the first step
+   * resolves through an immediate re-invoke (see the `hasAttributeEvents`
+   * branch in runtime.ts), so everything from this write until the step body
+   * runs is the duration of the setAttributes call — which is subtracted by
+   * ending the measurement at the point where the step would otherwise have
+   * been scheduled.
+   */
+  preStepAttrStartMs?: number;
+  /**
    * Epoch ms the previous step's terminal event was recorded (its
    * client-stamped `occurredAt`, falling back to `createdAt`). Present only
    * when the step qualifies for STSO.
@@ -53,14 +65,17 @@ export interface StepLatencyEventData {
  * - `hook_received` / `wait_created` / `wait_completed` mean the run's path to
  *   the first step depended on user-driven timing (a webhook arriving, a
  *   sleep elapsing), so the measurement would not reflect runtime overhead.
- * - `attr_set` (workflow-body `experimental_setAttributes`) forces a re-invoke
- *   through the queue before steps run, a detour whose duration spans
- *   invocations and cannot be measured wall-clock — so it disqualifies rather
- *   than subtracts.
  *
- * `hook_created` is deliberately absent: a fire-and-forget `createHook()`
- * before the first step commits in the same invocation, whose measured
- * duration is subtracted via {@link StepLatencyTracking.preStepBlockingMs}.
+ * Deliberately absent, with their cost subtracted instead:
+ *
+ * - `hook_created`: a fire-and-forget `createHook()` before the first step
+ *   commits in the same invocation, whose measured duration is subtracted via
+ *   {@link StepLatencyTracking.preStepBlockingMs}.
+ * - `attr_set` (workflow-body `experimental_setAttributes`): resolves through
+ *   an immediate re-invoke before steps run, so its duration spans
+ *   invocations. Subtracted by ending the measurement at the first attr
+ *   write's timestamp instead — see
+ *   {@link StepLatencyTracking.preStepAttrStartMs}.
  */
 const TTFS_DISQUALIFYING_EVENT_TYPES: ReadonlySet<Event['eventType']> = new Set(
   [
@@ -72,7 +87,6 @@ const TTFS_DISQUALIFYING_EVENT_TYPES: ReadonlySet<Event['eventType']> = new Set(
     'hook_received',
     'wait_created',
     'wait_completed',
-    'attr_set',
   ]
 );
 
@@ -88,9 +102,12 @@ export function computeStepLatencyTracking(params: {
   events: Event[];
   /**
    * Whether this invocation's initial event load contained nothing beyond
-   * run_created/run_started. Pre-existing hook/attr events were written by an
-   * earlier invocation, so the time they added (including the queue hop back
-   * to this invocation) is unmeasurable and disqualifies TTFS.
+   * run_created/run_started/attr_set. Pre-existing hook events were written
+   * by an earlier invocation, so the time they added (including the queue
+   * hop back to this invocation) is unmeasurable and disqualifies TTFS.
+   * attr_set is permitted: an attribute suspension re-invokes before steps
+   * run, so the invocation that executes the first step legitimately loads
+   * the attr events — their detour is subtracted via `preStepAttrStartMs`.
    */
   invocationStartedClean: boolean;
   /** Epoch ms of run creation, if recoverable. Absent disqualifies TTFS. */
@@ -120,12 +137,30 @@ export function computeStepLatencyTracking(params: {
     params.invocationStartedClean &&
     params.runCreatedAtMs !== undefined &&
     !params.suspensionHasWaits;
+  let preStepAttrStartMs: number | undefined;
   if (ttfsEligible) {
+    let sawHookCreated = false;
     for (const event of events) {
       if (TTFS_DISQUALIFYING_EVENT_TYPES.has(event.eventType)) {
         ttfsEligible = false;
         break;
       }
+      if (event.eventType === 'hook_created') {
+        sawHookCreated = true;
+      } else if (event.eventType === 'attr_set') {
+        const attrStartMs = +(event.occurredAt ?? event.createdAt);
+        preStepAttrStartMs =
+          preStepAttrStartMs === undefined
+            ? attrStartMs
+            : Math.min(preStepAttrStartMs, attrStartMs);
+      }
+    }
+    // Hooks before an attr detour were committed by an EARLIER invocation
+    // (the attr re-invoke moved the first step to this one), so their write
+    // time is not in this invocation's preStepBlockingMs accumulator and
+    // would contaminate the measurement — disqualify the combination.
+    if (sawHookCreated && preStepAttrStartMs !== undefined) {
+      ttfsEligible = false;
     }
   }
 
@@ -154,6 +189,7 @@ export function computeStepLatencyTracking(params: {
       ? {
           ttfsAnchorMs: params.runCreatedAtMs,
           preStepBlockingMs: params.preStepBlockingMs,
+          ...(preStepAttrStartMs !== undefined ? { preStepAttrStartMs } : {}),
         }
       : {}),
     ...(prevStepEndMs !== undefined ? { prevStepEndMs } : {}),
@@ -185,13 +221,17 @@ export function computeStepLatencyEventData(params: {
 
   // Clamp at 0: cross-invocation timestamps can come from another machine's
   // clock, so small skews must not produce negative durations.
+  //
+  // A pre-step setAttributes detour ends the measurement at the first attr
+  // write instead of the step's code start — the remainder is the duration
+  // of the setAttributes call (resolved via re-invoke), which is subtracted
+  // rather than disqualifying the sample.
+  const ttfsEndMs = tracking.preStepAttrStartMs ?? params.stepCodeStartedAtMs;
   const ttfs =
     tracking.ttfsAnchorMs !== undefined
       ? Math.max(
           0,
-          params.stepCodeStartedAtMs -
-            tracking.ttfsAnchorMs -
-            (tracking.preStepBlockingMs ?? 0)
+          ttfsEndMs - tracking.ttfsAnchorMs - (tracking.preStepBlockingMs ?? 0)
         )
       : undefined;
   const stso =

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -228,20 +228,18 @@ export function computeStepLatencyEventData(params: {
   //
   // A pre-step setAttributes detour ends the measurement at the first attr
   // write instead of the step's code start — the remainder is the duration
-  // of the setAttributes call (resolved via re-invoke), which is subtracted
-  // rather than disqualifying the sample.
-  const attrDetour = tracking.preStepAttrStartMs !== undefined;
+  // of the setAttributes call (resolved via an extra replay), which is
+  // subtracted rather than disqualifying the sample. In that case
+  // `tracking.preStepBlockingMs` already holds only the hook time from
+  // BEFORE the attr write — hook writes after the window closed are excluded
+  // by computeStepLatencyTracking (see preStepBlockingBeforeAttrMs).
   const ttfsEndMs = tracking.preStepAttrStartMs ?? params.stepCodeStartedAtMs;
-  // `preStepBlockingMs` measures hook writes committed by the invocation that
-  // schedules the first step. In an attr detour the measurement window ends
-  // at the first attr write (in an EARLIER invocation), so any hook writes
-  // this invocation reports happened strictly AFTER the window closed —
-  // subtracting them would contaminate the metric. Only subtract when there
-  // is no attr detour and the hook writes fall inside the window.
-  const preStepBlockingMs = attrDetour ? 0 : (tracking.preStepBlockingMs ?? 0);
   const ttfs =
     tracking.ttfsAnchorMs !== undefined
-      ? Math.max(0, ttfsEndMs - tracking.ttfsAnchorMs - preStepBlockingMs)
+      ? Math.max(
+          0,
+          ttfsEndMs - tracking.ttfsAnchorMs - (tracking.preStepBlockingMs ?? 0)
+        )
       : undefined;
   const stso =
     tracking.prevStepEndMs !== undefined

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -1,0 +1,216 @@
+import type { Event } from '@workflow/world';
+
+/**
+ * Client-side latency measurement (TTFS / STSO) threaded from the
+ * orchestrator's inline execution path into `executeStep`.
+ *
+ * TTFS (time-to-first-step) measures run creation → the first step's body
+ * beginning to execute. STSO (step-to-step overhead) measures the previous
+ * step's terminal event → the next step's body beginning to execute. Both are
+ * attached to the step's terminal event so a backend can emit latency metrics
+ * from the event write alone, without extra event-log queries.
+ *
+ * Eligibility is decided by the orchestrator (which owns the event log) via
+ * {@link computeStepLatencyTracking}; the final values are computed by
+ * `executeStep` right before user code runs via
+ * {@link computeStepLatencyEventData}.
+ */
+export interface StepLatencyTracking {
+  /**
+   * Epoch ms of run creation (from the run-id ULID, falling back to the run
+   * snapshot's `createdAt`). Present only when the step qualifies for TTFS.
+   */
+  ttfsAnchorMs?: number;
+  /**
+   * Wall-clock ms this invocation spent committing `hook_created` events
+   * before the first step (fire-and-forget `createHook()` ahead of the first
+   * step commits in the same suspension batch). Subtracted from TTFS so the
+   * metric reflects runtime overhead rather than the user's hook writes.
+   */
+  preStepBlockingMs?: number;
+  /**
+   * Epoch ms the previous step's terminal event was recorded (its
+   * client-stamped `occurredAt`, falling back to `createdAt`). Present only
+   * when the step qualifies for STSO.
+   */
+  prevStepEndMs?: number;
+  /** Whether turbo mode is active for this invocation. */
+  turbo: boolean;
+}
+
+/** Latency telemetry attached to a step's terminal event's `eventData`. */
+export interface StepLatencyEventData {
+  ttfs?: number;
+  stso?: number;
+  optimizations?: string[];
+}
+
+/**
+ * Event types that disqualify TTFS when present in the event log at the time
+ * the run's first step batch is scheduled:
+ *
+ * - Any step event means this is not the run's first step execution.
+ * - `hook_received` / `wait_created` / `wait_completed` mean the run's path to
+ *   the first step depended on user-driven timing (a webhook arriving, a
+ *   sleep elapsing), so the measurement would not reflect runtime overhead.
+ * - `attr_set` (workflow-body `experimental_setAttributes`) forces a re-invoke
+ *   through the queue before steps run, a detour whose duration spans
+ *   invocations and cannot be measured wall-clock — so it disqualifies rather
+ *   than subtracts.
+ *
+ * `hook_created` is deliberately absent: a fire-and-forget `createHook()`
+ * before the first step commits in the same invocation, whose measured
+ * duration is subtracted via {@link StepLatencyTracking.preStepBlockingMs}.
+ */
+const TTFS_DISQUALIFYING_EVENT_TYPES: ReadonlySet<Event['eventType']> = new Set(
+  [
+    'step_created',
+    'step_started',
+    'step_completed',
+    'step_failed',
+    'step_retrying',
+    'hook_received',
+    'wait_created',
+    'wait_completed',
+    'attr_set',
+  ]
+);
+
+/**
+ * Decide, from the orchestrator's view of the event log, whether the inline
+ * step batch about to execute qualifies for TTFS and/or STSO measurement.
+ * Returns undefined when neither applies. Called once per batch; the result
+ * is passed to the batch's first step only, so a parallel first batch emits a
+ * single sample rather than one per sibling.
+ */
+export function computeStepLatencyTracking(params: {
+  /** The orchestrator's current in-memory event log (ascending order). */
+  events: Event[];
+  /**
+   * Whether this invocation's initial event load contained nothing beyond
+   * run_created/run_started. Pre-existing hook/attr events were written by an
+   * earlier invocation, so the time they added (including the queue hop back
+   * to this invocation) is unmeasurable and disqualifies TTFS.
+   */
+  invocationStartedClean: boolean;
+  /** Epoch ms of run creation, if recoverable. Absent disqualifies TTFS. */
+  runCreatedAtMs: number | undefined;
+  /** See {@link StepLatencyTracking.preStepBlockingMs}. */
+  preStepBlockingMs: number;
+  /**
+   * Whether the suspension that scheduled this batch also created waits.
+   * Those `wait_created` writes are not in `events` yet (they were committed
+   * by this very suspension pass), so they must be reported separately. A
+   * wait disqualifies both measurements.
+   */
+  suspensionHasWaits: boolean;
+  /**
+   * Whether the suspension that scheduled this batch also created hooks
+   * (also not in `events` yet). Hooks keep TTFS eligible — their measured
+   * write time is subtracted via `preStepBlockingMs` — but disqualify STSO,
+   * which is only meaningful for a pure back-to-back step gap.
+   */
+  suspensionCreatedHooks: boolean;
+  /** Whether turbo mode is active for this invocation. */
+  turbo: boolean;
+}): StepLatencyTracking | undefined {
+  const { events } = params;
+
+  let ttfsEligible =
+    params.invocationStartedClean &&
+    params.runCreatedAtMs !== undefined &&
+    !params.suspensionHasWaits;
+  if (ttfsEligible) {
+    for (const event of events) {
+      if (TTFS_DISQUALIFYING_EVENT_TYPES.has(event.eventType)) {
+        ttfsEligible = false;
+        break;
+      }
+    }
+  }
+
+  // STSO: the two steps ran back-to-back — the newest known event is the
+  // previous step's terminal event, with nothing (hook_received, waits,
+  // attr_set, ...) in between and this suspension scheduling nothing but
+  // steps.
+  let prevStepEndMs: number | undefined;
+  const lastEvent = events[events.length - 1];
+  if (
+    !params.suspensionHasWaits &&
+    !params.suspensionCreatedHooks &&
+    lastEvent &&
+    (lastEvent.eventType === 'step_completed' ||
+      lastEvent.eventType === 'step_failed')
+  ) {
+    prevStepEndMs = +(lastEvent.occurredAt ?? lastEvent.createdAt);
+  }
+
+  if (!ttfsEligible && prevStepEndMs === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(ttfsEligible
+      ? {
+          ttfsAnchorMs: params.runCreatedAtMs,
+          preStepBlockingMs: params.preStepBlockingMs,
+        }
+      : {}),
+    ...(prevStepEndMs !== undefined ? { prevStepEndMs } : {}),
+    turbo: params.turbo,
+  };
+}
+
+/**
+ * Compute the latency telemetry to attach to the step's terminal event.
+ * Called by `executeStep` with the wall-clock timestamp taken immediately
+ * before user step code runs. Returns undefined when there is nothing to
+ * report (no tracking, or a retry attempt — retries measure neither TTFS nor
+ * STSO).
+ */
+export function computeStepLatencyEventData(params: {
+  tracking: StepLatencyTracking | undefined;
+  /** `Date.now()` taken immediately before user step code began executing. */
+  stepCodeStartedAtMs: number;
+  attempt: number;
+  /** Whether this step was started lazily (no separate step_created write). */
+  lazyStepStart: boolean;
+  /** Whether the body ran optimistically, without awaiting step_started. */
+  optimisticStart: boolean;
+}): StepLatencyEventData | undefined {
+  const { tracking } = params;
+  if (!tracking || params.attempt !== 1) {
+    return undefined;
+  }
+
+  // Clamp at 0: cross-invocation timestamps can come from another machine's
+  // clock, so small skews must not produce negative durations.
+  const ttfs =
+    tracking.ttfsAnchorMs !== undefined
+      ? Math.max(
+          0,
+          params.stepCodeStartedAtMs -
+            tracking.ttfsAnchorMs -
+            (tracking.preStepBlockingMs ?? 0)
+        )
+      : undefined;
+  const stso =
+    tracking.prevStepEndMs !== undefined
+      ? Math.max(0, params.stepCodeStartedAtMs - tracking.prevStepEndMs)
+      : undefined;
+
+  if (ttfs === undefined && stso === undefined) {
+    return undefined;
+  }
+
+  const optimizations: string[] = [];
+  if (tracking.turbo) optimizations.push('turbo');
+  if (params.lazyStepStart) optimizations.push('lazyStepStart');
+  if (params.optimisticStart) optimizations.push('optimisticStart');
+
+  return {
+    ...(ttfs !== undefined ? { ttfs } : {}),
+    ...(stso !== undefined ? { stso } : {}),
+    optimizations,
+  };
+}

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -103,6 +103,13 @@ export interface SuspensionHandlerResult {
    * inline start (a hook introduces later resume invocations that could race).
    */
   hasHookEvents: boolean;
+  /**
+   * Wall-clock ms spent committing this suspension's `hook_created` events
+   * (0 when it created none). The caller accumulates this across iterations
+   * and subtracts it from the TTFS latency measurement, so time spent
+   * durably creating the user's hooks doesn't count as runtime overhead.
+   */
+  hookCreationMs: number;
 }
 
 async function createHookEvent({
@@ -301,8 +308,10 @@ export async function handleSuspension({
   // so the V2 handler can re-invoke immediately.
   let hasHookConflict = false;
   let hasAwaitedHookCreation = false;
+  let hookCreationMs = 0;
 
   if (hookItemsByToken.size > 0) {
+    const hookPhaseStart = Date.now();
     await ensureRunReady();
     await Promise.all(
       [...hookItemsByToken.values()].map(async (items) => {
@@ -353,6 +362,7 @@ export async function handleSuspension({
         }
       })
     );
+    hookCreationMs = Date.now() - hookPhaseStart;
   }
 
   // Process abort requests — resume the hook with abort payload and write stream packet
@@ -672,6 +682,7 @@ export async function handleSuspension({
     hasAwaitedHookCreation,
     hasAttributeEvents: attributeItems.length > 0,
     hasHookEvents: hooksNeedingCreation.length > 0,
+    hookCreationMs,
   };
 }
 

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -179,6 +179,29 @@ export const StepTracePropagated = SemanticConvention<boolean>(
   'step.trace.propagated'
 );
 
+/**
+ * Client-measured time-to-first-step latency in milliseconds: run creation →
+ * this step's body beginning to execute, minus pre-step hook-creation time.
+ * Only present on the run's first step execution when it qualified for
+ * measurement (see runtime/step-latency.ts).
+ */
+export const StepTtfsMs = SemanticConvention<number>('step.ttfs_ms');
+
+/**
+ * Client-measured step-to-step overhead in milliseconds: the previous step's
+ * terminal event → this step's body beginning to execute. Only present when
+ * the two steps ran back-to-back.
+ */
+export const StepStsoMs = SemanticConvention<number>('step.stso_ms');
+
+/**
+ * Runtime startup-latency optimizations active for the ttfs/stso measurement
+ * (e.g. 'turbo', 'lazyStepStart', 'optimisticStart').
+ */
+export const StepLatencyOptimizations = SemanticConvention<string[]>(
+  'step.latency_optimizations'
+);
+
 /** Whether the step was skipped during execution */
 export const StepSkipped = SemanticConvention<boolean>('step.skipped');
 

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -144,6 +144,17 @@ export interface CreateEventV4Input {
   /** Opt-in for framework-level callers to write `$`-prefixed reserved
    *  attribute keys (attr_set / run_created / run_started). */
   allowReservedAttributes?: boolean;
+  /** Client-measured time-to-first-step ms, riding on the run's first
+   *  step_completed / step_failed. Consumed server-side for latency
+   *  metrics; not read back. */
+  ttfs?: number;
+  /** Client-measured step-to-step overhead ms (previous step's terminal
+   *  event → this step's body starting), riding on step_completed /
+   *  step_failed. Consumed server-side for latency metrics. */
+  stso?: number;
+  /** Runtime optimizations active for the ttfs/stso measurement
+   *  (e.g. 'turbo', 'lazyStepStart', 'optimisticStart'). */
+  optimizations?: string[];
   /** Opt-in inline-delta request. On a step-terminal write
    *  (step_completed / step_failed) the inline loop passes the cursor it
    *  held before the write so the server can return the authoritative
@@ -223,6 +234,11 @@ function buildPostFrameMeta(
   if (input.writer !== undefined) meta.writer = input.writer;
   if (input.allowReservedAttributes !== undefined) {
     meta.allowReservedAttributes = input.allowReservedAttributes;
+  }
+  if (input.ttfs !== undefined) meta.ttfs = input.ttfs;
+  if (input.stso !== undefined) meta.stso = input.stso;
+  if (input.optimizations !== undefined) {
+    meta.optimizations = input.optimizations;
   }
   if (input.sinceCursor !== undefined) meta.sinceCursor = input.sinceCursor;
   if (input.skipPreload !== undefined) meta.skipPreload = input.skipPreload;

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -225,6 +225,54 @@ describe('splitEventDataForV4 attribute fields', () => {
     expect(started.payload).toBeInstanceOf(Uint8Array);
     expect(started.meta.input).toBeUndefined();
   });
+
+  it('carries latency telemetry (ttfs/stso/optimizations) in the frame meta on step terminal events', () => {
+    const completed = splitEventDataForV4({
+      eventType: 'step_completed',
+      correlationId: 'step_1',
+      specVersion: 4,
+      eventData: {
+        stepName: 's',
+        workflowName: 'wf',
+        result: new TextEncoder().encode('"ok"'),
+        ttfs: 123,
+        optimizations: ['turbo', 'lazyStepStart'],
+      },
+    } as AnyEventRequest);
+    expect(completed.meta.ttfs).toBe(123);
+    expect(completed.meta.stso).toBeUndefined();
+    expect(completed.meta.optimizations).toEqual(['turbo', 'lazyStepStart']);
+
+    const failed = splitEventDataForV4({
+      eventType: 'step_failed',
+      correlationId: 'step_2',
+      specVersion: 4,
+      eventData: {
+        stepName: 's',
+        error: new TextEncoder().encode('"boom"'),
+        stso: 45,
+        optimizations: [],
+      },
+    } as AnyEventRequest);
+    expect(failed.meta.stso).toBe(45);
+    expect(failed.meta.ttfs).toBeUndefined();
+    expect(failed.meta.optimizations).toEqual([]);
+
+    // Malformed values (non-number, non-string-array) are dropped, not sent.
+    const malformed = splitEventDataForV4({
+      eventType: 'step_completed',
+      correlationId: 'step_3',
+      specVersion: 4,
+      eventData: {
+        stepName: 's',
+        result: new TextEncoder().encode('"ok"'),
+        ttfs: 'fast',
+        optimizations: [1, 2],
+      },
+    } as unknown as AnyEventRequest);
+    expect(malformed.meta.ttfs).toBeUndefined();
+    expect(malformed.meta.optimizations).toBeUndefined();
+  });
 });
 
 describe('createWorkflowRunEvent response coercion', () => {

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -190,6 +190,12 @@ interface SplitEventData {
     writer?: Record<string, unknown>;
     /** Reserved-attribute-key opt-in (attr_set / run_created / run_started). */
     allowReservedAttributes?: boolean;
+    /** Client-measured time-to-first-step ms (step_completed / step_failed). */
+    ttfs?: number;
+    /** Client-measured step-to-step overhead ms (step_completed / step_failed). */
+    stso?: number;
+    /** Runtime optimizations active for the ttfs/stso measurement. */
+    optimizations?: string[];
   };
 }
 
@@ -217,7 +223,10 @@ type MetaSourceField =
   | 'attributes'
   | 'changes'
   | 'writer'
-  | 'allowReservedAttributes';
+  | 'allowReservedAttributes'
+  | 'ttfs'
+  | 'stso'
+  | 'optimizations';
 
 /**
  * Compile-time guard that the v4 `eventData` wire allowlist is exhaustive
@@ -343,6 +352,20 @@ export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
   }
   if (typeof eventData.allowReservedAttributes === 'boolean') {
     meta.allowReservedAttributes = eventData.allowReservedAttributes;
+  }
+  // Client-measured latency telemetry on step terminal events (TTFS / STSO).
+  // The server consumes these for metrics; they are not read back.
+  if (typeof eventData.ttfs === 'number') {
+    meta.ttfs = eventData.ttfs;
+  }
+  if (typeof eventData.stso === 'number') {
+    meta.stso = eventData.stso;
+  }
+  if (
+    Array.isArray(eventData.optimizations) &&
+    eventData.optimizations.every((o) => typeof o === 'string')
+  ) {
+    meta.optimizations = eventData.optimizations as string[];
   }
 
   let payload: Uint8Array | undefined;

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -109,6 +109,29 @@ export const BaseEventSchema = z.object({
 // Note: Serialized data fields use SerializedDataSchema to support both:
 // - specVersion >= 2: Uint8Array (binary devalue format)
 // - specVersion 1: any (legacy JSON format)
+// Client-measured latency telemetry carried on a step's terminal event so a
+// backend can emit latency metrics without extra event-log queries. All three
+// fields are populated together by the runtime, only on the terminal event of
+// a first-attempt step execution that qualified for measurement (see
+// `@workflow/core` runtime/step-latency.ts). Backends may consume these for
+// metrics and are not required to persist them.
+const stepLatencyTelemetryFields = {
+  // Time-to-first-step: milliseconds from run creation until the run's first
+  // step body began executing, minus time spent committing hook_created
+  // events. Only reported when nothing else (hooks received, waits,
+  // attributes, other steps) happened before the first step.
+  ttfs: z.number().optional(),
+  // Step-to-step overhead: milliseconds between the previous step's terminal
+  // event and this step's body beginning to execute. Only reported when the
+  // two steps ran back-to-back (the previous event-log entry is a
+  // step_completed/step_failed).
+  stso: z.number().optional(),
+  // Names of the runtime's optional startup-latency optimizations that were
+  // active for this measurement (e.g. 'turbo', 'lazyStepStart',
+  // 'optimisticStart'), so latency metrics can be segmented by them.
+  optimizations: z.array(z.string()).optional(),
+};
+
 const StepCompletedEventSchema = BaseEventSchema.extend({
   eventType: z.literal('step_completed'),
   correlationId: z.string(),
@@ -119,6 +142,7 @@ const StepCompletedEventSchema = BaseEventSchema.extend({
     // Optional: older runtimes omit it and the backend falls back to a read.
     workflowName: z.string().optional(),
     result: SerializedDataSchema,
+    ...stepLatencyTelemetryFields,
   }),
 });
 
@@ -130,6 +154,7 @@ const StepFailedEventSchema = BaseEventSchema.extend({
     // The thrown value, serialized via the workflow serialization pipeline.
     // Can be any JavaScript value (string, number, object, Error, etc.)
     error: SerializedDataSchema,
+    ...stepLatencyTelemetryFields,
   }),
 });
 


### PR DESCRIPTION
## What

The runtime now measures two production latency signals and attaches them to step terminal events (`step_completed` / `step_failed`) so a backend can emit latency metrics from the event write alone — no extra event-log query:

- **`ttfs`** (time-to-first-step, ms): run creation (anchored at the `wrun_` ULID timestamp) → the run's first step body beginning to execute. Only reported when nothing user-driven preceded the first step:
  - disqualified if any `hook_received`, `wait_created`/`wait_completed`, `attr_set`, or step event precedes it (including waits created by the same suspension that scheduled the step);
  - a fire-and-forget `createHook()` before the first step keeps TTFS eligible — the measured wall-clock of the hook-create phase is subtracted instead;
  - `experimental_setAttributes` before the first step stays eligible: the call's duration is subtracted by ending the measurement at the first `attr_set` write's client timestamp — the point where the step would otherwise have been scheduled. Hook time from before that point is still subtracted (tracked via a per-attr-suspension snapshot); hook writes after it fall outside the window and are not.
- **`stso`** (step-to-step overhead, ms): previous step's terminal event (`occurredAt`, same client clock) → next step's body beginning to execute. Only reported when the two steps ran back-to-back (the newest log entry is a step terminal and the scheduling suspension created only steps).

Both ride with an **`optimizations`** list naming the active startup-latency optimizations — `turbo`, `lazyStepStart`, `optimisticStart` — so the backend can segment the distributions by them.

## Scheduling change: `setAttributes` no longer re-invokes through the queue

An attribute suspension previously did `reinvoke(0)` before processing pending steps, paying a full queue delivery round-trip for every workflow-body `experimental_setAttributes`. The invariant that mattered — a fresh replay must decide races like `Promise.race([setAttributes(), step()])` before any step body runs — only requires *a replay before steps*, which the orchestrator's main loop already provides: the attr suspension now `continue`s the loop, the next iteration reloads the log (holding the just-committed `attr_set`) and replays, resolving the promise in-process. Unlike hooks and waits, an `attr_set` introduces no out-of-band invocation source, so nothing requires yielding the message.

Consequences:
- The step that loses an attribute race still leaves zero events (lazy deferral is preserved), and the run can now complete in the same delivery.
- The attr detour no longer ends turbo's forced optimistic start — no resume invocation source exists, so the single-handler guarantee still holds.
- Validated end-to-end: all 9 `experimental_setAttributes` e2e tests (including the fire-and-forget and race cases) pass against a local dev server, plus the rewritten race unit test asserting completion within one delivery with no queue interaction.

## Notes

- Measured on the inline execution path only (the default in production); the background queued-step handler doesn't report. Retry attempts report nothing.
- A parallel first batch attaches the telemetry to its first step only, so one sample is emitted per scheduling gap rather than one per sibling.
- Durations are clamped at ≥ 0 (cross-machine clock skew).
- Wire: new optional `eventData` fields on the step terminal event schemas, routed through the v4 frame meta on both the split (`splitEventDataForV4`) and encode (`buildPostFrameMeta`) sides. Old backends ignore unknown meta keys; old SDKs simply don't send the fields.

- The telemetry is also mirrored onto the step's OTEL span (`step.ttfs_ms`, `step.stso_ms`, `step.latency_optimizations`) so traces carry it alongside the flame graph.

## Tests

- `packages/core/src/runtime/step-latency.test.ts` — eligibility + computation unit tests.
- `packages/core/src/runtime.test.ts` — end-to-end through `workflowEntrypoint`: turbo TTFS on the first step + STSO on the back-to-back second step, non-turbo redelivery flags, and disqualification when a wait races the first step.
- `packages/world-vercel/src/events.test.ts` — v4 wire meta round-trip incl. malformed-value dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


