### PR TITLE
[benchmarks] Add SO (stream overhead) scenario + collapse PR-comment smallprint

### DIFF
--- a/.changeset/sharp-points-occur.md
+++ b/.changeset/sharp-points-occur.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a Stream Overhead (SO) benchmark scenario modelling an LLM token stream, and collapse the benchmark PR-comment smallprint into a dropdown.

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -47,8 +47,13 @@ const METRIC_LABELS = {
     description:
       'stream latency (in-deployment write → read propagation, readAt - writtenAt)',
   },
+  so: {
+    name: 'SO',
+    description:
+      'stream overhead (end-to-end write+consume time beyond the modelled generation window)',
+  },
 };
-const METRIC_ORDER = ['ttfs', 'stso', 'wo', 'sl'];
+const METRIC_ORDER = ['ttfs', 'stso', 'wo', 'sl', 'so'];
 
 export function parseArgs(argv) {
   const args = {
@@ -347,7 +352,7 @@ function renderFooter(entries) {
     )
   );
 
-  return [
+  const smallprint = [
     ...(hasBaseline
       ? [
           '<sub>Best/P75/P90/P99 deltas compare against the most recent benchmark run on `main` at the time of this run. 🔻 flags a delta worse than +15%, 💚 one better than −15%.</sub>',
@@ -366,6 +371,17 @@ function renderFooter(entries) {
     '<sub>All metrics are measured from deployment-side timestamps only. Runs are triggered by an in-deployment route that stamps the anchor (`clientStart`) right before `start()`, so the CI runner’s request and its path through api.vercel.com sit outside every measured window. TTFS = in-deployment `start()` → first step body (turbo uses the in-process fast path, non-turbo the dispatch path), and includes the VQS dispatch hop plus any `/flow` cold start. STSO/WO are measured between step bodies on the deployment. SL is measured inside the workflow (parallel reader/writer steps), so it no longer includes the api.vercel.com read path.</sub>',
     '',
     '<sub>Cold starts are kept in the numbers on purpose — they are part of real bursty-workload latency. The workbench deployment cold-starts the `/flow` invocation for a large fraction of runs, inflating P75+; the **Best** column shows the fastest (warm-start) sample for comparison.</sub>',
+  ];
+
+  // Keep the definitions/methodology out of the way in a collapsed dropdown,
+  // mirroring the "Previous results" section. The blank line after <summary>
+  // lets GitHub render the markdown inside the <details> block.
+  return [
+    '<details>',
+    '<summary>ℹ️ Metric definitions & methodology</summary>',
+    '',
+    smallprint.join('\n'),
+    '</details>',
   ].join('\n');
 }
 

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -108,6 +108,11 @@ test('renders a completed run with a table and embedded history', async () => {
   assert.match(body, /\| 320 \| 398 🔴 \|/);
   // Metric definitions live in the footer, not in the table rows
   assert.doesNotMatch(body, /\| \*\*TTFS\*\* <sub>/);
+  // The smallprint footer is collapsed into a dropdown, like "Previous results"
+  assert.match(
+    body,
+    /<details>\n<summary>ℹ️ Metric definitions & methodology<\/summary>/
+  );
   assert.match(body, /<sub>Metrics — \*\*TTFS\*\*: time to first step body/);
   assert.match(body, /\*\*SL\*\*: stream latency/);
   // Scenario legend from the runner-provided descriptions
@@ -133,6 +138,45 @@ test('renders a completed run with a table and embedded history', async () => {
   assert.strictEqual(history.length, 1);
   assert.strictEqual(history[0].commit, 'abcdef1234567890');
   assert.strictEqual(history[0].results[0].metrics.length, 4);
+});
+
+test('renders the SO metric row and its footer definition', async () => {
+  const { renderComment } = await loadModule();
+  const result = sampleResult({
+    scenarios: [
+      {
+        name: 'stream overhead',
+        description: 'paced LLM-shaped stream, drained',
+      },
+    ],
+    metrics: [
+      {
+        metric: 'so',
+        scenario: 'stream overhead',
+        unit: 'ms',
+        best: 40,
+        avg: 120,
+        p75: 110,
+        p90: 220,
+        p99: 380,
+        samples: 30,
+        targets: { p75: 250, p90: 500, p99: 1000 },
+      },
+    ],
+  });
+  const body = renderComment({
+    status: 'completed',
+    results: [result],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+
+  // SO renders as a table row and is defined in the (collapsed) footer.
+  assert.match(body, /\| \*\*SO\*\* \| stream overhead \|/);
+  assert.match(body, /\*\*SO\*\*: stream overhead/);
+  // Within target on every percentile → the SO row carries no 🔴 mark.
+  assert.doesNotMatch(body, /\| \*\*SO\*\* \|.*🔴/);
+  assert.match(body, /Targets \(p75\/p90\/p99, ms\) — SO 250\/500\/1000/);
 });
 
 test('renders best/p75/p90/p99 deltas with 🔻/💚 threshold marks and embeds them', async () => {

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -47,6 +47,14 @@
  *          the writer's `writtenAt` and the reader's `readAt`. SL is
  *          `readAt - writtenAt`, so it excludes the api.vercel.com read path
  *          the old client-observed metric included.
+ * - SO    (stream overhead): end-to-end write+consume time in excess of a
+ *          modelled generation window, measured on the deployment by
+ *          `benchSoWorkflow`. A writer streams fake 4-byte LLM-token chunks at
+ *          a fixed rate for a fixed duration while a parallel reader drains the
+ *          whole stream; SO is `(doneAt - writtenAt) - chunkCount*intervalMs`,
+ *          i.e. the overhead/backpressure the stream adds on top of the token
+ *          rate. Same setup as SL, but the reader stamps `doneAt` after the
+ *          last chunk rather than `readAt` on the first.
  *
  * Scenarios (defined in workbench/example/workflows/97_bench.ts):
  *
@@ -55,6 +63,7 @@
  * 3. benchHookStreamWorkflow      — hook + 1 step, non-turbo → TTFS (non-turbo)
  * 4. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
  * 5. benchSlWorkflow              — parallel reader/writer steps → SL
+ * 6. benchSoWorkflow              — paced LLM-shaped stream, drained → SO
  *
  * Each scenario runs many iterations (env-tunable, see BENCH_* below) so the
  * percentiles are computed from real samples.
@@ -100,6 +109,7 @@ const envInt = (name: string, fallback: number, min = 1): number => {
 // iteration, so a single long run already provides solid percentiles.
 const STREAM_ITERATIONS = envInt('BENCH_STREAM_ITERATIONS', 30);
 const SL_ITERATIONS = envInt('BENCH_SL_ITERATIONS', STREAM_ITERATIONS);
+const SO_ITERATIONS = envInt('BENCH_SO_ITERATIONS', STREAM_ITERATIONS);
 const SEQUENTIAL_ITERATIONS = envInt('BENCH_SEQUENTIAL_ITERATIONS', 1);
 const SEQUENTIAL_STEP_COUNT = envInt('BENCH_SEQUENTIAL_STEP_COUNT', 1020);
 const WARMUP_ITERATIONS = envInt('BENCH_WARMUP_ITERATIONS', 2, 0);
@@ -117,6 +127,20 @@ const BENCH_METHODOLOGY_VERSION = 2;
 // re-tightened once a few in-deployment baselines land.
 const TTFS_TARGETS = { p75: 200, p90: 300, p99: 600 };
 const SL_TARGETS = { p75: 50, p90: 60, p99: 125 };
+
+// SO scenario: model a haiku-size LLM streaming tokens — ~100 tokens/sec, each
+// token a 4-byte chunk, for 3 seconds (300 chunks). The writer paces itself so
+// the write phase spans exactly `SO_CHUNK_COUNT * SO_INTERVAL_MS` ms; SO is the
+// end-to-end write+consume time beyond that window (see runSoIteration). These
+// derive `SO_NOMINAL_DURATION_MS`, the single value subtracted from the
+// measured span, so the workflow's write span and the subtraction never drift.
+const SO_CHUNK_RATE_PER_SEC = envInt('BENCH_SO_CHUNK_RATE', 100);
+const SO_DURATION_SECONDS = envInt('BENCH_SO_DURATION_SECONDS', 3);
+const SO_CHUNK_COUNT = SO_CHUNK_RATE_PER_SEC * SO_DURATION_SECONDS;
+const SO_INTERVAL_MS = 1000 / SO_CHUNK_RATE_PER_SEC;
+const SO_NOMINAL_DURATION_MS = SO_CHUNK_COUNT * SO_INTERVAL_MS;
+// Provisional, like TTFS/SL above: re-tighten once in-deployment baselines land.
+const SO_TARGETS = { p75: 250, p90: 500, p99: 1000 };
 
 // STSO percentiles are reported for sampled step-index windows: the gap
 // between steps k and k+1 counts toward the window where `from <= k < to`.
@@ -151,6 +175,12 @@ interface BenchStreamLatency {
   readAt: number;
 }
 
+interface BenchStreamOverhead {
+  writtenAt: number;
+  doneAt: number;
+  received: number;
+}
+
 interface StreamIterationResult {
   runId: string;
   /** `steps[0].start - clientStart`, both deployment-side clocks. */
@@ -169,6 +199,12 @@ interface SlIterationResult {
   runId: string;
   /** `readAt - writtenAt`, both deployment-side step-body clocks. */
   slMs: number;
+}
+
+interface SoIterationResult {
+  runId: string;
+  /** `(doneAt - writtenAt) - SO_NOMINAL_DURATION_MS`, deployment-side clocks. */
+  soMs: number;
 }
 
 /** Response shape of the in-deployment `POST /api/bench` trigger route. */
@@ -353,6 +389,46 @@ async function runSlIteration(): Promise<SlIterationResult> {
   }
 }
 
+async function runSoIteration(): Promise<SoIterationResult> {
+  const { runId } = await triggerBenchRun('benchSoWorkflow', [
+    SO_CHUNK_COUNT,
+    SO_INTERVAL_MS,
+  ]);
+  try {
+    const returnValue = await withTimeout(
+      getReturnValue(runId),
+      // The writer streams for the whole generation window before the run can
+      // complete, so extend the guard past the base run timeout by that window.
+      RUN_TIMEOUT_MS + SO_NOMINAL_DURATION_MS,
+      `benchSoWorkflow returnValue (run ${runId})`
+    );
+    const so = (returnValue as { so?: BenchStreamOverhead } | undefined)?.so;
+    if (
+      !so ||
+      typeof so.writtenAt !== 'number' ||
+      typeof so.doneAt !== 'number'
+    ) {
+      throw new Error(
+        `Run ${runId} returned no stream-overhead sample: ${JSON.stringify(returnValue)?.slice(0, 200)}`
+      );
+    }
+    if (so.received !== SO_CHUNK_COUNT) {
+      throw new Error(
+        `Run ${runId} consumed ${so.received} chunks, expected ${SO_CHUNK_COUNT}`
+      );
+    }
+    // Both timestamps are deployment-side; subtract the modelled generation
+    // window and clamp to absorb tiny intra-Vercel skew.
+    return {
+      runId,
+      soMs: Math.max(0, so.doneAt - so.writtenAt - SO_NOMINAL_DURATION_MS),
+    };
+  } catch (error) {
+    (error as Error).message += ` (run ${runId})`;
+    throw error;
+  }
+}
+
 /**
  * Runs recorded iterations (plus warmups) sequentially — concurrency would
  * contend on the same deployment and skew latencies. Failed iterations are
@@ -499,6 +575,7 @@ const SCENARIO_TURBO_STREAM = 'stream';
 const SCENARIO_HOOK_STREAM = 'hook + stream';
 const SCENARIO_SEQUENTIAL = `${SEQUENTIAL_STEP_COUNT} steps`;
 const SCENARIO_STREAM_LATENCY = 'stream latency';
+const SCENARIO_STREAM_OVERHEAD = 'stream overhead';
 const SCENARIO_DESCRIPTIONS = [
   {
     name: SCENARIO_STEP,
@@ -523,6 +600,10 @@ const SCENARIO_DESCRIPTIONS = [
     name: SCENARIO_STREAM_LATENCY,
     description:
       'parallel reader/writer steps on a dedicated stream; SL is the in-deployment write->read propagation (readAt - writtenAt)',
+  },
+  {
+    name: SCENARIO_STREAM_OVERHEAD,
+    description: `writer streams ${SO_CHUNK_COUNT} 4-byte chunks paced at ${SO_CHUNK_RATE_PER_SEC}/s for ${SO_DURATION_SECONDS}s (a haiku-size LLM's token throughput) while a parallel reader drains the whole stream; SO is the end-to-end write+consume time beyond the ${SO_DURATION_SECONDS}s generation window (overhead/backpressure)`,
   },
 ];
 
@@ -615,6 +696,20 @@ describe('workflow benchmarks', () => {
     );
   });
 
+  test('scenario: stream overhead', { timeout: 30 * 60_000 }, async () => {
+    const results = await runScenario(
+      SCENARIO_STREAM_OVERHEAD,
+      SO_ITERATIONS,
+      () => runSoIteration()
+    );
+    recordMetric(
+      'so',
+      SCENARIO_STREAM_OVERHEAD,
+      results.map((r) => r.soMs),
+      SO_TARGETS
+    );
+  });
+
   test('scenario: sequential steps', { timeout: 60 * 60_000 }, async () => {
     const results = await runScenario(
       SCENARIO_SEQUENTIAL,
@@ -676,6 +771,10 @@ describe('workflow benchmarks', () => {
       config: {
         streamIterations: STREAM_ITERATIONS,
         slIterations: SL_ITERATIONS,
+        soIterations: SO_ITERATIONS,
+        soChunkCount: SO_CHUNK_COUNT,
+        soChunkRatePerSec: SO_CHUNK_RATE_PER_SEC,
+        soDurationSeconds: SO_DURATION_SECONDS,
         sequentialIterations: SEQUENTIAL_ITERATIONS,
         sequentialStepCount: SEQUENTIAL_STEP_COUNT,
         warmupIterations: WARMUP_ITERATIONS,

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -16,6 +16,12 @@
 //   stream, and the workflow returns both the writer's `writtenAt` and the
 //   reader's `readAt` so SL (`readAt - writtenAt`) excludes the client read
 //   path.
+// - `benchSoWorkflow` measures stream overhead (SO), reusing the SL setup but
+//   streaming a realistic LLM-shaped workload: a writer emits fake 4-byte
+//   tokens paced at a fixed rate for a fixed duration while a parallel reader
+//   drains the whole stream. The workflow returns the writer's `writtenAt` and
+//   the reader's `doneAt`; the runner subtracts the modelled generation window
+//   from `doneAt - writtenAt`, leaving the stream's overhead/backpressure.
 
 import { createHook, getWorkflowMetadata, getWritable } from 'workflow';
 import { getRun } from 'workflow/api';
@@ -40,6 +46,15 @@ export interface BenchStreamLatency {
   readAt: number;
 }
 
+export interface BenchStreamOverhead {
+  /** Date.now() in the writer step just before the paced write loop begins */
+  writtenAt: number;
+  /** Date.now() in the reader step when the whole stream had been consumed */
+  doneAt: number;
+  /** Number of chunks the reader received (validated against the request) */
+  received: number;
+}
+
 // Dedicated stream for the SL scenario, kept off the default output stream so
 // it never interacts with the default-stream lifecycle.
 const SL_STREAM_NAMESPACE = 'bench-sl';
@@ -50,6 +65,15 @@ const SL_STREAM_NAMESPACE = 'bench-sl';
 // rather than being retained for a reader that started late — which a fixed
 // sleep could not guarantee under scheduler delay or load.
 const SL_READY_NAMESPACE = 'bench-sl-ready';
+
+// Dedicated streams for the SO scenario (its own namespaces so it never
+// interacts with the SL streams or the default output stream), plus the same
+// reader-ready barrier pattern SL uses.
+const SO_STREAM_NAMESPACE = 'bench-so';
+const SO_READY_NAMESPACE = 'bench-so-ready';
+// Payload for each SO chunk: 4 ASCII bytes, modelling ~one LLM token. Kept as a
+// tiny string so per-chunk framing (not payload size) dominates the overhead.
+const SO_CHUNK_PAYLOAD = 'aaaa';
 
 async function timedNoopStep(index: number): Promise<BenchStepTiming> {
   'use step';
@@ -212,4 +236,106 @@ export async function benchSlWorkflow(): Promise<{ sl: BenchStreamLatency }> {
   'use workflow';
   const [sl] = await Promise.all([slReaderStep(), slWriterStep()]);
   return { sl };
+}
+
+/** Reader half of the SO scenario. Same attach/ready handshake as
+ * {@link slReaderStep}, but instead of stamping on the first chunk it drains
+ * the whole stream and stamps `doneAt` once the writer has closed it, so the
+ * measured window covers writing *and* consuming every chunk. */
+async function soReaderStep(): Promise<{ doneAt: number; received: number }> {
+  'use step';
+  const { workflowRunId } = getWorkflowMetadata();
+  const reader = getRun<string>(workflowRunId)
+    .getReadable<string>({ namespace: SO_STREAM_NAMESPACE })
+    .getReader();
+  try {
+    // Initiate the read BEFORE signalling ready so the stream GET is in flight
+    // by the time the writer starts (identical to the SL handshake).
+    const firstRead = reader.read();
+
+    const ready = getWritable<{ ready: true }>({
+      namespace: SO_READY_NAMESPACE,
+    });
+    const readyWriter = ready.getWriter();
+    await readyWriter.write({ ready: true });
+    readyWriter.releaseLock();
+    await ready.close();
+
+    let received = 0;
+    let result = await firstRead;
+    while (!result.done) {
+      received++;
+      result = await reader.read();
+    }
+    return { doneAt: Date.now(), received };
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+}
+
+/** Writer half of the SO scenario: blocks on the reader-ready marker (as in
+ * {@link slWriterStep}), then streams `chunkCount` fixed-size chunks paced to
+ * one every `intervalMs`. `writtenAt` is stamped just before the loop, and each
+ * write is scheduled at `writtenAt + (i + 1) * intervalMs`, so the write phase
+ * spans `chunkCount * intervalMs` by construction — the modelled generation
+ * window. Pacing only sleeps while ahead of schedule; if backpressure puts the
+ * writer behind, it writes immediately and that lost time surfaces as SO. */
+async function soWriterStep(
+  chunkCount: number,
+  intervalMs: number
+): Promise<{ writtenAt: number }> {
+  'use step';
+  const { workflowRunId } = getWorkflowMetadata();
+  const readyReader = getRun<{ ready: true }>(workflowRunId)
+    .getReadable<{ ready: true }>({ namespace: SO_READY_NAMESPACE })
+    .getReader();
+  try {
+    await readyReader.read();
+  } finally {
+    readyReader.cancel().catch(() => {});
+  }
+
+  const writable = getWritable<string>({ namespace: SO_STREAM_NAMESPACE });
+  const writer = writable.getWriter();
+  const writtenAt = Date.now();
+  for (let i = 0; i < chunkCount; i++) {
+    const delay = writtenAt + (i + 1) * intervalMs - Date.now();
+    if (delay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+    await writer.write(SO_CHUNK_PAYLOAD);
+  }
+  writer.releaseLock();
+  await writable.close();
+  return { writtenAt };
+}
+
+/**
+ * Scenario 6: stream overhead (SO), measured entirely on the deployment.
+ *
+ * Reuses the SL scenario's dedicated-stream + reader-ready-barrier setup, but
+ * models a realistic LLM streaming workload: the writer emits `chunkCount`
+ * 4-byte chunks paced at one every `intervalMs` (e.g. 300 chunks at 10ms ≈ a
+ * haiku-size LLM streaming ~100 tokens/s for 3s) while the reader drains the
+ * whole stream in parallel. The workflow returns the writer's `writtenAt` and
+ * the reader's `doneAt`; the runner subtracts the modelled generation window
+ * (`chunkCount * intervalMs`) from `doneAt - writtenAt`, so SO isolates the
+ * stream's write+consume overhead/backpressure on top of the token rate.
+ */
+export async function benchSoWorkflow(
+  chunkCount: number,
+  intervalMs: number
+): Promise<{ so: BenchStreamOverhead }> {
+  'use workflow';
+  const [reader, writer] = await Promise.all([
+    soReaderStep(),
+    soWriterStep(chunkCount, intervalMs),
+  ]);
+  return {
+    so: {
+      writtenAt: writer.writtenAt,
+      doneAt: reader.doneAt,
+      received: reader.received,
+    },
+  };
 }


### PR DESCRIPTION
## What

Adds a new **SO (Stream Overhead)** benchmark scenario and metric, and hides the benchmark PR-comment smallprint behind a dropdown.

### SO scenario
Models a haiku-size LLM streaming tokens: a writer emits **300 fake 4-byte chunks** (~one token each) paced at **100 chunks/sec for 3 s** while a parallel reader drains the whole stream. Setup, trigger, ready-barrier and deployment-side timing are otherwise **identical to the existing SL scenario** — the only difference is the reader stamps `doneAt` after the *last* chunk rather than `readAt` on the first.

`SO = (doneAt - writtenAt) - 3000ms` — the end-to-end write+consume time in excess of the modelled generation window, i.e. the stream's overhead/backpressure on top of the token rate. All timestamps are deployment-side (same methodology as the other metrics).

The 3 s / 100-per-sec constants live once in the runner and are passed to `benchSoWorkflow(chunkCount, intervalMs)` as args (like `benchSequentialStepsWorkflow`), so the writer's paced span and the runner's subtraction can never drift. Targets are provisional, to be tightened once `main` baselines land. No methodology-version bump (SO is a new metric; existing baselines stay comparable).

### PR-comment smallprint dropdown
The metric/scenario/target definitions and methodology paragraphs are now wrapped in a collapsed `<details><summary>ℹ️ Metric definitions & methodology</summary>`, mirroring the existing "📜 Previous results" section, so the comment leads with the results table.

## Files
- `workbench/example/workflows/97_bench.ts` — `benchSoWorkflow` + `soReaderStep`/`soWriterStep` + `BenchStreamOverhead` (symlinked into `nextjs-turbopack`/`nitro-v3`).
- `packages/core/e2e/benchmark.test.ts` — SO constants, `runSoIteration`, scenario + `test(...)`, config/doc updates.
- `.github/scripts/render-benchmark-comment.mjs` — `so` in `METRIC_LABELS`/`METRIC_ORDER`; footer collapsed into `<details>`.
- `.github/scripts/render-benchmark-comment.test.js` — collapsed-footer + SO-row coverage.

## Testing
- `node --test .github/scripts/render-benchmark-comment.test.js` — 12/12 pass.
- `@workflow/core` typecheck passes (covers the bench runner); `97_bench.ts` compiles via SWC; `benchSoWorkflow` resolves by name through the workbench registry.
- Note: the bench suite runs against a Vercel deploy only (local dev fails uniformly on all bench workflows, including the unmodified ones), so SO is exercised end-to-end by the Performance Benchmarks workflow on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)