### PR TITLE
[world-testing] Fix Unit Tests flake after adding event-limit test

### DIFF
--- a/.changeset/fix-world-testing-shared-data-dir.md
+++ b/.changeset/fix-world-testing-shared-data-dir.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-testing": patch
+---
+
+Fix flaky Local World tests caused by concurrent test servers sharing one data directory and re-enqueuing each other's in-flight runs on startup

--- a/packages/world-testing/src/util.mts
+++ b/packages/world-testing/src/util.mts
@@ -1,5 +1,9 @@
 import cp from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { WorkflowRunSchema } from '@workflow/world';
 import chalk, { type ChalkInstance } from 'chalk';
@@ -30,17 +34,30 @@ export async function startServer(opts: {
     serverPath = new URL('./server.mjs', import.meta.url);
   }
 
+  // Give each spawned server its own data directory. The Local World's default
+  // (untagged) `.workflow-data` dir is otherwise shared by every concurrently
+  // running test file's server, and its startup recovery sweep re-enqueues
+  // every untagged run it finds — including runs still mid-flight in another
+  // test's server — dispatching them against the same on-disk event log and
+  // racing the run's actual owner into spurious `ReplayDivergenceError`s.
+  const dataDir = join(
+    tmpdir(),
+    `workflow-world-testing-${process.pid}-${randomUUID()}`
+  );
+
   const proc = cp.spawn('node', [fileURLToPath(serverPath)], {
     stdio: ['ignore', 'pipe', 'pipe', 'pipe'],
     env: {
       ...process.env,
       WORKFLOW_TARGET_WORLD: opts.world,
       CONTROL_FD: '3',
+      WORKFLOW_LOCAL_DATA_DIR: dataDir,
       ...(opts.env ?? {}),
     },
   });
   onTestFinished(() => {
     proc.kill();
+    void rm(dataDir, { recursive: true, force: true });
   });
 
   const stdio = [] as { stream: ChalkInstance; chunk: string }[];

--- a/packages/world-testing/src/util.mts
+++ b/packages/world-testing/src/util.mts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import { WorkflowRunSchema } from '@workflow/world';
 import chalk, { type ChalkInstance } from 'chalk';
@@ -55,9 +56,31 @@ export async function startServer(opts: {
       ...(opts.env ?? {}),
     },
   });
-  onTestFinished(() => {
-    proc.kill();
-    void rm(dataDir, { recursive: true, force: true });
+  onTestFinished(async () => {
+    // Wait for the child to actually exit before removing its data directory:
+    // `kill()` only requests termination, and on Windows `rm()` fails with
+    // EPERM/EBUSY while the server still holds file handles in `dataDir`.
+    if (proc.exitCode === null && proc.signalCode === null) {
+      const exited = new Promise<void>((resolve) => {
+        proc.once('exit', () => resolve());
+      });
+      proc.kill();
+      // Bounded, so a child that refuses to die can't hang test teardown.
+      await Promise.race([
+        exited,
+        setTimeout(5_000, undefined, { ref: false }),
+      ]);
+    }
+    // Windows can hold the handles for a moment past exit, hence the retries.
+    // A leaked temp dir is not worth failing an otherwise passing test over.
+    await rm(dataDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    }).catch((err) => {
+      console.warn(`Failed to remove test data dir ${dataDir}:`, err);
+    });
   });
 
   const stdio = [] as { stream: ChalkInstance; chunk: string }[];


### PR DESCRIPTION
## Summary

Windows Unit Tests failed on main's changeset-release PR (#3028) at the new `event-limit.test.ts` test (added in #2986):

```
FAIL test/event-limit.test.ts > fails a runaway run at the server-supplied event limit (turbo=1)
AssertionError: expected 'CORRUPTED_EVENT_LOG' to be 'MAX_EVENTS_EXCEEDED'
```

`CORRUPTED_EVENT_LOG` means the run hit `ReplayDivergenceError` 3+ times (`REPLAY_DIVERGENCE_MAX_RETRIES`) before the max-events guard could cleanly fail it.

## Root cause

Every `startServer()` call in `world-testing` spawns a fresh Local World server process against the **shared, untagged** `.workflow-data` directory (no `tag`, no isolated `dataDir`). The Local World's `start()` defaults `recoverActiveRuns` to `true` and, when untagged, its recovery sweep lists *every* untagged run in that shared directory — not just the ones the current process created (see the comment in `packages/world-local/src/index.ts` around the `isUntagged` filter).

So a server spawned by one test file, starting up while another test file's run is still mid-flight, re-enqueues that foreign run into its own in-process queue and dispatches it against the same on-disk event log — racing the run's actual owner. That produces spurious `ReplayDivergenceError`s under enough concurrency (the full suite, as CI runs it), which is why it reproduced on the Windows job's own head-to-head run but not on a solo re-run of the file.

Confirmed locally: running the full `world-testing` suite concurrently (6x in parallel, simulating CI-level file-level concurrency) reliably produced `idempotency` timeouts and `inline-batches-debug` failures before the fix, and passed cleanly 6/6 after.

## Fix

Give each spawned server its own `WORKFLOW_LOCAL_DATA_DIR` (a unique temp dir), removing the shared state entirely. Cleaned up in `onTestFinished`.

## Testing

- `pnpm build && npx vitest run` in `packages/world-testing`: 3/3 files, 15/15 tests pass.
- 6x concurrent full-suite runs (90 tests total): all pass, no flakes (previously reproduced the same failure family as CI).