### PR TITLE
[core] Thread queue namespace through o11y run actions and bound healthCheck stream reads

### DIFF
--- a/.changeset/o11y-queue-namespace.md
+++ b/.changeset/o11y-queue-namespace.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Add a `namespace` option to `start()`, `recreateRunFromExisting()`, `reenqueueRun()`, and `wakeUpRun()` so cross-context callers (e.g. the observability dashboard) can target deployments that use a queue namespace (`__{namespace}_wkf_workflow_*` topics), and bound `healthCheck()`'s stream read by its timeout so probes against unresponsive deployments fail at the configured deadline instead of hanging.
+Add a `namespace` option to `start()`, `recreateRunFromExisting()`, `reenqueueRun()`, and `wakeUpRun()` for targeting deployments with namespaced queue topics, and make `healthCheck()` respect its timeout when the stream read hangs.

--- a/.changeset/o11y-queue-namespace.md
+++ b/.changeset/o11y-queue-namespace.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Add a `namespace` option to `start()`, `recreateRunFromExisting()`, `reenqueueRun()`, and `wakeUpRun()` so cross-context callers (e.g. the observability dashboard) can target deployments that use a queue namespace (`__{namespace}_wkf_workflow_*` topics), and bound `healthCheck()`'s stream read by its timeout so probes against unresponsive deployments fail at the configured deadline instead of hanging.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -115,6 +115,7 @@ export {
   listStreams,
   type ReadStreamOptions,
   type RecreateRunOptions,
+  type ReenqueueRunOptions,
   readStream,
   recreateRunFromExisting,
   reenqueueRun,

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -223,6 +223,55 @@ describe('healthCheck response parsing', () => {
     expect(result.specVersion).toBeUndefined();
     expect(result.workflowCoreVersion).toBeUndefined();
   });
