### PR TITLE
feat(web-shared): Alt+hover span measurement in the new trace viewer

### DIFF
--- a/.changeset/spotty-lamps-measure.md
+++ b/.changeset/spotty-lamps-measure.md
@@ -2,4 +2,4 @@
 '@workflow/web-shared': minor
 ---
 
-Trace viewer: holding Alt with a span selected now measures the time delta between the selected span and any hovered span, Figma-style.
+Trace viewer: holding Alt with a span selected now measures the time delta between the selected span and any hovered span, Figma-style; the no-selection Alt gap overlay is restyled to the same measurement-line design.

--- a/.changeset/spotty-lamps-measure.md
+++ b/.changeset/spotty-lamps-measure.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': minor
+---
+
+Trace viewer: holding Alt with a span selected now measures the time delta between the selected span and any hovered span, Figma-style.

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -551,51 +551,9 @@ const TimelineBar = memo(function TimelineBar({
 export { TimelineBar };
 
 // ---------------------------------------------------------------------------
-// DeltaIndicator (Alt-key gap overlay)
-// ---------------------------------------------------------------------------
-
-const DELTA_CAP_HEIGHT_PX = 8;
-// Vertical offset to sit the indicator inside the gap between row N and N+1,
-// aligned with where the bar starts in the next row (rows center a 24px bar
-// inside 40px, so bars start ~8px from the top of the row).
-const DELTA_ROW_OFFSET_PX = 8;
-
-const DeltaIndicator = memo(function DeltaIndicator({
-  leftFrac,
-  rightFrac,
-  label,
-  rowIndex,
-}: {
-  leftFrac: number;
-  rightFrac: number;
-  label: string;
-  rowIndex: number;
-}) {
-  const centerY = DELTA_ROW_OFFSET_PX + (rowIndex + 1) * ROW_HEIGHT_PX;
-
-  return (
-    <div
-      className="absolute pointer-events-none"
-      style={{
-        left: `${leftFrac * 100}%`,
-        width: `${(rightFrac - leftFrac) * 100}%`,
-        top: centerY - DELTA_CAP_HEIGHT_PX / 2,
-        height: DELTA_CAP_HEIGHT_PX,
-      }}
-    >
-      <div className="absolute left-0 top-0 w-px h-full bg-amber-800" />
-      <div className="absolute left-0 right-0 top-1/2 h-px bg-amber-800" />
-      <div className="absolute right-0 top-0 w-px h-full bg-amber-800" />
-      <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-label-12 leading-none whitespace-nowrap rounded-xs px-1 py-0.5 text-gray-100 bg-amber-800">
-        {label}
-      </span>
-    </div>
-  );
-});
-
-// ---------------------------------------------------------------------------
-// DeltaMeasureLine (Alt+hover measurement between the selected span and the
-// hovered row's span)
+// DeltaMeasureLine (Alt-key measurement overlays: the selected ↔ hovered
+// measurement, and the ambient consecutive-gap indicators shown without a
+// selection)
 // ---------------------------------------------------------------------------
 
 // Horizontal distance between the anchor bar's measured edge and the vertical
@@ -779,8 +737,22 @@ export function Timeline({
     return () => ro.disconnect();
   }, []);
 
-  const gaps = useMemo(
-    () => computeSpanGaps(spans, viewStart, viewEnd),
+  // Each consecutive gap renders as a measurement from the earlier span's end
+  // edge to the next span's start, in the same visual language as the
+  // selected ↔ hovered measurement.
+  const gapMeasurements = useMemo(
+    () =>
+      computeSpanGaps(spans, viewStart, viewEnd).map((gap) => ({
+        delta: {
+          deltaMs: gap.gapMs,
+          anchorFrac: gap.leftFrac,
+          hoveredFrac: gap.rightFrac,
+          anchorEdge: 'end',
+          hoveredOffscreen: null,
+        } satisfies SpanDelta,
+        anchorRowIndex: gap.rowIndex,
+        hoveredRowIndex: gap.rowIndex + 1,
+      })),
     [spans, viewStart, viewEnd]
   );
 
@@ -858,13 +830,11 @@ export function Timeline({
           className="absolute inset-y-0 pointer-events-none"
           style={TIMELINE_INSET_STYLE}
         >
-          {gaps.map((gap) => (
-            <DeltaIndicator
-              key={gap.rowIndex}
-              leftFrac={gap.leftFrac}
-              rightFrac={gap.rightFrac}
-              label={formatDurationPrecise(gap.gapMs)}
-              rowIndex={gap.rowIndex}
+          {gapMeasurements.map((gap) => (
+            <DeltaMeasureLine
+              key={gap.anchorRowIndex}
+              {...gap}
+              timelineWidth={timelineWidth}
             />
           ))}
         </div>

--- a/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/components/timeline.tsx
@@ -22,10 +22,12 @@ import type {
   OffscreenMarkers,
   Segment,
   SegmentStatus,
+  SpanDelta,
   TimeMarker,
 } from '../utils';
 import {
   computeOffscreenMarkers,
+  computeSpanDelta,
   computeSpanGaps,
   computeSpanMarkers,
   computeSpanSegments,
@@ -223,6 +225,11 @@ function projectSegments(
 // Small render helpers
 // ---------------------------------------------------------------------------
 
+/** Estimated rendered width of a 10px-mono duration label (6px/glyph + padding). */
+function estimateLabelWidthPx(label: string): number {
+  return label.length * 6 + 12;
+}
+
 function DurationLabel({
   label,
   className,
@@ -317,7 +324,7 @@ function SegmentBar({
           const leadInLabel = formatDurationPrecise(seg.fullDurationMs);
           const showLeadInLabel =
             showLabels &&
-            seg.pixelWidth >= Math.max(40, leadInLabel.length * 6 + 12);
+            seg.pixelWidth >= Math.max(40, estimateLabelWidthPx(leadInLabel));
           const isFullWidthQueued = segments.length === 1;
           return (
             <Fragment key={i}>
@@ -341,7 +348,8 @@ function SegmentBar({
         const label = formatDurationPrecise(seg.fullDurationMs);
         // Only render the label when there's enough room for it without clipping.
         const showLabel =
-          showLabels && seg.pixelWidth >= Math.max(40, label.length * 6 + 12);
+          showLabels &&
+          seg.pixelWidth >= Math.max(40, estimateLabelWidthPx(label));
 
         return (
           <div
@@ -462,7 +470,8 @@ const TimelineBar = memo(function TimelineBar({
 
   const totalLabel = formatDurationPrecise(totalDurationMs);
   const showTotalLabel =
-    geometry.visiblePixelWidth >= Math.max(40, totalLabel.length * 6 + 12);
+    geometry.visiblePixelWidth >=
+    Math.max(40, estimateLabelWidthPx(totalLabel));
 
   const handleClick = useCallback(() => {
     onSelect(span.spanId);
@@ -585,6 +594,102 @@ const DeltaIndicator = memo(function DeltaIndicator({
 });
 
 // ---------------------------------------------------------------------------
+// DeltaMeasureLine (Alt+hover measurement between the selected span and the
+// hovered row's span)
+// ---------------------------------------------------------------------------
+
+// Horizontal distance between the anchor bar's measured edge and the vertical
+// guide — also the width of the connector stub bridging the two.
+const MEASURE_GUIDE_OUTSET_PX = 4;
+
+const DeltaMeasureLine = memo(function DeltaMeasureLine({
+  delta,
+  anchorRowIndex,
+  hoveredRowIndex,
+  timelineWidth,
+}: {
+  delta: SpanDelta;
+  anchorRowIndex: number;
+  hoveredRowIndex: number;
+  timelineWidth: number;
+}) {
+  // Both ends of the measurement align with the vertical middle of the bars
+  // (bars are centered in their rows, so bar center == row center).
+  const anchorCenterY = anchorRowIndex * ROW_HEIGHT_PX + ROW_HEIGHT_PX / 2;
+  const lineY = hoveredRowIndex * ROW_HEIGHT_PX + ROW_HEIGHT_PX / 2;
+
+  // Guide connecting the middle of the anchor bar down/up to the line, so
+  // the measurement's origin stays legible when the rows are far apart.
+  // It sits just outside the anchor bar's measured edge (so it doesn't blend
+  // into the bar's border), joined to the bar by a short horizontal stub. The
+  // line runs from the elbow corner (the guide's x) to the hovered span's
+  // measured edge — pulled short of the edge arrow when the hovered span is
+  // fully off-screen.
+  const guideTop = Math.min(anchorCenterY, lineY);
+  const guideBottom = Math.max(anchorCenterY, lineY);
+  const anchorX = delta.anchorFrac * timelineWidth;
+  const guideX =
+    anchorX +
+    (delta.anchorEdge === 'end'
+      ? MEASURE_GUIDE_OUTSET_PX
+      : -MEASURE_GUIDE_OUTSET_PX);
+  const arrowClearance =
+    delta.hoveredOffscreen === 'right'
+      ? -(TINY_BAR_BOX_SIZE_PX + 4)
+      : delta.hoveredOffscreen === 'left'
+        ? TINY_BAR_BOX_SIZE_PX + 4
+        : 0;
+  const hoveredX = delta.hoveredFrac * timelineWidth + arrowClearance;
+  const startX = Math.min(guideX, hoveredX);
+  const endX = Math.max(guideX, hoveredX);
+
+  const label = formatDurationPrecise(delta.deltaMs);
+  const labelWidthPx = estimateLabelWidthPx(label);
+  // Center the label on the line; when the line is too short, place it beside
+  // the right endpoint, flipping left near the viewport's right edge.
+  const labelPlacement =
+    endX - startX >= labelWidthPx
+      ? { left: (startX + endX) / 2, translate: '-translate-x-1/2' }
+      : endX + 4 + labelWidthPx <= timelineWidth
+        ? { left: endX + 4, translate: '' }
+        : { left: startX - 4, translate: '-translate-x-full' };
+
+  return (
+    <>
+      <div
+        className="absolute h-px bg-amber-800"
+        style={{
+          left: Math.min(anchorX, guideX),
+          width: MEASURE_GUIDE_OUTSET_PX,
+          top: anchorCenterY,
+        }}
+      />
+      <div
+        className="absolute w-px bg-amber-800"
+        style={{
+          left: guideX,
+          top: guideTop,
+          height: guideBottom - guideTop,
+        }}
+      />
+      <div
+        className="absolute h-px bg-amber-800"
+        style={{ left: startX, width: Math.max(endX - startX, 1), top: lineY }}
+      />
+      <span
+        className={cn(
+          'absolute -translate-y-1/2 font-mono text-[10px] font-medium leading-none tabular-nums whitespace-nowrap rounded-xs bg-background-100 px-1 py-0.5 text-amber-800',
+          labelPlacement.translate
+        )}
+        style={{ left: labelPlacement.left, top: lineY }}
+      >
+        {label}
+      </span>
+    </>
+  );
+});
+
+// ---------------------------------------------------------------------------
 // TimelineHeader
 // ---------------------------------------------------------------------------
 
@@ -624,6 +729,13 @@ export function TimelineHeader({
 // Timeline
 // ---------------------------------------------------------------------------
 
+export interface TimelineHover {
+  /** Pointer x as a fraction of the timeline's content width, in [0, 1]. */
+  fraction: number;
+  /** Row index under the pointer; may be past the last row — not validated. */
+  rowIndex: number;
+}
+
 export function Timeline({
   spans,
   viewStart,
@@ -633,7 +745,7 @@ export function Timeline({
   searchResult,
   onSelect,
   onRevealTime,
-  hoverFraction,
+  hover,
   altHeld = false,
 }: {
   spans: Span[];
@@ -644,7 +756,7 @@ export function Timeline({
   searchResult: SpanSearchResult;
   onSelect: (spanId: string) => void;
   onRevealTime?: (timeMs: number) => void;
-  hoverFraction?: number | null;
+  hover?: TimelineHover | null;
   altHeld?: boolean;
 }): ReactNode {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -672,6 +784,26 @@ export function Timeline({
     [spans, viewStart, viewEnd]
   );
 
+  // With a span selected, Alt+hover measures selected ↔ hovered instead of
+  // showing the all-sibling-gaps overlay.
+  const anchorIndex = useMemo(
+    () => (selectedId ? spans.findIndex((s) => s.spanId === selectedId) : -1),
+    [spans, selectedId]
+  );
+
+  const measurement = useMemo(() => {
+    if (!altHeld || hover == null || hover.rowIndex === anchorIndex) {
+      return null;
+    }
+    const anchorSpan = spans[anchorIndex];
+    const hoveredSpan = spans[hover.rowIndex];
+    if (!anchorSpan || !hoveredSpan) return null;
+    const delta = computeSpanDelta(anchorSpan, hoveredSpan, viewStart, viewEnd);
+    return delta
+      ? { delta, anchorRowIndex: anchorIndex, hoveredRowIndex: hover.rowIndex }
+      : null;
+  }, [altHeld, anchorIndex, hover, spans, viewStart, viewEnd]);
+
   return (
     <div
       ref={containerRef}
@@ -694,14 +826,14 @@ export function Timeline({
           ) : null
         )}
       </div>
-      {hoverFraction != null && (
+      {hover != null && (
         <div
           className="absolute inset-y-0 pointer-events-none z-10"
           style={TIMELINE_INSET_STYLE}
         >
           <div
             className="absolute top-0 bottom-0 w-px bg-gray-alpha-500"
-            style={{ left: `${hoverFraction * 100}%` }}
+            style={{ left: `${hover.fraction * 100}%` }}
           />
         </div>
       )}
@@ -720,7 +852,7 @@ export function Timeline({
           />
         ))}
       </div>
-      {altHeld && (
+      {altHeld && anchorIndex < 0 && (
         <div
           aria-hidden
           className="absolute inset-y-0 pointer-events-none"
@@ -735,6 +867,15 @@ export function Timeline({
               rowIndex={gap.rowIndex}
             />
           ))}
+        </div>
+      )}
+      {measurement && (
+        <div
+          aria-hidden
+          className="absolute inset-y-0 pointer-events-none z-20"
+          style={TIMELINE_INSET_STYLE}
+        >
+          <DeltaMeasureLine {...measurement} timelineWidth={timelineWidth} />
         </div>
       )}
     </div>

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -28,6 +28,7 @@ import {
   TIMELINE_PADDING_PX,
   Timeline,
   TimelineHeader,
+  type TimelineHover,
 } from './components/timeline';
 import { TraceShortcutHelper } from './components/trace-shortcut-helper';
 import { ROW_HEIGHT_PX, scrollRowIntoView } from './components/use-row-window';
@@ -400,14 +401,14 @@ function NewTraceViewerContent({
   }, [handleClearActiveSpan]);
 
   const timelineRef = useRef<HTMLDivElement>(null);
-  const [hoverFraction, setHoverFraction] = useState<number | null>(null);
+  const [hover, setHover] = useState<TimelineHover | null>(null);
 
   const hoverInfo = useMemo(() => {
-    if (hoverFraction == null) return null;
-    const absTime = viewport.start + hoverFraction * viewDuration;
+    if (hover == null) return null;
+    const absTime = viewport.start + hover.fraction * viewDuration;
     const offset = absTime - root.startTime;
-    return { fraction: hoverFraction, label: formatDurationPrecise(offset) };
-  }, [hoverFraction, viewport.start, viewDuration, root.startTime]);
+    return { fraction: hover.fraction, label: formatDurationPrecise(offset) };
+  }, [hover, viewport.start, viewDuration, root.startTime]);
 
   const handleTimelineMouseMove = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -423,13 +424,16 @@ function NewTraceViewerContent({
           (e.clientX - rect.left - TIMELINE_PADDING_PX) / contentWidth
         )
       );
-      setHoverFraction(fraction);
+      setHover({
+        fraction,
+        rowIndex: Math.floor((e.clientY - rect.top) / ROW_HEIGHT_PX),
+      });
     },
     []
   );
 
   const handleTimelineMouseLeave = useCallback(() => {
-    setHoverFraction(null);
+    setHover(null);
   }, []);
 
   useEffect(() => {
@@ -579,7 +583,7 @@ function NewTraceViewerContent({
               searchResult={searchResult}
               onSelect={handleSelectSpan}
               onRevealTime={handleRevealTime}
-              hoverFraction={hoverFraction}
+              hover={hover}
               altHeld={altHeld}
             />
           </div>

--- a/packages/web-shared/src/components/new-trace-viewer/utils.test.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.test.ts
@@ -3,6 +3,7 @@ import type { Span, SpanEvent } from './types';
 import {
   clampViewportToRoot,
   computeOffscreenMarkers,
+  computeSpanDelta,
   computeSpanMarkers,
   computeSpanSegments,
   computeTimeMarkers,
@@ -255,5 +256,203 @@ describe('getResourceColor', () => {
       errorBg: 'var(--ds-red-200)',
       errorBorder: 'var(--ds-red-500)',
     });
+  });
+});
+
+describe('computeSpanDelta', () => {
+  function span(id: string, startMs: number, endMs: number): Span {
+    return {
+      name: id,
+      kind: 0,
+      resource: 'step',
+      library: { name: 'workflow' },
+      spanId: id,
+      status: { code: 1 },
+      traceFlags: 0,
+      attributes: {},
+      links: [],
+      events: [],
+      startTime: ts(startMs),
+      endTime: ts(endMs),
+      duration: ts(endMs - startMs),
+    };
+  }
+
+  it('measures the gap between disjoint spans (anchor earlier)', () => {
+    const delta = computeSpanDelta(
+      span('a', 0, 100),
+      span('b', 300, 400),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 200,
+      anchorFrac: 0.1,
+      hoveredFrac: 0.3,
+      anchorEdge: 'end',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('is direction-agnostic: anchor later gives the same delta with edges swapped', () => {
+    const delta = computeSpanDelta(
+      span('b', 300, 400),
+      span('a', 0, 100),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 200,
+      anchorFrac: 0.3,
+      hoveredFrac: 0.1,
+      anchorEdge: 'start',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('measures start-to-start offset for overlapping spans', () => {
+    const delta = computeSpanDelta(
+      span('a', 0, 500),
+      span('b', 200, 800),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 200,
+      anchorFrac: 0,
+      hoveredFrac: 0.2,
+      anchorEdge: 'start',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('measures start-to-start offset for contained spans (step inside run)', () => {
+    const delta = computeSpanDelta(
+      span('run', 0, 1000),
+      span('step', 400, 600),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 400,
+      anchorFrac: 0,
+      hoveredFrac: 0.4,
+      anchorEdge: 'start',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('returns a zero delta for identical starts', () => {
+    const delta = computeSpanDelta(
+      span('a', 200, 500),
+      span('b', 200, 300),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 0,
+      anchorFrac: 0.2,
+      hoveredFrac: 0.2,
+      anchorEdge: 'start',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('keeps a zero delta sitting exactly on the viewport edge (root span anchor at default zoom)', () => {
+    const delta = computeSpanDelta(
+      span('run', 0, 1000),
+      span('step', 0, 400),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 0,
+      anchorFrac: 0,
+      hoveredFrac: 0,
+      anchorEdge: 'start',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('treats touching spans as a zero gap, not an overlap', () => {
+    const delta = computeSpanDelta(
+      span('a', 0, 300),
+      span('b', 300, 400),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 0,
+      anchorFrac: 0.3,
+      hoveredFrac: 0.3,
+      anchorEdge: 'end',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('handles zero-duration spans as points', () => {
+    const delta = computeSpanDelta(
+      span('a', 100, 100),
+      span('b', 400, 400),
+      0,
+      1000
+    );
+    expect(delta).toEqual({
+      deltaMs: 300,
+      anchorFrac: 0.1,
+      hoveredFrac: 0.4,
+      anchorEdge: 'end',
+      hoveredOffscreen: null,
+    });
+  });
+
+  it('clamps edges to the viewport but keeps the true delta', () => {
+    const delta = computeSpanDelta(
+      span('a', 0, 100),
+      span('b', 900, 950),
+      500,
+      800
+    );
+    expect(delta).toEqual({
+      deltaMs: 800,
+      anchorFrac: 0,
+      hoveredFrac: 1,
+      anchorEdge: 'end',
+      hoveredOffscreen: 'right',
+    });
+  });
+
+  it('flags a hovered span lying fully left of the viewport', () => {
+    const delta = computeSpanDelta(
+      span('anchor', 600, 700),
+      span('hovered', 0, 100),
+      200,
+      1200
+    );
+    expect(delta).toEqual({
+      deltaMs: 500,
+      anchorFrac: 0.4,
+      hoveredFrac: 0,
+      anchorEdge: 'start',
+      hoveredOffscreen: 'left',
+    });
+  });
+
+  it('returns null when the measurement is entirely left of the viewport', () => {
+    expect(
+      computeSpanDelta(span('a', 0, 100), span('b', 200, 300), 500, 1000)
+    ).toBeNull();
+  });
+
+  it('returns null when the measurement is entirely right of the viewport', () => {
+    expect(
+      computeSpanDelta(span('a', 600, 700), span('b', 900, 950), 0, 500)
+    ).toBeNull();
+  });
+
+  it('returns null for an empty viewport range', () => {
+    expect(
+      computeSpanDelta(span('a', 0, 100), span('b', 200, 300), 500, 500)
+    ).toBeNull();
   });
 });

--- a/packages/web-shared/src/components/new-trace-viewer/utils.ts
+++ b/packages/web-shared/src/components/new-trace-viewer/utils.ts
@@ -174,6 +174,11 @@ export interface SpanGap {
   rowIndex: number;
 }
 
+/** Project an absolute time onto the viewport as a clamped [0, 1] fraction. */
+function toViewportFrac(ms: number, viewStart: number, range: number): number {
+  return Math.min(Math.max((ms - viewStart) / range, 0), 1);
+}
+
 export function computeSpanGaps(
   spans: Span[],
   viewStart: number,
@@ -189,13 +194,85 @@ export function computeSpanGaps(
     const gapMs = startTime - endTime;
     if (gapMs <= 0) continue;
 
-    const leftFrac = Math.min(Math.max((endTime - viewStart) / range, 0), 1);
-    const rightFrac = Math.min(Math.max((startTime - viewStart) / range, 0), 1);
+    const leftFrac = toViewportFrac(endTime, viewStart, range);
+    const rightFrac = toViewportFrac(startTime, viewStart, range);
     if (rightFrac - leftFrac < 0.001) continue;
 
     gaps.push({ gapMs, leftFrac, rightFrac, rowIndex: i });
   }
   return gaps;
+}
+
+export interface SpanDelta {
+  /** True measured time between the two spans, unaffected by clamping. */
+  deltaMs: number;
+  /** Viewport-clamped fraction of the anchor span's measured edge. */
+  anchorFrac: number;
+  /** Viewport-clamped fraction of the hovered span's measured edge. */
+  hoveredFrac: number;
+  /**
+   * Which edge of the anchor span the measurement runs from: its end when the
+   * spans are disjoint and the anchor comes first, otherwise its start.
+   */
+  anchorEdge: 'start' | 'end';
+  /**
+   * Set when the hovered span lies entirely outside the viewport on one side,
+   * i.e. its row renders an off-screen arrow the line should stop short of.
+   */
+  hoveredOffscreen: 'left' | 'right' | null;
+}
+
+/**
+ * Measure the temporal delta between an anchor (selected) span and a hovered
+ * span for the Alt+hover measurement overlay. Ordering the two spans by start
+ * time (E = earlier-starting, L = later-starting), the measurement runs to
+ * L's start from E's end when the spans are disjoint ("how long after E ended
+ * did L start"), or from E's start when they overlap ("how long after E
+ * started did L start"). Fractions are clamped to the viewport like
+ * `computeSpanGaps`; `deltaMs` is always the true duration. Returns null when
+ * the measurement lies entirely outside the viewport.
+ */
+export function computeSpanDelta(
+  anchor: Span,
+  hovered: Span,
+  viewStart: number,
+  viewEnd: number
+): SpanDelta | null {
+  const range = viewEnd - viewStart;
+  if (range <= 0) return null;
+
+  const anchorStart = getHighResInMs(anchor.startTime);
+  const hoveredStart = getHighResInMs(hovered.startTime);
+  const anchorIsEarlier = anchorStart <= hoveredStart;
+  const earlierStart = anchorIsEarlier ? anchorStart : hoveredStart;
+  const earlierEnd = getHighResInMs(
+    anchorIsEarlier ? anchor.endTime : hovered.endTime
+  );
+  const laterStart = anchorIsEarlier ? hoveredStart : anchorStart;
+
+  const originMs = earlierEnd <= laterStart ? earlierEnd : earlierStart;
+  const deltaMs = laterStart - originMs;
+
+  // Entirely outside the viewport. Compared in time-space (not clamped
+  // fractions) so a zero-delta point sitting exactly on a viewport edge —
+  // e.g. the root span selected at default zoom — still renders.
+  if (laterStart < viewStart || originMs > viewEnd) {
+    return null;
+  }
+
+  const originFrac = toViewportFrac(originMs, viewStart, range);
+  const laterFrac = toViewportFrac(laterStart, viewStart, range);
+
+  const hoveredEnd = getHighResInMs(hovered.endTime);
+
+  return {
+    deltaMs,
+    anchorFrac: anchorIsEarlier ? originFrac : laterFrac,
+    hoveredFrac: anchorIsEarlier ? laterFrac : originFrac,
+    anchorEdge: anchorIsEarlier && earlierEnd <= laterStart ? 'end' : 'start',
+    hoveredOffscreen:
+      hoveredStart > viewEnd ? 'right' : hoveredEnd < viewStart ? 'left' : null,
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Figma-style measurement in the new trace viewer: with a span selected, hold <kbd>Alt</kbd> and hover any other row to see the time delta between the two spans, drawn as a single measurement line.

https://github.com/user-attachments/assets/1de127b7-0faa-4f28-b524-0464e9be2eb6


**How it works**
- **Selection + Alt + hover** → one measurement between the selected (anchor) span and the hovered row's span: a stub + vertical guide off the anchor bar's measured edge, elbowing into a 1px line that ends at the hovered span's start, with a duration chip.
- **Delta rule**: disjoint spans → gap (anchor end → later start, same semantic as the existing sibling gaps); overlapping/contained spans → start-to-start offset ("how far into the run did this step start").
- **No selection** → the existing all-consecutive-gaps overlay, restyled to the same measurement-line design (the old I-beam + pill `DeltaIndicator` is deleted; both modes render through one `DeltaMeasureLine` component).
- Edges clamped by the viewport keep the true duration in the label; if the hovered span is fully off-screen, the line stops short of the row's edge arrow.

**Implementation**
- New pure `computeSpanDelta()` in `utils.ts` next to `computeSpanGaps`, unit-tested (disjoint both directions, overlap, containment, identical starts, zero-duration, clamping, off-screen).
- Hovered row derived from `clientY` in the existing timeline mousemove handler (now a single `TimelineHover {fraction, rowIndex}` state) — no per-row listeners, `TimelineBar` memoization untouched.
- Overlay renders in the existing absolute, pointer-events-none layer, so it works across virtualized rows.

Replaces #2976 (was opened from the wrong branch and included stale commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
