### PR TITLE
Instrument workflow replay scaling

### DIFF
--- a/.changeset/tidy-spans-measure.md
+++ b/.changeset/tidy-spans-measure.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Add detailed workflow replay phase spans and aggregate event-consumption and step-hydration diagnostics.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -157,6 +157,10 @@ jobs:
           WORKFLOW_VERCEL_TEAM: "team_nO2mCG4W8IxPIeKoSsqwAxxB"
           WORKFLOW_VERCEL_PROJECT: ${{ matrix.target.project-id }}
           WORKFLOW_VERCEL_PROJECT_SLUG: ${{ matrix.target.project-slug }}
+          # Keep PR benchmarks entirely on preview infrastructure. This is the
+          # same protected workflow-server preview used by the Vercel E2E lane;
+          # main remains pointed at the public production server.
+          VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
           # Report the PR head SHA (not the synthetic merge commit) in results
           GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           # Trusted-sources OIDC token is minted on demand by

--- a/packages/core/bench/workflow-replay.bench.ts
+++ b/packages/core/bench/workflow-replay.bench.ts
@@ -1,0 +1,167 @@
+import type { Event, WorkflowRun } from '@workflow/world';
+import { monotonicFactory } from 'ulid';
+import { bench, describe } from 'vitest';
+import { WorkflowSuspension } from '../src/global.js';
+import {
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from '../src/serialization.js';
+import {
+  createStepHydrationCache,
+  type StepHydrationCache,
+} from '../src/step-hydration-cache.js';
+import { createContext } from '../src/vm/index.js';
+import { runWorkflow } from '../src/workflow.js';
+
+/**
+ * Isolated replay benchmark: no World, queue, workflow-server, or storage.
+ * Run from the repository root with:
+ * `pnpm vitest bench packages/core/bench/workflow-replay.bench.ts --run`
+ */
+
+type ResultMode = 'object-miss' | 'primitive-miss' | 'primitive-hit';
+
+interface ReplayFixture {
+  workflowRun: WorkflowRun;
+  events: Event[];
+  initialCache: StepHydrationCache;
+}
+
+const workflowCode = `
+  const timedNoopStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("timedNoopStep");
+  async function workflow(count) {
+    for (let i = 0; i < count; i++) await timedNoopStep(i);
+  }
+  globalThis.__private_workflows = new Map([["workflow", workflow]]);
+`;
+
+async function createReplayFixture(
+  completedSteps: number,
+  resultMode: ResultMode
+): Promise<ReplayFixture> {
+  const runId = `wrun_bench_${completedSteps}_${resultMode}`;
+  const workflowName = 'workflow';
+  const deploymentId = 'local-benchmark';
+  const startedAt = new Date('2024-01-01T00:00:00.000Z');
+  const input = await dehydrateWorkflowArguments(
+    [completedSteps + 1],
+    runId,
+    undefined
+  );
+  const workflowRun: WorkflowRun = {
+    runId,
+    workflowName,
+    deploymentId,
+    status: 'running',
+    input,
+    attributes: {},
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    startedAt,
+  };
+  const vm = createContext({
+    seed: `${runId}:${workflowName}:${deploymentId}`,
+    fixedTimestamp: +startedAt,
+  });
+  const ulid = monotonicFactory(() => vm.globalThis.Math.random());
+  const initialCache = createStepHydrationCache();
+  const events: Event[] = [
+    {
+      eventId: 'event-run-created',
+      runId,
+      eventType: 'run_created',
+      eventData: { deploymentId, workflowName, input },
+      createdAt: startedAt,
+    },
+    {
+      eventId: 'event-run-started',
+      runId,
+      eventType: 'run_started',
+      createdAt: startedAt,
+    },
+  ];
+
+  for (let i = 0; i < completedSteps; i++) {
+    const correlationId = `step_${ulid(+startedAt)}`;
+    const completedEventId = `event-${i}-completed`;
+    const result = resultMode === 'object-miss' ? { start: i, end: i } : i;
+    if (resultMode === 'primitive-hit') {
+      initialCache.set(completedEventId, result);
+    }
+    events.push(
+      {
+        eventId: `event-${i}-created`,
+        runId,
+        eventType: 'step_created',
+        correlationId,
+        eventData: { stepName: 'timedNoopStep', input: undefined },
+        createdAt: startedAt,
+      },
+      {
+        eventId: `event-${i}-started`,
+        runId,
+        eventType: 'step_started',
+        correlationId,
+        eventData: { stepName: 'timedNoopStep' },
+        createdAt: startedAt,
+      },
+      {
+        eventId: completedEventId,
+        runId,
+        eventType: 'step_completed',
+        correlationId,
+        eventData: {
+          stepName: 'timedNoopStep',
+          result: await dehydrateStepReturnValue(result, runId, undefined),
+        },
+        createdAt: startedAt,
+      }
+    );
+  }
+
+  return { workflowRun, events, initialCache };
+}
+
+process.env.VERCEL_URL = 'local-replay-benchmark.test';
+
+const fixtures = new Map<string, ReplayFixture>();
+for (const completedSteps of [20, 120, 1020]) {
+  for (const resultMode of [
+    'object-miss',
+    'primitive-miss',
+    'primitive-hit',
+  ] as const) {
+    fixtures.set(
+      `${completedSteps}:${resultMode}`,
+      await createReplayFixture(completedSteps, resultMode)
+    );
+  }
+}
+
+describe('runWorkflow sequential replay scaling', () => {
+  for (const completedSteps of [20, 120, 1020]) {
+    for (const resultMode of [
+      'object-miss',
+      'primitive-miss',
+      'primitive-hit',
+    ] as const) {
+      bench(`${completedSteps} completed steps / ${resultMode}`, async () => {
+        const fixture = fixtures.get(`${completedSteps}:${resultMode}`);
+        if (!fixture) throw new Error('Missing replay benchmark fixture');
+        const cache = new Map(fixture.initialCache);
+        try {
+          await runWorkflow(
+            workflowCode,
+            fixture.workflowRun,
+            fixture.events,
+            undefined,
+            cache
+          );
+          throw new Error('Expected workflow replay to suspend');
+        } catch (error) {
+          if (!WorkflowSuspension.is(error)) throw error;
+        }
+      });
+    }
+  }
+});

--- a/packages/core/src/events-consumer.ts
+++ b/packages/core/src/events-consumer.ts
@@ -1,5 +1,6 @@
 import { type Event, envNumber } from '@workflow/world';
 import { eventsLogger } from './logger.js';
+import type { WorkflowReplayMetrics } from './replay-telemetry.js';
 
 /**
  * Delay before firing the deferred unconsumed-event check after the promise
@@ -65,6 +66,8 @@ export interface EventsConsumerOptions {
    * deserialization delays the resolve() that triggers the next subscribe().
    */
   getPromiseQueue: () => Promise<void>;
+  /** Aggregate diagnostics for this replay; omitted when tracing is inactive. */
+  replayMetrics?: WorkflowReplayMetrics;
 }
 
 export class EventsConsumer {
@@ -76,7 +79,9 @@ export class EventsConsumer {
   private getPromiseQueue: () => Promise<void>;
   private pendingUnconsumedCheck: Promise<void> | null = null;
   private pendingUnconsumedTimeout: ReturnType<typeof setTimeout> | null = null;
+  private pendingUnconsumedStartedAt: number | null = null;
   private unconsumedCheckVersion = 0;
+  private replayMetrics?: WorkflowReplayMetrics;
 
   constructor(events: Event[], options: EventsConsumerOptions) {
     this.events = events;
@@ -84,6 +89,7 @@ export class EventsConsumer {
     this.onConsumedEvent = options.onConsumedEvent;
     this.onUnconsumedEvent = options.onUnconsumedEvent;
     this.getPromiseQueue = options.getPromiseQueue;
+    this.replayMetrics = options.replayMetrics;
   }
 
   /**
@@ -101,6 +107,12 @@ export class EventsConsumer {
     // Incrementing the version causes any in-flight promise chain check to no-op.
     // Also clear the pending setTimeout if it hasn't fired yet.
     if (this.pendingUnconsumedCheck !== null) {
+      if (this.replayMetrics && this.pendingUnconsumedStartedAt !== null) {
+        this.replayMetrics.subscriptionWaitCount++;
+        this.replayMetrics.subscriptionWaitMs +=
+          performance.now() - this.pendingUnconsumedStartedAt;
+      }
+      this.pendingUnconsumedStartedAt = null;
       this.unconsumedCheckVersion++;
       this.pendingUnconsumedCheck = null;
       if (this.pendingUnconsumedTimeout !== null) {
@@ -160,8 +172,23 @@ export class EventsConsumer {
    * sentinel).
    */
   private consumeOne(currentEvent: Event | null): boolean {
+    const metrics = this.replayMetrics;
+    if (!metrics) return this.consumeOneCallbacks(currentEvent);
+    const startedAt = performance.now();
+    try {
+      return this.consumeOneCallbacks(currentEvent, metrics);
+    } finally {
+      metrics.eventConsumeMs += performance.now() - startedAt;
+    }
+  }
+
+  private consumeOneCallbacks(
+    currentEvent: Event | null,
+    metrics?: WorkflowReplayMetrics
+  ): boolean {
     for (let i = 0; i < this.callbacks.length; i++) {
       const callback = this.callbacks[i];
+      if (metrics) metrics.eventCallbackInvocations++;
       let handled = EventConsumerResult.NotConsumed;
       try {
         handled = callback(currentEvent);
@@ -175,6 +202,7 @@ export class EventsConsumer {
         continue;
       }
       if (currentEvent !== null) {
+        if (metrics) metrics.eventsConsumed++;
         this.notifyConsumedEvent(currentEvent);
       }
       // consumer handled this event, so increase the event index
@@ -199,6 +227,9 @@ export class EventsConsumer {
     // resolve() → user code → subscribe()) completes first. If the event
     // is still unconsumed after the queue drains, it's truly orphaned.
     if (currentEvent !== null) {
+      if (this.replayMetrics) {
+        this.pendingUnconsumedStartedAt = performance.now();
+      }
       const checkVersion = ++this.unconsumedCheckVersion;
       this.pendingUnconsumedCheck = this.getPromiseQueue()
         .then(
@@ -222,6 +253,7 @@ export class EventsConsumer {
             this.pendingUnconsumedTimeout = null;
             if (this.unconsumedCheckVersion === checkVersion) {
               this.pendingUnconsumedCheck = null;
+              this.pendingUnconsumedStartedAt = null;
               this.onUnconsumedEvent(currentEvent);
             }
           }, getDeferredCheckDelayMs());

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -6,6 +6,7 @@ import { withResolvers } from '@workflow/utils';
 import type { CryptoKey } from './encryption.js';
 import type { EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
+import type { WorkflowReplayMetrics } from './replay-telemetry.js';
 import type { Serializable } from './schemas.js';
 import type { StepHydrationCache } from './step-hydration-cache.js';
 
@@ -207,6 +208,11 @@ export interface WorkflowOrchestratorContext {
    * gracefully to re-hydrating every replay — identical to previous behavior.
    */
   stepHydrationCache?: StepHydrationCache;
+  /**
+   * Low-overhead aggregate replay diagnostics for the active workflow.run
+   * span. Undefined when tracing is unavailable or the span is not recording.
+   */
+  replayMetrics?: WorkflowReplayMetrics;
 }
 
 /** The kind of branch-deciding delivery a barrier represents. */

--- a/packages/core/src/replay-telemetry.ts
+++ b/packages/core/src/replay-telemetry.ts
@@ -1,0 +1,129 @@
+import type { StepHydrationCache } from './step-hydration-cache.js';
+
+/**
+ * Aggregate diagnostics for one deterministic workflow replay.
+ *
+ * These counters intentionally avoid one span per event or completed step.
+ * A long sequential workflow can replay thousands of historical steps, so
+ * per-item spans would both distort the measurement and overwhelm the trace.
+ */
+export interface WorkflowReplayMetrics {
+  eventsConsumed: number;
+  eventCallbackInvocations: number;
+  /** Synchronous CPU time spent offering events to registered callbacks. */
+  eventConsumeMs: number;
+  subscriptionWaitCount: number;
+  /**
+   * Wall time from finding an event with no subscriber to the next subscribe.
+   * This includes and therefore overlaps hydration and VM promise continuation.
+   */
+  subscriptionWaitMs: number;
+  completedSteps: number;
+  /** Full ordered promise-queue slot time; includes stepHydrationMs. */
+  stepDeliveryMs: number;
+  /** Awaited cache lookup or deserialize/decrypt time for completed results. */
+  stepHydrationMs: number;
+  stepHydrationCacheHits: number;
+  stepHydrationCacheMisses: number;
+  stepHydrationCacheUnavailable: number;
+  stepHydrationNonMemoizable: number;
+}
+
+interface StepReplayMeasurement {
+  metrics: WorkflowReplayMetrics;
+  deliveryStartedAt: number;
+  hydrationStartedAt: number;
+  cacheAvailable: boolean;
+  cacheHit: boolean;
+}
+
+export function startStepReplayMeasurement(
+  metrics: WorkflowReplayMetrics,
+  cache: StepHydrationCache | undefined,
+  eventId: string | undefined
+): StepReplayMeasurement {
+  metrics.completedSteps++;
+  const cacheAvailable = cache !== undefined && eventId !== undefined;
+  return {
+    metrics,
+    deliveryStartedAt: performance.now(),
+    hydrationStartedAt: performance.now(),
+    cacheAvailable,
+    cacheHit: cacheAvailable && cache.has(eventId),
+  };
+}
+
+export function finishStepHydrationMeasurement(
+  measurement: StepReplayMeasurement,
+  cache: StepHydrationCache | undefined,
+  eventId: string | undefined
+): void {
+  const { metrics } = measurement;
+  metrics.stepHydrationMs += performance.now() - measurement.hydrationStartedAt;
+  if (!measurement.cacheAvailable) {
+    metrics.stepHydrationCacheUnavailable++;
+  } else if (measurement.cacheHit) {
+    metrics.stepHydrationCacheHits++;
+  } else {
+    metrics.stepHydrationCacheMisses++;
+    if (eventId === undefined || !cache?.has(eventId)) {
+      metrics.stepHydrationNonMemoizable++;
+    }
+  }
+}
+
+export function failStepHydrationMeasurement(
+  measurement: StepReplayMeasurement
+): void {
+  measurement.metrics.stepHydrationMs +=
+    performance.now() - measurement.hydrationStartedAt;
+}
+
+export function finishStepDeliveryMeasurement(
+  measurement: StepReplayMeasurement
+): void {
+  measurement.metrics.stepDeliveryMs +=
+    performance.now() - measurement.deliveryStartedAt;
+}
+
+export function createWorkflowReplayMetrics(): WorkflowReplayMetrics {
+  return {
+    eventsConsumed: 0,
+    eventCallbackInvocations: 0,
+    eventConsumeMs: 0,
+    subscriptionWaitCount: 0,
+    subscriptionWaitMs: 0,
+    completedSteps: 0,
+    stepDeliveryMs: 0,
+    stepHydrationMs: 0,
+    stepHydrationCacheHits: 0,
+    stepHydrationCacheMisses: 0,
+    stepHydrationCacheUnavailable: 0,
+    stepHydrationNonMemoizable: 0,
+  };
+}
+
+export function workflowReplayMetricAttributes(
+  metrics: WorkflowReplayMetrics
+): Record<string, number> {
+  return {
+    'workflow.replay.events.consumed': metrics.eventsConsumed,
+    'workflow.replay.events.callback_invocations':
+      metrics.eventCallbackInvocations,
+    'workflow.replay.events.consume_ms': metrics.eventConsumeMs,
+    'workflow.replay.events.subscription_wait.count':
+      metrics.subscriptionWaitCount,
+    'workflow.replay.events.subscription_wait_ms': metrics.subscriptionWaitMs,
+    'workflow.replay.steps.completed': metrics.completedSteps,
+    'workflow.replay.steps.delivery_ms': metrics.stepDeliveryMs,
+    'workflow.replay.steps.hydration_ms': metrics.stepHydrationMs,
+    'workflow.replay.steps.hydration.cache_hits':
+      metrics.stepHydrationCacheHits,
+    'workflow.replay.steps.hydration.cache_misses':
+      metrics.stepHydrationCacheMisses,
+    'workflow.replay.steps.hydration.cache_unavailable':
+      metrics.stepHydrationCacheUnavailable,
+    'workflow.replay.steps.hydration.non_memoizable':
+      metrics.stepHydrationNonMemoizable,
+  };
+}

--- a/packages/core/src/replay-telemetry.ts
+++ b/packages/core/src/replay-telemetry.ts
@@ -1,4 +1,5 @@
 import type { StepHydrationCache } from './step-hydration-cache.js';
+import type { StepHydrationPhaseTimings } from './serialization.js';
 
 /**
  * Aggregate diagnostics for one deterministic workflow replay.
@@ -23,6 +24,7 @@ export interface WorkflowReplayMetrics {
   stepDeliveryMs: number;
   /** Awaited cache lookup or deserialize/decrypt time for completed results. */
   stepHydrationMs: number;
+  stepHydrationPhases: StepHydrationPhaseTimings;
   stepHydrationCacheHits: number;
   stepHydrationCacheMisses: number;
   stepHydrationCacheUnavailable: number;
@@ -96,6 +98,12 @@ export function createWorkflowReplayMetrics(): WorkflowReplayMetrics {
     completedSteps: 0,
     stepDeliveryMs: 0,
     stepHydrationMs: 0,
+    stepHydrationPhases: {
+      decryptMs: 0,
+      decompressMs: 0,
+      telemetryMs: 0,
+      deserializeMs: 0,
+    },
     stepHydrationCacheHits: 0,
     stepHydrationCacheMisses: 0,
     stepHydrationCacheUnavailable: 0,
@@ -117,6 +125,14 @@ export function workflowReplayMetricAttributes(
     'workflow.replay.steps.completed': metrics.completedSteps,
     'workflow.replay.steps.delivery_ms': metrics.stepDeliveryMs,
     'workflow.replay.steps.hydration_ms': metrics.stepHydrationMs,
+    'workflow.replay.steps.hydration.decrypt_ms':
+      metrics.stepHydrationPhases.decryptMs,
+    'workflow.replay.steps.hydration.decompress_ms':
+      metrics.stepHydrationPhases.decompressMs,
+    'workflow.replay.steps.hydration.telemetry_ms':
+      metrics.stepHydrationPhases.telemetryMs,
+    'workflow.replay.steps.hydration.deserialize_ms':
+      metrics.stepHydrationPhases.deserializeMs,
     'workflow.replay.steps.hydration.cache_hits':
       metrics.stepHydrationCacheHits,
     'workflow.replay.steps.hydration.cache_misses':

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1165,100 +1165,131 @@ export function workflowEntrypoint(
                       // Load events — use cached events with incremental fetch on subsequent iterations.
                       // The server always returns a cursor when there are events (even on the
                       // final page), so we can reliably use it for incremental loading.
-                      let events: Event[];
-                      if (pendingInlineDelta && cachedEvents) {
-                        // Fast path: the previous iteration's inline step
-                        // terminal write returned the authoritative event-log
-                        // delta since the pre-write cursor, so we consume it
-                        // here instead of issuing an incremental events.list.
-                        // The delta is byte-for-byte what events.list(cursor)
-                        // would have returned at write time — it includes this
-                        // handler's own step events, any attr_set the step body
-                        // wrote, and any in-band events (e.g. hook_received,
-                        // wait_completed) another writer appended since the
-                        // cursor — so skipping the fetch cannot drop events or
-                        // skew the prefix from the server's log.
-                        const delta = pendingInlineDelta;
-                        pendingInlineDelta = null;
-                        if (delta.events.length > 0) {
-                          const existingIds = new Set(
-                            cachedEvents.map((e) => e.eventId)
-                          );
-                          for (const e of delta.events) {
-                            if (!existingIds.has(e.eventId)) {
-                              existingIds.add(e.eventId);
-                              cachedEvents.push(e);
+                      let events = await trace(
+                        'workflow.events.refresh',
+                        // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: preserves the existing event-source fallback order inside one measured interval
+                        async (refreshSpan) => {
+                          const cachedBefore = cachedEvents?.length ?? 0;
+                          let deltaCount = 0;
+                          let source = 'unknown';
+                          let refreshedEvents: Event[];
+
+                          if (pendingInlineDelta && cachedEvents) {
+                            // Fast path: the previous iteration's inline step
+                            // terminal write returned the authoritative event-log
+                            // delta since the pre-write cursor, so we consume it
+                            // here instead of issuing an incremental events.list.
+                            // The delta is byte-for-byte what events.list(cursor)
+                            // would have returned at write time — it includes this
+                            // handler's own step events, any attr_set the step body
+                            // wrote, and any in-band events (e.g. hook_received,
+                            // wait_completed) another writer appended since the
+                            // cursor — so skipping the fetch cannot drop events or
+                            // skew the prefix from the server's log.
+                            source = 'inline_delta';
+                            const delta = pendingInlineDelta;
+                            pendingInlineDelta = null;
+                            deltaCount = delta.events.length;
+                            if (delta.events.length > 0) {
+                              const existingIds = new Set(
+                                cachedEvents.map((e) => e.eventId)
+                              );
+                              for (const e of delta.events) {
+                                if (!existingIds.has(e.eventId)) {
+                                  existingIds.add(e.eventId);
+                                  cachedEvents.push(e);
+                                }
+                              }
                             }
-                          }
-                        }
-                        eventsCursor = delta.cursor ?? eventsCursor;
-                        events = cachedEvents;
-                      } else if (cachedEvents === null) {
-                        // First iteration: use preloaded events if available,
-                        // otherwise do a full load with cursor.
-                        if (preloadedEvents) {
-                          events = preloadedEvents;
-                          eventsCursor = preloadedEventsCursor ?? null;
-                        } else {
-                          const loaded = await loadWorkflowRunEvents(runId);
-                          events = loaded.events;
-                          eventsCursor = loaded.cursor;
-                        }
-                      } else if (eventsCursor) {
-                        // Subsequent iteration: fetch only new events since last cursor
-                        const loaded = await loadWorkflowRunEvents(
-                          runId,
-                          eventsCursor
-                        );
-                        // Dedupe by eventId: a previous iteration may have
-                        // appended a refreshed wait-completion delta before
-                        // the next loop observes the advanced cursor, so an
-                        // incremental fetch can return events we already have
-                        // locally.
-                        if (loaded.events.length > 0) {
-                          const existingIds = new Set(
-                            cachedEvents.map((e) => e.eventId)
-                          );
-                          for (const e of loaded.events) {
-                            if (!existingIds.has(e.eventId)) {
-                              existingIds.add(e.eventId);
-                              cachedEvents.push(e);
+                            eventsCursor = delta.cursor ?? eventsCursor;
+                            refreshedEvents = cachedEvents;
+                          } else if (cachedEvents === null) {
+                            // First iteration: use preloaded events if available,
+                            // otherwise do a full load with cursor.
+                            if (preloadedEvents) {
+                              source = 'preloaded';
+                              refreshedEvents = preloadedEvents;
+                              eventsCursor = preloadedEventsCursor ?? null;
+                            } else {
+                              source = 'full_load';
+                              const loaded = await loadWorkflowRunEvents(runId);
+                              deltaCount = loaded.events.length;
+                              refreshedEvents = loaded.events;
+                              eventsCursor = loaded.cursor;
                             }
+                          } else if (eventsCursor) {
+                            source = 'incremental_load';
+                            // Subsequent iteration: fetch only new events since last cursor
+                            const loaded = await loadWorkflowRunEvents(
+                              runId,
+                              eventsCursor
+                            );
+                            deltaCount = loaded.events.length;
+                            // Dedupe by eventId: a previous iteration may have
+                            // appended a refreshed wait-completion delta before
+                            // the next loop observes the advanced cursor, so an
+                            // incremental fetch can return events we already have
+                            // locally.
+                            if (loaded.events.length > 0) {
+                              const existingIds = new Set(
+                                cachedEvents.map((e) => e.eventId)
+                              );
+                              for (const e of loaded.events) {
+                                if (!existingIds.has(e.eventId)) {
+                                  existingIds.add(e.eventId);
+                                  cachedEvents.push(e);
+                                }
+                              }
+                            }
+                            eventsCursor = loaded.cursor ?? eventsCursor;
+                            refreshedEvents = cachedEvents;
+                          } else if (preloadedEvents) {
+                            source = 'preloaded_reload';
+                            // Iteration 2 after iteration 1 used preloaded events
+                            // (which don't carry a cursor). Do a full load now to
+                            // pick up any events written since the preloaded set
+                            // and obtain a cursor for subsequent incremental
+                            // loads. This is the expected path, not a bug.
+                            runtimeLogger.debug(
+                              'No cursor after preloaded-events first iteration; doing full reload to pick up cursor.',
+                              { workflowRunId: runId }
+                            );
+                            const loaded = await loadWorkflowRunEvents(runId);
+                            deltaCount = loaded.events.length;
+                            cachedEvents = loaded.events;
+                            eventsCursor = loaded.cursor;
+                            refreshedEvents = cachedEvents;
+                          } else {
+                            source = 'cursor_recovery_reload';
+                            // No cursor available despite having cached events
+                            // and no preloaded-events explanation. All World
+                            // implementations are required to return a cursor
+                            // when there are events, so this signals a bug in
+                            // the World. Fall back to a full reload to avoid
+                            // stale data.
+                            runtimeLogger.warn(
+                              'Event cursor missing after initial load — falling back to full reload. ' +
+                                'This indicates a bug in the World implementation.',
+                              { workflowRunId: runId }
+                            );
+                            const loaded = await loadWorkflowRunEvents(runId);
+                            deltaCount = loaded.events.length;
+                            cachedEvents = loaded.events;
+                            eventsCursor = loaded.cursor;
+                            refreshedEvents = cachedEvents;
                           }
+
+                          refreshSpan?.setAttributes({
+                            'workflow.events.refresh.source': source,
+                            'workflow.events.refresh.cached_before':
+                              cachedBefore,
+                            'workflow.events.refresh.delta_count': deltaCount,
+                            'workflow.events.refresh.total':
+                              refreshedEvents.length,
+                          });
+                          return refreshedEvents;
                         }
-                        eventsCursor = loaded.cursor ?? eventsCursor;
-                        events = cachedEvents;
-                      } else if (preloadedEvents) {
-                        // Iteration 2 after iteration 1 used preloaded events
-                        // (which don't carry a cursor). Do a full load now to
-                        // pick up any events written since the preloaded set
-                        // and obtain a cursor for subsequent incremental
-                        // loads. This is the expected path, not a bug.
-                        runtimeLogger.debug(
-                          'No cursor after preloaded-events first iteration; doing full reload to pick up cursor.',
-                          { workflowRunId: runId }
-                        );
-                        const loaded = await loadWorkflowRunEvents(runId);
-                        cachedEvents = loaded.events;
-                        eventsCursor = loaded.cursor;
-                        events = cachedEvents;
-                      } else {
-                        // No cursor available despite having cached events
-                        // and no preloaded-events explanation. All World
-                        // implementations are required to return a cursor
-                        // when there are events, so this signals a bug in
-                        // the World. Fall back to a full reload to avoid
-                        // stale data.
-                        runtimeLogger.warn(
-                          'Event cursor missing after initial load — falling back to full reload. ' +
-                            'This indicates a bug in the World implementation.',
-                          { workflowRunId: runId }
-                        );
-                        const loaded = await loadWorkflowRunEvents(runId);
-                        cachedEvents = loaded.events;
-                        eventsCursor = loaded.cursor;
-                        events = cachedEvents;
-                      }
+                      );
 
                       // Detect concurrent completion via the event log: if
                       // any other handler wrote a terminal run event, exit

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -207,6 +207,14 @@ async function recordCompression(
   }
 }
 
+/** Aggregate timings for the host-side phases of step-result hydration. */
+export interface StepHydrationPhaseTimings {
+  decryptMs: number;
+  decompressMs: number;
+  telemetryMs: number;
+  deserializeMs: number;
+}
+
 export function getSerializeStream(
   reducers: Partial<Reducers>,
   cryptoKey: EncryptionKeyParam
@@ -3343,21 +3351,40 @@ export async function hydrateStepReturnValue(
   _runId: string,
   key: CryptoKey | undefined,
   global: Record<string, any> = globalThis,
-  extraRevivers: Record<string, (value: any) => any> = {}
+  extraRevivers: Record<string, (value: any) => any> = {},
+  phaseTimings?: StepHydrationPhaseTimings
 ): Promise<any> {
   const compressionStats: CompressionStats = {};
-  const inflated = await decompress(
-    await maybeDecrypt(value, key),
-    compressionStats
-  );
+  let startedAt = phaseTimings ? performance.now() : 0;
+  const decrypted = await maybeDecrypt(value, key);
+  if (phaseTimings) {
+    phaseTimings.decryptMs += performance.now() - startedAt;
+    startedAt = performance.now();
+  }
+
+  const inflated = await decompress(decrypted, compressionStats);
+  if (phaseTimings) {
+    phaseTimings.decompressMs += performance.now() - startedAt;
+    startedAt = performance.now();
+  }
+
   await recordCompression(compressionStats, 'deserialize');
-  return workflowModule.deserialize(inflated, {
+  if (phaseTimings) {
+    phaseTimings.telemetryMs += performance.now() - startedAt;
+    startedAt = performance.now();
+  }
+
+  const result = workflowModule.deserialize(inflated, {
     global,
     extraRevivers: {
       ...getStreamAndRequestRevivers(getWorkflowRevivers(global)),
       ...extraRevivers,
     },
   });
+  if (phaseTimings) {
+    phaseTimings.deserializeMs += performance.now() - startedAt;
+  }
+  return result;
 }
 
 // ---- Helpers to extract stream/Request/Response reducers and revivers ----

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -7,9 +7,59 @@ import {
   scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from './private.js';
+import {
+  failStepHydrationMeasurement,
+  finishStepDeliveryMeasurement,
+  finishStepHydrationMeasurement,
+  startStepReplayMeasurement,
+} from './replay-telemetry.js';
 import type { Serializable } from './schemas.js';
 import { hydrateStepError, hydrateStepReturnValue } from './serialization.js';
 import { getOrHydrateStepReturnValue } from './step-hydration-cache.js';
+
+async function deliverCompletedStep<Result>(
+  ctx: WorkflowOrchestratorContext,
+  completedEventId: string | undefined,
+  serializedResult: unknown,
+  resolve: (value: Result) => void,
+  reject: (reason?: unknown) => void
+): Promise<void> {
+  const replayMetrics = ctx.replayMetrics;
+  const measurement = replayMetrics
+    ? startStepReplayMeasurement(
+        replayMetrics,
+        ctx.stepHydrationCache,
+        completedEventId
+      )
+    : undefined;
+  try {
+    const hydratedResult = await getOrHydrateStepReturnValue(
+      ctx.stepHydrationCache,
+      completedEventId,
+      () =>
+        hydrateStepReturnValue(
+          serializedResult,
+          ctx.runId,
+          ctx.encryptionKey,
+          ctx.globalThis
+        )
+    );
+    if (measurement) {
+      finishStepHydrationMeasurement(
+        measurement,
+        ctx.stepHydrationCache,
+        completedEventId
+      );
+    }
+    resolve(hydratedResult as Result);
+  } catch (error) {
+    if (measurement) failStepHydrationMeasurement(measurement);
+    reject(error);
+  } finally {
+    if (measurement) finishStepDeliveryMeasurement(measurement);
+    ctx.pendingDeliveries--;
+  }
+}
 
 export function createUseStep(ctx: WorkflowOrchestratorContext) {
   return function useStep<Args extends Serializable[], Result>(
@@ -226,26 +276,15 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
           const completedEventId = event.eventId;
           const serializedResult = event.eventData.result;
           ctx.pendingDeliveries++;
-          ctx.promiseQueue = ctx.promiseQueue.then(async () => {
-            try {
-              const hydratedResult = await getOrHydrateStepReturnValue(
-                ctx.stepHydrationCache,
-                completedEventId,
-                () =>
-                  hydrateStepReturnValue(
-                    serializedResult,
-                    ctx.runId,
-                    ctx.encryptionKey,
-                    ctx.globalThis
-                  )
-              );
-              resolve(hydratedResult as Result);
-            } catch (error) {
-              reject(error);
-            } finally {
-              ctx.pendingDeliveries--;
-            }
-          });
+          ctx.promiseQueue = ctx.promiseQueue.then(() =>
+            deliverCompletedStep(
+              ctx,
+              completedEventId,
+              serializedResult,
+              resolve,
+              reject
+            )
+          );
           return EventConsumerResult.Finished;
         }
 

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -41,7 +41,9 @@ async function deliverCompletedStep<Result>(
           serializedResult,
           ctx.runId,
           ctx.encryptionKey,
-          ctx.globalThis
+          ctx.globalThis,
+          {},
+          replayMetrics?.stepHydrationPhases
         )
     );
     if (measurement) {

--- a/packages/core/src/vm/script-cache.test.ts
+++ b/packages/core/src/vm/script-cache.test.ts
@@ -48,6 +48,27 @@ describe('script-cache', () => {
     expect(a).toBe(b);
   });
 
+  it('reports whether a run compiled or reused its Script', () => {
+    const cacheStatuses: boolean[] = [];
+    const { context: firstContext } = createContext({ seed, fixedTimestamp });
+    const { context: secondContext } = createContext({ seed, fixedTimestamp });
+
+    runCachedWorkflowScript(
+      SAMPLE_BUNDLE,
+      'workflows/a.ts',
+      firstContext,
+      (cacheHit) => cacheStatuses.push(cacheHit)
+    );
+    runCachedWorkflowScript(
+      SAMPLE_BUNDLE,
+      'workflows/a.ts',
+      secondContext,
+      (cacheHit) => cacheStatuses.push(cacheHit)
+    );
+
+    expect(cacheStatuses).toEqual([false, true]);
+  });
+
   it('returns distinct Scripts for the same code under different filenames', () => {
     const a = getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/a.ts');
     const b = getCachedWorkflowScript(SAMPLE_BUNDLE, 'workflows/b.ts');

--- a/packages/core/src/vm/script-cache.ts
+++ b/packages/core/src/vm/script-cache.ts
@@ -100,7 +100,8 @@ function touchBundle(code: string): Map<string, Script> | undefined {
  */
 export function getCachedWorkflowScript(
   code: string,
-  filename: string
+  filename: string,
+  onCacheStatus?: (cacheHit: boolean) => void
 ): Script {
   let byFilename = touchBundle(code);
   if (byFilename === undefined) {
@@ -117,6 +118,7 @@ export function getCachedWorkflowScript(
     }
   }
   let script = byFilename.get(filename);
+  onCacheStatus?.(script !== undefined);
   if (script === undefined) {
     script = new Script(code, { filename });
     byFilename.set(filename, script);
@@ -131,9 +133,12 @@ export function getCachedWorkflowScript(
 export function runCachedWorkflowScript(
   code: string,
   filename: string,
-  context: Context
+  context: Context,
+  onCacheStatus?: (cacheHit: boolean) => void
 ): unknown {
-  return getCachedWorkflowScript(code, filename).runInContext(context);
+  return getCachedWorkflowScript(code, filename, onCacheStatus).runInContext(
+    context
+  );
 }
 
 /**

--- a/packages/core/src/workflow-replay-telemetry.test.ts
+++ b/packages/core/src/workflow-replay-telemetry.test.ts
@@ -1,0 +1,195 @@
+import { trace as otelTrace } from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import type { Event, WorkflowRun } from '@workflow/world';
+import { monotonicFactory } from 'ulid';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { WorkflowSuspension } from './global.js';
+import {
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from './serialization.js';
+import { createStepHydrationCache } from './step-hydration-cache.js';
+import { createContext } from './vm/index.js';
+import { clearWorkflowScriptCache } from './vm/script-cache.js';
+import { runWorkflow } from './workflow.js';
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+
+beforeAll(() => {
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  otelTrace.setGlobalTracerProvider(provider);
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  otelTrace.disable();
+});
+
+beforeEach(() => {
+  vi.stubEnv('VERCEL_URL', 'workflow-replay.test');
+  clearWorkflowScriptCache();
+});
+
+afterEach(() => {
+  exporter.reset();
+  vi.unstubAllEnvs();
+});
+
+describe('workflow replay telemetry', () => {
+  it('partitions VM work and aggregates replay work without per-step spans', async () => {
+    const runId = 'wrun_replay_telemetry';
+    const workflowName = 'workflow';
+    const deploymentId = 'test-deployment';
+    const startedAt = new Date('2024-01-01T00:00:00.000Z');
+    const input = await dehydrateWorkflowArguments([3], runId, undefined);
+    const workflowRun: WorkflowRun = {
+      runId,
+      workflowName,
+      deploymentId,
+      status: 'running',
+      input,
+      attributes: {},
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      startedAt,
+    };
+
+    const vm = createContext({
+      seed: `${runId}:${workflowName}:${deploymentId}`,
+      fixedTimestamp: +startedAt,
+    });
+    const ulid = monotonicFactory(() => vm.globalThis.Math.random());
+    const events: Event[] = [
+      {
+        eventId: 'event-run-created',
+        runId,
+        eventType: 'run_created',
+        eventData: { deploymentId, workflowName, input },
+        createdAt: startedAt,
+      },
+      {
+        eventId: 'event-run-started',
+        runId,
+        eventType: 'run_started',
+        createdAt: startedAt,
+      },
+    ];
+
+    for (let i = 0; i < 2; i++) {
+      const correlationId = `step_${ulid(+startedAt)}`;
+      events.push(
+        {
+          eventId: `event-${i}-created`,
+          runId,
+          eventType: 'step_created',
+          correlationId,
+          eventData: { stepName: 'timedNoopStep', input: undefined },
+          createdAt: startedAt,
+        },
+        {
+          eventId: `event-${i}-started`,
+          runId,
+          eventType: 'step_started',
+          correlationId,
+          eventData: { stepName: 'timedNoopStep' },
+          createdAt: startedAt,
+        },
+        {
+          eventId: `event-${i}-completed`,
+          runId,
+          eventType: 'step_completed',
+          correlationId,
+          eventData: {
+            stepName: 'timedNoopStep',
+            result: await dehydrateStepReturnValue(
+              { start: i, end: i },
+              runId,
+              undefined
+            ),
+          },
+          createdAt: startedAt,
+        }
+      );
+    }
+
+    const workflowCode = `
+      const timedNoopStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("timedNoopStep");
+      async function workflow(count) {
+        for (let i = 0; i < count; i++) await timedNoopStep(i);
+      }
+      globalThis.__private_workflows = new Map([["workflow", workflow]]);
+    `;
+
+    await expect(
+      runWorkflow(
+        workflowCode,
+        workflowRun,
+        events,
+        undefined,
+        createStepHydrationCache()
+      )
+    ).rejects.toSatisfy((error) => WorkflowSuspension.is(error));
+
+    const spans = exporter.getFinishedSpans();
+    const parent = spans.find((span) => span.name === 'workflow.run workflow');
+    const execute = spans.find((span) => span.name === 'workflow.run.execute');
+    const evaluate = spans.find(
+      (span) => span.name === 'workflow.run.vm.evaluate_bundle'
+    );
+    const lookup = spans.find(
+      (span) => span.name === 'workflow.run.vm.lookup_function'
+    );
+
+    expect(parent).toBeDefined();
+    expect(execute).toBeDefined();
+    expect(evaluate?.attributes['workflow.vm.script_cache.hit']).toBe(false);
+    expect(lookup?.attributes['workflow.vm.script_cache.hit']).toBe(false);
+    expect(parent?.attributes['workflow.run.setup.duration_ms']).toEqual(
+      expect.any(Number)
+    );
+    expect(execute?.attributes).toMatchObject({
+      'workflow.replay.events.consumed': 8,
+      'workflow.replay.steps.completed': 2,
+      'workflow.replay.steps.hydration.cache_hits': 0,
+      'workflow.replay.steps.hydration.cache_misses': 2,
+      'workflow.replay.steps.hydration.cache_unavailable': 0,
+      'workflow.replay.steps.hydration.non_memoizable': 2,
+    });
+    expect(
+      execute?.attributes['workflow.replay.events.callback_invocations']
+    ).toEqual(expect.any(Number));
+    expect(
+      execute?.attributes['workflow.replay.events.consume_ms'] as number
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      execute?.attributes['workflow.replay.steps.hydration_ms'] as number
+    ).toBeGreaterThanOrEqual(0);
+
+    expect(spans.map((span) => span.name)).toEqual(
+      expect.arrayContaining([
+        'workflow.run.vm.create_context',
+        'workflow.run.vm.evaluate_bundle',
+        'workflow.run.vm.lookup_function',
+        'workflow.run.hydrate_arguments',
+        'workflow.run.execute',
+      ])
+    );
+    expect(
+      spans.filter((span) => span.name.startsWith('workflow.replay.step'))
+    ).toHaveLength(0);
+  });
+});

--- a/packages/core/src/workflow-replay-telemetry.test.ts
+++ b/packages/core/src/workflow-replay-telemetry.test.ts
@@ -178,6 +178,26 @@ describe('workflow replay telemetry', () => {
     expect(
       execute?.attributes['workflow.replay.steps.hydration_ms'] as number
     ).toBeGreaterThanOrEqual(0);
+    expect(
+      execute?.attributes[
+        'workflow.replay.steps.hydration.decrypt_ms'
+      ] as number
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      execute?.attributes[
+        'workflow.replay.steps.hydration.decompress_ms'
+      ] as number
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      execute?.attributes[
+        'workflow.replay.steps.hydration.telemetry_ms'
+      ] as number
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      execute?.attributes[
+        'workflow.replay.steps.hydration.deserialize_ms'
+      ] as number
+    ).toBeGreaterThanOrEqual(0);
 
     expect(spans.map((span) => span.name)).toEqual(
       expect.arrayContaining([

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -173,8 +173,8 @@ export async function runWorkflow(
       );
     }
 
-    // Detailed replay timing is only collected for sampled spans. This keeps
-    // the untraced hot path free of per-event/per-step clock reads.
+    // Detailed replay timing is only collected for recording spans. This keeps
+    // unsampled and untraced hot paths free of per-event/per-step clock reads.
     const replayMetrics = span?.isRecording()
       ? createWorkflowReplayMetrics()
       : undefined;

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -16,6 +16,10 @@ import type { QueueItem } from './global.js';
 import { ENOTSUP, WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
 import type { WorkflowOrchestratorContext } from './private.js';
+import {
+  createWorkflowReplayMetrics,
+  workflowReplayMetricAttributes,
+} from './replay-telemetry.js';
 import { getPortLazy } from './runtime/get-port-lazy.js';
 import { runIdCreatedAt } from './runtime/run-id-time.js';
 import { handleSuspension } from './runtime/suspension-handler.js';
@@ -169,6 +173,13 @@ export async function runWorkflow(
       );
     }
 
+    // Detailed replay timing is only collected for sampled spans. This keeps
+    // the untraced hot path free of per-event/per-step clock reads.
+    const replayMetrics = span?.isRecording()
+      ? createWorkflowReplayMetrics()
+      : undefined;
+    const setupStartedAt = replayMetrics ? performance.now() : 0;
+
     // The deterministic RNG seed is derived from identifiers that are all
     // known the instant the queue message arrives — `runId`, `workflowName`,
     // and `deploymentId` — with no timestamp component. `runId` alone already
@@ -204,10 +215,12 @@ export async function runWorkflow(
       context,
       globalThis: vmGlobalThis,
       updateTimestamp,
-    } = createContext({
-      seed: `${workflowRun.runId}:${workflowRun.workflowName}:${workflowRun.deploymentId}`,
-      fixedTimestamp,
-    });
+    } = await trace('workflow.run.vm.create_context', async () =>
+      createContext({
+        seed: `${workflowRun.runId}:${workflowRun.workflowName}:${workflowRun.deploymentId}`,
+        fixedTimestamp,
+      })
+    );
 
     const workflowDiscontinuation = withResolvers<void>();
 
@@ -234,6 +247,7 @@ export async function runWorkflow(
         );
       },
       getPromiseQueue: () => promiseQueueHolder.current,
+      replayMetrics,
     });
 
     const workflowContext: WorkflowOrchestratorContext = {
@@ -265,6 +279,7 @@ export async function runWorkflow(
       pendingDeliveries: 0,
       pendingDeliveryBarriers: new Map(),
       stepHydrationCache,
+      replayMetrics,
     };
 
     // Consume run lifecycle events - these are structural events that don't
@@ -823,6 +838,13 @@ export async function runWorkflow(
     const parsedName = parseWorkflowName(workflowRun.workflowName);
     const filename = parsedName?.moduleSpecifier || workflowRun.workflowName;
 
+    if (replayMetrics) {
+      span?.setAttribute(
+        'workflow.run.setup.duration_ms',
+        performance.now() - setupStartedAt
+      );
+    }
+
     // Evaluate the workflow bundle against the fresh context using a
     // process-wide cache of the compiled `vm.Script`. The bundle is the same
     // string for every replay and every invocation in this process, and
@@ -841,11 +863,21 @@ export async function runWorkflow(
     // Script rather than the line just past the end of the bundle. That path
     // is rare (it requires the lookup `?.get(...)` expression to throw) and
     // does not affect the workflow function or replay determinism.
-    runCachedWorkflowScript(workflowCode, filename, context);
-    const workflowFn = runCachedWorkflowScript(
-      `globalThis.__private_workflows?.get(${JSON.stringify(workflowRun.workflowName)})`,
-      filename,
-      context
+    await trace('workflow.run.vm.evaluate_bundle', async (evaluationSpan) =>
+      runCachedWorkflowScript(workflowCode, filename, context, (cacheHit) =>
+        evaluationSpan?.setAttribute('workflow.vm.script_cache.hit', cacheHit)
+      )
+    );
+    const workflowFn = await trace(
+      'workflow.run.vm.lookup_function',
+      async (lookupSpan) =>
+        runCachedWorkflowScript(
+          `globalThis.__private_workflows?.get(${JSON.stringify(workflowRun.workflowName)})`,
+          filename,
+          context,
+          (cacheHit) =>
+            lookupSpan?.setAttribute('workflow.vm.script_cache.hit', cacheHit)
+        )
     );
 
     if (typeof workflowFn !== 'function') {
@@ -859,11 +891,13 @@ export async function runWorkflow(
     let args: unknown[] = [];
     workflowContext.promiseQueue = workflowContext.promiseQueue.then(
       async () => {
-        args = await hydrateWorkflowArguments(
-          workflowRun.input,
-          workflowRun.runId,
-          encryptionKey,
-          vmGlobalThis
+        args = await trace('workflow.run.hydrate_arguments', async () =>
+          hydrateWorkflowArguments(
+            workflowRun.input,
+            workflowRun.runId,
+            encryptionKey,
+            vmGlobalThis
+          )
         );
       }
     );
@@ -875,34 +909,53 @@ export async function runWorkflow(
 
     // Invoke user workflow
     try {
-      const result = await Promise.race([
-        workflowFn(...args),
-        workflowDiscontinuation.promise,
-      ]);
+      const result = await trace(
+        'workflow.run.execute',
+        async (executeSpan) => {
+          try {
+            return await Promise.race([
+              workflowFn(...args),
+              workflowDiscontinuation.promise,
+            ]);
+          } finally {
+            if (replayMetrics) {
+              executeSpan?.setAttributes(
+                workflowReplayMetricAttributes(replayMetrics)
+              );
+            }
+          }
+        }
+      );
 
-      const dehydrated = await dehydrateWorkflowReturnValue(
-        result,
-        workflowRun.runId,
-        encryptionKey,
-        vmGlobalThis,
-        false,
-        // Gate payload compression on the run's specVersion: only runs
-        // marked as possibly containing compressed payloads (spec >= 5)
-        // get gzip data.
-        (workflowRun.specVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
+      const dehydrated = await trace(
+        'workflow.run.serialize_result',
+        async () =>
+          dehydrateWorkflowReturnValue(
+            result,
+            workflowRun.runId,
+            encryptionKey,
+            vmGlobalThis,
+            false,
+            // Gate payload compression on the run's specVersion: only runs
+            // marked as possibly containing compressed payloads (spec >= 5)
+            // get gzip data.
+            (workflowRun.specVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
+          )
       );
 
       span?.setAttributes({
         ...Attribute.WorkflowResultType(typeof result),
       });
 
-      await drainPendingQueueItems(
-        workflowRun.runId,
-        workflowContext.invocationsQueue,
-        vmGlobalThis,
-        workflowRun,
-        'completed',
-        runReadyBarrier
+      await trace('workflow.run.drain', async () =>
+        drainPendingQueueItems(
+          workflowRun.runId,
+          workflowContext.invocationsQueue,
+          vmGlobalThis,
+          workflowRun,
+          'completed',
+          runReadyBarrier
+        )
       );
 
       return dehydrated;
@@ -913,13 +966,15 @@ export async function runWorkflow(
         throw err;
       }
 
-      await drainPendingQueueItems(
-        workflowRun.runId,
-        workflowContext.invocationsQueue,
-        vmGlobalThis,
-        workflowRun,
-        'failed',
-        runReadyBarrier
+      await trace('workflow.run.drain', async () =>
+        drainPendingQueueItems(
+          workflowRun.runId,
+          workflowContext.invocationsQueue,
+          vmGlobalThis,
+          workflowRun,
+          'failed',
+          runReadyBarrier
+        )
       );
 
       throw err;

--- a/workbench/nextjs-turbopack/vercel.json
+++ b/workbench/nextjs-turbopack/vercel.json
@@ -1,9 +1,6 @@
 {
   "env": {
-    "DEBUG": "",
-    "WORKFLOW_PUBLIC_MANIFEST": "1",
-    "WORKFLOW_TRACE_MODE": "linked",
-    "WORKFLOW_TURBO": "0"
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
   },
   "regions": [
     "iad1",

--- a/workbench/nextjs-turbopack/vercel.json
+++ b/workbench/nextjs-turbopack/vercel.json
@@ -1,8 +1,6 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1",
-    "WORKFLOW_TRACE_MODE": "linked",
-    "WORKFLOW_TURBO": "0"
+    "WORKFLOW_PUBLIC_MANIFEST": "1"
   },
   "regions": [
     "iad1",

--- a/workbench/nextjs-turbopack/vercel.json
+++ b/workbench/nextjs-turbopack/vercel.json
@@ -1,6 +1,8 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "WORKFLOW_TRACE_MODE": "linked",
+    "WORKFLOW_TURBO": "0"
   },
   "regions": [
     "iad1",

--- a/workbench/nextjs-turbopack/vercel.json
+++ b/workbench/nextjs-turbopack/vercel.json
@@ -1,6 +1,9 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "DEBUG": "",
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "WORKFLOW_TRACE_MODE": "linked",
+    "WORKFLOW_TURBO": "0"
   },
   "regions": [
     "iad1",


### PR DESCRIPTION
## Summary

- split `workflow.run` into VM context, bundle evaluation, argument hydration, execution, serialization, and drain spans
- aggregate replay event-consumer, subscription-wait, step hydration, and cache diagnostics without per-step spans
- split step-result hydration into decrypt, decompress, compression telemetry, and deserialize timings
- add an isolated 20/120/1020-step replay benchmark and route PR benchmark CI through the protected workflow-server preview

## Production finding

The production VM itself is not intrinsically hundreds of milliseconds slower than local replay. The original comparison mixed a tiny synthetic local bundle with a 1.322 MB production bundle, encrypted object results, OpenTelemetry, and `DEBUG=workflow:*`.

Disabling debug logging on the same preview reduced late `workflow.run` from 604.6 ms to 247.6 ms. The synchronous event-consumer scan fell from 165.3 ms to 11.9 ms because each enabled per-event debug call emitted console output and an active-span event.

The final instrumented, debug-off, non-turbo run was [CI 29548488910](https://github.com/vercel/workflow/actions/runs/29548488910), workflow run `wrun_41KXPWKTB70GJFGJB4Q00XBH2W`.

| Mean (ms) | K1-K19 | K101-K119 | K1001-K1019 |
|---|---:|---:|---:|
| STSO | 232.0 | 355.3 | 503.5 |
| prior `step_completed` durable write | 70.9 | 78.5 | 71.1 |
| event refresh | 0.04 | 102.8 | 106.4 |
| `workflow.run` | 72.9 | 90.8 | 242.0 |
| next `step_started` durable write | 83.0 | 79.2 | 79.3 |

The refresh cliff is the event pagination issue being handled separately in workflow-server PR #632. It is not the continuous replay slope.

## Replay breakdown

| Mean (ms) | K1-K19 | K101-K119 | K1001-K1019 |
|---|---:|---:|---:|
| VM context | 1.00 | 0.96 | 1.08 |
| evaluate 1.322 MB bundle | 49.17 | 44.98 | 51.45 |
| workflow execute/replay | 16.82 | 42.48 | 187.21 |
| synchronous event scan | 0.22 | 1.44 | 11.54 |
| step-result hydration | 14.31 | 36.31 | 144.70 |
| AES-GCM decrypt | 13.57 | 30.71 | 101.85 |
| decompress | 0.07 | 0.63 | 3.68 |
| compression telemetry | 0.23 | 1.55 | 14.51 |
| deserialize | 0.35 | 2.65 | 17.73 |
| events / callback invocations | 32 / 75 | 332 / 775 | 3032 / 7075 |

The subscription-wait metric is 18.8 / 39.3 / 160.8 ms, but it overlaps hydration and VM continuation and must not be added to the rows above.

Every benchmark result is an object, so all 10 / 110 / 1010 historical step values are non-memoizable by the primitive-only hydration cache. Each replay serially performs one WebCrypto AES-GCM decrypt and one fresh deserialize per historical result. Across 1020 serial steps that is approximately `sum(1..1020) = 520,710` decrypt/parse operations in one invocation.

The exact local reproduction used the generated 1.322 MB bundle, encrypted object results, Node 22 Linux, and a 1-vCPU/2-GB container. At K1020 it measured 183.7 ms total `workflow.run`, including 50.6 ms bundle evaluation, 124.5 ms execution, 86.0 ms hydration, and 9.1 ms synchronous event scan. The preview measured 242.0 / 51.5 / 187.2 / 144.7 / 11.5 ms respectively. The remaining local-cloud gap is therefore hydration/WebCrypto throughput and scheduling, not `node:vm` context or bundle evaluation.

## Evidence

- original debug-on benchmark: [CI 29544762077](https://github.com/vercel/workflow/actions/runs/29544762077), traces `d6ec13404e2537410dac512a521da423` and `fec6da2c5114eb50e1eb9a9c31a23902`
- debug-off A/B benchmark: [CI 29547654943](https://github.com/vercel/workflow/actions/runs/29547654943)
- hydration split benchmark: [CI 29548488910](https://github.com/vercel/workflow/actions/runs/29548488910), traces `0d3358d44cc286fec90623114cce3d92` and `80879ec66b238c5727fb3f981d164ea3`

## Verification

- targeted replay telemetry and serialization tests: 4 passed
- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/core build`
