### PR TITLE
feat(world-vercel): client-observed stream write/read e2e latency spans

### DIFF
--- a/.changeset/stream-otel-spans.md
+++ b/.changeset/stream-otel-spans.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": patch
+---
+
+Name the stream write/read client spans for their operation (`workflow.stream.write` / `workflow.stream.read`) and tag them with `workflow.run.id`, `workflow.stream.name`, `workflow.stream.operation`, and `workflow.stream.start_index`, so stream latency is sliceable per run/stream in traces. Additive OTEL only — no behavior change when no OpenTelemetry SDK is registered.

--- a/.changeset/stream-otel-spans.md
+++ b/.changeset/stream-otel-spans.md
@@ -1,5 +1,6 @@
 ---
+"@workflow/core": patch
 "@workflow/world-vercel": patch
 ---
 
-Add OTEL stream spans. Writes: `workflow.stream.write` with `workflow.stream.write.e2e_ms` (client→server round-trip). Reads: `workflow.stream.read.connect` (network connect) plus `workflow.stream.read` carrying client-observed end-to-end time-to-first-chunk (`workflow.stream.read.ttfc_ms`, includes the network hop). Additive OTEL only.
+Add OTEL stream latency spans. Writes (`@workflow/world-vercel`): `workflow.stream.write` with `workflow.stream.write.e2e_ms` (client→backend round-trip), plus `workflow.stream.read.connect` for the read's network-connect leg. Reads (`@workflow/core`): `workflow.stream.read` carrying the client-observed end-to-end time-to-first-chunk (`workflow.stream.read.ttfc_ms`, includes the network hop), emitted from the core reader when the first chunk reaches the consumer. Additive OTEL only.

--- a/.changeset/stream-otel-spans.md
+++ b/.changeset/stream-otel-spans.md
@@ -3,4 +3,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Add OTEL stream latency spans. Writes (`@workflow/world-vercel`): `workflow.stream.write` with `workflow.stream.write.e2e_ms` (client→backend round-trip), plus `workflow.stream.read.connect` for the read's network-connect leg. Reads (`@workflow/core`): `workflow.stream.read` carrying the client-observed end-to-end time-to-first-chunk (`workflow.stream.read.ttfc_ms`, includes the network hop), emitted from the core reader when the first chunk reaches the consumer. Additive OTEL only.
+Add stream latency to OTEL spans

--- a/.changeset/stream-otel-spans.md
+++ b/.changeset/stream-otel-spans.md
@@ -2,4 +2,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Name the stream write/read client spans for their operation (`workflow.stream.write` / `workflow.stream.read`) and tag them with `workflow.run.id`, `workflow.stream.name`, `workflow.stream.operation`, and `workflow.stream.start_index`, so stream latency is sliceable per run/stream in traces. Additive OTEL only — no behavior change when no OpenTelemetry SDK is registered.
+Name the stream client spans `workflow.stream.write`/`workflow.stream.read` and tag them with run/stream attributes for per-stream latency tracing. Additive OTEL only.

--- a/.changeset/stream-otel-spans.md
+++ b/.changeset/stream-otel-spans.md
@@ -2,4 +2,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Add OTEL stream spans: `workflow.stream.write` for writes; for reads, `workflow.stream.read.connect` (network connect) plus `workflow.stream.read` carrying client-observed end-to-end time-to-first-chunk (`workflow.stream.read.ttfc_ms`, includes the network hop). Additive OTEL only.
+Add OTEL stream spans. Writes: `workflow.stream.write` with `workflow.stream.write.e2e_ms` (client→server round-trip). Reads: `workflow.stream.read.connect` (network connect) plus `workflow.stream.read` carrying client-observed end-to-end time-to-first-chunk (`workflow.stream.read.ttfc_ms`, includes the network hop). Additive OTEL only.

--- a/.changeset/stream-otel-spans.md
+++ b/.changeset/stream-otel-spans.md
@@ -2,4 +2,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Name the stream client spans `workflow.stream.write`/`workflow.stream.read` and tag them with run/stream attributes for per-stream latency tracing. Additive OTEL only.
+Add OTEL stream spans: `workflow.stream.write` for writes; for reads, `workflow.stream.read.connect` (network connect) plus `workflow.stream.read` carrying client-observed end-to-end time-to-first-chunk (`workflow.stream.read.ttfc_ms`, includes the network hop). Additive OTEL only.

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -37,8 +37,13 @@ No workflow-specific configuration is required. As soon as a tracer provider and
 | `workflow.execute <name>` | consumer (root) | a queue delivery invokes the workflow — replay, orchestration, and inline steps run under it |
 | `step.execute <name>` | internal (inline) / consumer + root (queue-delivered) | a step function executes |
 | `http <method>` | client | the SDK calls the workflow backend (event reads/writes) |
+| `workflow.stream.write` | client | a stream chunk (or the stream close) is flushed to the backend |
+| `workflow.stream.read.connect` | client | a live stream read opens; the span covers dispatch → response headers (network connect) |
+| `workflow.stream.read` | client | a live stream read receives its first chunk; the span's duration is the end-to-end time-to-first-chunk (see `workflow.stream.read.ttfc_ms`) |
 
 `<name>` is the short function name (for example `processOrder`); the full machine name, including the source module, is available in the `workflow.name` / `step.name` attributes.
