### PR TITLE
[test] Benchmark replay paging with workflow-server #632

### DIFF
--- a/.changeset/faster-workflow-replays.md
+++ b/.changeset/faster-workflow-replays.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Reduce workflow replay network calls by requesting up to 500 events per page.

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -365,6 +365,18 @@ describe('loadWorkflowRunEvents', () => {
       'evnt_c',
     ]);
     expect(result.cursor).toBe('eid:evnt_c');
+    expect(eventsListMock).toHaveBeenNthCalledWith(1, {
+      runId: 'wrun_test',
+      pagination: { limit: 500, sortOrder: 'asc', cursor: undefined },
+    });
+    expect(eventsListMock).toHaveBeenNthCalledWith(2, {
+      runId: 'wrun_test',
+      pagination: { limit: 500, sortOrder: 'asc', cursor: 'eid:evnt_a' },
+    });
+    expect(eventsListMock).toHaveBeenNthCalledWith(3, {
+      runId: 'wrun_test',
+      pagination: { limit: 500, sortOrder: 'asc', cursor: 'eid:evnt_b' },
+    });
   });
 
   it('falls back to the afterCursor when an incremental load returns no events', async () => {
@@ -421,11 +433,15 @@ describe('loadWorkflowRunEvents', () => {
     ]);
     expect(eventsListMock).toHaveBeenNthCalledWith(1, {
       runId: 'wrun_test',
-      pagination: { sortOrder: 'asc', cursor: 'opaque-cursor' },
+      pagination: {
+        limit: 500,
+        sortOrder: 'asc',
+        cursor: 'opaque-cursor',
+      },
     });
     expect(eventsListMock).toHaveBeenNthCalledWith(2, {
       runId: 'wrun_test',
-      pagination: { sortOrder: 'asc', cursor: undefined },
+      pagination: { limit: 500, sortOrder: 'asc', cursor: undefined },
     });
   });
 

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -31,6 +31,12 @@ import { getWorldLazy } from './get-world-lazy.js';
 const DEFAULT_HEALTH_CHECK_TIMEOUT = 30_000;
 
 /**
+ * Requested replay page size. The world may return fewer events when its
+ * storage or transport imposes a lower byte-based page limit.
+ */
+const REPLAY_EVENT_PAGE_LIMIT = 500;
+
+/**
  * Pattern for safe workflow names. Only allows alphanumeric characters,
  * underscores, hyphens, dots, forward slashes (for namespaced workflows),
  * and at signs (for scoped packages).
@@ -496,6 +502,7 @@ export async function loadWorkflowRunEvents(
           response = await world.events.list({
             runId,
             pagination: {
+              limit: REPLAY_EVENT_PAGE_LIMIT,
               sortOrder: 'asc',
               cursor: requestedCursor ?? undefined,
             },

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -32,7 +32,8 @@ import { version } from './version.js';
  * `main` — rewritten by external CI for branch-deployment testing.
  * Prefer `VERCEL_WORKFLOW_SERVER_URL` for deployment-time configuration.
  */
-export const WORKFLOW_SERVER_URL_OVERRIDE = '';
+export const WORKFLOW_SERVER_URL_OVERRIDE =
+  'https://workflow-server-rb43t17tx.vercel.sh';
 
 /**
  * HTTP methods that are safe to transparently re-issue inside the adapter.


### PR DESCRIPTION
## Test-only combined benchmark

This draft layers the replay page-size change from #2975 on top of the exact workflow-server preview deployment for vercel/workflow-server#632.

`WORKFLOW_SERVER_URL_OVERRIDE` points to the preview for server commit `063557ca5565d9dc3b182f602372c0222a7c9379` so both the benchmark runner and deployed workbench route through the bounded event-query implementation.

This PR is not intended to merge. It exists only to run and retain the combined performance benchmark. The mergeable SDK change remains #2975.