### PR TITLE
Add Rivet World to worlds-manifest.json

### DIFF
--- a/.changeset/add-rivet-community-world.md
+++ b/.changeset/add-rivet-community-world.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Rivet to the community Worlds manifest.

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -59,6 +59,22 @@
       "requiresDeployment": true
     },
     {
+      "id": "rivet",
+      "type": "community",
+      "package": "@rivet-dev/vercel-world",
+      "name": "Rivet",
+      "description": "A Vercel World powered by Rivet Actors.",
+      "repository": "https://github.com/rivet-dev/rivet/tree/main/integrations/vercel-world",
+      "docs": "https://rivet.dev/integrations/vercel-workflows/",
+      "example": "https://github.com/rivet-dev/rivet/tree/main/examples/vercel-workflow",
+      "features": [],
+      "env": {
+        "WORKFLOW_TARGET_WORLD": "@rivet-dev/vercel-world",
+        "WORKFLOW_RUNTIME_URL": "http://127.0.0.1:3000"
+      },
+      "services": []
+    },
+    {
       "id": "turso",
       "type": "community",
       "package": "@workflow-worlds/turso",

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -61,15 +61,15 @@
     {
       "id": "rivet",
       "type": "community",
-      "package": "@rivet-dev/vercel-world",
+      "package": "@rivet-dev/workflow-world",
       "name": "Rivet",
-      "description": "A Vercel World powered by Rivet Actors.",
-      "repository": "https://github.com/rivet-dev/rivet/tree/main/integrations/vercel-world",
-      "docs": "https://rivet.dev/integrations/vercel-workflows/",
-      "example": "https://github.com/rivet-dev/rivet/tree/main/examples/vercel-workflow",
+      "description": "Workflow World powered by Rivet Actors.",
+      "repository": "https://github.com/rivet-dev/rivet/tree/main/integrations/workflow-world",
+      "docs": "https://rivet.dev/actors/integrations/workflow-sdk/",
+      "example": "https://github.com/rivet-dev/rivet/tree/main/examples/workflow-sdk",
       "features": [],
       "env": {
-        "WORKFLOW_TARGET_WORLD": "@rivet-dev/vercel-world",
+        "WORKFLOW_TARGET_WORLD": "@rivet-dev/workflow-world",
         "WORKFLOW_RUNTIME_URL": "http://127.0.0.1:3000"
       },
       "services": []


### PR DESCRIPTION
### Description

Adds [`@rivet-dev/vercel-world`](https://www.npmjs.com/package/@rivet-dev/vercel-world) to `worlds-manifest.json` as a community World.

The package implements Vercel's World interface with Rivet Actors.

- [Source](https://github.com/rivet-dev/rivet/tree/main/integrations/vercel-world)
- [Documentation](https://rivet.dev/integrations/vercel-workflows/)
- [Example](https://github.com/rivet-dev/rivet/tree/main/examples/vercel-workflow)

### How did you test your changes?

- Ran `jq empty worlds-manifest.json`.
- Ran `node scripts/create-community-worlds-matrix.mjs` and verified the generated `rivet` entry.
- Ran `pnpm dlx @changesets/cli@2.29.8 status --since=upstream/main`.
- Ran `git diff --check`.
- Verified the source, documentation, example, and npm registry links return HTTP 200.
- Verified `@rivet-dev/vercel-world@2.3.7` is published on npm.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - An empty changeset is included because this is a manifest-only change.
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [x] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
