### PR TITLE
docs: clarify Vercel-specific analytics notes and align sidebar chevrons

### DIFF
--- a/docs/app/styles/geistdocs.css
+++ b/docs/app/styles/geistdocs.css
@@ -600,3 +600,13 @@
 :root {
   --color-fd-primary: var(--ds-gray-1000);
 }
+
+/* Sidebar folder rows without an index page render as <button>s (Radix
+   collapsible triggers), which don't stretch to the row width like the <a>
+   folder links do — so their ms-auto chevron hugs the label instead of
+   sitting at the end. Stretch them so every chevron aligns at the end.
+   The [data-icon] child scopes this to fumadocs folder-trigger chevrons. */
+[data-sidebar-placeholder] button[data-state]:has(> [data-icon]),
+[data-slot="sheet-content"] button[data-state]:has(> [data-icon]) {
+  @apply w-full;
+}

--- a/docs/content/docs/v5/api-reference/workflow-runtime/world/analytics.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-runtime/world/analytics.mdx
@@ -22,11 +22,10 @@ keywords:
 
 `world.analytics` is an optional, read-only namespace for observability surfaces — dashboards, CLIs, and admin tools that list large numbers of runs without touching payload data.
 
-It differs from [Storage](/docs/api-reference/workflow-runtime/world/storage) in three ways:
+It differs from [Storage](/docs/api-reference/workflow-runtime/world/storage) in two ways:
 
 - **Metadata only.** Results never include run input/output, step data, or hook tokens. There is no `resolveData` option.
-- **Served from the observability pipeline.** On Vercel, queries hit a ClickHouse-backed analytics store instead of the runtime database, so large listings do not compete with workflow execution. Data is ingested asynchronously and may trail the live state by a few seconds.
-- **Plan-bounded lookback.** Listings only cover the observability retention window for your plan (up to 30 days). Every page includes a `pageInfo` block describing the current window, and requesting an older window fails with an `observability-upgrade-required` error.
+- **Served from the observability pipeline.** On Vercel, queries are served from the Vercel observability data pipeline, so large listings do not compete with workflow execution. Data is ingested asynchronously and may trail the live state by a few seconds.
 
 The namespace is optional — worlds that don't implement it (such as the local development world) leave it `undefined`, so feature-detect before use:
 
@@ -129,10 +128,10 @@ Every paginated response carries `pageInfo` describing the window the query was 
 ```typescript
 {
   currentLookbackDays: 2,     // what your plan allows today
-  maxLookbackDays: 30,        // ceiling with Observability Plus
+  maxLookbackDays: 30,        // ceiling with Observability Plus on Vercel
   currentWindowStart: Date,
   maxWindowStart: Date,
-  upgradeAvailable: true,     // more history exists behind the plan gate
+  upgradeAvailable: true,     // for Vercel deployed workflows
 }
 ```
 


### PR DESCRIPTION
## What

**Analytics reference** (`/v5/docs/api-reference/workflow-runtime/world/analytics`):
- Reword the serving-path note: queries are served from the Vercel observability data pipeline (no ClickHouse implementation detail).
- Remove the "Plan-bounded lookback" bullet — it's Vercel-specific, and the Lookback windows section already covers the behavior.
- In the `pageInfo` snippet, mark the 30d ceiling as "with Observability Plus on Vercel" and change the `upgradeAvailable` comment to "for Vercel deployed workflows".

**Docs sidebar**: some chevrons hugged the label ("How it works", "AI Agents", "Testing", "Configuration") while others sat at the row end. Folders without an attached index page render as `<button>` collapsible triggers, which don't stretch to the row width like the `<a>` folder links do, so their `ms-auto` chevron had nothing to push against. A scoped CSS override stretches those triggers to full width, putting every chevron consistently at the end.

## Testing

- Verify the analytics page copy on the preview deployment.
- Open the v5 docs sidebar (desktop + mobile sheet): all folder chevrons should align at the row end, and the version selector should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)