### PR TITLE
[swc-plugin] Fix maxRetries dropped on steps nested inside a workflow

### DIFF
--- a/.changeset/nested-step-max-retries.md
+++ b/.changeset/nested-step-max-retries.md
@@ -1,0 +1,5 @@
+---
+'@workflow/swc-plugin': patch
+---
+
+Honor `maxRetries` set on a step defined inside a workflow body; the assignment was previously dropped, silently reverting the step to the default retry count.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1448,6 +1448,21 @@ describe('e2e', () => {
         expect(result.failed).toBe(true);
         expect(result.attempt).toBe(1);
       });
+
+      test(
+        'maxRetries=0 on a nested (in-workflow) step disables retries',
+        { timeout: 60_000 },
+        async () => {
+          // Regression: `.maxRetries` assigned inside the workflow body used to
+          // be dropped by the step transform, so a nested step silently
+          // retried the default number of times. It must run exactly once.
+          const run = await start(await e2e('errorRetryDisabledNested'), []);
+          const result = await run.returnValue;
+
+          expect(result.failed).toBe(true);
+          expect(result.attempt).toBe(1);
+        }
+      );
     });
 
     describe('catchability', () => {

--- a/packages/swc-plugin-workflow/spec.md
+++ b/packages/swc-plugin-workflow/spec.md
@@ -197,6 +197,53 @@ example.workflowId = "workflow//./input//example";
 })(example$innerStep, "step//./input//example/innerStep");
 ```
 
+#### Step config assignments on nested steps
+
+Step configuration is expressed by assigning a property on the step function
+(currently only `maxRetries`). When a step is defined *inside* a workflow body,
+such an assignment lives in that body — which step mode replaces wholesale with a
+`throw`. To keep the configuration from being silently dropped (which would reset
+the step to the default retry count), a `<step>.maxRetries = <literal>` assignment
+is re-emitted at module scope on the hoisted step function, right after its
+registration IIFE. Only literal right-hand sides are hoisted, since the statement
+is moved out of the workflow's scope and must not capture workflow-local bindings.
+
+Input:
+```javascript
+export async function example(a) {
+  "use workflow";
+
+  async function innerStep(x) {
+    "use step";
+    return x + 1;
+  }
+  innerStep.maxRetries = 0;
+
+  return await innerStep(a);
+}
+```
+
+Output (Step Mode):
+```javascript
+/**__internal_workflows{"workflows":{"input.js":{"example":{"workflowId":"workflow//./input//example"}}},"steps":{"input.js":{"innerStep":{"stepId":"step//./input//example/innerStep"}}}}*/;
+async function example$innerStep(x) {
+    return x + 1;
+}
+(function(__wf_fn, __wf_id) {
+    var __wf_sym = Symbol.for("@workflow/core//registeredSteps"), __wf_reg = globalThis[__wf_sym] || (globalThis[__wf_sym] = new Map());
+    __wf_reg.set(__wf_id, __wf_fn);
+    __wf_fn.stepId = __wf_id;
+})(example$innerStep, "step//./input//example/innerStep");
+example$innerStep.maxRetries = 0;
+export async function example(a) {
+    throw new Error("You attempted to execute workflow example function directly. To start a workflow, use start(example) from workflow/api");
+}
+example.workflowId = "workflow//./input//example";
+```
+
+In workflow mode the assignment is left in place on the step proxy; it is inert
+there because retry configuration is only read where the step executes.
+
 ### Steps in Nested Object Properties
 
 Step functions can be defined inside deeply nested object properties, including function call arguments. The plugin recursively processes nested objects to find step functions, generating compound paths for the step IDs.

--- a/packages/swc-plugin-workflow/transform/src/lib.rs
+++ b/packages/swc-plugin-workflow/transform/src/lib.rs
@@ -377,6 +377,21 @@ pub struct StepTransform {
         String,
         bool,
     )>,
+    // Config-property assignments (currently `maxRetries`) written on a step
+    // function that is defined *inside* a workflow body. In step mode the
+    // workflow body is replaced with a `throw`, so an assignment like
+    // `myStep.maxRetries = 0` living in that body would be dropped and the step
+    // would silently revert to the default retry count. These assignments are
+    // collected here and re-emitted at module scope on the hoisted step
+    // function so the runtime observes the configured value.
+    // Tuple: (parent_prefix, local_fn_name, prop_name, literal_value).
+    // `parent_prefix` matches the `parent_workflow_name` recorded in
+    // `nested_step_functions`, and `local_fn_name` matches that entry's
+    // `fn_name`, so the two are joined at emission time to target the hoisted
+    // `{parent}${local}` identifier. Only literal right-hand sides are
+    // collected, since the assignment is hoisted to module scope and must not
+    // capture workflow-local bindings.
+    nested_step_config_assignments: Vec<(String, String, String, Box<Expr>)>,
     // Counter for anonymous function names
     #[allow(dead_code)]
     anonymous_fn_counter: usize,
@@ -1804,11 +1819,63 @@ impl StepTransform {
                 }
                 stmt.visit_mut_children_with(self);
             }
+            Stmt::Expr(expr_stmt) => {
+                self.collect_nested_step_config_assignment(&expr_stmt.expr);
+                stmt.visit_mut_children_with(self);
+            }
             _ => {
                 stmt.visit_mut_children_with(self);
             }
         }
     }
+
+    /// In step mode, record a `<step>.maxRetries = <literal>` assignment that is
+    /// written inside a workflow (or other enclosing) function body so it can be
+    /// re-emitted on the hoisted step at module scope. Without this the
+    /// assignment is lost when the workflow body is replaced with a `throw`, and
+    /// the step silently reverts to the default retry count. Only literal
+    /// right-hand sides are collected, since the statement is moved to module
+    /// scope and must not depend on any enclosing binding. Non-matching
+    /// assignments recorded here are simply never emitted (see the nested-step
+    /// hoisting loop), so over-collection is harmless.
+    fn collect_nested_step_config_assignment(&mut self, expr: &Expr) {
+        if !matches!(self.mode, TransformMode::Step) {
+            return;
+        }
+        let Some(parent) = self.current_parent_function_name.clone() else {
+            return;
+        };
+        let Expr::Assign(assign) = expr else {
+            return;
+        };
+        if assign.op != AssignOp::Assign {
+            return;
+        }
+        if !matches!(&*assign.right, Expr::Lit(_)) {
+            return;
+        }
+        let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &assign.left else {
+            return;
+        };
+        let Expr::Ident(obj) = &*member.obj else {
+            return;
+        };
+        let MemberProp::Ident(prop) = &member.prop else {
+            return;
+        };
+        // Only `maxRetries` is a user-configurable step property today. Keeping
+        // the allowlist explicit avoids hoisting unrelated property writes.
+        if prop.sym.as_ref() != "maxRetries" {
+            return;
+        }
+        self.nested_step_config_assignments.push((
+            parent,
+            obj.sym.to_string(),
+            prop.sym.to_string(),
+            assign.right.clone(),
+        ));
+    }
+
     pub fn new(mode: TransformMode, filename: String, module_specifier: Option<String>) -> Self {
         Self {
             mode,
@@ -1838,6 +1905,7 @@ impl StepTransform {
             declared_identifiers: HashSet::new(),
             object_property_step_functions: Vec::new(),
             nested_step_functions: Vec::new(),
+            nested_step_config_assignments: Vec::new(),
             anonymous_fn_counter: 0,
             object_property_workflow_conversions: Vec::new(),
             nested_step_full_names: HashMap::new(),
@@ -5270,7 +5338,51 @@ impl VisitMut for StepTransform {
                             .body
                             .insert(current_insert_pos, ModuleItem::Stmt(registration_stmt));
                         current_insert_pos += 1;
+
+                        // Re-emit any config-property assignments (e.g.
+                        // `maxRetries`) that were written on this step inside the
+                        // workflow body. They are rewritten onto the hoisted step
+                        // identifier so the runtime observes them; without this,
+                        // the original assignment is discarded when the workflow
+                        // body is replaced with a `throw`.
+                        for (a_parent, a_local, a_prop, a_value) in
+                            &self.nested_step_config_assignments
+                        {
+                            if a_parent != &parent_workflow_name || a_local != &fn_name {
+                                continue;
+                            }
+                            let assign_stmt = Stmt::Expr(ExprStmt {
+                                span: DUMMY_SP,
+                                expr: Box::new(Expr::Assign(AssignExpr {
+                                    span: DUMMY_SP,
+                                    op: AssignOp::Assign,
+                                    left: AssignTarget::Simple(SimpleAssignTarget::Member(
+                                        MemberExpr {
+                                            span: DUMMY_SP,
+                                            obj: Box::new(Expr::Ident(Ident::new(
+                                                hoisted_name.clone().into(),
+                                                DUMMY_SP,
+                                                SyntaxContext::empty(),
+                                            ))),
+                                            prop: MemberProp::Ident(IdentName {
+                                                span: DUMMY_SP,
+                                                sym: a_prop.clone().into(),
+                                            }),
+                                        },
+                                    )),
+                                    right: a_value.clone(),
+                                })),
+                            });
+                            module
+                                .body
+                                .insert(current_insert_pos, ModuleItem::Stmt(assign_stmt));
+                            current_insert_pos += 1;
+                        }
                     }
+                    // Config assignments have now been re-emitted for every
+                    // hoisted nested step; drop them so a later module (or a
+                    // repeated pass) cannot re-emit stale entries.
+                    self.nested_step_config_assignments.clear();
 
                     // Then process object property step functions (they typically appear later)
                     // Collect hoisting information before the loop

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-max-retries/input.ts
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-max-retries/input.ts
@@ -1,0 +1,20 @@
+export async function example(a) {
+  "use workflow";
+
+  // Function-declaration step with an explicit retry count set inside the
+  // workflow body. The assignment must survive onto the hoisted step.
+  async function fnStep(x) {
+    "use step";
+    return x + 1;
+  }
+  fnStep.maxRetries = 0;
+
+  // Arrow step with a non-default retry count.
+  const arrowStep = async (x) => {
+    "use step";
+    return x * 2;
+  };
+  arrowStep.maxRetries = 7;
+
+  return (await fnStep(a)) + (await arrowStep(a));
+}

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-max-retries/output-step.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-max-retries/output-step.js
@@ -1,0 +1,31 @@
+/**__internal_workflows{"workflows":{"input.ts":{"example":{"workflowId":"workflow//./input//example"}}},"steps":{"input.ts":{"arrowStep":{"stepId":"step//./input//example/arrowStep"},"fnStep":{"stepId":"step//./input//example/fnStep"}}}}*/;
+// Function-declaration step with an explicit retry count set inside the
+// workflow body. The assignment must survive onto the hoisted step.
+async function example$fnStep(x) {
+    return x + 1;
+}
+(function(__wf_fn, __wf_id) {
+    var __wf_sym = Symbol.for("@workflow/core//registeredSteps"), __wf_reg = globalThis[__wf_sym] || (globalThis[__wf_sym] = new Map());
+    __wf_reg.set(__wf_id, __wf_fn);
+    __wf_fn.stepId = __wf_id;
+    Object.defineProperty(__wf_fn, "name", {
+        value: "example$fnStep",
+        configurable: true
+    });
+})(example$fnStep, "step//./input//example/fnStep");
+example$fnStep.maxRetries = 0;
+var example$arrowStep = async (x)=>x * 2;
+(function(__wf_fn, __wf_id) {
+    var __wf_sym = Symbol.for("@workflow/core//registeredSteps"), __wf_reg = globalThis[__wf_sym] || (globalThis[__wf_sym] = new Map());
+    __wf_reg.set(__wf_id, __wf_fn);
+    __wf_fn.stepId = __wf_id;
+    Object.defineProperty(__wf_fn, "name", {
+        value: "example$arrowStep",
+        configurable: true
+    });
+})(example$arrowStep, "step//./input//example/arrowStep");
+example$arrowStep.maxRetries = 7;
+export async function example(a) {
+    throw new Error("You attempted to execute workflow example function directly. To start a workflow, use start(example) from workflow/api");
+}
+example.workflowId = "workflow//./input//example";

--- a/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-max-retries/output-workflow.js
+++ b/packages/swc-plugin-workflow/transform/tests/fixture/nested-step-max-retries/output-workflow.js
@@ -1,0 +1,11 @@
+/**__internal_workflows{"workflows":{"input.ts":{"example":{"workflowId":"workflow//./input//example"}}},"steps":{"input.ts":{"arrowStep":{"stepId":"step//./input//example/arrowStep"},"fnStep":{"stepId":"step//./input//example/fnStep"}}}}*/;
+export async function example(a) {
+    var fnStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//./input//example/fnStep");
+    fnStep.maxRetries = 0;
+    // Arrow step with a non-default retry count.
+    const arrowStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//./input//example/arrowStep");
+    arrowStep.maxRetries = 7;
+    return await fnStep(a) + await arrowStep(a);
+}
+example.workflowId = "workflow//./input//example";
+globalThis.__private_workflows.set("workflow//./input//example", example);

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -1270,6 +1270,31 @@ export async function errorRetryDisabled() {
   }
 }
 
+/**
+ * Test: maxRetries set on a step defined *inside* the workflow body is honored.
+ * The `.maxRetries = 0` assignment lives in the workflow body, which the step
+ * transform replaces with a throw; the compiler must re-emit it onto the
+ * hoisted step so the runtime runs the step exactly once (attempt === 1)
+ * instead of falling back to the default of 3 retries.
+ */
+export async function errorRetryDisabledNested() {
+  'use workflow';
+  async function nestedThrowWithNoRetries() {
+    'use step';
+    const { attempt } = getStepMetadata();
+    throw new Error(`Failed on attempt ${attempt}`);
+  }
+  nestedThrowWithNoRetries.maxRetries = 0;
+
+  try {
+    await nestedThrowWithNoRetries();
+    return { failed: false, attempt: null };
+  } catch (e: any) {
+    const match = e.message?.match(/attempt (\d+)/);
+    return { failed: true, attempt: match ? parseInt(match[1]) : null };
+  }
+}
+
 // ------------------------------------------------------------
 // SECTION 3: CATCHABILITY
 // Tests that errors can be caught and inspected in workflow code


### PR DESCRIPTION
## Problem

A step configures its retry count via a property assignment on the step function (`myStep.maxRetries = N`, default 3). When the step is defined **inside a workflow body**, that assignment lives in the workflow body — which the step-mode transform replaces wholesale with a `throw`. The assignment was therefore dropped, and the nested step silently reverted to the default of 3 retries.

Top-level steps (including imported ones assigned at module scope) are unaffected, because those assignments are module-scope statements that survive the transform.

### Repro

```ts
export async function wf() {
  "use workflow";
  async function inner() {
    "use step";
    throw new Error("boom");
  }
  inner.maxRetries = 0; // dropped → step actually retried 3×
  return await inner();
}
```

Before this change the compiled step bundle contained no `maxRetries` assignment for `wf$inner`, so `getStepFunction(...).maxRetries` was `undefined` and the runtime used `DEFAULT_STEP_MAX_RETRIES = 3`.

## Fix

In the SWC plugin, collect `<step>.maxRetries = <literal>` assignments written inside a workflow body and re-emit them at module scope on the hoisted step function, immediately after its registration IIFE. Only literal right-hand sides are hoisted, so the moved statement can never capture a workflow-local binding. Workflow mode is unchanged (the assignment stays on the inert step proxy).

## Validation

- New Rust fixture `nested-step-max-retries` (step + workflow mode); full `cargo test` suite green (131 passed).
- Verified end-to-end through the production CLI build (`workflow build --target vercel-build-output-api`): the compiled step bundle now emits `errorRetryDisabledNested$nestedThrowWithNoRetries.maxRetries = 0;` right after registration.
- New e2e workflow `errorRetryDisabledNested` + assertion in `packages/core/e2e/e2e.test.ts` (asserts the failing nested step runs exactly once). Live e2e runs against the CI-provisioned backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)