### PR TITLE
fix(world): parse timezone-naive analytics timestamps as UTC

### DIFF
--- a/.changeset/analytics-utc-dates.md
+++ b/.changeset/analytics-utc-dates.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world': patch
+---
+
+Parse timezone-naive analytics timestamps as UTC so CLI and local web output shows correct times in any timezone.

--- a/packages/world/src/analytics.test.ts
+++ b/packages/world/src/analytics.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { AnalyticsRunSchema } from './analytics.js';
+
+const base = {
+  runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ',
+  status: 'completed',
+  deploymentId: 'dpl_1',
+  workflowName: 'workflow//./src/w//myWorkflow',
+  updatedAt: '2026-07-13 17:09:11.593',
+};
+
+describe('analytics date coercion', () => {
+  it('parses timezone-naive datetime strings as UTC regardless of process TZ', () => {
+    // ClickHouse DateTime64 JSON shape: naive, UTC by convention.
+    const run = AnalyticsRunSchema.parse({
+      ...base,
+      createdAt: '2026-07-13 17:09:11.593',
+    });
+    expect(run.createdAt.getTime()).toBe(Date.UTC(2026, 6, 13, 17, 9, 11, 593));
+    expect(run.createdAt.toISOString()).toBe('2026-07-13T17:09:11.593Z');
+  });
+
+  it('accepts naive strings without fractional seconds', () => {
+    const run = AnalyticsRunSchema.parse({
+      ...base,
+      createdAt: '2026-07-13 17:09:11',
+    });
+    expect(run.createdAt.toISOString()).toBe('2026-07-13T17:09:11.000Z');
+  });
+
+  it('leaves timezone-aware strings untouched', () => {
+    const run = AnalyticsRunSchema.parse({
+      ...base,
+      createdAt: '2026-07-13T10:09:11.593-07:00',
+    });
+    expect(run.createdAt.toISOString()).toBe('2026-07-13T17:09:11.593Z');
+    const zulu = AnalyticsRunSchema.parse({
+      ...base,
+      createdAt: '2026-07-13T17:09:11.593Z',
+    });
+    expect(zulu.createdAt.toISOString()).toBe('2026-07-13T17:09:11.593Z');
+  });
+
+  it('passes through Date objects and nullable fields', () => {
+    const d = new Date('2026-07-13T17:09:11.593Z');
+    const run = AnalyticsRunSchema.parse({
+      ...base,
+      createdAt: d,
+      startedAt: '2026-07-13 17:09:12.000',
+      completedAt: null,
+    });
+    expect(run.createdAt.getTime()).toBe(d.getTime());
+    expect(run.startedAt?.toISOString()).toBe('2026-07-13T17:09:12.000Z');
+    expect(run.completedAt).toBeNull();
+  });
+});

--- a/packages/world/src/analytics.ts
+++ b/packages/world/src/analytics.ts
@@ -5,7 +5,34 @@ import type { PaginatedResponse, PaginationOptions } from './shared.js';
 import { StepStatusSchema } from './steps.js';
 import { WaitStatusSchema } from './waits.js';
 
-const NullableDateSchema = z.coerce.date().nullable().optional();
+/**
+ * Timezone-naive datetime string, e.g. `2026-07-13 17:09:11.593` — the
+ * shape ClickHouse-backed analytics endpoints serialize `DateTime64`
+ * values as. Such values are UTC by convention but carry no designator.
+ */
+const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?$/;
+
+/**
+ * Date coercion that parses timezone-naive strings as UTC.
+ *
+ * `z.coerce.date()` delegates to `new Date(value)`, which interprets a
+ * naive string in the **process's local timezone**. That is only correct
+ * when the process runs in UTC (e.g. the deployed observability web app's
+ * server actions) and is wrong by the local UTC offset everywhere else —
+ * the CLI on a laptop, `workflow web --localUi`, tests. Normalizing naive
+ * strings to an explicit `Z` designator makes parsing timezone-independent.
+ * Values that already carry timezone information (a `Z` or `±hh:mm`
+ * offset), and non-string inputs (Date, epoch number), pass through
+ * unchanged.
+ */
+const UTCDateSchema = z.preprocess((value) => {
+  if (typeof value === 'string' && NAIVE_DATETIME.test(value)) {
+    return `${value.replace(' ', 'T')}Z`;
+  }
+  return value;
+}, z.coerce.date());
+
+const NullableDateSchema = UTCDateSchema.nullable().optional();
 const NullableStringSchema = z.string().nullable().optional();
 const NullableBooleanSchema = z.boolean().nullable().optional();
 
