### PR TITLE
fix(core): re-route runs delivered to the wrong deployment

### DIFF
--- a/.changeset/fail-cross-deployment-runs.md
+++ b/.changeset/fail-cross-deployment-runs.md
@@ -1,0 +1,8 @@
+---
+"@workflow/core": patch
+"@workflow/errors": minor
+"@workflow/world": minor
+"@workflow/world-vercel": patch
+---
+
+Re-route a queue delivery that reaches a deployment other than the one its run is pinned to, and fail the run with the new `DEPLOYMENT_MISMATCH` error code once the retry budget is spent, instead of exhausting retries on an undecryptable step.

--- a/.changeset/fail-cross-deployment-runs.md
+++ b/.changeset/fail-cross-deployment-runs.md
@@ -5,4 +5,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Re-route a queue delivery that reaches a deployment other than the one its run is pinned to, and fail the run with the new `DEPLOYMENT_MISMATCH` error code once the retry budget is spent, instead of exhausting retries on an undecryptable step.
+Re-route a queue delivery that reaches a deployment other than the one its run is pinned to, retry transient publishing failures through normal queue redelivery, and fail the run with the new `DEPLOYMENT_MISMATCH` error code once the recovery budget is spent.

--- a/docs/content/docs/v4/errors/deployment-mismatch.mdx
+++ b/docs/content/docs/v4/errors/deployment-mismatch.mdx
@@ -21,7 +21,7 @@ This is an SDK/runtime signal, not an error thrown by your workflow code, and it
 Workflow run "wrun_..." is pinned to deployment "dpl_A", but was received by deployment "dpl_B". The runtime re-routed the message to "dpl_A" 3 times and it kept arriving elsewhere, so the run was stopped to protect against code-skew errors. Verify that the run's deployment is still available and that queue callbacks are routed to it.
 ```
 
-When the run's deployment cannot be reached at all — it was deleted, or aged out of its retention window — no re-route is possible and the message omits the re-routing clause.
+When the queue definitively reports that the run's deployment cannot be reached — it was deleted, or aged out of its retention window — no re-route is possible and the message omits the re-routing clause. Transient or unknown publishing failures leave the current delivery unacknowledged so the queue can redeliver it; they do not fail the run or consume this recovery budget.
 
 ## Why A Run Is Pinned
 

--- a/docs/content/docs/v4/errors/deployment-mismatch.mdx
+++ b/docs/content/docs/v4/errors/deployment-mismatch.mdx
@@ -1,0 +1,71 @@
+---
+title: deployment-mismatch
+description: A workflow run was delivered to a deployment other than the one it is pinned to.
+type: troubleshooting
+summary: Understand how Workflow recovers from a misrouted delivery, and why a run eventually fails with DEPLOYMENT_MISMATCH.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/foundations/versioning
+  - /docs/errors/runtime-decryption-failed
+  - /docs/foundations/errors-and-retries
+---
+
+Every run is pinned to a single deployment when it starts. When a queued workflow or step callback is delivered to a **different** deployment, Workflow does not execute it there. Instead it re-routes the message to the deployment the run is pinned to, and only if the run keeps arriving elsewhere does it fail with the `DEPLOYMENT_MISMATCH` classification.
+
+This is an SDK/runtime signal, not an error thrown by your workflow code, and it is not catchable inside a workflow function.
+
+## Error Message
+
+```
+Workflow run "wrun_..." is pinned to deployment "dpl_A", but was received by deployment "dpl_B". The runtime re-routed the message to "dpl_A" 3 times and it kept arriving elsewhere, so the run was stopped to protect against code-skew errors. Verify that the run's deployment is still available and that queue callbacks are routed to it.
+```
+
+When the run's deployment cannot be reached at all — it was deleted, or aged out of its retention window — no re-route is possible and the message omits the re-routing clause.
+
+## Why A Run Is Pinned
+
+A run's deployment is chosen once, at [`start()`](/docs/api-reference/workflow-api/start):
+
+- By default it is the deployment that called `start()` — see [Versioning](/docs/foundations/versioning) for why runs are pinned this way.
+- With `start(workflow, args, { deploymentId })` it is the id you pass, so a run can deliberately target a deployment other than the one that created it.
+- With `deploymentId: "latest"` it is the most recent deployment for the current environment, resolved at start time.
+
+Whichever it is, that `deploymentId` is recorded on the run, and every subsequent workflow replay and step execution must happen on that deployment. Continuing on a different one is unsafe:
+
+1. **Code skew.** The workflow and step bundles on the receiving deployment may not match the code that produced the run's recorded history, so replay could diverge or produce incorrect results.
+2. **Encryption.** Step inputs and other event-log payloads are encrypted with a per-run key derived from the pinned deployment's key material. A different deployment derives the wrong key and cannot decrypt them — previously the source of a confusing [runtime-decryption-failed](/docs/errors/runtime-decryption-failed) that exhausted retries with no clear cause.
+
+So the runtime checks the pinned deployment before it executes anything, and `DEPLOYMENT_MISMATCH` names the result — instead of the mismatch surfacing later as an unrelated decryption failure.
+
+## Automatic Recovery
+
+A deployment that receives a run it does not own first tries to fix the delivery rather than fail the run:
+
+1. It re-enqueues the message **explicitly addressed** to the run's own deployment. This is strictly better-addressed than the send that misrouted, which inherited the producing deployment's ambient id.
+2. Delivery is delayed with a short exponential backoff (1s, 2s, 4s).
+3. If the run keeps arriving at the wrong deployment, the run is failed with `DEPLOYMENT_MISMATCH` after `WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES` attempts (default `3`). Set it to `0` to fail on the first misrouted delivery instead.
+
+Nothing is executed on the wrong deployment during recovery: no workflow code, no step body, no `step_started`, and no hook resume. Whatever the delivery was carrying travels with it, so a pending step keeps its identity and a hook resume keeps its payload — they run on the deployment that can actually decrypt them.
+
+Recovery attempts do not create events on the run, so a run that self-heals looks completely normal. They are reported on the invocation's trace span (`workflow.deployment.pinned_id`, `workflow.deployment_mismatch.retry_count`, `workflow.deployment_mismatch.recovered`) and as a runtime warning in your function logs.
+
+## What To Do
+
+- **Re-run from the current deployment.** Trigger the workflow again from your latest deployment (or use the **Re-run** button in the Workflow Dashboard). The new run is pinned to the current deployment.
+- **Keep a run's deployment available** for the lifetime of that run. A run whose deployment has been deleted or has aged out cannot be resumed and must be re-run — recovery cannot help, so these fail on the first misrouted delivery. This applies to runs started with an explicit `deploymentId` too: pinning a run to an older deployment keeps it dependent on that deployment for its whole lifetime.
+- **Report it** if the pinned deployment was still available. Include both deployment ids and the run id from the error message, plus the trace span attributes above — a run that failed this way despite a reachable target is a routing fault worth investigating rather than something to work around.
+
+## This Error Cannot Be Caught
+
+Like other runtime signals, `DEPLOYMENT_MISMATCH` is **not catchable** inside your workflow function — the run is failed before any workflow or step code executes on the receiving deployment. Check the run status from outside instead:
+
+```typescript lineNumbers
+import { getRun } from "workflow/api";
+
+const run = getRun("wrun_abc123");
+const status = await run.status;
+if (status === "failed") {
+  console.error("Run failed");
+}
+```

--- a/docs/content/docs/v5/configuration/runtime-tuning.mdx
+++ b/docs/content/docs/v5/configuration/runtime-tuning.mdx
@@ -55,6 +55,13 @@ For example, a workflow can run a 10-minute inline step even with `WORKFLOW_REPL
 - The runtime falls back to the sequential path automatically when the consumer or backend does not attest dedup support (or the payload is too large to inline on the queue message). On the sequential path the event is written *before* dispatch and its failure fails the resume — the fallback trades that resilience away to stay safe when dedup is not enforced, it does not preserve it.
 - Set `1` to force the sequential path as a kill switch. The chosen strategy is reported on the resume span as `workflow.hook.resume_strategy`.
 
+### `WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES`
+
+- Default: `3`
+- Times a delivery that reached a deployment other than the one its run is pinned to is re-routed to that deployment before the run is failed with [`DEPLOYMENT_MISMATCH`](/docs/errors/deployment-mismatch).
+- Re-routed deliveries back off exponentially (1s, 2s, 4s). Set to `0` to fail the run on the first misrouted delivery.
+- Only applies to Worlds with atomic, immutable deployments (the Vercel World). A run whose pinned deployment cannot be reached at all fails immediately regardless of this value.
+
 ### `WORKFLOW_PRECONDITION_GUARD`
 
 - Default: enabled

--- a/docs/content/docs/v5/configuration/runtime-tuning.mdx
+++ b/docs/content/docs/v5/configuration/runtime-tuning.mdx
@@ -61,6 +61,7 @@ For example, a workflow can run a 10-minute inline step even with `WORKFLOW_REPL
 - Times a delivery that reached a deployment other than the one its run is pinned to is re-routed to that deployment before the run is failed with [`DEPLOYMENT_MISMATCH`](/docs/errors/deployment-mismatch).
 - Re-routed deliveries back off exponentially (1s, 2s, 4s). Set to `0` to fail the run on the first misrouted delivery.
 - Only applies to Worlds with atomic, immutable deployments (the Vercel World). A run whose pinned deployment cannot be reached at all fails immediately regardless of this value.
+- Transient or unknown queue publishing failures use normal queue redelivery and do not consume this budget.
 
 ### `WORKFLOW_PRECONDITION_GUARD`
 

--- a/docs/content/docs/v5/errors/deployment-mismatch.mdx
+++ b/docs/content/docs/v5/errors/deployment-mismatch.mdx
@@ -21,7 +21,7 @@ This is an SDK/runtime signal, not an error thrown by your workflow code, and it
 Workflow run "wrun_..." is pinned to deployment "dpl_A", but was received by deployment "dpl_B". The runtime re-routed the message to "dpl_A" 3 times and it kept arriving elsewhere, so the run was stopped to protect against code-skew errors. Verify that the run's deployment is still available and that queue callbacks are routed to it.
 ```
 
