### PR TITLE
feat(core): experimental in-process VM continuation for inline replay

### DIFF
--- a/.changeset/vm-continuation.md
+++ b/.changeset/vm-continuation.md
@@ -2,4 +2,4 @@
 '@workflow/core': minor
 ---
 
-Add experimental in-process VM continuation (`WORKFLOW_VM_CONTINUATION=1`, off by default). When enabled, the inline replay loop keeps a suspended workflow VM alive and feeds newly-appended events into it for step-only suspensions, instead of rebuilding the `vm.Context` and replaying the event log from scratch each pass. Falls back to a full replay on any prefix divergence or non-step suspension, so behavior with the flag off is unchanged.
+Add in-process VM continuation (on by default; kill switch `WORKFLOW_VM_CONTINUATION=0`). The inline replay loop now keeps a suspended workflow VM alive and feeds newly-appended events into it for step-only suspensions, instead of rebuilding the `vm.Context` and replaying the event log from scratch each pass. Falls back to a full replay on any prefix divergence or non-step suspension, so the kill switch restores the previous behavior exactly.

--- a/.changeset/vm-continuation.md
+++ b/.changeset/vm-continuation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Add experimental in-process VM continuation (`WORKFLOW_VM_CONTINUATION=1`, off by default). When enabled, the inline replay loop keeps a suspended workflow VM alive and feeds newly-appended events into it for step-only suspensions, instead of rebuilding the `vm.Context` and replaying the event log from scratch each pass. Falls back to a full replay on any prefix divergence or non-step suspension, so behavior with the flag off is unchanged.

--- a/packages/core/src/events-consumer.ts
+++ b/packages/core/src/events-consumer.ts
@@ -1,3 +1,4 @@
+import { ReplayDivergenceError } from '@workflow/errors';
 import { type Event, envNumber } from '@workflow/world';
 import { eventsLogger } from './logger.js';
 
