### PR TITLE
Fix Windows HMR generated file updates

### DIFF
--- a/.changeset/bright-cycles-wait.md
+++ b/.changeset/bright-cycles-wait.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Use the Windows-safe generated-file writer for step registration output.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -902,9 +902,7 @@ ${importStatements.join('\n')}
 export const __steps_registered = true;
 `;
     await mkdir(dirname(outfile), { recursive: true });
-    const tempPath = `${outfile}.${randomUUID()}.tmp`;
-    await writeFile(tempPath, output);
-    await rename(tempPath, outfile);
+    await this.writeGeneratedFile(outfile, output);
 
     const manifestFiles = Array.from(
       new Set([...stepFiles, ...serdeOnlyFiles, resolvedBuiltInSteps])

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -82,6 +82,8 @@ export function createDevTests(config?: DevTestConfig) {
       : process.platform === 'win32'
         ? 140_000
         : 70_000;
+    const multiPhaseHmrTestTimeoutMs =
+      hmrTestTimeoutMs + hmrRediscoveryTimeoutMs;
     const flowRouteHmrFuzzTimeoutMs = finalConfig.canary ? 480_000 : 240_000;
     const readManifestStepFunctionNames = async (): Promise<string[]> => {
       const manifestJson = await fs.readFile(workflowManifestPath, 'utf8');
@@ -458,7 +460,11 @@ export async function hmrPageWorkflow() {
 
     test(
       'should rebuild on workflow change',
-      { timeout: hmrTestTimeoutMs },
+      {
+        timeout: usesNextFlowRoute
+          ? multiPhaseHmrTestTimeoutMs
+          : hmrTestTimeoutMs,
+      },
       async () => {
         if (usesNextFlowRoute) {
           await waitForHmrReady();
@@ -491,7 +497,7 @@ ${apiFileContent}`
           );
           await pollUntil({
             description: 'workflow-change fixture to appear in manifest',
-            timeoutMs: 50_000,
+            timeoutMs: hmrRediscoveryTimeoutMs,
             check: async () => {
               await prewarm();
               expect(await readManifestWorkflowFunctionNames()).toContain(
@@ -517,7 +523,7 @@ export async function myNewWorkflow() {
 
         await pollUntil({
           description: 'generated workflow to include myNewWorkflow',
-          timeoutMs: usesNextFlowRoute ? 50_000 : 25_000,
+          timeoutMs: usesNextFlowRoute ? hmrRediscoveryTimeoutMs : 25_000,
           check: async () => {
             if (usesNextFlowRoute) {
               await prewarm();
@@ -717,7 +723,7 @@ ${apiFileContent}`
 
         await pollUntil({
           description: 'generated workflow to include newWorkflowFile',
-          timeoutMs: 50_000,
+          timeoutMs: hmrRediscoveryTimeoutMs,
           check: async () => {
             if (usesNextFlowRoute) {
               const manifestJson = await fs.readFile(


### PR DESCRIPTION
## Summary

- write step registration output through the existing Windows-safe generated-file writer so `EPERM`/`EACCES` rename failures fall back to a direct overwrite
- use the configured HMR rediscovery timeout for workflow-manifest polling, including the longer Windows budget
- expand the outer timeout for the two-phase workflow-change test so both rediscovery polls have time to finish

Closes #1910.

## Test plan

- `pnpm exec biome check packages/builders/src/base-builder.ts packages/core/e2e/dev.test.ts .changeset/bright-cycles-wait.md`
- `pnpm --filter @workflow/builders typecheck`
- `pnpm --filter @workflow/builders build`
- `pnpm --filter @workflow/builders test` (221 tests)
- local Next.js 16.2.1 / Turbopack dev E2E:
  - `should rebuild on workflow change`
  - `should rebuild on adding workflow file`
- Windows E2E CI for the platform-specific file-locking behavior
