### PR TITLE
perf(core): cache port discovery for step invocations

### DIFF
--- a/.changeset/cache-step-port-discovery.md
+++ b/.changeset/cache-step-port-discovery.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Cache self-hosted step port discovery per process.

--- a/packages/core/src/runtime/get-port-lazy.ts
+++ b/packages/core/src/runtime/get-port-lazy.ts
@@ -12,12 +12,12 @@ import { pathToFileURL } from 'node:url';
 
 let _getPort: (() => Promise<number | undefined>) | undefined;
 
-// Per-process cache of the resolved port. The workflow dev server listens on a
+// Per-process cache of the resolved port. The workflow server listens on a
 // stable port for the lifetime of the process, but `getPort()` rediscovers it
 // on every call by querying the OS for the process's listening sockets — on
 // macOS that shells out to `lsof` (~60ms), which the runtime pays on EVERY
-// workflow replay (the non-Vercel branch of `runWorkflow`). Since the port does
-// not change within a process, resolve it once and reuse it. `_inFlight`
+// workflow replay or step invocation. Since the port does not change within a
+// process, resolve it once and reuse it. `_inFlight`
 // dedupes concurrent first calls so discovery never runs more than once.
 //
 // The first concrete port is pinned for the lifetime of the process — there is

--- a/packages/core/src/runtime/step-handler.test.ts
+++ b/packages/core/src/runtime/step-handler.test.ts
@@ -178,11 +178,6 @@ vi.mock('../private.js', () => ({
   getStepFunction: vi.fn().mockReturnValue(mockStepFn),
 }));
 
-// Mock get-port
-vi.mock('@workflow/utils/get-port', () => ({
-  getPort: vi.fn().mockResolvedValue(3000),
-}));
-
 import { getStepFunction } from '../private.js';
 import { cancelAbortReaders, dehydrateStepError } from '../serialization.js';
 import {
@@ -191,12 +186,27 @@ import {
   normalizeUnknownError,
 } from '../types.js';
 import { MAX_QUEUE_DELIVERIES } from './constants.js';
+import {
+  resetPortCacheForTesting,
+  setPortResolverForTesting,
+} from './get-port-lazy.js';
 import { executeStep } from './step-executor.js';
 // Import the module AFTER all mocks are set up
 // Since getWorldHandlers is now async, we need to call stepEntrypoint
 // to trigger createQueueHandler and populate capturedHandlerRef
 import { stepEntrypoint } from './step-handler.js';
 import { getWorld } from './world.js';
+
+const mockPortResolver = vi.fn(async () => 3000);
+
+beforeEach(() => {
+  mockPortResolver.mockReset().mockResolvedValue(3000);
+  setPortResolverForTesting(mockPortResolver);
+});
+
+afterEach(() => {
+  resetPortCacheForTesting();
+});
 
 function capturedHandler(
   message: unknown,
@@ -279,6 +289,13 @@ describe('step-handler 409 handling', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('reuses cached port discovery across step invocations', async () => {
+    await capturedHandler(createMessage(), createMetadata('myStep'));
+    await capturedHandler(createMessage(), createMetadata('myStep'));
+
+    expect(mockPortResolver).toHaveBeenCalledOnce();
   });
 
   describe('step_completed 409', () => {

--- a/packages/core/src/runtime/step-handler.ts
+++ b/packages/core/src/runtime/step-handler.ts
@@ -15,7 +15,6 @@ import {
   pluralize,
   stepDisplayName,
 } from '@workflow/utils';
-import { getPort } from '@workflow/utils/get-port';
 import {
   getQueueTopicPrefix,
   resolveQueueNamespace,
@@ -53,6 +52,7 @@ import {
 } from '../types.js';
 
 import { getMaxQueueDeliveries } from './constants.js';
+import { getPortLazy } from './get-port-lazy.js';
 import {
   getQueueOverhead,
   getWorkflowQueueName,
@@ -224,7 +224,7 @@ function createStepHandler(namespace?: string) {
 
         // Resolve local async values concurrently before entering the trace span
         const [port, spanKind] = await Promise.all([
-          isVercel ? undefined : getPort(),
+          isVercel ? undefined : getPortLazy(),
           getSpanKind('CONSUMER'),
         ]);
 


### PR DESCRIPTION
### Description

Reuse the process-level `getPortLazy()` cache from #2522 for self-hosted step invocations. The step handler currently calls `getPort()` for every step; in a production burst profile, `process.report.getReport()` beneath that lookup accounted for 83% of peak wall samples.

This is safe because the listening port is stable for the process lifetime, only concrete ports are cached, concurrent first calls are deduplicated, and `undefined` results retry. The existing Vercel branch still skips discovery.

### How did you test your changes?

- Added a regression test proving two step invocations share one port lookup.
- `pnpm --filter @workflow/core test` (1,483 passed; 3 expected failures)
- `pnpm --filter @workflow/core typecheck`
- `pnpm turbo build --filter='@workflow/core...'`
- Biome check on the changed TypeScript files

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - correct bump (patch for bug fixes, minor for new features, major for breaking changes)
  - only changed packages included
- [x] 🔒 DCO sign-off passes (run `git commit --signoff`)
- [x] 📝 Ping `@vercel/workflow` in a comment once PR ready and checklist complete
