### PR TITLE
fix(world-vercel): cancel v4 event frame stream on early exit to release undici connections

### DIFF
--- a/.changeset/cancel-v4-frame-stream.md
+++ b/.changeset/cancel-v4-frame-stream.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Cancel the v4 event frame stream when a reader stops early, so the response body's undici connection returns to the pool instead of leaking.

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -10,6 +10,7 @@ import { MockAgent } from 'undici';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createWorkflowRunEventV4,
+  getEventV4,
   getWorkflowRunEventsV4,
   throwForErrorResponse,
 } from './events-v4.js';
@@ -254,6 +255,52 @@ describe('getWorkflowRunEventsV4 over HTTP', () => {
         { token: 'test-token', dispatcher: agent }
       )
     ).rejects.toThrow(/end-of-stream sentinel/);
+  });
+});
+
+/**
+ * getEventV4 returns after the first frame. The early return must cancel the
+ * response body (releasing its undici socket) without corrupting the returned
+ * value or hanging — the trailing frame below is never read.
+ */
+describe('getEventV4 over HTTP', () => {
+  it('returns the first frame and stops reading the rest', async () => {
+    const origin = 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    const body = new TextEncoder().encode('event-payload');
+    const frames = Buffer.concat([
+      encodeFrame(
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_1',
+          eventType: 'run_created',
+          createdAt: '2026-06-10T00:00:00.000Z',
+          eventData: {},
+        },
+        body
+      ),
+      // Trailing bytes the reader must never need.
+      encodeFrame({ eventId: 'evnt_unused' }, new Uint8Array(8)),
+    ]);
+
+    agent
+      .get(origin)
+      .intercept({ path: '/api/v4/runs/wrun_1/events/evnt_1', method: 'GET' })
+      .reply(200, frames, {
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+
+    const { event, body: returnedBody } = await getEventV4('wrun_1', 'evnt_1', {
+      token: 'test-token',
+      dispatcher: agent,
+    });
+
+    expect(event.eventId).toBe('evnt_1');
+    expect(event.eventType).toBe('run_created');
+    expect(new Uint8Array(returnedBody)).toEqual(body);
+    agent.assertNoPendingInterceptors();
   });
 });
 

--- a/packages/world-vercel/src/frames.test.ts
+++ b/packages/world-vercel/src/frames.test.ts
@@ -1,4 +1,4 @@
-import { decode, encode } from 'cbor-x';
+import { decode } from 'cbor-x';
 import { describe, expect, it } from 'vitest';
 import {
   type DecodedFrame,
@@ -39,6 +39,29 @@ async function drainFrames(
   const out: DecodedFrame[] = [];
   for await (const f of decodeFrames(source)) out.push(f);
   return out;
+}
+
+/** A stream that stays open after delivering its payload (never signals EOF),
+ *  like a kept-alive HTTP socket, and records whether cancel() ran — the
+ *  signal undici uses to release the connection. highWaterMark: 0 suppresses
+ *  the pull-ahead that would otherwise auto-close a toy stream. */
+function spyStream(payload: Uint8Array) {
+  let sent = false;
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        if (sent) return;
+        controller.enqueue(payload);
+        sent = true;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    },
+    { highWaterMark: 0 }
+  );
+  return { stream, wasCancelled: () => cancelled };
 }
 
 describe('encodeFrame', () => {
@@ -207,6 +230,51 @@ describe('decodeFrames from an AsyncIterable source', () => {
     });
     expect(frames[0].body).toEqual(body);
     expect(frames[1].meta).toEqual({ _end: 1, next: 'cursor-1' });
+  });
+});
+
+describe('decodeFrames releases the stream on early exit', () => {
+  // Regression: a consumer that stops before EOF (getEventV4 returns after
+  // the first frame; consumeListFrameStream breaks at the sentinel) must
+  // cancel the body, or its undici socket stays pinned out of the pool.
+  function twoFramesThenEnd(): Uint8Array {
+    return new Uint8Array([
+      ...encodeFrame({ eventId: 'a' }, new Uint8Array([1, 2, 3])),
+      ...encodeFrame({ eventId: 'b' }, new Uint8Array([4, 5, 6])),
+      ...encodeEndFrame(),
+    ]);
+  }
+
+  it('cancels the underlying stream when the consumer breaks early', async () => {
+    const { stream, wasCancelled } = spyStream(twoFramesThenEnd());
+    for await (const f of decodeFrames(stream)) {
+      expect(f.meta).toEqual({ eventId: 'a' });
+      break; // mirrors getEventV4 returning after the first frame
+    }
+    expect(wasCancelled()).toBe(true);
+  });
+
+  it('cancels via the reader path when the source is not async-iterable', async () => {
+    const { stream, wasCancelled } = spyStream(twoFramesThenEnd());
+    // A bare { getReader } object forces the readerToIterator branch (a real
+    // ReadableStream is already async-iterable in Node).
+    const source = {
+      getReader: () => stream.getReader(),
+    } as unknown as ReadableStream<Uint8Array>;
+    for await (const f of decodeFrames(source)) {
+      expect(f.meta).toEqual({ eventId: 'a' });
+      break;
+    }
+    expect(wasCancelled()).toBe(true);
+  });
+
+  it('still decodes every frame when fully consumed', async () => {
+    const frames = await drainFrames(spyStream(twoFramesThenEnd()).stream);
+    expect(frames.map((f) => f.meta)).toEqual([
+      { eventId: 'a' },
+      { eventId: 'b' },
+      { _end: 1 },
+    ]);
   });
 });
 

