### PR TITLE
feat(world): add optional getMany() for batch run reads

### DIFF
--- a/.changeset/batch-run-reads.md
+++ b/.changeset/batch-run-reads.md
@@ -1,0 +1,8 @@
+---
+'@workflow/world': minor
+'@workflow/world-local': minor
+'@workflow/world-postgres': minor
+'@workflow/world-vercel': minor
+---
+
+Add `runs.getMany()` for retrieving ordered workflow run snapshots in one storage operation.

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -235,6 +235,35 @@ describe('Storage', () => {
       });
     });
 
+    describe('getMany', () => {
+      it('preserves input order, deduplicates reads, and returns null for missing runs', async () => {
+        const first = await createRun(storage, {
+          deploymentId: 'deployment-123',
+          workflowName: 'first-workflow',
+          input: new Uint8Array([1]),
+        });
+        const second = await createRun(storage, {
+          deploymentId: 'deployment-123',
+          workflowName: 'second-workflow',
+          input: new Uint8Array([2]),
+        });
+
+        const results = await storage.runs.getMany(
+          [first.runId, 'wrun_missing', second.runId, first.runId],
+          { resolveData: 'none' }
+        );
+
+        expect(results.map((run) => run?.runId ?? null)).toEqual([
+          first.runId,
+          null,
+          second.runId,
+          first.runId,
+        ]);
+        expect(results[0]?.input).toBeUndefined();
+        expect(results[2]?.output).toBeUndefined();
+      });
+    });
+
     describe('update via events', () => {
       it('should update run status to running via run_started event', async () => {
         const created = await createRun(storage, {

--- a/packages/world-local/src/storage/runs-storage.ts
+++ b/packages/world-local/src/storage/runs-storage.ts
@@ -38,6 +38,7 @@ export interface LocalListWorkflowRunsParams extends ListWorkflowRunsParams {
 
 export interface LocalRunsStorage {
   get: Storage['runs']['get'];
+  getMany: NonNullable<Storage['runs']['getMany']>;
   list: {
     (
       params: LocalListWorkflowRunsParams & { resolveData: 'none' }
@@ -117,6 +118,32 @@ export function createRunsStorage(
       const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
       return filterRunData(run, resolveData);
     }) as Storage['runs']['get'],
+
+    getMany: (async (ids: readonly string[], params?: any) => {
+      const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
+      const runsById = new Map<string, WorkflowRun | null>();
+
+      await Promise.all(
+        [...new Set(ids)].map(async (id) => {
+          assertSafeEntityId('runId', id);
+          runsById.set(
+            id,
+            await readJSONWithFallback(
+              basedir,
+              'runs',
+              id,
+              WorkflowRunSchema,
+              tag
+            )
+          );
+        })
+      );
+
+      return ids.map((id) => {
+        const run = runsById.get(id);
+        return run ? filterRunData(run, resolveData) : null;
+      });
+    }) as NonNullable<Storage['runs']['getMany']>,
 
     list: (async (params?: LocalListWorkflowRunsParams) => {
       const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;

--- a/packages/world-local/src/storage/runs-storage.ts
+++ b/packages/world-local/src/storage/runs-storage.ts
@@ -102,47 +102,41 @@ export function createRunsStorage(
   basedir: string,
   tag?: string
 ): LocalRunsStorage {
+  const get = (async (id: string, params?: any) => {
+    assertSafeEntityId('runId', id);
+    const run = await readJSONWithFallback(
+      basedir,
+      'runs',
+      id,
+      WorkflowRunSchema,
+      tag
+    );
+    if (!run) {
+      throw new WorkflowRunNotFoundError(id);
+    }
+    const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
+    return filterRunData(run, resolveData);
+  }) as Storage['runs']['get'];
+
   return {
-    get: (async (id: string, params?: any) => {
-      assertSafeEntityId('runId', id);
-      const run = await readJSONWithFallback(
-        basedir,
-        'runs',
-        id,
-        WorkflowRunSchema,
-        tag
-      );
-      if (!run) {
-        throw new WorkflowRunNotFoundError(id);
-      }
-      const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
-      return filterRunData(run, resolveData);
-    }) as Storage['runs']['get'],
+    get,
 
     getMany: (async (ids: readonly string[], params?: any) => {
-      const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
-      const runsById = new Map<string, WorkflowRun | null>();
-
-      await Promise.all(
-        [...new Set(ids)].map(async (id) => {
-          assertSafeEntityId('runId', id);
-          runsById.set(
-            id,
-            await readJSONWithFallback(
-              basedir,
-              'runs',
-              id,
-              WorkflowRunSchema,
-              tag
-            )
-          );
+      const uniqueIds = [...new Set(ids)];
+      const runs = await Promise.all(
+        uniqueIds.map(async (id) => {
+          try {
+            return await get(id, params);
+          } catch (error) {
+            if (error instanceof WorkflowRunNotFoundError) {
+              return null;
+            }
+            throw error;
+          }
         })
       );
-
-      return ids.map((id) => {
-        const run = runsById.get(id);
-        return run ? filterRunData(run, resolveData) : null;
-      });
+      const runById = new Map(uniqueIds.map((id, i) => [id, runs[i]]));
+      return ids.map((id) => runById.get(id) ?? null);
     }) as NonNullable<Storage['runs']['getMany']>,
 
     list: (async (params?: LocalListWorkflowRunsParams) => {

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -48,7 +48,17 @@ import {
   validateUlidTimestamp,
   WorkflowRunSchema,
 } from '@workflow/world';
-import { and, asc, desc, eq, gt, lt, notInArray, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  inArray,
+  lt,
+  notInArray,
+  sql,
+} from 'drizzle-orm';
 import { monotonicFactory } from 'ulid';
 import { type Drizzle, Schema } from './drizzle/index.js';
 import type { SerializedContent } from './drizzle/schema.js';
@@ -119,6 +129,32 @@ export function createRunsStorage(drizzle: Drizzle): Storage['runs'] {
       const resolveData = params?.resolveData ?? 'all';
       return filterRunData(parsed, resolveData);
     }) as Storage['runs']['get'],
+    getMany: (async (ids, params) => {
+      const uniqueIds = [...new Set(ids)];
+      if (uniqueIds.length === 0) {
+        return [];
+      }
+
+      const values = await drizzle
+        .select()
+        .from(runs)
+        .where(inArray(runs.runId, uniqueIds));
+      const resolveData = params?.resolveData ?? 'all';
+      const runsById = new Map(
+        values.map((value) => {
+          value.output ||= value.outputJson;
+          value.input ||= value.inputJson;
+          value.executionContext ||= value.executionContextJson;
+          value.error ||= parseErrorJson(value.errorJson);
+          const parsed = WorkflowRunSchema.parse(
+            deserializeRunError(compact(value))
+          );
+          return [value.runId, filterRunData(parsed, resolveData)] as const;
+        })
+      );
+
+      return ids.map((id) => runsById.get(id) ?? null);
+    }) as NonNullable<Storage['runs']['getMany']>,
     list: (async (params) => {
       const limit = params?.pagination?.limit ?? 20;
       const fromCursor = params?.pagination?.cursor;

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -13,6 +13,7 @@ import {
   expect,
   it,
   test,
+  vi,
 } from 'vitest';
 import { createClient } from '../src/drizzle/index.js';
 import * as DrizzleSchema from '../src/drizzle/schema.js';
@@ -254,6 +255,48 @@ describe('Storage (Postgres integration)', () => {
         await expect(runs.get('missing')).rejects.toMatchObject({
           name: 'WorkflowRunNotFoundError',
         });
+      });
+    });
+
+    describe('getMany', () => {
+      it('returns requested runs in order and keeps missing IDs as null', async () => {
+        const first = await createRun(events, {
+          deploymentId: 'deployment-123',
+          workflowName: 'first-workflow',
+          input: new Uint8Array([1]),
+        });
+        const second = await createRun(events, {
+          deploymentId: 'deployment-123',
+          workflowName: 'second-workflow',
+          input: new Uint8Array([2]),
+        });
+
+        const result = await runs.getMany(
+          [second.runId, 'wrun_missing', first.runId, second.runId],
+          { resolveData: 'none' }
+        );
+
+        expect(result.map((run) => run?.runId ?? null)).toEqual([
+          second.runId,
+          null,
+          first.runId,
+          second.runId,
+        ]);
+        expect(result[0]?.input).toBeUndefined();
+        expect(result[2]?.output).toBeUndefined();
+      });
+
+      it('uses one query regardless of duplicate requested IDs', async () => {
+        const run = await createRun(events, {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array(),
+        });
+        const query = vi.spyOn(pool, 'query');
+
+        await runs.getMany([run.runId, 'wrun_missing', run.runId]);
+
+        expect(query).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/world-vercel/src/runs.test.ts
+++ b/packages/world-vercel/src/runs.test.ts
@@ -1,4 +1,3 @@
-import { decode } from 'cbor-x';
 import { MockAgent } from 'undici';
 import { describe, expect, it } from 'vitest';
 import { getWorkflowRuns } from './runs.js';
@@ -7,35 +6,31 @@ import { WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
 const ORIGIN = WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
 
 describe('getWorkflowRuns', () => {
-  it('posts unique IDs once and maps an aligned response including missing runs', async () => {
+  it('delegates to getWorkflowRun for unique IDs, preserves input order, and returns null for missing runs', async () => {
     const agent = new MockAgent();
     agent.disableNetConnect();
     agent
       .get(ORIGIN)
       .intercept({
-        path: '/api/v2/runs/batch',
-        method: 'POST',
-        body: (body) => {
-          expect(decode(new Uint8Array(body))).toEqual({
-            runIds: ['wrun_first', 'wrun_missing'],
-            remoteRefBehavior: 'lazy',
-          });
-          return true;
-        },
+        path: '/api/v2/runs/wrun_first?remoteRefBehavior=lazy',
+        method: 'GET',
       })
       .reply(200, {
-        runs: [
-          {
-            runId: 'wrun_first',
-            status: 'running',
-            deploymentId: 'dpl_1',
-            workflowName: 'test-workflow',
-            createdAt: '2026-01-01T00:00:00.000Z',
-            updatedAt: '2026-01-01T00:00:00.000Z',
-          },
-          null,
-        ],
+        runId: 'wrun_first',
+        status: 'running',
+        deploymentId: 'dpl_1',
+        workflowName: 'test-workflow',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
       });
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v2/runs/wrun_missing?remoteRefBehavior=lazy',
+        method: 'GET',
+      })
+      .reply(404);
 
     const runs = await getWorkflowRuns(
       ['wrun_first', 'wrun_missing', 'wrun_first'],

--- a/packages/world-vercel/src/runs.test.ts
+++ b/packages/world-vercel/src/runs.test.ts
@@ -1,0 +1,54 @@
+import { decode } from 'cbor-x';
+import { MockAgent } from 'undici';
+import { describe, expect, it } from 'vitest';
+import { getWorkflowRuns } from './runs.js';
+import { WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
+
+const ORIGIN = WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
+
+describe('getWorkflowRuns', () => {
+  it('posts unique IDs once and maps an aligned response including missing runs', async () => {
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v2/runs/batch',
+        method: 'POST',
+        body: (body) => {
+          expect(decode(new Uint8Array(body))).toEqual({
+            runIds: ['wrun_first', 'wrun_missing'],
+            remoteRefBehavior: 'lazy',
+          });
+          return true;
+        },
+      })
+      .reply(200, {
+        runs: [
+          {
+            runId: 'wrun_first',
+            status: 'running',
+            deploymentId: 'dpl_1',
+            workflowName: 'test-workflow',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+          null,
+        ],
+      });
+
+    const runs = await getWorkflowRuns(
+      ['wrun_first', 'wrun_missing', 'wrun_first'],
+      { resolveData: 'none' },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(runs.map((run) => run?.runId ?? null)).toEqual([
+      'wrun_first',
+      null,
+      'wrun_first',
+    ]);
+    expect(runs[0]?.input).toBeUndefined();
+    agent.assertNoPendingInterceptors();
+  });
+});

--- a/packages/world-vercel/src/runs.ts
+++ b/packages/world-vercel/src/runs.ts
@@ -219,9 +219,8 @@ export async function getWorkflowRun(
 }
 
 /**
- * Retrieves a snapshot for each requested run ID. The workflow-server batch
- * endpoint returns rows aligned to the unique IDs in the request, using null
- * for IDs that do not exist.
+ * Retrieves a snapshot for each requested run ID. Delegates to
+ * `getWorkflowRun` for each ID and returns null for IDs that do not exist.
  */
 export async function getWorkflowRuns(
   ids: readonly string[],
@@ -244,46 +243,20 @@ export async function getWorkflowRuns(
   config?: APIConfig
 ): Promise<(WorkflowRun | WorkflowRunWithoutData | null)[]> {
   const uniqueIds = [...new Set(ids)];
-  if (uniqueIds.length === 0) {
-    return [];
-  }
-
-  const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
-  const remoteRefBehavior = resolveData === 'none' ? 'lazy' : 'resolve';
-  const schema = z.object({
-    runs: z.array(
-      z.union([
-        remoteRefBehavior === 'lazy'
-          ? WorkflowRunWireWithRefsSchema
-          : WorkflowRunWireSchema,
-        z.null(),
-      ])
-    ),
-  });
-  const response = await makeRequest({
-    endpoint: '/v2/runs/batch',
-    options: { method: 'POST' },
-    data: { runIds: uniqueIds, remoteRefBehavior },
-    config,
-    schema,
-  });
-
-  if (response.runs.length !== uniqueIds.length) {
-    throw new WorkflowWorldError(
-      `Batch run lookup returned ${response.runs.length} results for ${uniqueIds.length} IDs`
-    );
-  }
-
-  const runsById = new Map(
-    uniqueIds.map((id, index) => {
-      const run = response.runs[index];
-      return [
-        run?.runId ?? id,
-        run ? filterRunData(run, resolveData) : null,
-      ] as const;
+  const runs = await Promise.all(
+    uniqueIds.map(async (id) => {
+      try {
+        return await getWorkflowRun(id, params, config);
+      } catch (error) {
+        if (error instanceof WorkflowRunNotFoundError) {
+          return null;
+        }
+        throw error;
+      }
     })
   );
-  return ids.map((id) => runsById.get(id) ?? null);
+  const runById = new Map(uniqueIds.map((id, i) => [id, runs[i]]));
+  return ids.map((id) => runById.get(id) ?? null);
 }
 
 export async function cancelWorkflowRunV1(

--- a/packages/world-vercel/src/runs.ts
+++ b/packages/world-vercel/src/runs.ts
@@ -218,6 +218,74 @@ export async function getWorkflowRun(
   }
 }
 
+/**
+ * Retrieves a snapshot for each requested run ID. The workflow-server batch
+ * endpoint returns rows aligned to the unique IDs in the request, using null
+ * for IDs that do not exist.
+ */
+export async function getWorkflowRuns(
+  ids: readonly string[],
+  params: GetWorkflowRunParams & { resolveData: 'none' },
+  config?: APIConfig
+): Promise<(WorkflowRunWithoutData | null)[]>;
+export async function getWorkflowRuns(
+  ids: readonly string[],
+  params?: GetWorkflowRunParams & { resolveData?: 'all' },
+  config?: APIConfig
+): Promise<(WorkflowRun | null)[]>;
+export async function getWorkflowRuns(
+  ids: readonly string[],
+  params?: GetWorkflowRunParams,
+  config?: APIConfig
+): Promise<(WorkflowRun | WorkflowRunWithoutData | null)[]>;
+export async function getWorkflowRuns(
+  ids: readonly string[],
+  params?: GetWorkflowRunParams,
+  config?: APIConfig
+): Promise<(WorkflowRun | WorkflowRunWithoutData | null)[]> {
+  const uniqueIds = [...new Set(ids)];
+  if (uniqueIds.length === 0) {
+    return [];
+  }
+
+  const resolveData = params?.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
+  const remoteRefBehavior = resolveData === 'none' ? 'lazy' : 'resolve';
+  const schema = z.object({
+    runs: z.array(
+      z.union([
+        remoteRefBehavior === 'lazy'
+          ? WorkflowRunWireWithRefsSchema
+          : WorkflowRunWireSchema,
+        z.null(),
+      ])
+    ),
+  });
+  const response = await makeRequest({
+    endpoint: '/v2/runs/batch',
+    options: { method: 'POST' },
+    data: { runIds: uniqueIds, remoteRefBehavior },
+    config,
+    schema,
+  });
+
+  if (response.runs.length !== uniqueIds.length) {
+    throw new WorkflowWorldError(
+      `Batch run lookup returned ${response.runs.length} results for ${uniqueIds.length} IDs`
+    );
+  }
+
+  const runsById = new Map(
+    uniqueIds.map((id, index) => {
+      const run = response.runs[index];
+      return [
+        run?.runId ?? id,
+        run ? filterRunData(run, resolveData) : null,
+      ] as const;
+    })
+  );
+  return ids.map((id) => runsById.get(id) ?? null);
+}
+
 export async function cancelWorkflowRunV1(
   id: string,
   params: CancelWorkflowRunParams & { resolveData: 'none' },

--- a/packages/world-vercel/src/storage.ts
+++ b/packages/world-vercel/src/storage.ts
@@ -9,6 +9,7 @@ import { instrumentObject } from './instrumentObject.js';
 import {
   experimentalSetAttributes,
   getWorkflowRun,
+  getWorkflowRuns,
   listWorkflowRuns,
 } from './runs.js';
 import { getStep, listWorkflowRunSteps } from './steps.js';
@@ -20,6 +21,10 @@ export function createStorage(config?: APIConfig): Storage {
     runs: {
       get: ((id: string, params?: any) =>
         getWorkflowRun(id, params, config)) as Storage['runs']['get'],
+      getMany: ((ids: readonly string[], params?: any) =>
+        getWorkflowRuns(ids, params, config)) as NonNullable<
+        Storage['runs']['getMany']
+      >,
       list: ((params?: any) =>
         listWorkflowRuns(params, config)) as Storage['runs']['list'],
       experimentalSetAttributes: (runId, changes, options) =>

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -150,6 +150,25 @@ export interface Storage {
       params?: GetWorkflowRunParams
     ): Promise<WorkflowRun | WorkflowRunWithoutData>;
 
+    /**
+     * Retrieves several runs as one snapshot. The result preserves the input
+     * order and contains `null` for run IDs that do not exist.
+     */
+    getMany?: {
+      (
+        ids: readonly string[],
+        params: GetWorkflowRunParams & { resolveData: 'none' }
+      ): Promise<(WorkflowRunWithoutData | null)[]>;
+      (
+        ids: readonly string[],
+        params?: GetWorkflowRunParams & { resolveData?: 'all' }
+      ): Promise<(WorkflowRun | null)[]>;
+      (
+        ids: readonly string[],
+        params?: GetWorkflowRunParams
+      ): Promise<(WorkflowRun | WorkflowRunWithoutData | null)[]>;
+    };
+
     list(
       params: ListWorkflowRunsParams & { resolveData: 'none' }
     ): Promise<PaginatedResponse<WorkflowRunWithoutData>>;


### PR DESCRIPTION
### Description

Add optional `world.runs.getMany()` for one-operation snapshots of multiple workflow runs. It lets GraphQL list resolvers and bulk orchestration fetch many run snapshots in a single storage call, avoiding N+1 reads.

Results preserve input order, fetch duplicate IDs once, and use `null` for missing runs. `getMany` remains optional so existing community Worlds are source-compatible.

**local/vercel:** delegate to the per-ID `runs.get` handler via `Promise.all`, sharing the same read, schema validation, resolveData, and error handling.

**postgres:** uses a single `IN (...)` query for an indexed batch read.

### How did you test your changes?

- `pnpm --filter @workflow/world-local test` — 465 tests pass, including order, duplicate-ID, missing-ID, and metadata-only `getMany` coverage.
- `pnpm --filter @workflow/world-postgres exec vitest run test/storage.test.ts --testNamePattern getMany` — Postgres integration coverage passes for result mapping and a single-query assertion with duplicate IDs.
- `pnpm --filter @workflow/world-vercel test` — 295 tests pass, including MockAgent coverage of individual GET delegation with duplicate-ID deduplication and missing-run null handling.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run with minor changesets for `@workflow/world`, `@workflow/world-local`, `@workflow/world-postgres`, and `@workflow/world-vercel`.
- [x] 🔒 DCO sign-off passes.
- [x] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete.