### PR TITLE
feat(core): record replay lineage in run executionContext

### DIFF
--- a/.changeset/replay-lineage-execution-context.md
+++ b/.changeset/replay-lineage-execution-context.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Record the source run on replays: `recreateRunFromExisting` now stamps `replayedFromRunId` into the new run's `executionContext` (and `start` accepts a matching option) so tooling can surface a run as a replay and link back to its origin.

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -31,7 +31,7 @@ import {
   hydrateStepReturnValue,
 } from '../serialization.js';
 import { Run } from './run.js';
-import { reenqueueRun, wakeUpRun } from './runs.js';
+import { recreateRunFromExisting, reenqueueRun, wakeUpRun } from './runs.js';
 import { start } from './start.js';
 import { setWorld } from './world.js';
 

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -12,6 +12,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Mock version module to avoid missing generated file
 vi.mock('../version.js', () => ({ version: '0.0.0-test' }));
 
+// Stub `start` so recreateRunFromExisting can be tested for the options it
+// forwards without exercising the full run-creation pipeline (serialization,
+// telemetry, queueing).
+vi.mock('./start.js', () => ({ start: vi.fn() }));
+
+// Keep serialization real except for argument hydration, which needs a real
+// serialized payload we don't have in these unit tests.
+vi.mock('../serialization.js', async (importActual) => {
+  const actual = await importActual<typeof import('../serialization.js')>();
+  return { ...actual, hydrateWorkflowArguments: vi.fn().mockResolvedValue([]) };
+});
+
 import { registerSerializationClass } from '../class-serialization.js';
 import {
   dehydrateRunError,
@@ -19,7 +31,8 @@ import {
   hydrateStepReturnValue,
 } from '../serialization.js';
 import { Run } from './run.js';
-import { wakeUpRun } from './runs.js';
+import { recreateRunFromExisting, wakeUpRun } from './runs.js';
+import { start } from './start.js';
 import { setWorld } from './world.js';
 
 function createMockWorld(
@@ -106,6 +119,31 @@ describe('wakeUpRun', () => {
     const world = createMockWorld({ events, createError: serverError });
 
     await expect(wakeUpRun(world, 'wrun_123')).rejects.toThrow(AggregateError);
+  });
+});
+
+describe('recreateRunFromExisting', () => {
+  afterEach(() => {
+    vi.mocked(start).mockReset();
+  });
+
+  it('forwards the source run id to start as replayedFromRunId', async () => {
+    const world = createMockWorld({
+      run: { runId: 'wrun_source', deploymentId: 'deploy_source' },
+    });
+    vi.mocked(start).mockResolvedValue({ runId: 'wrun_new' } as Run<unknown>);
+
+    const newRunId = await recreateRunFromExisting(world, 'wrun_source');
+
+    expect(newRunId).toBe('wrun_new');
+    expect(start).toHaveBeenCalledWith(
+      { workflowId: 'test-workflow' },
+      expect.any(Array),
+      expect.objectContaining({
+        replayedFromRunId: 'wrun_source',
+        deploymentId: 'deploy_source',
+      })
+    );
   });
 });
 

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -80,6 +80,9 @@ export async function recreateRunFromExisting(
         deploymentId,
         world,
         specVersion,
+        // Record the run we're replaying from so the new run can be surfaced
+        // as a replay (e.g. "Replay of <runId>") in tooling.
+        replayedFromRunId: runId,
       }
     );
     return newRun.runId;

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -80,8 +80,6 @@ export async function recreateRunFromExisting(
         deploymentId,
         world,
         specVersion,
-        // Record the run we're replaying from so the new run can be surfaced
-        // as a replay (e.g. "Replay of <runId>") in tooling.
         replayedFromRunId: runId,
       }
     );

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -800,7 +800,8 @@ describe('start', () => {
     });
 
     it('records replayedFromRunId in executionContext when provided', async () => {
-      await start(validWorkflow, [], { replayedFromRunId: 'wrun_source' });
+      const sourceRunId = 'wrun_01ARZ3NDEKTSV4RRFFQ69G5FAV';
+      await start(validWorkflow, [], { replayedFromRunId: sourceRunId });
 
       expect(mockEventsCreate).toHaveBeenCalledWith(
         expect.stringMatching(/^wrun_/),
@@ -808,7 +809,7 @@ describe('start', () => {
           eventType: 'run_created',
           eventData: expect.objectContaining({
             executionContext: expect.objectContaining({
-              replayedFromRunId: 'wrun_source',
+              replayedFromRunId: sourceRunId,
             }),
           }),
         }),
@@ -828,16 +829,16 @@ describe('start', () => {
     it('rejects a replayedFromRunId without the wrun_ prefix', async () => {
       await expect(
         start(validWorkflow, [], { replayedFromRunId: 'not-a-run-id' })
-      ).rejects.toThrow(/replayedFromRunId must be a "wrun_"-prefixed run ID/);
+      ).rejects.toThrow(/replayedFromRunId must be a run ID/);
       expect(mockEventsCreate).not.toHaveBeenCalled();
     });
 
-    it('rejects a replayedFromRunId that exceeds the length cap', async () => {
+    it('rejects a wrun_-prefixed value whose body is not a valid ULID', async () => {
       await expect(
         start(validWorkflow, [], {
           replayedFromRunId: `wrun_${'x'.repeat(300)}`,
         })
-      ).rejects.toThrow(/at most 256 characters/);
+      ).rejects.toThrow(/replayedFromRunId must be a run ID/);
       expect(mockEventsCreate).not.toHaveBeenCalled();
     });
 
@@ -847,7 +848,7 @@ describe('start', () => {
           // Types forbid this, but JS callers can still pass it.
           replayedFromRunId: 12345 as unknown as string,
         })
-      ).rejects.toThrow(/replayedFromRunId must be a "wrun_"-prefixed run ID/);
+      ).rejects.toThrow(/replayedFromRunId must be a run ID/);
       expect(mockEventsCreate).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -824,6 +824,32 @@ describe('start', () => {
         'replayedFromRunId'
       );
     });
+
+    it('rejects a replayedFromRunId without the wrun_ prefix', async () => {
+      await expect(
+        start(validWorkflow, [], { replayedFromRunId: 'not-a-run-id' })
+      ).rejects.toThrow(/replayedFromRunId must be a "wrun_"-prefixed run ID/);
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects a replayedFromRunId that exceeds the length cap', async () => {
+      await expect(
+        start(validWorkflow, [], {
+          replayedFromRunId: `wrun_${'x'.repeat(300)}`,
+        })
+      ).rejects.toThrow(/at most 256 characters/);
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-string replayedFromRunId', async () => {
+      await expect(
+        start(validWorkflow, [], {
+          // Types forbid this, but JS callers can still pass it.
+          replayedFromRunId: 12345 as unknown as string,
+        })
+      ).rejects.toThrow(/replayedFromRunId must be a "wrun_"-prefixed run ID/);
+      expect(mockEventsCreate).not.toHaveBeenCalled();
+    });
   });
 
   describe('overload type inference', () => {

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -770,6 +770,62 @@ describe('start', () => {
     });
   });
 
