### PR TITLE
perf(core): path-independent stream write batching (group commit in the server writable)

### DIFF
--- a/.changeset/writable-group-commit.md
+++ b/.changeset/writable-group-commit.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Stream write batching now lives in the server writable itself (group commit), so raw `ReadableStream`s piped across workflow/step boundaries batch the same as `getWritable()` instead of sending one request per chunk.

--- a/docs/content/docs/v5/configuration/runtime-tuning.mdx
+++ b/docs/content/docs/v5/configuration/runtime-tuning.mdx
@@ -149,6 +149,11 @@ These variables are primarily for tests, debugging, or unusual deployments.
 - Default: `1048576` (1 MiB)
 - Wire limit: maximum cumulative bytes in a single coalesced multi-write, so large chunks don't produce a request body that platform limits reject. A single chunk larger than this is still sent on its own.
 
+### `WORKFLOW_STREAM_MAX_BUFFERED_BYTES`
+
+- Default: `8388608` (8 MiB)
+- Flow-control bound: maximum cumulative bytes accepted into the stream writer's group-commit buffer before `write()` applies backpressure. The byte-denominated counterpart of `WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS`; distinct from `WORKFLOW_STREAM_MAX_BYTES_PER_BATCH`, which only splits how much goes out in one request.
+
 ### `WORKFLOW_FRAMED_STREAM_MAX_RECONNECTS`
 
 - Default: `50`

--- a/packages/core/src/flushable-stream.test.ts
+++ b/packages/core/src/flushable-stream.test.ts
@@ -6,35 +6,33 @@ import {
   pollReadableLock,
   pollWritableLock,
 } from './flushable-stream.js';
-import { STREAM_WRITE_BATCH_SYMBOL } from './symbols.js';
+import { STREAM_DRAIN_SYMBOL } from './symbols.js';
 
 const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms));
 
 /**
- * A batch-capable mock sink, mirroring the durable batch entry point that
- * `WorkflowServerWritableStream` exposes under `STREAM_WRITE_BATCH_SYMBOL`.
- * `gate` (when provided) lets a test hold a batch write "in flight" so it can
- * enqueue more chunks and observe coalescing.
+ * A group-commit-style mock sink: acks `write()` on buffer entry and exposes
+ * a durability barrier under `STREAM_DRAIN_SYMBOL`, mirroring
+ * `WorkflowServerWritableStream`'s early-ack contract.
  */
-function makeBatchSink(
-  gate?: (call: number, chunks: Uint8Array[]) => Promise<void> | void
-) {
-  const batches: Uint8Array[][] = [];
+function makeDrainSink(drain: () => Promise<void>) {
+  const written: Uint8Array[] = [];
   let closed = false;
-  let call = 0;
   const sink = new WritableStream<Uint8Array>({
+    write(chunk) {
+      written.push(chunk);
+      // ack on buffer entry — durability is the barrier's job
+    },
     close() {
       closed = true;
     },
-  }) as WritableStream<Uint8Array> & {
-    [STREAM_WRITE_BATCH_SYMBOL]: (chunks: Uint8Array[]) => Promise<void>;
-  };
-  sink[STREAM_WRITE_BATCH_SYMBOL] = async (chunks: Uint8Array[]) => {
-    const n = call++;
-    batches.push(chunks.slice());
-    await gate?.(n, chunks);
-  };
-  return { sink, batches, isClosed: () => closed };
+  });
+  Object.defineProperty(sink, STREAM_DRAIN_SYMBOL, {
+    value: drain,
+    enumerable: false,
+    writable: false,
+  });
+  return { sink, written, isClosed: () => closed };
 }
 
 function makeControlledSource() {
@@ -441,263 +439,142 @@ describe('flushable stream behavior', () => {
   });
 });
 
