### PR TITLE
[world-vercel] Idempotent retry policy for stream close (5xx retriable)

### DIFF
--- a/.changeset/stream-close-retry.md
+++ b/.changeset/stream-close-retry.md
@@ -1,0 +1,12 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Retry stream close on retriable 5xx. Unlike chunk appends (which are not
+idempotent and deliberately never retry 5xx), closing a stream is
+idempotent on the server — a duplicate close of a completed stream is a
+no-op — and the server may surface transient close-time reconciliation
+states as retriable 503s that expect the writer to close again. The
+close call now uses its own dispatcher retrying 429 and 5xx with
+Retry-After honored; chunk writes keep the narrowed no-5xx retry policy
+unchanged.

--- a/.changeset/stream-close-retry.md
+++ b/.changeset/stream-close-retry.md
@@ -2,11 +2,4 @@
 '@workflow/world-vercel': patch
 ---
 
-Retry stream close on retriable 5xx. Unlike chunk appends (which are not
-idempotent and deliberately never retry 5xx), closing a stream is
-idempotent on the server — a duplicate close of a completed stream is a
-no-op — and the server may surface transient close-time reconciliation
-states as retriable 503s that expect the writer to close again. The
-close call now uses its own dispatcher retrying 429 and 5xx with
-Retry-After honored; chunk writes keep the narrowed no-5xx retry policy
-unchanged.
+Retry stream close on retriable 5xx. Close is idempotent on the server (unlike chunk appends, which keep their no-5xx retry policy), and the server may return retriable 503s expecting the writer to close again.

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -8,7 +8,9 @@ import {
   EVENTS_AGENT_OPTIONS,
   getDispatcher,
   getEventsDispatcher,
+  getStreamCloseDispatcher,
   getStreamDispatcher,
+  STREAM_CLOSE_RETRY_OPTIONS,
   STREAM_RETRY_OPTIONS,
 } from './http-client.js';
 
@@ -59,6 +61,28 @@ describe('getStreamDispatcher', () => {
     for (const code of [500, 502, 503, 504]) {
       expect(STREAM_RETRY_OPTIONS.statusCodes).not.toContain(code);
     }
+  });
+
+  // Stream CLOSE is the one idempotent stream PUT: a duplicate close of a
+  // completed stream early-returns, and the server's close-barrier fence is
+  // an if_not_exists stamp a re-entered close resumes. The barrier protocol
+  // RELIES on close retrying 5xx: transient reconciliation failures (and
+  // unsafe close shapes awaiting in-flight backups) surface as retriable
+  // 503s with the stream left durably closing. Without 5xx here, that 503
+  // rejects writer.close() and the stream stays fenced until run expiry.
+  it('retries stream close on 5xx (idempotent, and the close barrier depends on it)', () => {
+    expect(STREAM_CLOSE_RETRY_OPTIONS.methods).toEqual(['PUT']);
+    for (const code of [429, 500, 502, 503, 504]) {
+      expect(STREAM_CLOSE_RETRY_OPTIONS.statusCodes).toContain(code);
+    }
+    expect(STREAM_CLOSE_RETRY_OPTIONS.retryAfter).toBe(true);
+  });
+
+  it('close uses its own shared dispatcher, distinct from the write dispatcher', () => {
+    expect(getStreamCloseDispatcher()).toBe(getStreamCloseDispatcher());
+    expect(getStreamCloseDispatcher()).not.toBe(getStreamDispatcher());
+    const custom = {};
+    expect(getStreamCloseDispatcher({ dispatcher: custom })).toBe(custom);
   });
 });
 

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -4,6 +4,7 @@ import type { APIConfig } from './utils.js';
 let _dispatcher: RetryAgent | undefined;
 let _eventsDispatcher: RetryAgent | undefined;
 let _streamDispatcher: RetryAgent | undefined;
