### PR TITLE
perf(core): retain workflow VM across inline steps

### DIFF
--- a/.changeset/retain-workflow-vm.md
+++ b/.changeset/retain-workflow-vm.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': patch
+'workflow': patch
+---
+
+Retain workflow execution across inline steps within one invocation.

--- a/packages/core/src/events-consumer.test.ts
+++ b/packages/core/src/events-consumer.test.ts
@@ -45,6 +45,15 @@ describe('EventsConsumer', () => {
       expect(consumer.eventIndex).toBe(0);
       expect(consumer.callbacks).toEqual([]);
     });
+
+    it('should own its event array', () => {
+      const events = [createMockEvent()];
+      const consumer = new EventsConsumer(events, defaultOptions);
+
+      events.push(createMockEvent({ id: 'event-2' }));
+
+      expect(consumer.events).toHaveLength(1);
+    });
   });
 
   describe('subscribe', () => {
@@ -81,6 +90,24 @@ describe('EventsConsumer', () => {
 
       expect(callback).toHaveBeenCalledWith(event);
       expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should consume appended events', async () => {
+      const event = createMockEvent();
+      const consumer = new EventsConsumer([], defaultOptions);
+      const callback = vi
+        .fn()
+        .mockImplementation((value: Event | null) =>
+          value ? EventConsumerResult.Finished : EventConsumerResult.NotConsumed
+        );
+      consumer.subscribe(callback);
+      await waitForNextTick();
+
+      consumer.append([event]);
+      await waitForNextTick();
+
+      expect(callback).toHaveBeenLastCalledWith(event);
+      expect(consumer.eventIndex).toBe(1);
     });
   });
 

