### PR TITLE
[ci] Benchmark comment: Best column + best/p75/p99 deltas (drop Avg/P10)

### DIFF
--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -160,8 +160,8 @@ function formatMs(value) {
 }
 
 /**
- * Annotates each metric row with the matching baseline values (best, p75, p99)
- * from the most recent main-branch run, keyed by
+ * Annotates each metric row with the matching baseline values (best, p75, p90,
+ * p99) from the most recent main-branch run, keyed by
  * methodologyVersion/backend/app/metric/scenario. The methodology version is
  * part of the key so a change to the measurement window (e.g. the switch to
  * the in-deployment trigger) does not diff incomparable numbers: an old
@@ -170,39 +170,50 @@ function formatMs(value) {
  * so history re-renders keep showing the deltas each run was originally
  * compared against.
  */
+// Which run field each baseline annotation is compared against, and where the
+// baseline value is read from (best falls back to a pre-rename baseline's min).
+const BASELINE_FIELDS = [
+  { annotation: 'baselineBest', from: (base) => base.best ?? base.min },
+  { annotation: 'baselineP75', from: (base) => base.p75 },
+  { annotation: 'baselineP90', from: (base) => base.p90 },
+  { annotation: 'baselineP99', from: (base) => base.p99 },
+];
+
 export function annotateWithBaseline(results, baseline) {
   if (!baseline || baseline.length === 0) return results;
   const methodology = (result) => result.methodologyVersion ?? 'legacy';
+  const keyFor = (result, row) =>
+    `${methodology(result)}/${result.backend}/${result.app}/${row.metric}/${row.scenario}`;
   const baselineRows = new Map();
   for (const result of baseline) {
     for (const row of result.metrics ?? []) {
-      baselineRows.set(
-        `${methodology(result)}/${result.backend}/${result.app}/${row.metric}/${row.scenario}`,
-        row
-      );
+      baselineRows.set(keyFor(result, row), row);
     }
   }
+  const annotate = (result, row) => {
+    const base = baselineRows.get(keyFor(result, row));
+    if (!base) return row;
+    const annotated = { ...row };
+    for (const { annotation, from } of BASELINE_FIELDS) {
+      const value = from(base);
+      if (typeof value === 'number') annotated[annotation] = value;
+    }
+    return annotated;
+  };
   return results.map((result) => ({
     ...result,
-    metrics: (result.metrics ?? []).map((row) => {
-      const base = baselineRows.get(
-        `${methodology(result)}/${result.backend}/${result.app}/${row.metric}/${row.scenario}`
-      );
-      if (!base) return row;
-      // The fastest-sample field was renamed `min` -> `best`; fall back to
-      // `min` so deltas keep working against baselines from before the rename.
-      const baselineBest = base.best ?? base.min;
-      return {
-        ...row,
-        ...(typeof baselineBest === 'number' ? { baselineBest } : {}),
-        ...(typeof base.p75 === 'number' ? { baselineP75: base.p75 } : {}),
-        ...(typeof base.p99 === 'number' ? { baselineP99: base.p99 } : {}),
-      };
-    }),
+    metrics: (result.metrics ?? []).map((row) => annotate(result, row)),
   }));
 }
 
