### PR TITLE
[builders] Add opt-out for discovering workflows in node_modules

### DIFF
--- a/.changeset/discover-workflows-in-node-modules-opt-out.md
+++ b/.changeset/discover-workflows-in-node-modules-opt-out.md
@@ -2,4 +2,4 @@
 '@workflow/builders': minor
 ---
 
-Add a `discoverWorkflowsInNodeModules` option (and `WORKFLOW_DISCOVER_NODE_MODULES` env var) to opt out of discovering `"use workflow"`/`"use step"` files inside `node_modules`.
+Add a `discoverWorkflowsInNodeModules` option (and `WORKFLOW_DISCOVER_NODE_MODULES` env var) to stop workflow discovery from descending into `node_modules`, skipping the cost of scanning third-party dependencies for workflow/step/serde code.

--- a/.changeset/discover-workflows-in-node-modules-opt-out.md
+++ b/.changeset/discover-workflows-in-node-modules-opt-out.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': minor
+---
+
+Add a `discoverWorkflowsInNodeModules` option (and `WORKFLOW_DISCOVER_NODE_MODULES` env var) to opt out of discovering `"use workflow"`/`"use step"` files inside `node_modules`.

--- a/docs/content/docs/v5/configuration/build-and-diagnostics.mdx
+++ b/docs/content/docs/v5/configuration/build-and-diagnostics.mdx
@@ -42,6 +42,17 @@ Accepted values:
 - Set `1` to expose the workflow manifest at `/.well-known/workflow/v1/manifest.json`.
 - Useful for e2e tests and tools that need to discover workflows over HTTP.
 