--- a/packages/core/src/events-consumer.ts
+++ b/packages/core/src/events-consumer.ts
@@ -79,11 +79,16 @@ export class EventsConsumer {
   private unconsumedCheckVersion = 0;
 
   constructor(events: Event[], options: EventsConsumerOptions) {
-    this.events = events;
+    this.events = [...events];
     this.eventIndex = 0;
     this.onConsumedEvent = options.onConsumedEvent;
     this.onUnconsumedEvent = options.onUnconsumedEvent;
     this.getPromiseQueue = options.getPromiseQueue;
+  }
+
+  append(events: Event[]): void {
+    this.events.push(...events);
+    process.nextTick(this.consume);
   }
 
   /**

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@workflow/world';
 import { ulid } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runtimeLogger } from './logger.js';
 import { registerStepFunction } from './private.js';
 import { REPLAY_DIVERGENCE_MAX_RETRIES } from './runtime/constants.js';
 import { setWorld } from './runtime/world.js';
@@ -701,6 +702,9 @@ describe('workflowEntrypoint replay guards', () => {
   });
 
   it('replays attribute events before executing a step that loses the same race', async () => {
+    const debug = vi
+      .spyOn(runtimeLogger, 'debug')
+      .mockImplementation(() => undefined);
     const ops: Promise<any>[] = [];
     const workflowRun: WorkflowRun = {
       runId: 'wrun_attribute_step_race',
@@ -759,6 +763,11 @@ describe('workflowEntrypoint replay guards', () => {
     expect(createdEvents).not.toContainEqual(
       expect.objectContaining({ eventType: 'step_started' })
     );
+    const executionModes = debug.mock.calls
+      .filter(([message]) => message === 'Starting workflow execution')
+      .map(([, context]) => context?.executionMode);
+    expect(executionModes).toEqual(['replay', 'replay']);
+    debug.mockRestore();
   });
 
   it('fails the run when the World rejects an attr_set event as invalid', async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -311,6 +311,25 @@ function hasOpenHookOrWait(events: Event[]): boolean {
 }
 
 /**
+ * Retain only pure step boundaries with no out-of-band continuation source.
+ * Attributes require replay; hooks and waits can wake another invocation.
+ */
+function canRetainWorkflowSession(
+  suspension: WorkflowSuspension,
+  events: Event[]
+): boolean {
+  return (
+    suspension.stepCount > 0 &&
+    suspension.hookCount === 0 &&
+    suspension.waitCount === 0 &&
+    suspension.attributeCount === 0 &&
+    suspension.hookDisposedCount === 0 &&
+    suspension.abortCount === 0 &&
+    !hasOpenHookOrWait(events)
+  );
+}
+
+/**
  * Creates a single route which handles workflow execution requests,
  * executing steps inline when possible to reduce function invocations
  * and queue overhead.
@@ -1471,19 +1490,15 @@ export function workflowEntrypoint(
                       }
 
                       if (workflowResult.type === 'suspended') {
-                        workflowExecution =
-                          workflowResult.suspension.stepCount > 0 &&
-                          workflowResult.suspension.hookCount === 0 &&
-                          workflowResult.suspension.waitCount === 0 &&
-                          workflowResult.suspension.attributeCount === 0 &&
-                          workflowResult.suspension.hookDisposedCount === 0 &&
-                          workflowResult.suspension.abortCount === 0 &&
-                          !hasOpenHookOrWait(events)
-                            ? {
-                                type: 'retained',
-                                session: workflowResult.session,
-                              }
-                            : { type: 'replay' };
+                        workflowExecution = canRetainWorkflowSession(
+                          workflowResult.suspension,
+                          events
+                        )
+                          ? {
+                              type: 'retained',
+                              session: workflowResult.session,
+                            }
+                          : { type: 'replay' };
                         throw workflowResult.suspension;
                       }
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -90,7 +90,11 @@ import {
 } from './telemetry.js';
 import { getErrorName, getErrorStack, normalizeUnknownError } from './types.js';
 import { buildWorkflowSuspensionMessage } from './util.js';
-import { runWorkflow } from './workflow.js';
+import {
+  executeWorkflow,
+  type WorkflowExecutionResult,
+  type WorkflowSession,
+} from './workflow.js';
 
 export type { Event, WorkflowRun };
 export { WorkflowSuspension } from './global.js';
@@ -1100,6 +1104,13 @@ export function workflowEntrypoint(
                     encryptionKey
                   );
 
+                  let workflowExecution:
+                    | { readonly type: 'replay' }
+                    | {
+                        readonly type: 'retained';
+                        readonly session: WorkflowSession;
+                      } = { type: 'replay' };
+
                   // Main replay loop
                   // biome-ignore lint/correctness/noConstantCondition: intentional loop
                   while (true) {
@@ -1414,37 +1425,80 @@ export function workflowEntrypoint(
                       // point and the inline executeStep mutates eventsCursor.
                       preInlineWriteCursor = eventsCursor;
 
-                      // Replay workflow
-                      runtimeLogger.debug('Starting workflow replay', {
+                      let executionMode = workflowExecution.type;
+                      runtimeLogger.debug('Starting workflow execution', {
                         workflowRunId: runId,
                         loopIteration,
                         eventCount: events.length,
+                        executionMode,
                       });
                       replayStart = Date.now();
-                      // Start every missing decrypt/decompress operation before
-                      // VM setup. Web Crypto work can overlap bundle evaluation;
-                      // consumers still deserialize and resolve in event order.
-                      const payloadPrewarm = replayPayloadCache.prewarm(
-                        workflowRun,
-                        events
-                      );
-                      const result = await runWorkflow(
-                        workflowCode,
-                        workflowRun,
-                        events,
-                        encryptionKey,
-                        replayPayloadCache,
-                        // Turbo: the end-of-run drain inside runWorkflow commits
-                        // fire-and-forget `*_created` events before the terminal
-                        // `awaitRunReady()` below, so gate those writes on the
-                        // backgrounded run_started too. Undefined outside turbo.
-                        runReadyBarrier
-                      );
-                      await payloadPrewarm;
-                      runtimeLogger.debug('Workflow replay completed', {
+                      let workflowResult: WorkflowExecutionResult = {
+                        type: 'replay',
+                      };
+                      if (workflowExecution.type === 'retained') {
+                        workflowResult = await executeWorkflow({
+                          type: 'resume',
+                          session: workflowExecution.session,
+                          events,
+                        });
+                      }
+
+                      if (workflowResult.type === 'replay') {
+                        executionMode = 'replay';
+                        workflowExecution = { type: 'replay' };
+                        // Start every missing decrypt/decompress operation
+                        // before VM setup. Web Crypto work can overlap bundle
+                        // evaluation; consumers still deserialize and resolve
+                        // in event order.
+                        const payloadPrewarm = replayPayloadCache.prewarm(
+                          workflowRun,
+                          events
+                        );
+                        workflowResult = await executeWorkflow({
+                          type: 'replay',
+                          workflowCode,
+                          workflowRun,
+                          events,
+                          encryptionKey,
+                          replayPayloadCache,
+                          // Turbo: the end-of-run drain inside workflow
+                          // execution commits fire-and-forget `*_created`
+                          // events before the terminal `awaitRunReady()` below.
+                          runReadyBarrier,
+                        });
+                        await payloadPrewarm;
+                      }
+
+                      if (workflowResult.type === 'suspended') {
+                        workflowExecution =
+                          workflowResult.suspension.stepCount > 0 &&
+                          workflowResult.suspension.hookCount === 0 &&
+                          workflowResult.suspension.waitCount === 0 &&
+                          workflowResult.suspension.attributeCount === 0 &&
+                          workflowResult.suspension.hookDisposedCount === 0 &&
+                          workflowResult.suspension.abortCount === 0 &&
+                          !hasOpenHookOrWait(events)
+                            ? {
+                                type: 'retained',
+                                session: workflowResult.session,
+                              }
+                            : { type: 'replay' };
+                        throw workflowResult.suspension;
+                      }
+
+                      if (workflowResult.type === 'replay') {
+                        throw new Error(
+                          'Invariant violation: fresh workflow execution requested another replay'
+                        );
+                      }
+
+                      const result = workflowResult.output;
+                      runtimeLogger.debug('Workflow execution completed', {
                         workflowRunId: runId,
                         loopIteration,
                         replayMs: Date.now() - replayStart,
+                        executionMode,
                       });
 
                       // Workflow completed. Send the snapshot but do NOT

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -249,7 +249,10 @@ export async function trace<T>(
         code: otel.SpanStatusCode.ERROR,
         message: (e as Error).message,
       });
-      applyWorkflowSuspensionToSpan(e, otel, span);
+      if (WorkflowSuspension.is(e)) {
+        span.setStatus({ code: otel.SpanStatusCode.OK });
+        applyWorkflowSuspensionToSpan(e, span);
+      }
       throw e;
     } finally {
       span.end();
@@ -275,19 +278,12 @@ export async function recordElapsedSpan(
 }
 
 /**
- * Applies workflow suspension attributes to the given span if the error is a WorkflowSuspension
- * which is technically not an error, but an algebraic effect indicating suspension.
+ * Applies the workflow suspension algebraic effect to an active span.
  */
-function applyWorkflowSuspensionToSpan(
-  error: unknown,
-  otel: typeof api,
+export function applyWorkflowSuspensionToSpan(
+  error: WorkflowSuspension,
   span: api.Span
-) {
-  if (!error || !WorkflowSuspension.is(error)) {
-    return;
-  }
-
-  span.setStatus({ code: otel.SpanStatusCode.OK });
+): void {
   span.setAttributes({
     ...Attr.WorkflowSuspensionState('suspended'),
     ...Attr.WorkflowSuspensionStepCount(error.stepCount),

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -77,6 +77,11 @@ export const WorkflowEventsCount = SemanticConvention<number>(
   'workflow.events.count'
 );
 
+/** Whether workflow execution starts with replay or resumes a retained VM */
+export const WorkflowExecutionMode = SemanticConvention<'replay' | 'retained'>(
+  'workflow.execution.mode'
+);
+
 /** Number of arguments passed to the workflow */
 export const WorkflowArgumentsCount = SemanticConvention<number>(
   'workflow.arguments.count'

--- a/packages/core/src/workflow-session-telemetry.test.ts
+++ b/packages/core/src/workflow-session-telemetry.test.ts
@@ -1,0 +1,69 @@
+import { trace as otelTrace } from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import type { WorkflowRun } from '@workflow/world';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { ReplayPayloadCache } from './replay-payload-cache.js';
+import { dehydrateWorkflowArguments } from './serialization.js';
+import { executeWorkflow } from './workflow.js';
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+
+beforeAll(() => {
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  otelTrace.setGlobalTracerProvider(provider);
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  otelTrace.disable();
+});
+
+afterEach(() => {
+  exporter.reset();
+});
+
+describe('retained workflow telemetry', () => {
+  it('records suspension attributes on workflow.run spans', async () => {
+    const runId = 'wrun_retained_telemetry';
+    const workflowRun: WorkflowRun = {
+      runId,
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments([], runId, undefined, []),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const workflowCode = `
+      const step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step");
+      async function workflow() { await step(); }
+      globalThis.__private_workflows = new Map([["workflow", workflow]]);`;
+
+    const result = await executeWorkflow({
+      type: 'replay',
+      workflowCode,
+      workflowRun,
+      events: [],
+      encryptionKey: undefined,
+      replayPayloadCache: new ReplayPayloadCache(undefined),
+    });
+    expect(result.type).toBe('suspended');
+
+    const span = exporter
+      .getFinishedSpans()
+      .find((candidate) => candidate.name === 'workflow.run workflow');
+    expect(span?.attributes).toMatchObject({
+      'workflow.execution.mode': 'replay',
+      'workflow.suspension.state': 'suspended',
+      'workflow.suspension.step_count': 1,
+      'workflow.suspension.hook_count': 0,
+      'workflow.suspension.wait_count': 0,
+    });
+  });
+});

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -6,6 +6,7 @@ import { monotonicFactory } from 'ulid';
 import { afterEach, assert, describe, expect, it, vi } from 'vitest';
 import { DEFERRED_CHECK_DELAY_MS } from './events-consumer.js';
 import type { WorkflowSuspension } from './global.js';
+import { ReplayPayloadCache } from './replay-payload-cache.js';
 import { setWorld } from './runtime/world.js';
 import {
   dehydrateStepReturnValue,
@@ -13,7 +14,7 @@ import {
   hydrateWorkflowReturnValue,
 } from './serialization.js';
 import { createContext } from './vm/index.js';
-import { runWorkflow } from './workflow.js';
+import { executeWorkflow, runWorkflow } from './workflow.js';
 
 // No encryption key = encryption disabled
 const noEncryptionKey = undefined;
@@ -219,6 +220,124 @@ describe('runWorkflow', () => {
         ops
       )
     ).toEqual(3);
+  });
+
+  it('should retain workflow execution across sequential step suspensions', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_retained',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_retained',
+        noEncryptionKey,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const workflowCode = `
+      const add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("add");
+      async function workflow() {
+        console.log("retained:entered");
+        const first = await add(1, 2);
+        console.log("retained:continued");
+        const second = await add(first, 3);
+        return second;
+      }
+      ${getWorkflowTransformCode('workflow')}`;
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const events: Event[] = [];
+    let eventNumber = 0;
+    const appendStepEvents = async (
+      correlationId: string,
+      result: number
+    ): Promise<void> => {
+      const createdAt = new Date(`2024-01-01T00:00:0${eventNumber + 1}.000Z`);
+      events.push(
+        {
+          eventId: `event-${eventNumber++}`,
+          runId: workflowRun.runId,
+          eventType: 'step_created',
+          correlationId,
+          eventData: { stepName: 'add' },
+          createdAt,
+        },
+        {
+          eventId: `event-${eventNumber++}`,
+          runId: workflowRun.runId,
+          eventType: 'step_started',
+          correlationId,
+          eventData: { stepName: 'add' },
+          createdAt,
+        },
+        {
+          eventId: `event-${eventNumber++}`,
+          runId: workflowRun.runId,
+          eventType: 'step_completed',
+          correlationId,
+          eventData: {
+            stepName: 'add',
+            result: await dehydrateStepReturnValue(
+              result,
+              workflowRun.runId,
+              noEncryptionKey,
+              ops
+            ),
+          },
+          createdAt,
+        }
+      );
+    };
+
+    const first = await executeWorkflow({
+      type: 'replay',
+      workflowCode,
+      workflowRun,
+      events,
+      encryptionKey: noEncryptionKey,
+      replayPayloadCache: new ReplayPayloadCache(noEncryptionKey),
+    });
+    assert(first.type === 'suspended');
+    const firstStep = first.suspension.steps[0];
+    assert(firstStep?.type === 'step');
+    await appendStepEvents(firstStep.correlationId, 3);
+
+    const second = await executeWorkflow({
+      type: 'resume',
+      session: first.session,
+      events,
+    });
+    assert(second.type === 'suspended');
+    expect(second.session).toBe(first.session);
+    const secondStep = second.suspension.steps[0];
+    assert(secondStep?.type === 'step');
+    await appendStepEvents(secondStep.correlationId, 6);
+
+    const completed = await executeWorkflow({
+      type: 'resume',
+      session: second.session,
+      events,
+    });
+    assert(completed.type === 'completed');
+
+    expect(
+      await hydrateWorkflowReturnValue(
+        completed.output as any,
+        workflowRun.runId,
+        noEncryptionKey,
+        ops
+      )
+    ).toBe(6);
+    expect(
+      log.mock.calls
+        .map(([message]) => message)
+        .filter((message) => String(message).startsWith('retained:'))
+    ).toEqual(['retained:entered', 'retained:continued']);
+    log.mockRestore();
   });
 
   it('regenerates step correlation IDs independent of startedAt (turbo replay-stability)', async () => {

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -304,6 +304,14 @@ describe('runWorkflow', () => {
     assert(first.type === 'suspended');
     const firstStep = first.suspension.steps[0];
     assert(firstStep?.type === 'step');
+
+    const unchanged = await executeWorkflow({
+      type: 'resume',
+      session: first.session,
+      events,
+    });
+    expect(unchanged).toEqual({ type: 'replay' });
+
     await appendStepEvents(firstStep.correlationId, 3);
 
     const second = await executeWorkflow({
@@ -315,6 +323,18 @@ describe('runWorkflow', () => {
     expect(second.session).toBe(first.session);
     const secondStep = second.suspension.steps[0];
     assert(secondStep?.type === 'step');
+
+    const rewrittenEvents = [
+      { ...events[0], eventId: 'rewritten-event' } as Event,
+      ...events,
+    ];
+    const rewritten = await executeWorkflow({
+      type: 'resume',
+      session: second.session,
+      events: rewrittenEvents,
+    });
+    expect(rewritten).toEqual({ type: 'replay' });
+
     await appendStepEvents(secondStep.correlationId, 6);
 
     const completed = await executeWorkflow({

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -360,6 +360,74 @@ describe('runWorkflow', () => {
     log.mockRestore();
   });
 
+  it('returns a workflow that completes while its retained session is suspended', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_retained_async_completion',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_retained_async_completion',
+        noEncryptionKey,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const workflowCode = `
+      const step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step");
+      async function digestRepeatedly() {
+        const bytes = new Uint8Array(8 * 1024 * 1024);
+        for (let index = 0; index < 8; index++) {
+          await crypto.subtle.digest("SHA-256", bytes);
+        }
+      }
+      async function workflow() {
+        await Promise.race([step(), digestRepeatedly()]);
+        return "digest completed";
+      }
+      ${getWorkflowTransformCode('workflow')}`;
+    const events: Event[] = [];
+
+    const suspended = await executeWorkflow({
+      type: 'replay',
+      workflowCode,
+      workflowRun,
+      events,
+      encryptionKey: noEncryptionKey,
+      replayPayloadCache: new ReplayPayloadCache(noEncryptionKey),
+    });
+    assert(suspended.type === 'suspended');
+
+    let completed: Awaited<ReturnType<typeof executeWorkflow>> | undefined;
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const result = await executeWorkflow({
+        type: 'resume',
+        session: suspended.session,
+        events,
+      });
+      if (result.type === 'completed') {
+        completed = result;
+        break;
+      }
+      assert(result.type === 'replay');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    assert(completed?.type === 'completed');
+    expect(
+      await hydrateWorkflowReturnValue(
+        completed.output as any,
+        workflowRun.runId,
+        noEncryptionKey,
+        ops
+      )
+    ).toBe('digest completed');
+  });
+
   it('regenerates step correlation IDs independent of startedAt (turbo replay-stability)', async () => {
     // Turbo's first delivery synthesizes `startedAt` from the local clock,
     // while later (non-turbo) deliveries load the server-canonical `startedAt`.

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -305,13 +305,6 @@ describe('runWorkflow', () => {
     const firstStep = first.suspension.steps[0];
     assert(firstStep?.type === 'step');
 
-    const unchanged = await executeWorkflow({
-      type: 'resume',
-      session: first.session,
-      events,
-    });
-    expect(unchanged).toEqual({ type: 'replay' });
-
     await appendStepEvents(firstStep.correlationId, 3);
 
     const second = await executeWorkflow({
@@ -323,17 +316,6 @@ describe('runWorkflow', () => {
     expect(second.session).toBe(first.session);
     const secondStep = second.suspension.steps[0];
     assert(secondStep?.type === 'step');
-
-    const rewrittenEvents = [
-      { ...events[0], eventId: 'rewritten-event' } as Event,
-      ...events,
-    ];
-    const rewritten = await executeWorkflow({
-      type: 'resume',
-      session: second.session,
-      events: rewrittenEvents,
-    });
-    expect(rewritten).toEqual({ type: 'replay' });
 
     await appendStepEvents(secondStep.correlationId, 6);
 
@@ -387,10 +369,19 @@ describe('runWorkflow', () => {
       }
       async function workflow() {
         await Promise.race([step(), digestRepeatedly()]);
+        console.log("retained:digest-completed");
         return "digest completed";
       }
       ${getWorkflowTransformCode('workflow')}`;
-    const events: Event[] = [];
+    const events: Event[] = [
+      {
+        eventId: 'event-run-created',
+        runId: workflowRun.runId,
+        eventType: 'run_created',
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+    ];
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     const suspended = await executeWorkflow({
       type: 'replay',
@@ -401,23 +392,86 @@ describe('runWorkflow', () => {
       replayPayloadCache: new ReplayPayloadCache(noEncryptionKey),
     });
     assert(suspended.type === 'suspended');
+    const pendingStep = suspended.suspension.steps[0];
+    assert(pendingStep?.type === 'step');
 
-    let completed: Awaited<ReturnType<typeof executeWorkflow>> | undefined;
-    for (let attempt = 0; attempt < 100; attempt++) {
-      const result = await executeWorkflow({
+    const rewrittenSession = await executeWorkflow({
+      type: 'replay',
+      workflowCode,
+      workflowRun,
+      events,
+      encryptionKey: noEncryptionKey,
+      replayPayloadCache: new ReplayPayloadCache(noEncryptionKey),
+    });
+    assert(rewrittenSession.type === 'suspended');
+
+    await vi.waitFor(
+      () => {
+        expect(log).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 10_000, interval: 10 }
+    );
+    const rewrittenEvents = [
+      { ...events[0], eventId: 'rewritten-event' } as Event,
+      { ...events[0], eventId: 'new-event' } as Event,
+    ];
+    expect(
+      await executeWorkflow({
         type: 'resume',
-        session: suspended.session,
-        events,
-      });
-      if (result.type === 'completed') {
-        completed = result;
-        break;
-      }
-      assert(result.type === 'replay');
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
+        session: rewrittenSession.session,
+        events: rewrittenEvents,
+      })
+    ).toEqual({ type: 'replay' });
 
-    assert(completed?.type === 'completed');
+    const createdAt = new Date('2024-01-01T00:00:01.000Z');
+    events.push(
+      {
+        eventId: 'event-step-created',
+        runId: workflowRun.runId,
+        eventType: 'step_created',
+        correlationId: pendingStep.correlationId,
+        eventData: { stepName: pendingStep.stepName },
+        createdAt,
+      },
+      {
+        eventId: 'event-step-started',
+        runId: workflowRun.runId,
+        eventType: 'step_started',
+        correlationId: pendingStep.correlationId,
+        eventData: { stepName: pendingStep.stepName },
+        createdAt,
+      },
+      {
+        eventId: 'event-step-completed',
+        runId: workflowRun.runId,
+        eventType: 'step_completed',
+        correlationId: pendingStep.correlationId,
+        eventData: {
+          stepName: pendingStep.stepName,
+          result: await dehydrateStepReturnValue(
+            undefined,
+            workflowRun.runId,
+            noEncryptionKey,
+            ops
+          ),
+        },
+        createdAt,
+      }
+    );
+
+    const completed = await executeWorkflow({
+      type: 'resume',
+      session: suspended.session,
+      events,
+    });
+    assert(completed.type === 'completed');
+    expect(
+      await executeWorkflow({
+        type: 'resume',
+        session: rewrittenSession.session,
+        events,
+      })
+    ).toEqual({ type: 'replay' });
     expect(
       await hydrateWorkflowReturnValue(
         completed.output as any,
@@ -426,6 +480,85 @@ describe('runWorkflow', () => {
         ops
       )
     ).toBe('digest completed');
+    log.mockRestore();
+  });
+
+  it('does not drain operations from a discarded retained session', async () => {
+    const ops: Promise<any>[] = [];
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_retained_discarded',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_retained_discarded',
+        noEncryptionKey,
+        ops
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const workflowCode = `
+      const step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step");
+      const setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
+      async function digestRepeatedly() {
+        const bytes = new Uint8Array(8 * 1024 * 1024);
+        for (let index = 0; index < 8; index++) {
+          await crypto.subtle.digest("SHA-256", bytes);
+        }
+      }
+      async function workflow() {
+        await Promise.race([step(), digestRepeatedly()]);
+        void setAttributes([{ key: "stale", value: true }]);
+        console.log("retained:discarded-completed");
+        return "discarded";
+      }
+      ${getWorkflowTransformCode('workflow')}`;
+    const create = vi.fn();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      events: { create },
+      streams: { write: vi.fn(), close: vi.fn() },
+    } as any);
+
+    const suspended = await executeWorkflow({
+      type: 'replay',
+      workflowCode,
+      workflowRun,
+      events: [],
+      encryptionKey: noEncryptionKey,
+      replayPayloadCache: new ReplayPayloadCache(noEncryptionKey),
+    });
+    assert(suspended.type === 'suspended');
+
+    await vi.waitFor(
+      () => {
+        expect(log).toHaveBeenCalledWith('retained:discarded-completed');
+      },
+      { timeout: 10_000, interval: 10 }
+    );
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(
+      await executeWorkflow({
+        type: 'resume',
+        session: suspended.session,
+        events: [
+          {
+            eventId: 'event-run-created',
+            runId: workflowRun.runId,
+            eventType: 'run_created',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+          },
+        ],
+      })
+    ).toEqual({ type: 'replay' });
+    expect(create).not.toHaveBeenCalled();
+    setWorld(undefined);
+    log.mockRestore();
   });
 
   it('regenerates step correlation IDs independent of startedAt (turbo replay-stability)', async () => {

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -1113,8 +1113,7 @@ function createWorkflowSession({
             const isStrictExtension =
               nextEvents.length > consumedEvents.length &&
               consumedEvents.every(
-                (event, index) =>
-                  event.eventId === nextEvents[index]?.eventId
+                (event, index) => event.eventId === nextEvents[index]?.eventId
               );
             if (!isStrictExtension) {
               return { type: 'replay' };

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -149,7 +149,34 @@ type WorkflowSessionState =
     }
   | { readonly type: 'suspended'; readonly suspension: WorkflowSuspension }
   | { readonly type: 'failed'; readonly error: Error }
+  | { readonly type: 'replay' }
   | { readonly type: 'completed' };
+
+function isSameSuspensionBoundary(
+  previous: WorkflowSuspension,
+  next: WorkflowSuspension
+): boolean {
+  return (
+    previous.stepCount === next.stepCount &&
+    previous.hookCount === next.hookCount &&
+    previous.waitCount === next.waitCount &&
+    previous.attributeCount === next.attributeCount &&
+    previous.hookDisposedCount === next.hookDisposedCount &&
+    previous.abortCount === next.abortCount &&
+    previous.steps.length === next.steps.length &&
+    previous.steps.every((item, index) => item === next.steps[index])
+  );
+}
+
+function updateSuspendedSession(
+  suspension: WorkflowSuspension,
+  error: Error
+): WorkflowSessionState {
+  if (!WorkflowSuspension.is(error)) return { type: 'failed', error };
+  return isSameSuspensionBoundary(suspension, error)
+    ? { type: 'suspended', suspension }
+    : { type: 'replay' };
+}
 
 export interface WorkflowSession {
   readonly workflowRun: WorkflowRun;
@@ -360,11 +387,10 @@ function createWorkflowSession({
           return;
         }
         case 'suspended':
-          if (!WorkflowSuspension.is(error)) {
-            state = { type: 'failed', error };
-          }
+          state = updateSuspendedSession(state.suspension, error);
           return;
         case 'failed':
+        case 'replay':
         case 'completed':
           return;
       }
@@ -1033,10 +1059,35 @@ function createWorkflowSession({
     );
     await workflowContext.promiseQueue;
 
-    const workflowExecution = (async (): Promise<WorkflowCompletion> => {
+    const workflowExecution = (async (): Promise<unknown> => {
+      return await workflowFn(...args);
+    })();
+
+    const failWorkflow = async (error: unknown): Promise<never> => {
+      state = { type: 'completed' };
+      // Control-flow signals are handled by the runtime and do not mean the
+      // workflow has terminally failed.
+      if (WorkflowSuspension.is(error) || ReplayDivergenceError.is(error)) {
+        throw error;
+      }
+
+      await drainPendingQueueItems(
+        workflowRun.runId,
+        workflowContext.invocationsQueue,
+        vmGlobalThis,
+        workflowRun,
+        'failed',
+        runReadyBarrier
+      );
+
+      throw error;
+    };
+
+    const completeWorkflow = async (
+      result: unknown
+    ): Promise<WorkflowCompletion> => {
+      state = { type: 'completed' };
       try {
-        const result = await workflowFn(...args);
-        state = { type: 'completed' };
         const output = await dehydrateWorkflowReturnValue(
           result,
           workflowRun.runId,
@@ -1060,48 +1111,23 @@ function createWorkflowSession({
 
         return { output, resultType: typeof result };
       } catch (error) {
-        if (state.type === 'running') {
-          state = { type: 'completed' };
-        }
-        // Control-flow signals are handled by the runtime and do not mean the
-        // workflow has terminally failed.
-        if (WorkflowSuspension.is(error) || ReplayDivergenceError.is(error)) {
-          throw error;
-        }
-
-        await drainPendingQueueItems(
-          workflowRun.runId,
-          workflowContext.invocationsQueue,
-          vmGlobalThis,
-          workflowRun,
-          'failed',
-          runReadyBarrier
-        );
-
-        throw error;
+        return failWorkflow(error);
       }
-    })();
+    };
 
     const waitForExecution = async (
       interruption: PromiseWithResolvers<never>
     ): Promise<WorkflowCompletion> => {
+      let result: unknown;
       try {
-        const completed = await Promise.race([
-          workflowExecution,
-          interruption.promise,
-        ]);
-        state = { type: 'completed' };
-        return completed;
+        result = await Promise.race([workflowExecution, interruption.promise]);
       } catch (error) {
-        if (
-          (state.type === 'suspended' && error === state.suspension) ||
-          (state.type === 'failed' && error === state.error)
-        ) {
+        if (state.type === 'suspended' && error === state.suspension) {
           throw error;
         }
-        state = { type: 'completed' };
-        throw error;
+        return failWorkflow(error);
       }
+      return completeWorkflow(result);
     };
 
     const session: WorkflowSession = {
@@ -1117,6 +1143,7 @@ function createWorkflowSession({
                 (event, index) => event.eventId === nextEvents[index]?.eventId
               );
             if (!isStrictExtension) {
+              state = { type: 'replay' };
               return { type: 'replay' };
             }
             const interruption = withResolvers<never>();
@@ -1128,9 +1155,10 @@ function createWorkflowSession({
             };
           }
           case 'failed':
-            throw state.error;
+            return { type: 'resumed', execution: failWorkflow(state.error) };
+          case 'replay':
+            return { type: 'replay' };
           case 'completed':
-            return { type: 'resumed', execution: workflowExecution };
           case 'running':
             throw new WorkflowRuntimeError(
               `Cannot resume ${state.type} workflow "${workflowRun.runId}"`

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -40,7 +40,7 @@ import {
   WORKFLOW_USE_STEP,
 } from './symbols.js';
 import * as Attribute from './telemetry/semantic-conventions.js';
-import { trace } from './telemetry.js';
+import { applyWorkflowSuspensionToSpan, trace } from './telemetry.js';
 import { getWorkflowRunStreamId } from './util.js';
 import { createContext } from './vm/index.js';
 import { runCachedWorkflowScript } from './vm/script-cache.js';
@@ -238,6 +238,7 @@ export async function executeWorkflow(
       return { type: 'completed', output: completed.output };
     } catch (error) {
       if (WorkflowSuspension.is(error)) {
+        if (span) applyWorkflowSuspensionToSpan(error, span);
         return { type: 'suspended', suspension: error, session };
       }
       throw error;
@@ -1128,8 +1129,9 @@ function createWorkflowSession({
           }
           case 'failed':
             throw state.error;
-          case 'running':
           case 'completed':
+            return { type: 'resumed', execution: workflowExecution };
+          case 'running':
             throw new WorkflowRuntimeError(
               `Cannot resume ${state.type} workflow "${workflowRun.runId}"`
             );

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -4,7 +4,11 @@ import {
   WorkflowNotRegisteredError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
-import { createWorkflowBaseUrl, withResolvers } from '@workflow/utils';
+import {
+  createWorkflowBaseUrl,
+  type PromiseWithResolvers,
+  withResolvers,
+} from '@workflow/utils';
 import { parseWorkflowName } from '@workflow/utils/parse-name';
 import type { Event, WorkflowRun } from '@workflow/world';
 import { SPEC_VERSION_SUPPORTS_COMPRESSION } from '@workflow/world';
@@ -133,6 +137,114 @@ async function drainPendingQueueItems(
   }
 }
 
+interface WorkflowCompletion {
+  readonly output: unknown;
+  readonly resultType: string;
+}
+
+type WorkflowSessionState =
+  | {
+      readonly type: 'running';
+      readonly interruption: PromiseWithResolvers<never>;
+    }
+  | { readonly type: 'suspended'; readonly suspension: WorkflowSuspension }
+  | { readonly type: 'failed'; readonly error: Error }
+  | { readonly type: 'completed' };
+
+export interface WorkflowSession {
+  readonly workflowRun: WorkflowRun;
+  readonly argumentCount: number;
+  resume(events: Event[]): WorkflowSessionResumeResult;
+}
+
+type WorkflowSessionResumeResult =
+  | {
+      readonly type: 'resumed';
+      readonly execution: Promise<WorkflowCompletion>;
+    }
+  | { readonly type: 'replay' };
+
+interface WorkflowSessionOptions {
+  readonly workflowCode: string;
+  readonly workflowRun: WorkflowRun;
+  readonly events: Event[];
+  readonly encryptionKey: CryptoKey | undefined;
+  readonly replayPayloadCache: ReplayPayloadCache;
+  readonly runReadyBarrier?: Promise<unknown>;
+}
+
+type WorkflowExecutionRequest =
+  | ({ readonly type: 'replay' } & WorkflowSessionOptions)
+  | {
+      readonly type: 'resume';
+      readonly session: WorkflowSession;
+      readonly events: Event[];
+    };
+
+export type WorkflowExecutionResult =
+  | { readonly type: 'replay' }
+  | { readonly type: 'completed'; readonly output: unknown }
+  | {
+      readonly type: 'suspended';
+      readonly suspension: WorkflowSuspension;
+      readonly session: WorkflowSession;
+    };
+
+export async function executeWorkflow(
+  request: WorkflowExecutionRequest
+): Promise<WorkflowExecutionResult> {
+  const workflowRun =
+    request.type === 'replay'
+      ? request.workflowRun
+      : request.session.workflowRun;
+  const mode = request.type === 'replay' ? 'replay' : 'retained';
+
+  return trace(`workflow.run ${workflowRun.workflowName}`, async (span) => {
+    span?.setAttributes({
+      ...Attribute.WorkflowName(workflowRun.workflowName),
+      ...Attribute.WorkflowRunId(workflowRun.runId),
+      ...Attribute.WorkflowRunStatus(workflowRun.status),
+      ...Attribute.WorkflowEventsCount(request.events.length),
+      ...Attribute.WorkflowExecutionMode(mode),
+    });
+
+    let session: WorkflowSession;
+    let execution: Promise<WorkflowCompletion>;
+    switch (request.type) {
+      case 'replay': {
+        const started = await createWorkflowSession(request);
+        session = started.session;
+        execution = started.execution;
+        break;
+      }
+      case 'resume': {
+        session = request.session;
+        const resumed = session.resume(request.events);
+        if (resumed.type === 'replay') return resumed;
+        execution = resumed.execution;
+        break;
+      }
+    }
+
+    span?.setAttributes({
+      ...Attribute.WorkflowArgumentsCount(session.argumentCount),
+    });
+
+    try {
+      const completed = await execution;
+      span?.setAttributes({
+        ...Attribute.WorkflowResultType(completed.resultType),
+      });
+      return { type: 'completed', output: completed.output };
+    } catch (error) {
+      if (WorkflowSuspension.is(error)) {
+        return { type: 'suspended', suspension: error, session };
+      }
+      throw error;
+    }
+  });
+}
+
 export async function runWorkflow(
   workflowCode: string,
   workflowRun: WorkflowRun,
@@ -140,8 +252,7 @@ export async function runWorkflow(
   encryptionKey: CryptoKey | undefined,
   /**
    * Optional per-run cache for replay payload preparation and immutable final
-   * values. Owned by the inline replay loop so it survives fresh VM contexts
-   * created by successive iterations of this invocation.
+   * values. Owned by the inline execution loop for this invocation.
    */
   replayPayloadCache: ReplayPayloadCache = new ReplayPayloadCache(
     encryptionKey
@@ -154,14 +265,36 @@ export async function runWorkflow(
    */
   runReadyBarrier?: Promise<unknown>
 ): Promise<Uint8Array | unknown> {
-  return trace(`workflow.run ${workflowRun.workflowName}`, async (span) => {
-    span?.setAttributes({
-      ...Attribute.WorkflowName(workflowRun.workflowName),
-      ...Attribute.WorkflowRunId(workflowRun.runId),
-      ...Attribute.WorkflowRunStatus(workflowRun.status),
-      ...Attribute.WorkflowEventsCount(events.length),
-    });
+  const result = await executeWorkflow({
+    type: 'replay',
+    workflowCode,
+    workflowRun,
+    events,
+    encryptionKey,
+    replayPayloadCache,
+    runReadyBarrier,
+  });
+  if (result.type === 'replay') {
+    throw new WorkflowRuntimeError(
+      `Fresh workflow "${workflowRun.runId}" unexpectedly requested replay`
+    );
+  }
+  if (result.type === 'suspended') throw result.suspension;
+  return result.output;
+}
 
+function createWorkflowSession({
+  workflowCode,
+  workflowRun,
+  events,
+  encryptionKey,
+  replayPayloadCache,
+  runReadyBarrier,
+}: WorkflowSessionOptions): Promise<{
+  session: WorkflowSession;
+  execution: Promise<WorkflowCompletion>;
+}> {
+  return (async () => {
     const startedAt = workflowRun.startedAt;
     if (!startedAt) {
       throw new WorkflowRuntimeError(
@@ -209,7 +342,33 @@ export async function runWorkflow(
       fixedTimestamp,
     });
 
-    const workflowDiscontinuation = withResolvers<void>();
+    const initialInterruption = withResolvers<never>();
+    let state: WorkflowSessionState = {
+      type: 'running',
+      interruption: initialInterruption,
+    };
+
+    const onWorkflowError = (error: Error): void => {
+      switch (state.type) {
+        case 'running': {
+          const { interruption } = state;
+          state = WorkflowSuspension.is(error)
+            ? { type: 'suspended', suspension: error }
+            : { type: 'failed', error };
+          interruption.reject(error);
+          return;
+        }
+        case 'suspended':
+          if (!WorkflowSuspension.is(error)) {
+            state = { type: 'failed', error };
+          }
+          return;
+        case 'failed':
+        case 'completed':
+          return;
+      }
+      state satisfies never;
+    };
 
     const ulid = monotonicFactory(() => vmGlobalThis.Math.random());
     const generateNanoid = nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
@@ -226,7 +385,7 @@ export async function runWorkflow(
         updateTimestamp(+event.createdAt);
       },
       onUnconsumedEvent: (event) => {
-        workflowDiscontinuation.reject(
+        onWorkflowError(
           new ReplayDivergenceError(
             `Replay could not consume event: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}.`,
             { eventId: event.eventId }
@@ -240,7 +399,7 @@ export async function runWorkflow(
       runId: workflowRun.runId,
       encryptionKey,
       globalThis: vmGlobalThis,
-      onWorkflowError: workflowDiscontinuation.reject,
+      onWorkflowError,
       eventsConsumer,
       // Correlation IDs (step_/wait_/hook_) are derived from `generateUlid`, so
       // the time prefix fed to `ulid()` MUST be replay-stable across every
@@ -873,60 +1032,116 @@ export async function runWorkflow(
     );
     await workflowContext.promiseQueue;
 
-    span?.setAttributes({
-      ...Attribute.WorkflowArgumentsCount(args.length),
-    });
+    const workflowExecution = (async (): Promise<WorkflowCompletion> => {
+      try {
+        const result = await workflowFn(...args);
+        state = { type: 'completed' };
+        const output = await dehydrateWorkflowReturnValue(
+          result,
+          workflowRun.runId,
+          encryptionKey,
+          vmGlobalThis,
+          false,
+          // Gate payload compression on the run's specVersion: only runs
+          // marked as possibly containing compressed payloads (spec >= 5)
+          // get gzip data.
+          (workflowRun.specVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
+        );
 
-    // Invoke user workflow
-    try {
-      const result = await Promise.race([
-        workflowFn(...args),
-        workflowDiscontinuation.promise,
-      ]);
+        await drainPendingQueueItems(
+          workflowRun.runId,
+          workflowContext.invocationsQueue,
+          vmGlobalThis,
+          workflowRun,
+          'completed',
+          runReadyBarrier
+        );
 
-      const dehydrated = await dehydrateWorkflowReturnValue(
-        result,
-        workflowRun.runId,
-        encryptionKey,
-        vmGlobalThis,
-        false,
-        // Gate payload compression on the run's specVersion: only runs
-        // marked as possibly containing compressed payloads (spec >= 5)
-        // get gzip data.
-        (workflowRun.specVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION
-      );
+        return { output, resultType: typeof result };
+      } catch (error) {
+        if (state.type === 'running') {
+          state = { type: 'completed' };
+        }
+        // Control-flow signals are handled by the runtime and do not mean the
+        // workflow has terminally failed.
+        if (WorkflowSuspension.is(error) || ReplayDivergenceError.is(error)) {
+          throw error;
+        }
 
-      span?.setAttributes({
-        ...Attribute.WorkflowResultType(typeof result),
-      });
+        await drainPendingQueueItems(
+          workflowRun.runId,
+          workflowContext.invocationsQueue,
+          vmGlobalThis,
+          workflowRun,
+          'failed',
+          runReadyBarrier
+        );
 
-      await drainPendingQueueItems(
-        workflowRun.runId,
-        workflowContext.invocationsQueue,
-        vmGlobalThis,
-        workflowRun,
-        'completed',
-        runReadyBarrier
-      );
-
-      return dehydrated;
-    } catch (err) {
-      // Control-flow signals are handled by the runtime and do not mean the
-      // workflow has terminally failed.
-      if (WorkflowSuspension.is(err) || ReplayDivergenceError.is(err)) {
-        throw err;
+        throw error;
       }
+    })();
 
-      await drainPendingQueueItems(
-        workflowRun.runId,
-        workflowContext.invocationsQueue,
-        vmGlobalThis,
-        workflowRun,
-        'failed',
-        runReadyBarrier
-      );
+    const waitForExecution = async (
+      interruption: PromiseWithResolvers<never>
+    ): Promise<WorkflowCompletion> => {
+      try {
+        const completed = await Promise.race([
+          workflowExecution,
+          interruption.promise,
+        ]);
+        state = { type: 'completed' };
+        return completed;
+      } catch (error) {
+        if (
+          (state.type === 'suspended' && error === state.suspension) ||
+          (state.type === 'failed' && error === state.error)
+        ) {
+          throw error;
+        }
+        state = { type: 'completed' };
+        throw error;
+      }
+    };
 
-      throw err;
-    }
-  });
+    const session: WorkflowSession = {
+      workflowRun,
+      argumentCount: args.length,
+      resume(nextEvents) {
+        switch (state.type) {
+          case 'suspended': {
+            const consumedEvents = eventsConsumer.events;
+            const isStrictExtension =
+              nextEvents.length > consumedEvents.length &&
+              consumedEvents.every(
+                (event, index) =>
+                  event.eventId === nextEvents[index]?.eventId
+              );
+            if (!isStrictExtension) {
+              return { type: 'replay' };
+            }
+            const interruption = withResolvers<never>();
+            state = { type: 'running', interruption };
+            eventsConsumer.append(nextEvents.slice(consumedEvents.length));
+            return {
+              type: 'resumed',
+              execution: waitForExecution(interruption),
+            };
+          }
+          case 'failed':
+            throw state.error;
+          case 'running':
+          case 'completed':
+            throw new WorkflowRuntimeError(
+              `Cannot resume ${state.type} workflow "${workflowRun.runId}"`
+            );
+        }
+        state satisfies never;
+      },
+    };
+
+    return {
+      session,
+      execution: waitForExecution(initialInterruption),
+    };
+  })();
 }


### PR DESCRIPTION
## Summary

- retain one workflow VM, event consumer, async stack, and hydrated state across inline step suspensions within a single queue invocation
- append only newly durable events when the inline loop resumes the workflow
- fall back permanently to ordinary replay if the durable event prefix changes or a discarded session advances
- preserve `runWorkflow` as the one-shot compatibility API
- tag `workflow.run` spans with `workflow.execution.mode=replay|retained` for direct production decomposition

## Design

`runWorkflowSession` owns the invocation-local VM and exposes a small discriminated state machine: `running`, `suspended`, `failed`, `replay`, or `completed`. The runtime retains a session only for a completed inline step when no attributes, hooks, waits, or replay divergence require the normal durable path.

On resume, the session verifies that every previously observed event is still an exact prefix, appends only the new events to the existing consumer, and wakes the suspended execution. A prefix mismatch or a second suspension boundary from an unobserved/discarded session moves it permanently to `replay`. Background workflow code can only enqueue in-memory work; the active observer remains the sole owner of durable writes and terminal drains.

This is intentionally invocation-local. Re-invocation, retry, rollover, queued execution, and process loss discard the session and use normal durable replay. The event log remains the source of truth.

Stacked on #2980, which prepares and caches replay payloads.

## Validation

- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/core build`
- all core tests: 70 files, 1,483 passed, 3 expected failures
- retained-session coverage includes sequential suspensions, event-prefix divergence, late completion, discarded-session isolation, event-consumer quiescence, and telemetry context restoration
- simplify and quality-code passes completed
- final autoreview panel: Codex gpt-5.6-sol xhigh and Claude Opus 4.8 xhigh, zero findings

## Benchmark

Run against workflow-server #632 at `063557ca5565d9dc3b182f602372c0222a7c9379`. The benchmark-only SDK commit `bed8acd4bc0042119c21dac2607f9c81f6e3b609` is the clean PR head `d1907dc8fe22ddf331c7f047f6394e93224e9357` plus only the workflow-server preview URL override; the override is not present in this PR.

| STSO window | Cache only (#2980 + #632) | Retained VM + cache (#2980 + #632) | Average change |
| --- | ---: | ---: | ---: |
| Steps 1-20 | 286.6 ms | 166.6 ms | -41.9% |
| Steps 101-120 | 244.7 ms | 176.9 ms | -27.7% |
| Steps 1001-1020 | 556.4 ms | 228.3 ms | -59.0% |

In the exact 1,020-step trace, retained `workflow.run` calls are approximately 2.4 ms even at 3,000+ events. The remaining typical STSO is almost entirely the previous `step_completed` durable write plus the next `step_started` durable write. Two DynamoDB/write-path stalls dominate the retained late-window p90/p99; the VM remains constant during those samples.

- [retained benchmark run](https://github.com/vercel/workflow/actions/runs/29575232545)
- [cache-only benchmark run](https://github.com/vercel/workflow/actions/runs/29554462485)
- [exact retained sequential trace](https://app.datadoghq.com/apm/trace/40fbe9c98fd19a8500aaf19f3c07cf66)

The detailed trace decomposition and non-STSO metrics are in the benchmark comment below.