--- a/packages/world-vercel/src/frames.ts
+++ b/packages/world-vercel/src/frames.ts
@@ -79,41 +79,56 @@ export async function* decodeFrames(
     return out;
   };
 
-  while (true) {
-    if (!(await refill(4))) return;
-    const metaLen = new DataView(buffer.buffer, buffer.byteOffset, 4).getUint32(
-      0,
-      false
-    );
-    take(4);
+  try {
+    while (true) {
+      if (!(await refill(4))) return;
+      const metaLen = new DataView(
+        buffer.buffer,
+        buffer.byteOffset,
+        4
+      ).getUint32(0, false);
+      take(4);
 
-    if (!(await refill(metaLen))) {
-      throw new Error('decodeFrames: truncated meta block');
-    }
-    const meta = decode(take(metaLen)) as Record<string, unknown>;
+      if (!(await refill(metaLen))) {
+        throw new Error('decodeFrames: truncated meta block');
+      }
+      const meta = decode(take(metaLen)) as Record<string, unknown>;
 
-    if (!(await refill(4))) {
-      throw new Error('decodeFrames: truncated body length');
-    }
-    const bodyLen = new DataView(buffer.buffer, buffer.byteOffset, 4).getUint32(
-      0,
-      false
-    );
-    take(4);
+      if (!(await refill(4))) {
+        throw new Error('decodeFrames: truncated body length');
+      }
+      const bodyLen = new DataView(
+        buffer.buffer,
+        buffer.byteOffset,
+        4
+      ).getUint32(0, false);
+      take(4);
 
-    if (bodyLen > 0) {
-      if (!(await refill(bodyLen))) {
+      if (bodyLen > 0 && !(await refill(bodyLen))) {
         throw new Error('decodeFrames: truncated body bytes');
       }
-      // Slice (not subarray) so the yielded body owns its bytes —
-      // subsequent reads into the buffer won't overwrite it.
+      // Slice (not subarray) so the yielded body owns its bytes — later
+      // reads into the buffer won't overwrite it; bodyLen 0 yields empty.
       yield { meta, body: buffer.slice(0, bodyLen) };
       take(bodyLen);
-    } else {
-      yield { meta, body: new Uint8Array(0) };
-    }
 
-    if (meta._end === 1) return;
+      if (meta._end === 1) return;
+    }
+  } finally {
+    // Release the source when the consumer stops before EOF (early
+    // break/return): an unconsumed body pins its undici socket out of the
+    // connection pool. No-op once the stream is already drained.
+    await closeQuietly(() => chunks.return?.());
+  }
+}
+
+/** Best-effort source cleanup, safe to run from a `finally`: swallows errors
+ *  so cleanup can't mask the original outcome. */
+async function closeQuietly(close: () => unknown): Promise<void> {
+  try {
+    await close();
+  } catch {
+    // best-effort
   }
 }
 
@@ -122,9 +137,14 @@ export async function* decodeFrames(
 async function* readerToIterator(
   reader: ReadableStreamDefaultReader<Uint8Array>
 ): AsyncGenerator<Uint8Array> {
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) return;
-    if (value) yield value;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      if (value) yield value;
+    }
+  } finally {
+    // Cancel on early exit so the socket is released, not just unlocked.
+    await closeQuietly(() => reader.cancel());
   }
 }