-/** Formats a vs-main delta, e.g. " (+4.2%)"; empty without a baseline. */
+// Deltas beyond ±this vs main get a directional marker: 🔻 for a regression,
+// 💚 for an improvement. Smaller moves show the percentage alone.
+const DELTA_MARK_THRESHOLD_PCT = 15;
+
+/**
+ * Formats a vs-main delta, e.g. " (+4.2%)"; empty without a baseline. Moves
+ * worse than +15% are flagged 🔻 and moves better than -15% are flagged 💚.
+ */
 function formatDelta(current, baseline) {
   if (
     typeof current !== 'number' ||
@@ -213,19 +224,26 @@ function formatDelta(current, baseline) {
     return '';
   }
   const pct = ((current - baseline) / baseline) * 100;
+  const mark =
+    pct > DELTA_MARK_THRESHOLD_PCT
+      ? ' 🔻'
+      : pct < -DELTA_MARK_THRESHOLD_PCT
+        ? ' 💚'
+        : '';
   if (Math.abs(pct) < 0.5) return ' (±0%)';
   const digits = Math.abs(pct) >= 10 ? 0 : 1;
-  return ` (${pct > 0 ? '+' : ''}${pct.toFixed(digits)}%)`;
+  return ` (${pct > 0 ? '+' : ''}${pct.toFixed(digits)}%)${mark}`;
 }
 
 /**
- * Formats a percentile cell, marking it 🟢/🔴 against its target when one is
- * defined for this row.
+ * Formats a percentile cell, marking it 🔴 when it is over its target. Within
+ * target is left unmarked (no 🟢) to keep the table quiet — only misses stand
+ * out.
  */
 function formatCell(value, target) {
   const formatted = formatMs(value);
   if (formatted === '—' || typeof target !== 'number') return formatted;
-  return `${formatted} ${value <= target ? '🟢' : '🔴'}`;
+  return value > target ? `${formatted} 🔴` : formatted;
 }
 
 function shortCommit(commit) {
@@ -250,9 +268,9 @@ function renderResultTable(result) {
     // Abbreviations only — the definitions live in the comment footer.
     const name = label ? `**${label.name}**` : row.metric;
     const targets = row.targets ?? {};
-    // Deltas vs main are shown on Best/P75/P99 (not P90).
+    // Deltas vs main are shown on Best/P75/P90/P99.
     lines.push(
-      `| ${name} | ${row.scenario} | ${formatMs(row.best)}${formatDelta(row.best, row.baselineBest)} | ${formatCell(row.p75, targets.p75)}${formatDelta(row.p75, row.baselineP75)} | ${formatCell(row.p90, targets.p90)} | ${formatCell(row.p99, targets.p99)}${formatDelta(row.p99, row.baselineP99)} | ${row.samples} |`
+      `| ${name} | ${row.scenario} | ${formatMs(row.best)}${formatDelta(row.best, row.baselineBest)} | ${formatCell(row.p75, targets.p75)}${formatDelta(row.p75, row.baselineP75)} | ${formatCell(row.p90, targets.p90)}${formatDelta(row.p90, row.baselineP90)} | ${formatCell(row.p99, targets.p99)}${formatDelta(row.p99, row.baselineP99)} | ${row.samples} |`
     );
   }
   return lines.join('\n');
@@ -324,6 +342,7 @@ function renderFooter(entries) {
       (row) =>
         typeof row.baselineBest === 'number' ||
         typeof row.baselineP75 === 'number' ||
+        typeof row.baselineP90 === 'number' ||
         typeof row.baselineP99 === 'number'
     )
   );
@@ -331,7 +350,7 @@ function renderFooter(entries) {
   return [
     ...(hasBaseline
       ? [
-          '<sub>Best/P75/P99 deltas compare against the most recent benchmark run on `main` at the time of this run.</sub>',
+          '<sub>Best/P75/P90/P99 deltas compare against the most recent benchmark run on `main` at the time of this run. 🔻 flags a delta worse than +15%, 💚 one better than −15%.</sub>',
           '',
         ]
       : []),
@@ -340,7 +359,7 @@ function renderFooter(entries) {
     ...(targetsLegend
       ? [
           '',
-          `<sub>🟢/🔴 mark percentiles within/above target. Targets (p75/p90/p99, ms) — ${targetsLegend}</sub>`,
+          `<sub>🔴 marks a percentile over its target (within target is left unmarked). Targets (p75/p90/p99, ms) — ${targetsLegend}</sub>`,
         ]
       : []),
     '',

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -160,50 +160,59 @@ function formatMs(value) {
 }
 
 /**
- * Annotates each metric row with the matching baseline average (from the most
- * recent main-branch run), keyed by
+ * Annotates each metric row with the matching baseline values (best, p75, p99)
+ * from the most recent main-branch run, keyed by
  * methodologyVersion/backend/app/metric/scenario. The methodology version is
  * part of the key so a change to the measurement window (e.g. the switch to
  * the in-deployment trigger) does not diff incomparable numbers: an old
  * baseline won't match the new run, and the delta stays blank until `main` has
- * produced a same-methodology baseline. The annotation is stored on the entry
- * so history re-renders keep showing the delta each run was originally
+ * produced a same-methodology baseline. The annotations are stored on the entry
+ * so history re-renders keep showing the deltas each run was originally
  * compared against.
  */
 export function annotateWithBaseline(results, baseline) {
   if (!baseline || baseline.length === 0) return results;
   const methodology = (result) => result.methodologyVersion ?? 'legacy';
-  const baselineAvgs = new Map();
+  const baselineRows = new Map();
   for (const result of baseline) {
     for (const row of result.metrics ?? []) {
-      baselineAvgs.set(
+      baselineRows.set(
         `${methodology(result)}/${result.backend}/${result.app}/${row.metric}/${row.scenario}`,
-        row.avg
+        row
       );
     }
   }
   return results.map((result) => ({
     ...result,
     metrics: (result.metrics ?? []).map((row) => {
-      const baselineAvg = baselineAvgs.get(
+      const base = baselineRows.get(
         `${methodology(result)}/${result.backend}/${result.app}/${row.metric}/${row.scenario}`
       );
-      return typeof baselineAvg === 'number' ? { ...row, baselineAvg } : row;
+      if (!base) return row;
+      // The fastest-sample field was renamed `min` -> `best`; fall back to
+      // `min` so deltas keep working against baselines from before the rename.
+      const baselineBest = base.best ?? base.min;
+      return {
+        ...row,
+        ...(typeof baselineBest === 'number' ? { baselineBest } : {}),
+        ...(typeof base.p75 === 'number' ? { baselineP75: base.p75 } : {}),
+        ...(typeof base.p99 === 'number' ? { baselineP99: base.p99 } : {}),
+      };
     }),
   }));
 }
 
-/** Formats the avg-vs-main delta, e.g. " (+4.2%)"; empty without a baseline. */
-function formatDelta(current, baselineAvg) {
+/** Formats a vs-main delta, e.g. " (+4.2%)"; empty without a baseline. */
+function formatDelta(current, baseline) {
   if (
     typeof current !== 'number' ||
-    typeof baselineAvg !== 'number' ||
-    baselineAvg <= 0 ||
-    !Number.isFinite(current / baselineAvg)
+    typeof baseline !== 'number' ||
+    baseline <= 0 ||
+    !Number.isFinite(current / baseline)
   ) {
     return '';
   }
-  const pct = ((current - baselineAvg) / baselineAvg) * 100;
+  const pct = ((current - baseline) / baseline) * 100;
   if (Math.abs(pct) < 0.5) return ' (±0%)';
   const digits = Math.abs(pct) >= 10 ? 0 : 1;
   return ` (${pct > 0 ? '+' : ''}${pct.toFixed(digits)}%)`;
@@ -230,8 +239,8 @@ function metricSortKey(row) {
 
 function renderResultTable(result) {
   const lines = [
-    '| Metric | Scenario | Avg (ms) | P10 (ms) | P75 (ms) | P90 (ms) | P99 (ms) | Samples |',
-    '|--------|----------|---------:|---------:|---------:|---------:|---------:|--------:|',
+    '| Metric | Scenario | Best (ms) | P75 (ms) | P90 (ms) | P99 (ms) | Samples |',
+    '|--------|----------|----------:|---------:|---------:|---------:|--------:|',
   ];
   const rows = [...result.metrics].sort(
     (a, b) => metricSortKey(a) - metricSortKey(b)
@@ -241,8 +250,9 @@ function renderResultTable(result) {
     // Abbreviations only — the definitions live in the comment footer.
     const name = label ? `**${label.name}**` : row.metric;
     const targets = row.targets ?? {};
+    // Deltas vs main are shown on Best/P75/P99 (not P90).
     lines.push(
-      `| ${name} | ${row.scenario} | ${formatMs(row.avg)}${formatDelta(row.avg, row.baselineAvg)} | ${formatMs(row.p10)} | ${formatCell(row.p75, targets.p75)} | ${formatCell(row.p90, targets.p90)} | ${formatCell(row.p99, targets.p99)} | ${row.samples} |`
+      `| ${name} | ${row.scenario} | ${formatMs(row.best)}${formatDelta(row.best, row.baselineBest)} | ${formatCell(row.p75, targets.p75)}${formatDelta(row.p75, row.baselineP75)} | ${formatCell(row.p90, targets.p90)} | ${formatCell(row.p99, targets.p99)}${formatDelta(row.p99, row.baselineP99)} | ${row.samples} |`
     );
   }
   return lines.join('\n');
@@ -310,13 +320,18 @@ function renderFooter(entries) {
   const scenarioLegend = buildScenarioLegend(results);
   const targetsLegend = buildTargetsLegend(results);
   const hasBaseline = results.some((result) =>
-    (result.metrics ?? []).some((row) => typeof row.baselineAvg === 'number')
+    (result.metrics ?? []).some(
+      (row) =>
+        typeof row.baselineBest === 'number' ||
+        typeof row.baselineP75 === 'number' ||
+        typeof row.baselineP99 === 'number'
+    )
   );
 
   return [
     ...(hasBaseline
       ? [
-          '<sub>Avg deltas compare against the most recent benchmark run on `main` at the time of this run.</sub>',
+          '<sub>Best/P75/P99 deltas compare against the most recent benchmark run on `main` at the time of this run.</sub>',
           '',
         ]
       : []),
@@ -331,7 +346,7 @@ function renderFooter(entries) {
     '',
     '<sub>All metrics are measured from deployment-side timestamps only. Runs are triggered by an in-deployment route that stamps the anchor (`clientStart`) right before `start()`, so the CI runner’s request and its path through api.vercel.com sit outside every measured window. TTFS = in-deployment `start()` → first step body (turbo uses the in-process fast path, non-turbo the dispatch path), and includes the VQS dispatch hop plus any `/flow` cold start. STSO/WO are measured between step bodies on the deployment. SL is measured inside the workflow (parallel reader/writer steps), so it no longer includes the api.vercel.com read path.</sub>',
     '',
-    '<sub>Cold starts are kept in the numbers on purpose — they are part of real bursty-workload latency. The workbench deployment cold-starts the `/flow` invocation for a large fraction of runs, inflating P75+; the **P10** column shows the warm-start floor for comparison.</sub>',
+    '<sub>Cold starts are kept in the numbers on purpose — they are part of real bursty-workload latency. The workbench deployment cold-starts the `/flow` invocation for a large fraction of runs, inflating P75+; the **Best** column shows the fastest (warm-start) sample for comparison.</sub>',
   ].join('\n');
 }
 

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -115,9 +115,11 @@ test('renders a completed run with a table and embedded history', async () => {
     body,
     /<sub>Scenarios — \*\*stream\*\*: one streaming step in turbo mode/
   );
-  // Threshold marks: TTFS p75 398 > 200 → 🔴; SL p75 48 <= 50 → 🟢; WO unmarked
+  // Target marks: TTFS p75 398 > 200 → 🔴; SL row is within target on every
+  // percentile, so it stays unmarked (no 🟢 anywhere); WO has no targets.
   assert.match(body, /398 🔴/);
-  assert.match(body, /48 🟢/);
+  assert.match(body, /\| 30 \| 48 \| 55 \| 120 \|/);
+  assert.doesNotMatch(body, /🟢/);
   assert.match(body, /\| 1100 \|/);
   // Targets legend derived from row targets
   assert.match(body, /Targets \(p75\/p90\/p99, ms\) — TTFS 200\/300\/600/);
@@ -133,17 +135,19 @@ test('renders a completed run with a table and embedded history', async () => {
   assert.strictEqual(history[0].results[0].metrics.length, 4);
 });
 
-test('renders best/p75/p99 deltas against a baseline and embeds them in history', async () => {
+test('renders best/p75/p90/p99 deltas with 🔻/💚 threshold marks and embeds them', async () => {
   const { renderComment, extractHistory } = await loadModule();
   const baseline = sampleResult({
     metrics: sampleResult()
       .metrics.filter((row) => row.metric !== 'wo') // no baseline for WO
       .map((row) => ({
         ...row,
-        // ttfs best 320 vs 300 → +6.7%, p75 398 vs 380 → +4.7%,
-        //           p99 634 vs 600 → +5.7%; sl/stso unchanged → ±0%
-        best: { ttfs: 300, sl: 30, stso: 60 }[row.metric],
-        p75: { ttfs: 380, sl: 48, stso: 85 }[row.metric],
+        // ttfs: best 320 vs 250 → +28% 🔻, p75 398 vs 500 → -20% 💚,
+        //       p90 512 vs 512 → ±0%, p99 634 vs 600 → +5.7% (no mark).
+        // sl/stso baselines equal the run → ±0% everywhere.
+        best: { ttfs: 250, sl: 30, stso: 60 }[row.metric],
+        p75: { ttfs: 500, sl: 48, stso: 85 }[row.metric],
+        p90: { ttfs: 512, sl: 55, stso: 120 }[row.metric],
         p99: { ttfs: 600, sl: 120, stso: 200 }[row.metric],
       })),
   });
@@ -155,30 +159,32 @@ test('renders best/p75/p99 deltas against a baseline and embeds them in history'
     commit: 'abcdef1234567890',
   });
 
-  // Deltas land on Best, P75, and P99 for TTFS
-  assert.match(body, /\| 320 \(\+6\.7%\) \|/);
-  assert.match(body, /398 🔴 \(\+4\.7%\) \|/);
+  // Best regression past +15% → 🔻
+  assert.match(body, /\| 320 \(\+28%\) 🔻 \|/);
+  // P75 improvement past -15% → 💚 (alongside the 🔴 target miss)
+  assert.match(body, /398 🔴 \(-20%\) 💚/);
+  // P90 now carries a delta (previously undecorated); ±0%, no threshold mark
+  assert.match(body, /512 🔴 \(±0%\) \|/);
+  // P99 small delta, no threshold mark
   assert.match(body, /634 🔴 \(\+5\.7%\) \|/);
-  // Unchanged baselines render ±0% (SL best)
-  assert.match(body, /\| 30 \(±0%\) \|/);
-  // P90 never carries a delta
-  assert.doesNotMatch(body, /512 🔴 \(/);
   // WO has no baseline row → no delta on its Best cell
   assert.match(body, /\| 900 \|/);
   assert.match(
     body,
-    /Best\/P75\/P99 deltas compare against the most recent benchmark run on `main`/
+    /Best\/P75\/P90\/P99 deltas compare against the most recent benchmark run on `main`/
   );
-  // The annotation is embedded so history re-renders keep the deltas
+  assert.match(body, /💚 one better than/);
+  // The annotations are embedded so history re-renders keep the deltas
   const history = extractHistory(body);
-  assert.strictEqual(history[0].results[0].metrics[0].baselineBest, 300);
+  assert.strictEqual(history[0].results[0].metrics[0].baselineBest, 250);
+  assert.strictEqual(history[0].results[0].metrics[0].baselineP90, 512);
   const rerendered = renderComment({
     status: 'running',
     results: [],
     history,
     commit: 'ffffff1234567890',
   });
-  assert.match(rerendered, /\| 320 \(\+6\.7%\) \|/);
+  assert.match(rerendered, /\| 320 \(\+28%\) 🔻 \|/);
 });
 
 test('suppresses deltas when the baseline methodology version differs', async () => {

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -33,13 +33,11 @@ function sampleResult(overrides = {}) {
         metric: 'ttfs',
         scenario: 'stream',
         unit: 'ms',
+        best: 320,
         avg: 412.3,
-        p10: 357,
         p75: 398,
         p90: 512,
         p99: 634,
-        min: 320,
-        max: 700,
         samples: 30,
         targets: { p75: 200, p90: 300, p99: 600 },
       },
@@ -47,13 +45,11 @@ function sampleResult(overrides = {}) {
         metric: 'sl',
         scenario: 'stream',
         unit: 'ms',
+        best: 30,
         avg: 55.1,
-        p10: 41,
         p75: 48,
         p90: 55,
         p99: 120,
-        min: 30,
-        max: 130,
         samples: 30,
         targets: { p75: 50, p90: 60, p99: 125 },
       },
@@ -61,13 +57,11 @@ function sampleResult(overrides = {}) {
         metric: 'stso',
         scenario: '1020 steps (101-120)',
         unit: 'ms',
+        best: 60,
         avg: 91,
-        p10: 72,
         p75: 85,
         p90: 120,
         p99: 200,
-        min: 60,
-        max: 250,
         samples: 19,
         targets: { p75: 30, p90: 45, p99: 90 },
       },
@@ -75,13 +69,11 @@ function sampleResult(overrides = {}) {
         metric: 'wo',
         scenario: 'stream',
         unit: 'ms',
+        best: 900,
         avg: 1200,
-        p10: 1000,
         p75: 1100,
         p90: 1500,
         p99: 1900,
-        min: 900,
-        max: 2000,
         samples: 30,
       },
     ],
@@ -105,14 +97,15 @@ test('renders a completed run with a table and embedded history', async () => {
   assert.match(body, /\*\*SL\*\*/);
   assert.match(body, /\| stream \|/);
   assert.match(body, /1020 steps \(101-120\)/);
-  // "ms" lives in the column headers, not in the cells
+  // "ms" lives in the column headers, not in the cells; no Avg column
   assert.match(
     body,
-    /\| Avg \(ms\) \| P10 \(ms\) \| P75 \(ms\) \| P90 \(ms\) \| P99 \(ms\) \|/
+    /\| Best \(ms\) \| P75 \(ms\) \| P90 \(ms\) \| P99 \(ms\) \|/
   );
+  assert.doesNotMatch(body, /Avg \(ms\)/);
   assert.doesNotMatch(body, /\d ms \|/);
-  // P10 cell renders between Avg and P75 (warm-start floor for TTFS)
-  assert.match(body, /\| 412 \| 357 \| 398 🔴 \|/);
+  // Best cell (fastest sample) renders before P75 (warm-start floor for TTFS)
+  assert.match(body, /\| 320 \| 398 🔴 \|/);
   // Metric definitions live in the footer, not in the table rows
   assert.doesNotMatch(body, /\| \*\*TTFS\*\* <sub>/);
   assert.match(body, /<sub>Metrics — \*\*TTFS\*\*: time to first step body/);
@@ -140,15 +133,18 @@ test('renders a completed run with a table and embedded history', async () => {
   assert.strictEqual(history[0].results[0].metrics.length, 4);
 });
 
-test('renders avg deltas against a baseline and embeds them in history', async () => {
+test('renders best/p75/p99 deltas against a baseline and embeds them in history', async () => {
   const { renderComment, extractHistory } = await loadModule();
   const baseline = sampleResult({
     metrics: sampleResult()
       .metrics.filter((row) => row.metric !== 'wo') // no baseline for WO
       .map((row) => ({
         ...row,
-        // ttfs 412.3 vs 400 → +3.1%; sl 55.1 vs 50 → +10%; stso 91 vs 91 → ±0%
-        avg: { ttfs: 400, sl: 50, stso: 91 }[row.metric],
+        // ttfs best 320 vs 300 → +6.7%, p75 398 vs 380 → +4.7%,
+        //           p99 634 vs 600 → +5.7%; sl/stso unchanged → ±0%
+        best: { ttfs: 300, sl: 30, stso: 60 }[row.metric],
+        p75: { ttfs: 380, sl: 48, stso: 85 }[row.metric],
+        p99: { ttfs: 600, sl: 120, stso: 200 }[row.metric],
       })),
   });
   const body = renderComment({
@@ -159,26 +155,30 @@ test('renders avg deltas against a baseline and embeds them in history', async (
     commit: 'abcdef1234567890',
   });
 
-  // 412.3 renders rounded (>= 100), 55.1 keeps its decimal
-  assert.match(body, /\| 412 \(\+3\.1%\) \|/);
-  assert.match(body, /\| 55\.1 \(\+10%\) \|/);
-  assert.match(body, /\| 91 \(±0%\) \|/);
-  // WO has no baseline row → no delta
-  assert.match(body, /\| 1200 \|/);
+  // Deltas land on Best, P75, and P99 for TTFS
+  assert.match(body, /\| 320 \(\+6\.7%\) \|/);
+  assert.match(body, /398 🔴 \(\+4\.7%\) \|/);
+  assert.match(body, /634 🔴 \(\+5\.7%\) \|/);
+  // Unchanged baselines render ±0% (SL best)
+  assert.match(body, /\| 30 \(±0%\) \|/);
+  // P90 never carries a delta
+  assert.doesNotMatch(body, /512 🔴 \(/);
+  // WO has no baseline row → no delta on its Best cell
+  assert.match(body, /\| 900 \|/);
   assert.match(
     body,
-    /Avg deltas compare against the most recent benchmark run on `main`/
+    /Best\/P75\/P99 deltas compare against the most recent benchmark run on `main`/
   );
-  // The annotation is embedded so history re-renders keep the delta
+  // The annotation is embedded so history re-renders keep the deltas
   const history = extractHistory(body);
-  assert.strictEqual(history[0].results[0].metrics[0].baselineAvg, 400);
+  assert.strictEqual(history[0].results[0].metrics[0].baselineBest, 300);
   const rerendered = renderComment({
     status: 'running',
     results: [],
     history,
     commit: 'ffffff1234567890',
   });
-  assert.match(rerendered, /\| 412 \(\+3\.1%\) \|/);
+  assert.match(rerendered, /\| 320 \(\+6\.7%\) \|/);
 });
 
 test('suppresses deltas when the baseline methodology version differs', async () => {
@@ -188,7 +188,7 @@ test('suppresses deltas when the baseline methodology version differs', async ()
   // match — the numbers are not comparable.
   const baseline = sampleResult({
     methodologyVersion: 1,
-    metrics: sampleResult().metrics.map((row) => ({ ...row, avg: 400 })),
+    metrics: sampleResult().metrics.map((row) => ({ ...row, best: 200 })),
   });
   const body = renderComment({
     status: 'completed',
@@ -199,7 +199,7 @@ test('suppresses deltas when the baseline methodology version differs', async ()
   });
   // No percentage deltas, and the "compare against main" note is absent.
   assert.doesNotMatch(body, /%\)/);
-  assert.doesNotMatch(body, /Avg deltas/);
+  assert.doesNotMatch(body, /deltas compare against/);
 });
 
 test('renders no deltas without a baseline', async () => {
@@ -211,7 +211,7 @@ test('renders no deltas without a baseline', async () => {
     commit: 'abcdef1234567890',
   });
   assert.doesNotMatch(body, /%\)/);
-  assert.doesNotMatch(body, /Avg deltas/);
+  assert.doesNotMatch(body, /deltas compare against/);
 });
 
 test('collapses previous results on re-runs', async () => {
@@ -347,7 +347,7 @@ test('CLI renders results from a directory and previous body file', async () => 
     }
   );
   const baseline = sampleResult();
-  baseline.metrics = baseline.metrics.map((row) => ({ ...row, avg: 400 }));
+  baseline.metrics = baseline.metrics.map((row) => ({ ...row, best: 300 }));
   fs.writeFileSync(
     path.join(
       baselineDir,
@@ -376,8 +376,8 @@ test('CLI renders results from a directory and previous body file', async () => 
   const second = fs.readFileSync(secondOut, 'utf8');
   assert.match(second, /Previous results \(1\)/);
   assert.match(second, /#### 1111111/);
-  // ttfs avg 412.3 (rendered rounded) vs baseline 400 → +3.1%
-  assert.match(second, /\| 412 \(\+3\.1%\) \|/);
+  // ttfs best 320 vs baseline 300 → +6.7%
+  assert.match(second, /\| 320 \(\+6\.7%\) \|/);
 });
 
 test('CLI fails when completed with no results', async () => {

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -10,14 +10,15 @@
  * metrics below depend on the CI runner's clock or its network path to the
  * proxy; they are computed purely from Vercel-side timestamps.
  *
- * Metrics (all in milliseconds, reported as avg/p10/p75/p90/p99):
+ * Metrics (all in milliseconds, reported as best/p75/p90/p99; avg is kept in
+ * the JSON for reference but not shown in the PR comment):
  *
- * p10 is reported alongside the upper percentiles so warm-start latency (the
- * fast floor) is visible next to the cold-start tail: the workbench deployment
- * cold-starts the `/flow` invocation for a large fraction of runs (bursty,
- * low-traffic), which inflates p75+. Cold starts are kept in the numbers on
- * purpose — they are part of real bursty-workload latency — and p10 shows what
- * a warm trigger looks like.
+ * The best (fastest) sample is reported alongside the upper percentiles so
+ * warm-start latency (the fast floor) is visible next to the cold-start tail:
+ * the workbench deployment cold-starts the `/flow` invocation for a large
+ * fraction of runs (bursty, low-traffic), which inflates p75+. Cold starts are
+ * kept in the numbers on purpose — they are part of real bursty-workload
+ * latency — and the best sample shows what a fully warm trigger looks like.
  *
  * - TTFS  (time to first step): `steps[0].start` (first step body execution,
  *          deployment clock) minus the in-deployment `clientStart` returned by
@@ -25,8 +26,8 @@
  *          turbo path (no hooks) can exercise the runtime's in-process fast
  *          path; the non-turbo path (a hook registered before the step)
  *          exercises the dispatch path. Both are proxy-independent. TTFS
- *          includes the VQS dispatch hop and any `/flow` cold start (see p10
- *          note above).
+ *          includes the VQS dispatch hop and any `/flow` cold start (see the
+ *          best-sample note above).
  * - STSO  (step-to-step overhead): gap between consecutive step body
  *          executions (`steps[i].start - steps[i-1].end`) in a workflow with
  *          many trivial sequential steps. Both timestamps come from step
@@ -416,14 +417,13 @@ async function runScenario<T>(
 // ============================================================================
 
 interface MetricStats {
+  /** Fastest (best) sample — the warm-start floor vs the cold-start tail. */
+  best: number;
+  /** Mean; kept in the JSON for reference but not shown in the PR comment. */
   avg: number;
-  /** 10th percentile — surfaces the warm-start floor vs the cold-start tail. */
-  p10: number;
   p75: number;
   p90: number;
   p99: number;
-  min: number;
-  max: number;
   samples: number;
 }
 
@@ -444,13 +444,11 @@ function computeStats(samples: number[]): MetricStats {
     ];
   const round = (v: number) => Math.round(v * 10) / 10;
   return {
+    best: round(sorted[0]),
     avg: round(sorted.reduce((sum, v) => sum + v, 0) / sorted.length),
-    p10: round(percentile(10)),
     p75: round(percentile(75)),
     p90: round(percentile(90)),
     p99: round(percentile(99)),
-    min: round(sorted[0]),
-    max: round(sorted[sorted.length - 1]),
     samples: sorted.length,
   };
 }
@@ -689,11 +687,11 @@ describe('workflow benchmarks', () => {
     console.log(`[bench] Results written to ${outputPath}`);
     console.table(
       metricRows.map(
-        ({ metric, scenario, avg, p10, p75, p90, p99, samples }) => ({
+        ({ metric, scenario, best, avg, p75, p90, p99, samples }) => ({
           metric,
           scenario,
+          best,
           avg,
-          p10,
           p75,
           p90,
           p99,


### PR DESCRIPTION
## What

Reworks the Performance Benchmarks PR-comment table:

- **Drop the `Avg` column** entirely.
- **Rename `P10` → `Best`**, reporting the **fastest (warm-start) sample** (`min`) instead of the 10th percentile — a cleaner warm-start floor for these bursty, cold-start-heavy runs.
- **vs-`main` deltas on `Best`, `P75`, `P90`, and `P99`** (every latency column).
- **Directional threshold marks on deltas**: 🔻 when a delta is worse than **+15%** vs main, 💚 when better than **−15%**. Smaller moves show the percentage alone. (There is no green-triangle emoji, so 💚 is the improvement marker.)
- **Quieter target column**: 🔴 only when a percentile is **over** its target; within-target cells are left unmarked (dropped the 🟢).

### Example

| Metric | Scenario | Best (ms) | P75 (ms) | P90 (ms) | P99 (ms) | Samples |
|--------|----------|----------:|---------:|---------:|---------:|--------:|
| **TTFS** | step | 1210 (+34%) 🔻 | 1368 🔴 (+24%) 🔻 | 1396 🔴 (±0%) | 1726 🔴 (-14%) | 30 |
| **SL** | stream latency | 40 (-67%) 💚 | 48 (-68%) 💚 | 55 (-66%) 💚 | 120 (-60%) 💚 | 30 |

## How

- `packages/core/e2e/benchmark.test.ts` — `computeStats` emits `best` (the fastest sample) in place of `p10`/`min`/`max`. `avg` is kept in the results JSON for reference but no longer rendered.
- `.github/scripts/render-benchmark-comment.mjs`:
  - `Best (ms)` column; `annotateWithBaseline` records baseline `best`/`p75`/`p90`/`p99` per row (via a `BASELINE_FIELDS` table; `best` falls back to a pre-rename baseline's `min` so existing `main` baselines still light up).
  - `formatDelta` appends 🔻/💚 past ±`DELTA_MARK_THRESHOLD_PCT` (15%).
  - `formatCell` marks 🔴 only when over target; within-target is unmarked.
  - Footer legend/notes updated.
- `.github/scripts/render-benchmark-comment.test.js` — schema + assertions updated for the Best column, P90 deltas, the 🔻/💚 marks, and the quiet target column.

## Notes

- Methodology version stays **2** — the measurement window is unchanged, only which statistics are displayed/compared. Deltas remain comparable against existing `main` baselines (Best falls back to their stored `min`).
- CI-scripts + e2e test only; no published package output, so **no changeset** (matches #2967).

## Verification

- `node --test .github/scripts/render-benchmark-comment.test.js` → 11/11 pass
- `pnpm --filter @workflow/core typecheck` → clean; `biome check` → clean
- Rendered sample comments locally covering 🔻 regressions, 💚 improvements, 🔴 target misses, and blank within-target cells (see the example above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)