### PR TITLE
telemetry: stream flush span + otel load diagnostics

### DIFF
--- a/.changeset/stream-write-flush-span.md
+++ b/.changeset/stream-write-flush-span.md
@@ -1,5 +1,6 @@
 ---
 '@workflow/core': patch
+'@workflow/world-vercel': patch
 ---
 
-Emit a client-observed `workflow.stream.write` span per flushed stream-write batch, with a `buffer_dwell_ms` attribute separating client-side batching cost from network/server time
+Emit a client-observed `workflow.stream.flush` span per flushed stream-write batch, with a `buffer_dwell_ms` attribute separating client-side batching cost from network/server time (the per-request `workflow.stream.write` RPC span keeps its own name). Also log under `DEBUG=workflow:*` when `@opentelemetry/api` fails to load in world-vercel, so silently missing spans are diagnosable.

--- a/.changeset/stream-write-flush-span.md
+++ b/.changeset/stream-write-flush-span.md
@@ -3,4 +3,4 @@
 '@workflow/world-vercel': patch
 ---
 
-Emit a client-observed `workflow.stream.flush` span per flushed stream-write batch, with a `buffer_dwell_ms` attribute separating client-side batching cost from network/server time (the per-request `workflow.stream.write` RPC span keeps its own name). Also log under `DEBUG=workflow:*` when `@opentelemetry/api` fails to load in world-vercel, so silently missing spans are diagnosable.
+Emit a client-observed `workflow.stream.flush` span per stream-write batch, with a `buffer_dwell_ms` attribute separating client-side batching cost from network/server time. Log under `DEBUG=workflow:*` when `@opentelemetry/api` fails to load in world-vercel.

--- a/.changeset/stream-write-flush-span.md
+++ b/.changeset/stream-write-flush-span.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Emit a client-observed `workflow.stream.write` span per flushed stream-write batch, back-dated to the batch's first `write()` — its duration covers buffer dwell + RPC, with `workflow.stream.write.buffer_dwell_ms`/`chunks`/`bytes` attributes separating client-side batching cost from network/server time
+Emit a client-observed `workflow.stream.write` span per flushed stream-write batch, with a `buffer_dwell_ms` attribute separating client-side batching cost from network/server time

--- a/.changeset/stream-write-flush-span.md
+++ b/.changeset/stream-write-flush-span.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Emit a client-observed `workflow.stream.write` span per flushed stream-write batch, back-dated to the batch's first `write()` — its duration covers buffer dwell + RPC, with `workflow.stream.write.buffer_dwell_ms`/`chunks`/`bytes` attributes separating client-side batching cost from network/server time

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -42,6 +42,7 @@ No workflow-specific configuration is required. As soon as a tracer provider and
 | `step.execute <name>` | internal (inline) / consumer + root (queue-delivered) | a step function executes |
 | `http <method>` | client | the SDK calls the workflow backend (event reads/writes) |
 | `workflow.stream.write` | client | a stream chunk (or the stream close) is flushed to the backend |
+| `workflow.stream.flush` | client | a buffered batch of stream writes settles; back-dated to the batch's first `write()`, so its duration is the app-perceived batch latency (buffer dwell + RPC) |
 | `workflow.stream.read.connect` | client | a live stream read opens; the span covers dispatch → response headers (network connect) |
 | `workflow.stream.read` | client | a live stream read receives its first chunk; the span's duration is the end-to-end time-to-first-chunk (see `workflow.stream.read.ttfc_ms`) |
 
@@ -59,8 +60,9 @@ Stream spans are emitted by the SDK's world backend on the client that writes or
 | `workflow.trace.propagated` | Whether the invocation received trace context from the queue message. |
 | `workflow.queue.overhead_ms` | Time between the message being enqueued and the handler starting — queue dwell plus any cold start. |
 | `workflow.stream.name` | The stream name, on stream write/read spans. |
-| `workflow.stream.operation` | The stream operation: `write`, `write_multi`, `close`, or `read`. |
+| `workflow.stream.operation` | The stream operation: `write`, `write_multi`, `close`, `read`, or `flush`. |
 | `workflow.stream.write.chunk_rtt` | Time between emissions of a chunk to the wire, and receiving the `ack` message for that chunk. |