-When the run's deployment cannot be reached at all — it was deleted, or aged out of its retention window — no re-route is possible and the message omits the re-routing clause.
+When the queue definitively reports that the run's deployment cannot be reached — it was deleted, or aged out of its retention window — no re-route is possible and the message omits the re-routing clause. Transient or unknown publishing failures leave the current delivery unacknowledged so the queue can redeliver it; they do not fail the run or consume this recovery budget.
 
 ## Why A Run Is Pinned
 

--- a/docs/content/docs/v5/errors/deployment-mismatch.mdx
+++ b/docs/content/docs/v5/errors/deployment-mismatch.mdx
@@ -1,0 +1,71 @@
+---
+title: deployment-mismatch
+description: A workflow run was delivered to a deployment other than the one it is pinned to.
+type: troubleshooting
+summary: Understand how Workflow recovers from a misrouted delivery, and why a run eventually fails with DEPLOYMENT_MISMATCH.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/foundations/versioning
+  - /docs/errors/runtime-decryption-failed
+  - /docs/foundations/errors-and-retries
+---
+
+Every run is pinned to a single deployment when it starts. When a queued workflow or step callback is delivered to a **different** deployment, Workflow does not execute it there. Instead it re-routes the message to the deployment the run is pinned to, and only if the run keeps arriving elsewhere does it fail with the `DEPLOYMENT_MISMATCH` classification.
+
+This is an SDK/runtime signal, not an error thrown by your workflow code, and it is not catchable inside a workflow function.
+
+## Error Message
+
+```
+Workflow run "wrun_..." is pinned to deployment "dpl_A", but was received by deployment "dpl_B". The runtime re-routed the message to "dpl_A" 3 times and it kept arriving elsewhere, so the run was stopped to protect against code-skew errors. Verify that the run's deployment is still available and that queue callbacks are routed to it.
+```
+
+When the run's deployment cannot be reached at all — it was deleted, or aged out of its retention window — no re-route is possible and the message omits the re-routing clause.
+
+## Why A Run Is Pinned
+
+A run's deployment is chosen once, at [`start()`](/docs/api-reference/workflow-api/start):
+
+- By default it is the deployment that called `start()` — see [Versioning](/docs/foundations/versioning) for why runs are pinned this way.
+- With `start(workflow, args, { deploymentId })` it is the id you pass, so a run can deliberately target a deployment other than the one that created it.
+- With `deploymentId: "latest"` it is the most recent deployment for the current environment, resolved at start time.
+
+Whichever it is, that `deploymentId` is recorded on the run, and every subsequent workflow replay and step execution must happen on that deployment. Continuing on a different one is unsafe:
+
+1. **Code skew.** The workflow and step bundles on the receiving deployment may not match the code that produced the run's recorded history, so replay could diverge or produce incorrect results.
+2. **Encryption.** Step inputs and other event-log payloads are encrypted with a per-run key derived from the pinned deployment's key material. A different deployment derives the wrong key and cannot decrypt them — previously the source of a confusing [runtime-decryption-failed](/docs/errors/runtime-decryption-failed) that exhausted retries with no clear cause.
+
+So the runtime checks the pinned deployment before it executes anything, and `DEPLOYMENT_MISMATCH` names the result — instead of the mismatch surfacing later as an unrelated decryption failure.
+
+## Automatic Recovery
+
+A deployment that receives a run it does not own first tries to fix the delivery rather than fail the run:
+
+1. It re-enqueues the message **explicitly addressed** to the run's own deployment. This is strictly better-addressed than the send that misrouted, which inherited the producing deployment's ambient id.
+2. Delivery is delayed with a short exponential backoff (1s, 2s, 4s).
+3. If the run keeps arriving at the wrong deployment, the run is failed with `DEPLOYMENT_MISMATCH` after `WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES` attempts (default `3`). Set it to `0` to fail on the first misrouted delivery instead.
+
+Nothing is executed on the wrong deployment during recovery: no workflow code, no step body, no `step_started`, and no hook resume. Whatever the delivery was carrying travels with it, so a pending step keeps its identity and a hook resume keeps its payload — they run on the deployment that can actually decrypt them.
+
+Recovery attempts do not create events on the run, so a run that self-heals looks completely normal. They are reported on the invocation's trace span (`workflow.deployment.pinned_id`, `workflow.deployment_mismatch.retry_count`, `workflow.deployment_mismatch.recovered`) and as a runtime warning in your function logs.
+
+## What To Do
+
+- **Re-run from the current deployment.** Trigger the workflow again from your latest deployment (or use the **Re-run** button in the Workflow Dashboard). The new run is pinned to the current deployment.
+- **Keep a run's deployment available** for the lifetime of that run. A run whose deployment has been deleted or has aged out cannot be resumed and must be re-run — recovery cannot help, so these fail on the first misrouted delivery. This applies to runs started with an explicit `deploymentId` too: pinning a run to an older deployment keeps it dependent on that deployment for its whole lifetime.
+- **Report it** if the pinned deployment was still available. Include both deployment ids and the run id from the error message, plus the trace span attributes above — a run that failed this way despite a reachable target is a routing fault worth investigating rather than something to work around.
+
+## This Error Cannot Be Caught
+
+Like other runtime signals, `DEPLOYMENT_MISMATCH` is **not catchable** inside your workflow function — the run is failed before any workflow or step code executes on the receiving deployment. Check the run status from outside instead:
+
+```typescript lineNumbers
+import { getRun } from "workflow/api";
+
+const run = getRun("wrun_abc123");
+const status = await run.status;
+if (status === "failed") {
+  console.error("Run failed");
+}
+```

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -7,6 +7,7 @@ import {
   RuntimeDecryptionError,
   ThrottleError,
   TooEarlyError,
+  WorkflowDeploymentMismatchError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
   WorkflowWorldError,
@@ -47,6 +48,18 @@ describe('classifyRunError', () => {
     expect(classifyRunError(new WorkflowNotRegisteredError('myWorkflow'))).toBe(
       RUN_ERROR_CODES.RUNTIME_ERROR
     );
+  });
+
+  it('classifies WorkflowDeploymentMismatchError as DEPLOYMENT_MISMATCH', () => {
+    expect(
+      classifyRunError(
+        new WorkflowDeploymentMismatchError(
+          'wrun_test',
+          'dpl_expected',
+          'dpl_actual'
+        )
+      )
+    ).toBe(RUN_ERROR_CODES.DEPLOYMENT_MISMATCH);
   });
 
   it('classifies plain Error as USER_ERROR', () => {

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -7,6 +7,7 @@ import {
   RuntimeDecryptionError,
   StepNotRegisteredError,
   ThrottleError,
+  WorkflowDeploymentMismatchError,
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
   WorkflowWorldError,
@@ -119,6 +120,10 @@ export function classifyRunError(err: unknown): RunErrorCode {
 
   if (MaxEventsExceededError.is(err)) {
     return RUN_ERROR_CODES.MAX_EVENTS_EXCEEDED;
+  }
+
+  if (WorkflowDeploymentMismatchError.is(err)) {
+    return RUN_ERROR_CODES.DEPLOYMENT_MISMATCH;
   }
 
   // World-layer faults — both a malformed response (contract violation) and a

--- a/packages/core/src/describe-error.test.ts
+++ b/packages/core/src/describe-error.test.ts
@@ -3,6 +3,7 @@ import {
   RUN_ERROR_CODES,
   SerializationError,
   StepNotRegisteredError,
+  WorkflowDeploymentMismatchError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import { describe, expect, test } from 'vitest';
@@ -118,6 +119,15 @@ describe('describeError', () => {
     expect(result.hint).toContain('maximum number of events');
   });
 
+  test('WorkflowDeploymentMismatchError is attributed to the SDK with the deployment hint', () => {
+    const result = describeError(
+      new WorkflowDeploymentMismatchError('wrun', 'dpl_a', 'dpl_b')
+    );
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.DEPLOYMENT_MISMATCH);
+    expect(result.hint).toContain('deployment it is pinned to');
+  });
+
   test('precomputed errorCode wins over classifyRunError when both are provided', () => {
     // A plain Error would classify as USER_ERROR, but passing REPLAY_TIMEOUT
     // explicitly overrides that — useful for callers that know the failure
@@ -218,6 +228,16 @@ describe('describeRunError', () => {
     });
     expect(result.attribution).toBe('sdk');
     expect(result.hint).toContain('SDK contract');
+  });
+
+  test('DEPLOYMENT_MISMATCH errorCode is attributed to the SDK', () => {
+    const result = describeRunError({
+      errorCode: RUN_ERROR_CODES.DEPLOYMENT_MISMATCH,
+      errorName: 'WorkflowDeploymentMismatchError',
+    });
+    expect(result.attribution).toBe('sdk');
+    expect(result.errorCode).toBe(RUN_ERROR_CODES.DEPLOYMENT_MISMATCH);
+    expect(result.hint).toContain('deployment it is pinned to');
   });
 
   test('RUNTIME_ERROR code without errorName still lands as SDK', () => {

--- a/packages/core/src/describe-error.ts
+++ b/packages/core/src/describe-error.ts
@@ -87,6 +87,8 @@ const MAX_EVENTS_HINT =
   'The workflow exceeded the maximum number of events per run. This usually means unbounded work in the workflow function — e.g. a loop that keeps creating steps without terminating. Break long-running workflows into child workflows to stay under the limit.';
 const WORLD_CONTRACT_HINT =
   'The workflow backend returned data that violated the SDK contract. This is not retryable; please report it with the stack trace and runId.';
+const DEPLOYMENT_MISMATCH_HINT =
+  "The run was delivered to a deployment other than the deployment it is pinned to, and was stopped to protect against code-skew errors after the runtime failed to re-route it there. Verify that the run's deployment is still available and that queue callbacks route to it.";
 
 function normalizeErrorCode(code: string | undefined): RunErrorCode {
   // Values read back from persisted events are `string | undefined` — we
@@ -149,6 +151,9 @@ export function describeRunError(
       hint: WORLD_CONTRACT_HINT,
     };
   }
+  if (errorCode === RUN_ERROR_CODES.DEPLOYMENT_MISMATCH) {
+    return { attribution: 'sdk', errorCode, hint: DEPLOYMENT_MISMATCH_HINT };
+  }
   if (name === 'WorkflowRuntimeError' || name === 'StepNotRegisteredError') {
     return { attribution: 'sdk', errorCode, hint: RUNTIME_ERROR_HINT };
   }
@@ -206,6 +211,16 @@ export function describeError(
       attribution: 'sdk',
       errorCode: effectiveCode,
       hint: CORRUPTED_EVENT_LOG_HINT,
+    };
+  }
+
+  // Check DEPLOYMENT_MISMATCH before the generic WorkflowRuntimeError branch —
+  // WorkflowDeploymentMismatchError subclasses it, but has its own code + hint.
+  if (effectiveCode === RUN_ERROR_CODES.DEPLOYMENT_MISMATCH) {
+    return {
+      attribution: 'sdk',
+      errorCode: effectiveCode,
+      hint: DEPLOYMENT_MISMATCH_HINT,
     };
   }
 

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -13,12 +13,16 @@ import { ulid } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runtimeLogger } from './logger.js';
 import { registerStepFunction } from './private.js';
-import { REPLAY_DIVERGENCE_MAX_RETRIES } from './runtime/constants.js';
+import {
+  DEPLOYMENT_MISMATCH_MAX_RETRIES,
+  REPLAY_DIVERGENCE_MAX_RETRIES,
+} from './runtime/constants.js';
 import { setWorld } from './runtime/world.js';
 import { workflowEntrypoint } from './runtime.js';
 import {
   dehydrateStepReturnValue,
   dehydrateWorkflowArguments,
+  hydrateRunError,
 } from './serialization.js';
 
 // Capture every promise handed to `waitUntil` so tests can assert that
@@ -47,6 +51,13 @@ async function anyWaitUntilPromiseRejected(): Promise<boolean> {
   return results.some((r) => r.status === 'rejected');
 }
 
+/** One recorded `world.queue` call from the harness's queue mock. */
+type QueueCall = {
+  queueName: string;
+  message: any;
+  opts?: Record<string, unknown>;
+};
+
 async function runWorkflowHandlerWithEvents(
   workflowCode: string,
   workflowRun: WorkflowRun,
@@ -55,7 +66,7 @@ async function runWorkflowHandlerWithEvents(
     attempt?: number;
     createdEvents?: unknown[];
     createdEventParams?: unknown[];
-    queuedMessages?: unknown[];
+    queueCalls?: QueueCall[];
     replayDivergence?: { eventId: string; count: number };
     /**
      * Make created events visible to subsequent events.list calls (appended
@@ -65,6 +76,14 @@ async function runWorkflowHandlerWithEvents(
      * pin the log's contents keep full control.
      */
     dynamicEventLog?: boolean;
+    currentDeploymentId?: string;
+    /** `deploymentMismatchRetryCount` on the incoming queue message. */
+    deploymentMismatchRetryCount?: number;
+    /** Set both to drive the background-step branch of the combined handler. */
+    incomingStepId?: string;
+    incomingStepName?: string;
+    /** Lazy hook resume payload carried on the incoming queue message. */
+    hookInput?: Record<string, unknown>;
   } = {}
 ) {
   const createdEvents = options.createdEvents ?? [];
@@ -95,6 +114,12 @@ async function runWorkflowHandlerWithEvents(
 
   setWorld({
     specVersion: SPEC_VERSION_CURRENT,
+    // Declares atomic, immutable deployments (as world-vercel does); worlds
+    // that leave it unset (local/postgres) skip the deployment guard.
+    capabilities: { deploymentAffinity: true },
+    getDeploymentId: vi.fn(
+      async () => options.currentDeploymentId ?? workflowRun.deploymentId
+    ),
     createQueueHandler: vi.fn(
       (
         _prefix: string,
@@ -106,6 +131,11 @@ async function runWorkflowHandlerWithEvents(
               runId: workflowRun.runId,
               requestedAt: new Date('2024-01-01T00:00:00.000Z'),
               replayDivergence: options.replayDivergence,
+              deploymentMismatchRetryCount:
+                options.deploymentMismatchRetryCount,
+              stepId: options.incomingStepId,
+              stepName: options.incomingStepName,
+              hookInput: options.hookInput,
             },
             {
               requestId: 'req_test',
@@ -129,10 +159,16 @@ async function runWorkflowHandlerWithEvents(
     runs: {
       get: vi.fn(async () => workflowRun),
     },
-    queue: vi.fn(async (_queueName: string, message: unknown) => {
-      options.queuedMessages?.push(message);
-      return { messageId: null };
-    }),
+    queue: vi.fn(
+      async (
+        queueName: string,
+        message: unknown,
+        opts?: Record<string, unknown>
+      ) => {
+        options.queueCalls?.push({ queueName, message, opts });
+        return { messageId: null };
+      }
+    ),
     getEncryptionKeyForRun: vi.fn(async () => undefined),
   } as any);
 
@@ -151,6 +187,158 @@ describe('workflowEntrypoint replay guards', () => {
   const getWorkflowTransformCode = (workflowName: string) =>
     `;globalThis.__private_workflows = new Map();
     globalThis.__private_workflows.set(${JSON.stringify(workflowName)}, ${workflowName});`;
+
+  /** A run pinned to `dpl_origin`, for the deployment-affinity tests below. */
+  const misroutedRun = async (): Promise<WorkflowRun> => ({
+    runId: 'wrun_wrong_deployment',
+    workflowName: 'workflow',
+    status: 'running',
+    input: await dehydrateWorkflowArguments(
+      [],
+      'wrun_wrong_deployment',
+      undefined,
+      []
+    ),
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    startedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deploymentId: 'dpl_origin',
+    specVersion: SPEC_VERSION_CURRENT,
+  });
+
+  const mustNotRun = `async function workflow() {
+        throw new Error('workflow code must not execute');
+      }${getWorkflowTransformCode('workflow')}`;
+
+  it('re-routes a flow replay delivered to a different deployment', async () => {
+    const workflowRun = await misroutedRun();
+    const queueCalls: QueueCall[] = [];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      mustNotRun,
+      workflowRun,
+      [],
+      { currentDeploymentId: 'dpl_current', queueCalls }
+    );
+
+    expect(queueCalls).toHaveLength(1);
+    expect(queueCalls[0].opts).toMatchObject({
+      deploymentId: 'dpl_origin',
+      specVersion: SPEC_VERSION_CURRENT,
+      delaySeconds: 1,
+    });
+    expect(queueCalls[0].message).toMatchObject({
+      runId: 'wrun_wrong_deployment',
+      deploymentMismatchRetryCount: 1,
+    });
+    // `runInput` must not ride along — it would re-engage turbo on the next
+    // delivery and wedge the run.
+    expect(queueCalls[0].message).not.toHaveProperty('runInput');
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
+    );
+  });
+
+  it('re-routes a queued step execution, preserving the pending step', async () => {
+    const workflowRun = await misroutedRun();
+    const queueCalls: QueueCall[] = [];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      mustNotRun,
+      workflowRun,
+      [],
+      {
+        currentDeploymentId: 'dpl_current',
+        incomingStepId: 'step_1',
+        incomingStepName: 'myStep',
+        queueCalls,
+      }
+    );
+
+    expect(queueCalls).toHaveLength(1);
+    expect(queueCalls[0].opts).toMatchObject({ deploymentId: 'dpl_origin' });
+    expect(queueCalls[0].message).toMatchObject({
+      runId: 'wrun_wrong_deployment',
+      stepId: 'step_1',
+      stepName: 'myStep',
+      deploymentMismatchRetryCount: 1,
+    });
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'step_started' })
+    );
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
+    );
+  });
+
+  it('re-routes a misrouted lazy hook resume with its payload intact', async () => {
+    // The lazy-resume producer parallelizes the `hook_received` write with this
+    // queue publish, so `hookInput` may be the only copy of the payload. The
+    // guard runs ahead of the re-ensure, so nothing is written here — which
+    // means the re-routed message has to carry `hookInput` or the resume is
+    // lost when the producer's direct write had not landed.
+    const workflowRun = await misroutedRun();
+    const queueCalls: QueueCall[] = [];
+    const hookInput = {
+      resumeId: '01JQZ0000000000000000000000',
+      hookId: 'hook_1',
+      token: 'tok_1',
+      payload: { serialized: true },
+      payloadDigest: 'sha256:abc',
+    };
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      mustNotRun,
+      workflowRun,
+      [],
+      { currentDeploymentId: 'dpl_current', hookInput, queueCalls }
+    );
+
+    expect(queueCalls).toHaveLength(1);
+    expect(queueCalls[0].opts).toMatchObject({ deploymentId: 'dpl_origin' });
+    expect(queueCalls[0].message).toMatchObject({
+      deploymentMismatchRetryCount: 1,
+      hookInput,
+    });
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'hook_received' })
+    );
+  });
+
+  it('fails a misrouted run once the re-route budget is spent', async () => {
+    const workflowRun = await misroutedRun();
+    const queueCalls: QueueCall[] = [];
+
+    const createdEvents = await runWorkflowHandlerWithEvents(
+      mustNotRun,
+      workflowRun,
+      [],
+      {
+        currentDeploymentId: 'dpl_current',
+        deploymentMismatchRetryCount: DEPLOYMENT_MISMATCH_MAX_RETRIES,
+        queueCalls,
+      }
+    );
+
+    expect(queueCalls).toHaveLength(0);
+    const failedEvent = createdEvents.find(
+      (event: any) => event.eventType === 'run_failed'
+    ) as any;
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.eventData.errorCode).toBe(
+      RUN_ERROR_CODES.DEPLOYMENT_MISMATCH
+    );
+    const error = await hydrateRunError(
+      failedEvent.eventData.error,
+      workflowRun.runId,
+      undefined
+    );
+    // Wording is pinned by deployment-guard.test.ts; this checks the round trip.
+    expect(error).toMatchObject({ name: 'WorkflowDeploymentMismatchError' });
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_completed' })
+    );
+  });
 
   it('records run_failed when run_started response schema validation fails', async () => {
     const createdEvents: unknown[] = [];
@@ -179,6 +367,7 @@ describe('workflowEntrypoint replay guards', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => 'test-deployment'),
       createQueueHandler: vi.fn(
         (
           _prefix: string,
@@ -277,6 +466,7 @@ describe('workflowEntrypoint replay guards', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => 'test-deployment'),
       createQueueHandler: vi.fn(
         (
           _prefix: string,
@@ -374,6 +564,7 @@ describe('workflowEntrypoint replay guards', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => workflowRun.deploymentId),
       createQueueHandler: vi.fn(
         (
           _prefix: string,
@@ -453,6 +644,7 @@ describe('workflowEntrypoint replay guards', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => workflowRun.deploymentId),
       createQueueHandler: vi.fn(
         (
           _prefix: string,
@@ -592,7 +784,7 @@ describe('workflowEntrypoint replay guards', () => {
     ];
 
     const initialAttemptEvents: unknown[] = [];
-    const queuedMessages: unknown[] = [];
+    const queueCalls: QueueCall[] = [];
     await runWorkflowHandlerWithEvents(
       `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
       async function workflow() {
@@ -603,14 +795,14 @@ describe('workflowEntrypoint replay guards', () => {
       events,
       {
         createdEvents: initialAttemptEvents,
-        queuedMessages,
+        queueCalls,
       }
     );
 
     expect(initialAttemptEvents).not.toContainEqual(
       expect.objectContaining({ eventType: 'run_failed' })
     );
-    expect(queuedMessages).toContainEqual(
+    expect(queueCalls.map((c) => c.message)).toContainEqual(
       expect.objectContaining({
         replayDivergence: {
           eventId: 'event-0',
@@ -742,7 +934,7 @@ describe('workflowEntrypoint replay guards', () => {
     ];
 
     const createdEvents: unknown[] = [];
-    const queuedMessages: unknown[] = [];
+    const queueCalls: QueueCall[] = [];
     await runWorkflowHandlerWithEvents(
       `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
       async function workflow() {
@@ -752,13 +944,13 @@ describe('workflowEntrypoint replay guards', () => {
       }${getWorkflowTransformCode('workflow')}`,
       workflowRun,
       events,
-      { createdEvents, queuedMessages }
+      { createdEvents, queueCalls }
     );
 
     expect(createdEvents).not.toContainEqual(
       expect.objectContaining({ eventType: 'run_failed' })
     );
-    expect(queuedMessages).toContainEqual(
+    expect(queueCalls.map((c) => c.message)).toContainEqual(
       expect.objectContaining({
         replayDivergence: { eventId: 'event-0', count: 1 },
       })
@@ -798,10 +990,10 @@ describe('workflowEntrypoint replay guards', () => {
       }${getWorkflowTransformCode('workflow')}`;
 
     const createdEvents: any[] = [];
-    const queuedMessages: unknown[] = [];
+    const queueCalls: QueueCall[] = [];
     await runWorkflowHandlerWithEvents(workflowCode, workflowRun, [], {
       createdEvents,
-      queuedMessages,
+      queueCalls,
       dynamicEventLog: true,
     });
 
@@ -815,7 +1007,7 @@ describe('workflowEntrypoint replay guards', () => {
     expect(createdEvents).toContainEqual(
       expect.objectContaining({ eventType: 'run_completed' })
     );
-    expect(queuedMessages).toEqual([]);
+    expect(queueCalls).toEqual([]);
     // Under lazy inline start the step that loses the attribute race is NOT
     // eagerly created: its step_created is deferred for a lazy step_started
     // that never fires, because the attribute-resolving replay decides the
@@ -881,6 +1073,7 @@ describe('workflowEntrypoint replay guards', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => workflowRun.deploymentId),
       createQueueHandler: vi.fn(
         (
           _prefix: string,
@@ -990,6 +1183,7 @@ describe('workflowEntrypoint replay guards', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => workflowRun.deploymentId),
       createQueueHandler: vi.fn(
         (
           _prefix: string,
@@ -1211,6 +1405,7 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => workflowRun.deploymentId),
       createQueueHandler: vi.fn(
         (
           _prefix: string,
@@ -1456,6 +1651,7 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
     });
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => workflowRun.deploymentId),
       createQueueHandler: vi.fn(
         (_p: string, handler: (m: unknown, md: unknown) => Promise<unknown>) =>
           async () => {
@@ -1631,6 +1827,7 @@ describe('workflowEntrypoint turbo mode', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => 'test-deployment'),
       createQueueHandler: vi.fn(
         (_p: string, handler: (m: unknown, md: unknown) => Promise<unknown>) =>
           async () => {
@@ -2254,6 +2451,7 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
+      getDeploymentId: vi.fn(async () => 'test-deployment'),
       createQueueHandler: vi.fn(
         (_p: string, handler: (m: unknown, md: unknown) => Promise<unknown>) =>
           async () => {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -84,6 +84,8 @@ async function runWorkflowHandlerWithEvents(
     incomingStepName?: string;
     /** Lazy hook resume payload carried on the incoming queue message. */
     hookInput?: Record<string, unknown>;
+    queueImpl?: () => Promise<{ messageId: null }>;
+    isDeploymentUnavailableError?: (error: unknown) => boolean;
   } = {}
 ) {
   const createdEvents = options.createdEvents ?? [];
@@ -120,6 +122,7 @@ async function runWorkflowHandlerWithEvents(
     getDeploymentId: vi.fn(
       async () => options.currentDeploymentId ?? workflowRun.deploymentId
     ),
+    isDeploymentUnavailableError: options.isDeploymentUnavailableError,
     createQueueHandler: vi.fn(
       (
         _prefix: string,
@@ -166,6 +169,7 @@ async function runWorkflowHandlerWithEvents(
         opts?: Record<string, unknown>
       ) => {
         options.queueCalls?.push({ queueName, message, opts });
+        if (options.queueImpl) return options.queueImpl();
         return { messageId: null };
       }
     ),
@@ -234,6 +238,26 @@ describe('workflowEntrypoint replay guards', () => {
     // `runInput` must not ride along — it would re-engage turbo on the next
     // delivery and wedge the run.
     expect(queueCalls[0].message).not.toHaveProperty('runInput');
+    expect(createdEvents).not.toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
+    );
+  });
+
+  it('leaves a misrouted delivery unacked when re-enqueue fails transiently', async () => {
+    const workflowRun = await misroutedRun();
+    const createdEvents: unknown[] = [];
+    const sendError = new Error('transient VQS failure');
+
+    await expect(
+      runWorkflowHandlerWithEvents(mustNotRun, workflowRun, [], {
+        currentDeploymentId: 'dpl_current',
+        createdEvents,
+        queueImpl: async () => {
+          throw sendError;
+        },
+        isDeploymentUnavailableError: () => false,
+      })
+    ).rejects.toBe(sendError);
     expect(createdEvents).not.toContainEqual(
       expect.objectContaining({ eventType: 'run_failed' })
     );

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1219,6 +1219,8 @@ export function workflowEntrypoint(
                         requestId,
                         retryCount: deploymentMismatchRetryCount,
                         beforeStop,
+                        isDeploymentUnavailableError:
+                          world.isDeploymentUnavailableError,
                         reenqueue: async ({
                           deploymentId,
                           specVersion,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -56,6 +56,11 @@ import {
 } from './runtime/constants.js';
 import { countStepStartedEvents } from './runtime/count-step-started-events.js';
 import {
+  type DeploymentAffinityOutcome,
+  guardDeploymentAffinity,
+  type ReenqueueArgs,
+} from './runtime/deployment-guard.js';
+import {
   appendUniqueEvents,
   type EventCreator,
   getQueueOverhead,
@@ -577,6 +582,7 @@ export function workflowEntrypoint(
           stepName: incomingStepName,
           replayDivergence,
           preconditionReinvocations,
+          deploymentMismatchRetryCount,
           runInput,
           hookInput,
         } = WorkflowInvokePayloadSchema.parse(message_);
@@ -919,6 +925,17 @@ export function workflowEntrypoint(
                     }
                   };
 
+                  // A plain orchestrator-replay message. Omits `runInput` (it
+                  // re-engages turbo on the next delivery and wedges the run —
+                  // see `reinvoke` below) and `replayDivergence` /
+                  // `serverErrorRetryCount` (this delivery chain's budgets).
+                  const replayMessage =
+                    async (): Promise<WorkflowInvokePayload> => ({
+                      runId,
+                      traceCarrier: await nextTraceCarrier(),
+                      requestedAt: new Date(),
+                    });
+
                   const reinvoke = async (
                     delaySeconds: number,
                     /**
@@ -936,12 +953,7 @@ export function workflowEntrypoint(
                     await queueMessage(
                       world,
                       getWorkflowQueueName(workflowName, namespace),
-                      {
-                        runId,
-                        traceCarrier: await nextTraceCarrier(),
-                        requestedAt: new Date(),
-                        ...extraPayload,
-                      },
+                      { ...(await replayMessage()), ...extraPayload },
                       delaySeconds > 0 ? { delaySeconds } : undefined
                     );
                     return undefined;
@@ -1190,6 +1202,44 @@ export function workflowEntrypoint(
                     };
                   };
 
+                  // Deployment-affinity guard, shared by the two paths that
+                  // execute a run: queued step executions and flow replays.
+                  const guardDeployment = async (
+                    run: Pick<
+                      WorkflowRun,
+                      'runId' | 'deploymentId' | 'specVersion'
+                    >,
+                    reenqueuePayload: () => Promise<WorkflowInvokePayload>,
+                    beforeStop?: () => Promise<void>
+                  ): Promise<DeploymentAffinityOutcome> => {
+                    const { outcome, spanAttributes } =
+                      await guardDeploymentAffinity({
+                        world,
+                        run,
+                        requestId,
+                        retryCount: deploymentMismatchRetryCount,
+                        beforeStop,
+                        reenqueue: async ({
+                          deploymentId,
+                          specVersion,
+                          deploymentMismatchRetryCount: retryCount,
+                          delaySeconds,
+                        }: ReenqueueArgs) => {
+                          await queueMessage(
+                            world,
+                            getWorkflowQueueName(workflowName, namespace),
+                            {
+                              ...(await reenqueuePayload()),
+                              deploymentMismatchRetryCount: retryCount,
+                            },
+                            { deploymentId, specVersion, delaySeconds }
+                          );
+                        },
+                      });
+                    if (spanAttributes) span?.setAttributes(spanAttributes);
+                    return outcome;
+                  };
+
                   // If incoming message has a stepId, this is a background step
                   // execution. Execute the step, then check if all parallel steps
                   // from the batch are done. If so, replay inline (saving a queue
@@ -1205,6 +1255,17 @@ export function workflowEntrypoint(
                           'Run already finished, skipping background step',
                           { workflowRunId: runId, status: bgRun.status }
                         );
+                        return;
+                      }
+                      // Covers every queued step execution — first dispatch and
+                      // redeliveries/retries alike.
+                      if (
+                        (await guardDeployment(bgRun, async () => ({
+                          ...(await replayMessage()),
+                          stepId: incomingStepId,
+                          stepName: incomingStepName,
+                        }))) !== 'continue'
+                      ) {
                         return;
                       }
                       const bgStartedAt = bgRun.startedAt
@@ -1662,6 +1723,32 @@ export function workflowEntrypoint(
                       }
                     } // end else (non-turbo run_started)
                   } // end if (!workflowRun)
+
+                  // Covers every flow replay — initial start, step completions,
+                  // hook resumptions, wait completions — and stops before any
+                  // workflow code, inline step, or event write happens when the
+                  // run is not pinned here (see `guardDeploymentAffinity`).
+                  // `awaitRunReady` orders turbo's `run_started` before either
+                  // stopping action.
+                  //
+                  // Runs ahead of the lazy-hook re-ensure below, so a misrouted
+                  // resume writes nothing here — which means the re-routed
+                  // message must carry `hookInput`, or a resume whose producer
+                  // write had not yet landed would be lost (that re-ensure is
+                  // idempotent per `resumeId`, so the pinned deployment still
+                  // converges on one event).
+                  if (
+                    (await guardDeployment(
+                      workflowRun,
+                      async () => ({
+                        ...(await replayMessage()),
+                        ...(hookInput ? { hookInput } : {}),
+                      }),
+                      awaitRunReady
+                    )) !== 'continue'
+                  ) {
+                    return;
+                  }
 
                   // Lazy hook resume: the producer (resumeHook fast path)
                   // parallelized the `hook_received` write with this queue

--- a/packages/core/src/runtime/constants.ts
+++ b/packages/core/src/runtime/constants.ts
@@ -464,3 +464,21 @@ export function getPreconditionReinvokeDelaySeconds(): number {
     { integer: true }
   );
 }
+
+// A delivery reaching a deployment the run is not pinned to is not treated as
+// permanent. Re-route the message at the run's own deployment a bounded number
+// of times before failing the run with DEPLOYMENT_MISMATCH.
+export const DEPLOYMENT_MISMATCH_MAX_RETRIES = 3;
+
+/**
+ * Effective deployment-mismatch re-route budget. Override via
+ * `WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES`; `0` fails the run on the first
+ * misrouted delivery instead of attempting recovery.
+ */
+export function getDeploymentMismatchMaxRetries(): number {
+  return envNumber(
+    'WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES',
+    DEPLOYMENT_MISMATCH_MAX_RETRIES,
+    { integer: true, min: 0 }
+  );
+}

--- a/packages/core/src/runtime/deployment-guard.test.ts
+++ b/packages/core/src/runtime/deployment-guard.test.ts
@@ -159,14 +159,19 @@ describe('guardDeploymentAffinity', () => {
     expect((error as Error).message).toContain('/err/deployment-mismatch');
   });
 
-  it('fails immediately when the pinned deployment cannot be reached', async () => {
+  it('fails immediately when the World confirms the pinned deployment is unavailable', async () => {
     // Deleted or aged-out deployment: the pinned target is unroutable.
     const { world, eventsCreate } = createWorld('dpl_current');
     const enqueueError = new Error('deployment not found');
     const reenqueue = vi.fn().mockRejectedValue(enqueueError);
 
     await expect(
-      guardDeploymentAffinity({ world, run, reenqueue })
+      guardDeploymentAffinity({
+        world,
+        run,
+        reenqueue,
+        isDeploymentUnavailableError: (error) => error === enqueueError,
+      })
     ).resolves.toMatchObject({ outcome: 'failed' });
     expect(reenqueue).toHaveBeenCalledTimes(1);
 
@@ -174,6 +179,23 @@ describe('guardDeploymentAffinity', () => {
     expect(WorkflowDeploymentMismatchError.is(error)).toBe(true);
     // No re-route succeeded, so the message must not claim any.
     expect((error as Error).message).not.toContain('re-routed the message');
+  });
+
+  it('rethrows an unclassified re-enqueue failure for queue redelivery', async () => {
+    const { world, eventsCreate } = createWorld('dpl_current');
+    const enqueueError = new Error('transient VQS failure');
+    const reenqueue = vi.fn().mockRejectedValue(enqueueError);
+
+    await expect(
+      guardDeploymentAffinity({
+        world,
+        run,
+        reenqueue,
+        isDeploymentUnavailableError: () => false,
+      })
+    ).rejects.toBe(enqueueError);
+    expect(reenqueue).toHaveBeenCalledTimes(1);
+    expect(eventsCreate).not.toHaveBeenCalled();
   });
 
   it('fails fast when no re-enqueue is possible', async () => {

--- a/packages/core/src/runtime/deployment-guard.test.ts
+++ b/packages/core/src/runtime/deployment-guard.test.ts
@@ -1,0 +1,247 @@
+import {
+  RUN_ERROR_CODES,
+  WorkflowDeploymentMismatchError,
+} from '@workflow/errors';
+import type { WorkflowRun, World } from '@workflow/world';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hydrateRunError } from '../serialization.js';
+import { guardDeploymentAffinity } from './deployment-guard.js';
+
+const run = {
+  runId: 'wrun_test',
+  deploymentId: 'dpl_pinned',
+  specVersion: 5,
+} satisfies Pick<WorkflowRun, 'runId' | 'deploymentId' | 'specVersion'>;
+
+function createWorld(currentDeploymentId: string) {
+  const eventsCreate = vi.fn().mockResolvedValue({ event: {} });
+  const getEncryptionKeyForRun = vi.fn().mockResolvedValue(undefined);
+  const world = {
+    // Declares atomic, immutable deployments (as world-vercel does). Worlds
+    // that leave it unset (local/postgres) skip the guard entirely.
+    capabilities: { deploymentAffinity: true },
+    getDeploymentId: vi.fn().mockResolvedValue(currentDeploymentId),
+    getEncryptionKeyForRun,
+    events: { create: eventsCreate },
+  } as unknown as World;
+  return { world, eventsCreate, getEncryptionKeyForRun };
+}
+
+/** Reads back the persisted `run_failed` payload as a live error. */
+async function hydrateFailure(eventsCreate: ReturnType<typeof vi.fn>) {
+  const failedEvent = eventsCreate.mock.calls[0][1];
+  expect(failedEvent.eventType).toBe('run_failed');
+  expect(failedEvent.eventData.errorCode).toBe(
+    RUN_ERROR_CODES.DEPLOYMENT_MISMATCH
+  );
+  return await hydrateRunError(
+    failedEvent.eventData.error,
+    'wrun_test',
+    undefined
+  );
+}
+
+afterEach(() => {
+  delete process.env.WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES;
+});
+
+describe('guardDeploymentAffinity', () => {
+  it('continues when the run is pinned to the current deployment', async () => {
+    const { world, eventsCreate, getEncryptionKeyForRun } =
+      createWorld('dpl_pinned');
+    const reenqueue = vi.fn();
+
+    await expect(
+      guardDeploymentAffinity({ world, run, reenqueue })
+    ).resolves.toMatchObject({ outcome: 'continue' });
+    expect(reenqueue).not.toHaveBeenCalled();
+    expect(eventsCreate).not.toHaveBeenCalled();
+    expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+  });
+
+  it('skips worlds that do not declare deploymentAffinity', async () => {
+    const { world, eventsCreate } = createWorld('dpl_current');
+    (world as { capabilities?: unknown }).capabilities = {};
+    const reenqueue = vi.fn();
+
+    await expect(
+      guardDeploymentAffinity({ world, run, reenqueue })
+    ).resolves.toMatchObject({ outcome: 'continue' });
+    expect(reenqueue).not.toHaveBeenCalled();
+    expect(eventsCreate).not.toHaveBeenCalled();
+  });
+
+  it('re-routes a misrouted delivery to the deployment the run is pinned to', async () => {
+    const { world, eventsCreate } = createWorld('dpl_current');
+    const reenqueue = vi.fn();
+
+    await expect(
+      guardDeploymentAffinity({ world, run, reenqueue, requestId: 'req_test' })
+    ).resolves.toMatchObject({ outcome: 'rerouted' });
+
+    expect(reenqueue).toHaveBeenCalledWith({
+      deploymentId: 'dpl_pinned',
+      specVersion: 5,
+      deploymentMismatchRetryCount: 1,
+      delaySeconds: 1,
+    });
+    expect(eventsCreate).not.toHaveBeenCalled();
+  });
+
+  it('increments the count and backs off exponentially across attempts', async () => {
+    const sent: { count: number; delay: number }[] = [];
+    for (const retryCount of [0, 1, 2]) {
+      const { world } = createWorld('dpl_current');
+      await expect(
+        guardDeploymentAffinity({
+          world,
+          run,
+          retryCount,
+          reenqueue: async ({ deploymentMismatchRetryCount, delaySeconds }) => {
+            sent.push({
+              count: deploymentMismatchRetryCount,
+              delay: delaySeconds,
+            });
+          },
+        })
+      ).resolves.toMatchObject({ outcome: 'rerouted' });
+    }
+    expect(sent).toEqual([
+      { count: 1, delay: 1 },
+      { count: 2, delay: 2 },
+      { count: 3, delay: 4 },
+    ]);
+  });
+
+  it('fails the run once the re-route budget is spent', async () => {
+    const { world, eventsCreate, getEncryptionKeyForRun } =
+      createWorld('dpl_current');
+    const reenqueue = vi.fn();
+
+    // Default budget is 3, so a message arriving with 3 attempts is out.
+    await expect(
+      guardDeploymentAffinity({
+        world,
+        run,
+        retryCount: 3,
+        reenqueue,
+        requestId: 'req_test',
+      })
+    ).resolves.toMatchObject({ outcome: 'failed' });
+    expect(reenqueue).not.toHaveBeenCalled();
+
+    // The failure must be recordable without the pinned deployment's key,
+    // which is often gone once a run outlives its deployment.
+    expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+    expect(eventsCreate).toHaveBeenCalledWith(
+      'wrun_test',
+      expect.objectContaining({
+        eventType: 'run_failed',
+        eventData: expect.objectContaining({
+          errorCode: RUN_ERROR_CODES.DEPLOYMENT_MISMATCH,
+        }),
+      }),
+      { requestId: 'req_test' }
+    );
+
+    const error = await hydrateFailure(eventsCreate);
+    expect(WorkflowDeploymentMismatchError.is(error)).toBe(true);
+    expect((error as Error).message).toContain(
+      'is pinned to deployment "dpl_pinned", but was received by deployment "dpl_current"'
+    );
+    expect((error as Error).message).toContain(
+      're-routed the message to "dpl_pinned" 3 times'
+    );
+    expect((error as Error).message).toContain(
+      "Verify that the run's deployment is still available"
+    );
+    // Carries the docs link built from the DEPLOYMENT_MISMATCH slug.
+    expect((error as Error).message).toContain('/err/deployment-mismatch');
+  });
+
+  it('fails immediately when the pinned deployment cannot be reached', async () => {
+    // Deleted or aged-out deployment: the pinned target is unroutable.
+    const { world, eventsCreate } = createWorld('dpl_current');
+    const enqueueError = new Error('deployment not found');
+    const reenqueue = vi.fn().mockRejectedValue(enqueueError);
+
+    await expect(
+      guardDeploymentAffinity({ world, run, reenqueue })
+    ).resolves.toMatchObject({ outcome: 'failed' });
+    expect(reenqueue).toHaveBeenCalledTimes(1);
+
+    const error = await hydrateFailure(eventsCreate);
+    expect(WorkflowDeploymentMismatchError.is(error)).toBe(true);
+    // No re-route succeeded, so the message must not claim any.
+    expect((error as Error).message).not.toContain('re-routed the message');
+  });
+
+  it('fails fast when no re-enqueue is possible', async () => {
+    const { world, eventsCreate } = createWorld('dpl_current');
+
+    await expect(
+      guardDeploymentAffinity({ world, run })
+    ).resolves.toMatchObject({ outcome: 'failed' });
+    expect(eventsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES=0 as fail-fast', async () => {
+    process.env.WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES = '0';
+    const { world, eventsCreate } = createWorld('dpl_current');
+    const reenqueue = vi.fn();
+
+    await expect(
+      guardDeploymentAffinity({ world, run, reenqueue })
+    ).resolves.toMatchObject({ outcome: 'failed' });
+    expect(reenqueue).not.toHaveBeenCalled();
+    expect(eventsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('awaits the ordering barrier before stopping, on both outcomes', async () => {
+    for (const retryCount of [0, 3]) {
+      const { world } = createWorld('dpl_current');
+      const order: string[] = [];
+      const beforeStop = vi.fn(async () => {
+        order.push('barrier');
+      });
+      await guardDeploymentAffinity({
+        world,
+        run,
+        retryCount,
+        beforeStop,
+        reenqueue: async () => {
+          order.push('reenqueue');
+        },
+      });
+      expect(beforeStop).toHaveBeenCalledTimes(1);
+      expect(order[0]).toBe('barrier');
+    }
+  });
+
+  it('guards a run pinned to a deployment other than its creator', async () => {
+    // `start({ deploymentId })` (and `'latest'`) pin a run to a deployment that
+    // did not create it: such a run executes normally on its target...
+    const target = createWorld('dpl_explicit_target');
+    await expect(
+      guardDeploymentAffinity({
+        world: target.world,
+        run: { ...run, deploymentId: 'dpl_explicit_target' },
+      })
+    ).resolves.toMatchObject({ outcome: 'continue' });
+    expect(target.eventsCreate).not.toHaveBeenCalled();
+
+    // ...and is still re-routed if delivery lands on its creator instead.
+    const creator = createWorld('dpl_creator');
+    const reenqueue = vi.fn();
+    await expect(
+      guardDeploymentAffinity({
+        world: creator.world,
+        run: { ...run, deploymentId: 'dpl_explicit_target' },
+        reenqueue,
+      })
+    ).resolves.toMatchObject({ outcome: 'rerouted' });
+    expect(reenqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ deploymentId: 'dpl_explicit_target' })
+    );
+  });
+});

--- a/packages/core/src/runtime/deployment-guard.ts
+++ b/packages/core/src/runtime/deployment-guard.ts
@@ -120,6 +120,7 @@ export async function guardDeploymentAffinity({
   requestId,
   retryCount = 0,
   reenqueue,
+  isDeploymentUnavailableError,
   beforeStop,
 }: {
   world: World;
@@ -133,6 +134,12 @@ export async function guardDeploymentAffinity({
    * makes the guard fail-fast.
    */
   reenqueue?: (args: ReenqueueArgs) => Promise<void>;
+  /**
+   * Classifies a re-enqueue failure as definitive proof that the pinned
+   * deployment cannot receive the message. Unclassified failures are retried
+   * by rejecting the handler and leaving the current queue message unacked.
+   */
+  isDeploymentUnavailableError?: (error: unknown) => boolean;
   /**
    * Ordering barrier awaited once a mismatch is confirmed, before either
    * stopping action. Under turbo the `run_started` write is backgrounded, and
@@ -237,10 +244,17 @@ export async function guardDeploymentAffinity({
       );
       return result('rerouted', run.deploymentId, attempt);
     } catch (reenqueueError) {
-      // The target deployment is unroutable — deleted, aged out of its
-      // retention window, or rejected by the queue. Burning the rest of the
-      // budget (plus its backoff) on a deployment that provably cannot be
-      // reached only delays the failure, so fail now.
+      // A generic send failure can be transient (429, 5xx, connect/DNS). Do not
+      // turn one infrastructure blip into a terminal run failure: reject the
+      // handler so the current message remains unacked and is redelivered.
+      if (!isDeploymentUnavailableError?.(reenqueueError)) {
+        throw reenqueueError;
+      }
+
+      // The World explicitly classified the target as unavailable — deleted,
+      // aged out of its retention window, or otherwise undiscoverable. Burning
+      // the rest of the budget on a deployment that provably cannot be reached
+      // only delays the failure, so fail now.
       runtimeLogger.error(
         'Cannot re-route a misrouted workflow run to its own deployment; failing the run',
         {

--- a/packages/core/src/runtime/deployment-guard.ts
+++ b/packages/core/src/runtime/deployment-guard.ts
@@ -1,0 +1,268 @@
+import {
+  EntityConflictError,
+  RUN_ERROR_CODES,
+  RunExpiredError,
+  WorkflowDeploymentMismatchError,
+} from '@workflow/errors';
+import {
+  SPEC_VERSION_CURRENT,
+  SPEC_VERSION_SUPPORTS_COMPRESSION,
+  type WorkflowRun,
+  type World,
+} from '@workflow/world';
+import { runtimeLogger } from '../logger.js';
+import { dehydrateRunError } from '../serialization.js';
+import * as Attribute from '../telemetry/semantic-conventions.js';
+import { getDeploymentMismatchMaxRetries } from './constants.js';
+
+/** Cap on the re-route backoff, in seconds. */
+const MAX_REROUTE_DELAY_SECONDS = 8;
+
+/**
+ * How the guard resolved a delivery. Both non-`continue` outcomes mean the
+ * caller must ack the message and return without executing anything.
+ */
+export type DeploymentAffinityOutcome =
+  /** The run belongs here (or this world has no deployment affinity). */
+  | 'continue'
+  /** Misrouted; re-enqueued at the run's own deployment. */
+  | 'rerouted'
+  /** Misrouted and out of budget (or unroutable); `run_failed` recorded. */
+  | 'failed';
+
+/**
+ * `spanAttributes` is present only on a misrouted delivery — mismatches are
+ * rare, so the presence of `workflow.deployment.pinned_id` on a span *is* the
+ * signal that one happened, and `recovered` separates the ones a re-route fixed
+ * from the ones that kept misrouting.
+ */
+export interface DeploymentAffinityResult {
+  outcome: DeploymentAffinityOutcome;
+  spanAttributes?: Record<string, string | number | boolean>;
+}
+
+/** The common case, allocation-free. */
+const CONTINUE: DeploymentAffinityResult = { outcome: 'continue' };
+
+/**
+ * Builds a stopping result. `attempts` is the re-route count *including* this
+ * invocation's own attempt, so the span attribute reads as "attempts so far".
+ */
+function result(
+  outcome: 'rerouted' | 'failed',
+  pinnedDeploymentId: string,
+  attempts: number
+): DeploymentAffinityResult {
+  return {
+    outcome,
+    spanAttributes: {
+      ...Attribute.WorkflowRunPinnedDeploymentId(pinnedDeploymentId),
+      ...Attribute.WorkflowDeploymentMismatchRetryCount(attempts),
+      ...Attribute.WorkflowDeploymentMismatchRecovered(outcome === 'rerouted'),
+    },
+  };
+}
+
+/**
+ * Arguments handed to a call site's re-enqueue closure. The guard owns the
+ * policy — counting, backoff, logging, telemetry, escalation — and the call
+ * site owns only the shape of the message it needs to put back on the queue.
+ */
+export interface ReenqueueArgs {
+  /** The deployment to target: the one the run is pinned to. */
+  deploymentId: string;
+  /**
+   * The run's spec version, so the world picks the right queue transport
+   * (CBOR vs JSON). Undefined on legacy runs that predate the field; worlds
+   * then fall back to their current default.
+   */
+  specVersion: number | undefined;
+  deploymentMismatchRetryCount: number;
+  /** Backoff before the re-routed message becomes visible. */
+  delaySeconds: number;
+}
+
+/**
+ * Guards deployment affinity: a run may only execute on the deployment it is
+ * pinned to.
+ *
+ * A run's `deploymentId` is fixed when it starts — the deployment that called
+ * `start()`, or whatever `start({ deploymentId })` resolved to (an explicit id
+ * or `'latest'`) — and no replay or step execution may happen anywhere else:
+ * the bundles here may not match the run's persisted history, and any step
+ * dispatched from here derives the per-run encryption key from the wrong
+ * deployment's master key, which surfaces as a `RuntimeDecryptionError` the
+ * queue retry callback swallows into a blank "exceeded max retries".
+ *
+ * A misrouted delivery is not treated as permanent. Rather than failing
+ * immediately, re-enqueue the message *explicitly targeted* at the run's own
+ * deployment; that send is strictly better-addressed than the one that
+ * misrouted, which inherited the producing deployment's ambient id. Fail only
+ * once the budget (`WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES`, default 3) is
+ * spent, mirroring how a replay divergence gets bounded recovery replays before
+ * being recorded as a corrupted event log.
+ *
+ * Callers must pass a run entity they already have in hand — every call site
+ * loads the run for other reasons — so the guard costs no extra round trip.
+ * (`world.getDeploymentId()` reads the ambient deployment id, e.g.
+ * `VERCEL_DEPLOYMENT_ID`, and does not call the backend either.)
+ *
+ * The failure is recorded **without resolving the run's encryption key**: the
+ * key is fetched from the pinned deployment's API, often unavailable once that
+ * deployment is past its retention window, so depending on it would throw here
+ * instead of recording the failure. The payload is written unencrypted (it
+ * holds only deployment ids, nothing sensitive), and the plaintext `errorCode`
+ * is the signal observability and the UI key off.
+ */
+export async function guardDeploymentAffinity({
+  world,
+  run,
+  requestId,
+  retryCount = 0,
+  reenqueue,
+  beforeStop,
+}: {
+  world: World;
+  run: Pick<WorkflowRun, 'runId' | 'deploymentId' | 'specVersion'>;
+  requestId?: string;
+  /** `deploymentMismatchRetryCount` from the incoming message, if any. */
+  retryCount?: number;
+  /**
+   * Puts this delivery's message back on the queue, targeted at the run's own
+   * deployment. Omitted by callers that cannot reconstruct their message, which
+   * makes the guard fail-fast.
+   */
+  reenqueue?: (args: ReenqueueArgs) => Promise<void>;
+  /**
+   * Ordering barrier awaited once a mismatch is confirmed, before either
+   * stopping action. Under turbo the `run_started` write is backgrounded, and
+   * both outcomes hand the run off (to a `run_failed` here, or to the pinned
+   * deployment's own `run_started`) — so that write must have landed first.
+   */
+  beforeStop?: () => Promise<void>;
+}): Promise<DeploymentAffinityResult> {
+  // Deployment affinity is only meaningful in worlds whose deployments are
+  // atomic and immutable, which the World declares (world-vercel does) and
+  // capabilities default to unsupported. Local and self-hosted worlds report a
+  // synthetic deployment id (e.g. `dpl_local@<sdk-version>`) that legitimately
+  // differs across SDK versions within one logical environment, so guarding
+  // them would fail ordinary local runs after a version bump.
+  if (world.capabilities?.deploymentAffinity !== true) {
+    return CONTINUE;
+  }
+
+  const currentDeploymentId = await world.getDeploymentId();
+  if (run.deploymentId === currentDeploymentId) {
+    return CONTINUE;
+  }
+
+  await beforeStop?.();
+
+  const maxRetries = getDeploymentMismatchMaxRetries();
+  const logContext = {
+    workflowRunId: run.runId,
+    pinnedDeploymentId: run.deploymentId,
+    actualDeploymentId: currentDeploymentId,
+    retryCount,
+    maxRetries,
+  };
+
+  /**
+   * Records the terminal `run_failed`. Mirrors `recordFatalRunError`: it
+   * records and returns rather than throwing, so the caller acks the message
+   * instead of letting the queue redeliver a run that is now terminal.
+   */
+  const failRun = async (
+    recoveryAttempts: number,
+    cause?: unknown
+  ): Promise<DeploymentAffinityResult> => {
+    const error = new WorkflowDeploymentMismatchError(
+      run.runId,
+      run.deploymentId,
+      currentDeploymentId,
+      { recoveryAttempts, cause }
+    );
+
+    try {
+      await world.events.create(
+        run.runId,
+        {
+          eventType: 'run_failed',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            // Unencrypted (undefined key): see the note on
+            // `guardDeploymentAffinity`. dehydrate/hydrate are self-describing,
+            // so this reads back without a key.
+            error: await dehydrateRunError(
+              error,
+              run.runId,
+              undefined,
+              undefined,
+              (run.specVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
+            ),
+            errorCode: RUN_ERROR_CODES.DEPLOYMENT_MISMATCH,
+          },
+        },
+        { requestId }
+      );
+    } catch (failError) {
+      // Run already reached a terminal state (a concurrent writer failed it, or
+      // it was cancelled/expired) — still stop. Anything else is a transient
+      // persistence failure: rethrow so the queue redelivers and we try again.
+      if (
+        !EntityConflictError.is(failError) &&
+        !RunExpiredError.is(failError)
+      ) {
+        throw failError;
+      }
+    }
+    return result('failed', run.deploymentId, recoveryAttempts);
+  };
+
+  if (reenqueue && retryCount < maxRetries) {
+    const attempt = retryCount + 1;
+    // Exponential, capped: 1s, 2s, 4s — cheap insurance against a hot
+    // re-enqueue loop, and time for a mid-flight routing change to settle.
+    const delaySeconds = Math.min(2 ** retryCount, MAX_REROUTE_DELAY_SECONDS);
+    try {
+      await reenqueue({
+        deploymentId: run.deploymentId,
+        specVersion: run.specVersion,
+        deploymentMismatchRetryCount: attempt,
+        delaySeconds,
+      });
+      runtimeLogger.warn(
+        'Workflow run received by a deployment it is not pinned to; re-routing to its own deployment',
+        { ...logContext, attempt, delaySeconds }
+      );
+      return result('rerouted', run.deploymentId, attempt);
+    } catch (reenqueueError) {
+      // The target deployment is unroutable — deleted, aged out of its
+      // retention window, or rejected by the queue. Burning the rest of the
+      // budget (plus its backoff) on a deployment that provably cannot be
+      // reached only delays the failure, so fail now.
+      runtimeLogger.error(
+        'Cannot re-route a misrouted workflow run to its own deployment; failing the run',
+        {
+          ...logContext,
+          attempt,
+          errorMessage:
+            reenqueueError instanceof Error
+              ? reenqueueError.message
+              : String(reenqueueError),
+        }
+      );
+      // Recovery never actually happened, so report 0 attempts and let `cause`
+      // explain why.
+      return failRun(0, reenqueueError);
+    }
+  }
+
+  runtimeLogger.error(
+    retryCount > 0
+      ? 'Workflow run kept arriving at a deployment it is not pinned to after re-routing; failing the run'
+      : 'Workflow run received by a deployment it is not pinned to; failing the run',
+    logContext
+  );
+  return failRun(retryCount);
+}

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -364,6 +364,21 @@ export const QueueOverheadMs = SemanticConvention<number>(
 /** Unique identifier for the deployment environment */
 export const DeploymentId = SemanticConvention<string>('deployment.id');
 
+/** The deployment a run is pinned to, set only on a misrouted delivery. */
+export const WorkflowRunPinnedDeploymentId = SemanticConvention<string>(
+  'workflow.deployment.pinned_id'
+);
+
+/** Re-route attempts for this misrouted delivery, including this one. */
+export const WorkflowDeploymentMismatchRetryCount = SemanticConvention<number>(
+  'workflow.deployment_mismatch.retry_count'
+);
+
+/** Whether the misrouted delivery was re-routed instead of failing the run. */
+export const WorkflowDeploymentMismatchRecovered = SemanticConvention<boolean>(
+  'workflow.deployment_mismatch.recovered'
+);
+
 // Hook attributes
 
 /** Token identifying a specific hook */

--- a/packages/errors/src/error-codes.ts
+++ b/packages/errors/src/error-codes.ts
@@ -20,6 +20,8 @@ export const RUN_ERROR_CODES = {
   REPLAY_TIMEOUT: 'REPLAY_TIMEOUT',
   /** World response violated the SDK contract and cannot be retried safely */
   WORLD_CONTRACT_ERROR: 'WORLD_CONTRACT_ERROR',
+  /** Run was delivered to a deployment other than the one it is pinned to */
+  DEPLOYMENT_MISMATCH: 'DEPLOYMENT_MISMATCH',
 } as const;
 
 export type RunErrorCode =

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,4 +1,4 @@
-import { parseDurationToDate } from '@workflow/utils';
+import { parseDurationToDate, pluralize } from '@workflow/utils';
 
 import type { StringValue } from 'ms';
 
@@ -89,6 +89,7 @@ export const ERROR_SLUGS = {
   STEP_NOT_REGISTERED: 'step-not-registered',
   WORKFLOW_NOT_REGISTERED: 'workflow-not-registered',
   RUNTIME_DECRYPTION_FAILED: 'runtime-decryption-failed',
+  DEPLOYMENT_MISMATCH: 'deployment-mismatch',
 } as const;
 
 type ErrorSlug = (typeof ERROR_SLUGS)[keyof typeof ERROR_SLUGS];
@@ -587,6 +588,53 @@ export class WorkflowNotRegisteredError extends WorkflowRuntimeError {
 
   static is(value: unknown): value is WorkflowNotRegisteredError {
     return isError(value) && value.name === 'WorkflowNotRegisteredError';
+  }
+}
+
+/**
+ * Thrown when a workflow run is delivered to a deployment other than the one
+ * it is pinned to.
+ *
+ * A run is pinned to one deployment when it starts, and executing anywhere
+ * else is unsafe: that deployment's bundles may not match the run's history.
+ */
+export class WorkflowDeploymentMismatchError extends WorkflowRuntimeError {
+  readonly runId: string;
+  readonly expectedDeploymentId: string;
+  readonly actualDeploymentId: string;
+  /**
+   * How many times the runtime re-routed the message before giving up. `0`
+   * means recovery was never attempted: the budget is disabled, or the
+   * re-route itself failed and `cause` holds the enqueue error.
+   */
+  readonly recoveryAttempts: number;
+
+  constructor(
+    runId: string,
+    expectedDeploymentId: string,
+    actualDeploymentId: string,
+    options?: { recoveryAttempts?: number; cause?: unknown }
+  ) {
+    const recoveryAttempts = options?.recoveryAttempts ?? 0;
+    // Carried in the persisted message, not just a log line: the attempt count
+    // separates racing routing from a deployment that is simply gone.
+    const recovery =
+      recoveryAttempts > 0
+        ? ` The runtime re-routed the message to "${expectedDeploymentId}" ${recoveryAttempts} ${pluralize('time', 'times', recoveryAttempts)} and it kept arriving elsewhere, so the run was stopped to protect against code-skew errors.`
+        : ' The run was stopped to protect against code-skew errors.';
+    super(
+      `Workflow run "${runId}" is pinned to deployment "${expectedDeploymentId}", but was received by deployment "${actualDeploymentId}".${recovery} Verify that the run's deployment is still available and that queue callbacks are routed to it.`,
+      { slug: ERROR_SLUGS.DEPLOYMENT_MISMATCH, cause: options?.cause }
+    );
+    this.name = 'WorkflowDeploymentMismatchError';
+    this.runId = runId;
+    this.expectedDeploymentId = expectedDeploymentId;
+    this.actualDeploymentId = actualDeploymentId;
+    this.recoveryAttempts = recoveryAttempts;
+  }
+
+  static is(value: unknown): value is WorkflowDeploymentMismatchError {
+    return isError(value) && value.name === 'WorkflowDeploymentMismatchError';
   }
 }
 

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -42,6 +42,9 @@ export function createWorld(config?: APIConfig): World {
       // WORKFLOW_SEQUENTIAL_REPLAYS=1 uses for per-run `maxConcurrency: 1`
       // flow topics (see queue.ts and @workflow/builders).
       maxConcurrency: true,
+      // Vercel deployments are atomic and immutable, so a deployment id names
+      // one fixed build for its whole lifetime.
+      deploymentAffinity: true,
       // NOTE: the backend half of resumeHook()'s parallel fast path — that
       // the server enforces the `(runId, resumeId)` dedup constraint — is
       // NO LONGER a static world capability here. It is attested per-lookup by

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockSend,
+  MockConsumerDiscoveryError,
   MockDuplicateMessageError,
   MockQueueClient,
   mockHandleCallback,
@@ -12,6 +13,13 @@ const {
       super(message);
       this.name = 'DuplicateMessageError';
       this.idempotencyKey = idempotencyKey;
+    }
+  }
+
+  class MockConsumerDiscoveryError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'ConsumerDiscoveryError';
     }
   }
 
@@ -29,6 +37,7 @@ const {
 
   return {
     mockSend,
+    MockConsumerDiscoveryError,
     MockDuplicateMessageError,
     MockQueueClient,
     mockHandleCallback,
@@ -37,6 +46,7 @@ const {
 
 vi.mock('@vercel/queue', () => ({
   QueueClient: MockQueueClient,
+  ConsumerDiscoveryError: MockConsumerDiscoveryError,
   DuplicateMessageError: MockDuplicateMessageError,
 }));
 
@@ -58,6 +68,19 @@ describe('createQueue', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('classifies only consumer discovery failures as unavailable deployments', () => {
+    const queue = createQueue();
+
+    expect(
+      queue.isDeploymentUnavailableError?.(
+        new MockConsumerDiscoveryError('deployment not found')
+      )
+    ).toBe(true);
+    expect(
+      queue.isDeploymentUnavailableError?.(new Error('transient send failure'))
+    ).toBe(false);
   });
 
   describe('proxy region header', () => {

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -1,6 +1,10 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Transport } from '@vercel/queue';
-import { DuplicateMessageError, QueueClient } from '@vercel/queue';
+import {
+  ConsumerDiscoveryError,
+  DuplicateMessageError,
+  QueueClient,
+} from '@vercel/queue';
 import {
   MessageId,
   type Queue,
@@ -535,5 +539,14 @@ export function createQueue(config?: APIConfig): Queue {
     return deploymentId;
   };
 
-  return { queue, createQueueHandler, getDeploymentId };
+  const isDeploymentUnavailableError: Queue['isDeploymentUnavailableError'] = (
+    error
+  ) => error instanceof ConsumerDiscoveryError;
+
+  return {
+    queue,
+    createQueueHandler,
+    getDeploymentId,
+    isDeploymentUnavailableError,
+  };
 }

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -387,6 +387,21 @@ export interface WorldCapabilities {
    * `resumeCapabilities.hookResumeDedupVersion` on the by-token hook.
    */
   hookResumeDedup?: boolean;
+
+  /**
+   * Deployments are atomic and immutable: a deployment id names one fixed
+   * build for its whole lifetime, so a run pinned to one may only execute
+   * there. Worlds that declare this get the runtime's deployment-affinity
+   * guard, which re-routes a misrouted delivery to the run's own deployment
+   * and ultimately fails the run with `DEPLOYMENT_MISMATCH`.
+   *
+   * Worlds whose deployment id is synthetic or version-tagged (e.g.
+   * `dpl_local@<sdk-version>`, which legitimately differs across SDK versions
+   * within one logical environment) must leave this unset: there a
+   * "mismatch" is not a real cross-deployment delivery, and guarding would
+   * fail ordinary runs after a version bump.
+   */
+  deploymentAffinity?: boolean;
 }
 
 /**

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -193,6 +193,8 @@ export const WorkflowInvokePayloadSchema = z.object({
   preconditionReinvocations: z.number().int().positive().optional(),
   /** Number of times this message has been re-enqueued due to server errors (5xx) */
   serverErrorRetryCount: z.number().int().optional(),
+  /** Number of times this message has been re-routed after a deployment mismatch */
+  deploymentMismatchRetryCount: z.number().int().nonnegative().optional(),
   /** Step ID for inline step execution in combined handler. If provided, the flow execution
    * will jump directly to execute the step with the given ID before doing an event replay. */
   stepId: z.string().optional(),

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -282,6 +282,13 @@ export interface Queue {
   getDeploymentId(): Promise<string>;
 
   /**
+   * Returns true only when a queue error definitively means the explicitly
+   * targeted deployment cannot receive the message. Unknown and transient
+   * errors must return false so the current delivery can be retried safely.
+   */
+  isDeploymentUnavailableError?(error: unknown): boolean;
+
+  /**
    * Enqueues a message to the specified queue.
    *
    * @param queueName - The name of the queue to which the message will be sent.


### PR DESCRIPTION
## Summary & Motivation

A queue callback that reaches a deployment other than the one its run is pinned to derives the per-run encryption key from the wrong master key, so the delivery fails before user code runs and the run dies as a blank "exceeded max retries". The delivery is re-enqueued explicitly addressed to the run's own deployment — strictly better-targeted than the send that misrouted — and the run is failed with the new `DEPLOYMENT_MISMATCH` error code only once `WORKFLOW_DEPLOYMENT_MISMATCH_MAX_RETRIES` (default 3) is spent. Gated on the new World capability `deploymentAffinity`, so worlds with synthetic or version-tagged deployment ids are unaffected.

## Test Plan

Unit tests added for the guard and both runtime paths; local vitest and typechecks pass.