+let _streamCloseDispatcher: RetryAgent | undefined;
 
 /** Shared between both agents — connection pooling and H1 pipelining tuning. */
 const BASE_AGENT_OPTIONS = {
@@ -86,6 +87,28 @@ export const STREAM_RETRY_OPTIONS: RetryHandler.RetryOptions = {
 };
 
 /**
+ * Retry options for stream CLOSE (the `X-Stream-Done` PUT). Unlike chunk
+ * appends, close is idempotent on the server: a duplicate close of a
+ * completed stream early-returns, and the close-barrier protocol's durable
+ * `closing` fence is an if_not_exists stamp that a re-entered close resumes
+ * — so a 5xx whose effect may or may not have applied is safe to retry,
+ * and the server's close barrier *relies* on it: a transient reconciliation
+ * failure (or an unsafe close shape awaiting in-flight backups) is surfaced
+ * as a retriable 503 with the stream left durably closing, expecting the
+ * writer to close again. Without 5xx here, that 503 would reject
+ * `writer.close()` outright and leave the stream fenced until run expiry.
+ * 429 keeps the same pass-through-to-queue reasoning as chunk writes not
+ * applying: close is one terminal request, so honoring Retry-After
+ * in-process is the cleaner behavior. Exported so a test can pin the
+ * close-is-retriable contract.
+ */
+export const STREAM_CLOSE_RETRY_OPTIONS: RetryHandler.RetryOptions = {
+  retryAfter: true,
+  methods: ['PUT'],
+  statusCodes: [429, 500, 502, 503, 504],
+};
+
+/**
  * Resolves the undici dispatcher for a request: the caller's override, or the
  * shared default agent (HTTP/1.1).
  */
@@ -111,6 +134,15 @@ export function getEventsDispatcher(config?: APIConfig): unknown {
  */
 export function getStreamDispatcher(config?: APIConfig): unknown {
   return config?.dispatcher ?? getDefaultStreamDispatcher();
+}
+
+/**
+ * Resolves the dispatcher for stream CLOSE: the caller's override, or the
+ * shared close agent whose retry policy includes 5xx — close is idempotent
+ * (see STREAM_CLOSE_RETRY_OPTIONS), unlike chunk appends.
+ */
+export function getStreamCloseDispatcher(config?: APIConfig): unknown {
+  return config?.dispatcher ?? getDefaultStreamCloseDispatcher();
 }
 
 /** Build a shared undici RetryAgent wrapping an Agent with the given options. */
@@ -168,4 +200,13 @@ function getDefaultStreamDispatcher(): RetryAgent {
     STREAM_RETRY_OPTIONS
   );
   return _streamDispatcher;
+}
+
+/** Shared agent for the idempotent stream close (5xx retriable). */
+function getDefaultStreamCloseDispatcher(): RetryAgent {
+  _streamCloseDispatcher ??= makeRetryDispatcher(
+    EVENTS_AGENT_OPTIONS,
+    STREAM_CLOSE_RETRY_OPTIONS
+  );
+  return _streamCloseDispatcher;
 }

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -6,7 +6,10 @@ import {
   type StreamInfoResponse,
 } from '@workflow/world';
 import { z } from 'zod';
-import { getStreamDispatcher } from './http-client.js';
+import {
+  getStreamCloseDispatcher,
+  getStreamDispatcher,
+} from './http-client.js';
 import { getVercelDiagnostics, instrumentedFetch } from './http-core.js';
 import {
   WorkflowRunId,
@@ -271,7 +274,11 @@ export function createStreamer(config?: APIConfig): Streamer {
           method: 'PUT',
           url: url.toString(),
           headers: httpConfig.headers,
-          dispatcher: getStreamDispatcher(config),
+          // Close is idempotent (unlike chunk appends), so its dispatcher
+          // retries 5xx — required by the server's close-barrier protocol,
+          // which surfaces transient reconciliation states as retriable
+          // 503s with the stream left durably closing.
+          dispatcher: getStreamCloseDispatcher(config),
           timeoutMs: null,
           logLabel: url.pathname,
           spanName: 'workflow.stream.write',


### PR DESCRIPTION
Stream close is the one idempotent stream PUT, and its retry policy now reflects that.

## Why

Chunk appends deliberately never retry 5xx: a 5xx can mean the chunk *was* written but the response failed, and a retry would duplicate it (`STREAM_RETRY_OPTIONS`, unchanged here). Close is different:

- A duplicate close of a completed stream is a server-side no-op, so re-sending it is always safe.
- The server may surface transient close-time reconciliation states (e.g., storage backups still landing when the close is processed) as **retriable 503s that expect the writer to close again** — under the write dispatcher's no-5xx policy, that 503 rejected `writer.close()` outright, turning a self-healing timing condition into a user-visible stream error.

## What changed

- New `STREAM_CLOSE_RETRY_OPTIONS` and a dedicated shared `RetryAgent` for the close PUT: retries 429 + 500/502/503/504 plus transient connection errors, honoring `Retry-After`.
- `streamer.ts` `close()` switched to the new dispatcher. Chunk writes (`write`/`writeMulti`) keep the narrowed no-5xx policy unchanged.
- Contract pinned by tests: 5xx present in the close retry set, absent from the write retry set, distinct shared dispatchers, caller-supplied dispatcher still respected.

## Notes for reviewers

- Close-as-fence semantics: once a close has been issued, a concurrent slow write to the same stream may be refused by the server rather than silently included — the changelog entry for the next release should carry a line to that effect.
- All 299 `world-vercel` tests green; the change is confined to `http-client.ts` / `streamer.ts` plus tests and a changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)