### PR TITLE
Animate new trace viewer zoom controls

### DIFF
--- a/.changeset/smooth-timeline-zoom.md
+++ b/.changeset/smooth-timeline-zoom.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Animate the new trace viewer's zoom controls consistently with span focus.

--- a/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
+++ b/packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx
@@ -213,8 +213,8 @@ function NewTraceViewerContent({
 
   const viewDuration = viewport.end - viewport.start;
 
-  // Keep a ref to the live viewport so the reveal callback can read the current
-  // zoom without being recreated on every pan (which would bust TimelineBar's
+  // Keep a ref to the live viewport so zoom callbacks can read the current
+  // range without being recreated on every pan (which would bust TimelineBar's
   // memo and re-render every row each animation frame).
   const viewportRef = useRef(viewport);
   viewportRef.current = viewport;
@@ -254,19 +254,17 @@ function NewTraceViewerContent({
 
   const zoomBy = useCallback(
     (factor: number) => {
-      setViewport((prev) => {
-        const center = (prev.start + prev.end) / 2;
-        const newDuration = Math.max(
-          MIN_VIEWPORT_MS,
-          (prev.end - prev.start) * factor
-        );
-        return clampToRoot({
+      const { start, end } = viewportRef.current;
+      const center = (start + end) / 2;
+      const newDuration = Math.max(MIN_VIEWPORT_MS, (end - start) * factor);
+      animateTo(
+        clampToRoot({
           start: center - newDuration / 2,
           end: center + newDuration / 2,
-        });
-      });
+        })
+      );
     },
-    [setViewport, clampToRoot]
+    [animateTo, clampToRoot]
   );
 
   const zoomIn = useCallback(() => zoomBy(ZOOM_FACTOR), [zoomBy]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Use the new trace viewer's existing viewport animation when zooming in or out with the timeline controls, matching the animation used when focusing a span.

### How did you test your changes?

- `pnpm --filter @workflow/web-shared... build`
- `pnpm --filter @workflow/web-shared exec vitest run src/components/new-trace-viewer/utils.test.ts` (33 passed)
- `pnpm exec biome check packages/web-shared/src/components/new-trace-viewer/trace-viewer.tsx .changeset/smooth-timeline-zoom.md`
- `pnpm changeset status --since=main`
- Full `@workflow/web-shared` test run: 158 passed, with the two zstd compatibility tests unable to run because this environment uses Node 22.14.0, which does not expose `zlib.zstdCompressSync`.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - Uses a patch changeset for `@workflow/web-shared`.
- [x] 🔒 DCO sign-off passes (commit created with `--signoff`)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-699a65ff-093b-449e-b181-c59312864fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-699a65ff-093b-449e-b181-c59312864fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

