### PR TITLE
feat(web-shared): tooltip on event list icons in new trace viewer

### DIFF
--- a/.changeset/trace-viewer-event-icon-tooltips.md
+++ b/.changeset/trace-viewer-event-icon-tooltips.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Show a delayed tooltip (Step, Hook, Sleep, Workflow) when hovering the icon on each row in the new trace viewer's event list.

--- a/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/event-list.tsx
@@ -2,6 +2,7 @@ import { Circle } from 'lucide-react';
 import { useRef } from 'react';
 import { cn } from '../../../lib/cn';
 import { formatDurationPrecise } from '../../trace-viewer/util/timing';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../ui/tooltip';
 import {
   SleepIcon,
   StepForwardIcon,
@@ -17,18 +18,20 @@ import { ROW_HEIGHT_PX, useRowWindow } from './use-row-window';
 interface EventStyle {
   icon: React.ComponentType<{ className?: string }>;
   className: string;
+  label: string;
 }
 
 const eventStyles: Record<string, EventStyle> = {
-  run: { icon: WorkflowIcon, className: 'text-blue-900' },
-  step: { icon: StepForwardIcon, className: 'text-green-900' },
-  hook: { icon: WebhookIcon, className: 'text-gray-900' },
-  sleep: { icon: SleepIcon, className: 'text-gray-900' },
+  run: { icon: WorkflowIcon, className: 'text-blue-900', label: 'Workflow' },
+  step: { icon: StepForwardIcon, className: 'text-green-900', label: 'Step' },
+  hook: { icon: WebhookIcon, className: 'text-gray-900', label: 'Hook' },
+  sleep: { icon: SleepIcon, className: 'text-gray-900', label: 'Sleep' },
 };
 
 const defaultStyle: EventStyle = {
   icon: Circle,
   className: 'text-gray-900',
+  label: 'Event',
 };
 
 const ROW_HEIGHT_CLASS = 'h-10';
@@ -38,6 +41,7 @@ function getEventStyle(resource: string, isErrored: boolean): EventStyle {
   return {
     icon: style.icon,
     className: cn(isErrored ? 'text-red-900' : style.className),
+    label: style.label,
   };
 }
 
@@ -54,10 +58,11 @@ const EventRow = ({
 }) => {
   const durationMs = getSpanDurationMs(span);
   const isErrored = isSpanErrored(span);
-  const { icon: Icon, className: tagClassName } = getEventStyle(
-    span.resource,
-    isErrored
-  );
+  const {
+    icon: Icon,
+    className: tagClassName,
+    label: iconLabel,
+  } = getEventStyle(span.resource, isErrored);
 
   return (
     <li
@@ -75,9 +80,14 @@ const EventRow = ({
       <div className="h-full hover:bg-gray-100 group-aria-selected:bg-gray-100 group-aria-selected:hover:bg-gray-200">
         <div className="flex h-full min-w-0 items-center pl-4 pr-2">
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <span className={cn('shrink-0', tagClassName)}>
-              <Icon className="w-4 h-4" />
-            </span>
+            <Tooltip delayDuration={500}>
+              <TooltipTrigger asChild>
+                <span className={cn('shrink-0', tagClassName)}>
+                  <Icon className="w-4 h-4" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">{iconLabel}</TooltipContent>
+            </Tooltip>
             <span className="min-w-0 text-label-14">
               <MiddleTruncate value={span.name} />
             </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a delayed tooltip over the icon on each row in the new trace viewer's event list so users can tell at a glance what each icon represents.

Labels map by span `resource`:

| resource | label |
|----------|-------|
| `run` | Workflow |
| `step` | Step |
| `hook` | Hook |
| `sleep` | Sleep |
| fallback | Event |

The tooltip uses a 500ms `delayDuration` so it doesn't flash on incidental mouse movement across the list, and it lives inside the existing `TooltipProvider` in `new-trace-viewer/trace-viewer.tsx`.

### How did you test your changes?

- `pnpm typecheck` in `packages/web-shared` passes.
- Verified via reading — tooltip wraps only the icon `<span>`, so row click / hover selection behavior is unchanged. Radix `Tooltip` renders content in a portal (`z-[99999]`), so it isn't clipped by the list's virtualization windowing.

Not covered by an automated test — this is a small presentational addition and the observability UI relies primarily on visual QA per the PR template.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0AFKL7AT9N/p1784231598810929?thread_ts=1784231598.810929&cid=C0AFKL7AT9N)

<div><a href="https://cursor.com/agents/bc-02bba22b-46c3-5299-8f15-a615c573f799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02bba22b-46c3-5299-8f15-a615c573f799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

