### PR TITLE
test(e2e): force storage-backed inspect listings (read-your-writes) via WORKFLOW_DISABLE_ANALYTICS_READS

### DIFF
--- a/.changeset/inspect-storage-reads.md
+++ b/.changeset/inspect-storage-reads.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world-vercel": patch
+---
+
+Add `WORKFLOW_DISABLE_ANALYTICS_READS=1` to opt the world's `analytics` read namespace off, forcing `workflow inspect` list paths onto strongly consistent primary storage. Intended for tests and tooling that read entities immediately after writing them, where the analytics store's asynchronous ingestion can return stale pages.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2375,21 +2375,12 @@ describe('e2e', () => {
       // Verify that exactly 2 steps were executed:
       // 1. stepWithStepFunctionArg(doubleNumber)
       //   (doubleNumber(10) is run inside the stepWithStepFunctionArg step)
-      // The events listing prefers the analytics store, which ingests
-      // asynchronously — a read issued immediately after completion can
-      // miss the freshest events. Poll briefly until they land.
-      let stepCompletedEvents: unknown[] = [];
-      const eventsDeadline = Date.now() + 20_000;
-      while (Date.now() < eventsDeadline) {
-        const { json: eventsData } = await cliInspectJson(
-          `events --run ${run.runId} --json`
-        );
-        stepCompletedEvents = eventsData.filter(
-          (event) => event.eventType === 'step_completed'
-        );
-        if (stepCompletedEvents.length > 0) break;
-        await new Promise((resolve) => setTimeout(resolve, 1_000));
-      }
+      const { json: eventsData } = await cliInspectJson(
+        `events --run ${run.runId} --json`
+      );
+      const stepCompletedEvents = eventsData.filter(
+        (event) => event.eventType === 'step_completed'
+      );
       expect(stepCompletedEvents).toHaveLength(1);
     }
   );

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2375,12 +2375,21 @@ describe('e2e', () => {
       // Verify that exactly 2 steps were executed:
       // 1. stepWithStepFunctionArg(doubleNumber)
       //   (doubleNumber(10) is run inside the stepWithStepFunctionArg step)
-      const { json: eventsData } = await cliInspectJson(
-        `events --run ${run.runId} --json`
-      );
-      const stepCompletedEvents = eventsData.filter(
-        (event) => event.eventType === 'step_completed'
-      );
+      // The events listing prefers the analytics store, which ingests
+      // asynchronously — a read issued immediately after completion can
+      // miss the freshest events. Poll briefly until they land.
+      let stepCompletedEvents: unknown[] = [];
+      const eventsDeadline = Date.now() + 20_000;
+      while (Date.now() < eventsDeadline) {
+        const { json: eventsData } = await cliInspectJson(
+          `events --run ${run.runId} --json`
+        );
+        stepCompletedEvents = eventsData.filter(
+          (event) => event.eventType === 'step_completed'
+        );
+        if (stepCompletedEvents.length > 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+      }
       expect(stepCompletedEvents).toHaveLength(1);
     }
   );

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -298,7 +298,14 @@ export const cliInspectJson = async (args: string) => {
       ...inspectArgs,
       ...cliArgs,
     ],
-    cliAppPath
+    cliAppPath,
+    undefined,
+    {
+      // e2e assertions read entities immediately after writing them; the
+      // analytics store ingests asynchronously and can miss the freshest
+      // rows. Force the storage-backed list paths for determinism.
+      WORKFLOW_DISABLE_ANALYTICS_READS: '1',
+    }
   );
   if (!result.stdout.trim()) {
     throw new Error(

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -56,7 +56,14 @@ export function createWorld(config?: APIConfig): World {
     processExitTriggersQueueRedelivery: true,
     ...createQueue(config),
     ...createStorage(config),
-    analytics: createAnalytics(config),
+    // Analytics list reads are served from an eventually-ingested store.
+    // Tooling that needs read-your-writes listings immediately after a
+    // write (e.g. deterministic e2e assertions) can force the CLI/world
+    // list paths back onto primary storage by disabling the namespace.
+    analytics:
+      process.env.WORKFLOW_DISABLE_ANALYTICS_READS === '1'
+        ? undefined
+        : createAnalytics(config),
     ...instrumentObject('world.streams', createStreamer(config)),
     createRunId,
     describeRun,


### PR DESCRIPTION
## Problem

The e2e suites assert on `workflow inspect` listings (events, steps) **immediately after run completion**. Those listings prefer the world's `analytics` read namespace, which is served from an eventually-ingested store — a read racing ingestion can return a page that includes the run's earlier rows but not the freshest ones, so the CLI's empty-page storage fallback doesn't trigger and the assertion fails.

Observed fingerprints (all with the run demonstrably completed with correct status/output):
- `stepFunctionPassingWorkflow`: `expected [] to have a length of 1` on the `step_completed` events readback (two CI occurrences on different lanes).
- `instanceMethodStepWorkflow`: `counterSteps.every(status === 'completed')` false on the **steps** listing — same race, different resource (two occurrences on different lanes/days).

## Fix

Deterministic rather than bounded-wait (supersedes the earlier poll commit):

1. `@workflow/world-vercel`: `WORKFLOW_DISABLE_ANALYTICS_READS=1` opts the world's `analytics` namespace off, so every inspect list path falls back to strongly consistent primary storage.
2. e2e `cliInspectJson` sets that env for its spawned CLI invocations — every entity readback in the suites becomes read-your-writes, covering both observed variants and any future listing assertions, with no per-test changes.

Production behavior is unchanged (the env is opt-in); the analytics-backed listings remain the CLI default everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)