### PR TITLE
Avoid resolving run data for background steps

### DIFF
--- a/.changeset/background-step-unresolved-run.md
+++ b/.changeset/background-step-unresolved-run.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Avoid resolving run data before background step execution.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -18,6 +18,7 @@ import {
 import {
   type Event,
   getQueueTopicPrefix,
+  isLegacySpecVersion,
   ROOT_RUN_ID_ATTRIBUTE,
   resolveQueueNamespace,
   SPEC_VERSION_CURRENT,
@@ -852,8 +853,31 @@ export function workflowEntrypoint(
                           'All parallel steps done, replaying inline after background step',
                           { workflowRunId: runId }
                         );
+                        const runCreatedEvent = cachedEvents.find(
+                          (event) => event.eventType === 'run_created'
+                        );
+                        let replayInput: unknown;
+                        if (runCreatedEvent) {
+                          replayInput = runCreatedEvent.eventData.input;
+                        } else {
+                          if (!isLegacySpecVersion(bgRun.specVersion)) {
+                            throw new WorkflowRuntimeError(
+                              `Workflow run "${runId}" has no "run_created" event`
+                            );
+                          }
+                          // Legacy runs predate the event-sourced run_created
+                          // invariant, so retain the resolved GET only for them.
+                          const legacyRun = await world.runs.get(runId, {
+                            resolveData: 'all',
+                          });
+                          if (legacyRun.status !== 'running') {
+                            return;
+                          }
+                          replayInput = legacyRun.input;
+                        }
                         workflowRun = {
                           ...bgRun,
+                          input: replayInput,
                           status: 'running',
                           output: undefined,
                           error: undefined,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -706,7 +706,9 @@ export function workflowEntrypoint(
                   // will pick up the replay.
                   if (incomingStepId && incomingStepName) {
                     try {
-                      const bgRun = await world.runs.get(runId);
+                      const bgRun = await world.runs.get(runId, {
+                        resolveData: 'none',
+                      });
                       if (bgRun.status !== 'running') {
                         runtimeLogger.debug(
                           'Run already finished, skipping background step',
@@ -850,7 +852,13 @@ export function workflowEntrypoint(
                           'All parallel steps done, replaying inline after background step',
                           { workflowRunId: runId }
                         );
-                        workflowRun = bgRun;
+                        workflowRun = {
+                          ...bgRun,
+                          status: 'running',
+                          output: undefined,
+                          error: undefined,
+                          completedAt: undefined,
+                        };
                         workflowStartedAt = bgStartedAt;
                         // cachedEvents and eventsCursor already set from load above
                       } else {


### PR DESCRIPTION
## Summary

- load only run metadata before executing a background step
- keep the existing terminal-state guard and replay behavior unchanged

## Why

Background-step setup only consumes run status, timing, deployment, attributes, and spec version. Resolving input and output data at this point is unnecessary, especially for fan-out workloads and runs with large inputs.

## Impact

Reduces data loading and response payload size during background-step startup without changing execution semantics.

## Validation

- `pnpm turbo run build --filter=@workflow/core...`
- `pnpm test` in `packages/core` — 1,483 passed, 3 expected failures
- `pnpm typecheck`
- targeted Biome check for the changed files
