### PR TITLE
fix(web-shared): remove unused flex-1 from attribute copy-value rows

### DIFF
--- a/.changeset/attributes-row-remove-flex-1.md
+++ b/.changeset/attributes-row-remove-flex-1.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Remove unused `flex-1` from attribute copy-value rows so values hug their content.

--- a/packages/web-shared/src/components/sidebar/attributes-block.tsx
+++ b/packages/web-shared/src/components/sidebar/attributes-block.tsx
@@ -37,7 +37,7 @@ const rowValueVariants = cva(
 );
 
 const rowCopyValueVariants = cva(
-  'flex min-w-0 flex-1 items-center justify-end gap-1 text-copy-13 text-gray-1000',
+  'flex min-w-0 items-center justify-end gap-1 text-copy-13 text-gray-1000',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- The attribute copy-value row is already right-aligned by the parent's `justify-between`, so `flex-1` only forced the value column to stretch across leftover space.
- Removes `flex-1` from `rowCopyValueVariants` so values hug their content.

## Test plan
- [ ] Open a run's Attributes / Metadata sidebar and confirm copyable values render right-aligned and truncate/copy correctly.

Made with [Cursor](https://cursor.com)