### PR TITLE
Use gray for hook bars in the trace viewer

### DIFF
--- a/.changeset/hook-trace-bar-gray.md
+++ b/.changeset/hook-trace-bar-gray.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Use gray instead of amber for hook bars in the trace viewer.

--- a/packages/web-shared/src/components/new-trace-viewer/utils.test.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.test.ts
@@ -6,6 +6,7 @@ import {
   computeSpanMarkers,
   computeSpanSegments,
   computeTimeMarkers,
+  getResourceColor,
 } from './utils';
 
 /** Build a high-res timestamp tuple ([seconds, nanoseconds]) for a given ms. */
@@ -243,5 +244,16 @@ describe('computeTimeMarkers', () => {
       '100ms',
       '120ms',
     ]);
+  });
+});
+
+describe('getResourceColor', () => {
+  it('uses gray for hooks (passive spans), not amber', () => {
+    expect(getResourceColor('hook')).toEqual({
+      bg: 'var(--ds-gray-200)',
+      border: 'var(--ds-gray-500)',
+      errorBg: 'var(--ds-red-200)',
+      errorBorder: 'var(--ds-red-500)',
+    });
   });
 });

--- a/packages/web-shared/src/components/new-trace-viewer/utils.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.ts
@@ -223,9 +223,10 @@ export const RESOURCE_COLORS: Record<
     errorBg: 'var(--ds-red-200)',
     errorBorder: 'var(--ds-red-500)',
   },
+  // Passive spans (hooks) stay gray — matches event-list icons and the minimap.
   hook: {
-    bg: 'var(--ds-amber-200)',
-    border: 'var(--ds-amber-500)',
+    bg: 'var(--ds-gray-200)',
+    border: 'var(--ds-gray-500)',
     errorBg: 'var(--ds-red-200)',
     errorBorder: 'var(--ds-red-500)',
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hook timeline bars in the new trace viewer were rendered amber/yellow via `RESOURCE_COLORS`. Passive spans (hooks) should be gray to match the event-list icons and minimap.

## Changes

- Update `RESOURCE_COLORS.hook` from amber to gray (`--ds-gray-200` / `--ds-gray-500`)
- Add a regression test asserting hook resource colors
- Add changeset for `@workflow/web-shared`

## Test plan

- [x] `pnpm vitest run src/components/new-trace-viewer/utils.test.ts` in `packages/web-shared`
- [ ] Visually confirm hook bars in the run detail trace viewer are gray (not yellow/amber)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59e67827-8229-423f-b847-89845c603ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59e67827-8229-423f-b847-89845c603ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