+
+Stream spans are emitted by the SDK's world backend on the client that writes or reads the stream, and (like all SDK spans) are no-ops when no OpenTelemetry SDK is registered. The `workflow.stream.read` span only appears once the first non-empty chunk arrives.
 
 ## Key attributes
 
@@ -49,6 +54,10 @@ No workflow-specific configuration is required. As soon as a tracer provider and
 | `workflow.trace.mode` | The active trace mode (`linked` or `continuous`). |
 | `workflow.trace.propagated` | Whether the invocation received trace context from the queue message. |
 | `workflow.queue.overhead_ms` | Time between the message being enqueued and the handler starting — queue dwell plus any cold start. |
+| `workflow.stream.name` | The stream name, on stream write/read spans. |
+| `workflow.stream.operation` | The stream operation: `write`, `write_multi`, `close`, or `read`. |
+| `workflow.stream.write.e2e_ms` | Client→backend round-trip for a stream write, in ms — the backend acks only after capturing the chunk, so this is the client-observed write latency including the network hop. |
+| `workflow.stream.read.ttfc_ms` | Client-observed end-to-end time-to-first-chunk for a live read, in ms — read dispatch → first non-empty chunk in the reader, including the network hop. |
 
 ## Trace shape: one trace per invocation
 

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -57,7 +57,7 @@ Stream spans are emitted by the SDK's world backend on the client that writes or
 | `workflow.stream.name` | The stream name, on stream write/read spans. |
 | `workflow.stream.operation` | The stream operation: `write`, `write_multi`, `close`, or `read`. |
 | `workflow.stream.write.chunk_rtt` | Time between emissions of a chunk to the wire, and receiving the `ack` message for that chunk. |
-| `workflow.stream.read.ttfc_ms` | Client-observed end-to-end time-to-first-chunk for a live read, in ms — read dispatch → first non-empty chunk in the reader, including the network hop. |
+| `workflow.stream.read.ttfc_ms` | Time between opening a read connection and observing and receiving the first chunk back. |
 
 ## Trace shape: one trace per invocation
 

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -56,7 +56,7 @@ Stream spans are emitted by the SDK's world backend on the client that writes or
 | `workflow.queue.overhead_ms` | Time between the message being enqueued and the handler starting — queue dwell plus any cold start. |
 | `workflow.stream.name` | The stream name, on stream write/read spans. |
 | `workflow.stream.operation` | The stream operation: `write`, `write_multi`, `close`, or `read`. |
-| `workflow.stream.write.e2e_ms` | Client→backend round-trip for a stream write, in ms — the backend acks only after capturing the chunk, so this is the client-observed write latency including the network hop. |
+| `workflow.stream.write.chunk_rtt` | Time between emissions of a chunk to the wire, and receiving the `ack` message for that chunk. |
 | `workflow.stream.read.ttfc_ms` | Client-observed end-to-end time-to-first-chunk for a live read, in ms — read dispatch → first non-empty chunk in the reader, including the network hop. |
 
 ## Trace shape: one trace per invocation

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -84,7 +84,7 @@ import {
   WEBHOOK_RESPONSE_WRITABLE,
 } from './symbols.js';
 import * as Attr from './telemetry/semantic-conventions.js';
-import { getActiveSpan } from './telemetry.js';
+import { getActiveSpan, getSpanKind, recordElapsedSpan } from './telemetry.js';
 import { getAbortStreamId } from './util.js';
 import { WorkflowAbortSignal } from './workflow/abort-controller.js';
 
@@ -552,6 +552,33 @@ export function getByteUnframingStream(): TransformStream<
   });
 }
 
+/**
+ * Emit the client-observed end-to-end time-to-first-chunk span for a live read:
+ * read dispatch (`startEpochMs`) → the first non-empty chunk reaching the
+ * reader, including the network hop. Fire-and-forget; no-op without OTEL.
+ */
+function recordReadTimeToFirstChunk(
+  startEpochMs: number,
+  runId: string,
+  name: string,
+  startIndex?: number
+): void {
+  void (async () => {
+    await recordElapsedSpan('workflow.stream.read', startEpochMs, {
+      kind: await getSpanKind('CLIENT'),
+      attributes: {
+        'workflow.run.id': runId,
+        'workflow.stream.name': name,
+        'workflow.stream.operation': 'read',
+        'workflow.stream.read.ttfc_ms': Date.now() - startEpochMs,
+        ...(typeof startIndex === 'number'
+          ? { 'workflow.stream.start_index': startIndex }
+          : {}),
+      },
+    });
+  })();
+}
+
 export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
   #reader?: ReadableStreamDefaultReader<Uint8Array>;
 
@@ -559,6 +586,13 @@ export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
     if (typeof name !== 'string' || name.length === 0) {
       throw new WorkflowRuntimeError(`"name" is required, got "${name}"`);
     }
+    // Client-observed time-to-first-chunk state. `readStart` is stamped when the
+    // reader starts consuming (first pull → the read dispatch); the span is
+    // emitted once, when the first non-empty chunk reaches the reader. So its
+    // duration is the end-to-end TTFC including the network hop. No-op without
+    // an OpenTelemetry SDK registered.
+    let readStart: number | undefined;
+    let firstChunkReported = false;
     super({
       // @ts-expect-error Not sure why TypeScript is complaining about this
       type: 'bytes',
@@ -566,6 +600,7 @@ export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
       pull: async (controller) => {
         let reader = this.#reader;
         if (!reader) {
+          if (readStart === undefined) readStart = Date.now();
           const world = await getWorldLazy();
           const stream = await world.streams.get(runId, name, startIndex);
           reader = this.#reader = stream.getReader();
@@ -580,6 +615,17 @@ export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
           this.#reader = undefined;
           controller.close();
         } else {
+          // The server flushes a leading zero-length chunk (v3+) to commit
+          // response headers before any data; skip empties so TTFC measures to
+          // the first real chunk.
+          if (
+            !firstChunkReported &&
+            result.value.byteLength > 0 &&
+            readStart !== undefined
+          ) {
+            firstChunkReported = true;
+            recordReadTimeToFirstChunk(readStart, runId, name, startIndex);
+          }
           // Forward raw bytes; encryption/decryption is handled at the
           // framing level by getSerializeStream/getDeserializeStream.
           controller.enqueue(result.value);

--- a/packages/core/src/telemetry-elapsed-span.test.ts
+++ b/packages/core/src/telemetry-elapsed-span.test.ts
@@ -1,0 +1,43 @@
+import { trace as otelTrace } from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { recordElapsedSpan } from './telemetry.js';
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+
+beforeAll(() => {
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  otelTrace.setGlobalTracerProvider(provider);
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  otelTrace.disable();
+});
+
+afterEach(() => {
+  exporter.reset();
+});
+
+describe('recordElapsedSpan (back-dated timing span)', () => {
+  it('emits a span whose duration reflects the back-dated interval', async () => {
+    const startMs = Date.now() - 250;
+    await recordElapsedSpan('workflow.stream.read', startMs, {
+      attributes: { 'workflow.stream.read.ttfc_ms': 250 },
+    });
+
+    const span = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'workflow.stream.read');
+    expect(span).toBeDefined();
+    expect(span!.attributes['workflow.stream.read.ttfc_ms']).toBe(250);
+    // duration is hrtime [seconds, nanos]; the 250ms back-date should show up.
+    const durationSec = span!.duration[0] + span!.duration[1] / 1e9;
+    expect(durationSec).toBeGreaterThanOrEqual(0.2);
+  });
+});

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -203,6 +203,23 @@ export async function trace<T>(
 }
 
 /**
+ * Emit a span whose start is back-dated to `startEpochMs` and whose end is now,
+ * so its duration reflects an interval only measurable at its end (e.g.
+ * time-to-first-chunk, known when the first chunk arrives). Unlike `trace()`,
+ * this records an already-elapsed span in one shot rather than wrapping a
+ * callback. No-op when OpenTelemetry is not available.
+ */
+export async function recordElapsedSpan(
+  spanName: string,
+  startEpochMs: number,
+  opts?: SpanOptions
+): Promise<void> {
+  const tracer = await Tracer.value;
+  if (!tracer) return;
+  tracer.startSpan(spanName, { ...opts, startTime: startEpochMs }).end();
+}
+
+/**
  * Applies workflow suspension attributes to the given span if the error is a WorkflowSuspension
  * which is technically not an error, but an algebraic effect indicating suspension.
  */

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -311,6 +311,17 @@ export interface InstrumentedFetchOptions {
   /** Short label for logs (endpoint path). Defaults to the full URL. */
   logLabel?: string;
   /**
+   * Override the client-span name. Defaults to `http ${method}`. Pass a
+   * semantic operation name (e.g. `workflow.stream.write`) so the operation is
+   * discoverable in traces beyond the generic HTTP verb.
+   */
+  spanName?: string;
+  /**
+   * Extra attributes merged onto the client span, in addition to the standard
+   * HTTP attributes (e.g. stream name / run id on stream operations).
+   */
+  attributes?: Record<string, string | number>;
+  /**
    * Build the error to throw on a non-2xx response. Receives the raw Response
    * so the caller can read its body in the right format and craft a path-
    * specific message (the message *strings* legitimately differ per API
@@ -348,16 +359,19 @@ export async function instrumentedFetch(
     cacheBust = true,
     logLabel,
     buildError,
+    spanName,
+    attributes,
   } = opts;
   const label = logLabel ?? url;
 
   return trace(
-    `http ${method}`,
+    spanName ?? `http ${method}`,
     { kind: await getSpanKind('CLIENT') },
     async (span) => {
       span?.setAttributes(
         httpClientSpanAttributes({ method, url, peerService })
       );
+      if (attributes) span?.setAttributes(attributes);
 
       // Explicitly propagate trace context so the receiving server can parent
       // its spans to this client span — the custom undici dispatcher bypasses

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -322,6 +322,14 @@ export interface InstrumentedFetchOptions {
    */
   attributes?: Record<string, string | number>;
   /**
+   * When set, stamp the measured request round-trip (dispatch -> response
+   * received, in ms) onto the client span under this attribute key. For a
+   * write PUT this equals the client->server end-to-end latency, since the
+   * server responds only after capturing the chunk. Equivalent to the span's
+   * own duration; exposed as a named attribute for direct querying.
+   */
+  durationAttribute?: string;
+  /**
    * Build the error to throw on a non-2xx response. Receives the raw Response
    * so the caller can read its body in the right format and craft a path-
    * specific message (the message *strings* legitimately differ per API
@@ -361,6 +369,7 @@ export async function instrumentedFetch(
     buildError,
     spanName,
     attributes,
+    durationAttribute,
   } = opts;
   const label = logLabel ?? url;
 
@@ -424,6 +433,7 @@ export async function instrumentedFetch(
 
       httpLog(method, label, response, ms);
       span?.setAttributes({ ...HttpResponseStatusCode(response.status) });
+      if (durationAttribute) span?.setAttributes({ [durationAttribute]: ms });
 
       if (!response.ok) {
         span?.setAttributes({ ...ErrorType(`HTTP ${response.status}`) });

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -324,9 +324,9 @@ export interface InstrumentedFetchOptions {
   /**
    * When set, stamp the measured request round-trip (dispatch -> response
    * received, in ms) onto the client span under this attribute key. For a
-   * write PUT this equals the client->server end-to-end latency, since the
-   * server responds only after capturing the chunk. Equivalent to the span's
-   * own duration; exposed as a named attribute for direct querying.
+   * write PUT this is the per-chunk client->server round-trip (the server acks
+   * only after capturing the chunk). Equivalent to the span's own duration;
+   * exposed as a named attribute for direct querying.
    */
   durationAttribute?: string;
   /**

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -9,6 +9,12 @@ import { z } from 'zod';
 import { getStreamDispatcher } from './http-client.js';
 import { getVercelDiagnostics, instrumentedFetch } from './http-core.js';
 import {
+  WorkflowRunId,
+  WorkflowStreamName,
+  WorkflowStreamOperation,
+  WorkflowStreamStartIndex,
+} from './telemetry.js';
+import {
   type APIConfig,
   getHttpConfig,
   type HttpConfig,
@@ -68,6 +74,28 @@ function getStreamReadUrl(name: string, runId: string, httpConfig: HttpConfig) {
   return new URL(
     `${httpConfig.baseUrl}/v3/runs/${encodeURIComponent(runId)}/stream/${encodeURIComponent(name)}`
   );
+}
+
+/**
+ * Stream-operation attributes layered onto the shared HTTP client span (see
+ * instrumentedFetch). These make stream writes/reads sliceable by run, stream
+ * name, and operation — beyond the generic `http PUT`/`http GET` verb — and
+ * are no-ops when no OTEL SDK is registered (the span is undefined).
+ */
+function streamSpanAttributes(args: {
+  runId: string;
+  name: string;
+  operation: 'write' | 'write_multi' | 'close' | 'read';
+  startIndex?: number;
+}): Record<string, string | number> {
+  return {
+    ...WorkflowRunId(args.runId),
+    ...WorkflowStreamName(args.name),
+    ...WorkflowStreamOperation(args.operation),
+    ...(typeof args.startIndex === 'number'
+      ? WorkflowStreamStartIndex(args.startIndex)
+      : {}),
+  };
 }
 
 function createStreamRequestError(
@@ -167,6 +195,12 @@ export function createStreamer(config?: APIConfig): Streamer {
           dispatcher: getStreamDispatcher(config),
           timeoutMs: null,
           logLabel: url.pathname,
+          spanName: 'workflow.stream.write',
+          attributes: streamSpanAttributes({
+            runId: resolvedRunId,
+            name,
+            operation: 'write',
+          }),
           buildError: async (res) =>
             createStreamRequestError('write', url, res, await res.text()),
         });
@@ -210,6 +244,12 @@ export function createStreamer(config?: APIConfig): Streamer {
             dispatcher: getStreamDispatcher(config),
             timeoutMs: null,
             logLabel: url.pathname,
+            spanName: 'workflow.stream.write',
+            attributes: streamSpanAttributes({
+              runId: resolvedRunId,
+              name,
+              operation: 'write_multi',
+            }),
             buildError: async (res) =>
               createStreamRequestError('write', url, res, await res.text()),
           });
@@ -232,6 +272,12 @@ export function createStreamer(config?: APIConfig): Streamer {
           dispatcher: getStreamDispatcher(config),
           timeoutMs: null,
           logLabel: url.pathname,
+          spanName: 'workflow.stream.write',
+          attributes: streamSpanAttributes({
+            runId: resolvedRunId,
+            name,
+            operation: 'close',
+          }),
           buildError: async (res) =>
             createStreamRequestError('close', url, res, await res.text()),
         });
@@ -254,6 +300,13 @@ export function createStreamer(config?: APIConfig): Streamer {
           dispatcher: undefined,
           timeoutMs: null,
           logLabel: url.pathname,
+          spanName: 'workflow.stream.read',
+          attributes: streamSpanAttributes({
+            runId,
+            name,
+            operation: 'read',
+            startIndex,
+          }),
           buildError: (res) =>
             new Error(`Failed to fetch stream: ${res.status}`),
         });

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -196,7 +196,7 @@ export function createStreamer(config?: APIConfig): Streamer {
           timeoutMs: null,
           logLabel: url.pathname,
           spanName: 'workflow.stream.write',
-          durationAttribute: 'workflow.stream.write.e2e_ms',
+          durationAttribute: 'workflow.stream.write.chunk_rtt',
           attributes: streamSpanAttributes({
             runId: resolvedRunId,
             name,
@@ -246,7 +246,7 @@ export function createStreamer(config?: APIConfig): Streamer {
             timeoutMs: null,
             logLabel: url.pathname,
             spanName: 'workflow.stream.write',
-            durationAttribute: 'workflow.stream.write.e2e_ms',
+            durationAttribute: 'workflow.stream.write.chunk_rtt',
             attributes: streamSpanAttributes({
               runId: resolvedRunId,
               name,
@@ -275,7 +275,7 @@ export function createStreamer(config?: APIConfig): Streamer {
           timeoutMs: null,
           logLabel: url.pathname,
           spanName: 'workflow.stream.write',
-          durationAttribute: 'workflow.stream.write.e2e_ms',
+          durationAttribute: 'workflow.stream.write.chunk_rtt',
           attributes: streamSpanAttributes({
             runId: resolvedRunId,
             name,

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -199,6 +199,7 @@ export function createStreamer(config?: APIConfig): Streamer {
           timeoutMs: null,
           logLabel: url.pathname,
           spanName: 'workflow.stream.write',
+          durationAttribute: 'workflow.stream.write.e2e_ms',
           attributes: streamSpanAttributes({
             runId: resolvedRunId,
             name,
@@ -248,6 +249,7 @@ export function createStreamer(config?: APIConfig): Streamer {
             timeoutMs: null,
             logLabel: url.pathname,
             spanName: 'workflow.stream.write',
+            durationAttribute: 'workflow.stream.write.e2e_ms',
             attributes: streamSpanAttributes({
               runId: resolvedRunId,
               name,
@@ -276,6 +278,7 @@ export function createStreamer(config?: APIConfig): Streamer {
           timeoutMs: null,
           logLabel: url.pathname,
           spanName: 'workflow.stream.write',
+          durationAttribute: 'workflow.stream.write.e2e_ms',
           attributes: streamSpanAttributes({
             runId: resolvedRunId,
             name,

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -9,12 +9,9 @@ import { z } from 'zod';
 import { getStreamDispatcher } from './http-client.js';
 import { getVercelDiagnostics, instrumentedFetch } from './http-core.js';
 import {
-  getSpanKind,
-  recordElapsedSpan,
   WorkflowRunId,
   WorkflowStreamName,
   WorkflowStreamOperation,
-  WorkflowStreamReadTtfcMs,
   WorkflowStreamStartIndex,
 } from './telemetry.js';
 import {
@@ -297,16 +294,11 @@ export function createStreamer(config?: APIConfig): Streamer {
         if (typeof startIndex === 'number') {
           url.searchParams.set('startIndex', String(startIndex));
         }
-        const readAttributes = streamSpanAttributes({
-          runId,
-          name,
-          operation: 'read',
-          startIndex,
-        });
-        // Client-observed time-to-first-chunk is measured from the moment we
-        // dispatch the read; the `.connect` span below only covers up to
-        // response headers (the network-connect portion).
-        const readStart = Date.now();
+        // The `.connect` span covers dispatch → response headers (the
+        // network-connect portion). The end-to-end time-to-first-chunk span
+        // (`workflow.stream.read`) is emitted from the core reader
+        // (`WorkflowServerReadableStream`) when the first chunk reaches the
+        // consumer, so it includes deframing and doesn't need a wrapper here.
         // Live read: keep the global dispatcher and no request timeout so the
         // long-lived, reconnecting read isn't truncated.
         const response = await instrumentedFetch({
@@ -317,41 +309,19 @@ export function createStreamer(config?: APIConfig): Streamer {
           timeoutMs: null,
           logLabel: url.pathname,
           spanName: 'workflow.stream.read.connect',
-          attributes: readAttributes,
+          attributes: streamSpanAttributes({
+            runId,
+            name,
+            operation: 'read',
+            startIndex,
+          }),
           buildError: (res) =>
             new Error(`Failed to fetch stream: ${res.status}`),
         });
         if (!response.body) {
           throw new Error('No response body for stream');
         }
-
-        // Client-observed end-to-end time-to-first-chunk: read dispatch -> the
-        // first non-empty chunk landing in the reader (includes the network hop
-        // and any server-side wait for the producer). Emitted once as a span
-        // back-dated to `readStart`, so its duration IS the TTFC — the
-        // client-side complement to the server's server-derived ttfc_ms. v3+
-        // servers flush a leading zero-length chunk to commit headers, so empty
-        // chunks are skipped. No-op when no OpenTelemetry SDK is registered.
-        const readSpanKind = await getSpanKind('CLIENT');
-        let firstChunkSeen = false;
-        const ttfcProbe = new TransformStream<Uint8Array, Uint8Array>({
-          transform(chunk, controller) {
-            if (!firstChunkSeen && chunk.byteLength > 0) {
-              firstChunkSeen = true;
-              void recordElapsedSpan('workflow.stream.read', readStart, {
-                kind: readSpanKind,
-                attributes: {
-                  ...readAttributes,
-                  ...WorkflowStreamReadTtfcMs(Date.now() - readStart),
-                },
-              });
-            }
-            controller.enqueue(chunk);
-          },
-        });
-        return (response.body as ReadableStream<Uint8Array>).pipeThrough(
-          ttfcProbe
-        );
+        return response.body as ReadableStream<Uint8Array>;
       },
 
       async getChunks(

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -9,9 +9,12 @@ import { z } from 'zod';
 import { getStreamDispatcher } from './http-client.js';
 import { getVercelDiagnostics, instrumentedFetch } from './http-core.js';
 import {
+  getSpanKind,
+  recordElapsedSpan,
   WorkflowRunId,
   WorkflowStreamName,
   WorkflowStreamOperation,
+  WorkflowStreamReadTtfcMs,
   WorkflowStreamStartIndex,
 } from './telemetry.js';
 import {
@@ -291,6 +294,16 @@ export function createStreamer(config?: APIConfig): Streamer {
         if (typeof startIndex === 'number') {
           url.searchParams.set('startIndex', String(startIndex));
         }
+        const readAttributes = streamSpanAttributes({
+          runId,
+          name,
+          operation: 'read',
+          startIndex,
+        });
+        // Client-observed time-to-first-chunk is measured from the moment we
+        // dispatch the read; the `.connect` span below only covers up to
+        // response headers (the network-connect portion).
+        const readStart = Date.now();
         // Live read: keep the global dispatcher and no request timeout so the
         // long-lived, reconnecting read isn't truncated.
         const response = await instrumentedFetch({
@@ -300,20 +313,42 @@ export function createStreamer(config?: APIConfig): Streamer {
           dispatcher: undefined,
           timeoutMs: null,
           logLabel: url.pathname,
-          spanName: 'workflow.stream.read',
-          attributes: streamSpanAttributes({
-            runId,
-            name,
-            operation: 'read',
-            startIndex,
-          }),
+          spanName: 'workflow.stream.read.connect',
+          attributes: readAttributes,
           buildError: (res) =>
             new Error(`Failed to fetch stream: ${res.status}`),
         });
         if (!response.body) {
           throw new Error('No response body for stream');
         }
-        return response.body as ReadableStream<Uint8Array>;
+
+        // Client-observed end-to-end time-to-first-chunk: read dispatch -> the
+        // first non-empty chunk landing in the reader (includes the network hop
+        // and any server-side wait for the producer). Emitted once as a span
+        // back-dated to `readStart`, so its duration IS the TTFC — the
+        // client-side complement to the server's server-derived ttfc_ms. v3+
+        // servers flush a leading zero-length chunk to commit headers, so empty
+        // chunks are skipped. No-op when no OpenTelemetry SDK is registered.
+        const readSpanKind = await getSpanKind('CLIENT');
+        let firstChunkSeen = false;
+        const ttfcProbe = new TransformStream<Uint8Array, Uint8Array>({
+          transform(chunk, controller) {
+            if (!firstChunkSeen && chunk.byteLength > 0) {
+              firstChunkSeen = true;
+              void recordElapsedSpan('workflow.stream.read', readStart, {
+                kind: readSpanKind,
+                attributes: {
+                  ...readAttributes,
+                  ...WorkflowStreamReadTtfcMs(Date.now() - readStart),
+                },
+              });
+            }
+            controller.enqueue(chunk);
+          },
+        });
+        return (response.body as ReadableStream<Uint8Array>).pipeThrough(
+          ttfcProbe
+        );
       },
 
       async getChunks(

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -162,3 +162,21 @@ export const WorkflowRunId = SemanticConvention<string>('workflow.run.id');
 
 /** Unique identifier for the step instance */
 export const StepId = SemanticConvention<string>('step.id');
+
+/** Name of the stream being written or read (workflow.stream.name) */
+export const WorkflowStreamName = SemanticConvention<string>(
+  'workflow.stream.name'
+);
+
+/**
+ * Stream operation performed by the client span
+ * (workflow.stream.operation): write | write_multi | close | read.
+ */
+export const WorkflowStreamOperation = SemanticConvention<string>(
+  'workflow.stream.operation'
+);
+
+/** Requested start index for a live stream read (workflow.stream.start_index) */
+export const WorkflowStreamStartIndex = SemanticConvention<number>(
+  'workflow.stream.start_index'
+);

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -108,6 +108,23 @@ export async function injectTraceContextIntoHeaders(
   }
 }
 
+/**
+ * Emit a span whose start is back-dated to `startEpochMs` and whose end is now,
+ * so its duration reflects an elapsed interval only measurable at its end (e.g.
+ * time-to-first-chunk, known when the first chunk lands). Unlike `trace()`,
+ * this doesn't wrap a callback — it records an already-elapsed span in one shot.
+ * No-op when no OpenTelemetry SDK is registered.
+ */
+export async function recordElapsedSpan(
+  spanName: string,
+  startEpochMs: number,
+  opts?: SpanOptions
+): Promise<void> {
+  const tracer = await getTracer();
+  if (!tracer) return;
+  tracer.startSpan(spanName, { ...opts, startTime: startEpochMs }).end();
+}
+
 // Semantic conventions for World/Storage tracing
 // Standard OTEL conventions: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 function SemanticConvention<T>(...names: string[]) {
@@ -179,4 +196,14 @@ export const WorkflowStreamOperation = SemanticConvention<string>(
 /** Requested start index for a live stream read (workflow.stream.start_index) */
 export const WorkflowStreamStartIndex = SemanticConvention<number>(
   'workflow.stream.start_index'
+);
+
+/**
+ * Client-observed end-to-end time-to-first-chunk for a live read, in ms
+ * (workflow.stream.read.ttfc_ms): read dispatch -> first non-empty chunk in the
+ * reader, including the network hop. The client-side complement to the server's
+ * server-derived ttfc_ms.
+ */
+export const WorkflowStreamReadTtfcMs = SemanticConvention<number>(
+  'workflow.stream.read.ttfc_ms'
 );

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -108,23 +108,6 @@ export async function injectTraceContextIntoHeaders(
   }
 }
 
-/**
- * Emit a span whose start is back-dated to `startEpochMs` and whose end is now,
- * so its duration reflects an elapsed interval only measurable at its end (e.g.
- * time-to-first-chunk, known when the first chunk lands). Unlike `trace()`,
- * this doesn't wrap a callback — it records an already-elapsed span in one shot.
- * No-op when no OpenTelemetry SDK is registered.
- */
-export async function recordElapsedSpan(
-  spanName: string,
-  startEpochMs: number,
-  opts?: SpanOptions
-): Promise<void> {
-  const tracer = await getTracer();
-  if (!tracer) return;
-  tracer.startSpan(spanName, { ...opts, startTime: startEpochMs }).end();
-}
-
 // Semantic conventions for World/Storage tracing
 // Standard OTEL conventions: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 function SemanticConvention<T>(...names: string[]) {
@@ -196,14 +179,4 @@ export const WorkflowStreamOperation = SemanticConvention<string>(
 /** Requested start index for a live stream read (workflow.stream.start_index) */
 export const WorkflowStreamStartIndex = SemanticConvention<number>(
   'workflow.stream.start_index'
-);
-
-/**
- * Client-observed end-to-end time-to-first-chunk for a live read, in ms
- * (workflow.stream.read.ttfc_ms): read dispatch -> first non-empty chunk in the
- * reader, including the network hop. The client-side complement to the server's
- * server-derived ttfc_ms.
- */
-export const WorkflowStreamReadTtfcMs = SemanticConvention<number>(
-  'workflow.stream.read.ttfc_ms'
 );

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -200,10 +200,16 @@ describe('streamer write trace propagation', () => {
     // the instrumented envelope, so workflow-server can correlate the write.
     expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
 
+    // The stream write shares the instrumented envelope but is named for the
+    // stream operation (not the bare `http PUT` verb) and carries stream
+    // attributes so write latency is sliceable by run/stream.
     const clientSpan = exporter
       .getFinishedSpans()
-      .find((s) => s.name === 'http PUT');
+      .find((s) => s.name === 'workflow.stream.write');
     expect(clientSpan).toBeDefined();
+    expect(clientSpan?.attributes['workflow.stream.operation']).toBe('write');
+    expect(clientSpan?.attributes['workflow.stream.name']).toBe('user');
+    expect(clientSpan?.attributes['workflow.run.id']).toBe('wrun_1');
     expect(clientSpan?.spanContext().traceId).toBe(traceId);
     expect(clientSpan?.parentSpanId).toBe(spanId);
     expect(traceparent).toBe(

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -20,7 +20,10 @@ import {
 import { z } from 'zod';
 import { getWorkflowRunEventsV4 } from './events-v4.js';
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
-import { injectTraceContextIntoHeaders } from './telemetry.js';
+import {
+  injectTraceContextIntoHeaders,
+  recordElapsedSpan,
+} from './telemetry.js';
 import { makeRequest } from './utils.js';
 
 vi.mock('@vercel/oidc', () => ({
@@ -84,6 +87,23 @@ describe('injectTraceContextIntoHeaders', () => {
     const headers = new Headers();
     await injectTraceContextIntoHeaders(headers);
     expect(headers.get('traceparent')).toBeNull();
+  });
+});
+
+describe('recordElapsedSpan (back-dated timing span)', () => {
+  it('emits a span whose duration reflects the elapsed interval', async () => {
+    const startMs = Date.now() - 250;
+    await recordElapsedSpan('workflow.stream.read', startMs, {
+      attributes: { 'workflow.stream.read.ttfc_ms': 250 },
+    });
+    const span = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'workflow.stream.read');
+    expect(span).toBeDefined();
+    expect(span!.attributes['workflow.stream.read.ttfc_ms']).toBe(250);
+    // duration is hrtime [seconds, nanos]; the 250ms back-date should show up.
+    const durationSec = span!.duration[0] + span!.duration[1] / 1e9;
+    expect(durationSec).toBeGreaterThanOrEqual(0.2);
   });
 });
 

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -20,10 +20,7 @@ import {
 import { z } from 'zod';
 import { getWorkflowRunEventsV4 } from './events-v4.js';
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
-import {
-  injectTraceContextIntoHeaders,
-  recordElapsedSpan,
-} from './telemetry.js';
+import { injectTraceContextIntoHeaders } from './telemetry.js';
 import { makeRequest } from './utils.js';
 
 vi.mock('@vercel/oidc', () => ({
@@ -87,23 +84,6 @@ describe('injectTraceContextIntoHeaders', () => {
     const headers = new Headers();
     await injectTraceContextIntoHeaders(headers);
     expect(headers.get('traceparent')).toBeNull();
-  });
-});
-
-describe('recordElapsedSpan (back-dated timing span)', () => {
-  it('emits a span whose duration reflects the elapsed interval', async () => {
-    const startMs = Date.now() - 250;
-    await recordElapsedSpan('workflow.stream.read', startMs, {
-      attributes: { 'workflow.stream.read.ttfc_ms': 250 },
-    });
-    const span = exporter
-      .getFinishedSpans()
-      .find((s) => s.name === 'workflow.stream.read');
-    expect(span).toBeDefined();
-    expect(span!.attributes['workflow.stream.read.ttfc_ms']).toBe(250);
-    // duration is hrtime [seconds, nanos]; the 250ms back-date should show up.
-    const durationSec = span!.duration[0] + span!.duration[1] / 1e9;
-    expect(durationSec).toBeGreaterThanOrEqual(0.2);
   });
 });
 


### PR DESCRIPTION
## What

Adds OpenTelemetry client spans that make stream **write** and **read** end-to-end latency measurable from the SDK — the client→server timing that server-side metrics can't see (the network hop + client-side legs). These back `getWritable()` / `run.readable`.

### Write
- `workflow.stream.write` span (for `write` / `writeMulti` / `close`), `SpanKind.CLIENT`.
- `workflow.stream.write.e2e_ms` attribute = client→backend round-trip. The PUT is request/response and the backend acks only after capturing the chunk, so this is the client-observed write latency **including the network hop**. (It equals the span's own duration; exposed as a named attribute for direct querying.)

### Read
- `workflow.stream.read.connect` span — dispatch → response headers (the network-connect portion).
- `workflow.stream.read` span — its duration is the client-observed **end-to-end time-to-first-chunk**: read dispatch → first non-empty chunk in the reader, **including the network hop** — also stamped as `workflow.stream.read.ttfc_ms`. Since that value is only known once the first chunk arrives, it's emitted as a span **back-dated** to dispatch time (new `recordElapsedSpan` helper). v3+ servers flush a leading zero-length chunk to commit headers, which is skipped. If no chunk ever arrives, no `workflow.stream.read` span is emitted (`.connect` still is).

### Common attributes
`workflow.run.id` (dotted — the standardized run-id attribute), `workflow.stream.name`, `workflow.stream.operation` (`write` | `write_multi` | `close` | `read`), `workflow.stream.start_index` (read).

## How
- `instrumentedFetch` gains three optional, defaulted fields — `spanName`, `attributes`, and `durationAttribute` (stamps the measured round-trip under a named key). Reuses the existing envelope (W3C trace-context injection, timeout, error mapping, DEBUG logging); no new span layer, no extra requests.
- Read TTFC is measured by a passthrough on `response.body` that emits the back-dated `workflow.stream.read` span on the first non-empty chunk.

## Backward compatibility
Additive OTEL only. With no OpenTelemetry SDK registered, `trace()` / `recordElapsedSpan` no-op and spans/attributes are dropped — behavior is byte-identical to today. The new `instrumentedFetch` options are optional and defaulted, so all other callers are unaffected. (Client spans are emitted only when the reader/writer has OTEL registered; server metrics cover the rest.)

## Docs
Documented the stream spans + attributes in `docs/content/docs/v5/observability/tracing.mdx`.

### Docs Preview
| Page | Preview |
| --- | --- |
| Observability → Tracing | https://workflow-docs-git-karthik-stream-latency-otel.vercel.sh/v5/docs/observability/tracing |

## Test plan
- `packages/world-vercel` unit suite: **229 passed** (`pnpm test`).
- `trace-propagation.test.ts`: asserts the write span name + attributes + `traceparent` injection, and covers the new `recordElapsedSpan` back-dated span (duration reflects the elapsed interval + attribute set).
- Typecheck/build clean (`pnpm --filter "@workflow/world-vercel..." build`).
