### PR TITLE
[docs] fix code highlight in child workflows cookbook

### DIFF
--- a/docs/content/docs/v4/cookbook/advanced/child-workflows.mdx
+++ b/docs/content/docs/v4/cookbook/advanced/child-workflows.mdx
@@ -117,10 +117,10 @@ async function spawnProcessDocument(
 ): Promise<string> {
   "use step"; // [!code highlight]
 
-  const run = await start(processDocumentWithCompletion, [
+  const run = await start(processDocumentWithCompletion, [ // [!code highlight]
     documentId,
     completionTokenArg,
-  ]); // [!code highlight]
+  ]);
   return run.runId;
 }
 


### PR DESCRIPTION
Wrong line is highlighted 
<img width="865" height="266" alt="CleanShot 2026-07-14 at 13 24 08" src="https://github.com/user-attachments/assets/1c547935-c939-4039-ae71-2b65d289b30d" />
