### PR TITLE
fix(world-postgres): throw EntityConflictError on duplicate run_created

### DIFF
--- a/.changeset/postgres-run-created-conflict.md
+++ b/.changeset/postgres-run-created-conflict.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Throw `EntityConflictError` when a `run_created` event targets a run that already exists, instead of resolving with no run. This matches `world-local` and `world-vercel`, and stops `start()` from throwing `Missing 'run' in server response for 'run_created' event` when the resilient start path wins the race.

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -819,9 +819,17 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
           })
           .onConflictDoNothing()
           .returning();
-        if (runValue) {
-          run = deserializeRunError(compact(runValue));
+        // No row back means the run already exists: the resilient start path
+        // (run_started on a non-existent run) won a TOCTOU race and created
+        // it. Surface the conflict rather than returning `{ run: undefined }`
+        // — start() already treats EntityConflictError as benign, and falling
+        // through would append a duplicate run_created event to the log.
+        if (!runValue) {
+          throw new EntityConflictError(
+            `Workflow run "${effectiveRunId}" already exists`
+          );
         }
+        run = deserializeRunError(compact(runValue));
       }
 
       // Handle run_started event: update run status

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -4,7 +4,7 @@ import type { Hook, Step, WorkflowRun } from '@workflow/world';
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { encode } from 'cbor-x';
 import { Pool } from 'pg';
-import { decodeTime } from 'ulid';
+import { decodeTime, ulid } from 'ulid';
 import {
   afterAll,
   beforeAll,
@@ -234,6 +234,60 @@ describe('Storage (Postgres integration)', () => {
         });
 
         expect(run.attributes).toEqual({ [key]: 'literal' });
+      });
+
+      it('rejects a duplicate run_created with EntityConflictError', async () => {
+        const runId = `wrun_${ulid()}`;
+        const runData = {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array([1, 2]),
+        };
+        await events.create(runId, {
+          eventType: 'run_created',
+          eventData: runData,
+        });
+
+        await expect(
+          events.create(runId, {
+            eventType: 'run_created',
+            eventData: runData,
+          })
+        ).rejects.toMatchObject({ name: 'EntityConflictError' });
+      });
+
+      it('rejects run_created when resilient start already created the run', async () => {
+        // start() races events.create(run_created) against world.queue(). When
+        // the worker dequeues first, run_started on the not-yet-existent run
+        // takes the resilient start path and creates the run itself. The late
+        // run_created must lose loudly: start() treats EntityConflictError as
+        // benign, while a silent no-op both fails its `run` assertion and
+        // appends a duplicate run_created to the log.
+        const runId = `wrun_${ulid()}`;
+        const runData = {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array([1, 2]),
+        };
+        await events.create(runId, {
+          eventType: 'run_started',
+          eventData: runData,
+        });
+
+        await expect(
+          events.create(runId, {
+            eventType: 'run_created',
+            eventData: runData,
+          })
+        ).rejects.toMatchObject({ name: 'EntityConflictError' });
+
+        const result = await events.list({
+          runId,
+          pagination: { sortOrder: 'asc' },
+        });
+        expect(
+          result.data.filter((e) => e.eventType === 'run_created')
+        ).toHaveLength(1);
       });
     });
 


### PR DESCRIPTION
### Description

`events.create` with a `run_created` event inserts the run with `onConflictDoNothing()`, so when the run already exists the insert returns no row and `create` resolves with `{ run: undefined }` instead of signalling the conflict. `start()` asserts on that field and throws `Missing 'run' in server response for 'run_created' event` — even though the run is healthy and already running.

This is the race `start()` documents: it fires `events.create(run_created)` and `world.queue()` in parallel, and when the worker dequeues first, `run_started` on the not-yet-existent run takes the resilient start path and creates the run itself. `start()` already treats `EntityConflictError` here as benign ("we can safely return", expected in `<=1%` of cases) — but the Postgres world never gives it one. `world-local` throws it for this same race and `world-vercel` surfaces a 409 that maps to it; `world-postgres` is the only world that resolves silently.

Throwing before the event insert also stops a duplicate `run_created` landing in the event log.

Observed on a self-hosted Postgres deployment on 3 of 261 runs (~1%, matching the estimate above) of our highest-frequency workflow over 7 days: each affected run has two `run_created` events and completed normally, while the trigger that started it returned a 500.

### How did you test your changes?

Two cases added to `packages/world-postgres/test/storage.test.ts` (`runs` › `create`):

- `rejects a duplicate run_created with EntityConflictError` — the direct conflict.
- `rejects run_created when resilient start already created the run` — reproduces the production race (`run_started` on a non-existent run → resilient start → late `run_created`), asserting exactly one `run_created` remains in the event log.

Both resolve instead of rejecting against the current insert, and pass with the fix.

- `pnpm --filter @workflow/world-postgres exec vitest run test/storage.test.ts` (119 tests)
- `pnpm --filter @workflow/world-postgres typecheck`
- `biome check packages/world-postgres/src/storage.ts packages/world-postgres/test/storage.test.ts`

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
