### PR TITLE
Add workflow observability event reporting

### DIFF
--- a/.changeset/eve-observability-events.md
+++ b/.changeset/eve-observability-events.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+'@workflow/world-vercel': patch
+---
+
+Add an experimental workflow observability event reporter for platform-side agent issue materialization.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   type WebhookOptions,
 } from './create-hook.js';
 export { defineHook, type TypedHook } from './define-hook.js';
+export { experimental_reportObservabilityEvent } from './report-observability-event.js';
 export { experimental_setAttributes } from './set-attributes.js';
 export { sleep } from './sleep.js';
 export {

--- a/packages/core/src/report-observability-event.test.ts
+++ b/packages/core/src/report-observability-event.test.ts
@@ -3,8 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { experimental_reportObservabilityEvent } from './report-observability-event.js';
 import { contextStorage, type StepContext } from './step/context-storage.js';
 
+const waitUntilPromises: Promise<unknown>[] = [];
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn((promise: Promise<unknown>) => {
+    waitUntilPromises.push(promise);
+  }),
+}));
+
 const WORLD_CACHE = Symbol.for('@workflow/world//cache');
 const globals = globalThis as Record<symbol, unknown>;
+
+async function flushWaitUntil(): Promise<void> {
+  await vi.waitFor(() => expect(waitUntilPromises.length).toBeGreaterThan(0));
+  await Promise.all(waitUntilPromises.splice(0));
+}
 
 function stepContext(runId = 'run_123'): StepContext {
   return {
@@ -30,6 +43,7 @@ describe('experimental_reportObservabilityEvent', () => {
 
   beforeEach(() => {
     originalWorld = globals[WORLD_CACHE];
+    waitUntilPromises.length = 0;
   });
 
   afterEach(() => {
@@ -43,12 +57,12 @@ describe('experimental_reportObservabilityEvent', () => {
   });
 
   it('no-ops outside workflow context', async () => {
-    await expect(
+    expect(
       experimental_reportObservabilityEvent({
         type: 'action.result',
         data: { status: 'failed' },
       })
-    ).resolves.toBeUndefined();
+    ).toBeUndefined();
   });
 
   it('posts event through an observability-capable world', async () => {
@@ -65,6 +79,7 @@ describe('experimental_reportObservabilityEvent', () => {
         meta: { at: '2026-01-01T00:00:00.000Z' },
       })
     );
+    await flushWaitUntil();
 
     expect(reportEvent).toHaveBeenCalledWith('run_123', {
       event: {
@@ -79,13 +94,14 @@ describe('experimental_reportObservabilityEvent', () => {
   it('no-ops when the world has no observability reporter', async () => {
     globals[WORLD_CACHE] = { specVersion: SPEC_VERSION_CURRENT };
 
-    await expect(
+    expect(
       contextStorage.run(stepContext(), () =>
         experimental_reportObservabilityEvent({
           type: 'action.result',
           data: { status: 'failed' },
         })
       )
-    ).resolves.toBeUndefined();
+    ).toBeUndefined();
+    await flushWaitUntil();
   });
 });

--- a/packages/core/src/report-observability-event.test.ts
+++ b/packages/core/src/report-observability-event.test.ts
@@ -1,0 +1,91 @@
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { experimental_reportObservabilityEvent } from './report-observability-event.js';
+import { contextStorage, type StepContext } from './step/context-storage.js';
+
+const WORLD_CACHE = Symbol.for('@workflow/world//cache');
+const globals = globalThis as Record<symbol, unknown>;
+
+function stepContext(runId = 'run_123'): StepContext {
+  return {
+    stepMetadata: {
+      stepName: 'observabilityStep',
+      stepId: 'step',
+      stepStartedAt: new Date('2026-01-01T00:00:00.000Z'),
+      attempt: 2,
+    },
+    workflowMetadata: {
+      workflowName: 'workflow',
+      workflowRunId: runId,
+      workflowStartedAt: new Date('2026-01-01T00:00:00.000Z'),
+      url: 'http://localhost/.well-known/workflow/v1/flow',
+      features: { encryption: false },
+    },
+    ops: [],
+  };
+}
+
+describe('experimental_reportObservabilityEvent', () => {
+  let originalWorld: unknown;
+
+  beforeEach(() => {
+    originalWorld = globals[WORLD_CACHE];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalWorld === undefined) {
+      delete globals[WORLD_CACHE];
+    } else {
+      globals[WORLD_CACHE] = originalWorld;
+    }
+  });
+
+  it('no-ops outside workflow context', async () => {
+    await expect(
+      experimental_reportObservabilityEvent({
+        type: 'action.result',
+        data: { status: 'failed' },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('posts event through an observability-capable world', async () => {
+    const reportEvent = vi.fn().mockResolvedValue({ ok: true });
+    globals[WORLD_CACHE] = {
+      specVersion: SPEC_VERSION_CURRENT,
+      observability: { reportEvent },
+    };
+
+    await contextStorage.run(stepContext(), () =>
+      experimental_reportObservabilityEvent({
+        type: 'action.result',
+        data: { status: 'failed' },
+        meta: { at: '2026-01-01T00:00:00.000Z' },
+      })
+    );
+
+    expect(reportEvent).toHaveBeenCalledWith('run_123', {
+      event: {
+        type: 'action.result',
+        data: { status: 'failed' },
+        meta: { at: '2026-01-01T00:00:00.000Z' },
+      },
+      writer: { type: 'step', stepId: 'step', attempt: 2 },
+    });
+  });
+
+  it('no-ops when the world has no observability reporter', async () => {
+    globals[WORLD_CACHE] = { specVersion: SPEC_VERSION_CURRENT };
+
+    await expect(
+      contextStorage.run(stepContext(), () =>
+        experimental_reportObservabilityEvent({
+          type: 'action.result',
+          data: { status: 'failed' },
+        })
+      )
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/report-observability-event.ts
+++ b/packages/core/src/report-observability-event.ts
@@ -1,0 +1,34 @@
+import type { WorkflowObservabilityEvent } from '@workflow/world';
+import { getWorldLazy } from './runtime/get-world-lazy.js';
+import { contextStorage } from './step/context-storage.js';
+
+export async function experimental_reportObservabilityEvent(
+  event: WorkflowObservabilityEvent
+): Promise<void> {
+  const store = contextStorage.getStore();
+  const runId = store?.workflowMetadata?.workflowRunId;
+  if (!runId) return;
+
+  if (store.runReadyBarrier) {
+    try {
+      await store.runReadyBarrier;
+    } catch {
+      // Ordering barrier only. If the run truly does not exist, reporting below
+      // fails and is swallowed as best-effort observability.
+    }
+  }
+
+  try {
+    const world = await getWorldLazy();
+    await world.observability?.reportEvent(runId, {
+      event,
+      writer: {
+        type: 'step',
+        stepId: store.stepMetadata.stepId,
+        attempt: store.stepMetadata.attempt,
+      },
+    });
+  } catch {
+    // Observability indexing must never change workflow execution behavior.
+  }
+}

--- a/packages/core/src/report-observability-event.ts
+++ b/packages/core/src/report-observability-event.ts
@@ -1,34 +1,37 @@
 import type { WorkflowObservabilityEvent } from '@workflow/world';
+import { safeWaitUntil } from './runtime/wait-until.js';
 import { getWorldLazy } from './runtime/get-world-lazy.js';
 import { contextStorage } from './step/context-storage.js';
 
-export async function experimental_reportObservabilityEvent(
+export function experimental_reportObservabilityEvent(
   event: WorkflowObservabilityEvent
-): Promise<void> {
+): void {
   const store = contextStorage.getStore();
   const runId = store?.workflowMetadata?.workflowRunId;
   if (!runId) return;
 
-  if (store.runReadyBarrier) {
-    try {
-      await store.runReadyBarrier;
-    } catch {
-      // Ordering barrier only. If the run truly does not exist, reporting below
-      // fails and is swallowed as best-effort observability.
+  safeWaitUntil(
+    (async () => {
+      if (store.runReadyBarrier) {
+        try {
+          await store.runReadyBarrier;
+        } catch {
+          // Ordering barrier only. If the run truly does not exist, reporting below
+          // fails and is swallowed as best-effort observability.
+        }
+      }
+      const world = await getWorldLazy();
+      const writer = store.stepMetadata
+        ? ({
+            type: 'step',
+            stepId: store.stepMetadata.stepId,
+            attempt: store.stepMetadata.attempt,
+          } as const)
+        : undefined;
+      await world.observability?.reportEvent(runId, { event, writer });
+    })(),
+    () => {
+      // Observability indexing must never change workflow execution behavior.
     }
-  }
-
-  try {
-    const world = await getWorldLazy();
-    await world.observability?.reportEvent(runId, {
-      event,
-      writer: {
-        type: 'step',
-        stepId: store.stepMetadata.stepId,
-        attempt: store.stepMetadata.attempt,
-      },
-    });
-  } catch {
-    // Observability indexing must never change workflow execution behavior.
-  }
+  );
 }

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -3,6 +3,7 @@ import { SPEC_VERSION_SUPPORTS_COMPRESSION } from '@workflow/world';
 import { createAnalytics } from './analytics.js';
 import { createGetEncryptionKeyForRun } from './encryption.js';
 import { instrumentObject } from './instrumentObject.js';
+import { createObservability } from './observability.js';
 import { createQueue } from './queue.js';
 import { createResolveLatestDeploymentId } from './resolve-latest-deployment.js';
 import { createStorage } from './storage.js';
@@ -44,6 +45,7 @@ export function createWorld(config?: APIConfig): World {
     ...createQueue(config),
     ...createStorage(config),
     analytics: createAnalytics(config),
+    ...createObservability(config),
     ...instrumentObject('world.streams', createStreamer(config)),
     getEncryptionKeyForRun: createGetEncryptionKeyForRun(
       projectId,

--- a/packages/world-vercel/src/observability.ts
+++ b/packages/world-vercel/src/observability.ts
@@ -1,0 +1,27 @@
+import {
+  ReportWorkflowObservabilityEventRequestSchema,
+  ReportWorkflowObservabilityEventResponseSchema,
+  type ReportWorkflowObservabilityEventRequest,
+  type ReportWorkflowObservabilityEventResponse,
+} from '@workflow/world';
+import type { APIConfig } from './utils.js';
+import { makeRequest } from './utils.js';
+
+export function createObservability(config?: APIConfig) {
+  return {
+    observability: {
+      async reportEvent(
+        runId: string,
+        data: ReportWorkflowObservabilityEventRequest
+      ): Promise<ReportWorkflowObservabilityEventResponse> {
+        return makeRequest({
+          endpoint: `/v2/runs/${runId}/observability-events`,
+          options: { method: 'POST' },
+          data: ReportWorkflowObservabilityEventRequestSchema.parse(data),
+          config,
+          schema: ReportWorkflowObservabilityEventResponseSchema,
+        });
+      },
+    },
+  };
+}

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -41,6 +41,13 @@ export {
 export type * from './hooks.js';
 export { HookSchema } from './hooks.js';
 export type * from './interfaces.js';
+export type * from './observability.js';
+export {
+  ReportWorkflowObservabilityEventRequestSchema,
+  ReportWorkflowObservabilityEventResponseSchema,
+  WorkflowObservabilityEventSchema,
+  WorkflowObservabilityEventWriterSchema,
+} from './observability.js';
 export type * from './queue.js';
 export {
   getQueuePrefixKind,

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -14,6 +14,10 @@ import type {
   RunCreatedEventRequest,
 } from './events.js';
 import type { GetHookParams, Hook, ListHooksParams } from './hooks.js';
+import type {
+  ReportWorkflowObservabilityEventRequest,
+  ReportWorkflowObservabilityEventResponse,
+} from './observability.js';
 import type { Queue } from './queue.js';
 import type {
   GetWorkflowRunParams,
@@ -284,6 +288,13 @@ export interface World extends Queue, Streamer, Storage {
    * resolution path.
    */
   analytics?: Analytics;
+
+  observability?: {
+    reportEvent(
+      runId: string,
+      data: ReportWorkflowObservabilityEventRequest
+    ): Promise<ReportWorkflowObservabilityEventResponse>;
+  };
 
   /**
    * The Workflow protocol spec version this World implements.

--- a/packages/world/src/observability.ts
+++ b/packages/world/src/observability.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+const WorkflowObservabilityEventMetaSchema = z
+  .object({
+    at: z.string().optional(),
+  })
+  .passthrough();
+
+export const WorkflowObservabilityEventSchema = z
+  .object({
+    type: z.string().min(1),
+    data: z.record(z.string(), z.unknown()).default({}),
+    meta: WorkflowObservabilityEventMetaSchema.optional(),
+  })
+  .passthrough();
+
+export type WorkflowObservabilityEvent = z.infer<
+  typeof WorkflowObservabilityEventSchema
+>;
+
+export const WorkflowObservabilityEventWriterSchema = z.object({
+  type: z.literal('step'),
+  stepId: z.string().min(1),
+  attempt: z.number().int().nonnegative(),
+});
+
+export type WorkflowObservabilityEventWriter = z.infer<
+  typeof WorkflowObservabilityEventWriterSchema
+>;
+
+export const ReportWorkflowObservabilityEventRequestSchema = z.object({
+  event: WorkflowObservabilityEventSchema,
+  writer: WorkflowObservabilityEventWriterSchema.optional(),
+});
+
+export type ReportWorkflowObservabilityEventRequest = z.infer<
+  typeof ReportWorkflowObservabilityEventRequestSchema
+>;
+
+export const ReportWorkflowObservabilityEventResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export type ReportWorkflowObservabilityEventResponse = z.infer<
+  typeof ReportWorkflowObservabilityEventResponseSchema
+>;


### PR DESCRIPTION
- Why: Vercel needs typed issue-source events before Workflow serializes or encrypts stream chunks.
- What: adds an optional world observability reporter and a best-effort core helper frameworks can call during execution.
- What: posts those events from the Vercel world without changing workflow execution or stream persistence.