@@ -69,7 +70,7 @@ export interface EventsConsumerOptions {
 
 export class EventsConsumer {
   eventIndex: number;
-  readonly events: Event[] = [];
+  events: Event[] = [];
   readonly callbacks: EventConsumerCallback[] = [];
   private onConsumedEvent?: (event: Event) => void;
   private onUnconsumedEvent: (event: Event) => void;
@@ -108,6 +109,39 @@ export class EventsConsumer {
         this.pendingUnconsumedTimeout = null;
       }
     }
+    process.nextTick(this.consume);
+  }
+
+  /**
+   * Resume consuming against an updated event log without rebuilding the VM.
+   *
+   * Used by the in-process VM-continuation path (see
+   * `isVmContinuationEnabled`): after new events are appended to the run's log
+   * (e.g. an inline step's `step_completed`), the loop adopts the authoritative
+   * array here and re-drives {@link consume} so the still-registered step
+   * consumers advance the SAME live workflow VM to its next suspension point.
+   *
+   * Safety: the events already consumed by this instance (indices
+   * `0..eventIndex`) MUST be a byte-stable prefix of `events` — the durable log
+   * is the source of truth, and a live VM that consumed a now-diverged prefix
+   * can no longer be trusted. Any mismatch throws {@link ReplayDivergenceError}
+   * so the caller falls back to a full replay in a fresh VM. Matching is by
+   * `eventId`, which is immutable per event across reads.
+   */
+  resume(events: Event[]): void {
+    for (let i = 0; i < this.eventIndex; i++) {
+      const consumed = this.events[i];
+      const incoming = events[i];
+      if (!incoming || consumed?.eventId !== incoming.eventId) {
+        throw new ReplayDivergenceError(
+          `VM continuation prefix diverged at index ${i}: consumed ` +
+            `${consumed?.eventId ?? '<none>'} but the authoritative log has ` +
+            `${incoming?.eventId ?? '<none>'}.`,
+          { eventId: incoming?.eventId ?? consumed?.eventId }
+        );
+      }
+    }
+    this.events = events;
     process.nextTick(this.consume);
   }
 

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -69,6 +69,23 @@ export type QueueItem =
   | AttributeInvocationQueueItem;
 
 /**
+ * Handle attached to a {@link WorkflowSuspension} when in-process VM
+ * continuation is armed (see `isVmContinuationEnabled`). Calling `resume`
+ * feeds newly-appended events into the SAME live workflow VM that produced the
+ * suspension and drives it to its next checkpoint, returning the workflow's
+ * dehydrated result on completion or throwing the next `WorkflowSuspension`
+ * (which itself may carry a fresh `continuation`). It throws
+ * `ReplayDivergenceError` if the live VM's consumed prefix no longer matches
+ * the authoritative log, signalling the caller to fall back to a full replay.
+ *
+ * `events` is the authoritative event array (`@workflow/world` `Event[]`),
+ * typed loosely here to keep `global.ts` free of the world dependency.
+ */
+export interface WorkflowContinuation {
+  resume(events: unknown[]): Promise<Uint8Array | unknown>;
+}
+
+/**
  * An error that is thrown when one or more operations (steps/hooks/etc.) are called but do
  * not yet have corresponding entries in the event log. The workflow
  * dispatcher will catch this error and push the operations
@@ -83,6 +100,14 @@ export class WorkflowSuspension extends Error {
   attributeCount: number;
   hookDisposedCount: number;
   abortCount: number;
+  /**
+   * Set by `runWorkflow` when in-process VM continuation is armed for this
+   * (step-only) suspension. When present, the inline replay loop can resume
+   * the SAME live VM with newly-appended events instead of rebuilding the
+   * context and replaying from scratch. Absent when continuation is disabled
+   * or the suspension is not continuation-eligible.
+   */
+  continuation?: WorkflowContinuation;
 
   constructor(stepsInput: Map<string, QueueItem>, global: typeof globalThis) {
     // Convert Map to array for iteration and storage

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -32,7 +32,11 @@ import {
   isWorldContractError,
 } from './classify-error.js';
 import { describeError } from './describe-error.js';
-import { type StepInvocationQueueItem, WorkflowSuspension } from './global.js';
+import {
+  type StepInvocationQueueItem,
+  type WorkflowContinuation,
+  WorkflowSuspension,
+} from './global.js';
 import { runtimeLogger } from './logger.js';
 import { ReplayPayloadCache } from './replay-payload-cache.js';
 import {
@@ -40,6 +44,7 @@ import {
   getReplayDivergenceMaxRetries,
   isInlineOwnershipEnabled,
   isTurboEnabled,
+  isVmContinuationEnabled,
 } from './runtime/constants.js';
 import {
   getQueueOverhead,
@@ -546,6 +551,17 @@ export function workflowEntrypoint(
                     events: Event[];
                     cursor: string | null;
                   } | null = null;
+
+                  // In-process VM continuation (experimental, off by default —
+                  // see isVmContinuationEnabled). When a step-only suspension
+                  // arms a continuation, it is stashed here so the NEXT loop
+                  // iteration resumes the SAME live workflow VM with the freshly
+                  // appended events instead of rebuilding the context and
+                  // replaying the whole event log. Cleared whenever a resume
+                  // diverges (falls back to a fresh replay) or the suspension is
+                  // not continuation-eligible.
+                  const vmContinuationEnabled = isVmContinuationEnabled();
+                  let pendingContinuation: WorkflowContinuation | null = null;
 
                   // Shared state: set by either the background step path
                   // or the run_started setup below.
@@ -1429,22 +1445,56 @@ export function workflowEntrypoint(
                       // Start every missing decrypt/decompress operation before
                       // VM setup. Web Crypto work can overlap bundle evaluation;
                       // consumers still deserialize and resolve in event order.
+                      // Also warms the cache for a continuation resume, whose
+                      // step consumers hydrate the newly-appended results.
                       const payloadPrewarm = replayPayloadCache.prewarm(
                         workflowRun,
                         events
                       );
-                      const result = await runWorkflow(
-                        workflowCode,
-                        workflowRun,
-                        events,
-                        encryptionKey,
-                        replayPayloadCache,
-                        // Turbo: the end-of-run drain inside runWorkflow commits
-                        // fire-and-forget `*_created` events before the terminal
-                        // `awaitRunReady()` below, so gate those writes on the
-                        // backgrounded run_started too. Undefined outside turbo.
-                        runReadyBarrier
-                      );
+                      // Fresh replay in a new VM, unless a prior step-only
+                      // suspension armed a continuation — in which case resume
+                      // the SAME live VM with the freshly appended events. Both
+                      // paths obey the same contract: return the dehydrated
+                      // result, or throw a WorkflowSuspension (which may carry a
+                      // fresh continuation). A resume whose consumed prefix has
+                      // diverged from the authoritative log throws
+                      // ReplayDivergenceError; we swallow it here and fall back
+                      // to a full replay in a fresh VM so behavior degrades to
+                      // exactly today's.
+                      const runReplay = () =>
+                        runWorkflow(
+                          workflowCode,
+                          workflowRun,
+                          events,
+                          encryptionKey,
+                          replayPayloadCache,
+                          // Turbo: the end-of-run drain inside runWorkflow commits
+                          // fire-and-forget `*_created` events before the terminal
+                          // `awaitRunReady()` below, so gate those writes on the
+                          // backgrounded run_started too. Undefined outside turbo.
+                          runReadyBarrier,
+                          vmContinuationEnabled
+                        );
+                      let result: Uint8Array | unknown;
+                      if (pendingContinuation) {
+                        const continuation = pendingContinuation;
+                        pendingContinuation = null;
+                        try {
+                          result = await continuation.resume(events);
+                        } catch (resumeErr) {
+                          if (ReplayDivergenceError.is(resumeErr)) {
+                            runtimeLogger.debug(
+                              'VM continuation resume diverged; falling back to full replay',
+                              { workflowRunId: runId, loopIteration }
+                            );
+                            result = await runReplay();
+                          } else {
+                            throw resumeErr;
+                          }
+                        }
+                      } else {
+                        result = await runReplay();
+                      }
                       await payloadPrewarm;
                       runtimeLogger.debug('Workflow replay completed', {
                         workflowRunId: runId,
@@ -1496,6 +1546,14 @@ export function workflowEntrypoint(
                       return;
                     } catch (err) {
                       if (WorkflowSuspension.is(err)) {
+                        // VM continuation: a step-only suspension carries a
+                        // handle that resumes the same live VM next iteration.
+                        // Non-eligible suspensions (hooks/waits/attrs) leave it
+                        // undefined, so we fall back to a fresh replay. The
+                        // handle is process-local and dropped if this invocation
+                        // returns instead of looping.
+                        pendingContinuation = err.continuation ?? null;
+
                         // Synchronous `runWorkflow` duration for THIS
                         // suspension only — anchors the `finalSchedulingReplay`
                         // telemetry field below (see

--- a/packages/core/src/runtime/constants.ts
+++ b/packages/core/src/runtime/constants.ts
@@ -294,6 +294,32 @@ export function isInlineOwnershipEnabled(): boolean {
 }
 
 /**
+ * Whether in-process VM continuation is enabled (default OFF — experimental).
+ *
+ * When on, the inline replay loop keeps a suspended workflow VM alive across
+ * iterations instead of rebuilding the `vm.Context` and replaying the whole
+ * event log from event 1 on every pass. After an inline step's terminal event
+ * is appended, the loop feeds the newly-appended events into the SAME live VM
+ * (resolving the pending step promise) so the workflow body advances to its
+ * next suspension point — skipping the from-scratch replay entirely.
+ *
+ * This is sound ONLY within a single invocation's inline loop: the same process
+ * holds the VM and the same handler owns the appended writes, so the durable
+ * event log stays authoritative. It is scoped further to *simple, step-only*
+ * suspensions (no hooks/waits/attribute writes); any other suspension, or any
+ * divergence between the live VM's consumed prefix and the authoritative log,
+ * makes the continuation bail out and the loop falls back to a full replay in
+ * a fresh VM. Worst case is therefore identical to today's behavior.
+ *
+ * `WORKFLOW_VM_CONTINUATION=1` (or `true`) opts in. Default OFF.
+ */
+export function isVmContinuationEnabled(): boolean {
+  const raw = process.env.WORKFLOW_VM_CONTINUATION;
+  if (raw === undefined || raw === '') return false;
+  return raw === '1' || raw.toLowerCase() === 'true';
+}
+
+/**
  * Default inline-ownership lease, in seconds: how long after a step's latest
  * (stamped) `step_started` a non-owner invocation assumes the owning
  * invocation may still be alive. Within the lease, wake replays enqueue the

--- a/packages/core/src/runtime/constants.ts
+++ b/packages/core/src/runtime/constants.ts
@@ -309,14 +309,16 @@ export function isInlineOwnershipEnabled(): boolean {
  * suspensions (no hooks/waits/attribute writes); any other suspension, or any
  * divergence between the live VM's consumed prefix and the authoritative log,
  * makes the continuation bail out and the loop falls back to a full replay in
- * a fresh VM. Worst case is therefore identical to today's behavior.
+ * a fresh VM. Worst case is therefore identical to the from-scratch replay path.
  *
- * `WORKFLOW_VM_CONTINUATION=1` (or `true`) opts in. Default OFF.
+ * Default **ON** so CI and benchmarks exercise (and measure) the continuation
+ * path. `WORKFLOW_VM_CONTINUATION=0` (or `false`) is the kill switch that
+ * reverts to rebuilding the VM and replaying from scratch on every pass.
  */
 export function isVmContinuationEnabled(): boolean {
   const raw = process.env.WORKFLOW_VM_CONTINUATION;
-  if (raw === undefined || raw === '') return false;
-  return raw === '1' || raw.toLowerCase() === 'true';
+  if (raw === undefined || raw === '') return true;
+  return !(raw === '0' || raw.toLowerCase() === 'false');
 }
 
 /**

--- a/packages/core/src/vm-continuation-loop.test.ts
+++ b/packages/core/src/vm-continuation-loop.test.ts
@@ -1,0 +1,184 @@
+import {
+  type Event,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+} from '@workflow/world';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Spy on VM-context construction while preserving the real implementation, so
+// we can prove the continuation path builds ONE VM for a whole run instead of
+// one per replay iteration. workflow.ts imports `createContext` from this same
+// module, so the spy observes its constructions too.
+vi.mock('./vm/index.js', async (importActual) => {
+  const actual = await importActual<typeof import('./vm/index.js')>();
+  return { ...actual, createContext: vi.fn(actual.createContext) };
+});
+
+const { createContext } = await import('./vm/index.js');
+const { registerStepFunction } = await import('./private.js');
+const { setWorld } = await import('./runtime/world.js');
+const { workflowEntrypoint } = await import('./runtime.js');
+const { dehydrateWorkflowArguments } = await import('./serialization.js');
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn((p: Promise<unknown>) => {
+    p.catch(() => {});
+  }),
+}));
+
+const createContextSpy = createContext as unknown as ReturnType<typeof vi.fn>;
+
+// Sequential two-step workflow: two replay-advancing suspensions before it
+// completes — so a from-scratch replay rebuilds the VM three times while
+// continuation builds it once.
+const xform = (name: string) =>
+  `;globalThis.__private_workflows = new Map();
+   globalThis.__private_workflows.set(${JSON.stringify(name)}, ${name});`;
+
+const twoStepWorkflow = `const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("c_s1");
+  const s2 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("c_s2");
+  async function workflow() {
+    const a = await s1();
+    const b = await s2();
+    return a + b;
+  }${xform('workflow')}`;
+
+registerStepFunction('c_s1', async () => 10);
+registerStepFunction('c_s2', async () => 20);
+
+async function makeRun(runId: string): Promise<WorkflowRun> {
+  return {
+    runId,
+    workflowName: 'workflow',
+    status: 'running',
+    input: await dehydrateWorkflowArguments([], runId, undefined, []),
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    startedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deploymentId: 'test-deployment',
+  };
+}
+
+// Drive the full workflow handler over a stateful (dynamic) event log so the
+// inline loop makes real progress across its own writes, exactly like a World.
+// Non-turbo (no runInput, attempt 2) to keep the path simple and deterministic.
+async function drive(runId: string) {
+  const run = await makeRun(runId);
+  const events: Event[] = [];
+  const createdEvents: any[] = [];
+  let seq = 0;
+
+  const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+    createdEvents.push(data);
+    if (data.eventType === 'run_started') {
+      return { run, events };
+    }
+    const event = {
+      eventId: `e-${++seq}`,
+      runId,
+      createdAt: new Date(),
+      ...data,
+    } as Event;
+    events.push(event);
+    // step_started returns a running step entity so executeStep proceeds to
+    // run the body and write step_completed.
+    if (data.eventType === 'step_started') {
+      const d = data.eventData as { stepName?: string; input?: unknown };
+      return {
+        event,
+        step: {
+          runId,
+          stepId: data.correlationId,
+          stepName: d?.stepName,
+          status: 'running' as const,
+          attempt: 1,
+          input: d?.input,
+          startedAt: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        ...(d?.input !== undefined ? { stepCreated: true } : {}),
+      };
+    }
+    return { event };
+  });
+
+  setWorld({
+    specVersion: SPEC_VERSION_CURRENT,
+    createQueueHandler: vi.fn(
+      (_p: string, handler: (m: unknown, md: unknown) => Promise<unknown>) =>
+        async () => {
+          await handler(
+            { runId, requestedAt: new Date('2024-01-01T00:00:00.000Z') },
+            {
+              requestId: 'req_c',
+              attempt: 2,
+              queueName: '__wkf_workflow_workflow',
+              messageId: 'msg_c',
+            }
+          );
+          return new Response(null, { status: 204 });
+        }
+    ),
+    events: {
+      create: eventsCreate,
+      list: vi.fn(async () => ({
+        data: [...events],
+        hasMore: false,
+        cursor: 'cursor_c',
+      })),
+    },
+    runs: { get: vi.fn(async () => run) },
+    queue: vi.fn(async () => ({ messageId: null })),
+    getEncryptionKeyForRun: vi.fn(async () => undefined),
+  } as any);
+
+  await workflowEntrypoint(twoStepWorkflow)(
+    new Request('https://example.test')
+  );
+
+  const runCompleted = createdEvents.find(
+    (e) => e.eventType === 'run_completed'
+  );
+  return {
+    vmBuilds: createContextSpy.mock.calls.length,
+    output: runCompleted?.eventData?.output as Uint8Array | undefined,
+  };
+}
+
+describe('VM continuation through the inline replay loop', () => {
+  beforeEach(() => {
+    createContextSpy.mockClear();
+  });
+  afterEach(() => {
+    delete process.env.WORKFLOW_VM_CONTINUATION;
+    setWorld(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('rebuilds the VM once per replay when continuation is OFF (baseline)', async () => {
+    delete process.env.WORKFLOW_VM_CONTINUATION;
+    const { vmBuilds, output } = await drive('wrun_cont_off');
+    expect(output).toBeInstanceOf(Uint8Array);
+    // A 2-step sequential workflow suspends twice then completes → >1 replay,
+    // each rebuilding the VM from scratch.
+    expect(vmBuilds).toBeGreaterThan(1);
+  });
+
+  it('builds the VM once and resumes it when continuation is ON', async () => {
+    // Baseline (continuation OFF) to compare the dehydrated result against.
+    delete process.env.WORKFLOW_VM_CONTINUATION;
+    const off = await drive('wrun_cont_on_baseline_off');
+    createContextSpy.mockClear();
+
+    process.env.WORKFLOW_VM_CONTINUATION = '1';
+    const on = await drive('wrun_cont_on');
+
+    expect(on.output).toBeInstanceOf(Uint8Array);
+    // The whole run is served by a single VM: built once on the first pass,
+    // resumed (not rebuilt) for every subsequent step.
+    expect(on.vmBuilds).toBe(1);
+    // And it produces the identical dehydrated result as the replay path.
+    expect(on.output).toEqual(off.output);
+  });
+});

--- a/packages/core/src/vm-continuation-loop.test.ts
+++ b/packages/core/src/vm-continuation-loop.test.ts
@@ -156,8 +156,8 @@ describe('VM continuation through the inline replay loop', () => {
     vi.clearAllMocks();
   });
 
-  it('rebuilds the VM once per replay when continuation is OFF (baseline)', async () => {
-    delete process.env.WORKFLOW_VM_CONTINUATION;
+  it('rebuilds the VM once per replay under the kill switch (WORKFLOW_VM_CONTINUATION=0)', async () => {
+    process.env.WORKFLOW_VM_CONTINUATION = '0';
     const { vmBuilds, output } = await drive('wrun_cont_off');
     expect(output).toBeInstanceOf(Uint8Array);
     // A 2-step sequential workflow suspends twice then completes → >1 replay,
@@ -165,13 +165,14 @@ describe('VM continuation through the inline replay loop', () => {
     expect(vmBuilds).toBeGreaterThan(1);
   });
 
-  it('builds the VM once and resumes it when continuation is ON', async () => {
-    // Baseline (continuation OFF) to compare the dehydrated result against.
-    delete process.env.WORKFLOW_VM_CONTINUATION;
+  it('builds the VM once and resumes it when continuation is ON (the default)', async () => {
+    // Baseline via the kill switch, to compare the dehydrated result against.
+    process.env.WORKFLOW_VM_CONTINUATION = '0';
     const off = await drive('wrun_cont_on_baseline_off');
     createContextSpy.mockClear();
 
-    process.env.WORKFLOW_VM_CONTINUATION = '1';
+    // Unset → continuation is ON by default.
+    delete process.env.WORKFLOW_VM_CONTINUATION;
     const on = await drive('wrun_cont_on');
 
     expect(on.output).toBeInstanceOf(Uint8Array);

--- a/packages/core/src/vm-continuation.test.ts
+++ b/packages/core/src/vm-continuation.test.ts
@@ -1,0 +1,159 @@
+import { ReplayDivergenceError } from '@workflow/errors';
+import type { Event } from '@workflow/world';
+import * as nanoid from 'nanoid';
+import { monotonicFactory } from 'ulid';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventsConsumer } from './events-consumer.js';
+import type { WorkflowOrchestratorContext } from './private.js';
+import { ReplayPayloadCache } from './replay-payload-cache.js';
+import { dehydrateStepReturnValue } from './serialization.js';
+import { createUseStep } from './step.js';
+import { createContext } from './vm/index.js';
+
+/**
+ * Focused tests for the in-process VM-continuation primitive: after new events
+ * are appended to a run's log, {@link EventsConsumer.resume} re-drives the SAME
+ * live step consumers so the workflow body advances — instead of rebuilding the
+ * VM and replaying from event 0. These exercise the resume mechanic and its
+ * prefix-divergence guard directly through the real `createUseStep` consumer.
+ *
+ * The correlation IDs used here (`step_01K11TFZ62YS0YYFDQ3E8B9YCV` /`…YCW`) are
+ * the first two IDs the deterministic monotonic ULID factory produces for seed
+ * `'test'` at the pinned timestamp — the same anchoring as
+ * `step-hydration-memoization.test.ts`.
+ */
+
+function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
+  const context = createContext({
+    seed: 'test',
+    fixedTimestamp: 1753481739458,
+  });
+  const ulid = monotonicFactory(() => context.globalThis.Math.random());
+  const workflowStartedAt = context.globalThis.Date.now();
+  const holder = { current: Promise.resolve() };
+  return {
+    runId: 'wrun_test',
+    encryptionKey: undefined,
+    globalThis: context.globalThis,
+    eventsConsumer: new EventsConsumer(events, {
+      onUnconsumedEvent: () => {},
+      getPromiseQueue: () => holder.current,
+    }),
+    invocationsQueue: new Map(),
+    generateUlid: () => ulid(workflowStartedAt),
+    generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
+      new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
+    ),
+    onWorkflowError: vi.fn(),
+    get promiseQueue() {
+      return holder.current;
+    },
+    set promiseQueue(value: Promise<void>) {
+      holder.current = value;
+    },
+    pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
+    replayPayloadCache: new ReplayPayloadCache(undefined),
+  };
+}
+
+async function stepCompleted(
+  eventId: string,
+  correlationId: string,
+  stepName: string,
+  result: unknown
+): Promise<Event> {
+  return {
+    eventId,
+    runId: 'wrun_test',
+    eventType: 'step_completed',
+    correlationId,
+    eventData: {
+      stepName,
+      result: await dehydrateStepReturnValue(result, 'wrun_test', undefined),
+    },
+    createdAt: new Date(),
+  } as Event;
+}
+
+const STEP1 = 'step_01K11TFZ62YS0YYFDQ3E8B9YCV';
+const STEP2 = 'step_01K11TFZ62YS0YYFDQ3E8B9YCW';
+
+// Flush pending microtasks + the process.nextTick(consume) re-drive.
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+describe('VM continuation: EventsConsumer.resume', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('advances a live workflow across appended events without rebuilding the VM', async () => {
+    // Start with an empty log — the same live context/consumer is reused for
+    // the whole run, exactly as the continuation path keeps it alive.
+    const events: Event[] = [];
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+
+    const order: string[] = [];
+    // A sequential two-step workflow body running in ONE live VM.
+    const body = (async () => {
+      const a = await useStep('step1')();
+      order.push(`a:${a}`);
+      const b = await useStep('step2')();
+      order.push(`b:${b}`);
+      return `${a}-${b}`;
+    })();
+
+    // step1 is pending (its event isn't in the log yet) — the body is parked.
+    await flush();
+    expect(order).toEqual([]);
+
+    // Append step1's completion and resume the SAME consumer.
+    events.push(await stepCompleted('evnt_0', STEP1, 'step1', 'one'));
+    ctx.eventsConsumer.resume(events);
+    await flush();
+    // The body advanced to (and parked on) step2 in the same VM.
+    expect(order).toEqual(['a:one']);
+
+    // Append step2's completion and resume again — body runs to completion.
+    events.push(await stepCompleted('evnt_1', STEP2, 'step2', 'two'));
+    ctx.eventsConsumer.resume(events);
+    expect(await body).toBe('one-two');
+    expect(order).toEqual(['a:one', 'b:two']);
+  });
+
+  it('throws ReplayDivergenceError when the consumed prefix no longer matches the log', async () => {
+    const events: Event[] = [
+      await stepCompleted('evnt_0', STEP1, 'step1', 'one'),
+      await stepCompleted('evnt_1', STEP2, 'step2', 'two'),
+    ];
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+
+    // Consume both events (eventIndex advances to 2).
+    const [a, b] = await Promise.all([useStep('step1')(), useStep('step2')()]);
+    expect([a, b]).toEqual(['one', 'two']);
+
+    // A log whose already-consumed prefix diverges (different eventId at 0)
+    // must be rejected so the caller falls back to a full replay.
+    const diverged: Event[] = [
+      { ...events[0], eventId: 'evnt_DIFFERENT' },
+      events[1],
+    ];
+    expect(() => ctx.eventsConsumer.resume(diverged)).toThrow(
+      ReplayDivergenceError
+    );
+  });
+
+  it('accepts an identical prefix (no divergence) and is a no-op past the cursor', async () => {
+    const events: Event[] = [
+      await stepCompleted('evnt_0', STEP1, 'step1', 'x'),
+    ];
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    expect(await useStep('step1')()).toBe('x');
+
+    // Re-driving with the same prefix and no new events must not throw.
+    expect(() => ctx.eventsConsumer.resume([...events])).not.toThrow();
+  });
+});

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -152,7 +152,16 @@ export async function runWorkflow(
    * committed at workflow completion order after the run's creation. Undefined
    * outside turbo, where `run_started` is awaited up front.
    */
-  runReadyBarrier?: Promise<unknown>
+  runReadyBarrier?: Promise<unknown>,
+  /**
+   * When true, and the workflow suspends on steps only (no hooks/waits/attribute
+   * writes), the returned/thrown `WorkflowSuspension` carries a `continuation`
+   * handle that resumes the SAME live VM with newly-appended events instead of
+   * replaying from scratch. Gated by the inline loop on
+   * `isVmContinuationEnabled()`. Default false → behavior is byte-identical to
+   * the pre-continuation code path.
+   */
+  enableContinuation?: boolean
 ): Promise<Uint8Array | unknown> {
   return trace(`workflow.run ${workflowRun.workflowName}`, async (span) => {
     span?.setAttributes({
@@ -211,6 +220,23 @@ export async function runWorkflow(
 
     const workflowDiscontinuation = withResolvers<void>();
 
+    // VM continuation: in continuation mode a step-only suspension is a
+    // resumable checkpoint, not a terminal reject. `suspendSignal` is resolved
+    // (re-armed each resume cycle) when the live VM reaches such a checkpoint;
+    // any non-suspension error still rejects `workflowDiscontinuation`. Outside
+    // continuation mode the signal is never resolved, so the race below behaves
+    // exactly as `Promise.race([workflowFn, discontinuation])` did before.
+    let suspendSignal = withResolvers<void>();
+    let lastSuspension: WorkflowSuspension | undefined;
+    const onWorkflowError = (error: Error) => {
+      if (enableContinuation && WorkflowSuspension.is(error)) {
+        lastSuspension = error;
+        suspendSignal.resolve();
+        return;
+      }
+      workflowDiscontinuation.reject(error);
+    };
+
     const ulid = monotonicFactory(() => vmGlobalThis.Math.random());
     const generateNanoid = nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
       new Uint8Array(size).map(() => 256 * vmGlobalThis.Math.random())
@@ -240,7 +266,7 @@ export async function runWorkflow(
       runId: workflowRun.runId,
       encryptionKey,
       globalThis: vmGlobalThis,
-      onWorkflowError: workflowDiscontinuation.reject,
+      onWorkflowError,
       eventsConsumer,
       // Correlation IDs (step_/wait_/hook_) are derived from `generateUlid`, so
       // the time prefix fed to `ulid()` MUST be replay-stable across every
@@ -877,13 +903,13 @@ export async function runWorkflow(
       ...Attribute.WorkflowArgumentsCount(args.length),
     });
 
-    // Invoke user workflow
-    try {
-      const result = await Promise.race([
-        workflowFn(...args),
-        workflowDiscontinuation.promise,
-      ]);
-
+    // Finalize a completed workflow: dehydrate the return value and drain any
+    // fire-and-forget queue items. Shared by the first pass and every
+    // continuation resume so completion is handled identically regardless of
+    // how the VM reached its terminal state.
+    const finalizeCompleted = async (
+      result: unknown
+    ): Promise<Uint8Array | unknown> => {
       const dehydrated = await dehydrateWorkflowReturnValue(
         result,
         workflowRun.runId,
@@ -910,7 +936,9 @@ export async function runWorkflow(
       );
 
       return dehydrated;
-    } catch (err) {
+    };
+
+    const finalizeFailed = async (err: unknown): Promise<never> => {
       // Control-flow signals are handled by the runtime and do not mean the
       // workflow has terminally failed.
       if (WorkflowSuspension.is(err) || ReplayDivergenceError.is(err)) {
@@ -927,6 +955,74 @@ export async function runWorkflow(
       );
 
       throw err;
-    }
+    };
+
+    // A step-only suspension (no hooks, waits, attribute writes, hook
+    // disposals, or aborts) is the sole continuation-eligible checkpoint: those
+    // other operations introduce out-of-band resume/parallel invocations and
+    // delivery-barrier ordering that the from-scratch replay path handles
+    // specially. Anything else leaves `continuation` unset so the caller falls
+    // back to a fresh replay.
+    const isContinuationEligible = (s: WorkflowSuspension): boolean =>
+      s.hookCount === 0 &&
+      s.waitCount === 0 &&
+      s.attributeCount === 0 &&
+      s.hookDisposedCount === 0 &&
+      s.abortCount === 0;
+
+    // Kick off the user workflow once. In continuation mode the same underlying
+    // promise is raced on every resume cycle; it settles only when the workflow
+    // truly completes or throws.
+    const workflowResult = Promise.resolve(workflowFn(...args)).then(
+      (value: unknown) => ({ kind: 'done' as const, value })
+    );
+
+    // Drive the VM to its next checkpoint. Returns the dehydrated result on
+    // completion; throws a `WorkflowSuspension` (carrying a `continuation` when
+    // eligible) on suspension; throws the workflow's error otherwise.
+    const pump = async (): Promise<Uint8Array | unknown> => {
+      let outcome: { kind: 'done'; value: unknown } | { kind: 'suspended' };
+      try {
+        outcome = await Promise.race([
+          workflowResult,
+          suspendSignal.promise.then(() => ({ kind: 'suspended' as const })),
+          // Rejects only — a non-suspension workflow error routes here.
+          workflowDiscontinuation.promise as Promise<never>,
+        ]);
+      } catch (err) {
+        return await finalizeFailed(err);
+      }
+
+      if (outcome.kind === 'done') {
+        return await finalizeCompleted(outcome.value);
+      }
+
+      // Suspended checkpoint.
+      const suspension = lastSuspension;
+      if (!suspension) {
+        // Defensive: signal resolved without a recorded suspension. Fall back
+        // to the terminal reject path (never expected in practice).
+        throw new WorkflowRuntimeError(
+          'VM continuation: suspended without a recorded suspension'
+        );
+      }
+      if (enableContinuation && isContinuationEligible(suspension)) {
+        suspension.continuation = {
+          resume: async (newEvents: unknown[]) => {
+            // Re-arm the checkpoint signal BEFORE feeding events so the next
+            // end-of-events detection resolves the fresh signal, not a stale one.
+            suspendSignal = withResolvers<void>();
+            lastSuspension = undefined;
+            // Adopt the authoritative log and re-drive the live consumer. A
+            // diverged prefix throws ReplayDivergenceError → caller falls back.
+            eventsConsumer.resume(newEvents as Event[]);
+            return pump();
+          },
+        };
+      }
+      throw suspension;
+    };
+
+    return await pump();
   });
 }


### PR DESCRIPTION
## Summary

Adds **in-process VM continuation** — **on by default**, kill switch `WORKFLOW_VM_CONTINUATION=0`. When active, the inline replay loop keeps a suspended workflow VM alive across iterations and feeds newly-appended events into it, instead of rebuilding the `vm.Context` and replaying the event log from event 0 on every pass.

Default-on so CI lanes and benchmarks actually exercise and measure the new path. The kill switch restores the previous rebuild-and-replay behavior exactly.

This is the "cache the VM" idea, scoped to the **only place it's sound**: within a single invocation's inline loop, where the same process owns the appended writes so the durable event log stays authoritative. It does **not** cache a VM across process/invocation boundaries (sleeps, hooks, redelivery) — there is no live VM to resume there and a snapshot would drift from the log.

## How it works

1. On a **step-only** suspension, `runWorkflow` attaches a `continuation` handle to the thrown `WorkflowSuspension`.
2. The inline loop runs the step(s) inline as today, appending their terminal events to the log.
3. Next iteration, instead of a fresh `runWorkflow`, it calls `continuation.resume(events)`: `EventsConsumer.resume()` adopts the authoritative event array and re-drives the still-registered step consumers, resolving the pending step promise so the **same live VM** advances to its next checkpoint.

The step consumer already stays registered after hitting end-of-events (it only removes itself on terminal events), so resuming is just feeding it the events a fresh replay would have consumed next — the same deterministic call sequence, not restarted. RNG/clock/correlation-id state advance naturally in the live VM, exactly matching what a from-scratch replay reconstructs.

## Safety (why this can't corrupt a run)

- **Scoped to step-only suspensions.** Hooks / waits / attribute writes / aborts leave `continuation` unset → the loop falls back to a full replay. Those paths involve out-of-band resume/parallel invocations and delivery-barrier ordering that the replay path handles specially and that aren't validated for continuation here.
- **Prefix-divergence guard.** `resume()` checks that the events already consumed by the live VM are a byte-stable prefix (by `eventId`) of the authoritative log. Any mismatch throws `ReplayDivergenceError`; the loop swallows it and falls back to a fresh replay.
- **Kill switch == today.** `WORKFLOW_VM_CONTINUATION=0` disables the continuation attach entirely; the suspend/complete/error control flow is byte-identical to before (verified by the full suite passing under the kill switch).
- **Worst case == today.** Any bail-out reverts to a from-scratch replay in a fresh VM.

## Scope / limitations (intentionally not in this PR)

- Cross-process/invocation continuation (sleeps, hooks, redelivery) — not possible in-memory; excluded by design.
- Fan-out where not all pending steps run inline still works (the VM re-suspends on the remaining ones, identical to a fresh replay) but gets no extra benefit beyond the inline batch.
- Hook/wait/attribute suspensions deliberately fall back.

## Verification

- `packages/core` full suite green **with the default (on) and under the kill switch (=0)**: 1488 passed, 3 pre-existing expected-fails.
- `vm-continuation.test.ts`: proves `resume()` advances a live two-step workflow across appended events in one VM, plus the divergence guard.
- `vm-continuation-loop.test.ts`: drives a 2-step sequential workflow through the real `workflowEntrypoint` loop and asserts `createContext` (VM construction) is called **once** by default (resumed per step) vs **>1** under the kill switch (rebuilt per replay), and that the dehydrated `run_completed` output is **byte-identical** between the two modes.
- `pnpm --filter @workflow/core build` + `typecheck` clean.

## Notes

- **Default-on affects production too**, not just CI — this env flag is read at runtime everywhere. `WORKFLOW_VM_CONTINUATION=0` is the per-deployment kill switch.
- The e2e / world-vercel lanes exercise continuation for the first time via this PR's default flip; CI results on those lanes are the real signal for the non-`world-local` paths.
- Draft / proof-of-concept: demonstrates the mechanism and the sequential hot-path win while keeping the log authoritative and a kill switch away from the prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)