+| `workflow.stream.flush.buffer_dwell_ms` | On `workflow.stream.flush`: time the batch's first chunk waited in the client-side write buffer (flush timer, run-ready barrier) before the request was dispatched. `workflow.stream.flush.chunks` / `.bytes` carry the batch shape. |
 | `workflow.stream.read.ttfc_ms` | Time between opening a read connection and observing and receiving the first chunk back. |
 
 ## Trace shape: one trace per invocation

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -877,8 +877,9 @@ const getStreamFlushIntervalMs = (): number =>
  * span's duration is therefore the app-perceived latency of the batch
  * (buffer dwell + backpressure + RPC); `buffer_dwell_ms` isolates the
  * pre-dispatch share so client-side batching cost can be told apart from
- * network/server time (the RPC itself has its own `world.streams.*` child
- * span). Fire-and-forget; no-op without OTEL.
+ * network/server time. Named `workflow.stream.flush` — the per-request RPC
+ * beneath it is world-vercel's `workflow.stream.write` span (chunk_rtt), and
+ * the two must stay distinguishable. Fire-and-forget; no-op without OTEL.
  */
 function recordStreamWriteFlush(
   startEpochMs: number,
@@ -889,15 +890,15 @@ function recordStreamWriteFlush(
   byteCount: number
 ): void {
   void (async () => {
-    await recordElapsedSpan('workflow.stream.write', startEpochMs, {
+    await recordElapsedSpan('workflow.stream.flush', startEpochMs, {
       kind: await getSpanKind('CLIENT'),
       attributes: {
         'workflow.run.id': runId,
         'workflow.stream.name': name,
-        'workflow.stream.operation': 'write',
-        'workflow.stream.write.buffer_dwell_ms': dispatchEpochMs - startEpochMs,
-        'workflow.stream.write.chunks': chunkCount,
-        'workflow.stream.write.bytes': byteCount,
+        'workflow.stream.operation': 'flush',
+        'workflow.stream.flush.buffer_dwell_ms': dispatchEpochMs - startEpochMs,
+        'workflow.stream.flush.chunks': chunkCount,
+        'workflow.stream.flush.bytes': byteCount,
       },
     });
   })();

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -871,6 +871,38 @@ const getStreamFlushIntervalMs = (): number =>
     integer: true,
   });
 
+/**
+ * Emit the client-observed span for one flushed batch of stream writes: first
+ * `write()` of the batch (`startEpochMs`) → the server write settling. The
+ * span's duration is therefore the app-perceived latency of the batch
+ * (buffer dwell + backpressure + RPC); `buffer_dwell_ms` isolates the
+ * pre-dispatch share so client-side batching cost can be told apart from
+ * network/server time (the RPC itself has its own `world.streams.*` child
+ * span). Fire-and-forget; no-op without OTEL.
+ */
+function recordStreamWriteFlush(
+  startEpochMs: number,
+  dispatchEpochMs: number,
+  runId: string,
+  name: string,
+  chunkCount: number,
+  byteCount: number
+): void {
+  void (async () => {
+    await recordElapsedSpan('workflow.stream.write', startEpochMs, {
+      kind: await getSpanKind('CLIENT'),
+      attributes: {
+        'workflow.run.id': runId,
+        'workflow.stream.name': name,
+        'workflow.stream.operation': 'write',
+        'workflow.stream.write.buffer_dwell_ms': dispatchEpochMs - startEpochMs,
+        'workflow.stream.write.chunks': chunkCount,
+        'workflow.stream.write.bytes': byteCount,
+      },
+    });
+  })();
+}
+
 export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
   /**
    * @param runReadyBarrier Turbo mode only: a promise that resolves once the
@@ -915,6 +947,12 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
     let flushPromise: Promise<void> | null = null;
     let resolvedFlushIntervalMs: number | undefined;
+    // Client-observed write-batch timing: stamped at `write()` entry for the
+    // first chunk of a batch — before the backpressure wait on any in-flight
+    // flush — so the emitted span covers the full app-perceived latency
+    // (queueing + flush-timer dwell + RPC). Cleared when a flush takes the
+    // batch; restored on write failure so a retried batch keeps its true t0.
+    let batchStartAt: number | undefined;
 
     const flush = async (): Promise<void> => {
       if (flushTimer) {
@@ -931,6 +969,9 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
       // Copy chunks to flush, but don't clear buffer until write succeeds
       // This prevents data loss if the write operation fails
       const chunksToFlush = buffer.slice();
+      const batchStart = batchStartAt;
+      batchStartAt = undefined;
+      const dispatchAt = Date.now();
 
       const world = await worldPromise;
       // Cache the flush interval from the world on first use
@@ -938,17 +979,41 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
         resolvedFlushIntervalMs =
           world.streamFlushIntervalMs ?? getStreamFlushIntervalMs();
       }
-      // Use writeMulti if available for batch writes
-      if (
-        typeof world.streams.writeMulti === 'function' &&
-        chunksToFlush.length > 1
-      ) {
-        await world.streams.writeMulti(runId, name, chunksToFlush);
-      } else {
-        // Fall back to sequential writes
-        for (const chunk of chunksToFlush) {
-          await world.streams.write(runId, name, chunk);
+      try {
+        // Use writeMulti if available for batch writes
+        if (
+          typeof world.streams.writeMulti === 'function' &&
+          chunksToFlush.length > 1
+        ) {
+          await world.streams.writeMulti(runId, name, chunksToFlush);
+        } else {
+          // Fall back to sequential writes
+          for (const chunk of chunksToFlush) {
+            await world.streams.write(runId, name, chunk);
+          }
         }
+      } catch (error) {
+        // The batch stays buffered for retry — restore its original t0 (the
+        // oldest, if a newer write stamped one meanwhile) so the eventually
+        // successful flush reports the full dwell.
+        if (batchStart !== undefined) {
+          batchStartAt =
+            batchStartAt === undefined
+              ? batchStart
+              : Math.min(batchStartAt, batchStart);
+        }
+        throw error;
+      }
+
+      if (batchStart !== undefined) {
+        recordStreamWriteFlush(
+          batchStart,
+          dispatchAt,
+          runId,
+          name,
+          chunksToFlush.length,
+          chunksToFlush.reduce((sum, c) => sum + c.byteLength, 0)
+        );
       }
 
       // Only clear buffer after successful write to prevent data loss
@@ -981,6 +1046,11 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
 
     super({
       async write(chunk) {
+        // Batch t0 for the write-flush span: at entry, before the
+        // backpressure wait below, so queueing behind an in-flight flush
+        // counts toward the app-perceived dwell.
+        if (batchStartAt === undefined) batchStartAt = Date.now();
+
         // Wait for any in-progress flush to complete before adding to buffer
         if (flushPromise) {
           await flushPromise;

--- a/packages/core/src/writable-stream-telemetry.test.ts
+++ b/packages/core/src/writable-stream-telemetry.test.ts
@@ -73,23 +73,23 @@ describe('WorkflowServerWritableStream write-flush telemetry', () => {
     vi.clearAllMocks();
   });
 
-  it('emits a CLIENT workflow.stream.write span per flushed batch with dwell/chunk/byte attributes', async () => {
+  it('emits a CLIENT workflow.stream.flush span per flushed batch with dwell/chunk/byte attributes', async () => {
     const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
     const writer = stream.getWriter();
 
     await writer.write(new Uint8Array([1, 2, 3]));
     await writer.close();
 
-    const [span] = await waitForSpans('workflow.stream.write', 1);
+    const [span] = await waitForSpans('workflow.stream.flush', 1);
     expect(span).toBeDefined();
     expect(span.kind).toBe(SpanKind.CLIENT);
     expect(span.attributes['workflow.run.id']).toBe('run-123');
     expect(span.attributes['workflow.stream.name']).toBe('test-stream');
-    expect(span.attributes['workflow.stream.operation']).toBe('write');
-    expect(span.attributes['workflow.stream.write.chunks']).toBe(1);
-    expect(span.attributes['workflow.stream.write.bytes']).toBe(3);
+    expect(span.attributes['workflow.stream.operation']).toBe('flush');
+    expect(span.attributes['workflow.stream.flush.chunks']).toBe(1);
+    expect(span.attributes['workflow.stream.flush.bytes']).toBe(3);
 
-    const dwell = span.attributes['workflow.stream.write.buffer_dwell_ms'];
+    const dwell = span.attributes['workflow.stream.flush.buffer_dwell_ms'];
     expect(typeof dwell).toBe('number');
     expect(dwell as number).toBeGreaterThanOrEqual(0);
 
@@ -108,10 +108,10 @@ describe('WorkflowServerWritableStream write-flush telemetry', () => {
     await writer.write(new Uint8Array([3]));
     await writer.close();
 
-    const spans = await waitForSpans('workflow.stream.write', 3);
+    const spans = await waitForSpans('workflow.stream.flush', 3);
     expect(spans).toHaveLength(3);
     for (const span of spans) {
-      expect(span.attributes['workflow.stream.write.chunks']).toBe(1);
+      expect(span.attributes['workflow.stream.flush.chunks']).toBe(1);
     }
   });
 
@@ -135,10 +135,10 @@ describe('WorkflowServerWritableStream write-flush telemetry', () => {
     await writePromise;
     await writer.close();
 
-    const [span] = await waitForSpans('workflow.stream.write', 1);
+    const [span] = await waitForSpans('workflow.stream.flush', 1);
     expect(span).toBeDefined();
     const dwell = span.attributes[
-      'workflow.stream.write.buffer_dwell_ms'
+      'workflow.stream.flush.buffer_dwell_ms'
     ] as number;
     expect(dwell).toBeGreaterThanOrEqual(40);
   });
@@ -153,7 +153,7 @@ describe('WorkflowServerWritableStream write-flush telemetry', () => {
     expect(
       exporter
         .getFinishedSpans()
-        .filter((s) => s.name === 'workflow.stream.write')
+        .filter((s) => s.name === 'workflow.stream.flush')
     ).toHaveLength(0);
   });
 });

--- a/packages/core/src/writable-stream-telemetry.test.ts
+++ b/packages/core/src/writable-stream-telemetry.test.ts
@@ -1,0 +1,159 @@
+import { trace as otelTrace, SpanKind } from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { setWorld } from './runtime/world.js';
+import { WorkflowServerWritableStream } from './serialization.js';
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+
+beforeAll(() => {
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  otelTrace.setGlobalTracerProvider(provider);
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  otelTrace.disable();
+});
+
+/**
+ * The write-flush span is emitted fire-and-forget after the server write
+ * settles, so poll briefly instead of asserting synchronously.
+ */
+async function waitForSpans(
+  name: string,
+  count: number
+): Promise<ReadableSpan[]> {
+  for (let i = 0; i < 50; i++) {
+    const spans = exporter.getFinishedSpans().filter((s) => s.name === name);
+    if (spans.length >= count) return spans;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  return exporter.getFinishedSpans().filter((s) => s.name === name);
+}
+
+describe('WorkflowServerWritableStream write-flush telemetry', () => {
+  let mockStreams: {
+    write: ReturnType<typeof vi.fn>;
+    writeMulti: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    exporter.reset();
+    mockStreams = {
+      write: vi.fn().mockResolvedValue(undefined),
+      writeMulti: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      streams: mockStreams,
+    } as any);
+  });
+
+  afterEach(() => {
+    setWorld(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('emits a CLIENT workflow.stream.write span per flushed batch with dwell/chunk/byte attributes', async () => {
+    const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+    const writer = stream.getWriter();
+
+    await writer.write(new Uint8Array([1, 2, 3]));
+    await writer.close();
+
+    const [span] = await waitForSpans('workflow.stream.write', 1);
+    expect(span).toBeDefined();
+    expect(span.kind).toBe(SpanKind.CLIENT);
+    expect(span.attributes['workflow.run.id']).toBe('run-123');
+    expect(span.attributes['workflow.stream.name']).toBe('test-stream');
+    expect(span.attributes['workflow.stream.operation']).toBe('write');
+    expect(span.attributes['workflow.stream.write.chunks']).toBe(1);
+    expect(span.attributes['workflow.stream.write.bytes']).toBe(3);
+
+    const dwell = span.attributes['workflow.stream.write.buffer_dwell_ms'];
+    expect(typeof dwell).toBe('number');
+    expect(dwell as number).toBeGreaterThanOrEqual(0);
+
+    // The back-dated span covers dwell + RPC, so its duration must be at
+    // least the reported dwell.
+    const durationMs = span.duration[0] * 1e3 + span.duration[1] / 1e6;
+    expect(durationMs).toBeGreaterThanOrEqual(dwell as number);
+  });
+
+  it('emits one span per flush cycle', async () => {
+    const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+    const writer = stream.getWriter();
+
+    await writer.write(new Uint8Array([1]));
+    await writer.write(new Uint8Array([2]));
+    await writer.write(new Uint8Array([3]));
+    await writer.close();
+
+    const spans = await waitForSpans('workflow.stream.write', 3);
+    expect(spans).toHaveLength(3);
+    for (const span of spans) {
+      expect(span.attributes['workflow.stream.write.chunks']).toBe(1);
+    }
+  });
+
+  it('counts the turbo run-ready barrier wait as buffer dwell', async () => {
+    let releaseBarrier!: () => void;
+    const runReadyBarrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+
+    const stream = new WorkflowServerWritableStream(
+      'run-123',
+      'test-stream',
+      runReadyBarrier
+    );
+    const writer = stream.getWriter();
+
+    const writePromise = writer.write(new Uint8Array([1, 2, 3]));
+    // Hold the first flush on the barrier long enough to dominate the dwell.
+    await new Promise((r) => setTimeout(r, 50));
+    releaseBarrier();
+    await writePromise;
+    await writer.close();
+
+    const [span] = await waitForSpans('workflow.stream.write', 1);
+    expect(span).toBeDefined();
+    const dwell = span.attributes[
+      'workflow.stream.write.buffer_dwell_ms'
+    ] as number;
+    expect(dwell).toBeGreaterThanOrEqual(40);
+  });
+
+  it('does not emit spans for an empty close', async () => {
+    const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+    const writer = stream.getWriter();
+    await writer.close();
+
+    // Give any stray fire-and-forget emit a chance to land.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(
+      exporter
+        .getFinishedSpans()
+        .filter((s) => s.name === 'workflow.stream.write')
+    ).toHaveLength(0);
+  });
+});

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -28,7 +28,23 @@ async function getOtelApi(): Promise<typeof api | null> {
     // esbuild and would silently disable tracing there. Bundlers that reject
     // an unresolvable static `import()` when the peer is absent (Rollup/Vite,
     // e.g. SvelteKit) externalize it in the framework integration instead.
-    otelApiPromise = import('@opentelemetry/api').catch(() => null);
+    otelApiPromise = import('@opentelemetry/api').catch((error) => {
+      // A missing module is expected for apps without OTEL — but the same
+      // silent null also swallows bundler/resolution failures in apps that
+      // DO register a tracer, which then just lose every world-vercel span.
+      // Surface the reason under DEBUG so that failure mode is diagnosable.
+      if (
+        typeof process !== 'undefined' &&
+        typeof process.env.DEBUG === 'string' &&
+        (process.env.DEBUG.includes('workflow:') || process.env.DEBUG === '*')
+      ) {
+        console.warn(
+          '[workflow] @opentelemetry/api unavailable — world-vercel spans disabled:',
+          error instanceof Error ? error.message : error
+        );
+      }
+      return null;
+    });
   }
   return otelApiPromise;
 }


### PR DESCRIPTION
## Summary

Stream reads already have a client-observed span (`workflow.stream.read` + `read.ttfc_ms`, #2857). This adds the missing write-side piece — the client-side buffering that no server measurement can see — plus a diagnostic for a gap found while validating #2857 in production.

### `workflow.stream.flush` span (core)

Each flushed batch from `WorkflowServerWritableStream` emits a back-dated CLIENT span whose duration is the app-perceived latency of the batch (first `write()` → server write settled), with:

- `workflow.stream.flush.buffer_dwell_ms` — first `write()` of the batch → RPC dispatch. Captures the flush-timer wait and the turbo run-ready barrier hold on a stream's first write.
- `workflow.stream.flush.chunks` / `.bytes` — batch shape.
- `workflow.run.id` / `workflow.stream.name` / `workflow.stream.operation: flush`.

Named `workflow.stream.flush` (not `.write`) because #2857 already uses `workflow.stream.write` for the per-request RPC span (`chunk_rtt`) — in a trace the flush span sits above the RPC span, decomposing a write into **dwell vs network/server**. Failed flushes keep the batch's original t0 so a retried batch reports its full dwell; emission is fire-and-forget and no-ops without OTEL; empty closes emit nothing. Documented in the tracing docs alongside #2857's spans.

### DEBUG log for world-vercel OTEL load failure (world-vercel)

While validating #2857's spans in production we found its **core**-emitted span flows but its **world-vercel**-emitted spans (`workflow.stream.write`, `workflow.stream.read.connect`) don't appear from deployed apps, despite the same code emitting correctly in local tests — pointing at an environment-specific `@opentelemetry/api` load/resolution issue. world-vercel's `import('@opentelemetry/api').catch(() => null)` silently latches the failure, making that indistinguishable from "app has no OTEL". This PR logs the failure reason under `DEBUG=workflow:*` so the root cause is diagnosable from a deployment; the actual fix will follow once a deployment surfaces the reason.

## Testing

- `writable-stream-telemetry.test.ts` (InMemorySpanExporter): span kind/attributes per batch, one span per flush cycle, run-ready-barrier hold counted as dwell, no span on empty close.
- world-vercel `trace-propagation` + `http-core` suites pass (18 tests).
- `pnpm test` (packages/core): 1451 passed; `pnpm typecheck` passes; biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)