### PR TITLE
[docs] Document WORKFLOW_SEQUENTIAL_REPLAYS on the v4 Vercel World page

### DIFF
--- a/.changeset/document-sequential-replays.md
+++ b/.changeset/document-sequential-replays.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document the `WORKFLOW_SEQUENTIAL_REPLAYS` environment variable on the v4 Vercel World configuration page.

--- a/docs/content/docs/v4/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v4/deploying/world/vercel-world.mdx
@@ -111,6 +111,20 @@ Vercel team ID for API requests. Automatically detected.
 
 Custom base URL for the Vercel workflow API. Automatically detected.
 
+### `WORKFLOW_SEQUENTIAL_REPLAYS`
+
+Set `WORKFLOW_SEQUENTIAL_REPLAYS=1` to guarantee that **at most one orchestrator (flow) invocation runs at a time per workflow run**. This behavior is off by default; without it, the runtime relies on idempotency and the event log to tolerate concurrent flow invocations of the same run.
+
+When enabled, each run is given its own queue topic and the flow route is configured with `maxConcurrency: 1`, so [Vercel Queues](https://vercel.com/docs/queues) processes flow messages for a given run strictly one at a time. Step routes are unaffected and continue to run with full concurrency.
+
+<Callout type="warn">
+  This variable is read at **both build time and runtime**, so it must be set as a project-level environment variable that applies to your build and your deployed functions. Setting it for only one will produce an inconsistent configuration. The same applies to framework integrations that write their own queue trigger configuration instead of using `getWorkflowQueueTrigger()` from `@workflow/builders`: they only get the runtime half (per-run topics) unless they also emit `maxConcurrency: 1` on their flow trigger.
+
+  Enabling sequential replays has a cost. Per [Vercel Queues pricing](https://vercel.com/docs/queues/pricing), push deliveries under `maxConcurrency` are billed at **2x units** for that operation, so every flow-route delivery costs double while this is enabled. It also creates one queue topic per run, which increases the number of distinct queues surfaced in queue observability, and each flow invocation waits for a per-run concurrency slot before delivery, which can add queueing latency. Leave it off unless you specifically need the per-run serialization guarantee.
+
+  The guarantee covers messages sent by the Workflow SDK itself. External producers that compute a flow topic name directly (rather than enqueueing through the SDK) still deliver, but bypass the per-run serialization slot.
+</Callout>
+
 ### Programmatic configuration
 
 {/*@skip-typecheck: incomplete code sample*/}


### PR DESCRIPTION
## Why

- `WORKFLOW_SEQUENTIAL_REPLAYS` ships on the 4.x stable line (#2193), but the docs site deploys from `main` — without this page the variable is undiscoverable on the live docs.
- Documents the build+runtime env requirement, the 2x per-delivery billing under `maxConcurrency` ([Vercel Queues pricing](https://vercel.com/docs/queues/pricing)), topic-cardinality and queueing-latency costs, and the SDK-only serialization boundary.
- `WORKFLOW_INLINE_OWNERSHIP` and `WORKFLOW_INLINE_OWNERSHIP_LEASE_SECONDS` were checked as part of the same audit and are already documented on the v5 Runtime Tuning configuration page; `WORKFLOW_PRECONDITION_GUARD` is documented in #2266 alongside its implementation.

Docs-only; empty changeset included.

## Docs Preview

| Page | v4 |
| --- | --- |
| Vercel World — `WORKFLOW_SEQUENTIAL_REPLAYS` | [/docs/deploying/world/vercel-world#workflow_sequential_replays](https://workflow-docs-git-peter-document-runtime-env-vars.vercel.sh/docs/deploying/world/vercel-world#workflow_sequential_replays) |

(Preview is behind deployment protection — requires Vercel team access.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
