### PR TITLE
cli: show world-specific run fields in inspect output via World.describeRun

### DIFF
--- a/.changeset/inspect-region-column.md
+++ b/.changeset/inspect-region-column.md
@@ -1,0 +1,7 @@
+---
+'@workflow/world': patch
+'@workflow/world-vercel': patch
+'@workflow/cli': patch
+---
+
+Show each run's region in `workflow inspect` output via the new optional `World.regionForRunId` reverse lookup.

--- a/.changeset/inspect-region-column.md
+++ b/.changeset/inspect-region-column.md
@@ -4,4 +4,4 @@
 '@workflow/cli': patch
 ---
 
-Show each run's region in `workflow inspect` output via the new optional `World.regionForRunId` reverse lookup.
+Show world-specific run fields (e.g. region on Vercel) in `workflow inspect` output via the new optional `World.describeRun` hook.

--- a/packages/cli/src/lib/inspect/output.test.ts
+++ b/packages/cli/src/lib/inspect/output.test.ts
@@ -275,6 +275,91 @@ describe('listRuns', () => {
     expect(output.data[0].region).toBeNull();
   });
 
+  it('never lets describeRun overwrite canonical run fields', async () => {
+    const run = {
+      runId: 'wrun_41KX206BTK10M0C31CMN2AS1JS',
+      status: 'running',
+      deploymentId: 'dep-1',
+      workflowName: 'workflow//./src/workflows/test//myWorkflow',
+      specVersion: 2,
+      attributes: {},
+      createdAt: new Date('2026-06-30T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-30T00:00:00.000Z'),
+      startedAt: new Date('2026-06-30T00:00:01.000Z'),
+      completedAt: null,
+      errorCode: null,
+      workflowCoreVersion: null,
+      workflowEncryptionEnabled: false,
+    } satisfies AnalyticsRun;
+    const world = {
+      // Hostile/buggy world: tries to clobber canonical fields.
+      describeRun: vi
+        .fn()
+        .mockReturnValue({ status: 'hacked', runId: 'nope', region: 'sfo1' }),
+      analytics: {
+        runs: {
+          list: vi.fn().mockResolvedValue({
+            data: [run],
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      },
+    } as unknown as World;
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await listRuns(world, { json: true });
+
+    const output = JSON.parse(String(write.mock.calls[0][0]));
+    expect(output.data[0].status).toBe('running');
+    expect(output.data[0].runId).toBe(run.runId);
+    expect(output.data[0].region).toBe('sfo1');
+  });
+
+  it('treats a throwing describeRun as contributing no fields', async () => {
+    const run = {
+      runId: 'wrun_41KX206BTK10M0C31CMN2AS1JS',
+      status: 'running',
+      deploymentId: 'dep-1',
+      workflowName: 'workflow//./src/workflows/test//myWorkflow',
+      specVersion: 2,
+      attributes: {},
+      createdAt: new Date('2026-06-30T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-30T00:00:00.000Z'),
+      startedAt: new Date('2026-06-30T00:00:01.000Z'),
+      completedAt: null,
+      errorCode: null,
+      workflowCoreVersion: null,
+      workflowEncryptionEnabled: false,
+    } satisfies AnalyticsRun;
+    const world = {
+      describeRun: vi.fn().mockImplementation(() => {
+        throw new Error('buggy world');
+      }),
+      analytics: {
+        runs: {
+          list: vi.fn().mockResolvedValue({
+            data: [run],
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      },
+    } as unknown as World;
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    // Must not throw despite the world violating the no-throw contract.
+    await listRuns(world, { json: true });
+
+    const output = JSON.parse(String(write.mock.calls[0][0]));
+    expect(output.data[0].status).toBe('running');
+    expect('region' in output.data[0]).toBe(false);
+  });
+
   it('adds no world fields when the world lacks describeRun', async () => {
     const run = {
       runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ',

--- a/packages/cli/src/lib/inspect/output.test.ts
+++ b/packages/cli/src/lib/inspect/output.test.ts
@@ -190,6 +190,83 @@ describe('listRuns', () => {
       },
     });
   });
+
+  it('includes a region property when the world defines regionForRunId', async () => {
+    const run = {
+      runId: 'wrun_41KX206BTK10M0C31CMN2AS1JS',
+      status: 'running',
+      deploymentId: 'dep-1',
+      workflowName: 'workflow//./src/workflows/test//myWorkflow',
+      specVersion: 2,
+      attributes: {},
+      createdAt: new Date('2026-06-30T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-30T00:00:00.000Z'),
+      startedAt: new Date('2026-06-30T00:00:01.000Z'),
+      completedAt: null,
+      errorCode: null,
+      workflowCoreVersion: null,
+      workflowEncryptionEnabled: false,
+    } satisfies AnalyticsRun;
+    const regionForRunId = vi.fn().mockReturnValue('sfo1');
+    const world = {
+      regionForRunId,
+      analytics: {
+        runs: {
+          list: vi.fn().mockResolvedValue({
+            data: [run],
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      },
+    } as unknown as World;
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await listRuns(world, { json: true });
+
+    expect(regionForRunId).toHaveBeenCalledWith(run.runId);
+    const output = JSON.parse(String(write.mock.calls[0][0]));
+    expect(output.data[0].region).toBe('sfo1');
+  });
+
+  it('omits the region property when the world lacks regionForRunId', async () => {
+    const run = {
+      runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ',
+      status: 'running',
+      deploymentId: 'dep-1',
+      workflowName: 'workflow//./src/workflows/test//myWorkflow',
+      specVersion: 2,
+      attributes: {},
+      createdAt: new Date('2026-06-30T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-30T00:00:00.000Z'),
+      startedAt: new Date('2026-06-30T00:00:01.000Z'),
+      completedAt: null,
+      errorCode: null,
+      workflowCoreVersion: null,
+      workflowEncryptionEnabled: false,
+    } satisfies AnalyticsRun;
+    const world = {
+      analytics: {
+        runs: {
+          list: vi.fn().mockResolvedValue({
+            data: [run],
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      },
+    } as unknown as World;
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await listRuns(world, { json: true });
+
+    const output = JSON.parse(String(write.mock.calls[0][0]));
+    expect('region' in output.data[0]).toBe(false);
+  });
 });
 
 describe('listSteps', () => {

--- a/packages/cli/src/lib/inspect/output.test.ts
+++ b/packages/cli/src/lib/inspect/output.test.ts
@@ -360,6 +360,83 @@ describe('listRuns', () => {
     expect('region' in output.data[0]).toBe(false);
   });
 
+  it('supports async describeRun implementations', async () => {
+    const run = {
+      runId: 'wrun_41KX206BTK10M0C31CMN2AS1JS',
+      status: 'running',
+      deploymentId: 'dep-1',
+      workflowName: 'workflow//./src/workflows/test//myWorkflow',
+      specVersion: 2,
+      attributes: {},
+      createdAt: new Date('2026-06-30T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-30T00:00:00.000Z'),
+      startedAt: new Date('2026-06-30T00:00:01.000Z'),
+      completedAt: null,
+      errorCode: null,
+      workflowCoreVersion: null,
+      workflowEncryptionEnabled: false,
+    } satisfies AnalyticsRun;
+    const world = {
+      describeRun: vi.fn().mockResolvedValue({ region: 'sfo1' }),
+      analytics: {
+        runs: {
+          list: vi.fn().mockResolvedValue({
+            data: [run],
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      },
+    } as unknown as World;
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await listRuns(world, { json: true });
+
+    const output = JSON.parse(String(write.mock.calls[0][0]));
+    expect(output.data[0].region).toBe('sfo1');
+  });
+
+  it('treats a rejecting async describeRun as contributing no fields', async () => {
+    const run = {
+      runId: 'wrun_41KX206BTK10M0C31CMN2AS1JS',
+      status: 'running',
+      deploymentId: 'dep-1',
+      workflowName: 'workflow//./src/workflows/test//myWorkflow',
+      specVersion: 2,
+      attributes: {},
+      createdAt: new Date('2026-06-30T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-30T00:00:00.000Z'),
+      startedAt: new Date('2026-06-30T00:00:01.000Z'),
+      completedAt: null,
+      errorCode: null,
+      workflowCoreVersion: null,
+      workflowEncryptionEnabled: false,
+    } satisfies AnalyticsRun;
+    const world = {
+      describeRun: vi.fn().mockRejectedValue(new Error('async buggy world')),
+      analytics: {
+        runs: {
+          list: vi.fn().mockResolvedValue({
+            data: [run],
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      },
+    } as unknown as World;
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await listRuns(world, { json: true });
+
+    const output = JSON.parse(String(write.mock.calls[0][0]));
+    expect(output.data[0].status).toBe('running');
+    expect('region' in output.data[0]).toBe(false);
+  });
+
   it('adds no world fields when the world lacks describeRun', async () => {
     const run = {
       runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ',

--- a/packages/cli/src/lib/inspect/output.test.ts
+++ b/packages/cli/src/lib/inspect/output.test.ts
@@ -191,7 +191,7 @@ describe('listRuns', () => {
     });
   });
 
-  it('includes a region property when the world defines regionForRunId', async () => {
+  it('includes world-specific fields when the world defines describeRun', async () => {
     const run = {
       runId: 'wrun_41KX206BTK10M0C31CMN2AS1JS',
       status: 'running',
@@ -207,9 +207,9 @@ describe('listRuns', () => {
       workflowCoreVersion: null,
       workflowEncryptionEnabled: false,
     } satisfies AnalyticsRun;
-    const regionForRunId = vi.fn().mockReturnValue('sfo1');
+    const describeRun = vi.fn().mockReturnValue({ region: 'sfo1', shard: 'a' });
     const world = {
-      regionForRunId,
+      describeRun,
       analytics: {
         runs: {
           list: vi.fn().mockResolvedValue({
@@ -226,12 +226,56 @@ describe('listRuns', () => {
 
     await listRuns(world, { json: true });
 
-    expect(regionForRunId).toHaveBeenCalledWith(run.runId);
+    expect(describeRun).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: run.runId })
+    );
     const output = JSON.parse(String(write.mock.calls[0][0]));
     expect(output.data[0].region).toBe('sfo1');
+    expect(output.data[0].shard).toBe('a');
   });
 
-  it('omits the region property when the world lacks regionForRunId', async () => {
+  it('preserves null field values from describeRun in JSON output', async () => {
+    // null means "applicable but undeterminable" — distinguishable from
+    // the hook being absent (key missing entirely).
+    const run = {
+      runId: 'wrun_malformed',
+      status: 'running',
+      deploymentId: 'dep-1',
+      workflowName: 'workflow//./src/workflows/test//myWorkflow',
+      specVersion: 2,
+      attributes: {},
+      createdAt: new Date('2026-06-30T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-30T00:00:00.000Z'),
+      startedAt: new Date('2026-06-30T00:00:01.000Z'),
+      completedAt: null,
+      errorCode: null,
+      workflowCoreVersion: null,
+      workflowEncryptionEnabled: false,
+    } satisfies AnalyticsRun;
+    const world = {
+      describeRun: vi.fn().mockReturnValue({ region: null }),
+      analytics: {
+        runs: {
+          list: vi.fn().mockResolvedValue({
+            data: [run],
+            cursor: null,
+            hasMore: false,
+          }),
+        },
+      },
+    } as unknown as World;
+    const write = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await listRuns(world, { json: true });
+
+    const output = JSON.parse(String(write.mock.calls[0][0]));
+    expect('region' in output.data[0]).toBe(true);
+    expect(output.data[0].region).toBeNull();
+  });
+
+  it('adds no world fields when the world lacks describeRun', async () => {
     const run = {
       runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ',
       status: 'running',

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -646,26 +646,31 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
         (prop) => !WORKFLOW_RUN_IO_PROPS.includes(prop)
       );
 
-  // Region is world-specific: only worlds that can reverse-lookup a
-  // run's region from its ID (World.regionForRunId) get the column.
-  const regionForRunId = world.regionForRunId?.bind(world);
-  const props: string[] = regionForRunId
-    ? (() => {
-        const withRegion: string[] = [...baseProps];
-        withRegion.splice(withRegion.indexOf('status'), 0, 'region');
-        return withRegion;
-      })()
-    : [...baseProps];
-
-  const withRegion = (
+  // World-specific display fields (World.describeRun): each key the
+  // world returns becomes an extra column, inserted before `status`.
+  // Detached call site, so bind explicitly. `null` field values are
+  // preserved (they mean "applicable but undeterminable" per the
+  // interface contract), distinguishing them in JSON output from the
+  // hook being absent entirely.
+  const describeRun = world.describeRun?.bind(world);
+  const describedKeys: string[] = [];
+  const withWorldFields = (
     rows: Record<string, unknown>[]
-  ): Record<string, unknown>[] =>
-    regionForRunId
-      ? rows.map((row) => ({
-          ...row,
-          region: regionForRunId(String(row.runId)) ?? undefined,
-        }))
-      : rows;
+  ): Record<string, unknown>[] => {
+    if (!describeRun) return rows;
+    return rows.map((row) => {
+      const fields = describeRun(row) ?? {};
+      for (const key of Object.keys(fields)) {
+        if (!describedKeys.includes(key)) describedKeys.push(key);
+      }
+      return { ...row, ...fields };
+    });
+  };
+  const propsFor = (baseList: (keyof WorkflowRun)[]): string[] => {
+    const list: string[] = [...baseList];
+    list.splice(list.indexOf('status'), 0, ...describedKeys);
+    return list;
+  };
 
   const fetchRunsPage = async (
     cursor: string | undefined
@@ -683,7 +688,9 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
         pagination,
       });
       return {
-        data: withRegion(runs.data as unknown as Record<string, unknown>[]),
+        data: withWorldFields(
+          runs.data as unknown as Record<string, unknown>[]
+        ),
         cursor: runs.cursor,
         hasMore: runs.hasMore,
         pageInfo: getPageInfo(runs),
@@ -699,7 +706,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
       runs.data.map((r) => hydrateResourceIO(r, resolveKey))
     );
     return {
-      data: withRegion(data as unknown as Record<string, unknown>[]),
+      data: withWorldFields(data as unknown as Record<string, unknown>[]),
       cursor: runs.cursor,
       hasMore: runs.hasMore,
       pageInfo: getPageInfo(runs),
@@ -734,7 +741,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
       }
     },
     displayPage: async (runs) => {
-      logger.log(showTable(runs, props, opts));
+      logger.log(showTable(runs, propsFor(baseProps), opts));
     },
   });
 };
@@ -776,11 +783,15 @@ export const showRun = async (
   try {
     const run = await world.runs.get(runId, { resolveData: 'all' });
     const hydrated = await hydrateResourceIO(run, resolveKey);
-    // Region is world-specific: present only when the world can
-    // reverse-lookup a run's region from its ID.
-    const region = world.regionForRunId?.(runId) ?? undefined;
-    const runWithHydratedIO =
-      region !== undefined ? { ...hydrated, region } : hydrated;
+    // World-specific display fields (World.describeRun). Method-style
+    // call preserves `this`; `null` field values are kept so structured
+    // output distinguishes "undeterminable" from "hook absent".
+    const worldFields = world.describeRun?.(
+      run as unknown as Record<string, unknown>
+    );
+    const runWithHydratedIO = worldFields
+      ? { ...hydrated, ...worldFields }
+      : hydrated;
     if (opts.json) {
       showJson(runWithHydratedIO);
       return;

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -469,13 +469,15 @@ const showJson = (data: unknown) => {
  * dropped so a world can never overwrite canonical fields (`status`,
  * `runId`, ...) in inspect output.
  */
-const safeWorldFields = (
+const safeWorldFields = async (
   describeRun: NonNullable<World['describeRun']>,
   row: Record<string, unknown>
-): Record<string, string | null> => {
+): Promise<Record<string, string | null>> => {
   let fields: Record<string, string | null> | null;
   try {
-    fields = describeRun(row);
+    // The hook may be sync or async; a rejection is treated the same as
+    // a throw — no fields.
+    fields = await describeRun(row);
   } catch {
     return {};
   }
@@ -684,17 +686,21 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
   // hook being absent entirely.
   const describeRun = world.describeRun?.bind(world);
   const describedKeys: string[] = [];
-  const withWorldFields = (
+  const withWorldFields = async (
     rows: Record<string, unknown>[]
-  ): Record<string, unknown>[] => {
+  ): Promise<Record<string, unknown>[]> => {
     if (!describeRun) return rows;
-    return rows.map((row) => {
-      const fields = safeWorldFields(describeRun, row);
-      for (const key of Object.keys(fields)) {
-        if (!describedKeys.includes(key)) describedKeys.push(key);
-      }
-      return { ...row, ...fields };
-    });
+    // Rows evaluated concurrently so an async implementation costs one
+    // await per page, not per row.
+    return Promise.all(
+      rows.map(async (row) => {
+        const fields = await safeWorldFields(describeRun, row);
+        for (const key of Object.keys(fields)) {
+          if (!describedKeys.includes(key)) describedKeys.push(key);
+        }
+        return { ...row, ...fields };
+      })
+    );
   };
   const propsFor = (baseList: (keyof WorkflowRun)[]): string[] => {
     const list: string[] = [...baseList];
@@ -718,7 +724,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
         pagination,
       });
       return {
-        data: withWorldFields(
+        data: await withWorldFields(
           runs.data as unknown as Record<string, unknown>[]
         ),
         cursor: runs.cursor,
@@ -736,7 +742,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
       runs.data.map((r) => hydrateResourceIO(r, resolveKey))
     );
     return {
-      data: withWorldFields(data as unknown as Record<string, unknown>[]),
+      data: await withWorldFields(data as unknown as Record<string, unknown>[]),
       cursor: runs.cursor,
       hasMore: runs.hasMore,
       pageInfo: getPageInfo(runs),
@@ -817,7 +823,7 @@ export const showRun = async (
     // defensively — see safeWorldFields. `null` field values are kept so
     // structured output distinguishes "undeterminable" from "hook absent".
     const worldFields = world.describeRun
-      ? safeWorldFields(
+      ? await safeWorldFields(
           world.describeRun.bind(world),
           run as unknown as Record<string, unknown>
         )

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -640,11 +640,32 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
   }
 
   // Determine which props to show based on withData flag
-  const props = opts.withData
+  const baseProps = opts.withData
     ? WORKFLOW_RUN_LISTED_PROPS
     : WORKFLOW_RUN_LISTED_PROPS.filter(
         (prop) => !WORKFLOW_RUN_IO_PROPS.includes(prop)
       );
+
+  // Region is world-specific: only worlds that can reverse-lookup a
+  // run's region from its ID (World.regionForRunId) get the column.
+  const regionForRunId = world.regionForRunId?.bind(world);
+  const props: string[] = regionForRunId
+    ? (() => {
+        const withRegion: string[] = [...baseProps];
+        withRegion.splice(withRegion.indexOf('status'), 0, 'region');
+        return withRegion;
+      })()
+    : [...baseProps];
+
+  const withRegion = (
+    rows: Record<string, unknown>[]
+  ): Record<string, unknown>[] =>
+    regionForRunId
+      ? rows.map((row) => ({
+          ...row,
+          region: regionForRunId(String(row.runId)) ?? undefined,
+        }))
+      : rows;
 
   const fetchRunsPage = async (
     cursor: string | undefined
@@ -662,7 +683,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
         pagination,
       });
       return {
-        data: runs.data as unknown as Record<string, unknown>[],
+        data: withRegion(runs.data as unknown as Record<string, unknown>[]),
         cursor: runs.cursor,
         hasMore: runs.hasMore,
         pageInfo: getPageInfo(runs),
@@ -678,7 +699,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
       runs.data.map((r) => hydrateResourceIO(r, resolveKey))
     );
     return {
-      data: data as unknown as Record<string, unknown>[],
+      data: withRegion(data as unknown as Record<string, unknown>[]),
       cursor: runs.cursor,
       hasMore: runs.hasMore,
       pageInfo: getPageInfo(runs),
@@ -754,7 +775,12 @@ export const showRun = async (
   }
   try {
     const run = await world.runs.get(runId, { resolveData: 'all' });
-    const runWithHydratedIO = await hydrateResourceIO(run, resolveKey);
+    const hydrated = await hydrateResourceIO(run, resolveKey);
+    // Region is world-specific: present only when the world can
+    // reverse-lookup a run's region from its ID.
+    const region = world.regionForRunId?.(runId) ?? undefined;
+    const runWithHydratedIO =
+      region !== undefined ? { ...hydrated, region } : hydrated;
     if (opts.json) {
       showJson(runWithHydratedIO);
       return;

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -459,6 +459,36 @@ const showJson = (data: unknown) => {
   process.stdout.write(`${json}\n`);
 };
 
+/**
+ * Defensively evaluate `World.describeRun` for one run row.
+ *
+ * The interface contract says implementations are pure and must not
+ * throw — but it is an external extension point, so the CLI does not
+ * trust that: a throwing implementation contributes no fields instead
+ * of crashing the command. Keys that already exist on the run row are
+ * dropped so a world can never overwrite canonical fields (`status`,
+ * `runId`, ...) in inspect output.
+ */
+const safeWorldFields = (
+  describeRun: NonNullable<World['describeRun']>,
+  row: Record<string, unknown>
+): Record<string, string | null> => {
+  let fields: Record<string, string | null> | null;
+  try {
+    fields = describeRun(row);
+  } catch {
+    return {};
+  }
+  if (!fields) return {};
+  const safe: Record<string, string | null> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (!(key in row)) {
+      safe[key] = value;
+    }
+  }
+  return safe;
+};
+
 const showJsonPage = <T>(page: PageData<T>) => {
   showJson({
     data: page.data,
@@ -659,7 +689,7 @@ export const listRuns = async (world: World, opts: InspectCLIOptions = {}) => {
   ): Record<string, unknown>[] => {
     if (!describeRun) return rows;
     return rows.map((row) => {
-      const fields = describeRun(row) ?? {};
+      const fields = safeWorldFields(describeRun, row);
       for (const key of Object.keys(fields)) {
         if (!describedKeys.includes(key)) describedKeys.push(key);
       }
@@ -783,15 +813,19 @@ export const showRun = async (
   try {
     const run = await world.runs.get(runId, { resolveData: 'all' });
     const hydrated = await hydrateResourceIO(run, resolveKey);
-    // World-specific display fields (World.describeRun). Method-style
-    // call preserves `this`; `null` field values are kept so structured
-    // output distinguishes "undeterminable" from "hook absent".
-    const worldFields = world.describeRun?.(
-      run as unknown as Record<string, unknown>
-    );
-    const runWithHydratedIO = worldFields
-      ? { ...hydrated, ...worldFields }
-      : hydrated;
+    // World-specific display fields (World.describeRun), evaluated
+    // defensively — see safeWorldFields. `null` field values are kept so
+    // structured output distinguishes "undeterminable" from "hook absent".
+    const worldFields = world.describeRun
+      ? safeWorldFields(
+          world.describeRun.bind(world),
+          run as unknown as Record<string, unknown>
+        )
+      : undefined;
+    const runWithHydratedIO =
+      worldFields && Object.keys(worldFields).length > 0
+        ? { ...hydrated, ...worldFields }
+        : hydrated;
     if (opts.json) {
       showJson(runWithHydratedIO);
       return;

--- a/packages/world-vercel/src/create-run-id.test.ts
+++ b/packages/world-vercel/src/create-run-id.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRunId, regionForRunId } from './create-run-id.js';
+import { createRunId, describeRun, regionForRunId } from './create-run-id.js';
 import { decode } from './run-id/index.js';
 import { REGION_IDS } from './run-id/regions.js';
 
@@ -194,5 +194,30 @@ describe('regionForRunId', () => {
   it('returns null for malformed run IDs instead of throwing', () => {
     expect(regionForRunId('wrun_not-a-ulid')).toBeNull();
     expect(regionForRunId('')).toBeNull();
+  });
+});
+
+describe('describeRun', () => {
+  it('returns a region field derived from the run ID tag', () => {
+    const runId = `wrun_${createRunId({ region: 'sfo1' })}`;
+    expect(describeRun({ runId })).toEqual({ region: 'sfo1' });
+  });
+
+  it('resolves untagged legacy runs to the default region', () => {
+    expect(describeRun({ runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ' })).toEqual({
+      region: 'iad1',
+    });
+  });
+
+  it('returns a null region for undecodable run IDs (never throws)', () => {
+    expect(describeRun({ runId: 'wrun_not-a-ulid' })).toEqual({
+      region: null,
+    });
+  });
+
+  it('contributes nothing when the entity has no usable runId', () => {
+    expect(describeRun({})).toBeNull();
+    expect(describeRun({ runId: 42 })).toBeNull();
+    expect(describeRun({ runId: '' })).toBeNull();
   });
 });

--- a/packages/world-vercel/src/create-run-id.test.ts
+++ b/packages/world-vercel/src/create-run-id.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRunId } from './create-run-id.js';
+import { createRunId, regionForRunId } from './create-run-id.js';
 import { decode } from './run-id/index.js';
 import { REGION_IDS } from './run-id/regions.js';
 
@@ -177,5 +177,22 @@ describe('createRunId', () => {
       const decoded = decode(createRunId(undefined));
       expect(decoded.region).toBe('iad1');
     });
+  });
+});
+
+describe('regionForRunId', () => {
+  it('decodes the region from tagged run IDs (with or without prefix)', () => {
+    const runId = `wrun_${createRunId({ region: 'sfo1' })}`;
+    expect(regionForRunId(runId)).toBe('sfo1');
+    expect(regionForRunId(runId.slice('wrun_'.length))).toBe('sfo1');
+  });
+
+  it('resolves untagged legacy run IDs to the default region', () => {
+    expect(regionForRunId('wrun_01KX2M5N3RBNC12RYWYYH4WWQJ')).toBe('iad1');
+  });
+
+  it('returns null for malformed run IDs instead of throwing', () => {
+    expect(regionForRunId('wrun_not-a-ulid')).toBeNull();
+    expect(regionForRunId('')).toBeNull();
   });
 });

--- a/packages/world-vercel/src/create-run-id.ts
+++ b/packages/world-vercel/src/create-run-id.ts
@@ -120,8 +120,7 @@ export function createRunId(
 }
 
 /**
- * `World.regionForRunId` implementation: derive the region a run's data
- * lives in from its run ID.
+ * Derive the region a run's data lives in from its run ID.
  *
  * - Region-tagged IDs (minted by {@link createRunId}) decode to their
  *   embedded region.
@@ -141,4 +140,25 @@ export function regionForRunId(runId: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * `World.describeRun` implementation: Vercel-specific display fields
+ * for a run.
+ *
+ * Currently a single field — `region`, decoded from the run ID's
+ * region tag (see {@link regionForRunId}) — but the shape leaves room
+ * for additional fields derived from other run-entity properties
+ * (e.g. `executionContext`) without another interface change. A
+ * `null` region means the run ID was present but undecodable;
+ * a missing/non-string run ID contributes nothing.
+ */
+export function describeRun(
+  run: Readonly<Record<string, unknown>>
+): Record<string, string | null> | null {
+  const runId = run.runId;
+  if (typeof runId !== 'string' || runId.length === 0) {
+    return null;
+  }
+  return { region: regionForRunId(runId) };
 }

--- a/packages/world-vercel/src/create-run-id.ts
+++ b/packages/world-vercel/src/create-run-id.ts
@@ -1,6 +1,6 @@
 import { monotonicFactory } from 'ulid';
 import { bytesToUlid, ulidToBytes } from './run-id/codec.js';
-import { encode } from './run-id/index.js';
+import { decode, encode } from './run-id/index.js';
 import {
   DEFAULT_REGION_CODE,
   REGION_IDS,
@@ -117,4 +117,28 @@ export function createRunId(
   }
   lastRunId = candidate;
   return candidate;
+}
+
+/**
+ * `World.regionForRunId` implementation: derive the region a run's data
+ * lives in from its run ID.
+ *
+ * - Region-tagged IDs (minted by {@link createRunId}) decode to their
+ *   embedded region.
+ * - Untagged legacy IDs — and tagged IDs whose region code is unknown to
+ *   this SDK version — resolve to {@link DEFAULT_REGION_CODE}: all
+ *   pre-tagging data lives there by convention, matching the backend's
+ *   routing.
+ * - Malformed IDs return `null` (never throws).
+ */
+export function regionForRunId(runId: string): string | null {
+  const bare = runId.startsWith('wrun_') ? runId.slice('wrun_'.length) : runId;
+  try {
+    const decoded = decode(bare);
+    return decoded.tagged && decoded.region
+      ? decoded.region
+      : DEFAULT_REGION_CODE;
+  } catch {
+    return null;
+  }
 }

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -1,7 +1,7 @@
 import type { World } from '@workflow/world';
 import { SPEC_VERSION_SUPPORTS_COMPRESSION } from '@workflow/world';
 import { createAnalytics } from './analytics.js';
-import { createRunId, regionForRunId } from './create-run-id.js';
+import { createRunId, describeRun } from './create-run-id.js';
 import { createGetEncryptionKeyForRun } from './encryption.js';
 import { instrumentObject } from './instrumentObject.js';
 import { createQueue } from './queue.js';
@@ -11,7 +11,7 @@ import { createStreamer } from './streamer.js';
 import type { APIConfig } from './utils.js';
 
 export { createAnalytics } from './analytics.js';
-export { createRunId, regionForRunId } from './create-run-id.js';
+export { createRunId, describeRun, regionForRunId } from './create-run-id.js';
 export {
   createGetEncryptionKeyForRun,
   deriveRunKey,
@@ -48,7 +48,7 @@ export function createWorld(config?: APIConfig): World {
     analytics: createAnalytics(config),
     ...instrumentObject('world.streams', createStreamer(config)),
     createRunId,
-    regionForRunId,
+    describeRun,
     getEncryptionKeyForRun: createGetEncryptionKeyForRun(
       projectId,
       config?.projectConfig?.teamId,

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -1,7 +1,7 @@
 import type { World } from '@workflow/world';
 import { SPEC_VERSION_SUPPORTS_COMPRESSION } from '@workflow/world';
 import { createAnalytics } from './analytics.js';
-import { createRunId } from './create-run-id.js';
+import { createRunId, regionForRunId } from './create-run-id.js';
 import { createGetEncryptionKeyForRun } from './encryption.js';
 import { instrumentObject } from './instrumentObject.js';
 import { createQueue } from './queue.js';
@@ -11,7 +11,7 @@ import { createStreamer } from './streamer.js';
 import type { APIConfig } from './utils.js';
 
 export { createAnalytics } from './analytics.js';
-export { createRunId } from './create-run-id.js';
+export { createRunId, regionForRunId } from './create-run-id.js';
 export {
   createGetEncryptionKeyForRun,
   deriveRunKey,
@@ -48,6 +48,7 @@ export function createWorld(config?: APIConfig): World {
     analytics: createAnalytics(config),
     ...instrumentObject('world.streams', createStreamer(config)),
     createRunId,
+    regionForRunId,
     getEncryptionKeyForRun: createGetEncryptionKeyForRun(
       projectId,
       config?.projectConfig?.teamId,

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -407,10 +407,7 @@ export interface World extends Queue, Streamer, Storage {
    *
    * The contract:
    * - **Cheap and pure.** Called once per displayed run, so avoid I/O —
-   *   prefer deriving fields from the entity you are given. Returning a
-   *   Promise is allowed for implementations that cannot avoid async
-   *   work, but consumers may evaluate rows concurrently and output
-   *   rendering blocks on the slowest row.
+   *   prefer deriving fields from the entity you are given.
    * - **Read only what you recognise.** The argument is the run entity
    *   as the caller has it (a full storage run, or a leaner analytics
    *   row) — typed loosely for the same reason as {@link createRunId}.

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -396,20 +396,29 @@ export interface World extends Queue, Streamer, Storage {
   createRunId?(options?: Readonly<Record<string, unknown>>): string;
 
   /**
-   * Reverse lookup: derive the region a run's data lives in from its
-   * run ID.
+   * World-specific display fields for a run.
    *
-   * Worlds that embed placement metadata in their run IDs (see
-   * {@link createRunId}) can expose it here so tooling — e.g. the
-   * `workflow inspect` CLI — can display a run's region generically.
-   * Consumers must treat this as optional: when the hook is absent the
-   * world has no regional dimension and region output should be
-   * omitted entirely.
+   * Tooling — e.g. the `workflow inspect` CLI — calls this to enrich a
+   * run's listing row / detail output with fields only the world can
+   * derive: a region decoded from the run ID, placement read off the
+   * run's `executionContext`, a shard, a billing tier, etc. Consumers
+   * render each returned key as an additional column/property; when the
+   * hook is absent, no extra fields appear at all.
    *
-   * @param runId - The run ID, with or without the `wrun_` prefix.
-   * @returns The region identifier the run's data lives in, or `null`
-   *   when no region can be determined for the given ID (e.g. it is
-   *   malformed). Implementations must not throw.
+   * The contract:
+   * - **Synchronous and pure** — called once per displayed run, so no
+   *   I/O; derive fields from the entity you are given.
+   * - **Read only what you recognise.** The argument is the run entity
+   *   as the caller has it (a full storage run, or a leaner analytics
+   *   row) — typed loosely for the same reason as {@link createRunId}.
+   *   Tolerate missing fields.
+   * - **Must not throw.**
+   * - A `null` field value means "applicable but undeterminable" and is
+   *   preserved as `null` in structured output (vs. the hook being
+   *   absent, where the key does not exist at all). Return `null` or an
+   *   empty object to add nothing for a given run.
    */
-  regionForRunId?(runId: string): string | null;
+  describeRun?(
+    run: Readonly<Record<string, unknown>>
+  ): Record<string, string | null> | null;
 }

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -394,4 +394,22 @@ export interface World extends Queue, Streamer, Storage {
    *   tolerate `undefined` for direct callers.
    */
   createRunId?(options?: Readonly<Record<string, unknown>>): string;
+
+  /**
+   * Reverse lookup: derive the region a run's data lives in from its
+   * run ID.
+   *
+   * Worlds that embed placement metadata in their run IDs (see
+   * {@link createRunId}) can expose it here so tooling — e.g. the
+   * `workflow inspect` CLI — can display a run's region generically.
+   * Consumers must treat this as optional: when the hook is absent the
+   * world has no regional dimension and region output should be
+   * omitted entirely.
+   *
+   * @param runId - The run ID, with or without the `wrun_` prefix.
+   * @returns The region identifier the run's data lives in, or `null`
+   *   when no region can be determined for the given ID (e.g. it is
+   *   malformed). Implementations must not throw.
+   */
+  regionForRunId?(runId: string): string | null;
 }

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -406,8 +406,11 @@ export interface World extends Queue, Streamer, Storage {
    * hook is absent, no extra fields appear at all.
    *
    * The contract:
-   * - **Synchronous and pure** — called once per displayed run, so no
-   *   I/O; derive fields from the entity you are given.
+   * - **Cheap and pure.** Called once per displayed run, so avoid I/O —
+   *   prefer deriving fields from the entity you are given. Returning a
+   *   Promise is allowed for implementations that cannot avoid async
+   *   work, but consumers may evaluate rows concurrently and output
+   *   rendering blocks on the slowest row.
    * - **Read only what you recognise.** The argument is the run entity
    *   as the caller has it (a full storage run, or a leaner analytics
    *   row) — typed loosely for the same reason as {@link createRunId}.
@@ -420,5 +423,8 @@ export interface World extends Queue, Streamer, Storage {
    */
   describeRun?(
     run: Readonly<Record<string, unknown>>
-  ): Record<string, string | null> | null;
+  ):
+    | Record<string, string | null>
+    | null
+    | Promise<Record<string, string | null> | null>;
 }


### PR DESCRIPTION
## What

World-specific fields in the `workflow inspect` commands — on Vercel, each run's **region** — implemented via a new **optional hook on the World interface**:

```ts
describeRun?(run: Readonly<Record<string, unknown>>): Record<string, string | null> | null;
```

The hook receives the **run entity** (not just the ID), so worlds can derive display fields from anything on it — a region tag in the run ID, `executionContext`, a shard, etc. — and can add fields later without another interface change. Each returned key becomes an inspect column/property.

- **`@workflow/world`** — the hook + contract: synchronous/pure, read only recognized fields (loosely typed, mirroring `createRunId`), must not throw; `null` field value = "applicable but undeterminable" (preserved in structured output), vs. hook absent = keys don't exist at all.
- **`@workflow/world-vercel`** — `describeRun` returns `{ region }` decoded from the run-ID tag: tagged → embedded region, untagged legacy → default region, undecodable → `null`. `regionForRunId` remains exported as a utility.
- **`@workflow/cli`** —
  - `workflow inspect runs`: extra columns from the union of keys the world returns for the page, inserted before `status`; both analytics and storage list paths; table + JSON
  - `workflow inspect run <id>`: fields merged into the detail/JSON output
  - Worlds without the hook (local/postgres): zero schema noise

## Stacked on #1981

Based on `world-create-run-id` — the Vercel implementation decodes the region tags that PR introduces. Merge after (or into) #1981.

## Tests

- CLI: multi-key field merging + hook invoked with the entity; `null` preservation in JSON; hook-absent case (20 green)
- world-vercel: tagged→region, untagged→default, undecodable→`{region: null}`, no-usable-runId→nothing (260 green)

Changeset: patch × 3 packages.