### PR TITLE
Fix legacy structured errors in v4 event reads

### DIFF
--- a/.changeset/fuzzy-ducks-retry.md
+++ b/.changeset/fuzzy-ducks-retry.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Decode stable-line CBOR structured errors when reading v4 workflow events while preserving current serialized error payloads.

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -803,6 +803,84 @@ describe('getWorkflowRunEvents remoteRefBehavior mapping', () => {
   });
 });
 
+describe('getWorkflowRunEvents legacy structured-error compatibility', () => {
+  const structuredErrorEventTypes = [
+    'run_failed',
+    'step_failed',
+    'step_retrying',
+  ] as const;
+
+  function listResponse(
+    eventType: (typeof structuredErrorEventTypes)[number],
+    body: Uint8Array
+  ): Buffer {
+    return Buffer.concat([
+      encodeFrame(
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_1',
+          eventType,
+          ...(eventType === 'run_failed' ? {} : { correlationId: 'step_1' }),
+          createdAt: '2026-06-10T00:00:00.000Z',
+          eventData: {},
+        },
+        body
+      ),
+      encodeFrame({ _end: 1 }, new Uint8Array(0)),
+    ]);
+  }
+
+  async function readError(
+    eventType: (typeof structuredErrorEventTypes)[number],
+    body: Uint8Array
+  ): Promise<unknown> {
+    const agent = mockAgent();
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events',
+        method: 'GET',
+        query: { remoteRefBehavior: 'resolve' },
+      })
+      .reply(200, listResponse(eventType, body), {
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+
+    const result = await getWorkflowRunEvents(
+      { runId: 'wrun_1', resolveData: 'all' },
+      { token: 'test-token', dispatcher: agent }
+    );
+    agent.assertNoPendingInterceptors();
+    return (result.data[0] as { eventData?: Record<string, unknown> }).eventData
+      ?.error;
+  }
+
+  it.each(
+    structuredErrorEventTypes
+  )('decodes a stable-line CBOR error for %s', async (eventType) => {
+    const structuredError = {
+      message: 'boom',
+      stack: 'Error: boom\n    at fn (/app/step.js:10:5)',
+    };
+
+    await expect(
+      readError(eventType, new Uint8Array(encode(structuredError)))
+    ).resolves.toEqual(structuredError);
+  });
+
+  it.each([
+    ['devalue', new TextEncoder().encode('devlserialized-error')],
+    ['encrypted', new TextEncoder().encode('encrciphertext')],
+  ])('preserves current %s error bytes', async (_name, body) => {
+    await expect(readError('step_retrying', body)).resolves.toEqual(body);
+  });
+
+  it('leaves CBOR that is not a StructuredError as bytes', async () => {
+    const body = new Uint8Array(encode({ value: 'not an error' }));
+    await expect(readError('step_retrying', body)).resolves.toEqual(body);
+  });
+});
+
 /**
  * The v4 LIST sentinel carries a trailing `next` cursor even on the final
  * page (it doubles as the incremental-load resume point), so the runtime's

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -47,10 +47,12 @@ import {
   type ListEventsByCorrelationIdParams,
   type ListEventsParams,
   type PaginatedResponse,
+  StructuredErrorSchema,
   stripEventDataRefs,
   validateUlidTimestamp,
   type WorkflowRun,
 } from '@workflow/world';
+import { decode } from 'cbor-x';
 import { withEventPostRetry } from './event-retry.js';
 import {
   createWorkflowRunEventV4,
@@ -62,6 +64,7 @@ import {
 import { decode as decodeRunId } from './run-id/index.js';
 import { cancelWorkflowRunV1, createWorkflowRunV1 } from './runs.js';
 import {
+  hasSerializedDataFormatPrefix,
   normalizeEventData,
   normalizeSerializedData,
 } from './serialized-data.js';
@@ -106,6 +109,15 @@ const eventsNeedingResolve = new Set<string>([
   'run_created', // runtime reads result.run.runId
   'run_started', // runtime reads result.run (checks startedAt, status)
   'step_started', // runtime reads result.step (checks attempt, state)
+]);
+
+// Stable runtimes stored these errors as backend-materialized
+// StructuredError objects. Their resolved v4 frame bodies are CBOR rather
+// than the format-prefixed serialized data emitted by current runtimes.
+const legacyStructuredErrorEventTypes = new Set<string>([
+  'run_failed',
+  'step_failed',
+  'step_retrying',
 ]);
 
 // =============================================================================
@@ -435,6 +447,21 @@ function coerceNormalizedEvent(raw: Record<string, unknown>): Event {
   return coerceEventDates(normalizeEventData(raw));
 }
 
+function decodeLegacyStructuredError(payload: Uint8Array): unknown {
+  if (hasSerializedDataFormatPrefix(payload)) {
+    return payload;
+  }
+
+  try {
+    // cbor-x caches decode state on its input, so decode a copy to keep the
+    // raw-byte fallback byte-for-byte and property-for-property unchanged.
+    const parsed = StructuredErrorSchema.safeParse(decode(payload.slice()));
+    return parsed.success ? parsed.data : payload;
+  } catch {
+    return payload;
+  }
+}
+
 /**
  * Turn a v4 event (frame meta + frame body) into the Event shape the
  * workflow runtime expects.
@@ -444,9 +471,10 @@ function coerceNormalizedEvent(raw: Record<string, unknown>): Event {
  * the resolved payload bytes (possibly empty). This helper splices the
  * body bytes into `eventData[fieldName]`, normalizing any zstd wrapper
  * back to the raw devalue-with-format-prefix Uint8Array the runtime's
- * hydrate helpers (hydrateStepIO, hydrateRunError, …) consume. No CBOR
- * decode here, symmetric with the pass-through write in
- * `splitEventDataForV4`.
+ * hydrate helpers (hydrateStepIO, hydrateRunError, …) consume. Stable-line
+ * structured errors are the exception: the backend stored those as CBOR,
+ * so they are decoded after checking that the payload is not a current
+ * format-prefixed serialized value.
  */
 function buildEventFromV4(
   decoded: DecodedV4Event,
@@ -459,7 +487,11 @@ function buildEventFromV4(
     const payloadField = getEventDataPayloadField(decoded.eventType);
     const normalizedPayload = normalizeSerializedData(payloadBody);
     if (payloadField && normalizedPayload instanceof Uint8Array) {
-      eventData[payloadField] = normalizedPayload;
+      eventData[payloadField] = legacyStructuredErrorEventTypes.has(
+        decoded.eventType
+      )
+        ? decodeLegacyStructuredError(normalizedPayload)
+        : normalizedPayload;
     }
   }
 

--- a/packages/world-vercel/src/serialized-data.ts
+++ b/packages/world-vercel/src/serialized-data.ts
@@ -2,9 +2,18 @@ import { WorkflowWorldError } from '@workflow/errors';
 import { getEventDataRefFields } from '@workflow/world';
 
 const FORMAT_PREFIX_LENGTH = 4;
+const DEVALUE_FORMAT_PREFIX = 'devl';
+const ENCRYPTED_FORMAT_PREFIX = 'encr';
 const GZIP_FORMAT_PREFIX = 'gzip';
 const ZSTD_FORMAT_PREFIX = 'zstd';
 const formatDecoder = new TextDecoder();
+
+const SERIALIZED_DATA_FORMAT_PREFIXES = new Set([
+  DEVALUE_FORMAT_PREFIX,
+  ENCRYPTED_FORMAT_PREFIX,
+  GZIP_FORMAT_PREFIX,
+  ZSTD_FORMAT_PREFIX,
+]);
 
 interface NodeZlibDecode {
   gunzipSync?: (data: Uint8Array) => Uint8Array;
@@ -31,6 +40,11 @@ function peekFormatPrefix(value: unknown): string | null {
     return null;
   }
   return formatDecoder.decode(value.subarray(0, FORMAT_PREFIX_LENGTH));
+}
+
+export function hasSerializedDataFormatPrefix(value: unknown): boolean {
+  const format = peekFormatPrefix(value);
+  return format !== null && SERIALIZED_DATA_FORMAT_PREFIXES.has(format);
 }
 
 function decompress(format: string, payload: Uint8Array): Uint8Array {


### PR DESCRIPTION
## What changed

- Decode stable-line CBOR `StructuredError` payloads when reading v4 `run_failed`, `step_failed`, and `step_retrying` events.
- Guard the fallback with known Workflow serialization prefixes and `StructuredErrorSchema`, preserving current devalue/encrypted payloads and unrelated binary data.
- Add regression coverage for all affected event types and a patch changeset for `@workflow/world-vercel`.

## Why

Stable runtimes store these errors as backend-materialized CBOR objects. Current `@workflow/world-vercel` treated every resolved v4 error body as modern format-prefixed Workflow data, so web hydration rejected the CBOR prefix and left a raw `Uint8Array` for the detail panel to render.

This restores compatibility without decoding modern serialized or encrypted errors.

## Validation

- `pnpm --filter @workflow/world-vercel... build`
- `pnpm --filter @workflow/world-vercel typecheck`
- `pnpm --filter @workflow/world-vercel test` — 294 tests passed
- `pnpm exec vitest run packages/world-vercel/src/events.test.ts` — 31 tests passed
- Biome check on changed source/test files; only the two pre-existing complexity warnings in `events.ts`
- `git diff --check`
