### PR TITLE
fix(workbench/nest): set outputDirectory so stable Vercel deploy succeeds

### DIFF
--- a/workbench/nest/vercel.json
+++ b/workbench/nest/vercel.json
@@ -1,5 +1,6 @@
 {
   "env": {
     "WORKFLOW_PUBLIC_MANIFEST": "1"
-  }
+  },
+  "outputDirectory": "dist"
 }


### PR DESCRIPTION
## Problem

The `workbench-nestjs-workflow` Vercel project (framework **Other**, root directory `workbench/nest`) builds **every** repo branch since its Git integration was reconnected. On `stable` it deploys as **ERROR**, so every `stable` PR shows a red `Vercel – workbench-nestjs-workflow` check.

Confirmed via the Vercel API: `stable`, `changeset-release/stable`, and `backport/pr-2963-to-stable` all deploy **ERROR**; `main` is **READY**.

### Root cause

Stable has no `vercel-build` script, so Vercel runs the default build (`nest build` via the monorepo Turbo graph). The package builds fine, but `nest build` only emits `dist/` — it never produces `.vercel/output`. With no `.vercel/output` and no `public/` directory, the build ends with:

```
Error: No Output Directory named "public" found after the Build completed.
Configure the Output Directory in your Project Settings. Alternatively, configure vercel.json#outputDirectory.
```

`main` doesn't hit this because #2988 added the nest Vercel builder + `vercel-build` script, which emits `.vercel/output`.

## Fix

Point `outputDirectory` at `dist` in `workbench/nest/vercel.json` so Vercel accepts the plain `nest build` output and the deploy goes green.

This is the minimal, stable-scoped fix — it does **not** backport the experimental nest Vercel builder (which would ship experimental `@workflow/nest` / `workflow` APIs to the GA `latest` npm channel just to satisfy a CI check). Stable has no nest e2e tests, so a static build of `dist/` is sufficient for the deploy to succeed.

Isolated to `stable`: `main` continues to emit `.vercel/output`, which takes precedence over `outputDirectory` regardless, so this change is inert if the builder is ever backported later.

## Testing

- Verified the exact failure in the `stable` branch deployment's build logs (`No Output Directory named "public" found`).
- Workbench-only config change — no changeset needed (workbench is not a published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)