### PR TITLE
docs: fix stale and broken vercel.com links

### DIFF
--- a/docs/content/docs/v4/ai/index.mdx
+++ b/docs/content/docs/v4/ai/index.mdx
@@ -64,7 +64,7 @@ In order to connect to an LLM, we'll need to set up an API key. The easiest way 
 
 <Tab value="Gateway">
 
-Get a Gateway API key from the [Vercel Gateway](https://vercel.com/docs/gateway/api-reference/overview) page.
+Get a Gateway API key from the [Vercel Gateway](https://vercel.com/docs/ai-gateway/authentication) page.
 
 Then add it to your `.env.local` file:
 

--- a/docs/content/docs/v4/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v4/deploying/world/vercel-world.mdx
@@ -36,7 +36,7 @@ That's it. Vercel automatically:
 
 For complete details on pricing, usage limits, and included allotments on Vercel, see the official Vercel documentation:
 
-- **[Vercel Workflow](https://vercel.com/docs/workflow)** — Pricing details, concepts, and observability for Workflow on Vercel
+- **[Vercel Workflow](https://vercel.com/docs/workflows)** — Pricing details, concepts, and observability for Workflow on Vercel
 - **[Vercel limits](https://vercel.com/docs/limits)** — Platform-wide limits including Workflow-specific constraints
 - **[Vercel Hobby plan](https://vercel.com/docs/plans/hobby)** — Free tier included usage for Workflow and other resources
 
@@ -204,4 +204,4 @@ The Vercel World uses Vercel's infrastructure for workflow execution:
 - **Queuing** - Steps are distributed across serverless functions via [Vercel Queues](https://vercel.com/docs/queues) with automatic retries and [consumer function security](#consumer-function-security)
 - **Authentication** - OIDC tokens provide secure, automatic authentication
 
-For more details, see the [Vercel Workflow documentation](https://vercel.com/docs/workflow).
+For more details, see the [Vercel Workflow documentation](https://vercel.com/docs/workflows).

--- a/docs/content/docs/v4/getting-started/python.mdx
+++ b/docs/content/docs/v4/getting-started/python.mdx
@@ -15,7 +15,7 @@ related:
 />
 
 <Callout type="warn">
-The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python?language=py).
+The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflows/python).
 </Callout>
 
 You can build durable workflows in Python using the [`vercel` Python SDK](https://pypi.org/project/vercel/). Your workflow code can pause, resume, and maintain state, just like the JavaScript and TypeScript Workflow SDK.
@@ -160,7 +160,7 @@ When a hook receives data, the workflow resumes automatically. You don&apos;t ne
 
 ## Learn More
 
-For comprehensive documentation, examples, and the latest updates, visit the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python).
+For comprehensive documentation, examples, and the latest updates, visit the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflows/python).
 
 ## Next Steps
 

--- a/docs/content/docs/v5/ai/index.mdx
+++ b/docs/content/docs/v5/ai/index.mdx
@@ -64,7 +64,7 @@ In order to connect to an LLM, we'll need to set up an API key. The easiest way 
 
 <Tab value="Gateway">
 
-Get a Gateway API key from the [Vercel Gateway](https://vercel.com/docs/gateway/api-reference/overview) page.
+Get a Gateway API key from the [Vercel Gateway](https://vercel.com/docs/ai-gateway/authentication) page.
 
 Then add it to your `.env.local` file:
 

--- a/docs/content/docs/v5/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/v5/deploying/world/vercel-world.mdx
@@ -36,7 +36,7 @@ That's it. Vercel automatically:
 
 For complete details on pricing, usage limits, and included allotments on Vercel, see the official Vercel documentation:
 
-- **[Vercel Workflow](https://vercel.com/docs/workflow)** — Pricing details, concepts, and observability for Workflow on Vercel
+- **[Vercel Workflow](https://vercel.com/docs/workflows)** — Pricing details, concepts, and observability for Workflow on Vercel
 - **[Vercel limits](https://vercel.com/docs/limits)** — Platform-wide limits including Workflow-specific constraints
 - **[Vercel Hobby plan](https://vercel.com/docs/plans/hobby)** — Free tier included usage for Workflow and other resources
 
@@ -56,7 +56,7 @@ The Vercel World runs in every [Vercel Function region](https://vercel.com/docs/
 
 No configuration is needed. A run is pinned to the region of the function that creates it:
 
-- Deploy your app to a single region (via [`regions`](https://vercel.com/docs/project-configuration#regions) in `vercel.json` or the project settings), and every run lives there.
+- Deploy your app to a single region (via [`regions`](https://vercel.com/docs/project-configuration/vercel-json#regions) in `vercel.json` or the project settings), and every run lives there.
 - Deploy to multiple regions for a globally distributed audience, and each run is pinned to the region that served the user who triggered it — workflow data and streaming stay close to that user.
 
 ### Explicit region selection
@@ -76,7 +76,7 @@ const run = await start(myWorkflow, [input], { region: "sfo1" });
   there. Your workflow and step functions execute in the regions your
   application is deployed to. For execution to actually happen in the
   specified region, your app must be deployed there — via
-  [`regions`](https://vercel.com/docs/project-configuration#regions) in
+  [`regions`](https://vercel.com/docs/project-configuration/vercel-json#regions) in
   `vercel.json` or the Function Regions setting in your project settings.
   If it isn't, the run's data lives in the requested region but its steps
   execute in the nearest region your app is deployed to.
@@ -272,4 +272,4 @@ The Vercel World uses Vercel's infrastructure for workflow execution:
 - **Queuing** - Steps are distributed across serverless functions via [Vercel Queues](https://vercel.com/docs/queues) with automatic retries and [consumer function security](#consumer-function-security)
 - **Authentication** - OIDC tokens provide secure, automatic authentication
 
-For more details, see the [Vercel Workflow documentation](https://vercel.com/docs/workflow).
+For more details, see the [Vercel Workflow documentation](https://vercel.com/docs/workflows).

--- a/docs/content/docs/v5/getting-started/python.mdx
+++ b/docs/content/docs/v5/getting-started/python.mdx
@@ -15,7 +15,7 @@ related:
 />
 
 <Callout type="warn">
-The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python?language=py).
+The Python SDK is currently in **beta**. APIs and behavior may change. For the latest documentation and updates, see the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflows/python).
 </Callout>
 
 You can build durable workflows in Python using the [`vercel` Python SDK](https://pypi.org/project/vercel/). Your workflow code can pause, resume, and maintain state, just like the JavaScript and TypeScript Workflow SDK.
@@ -160,7 +160,7 @@ When a hook receives data, the workflow resumes automatically. You don&apos;t ne
 
 ## Learn More
 
-For comprehensive documentation, examples, and the latest updates, visit the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflow/python).
+For comprehensive documentation, examples, and the latest updates, visit the [official Vercel Workflow Python documentation](https://vercel.com/docs/workflows/python).
 
 ## Next Steps
 

--- a/docs/content/docs/v5/observability/tracing.mdx
+++ b/docs/content/docs/v5/observability/tracing.mdx
@@ -17,7 +17,7 @@ The SDK only depends on the OpenTelemetry **API**, never on an SDK or exporter. 
 
 ## Enabling tracing
 
-Register any OpenTelemetry Node SDK in your application. On Vercel with Next.js, the simplest setup is [`@vercel/otel`](https://vercel.com/docs/observability/otel-overview) in `instrumentation.ts`:
+Register any OpenTelemetry Node SDK in your application. On Vercel with Next.js, the simplest setup is [`@vercel/otel`](https://vercel.com/docs/tracing/instrumentation) in `instrumentation.ts`:
 
 ```typescript title="instrumentation.ts" lineNumbers
 import { registerOTel } from "@vercel/otel"


### PR DESCRIPTION
## What

Full audit of every `vercel.com` link in `docs/content` (20 unique URLs, validated by HTTP status **and** anchor-fragment presence in page content):

| Problem | Links | Fix |
|---|---|---|
| **Dead anchor** — `#regions` no longer exists on `/docs/project-configuration` (content split into subpages) | 2× | → `/docs/project-configuration/vercel-json#regions` (anchor verified live) |
| **Hard 404** — `/docs/gateway/api-reference/overview` (AI Gateway docs restructured) | 2× | → `/docs/ai-gateway/authentication` (the "get an API key" context) |
| **Stale redirect** — `/docs/observability/otel-overview` | 1× | → `/docs/tracing/instrumentation` (the redirect target) |
| **Stale redirect** — `/docs/workflow` + `/docs/workflow/python` (singular → plural rename) | 8× | → `/docs/workflows` / `/docs/workflows/python` (also drops a redundant `?language=py` the redirect discards) |

All remaining links verified 200 with live anchors (queues + `#consumer-function-security`, `workflows/pricing#storage-retention`, plans/hobby, limits, regions, sandbox, cli/project-linking, audit-log, home, help, blog).

Prompted by a report that the `vercel.json` regions link in the new multi-region docs pointed at the wrong page.