### PR TITLE
Report STSO step progress telemetry

### DIFF
--- a/.changeset/bright-steps-count.md
+++ b/.changeset/bright-steps-count.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'@workflow/world': minor
+'@workflow/world-vercel': minor
+---
+
+Report step progress alongside step-to-step overhead latency telemetry.

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1914,6 +1914,7 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     expect(second.eventData.ttfs).toBeUndefined();
     expect(second.eventData.stso).toBeGreaterThanOrEqual(0);
     expect(second.eventData.stso).toBeLessThanOrEqual(elapsed);
+    expect(second.eventData.stsoAfterTerminalSteps).toBe(1);
     expect(second.eventData.optimizations).toEqual([
       'turbo',
       'lazyStepStart',

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1914,7 +1914,8 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     expect(second.eventData.ttfs).toBeUndefined();
     expect(second.eventData.stso).toBeGreaterThanOrEqual(0);
     expect(second.eventData.stso).toBeLessThanOrEqual(elapsed);
-    expect(second.eventData.stsoAfterTerminalSteps).toBe(1);
+    expect(second.eventData.stepCount).toBe(1);
+    expect(second.eventData.eventCount).toBeGreaterThan(0);
     expect(second.eventData.optimizations).toEqual([
       'turbo',
       'lazyStepStart',

--- a/packages/core/src/runtime/step-latency.test.ts
+++ b/packages/core/src/runtime/step-latency.test.ts
@@ -195,7 +195,8 @@ describe('computeStepLatencyTracking', () => {
     // step events disqualify TTFS but qualify STSO.
     expect(tracking).toEqual({
       prevStepEndMs: 4_500,
-      stsoAfterTerminalSteps: 1,
+      stepCount: 1,
+      eventCount: 3,
       turbo: false,
     });
   });
@@ -207,7 +208,8 @@ describe('computeStepLatencyTracking', () => {
     });
     expect(tracking).toEqual({
       prevStepEndMs: 5_000,
-      stsoAfterTerminalSteps: 1,
+      stepCount: 1,
+      eventCount: 1,
       turbo: false,
     });
   });
@@ -224,7 +226,8 @@ describe('computeStepLatencyTracking', () => {
     });
     expect(tracking).toEqual({
       prevStepEndMs: new Date('2024-01-01T00:00:00.000Z').getTime(),
-      stsoAfterTerminalSteps: 2,
+      stepCount: 2,
+      eventCount: 3,
       turbo: false,
     });
   });