+  describe('replay lineage (executionContext.replayedFromRunId)', () => {
+    let mockEventsCreate: ReturnType<typeof vi.fn>;
+    let mockQueue: ReturnType<typeof vi.fn>;
+
+    const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+      workflowId: 'test-workflow',
+    });
+
+    beforeEach(() => {
+      mockEventsCreate = vi.fn().mockImplementation((runId) => {
+        return Promise.resolve({
+          run: { runId: runId ?? 'wrun_test123', status: 'pending' },
+        });
+      });
+      mockQueue = vi.fn().mockResolvedValue(undefined);
+
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      });
+    });
+
+    afterEach(() => {
+      setWorld(undefined);
+      vi.clearAllMocks();
+    });
+
+    it('records replayedFromRunId in executionContext when provided', async () => {
+      await start(validWorkflow, [], { replayedFromRunId: 'wrun_source' });
+
+      expect(mockEventsCreate).toHaveBeenCalledWith(
+        expect.stringMatching(/^wrun_/),
+        expect.objectContaining({
+          eventType: 'run_created',
+          eventData: expect.objectContaining({
+            executionContext: expect.objectContaining({
+              replayedFromRunId: 'wrun_source',
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('omits replayedFromRunId from executionContext when not provided', async () => {
+      await start(validWorkflow, []);
+
+      const eventData = mockEventsCreate.mock.calls[0]?.[1]?.eventData;
+      expect(eventData.executionContext).not.toHaveProperty(
+        'replayedFromRunId'
+      );
+    });
+  });
+
   describe('overload type inference', () => {
     // Type-only assertions that don't execute start() at runtime.
     // We use expectTypeOf on the function signature's return type directly.

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -89,6 +89,17 @@ export interface StartOptionsBase {
    * the `experimental_setAttributes` option of the same name.
    */
   allowReservedAttributes?: boolean;
+
+  /**
+   * The ID of an existing run this run is being replayed from, if any.
+   *
+   * Recorded on the new run's `executionContext` as `replayedFromRunId` so
+   * tooling (e.g. the dashboard runs list) can show that a run originated as
+   * a replay and link back to its source. Set automatically by
+   * {@link recreateRunFromExisting}; there's usually no reason to pass it
+   * directly.
+   */
+  replayedFromRunId?: string;
 }
 
 export interface StartOptionsWithDeploymentId extends StartOptionsBase {
@@ -356,6 +367,10 @@ export async function start<TArgs extends unknown[], TResult>(
         traceCarrier,
         workflowCoreVersion,
         features: { encryption: !!encryptionKey },
+        // Preserve replay lineage so the run can be shown as "Replay of <id>".
+        ...(opts.replayedFromRunId
+          ? { replayedFromRunId: opts.replayedFromRunId }
+          : {}),
       };
 
       // Call events.create (run_created) and queue in parallel.

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -6,6 +6,7 @@ import {
   SPEC_VERSION_SUPPORTS_ATTRIBUTES,
   SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
   SPEC_VERSION_SUPPORTS_COMPRESSION,
+  workflowRunIdSchema,
 } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 import { normalizeAttributeChanges } from '../attribute-changes.js';
@@ -99,9 +100,9 @@ export interface StartOptionsBase {
    * {@link recreateRunFromExisting}; there's usually no reason to pass it
    * directly.
    *
-   * Must be a run ID: a `wrun_`-prefixed string of at most 256 characters.
-   * It is persisted verbatim on the size-capped run item, so `start()`
-   * rejects anything else to keep the option from being misused to bloat it.
+   * Must be a run ID: `wrun_` followed by a 26-char ULID. It's a foreign key
+   * to the source run, so `start()` validates the exact shape and rejects
+   * anything else rather than persist a lineage link that points at garbage.
    */
   replayedFromRunId?: string;
   /**
@@ -349,25 +350,17 @@ export async function start<TArgs extends unknown[], TResult>(
           }
         : {};
 
-      // `replayedFromRunId` is stamped verbatim into `executionContext`, which
-      // is persisted on the (size-capped) run item. It's meant to be a run ID
-      // (~31 chars), so reject anything that isn't a short `wrun_`-prefixed
-      // string up front rather than let the option be misused to bloat it.
-      if (opts.replayedFromRunId !== undefined) {
-        const id: unknown = opts.replayedFromRunId;
-        if (
-          typeof id !== 'string' ||
-          !id.startsWith('wrun_') ||
-          id.length > 256
-        ) {
-          const received =
-            typeof id === 'string'
-              ? `${JSON.stringify(id.slice(0, 64))} (length ${id.length})`
-              : `a ${typeof id} value`;
-          throw new WorkflowRuntimeError(
-            `replayedFromRunId must be a "wrun_"-prefixed run ID of at most 256 characters; received ${received}.`
-          );
-        }
+      // `replayedFromRunId` is a foreign key to the source run; reject anything
+      // that isn't a real run ID so the lineage link can't point at garbage.
+      if (
+        opts.replayedFromRunId !== undefined &&
+        !workflowRunIdSchema.safeParse(opts.replayedFromRunId).success
+      ) {
+        throw new WorkflowRuntimeError(
+          `replayedFromRunId must be a run ID (wrun_<ulid>); received ${JSON.stringify(
+            String(opts.replayedFromRunId).slice(0, 64)
+          )}.`
+        );
       }
 
       // Resolve encryption key for the new run. The runId has already been

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -98,6 +98,10 @@ export interface StartOptionsBase {
    * a replay and link back to its source. Set automatically by
    * {@link recreateRunFromExisting}; there's usually no reason to pass it
    * directly.
+   *
+   * Must be a run ID: a `wrun_`-prefixed string of at most 256 characters.
+   * It is persisted verbatim on the size-capped run item, so `start()`
+   * rejects anything else to keep the option from being misused to bloat it.
    */
   replayedFromRunId?: string;
 }
@@ -330,6 +334,27 @@ export async function start<TArgs extends unknown[], TResult>(
           }
         : {};
 
+      // `replayedFromRunId` is stamped verbatim into `executionContext`, which
+      // is persisted on the (size-capped) run item. It's meant to be a run ID
+      // (~31 chars), so reject anything that isn't a short `wrun_`-prefixed
+      // string up front rather than let the option be misused to bloat it.
+      if (opts.replayedFromRunId !== undefined) {
+        const id: unknown = opts.replayedFromRunId;
+        if (
+          typeof id !== 'string' ||
+          !id.startsWith('wrun_') ||
+          id.length > 256
+        ) {
+          const received =
+            typeof id === 'string'
+              ? `${JSON.stringify(id.slice(0, 64))} (length ${id.length})`
+              : `a ${typeof id} value`;
+          throw new WorkflowRuntimeError(
+            `replayedFromRunId must be a "wrun_"-prefixed run ID of at most 256 characters; received ${received}.`
+          );
+        }
+      }
+
       // Resolve encryption key for the new run. The runId has already been
       // generated above (client-generated ULID) and will be used for both
       // key derivation and the run_created event. The World implementation
@@ -367,7 +392,6 @@ export async function start<TArgs extends unknown[], TResult>(
         traceCarrier,
         workflowCoreVersion,
         features: { encryption: !!encryptionKey },
-        // Preserve replay lineage so the run can be shown as "Replay of <id>".
         ...(opts.replayedFromRunId
           ? { replayedFromRunId: opts.replayedFromRunId }
           : {}),

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -125,6 +125,8 @@ export {
   DEFAULT_TIMESTAMP_THRESHOLD_PAST_MS,
   ulidToDate,
   validateUlidTimestamp,
+  workflowRunIdSchema,
 } from './ulid.js';
+export type { WorkflowRunId } from './ulid.js';
 export type * from './waits.js';
 export { WaitSchema, WaitStatusSchema } from './waits.js';

--- a/packages/world/src/ulid.ts
+++ b/packages/world/src/ulid.ts
@@ -4,6 +4,16 @@ import { z } from 'zod';
 const UlidSchema = z.string().ulid();
 
 /**
+ * A workflow run ID: the `wrun_` prefix followed by a 26-char ULID (minted
+ * client-side in core's `start()`). Validates the exact shape — prefix plus a
+ * well-formed ULID — rather than a loose length bound, so callers can't smuggle
+ * arbitrary strings through APIs that persist a run ID verbatim.
+ */
+export const workflowRunIdSchema = z.templateLiteral(['wrun_', z.ulid()]);
+
+export type WorkflowRunId = z.infer<typeof workflowRunIdSchema>;
+
+/**
  * Default threshold for ULID timestamps in the past (24 hours).
  *
  * Set to 24 hours to support the resilient start path: when start() fails to


### PR DESCRIPTION
## Summary

Replays currently start a brand-new run with **no link back to the run they were replayed from**, so tooling can't tell that a run originated as a replay. This adds that link.

- `recreateRunFromExisting` now stamps the source run id into the new run's `executionContext` as `replayedFromRunId`.
- `start` gains an optional `replayedFromRunId` option (used by `recreateRunFromExisting`; rarely needed directly) that is merged into the run's `executionContext` on both the `run_created` event and the resilient-start queue input.

`executionContext` is the right home per the repo's own architecture notes ("flexible object that can store arbitrary data without schema changes… flows through all worlds"), and it's already returned on `WorkflowRunWithoutData` from `runs.list`, so consumers can read it without resolving full run data.

## Motivation

This is the SDK half of a dashboard feature in `vercel/front` that shows a **"Replay of &lt;run id&gt;"** indicator next to the workflow name in the all-runs table (mirroring the deployment list's "Redeploy of …"). That PR already reads `executionContext.replayedFromRunId`; this change is what populates it. Until this lands, the indicator is a no-op because the origin is never recorded.

## Changes

- `packages/core/src/runtime/start.ts` — add `replayedFromRunId?` to `StartOptionsBase`; include it in `executionContext` when set.
- `packages/core/src/runtime/runs.ts` — pass `replayedFromRunId: runId` from `recreateRunFromExisting` into `start`.
- Tests: `start` records/omits the key correctly; `recreateRunFromExisting` forwards the source run id.
- Changeset (`minor`, `@workflow/core`).

## Testing

- `pnpm -F @workflow/core vitest run src/runtime/runs.test.ts src/runtime/start.test.ts` → 50 passed (incl. 3 new).
- `pnpm -F @workflow/core typecheck` → clean.

## Notes

- Observability hydration (`hydrateResourceIO`) strips `executionContext` before UI display in this repo's own dashboard; the `vercel/front` runs list reads `world.runs.list` directly and is unaffected. If the workflow-repo dashboard should also show this, the value would need to be extracted before stripping (follow-up).

Made with [Cursor](https://cursor.com)