+
+  it('publishes to the default health-check topic when no namespace is given', async () => {
+    const world = makeWorldWithResponse(
+      JSON.stringify({ healthy: true, endpoint: 'workflow' })
+    );
+
+    await healthCheck(world, 'workflow', { timeout: 1000 });
+
+    expect(world.queue).toHaveBeenCalledWith(
+      '__wkf_workflow_health_check',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('publishes to the namespaced health-check topic when a namespace is given', async () => {
+    const world = makeWorldWithResponse(
+      JSON.stringify({ healthy: true, endpoint: 'workflow' })
+    );
+
+    const result = await healthCheck(world, 'workflow', {
+      timeout: 1000,
+      namespace: 'eve',
+    });
+
+    expect(result.healthy).toBe(true);
+    expect(world.queue).toHaveBeenCalledWith(
+      '__eve_wkf_workflow_health_check',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('returns unhealthy within the timeout when streams.get never resolves', async () => {
+    // Regression test: some worlds hold the stream GET open until data is
+    // written (workflow-server holds unwritten streams for ~2 minutes).
+    // The timeout must bound that call too, not just the poll loop.
+    const world = {
+      queue: vi.fn().mockResolvedValue(undefined),
+      streams: {
+        get: vi.fn(() => new Promise<never>(() => {})),
+      },
+    } as unknown as World;
+
+    const result = await healthCheck(world, 'workflow', { timeout: 300 });
+
+    expect(result.healthy).toBe(false);
+    expect(result.error).toMatch(/timed out/);
+  });
 });
 
 describe('loadWorkflowRunEvents', () => {

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -143,6 +143,16 @@ export interface HealthCheckOptions {
   timeout?: number;
   /** Deployment ID to send the health check to. Falls back to process.env.VERCEL_DEPLOYMENT_ID. */
   deploymentId?: string;
+  /**
+   * Queue namespace of the target deployment (e.g. `'eve'` for topics like
+   * `__eve_wkf_workflow_*`). Falls back to `WORKFLOW_QUEUE_NAMESPACE` in the
+   * calling process. Cross-context callers (e.g. the observability
+   * dashboard) must pass the target deployment's namespace explicitly —
+   * the env fallback resolves in the caller's process, and a message
+   * published to a mismatched topic has no consumer, so the check would
+   * always time out.
+   */
+  namespace?: string;
 }
 
 /**
@@ -167,6 +177,28 @@ const HEALTH_CHECK_READ_TIMEOUT = 500;
  * Read chunks from a stream with a timeout per read operation.
  * Returns { chunks, timedOut } where timedOut indicates if a read timed out.
  */
+/**
+ * Race a promise against a deadline. Rejects with a timeout error when the
+ * deadline elapses first. Used to bound `world.streams.get()` inside the
+ * health-check poll loop: some worlds hold that request open until the
+ * stream has data (e.g. workflow-server holds unwritten streams open for
+ * ~2 minutes), which would otherwise blow through the configured health
+ * check timeout — the `while` condition is only re-checked between
+ * iterations.
+ */
+function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`Operation timed out after ${ms}ms`)),
+        ms
+      );
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
 async function readStreamWithTimeout(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   readTimeout: number
@@ -255,7 +287,7 @@ function parseHealthCheckResponse(chunks: Uint8Array[]): {
 export async function healthCheck(
   world: World,
   endpoint: HealthCheckEndpoint,
-  options?: HealthCheckOptions & { namespace?: string }
+  options?: HealthCheckOptions
 ): Promise<HealthCheckResult> {
   const timeout = options?.timeout ?? DEFAULT_HEALTH_CHECK_TIMEOUT;
   const correlationId = generateId();
@@ -280,9 +312,13 @@ export async function healthCheck(
 
     while (Date.now() - startTime < timeout) {
       try {
-        const stream = await world.streams.get(
-          generateHealthCheckRunId(correlationId),
-          streamName
+        const remainingMs = timeout - (Date.now() - startTime);
+        const stream = await withDeadline(
+          world.streams.get(
+            generateHealthCheckRunId(correlationId),
+            streamName
+          ),
+          remainingMs
         );
         const reader = stream.getReader();
         const { chunks, timedOut } = await readStreamWithTimeout(

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -19,7 +19,7 @@ import {
   hydrateStepReturnValue,
 } from '../serialization.js';
 import { Run } from './run.js';
-import { wakeUpRun } from './runs.js';
+import { reenqueueRun, wakeUpRun } from './runs.js';
 import { setWorld } from './world.js';
 
 function createMockWorld(
@@ -106,6 +106,52 @@ describe('wakeUpRun', () => {
     const world = createMockWorld({ events, createError: serverError });
 
     await expect(wakeUpRun(world, 'wrun_123')).rejects.toThrow(AggregateError);
+  });
+
+  it('should re-enqueue to the namespaced queue when namespace is provided', async () => {
+    const events: Event[] = [
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_123',
+        eventType: 'wait_created',
+        correlationId: 'wait_abc',
+        eventData: { resumeAt: new Date('2024-01-01T00:00:01.000Z') },
+        createdAt: new Date(),
+      },
+    ];
+
+    const world = createMockWorld({ events });
+    await wakeUpRun(world, 'wrun_123', { namespace: 'eve' });
+
+    expect(world.queue).toHaveBeenCalledWith(
+      '__eve_wkf_workflow_test-workflow',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+});
+
+describe('reenqueueRun', () => {
+  it('should enqueue to the default queue when no namespace is provided', async () => {
+    const world = createMockWorld();
+    await reenqueueRun(world, 'wrun_123');
+
+    expect(world.queue).toHaveBeenCalledWith(
+      '__wkf_workflow_test-workflow',
+      { runId: 'wrun_123' },
+      expect.anything()
+    );
+  });
+
+  it('should enqueue to the namespaced queue when namespace is provided', async () => {
+    const world = createMockWorld();
+    await reenqueueRun(world, 'wrun_123', { namespace: 'eve' });
+
+    expect(world.queue).toHaveBeenCalledWith(
+      '__eve_wkf_workflow_test-workflow',
+      { runId: 'wrun_123' },
+      expect.anything()
+    );
   });
 });
 

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -13,6 +13,15 @@ import { start } from './start.js';
 export interface RecreateRunOptions {
   deploymentId?: string;
   specVersion?: number;
+  /**
+   * Queue namespace of the target deployment (e.g. `'eve'` for topics like
+   * `__eve_wkf_workflow_*`). Falls back to `WORKFLOW_QUEUE_NAMESPACE` in
+   * the calling process. Cross-context callers (e.g. the observability
+   * dashboard) must pass the target deployment's namespace explicitly —
+   * a run enqueued to a topic the target deployment has no consumer for
+   * is never picked up.
+   */
+  namespace?: string;
 }
 
 export interface StopSleepResult {
@@ -35,6 +44,22 @@ export interface StopSleepOptions {
    * If not provided, all pending sleep calls will be interrupted.
    */
   correlationIds?: string[];
+  /**
+   * Queue namespace of the run's deployment (e.g. `'eve'`), used when
+   * re-enqueueing the run after completing its waits. Falls back to
+   * `WORKFLOW_QUEUE_NAMESPACE` in the calling process. Cross-context
+   * callers (e.g. the observability dashboard) must pass it explicitly.
+   */
+  namespace?: string;
+}
+
+export interface ReenqueueRunOptions {
+  /**
+   * Queue namespace of the run's deployment (e.g. `'eve'`). Falls back to
+   * `WORKFLOW_QUEUE_NAMESPACE` in the calling process. Cross-context
+   * callers (e.g. the observability dashboard) must pass it explicitly.
+   */
+  namespace?: string;
 }
 
 export interface CancelRunOptions {
@@ -80,6 +105,7 @@ export async function recreateRunFromExisting(
         deploymentId,
         world,
         specVersion,
+        namespace: options.namespace,
       }
     );
     return newRun.runId;
@@ -125,11 +151,15 @@ export async function cancelRun(
 /**
  * Re-enqueue a workflow run.
  */
-export async function reenqueueRun(world: World, runId: string): Promise<void> {
+export async function reenqueueRun(
+  world: World,
+  runId: string,
+  options?: ReenqueueRunOptions
+): Promise<void> {
   try {
     const run = await world.runs.get(runId, { resolveData: 'none' });
     await world.queue(
-      getWorkflowQueueName(run.workflowName),
+      getWorkflowQueueName(run.workflowName, options?.namespace),
       {
         runId,
       },
@@ -225,7 +255,7 @@ export async function wakeUpRun(
 
     if (stoppedCount > 0) {
       await world.queue(
-        getWorkflowQueueName(run.workflowName),
+        getWorkflowQueueName(run.workflowName, options?.namespace),
         {
           runId,
         },

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -812,4 +812,100 @@ describe('start', () => {
       expectTypeOf<DeploymentIdOverload>().toMatchTypeOf<typeof start>();
     });
   });
+  describe('queue namespace', () => {
+    let mockEventsCreate: ReturnType<typeof vi.fn>;
+    let mockQueue: ReturnType<typeof vi.fn>;
+
+    const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+      workflowId: 'test-workflow',
+    });
+
+    beforeEach(() => {
+      mockEventsCreate = vi.fn().mockImplementation((runId) => {
+        return Promise.resolve({
+          run: { runId: runId ?? 'wrun_test123', status: 'pending' },
+        });
+      });
+      mockQueue = vi.fn().mockResolvedValue(undefined);
+
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      });
+    });
+
+    afterEach(() => {
+      setWorld(undefined);
+      vi.clearAllMocks();
+    });
+
+    it('enqueues to the default topic when no namespace is provided', async () => {
+      await start(validWorkflow, []);
+
+      expect(mockQueue).toHaveBeenCalledWith(
+        '__wkf_workflow_test-workflow',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('enqueues to the namespaced topic when a namespace is provided', async () => {
+      await start(validWorkflow, [], { namespace: 'eve' });
+
+      expect(mockQueue).toHaveBeenCalledWith(
+        '__eve_wkf_workflow_test-workflow',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('probes the namespaced health-check topic on cross-deployment starts', async () => {
+      // Cross-deployment starts (explicit deploymentId different from the
+      // current one) run a capability probe before enqueueing. The probe
+      // must target the same namespaced topic family as the run itself —
+      // otherwise deployments using a queue namespace never see it.
+      const healthResponse = JSON.stringify({
+        healthy: true,
+        endpoint: 'workflow',
+        specVersion: SPEC_VERSION_CURRENT,
+        workflowCoreVersion: '0.0.0-test',
+      });
+
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+        streams: {
+          get: vi.fn(
+            async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode(healthResponse));
+                  controller.close();
+                },
+              })
+          ),
+        },
+      });
+
+      await start(validWorkflow, [], {
+        deploymentId: 'dpl_other',
+        namespace: 'eve',
+      });
+
+      expect(mockQueue).toHaveBeenCalledWith(
+        '__eve_wkf_workflow_health_check',
+        expect.objectContaining({ __healthCheck: true }),
+        expect.objectContaining({ deploymentId: 'dpl_other' })
+      );
+      expect(mockQueue).toHaveBeenCalledWith(
+        '__eve_wkf_workflow_test-workflow',
+        expect.anything(),
+        expect.objectContaining({ deploymentId: 'dpl_other' })
+      );
+    });
+  });
 });

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -89,6 +89,21 @@ export interface StartOptionsBase {
    * the `experimental_setAttributes` option of the same name.
    */
   allowReservedAttributes?: boolean;
+
+  /**
+   * Queue namespace of the target deployment. Scopes the workflow queue
+   * topic to `__{namespace}_wkf_workflow_*` (e.g. `'eve'`) instead of the
+   * default `__wkf_workflow_*`, and is also used for the cross-deployment
+   * capability probe. Falls back to `WORKFLOW_QUEUE_NAMESPACE` in the
+   * calling process.
+   *
+   * Within a deployment the env fallback is correct. Cross-context callers
+   * (e.g. the observability dashboard replaying a run) must pass the
+   * TARGET deployment's namespace explicitly: the env fallback resolves in
+   * the caller's process, and a run enqueued to a topic the target has no
+   * consumer for is never picked up.
+   */
+  namespace?: string;
 }
 
 export interface StartOptionsWithDeploymentId extends StartOptionsBase {
@@ -260,6 +275,7 @@ export async function start<TArgs extends unknown[], TResult>(
         const probe = await healthCheck(world, 'workflow', {
           deploymentId,
           timeout: CROSS_DEPLOYMENT_CAPABILITY_PROBE_TIMEOUT_MS,
+          namespace: opts.namespace,
         }).catch(() => undefined);
         const capabilities = getRunCapabilities(probe?.workflowCoreVersion);
         framedByteStreams = capabilities.framedByteStreams;
@@ -378,7 +394,7 @@ export async function start<TArgs extends unknown[], TResult>(
           { v1Compat }
         ),
         world.queue(
-          getWorkflowQueueName(workflowName),
+          getWorkflowQueueName(workflowName, opts.namespace),
           {
             runId,
             traceCarrier,


### PR DESCRIPTION
## Why

Replaying an eve agent run from the dashboard hangs ~30s and then fails with a 504. Two compounding issues in `@workflow/core`:

- **Queue namespace is caller-derived.** Eve deployments only consume `__eve_wkf_workflow_*` topics (they set `WORKFLOW_QUEUE_NAMESPACE=eve` at build time), but `start()` / `recreateRunFromExisting()` / `reenqueueRun()` / `wakeUpRun()` build queue names from the **calling process's** env. The dashboard has no namespace set, so its health-check probe and run enqueue publish to unprefixed topics that have no consumer — the message is never dispatched.
- **`healthCheck()` can hang past its timeout.** The poll loop only checks the deadline between iterations; `world.streams.get()` itself is unbounded. workflow-server holds unwritten streams open for ~2 minutes, so the 2s cross-deployment capability probe in `start()` hung until the dashboard function's 30s limit killed the request.

## What

- Add a `namespace` option to `StartOptionsBase`, `RecreateRunOptions`, `StopSleepOptions`, and new `ReenqueueRunOptions`; thread it into `getWorkflowQueueName()` and the cross-deployment capability probe. Env fallback behavior is unchanged when the option is omitted.
- Fold the previously-inline `namespace` param into `HealthCheckOptions`.
- Race `streams.get()` against the remaining health-check budget so probes fail at the configured deadline instead of hanging.

A follow-up in `front` will pass the target deployment's namespace from the observability replay / wake-up / deployment-health routes. Longer term, persisting the namespace on the run record would remove the need for callers to supply it.

## Validation

- New unit tests: namespaced health-check topic selection, namespaced enqueue for `start`/`wakeUpRun`/`reenqueueRun`, cross-deployment probe topic, and a hang-regression test (never-resolving `streams.get` now returns unhealthy at the deadline; previously it hung indefinitely).
- `packages/core` full unit suite: 1439 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)