### PR TITLE
Increase workflow replay page size to 500

### DIFF
--- a/.changeset/faster-workflow-replays.md
+++ b/.changeset/faster-workflow-replays.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Reduce workflow replay network calls by requesting up to 500 events per page.

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -365,6 +365,18 @@ describe('loadWorkflowRunEvents', () => {
       'evnt_c',
     ]);
     expect(result.cursor).toBe('eid:evnt_c');
+    expect(eventsListMock).toHaveBeenNthCalledWith(1, {
+      runId: 'wrun_test',
+      pagination: { limit: 500, sortOrder: 'asc', cursor: undefined },
+    });
+    expect(eventsListMock).toHaveBeenNthCalledWith(2, {
+      runId: 'wrun_test',
+      pagination: { limit: 500, sortOrder: 'asc', cursor: 'eid:evnt_a' },
+    });
+    expect(eventsListMock).toHaveBeenNthCalledWith(3, {
+      runId: 'wrun_test',
+      pagination: { limit: 500, sortOrder: 'asc', cursor: 'eid:evnt_b' },
+    });
   });
 
   it('falls back to the afterCursor when an incremental load returns no events', async () => {
@@ -421,11 +433,15 @@ describe('loadWorkflowRunEvents', () => {
     ]);
     expect(eventsListMock).toHaveBeenNthCalledWith(1, {
       runId: 'wrun_test',
-      pagination: { sortOrder: 'asc', cursor: 'opaque-cursor' },
+      pagination: {
+        limit: 500,
+        sortOrder: 'asc',
+        cursor: 'opaque-cursor',
+      },
     });
     expect(eventsListMock).toHaveBeenNthCalledWith(2, {
       runId: 'wrun_test',
-      pagination: { sortOrder: 'asc', cursor: undefined },
+      pagination: { limit: 500, sortOrder: 'asc', cursor: undefined },
     });
   });
 

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -31,6 +31,12 @@ import { getWorldLazy } from './get-world-lazy.js';
 const DEFAULT_HEALTH_CHECK_TIMEOUT = 30_000;
 
 /**
+ * Requested replay page size. The world may return fewer events when its
+ * storage or transport imposes a lower byte-based page limit.
+ */
+const REPLAY_EVENT_PAGE_LIMIT = 500;
+
+/**
  * Pattern for safe workflow names. Only allows alphanumeric characters,
  * underscores, hyphens, dots, forward slashes (for namespaced workflows),
  * and at signs (for scoped packages).
@@ -496,6 +502,7 @@ export async function loadWorkflowRunEvents(
           response = await world.events.list({
             runId,
             pagination: {
+              limit: REPLAY_EVENT_PAGE_LIMIT,
               sortOrder: 'asc',
               cursor: requestedCursor ?? undefined,
             },


### PR DESCRIPTION
## Summary

- request up to 500 events per workflow replay page instead of relying on the v4 server default of 100
- apply the limit consistently to full loads, incremental loads, and the invalid-cursor full-reload fallback
- add regression assertions and a patch changeset for `@workflow/core`