### PR TITLE
fix(world-vercel): surface queue handler retry errors

### DIFF
--- a/.changeset/log-queue-handler-retries.md
+++ b/.changeset/log-queue-handler-retries.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": patch
+---
+
+Log the underlying queue handler error before retrying a failed delivery.

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -625,18 +625,26 @@ describe('createQueue', () => {
     it('should ask VQS to retry handler errors with bounded backoff', () => {
       mockHandleCallback.mockReturnValue(async () => new Response('ok'));
       const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
 
       try {
         const queue = createQueue();
         queue.createQueueHandler('__wkf_workflow_', async () => undefined);
 
         const options = mockHandleCallback.mock.calls[0][1];
+        const handlerError = new Error('workflow server unavailable');
         expect(
-          options.retry(new Error('workflow server unavailable'), {
+          options.retry(handlerError, {
             messageId: 'msg-123',
             deliveryCount: 1,
           })
         ).toEqual({ afterSeconds: 1 });
+        expect(consoleErrorSpy).toHaveBeenLastCalledWith(
+          '[workflow] Queue handler failed for message "msg-123" on delivery attempt 1; retrying in 1s:',
+          handlerError
+        );
         expect(
           options.retry(new Error('workflow server unavailable'), {
             messageId: 'msg-123',
@@ -685,6 +693,7 @@ describe('createQueue', () => {
         ).toEqual({ afterSeconds: 96 });
       } finally {
         randomSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
       }
     });
 

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -505,9 +505,14 @@ export function createQueue(config?: APIConfig): Queue {
         // with jitter so an outage or poison message cannot hot-loop or
         // redrive in lockstep. Workflow handlers are event-sourced and must
         // remain idempotent because queue retries can happen close together.
-        retry: (_error, { deliveryCount }) => ({
-          afterSeconds: getHandlerErrorRetryAfterSeconds(deliveryCount),
-        }),
+        retry: (error, { messageId, deliveryCount }) => {
+          const afterSeconds = getHandlerErrorRetryAfterSeconds(deliveryCount);
+          console.error(
+            `[workflow] Queue handler failed for message "${messageId}" on delivery attempt ${deliveryCount}; retrying in ${afterSeconds}s:`,
+            error
+          );
+          return { afterSeconds };
+        },
       }
     );
 


### PR DESCRIPTION
## Summary

- log queue handler failures before VQS retries them
- include the message ID, delivery count, retry delay, and original error/stack
- preserve the existing bounded backoff behavior


## Testing

- `pnpm --filter @workflow/world-vercel... build`
- `pnpm --filter @workflow/world-vercel exec vitest run src/queue.test.ts` (45 tests)
- `pnpm --filter @workflow/world-vercel typecheck`
- `biome check packages/world-vercel/src/queue.ts packages/world-vercel/src/queue.test.ts`