@@ -291,7 +294,8 @@ describe('computeStepLatencyEventData', () => {
     const data = computeStepLatencyEventData({
       tracking: {
         prevStepEndMs: 1_500,
-        stsoAfterTerminalSteps: 7,
+        stepCount: 7,
+        eventCount: 42,
         turbo: false,
       },
       stepCodeStartedAtMs: 2_000,
@@ -301,7 +305,8 @@ describe('computeStepLatencyEventData', () => {
     });
     expect(data).toEqual({
       stso: 500,
-      stsoAfterTerminalSteps: 7,
+      stepCount: 7,
+      eventCount: 42,
       optimizations: ['lazyStepStart'],
     });
   });
@@ -312,7 +317,8 @@ describe('computeStepLatencyEventData', () => {
         ttfsAnchorMs: 5_000,
         preStepBlockingMs: 0,
         prevStepEndMs: 5_000,
-        stsoAfterTerminalSteps: 3,
+        stepCount: 3,
+        eventCount: 9,
         turbo: false,
       },
       stepCodeStartedAtMs: 4_000,
@@ -323,7 +329,8 @@ describe('computeStepLatencyEventData', () => {
     expect(data).toEqual({
       ttfs: 0,
       stso: 0,
-      stsoAfterTerminalSteps: 3,
+      stepCount: 3,
+      eventCount: 9,
       optimizations: [],
     });
   });

--- a/packages/core/src/runtime/step-latency.test.ts
+++ b/packages/core/src/runtime/step-latency.test.ts
@@ -9,12 +9,18 @@ const RUN_ID = 'wrun_test';
 
 function makeEvent(
   eventType: Event['eventType'],
-  overrides: { createdAt?: Date; occurredAt?: Date } = {}
+  overrides: {
+    createdAt?: Date;
+    occurredAt?: Date;
+    correlationId?: string;
+  } = {}
 ): Event {
   return {
     eventId: `e-${Math.random().toString(36).slice(2)}`,
     runId: RUN_ID,
     eventType,
+    correlationId:
+      overrides.correlationId ?? `corr-${Math.random().toString(36).slice(2)}`,
     createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
     ...(overrides.occurredAt ? { occurredAt: overrides.occurredAt } : {}),
   } as Event;
@@ -187,7 +193,11 @@ describe('computeStepLatencyTracking', () => {
       ],
     });
     // step events disqualify TTFS but qualify STSO.
-    expect(tracking).toEqual({ prevStepEndMs: 4_500, turbo: false });
+    expect(tracking).toEqual({
+      prevStepEndMs: 4_500,
+      stsoAfterTerminalSteps: 1,
+      turbo: false,
+    });
   });
 
   it('falls back to createdAt for STSO when occurredAt is absent', () => {
@@ -195,7 +205,28 @@ describe('computeStepLatencyTracking', () => {
       ...BASE,
       events: [makeEvent('step_failed', { createdAt: new Date(5_000) })],
     });
-    expect(tracking).toEqual({ prevStepEndMs: 5_000, turbo: false });
+    expect(tracking).toEqual({
+      prevStepEndMs: 5_000,
+      stsoAfterTerminalSteps: 1,
+      turbo: false,
+    });
+  });
+
+  it('counts unique terminal steps before the STSO gap', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [
+        makeEvent('step_completed', { correlationId: 'step_1' }),
+        makeEvent('step_failed', { correlationId: 'step_2' }),
+        makeEvent('step_completed', { correlationId: 'step_2' }),
+      ],
+      invocationStartedClean: false,
+    });
+    expect(tracking).toEqual({
+      prevStepEndMs: new Date('2024-01-01T00:00:00.000Z').getTime(),
+      stsoAfterTerminalSteps: 2,
+      turbo: false,
+    });
   });
 
   it('does not mark STSO when the last event is not a step terminal', () => {
@@ -258,13 +289,21 @@ describe('computeStepLatencyEventData', () => {
 
   it('computes stso against the previous step terminal timestamp', () => {
     const data = computeStepLatencyEventData({
-      tracking: { prevStepEndMs: 1_500, turbo: false },
+      tracking: {
+        prevStepEndMs: 1_500,
+        stsoAfterTerminalSteps: 7,
+        turbo: false,
+      },
       stepCodeStartedAtMs: 2_000,
       attempt: 1,
       lazyStepStart: true,
       optimisticStart: false,
     });
-    expect(data).toEqual({ stso: 500, optimizations: ['lazyStepStart'] });
+    expect(data).toEqual({
+      stso: 500,
+      stsoAfterTerminalSteps: 7,
+      optimizations: ['lazyStepStart'],
+    });
   });
 
   it('clamps negative durations (cross-machine clock skew) to zero', () => {
@@ -273,6 +312,7 @@ describe('computeStepLatencyEventData', () => {
         ttfsAnchorMs: 5_000,
         preStepBlockingMs: 0,
         prevStepEndMs: 5_000,
+        stsoAfterTerminalSteps: 3,
         turbo: false,
       },
       stepCodeStartedAtMs: 4_000,
@@ -280,7 +320,12 @@ describe('computeStepLatencyEventData', () => {
       lazyStepStart: false,
       optimisticStart: false,
     });
-    expect(data).toEqual({ ttfs: 0, stso: 0, optimizations: [] });
+    expect(data).toEqual({
+      ttfs: 0,
+      stso: 0,
+      stsoAfterTerminalSteps: 3,
+      optimizations: [],
+    });
   });
 
   it('reports nothing on a retry attempt', () => {

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -46,6 +46,12 @@ export interface StepLatencyTracking {
    * when the step qualifies for STSO.
    */
   prevStepEndMs?: number;
+  /**
+   * Number of unique terminal steps already in the event log when the STSO
+   * gap began. For a sequential run, the gap between steps 1 and 2 carries 1.
+   * Parallel batches can advance this count by more than one between samples.
+   */
+  stsoAfterTerminalSteps?: number;
   /** Whether turbo mode is active for this invocation. */
   turbo: boolean;
 }
@@ -54,6 +60,7 @@ export interface StepLatencyTracking {
 export interface StepLatencyEventData {
   ttfs?: number;
   stso?: number;
+  stsoAfterTerminalSteps?: number;
   optimizations?: string[];
 }
 
@@ -168,6 +175,7 @@ export function computeStepLatencyTracking(params: {
   // attr_set, ...) in between and this suspension scheduling nothing but
   // steps.
   let prevStepEndMs: number | undefined;
+  let stsoAfterTerminalSteps: number | undefined;
   const lastEvent = events[events.length - 1];
   if (
     !params.suspensionHasWaits &&
@@ -177,6 +185,17 @@ export function computeStepLatencyTracking(params: {
       lastEvent.eventType === 'step_failed')
   ) {
     prevStepEndMs = +(lastEvent.occurredAt ?? lastEvent.createdAt);
+    const terminalStepIds = new Set<string>();
+    for (const event of events) {
+      if (
+        (event.eventType === 'step_completed' ||
+          event.eventType === 'step_failed') &&
+        event.correlationId !== undefined
+      ) {
+        terminalStepIds.add(event.correlationId);
+      }
+    }
+    stsoAfterTerminalSteps = terminalStepIds.size;
   }
 
   if (!ttfsEligible && prevStepEndMs === undefined) {
@@ -196,7 +215,9 @@ export function computeStepLatencyTracking(params: {
           ...(preStepAttrStartMs !== undefined ? { preStepAttrStartMs } : {}),
         }
       : {}),
-    ...(prevStepEndMs !== undefined ? { prevStepEndMs } : {}),
+    ...(prevStepEndMs !== undefined
+      ? { prevStepEndMs, stsoAfterTerminalSteps }
+      : {}),
     turbo: params.turbo,
   };
 }
@@ -258,6 +279,9 @@ export function computeStepLatencyEventData(params: {
   return {
     ...(ttfs !== undefined ? { ttfs } : {}),
     ...(stso !== undefined ? { stso } : {}),
+    ...(stso !== undefined && tracking.stsoAfterTerminalSteps !== undefined
+      ? { stsoAfterTerminalSteps: tracking.stsoAfterTerminalSteps }
+      : {}),
     optimizations,
   };
 }

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -46,12 +46,10 @@ export interface StepLatencyTracking {
    * when the step qualifies for STSO.
    */
   prevStepEndMs?: number;
-  /**
-   * Number of unique terminal steps already in the event log when the STSO
-   * gap began. For a sequential run, the gap between steps 1 and 2 carries 1.
-   * Parallel batches can advance this count by more than one between samples.
-   */
-  stsoAfterTerminalSteps?: number;
+  /** Number of unique terminal steps already in the event log. */
+  stepCount?: number;
+  /** Number of events already in the event log. */
+  eventCount?: number;
   /** Whether turbo mode is active for this invocation. */
   turbo: boolean;
 }
@@ -60,7 +58,8 @@ export interface StepLatencyTracking {
 export interface StepLatencyEventData {
   ttfs?: number;
   stso?: number;
-  stsoAfterTerminalSteps?: number;
+  stepCount?: number;
+  eventCount?: number;
   optimizations?: string[];
 }
 
@@ -175,7 +174,8 @@ export function computeStepLatencyTracking(params: {
   // attr_set, ...) in between and this suspension scheduling nothing but
   // steps.
   let prevStepEndMs: number | undefined;
-  let stsoAfterTerminalSteps: number | undefined;
+  let stepCount: number | undefined;
+  let eventCount: number | undefined;
   const lastEvent = events[events.length - 1];
   if (
     !params.suspensionHasWaits &&
@@ -195,7 +195,8 @@ export function computeStepLatencyTracking(params: {
         terminalStepIds.add(event.correlationId);
       }
     }
-    stsoAfterTerminalSteps = terminalStepIds.size;
+    stepCount = terminalStepIds.size;
+    eventCount = events.length;
   }
 
   if (!ttfsEligible && prevStepEndMs === undefined) {
@@ -216,7 +217,7 @@ export function computeStepLatencyTracking(params: {
         }
       : {}),
     ...(prevStepEndMs !== undefined
-      ? { prevStepEndMs, stsoAfterTerminalSteps }
+      ? { prevStepEndMs, stepCount, eventCount }
       : {}),
     turbo: params.turbo,
   };
@@ -279,8 +280,11 @@ export function computeStepLatencyEventData(params: {
   return {
     ...(ttfs !== undefined ? { ttfs } : {}),
     ...(stso !== undefined ? { stso } : {}),
-    ...(stso !== undefined && tracking.stsoAfterTerminalSteps !== undefined
-      ? { stsoAfterTerminalSteps: tracking.stsoAfterTerminalSteps }
+    ...(stso !== undefined && tracking.stepCount !== undefined
+      ? { stepCount: tracking.stepCount }
+      : {}),
+    ...(stso !== undefined && tracking.eventCount !== undefined
+      ? { eventCount: tracking.eventCount }
       : {}),
     optimizations,
   };

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -155,8 +155,9 @@ export interface CreateEventV4Input {
    *  event → this step's body starting), riding on step_completed /
    *  step_failed. Consumed server-side for latency metrics. */
   stso?: number;
-  /** Number of terminal steps already recorded when the STSO gap began. */
-  stsoAfterTerminalSteps?: number;
+  /** Progress counters taken when the STSO gap began. */
+  stepCount?: number;
+  eventCount?: number;
   /** Runtime optimizations active for the ttfs/stso measurement
    *  (e.g. 'turbo', 'lazyStepStart', 'optimisticStart'). */
   optimizations?: string[];
@@ -243,9 +244,8 @@ function buildPostFrameMeta(
   }
   if (input.ttfs !== undefined) meta.ttfs = input.ttfs;
   if (input.stso !== undefined) meta.stso = input.stso;
-  if (input.stsoAfterTerminalSteps !== undefined) {
-    meta.stsoAfterTerminalSteps = input.stsoAfterTerminalSteps;
-  }
+  if (input.stepCount !== undefined) meta.stepCount = input.stepCount;
+  if (input.eventCount !== undefined) meta.eventCount = input.eventCount;
   if (input.optimizations !== undefined) {
     meta.optimizations = input.optimizations;
   }

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -155,6 +155,8 @@ export interface CreateEventV4Input {
    *  event → this step's body starting), riding on step_completed /
    *  step_failed. Consumed server-side for latency metrics. */
   stso?: number;
+  /** Number of terminal steps already recorded when the STSO gap began. */
+  stsoAfterTerminalSteps?: number;
   /** Runtime optimizations active for the ttfs/stso measurement
    *  (e.g. 'turbo', 'lazyStepStart', 'optimisticStart'). */
   optimizations?: string[];
@@ -241,6 +243,9 @@ function buildPostFrameMeta(
   }
   if (input.ttfs !== undefined) meta.ttfs = input.ttfs;
   if (input.stso !== undefined) meta.stso = input.stso;
+  if (input.stsoAfterTerminalSteps !== undefined) {
+    meta.stsoAfterTerminalSteps = input.stsoAfterTerminalSteps;
+  }
   if (input.optimizations !== undefined) {
     meta.optimizations = input.optimizations;
   }

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -247,7 +247,7 @@ describe('splitEventDataForV4 attribute fields', () => {
     expect(meta.cancelReason).toBeUndefined();
   });
 
-  it('carries latency telemetry (ttfs/stso/optimizations) in the frame meta on step terminal events', () => {
+  it('carries latency telemetry in the frame meta on step terminal events', () => {
     const completed = splitEventDataForV4({
       eventType: 'step_completed',
       correlationId: 'step_1',
@@ -272,10 +272,12 @@ describe('splitEventDataForV4 attribute fields', () => {
         stepName: 's',
         error: new TextEncoder().encode('"boom"'),
         stso: 45,
+        stsoAfterTerminalSteps: 7,
         optimizations: [],
       },
     } as AnyEventRequest);
     expect(failed.meta.stso).toBe(45);
+    expect(failed.meta.stsoAfterTerminalSteps).toBe(7);
     expect(failed.meta.ttfs).toBeUndefined();
     expect(failed.meta.optimizations).toEqual([]);
 
@@ -288,10 +290,12 @@ describe('splitEventDataForV4 attribute fields', () => {
         stepName: 's',
         result: new TextEncoder().encode('"ok"'),
         ttfs: 'fast',
+        stsoAfterTerminalSteps: 0,
         optimizations: [1, 2],
       },
     } as unknown as AnyEventRequest);
     expect(malformed.meta.ttfs).toBeUndefined();
+    expect(malformed.meta.stsoAfterTerminalSteps).toBeUndefined();
     expect(malformed.meta.optimizations).toBeUndefined();
   });
 });

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -272,12 +272,14 @@ describe('splitEventDataForV4 attribute fields', () => {
         stepName: 's',
         error: new TextEncoder().encode('"boom"'),
         stso: 45,
-        stsoAfterTerminalSteps: 7,
+        stepCount: 7,
+        eventCount: 42,
         optimizations: [],
       },
     } as AnyEventRequest);
     expect(failed.meta.stso).toBe(45);
-    expect(failed.meta.stsoAfterTerminalSteps).toBe(7);
+    expect(failed.meta.stepCount).toBe(7);
+    expect(failed.meta.eventCount).toBe(42);
     expect(failed.meta.ttfs).toBeUndefined();
     expect(failed.meta.optimizations).toEqual([]);
 
@@ -290,12 +292,14 @@ describe('splitEventDataForV4 attribute fields', () => {
         stepName: 's',
         result: new TextEncoder().encode('"ok"'),
         ttfs: 'fast',
-        stsoAfterTerminalSteps: 0,
+        stepCount: 0,
+        eventCount: 2.5,
         optimizations: [1, 2],
       },
     } as unknown as AnyEventRequest);
     expect(malformed.meta.ttfs).toBeUndefined();
-    expect(malformed.meta.stsoAfterTerminalSteps).toBeUndefined();
+    expect(malformed.meta.stepCount).toBeUndefined();
+    expect(malformed.meta.eventCount).toBeUndefined();
     expect(malformed.meta.optimizations).toBeUndefined();
   });
 });

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -195,8 +195,9 @@ interface SplitEventData {
     ttfs?: number;
     /** Client-measured step-to-step overhead ms (step_completed / step_failed). */
     stso?: number;
-    /** Number of terminal steps already recorded when the STSO gap began. */
-    stsoAfterTerminalSteps?: number;
+    /** Progress counters taken when the STSO gap began. */
+    stepCount?: number;
+    eventCount?: number;
     /** Runtime optimizations active for the ttfs/stso measurement. */
     optimizations?: string[];
   };
@@ -230,7 +231,8 @@ type MetaSourceField =
   | 'allowReservedAttributes'
   | 'ttfs'
   | 'stso'
-  | 'stsoAfterTerminalSteps'
+  | 'stepCount'
+  | 'eventCount'
   | 'optimizations';
 
 /**
@@ -372,11 +374,18 @@ export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
     meta.stso = eventData.stso;
   }
   if (
-    typeof eventData.stsoAfterTerminalSteps === 'number' &&
-    Number.isSafeInteger(eventData.stsoAfterTerminalSteps) &&
-    eventData.stsoAfterTerminalSteps > 0
+    typeof eventData.stepCount === 'number' &&
+    Number.isSafeInteger(eventData.stepCount) &&
+    eventData.stepCount > 0
   ) {
-    meta.stsoAfterTerminalSteps = eventData.stsoAfterTerminalSteps;
+    meta.stepCount = eventData.stepCount;
+  }
+  if (
+    typeof eventData.eventCount === 'number' &&
+    Number.isSafeInteger(eventData.eventCount) &&
+    eventData.eventCount > 0
+  ) {
+    meta.eventCount = eventData.eventCount;
   }
   if (
     Array.isArray(eventData.optimizations) &&

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -195,6 +195,8 @@ interface SplitEventData {
     ttfs?: number;
     /** Client-measured step-to-step overhead ms (step_completed / step_failed). */
     stso?: number;
+    /** Number of terminal steps already recorded when the STSO gap began. */
+    stsoAfterTerminalSteps?: number;
     /** Runtime optimizations active for the ttfs/stso measurement. */
     optimizations?: string[];
   };
@@ -228,6 +230,7 @@ type MetaSourceField =
   | 'allowReservedAttributes'
   | 'ttfs'
   | 'stso'
+  | 'stsoAfterTerminalSteps'
   | 'optimizations';
 
 /**
@@ -367,6 +370,13 @@ export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
   }
   if (typeof eventData.stso === 'number') {
     meta.stso = eventData.stso;
+  }
+  if (
+    typeof eventData.stsoAfterTerminalSteps === 'number' &&
+    Number.isSafeInteger(eventData.stsoAfterTerminalSteps) &&
+    eventData.stsoAfterTerminalSteps > 0
+  ) {
+    meta.stsoAfterTerminalSteps = eventData.stsoAfterTerminalSteps;
   }
   if (
     Array.isArray(eventData.optimizations) &&

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -126,9 +126,10 @@ const stepLatencyTelemetryFields = {
   // two steps ran back-to-back (the previous event-log entry is a
   // step_completed/step_failed).
   stso: z.number().optional(),
-  // Number of unique terminal steps already in the event log when the STSO
-  // gap began. Only present alongside stso.
-  stsoAfterTerminalSteps: z.number().int().positive().optional(),
+  // Progress counters taken when the STSO gap began. Only present alongside
+  // stso.
+  stepCount: z.number().int().positive().optional(),
+  eventCount: z.number().int().positive().optional(),
   // Names of the runtime's optional startup-latency optimizations that were
   // active for this measurement (e.g. 'turbo', 'lazyStepStart',
   // 'optimisticStart'), so latency metrics can be segmented by them.

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -110,8 +110,8 @@ export const BaseEventSchema = z.object({
 // - specVersion >= 2: Uint8Array (binary devalue format)
 // - specVersion 1: any (legacy JSON format)
 // Client-measured latency telemetry carried on a step's terminal event so a
-// backend can emit latency metrics without extra event-log queries. All three
-// fields are populated together by the runtime, only on the terminal event of
+// backend can emit latency metrics without extra event-log queries. Fields
+// are populated as applicable by the runtime, only on the terminal event of
 // a first-attempt step execution that qualified for measurement (see
 // `@workflow/core` runtime/step-latency.ts). Backends may consume these for
 // metrics and are not required to persist them.
@@ -126,6 +126,9 @@ const stepLatencyTelemetryFields = {
   // two steps ran back-to-back (the previous event-log entry is a
   // step_completed/step_failed).
   stso: z.number().optional(),
+  // Number of unique terminal steps already in the event log when the STSO
+  // gap began. Only present alongside stso.
+  stsoAfterTerminalSteps: z.number().int().positive().optional(),
   // Names of the runtime's optional startup-latency optimizations that were
   // active for this measurement (e.g. 'turbo', 'lazyStepStart',
   // 'optimisticStart'), so latency metrics can be segmented by them.


### PR DESCRIPTION
## What

- count unique terminal steps before each STSO measurement
- carry that optional progress value with step latency telemetry
- preserve compatibility for consumers that do not read the new field

## Why

This enables comparing step-to-step overhead at different points in long-running workflows.

## Validation

- `pnpm build`
- `pnpm typecheck`
- targeted runtime and transport tests (71 passed)
- scoped Biome check

The full suite reached its Docker-backed Postgres package; that package was not run after Docker testing was skipped.
