### PR TITLE
fix(docs): version-switcher fallback redirects for pages missing in one version

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -160,17 +160,21 @@ const config: NextConfig = {
         permanent: true,
       },
       // setAttributes graduated from experimental_setAttributes; the API
-      // reference page moved with it. Cover both the versioned (v5) path and
-      // the unversioned path so links keep working once v5 becomes default.
+      // reference page moved with it.
       {
         source: '/v5/docs/api-reference/workflow/experimental-set-attributes',
         destination: '/v5/docs/api-reference/workflow/set-attributes',
         permanent: true,
       },
+      // setAttributes is v5-only, so the unversioned path has no page yet.
+      // Land on the section index directly (no redirect chain through the
+      // /docs/api-reference/workflow/set-attributes fallback below). Point
+      // this at /docs/api-reference/workflow/set-attributes once v5 becomes
+      // the default version.
       {
         source: '/docs/api-reference/workflow/experimental-set-attributes',
-        destination: '/docs/api-reference/workflow/set-attributes',
-        permanent: true,
+        destination: '/docs/api-reference/workflow',
+        permanent: false,
       },
       {
         source: '/python',
@@ -222,6 +226,97 @@ const config: NextConfig = {
         source: '/v5/docs/api-reference/workflow-api/world/:path*',
         destination: '/v5/docs/api-reference/workflow-runtime/world/:path*',
         permanent: true,
+      },
+      // --- Version-switcher fallbacks ---
+      // The version switcher swaps the /v5 route prefix without checking
+      // that the page exists in the target version, so pages that exist in
+      // only one docs tree 404 on switch. Each rule below covers a page
+      // missing from one version and lands on the nearest equivalent
+      // (usually the section index). All are temporary redirects: they must
+      // be revisited when content is backported or when v5 becomes the
+      // default version (which swaps the trees served at /docs).
+      //
+      // Pages that exist only in v5 (v5 -> v4 switch):
+      {
+        source: '/docs/api-reference/workflow/set-attributes',
+        destination: '/docs/api-reference/workflow',
+        permanent: false,
+      },
+      {
+        source: '/docs/api-reference/workflow-errors/precondition-failed-error',
+        destination: '/docs/api-reference/workflow-errors',
+        permanent: false,
+      },
+      {
+        source: '/docs/api-reference/workflow-runtime/world/analytics',
+        destination: '/docs/api-reference/workflow-runtime/world',
+        permanent: false,
+      },
+      {
+        source:
+          '/docs/changelog/(attributes-mvp|eager-processing|step-message-ownership)',
+        destination: '/docs/changelog',
+        permanent: false,
+      },
+      {
+        source: '/docs/configuration',
+        destination: '/docs/deploying',
+        permanent: false,
+      },
+      {
+        source: '/docs/configuration/:path*',
+        destination: '/docs/deploying',
+        permanent: false,
+      },
+      {
+        source: '/docs/errors/abort-signal-timeout-in-workflow',
+        destination: '/docs/errors',
+        permanent: false,
+      },
+      {
+        source: '/docs/foundations/cancellation',
+        destination: '/docs/foundations',
+        permanent: false,
+      },
+      // v4 has no how-it-works index page; foundations is the closest
+      // conceptual landing for the v5 cancellation internals page.
+      {
+        source: '/docs/how-it-works/cancellation',
+        destination: '/docs/foundations',
+        permanent: false,
+      },
+      {
+        source: '/docs/getting-started/react-router',
+        destination: '/docs/getting-started',
+        permanent: false,
+      },
+      {
+        source: '/docs/getting-started/react-router/:path*',
+        destination: '/docs/getting-started',
+        permanent: false,
+      },
+      {
+        source:
+          '/docs/internal/(nitro-native-build|nitro-web-ui|serializable-abort-controller)',
+        destination: '/docs/internal',
+        permanent: false,
+      },
+      {
+        source: '/docs/observability/(attributes|tracing)',
+        destination: '/docs/observability',
+        permanent: false,
+      },
+      // Pages that exist only in v4 (v4 -> v5 switch):
+      {
+        source: '/v5/docs/api-reference/workflow-runtime/step-entrypoint',
+        destination: '/v5/docs/api-reference/workflow-runtime',
+        permanent: false,
+      },
+      // /v5/cookbook/advanced has no index page; fall back to the root.
+      {
+        source: '/v5/cookbook/advanced/distributed-abort-controller',
+        destination: '/v5/cookbook',
+        permanent: false,
       },
     ];
   },


### PR DESCRIPTION
## Summary

The docs version switcher swaps the `/v5` route prefix without checking that the page exists in the target version (`resolveRouteHref` in `@vercel/geistdocs` is a pure prefix swap), so any page that exists in only one docs tree 404s on switch. Example on production: https://workflow-sdk.dev/v5/docs/configuration → switch to v4 → 404 at `/docs/configuration`.

This adds fallback redirects in `docs/next.config.ts` for every page that currently exists in only one version, generated by diffing `docs/content/docs/v4` against `docs/content/docs/v5`. Each lands on the nearest equivalent in the target version (usually the section index):

**v5-only pages (v5 → v4 switch), `/docs/...`:**
- `configuration` + all subpages → `/docs/deploying`
- `api-reference/workflow/set-attributes` → `/docs/api-reference/workflow`
- `api-reference/workflow-errors/precondition-failed-error` → section index
- `api-reference/workflow-runtime/world/analytics` → section index
- `changelog/{attributes-mvp,eager-processing,step-message-ownership}` → `/docs/changelog`
- `errors/abort-signal-timeout-in-workflow` → `/docs/errors`
- `foundations/cancellation`, `how-it-works/cancellation` → `/docs/foundations` (v4 has no how-it-works index)
- `getting-started/react-router` (+ `v7`/`v8`) → `/docs/getting-started`
- `internal/{nitro-native-build,nitro-web-ui,serializable-abort-controller}` → `/docs/internal`
- `observability/{attributes,tracing}` → `/docs/observability`

**v4-only pages (v4 → v5 switch), `/v5/...`:**
- `api-reference/workflow-runtime/step-entrypoint` → `/v5/docs/api-reference/workflow-runtime`
- `cookbook/advanced/distributed-abort-controller` → `/v5/cookbook` (no `/v5/cookbook/advanced` index)

All fallbacks are `permanent: false` — they need revisiting when content is backported or when v5 becomes the default version (which swaps the trees served at `/docs`).

Also fixes a related live 404: `/docs/api-reference/workflow/experimental-set-attributes` redirected to `/docs/api-reference/workflow/set-attributes`, which doesn't exist on v4. It now lands on the section index directly (no redirect chain through the new fallback).

The proper fix for the whole class is upstream in geistdocs (version switcher falling back to the nearest existing page in the target tree); these redirects fix production now.

## Testing

- `pnpm --filter docs build`
- `next start` + curl: all 16 fallback sources return 307 to their documented destinations, every destination returns 200, and existing pages (e.g. `/docs/changelog/resilient-start`, `/cookbook/advanced/distributed-abort-controller`, `/v5/docs/configuration`) still return 200

No changeset needed: docs-app-only change (`pnpm changeset status --since=origin/main` passes).