### PR TITLE
[ci] Run benchmarks in-deployment to avoid proxy overhead

### DIFF
--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -161,17 +161,23 @@ function formatMs(value) {
 
 /**
  * Annotates each metric row with the matching baseline average (from the most
- * recent main-branch run), keyed by backend/app/metric/scenario. The
- * annotation is stored on the entry so history re-renders keep showing the
- * delta each run was originally compared against.
+ * recent main-branch run), keyed by
+ * methodologyVersion/backend/app/metric/scenario. The methodology version is
+ * part of the key so a change to the measurement window (e.g. the switch to
+ * the in-deployment trigger) does not diff incomparable numbers: an old
+ * baseline won't match the new run, and the delta stays blank until `main` has
+ * produced a same-methodology baseline. The annotation is stored on the entry
+ * so history re-renders keep showing the delta each run was originally
+ * compared against.
  */
 export function annotateWithBaseline(results, baseline) {
   if (!baseline || baseline.length === 0) return results;
+  const methodology = (result) => result.methodologyVersion ?? 'legacy';
   const baselineAvgs = new Map();
   for (const result of baseline) {
     for (const row of result.metrics ?? []) {
       baselineAvgs.set(
-        `${result.backend}/${result.app}/${row.metric}/${row.scenario}`,
+        `${methodology(result)}/${result.backend}/${result.app}/${row.metric}/${row.scenario}`,
         row.avg
       );
     }
@@ -180,7 +186,7 @@ export function annotateWithBaseline(results, baseline) {
     ...result,
     metrics: (result.metrics ?? []).map((row) => {
       const baselineAvg = baselineAvgs.get(
-        `${result.backend}/${result.app}/${row.metric}/${row.scenario}`
+        `${methodology(result)}/${result.backend}/${result.app}/${row.metric}/${row.scenario}`
       );
       return typeof baselineAvg === 'number' ? { ...row, baselineAvg } : row;
     }),

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -31,7 +31,7 @@ const METRIC_LABELS = {
   ttfs: {
     name: 'TTFS',
     description:
-      'time to first step body (server run_created → step body, Vercel clocks; +80ms est. RTT)',
+      'time to first step body (in-deployment start() → first step body, deployment clocks)',
   },
   stso: {
     name: 'STSO',
@@ -40,11 +40,12 @@ const METRIC_LABELS = {
   wo: {
     name: 'WO',
     description:
-      'workflow overhead (whole-run time outside step bodies, server-anchored; +80ms est. RTT)',
+      'workflow overhead (whole-run time outside step bodies, in-deployment anchored)',
   },
   sl: {
     name: 'SL',
-    description: 'stream latency (first chunk write → visible to the reader)',
+    description:
+      'stream latency (in-deployment write → read propagation, readAt - writtenAt)',
   },
 };
 const METRIC_ORDER = ['ttfs', 'stso', 'wo', 'sl'];
@@ -322,7 +323,7 @@ function renderFooter(entries) {
         ]
       : []),
     '',
-    '<sub>TTFS/WO are measured from Vercel server timestamps (run creation → step body), so they’re independent of the CI runner’s clock and its network path to api.vercel.com; a flat +80ms is added as an estimate of the client→ingress request overhead (RTT) the server timestamps don’t capture. STSO is measured between step bodies on the deployment. SL is client-observed and includes the api.vercel.com read path.</sub>',
+    '<sub>All metrics are measured from deployment-side timestamps only. Runs are triggered by an in-deployment route that stamps the anchor (`clientStart`) right before `start()`, so the CI runner’s request and its path through api.vercel.com sit outside every measured window. TTFS = in-deployment `start()` → first step body (turbo uses the in-process fast path, non-turbo the dispatch path). STSO/WO are measured between step bodies on the deployment. SL is measured inside the workflow (parallel reader/writer steps), so it no longer includes the api.vercel.com read path.</sub>',
   ].join('\n');
 }
 

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -28,7 +28,11 @@ const MAX_HISTORY_ENTRIES = 10;
 const MAX_COMMENT_CHARS = 60_000;
 
 const METRIC_LABELS = {
-  ttfs: { name: 'TTFS', description: 'time to first step body execution' },
+  ttfs: {
+    name: 'TTFS',
+    description:
+      'time to first step body (server run_created → step body, Vercel clocks; +80ms est. RTT)',
+  },
   stso: {
     name: 'STSO',
     description: 'step-to-step overhead (gap between consecutive step bodies)',
@@ -36,7 +40,7 @@ const METRIC_LABELS = {
   wo: {
     name: 'WO',
     description:
-      'workflow overhead (time outside step bodies, client start → last step body exit)',
+      'workflow overhead (whole-run time outside step bodies, server-anchored; +80ms est. RTT)',
   },
   sl: {
     name: 'SL',
@@ -318,7 +322,7 @@ function renderFooter(entries) {
         ]
       : []),
     '',
-    '<sub>TTFS/WO compare client vs deployment clocks and SL compares the step runner’s clock vs the client’s (NTP-synced in CI). WO ends at the last step body exit, the closest observable proxy for the final step-completion request.</sub>',
+    '<sub>TTFS/WO are measured from Vercel server timestamps (run creation → step body), so they’re independent of the CI runner’s clock and its network path to api.vercel.com; a flat +80ms is added as an estimate of the client→ingress request overhead (RTT) the server timestamps don’t capture. STSO is measured between step bodies on the deployment. SL is client-observed and includes the api.vercel.com read path.</sub>',
   ].join('\n');
 }
 

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -224,8 +224,8 @@ function metricSortKey(row) {
 
 function renderResultTable(result) {
   const lines = [
-    '| Metric | Scenario | Avg (ms) | P75 (ms) | P90 (ms) | P99 (ms) | Samples |',
-    '|--------|----------|---------:|---------:|---------:|---------:|--------:|',
+    '| Metric | Scenario | Avg (ms) | P10 (ms) | P75 (ms) | P90 (ms) | P99 (ms) | Samples |',
+    '|--------|----------|---------:|---------:|---------:|---------:|---------:|--------:|',
   ];
   const rows = [...result.metrics].sort(
     (a, b) => metricSortKey(a) - metricSortKey(b)
@@ -236,7 +236,7 @@ function renderResultTable(result) {
     const name = label ? `**${label.name}**` : row.metric;
     const targets = row.targets ?? {};
     lines.push(
-      `| ${name} | ${row.scenario} | ${formatMs(row.avg)}${formatDelta(row.avg, row.baselineAvg)} | ${formatCell(row.p75, targets.p75)} | ${formatCell(row.p90, targets.p90)} | ${formatCell(row.p99, targets.p99)} | ${row.samples} |`
+      `| ${name} | ${row.scenario} | ${formatMs(row.avg)}${formatDelta(row.avg, row.baselineAvg)} | ${formatMs(row.p10)} | ${formatCell(row.p75, targets.p75)} | ${formatCell(row.p90, targets.p90)} | ${formatCell(row.p99, targets.p99)} | ${row.samples} |`
     );
   }
   return lines.join('\n');
@@ -323,7 +323,9 @@ function renderFooter(entries) {
         ]
       : []),
     '',
-    '<sub>All metrics are measured from deployment-side timestamps only. Runs are triggered by an in-deployment route that stamps the anchor (`clientStart`) right before `start()`, so the CI runner’s request and its path through api.vercel.com sit outside every measured window. TTFS = in-deployment `start()` → first step body (turbo uses the in-process fast path, non-turbo the dispatch path). STSO/WO are measured between step bodies on the deployment. SL is measured inside the workflow (parallel reader/writer steps), so it no longer includes the api.vercel.com read path.</sub>',
+    '<sub>All metrics are measured from deployment-side timestamps only. Runs are triggered by an in-deployment route that stamps the anchor (`clientStart`) right before `start()`, so the CI runner’s request and its path through api.vercel.com sit outside every measured window. TTFS = in-deployment `start()` → first step body (turbo uses the in-process fast path, non-turbo the dispatch path), and includes the VQS dispatch hop plus any `/flow` cold start. STSO/WO are measured between step bodies on the deployment. SL is measured inside the workflow (parallel reader/writer steps), so it no longer includes the api.vercel.com read path.</sub>',
+    '',
+    '<sub>Cold starts are kept in the numbers on purpose — they are part of real bursty-workload latency. The workbench deployment cold-starts the `/flow` invocation for a large fraction of runs, inflating P75+; the **P10** column shows the warm-start floor for comparison.</sub>',
   ].join('\n');
 }
 

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -13,6 +13,7 @@ const loadModule = () => import('./render-benchmark-comment.mjs');
 function sampleResult(overrides = {}) {
   return {
     version: 1,
+    methodologyVersion: 2,
     app: 'nextjs-turbopack',
     backend: 'vercel',
     generatedAt: '2026-07-08T12:00:00.000Z',
@@ -33,6 +34,7 @@ function sampleResult(overrides = {}) {
         scenario: 'stream',
         unit: 'ms',
         avg: 412.3,
+        p10: 357,
         p75: 398,
         p90: 512,
         p99: 634,
@@ -46,6 +48,7 @@ function sampleResult(overrides = {}) {
         scenario: 'stream',
         unit: 'ms',
         avg: 55.1,
+        p10: 41,
         p75: 48,
         p90: 55,
         p99: 120,
@@ -59,6 +62,7 @@ function sampleResult(overrides = {}) {
         scenario: '1020 steps (101-120)',
         unit: 'ms',
         avg: 91,
+        p10: 72,
         p75: 85,
         p90: 120,
         p99: 200,
@@ -72,6 +76,7 @@ function sampleResult(overrides = {}) {
         scenario: 'stream',
         unit: 'ms',
         avg: 1200,
+        p10: 1000,
         p75: 1100,
         p90: 1500,
         p99: 1900,
@@ -103,15 +108,14 @@ test('renders a completed run with a table and embedded history', async () => {
   // "ms" lives in the column headers, not in the cells
   assert.match(
     body,
-    /\| Avg \(ms\) \| P75 \(ms\) \| P90 \(ms\) \| P99 \(ms\) \|/
+    /\| Avg \(ms\) \| P10 \(ms\) \| P75 \(ms\) \| P90 \(ms\) \| P99 \(ms\) \|/
   );
   assert.doesNotMatch(body, /\d ms \|/);
+  // P10 cell renders between Avg and P75 (warm-start floor for TTFS)
+  assert.match(body, /\| 412 \| 357 \| 398 🔴 \|/);
   // Metric definitions live in the footer, not in the table rows
   assert.doesNotMatch(body, /\| \*\*TTFS\*\* <sub>/);
-  assert.match(
-    body,
-    /<sub>Metrics — \*\*TTFS\*\*: time to first step body execution/
-  );
+  assert.match(body, /<sub>Metrics — \*\*TTFS\*\*: time to first step body/);
   assert.match(body, /\*\*SL\*\*: stream latency/);
   // Scenario legend from the runner-provided descriptions
   assert.match(
@@ -175,6 +179,27 @@ test('renders avg deltas against a baseline and embeds them in history', async (
     commit: 'ffffff1234567890',
   });
   assert.match(rerendered, /\| 412 \(\+3\.1%\) \|/);
+});
+
+test('suppresses deltas when the baseline methodology version differs', async () => {
+  const { renderComment } = await loadModule();
+  // Old-methodology baseline (e.g. proxy-inclusive TTFS) must not be diffed
+  // against a new-methodology run, even though backend/app/metric/scenario
+  // match — the numbers are not comparable.
+  const baseline = sampleResult({
+    methodologyVersion: 1,
+    metrics: sampleResult().metrics.map((row) => ({ ...row, avg: 400 })),
+  });
+  const body = renderComment({
+    status: 'completed',
+    results: [sampleResult()], // methodologyVersion: 2
+    baseline: [baseline],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+  // No percentage deltas, and the "compare against main" note is absent.
+  assert.doesNotMatch(body, /%\)/);
+  assert.doesNotMatch(body, /Avg deltas/);
 });
 
 test('renders no deltas without a baseline', async () => {

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -95,9 +95,10 @@ jobs:
   # backend (e.g. postgres or local), add a matrix entry with
   # `world: postgres` / `world: local` and gate the Vercel-specific steps —
   # the runner (packages/core/e2e/benchmark.test.ts) already selects its
-  # backend from the same env vars as the e2e tests. Note that the stream
-  # latency (SL) metric requires `run.getReadable()` to work from the test
-  # process, which the local world's in-process streamer does not support.
+  # backend from the same env vars as the e2e tests. SL is measured inside the
+  # workflow (benchSlWorkflow's parallel reader/writer steps read/write on the
+  # deployment), so it no longer needs `run.getReadable()` to work from the
+  # test process; the runner only polls returnValue for the collected timings.
   benchmark:
     name: Benchmark (${{ matrix.target.world }}, ${{ matrix.target.app }})
     runs-on: ubuntu-latest

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -10,14 +10,23 @@
  * metrics below depend on the CI runner's clock or its network path to the
  * proxy; they are computed purely from Vercel-side timestamps.
  *
- * Metrics (all in milliseconds, reported as avg/p75/p90/p99):
+ * Metrics (all in milliseconds, reported as avg/p10/p75/p90/p99):
+ *
+ * p10 is reported alongside the upper percentiles so warm-start latency (the
+ * fast floor) is visible next to the cold-start tail: the workbench deployment
+ * cold-starts the `/flow` invocation for a large fraction of runs (bursty,
+ * low-traffic), which inflates p75+. Cold starts are kept in the numbers on
+ * purpose — they are part of real bursty-workload latency — and p10 shows what
+ * a warm trigger looks like.
  *
  * - TTFS  (time to first step): `steps[0].start` (first step body execution,
  *          deployment clock) minus the in-deployment `clientStart` returned by
  *          the trigger route. Because `start()` runs inside the deployment, the
- *          turbo path (no hooks) exercises the runtime's in-process fast path
- *          (optimisticStart); the non-turbo path (a hook registered before the
- *          step) exercises the dispatch path. Both are proxy-independent.
+ *          turbo path (no hooks) can exercise the runtime's in-process fast
+ *          path; the non-turbo path (a hook registered before the step)
+ *          exercises the dispatch path. Both are proxy-independent. TTFS
+ *          includes the VQS dispatch hop and any `/flow` cold start (see p10
+ *          note above).
  * - STSO  (step-to-step overhead): gap between consecutive step body
  *          executions (`steps[i].start - steps[i-1].end`) in a workflow with
  *          many trivial sequential steps. Both timestamps come from step
@@ -40,10 +49,11 @@
  *
  * Scenarios (defined in workbench/example/workflows/97_bench.ts):
  *
- * 1. benchStreamWorkflow          — 1 step, turbo mode → TTFS (turbo)
- * 2. benchHookStreamWorkflow      — hook + 1 step, non-turbo → TTFS (non-turbo)
- * 3. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
- * 4. benchSlWorkflow              — parallel reader/writer steps → SL
+ * 1. benchStepWorkflow            — 1 no-op step, turbo mode → TTFS (turbo)
+ * 2. benchStreamWorkflow          — 1 streaming step, turbo mode → TTFS (turbo)
+ * 3. benchHookStreamWorkflow      — hook + 1 step, non-turbo → TTFS (non-turbo)
+ * 4. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
+ * 5. benchSlWorkflow              — parallel reader/writer steps → SL
  *
  * Each scenario runs many iterations (env-tunable, see BENCH_* below) so the
  * percentiles are computed from real samples.
@@ -399,6 +409,8 @@ async function runScenario<T>(
 
 interface MetricStats {
   avg: number;
+  /** 10th percentile — surfaces the warm-start floor vs the cold-start tail. */
+  p10: number;
   p75: number;
   p90: number;
   p99: number;
@@ -425,6 +437,7 @@ function computeStats(samples: number[]): MetricStats {
   const round = (v: number) => Math.round(v * 10) / 10;
   return {
     avg: round(sorted.reduce((sum, v) => sum + v, 0) / sorted.length),
+    p10: round(percentile(10)),
     p75: round(percentile(75)),
     p90: round(percentile(90)),
     p99: round(percentile(99)),
@@ -475,15 +488,21 @@ function getBackend(): string {
 
 // Short scenario labels for the results table; the descriptions are rendered
 // as a legend at the bottom of the PR comment.
+const SCENARIO_STEP = 'step';
 const SCENARIO_TURBO_STREAM = 'stream';
 const SCENARIO_HOOK_STREAM = 'hook + stream';
 const SCENARIO_SEQUENTIAL = `${SEQUENTIAL_STEP_COUNT} steps`;
 const SCENARIO_STREAM_LATENCY = 'stream latency';
 const SCENARIO_DESCRIPTIONS = [
   {
+    name: SCENARIO_STEP,
+    description:
+      'one trivial no-op step, no stream; no hooks, so the run stays in turbo mode (in-process fast path)',
+  },
+  {
     name: SCENARIO_TURBO_STREAM,
     description:
-      'one step; no hooks, so the run stays in turbo mode (in-process fast path)',
+      'one streaming step; no hooks, so the run stays in turbo mode (in-process fast path)',
   },
   {
     name: SCENARIO_HOOK_STREAM,
@@ -528,19 +547,35 @@ describe('workflow benchmarks', () => {
     }
   }, PREFLIGHT_TIMEOUT_MS + 60_000);
 
-  test('scenario: 1 step (turbo)', { timeout: 30 * 60_000 }, async () => {
-    const results = await runScenario(
-      SCENARIO_TURBO_STREAM,
-      STREAM_ITERATIONS,
-      () => runStreamIteration('benchStreamWorkflow')
+  test('scenario: 1 no-op step (turbo)', { timeout: 30 * 60_000 }, async () => {
+    const results = await runScenario(SCENARIO_STEP, STREAM_ITERATIONS, () =>
+      runStreamIteration('benchStepWorkflow')
     );
     recordMetric(
       'ttfs',
-      SCENARIO_TURBO_STREAM,
+      SCENARIO_STEP,
       results.map((r) => r.ttfsMs),
       TTFS_TARGETS
     );
   });
+
+  test(
+    'scenario: 1 streaming step (turbo)',
+    { timeout: 30 * 60_000 },
+    async () => {
+      const results = await runScenario(
+        SCENARIO_TURBO_STREAM,
+        STREAM_ITERATIONS,
+        () => runStreamIteration('benchStreamWorkflow')
+      );
+      recordMetric(
+        'ttfs',
+        SCENARIO_TURBO_STREAM,
+        results.map((r) => r.ttfsMs),
+        TTFS_TARGETS
+      );
+    }
+  );
 
   test(
     'scenario: hook + 1 step (non-turbo)',
@@ -642,15 +677,18 @@ describe('workflow benchmarks', () => {
     fs.writeFileSync(outputPath, JSON.stringify(results, null, 2));
     console.log(`[bench] Results written to ${outputPath}`);
     console.table(
-      metricRows.map(({ metric, scenario, avg, p75, p90, p99, samples }) => ({
-        metric,
-        scenario,
-        avg,
-        p75,
-        p90,
-        p99,
-        samples,
-      }))
+      metricRows.map(
+        ({ metric, scenario, avg, p10, p75, p90, p99, samples }) => ({
+          metric,
+          scenario,
+          avg,
+          p10,
+          p75,
+          p90,
+          p99,
+          samples,
+        })
+      )
     );
   });
 });

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -4,28 +4,40 @@
  *
  * Metrics (all in milliseconds, reported as avg/p75/p90/p99):
  *
- * - TTFS  (time to first step): client-side timestamp taken when `start()` is
- *          called (the run_created request) → first step body execution.
- *          Measured for both the turbo path (no hooks) and the non-turbo path
- *          (a hook was registered before the step).
+ * - TTFS  (time to first step): server-side `run_created` timestamp
+ *          (Vercel-assigned `createdAt`) → first step body execution
+ *          (`steps[0].start`, the deployment's clock). Both endpoints are
+ *          Vercel-provided, so the measurement is independent of the CI
+ *          runner's clock and its network path to api.vercel.com. Because the
+ *          server anchor starts *after* the create request's inbound leg, a
+ *          flat RTT_OVERHEAD_MS is added as an estimate of that client→ingress
+ *          request overhead. Measured for both the turbo path (no hooks) and
+ *          the non-turbo path (a hook was registered before the step).
  * - STSO  (step-to-step overhead): gap between consecutive step body
  *          executions (`steps[i].start - steps[i-1].end`) in a workflow with
- *          many trivial sequential steps. Reported per step-index range
+ *          many trivial sequential steps. Both timestamps come from step
+ *          bodies on the deployment, so STSO is already independent of the CI
+ *          client and the api.vercel.com proxy. Reported per step-index range
  *          (see STSO_BUCKETS) because early steps behave differently from
  *          late ones (first-invocation fast paths, growing event log).
  * - WO    (workflow overhead): total time the run spends outside of step
- *          bodies, from the client-side `start()` timestamp to the end of the
- *          last step body (the moment just before the final step_completed
- *          request is sent): `(lastStep.end - clientStart) - Σ(step durations)`.
+ *          bodies over the whole sequential run, from the server-side
+ *          `run_created` timestamp to the end of the last step body:
+ *          `(lastStep.end - runCreatedServerMs) - Σ(step durations)`, plus the
+ *          flat RTT_OVERHEAD_MS. Measured on the sequential scenario only — on
+ *          a single-step workflow WO reduces algebraically to TTFS.
  * - SL    (stream latency): time between a step writing the first chunk to
  *          the workflow's default output stream and that chunk becoming
- *          visible to a reader attached via `run.getReadable()`.
+ *          visible to a reader attached via `run.getReadable()`. Unlike the
+ *          other metrics this is inherently client-observed: it includes the
+ *          api.vercel.com read path (a server-side measurement would need
+ *          runtime/world changes and is a separate follow-up).
  *
  * Scenarios (defined in workbench/example/workflows/97_bench.ts):
  *
- * 1. benchStreamWorkflow          — 1 streaming step, turbo mode → TTFS + SL + WO
- * 2. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO
- * 3. benchHookStreamWorkflow      — hook + 1 streaming step, non-turbo → TTFS + SL + WO
+ * 1. benchStreamWorkflow          — 1 streaming step, turbo mode → TTFS + SL
+ * 2. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
+ * 3. benchHookStreamWorkflow      — hook + 1 streaming step, non-turbo → TTFS + SL
  *
  * Each scenario runs many iterations (env-tunable, see BENCH_* below) so the
  * percentiles are computed from real samples.
@@ -37,15 +49,16 @@
  * in-process streamer does not support — CI currently runs this file against
  * Vercel only.
  *
- * TTFS and WO compare a client-side clock against the deployment's clock, and
- * SL compares the step runner's clock against the client's; both machines are
- * NTP-synced in CI, so skew is small relative to the measured values.
+ * TTFS/WO anchor on the Vercel-assigned `run_created` timestamp (fetched via
+ * the world's event log) and end on the deployment's step-body clock; the only
+ * residual skew is intra-Vercel (workflow-server vs step runner), NTP-bounded
+ * and small. SL still compares the step runner's clock against the client's.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, test } from 'vitest';
-import { start } from '../src/runtime';
+import { getWorld, start } from '../src/runtime';
 import { getWorkflowMetadata, setupWorld } from './utils';
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
@@ -72,6 +85,14 @@ const STREAM_ITERATIONS = envInt('BENCH_STREAM_ITERATIONS', 30);
 const SEQUENTIAL_ITERATIONS = envInt('BENCH_SEQUENTIAL_ITERATIONS', 1);
 const SEQUENTIAL_STEP_COUNT = envInt('BENCH_SEQUENTIAL_STEP_COUNT', 1020);
 const WARMUP_ITERATIONS = envInt('BENCH_WARMUP_ITERATIONS', 2, 0);
+
+// TTFS/WO anchor on the Vercel-assigned `run_created` timestamp, which is
+// stamped only after the client's create request has reached the ingress — so
+// the server anchor excludes that client→api.vercel.com inbound leg. We add
+// this flat estimate of the request overhead (RTT) back in, keeping the metric
+// deterministic (no CI-network variance) while still approximating end-to-end.
+// The observed inbound leg is ~100-200ms; 80ms is a conservative flat default.
+const RTT_OVERHEAD_MS = envInt('BENCH_RTT_OVERHEAD_MS', 80, 0);
 
 // Per-metric latency targets (ms) rendered as 🟢/🔴 marks in the PR comment.
 const TTFS_TARGETS = { p75: 200, p90: 300, p99: 600 };
@@ -112,8 +133,15 @@ interface BenchStreamChunk {
 
 interface StreamIterationResult {
   runId: string;
+  /** Server-anchored TTFS (+ flat RTT estimate); the reported metric. */
   ttfsMs: number;
-  woMs: number;
+  /**
+   * Client wall-clock TTFS (`steps[0].start - clientStart`), kept for
+   * diagnostics only (logged/serialized, not reported as a metric). Comparing
+   * it against `ttfsMs - RTT_OVERHEAD_MS` shows how well the flat 80ms tracks
+   * the real client→ingress overhead.
+   */
+  ttfsWallMs: number;
   slMs: number;
 }
 
@@ -121,6 +149,8 @@ interface SequentialIterationResult {
   runId: string;
   /** stsoMs[i] is the gap between steps i+1 and i+2 (1-indexed). */
   stsoMs: number[];
+  /** Server-anchored whole-run workflow overhead (+ flat RTT estimate). */
+  woMs: number;
 }
 
 const benchWf = (fn: string) =>
@@ -165,14 +195,46 @@ function timingsFromReturnValue(
   return steps;
 }
 
-/** WO: total time outside of step bodies, from client start to last body end. */
+/**
+ * Vercel-assigned run-creation timestamp (epoch ms), read from the world's
+ * event log so TTFS/WO anchor on a server clock rather than the CI runner's.
+ * Prefers the `run_created` event's `createdAt` (server-stamped, distinct from
+ * the client `occurredAt`); falls back to the run snapshot's `createdAt`.
+ * Returns undefined if neither can be read, so callers can degrade to the
+ * client anchor rather than dropping the sample.
+ */
+async function runCreatedServerMs(runId: string): Promise<number | undefined> {
+  try {
+    const world = await getWorld();
+    const { data } = await world.events.list({ runId });
+    const created = data.find((e) => e.eventType === 'run_created');
+    const createdMs = created?.createdAt?.getTime?.();
+    if (typeof createdMs === 'number' && Number.isFinite(createdMs)) {
+      return createdMs;
+    }
+    const run = await world.runs.get(runId);
+    const runCreatedMs = run.createdAt?.getTime?.();
+    return typeof runCreatedMs === 'number' && Number.isFinite(runCreatedMs)
+      ? runCreatedMs
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Raw WO: total time outside of step bodies, from `anchorMs` to the last step
+ * body's exit. The caller supplies the server `run_created` timestamp as the
+ * anchor and adds RTT_OVERHEAD_MS; the value is clamped at 0 to absorb small
+ * intra-Vercel clock skew.
+ */
 function workflowOverheadMs(
-  clientStart: number,
+  anchorMs: number,
   steps: BenchStepTiming[]
 ): number {
   const lastEnd = steps[steps.length - 1].end;
   const inStep = steps.reduce((sum, s) => sum + (s.end - s.start), 0);
-  return lastEnd - clientStart - inStep;
+  return Math.max(0, lastEnd - anchorMs - inStep);
 }
 
 async function runStreamIteration(
@@ -224,10 +286,27 @@ async function runStreamIteration(
     );
     const steps = timingsFromReturnValue(returnValue, run.runId);
 
+    // Anchor TTFS at the Vercel-assigned run-creation time so the metric is
+    // independent of the CI runner's clock and its path to api.vercel.com,
+    // then add the flat RTT estimate for the create request's inbound leg.
+    // If the server timestamp can't be read, degrade to the client anchor
+    // (which already includes the real RTT — no flat estimate is added).
+    const serverAnchor = await runCreatedServerMs(run.runId);
+    const ttfsWallMs = steps[0].start - clientStart;
+    const ttfsMs =
+      serverAnchor !== undefined
+        ? Math.max(0, steps[0].start - serverAnchor) + RTT_OVERHEAD_MS
+        : ttfsWallMs;
+    if (serverAnchor === undefined) {
+      console.warn(
+        `[bench] ${workflowFn} run ${run.runId}: no server run_created timestamp; TTFS degraded to client anchor`
+      );
+    }
+
     return {
       runId: run.runId,
-      ttfsMs: steps[0].start - clientStart,
-      woMs: workflowOverheadMs(clientStart, steps),
+      ttfsMs,
+      ttfsWallMs,
       slMs,
     };
   } catch (error) {
@@ -253,6 +332,7 @@ async function runSequentialIteration(
   stepCount: number
 ): Promise<SequentialIterationResult> {
   const wf = await benchWf('benchSequentialStepsWorkflow');
+  const clientStart = Date.now();
   const run = await start(wf, [stepCount]);
   try {
     const returnValue = await withTimeout(
@@ -272,9 +352,19 @@ async function runSequentialIteration(
       stsoMs.push(steps[i].start - steps[i - 1].end);
     }
 
+    // Server-anchored whole-run WO (+ flat RTT). Degrade to the client start
+    // if the server timestamp is unavailable (then the RTT is already
+    // included, so no flat estimate is added).
+    const serverAnchor = await runCreatedServerMs(run.runId);
+    const woMs =
+      serverAnchor !== undefined
+        ? workflowOverheadMs(serverAnchor, steps) + RTT_OVERHEAD_MS
+        : workflowOverheadMs(clientStart, steps);
+
     return {
       runId: run.runId,
       stsoMs,
+      woMs,
     };
   } catch (error) {
     (error as Error).message += ` (run ${run.runId})`;
@@ -410,6 +500,25 @@ function recordMetric(
   });
 }
 
+/**
+ * Log the client wall-clock TTFS alongside the reported server-anchored TTFS
+ * so the flat RTT_OVERHEAD_MS assumption can be validated from CI logs. Not a
+ * reported metric — diagnostics only. `wall - (server - RTT)` is the residual
+ * between the real client→ingress overhead and our flat estimate.
+ */
+function logTtfsWallDiagnostic(
+  scenario: string,
+  results: StreamIterationResult[]
+) {
+  if (results.length === 0) return;
+  const wall = computeStats(results.map((r) => r.ttfsWallMs));
+  const server = computeStats(results.map((r) => r.ttfsMs));
+  console.log(
+    `[bench] ${scenario} TTFS diagnostic: server+RTT avg ${server.avg}ms, ` +
+      `client wall-clock avg ${wall.avg}ms (RTT flat estimate ${RTT_OVERHEAD_MS}ms)`
+  );
+}
+
 function getBackend(): string {
   if (process.env.WORKFLOW_BENCH_BACKEND) {
     return process.env.WORKFLOW_BENCH_BACKEND;
@@ -439,7 +548,7 @@ const SCENARIO_DESCRIPTIONS = [
   },
   {
     name: SCENARIO_SEQUENTIAL,
-    description: `${SEQUENTIAL_STEP_COUNT} trivial sequential steps; STSO is measured between consecutive steps in the given step ranges`,
+    description: `${SEQUENTIAL_STEP_COUNT} trivial sequential steps; STSO is measured between consecutive steps in the given step ranges, and WO is the whole-run overhead outside step bodies`,
   },
 ];
 
@@ -483,16 +592,12 @@ describe('workflow benchmarks', () => {
         results.map((r) => r.ttfsMs),
         TTFS_TARGETS
       );
+      logTtfsWallDiagnostic(SCENARIO_TURBO_STREAM, results);
       recordMetric(
         'sl',
         SCENARIO_TURBO_STREAM,
         results.map((r) => r.slMs),
         SL_TARGETS
-      );
-      recordMetric(
-        'wo',
-        SCENARIO_TURBO_STREAM,
-        results.map((r) => r.woMs)
       );
     }
   );
@@ -512,16 +617,12 @@ describe('workflow benchmarks', () => {
         results.map((r) => r.ttfsMs),
         TTFS_TARGETS
       );
+      logTtfsWallDiagnostic(SCENARIO_HOOK_STREAM, results);
       recordMetric(
         'sl',
         SCENARIO_HOOK_STREAM,
         results.map((r) => r.slMs),
         SL_TARGETS
-      );
-      recordMetric(
-        'wo',
-        SCENARIO_HOOK_STREAM,
-        results.map((r) => r.woMs)
       );
     }
   );
@@ -553,6 +654,14 @@ describe('workflow benchmarks', () => {
         targets
       );
     }
+    // WO: whole-run overhead outside step bodies (server-anchored + flat RTT).
+    // Measured here rather than on the stream scenarios, where a single step
+    // makes WO algebraically identical to TTFS.
+    recordMetric(
+      'wo',
+      SCENARIO_SEQUENTIAL,
+      results.map((r) => r.woMs)
+    );
   });
 
   afterAll(() => {

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -103,6 +103,14 @@ const SEQUENTIAL_ITERATIONS = envInt('BENCH_SEQUENTIAL_ITERATIONS', 1);
 const SEQUENTIAL_STEP_COUNT = envInt('BENCH_SEQUENTIAL_STEP_COUNT', 1020);
 const WARMUP_ITERATIONS = envInt('BENCH_WARMUP_ITERATIONS', 2, 0);
 
+// Methodology version — bump whenever the measurement window changes in a way
+// that makes numbers incomparable across runs (e.g. the switch from a
+// CI/proxy-inclusive clock to the in-deployment trigger). The PR-comment
+// renderer keys baseline deltas on this, so old-methodology baselines on `main`
+// are not diffed against new-methodology runs (deltas stay blank until `main`
+// has produced a same-version baseline). v2 = in-deployment trigger.
+const BENCH_METHODOLOGY_VERSION = 2;
+
 // Per-metric latency targets (ms) rendered as 🟢/🔴 marks in the PR comment.
 // Provisional: now that the proxy leg is out of every window, these will be
 // re-tightened once a few in-deployment baselines land.
@@ -660,6 +668,9 @@ describe('workflow benchmarks', () => {
     );
     const results = {
       version: 1,
+      // Measurement-methodology version; baseline deltas only compare runs
+      // with the same value (see annotateWithBaseline in the renderer).
+      methodologyVersion: BENCH_METHODOLOGY_VERSION,
       app: appName,
       backend,
       generatedAt: new Date().toISOString(),

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -2,64 +2,70 @@
  * Benchmark runner measuring the workflow runtime's core latency metrics
  * against a deployed workbench app.
  *
+ * Every run is triggered through an in-deployment route (`POST /api/bench` on
+ * the workbench app) rather than by calling `start()` from this CI process. The
+ * route stamps `clientStart` with the deployment's own clock immediately before
+ * `start()`, so the CI runner's request — and its entire path through
+ * api.vercel.com — sits OUTSIDE every measured window. As a result none of the
+ * metrics below depend on the CI runner's clock or its network path to the
+ * proxy; they are computed purely from Vercel-side timestamps.
+ *
  * Metrics (all in milliseconds, reported as avg/p75/p90/p99):
  *
- * - TTFS  (time to first step): server-side `run_created` timestamp
- *          (Vercel-assigned `createdAt`) → first step body execution
- *          (`steps[0].start`, the deployment's clock). Both endpoints are
- *          Vercel-provided, so the measurement is independent of the CI
- *          runner's clock and its network path to api.vercel.com. Because the
- *          server anchor starts *after* the create request's inbound leg, a
- *          flat RTT_OVERHEAD_MS is added as an estimate of that client→ingress
- *          request overhead. Measured for both the turbo path (no hooks) and
- *          the non-turbo path (a hook was registered before the step).
+ * - TTFS  (time to first step): `steps[0].start` (first step body execution,
+ *          deployment clock) minus the in-deployment `clientStart` returned by
+ *          the trigger route. Because `start()` runs inside the deployment, the
+ *          turbo path (no hooks) exercises the runtime's in-process fast path
+ *          (optimisticStart); the non-turbo path (a hook registered before the
+ *          step) exercises the dispatch path. Both are proxy-independent.
  * - STSO  (step-to-step overhead): gap between consecutive step body
  *          executions (`steps[i].start - steps[i-1].end`) in a workflow with
  *          many trivial sequential steps. Both timestamps come from step
- *          bodies on the deployment, so STSO is already independent of the CI
- *          client and the api.vercel.com proxy. Reported per step-index range
- *          (see STSO_BUCKETS) because early steps behave differently from
- *          late ones (first-invocation fast paths, growing event log).
+ *          bodies on the deployment. Reported per step-index range (see
+ *          STSO_BUCKETS) because early steps behave differently from late ones
+ *          (first-invocation fast paths, growing event log).
  * - WO    (workflow overhead): total time the run spends outside of step
- *          bodies over the whole sequential run, from the server-side
- *          `run_created` timestamp to the end of the last step body:
- *          `(lastStep.end - runCreatedServerMs) - Σ(step durations)`, plus the
- *          flat RTT_OVERHEAD_MS. Measured on the sequential scenario only — on
- *          a single-step workflow WO reduces algebraically to TTFS.
- * - SL    (stream latency): time between a step writing the first chunk to
- *          the workflow's default output stream and that chunk becoming
- *          visible to a reader attached via `run.getReadable()`. Unlike the
- *          other metrics this is inherently client-observed: it includes the
- *          api.vercel.com read path (a server-side measurement would need
- *          runtime/world changes and is a separate follow-up).
+ *          bodies over the whole sequential run, from the in-deployment
+ *          `clientStart` to the end of the last step body:
+ *          `(lastStep.end - clientStart) - Σ(step durations)`. Measured on the
+ *          sequential scenario only — on a single-step workflow WO reduces
+ *          algebraically to TTFS.
+ * - SL    (stream latency): live write->read propagation for the default
+ *          output stream, measured entirely on the deployment by
+ *          `benchSlWorkflow`: a reader step and a writer step run in parallel,
+ *          the reader blocks on the first chunk, and the workflow returns both
+ *          the writer's `writtenAt` and the reader's `readAt`. SL is
+ *          `readAt - writtenAt`, so it excludes the api.vercel.com read path
+ *          the old client-observed metric included.
  *
  * Scenarios (defined in workbench/example/workflows/97_bench.ts):
  *
- * 1. benchStreamWorkflow          — 1 streaming step, turbo mode → TTFS + SL
- * 2. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
- * 3. benchHookStreamWorkflow      — hook + 1 streaming step, non-turbo → TTFS + SL
+ * 1. benchStreamWorkflow          — 1 step, turbo mode → TTFS (turbo)
+ * 2. benchHookStreamWorkflow      — hook + 1 step, non-turbo → TTFS (non-turbo)
+ * 3. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
+ * 4. benchSlWorkflow              — parallel reader/writer steps → SL
  *
  * Each scenario runs many iterations (env-tunable, see BENCH_* below) so the
  * percentiles are computed from real samples.
  *
  * The backend is selected exactly like the e2e tests (setupWorld): Vercel when
  * WORKFLOW_VERCEL_ENV is set, Postgres when WORKFLOW_TARGET_WORLD is
- * @workflow/world-postgres, local filesystem otherwise. Note that SL requires
- * `run.getReadable()` to work from a separate process, which the local world's
- * in-process streamer does not support — CI currently runs this file against
- * Vercel only.
+ * @workflow/world-postgres, local filesystem otherwise. Because SL is now
+ * measured inside the workflow (not by a reader in this process), it no longer
+ * depends on `run.getReadable()` working across processes; CI still runs this
+ * file against Vercel only.
  *
- * TTFS/WO anchor on the Vercel-assigned `run_created` timestamp (fetched via
- * the world's event log) and end on the deployment's step-body clock; the only
- * residual skew is intra-Vercel (workflow-server vs step runner), NTP-bounded
- * and small. SL still compares the step runner's clock against the client's.
+ * All timestamps are deployment-side, so the only residual skew is intra-Vercel
+ * (between step-runner instances in the same region), NTP-bounded and small
+ * relative to the measured values.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, test } from 'vitest';
-import { getWorld, start } from '../src/runtime';
-import { getWorkflowMetadata, setupWorld } from './utils';
+import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
+import { getRun } from '../src/runtime';
+import { setupWorld } from './utils';
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
 if (!deploymentUrl) {
@@ -78,23 +84,18 @@ const envInt = (name: string, fallback: number, min = 1): number => {
   return value;
 };
 
-// Iteration counts. Stream scenarios yield one TTFS/SL/WO sample per
+// Iteration counts. The stream/hook/SL scenarios yield one sample per
 // iteration; the sequential scenario yields (stepCount - 1) STSO samples per
 // iteration, so a single long run already provides solid percentiles.
 const STREAM_ITERATIONS = envInt('BENCH_STREAM_ITERATIONS', 30);
+const SL_ITERATIONS = envInt('BENCH_SL_ITERATIONS', STREAM_ITERATIONS);
 const SEQUENTIAL_ITERATIONS = envInt('BENCH_SEQUENTIAL_ITERATIONS', 1);
 const SEQUENTIAL_STEP_COUNT = envInt('BENCH_SEQUENTIAL_STEP_COUNT', 1020);
 const WARMUP_ITERATIONS = envInt('BENCH_WARMUP_ITERATIONS', 2, 0);
 
-// TTFS/WO anchor on the Vercel-assigned `run_created` timestamp, which is
-// stamped only after the client's create request has reached the ingress — so
-// the server anchor excludes that client→api.vercel.com inbound leg. We add
-// this flat estimate of the request overhead (RTT) back in, keeping the metric
-// deterministic (no CI-network variance) while still approximating end-to-end.
-// The observed inbound leg is ~100-200ms; 80ms is a conservative flat default.
-const RTT_OVERHEAD_MS = envInt('BENCH_RTT_OVERHEAD_MS', 80, 0);
-
 // Per-metric latency targets (ms) rendered as 🟢/🔴 marks in the PR comment.
+// Provisional: now that the proxy leg is out of every window, these will be
+// re-tightened once a few in-deployment baselines land.
 const TTFS_TARGETS = { p75: 200, p90: 300, p99: 600 };
 const SL_TARGETS = { p75: 50, p90: 60, p99: 125 };
 
@@ -126,35 +127,37 @@ interface BenchStepTiming {
   end: number;
 }
 
-interface BenchStreamChunk {
-  seq: number;
+interface BenchStreamLatency {
   writtenAt: number;
+  readAt: number;
 }
 
 interface StreamIterationResult {
   runId: string;
-  /** Server-anchored TTFS (+ flat RTT estimate); the reported metric. */
+  /** `steps[0].start - clientStart`, both deployment-side clocks. */
   ttfsMs: number;
-  /**
-   * Client wall-clock TTFS (`steps[0].start - clientStart`), kept for
-   * diagnostics only (logged/serialized, not reported as a metric). Comparing
-   * it against `ttfsMs - RTT_OVERHEAD_MS` shows how well the flat 80ms tracks
-   * the real client→ingress overhead.
-   */
-  ttfsWallMs: number;
-  slMs: number;
 }
 
 interface SequentialIterationResult {
   runId: string;
   /** stsoMs[i] is the gap between steps i+1 and i+2 (1-indexed). */
   stsoMs: number[];
-  /** Server-anchored whole-run workflow overhead (+ flat RTT estimate). */
+  /** Whole-run workflow overhead, anchored on the in-deployment clientStart. */
   woMs: number;
 }
 
-const benchWf = (fn: string) =>
-  getWorkflowMetadata(deploymentUrl, 'workflows/97_bench.ts', fn);
+interface SlIterationResult {
+  runId: string;
+  /** `readAt - writtenAt`, both deployment-side step-body clocks. */
+  slMs: number;
+}
+
+/** Response shape of the in-deployment `POST /api/bench` trigger route. */
+interface BenchTriggerResponse {
+  runId: string;
+  /** Date.now() stamped in the route immediately before start(). */
+  clientStart: number;
+}
 
 function withTimeout<T>(
   promise: Promise<T>,
@@ -173,6 +176,45 @@ function withTimeout<T>(
       timer.unref?.();
     }),
   ]);
+}
+
+/**
+ * Trigger a benchmark workflow via the in-deployment route so `clientStart` is
+ * stamped by the deployment's clock (excluding the CI->ingress request path).
+ * Returns the created run id and that anchor.
+ */
+async function triggerBenchRun(
+  workflowFn: string,
+  args: unknown[] = []
+): Promise<BenchTriggerResponse> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    ...(await getTrustedSourcesHeaders()),
+  };
+  const response = await fetch(`${deploymentUrl}/api/bench`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ workflowFn, args }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(
+      `bench trigger for ${workflowFn} failed: ${response.status} ${body.slice(0, 300)}`
+    );
+  }
+  const data = (await response.json()) as Partial<BenchTriggerResponse>;
+  if (typeof data.runId !== 'string' || typeof data.clientStart !== 'number') {
+    throw new Error(
+      `bench trigger for ${workflowFn} returned malformed body: ${JSON.stringify(data)?.slice(0, 200)}`
+    );
+  }
+  return { runId: data.runId, clientStart: data.clientStart };
+}
+
+/** Poll a run's return value to completion (the handle polls internally). */
+async function getReturnValue(runId: string): Promise<unknown> {
+  const run = await getRun(runId);
+  return run.returnValue;
 }
 
 function timingsFromReturnValue(
@@ -196,36 +238,8 @@ function timingsFromReturnValue(
 }
 
 /**
- * Vercel-assigned run-creation timestamp (epoch ms), read from the world's
- * event log so TTFS/WO anchor on a server clock rather than the CI runner's.
- * Prefers the `run_created` event's `createdAt` (server-stamped, distinct from
- * the client `occurredAt`); falls back to the run snapshot's `createdAt`.
- * Returns undefined if neither can be read, so callers can degrade to the
- * client anchor rather than dropping the sample.
- */
-async function runCreatedServerMs(runId: string): Promise<number | undefined> {
-  try {
-    const world = await getWorld();
-    const { data } = await world.events.list({ runId });
-    const created = data.find((e) => e.eventType === 'run_created');
-    const createdMs = created?.createdAt?.getTime?.();
-    if (typeof createdMs === 'number' && Number.isFinite(createdMs)) {
-      return createdMs;
-    }
-    const run = await world.runs.get(runId);
-    const runCreatedMs = run.createdAt?.getTime?.();
-    return typeof runCreatedMs === 'number' && Number.isFinite(runCreatedMs)
-      ? runCreatedMs
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Raw WO: total time outside of step bodies, from `anchorMs` to the last step
- * body's exit. The caller supplies the server `run_created` timestamp as the
- * anchor and adds RTT_OVERHEAD_MS; the value is clamped at 0 to absorb small
+ * WO: total time outside of step bodies, from `anchorMs` (the in-deployment
+ * clientStart) to the last step body's exit. Clamped at 0 to absorb small
  * intra-Vercel clock skew.
  */
 function workflowOverheadMs(
@@ -240,90 +254,21 @@ function workflowOverheadMs(
 async function runStreamIteration(
   workflowFn: string
 ): Promise<StreamIterationResult> {
-  const wf = await benchWf(workflowFn);
-  const clientStart = Date.now();
-  const run = await start(wf, []);
+  const { runId, clientStart } = await triggerBenchRun(workflowFn);
   try {
-    // Attach the reader right away — before the step executes — so first-chunk
-    // visibility is bounded by the streaming pipeline, not by when we read.
-    const reader = run
-      .getReadable<BenchStreamChunk>()
-      .getReader() as ReadableStreamDefaultReader<BenchStreamChunk>;
-
-    let slMs: number | undefined;
-    let chunksSeen = 0;
-    // Drain the whole stream (the step closes it); the first chunk yields the
-    // SL sample. Intentionally no reader.cancel() — leave the reader behind on
-    // timeout instead (cancellation of in-flight world streams can hang).
-    await withTimeout(
-      (async () => {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          const readAt = Date.now();
-          if (chunksSeen === 0) {
-            if (typeof value?.writtenAt !== 'number') {
-              throw new Error(
-                `Malformed stream chunk: ${JSON.stringify(value)?.slice(0, 200)}`
-              );
-            }
-            slMs = readAt - value.writtenAt;
-          }
-          chunksSeen++;
-        }
-      })(),
-      RUN_TIMEOUT_MS,
-      `${workflowFn} stream read (run ${run.runId})`
-    );
-    if (slMs === undefined) {
-      throw new Error(`Run ${run.runId} produced no stream chunks`);
-    }
-
     const returnValue = await withTimeout(
-      run.returnValue,
+      getReturnValue(runId),
       RUN_TIMEOUT_MS,
-      `${workflowFn} returnValue (run ${run.runId})`
+      `${workflowFn} returnValue (run ${runId})`
     );
-    const steps = timingsFromReturnValue(returnValue, run.runId);
-
-    // Anchor TTFS at the Vercel-assigned run-creation time so the metric is
-    // independent of the CI runner's clock and its path to api.vercel.com,
-    // then add the flat RTT estimate for the create request's inbound leg.
-    // If the server timestamp can't be read, degrade to the client anchor
-    // (which already includes the real RTT — no flat estimate is added).
-    const serverAnchor = await runCreatedServerMs(run.runId);
-    const ttfsWallMs = steps[0].start - clientStart;
-    const ttfsMs =
-      serverAnchor !== undefined
-        ? Math.max(0, steps[0].start - serverAnchor) + RTT_OVERHEAD_MS
-        : ttfsWallMs;
-    if (serverAnchor === undefined) {
-      console.warn(
-        `[bench] ${workflowFn} run ${run.runId}: no server run_created timestamp; TTFS degraded to client anchor`
-      );
-    }
-
+    const steps = timingsFromReturnValue(returnValue, runId);
     return {
-      runId: run.runId,
-      ttfsMs,
-      ttfsWallMs,
-      slMs,
+      runId,
+      // Both timestamps are deployment-side; clamp to absorb tiny skew.
+      ttfsMs: Math.max(0, steps[0].start - clientStart),
     };
   } catch (error) {
-    // A stream-read timeout alone can't distinguish "the run never executed"
-    // (queue not delivering to this deployment) from "the read path is
-    // broken" (run finished but chunks never became visible). Probe the run
-    // state so the failure log answers that question.
-    let runState = 'unknown';
-    try {
-      await withTimeout(run.returnValue, 5_000, 'run state probe');
-      runState = 'run completed';
-    } catch (probe) {
-      runState = (probe as Error).message.startsWith('Timed out')
-        ? 'run still not finished'
-        : `run failed: ${(probe as Error).message}`;
-    }
-    (error as Error).message += ` (run ${run.runId}; ${runState})`;
+    (error as Error).message += ` (run ${runId})`;
     throw error;
   }
 }
@@ -331,19 +276,20 @@ async function runStreamIteration(
 async function runSequentialIteration(
   stepCount: number
 ): Promise<SequentialIterationResult> {
-  const wf = await benchWf('benchSequentialStepsWorkflow');
-  const clientStart = Date.now();
-  const run = await start(wf, [stepCount]);
+  const { runId, clientStart } = await triggerBenchRun(
+    'benchSequentialStepsWorkflow',
+    [stepCount]
+  );
   try {
     const returnValue = await withTimeout(
-      run.returnValue,
+      getReturnValue(runId),
       RUN_TIMEOUT_MS + stepCount * 2_000,
-      `benchSequentialStepsWorkflow returnValue (run ${run.runId})`
+      `benchSequentialStepsWorkflow returnValue (run ${runId})`
     );
-    const steps = timingsFromReturnValue(returnValue, run.runId);
+    const steps = timingsFromReturnValue(returnValue, runId);
     if (steps.length !== stepCount) {
       throw new Error(
-        `Run ${run.runId} returned ${steps.length} step timings, expected ${stepCount}`
+        `Run ${runId} returned ${steps.length} step timings, expected ${stepCount}`
       );
     }
 
@@ -352,22 +298,38 @@ async function runSequentialIteration(
       stsoMs.push(steps[i].start - steps[i - 1].end);
     }
 
-    // Server-anchored whole-run WO (+ flat RTT). Degrade to the client start
-    // if the server timestamp is unavailable (then the RTT is already
-    // included, so no flat estimate is added).
-    const serverAnchor = await runCreatedServerMs(run.runId);
-    const woMs =
-      serverAnchor !== undefined
-        ? workflowOverheadMs(serverAnchor, steps) + RTT_OVERHEAD_MS
-        : workflowOverheadMs(clientStart, steps);
-
     return {
-      runId: run.runId,
+      runId,
       stsoMs,
-      woMs,
+      woMs: workflowOverheadMs(clientStart, steps),
     };
   } catch (error) {
-    (error as Error).message += ` (run ${run.runId})`;
+    (error as Error).message += ` (run ${runId})`;
+    throw error;
+  }
+}
+
+async function runSlIteration(): Promise<SlIterationResult> {
+  const { runId } = await triggerBenchRun('benchSlWorkflow');
+  try {
+    const returnValue = await withTimeout(
+      getReturnValue(runId),
+      RUN_TIMEOUT_MS,
+      `benchSlWorkflow returnValue (run ${runId})`
+    );
+    const sl = (returnValue as { sl?: BenchStreamLatency } | undefined)?.sl;
+    if (
+      !sl ||
+      typeof sl.writtenAt !== 'number' ||
+      typeof sl.readAt !== 'number'
+    ) {
+      throw new Error(
+        `Run ${runId} returned no stream-latency sample: ${JSON.stringify(returnValue)?.slice(0, 200)}`
+      );
+    }
+    return { runId, slMs: Math.max(0, sl.readAt - sl.writtenAt) };
+  } catch (error) {
+    (error as Error).message += ` (run ${runId})`;
     throw error;
   }
 }
@@ -500,25 +462,6 @@ function recordMetric(
   });
 }
 
-/**
- * Log the client wall-clock TTFS alongside the reported server-anchored TTFS
- * so the flat RTT_OVERHEAD_MS assumption can be validated from CI logs. Not a
- * reported metric — diagnostics only. `wall - (server - RTT)` is the residual
- * between the real client→ingress overhead and our flat estimate.
- */
-function logTtfsWallDiagnostic(
-  scenario: string,
-  results: StreamIterationResult[]
-) {
-  if (results.length === 0) return;
-  const wall = computeStats(results.map((r) => r.ttfsWallMs));
-  const server = computeStats(results.map((r) => r.ttfsMs));
-  console.log(
-    `[bench] ${scenario} TTFS diagnostic: server+RTT avg ${server.avg}ms, ` +
-      `client wall-clock avg ${wall.avg}ms (RTT flat estimate ${RTT_OVERHEAD_MS}ms)`
-  );
-}
-
 function getBackend(): string {
   if (process.env.WORKFLOW_BENCH_BACKEND) {
     return process.env.WORKFLOW_BENCH_BACKEND;
@@ -535,41 +478,49 @@ function getBackend(): string {
 const SCENARIO_TURBO_STREAM = 'stream';
 const SCENARIO_HOOK_STREAM = 'hook + stream';
 const SCENARIO_SEQUENTIAL = `${SEQUENTIAL_STEP_COUNT} steps`;
+const SCENARIO_STREAM_LATENCY = 'stream latency';
 const SCENARIO_DESCRIPTIONS = [
   {
     name: SCENARIO_TURBO_STREAM,
     description:
-      'one step that streams chunks back to the client; no hooks, so the run stays in turbo mode',
+      'one step; no hooks, so the run stays in turbo mode (in-process fast path)',
   },
   {
     name: SCENARIO_HOOK_STREAM,
     description:
-      'registers a hook before the same streaming step, which exits turbo mode',
+      'registers a hook before one step, which exits turbo mode (dispatch path)',
   },
   {
     name: SCENARIO_SEQUENTIAL,
     description: `${SEQUENTIAL_STEP_COUNT} trivial sequential steps; STSO is measured between consecutive steps in the given step ranges, and WO is the whole-run overhead outside step bodies`,
   },
+  {
+    name: SCENARIO_STREAM_LATENCY,
+    description:
+      'parallel reader/writer steps on a dedicated stream; SL is the in-deployment write->read propagation (readAt - writtenAt)',
+  },
 ];
 
 describe('workflow benchmarks', () => {
-  // Preflight: prove the deployment executes workflows at all before any
-  // scenario spends its attempt budget. Without this, a target that accepts
-  // run creation but never executes runs (e.g. queue not delivering to the
-  // deployment) makes every iteration of every scenario wait out
-  // RUN_TIMEOUT_MS, and the job dies at its time limit without a useful
+  // Preflight: prove the deployment executes workflows (and the trigger route
+  // works) before any scenario spends its attempt budget. Without this, a
+  // target that accepts run creation but never executes runs (e.g. queue not
+  // delivering to the deployment) makes every iteration of every scenario wait
+  // out RUN_TIMEOUT_MS, and the job dies at its time limit without a useful
   // error.
   beforeAll(async () => {
-    const wf = await benchWf('benchSequentialStepsWorkflow');
-    const run = await start(wf, [1]);
+    const { runId } = await triggerBenchRun(
+      'benchSequentialStepsWorkflow',
+      [1]
+    );
     try {
       const returnValue = await withTimeout(
-        run.returnValue,
+        getReturnValue(runId),
         PREFLIGHT_TIMEOUT_MS,
-        `preflight run (run ${run.runId})`
+        `preflight run (run ${runId})`
       );
-      timingsFromReturnValue(returnValue, run.runId);
-      console.log(`[bench] preflight ok (run ${run.runId})`);
+      timingsFromReturnValue(returnValue, runId);
+      console.log(`[bench] preflight ok (run ${runId})`);
     } catch (error) {
       throw new Error(
         `Benchmark preflight failed — the deployment accepted the run but did not execute it to completion; aborting all scenarios. ${(error as Error).message}`
@@ -577,33 +528,22 @@ describe('workflow benchmarks', () => {
     }
   }, PREFLIGHT_TIMEOUT_MS + 60_000);
 
-  test(
-    'scenario: 1 step + stream (turbo)',
-    { timeout: 30 * 60_000 },
-    async () => {
-      const results = await runScenario(
-        SCENARIO_TURBO_STREAM,
-        STREAM_ITERATIONS,
-        () => runStreamIteration('benchStreamWorkflow')
-      );
-      recordMetric(
-        'ttfs',
-        SCENARIO_TURBO_STREAM,
-        results.map((r) => r.ttfsMs),
-        TTFS_TARGETS
-      );
-      logTtfsWallDiagnostic(SCENARIO_TURBO_STREAM, results);
-      recordMetric(
-        'sl',
-        SCENARIO_TURBO_STREAM,
-        results.map((r) => r.slMs),
-        SL_TARGETS
-      );
-    }
-  );
+  test('scenario: 1 step (turbo)', { timeout: 30 * 60_000 }, async () => {
+    const results = await runScenario(
+      SCENARIO_TURBO_STREAM,
+      STREAM_ITERATIONS,
+      () => runStreamIteration('benchStreamWorkflow')
+    );
+    recordMetric(
+      'ttfs',
+      SCENARIO_TURBO_STREAM,
+      results.map((r) => r.ttfsMs),
+      TTFS_TARGETS
+    );
+  });
 
   test(
-    'scenario: hook + 1 step + stream (non-turbo)',
+    'scenario: hook + 1 step (non-turbo)',
     { timeout: 30 * 60_000 },
     async () => {
       const results = await runScenario(
@@ -617,15 +557,22 @@ describe('workflow benchmarks', () => {
         results.map((r) => r.ttfsMs),
         TTFS_TARGETS
       );
-      logTtfsWallDiagnostic(SCENARIO_HOOK_STREAM, results);
-      recordMetric(
-        'sl',
-        SCENARIO_HOOK_STREAM,
-        results.map((r) => r.slMs),
-        SL_TARGETS
-      );
     }
   );
+
+  test('scenario: stream latency', { timeout: 30 * 60_000 }, async () => {
+    const results = await runScenario(
+      SCENARIO_STREAM_LATENCY,
+      SL_ITERATIONS,
+      () => runSlIteration()
+    );
+    recordMetric(
+      'sl',
+      SCENARIO_STREAM_LATENCY,
+      results.map((r) => r.slMs),
+      SL_TARGETS
+    );
+  });
 
   test('scenario: sequential steps', { timeout: 60 * 60_000 }, async () => {
     const results = await runScenario(
@@ -634,7 +581,7 @@ describe('workflow benchmarks', () => {
       () => runSequentialIteration(SEQUENTIAL_STEP_COUNT),
       {
         // No warmup: STSO gaps are measured entirely on the deployment (the
-        // stream scenarios already warmed the client + world), and a warmup
+        // other scenarios already warmed the client + world), and a warmup
         // run of this scenario would cost as much as a recorded one.
         warmupIterations: 0,
         // A long run occasionally fails outright (e.g. replay divergence
@@ -654,9 +601,9 @@ describe('workflow benchmarks', () => {
         targets
       );
     }
-    // WO: whole-run overhead outside step bodies (server-anchored + flat RTT).
-    // Measured here rather than on the stream scenarios, where a single step
-    // makes WO algebraically identical to TTFS.
+    // WO: whole-run overhead outside step bodies, anchored on the in-deployment
+    // clientStart. Measured here rather than on the stream scenarios, where a
+    // single step makes WO algebraically identical to TTFS.
     recordMetric(
       'wo',
       SCENARIO_SEQUENTIAL,
@@ -684,6 +631,7 @@ describe('workflow benchmarks', () => {
       commit: process.env.GITHUB_SHA || undefined,
       config: {
         streamIterations: STREAM_ITERATIONS,
+        slIterations: SL_ITERATIONS,
         sequentialIterations: SEQUENTIAL_ITERATIONS,
         sequentialStepCount: SEQUENTIAL_STEP_COUNT,
         warmupIterations: WARMUP_ITERATIONS,

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -74,10 +74,21 @@ async function timedStreamingStep(chunks: number): Promise<BenchStepTiming> {
 }
 
 /**
- * Scenario 1: one step that streams data back to a reader.
- *
- * No hooks are created, so the first invocation runs in turbo mode. Used to
- * measure TTFS (turbo) and SL (turbo).
+ * Scenario 1a: one trivial no-op step — no stream, no hooks (turbo mode). The
+ * cleanest TTFS measurement, with no stream machinery in the step body.
+ */
+export async function benchStepWorkflow(): Promise<{
+  steps: BenchStepTiming[];
+}> {
+  'use workflow';
+  const step = await timedNoopStep(0);
+  return { steps: [step] };
+}
+
+/**
+ * Scenario 1b: one step that streams data back. No hooks, so the first
+ * invocation runs in turbo mode. Used to measure TTFS (turbo) with a streaming
+ * step body (contrast with {@link benchStepWorkflow}).
  */
 export async function benchStreamWorkflow(): Promise<{
   steps: BenchStepTiming[];

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -43,12 +43,13 @@ export interface BenchStreamLatency {
 // Dedicated stream for the SL scenario, kept off the default output stream so
 // it never interacts with the default-stream lifecycle.
 const SL_STREAM_NAMESPACE = 'bench-sl';
-// The writer waits this long before writing its first chunk so the parallel
-// reader step is guaranteed to be attached and blocked on the stream first.
-// SL then reflects live write->read propagation (pub/sub wake + delivery),
-// not a warm read of an already-written chunk. The wait happens before
-// `writtenAt` is stamped, so it never enters the SL measurement.
-const SL_WRITE_DELAY_MS = 750;
+// A second stream used as a reader-ready barrier: the reader initiates its
+// read on the SL stream, then writes a marker here; the writer blocks on this
+// marker before writing to the SL stream. This guarantees the SL chunk is
+// delivered to an already-attached reader (live write->read propagation)
+// rather than being retained for a reader that started late — which a fixed
+// sleep could not guarantee under scheduler delay or load.
+const SL_READY_NAMESPACE = 'bench-sl-ready';
 
 async function timedNoopStep(index: number): Promise<BenchStepTiming> {
   'use step';
@@ -131,19 +132,32 @@ export async function benchHookStreamWorkflow(): Promise<{
   return { steps: [step], hookToken: hook.token };
 }
 
-/** Reader half of the SL scenario: attaches to the dedicated stream and blocks
- * on the first chunk, stamping `readAt` the instant it arrives. Reads via
- * `getRun(runId).getReadable()` — the same in-deployment path a co-located
- * consumer uses, so the api.vercel.com read path is never involved. */
+/** Reader half of the SL scenario. Reads via `getRun(runId).getReadable()` —
+ * the same in-deployment path a co-located consumer uses, so the
+ * api.vercel.com read path is never involved. Initiates the SL read (which
+ * establishes the server-side stream connection), signals readiness on the
+ * ready stream, then awaits the first chunk and stamps `readAt`. */
 async function slReaderStep(): Promise<BenchStreamLatency> {
   'use step';
   const { workflowRunId } = getWorkflowMetadata();
-  const run = getRun<BenchStreamChunk>(workflowRunId);
-  const reader = run
+  const reader = getRun<BenchStreamChunk>(workflowRunId)
     .getReadable<BenchStreamChunk>({ namespace: SL_STREAM_NAMESPACE })
     .getReader();
   try {
-    const { value } = await reader.read();
+    // Initiate the read BEFORE signalling ready so the stream GET is in flight;
+    // the writer only writes after observing the signal (plus its own
+    // round-trip), by which point this reader is attached and blocked.
+    const readPromise = reader.read();
+
+    const ready = getWritable<{ ready: true }>({
+      namespace: SL_READY_NAMESPACE,
+    });
+    const readyWriter = ready.getWriter();
+    await readyWriter.write({ ready: true });
+    readyWriter.releaseLock();
+    await ready.close();
+
+    const { value } = await readPromise;
     const readAt = Date.now();
     if (!value || typeof value.writtenAt !== 'number') {
       throw new Error(
@@ -157,15 +171,26 @@ async function slReaderStep(): Promise<BenchStreamLatency> {
   }
 }
 
-/** Writer half of the SL scenario: waits so the reader is attached first, then
- * writes a single chunk stamped with `writtenAt` and closes the stream. */
+/** Writer half of the SL scenario: blocks on the reader-ready marker, then
+ * writes a single chunk stamped with `writtenAt` and closes the stream. The
+ * barrier read only needs to observe the marker (a retained chunk is fine), so
+ * its own attach timing doesn't matter — it just gates the SL write. */
 async function slWriterStep(): Promise<void> {
   'use step';
+  const { workflowRunId } = getWorkflowMetadata();
+  const readyReader = getRun<{ ready: true }>(workflowRunId)
+    .getReadable<{ ready: true }>({ namespace: SL_READY_NAMESPACE })
+    .getReader();
+  try {
+    await readyReader.read();
+  } finally {
+    readyReader.cancel().catch(() => {});
+  }
+
   const writable = getWritable<BenchStreamChunk>({
     namespace: SL_STREAM_NAMESPACE,
   });
   const writer = writable.getWriter();
-  await new Promise((resolve) => setTimeout(resolve, SL_WRITE_DELAY_MS));
   await writer.write({ seq: 0, writtenAt: Date.now() });
   writer.releaseLock();
   await writable.close();
@@ -175,10 +200,12 @@ async function slWriterStep(): Promise<void> {
  * Scenario 4: stream latency (SL), measured entirely on the deployment.
  *
  * The reader and writer steps run in parallel on a dedicated namespaced
- * stream. The reader attaches and blocks; the writer waits {@link
- * SL_WRITE_DELAY_MS} (guaranteeing the reader is blocked first) and then
- * writes. Both `writtenAt` and `readAt` are step-body `Date.now()` values on
- * the deployment, so the returned SL is independent of the CI client and the
+ * stream, coordinated by an explicit reader-ready barrier (a second stream):
+ * the writer writes its `writtenAt` chunk only after the reader has initiated
+ * its read and signalled readiness, so SL reflects live write->read
+ * propagation rather than a late reader catching up on a retained chunk. Both
+ * `writtenAt` and `readAt` are step-body `Date.now()` values on the
+ * deployment, so the returned SL is independent of the CI client and the
  * api.vercel.com read path.
  */
 export async function benchSlWorkflow(): Promise<{ sl: BenchStreamLatency }> {

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -1,19 +1,24 @@
 // Benchmark workflows for performance measurement.
 //
-// The benchmark runner (packages/core/e2e/benchmark.test.ts) derives all
-// metrics from wall-clock timestamps recorded here:
+// The benchmark runner (packages/core/e2e/benchmark.test.ts) triggers these
+// workflows through an in-deployment route (workbench app `/api/bench`) that
+// stamps `clientStart` with the deployment's own clock right before calling
+// `start()`. Every metric is then derived from timestamps recorded on the
+// deployment — never from the CI runner's clock or its path to
+// api.vercel.com:
 //
 // - Every step records `start`/`end` (`Date.now()` at body entry/exit) and the
-//   workflow returns the collected timings. The runner combines them with its
-//   own client-side timestamp taken when `start()` is called to compute
-//   time-to-first-step (TTFS), step-to-step overhead (STSO), and workflow
-//   overhead (WO).
-// - Streaming steps embed `writtenAt` into every chunk written to the default
-//   output stream so a reader can compute stream latency (SL) as
-//   `readTime - writtenAt` without needing a shared clock with the runner
-//   process beyond NTP.
+//   workflow returns the collected timings. The runner combines them with the
+//   in-deployment `clientStart` to compute time-to-first-step (TTFS),
+//   step-to-step overhead (STSO), and workflow overhead (WO).
+// - `benchSlWorkflow` measures stream latency (SL) entirely on the deployment:
+//   a reader step and a writer step run in parallel on a dedicated namespaced
+//   stream, and the workflow returns both the writer's `writtenAt` and the
+//   reader's `readAt` so SL (`readAt - writtenAt`) excludes the client read
+//   path.
 
-import { createHook, getWritable } from 'workflow';
+import { createHook, getWorkflowMetadata, getWritable } from 'workflow';
+import { getRun } from 'workflow/api';
 
 export interface BenchStepTiming {
   /** Date.now() at step body entry */
@@ -27,6 +32,23 @@ export interface BenchStreamChunk {
   /** Date.now() in the step when this chunk was written */
   writtenAt: number;
 }
+
+export interface BenchStreamLatency {
+  /** Date.now() in the writer step when the first chunk was written */
+  writtenAt: number;
+  /** Date.now() in the reader step when the first chunk was received */
+  readAt: number;
+}
+
+// Dedicated stream for the SL scenario, kept off the default output stream so
+// it never interacts with the default-stream lifecycle.
+const SL_STREAM_NAMESPACE = 'bench-sl';
+// The writer waits this long before writing its first chunk so the parallel
+// reader step is guaranteed to be attached and blocked on the stream first.
+// SL then reflects live write->read propagation (pub/sub wake + delivery),
+// not a warm read of an already-written chunk. The wait happens before
+// `writtenAt` is stamped, so it never enters the SL measurement.
+const SL_WRITE_DELAY_MS = 750;
 
 async function timedNoopStep(index: number): Promise<BenchStepTiming> {
   'use step';
@@ -81,11 +103,11 @@ export async function benchSequentialStepsWorkflow(count: number): Promise<{
 }
 
 /**
- * Scenario 3: registers a hook, then runs one step that streams data back.
+ * Scenario 3: registers a hook, then runs one step.
  *
  * The fire-and-forget hook is never awaited — its `hook_created` event at the
  * first suspension makes the runtime exit turbo mode, so this scenario
- * measures the non-turbo TTFS and SL paths (contrast with
+ * measures the non-turbo TTFS path (contrast with
  * {@link benchStreamWorkflow}).
  */
 export async function benchHookStreamWorkflow(): Promise<{
@@ -96,4 +118,60 @@ export async function benchHookStreamWorkflow(): Promise<{
   const hook = createHook<never>();
   const step = await timedStreamingStep(3);
   return { steps: [step], hookToken: hook.token };
+}
+
+/** Reader half of the SL scenario: attaches to the dedicated stream and blocks
+ * on the first chunk, stamping `readAt` the instant it arrives. Reads via
+ * `getRun(runId).getReadable()` — the same in-deployment path a co-located
+ * consumer uses, so the api.vercel.com read path is never involved. */
+async function slReaderStep(): Promise<BenchStreamLatency> {
+  'use step';
+  const { workflowRunId } = getWorkflowMetadata();
+  const run = getRun<BenchStreamChunk>(workflowRunId);
+  const reader = run
+    .getReadable<BenchStreamChunk>({ namespace: SL_STREAM_NAMESPACE })
+    .getReader();
+  try {
+    const { value } = await reader.read();
+    const readAt = Date.now();
+    if (!value || typeof value.writtenAt !== 'number') {
+      throw new Error(
+        `bench SL reader: malformed first chunk ${JSON.stringify(value)?.slice(0, 120)}`
+      );
+    }
+    return { writtenAt: value.writtenAt, readAt };
+  } finally {
+    // Best-effort: don't let a hanging cancel fail the run.
+    reader.cancel().catch(() => {});
+  }
+}
+
+/** Writer half of the SL scenario: waits so the reader is attached first, then
+ * writes a single chunk stamped with `writtenAt` and closes the stream. */
+async function slWriterStep(): Promise<void> {
+  'use step';
+  const writable = getWritable<BenchStreamChunk>({
+    namespace: SL_STREAM_NAMESPACE,
+  });
+  const writer = writable.getWriter();
+  await new Promise((resolve) => setTimeout(resolve, SL_WRITE_DELAY_MS));
+  await writer.write({ seq: 0, writtenAt: Date.now() });
+  writer.releaseLock();
+  await writable.close();
+}
+
+/**
+ * Scenario 4: stream latency (SL), measured entirely on the deployment.
+ *
+ * The reader and writer steps run in parallel on a dedicated namespaced
+ * stream. The reader attaches and blocks; the writer waits {@link
+ * SL_WRITE_DELAY_MS} (guaranteeing the reader is blocked first) and then
+ * writes. Both `writtenAt` and `readAt` are step-body `Date.now()` values on
+ * the deployment, so the returned SL is independent of the CI client and the
+ * api.vercel.com read path.
+ */
+export async function benchSlWorkflow(): Promise<{ sl: BenchStreamLatency }> {
+  'use workflow';
+  const [sl] = await Promise.all([slReaderStep(), slWriterStep()]);
+  return { sl };
 }

--- a/workbench/nextjs-turbopack/app/api/bench/route.ts
+++ b/workbench/nextjs-turbopack/app/api/bench/route.ts
@@ -1,0 +1,70 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { start } from 'workflow/api';
+import { allWorkflows } from '@/_workflows';
+
+// In-deployment trigger for the benchmark runner
+// (packages/core/e2e/benchmark.test.ts).
+//
+// The runner POSTs here instead of calling `start()` from the CI runner so that
+// `clientStart` is stamped by the deployment's own clock, immediately before
+// `start()` — putting the CI runner's request (and its path through
+// api.vercel.com) entirely OUTSIDE the measured window. Calling `start()` from
+// inside the deployment also engages the runtime's in-process fast paths
+// (optimisticStart), matching how a real Vercel app triggers a workflow.
+//
+// The route returns as soon as the run is created; it never awaits the run
+// (the 1020-step sequential scenario would exceed the function's max
+// duration). The runner reads step timings back from `run.returnValue`.
+
+const BENCH_WORKFLOW_FILE = 'workflows/97_bench.ts';
+
+export async function POST(request: NextRequest) {
+  let workflowFn: string;
+  let args: unknown[];
+  try {
+    const body = (await request.json()) as {
+      workflowFn?: string;
+      args?: unknown[];
+    };
+    if (!body.workflowFn) {
+      return NextResponse.json(
+        { error: '`workflowFn` is required' },
+        { status: 400 }
+      );
+    }
+    workflowFn = body.workflowFn;
+    args = body.args ?? [];
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const benchWorkflows = allWorkflows[BENCH_WORKFLOW_FILE] as Record<
+    string,
+    unknown
+  >;
+  const fn = benchWorkflows[workflowFn];
+  if (typeof fn !== 'function') {
+    return NextResponse.json(
+      { error: `Benchmark workflow "${workflowFn}" not found` },
+      { status: 404 }
+    );
+  }
+
+  try {
+    // Stamp the anchor on the deployment's clock, right before start(), so the
+    // measured window contains none of the CI->ingress request path.
+    const clientStart = Date.now();
+    // @ts-expect-error - arbitrary call to a dynamically resolved workflow
+    const run = await start(fn, args);
+    return NextResponse.json({ runId: run.runId, clientStart });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Failed to start benchmark workflow',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Problem

The CI benchmark drove load from a GitHub Actions runner **through the public `api.vercel.com` ingress**. Datadog traces of real runs proved the reported latencies were dominated by that external path and the CI runner's clock, not the runtime:

- **TTFS** was `steps[0].start − clientStart(GHA)`, so it included the CI→ingress leg, GHA↔deployment clock skew, and the full VQS dispatch. The earlier revision of this PR anchored TTFS/WO on the server `run_created` timestamp and added a flat +80ms RTT estimate — proxy-independent, but a fudge, and it still measured the external-trigger dispatch rather than what a real in-Vercel caller experiences.
- **SL** read the stream from the GHA runner, so it was dominated by the api.vercel.com **read** path.

Goal (hard requirement): **no api.vercel.com / CI-runner timing may appear in any measured window.**

## Approach

Trigger every run from **inside the deployment** and measure entirely from deployment-side clocks.

- **New `POST /api/bench` route** on the nextjs-turbopack workbench app resolves a bench workflow from the generated registry, stamps `clientStart` with the **deployment's** clock immediately before `start()`, and returns `{ runId, clientStart }`. The GHA→route request (and its proxy path) sits *before* `clientStart`, so it is outside every measured window. Calling `start()` in-deployment also engages the runtime's in-process fast path (`optimisticStart`), so turbo TTFS now reflects the inline path and non-turbo (hook) reflects the dispatch path — both proxy-free.
- **`benchSlWorkflow`** measures SL entirely on the deployment: a reader step and a writer step run in parallel on a dedicated namespaced stream. The writer waits a fixed delay so the reader is attached and blocked on the first chunk first (measuring live pub/sub propagation, not a warm read), then writes `writtenAt`; the reader stamps `readAt`. `SL = readAt − writtenAt`, both deployment step-body clocks, excluding the api.vercel.com read path.
- **`benchmark.test.ts`** triggers each run via the route (with trusted-sources headers) and polls `returnValue` by runId. TTFS/WO derive from the in-deployment `clientStart` + step timings; SL from the return value. Removed `runCreatedServerMs`, the flat RTT estimate, and the wall-clock diagnostic. STSO was already deployment-clock only and is unchanged.

## Result

All four metrics (TTFS, STSO, WO, SL) are now computed purely from Vercel-side timestamps. The only residual skew is intra-Vercel (step-runner instances in the same region), NTP-bounded and small relative to the measured values.

Latency **targets are provisional** — now that the proxy leg and the external-dispatch framing are gone, they will be re-tightened once a few in-deployment baselines land on `main`.

## Notes

- Touches an e2e test + CI script + workbench (route + workflow) only — no published package output, so no changeset is required (`pnpm changeset status --since=main` is clean).
- Bench matrix is nextjs-turbopack only; the route lives in that app.