--- a/packages/world-vercel/src/frames.ts
+++ b/packages/world-vercel/src/frames.ts
@@ -118,15 +118,22 @@ export async function* decodeFrames(
     // Release the source when the consumer stops before EOF (early
     // break/return): an unconsumed body pins its undici socket out of the
     // connection pool. No-op once the stream is already drained.
-    await closeQuietly(() => chunks.return?.());
+    //
+    // Fire-and-forget, NOT awaited: on a service-backed World this cancel
+    // can hit the network (an H2 stream reset, or an H1 socket teardown),
+    // and awaiting it here would block every early-exit caller (getEventV4,
+    // every replay's list read) on that round-trip. Awaiting it previously
+    // hung indefinitely on the Next.js Vercel Function lanes specifically —
+    // same class of bug as the abort-stream reader in #2807.
+    closeQuietly(() => chunks.return?.());
   }
 }
 
-/** Best-effort source cleanup, safe to run from a `finally`: swallows errors
- *  so cleanup can't mask the original outcome. */
-async function closeQuietly(close: () => unknown): Promise<void> {
+/** Best-effort source cleanup, safe to run detached from a `finally`:
+ *  swallows errors so cleanup can't mask the original outcome. */
+function closeQuietly(close: () => unknown): void {
   try {
-    await close();
+    void Promise.resolve(close()).catch(() => {});
   } catch {
     // best-effort
   }
@@ -145,6 +152,7 @@ async function* readerToIterator(
     }
   } finally {
     // Cancel on early exit so the socket is released, not just unlocked.
-    await closeQuietly(() => reader.cancel());
+    // Fire-and-forget — see closeQuietly's call site above.
+    closeQuietly(() => reader.cancel());
   }
 }


### PR DESCRIPTION
## Summary

Reapplies #2547, which was reverted in #2554 with no recorded rationale.

`decodeFrames` (the v4 event frame-stream reader) never cancelled its underlying `response.body` when a consumer stopped reading before EOF. With Node's `fetch`/undici, a response body that is neither fully drained nor cancelled keeps its socket checked out of the connection pool — so every such read leaks a connection until keepalive timeout/GC.

Two live read paths stop early by design and hit this:

| Caller | Early exit | Frequency |
|---|---|---|
| `getEventV4` | `return`s after the first frame (single-frame response) | per event read |
| `consumeListFrameStream` (`getWorkflowRunEventsV4` / `getEventsByCorrelationIdV4`) | `break`s at the `{_end:1}` sentinel | per event-list, i.e. ~every replay |

## Fix

`packages/world-vercel/src/frames.ts`:

- Wrap the `decodeFrames` read loop in `try/finally` and call `chunks.return?.()` on exit, which cancels the source stream (releasing the socket) on early break/return, normal completion, and error paths alike. No-op once drained.
- `readerToIterator` now cancels its reader in a `finally` (the non-async-iterable fallback branch).
- **The cancel is fire-and-forget, not awaited** (see "Why not a straight reapply" below).

## Why not a straight reapply

The original #2547 diff `await`ed the cancel inside the `finally` block. Pushing that verbatim onto current `main` first (see commit history) hung **every single** `E2E Vercel Prod Tests (nextjs-turbopack)` and `(nextjs-webpack)` run for the full 30-minute CI window — each run's step completed (`step_completed` observed) but the run never reached a terminal event, because the SDK's own subsequent event read was blocked awaiting the cancel. All 10 other frameworks passed cleanly in ~15 minutes.

This is the same failure signature and the same two CI lanes as #2807 ([world-local] Fix per-step AbortSignal latency), where an awaited `reader.cancel()` in the core abort-stream reader hung specifically on Next.js's Vercel Function lanes because a service-backed World's `cancel()` can hit the network, and Next.js's runtime doesn't tolerate blocking on it the way other frameworks do. That PR's fix — fire-and-forget the cancel — is applied here too.

This is very likely the actual (undocumented) reason #2547 was reverted in June, before that failure mode had a name.

## Test plan

- `packages/world-vercel/src/frames.test.ts`: asserts the underlying stream is cancelled when the consumer breaks early (for both the async-iterable and `readerToIterator` branches), plus a guard that full consumption still decodes every frame. These pass unchanged with the fire-and-forget cancel — invoking `.cancel()`/`.return()` runs the underlying source's cancel algorithm synchronously; only *awaiting completion* is deferred.
- `packages/world-vercel/src/events-v4.test.ts`: `getEventV4` HTTP round-trip via undici `MockAgent`, with a trailing frame the reader must never read.
- Locally: `pnpm test` (world-vercel) 235 passed, `pnpm typecheck` and `biome check` clean.
- CI: pushed the straight reapply first, confirmed the Next.js-only hang empirically, then pushed the fire-and-forget fix as a second commit.