-describe('flushablePipe batching (STREAM_WRITE_BATCH_SYMBOL sinks)', () => {
+describe('flushablePipe drain barrier (group-commit sinks)', () => {
   afterEach(() => {
     delete process.env.WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS;
     delete process.env.WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH;
     delete process.env.WORKFLOW_STREAM_MAX_BYTES_PER_BATCH;
   });
 
-  it('coalesces chunks that arrive during an in-flight batch into one write', async () => {
-    // Hold the first batch write "in flight" so the chunks that arrive while
-    // it is pending accumulate and go out together as the next batch.
-    let releaseFirst!: () => void;
-    const firstInFlight = new Promise<void>((r) => {
-      releaseFirst = r;
-    });
-    const { sink, batches } = makeBatchSink((call) =>
-      call === 0 ? firstInFlight : undefined
-    );
+  it('adopts the sink drain barrier onto the flushable state', async () => {
+    const { sink } = makeDrainSink(async () => {});
     const { source, controller } = makeControlledSource();
     const state = createFlushableState();
 
     const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    // First chunk: consumer picks it up alone and blocks on the gate.
-    controller().enqueue(new Uint8Array([1]));
-    await tick();
-    expect(batches).toHaveLength(1);
-    expect(batches[0]).toHaveLength(1);
-
-    // While the first write is in flight, three more chunks arrive.
-    controller().enqueue(new Uint8Array([2]));
-    controller().enqueue(new Uint8Array([3]));
-    controller().enqueue(new Uint8Array([4]));
-    await tick();
-    // Still only the first batch has been dispatched — the rest are queued.
-    expect(batches).toHaveLength(1);
-    // They are counted as pending (read but not yet durable): 1 in-flight + 3.
-    expect(state.pendingOps).toBe(4);
-
-    // Release the first write; the queued chunks flush as a single batch.
-    releaseFirst();
-    await tick();
-    expect(batches).toHaveLength(2);
-    expect(Array.from(batches[1].map((c) => c[0]))).toEqual([2, 3, 4]);
+    expect(typeof state.drainBarrier).toBe('function');
 
     controller().close();
     await pipe;
     await expect(state.promise).resolves.toBeUndefined();
-    expect(state.pendingOps).toBe(0);
   });
 
-  it('delivers every chunk in order and closes the sink on completion', async () => {
-    const { sink, batches, isClosed } = makeBatchSink();
+  it('lock-release completion waits for the drain barrier (early-ack durability)', async () => {
+    // In production the poll watches the USER-side writable (the serialize
+    // transform's writable) while the pipe drives the server sink. Model
+    // that: an unlocked user writable, pendingOps at 0 (the sink early-acks),
+    // and a drain barrier that is still pending — completion must wait.
+    let releaseDrain!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseDrain = r;
+    });
+    const state = createFlushableState();
+    state.drainBarrier = () => gate;
+    const userWritable = new WritableStream<Uint8Array>();
+
+    pollWritableLock(userWritable, state);
+    await tick(LOCK_POLL_INTERVAL_MS + 20);
+
+    // The poll claimed completion (stopped polling) but the promise must
+    // still be pending — data is client-buffered until the barrier resolves.
+    expect(state.doneResolved).toBe(true);
+    let settled = false;
+    void state.promise.then(() => {
+      settled = true;
+    });
+    await tick();
+    expect(settled).toBe(false);
+
+    releaseDrain();
+    await expect(state.promise).resolves.toBeUndefined();
+  });
+
+  it('rejects the completion when the drain barrier reports a failed flush', async () => {
+    const state = createFlushableState();
+    state.drainBarrier = async () => {
+      throw new Error('group flush failed');
+    };
+    const userWritable = new WritableStream<Uint8Array>();
+
+    pollWritableLock(userWritable, state);
+    await tick(LOCK_POLL_INTERVAL_MS + 20);
+
+    await expect(state.promise).rejects.toThrow('group flush failed');
+  });
+
+  it('drains the accepted prefix before settling a failed pipe', async () => {
+    // Source fails while accepted chunks are still behind the sink's
+    // barrier: the failure must not settle (letting the step persist it and
+    // the invocation finish) until the prefix is durable.
+    let releaseDrain!: () => void;
+    let drained = false;
+    const gate = new Promise<void>((r) => {
+      releaseDrain = () => {
+        drained = true;
+        r();
+      };
+    });
+    const { sink, written } = makeDrainSink(() => gate);
     const { source, controller } = makeControlledSource();
     const state = createFlushableState();
 
     const pipe = flushablePipe(source, sink, state).catch(() => {});
+    controller().enqueue(new Uint8Array([1]));
+    await tick();
+    expect(written).toHaveLength(1); // acked into the sink
 
+    controller().error(new Error('producer failed'));
+    await tick();
+
+    // The failure is known but must not settle while the barrier is held.
+    let settled = false;
+    void state.promise.catch(() => {
+      settled = true;
+    });
+    await tick(5);
+    expect(settled).toBe(false);
+
+    releaseDrain();
+    await pipe;
+    expect(drained).toBe(true);
+    await expect(state.promise).rejects.toThrow('producer failed');
+  });
+
+  it('does not attach a barrier for plain sinks (per-write durability)', async () => {
+    const written: Uint8Array[] = [];
+    const sink = new WritableStream<Uint8Array>({
+      write(chunk) {
+        written.push(chunk);
+      },
+    });
+    const { source, controller } = makeControlledSource();
+    const state = createFlushableState();
+
+    const pipe = flushablePipe(source, sink, state).catch(() => {});
+    expect(state.drainBarrier).toBeUndefined();
+
+    controller().enqueue(new Uint8Array([1]));
+    controller().close();
+    await pipe;
+    expect(written).toHaveLength(1);
+    await expect(state.promise).resolves.toBeUndefined();
+  });
+
+  it('delivers every chunk in order and closes the sink on completion', async () => {
+    const { sink, written, isClosed } = makeDrainSink(async () => {});
+    const { source, controller } = makeControlledSource();
+    const state = createFlushableState();
+
+    const pipe = flushablePipe(source, sink, state).catch(() => {});
     for (let i = 0; i < 25; i++) controller().enqueue(new Uint8Array([i]));
     controller().close();
     await pipe;
 
-    const delivered = batches.flat().map((c) => c[0]);
-    expect(delivered).toEqual(Array.from({ length: 25 }, (_, i) => i));
+    expect(written.map((c) => c[0])).toEqual(
+      Array.from({ length: 25 }, (_, i) => i)
+    );
     expect(isClosed()).toBe(true);
     await expect(state.promise).resolves.toBeUndefined();
-    expect(state.pendingOps).toBe(0);
-  });
-
-  it('keeps pendingOps > 0 until batches are durable (lock-release durability)', async () => {
-    let releaseWrite!: () => void;
-    const inFlight = new Promise<void>((r) => {
-      releaseWrite = r;
-    });
-    const { sink } = makeBatchSink(() => inFlight);
-    const { source, controller } = makeControlledSource();
-    const state = createFlushableState();
-
-    const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    controller().enqueue(new Uint8Array([1]));
-    controller().close();
-    await tick();
-
-    // Source is done, but the write has not landed yet: a lock-release poll
-    // must NOT resolve while the chunk is still un-durable.
-    pollReadableLock(source, state);
-    await tick(LOCK_POLL_INTERVAL_MS + 20);
-    expect(state.doneResolved).toBe(false);
-    expect(state.pendingOps).toBe(1);
-
-    releaseWrite();
-    await pipe;
-    expect(state.pendingOps).toBe(0);
-    await expect(state.promise).resolves.toBeUndefined();
-  });
-
-  it('propagates a batch-write failure through state.promise', async () => {
-    const { sink } = makeBatchSink((call) => {
-      if (call === 0) throw new Error('batch write failed');
-    });
-    const { source, controller } = makeControlledSource();
-    const state = createFlushableState();
-
-    const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    controller().enqueue(new Uint8Array([1]));
-    await tick();
-
-    await pipe;
-    await expect(state.promise).rejects.toThrow('batch write failed');
-    expect(state.streamEnded).toBe(true);
-  });
-
-  it('does NOT decrement pendingOps for a failed (retained, un-durable) batch', async () => {
-    // On failure the sink retains the batch in its buffer, so those chunks are
-    // still "read but not durable" — pendingOps must keep counting them.
-    const { sink } = makeBatchSink((call) => {
-      if (call === 0) throw new Error('batch write failed');
-    });
-    const { source, controller } = makeControlledSource();
-    const state = createFlushableState();
-
-    const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    controller().enqueue(new Uint8Array([1]));
-    controller().enqueue(new Uint8Array([2]));
-    await tick();
-
-    await pipe;
-    await expect(state.promise).rejects.toThrow('batch write failed');
-    // Both chunks were read; the batch write failed and retained them, so the
-    // count stays at 2 rather than being silently zeroed in a `finally`.
-    expect(state.pendingOps).toBe(2);
-  });
-
-  it('splits a coalesced batch at the chunk-count wire limit', async () => {
-    process.env.WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH = '2';
-
-    let releaseFirst!: () => void;
-    const firstInFlight = new Promise<void>((r) => {
-      releaseFirst = r;
-    });
-    const { sink, batches } = makeBatchSink((call) =>
-      call === 0 ? firstInFlight : undefined
-    );
-    const { source, controller } = makeControlledSource();
-    const state = createFlushableState();
-    const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    // First chunk goes out alone and blocks; five more queue behind it.
-    controller().enqueue(new Uint8Array([1]));
-    await tick();
-    for (const n of [2, 3, 4, 5, 6]) controller().enqueue(new Uint8Array([n]));
-    await tick();
-
-    releaseFirst();
-    controller().close();
-    await pipe;
-
-    // No batch exceeds the 2-chunk cap, and every chunk is delivered in order.
-    expect(batches.every((b) => b.length <= 2)).toBe(true);
-    expect(batches.flat().map((c) => c[0])).toEqual([1, 2, 3, 4, 5, 6]);
-    await expect(state.promise).resolves.toBeUndefined();
-  });
-
-  it('splits a coalesced batch at the byte wire limit', async () => {
-    // Cap at 10 bytes; each chunk is 4 bytes, so at most 2 fit per batch.
-    process.env.WORKFLOW_STREAM_MAX_BYTES_PER_BATCH = '10';
-
-    let releaseFirst!: () => void;
-    const firstInFlight = new Promise<void>((r) => {
-      releaseFirst = r;
-    });
-    const { sink, batches } = makeBatchSink((call) =>
-      call === 0 ? firstInFlight : undefined
-    );
-    const { source, controller } = makeControlledSource();
-    const state = createFlushableState();
-    const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    controller().enqueue(new Uint8Array([0, 0, 0, 1]));
-    await tick();
-    for (let i = 2; i <= 5; i++) {
-      controller().enqueue(new Uint8Array([0, 0, 0, i]));
-    }
-    await tick();
-
-    releaseFirst();
-    controller().close();
-    await pipe;
-
-    for (const b of batches) {
-      const bytes = b.reduce((sum, c) => sum + c.byteLength, 0);
-      expect(bytes).toBeLessThanOrEqual(10);
-    }
-    expect(batches.flat().map((c) => c[3])).toEqual([1, 2, 3, 4, 5]);
-    await expect(state.promise).resolves.toBeUndefined();
-  });
-
-  it('sends an oversized single chunk alone rather than stalling', async () => {
-    process.env.WORKFLOW_STREAM_MAX_BYTES_PER_BATCH = '4';
-
-    const { sink, batches } = makeBatchSink();
-    const { source, controller } = makeControlledSource();
-    const state = createFlushableState();
-    const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    // A single chunk larger than the byte cap must still be delivered (alone).
-    controller().enqueue(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
-    controller().close();
-    await pipe;
-
-    expect(batches).toHaveLength(1);
-    expect(batches[0]).toHaveLength(1);
-    expect(batches[0][0].byteLength).toBe(8);
-    await expect(state.promise).resolves.toBeUndefined();
-  });
-
-  it('applies backpressure once too many chunks are outstanding', async () => {
-    process.env.WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS = '2';
-
-    let releaseFirst!: () => void;
-    const firstInFlight = new Promise<void>((r) => {
-      releaseFirst = r;
-    });
-    const { sink, batches } = makeBatchSink((call) =>
-      call === 0 ? firstInFlight : undefined
-    );
-
-    // A source that records how many chunks the pipe has pulled, so we can
-    // assert the producer stops reading under backpressure.
-    let pulled = 0;
-    const total = 6;
-    const source = new ReadableStream<Uint8Array>({
-      pull(controller) {
-        if (pulled < total) {
-          controller.enqueue(new Uint8Array([pulled]));
-          pulled++;
-        } else {
-          controller.close();
-        }
-      },
-    });
-    const state = createFlushableState();
-    const pipe = flushablePipe(source, sink, state).catch(() => {});
-
-    // First chunk is in flight; the producer may read ahead only up to the cap
-    // (2 outstanding) and then must wait, so it cannot drain all 6.
-    await tick(20);
-    expect(batches).toHaveLength(1);
-    expect(pulled).toBeLessThan(total);
-    expect(state.pendingOps).toBeLessThanOrEqual(2);
-
-    // Releasing the in-flight write lets the pipe drain the rest.
-    releaseFirst();
-    await pipe;
-    expect(batches.flat()).toHaveLength(total);
     expect(state.pendingOps).toBe(0);
   });
 });

--- a/packages/core/src/flushable-stream.ts
+++ b/packages/core/src/flushable-stream.ts
@@ -1,14 +1,14 @@
 import { WorkflowRuntimeError } from '@workflow/errors';
 import { type PromiseWithResolvers, withResolvers } from '@workflow/utils';
 import { envNumber } from '@workflow/world';
-import { STREAM_WRITE_BATCH_SYMBOL } from './symbols.js';
+import { STREAM_DRAIN_SYMBOL } from './symbols.js';
 
 /**
- * A batched, durable write entry point a sink may expose under
- * {@link STREAM_WRITE_BATCH_SYMBOL}. Resolves once every chunk in the batch
- * has reached the server. See `WorkflowServerWritableStream`.
+ * A durability barrier a sink may expose under {@link STREAM_DRAIN_SYMBOL}:
+ * resolves once every chunk the sink has accepted is durably written, rejects
+ * if any server write failed. See `WorkflowServerWritableStream`.
  */
-type BatchWrite = (chunks: Uint8Array[]) => Promise<void>;
+type DrainBarrier = () => Promise<void>;
 
 /**
  * Flow-control knob: upper bound on chunks read-but-not-yet-durably-written
@@ -24,7 +24,7 @@ type BatchWrite = (chunks: Uint8Array[]) => Promise<void>;
  */
 export const MAX_INFLIGHT_CHUNKS = 1000;
 
-const getMaxInflightChunks = (): number =>
+export const getMaxInflightChunks = (): number =>
   envNumber('WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS', MAX_INFLIGHT_CHUNKS, {
     integer: true,
     min: 1,
@@ -38,7 +38,7 @@ const getMaxInflightChunks = (): number =>
  */
 export const MAX_CHUNKS_PER_BATCH = 1000;
 
-const getMaxChunksPerBatch = (): number =>
+export const getMaxChunksPerBatch = (): number =>
   envNumber('WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH', MAX_CHUNKS_PER_BATCH, {
     integer: true,
     min: 1,
@@ -54,8 +54,23 @@ const getMaxChunksPerBatch = (): number =>
  */
 export const MAX_BYTES_PER_BATCH = 1024 * 1024;
 
-const getMaxBytesPerBatch = (): number =>
+export const getMaxBytesPerBatch = (): number =>
   envNumber('WORKFLOW_STREAM_MAX_BYTES_PER_BATCH', MAX_BYTES_PER_BATCH, {
+    integer: true,
+    min: 1,
+  });
+
+/**
+ * Buffer bound (bytes) for the server writable's group-commit buffer — the
+ * byte-denominated counterpart of {@link MAX_INFLIGHT_CHUNKS}. `write()`
+ * blocks once this much data is buffered-but-not-durable, so a fast producer
+ * of large chunks can't grow client memory without bound. Default 8 MiB
+ * (eight request-sized groups). Override: `WORKFLOW_STREAM_MAX_BUFFERED_BYTES`.
+ */
+export const MAX_BUFFERED_BYTES = 8 * 1024 * 1024;
+
+export const getMaxBufferedBytes = (): number =>
+  envNumber('WORKFLOW_STREAM_MAX_BUFFERED_BYTES', MAX_BUFFERED_BYTES, {
     integer: true,
     min: 1,
   });
@@ -112,6 +127,13 @@ export interface FlushableStreamState extends PromiseWithResolvers<void> {
   writablePollingInterval?: ReturnType<typeof setInterval>;
   /** Interval ID for readable lock polling (if active) */
   readablePollingInterval?: ReturnType<typeof setInterval>;
+  /**
+   * Durability barrier of the pipe's sink, when it acks writes on buffer
+   * entry (see {@link STREAM_DRAIN_SYMBOL}). Lock-release completion awaits
+   * this before resolving so `pendingOps === 0` (fast, buffered acks) can't
+   * complete a step while data is still client-side.
+   */
+  drainBarrier?: DrainBarrier;
 }
 
 export function createFlushableState(): FlushableStreamState {
@@ -187,6 +209,27 @@ function isReadableUnlockedNotClosed(readable: ReadableStream): boolean {
 }
 
 /**
+ * Settle the flushable completion after the sink's durability barrier.
+ *
+ * Lock release means the producer is done *writing*; with a group-commit
+ * sink, accepted chunks may still be client-buffered or in a request that is
+ * in flight. Awaiting the barrier here keeps the completion's meaning —
+ * "everything written so far is durable" — identical to the pre-batching
+ * behavior where each write() was individually durable.
+ */
+function resolveAfterDrain(state: FlushableStreamState): void {
+  const barrier = state.drainBarrier;
+  if (!barrier) {
+    state.resolve();
+    return;
+  }
+  barrier().then(
+    () => state.resolve(),
+    (err) => state.reject(err)
+  );
+}
+
+/**
  * Polls a WritableStream to check if the user has released their lock.
  * Resolves the done promise when lock is released and no pending ops remain.
  *
@@ -216,9 +259,9 @@ export function pollWritableLock(
     // Check if lock is released (not closed) and no pending ops
     if (isWritableUnlockedNotClosed(writable) && state.pendingOps === 0) {
       state.doneResolved = true;
-      state.resolve();
       clearInterval(intervalId);
       state.writablePollingInterval = undefined;
+      resolveAfterDrain(state);
     }
   }, getLockPollIntervalMs());
 
@@ -255,9 +298,9 @@ export function pollReadableLock(
     // Check if lock is released (not closed) and no pending ops
     if (isReadableUnlockedNotClosed(readable) && state.pendingOps === 0) {
       state.doneResolved = true;
-      state.resolve();
       clearInterval(intervalId);
       state.readablePollingInterval = undefined;
+      resolveAfterDrain(state);
     }
   }, getLockPollIntervalMs());
 
@@ -280,25 +323,29 @@ export function flushablePipe(
   sink: WritableStream,
   state: FlushableStreamState
 ): Promise<void> {
-  // When the sink can accept a batch of chunks in one durable write (server
-  // writables do), coalesce chunks that arrive while a previous batch is still
-  // in flight into a single server write. Without this, the WHATWG
-  // `WritableStream` contract serializes the sink one chunk per write() and the
-  // per-chunk `await writer.write()` in the fallback means the sink's buffer
-  // never holds more than one chunk — so its `writeMulti` batching path never
-  // engages and every chunk becomes its own server round trip.
-  const batchWrite = (sink as { [STREAM_WRITE_BATCH_SYMBOL]?: BatchWrite })[
-    STREAM_WRITE_BATCH_SYMBOL
+  // Batching lives in the sink (`WorkflowServerWritableStream` group-commits
+  // its buffer), so this pipe is a plain per-chunk pump regardless of path —
+  // its only responsibilities are lock-release completion and durability
+  // tracking. Group-commit sinks ack write() on buffer entry; adopt their
+  // durability barrier so the lock-release completion still means
+  // "everything written is durable" (see resolveAfterDrain).
+  const drain = (sink as { [STREAM_DRAIN_SYMBOL]?: DrainBarrier })[
+    STREAM_DRAIN_SYMBOL
   ];
-  return typeof batchWrite === 'function'
-    ? flushablePipeCoalescing(source, sink, state, batchWrite)
-    : flushablePipePerChunk(source, sink, state);
+  if (typeof drain === 'function') {
+    state.drainBarrier = drain;
+  }
+  return flushablePipePerChunk(source, sink, state);
 }
 
 /**
- * Per-chunk variant of {@link flushablePipe}: awaits each `writer.write()`
- * before reading the next chunk. Used for sinks without a durable batch write
- * (plain `WritableStream`s, `TransformStream` writables on the read path).
+ * The pump behind {@link flushablePipe}: awaits each `writer.write()` before
+ * reading the next chunk. Against a group-commit sink, write() acks on buffer
+ * entry, so this loop feeds the sink as fast as the producer emits (bounded
+ * by the sink's buffer bound) and batching happens inside the sink; against a
+ * plain sink each write is individually durable, as before. The source-done
+ * path closes the sink, which drains it, so completion always implies
+ * durability.
  */
 async function flushablePipePerChunk(
   source: ReadableStream,
@@ -353,6 +400,15 @@ async function flushablePipePerChunk(
   } catch (err) {
     state.streamEnded = true;
     cancelReason = err;
+    // Against an early-ack sink, chunks can still be buffered or in flight
+    // when the pipe fails (pendingOps only counts un-acked writes). Deliver
+    // that accepted prefix before settling the failure: once the state
+    // rejects, the step may persist its failure and the invocation finish,
+    // and anything still client-side would be lost. The original pipe error
+    // stays primary — a drain failure is already sticky on the sink.
+    if (state.drainBarrier) {
+      await state.drainBarrier().catch(() => {});
+    }
     if (!state.doneResolved) {
       state.doneResolved = true;
       state.reject(err);
@@ -368,216 +424,6 @@ async function flushablePipePerChunk(
     // Uses cancelReason (set in the catch block) so the source receives context
     // about why it was cancelled. On normal completion cancelReason is undefined,
     // which is a harmless no-op on an already-done reader.
-    reader.cancel(cancelReason).catch(() => {});
-    reader.releaseLock();
-    writer.releaseLock();
-  }
-}
-
-/**
- * Shared, mutable coordination state between the coalescing pipe's producer
- * (reads from source into `queue`) and consumer (drains `queue` in batches).
- */
-interface CoalesceContext {
-  state: FlushableStreamState;
-  batchWrite: BatchWrite;
-  /** Chunks read but not yet handed to a batch write. */
-  queue: Uint8Array[];
-  /** Set once the source has reported `done`. */
-  sourceDone: boolean;
-  /** Resolver that wakes the consumer when the queue grows or the source ends. */
-  wakeConsumer: (() => void) | null;
-  /** Resolver that wakes the producer when the consumer relieves backpressure. */
-  wakeProducer: (() => void) | null;
-  /** Wire limit: max chunks per coalesced `writeMulti`. */
-  maxChunksPerBatch: number;
-  /** Wire limit: max cumulative bytes per coalesced `writeMulti`. */
-  maxBytesPerBatch: number;
-}
-
-function wake(ctx: CoalesceContext, which: 'wakeConsumer' | 'wakeProducer') {
-  const resolve = ctx[which];
-  if (resolve) {
-    ctx[which] = null;
-    resolve();
-  }
-}
-
-/**
- * How many leading queued chunks fit in one `writeMulti` without crossing the
- * chunk-count or byte wire limits. Always returns at least 1 so a single chunk
- * larger than the byte cap still makes progress (alone).
- */
-function nextBatchSize(ctx: CoalesceContext): number {
-  let count = 0;
-  let bytes = 0;
-  for (const chunk of ctx.queue) {
-    if (count >= ctx.maxChunksPerBatch) break;
-    if (count > 0 && bytes + chunk.byteLength > ctx.maxBytesPerBatch) break;
-    count++;
-    bytes += chunk.byteLength;
-  }
-  return count;
-}
-
-/**
- * Consumer loop: drains the queue one batch at a time, awaiting each batch so it
- * is durable on the server before its chunks leave `pendingOps`. It takes as
- * much of the queue as the wire limits allow each round, so chunks that arrived
- * while the previous batch was in flight coalesce into the next server write.
- *
- * `pendingOps` is decremented only after `batchWrite` *succeeds*: on failure the
- * chunks stay retained in the sink's buffer (see `WorkflowServerWritableStream`)
- * and are therefore still "read but not durable", so they must keep counting.
- * A throw propagates out of the loop; the pipe's producer then tears down.
- */
-async function drainBatches(ctx: CoalesceContext): Promise<void> {
-  while (true) {
-    if (ctx.queue.length === 0) {
-      if (ctx.sourceDone) return;
-      await new Promise<void>((resolve) => {
-        ctx.wakeConsumer = resolve;
-      });
-      continue;
-    }
-    const count = nextBatchSize(ctx);
-    const batch = ctx.queue.slice(0, count);
-    ctx.queue = ctx.queue.slice(count);
-    await ctx.batchWrite(batch);
-    ctx.state.pendingOps -= batch.length;
-    // Relieve producer backpressure now that this batch is durable.
-    wake(ctx, 'wakeProducer');
-  }
-}
-
-/**
- * Await the next chunk while a batch write is in flight, racing three outcomes:
- * a read result, the sink closing under us, or a server-write failure from the
- * consumer (surfaced promptly even while blocked on the read). On normal
- * completion the consumer only settles after the producer sets `sourceDone`, so
- * its branch throws only on real failure.
- */
-function readNextChunk(
-  reader: ReadableStreamDefaultReader,
-  writer: WritableStreamDefaultWriter,
-  consumer: Promise<void>
-): Promise<Awaited<ReturnType<ReadableStreamDefaultReader['read']>>> {
-  return Promise.race([
-    reader.read(),
-    writer.closed.then(() => {
-      throw new WorkflowRuntimeError('Writable stream closed prematurely');
-    }),
-    consumer.then(
-      () => {
-        throw new WorkflowRuntimeError('Stream consumer ended prematurely');
-      },
-      (err) => {
-        throw err;
-      }
-    ),
-  ]);
-}
-
-/**
- * Backpressure: once too many chunks are outstanding, stop reading until the
- * consumer drains a batch. Racing the consumer avoids a deadlock if it ends or
- * fails while we wait.
- */
-async function awaitBackpressureRelief(
-  ctx: CoalesceContext,
-  consumer: Promise<void>,
-  maxInflight: number
-): Promise<void> {
-  if (ctx.state.pendingOps < maxInflight) return;
-  await Promise.race([
-    new Promise<void>((resolve) => {
-      ctx.wakeProducer = resolve;
-    }),
-    consumer.then(
-      () => undefined,
-      () => undefined
-    ),
-  ]);
-}
-
-/**
- * Batching variant of {@link flushablePipe} for sinks that expose a durable
- * batch write ({@link STREAM_WRITE_BATCH_SYMBOL}). A producer reads from
- * `source` into a queue; {@link drainBatches} coalesces queued chunks into as
- * few server writes as possible — turning a fast burst of chunks into a handful
- * of round trips instead of one per chunk.
- *
- * Durability is preserved exactly as in the per-chunk path: `state.pendingOps`
- * counts chunks that have been read but not yet durably written, so the
- * lock-release completion (`pollWritableLock` / `pollReadableLock`) never fires
- * while data is still queued or in flight, and the source-done path awaits every
- * batch before closing.
- */
-async function flushablePipeCoalescing(
-  source: ReadableStream,
-  sink: WritableStream,
-  state: FlushableStreamState,
-  batchWrite: BatchWrite
-): Promise<void> {
-  const reader = source.getReader();
-  const writer = sink.getWriter();
-  const maxInflight = getMaxInflightChunks();
-  let cancelReason: unknown;
-
-  const ctx: CoalesceContext = {
-    state,
-    batchWrite,
-    queue: [],
-    sourceDone: false,
-    wakeConsumer: null,
-    wakeProducer: null,
-    maxChunksPerBatch: getMaxChunksPerBatch(),
-    maxBytesPerBatch: getMaxBytesPerBatch(),
-  };
-  const consumer = drainBatches(ctx);
-
-  try {
-    while (!state.streamEnded) {
-      const readResult = await readNextChunk(reader, writer, consumer);
-      if (state.streamEnded) return;
-
-      if (readResult.done) {
-        // Signal end-of-source and wait for every queued/in-flight batch to
-        // reach the server before closing, so no chunk is dropped.
-        ctx.sourceDone = true;
-        wake(ctx, 'wakeConsumer');
-        await consumer;
-        state.streamEnded = true;
-        await writer.close();
-        if (!state.doneResolved) {
-          state.doneResolved = true;
-          state.resolve();
-        }
-        return;
-      }
-
-      // Count the chunk as pending the moment it is read — it stays counted
-      // until its batch is durably written.
-      ctx.queue.push(readResult.value as Uint8Array);
-      state.pendingOps++;
-      wake(ctx, 'wakeConsumer');
-
-      await awaitBackpressureRelief(ctx, consumer, maxInflight);
-    }
-  } catch (err) {
-    state.streamEnded = true;
-    cancelReason = err;
-    // Let the consumer settle so its rejection (if any) is observed here rather
-    // than surfacing as an unhandled rejection.
-    ctx.sourceDone = true;
-    wake(ctx, 'wakeConsumer');
-    await consumer.catch(() => {});
-    if (!state.doneResolved) {
-      state.doneResolved = true;
-      state.reject(err);
-    }
-    throw err;
-  } finally {
     reader.cancel(cancelReason).catch(() => {});
     reader.releaseLock();
     writer.releaseLock();

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -929,10 +929,11 @@ export async function executeStep(
       });
 
       // Flush pending ops (stream writes, etc.) with a short inline wait.
-      // Now that WorkflowServerWritableStream flushes synchronously on
-      // each write (not via setTimeout), the flushablePipe's pendingOps
-      // accurately reflects whether data has reached the server. Most ops
-      // settle within ~200ms (100ms lock-release polling + HTTP flush).
+      // WorkflowServerWritableStream acks writes on buffer entry
+      // (group-commit batching); durability is enforced by its drain
+      // barrier, which the flushable state's completion awaits after
+      // lock release. Most ops settle within ~200ms (lock-release
+      // polling + one batched HTTP flush).
       // If ops don't settle in 500ms (e.g., WritableStream kept open
       // across steps), waitUntil handles the rest.
       if (ops.length > 0) {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -15,6 +15,10 @@ import {
 import {
   createFlushableState,
   flushablePipe,
+  getMaxBufferedBytes,
+  getMaxBytesPerBatch,
+  getMaxChunksPerBatch,
+  getMaxInflightChunks,
   pollReadableLock,
   pollWritableLock,
 } from './flushable-stream.js';
@@ -76,12 +80,12 @@ import {
   ABORT_STREAM_NAME,
   BODY_INIT_SYMBOL,
   STABLE_ULID,
+  STREAM_DRAIN_SYMBOL,
   STREAM_FRAMING_SYMBOL,
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
   STREAM_TYPE_SYMBOL,
-  STREAM_WRITE_BATCH_SYMBOL,
   WEBHOOK_RESPONSE_WRITABLE,
 } from './symbols.js';
 import * as Attr from './telemetry/semantic-conventions.js';
@@ -1065,149 +1069,271 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
       }
     };
 
-    // Buffering state for batched writes
+    // ------------------------------------------------------------------
+    // Group-commit buffering.
+    //
+    // `write()` resolves as soon as the chunk enters this bounded buffer —
+    // NOT when it is durable. That is the property that makes batching
+    // path-independent: a native `readable.pipeTo(serverWritable)` pulls the
+    // next chunk the moment `write()` resolves, so chunks accumulate here
+    // during the flush-timer window and while a server request is in
+    // flight, and each accumulated group goes out as one `writeMulti`.
+    // (Previously `write()` resolved only after the timer AND the server
+    // round trip, so native piping serialized to one request per chunk and
+    // batching only worked through `flushablePipe`'s bespoke coalescing.)
+    //
+    // Durability has a dedicated barrier instead: `drain()` (exposed via
+    // {@link STREAM_DRAIN_SYMBOL}) resolves only when the buffer is empty
+    // and no request is in flight. `close()` awaits it before closing the
+    // server stream, and the flushable-stream lock-release completion
+    // awaits it before letting a step finish — so "step completed" still
+    // implies "stream data durable", exactly as before.
+    //
     // Encryption/decryption is handled at the framing level by
     // getSerializeStream/getDeserializeStream, not here.
+    // ------------------------------------------------------------------
     let buffer: Uint8Array[] = [];
+    let bufferBytes = 0;
+    // The group currently inside a server request. Counted against the
+    // buffer bound so `WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS` keeps its
+    // documented meaning — an upper bound across ALL read-but-not-durable
+    // chunks — not just the queued follow-up group.
+    let inFlightChunks = 0;
+    let inFlightBytes = 0;
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
-    let flushPromise: Promise<void> | null = null;
+    /** The in-flight dispatch chain. At most one, preserving chunk order. */
+    let inFlight: Promise<void> | null = null;
+    /**
+     * Sticky failure: once a dispatch fails, the failed group is re-queued
+     * (retained, exactly as the previous implementation retained its buffer)
+     * and every subsequent `write()`, `close()` and `drain()` rejects with
+     * the original error. Chunks whose `write()` already resolved surface
+     * their failure at the durability barrier — that is the contract of an
+     * early-ack sink.
+     */
+    let sinkError: unknown;
     let resolvedFlushIntervalMs: number | undefined;
-    // Client-observed write-batch timing: stamped at `write()` entry for the
-    // first chunk of a batch — before the backpressure wait on any in-flight
-    // flush — so the emitted span covers the full app-perceived latency
-    // (queueing + flush-timer dwell + RPC). Cleared when a flush takes the
-    // batch; restored on write failure so a retried batch keeps its true t0.
-    let batchStartAt: number | undefined;
+    // Per-request wire limits (server caps) and the buffer bound. The bound
+    // uses the same knobs the coalescing pipe used, so producer backpressure
+    // behavior is unchanged: once a request-worth of chunks (or the byte
+    // bound) is buffered, `write()` blocks until a group lands durably.
+    const maxChunksPerRequest = getMaxChunksPerBatch();
+    const maxBytesPerRequest = getMaxBytesPerBatch();
+    const maxBufferedChunks = getMaxInflightChunks();
+    const maxBufferedBytes = getMaxBufferedBytes();
+    // Client-observed write-batch timing: stamped when the buffer goes
+    // empty→non-empty, consumed by the group that carries that chunk out.
+    let bufferT0: number | undefined;
 
-    const flush = async (): Promise<void> => {
-      if (flushTimer) {
-        clearTimeout(flushTimer);
-        flushTimer = null;
+    type Waiter = { resolve: () => void; reject: (err: unknown) => void };
+    /** write() calls blocked on the buffer bound. */
+    let capacityWaiters: Waiter[] = [];
+    /** drain() calls waiting for full durability. */
+    let drainWaiters: Waiter[] = [];
+
+    const rejectWaiters = (err: unknown): void => {
+      const all = [...capacityWaiters, ...drainWaiters];
+      capacityWaiters = [];
+      drainWaiters = [];
+      for (const w of all) w.reject(err);
+    };
+
+    /**
+     * Take the largest leading group that fits one request: at most
+     * `maxChunksPerRequest` chunks and `maxBytesPerRequest` cumulative bytes
+     * (a single oversized chunk still goes out alone).
+     */
+    const takeGroup = (): { group: Uint8Array[]; bytes: number } => {
+      let count = 0;
+      let bytes = 0;
+      for (const chunk of buffer) {
+        if (count >= maxChunksPerRequest) break;
+        if (count > 0 && bytes + chunk.byteLength > maxBytesPerRequest) break;
+        count++;
+        bytes += chunk.byteLength;
       }
+      const group = buffer.slice(0, count);
+      buffer = buffer.slice(count);
+      bufferBytes -= bytes;
+      return { group, bytes };
+    };
 
-      if (buffer.length === 0) return;
-
-      // Order the first server write after the run exists (turbo optimistic
-      // start); a no-op on every later flush and outside turbo.
+    /**
+     * Dispatch loop: while chunks are buffered, send them group by group.
+     * Exactly one loop runs at a time (`inFlight`), so groups reach the
+     * server in write order. Chunks that arrive while a group's request is
+     * in flight accumulate and form the next group — the group-commit
+     * behavior, now independent of how the producer pipes.
+     */
+    /**
+     * Send one group to the server: gate on run readiness, resolve the flush
+     * interval from the world (lazy, first dispatch only), then one
+     * `writeMulti` (or sequential `write`s when the world lacks it). Emits
+     * the write-flush span; dwell is measured up to just before the RPC so a
+     * turbo run-ready barrier wait counts as buffer dwell, matching the
+     * pre-group-commit telemetry.
+     */
+    const sendGroup = async (
+      group: Uint8Array[],
+      bytes: number,
+      groupT0: number | undefined
+    ): Promise<void> => {
       await ensureRunReady();
-
-      // Copy chunks to flush, but don't clear buffer until write succeeds
-      // This prevents data loss if the write operation fails
-      const chunksToFlush = buffer.slice();
-      const batchStart = batchStartAt;
-      batchStartAt = undefined;
-      const dispatchAt = Date.now();
-
       const world = await worldPromise;
-      // Cache the flush interval from the world on first use
       if (resolvedFlushIntervalMs === undefined) {
         resolvedFlushIntervalMs =
           world.streamFlushIntervalMs ?? getStreamFlushIntervalMs();
       }
-      const rpcStartAt = Date.now();
-      try {
-        // Use writeMulti if available for batch writes
-        if (
-          typeof world.streams.writeMulti === 'function' &&
-          chunksToFlush.length > 1
-        ) {
-          await world.streams.writeMulti(runId, name, chunksToFlush);
-        } else {
-          // Fall back to sequential writes
-          for (const chunk of chunksToFlush) {
-            await world.streams.write(runId, name, chunk);
-          }
+      const dispatchAt = Date.now();
+      if (typeof world.streams.writeMulti === 'function' && group.length > 1) {
+        await world.streams.writeMulti(runId, name, group);
+      } else {
+        // Fall back to sequential writes
+        for (const chunk of group) {
+          await world.streams.write(runId, name, chunk);
         }
-      } catch (error) {
-        // The batch stays buffered for retry — restore its original t0 (the
-        // oldest, if a newer write stamped one meanwhile) so the eventually
-        // successful flush reports the full dwell.
-        if (batchStart !== undefined) {
-          batchStartAt =
-            batchStartAt === undefined
-              ? batchStart
-              : Math.min(batchStartAt, batchStart);
-        }
-        throw error;
       }
-
-      if (batchStart !== undefined) {
+      if (groupT0 !== undefined) {
         recordStreamWriteFlush(
-          batchStart,
+          groupT0,
           dispatchAt,
           runId,
           name,
-          chunksToFlush.length,
-          chunksToFlush.reduce((sum, c) => sum + c.byteLength, 0),
-          Date.now() - rpcStartAt
+          group.length,
+          bytes,
+          Date.now() - dispatchAt
         );
       }
-
-      // Only clear buffer after successful write to prevent data loss
-      buffer = [];
     };
 
-    /** Resolvers/rejectors waiting for the current scheduled flush */
-    let flushWaiters: Array<{
-      resolve: () => void;
-      reject: (err: unknown) => void;
-    }> = [];
+    const dispatchLoop = async (): Promise<void> => {
+      while (buffer.length > 0) {
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
+        const groupT0 = bufferT0;
+        const groupTakenAt = Date.now();
+        const { group, bytes } = takeGroup();
+        inFlightChunks = group.length;
+        inFlightBytes = bytes;
+        bufferT0 = buffer.length > 0 ? groupTakenAt : undefined;
 
-    const scheduleFlush = (): void => {
-      if (flushTimer) return; // Already scheduled
+        try {
+          await sendGroup(group, bytes, groupT0);
+          inFlightChunks = 0;
+          inFlightBytes = 0;
+        } catch (error) {
+          // Retain the failed group (and its original t0) at the front of
+          // the buffer, poison the sink, and surface the failure to every
+          // blocked writer and drain waiter.
+          buffer = group.concat(buffer);
+          bufferBytes += bytes;
+          inFlightChunks = 0;
+          inFlightBytes = 0;
+          bufferT0 =
+            groupT0 !== undefined && bufferT0 !== undefined
+              ? Math.min(groupT0, bufferT0)
+              : (groupT0 ?? bufferT0);
+          throw error;
+        }
 
+        // This group is durable: relieve writers blocked on the bound (they
+        // re-check it and may block again).
+        const relieved = capacityWaiters;
+        capacityWaiters = [];
+        for (const w of relieved) w.resolve();
+      }
+    };
+
+    /** Start (or join) the dispatch chain. Never leaves an unhandled rejection. */
+    const startDispatch = (): void => {
+      if (inFlight || sinkError !== undefined || buffer.length === 0) return;
+      inFlight = dispatchLoop().then(
+        () => {
+          inFlight = null;
+          // Fully idle (the loop only exits with an empty buffer): settle
+          // the durability barrier.
+          const settled = drainWaiters;
+          drainWaiters = [];
+          for (const w of settled) w.resolve();
+        },
+        (error) => {
+          inFlight = null;
+          sinkError ??= error;
+          rejectWaiters(sinkError);
+        }
+      );
+    };
+
+    /** Arm the group-commit window unless a dispatch is already running. */
+    const scheduleGroupCommit = (): void => {
+      if (flushTimer || inFlight) return;
       flushTimer = setTimeout(() => {
         flushTimer = null;
-        const currentWaiters = flushWaiters;
-        flushWaiters = [];
-        flushPromise = flush().then(
-          () => {
-            for (const w of currentWaiters) w.resolve();
-          },
-          (err) => {
-            for (const w of currentWaiters) w.reject(err);
-          }
-        );
+        startDispatch();
       }, resolvedFlushIntervalMs ?? getStreamFlushIntervalMs());
+    };
+
+    /**
+     * Durability barrier: resolves when every accepted chunk has reached the
+     * server and nothing is buffered or in flight; rejects with the sink's
+     * sticky error if any dispatch failed. Flushes a pending group-commit
+     * window immediately rather than waiting out the timer.
+     */
+    const drain = async (): Promise<void> => {
+      while (true) {
+        if (sinkError !== undefined) throw sinkError;
+        if (buffer.length === 0 && !inFlight) return;
+        startDispatch();
+        await new Promise<void>((resolve, reject) => {
+          drainWaiters.push({ resolve, reject });
+        });
+      }
     };
 
     super({
       async write(chunk) {
-        // Batch t0 for the write-flush span: at entry, before the
-        // backpressure wait below, so queueing behind an in-flight flush
-        // counts toward the app-perceived dwell.
-        if (batchStartAt === undefined) batchStartAt = Date.now();
+        if (sinkError !== undefined) throw sinkError;
+        if (bufferT0 === undefined) bufferT0 = Date.now();
+        buffer.push(chunk);
+        bufferBytes += chunk.byteLength;
 
-        // Wait for any in-progress flush to complete before adding to buffer
-        if (flushPromise) {
-          await flushPromise;
-          flushPromise = null;
+        if (
+          buffer.length >= maxChunksPerRequest ||
+          bufferBytes >= maxBytesPerRequest
+        ) {
+          // The buffered group already fills a request: no point dwelling in
+          // the commit window.
+          startDispatch();
+        } else {
+          scheduleGroupCommit();
         }
 
-        buffer.push(chunk);
-        scheduleFlush();
-
-        // Wait for the scheduled flush to complete so that callers
-        // (like flushablePipe) know data has reached the server
-        // before decrementing pendingOps. Without this, pendingOps
-        // reaches 0 when the buffered write returns (instant), but
-        // the 10ms flush timer hasn't fired yet.
-        await new Promise<void>((resolve, reject) => {
-          flushWaiters.push({ resolve, reject });
-        });
+        // Bounded buffer: accept the chunk (never drop), then block until
+        // the read-but-not-durable population — buffered AND in the active
+        // request — is back under the bound. Each durably-sent group
+        // relieves this.
+        while (
+          sinkError === undefined &&
+          (buffer.length + inFlightChunks >= maxBufferedChunks ||
+            bufferBytes + inFlightBytes >= maxBufferedBytes)
+        ) {
+          startDispatch();
+          await new Promise<void>((resolve, reject) => {
+            capacityWaiters.push({ resolve, reject });
+          });
+        }
+        if (sinkError !== undefined) throw sinkError;
       },
       async close() {
-        // Wait for any in-progress flush to complete
-        if (flushPromise) {
-          await flushPromise;
-          flushPromise = null;
-        }
+        // Everything accepted must be durable before the server stream is
+        // closed — the server fences post-close writes.
+        await drain();
 
-        // Flush any remaining buffered chunks
-        await flush();
-
-        // A close with an empty buffer skips flush()'s write (and its barrier),
-        // but can itself be the first write to a brand-new stream — gate it too.
+        // A close with an empty buffer skips the dispatch path (and its
+        // barrier), but can itself be the first write to a brand-new
+        // stream — gate it too.
         await ensureRunReady();
 
         const world = await worldPromise;
@@ -1215,47 +1341,38 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
         await world.streams.close(runId, name);
         recordStreamClose(closeStart, runId, name);
       },
-      abort(reason) {
-        // Clean up timer to prevent leaks
+      async abort(reason) {
+        // Buffered chunks were already ACKED to their writers (early-ack
+        // contract), and native pipeTo aborts this sink whenever its SOURCE
+        // errors — e.g. an AI stream that emits ten deltas and then throws.
+        // Discarding here would silently lose the accepted tail of the
+        // prefix, so deliver it first; only the server stream close is
+        // skipped. A dispatch failure during this drain is already sticky
+        // and surfaces through the sink's error paths.
+        try {
+          await drain();
+        } catch {
+          // sinkError is set; accepted-but-undeliverable chunks surface it.
+        }
         if (flushTimer) {
           clearTimeout(flushTimer);
           flushTimer = null;
         }
-        // Discard buffered chunks - they won't be written
         buffer = [];
-        // Reject any pending flushWaiters so the write() promises settle
-        // and don't leak. Without this, write() hangs forever on an
-        // unsettled promise because the cleared timer will never fire.
-        const waiters = flushWaiters;
-        flushWaiters = [];
-        const abortError = reason ?? new Error('Stream aborted');
-        for (const w of waiters) w.reject(abortError);
+        bufferBytes = 0;
+        sinkError ??= reason ?? new Error('Stream aborted');
+        // Reject blocked writers and drain waiters so nothing leaks or
+        // hangs on a promise whose timer was just cleared.
+        rejectWaiters(sinkError);
       },
     });
 
-    // Batched, durable write entry point used by `flushablePipe` to coalesce
-    // chunks that arrive while a previous batch is still in flight into a
-    // single server write. It buffers every chunk and awaits one `flush()`,
-    // so the whole batch goes out as one `writeMulti` and resolves only once
-    // the batch has reached the server. It shares the buffer/flush machinery
-    // with the per-chunk sink `write()`, but the two are never used
-    // concurrently on the same stream: `flushablePipe` uses either this path
-    // or the writer, never both. On failure `flush()` retains the batch in the
-    // buffer and rethrows, so the caller's durability tracking stays accurate.
-    //
-    // No-`writeMulti` fallback: when the world lacks `writeMulti`, `flush()`
-    // degrades to sequential `write`s for the batch's chunks — one round trip
-    // each, within this single call, while backpressure holds the producer.
-    // `flushablePipe` bounds that stall by capping each coalesced batch (see
-    // `MAX_CHUNKS_PER_BATCH` / `MAX_BYTES_PER_BATCH`), so the fallback can't
-    // turn one drain into an unbounded sequential run.
-    Object.defineProperty(this, STREAM_WRITE_BATCH_SYMBOL, {
-      value: async (chunks: Uint8Array[]): Promise<void> => {
-        if (chunks.length === 0) return;
-        if (batchStartAt === undefined) batchStartAt = Date.now();
-        for (const chunk of chunks) buffer.push(chunk);
-        await flush();
-      },
+    // Durability barrier for owners that complete without closing the
+    // stream: `flushablePipe`'s lock-release completion awaits this so a
+    // step cannot finish (and the function suspend) while accepted chunks
+    // are still client-buffered or in flight.
+    Object.defineProperty(this, STREAM_DRAIN_SYMBOL, {
+      value: drain,
       enumerable: false,
       writable: false,
     });

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1252,6 +1252,16 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
       inFlight = dispatchLoop().then(
         () => {
           inFlight = null;
+          // A write can land in the microtask gap between the loop's
+          // empty-buffer exit and this reaction. scheduleGroupCommit saw
+          // inFlight still set and armed no timer, so without this check
+          // the chunk would sit stranded until a later write/close/drain.
+          // Treat it like an in-request arrival: dispatch immediately (the
+          // new chain settles the drain waiters when it finishes).
+          if (buffer.length > 0) {
+            startDispatch();
+            return;
+          }
           // Fully idle (the loop only exits with an empty buffer): settle
           // the durability barrier.
           const settled = drainWaiters;

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1359,6 +1359,15 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
         // prefix, so deliver it first; only the server stream close is
         // skipped. A dispatch failure during this drain is already sticky
         // and surfaces through the sink's error paths.
+        //
+        // Deliberately un-timeboxed (unlike the step-executor's 500ms
+        // inline flush): giving up early would drop acked chunks — the
+        // exact loss this path exists to prevent. It is still bounded in
+        // practice by the World transport's own timeout/retry budget: a
+        // stalled write ends in a terminal rejection after finite retries,
+        // which rejects the dispatch and lands in the catch below. The
+        // same catch absorbs the expected conflict when a teardown-driven
+        // abort drains into an already-terminal run.
         try {
           await drain();
         } catch {

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -35,20 +35,18 @@ export const STREAM_SERVER_DEPLOYMENT_ID_SYMBOL = Symbol.for(
   'WORKFLOW_STREAM_SERVER_DEPLOYMENT_ID'
 );
 /**
- * Stamped on a `WorkflowServerWritableStream` instance to expose a batched,
- * durable write entry point: `(chunks) => Promise<void>` that flushes every
- * chunk in one `writeMulti` (falling back to sequential `write`s when the
- * world lacks `writeMulti`) and resolves only once the whole batch has
- * reached the server.
+ * Stamped on a `WorkflowServerWritableStream` instance to expose its
+ * durability barrier: `() => Promise<void>` that resolves once every accepted
+ * chunk has durably reached the server (nothing buffered, nothing in flight)
+ * and rejects if any dispatch failed.
  *
- * `flushablePipe` feature-detects this to coalesce chunks that arrive while a
- * previous batch is still in flight into a single server write. Sinks without
- * it (plain `WritableStream`s, `TransformStream` writables on the read path)
- * fall back to the per-chunk write loop. See `flushablePipe`.
+ * The sink acks `write()` on buffer entry (group-commit batching), so
+ * durability tracking lives here instead: `flushablePipe` feature-detects
+ * this and awaits it before resolving its lock-release completion, keeping
+ * the invariant that a step cannot complete while stream data is still
+ * client-side. Sinks without it are fully durable per `write()` already.
  */
-export const STREAM_WRITE_BATCH_SYMBOL = Symbol.for(
-  'WORKFLOW_STREAM_WRITE_BATCH'
-);
+export const STREAM_DRAIN_SYMBOL = Symbol.for('WORKFLOW_STREAM_DRAIN');
 
 export const BODY_INIT_SYMBOL = Symbol.for('BODY_INIT');
 export const WEBHOOK_RESPONSE_WRITABLE = Symbol.for(

--- a/packages/core/src/writable-stream-telemetry.test.ts
+++ b/packages/core/src/writable-stream-telemetry.test.ts
@@ -104,17 +104,34 @@ describe('WorkflowServerWritableStream write-flush telemetry', () => {
     expect(durationMs).toBeGreaterThanOrEqual(dwell as number);
   });
 
-  it('emits one span per flush cycle', async () => {
+  it('emits one span per dispatched group (group commit coalesces rapid writes)', async () => {
     const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
     const writer = stream.getWriter();
 
+    // Rapid awaited writes ack on buffer entry and land in one commit
+    // window: ONE group, ONE flush span covering all three chunks.
     await writer.write(new Uint8Array([1]));
     await writer.write(new Uint8Array([2]));
     await writer.write(new Uint8Array([3]));
     await writer.close();
 
-    const spans = await waitForSpans('workflow.stream.flush', 3);
-    expect(spans).toHaveLength(3);
+    const spans = await waitForSpans('workflow.stream.flush', 1);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attributes['workflow.stream.flush.chunks']).toBe(3);
+    expect(spans[0].attributes['workflow.stream.flush.bytes']).toBe(3);
+  });
+
+  it('emits separate spans for groups separated by a commit window', async () => {
+    const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+    const writer = stream.getWriter();
+
+    await writer.write(new Uint8Array([1]));
+    await new Promise((r) => setTimeout(r, 25)); // let the window fire
+    await writer.write(new Uint8Array([2]));
+    await writer.close();
+
+    const spans = await waitForSpans('workflow.stream.flush', 2);
+    expect(spans).toHaveLength(2);
     for (const span of spans) {
       expect(span.attributes['workflow.stream.flush.chunks']).toBe(1);
     }
@@ -133,11 +150,11 @@ describe('WorkflowServerWritableStream write-flush telemetry', () => {
     );
     const writer = stream.getWriter();
 
-    const writePromise = writer.write(new Uint8Array([1, 2, 3]));
-    // Hold the first flush on the barrier long enough to dominate the dwell.
+    await writer.write(new Uint8Array([1, 2, 3]));
+    // Hold the first dispatch on the barrier long enough to dominate the
+    // dwell (write() itself acks on buffer entry and does not wait).
     await new Promise((r) => setTimeout(r, 50));
     releaseBarrier();
-    await writePromise;
     await writer.close();
 
     const [span] = await waitForSpans('workflow.stream.flush', 1);

--- a/packages/core/src/writable-stream.test.ts
+++ b/packages/core/src/writable-stream.test.ts
@@ -348,6 +348,50 @@ describe('WorkflowServerWritableStream', () => {
     });
   });
 
+  describe('dispatch settle race', () => {
+    it('does not strand a chunk written in the settle gap of the previous request', async () => {
+      // A write can land in the microtask window between the dispatch
+      // loop's empty-buffer exit and the reaction that clears the in-flight
+      // marker. In that window no group-commit timer is armed (the marker
+      // is still set), so without the settle-gap re-dispatch the chunk
+      // would never flush on an open stream. The mock lands the second
+      // write a few microtasks after the first request resolves to aim at
+      // exactly that gap; the assertion holds wherever it lands.
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      let landed = false;
+      mockStreams.write.mockImplementationOnce(async () => {
+        void Promise.resolve()
+          .then(() => undefined)
+          .then(() => {
+            void writer.write(new Uint8Array([2])).then(() => {
+              landed = true;
+            });
+          });
+      });
+
+      await writer.write(new Uint8Array([1]));
+
+      // Well past the 10ms commit window: BOTH chunks must have dispatched
+      // without any close/drain nudge. A stranded chunk has no timer and
+      // would never arrive.
+      await new Promise((r) => setTimeout(r, 60));
+      expect(landed).toBe(true);
+      const delivered = [
+        ...mockStreams.write.mock.calls.map(
+          (call: unknown[]) => (call[2] as Uint8Array)[0]
+        ),
+        ...mockStreams.writeMulti.mock.calls.flatMap((call: unknown[]) =>
+          (call[2] as Uint8Array[]).map((c) => c[0])
+        ),
+      ];
+      expect(delivered.sort()).toEqual([1, 2]);
+
+      await writer.close();
+    });
+  });
+
   describe('close behavior', () => {
     it('should call close on close', async () => {
       const stream = new WorkflowServerWritableStream('run-123', 'test-stream');

--- a/packages/core/src/writable-stream.test.ts
+++ b/packages/core/src/writable-stream.test.ts
@@ -56,14 +56,19 @@ describe('WorkflowServerWritableStream', () => {
     });
   });
 
-  describe('flush-on-write behavior', () => {
-    it('write() resolves only after data reaches server', async () => {
+  describe('group-commit write behavior', () => {
+    it('write() resolves on buffer entry; the chunk reaches the server after the commit window', async () => {
       const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array([1, 2, 3]));
 
-      // After write() resolves, data must be on the server
+      // write() acked on buffer entry — nothing has gone to the server yet.
+      expect(mockStreams.write).not.toHaveBeenCalled();
+      expect(mockStreams.writeMulti).not.toHaveBeenCalled();
+
+      // The group-commit window fires and dispatches the chunk.
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
       expect(mockStreams.write).toHaveBeenCalledWith(
         'run-123',
@@ -74,17 +79,32 @@ describe('WorkflowServerWritableStream', () => {
       await writer.close();
     });
 
-    it('should use write for single chunk', async () => {
+    it('uses a single write (not writeMulti) for a lone chunk', async () => {
       const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array([1, 2, 3]));
+      await writer.close(); // close drains immediately, no timer wait needed
 
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
-      // Single chunk should NOT use writeMulti
       expect(mockStreams.writeMulti).not.toHaveBeenCalled();
+    });
 
+    it('coalesces rapid awaited writes into one writeMulti group', async () => {
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      // Each write resolves on buffer entry, so an awaited per-chunk loop —
+      // the previously-unbatchable pattern — lands in one commit window.
+      for (let i = 0; i < 5; i++) {
+        await writer.write(new Uint8Array([i]));
+      }
       await writer.close();
+
+      expect(mockStreams.writeMulti).toHaveBeenCalledTimes(1);
+      const [, , group] = mockStreams.writeMulti.mock.calls[0];
+      expect(group.map((c: Uint8Array) => c[0])).toEqual([0, 1, 2, 3, 4]);
+      expect(mockStreams.write).not.toHaveBeenCalled();
     });
 
     it('should fall back to sequential writes when writeMulti is unavailable', async () => {
@@ -94,70 +114,237 @@ describe('WorkflowServerWritableStream', () => {
       const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
       const writer = stream.getWriter();
 
-      await writer.write(new Uint8Array([1, 2, 3]));
-
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
-
+      await writer.write(new Uint8Array([1]));
+      await writer.write(new Uint8Array([2]));
       await writer.close();
-    });
 
-    it('should handle multiple sequential writes (multiple flush cycles)', async () => {
-      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
-      const writer = stream.getWriter();
-
-      // Each write triggers its own flush cycle
-      for (let i = 0; i < 5; i++) {
-        await writer.write(new Uint8Array([i]));
-      }
-
-      expect(mockStreams.write).toHaveBeenCalledTimes(5);
-      expect(mockStreams.write).toHaveBeenNthCalledWith(
-        1,
-        'run-123',
-        'test-stream',
-        new Uint8Array([0])
-      );
-      expect(mockStreams.write).toHaveBeenNthCalledWith(
-        5,
-        'run-123',
-        'test-stream',
-        new Uint8Array([4])
-      );
-
-      await writer.close();
-    });
-
-    it('should wait for in-progress flush before adding to buffer', async () => {
-      // Simulate a slow flush to test concurrent write behavior
-      let resolveFlush!: () => void;
-      mockStreams.write.mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveFlush = resolve;
-          })
-      );
-
-      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
-      const writer = stream.getWriter();
-
-      // Start first write — it will wait for the slow flush
-      const write1 = writer.write(new Uint8Array([1, 2, 3]));
-
-      // Give the timer time to fire and start the flush
-      await new Promise((r) => setTimeout(r, 20));
-
-      // Flush has started but not completed
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
-
-      // Resolve the first flush
-      resolveFlush();
-      await write1;
-
-      // Second write should proceed normally after flush completes
-      await writer.write(new Uint8Array([4, 5, 6]));
       expect(mockStreams.write).toHaveBeenCalledTimes(2);
+      const delivered = mockStreams.write.mock.calls.map(
+        (call: unknown[]) => (call[2] as Uint8Array)[0]
+      );
+      expect(delivered).toEqual([1, 2]);
+    });
+
+    it('chunks accepted during an in-flight request form the next group', async () => {
+      // Hold the first request in flight; chunks written meanwhile must
+      // accumulate and go out as ONE writeMulti when it settles — with a
+      // plain writer, no special pipe.
+      let releaseFirst!: () => void;
+      const firstInFlight = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      mockStreams.write.mockImplementationOnce(async () => {
+        await firstInFlight;
+      });
+
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      await writer.write(new Uint8Array([1]));
+      // Let the commit window fire and the first request go in flight.
+      await new Promise((r) => setTimeout(r, 25));
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+
+      await writer.write(new Uint8Array([2]));
+      await writer.write(new Uint8Array([3]));
+      await writer.write(new Uint8Array([4]));
+      expect(mockStreams.writeMulti).not.toHaveBeenCalled();
+
+      releaseFirst();
+      await writer.close();
+
+      expect(mockStreams.writeMulti).toHaveBeenCalledTimes(1);
+      const [, , group] = mockStreams.writeMulti.mock.calls[0];
+      expect(group.map((c: Uint8Array) => c[0])).toEqual([2, 3, 4]);
+    });
+
+    it('batches through a NATIVE pipeTo — no flushablePipe required', async () => {
+      // The regression this rework exists for: a raw ReadableStream piped
+      // with the platform pipeTo() (the cross-boundary serialization path)
+      // must batch exactly like the flushablePipe path.
+      let releaseFirst!: () => void;
+      const firstInFlight = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      mockStreams.write.mockImplementationOnce(async () => {
+        await firstInFlight;
+      });
+
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      let controller!: ReadableStreamDefaultController<Uint8Array>;
+      const source = new ReadableStream<Uint8Array>({
+        start(c) {
+          controller = c;
+        },
+      });
+      const piped = source.pipeTo(stream);
+
+      controller.enqueue(new Uint8Array([1]));
+      await new Promise((r) => setTimeout(r, 25));
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+
+      // pipeTo pulls the next chunk as soon as write() acks (buffer entry),
+      // so these accumulate during the in-flight request.
+      controller.enqueue(new Uint8Array([2]));
+      controller.enqueue(new Uint8Array([3]));
+      controller.enqueue(new Uint8Array([4]));
+      await new Promise((r) => setTimeout(r, 5));
+      expect(mockStreams.writeMulti).not.toHaveBeenCalled();
+
+      releaseFirst();
+      controller.close();
+      await piped;
+
+      expect(mockStreams.writeMulti).toHaveBeenCalledTimes(1);
+      const [, , group] = mockStreams.writeMulti.mock.calls[0];
+      expect(group.map((c: Uint8Array) => c[0])).toEqual([2, 3, 4]);
+      expect(mockStreams.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('wire limits and backpressure', () => {
+    afterEach(() => {
+      delete process.env.WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS;
+      delete process.env.WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH;
+      delete process.env.WORKFLOW_STREAM_MAX_BYTES_PER_BATCH;
+      delete process.env.WORKFLOW_STREAM_MAX_BUFFERED_BYTES;
+    });
+
+    it('splits groups at the chunk-count wire limit', async () => {
+      process.env.WORKFLOW_STREAM_MAX_CHUNKS_PER_BATCH = '2';
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      for (let i = 0; i < 5; i++) await writer.write(new Uint8Array([i]));
+      await writer.close();
+
+      // 5 chunks in one commit window → requests of 2, 2, 1 in order.
+      const groups = [
+        ...mockStreams.writeMulti.mock.calls.map((call: unknown[]) =>
+          (call[2] as Uint8Array[]).map((c) => c[0])
+        ),
+        ...mockStreams.write.mock.calls.map((call: unknown[]) => [
+          (call[2] as Uint8Array)[0],
+        ]),
+      ];
+      expect(groups.flat().sort()).toEqual([0, 1, 2, 3, 4]);
+      for (const group of groups) expect(group.length).toBeLessThanOrEqual(2);
+    });
+
+    it('splits groups at the byte wire limit', async () => {
+      process.env.WORKFLOW_STREAM_MAX_BYTES_PER_BATCH = '10';
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      // 5 × 4-byte chunks: at most two fit under the 10-byte request cap.
+      for (let i = 0; i < 5; i++) {
+        await writer.write(new Uint8Array([i, i, i, i]));
+      }
+      await writer.close();
+
+      const groups = [
+        ...mockStreams.writeMulti.mock.calls.map(
+          (call: unknown[]) => call[2] as Uint8Array[]
+        ),
+        ...mockStreams.write.mock.calls.map((call: unknown[]) => [
+          call[2] as Uint8Array,
+        ]),
+      ];
+      let delivered = 0;
+      for (const group of groups) {
+        const bytes = group.reduce((sum, c) => sum + c.byteLength, 0);
+        expect(bytes).toBeLessThanOrEqual(10);
+        delivered += group.length;
+      }
+      expect(delivered).toBe(5);
+    });
+
+    it('sends an oversized single chunk alone rather than stalling', async () => {
+      process.env.WORKFLOW_STREAM_MAX_BYTES_PER_BATCH = '4';
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      await writer.write(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+      await writer.close();
+
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      const [, , chunk] = mockStreams.write.mock.calls[0];
+      expect((chunk as Uint8Array).byteLength).toBe(8);
+    });
+
+    it('backpressure counts the in-flight request against the chunk bound', async () => {
+      // Cap of 2 across the WHOLE read-but-not-durable population: one
+      // chunk in the active request plus one buffered must block the next
+      // write() until the request lands.
+      process.env.WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS = '2';
+      let releaseFirst!: () => void;
+      const firstInFlight = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      mockStreams.write.mockImplementationOnce(async () => {
+        await firstInFlight;
+      });
+
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      await writer.write(new Uint8Array([1]));
+      await new Promise((r) => setTimeout(r, 25)); // request in flight
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+
+      // buffered(1) + inFlight(1) == bound → this write must block.
+      let secondResolved = false;
+      const second = writer.write(new Uint8Array([2])).then(() => {
+        secondResolved = true;
+      });
+      await new Promise((r) => setTimeout(r, 25));
+      expect(secondResolved).toBe(false);
+
+      releaseFirst();
+      await second;
+      expect(secondResolved).toBe(true);
 
       await writer.close();
+      const delivered = [
+        ...mockStreams.write.mock.calls.map(
+          (call: unknown[]) => (call[2] as Uint8Array)[0]
+        ),
+        ...mockStreams.writeMulti.mock.calls.flatMap((call: unknown[]) =>
+          (call[2] as Uint8Array[]).map((c) => c[0])
+        ),
+      ];
+      expect(delivered.sort()).toEqual([1, 2]);
+    });
+
+    it('WORKFLOW_STREAM_MAX_BUFFERED_BYTES applies byte-denominated backpressure', async () => {
+      process.env.WORKFLOW_STREAM_MAX_BUFFERED_BYTES = '8';
+      let releaseFirst!: () => void;
+      const firstInFlight = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      mockStreams.write.mockImplementationOnce(async () => {
+        await firstInFlight;
+      });
+
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      await writer.write(new Uint8Array(6)); // in the active request: 6 bytes
+      await new Promise((r) => setTimeout(r, 25));
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+
+      // inFlight(6B) + buffered(6B) ≥ 8B bound → blocks until the request lands.
+      let secondResolved = false;
+      const second = writer.write(new Uint8Array(6)).then(() => {
+        secondResolved = true;
+      });
+      await new Promise((r) => setTimeout(r, 25));
+      expect(secondResolved).toBe(false);
+
+      releaseFirst();
+      await second;
+      await writer.close();
+      expect(secondResolved).toBe(true);
     });
   });
 
@@ -197,29 +384,93 @@ describe('WorkflowServerWritableStream', () => {
   });
 
   describe('abort behavior', () => {
-    it('should discard buffer and not call close on abort', async () => {
+    it('delivers the accepted prefix on abort without closing the server stream', async () => {
       const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
       const writer = stream.getWriter();
 
+      // The chunk was ACKED into the buffer — abort must deliver it (the
+      // early-ack durability contract) but never close the server stream.
       await writer.write(new Uint8Array([1, 2, 3]));
       await writer.abort();
+      await new Promise((r) => setTimeout(r, 25));
 
-      // Write should have flushed, but no close since we aborted
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      expect(mockStreams.write).toHaveBeenCalledWith(
+        'run-123',
+        'test-stream',
+        new Uint8Array([1, 2, 3])
+      );
+      expect(mockStreams.close).not.toHaveBeenCalled();
+    });
+
+    it('source error during native pipeTo still delivers the accepted prefix', async () => {
+      // The review scenario: an AI stream emits a prefix of deltas whose
+      // write()s all acked (inside the commit window), then throws. pipeTo
+      // aborts the sink — the accepted prefix must still reach the World.
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      let controller!: ReadableStreamDefaultController<Uint8Array>;
+      const source = new ReadableStream<Uint8Array>({
+        start(c) {
+          controller = c;
+        },
+      });
+      const piped = source.pipeTo(stream);
+
+      controller.enqueue(new Uint8Array([1]));
+      controller.enqueue(new Uint8Array([2]));
+      controller.enqueue(new Uint8Array([3]));
+      // Give pipeTo a beat to hand the chunks to the sink (all acked into
+      // the buffer, commit window still open), then fail the producer.
+      await new Promise((r) => setTimeout(r, 2));
+      controller.error(new Error('producer failed'));
+
+      await expect(piped).rejects.toThrow('producer failed');
+      await new Promise((r) => setTimeout(r, 25));
+
+      // Every accepted chunk was delivered; the stream was not closed.
+      const delivered = [
+        ...mockStreams.write.mock.calls.map(
+          (call: unknown[]) => (call[2] as Uint8Array)[0]
+        ),
+        ...mockStreams.writeMulti.mock.calls.flatMap((call: unknown[]) =>
+          (call[2] as Uint8Array[]).map((c) => c[0])
+        ),
+      ];
+      expect(delivered).toEqual([1, 2, 3]);
       expect(mockStreams.close).not.toHaveBeenCalled();
     });
   });
 
   describe('error handling', () => {
-    it('should propagate write errors to the caller', async () => {
+    it('surfaces a dispatch failure at the durability barrier (close) and poisons later writes', async () => {
       mockStreams.write.mockRejectedValueOnce(new Error('write error'));
 
       const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
       const writer = stream.getWriter();
 
-      await expect(writer.write(new Uint8Array([1, 2, 3]))).rejects.toThrow(
+      // The failing chunk's own write() already acked (buffer entry) —
+      // that is the early-ack contract. The failure surfaces at the next
+      // interaction with the sink.
+      await writer.write(new Uint8Array([1, 2, 3]));
+      await expect(writer.close()).rejects.toThrow('write error');
+      expect(mockStreams.close).not.toHaveBeenCalled();
+    });
+
+    it('rejects a write that is issued after a dispatch failed (sticky error)', async () => {
+      mockStreams.write.mockRejectedValueOnce(new Error('write error'));
+
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      await writer.write(new Uint8Array([1]));
+      // Let the commit window dispatch and fail.
+      await new Promise((r) => setTimeout(r, 25));
+
+      await expect(writer.write(new Uint8Array([2]))).rejects.toThrow(
         'write error'
       );
+      // The retained chunk was not re-sent by a leaked timer.
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
     });
 
     it('should propagate close errors', async () => {
@@ -232,9 +483,7 @@ describe('WorkflowServerWritableStream', () => {
       await expect(writer.close()).rejects.toThrow('close error');
     });
 
-    it('should propagate write errors from close flush', async () => {
-      // Make close's flush fail (close calls flush() for remaining buffer)
-      // by having the write succeed but the stream fail on a second write
+    it('should propagate write errors from the drain performed by close', async () => {
       mockStreams.write
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error('flush error on close'));
@@ -242,14 +491,13 @@ describe('WorkflowServerWritableStream', () => {
       const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
       const writer = stream.getWriter();
 
-      // First write succeeds
       await writer.write(new Uint8Array([1, 2, 3]));
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
 
-      // Second write fails
-      await expect(writer.write(new Uint8Array([4, 5, 6]))).rejects.toThrow(
-        'flush error on close'
-      );
+      await writer.write(new Uint8Array([4, 5, 6]));
+      await expect(writer.close()).rejects.toThrow('flush error on close');
+      expect(mockStreams.close).not.toHaveBeenCalled();
     });
   });
 
@@ -260,8 +508,9 @@ describe('WorkflowServerWritableStream', () => {
       const stream = new WorkflowServerWritableStream('s', 'run-1');
       const writer = stream.getWriter();
 
-      // With interval=0, the flush fires on the next microtask tick via setTimeout(fn, 0)
+      // With interval=0, the commit window fires on the next timer tick.
       await writer.write(new Uint8Array([1]));
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
 
       await writer.close();
@@ -275,6 +524,7 @@ describe('WorkflowServerWritableStream', () => {
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array([1]));
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
 
       await writer.close();
@@ -286,16 +536,22 @@ describe('WorkflowServerWritableStream', () => {
       const stream = new WorkflowServerWritableStream('s', 'run-1');
       const writer = stream.getWriter();
 
-      // Start a write — the flush is scheduled 50ms from now
-      const writePromise = writer.write(new Uint8Array([1]));
-
-      // After 10ms (the old default), data should NOT have flushed yet
-      await new Promise((r) => setTimeout(r, 10));
-      expect(mockStreams.write).not.toHaveBeenCalled();
-
-      // Wait for the write to complete (will resolve after the 50ms timer fires)
-      await writePromise;
+      // The interval is learned from the world during the first dispatch
+      // (same lazy resolution as before this rework) — prime it with a
+      // drained first group so the window under test uses 50ms.
+      await writer.write(new Uint8Array([0]));
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
+
+      await writer.write(new Uint8Array([1]));
+
+      // Well past the 10ms default, inside the 50ms window: not dispatched.
+      await new Promise((r) => setTimeout(r, 25));
+      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+
+      // The 50ms window elapses and the second group goes out.
+      await new Promise((r) => setTimeout(r, 40));
+      expect(mockStreams.write).toHaveBeenCalledTimes(2);
 
       await writer.close();
     });
@@ -322,20 +578,20 @@ describe('WorkflowServerWritableStream', () => {
         runReadyBarrier
       );
       const writer = stream.getWriter();
-      const writePromise = writer.write(new Uint8Array([1, 2, 3]));
+      await writer.write(new Uint8Array([1, 2, 3]));
 
-      // The body wrote a chunk before run_started is durable: the flush timer
-      // may fire, but the server write must not happen until the run exists.
+      // The body wrote a chunk before run_started is durable: the commit
+      // window may fire, but the server write must not happen until the
+      // run exists.
       await new Promise((r) => setTimeout(r, 30));
       expect(mockStreams.write).not.toHaveBeenCalled();
 
       releaseBarrier();
-      await writePromise;
+      // close() drains: it completes only after the gated dispatch lands.
+      await writer.close();
 
       // The chunk reaches the server strictly after the barrier resolves.
       expect(order).toEqual(['barrier', 'write']);
-
-      await writer.close();
     });
 
     it('only awaits the barrier once — later flushes are not gated', async () => {
@@ -350,10 +606,19 @@ describe('WorkflowServerWritableStream', () => {
       await writer.write(new Uint8Array([1]));
       await writer.write(new Uint8Array([2]));
       await writer.write(new Uint8Array([3]));
-
-      expect(mockStreams.write).toHaveBeenCalledTimes(3);
-
       await writer.close();
+
+      // All three chunks are delivered (grouping may vary); the resolved
+      // barrier gated nothing after the first dispatch.
+      const delivered = [
+        ...mockStreams.write.mock.calls.map(
+          (call: unknown[]) => (call[2] as Uint8Array)[0]
+        ),
+        ...mockStreams.writeMulti.mock.calls.flatMap((call: unknown[]) =>
+          (call[2] as Uint8Array[]).map((c) => c[0])
+        ),
+      ];
+      expect(delivered.sort()).toEqual([1, 2, 3]);
     });
 
     it('still writes when the barrier rejects (write surfaces the real error)', async () => {
@@ -368,12 +633,11 @@ describe('WorkflowServerWritableStream', () => {
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array([1, 2, 3]));
+      await writer.close();
 
       // Barrier rejection is swallowed for ordering only — the write still
       // fires and would surface a genuine run-not-found error from the World.
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
-
-      await writer.close();
     });
 
     it('gates the first write of a stream RETURNED from a turbo first step', async () => {
@@ -461,7 +725,7 @@ describe('WorkflowServerWritableStream', () => {
     });
   });
 
-  describe('writeMulti batching via flushablePipe', () => {
+  describe('writeMulti batching via flushablePipe (equivalent to the native path)', () => {
     it('coalesces chunks that arrive during an in-flight write into one writeMulti', async () => {
       // Hold the first server write in flight so the chunks produced while it
       // is pending accumulate and flush together via writeMulti. Without the
@@ -492,7 +756,7 @@ describe('WorkflowServerWritableStream', () => {
 
       // First chunk goes out alone (a single write) and blocks in flight.
       controller.enqueue(new Uint8Array([1]));
-      await new Promise((r) => setTimeout(r, 10));
+      await new Promise((r) => setTimeout(r, 25));
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
       expect(mockStreams.writeMulti).not.toHaveBeenCalled();
 
@@ -540,7 +804,7 @@ describe('WorkflowServerWritableStream', () => {
       const pipe = flushablePipe(source, serverWritable, state).catch(() => {});
 
       controller.enqueue(new Uint8Array([1]));
-      await new Promise((r) => setTimeout(r, 10));
+      await new Promise((r) => setTimeout(r, 25));
       controller.enqueue(new Uint8Array([2]));
       controller.enqueue(new Uint8Array([3]));
       await new Promise((r) => setTimeout(r, 10));
@@ -585,11 +849,16 @@ describe('WorkflowServerWritableStream', () => {
       const pipe = flushablePipe(source, serverWritable, state).catch(() => {});
 
       controller.enqueue(new Uint8Array([1]));
-      await new Promise((r) => setTimeout(r, 10));
+      await new Promise((r) => setTimeout(r, 25));
       controller.enqueue(new Uint8Array([2]));
       controller.enqueue(new Uint8Array([3]));
       await new Promise((r) => setTimeout(r, 10));
       releaseFirst();
+      // Let the failed batch settle; the sink is now poisoned. The writes
+      // already acked (buffer entry), so the failure surfaces when the pipe
+      // closes the sink — its drain rethrows the sticky error.
+      await new Promise((r) => setTimeout(r, 10));
+      controller.close();
       await pipe;
 
       await expect(state.promise).rejects.toThrow('batch failed');

--- a/packages/core/src/writable-stream.test.ts
+++ b/packages/core/src/writable-stream.test.ts
@@ -7,6 +7,28 @@ import {
   WorkflowServerWritableStream,
 } from './serialization.js';
 
+/**
+ * Poll until the expectation passes — replaces fixed sleeps for
+ * "dispatch has happened" assertions, which flake on slow CI runners
+ * where the 10ms commit window and scheduler jitter exceed a fixed wait.
+ */
+async function waitFor(
+  assertion: () => void,
+  timeoutMs = 3000,
+  intervalMs = 5
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) throw err;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+}
+
 describe('WorkflowServerWritableStream', () => {
   let mockStreams: {
     write: ReturnType<typeof vi.fn>;
@@ -68,8 +90,7 @@ describe('WorkflowServerWritableStream', () => {
       expect(mockStreams.writeMulti).not.toHaveBeenCalled();
 
       // The group-commit window fires and dispatches the chunk.
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
       expect(mockStreams.write).toHaveBeenCalledWith(
         'run-123',
         'test-stream',
@@ -142,8 +163,7 @@ describe('WorkflowServerWritableStream', () => {
 
       await writer.write(new Uint8Array([1]));
       // Let the commit window fire and the first request go in flight.
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       await writer.write(new Uint8Array([2]));
       await writer.write(new Uint8Array([3]));
@@ -180,8 +200,7 @@ describe('WorkflowServerWritableStream', () => {
       const piped = source.pipeTo(stream);
 
       controller.enqueue(new Uint8Array([1]));
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       // pipeTo pulls the next chunk as soon as write() acks (buffer entry),
       // so these accumulate during the in-flight request.
@@ -289,8 +308,8 @@ describe('WorkflowServerWritableStream', () => {
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array([1]));
-      await new Promise((r) => setTimeout(r, 25)); // request in flight
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      // request in flight
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       // buffered(1) + inFlight(1) == bound → this write must block.
       let secondResolved = false;
@@ -330,8 +349,7 @@ describe('WorkflowServerWritableStream', () => {
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array(6)); // in the active request: 6 bytes
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       // inFlight(6B) + buffered(6B) ≥ 8B bound → blocks until the request lands.
       let secondResolved = false;
@@ -373,11 +391,16 @@ describe('WorkflowServerWritableStream', () => {
 
       await writer.write(new Uint8Array([1]));
 
-      // Well past the 10ms commit window: BOTH chunks must have dispatched
-      // without any close/drain nudge. A stranded chunk has no timer and
-      // would never arrive.
-      await new Promise((r) => setTimeout(r, 60));
-      expect(landed).toBe(true);
+      // Both chunks must dispatch without any close/drain nudge. A
+      // stranded chunk has no timer and would never arrive, so the poll
+      // (bounded well above the 10ms commit window) discriminates cleanly.
+      await waitFor(() => expect(landed).toBe(true));
+      await waitFor(() =>
+        expect(
+          mockStreams.write.mock.calls.length +
+            mockStreams.writeMulti.mock.calls.length
+        ).toBeGreaterThanOrEqual(2)
+      );
       const delivered = [
         ...mockStreams.write.mock.calls.map(
           (call: unknown[]) => (call[2] as Uint8Array)[0]
@@ -508,7 +531,8 @@ describe('WorkflowServerWritableStream', () => {
 
       await writer.write(new Uint8Array([1]));
       // Let the commit window dispatch and fail.
-      await new Promise((r) => setTimeout(r, 25));
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
+      await new Promise((r) => setTimeout(r, 5));
 
       await expect(writer.write(new Uint8Array([2]))).rejects.toThrow(
         'write error'
@@ -536,8 +560,7 @@ describe('WorkflowServerWritableStream', () => {
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array([1, 2, 3]));
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       await writer.write(new Uint8Array([4, 5, 6]));
       await expect(writer.close()).rejects.toThrow('flush error on close');
@@ -554,8 +577,7 @@ describe('WorkflowServerWritableStream', () => {
 
       // With interval=0, the commit window fires on the next timer tick.
       await writer.write(new Uint8Array([1]));
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       await writer.close();
     });
@@ -568,8 +590,7 @@ describe('WorkflowServerWritableStream', () => {
       const writer = stream.getWriter();
 
       await writer.write(new Uint8Array([1]));
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       await writer.close();
     });
@@ -584,8 +605,7 @@ describe('WorkflowServerWritableStream', () => {
       // (same lazy resolution as before this rework) — prime it with a
       // drained first group so the window under test uses 50ms.
       await writer.write(new Uint8Array([0]));
-      await new Promise((r) => setTimeout(r, 25));
-      expect(mockStreams.write).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(1));
 
       await writer.write(new Uint8Array([1]));
 
@@ -594,8 +614,7 @@ describe('WorkflowServerWritableStream', () => {
       expect(mockStreams.write).toHaveBeenCalledTimes(1);
 
       // The 50ms window elapses and the second group goes out.
-      await new Promise((r) => setTimeout(r, 40));
-      expect(mockStreams.write).toHaveBeenCalledTimes(2);
+      await waitFor(() => expect(mockStreams.write).toHaveBeenCalledTimes(2));
 
       await writer.close();
     });


### PR DESCRIPTION
## Problem

Batching was implemented in `flushablePipe`'s coalescing loop, so it depended on which piping path ran. `getWritable()` batched; a raw `ReadableStream` crossing a workflow/step boundary uses native `pipeTo()`, which doesn't pull chunk N+1 until `write(chunk N)` resolves — and `write()` resolved only after the flush timer **and** the server round trip. The buffer never held more than one chunk: one request per token.

## Fix

Batching moves into `WorkflowServerWritableStream`, identical on every path:

- `write()` resolves when the chunk enters a bounded client buffer (`WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS` counts buffered **and** in-request chunks; new byte bound `WORKFLOW_STREAM_MAX_BUFFERED_BYTES`, default 8 MiB, documented).
- The flush interval is a real group-commit window; chunks arriving while a request is in flight form the next `writeMulti` group. One request in flight preserves order; 1,000-chunk / 1 MiB per-request limits preserved.
- Durability is an explicit barrier: `close()` drains first; `flushablePipe` (now a plain pump: lock-release + durability tracking only) adopts the barrier so step completion still implies durability; `abort()` **drains the accepted prefix without closing** (a producer error after acked writes can't lose data); a failed pipe drains before settling. Dispatch failures are sticky and surface at the next write/close/drain.

## Trade-off

An open `getWritable()` stream's first chunk now waits up to the group-commit interval (10ms default) instead of dispatching eagerly — watch TTFC / `buffer_dwell_ms` after release.

## Validation

1,572 core unit tests pass, including new regressions for: native-`pipeTo` batching, awaited per-chunk loops coalescing into one `writeMulti`, wire-cap splits, in-flight-inclusive backpressure on both bounds, source-error prefix delivery through abort, failed-pipe drain-before-reject, and turbo run-ready barrier gating. E2E tier requires a deployment and was not run here.

Addressed some of the streaming perf concerns for use cases mentioned in #1930
