### PR TITLE
fix(world-vercel): append caller User-Agent products instead of discarding them

### DIFF
--- a/.changeset/world-vercel-caller-user-agent.md
+++ b/.changeset/world-vercel-caller-user-agent.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Append caller-provided user-agent tokens to the world-vercel user-agent instead of discarding them.

--- a/packages/world-vercel/README.md
+++ b/packages/world-vercel/README.md
@@ -18,3 +18,15 @@ import { setWorld } from '@workflow/core/runtime';
 setWorld(createWorld({ dispatcher: new Agent({ connections: 16 }) }));
 ```
 
+## Caller user agent
+
+Pass a `User-Agent` header to append a caller-specific product token while
+preserving the world-vercel token:
+
+```ts
+import { createWorld } from '@workflow/world-vercel';
+
+const world = createWorld({
+  headers: { 'User-Agent': 'my-framework/1.2.3' },
+});
+```

--- a/packages/world-vercel/src/utils.test.ts
+++ b/packages/world-vercel/src/utils.test.ts
@@ -90,6 +90,17 @@ describe('getHeaders', () => {
     expect(headers.get('x-workflow-test-limit-overrides')).toBeNull();
   });
 
+  it('appends a caller user-agent token to the world-vercel user-agent', () => {
+    const headers = getHeaders(
+      { headers: { 'User-Agent': 'eve/0.18.1' } },
+      { usingProxy: false }
+    );
+
+    expect(headers.get('User-Agent')).toMatch(
+      /^@workflow\/world-vercel\/\S+ node-\S+ \S+ \([^)]*\)(?: \S+)? eve\/0\.18\.1$/
+    );
+  });
+
   it('forwards WORKFLOW_TEST_LIMIT_OVERRIDES verbatim as x-workflow-test-limit-overrides', () => {
     const overrides = '{"STREAM_MAX_DURATION_MS":5000}';
     process.env.WORKFLOW_TEST_LIMIT_OVERRIDES = overrides;

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -201,6 +201,17 @@ export function serializeError<T extends { error?: SerializedData }>(
   return data;
 }
 
+/**
+ * Joins User-Agent product tokens with spaces per the RFC 9110 `User-Agent`
+ * grammar (`product *( RWS ( product / comment ) )`), skipping empty parts.
+ * Never join UA products with `Headers.append()` — repeated header values
+ * combine with `", "`, and a comma glued to a product token breaks
+ * whitespace-delimited parsers on the receiving side.
+ */
+const joinUserAgentProducts = (
+  ...products: (string | null | undefined)[]
+): string => products.filter(Boolean).join(' ');
+
 const getUserAgent = () => {
   const deploymentId = process.env.VERCEL_DEPLOYMENT_ID;
   if (deploymentId) {
@@ -239,7 +250,10 @@ export const getHeaders = (
 ): Headers => {
   const projectConfig = config?.projectConfig;
   const headers = new Headers(config?.headers);
-  headers.set('User-Agent', getUserAgent());
+  headers.set(
+    'User-Agent',
+    joinUserAgentProducts(getUserAgent(), headers.get('User-Agent'))
+  );
   const testLimitOverrides = getTestLimitOverridesHeader();
   if (testLimitOverrides) {
     headers.set(TEST_LIMIT_OVERRIDES_HEADER, testLimitOverrides);


### PR DESCRIPTION
`getHeaders()` overwrites the caller's `User-Agent` with world-vercel's own product string, so anything embedding the SDK — a framework constructing the world via `createWorld({ headers })` — has no way to identify itself to workflow-server. This appends the caller's products after world-vercel's own:

```
@workflow/world-vercel/5.0.0-beta.31 node-v26.0.0 darwin (arm64) eve/0.24.6
```

All egress goes through this one `getHeaders` choke point (v3 `makeRequest`, v4 events via `getHttpConfig`, queue), so the append covers every request path.

The join is a space, not `Headers.append()`: repeated header values combine with `", "`, and a comma glued to a product token breaks whitespace-delimited User-Agent parsers on the receiving side. `joinUserAgentProducts` carries that constraint in one place.

First consumer is eve, which passes its `eve/<version>` token through `createWorld({ headers })` so workflow-server can attribute framework traffic.