### PR TITLE
feat(core): emit faas.instance span attribute for compute instance identity

### DIFF
--- a/.changeset/faas-instance-span-attr.md
+++ b/.changeset/faas-instance-span-attr.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Emit a `faas.instance` OTEL span attribute (a synthesized per-warm-instance id) on the flow and step route spans, so traces can distinguish which compute instance handled each request.

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -267,6 +267,9 @@ describe('workflowEntrypoint trace modes', () => {
     expect(routeSpan?.attributes['workflow.route.type']).toBe('flow');
     expect(routeSpan?.attributes['workflow.route.handler_cached']).toBe(false);
     expect(routeSpan?.attributes['workflow.route.invocation_count']).toBe(1);
+    expect(routeSpan?.attributes['faas.instance']).toMatch(
+      /^cinst_[0-9A-HJKMNP-TV-Z]{26}$/
+    );
     const moduleBodyInitMs =
       routeSpan?.attributes['workflow.route.module_body_init_ms'];
     expect(typeof moduleBodyInitMs).toBe('number');
@@ -432,6 +435,11 @@ describe('workflowEntrypoint trace modes', () => {
     expect(routeSpans[1]?.attributes['workflow.route.invocation_count']).toBe(
       2
     );
+    // Minted once at module load, so it identifies the compute instance rather
+    // than the invocation: both invocations report the same id.
+    const instanceId = routeSpans[0]?.attributes['faas.instance'];
+    expect(instanceId).toMatch(/^cinst_[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(routeSpans[1]?.attributes['faas.instance']).toBe(instanceId);
   });
 
   it('continuous: preserves the legacy shape — parented to the run-origin context with a delivery link', async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -65,6 +65,7 @@ import {
   handleReplayBudgetExhausted,
   ReplayBudget,
 } from './runtime/replay-budget.js';
+import { COMPUTE_INSTANCE_ID } from './runtime/compute-instance.js';
 import { runIdCreatedAt } from './runtime/run-id-time.js';
 import {
   DEFAULT_STEP_MAX_RETRIES,
@@ -2829,6 +2830,7 @@ export function workflowEntrypoint(
         kind: spanKind,
         attributes: {
           ...Attribute.WorkflowRouteType('flow'),
+          ...Attribute.FaasInstance(COMPUTE_INSTANCE_ID),
           ...Attribute.WorkflowRouteHandlerCached(handlerCached),
           ...Attribute.WorkflowRouteInvocationCount(invocationCount),
           ...Attribute.WorkflowRouteEntrypointAgeMs(

--- a/packages/core/src/runtime/compute-instance.ts
+++ b/packages/core/src/runtime/compute-instance.ts
@@ -1,0 +1,13 @@
+import { ulid } from 'ulid';
+
+/**
+ * Identifier for the compute instance (microVM) this module was loaded into.
+ *
+ * Vercel exposes no native per-instance id under Fluid compute (`AWS_LAMBDA_*`
+ * is blocked), so we synthesize one at module load: a prefixed ULID
+ * (`cinst_<ulid>`, per the `wrun_`/`step_` convention) whose timestamp is the
+ * instance's birth time. Stable for the instance's life and shared by every
+ * invocation it handles — including the concurrent ones Fluid packs onto it;
+ * cold starts mint fresh ids. Emitted as the OTEL `faas.instance` attribute.
+ */
+export const COMPUTE_INSTANCE_ID = `cinst_${ulid()}`;

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -175,6 +175,14 @@ export const WorkflowRouteModuleBodyInitMs = SemanticConvention<number>(
   'workflow.route.module_body_init_ms'
 );
 
+/**
+ * Compute instance handling this route — the synthesized `COMPUTE_INSTANCE_ID`.
+ * Uses OTEL `faas.instance` (execution-environment id, reused across
+ * invocations to the same function):
+ * https://opentelemetry.io/docs/specs/semconv/attributes-registry/faas/
+ */
+export const FaasInstance = SemanticConvention<string>('faas.instance');
+
 // Step attributes
 
 /** Name of the step function being executed */


### PR DESCRIPTION
### Summary & Motivation

Add a way to track which compute instance things are happening on, exposed as `faas.instance` on spans since thats the OTEL standard.

### Test Plan

Added new test coverage