### PR TITLE
test: remove neighboring-region leniency from multi-region e2e; report run + request IDs on mismatch

### DIFF
--- a/.changeset/strict-region-e2e-assertions.md
+++ b/.changeset/strict-region-e2e-assertions.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove the neighboring-region execution leniency from the multi-region e2e suite: the workflow and step must now execute strictly in the run's tagged region. Region mismatches fail with the workflow run ID and the offending invocation's Vercel proxy request ID (x-vercel-id) so CI reports carry everything needed to investigate routing bugs.

--- a/.github/scripts/fetch-e2e-runtime-logs.mjs
+++ b/.github/scripts/fetch-e2e-runtime-logs.mjs
@@ -72,7 +72,13 @@ function readFailedRunIds() {
   try {
     const failures = JSON.parse(fs.readFileSync(failuresPath, 'utf-8'));
     for (const failure of failures) {
-      if (failure.runId) failedRunIds.set(failure.runId, failure.testName);
+      // `runIds` carries every run referenced by the failure (batch tests
+      // aggregate several runs into one error); `runId` is the legacy
+      // single-run field.
+      const runIds = failure.runIds ?? (failure.runId ? [failure.runId] : []);
+      for (const runId of runIds) {
+        failedRunIds.set(runId, failure.testName);
+      }
     }
   } catch {
     // Sidecar absent (no failures, or reporter didn't run) — fine.

--- a/packages/core/e2e/e2e-region.test.ts
+++ b/packages/core/e2e/e2e-region.test.ts
@@ -1,5 +1,12 @@
 import { decode, isTagged } from '@workflow/world-vercel/run-id';
-import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'vitest';
 import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
 import {
@@ -15,6 +22,7 @@ import {
   setupRunTracking,
   setupWorld,
   trackRun,
+  writeDiagnosticsSidecar,
 } from './utils';
 
 /**
@@ -86,48 +94,12 @@ const ALL_REGIONS = [
 ] as const;
 const REGIONS = ['iad1', 'sfo1', 'fra1'] as const;
 
-/**
- * Queue delivery is GUARANTEED to the tagged region's dataplane (failed
- * sends buffer durably and are re-driven), and the delivery callback
- * always egresses from that region. Execution locality of the consumer
- * invocation is looser, though: the callback enters Vercel's edge at
- * whichever POP the egress geolocates to, and adjacent regions can
- * resolve to each other's functions (observed live: kix1-tagged runs —
- * callback egressing from Osaka — executing in hnd1/Tokyo). Run-ID
- * tagging, data placement, and completion remain strictly the tagged
- * region; only where the handler physically runs is geo-elastic, so the
- * assertion tolerates each region's geographic neighbors.
- */
-const EXECUTION_ADJACENCY: Record<string, readonly string[]> = {
-  arn1: ['fra1', 'dub1'],
-  bom1: ['sin1', 'hkg1'],
-  cdg1: ['lhr1', 'fra1'],
-  cle1: ['iad1', 'pdx1'],
-  cpt1: ['fra1', 'lhr1'],
-  dub1: ['lhr1', 'fra1'],
-  fra1: ['cdg1', 'dub1'],
-  gru1: ['iad1', 'cle1'],
-  hkg1: ['sin1', 'syd1'],
-  hnd1: ['kix1', 'sin1'],
-  iad1: ['cle1', 'pdx1'],
-  icn1: ['kix1', 'syd1', 'hnd1'],
-  kix1: ['hnd1', 'syd1'],
-  lhr1: ['cdg1', 'arn1'],
-  pdx1: ['sfo1', 'cle1'],
-  sfo1: ['pdx1', 'cle1'],
-  sin1: ['hkg1', 'syd1'],
-  syd1: ['sin1', 'hkg1'],
-  yul1: ['iad1', 'pdx1'],
-};
-
-function allowedExecutionRegions(region: string): readonly string[] {
-  return [region, ...(EXECUTION_ADJACENCY[region] ?? [])];
-}
-
 interface RegionProbeResult {
   label: string;
   workflowRegion: string | null;
+  workflowRequestId: string | null;
   stepRegion: string | null;
+  stepRequestId: string | null;
 }
 
 /** Tracked wrapper around start() for run diagnostics on failure. */
@@ -192,19 +164,27 @@ async function expectRunInRegion(
   expect(decoded.tagged && decoded.region).toBe(region);
 
   // 2. The workflow and its step actually executed in the tagged region
-  // (or a geographic neighbor — see EXECUTION_ADJACENCY; tagging and
-  // data placement stay strict).
+  // — strictly. Queue delivery targets the tagged region's dataplane and
+  // the delivery callback is expected to be invoked in that SAME region,
+  // so any mismatch is a routing bug, not tolerable geo-elasticity. The
+  // failure message carries the run ID (in the `Run ID:` form the CI
+  // reporter extracts for runtime-log capture) plus the offending
+  // invocation's Vercel proxy request ID (x-vercel-id) so mismatches can
+  // be escalated with everything needed to trace them server-side.
   const returnValue = await run.returnValue;
   expect(returnValue.label).toBe(label);
-  const allowed = allowedExecutionRegions(region);
   expect(
-    allowed,
-    `workflow executed in ${returnValue.workflowRegion}, tagged ${region}`
-  ).toContain(returnValue.workflowRegion);
+    returnValue.workflowRegion,
+    `workflow executed in ${returnValue.workflowRegion}, tagged ${region} — ` +
+      `Run ID: ${run.runId} — workflow invocation x-vercel-id: ` +
+      `${returnValue.workflowRequestId ?? 'unavailable'}`
+  ).toBe(region);
   expect(
-    allowed,
-    `step executed in ${returnValue.stepRegion}, tagged ${region}`
-  ).toContain(returnValue.stepRegion);
+    returnValue.stepRegion,
+    `step executed in ${returnValue.stepRegion}, tagged ${region} — ` +
+      `Run ID: ${run.runId} — step invocation x-vercel-id: ` +
+      `${returnValue.stepRequestId ?? 'unavailable'}`
+  ).toBe(region);
 
   // 3. The server agrees the run completed (data reachable via the same
   // tag-derived region routing the writes used).
@@ -220,6 +200,13 @@ describe.skipIf(isLocalDeployment())('multi-region (world-vercel)', () => {
 
   beforeEach((ctx) => {
     setupRunTracking(ctx.task.name);
+  });
+
+  // Write the run-diagnostics sidecar so the CI reporter can map failed
+  // tests to run IDs (and the runtime-log capture can then pull every
+  // request row — proxy request IDs included — for those runs).
+  afterAll(() => {
+    writeDiagnosticsSidecar();
   });
 
   describe('explicit region: start({ region }) in the test process', () => {

--- a/packages/core/e2e/github-reporter.ts
+++ b/packages/core/e2e/github-reporter.ts
@@ -26,6 +26,13 @@ interface FailedTestInfo {
   file: string;
   errorMessage: string;
   runId?: string;
+  /**
+   * All run IDs found in the failure output. Tests that assert over a
+   * batch of runs (e.g. the multi-region all-regions case) aggregate
+   * several failures — each with its own `Run ID:` marker — into one
+   * error message; the runtime-log capture wants every one of them.
+   */
+  runIds?: string[];
   dashboardUrl?: string;
   status?: string;
 }
@@ -69,8 +76,15 @@ export default class GithubAnnotationReporter implements Reporter {
         .join('\n');
 
       // Try to extract run diagnostics from error output.
-      // The onTestFailed hook in utils.ts writes diagnostics with specific markers.
-      const diagnosticsMatch = errorMessage.match(/Run ID:\s+(wrun_\S+)/);
+      // The onTestFailed hook in utils.ts writes diagnostics with specific
+      // markers, and assertion messages may embed the same `Run ID:` form.
+      // Extract from the FULL message (before truncation below) so batch
+      // failures spanning many runs keep every ID.
+      const runIds = [
+        ...new Set(
+          [...errorMessage.matchAll(/Run ID:\s+(wrun_\S+)/g)].map((m) => m[1])
+        ),
+      ];
       const dashboardMatch = errorMessage.match(/Dashboard:\s+(https:\/\/\S+)/);
       const statusMatch = errorMessage.match(/Status:\s+(\S+)/);
 
@@ -79,7 +93,8 @@ export default class GithubAnnotationReporter implements Reporter {
         fullName: test.fullName,
         file: module.moduleId,
         errorMessage: errorMessage.slice(0, 500),
-        runId: diagnosticsMatch?.[1],
+        runId: runIds[0],
+        runIds: runIds.length > 0 ? runIds : undefined,
         dashboardUrl: dashboardMatch?.[1],
         status: statusMatch?.[1],
       });
@@ -114,6 +129,7 @@ export default class GithubAnnotationReporter implements Reporter {
       const diag = byTestName.get(test.testName);
       if (diag) {
         test.runId ??= diag.runId;
+        test.runIds ??= [diag.runId];
         test.dashboardUrl ??= diag.dashboardUrl ?? undefined;
       }
     }
@@ -128,8 +144,17 @@ export default class GithubAnnotationReporter implements Reporter {
    */
   private emitAnnotations() {
     for (const test of this.failedTests) {
-      const parts = [test.errorMessage.split('\n')[0].slice(0, 150)];
-      if (test.runId) parts.push(`Run: ${test.runId}`);
+      // 300 chars keeps region-mismatch messages (run ID + x-vercel-id
+      // proxy request ID) intact in the annotation.
+      const parts = [test.errorMessage.split('\n')[0].slice(0, 300)];
+      const runIds = test.runIds ?? (test.runId ? [test.runId] : []);
+      if (runIds.length === 1) {
+        parts.push(`Run: ${runIds[0]}`);
+      } else if (runIds.length > 1) {
+        const shown = runIds.slice(0, 3).join(', ');
+        const more = runIds.length - 3;
+        parts.push(`Runs: ${shown}${more > 0 ? ` (+${more} more)` : ''}`);
+      }
       if (test.status) parts.push(`Status: ${test.status}`);
       if (test.dashboardUrl) parts.push(test.dashboardUrl);
       const body = parts.join(' | ');

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -3677,6 +3677,26 @@ export async function parallelStepsThenWebhookWorkflow(iterations: number) {
 }
 
 /**
+ * Best-effort capture of the Vercel proxy request ID (`x-vercel-id`) of
+ * the invocation currently executing. Reads the ambient Vercel request
+ * context straight off globalThis — the same source `@vercel/functions`'
+ * getContext() uses — rather than importing the package, because this
+ * file is shared by every workbench app. The symbol is populated by the
+ * Vercel runtime per request (and propagated into the workflow VM by
+ * @workflow/core), so this returns null on non-Vercel deployments.
+ */
+function readInvocationRequestId(): string | null {
+  const requestContext = (
+    globalThis as {
+      [key: symbol]:
+        | { get?: () => { headers?: Record<string, string> } | undefined }
+        | undefined;
+    }
+  )[Symbol.for('@vercel/request-context')]?.get?.();
+  return requestContext?.headers?.['x-vercel-id'] ?? null;
+}
+
+/**
  * Multi-region e2e probe (see packages/core/e2e/e2e-region.test.ts).
  *
  * Returns the `VERCEL_REGION` observed by both the workflow (flow route)
@@ -3686,17 +3706,41 @@ export async function parallelStepsThenWebhookWorkflow(iterations: number) {
  * to be deployed to the target regions (workbench/nextjs-turbopack
  * vercel.json pins iad1+sfo1+fra1) and the world's queue to route the
  * flow message by the run ID's region tag (@workflow/world-vercel).
+ *
+ * Alongside each observed region the probe records the invocation's
+ * Vercel proxy request ID (`x-vercel-id`) so that a region mismatch can
+ * be reported with the exact request that executed in the wrong region
+ * (queue delivery is expected to invoke the callback in the tagged
+ * region — a mismatch is a routing bug to escalate, and the request ID
+ * is what the platform team needs to trace it). Reading a per-request
+ * value inside the workflow function is non-deterministic across
+ * replays, which is fine here: it is never branched on, and the value
+ * that ends up in the return value belongs to the same (final)
+ * invocation whose VERCEL_REGION is being asserted.
  */
 export async function regionProbeWorkflow(label: string) {
   'use workflow';
   const workflowRegion = process.env.VERCEL_REGION ?? null;
-  const stepRegion = await regionProbeStep();
-  return { label, workflowRegion, stepRegion };
+  const workflowRequestId = readInvocationRequestId();
+  const step = await regionProbeStep();
+  return {
+    label,
+    workflowRegion,
+    workflowRequestId,
+    stepRegion: step.region,
+    stepRequestId: step.requestId,
+  };
 }
 
-async function regionProbeStep(): Promise<string | null> {
+async function regionProbeStep(): Promise<{
+  region: string | null;
+  requestId: string | null;
+}> {
   'use step';
-  return process.env.VERCEL_REGION ?? null;
+  return {
+    region: process.env.VERCEL_REGION ?? null,
+    requestId: readInvocationRequestId(),
+  };
 }
 
 async function writeCrossRegionStreamChunks(


### PR DESCRIPTION
## Summary

The multi-region e2e suite tolerated workflow/step execution landing in a *geographic neighbor* of the run's tagged region (`EXECUTION_ADJACENCY`). Per platform guidance, when Vercel Queue targets a specific region the user callback endpoint should always be invoked in that same region — so a mismatch is a routing bug to investigate, not expected geo-elasticity.

This PR removes the leniency and makes any mismatch fail CI with everything needed to escalate: the workflow run ID and the Vercel proxy request ID (`x-vercel-id`) of the exact invocation that executed in the wrong region.

## Changes

**Strict assertions** — `packages/core/e2e/e2e-region.test.ts`
- Removed `EXECUTION_ADJACENCY` / `allowedExecutionRegions()`; `expectRunInRegion` now asserts the workflow and step execution regions strictly equal the tagged region.
- Failure messages embed `Run ID: wrun_…` (the exact form the CI reporter extracts) plus the offending invocation's `x-vercel-id`, e.g.:
  > `step executed in hnd1, tagged kix1 — Run ID: wrun_01K… — step invocation x-vercel-id: kix1::abc…`
- Added `afterAll(writeDiagnosticsSidecar)` — the `e2e-diagnostics-*.json` artifact was already in the job's upload list but this suite never wrote it.

**Request-ID capture at the source** — `workbench/example/workflows/99_e2e.ts` (symlinked into all workbenches)
- `regionProbeWorkflow`/`regionProbeStep` now record each invocation's `x-vercel-id` alongside `VERCEL_REGION`, read from the ambient `Symbol.for('@vercel/request-context')` (no `@vercel/functions` import since this file is shared by every workbench; returns `null` off-Vercel).

**CI reporting plumbing**
- `github-reporter.ts`: extracts **all** `Run ID:` occurrences from a failure (the all-regions batch test aggregates 19 regions into one error message) into a new `runIds` field on the failures sidecar; annotation first-line slice bumped 150 → 300 chars so the IDs aren't truncated.
- `.github/scripts/fetch-e2e-runtime-logs.mjs`: consumes `runIds`, so the on-failure runtime-logs artifact pulls every request row (proxy request IDs, status codes, function logs) for **each** mis-routed run.

## Expected behavior change in CI

The adjacency map existed because mismatches were observed live (kix1-tagged runs executing in hnd1). If/when that recurs, the `e2e-vercel-multi-region` job will now go red — intentionally — and the annotation + `e2e-failures`/`e2e-runtime-logs` artifacts will contain the run IDs and proxy request IDs to hand off for platform-side investigation.

## Testing

- `pnpm turbo typecheck --filter=@workflow/core` passes; example workbench builds cleanly through the SWC transform.
- Suite collects correctly (skips against local deployments as before); real validation happens in the `e2e-vercel-multi-region` CI job on this PR.