### PR TITLE
Add WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS env var to local world

### DIFF
--- a/.changeset/brave-eyes-shake.md
+++ b/.changeset/brave-eyes-shake.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': minor
+---
+
+Add `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS` env var as a fallback for the `recoverActiveRuns` option, so re-enqueueing of pending/running runs on startup can be disabled without a custom world module.

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -82,9 +82,9 @@ The Local World is the default outside Vercel and is intended for development.
 
 ### `recoverActiveRuns`
 
-- Environment variable: none
+- Environment variable: `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS`
 - Default: `true`
-- Re-enqueues pending and running local runs when the World starts.
+- Re-enqueues pending and running local runs when the World starts. Set the environment variable to `0` or `false` to skip recovery; the factory option wins when both are set.
 
 ### `tag`
 

--- a/docs/content/docs/v5/deploying/world/local-world.mdx
+++ b/docs/content/docs/v5/deploying/world/local-world.mdx
@@ -62,6 +62,10 @@ Maximum number of concurrent queue message handlers. Default: `1000`
 
 Maximum number of seconds a local queue message can stay hidden before the handler rechecks the run. Default: unlimited.
 
+### `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS`
+
+Whether pending and running runs found in the data directory are re-enqueued when the world starts. Set to `0` or `false` to skip recovery and leave stale runs untouched. Default: `true`
+
 ### `WORKFLOW_STREAM_FLUSH_INTERVAL_MS`
 
 Flush interval, in milliseconds, for buffered stream writes. Default: `10`.
@@ -78,7 +82,7 @@ export default createWorld({
   port: 5173,
   // baseUrl overrides port if set
   baseUrl: "https://local.example.com:3000",
-  recoverActiveRuns: true,
+  recoverActiveRuns: true, // overrides WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS
   streamFlushIntervalMs: 10, // overrides WORKFLOW_STREAM_FLUSH_INTERVAL_MS
 });
 ```

--- a/packages/world-local/src/config.test.ts
+++ b/packages/world-local/src/config.test.ts
@@ -1,6 +1,6 @@
 import { setWorkflowBasePath } from '@workflow/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveBaseUrl } from './config';
+import { resolveBaseUrl, resolveRecoverActiveRuns } from './config';
 
 // Mock the getWorkflowPort function from @workflow/utils/get-port
 vi.mock('@workflow/utils/get-port', () => ({
@@ -301,5 +301,59 @@ describe('resolveBaseUrl', () => {
         'Unable to resolve base URL for workflow queue.'
       );
     });
+  });
+});
+
+describe('resolveRecoverActiveRuns', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults to true when neither config nor env is set', () => {
+    expect(resolveRecoverActiveRuns({})).toBe(true);
+  });
+
+  it('prioritizes explicit config over the env var', () => {
+    process.env.WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS = '1';
+    expect(resolveRecoverActiveRuns({ recoverActiveRuns: false })).toBe(false);
+
+    process.env.WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS = '0';
+    expect(resolveRecoverActiveRuns({ recoverActiveRuns: true })).toBe(true);
+  });
+
+  it.each([
+    '0',
+    'false',
+    'FALSE',
+    'False',
+  ])('disables recovery for env value %j', (value) => {
+    process.env.WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS = value;
+    expect(resolveRecoverActiveRuns({})).toBe(false);
+  });
+
+  it.each([
+    '1',
+    'true',
+    'TRUE',
+  ])('enables recovery for env value %j', (value) => {
+    process.env.WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS = value;
+    expect(resolveRecoverActiveRuns({})).toBe(true);
+  });
+
+  it.each([
+    '',
+    'yes',
+    'off',
+    'nonsense',
+  ])('falls back to the default for unrecognized env value %j', (value) => {
+    process.env.WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS = value;
+    expect(resolveRecoverActiveRuns({})).toBe(true);
   });
 });

--- a/packages/world-local/src/config.ts
+++ b/packages/world-local/src/config.ts
@@ -21,8 +21,10 @@ export type Config = {
   baseUrl?: string;
   /**
    * Whether start() should re-enqueue pending/running runs from storage.
-   * Defaults to true. Test harnesses that always start from a clean slate can
-   * disable recovery to avoid replaying stale runs.
+   * Defaults to true; the `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS` env var is
+   * used as a fallback when this option is unset. Test harnesses that always
+   * start from a clean slate can disable recovery to avoid replaying stale
+   * runs.
    */
   recoverActiveRuns?: boolean;
   /**
@@ -45,6 +47,27 @@ export const config = once<Config>(() => {
 
   return { dataDir, baseUrl };
 });
+
+/**
+ * Resolves whether start() should re-enqueue pending/running runs from
+ * storage, following the priority order:
+ * 1. config.recoverActiveRuns (explicit factory option)
+ * 2. WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS env var (`0`/`false` disables,
+ *    `1`/`true` enables; read lazily to handle late env var setting)
+ * 3. Default: true
+ *
+ * An unrecognized env value falls through to the default — the env var is an
+ * escape hatch, not a hard requirement.
+ */
+export function resolveRecoverActiveRuns(config: Partial<Config>): boolean {
+  if (config.recoverActiveRuns !== undefined) {
+    return config.recoverActiveRuns;
+  }
+  const raw = process.env.WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS?.toLowerCase();
+  if (raw === '0' || raw === 'false') return false;
+  if (raw === '1' || raw === 'true') return true;
+  return true;
+}
 
 export function resolveDirectBaseUrl(config: Partial<Config>): string {
   return (

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type { QueuePrefix, World } from '@workflow/world';
 import { reenqueueActiveRuns, SPEC_VERSION_CURRENT } from '@workflow/world';
 import type { Config } from './config.js';
-import { config } from './config.js';
+import { config, resolveRecoverActiveRuns } from './config.js';
 import {
   clearCreatedFilesCache,
   deleteJSON,
@@ -48,7 +48,7 @@ export type LocalWorld = World & {
  * @param args.dataDir - Directory for storing workflow data (default: `.workflow-data/`)
  * @param args.port - Port override for queue transport (default: auto-detected)
  * @param args.baseUrl - Full base URL override for queue transport (default: `http://localhost:{port}`)
- * @param args.recoverActiveRuns - Whether `start()` should re-enqueue pending/running runs from storage (default: `true`)
+ * @param args.recoverActiveRuns - Whether `start()` should re-enqueue pending/running runs from storage (default: `true`; falls back to the `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS` env var when unset)
  * @param args.tag - Optional tag to scope files (e.g., `vitest-0`). When set, files are written
  *   as `{id}.{tag}.json` and `clear()` only deletes files matching this tag.
  * @throws {DataDirAccessError} If the data directory cannot be created or accessed
@@ -67,7 +67,7 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
     mergedConfig.dataDir,
     tag
   );
-  const recoverActiveRuns = mergedConfig.recoverActiveRuns ?? true;
+  const recoverActiveRuns = resolveRecoverActiveRuns(mergedConfig);
   return {
     specVersion: SPEC_VERSION_CURRENT,
     ...queue,


### PR DESCRIPTION
The local world re-enqueues all pending/running runs on startup. The `recoverActiveRuns` option can disable this but had no env var, so turning it off required a custom world module.

This adds `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS` as a fallback (`0`/`false` disables, `1`/`true` enables; the factory option wins, unrecognized values fall back to the default `true`). Includes unit tests and docs updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)