+## Discovery
+
+### `WORKFLOW_DISCOVER_NODE_MODULES`
+
+- Framework option: `discoverWorkflowsInNodeModules` where supported
+- Default: enabled
+- Controls whether `"use workflow"` and `"use step"` files inside `node_modules` are discovered and compiled into your app's bundles. By default, dependencies that declare a `workflow`/`@workflow/*` dependency can ship workflow code that is discovered and transformed.
+- Set `0` or `false` to opt out — files under `node_modules` are no longer registered as workflows or steps, so third-party workflow code is neither transformed nor bundled. Useful when a dependency ships workflow code you don't want compiled into your app, or trips discovery with directive strings you don't intend to run.
+- Serde class discovery (including the SDK's own runtime classes) is unaffected.
+- Explicit framework config wins over this environment variable.
+
 ## Development diagnostics
 
 ### `WORKFLOW_DEV_HMR_LOGS`

--- a/docs/content/docs/v5/configuration/build-and-diagnostics.mdx
+++ b/docs/content/docs/v5/configuration/build-and-diagnostics.mdx
@@ -48,9 +48,9 @@ Accepted values:
 
 - Framework option: `discoverWorkflowsInNodeModules` where supported
 - Default: enabled
-- Controls whether `"use workflow"` and `"use step"` files inside `node_modules` are discovered and compiled into your app's bundles. By default, dependencies that declare a `workflow`/`@workflow/*` dependency can ship workflow code that is discovered and transformed.
-- Set `0` or `false` to opt out — files under `node_modules` are no longer registered as workflows or steps, so third-party workflow code is neither transformed nor bundled. Useful when a dependency ships workflow code you don't want compiled into your app, or trips discovery with directive strings you don't intend to run.
-- Serde class discovery (including the SDK's own runtime classes) is unaffected.
+- Controls whether workflow discovery descends into `node_modules`. By default, dependencies that declare a `workflow`/`@workflow/*` dependency can ship `"use workflow"`/`"use step"` files that are discovered and compiled into your app's bundles.
+- Set `0` or `false` to opt out — imports from your application code that resolve into `node_modules` are not followed, so the build never reads, scans, or descends into dependency file graphs. This skips the cost of scanning `node_modules` and stops third-party workflow/step/serde code from being discovered. Useful when a dependency ships workflow code you don't want compiled into your app, or trips discovery with directive strings you don't intend to run.
+- The SDK's own runtime serde classes (e.g. `Run`) stay registered — they are reached through a seeded entry point, and imports *within* `node_modules` are still followed.
 - Explicit framework config wins over this environment variable.
 
 ## Development diagnostics

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -97,6 +97,18 @@ function parseSourcemapEnv(
   }
 }
 
+/**
+ * Parse the value of the `WORKFLOW_DISCOVER_NODE_MODULES` environment variable
+ * into a boolean. Returns `undefined` if the env var is unset or empty so
+ * callers can fall back to config/default.
+ */
+function parseDiscoverNodeModulesEnv(
+  value: string | undefined
+): boolean | undefined {
+  if (value === undefined || value === '') return undefined;
+  return value !== '0' && value !== 'false';
+}
+
 function formatBuildDuration(durationMs: number): string {
   if (durationMs < 1000) {
     return `${durationMs}ms`;
@@ -611,6 +623,8 @@ export abstract class BaseBuilder {
       state,
       defaultTsconfigPath: effectiveTsconfigPath,
       workingDir: this.config.workingDir,
+      discoverWorkflowsInNodeModules:
+        this.resolveDiscoverWorkflowsInNodeModules(),
     });
 
     this.logBaseBuilderInfo(
@@ -2321,6 +2335,23 @@ export const OPTIONS = handler;`;
     const envMode = parseSourcemapEnv(process.env.WORKFLOW_SOURCEMAP);
     if (envMode !== undefined) return envMode;
     return defaultMode;
+  }
+
+  /**
+   * Resolve whether workflow/step files under `node_modules` are discovered.
+   * Precedence: explicit `discoverWorkflowsInNodeModules` config > the
+   * `WORKFLOW_DISCOVER_NODE_MODULES` env var (`0`/`false` disables) > the
+   * default (`true`, discover them).
+   */
+  protected resolveDiscoverWorkflowsInNodeModules(): boolean {
+    if (this.config.discoverWorkflowsInNodeModules !== undefined) {
+      return this.config.discoverWorkflowsInNodeModules;
+    }
+    const envValue = parseDiscoverNodeModulesEnv(
+      process.env.WORKFLOW_DISCOVER_NODE_MODULES
+    );
+    if (envValue !== undefined) return envValue;
+    return true;
   }
 
   /**

--- a/packages/builders/src/fast-discovery.test.ts
+++ b/packages/builders/src/fast-discovery.test.ts
@@ -171,7 +171,7 @@ describe('fast workflow discovery', () => {
     ).toBe(true);
   });
 
-  it('skips node_modules workflow files when discoverWorkflowsInNodeModules is false', async () => {
+  it('does not descend into node_modules when discoverWorkflowsInNodeModules is false', async () => {
     const entryFile = join(testRoot, 'src', 'entry.ts');
     const localWorkflow = join(testRoot, 'src', 'local-workflow.ts');
     const packageRoot = join(testRoot, 'node_modules', 'workflow-pkg');
@@ -236,6 +236,58 @@ describe('fast workflow discovery', () => {
       false
     );
     expect(discovered.discoveredSteps.has(normalize(packageStep))).toBe(false);
+    // The dependency's files are never read/scanned: the import graph is not
+    // descended into at all, so none of them show up as discovered files and
+    // the parent edge into the package is not recorded.
+    for (const file of [packageIndex, packageWorkflow, packageStep]) {
+      expect(discovered.discoveredFiles?.has(normalize(file))).toBe(false);
+    }
+    expect(parentHasChild(normalize(entryFile), normalize(packageIndex))).toBe(
+      false
+    );
+  });
+
+  it('still follows imports within node_modules so seeded package entries resolve their subtree', async () => {
+    // Mirrors how the SDK seeds `@workflow/core/runtime/run` (a node_modules
+    // file) as an entry point: descent is blocked from application code, but a
+    // node_modules file may still reach its own transitive files.
+    const entryFile = join(testRoot, 'src', 'entry.ts');
+    const packageRoot = join(testRoot, 'node_modules', 'seeded-pkg');
+    const packageIndex = join(packageRoot, 'index.js');
+    const packageWorkflow = join(packageRoot, 'workflow.js');
+
+    writeFile(entryFile, `export const noop = 1;\n`);
+    writeFile(
+      join(packageRoot, 'package.json'),
+      JSON.stringify({
+        name: 'seeded-pkg',
+        version: '1.0.0',
+        main: 'index.js',
+        dependencies: { workflow: '^1.0.0' },
+      })
+    );
+    writeFile(packageIndex, `export { run } from './workflow.js';\n`);
+    writeFile(
+      packageWorkflow,
+      `export async function run() {
+  "use workflow";
+  return "ok";
+}
+`
+    );
+
+    // Seed the node_modules index directly as an entry point (as the builder
+    // does for the SDK runtime serde entry).
+    const discovered = await createBuilder(testRoot, {
+      discoverWorkflowsInNodeModules: false,
+    }).discoverEntriesPublic([entryFile, packageIndex], join(testRoot, 'out'));
+
+    expect(discovered.discoveredWorkflows.has(normalize(packageWorkflow))).toBe(
+      true
+    );
+    expect(
+      parentHasChild(normalize(packageIndex), normalize(packageWorkflow))
+    ).toBe(true);
   });
 
   it('discovers files reached through tsconfig path aliases', async () => {

--- a/packages/builders/src/fast-discovery.test.ts
+++ b/packages/builders/src/fast-discovery.test.ts
@@ -47,7 +47,10 @@ function writeFile(path: string, contents: string): void {
   writeFileSync(path, contents, 'utf-8');
 }
 
-function createBuilder(workingDir: string): TestBuilder {
+function createBuilder(
+  workingDir: string,
+  overrides?: Partial<StandaloneConfig>
+): TestBuilder {
   const config: StandaloneConfig = {
     buildTarget: 'standalone',
     workingDir,
@@ -55,6 +58,7 @@ function createBuilder(workingDir: string): TestBuilder {
     stepsBundlePath: join(workingDir, 'steps.js'),
     workflowsBundlePath: join(workingDir, 'workflows.js'),
     webhookBundlePath: join(workingDir, 'webhook.js'),
+    ...overrides,
   };
   return new TestBuilder(config);
 }
@@ -165,6 +169,73 @@ describe('fast workflow discovery', () => {
     expect(
       parentHasChild(normalize(packageIndex), normalize(packageWorkflow))
     ).toBe(true);
+  });
+
+  it('skips node_modules workflow files when discoverWorkflowsInNodeModules is false', async () => {
+    const entryFile = join(testRoot, 'src', 'entry.ts');
+    const localWorkflow = join(testRoot, 'src', 'local-workflow.ts');
+    const packageRoot = join(testRoot, 'node_modules', 'workflow-pkg');
+    const packageIndex = join(packageRoot, 'index.js');
+    const packageWorkflow = join(packageRoot, 'workflow.js');
+    const packageStep = join(packageRoot, 'step.js');
+
+    writeFile(
+      entryFile,
+      `import './local-workflow';\nimport { run } from 'workflow-pkg';\nvoid run;\n`
+    );
+    writeFile(
+      localWorkflow,
+      `export async function localRun() {
+  'use workflow';
+  return 'ok';
+}
+`
+    );
+    writeFile(
+      join(packageRoot, 'package.json'),
+      JSON.stringify({
+        name: 'workflow-pkg',
+        version: '1.0.0',
+        main: 'index.js',
+        dependencies: {
+          workflow: '^1.0.0',
+        },
+      })
+    );
+    writeFile(
+      packageIndex,
+      `export { run } from './workflow.js';\nexport { doWork } from './step.js';\n`
+    );
+    writeFile(
+      packageWorkflow,
+      `export async function run() {
+  "use workflow";
+  return "ok";
+}
+`
+    );
+    writeFile(
+      packageStep,
+      `export async function doWork() {
+  "use step";
+  return "done";
+}
+`
+    );
+
+    const discovered = await createBuilder(testRoot, {
+      discoverWorkflowsInNodeModules: false,
+    }).discoverEntriesPublic([entryFile], join(testRoot, 'out'));
+
+    // Local (non-node_modules) workflow is still discovered.
+    expect(discovered.discoveredWorkflows).toEqual(
+      new Set([normalize(localWorkflow)])
+    );
+    // The node_modules workflow and step are not registered.
+    expect(discovered.discoveredWorkflows.has(normalize(packageWorkflow))).toBe(
+      false
+    );
+    expect(discovered.discoveredSteps.has(normalize(packageStep))).toBe(false);
   });
 
   it('discovers files reached through tsconfig path aliases', async () => {

--- a/packages/builders/src/fast-discovery.ts
+++ b/packages/builders/src/fast-discovery.ts
@@ -62,6 +62,13 @@ interface FastDiscoverEntriesOptions {
   state: DiscoveredEntries;
   defaultTsconfigPath: string | undefined;
   workingDir: string;
+  /**
+   * Whether files located under `node_modules` may be registered as workflows
+   * or steps. When `false`, third-party workflow/step files are skipped so
+   * their code is neither transformed nor bundled. Import traversal and serde
+   * discovery are unaffected. Defaults to `true`.
+   */
+  discoverWorkflowsInNodeModules?: boolean;
 }
 
 interface PackageInfo {
@@ -638,6 +645,7 @@ export async function fastDiscoverEntries({
   state,
   defaultTsconfigPath,
   workingDir,
+  discoverWorkflowsInNodeModules = true,
 }: FastDiscoverEntriesOptions): Promise<void> {
   const readLimit = createLimiter(FAST_DISCOVERY_READ_CONCURRENCY);
   const resolveLimit = createLimiter(FAST_DISCOVERY_RESOLVE_CONCURRENCY);
@@ -960,10 +968,17 @@ export async function fastDiscoverEntries({
     }
 
     const patterns = detectWorkflowPatterns(source);
-    if (patterns.hasUseWorkflow) {
+    // When node_modules discovery is opted out, files under node_modules are
+    // not registered as workflows or steps (so third-party workflow code is
+    // neither transformed nor bundled). Serde registration and import
+    // traversal below are intentionally left intact — the SDK seeds its own
+    // runtime serde entry point, which lives in node_modules.
+    const registerWorkflowsAndSteps =
+      discoverWorkflowsInNodeModules || !isNodeModulesPath(filePath);
+    if (patterns.hasUseWorkflow && registerWorkflowsAndSteps) {
       state.discoveredWorkflows.add(filePath);
     }
-    if (patterns.hasUseStep) {
+    if (patterns.hasUseStep && registerWorkflowsAndSteps) {
       state.discoveredSteps.add(filePath);
     }
     if (patterns.hasSerde && hasLikelySerdeClass(source)) {

--- a/packages/builders/src/fast-discovery.ts
+++ b/packages/builders/src/fast-discovery.ts
@@ -63,10 +63,12 @@ interface FastDiscoverEntriesOptions {
   defaultTsconfigPath: string | undefined;
   workingDir: string;
   /**
-   * Whether files located under `node_modules` may be registered as workflows
-   * or steps. When `false`, third-party workflow/step files are skipped so
-   * their code is neither transformed nor bundled. Import traversal and serde
-   * discovery are unaffected. Defaults to `true`.
+   * Whether workflow discovery descends into `node_modules`. When `false`,
+   * imports from application code that resolve into `node_modules` are not
+   * followed, so no dependency file is read, scanned, or registered — third
+   * party workflow/step/serde code is neither transformed nor bundled. Imports
+   * *within* `node_modules` are still followed, so the SDK's own seeded runtime
+   * serde entry keeps discovering its transitive classes. Defaults to `true`.
    */
   discoverWorkflowsInNodeModules?: boolean;
 }
@@ -943,6 +945,20 @@ export async function fastDiscoverEntries({
       return;
     }
 
+    // Opt-out: don't descend into node_modules from application code. This
+    // stops workflow discovery from reading, scanning, or following any
+    // third-party dependency's file graph. Imports *within* node_modules are
+    // still followed (importer already under node_modules), so the SDK's own
+    // seeded runtime serde entry point keeps discovering its transitive
+    // classes (e.g. `Run`) even though it lives under node_modules.
+    if (
+      !discoverWorkflowsInNodeModules &&
+      isNodeModulesPath(resolved) &&
+      !isNodeModulesPath(filePath)
+    ) {
+      return;
+    }
+
     addImportParent(filePath, resolved);
     if (!isJsTsFile(resolved) || isGeneratedBuildArtifactPath(resolved)) {
       return;
@@ -968,17 +984,10 @@ export async function fastDiscoverEntries({
     }
 
     const patterns = detectWorkflowPatterns(source);
-    // When node_modules discovery is opted out, files under node_modules are
-    // not registered as workflows or steps (so third-party workflow code is
-    // neither transformed nor bundled). Serde registration and import
-    // traversal below are intentionally left intact — the SDK seeds its own
-    // runtime serde entry point, which lives in node_modules.
-    const registerWorkflowsAndSteps =
-      discoverWorkflowsInNodeModules || !isNodeModulesPath(filePath);
-    if (patterns.hasUseWorkflow && registerWorkflowsAndSteps) {
+    if (patterns.hasUseWorkflow) {
       state.discoveredWorkflows.add(filePath);
     }
-    if (patterns.hasUseStep && registerWorkflowsAndSteps) {
+    if (patterns.hasUseStep) {
       state.discoveredSteps.add(filePath);
     }
     if (patterns.hasSerde && hasLikelySerdeClass(source)) {

--- a/packages/builders/src/types.ts
+++ b/packages/builders/src/types.ts
@@ -97,6 +97,25 @@ interface BaseWorkflowConfig {
    * config wins over env var, env var wins over the default.
    */
   sourcemap?: SourcemapMode;
+
+  /**
+   * Whether to discover workflow (`"use workflow"`) and step (`"use step"`)
+   * files inside `node_modules`. Defaults to `true`: workflow/step files
+   * shipped by dependencies that declare a `workflow`/`@workflow/*` dependency
+   * are discovered and compiled into the app's bundles.
+   *
+   * Set to `false` to opt out — files located under `node_modules` are no
+   * longer registered as workflows or steps, so third-party workflow code is
+   * neither transformed nor bundled. Useful when a dependency ships workflow
+   * code you don't want compiled into your app, or trips discovery with
+   * `"use workflow"`/`"use step"` strings you don't intend to run. Serde class
+   * discovery (including the SDK's own runtime classes) is unaffected.
+   *
+   * Can also be set via the `WORKFLOW_DISCOVER_NODE_MODULES` environment
+   * variable (`0`/`false` to disable); config wins over env var, env var wins
+   * over the default.
+   */
+  discoverWorkflowsInNodeModules?: boolean;
 }
 
 /**

--- a/packages/builders/src/types.ts
+++ b/packages/builders/src/types.ts
@@ -99,17 +99,22 @@ interface BaseWorkflowConfig {
   sourcemap?: SourcemapMode;
 
   /**
-   * Whether to discover workflow (`"use workflow"`) and step (`"use step"`)
-   * files inside `node_modules`. Defaults to `true`: workflow/step files
-   * shipped by dependencies that declare a `workflow`/`@workflow/*` dependency
-   * are discovered and compiled into the app's bundles.
+   * Whether workflow discovery descends into `node_modules`. Defaults to
+   * `true`: workflow/step/serde files shipped by dependencies that declare a
+   * `workflow`/`@workflow/*` dependency are discovered and compiled into the
+   * app's bundles.
    *
-   * Set to `false` to opt out — files located under `node_modules` are no
-   * longer registered as workflows or steps, so third-party workflow code is
-   * neither transformed nor bundled. Useful when a dependency ships workflow
-   * code you don't want compiled into your app, or trips discovery with
-   * `"use workflow"`/`"use step"` strings you don't intend to run. Serde class
-   * discovery (including the SDK's own runtime classes) is unaffected.
+   * Set to `false` to opt out — imports from your application code that resolve
+   * into `node_modules` are not followed, so the build never reads, scans, or
+   * descends into dependency file graphs. This skips the cost of scanning
+   * `node_modules` and stops third-party workflow/step/serde code from being
+   * discovered. Useful when a dependency ships workflow code you don't want
+   * compiled into your app, or trips discovery with `"use workflow"`/`"use
+   * step"` strings you don't intend to run.
+   *
+   * The SDK's own runtime serde classes (e.g. `Run`) stay registered: they are
+   * reached through a seeded entry point that lives under `node_modules`, and
+   * imports *within* `node_modules` are still followed.
    *
    * Can also be set via the `WORKFLOW_DISCOVER_NODE_MODULES` environment
    * variable (`0`/`false` to disable); config wins over env var, env var wins


### PR DESCRIPTION
## Summary

Adds an opt-out that stops workflow discovery from **descending into `node_modules`**.

Today, `getInputFiles()` excludes `node_modules`, but the fast-discovery import-graph walk follows imports into any dependency that declares a `workflow`/`@workflow/*` dependency and reads/scans its files (registering the workflow/step/serde files it finds). There was no way to turn that off. This PR adds one.

## What's added

- **Config option** — `discoverWorkflowsInNodeModules?: boolean` on `BaseWorkflowConfig` (default `true`, current behavior).
- **Env var** — `WORKFLOW_DISCOVER_NODE_MODULES` (`0`/`false` to disable). Precedence mirrors `sourcemap`: config > env var > default.
- **Behavior when disabled** — imports from application code that resolve into `node_modules` are not followed, so the build never reads, scans, or descends into dependency file graphs. This skips the scanning cost and stops third-party workflow/step/serde code from being discovered.

## Implementation

The gate is a single stateless rule in `processImportSpecifier`: when opted out, skip an import whose resolved target is under `node_modules` **if the importer is not itself under `node_modules`**. Application code therefore can't pull third-party dependencies into discovery, but imports *within* `node_modules` are still followed.

That last part is deliberate and load-bearing: in an installed app `@workflow/core` lives under `node_modules`, and the SDK seeds `@workflow/core/runtime/run` as an entry point so built-in serde classes (`Run`, plus its transitive `serialization.js`/`runs.js`) get registered. Because the seeded entry is itself under `node_modules`, it keeps traversing its own subtree — so **the SDK's own serde discovery is preserved**; only third-party `node_modules` descent is dropped.

## Tests

- `fast-discovery.test.ts`: a dependency's files are never read/scanned/traversed when the option is `false` (asserts they're absent from `discoveredFiles` and no parent edge into the package is recorded). Mutation-verified: fails without the gate, passes with it.
- A companion test seeds a `node_modules` package as an entry point (mirroring the SDK runtime serde entry) and asserts its subtree is still discovered — proving the SDK-serde carve-out.
- Existing `src` suite green (17/17 in the file); `pnpm typecheck` clean.

## Docs

Documented `WORKFLOW_DISCOVER_NODE_MODULES` in `docs/content/docs/v5/configuration/build-and-diagnostics.mdx`.

## Docs Preview

| Page | Preview |
| :--- | :--- |
| Build and Diagnostics → Discovery | [`/v5/docs/configuration/build-and-diagnostics#discovery`](https://workflow-docs-2f0yub32f.vercel.sh/v5/docs/configuration/build-and-diagnostics#discovery) |

_(Preview is behind Vercel deployment protection; requires team access.)_

## Follow-up (not in this PR)

The option is exposed as a builders config field + env var only. Surfacing it as a first-class framework option (e.g. `withWorkflow({ discoverWorkflowsInNodeModules })`) is a possible follow-up; the env var already works across all integrations today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
