### PR TITLE
Use ease-in-out curve for trace viewer click-to-focus zoom

### DIFF
--- a/.changeset/trace-viewer-focus-easing.md
+++ b/.changeset/trace-viewer-focus-easing.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Smooth the new trace viewer's click-to-focus zoom with a stronger ease-in-out curve.

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -87,8 +87,8 @@ function useAnimatedViewport(initial: ViewportRange) {
       const anim = { raf: 0, from, to: target, start: performance.now() };
 
       const tick = () => {
-        const t = Math.min((performance.now() - anim.start) / 150, 1);
-        const e = 1 - (1 - t) * (1 - t);
+        const t = Math.min((performance.now() - anim.start) / 240, 1);
+        const e = t < 0.5 ? 8 * t * t * t * t : 1 - (-2 * t + 2) ** 4 / 2;
         setViewportState({
           start: anim.from.start + (anim.to.start - anim.from.start) * e,
           end: anim.from.end + (anim.to.end - anim.from.end) * e,


### PR DESCRIPTION
## What

Clicking a step in the new trace viewer zooms/pans the timeline camera to frame that span. The reframe animation used a weak quadratic ease-out over 150ms, which read as a near-linear snap.

This switches it to a stronger **easeInOutQuart** curve (≈ `cubic-bezier(0.77, 0, 0.175, 1)`) over **240ms**, so the camera accelerates off the current framing and decelerates into the target — a smooth move rather than a flat slide. The same `animateTo` also powers reset-to-full-view and minimap click-to-jump, so those get the smoother curve too.

Reduced-motion still snaps straight to the target with no animation.

## Change

```diff
-        const t = Math.min((performance.now() - anim.start) / 150, 1);
-        const e = 1 - (1 - t) * (1 - t);
+        const t = Math.min((performance.now() - anim.start) / 240, 1);
+        const e = t < 0.5 ? 8 * t * t * t * t : 1 - (-2 * t + 2) ** 4 / 2;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)