### PR TITLE
docs(agents): note lint/format/typecheck are advisory, not blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,10 @@ This project uses pnpm with workspace configuration. The required version is spe
 - Import type enforcement enabled
 - Explicit `any` is discouraged (Biome's `noExplicitAny` rule is currently disabled); exhaustive dependencies warnings enabled
 
+## Local Checks vs. CI
+
+Linting, formatting, and typechecking (`pnpm lint`, `pnpm format`, `pnpm typecheck`) are all facets of the same static-quality gate, and CI runs them on every PR. Treat them as **advisory** while working locally: run them and fix obvious issues when it's convenient, but a failure in any of them should **not** block you from committing, pushing, or opening a PR. CI is the source of truth and will report anything that matters — don't get stuck iterating locally just to make these pass before handing off.
+
 ## Documentation Standards
 
 - README.md files in each package must accurately reflect the current functionality and purpose of that package


### PR DESCRIPTION
### Description

Adds a new "Local Checks vs. CI" section to `AGENTS.md` (which `CLAUDE.md` symlinks to). It clarifies that linting, formatting, and typechecking (`pnpm lint`, `pnpm format`, `pnpm typecheck`) are all facets of a single, advisory static-quality gate. Agents should run them and fix obvious issues when convenient, but a failure in any of them should not block committing, pushing, or opening a PR — CI enforces them on every PR and is the source of truth.

The section is inserted immediately after `## Code Style` and before `## Documentation Standards`. No other files are changed.

Slack thread: https://vercel.slack.com/archives/C09G3EQAL84/p1783842727323939?thread_ts=1783790478.067249&cid=C09G3EQAL84

### How did you test your changes?

Documentation-only change to a root markdown file; no code paths affected. Verified the new section is placed exactly between the `## Code Style` and `## Documentation Standards` sections.

### PR Checklist - Required to merge

- [ ] 📦 `pnpm changeset` was run to create a changelog for this PR
  - This is a root markdown-only change (`AGENTS.md`) that touches no package, so no changeset is needed.
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016fNvoYwmEToPL82GB1Pbfs)_