@@ -19,8 +46,8 @@ export const AnalyticsRunSchema = z.object({
   workflowName: z.string(),
   specVersion: z.coerce.number().optional(),
   attributes: z.record(z.string(), z.string()).default({}),
-  createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date(),
+  createdAt: UTCDateSchema,
+  updatedAt: UTCDateSchema,
   startedAt: NullableDateSchema,
   completedAt: NullableDateSchema,
   errorCode: NullableStringSchema,
@@ -34,8 +61,8 @@ export const AnalyticsStepSchema = z.object({
   stepName: NullableStringSchema,
   status: StepStatusSchema,
   attempt: z.number().optional(),
-  createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date(),
+  createdAt: UTCDateSchema,
+  updatedAt: UTCDateSchema,
   startedAt: NullableDateSchema,
   completedAt: NullableDateSchema,
   retryAfter: NullableDateSchema,
@@ -54,8 +81,8 @@ export const AnalyticsEventSchema = z.object({
   workflowName: z.string(),
   deploymentId: z.string(),
   specVersion: z.coerce.number().optional(),
-  runCreatedAt: z.coerce.date(),
-  createdAt: z.coerce.date(),
+  runCreatedAt: UTCDateSchema,
+  createdAt: UTCDateSchema,
   region: NullableStringSchema,
   vercelId: NullableStringSchema,
   requestId: NullableStringSchema,
@@ -72,8 +99,8 @@ export const AnalyticsHookSchema = z.object({
   runId: z.string(),
   hookId: z.string(),
   status: z.enum(['created', 'received', 'disposed', 'conflict']),
-  createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date(),
+  createdAt: UTCDateSchema,
+  updatedAt: UTCDateSchema,
   receivedAt: NullableDateSchema,
   disposedAt: NullableDateSchema,
   isWebhook: NullableBooleanSchema,
@@ -87,8 +114,8 @@ export const AnalyticsWaitSchema = z.object({
   waitId: z.string(),
   status: WaitStatusSchema,
   resumeAt: NullableDateSchema,
-  createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date(),
+  createdAt: UTCDateSchema,
+  updatedAt: UTCDateSchema,
   completedAt: NullableDateSchema,
   workflowCoreVersion: NullableStringSchema,
   workflowEncryptionEnabled: NullableBooleanSchema,

--- a/packages/world/src/analytics.ts
+++ b/packages/world/src/analytics.ts
@@ -22,8 +22,8 @@ const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?$/;
  * the CLI on a laptop, `workflow web --localUi`, tests. Normalizing naive
  * strings to an explicit `Z` designator makes parsing timezone-independent.
  * Values that already carry timezone information (a `Z` or `±hh:mm`
- * offset), and non-string inputs (Date, epoch number), pass through
- * unchanged.
+ * offset), and non-string inputs (Date, epoch number), are forwarded
+ * without modification before coercion.
  */
 const UTCDateSchema = z.preprocess((value) => {
   if (typeof value === 'string' && NAIVE_DATETIME.test(value)) {


### PR DESCRIPTION
## Bug

`workflow inspect runs --backend=vercel` shows nonsense relative times for any user not in UTC:

```
startedAt: 2026-07-14 00:09:11.593 (in about 7 hours)   # PDT user, actual time 17:09 UTC
```

## Root cause

ClickHouse-backed analytics endpoints serialize `DateTime64` as **timezone-naive strings** (`2026-07-13 17:09:11.593`, UTC by convention). The analytics schemas coerce with `z.coerce.date()` → `new Date(value)`, which parses naive strings in the **process's local timezone**. The epoch ends up shifted by the local UTC offset (+7h for PDT).

Why the web UI looks fine: its `world.analytics` calls run inside server actions on Vercel's **UTC** runtime, where naive-as-local happens to be correct — *accidental* correctness. `workflow web --localUi` (parsing on the laptop) shares the CLI's bug.

## Fix

A `z.preprocess` step in `@workflow/world`'s analytics schemas normalizes naive datetime strings to an explicit `Z` designator before parsing, making the result timezone-independent. Timezone-aware strings (`Z` / `±hh:mm`) and non-string inputs (Date, epoch) pass through untouched — so a future server-side change to emit proper ISO 8601 stays compatible.

## Verification

- 4 new tests pin the contract (naive→UTC epoch, no-fractional-seconds, tz-aware passthrough, Date/null passthrough)
- Verified under `TZ=America/Los_Angeles` and `TZ=Asia/Tokyo`: all pass with the fix; **3 of 4 fail against the old coercion in PDT** — and none fail in UTC, which is exactly how this shipped past CI

Not introduced by the region work — pre-existing on the analytics read path.