### PR TITLE
[benchmarks/ci] SO payload variants + restructured E2E Test Results comment

### DIFF
--- a/.changeset/great-news-beg.md
+++ b/.changeset/great-news-beg.md
@@ -1,0 +1,4 @@
+---
+---
+
+Make the SO benchmark stream deterministic variable-length token deltas and add a structured-delta (AI-SDK-shaped) payload variant.

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -433,6 +433,11 @@ const categoryOrder = [
   'other',
 ];
 
+// In the "Failed E2E Tests" section, a category with fewer than this many
+// failed tests is listed inline under a heading; at or above it, the list is
+// tucked into a <details> to keep the top of the comment scannable.
+const FAILED_INLINE_THRESHOLD = 10;
+
 // Render aggregated PR comment summary
 function renderAggregatedSummary(
   categories,
@@ -453,37 +458,63 @@ function renderAggregatedSummary(
   console.log(`## 🧪 E2E Test Results\n`);
   console.log(`${statusEmoji} **${statusText}**\n`);
 
-  // Overall summary table
-  console.log('### Summary\n');
-  console.log('| | Passed | Failed | Skipped | Total |');
-  console.log('|:--|------:|-------:|--------:|------:|');
-
-  // Sort categories by defined order
+  // Sort categories by defined order (shared by every section below)
   const sortedCategories = Array.from(categories.entries()).sort(
     ([a], [b]) =>
       (categoryOrder.indexOf(a) === -1 ? 999 : categoryOrder.indexOf(a)) -
       (categoryOrder.indexOf(b) === -1 ? 999 : categoryOrder.indexOf(b))
   );
 
-  for (const [catName, cat] of sortedCategories) {
-    const catTotal = cat.passed + cat.failed + cat.skipped;
-    const catStatus = cat.failed > 0 ? '❌' : '✅';
-    const displayName = categoryNames[catName] || catName;
-    console.log(
-      `| ${catStatus} ${displayName} | ${cat.passed} | ${cat.failed} | ${cat.skipped} | ${catTotal} |`
-    );
-  }
+  // Renders the failed tests of one category, grouped by app. Callers wrap this
+  // in either a heading (few failures) or a <details> (many).
+  const renderFailedCategoryTests = (catName, appsMap) => {
+    for (const [appName, tests] of appsMap.entries()) {
+      console.log(`**${appName}** (${tests.length} failed):\n`);
+      for (const test of tests) {
+        // Extract just the test name without "e2e " prefix if present
+        const testName = test.name.replace(/^e2e\s+/, '');
 
-  console.log(
-    `| **Total** | **${overallSummary.totalPassed}** | **${overallSummary.totalFailed}** | **${overallSummary.totalSkipped}** | **${total}** |`
-  );
-  console.log('');
+        // Look up enriched diagnostics for this test.
+        // Only show observability links for vercel-prod tests — other
+        // categories (local, community) don't run on Vercel's world
+        // backend so there's no dashboard to link to.
+        const isVercelProd = catName === 'vercel-prod';
+        const diag = diagnostics.get(test.name) || diagnostics.get(testName);
+        const failureInfo = failures.get(testName) || failures.get(test.name);
+        const obsUrl = isVercelProd
+          ? getObservabilityUrl(metadata, appName, test.name)
+          : null;
+        const dashboardUrl = isVercelProd
+          ? diag?.dashboardUrl || failureInfo?.dashboardUrl || obsUrl
+          : null;
+        const runId = diag?.runId || failureInfo?.runId;
+        const runStatus = failureInfo?.status;
 
-  // Failed tests section - grouped by category and app
+        // Build the line with available info
+        const links = [];
+        if (dashboardUrl) links.push(`[🔍 observability](${dashboardUrl})`);
+
+        if (links.length > 0 || runId) {
+          const parts = [`\`${testName}\``];
+          if (runId) parts.push(`\`${runId}\``);
+          if (runStatus) parts.push(`status: \`${runStatus}\``);
+          if (links.length > 0) parts.push(links.join(' '));
+          console.log(`- ${parts.join(' | ')}`);
+        } else {
+          console.log(`- \`${testName}\``);
+        }
+      }
+      console.log('');
+    }
+  };
+
+  // Failed tests first (hidden entirely when everything passed), grouped by
+  // category and app. A category with fewer than FAILED_INLINE_THRESHOLD
+  // failures is listed inline under a heading; larger ones collapse into a
+  // <details> so the top of the comment stays scannable.
   if (overallSummary.allFailedTests.length > 0) {
-    console.log('### ❌ Failed Tests\n');
+    console.log('### ❌ Failed E2E Tests\n');
 
-    // Group failed tests by category, then by app
     const failedByCategory = new Map();
     for (const test of overallSummary.allFailedTests) {
       if (!failedByCategory.has(test.category)) {
@@ -496,7 +527,6 @@ function renderAggregatedSummary(
       catMap.get(test.app).push(test);
     }
 
-    // Sort categories by defined order
     const sortedFailedCategories = Array.from(failedByCategory.entries()).sort(
       ([a], [b]) =>
         (categoryOrder.indexOf(a) === -1 ? 999 : categoryOrder.indexOf(a)) -
@@ -510,63 +540,48 @@ function renderAggregatedSummary(
         0
       );
 
-      console.log(`<details>`);
-      console.log(
-        `<summary>${catDisplay} (${catFailedCount} failed)</summary>\n`
-      );
-
-      for (const [appName, tests] of appsMap.entries()) {
-        console.log(`**${appName}** (${tests.length} failed):\n`);
-        for (const test of tests) {
-          // Extract just the test name without "e2e " prefix if present
-          const testName = test.name.replace(/^e2e\s+/, '');
-
-          // Look up enriched diagnostics for this test.
-          // Only show observability links for vercel-prod tests — other
-          // categories (local, community) don't run on Vercel's world
-          // backend so there's no dashboard to link to.
-          const isVercelProd = catName === 'vercel-prod';
-          const diag = diagnostics.get(test.name) || diagnostics.get(testName);
-          const failureInfo = failures.get(testName) || failures.get(test.name);
-          const obsUrl = isVercelProd
-            ? getObservabilityUrl(metadata, appName, test.name)
-            : null;
-          const dashboardUrl = isVercelProd
-            ? diag?.dashboardUrl || failureInfo?.dashboardUrl || obsUrl
-            : null;
-          const runId = diag?.runId || failureInfo?.runId;
-          const runStatus = failureInfo?.status;
-
-          // Build the line with available info
-          const links = [];
-          if (dashboardUrl) links.push(`[🔍 observability](${dashboardUrl})`);
-
-          if (links.length > 0 || runId) {
-            const parts = [`\`${testName}\``];
-            if (runId) parts.push(`\`${runId}\``);
-            if (runStatus) parts.push(`status: \`${runStatus}\``);
-            if (links.length > 0) parts.push(links.join(' '));
-            console.log(`- ${parts.join(' | ')}`);
-          } else {
-            console.log(`- \`${testName}\``);
-          }
-        }
-        console.log('');
+      if (catFailedCount >= FAILED_INLINE_THRESHOLD) {
+        console.log('<details>');
+        console.log(
+          `<summary>${catDisplay} (${catFailedCount} failed)</summary>\n`
+        );
+        renderFailedCategoryTests(catName, appsMap);
+        console.log('</details>\n');
+      } else {
+        console.log(`#### ${catDisplay} (${catFailedCount} failed)\n`);
+        renderFailedCategoryTests(catName, appsMap);
       }
-
-      console.log('</details>\n');
     }
   }
 
-  // Detailed breakdown by category
-  console.log('### Details by Category\n');
+  // Everything else lives under one collapsible summary section.
+  console.log('### E2E Test Summary\n');
 
+  // Overall summary table (expandable)
+  console.log('<details>');
+  console.log('<summary>Summary</summary>\n');
+  console.log('| | Passed | Failed | Skipped | Total |');
+  console.log('|:--|------:|-------:|--------:|------:|');
+  for (const [catName, cat] of sortedCategories) {
+    const catTotal = cat.passed + cat.failed + cat.skipped;
+    const catStatus = cat.failed > 0 ? '❌' : '✅';
+    const displayName = categoryNames[catName] || catName;
+    console.log(
+      `| ${catStatus} ${displayName} | ${cat.passed} | ${cat.failed} | ${cat.skipped} | ${catTotal} |`
+    );
+  }
+  console.log(
+    `| **Total** | **${overallSummary.totalPassed}** | **${overallSummary.totalFailed}** | **${overallSummary.totalSkipped}** | **${total}** |`
+  );
+  console.log('</details>\n');
+
+  // Per-app breakdown (expandable) — one flat list, no nested collapsibles.
+  console.log('<details>');
+  console.log('<summary>Details by Category</summary>\n');
   for (const [catName, cat] of sortedCategories) {
     const catStatus = cat.failed > 0 ? '❌' : '✅';
     const displayName = categoryNames[catName] || catName;
-
-    console.log(`<details>`);
-    console.log(`<summary>${catStatus} ${displayName}</summary>\n`);
+    console.log(`**${catStatus} ${displayName}**\n`);
     console.log('| App | Passed | Failed | Skipped |');
     console.log('|:----|-------:|-------:|--------:|');
     for (const app of cat.apps) {
@@ -575,8 +590,9 @@ function renderAggregatedSummary(
         `| ${appStatus} ${app.name} | ${app.passed} | ${app.failed} | ${app.skipped} |`
       );
     }
-    console.log('</details>\n');
+    console.log('');
   }
+  console.log('</details>\n');
 
   // Add link to workflow run
   if (runUrl) {

--- a/.github/scripts/aggregate-e2e-results.test.js
+++ b/.github/scripts/aggregate-e2e-results.test.js
@@ -1,0 +1,131 @@
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const SCRIPT = path.join(__dirname, 'aggregate-e2e-results.js');
+
+// vitest JSON-reporter shape for one result file: `passed` passing assertions
+// plus one failed assertion per title in `failedTitles`.
+function resultJson(fileLabel, passed, failedTitles = []) {
+  const assertionResults = [];
+  for (let i = 0; i < passed; i++) {
+    assertionResults.push({
+      status: 'passed',
+      title: `pass ${i}`,
+      fullName: `e2e pass ${i}`,
+    });
+  }
+  for (const title of failedTitles) {
+    assertionResults.push({
+      status: 'failed',
+      title,
+      fullName: `e2e ${title}`,
+      failureMessages: ['AssertionError: boom'],
+    });
+  }
+  return JSON.stringify({
+    testResults: [
+      { name: `/x/${fileLabel}`, duration: 1000, assertionResults },
+    ],
+  });
+}
+
+// Writes fixture files (map of `e2e-<category>-<app>.json` -> JSON) into a fresh
+// temp dir, runs the aggregate script against it, and returns stdout. The
+// script exits non-zero when tests failed, so read stdout off the thrown error.
+function renderAggregate(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-agg-'));
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), contents);
+  }
+  try {
+    return execFileSync(
+      process.execPath,
+      [SCRIPT, dir, '--mode', 'aggregate', '--run-url', 'https://gh/run/1'],
+      { encoding: 'utf8' }
+    );
+  } catch (error) {
+    return error.stdout;
+  }
+}
+
+test('few failures list inline above a collapsed summary section', () => {
+  const body = renderAggregate({
+    'e2e-vercel-prod-nextjs-turbopack.json': resultJson('a', 40, [
+      'sleeps forever',
+      'hook race',
+    ]),
+    'e2e-local-dev-hono.json': resultJson('b', 30),
+  });
+
+  // Failed section is first, renamed, and appears before the summary section.
+  assert.match(body, /### ❌ Failed E2E Tests/);
+  assert.doesNotMatch(body, /### ❌ Failed Tests\n/);
+  assert.ok(
+    body.indexOf('### ❌ Failed E2E Tests') <
+      body.indexOf('### E2E Test Summary'),
+    'Failed E2E Tests should come before E2E Test Summary'
+  );
+
+  // Under the inline threshold → heading, not a <details>, and every test listed.
+  assert.match(body, /#### ▲ Vercel Production \(2 failed\)/);
+  assert.match(body, /- `sleeps forever`/);
+  assert.match(body, /- `hook race`/);
+
+  // Summary and per-category breakdown are both collapsible under the section.
+  assert.match(body, /### E2E Test Summary/);
+  assert.match(body, /<details>\n<summary>Summary<\/summary>/);
+  assert.match(body, /<details>\n<summary>Details by Category<\/summary>/);
+
+  // One workflow-run link, and no leftover redundant blurbs.
+  assert.match(body, /📋 \[View full workflow run\]\(https:\/\/gh\/run\/1\)/);
+  assert.doesNotMatch(body, /Some E2E test jobs failed/);
+  assert.doesNotMatch(body, /Check the \[workflow run\]/);
+});
+
+test('a category with >= 10 failures collapses into a <details>', () => {
+  const failedTitles = Array.from({ length: 12 }, (_, i) => `fail-${i}`);
+  const body = renderAggregate({
+    'e2e-vercel-prod-nextjs-turbopack.json': resultJson('a', 5, failedTitles),
+  });
+
+  assert.match(body, /### ❌ Failed E2E Tests/);
+  // The category heading is now the <summary>, not a #### heading.
+  assert.match(
+    body,
+    /<details>\n<summary>▲ Vercel Production \(12 failed\)<\/summary>/
+  );
+  assert.doesNotMatch(body, /#### ▲ Vercel Production/);
+  assert.match(body, /- `fail-11`/);
+});
+
+test('all-passing runs omit the Failed E2E Tests section entirely', () => {
+  const body = renderAggregate({
+    'e2e-vercel-prod-vite.json': resultJson('a', 20),
+  });
+
+  assert.match(body, /✅ \*\*All tests passed\*\*/);
+  assert.doesNotMatch(body, /Failed E2E Tests/);
+  // The summary section is still present.
+  assert.match(body, /### E2E Test Summary/);
+  assert.match(body, /<details>\n<summary>Summary<\/summary>/);
+});
+
+test('Details by Category has no nested collapsibles', () => {
+  const body = renderAggregate({
+    'e2e-vercel-prod-nextjs-turbopack.json': resultJson('a', 40, ['x']),
+    'e2e-local-dev-hono.json': resultJson('b', 30),
+  });
+
+  // Isolate the Details-by-Category block and assert it opens exactly one
+  // <details> (its own) — categories inside are plain bold headings.
+  const start = body.indexOf('<summary>Details by Category</summary>');
+  const block = body.slice(start);
+  const nestedDetails = (block.match(/<details>/g) || []).length;
+  assert.strictEqual(nestedDetails, 0, 'no nested <details> inside the block');
+  assert.match(block, /\*\*❌ ▲ Vercel Production\*\*/);
+  assert.match(block, /\*\*✅ 💻 Local Development\*\*/);
+});

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -140,28 +140,35 @@ test('renders a completed run with a table and embedded history', async () => {
   assert.strictEqual(history[0].results[0].metrics.length, 4);
 });
 
-test('renders the SO metric row and its footer definition', async () => {
+test('renders both SO payload-shape rows under one metric', async () => {
   const { renderComment } = await loadModule();
+  const soRow = (scenario, overrides) => ({
+    metric: 'so',
+    scenario,
+    unit: 'ms',
+    best: 40,
+    avg: 120,
+    p75: 110,
+    p90: 220,
+    p99: 380,
+    samples: 30,
+    targets: { p75: 250, p90: 500, p99: 1000 },
+    ...overrides,
+  });
   const result = sampleResult({
     scenarios: [
       {
-        name: 'stream overhead',
-        description: 'paced LLM-shaped stream, drained',
+        name: 'stream overhead (text)',
+        description: 'raw string token deltas',
+      },
+      {
+        name: 'stream overhead (structured)',
+        description: 'AI-SDK-style structured deltas',
       },
     ],
     metrics: [
-      {
-        metric: 'so',
-        scenario: 'stream overhead',
-        unit: 'ms',
-        best: 40,
-        avg: 120,
-        p75: 110,
-        p90: 220,
-        p99: 380,
-        samples: 30,
-        targets: { p75: 250, p90: 500, p99: 1000 },
-      },
+      soRow('stream overhead (text)'),
+      soRow('stream overhead (structured)', { p75: 140, p90: 260, p99: 440 }),
     ],
   });
   const body = renderComment({
@@ -171,11 +178,22 @@ test('renders the SO metric row and its footer definition', async () => {
     commit: 'abcdef1234567890',
   });
 
-  // SO renders as a table row and is defined in the (collapsed) footer.
-  assert.match(body, /\| \*\*SO\*\* \| stream overhead \|/);
-  assert.match(body, /\*\*SO\*\*: stream overhead/);
-  // Within target on every percentile → the SO row carries no 🔴 mark.
+  // Both payload shapes render as distinct SO rows.
+  assert.match(body, /\| \*\*SO\*\* \| stream overhead \(text\) \|/);
+  assert.match(body, /\| \*\*SO\*\* \| stream overhead \(structured\) \|/);
+  // Both scenarios are described in the (collapsed) footer legend.
+  assert.match(
+    body,
+    /\*\*stream overhead \(text\)\*\*: raw string token deltas/
+  );
+  assert.match(
+    body,
+    /\*\*stream overhead \(structured\)\*\*: AI-SDK-style structured deltas/
+  );
+  // Within target on every percentile → neither SO row carries a 🔴 mark.
   assert.doesNotMatch(body, /\| \*\*SO\*\* \|.*🔴/);
+  // Both rows share the one SO metric definition and targets entry.
+  assert.match(body, /\*\*SO\*\*: stream overhead/);
   assert.match(body, /Targets \(p75\/p90\/p99, ms\) — SO 250\/500\/1000/);
 });
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1068,51 +1068,12 @@ jobs:
         run: |
           node .github/scripts/aggregate-e2e-results.js e2e-results --mode aggregate --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" | tee e2e-summary.md >> $GITHUB_STEP_SUMMARY
 
-      - name: Check E2E job statuses
-        id: check-status
-        run: |
-          VERCEL_STATUS="${{ needs.e2e-vercel-prod.result }}"
-          LOCAL_DEV_STATUS="${{ needs.e2e-local-dev.result }}"
-          LOCAL_PROD_STATUS="${{ needs.e2e-local-prod.result }}"
-          POSTGRES_STATUS="${{ needs.e2e-local-postgres.result }}"
-          WINDOWS_STATUS="${{ needs.e2e-windows.result }}"
-
-          echo "vercel=$VERCEL_STATUS" >> $GITHUB_OUTPUT
-          echo "local-dev=$LOCAL_DEV_STATUS" >> $GITHUB_OUTPUT
-          echo "local-prod=$LOCAL_PROD_STATUS" >> $GITHUB_OUTPUT
-          echo "postgres=$POSTGRES_STATUS" >> $GITHUB_OUTPUT
-          echo "windows=$WINDOWS_STATUS" >> $GITHUB_OUTPUT
-
-          if [[ "$VERCEL_STATUS" == "failure" || "$LOCAL_DEV_STATUS" == "failure" || "$LOCAL_PROD_STATUS" == "failure" || "$POSTGRES_STATUS" == "failure" || "$WINDOWS_STATUS" == "failure" ]]; then
-            echo "has_failures=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_failures=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Update PR comment with results
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-test-results
           path: e2e-summary.md
-
-      - name: Append failure notice to PR comment
-        if: github.event_name == 'pull_request' && steps.check-status.outputs.has_failures == 'true'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          header: e2e-test-results
-          append: true
-          message: |
-
-            ---
-            ❌ **Some E2E test jobs failed:**
-            - Vercel Prod: ${{ needs.e2e-vercel-prod.result }}
-            - Local Dev: ${{ needs.e2e-local-dev.result }}
-            - Local Prod: ${{ needs.e2e-local-prod.result }}
-            - Local Postgres: ${{ needs.e2e-local-postgres.result }}
-            - Windows: ${{ needs.e2e-windows.result }}
-
-            Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
   # Final required check: passes only when unit + all E2E jobs succeed.
   # Community worlds are intentionally excluded — they are disabled on main.

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -49,12 +49,15 @@
  *          the old client-observed metric included.
  * - SO    (stream overhead): end-to-end write+consume time in excess of a
  *          modelled generation window, measured on the deployment by
- *          `benchSoWorkflow`. A writer streams fake 4-byte LLM-token chunks at
- *          a fixed rate for a fixed duration while a parallel reader drains the
- *          whole stream; SO is `(doneAt - writtenAt) - chunkCount*intervalMs`,
- *          i.e. the overhead/backpressure the stream adds on top of the token
- *          rate. Same setup as SL, but the reader stamps `doneAt` after the
- *          last chunk rather than `readAt` on the first.
+ *          `benchSoWorkflow`. A writer streams deterministic variable-length
+ *          LLM-token deltas at a fixed rate for a fixed duration while a
+ *          parallel reader drains the whole stream; SO is
+ *          `(doneAt - writtenAt) - chunkCount*intervalMs`, i.e. the
+ *          overhead/backpressure the stream adds on top of the token rate. Same
+ *          setup as SL, but the reader stamps `doneAt` after the last chunk
+ *          rather than `readAt` on the first. Measured for two payload shapes
+ *          (raw text vs AI-SDK-style structured deltas) so the SO delta between
+ *          them isolates serialization cost.
  *
  * Scenarios (defined in workbench/example/workflows/97_bench.ts):
  *
@@ -64,6 +67,7 @@
  * 4. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
  * 5. benchSlWorkflow              — parallel reader/writer steps → SL
  * 6. benchSoWorkflow              — paced LLM-shaped stream, drained → SO
+ *                                   (run in text and structured payload modes)
  *
  * Each scenario runs many iterations (env-tunable, see BENCH_* below) so the
  * percentiles are computed from real samples.
@@ -389,10 +393,13 @@ async function runSlIteration(): Promise<SlIterationResult> {
   }
 }
 
-async function runSoIteration(): Promise<SoIterationResult> {
+async function runSoIteration(
+  mode: 'text' | 'structured'
+): Promise<SoIterationResult> {
   const { runId } = await triggerBenchRun('benchSoWorkflow', [
     SO_CHUNK_COUNT,
     SO_INTERVAL_MS,
+    mode,
   ]);
   try {
     const returnValue = await withTimeout(
@@ -400,7 +407,7 @@ async function runSoIteration(): Promise<SoIterationResult> {
       // The writer streams for the whole generation window before the run can
       // complete, so extend the guard past the base run timeout by that window.
       RUN_TIMEOUT_MS + SO_NOMINAL_DURATION_MS,
-      `benchSoWorkflow returnValue (run ${runId})`
+      `benchSoWorkflow (${mode}) returnValue (run ${runId})`
     );
     const so = (returnValue as { so?: BenchStreamOverhead } | undefined)?.so;
     if (
@@ -575,7 +582,12 @@ const SCENARIO_TURBO_STREAM = 'stream';
 const SCENARIO_HOOK_STREAM = 'hook + stream';
 const SCENARIO_SEQUENTIAL = `${SEQUENTIAL_STEP_COUNT} steps`;
 const SCENARIO_STREAM_LATENCY = 'stream latency';
-const SCENARIO_STREAM_OVERHEAD = 'stream overhead';
+// Two SO scenarios differing only in payload shape. The labels are distinct
+// from the pre-existing 'stream overhead' baseline key, so the payload change
+// doesn't diff against the old fixed-'aaaa' numbers — the SO deltas start blank
+// and re-baseline on the next `main` run.
+const SCENARIO_STREAM_OVERHEAD_TEXT = 'stream overhead (text)';
+const SCENARIO_STREAM_OVERHEAD_STRUCTURED = 'stream overhead (structured)';
 const SCENARIO_DESCRIPTIONS = [
   {
     name: SCENARIO_STEP,
@@ -602,8 +614,12 @@ const SCENARIO_DESCRIPTIONS = [
       'parallel reader/writer steps on a dedicated stream; SL is the in-deployment write->read propagation (readAt - writtenAt)',
   },
   {
-    name: SCENARIO_STREAM_OVERHEAD,
-    description: `writer streams ${SO_CHUNK_COUNT} 4-byte chunks paced at ${SO_CHUNK_RATE_PER_SEC}/s for ${SO_DURATION_SECONDS}s (a haiku-size LLM's token throughput) while a parallel reader drains the whole stream; SO is the end-to-end write+consume time beyond the ${SO_DURATION_SECONDS}s generation window (overhead/backpressure)`,
+    name: SCENARIO_STREAM_OVERHEAD_TEXT,
+    description: `writer streams ${SO_CHUNK_COUNT} variable-length text token deltas paced at ${SO_CHUNK_RATE_PER_SEC}/s for ${SO_DURATION_SECONDS}s (a haiku-size LLM's token throughput) while a parallel reader drains the whole stream; SO is the end-to-end write+consume time beyond the ${SO_DURATION_SECONDS}s generation window (overhead/backpressure)`,
+  },
+  {
+    name: SCENARIO_STREAM_OVERHEAD_STRUCTURED,
+    description: `same workload as ${SCENARIO_STREAM_OVERHEAD_TEXT}, but each delta is an AI-SDK-style structured object ({ type: 'text-delta', id, text }) instead of a raw string, so the SO gap vs the text scenario is the added serialization cost`,
   },
 ];
 
@@ -696,19 +712,41 @@ describe('workflow benchmarks', () => {
     );
   });
 
-  test('scenario: stream overhead', { timeout: 30 * 60_000 }, async () => {
-    const results = await runScenario(
-      SCENARIO_STREAM_OVERHEAD,
-      SO_ITERATIONS,
-      () => runSoIteration()
-    );
-    recordMetric(
-      'so',
-      SCENARIO_STREAM_OVERHEAD,
-      results.map((r) => r.soMs),
-      SO_TARGETS
-    );
-  });
+  test(
+    'scenario: stream overhead (text)',
+    { timeout: 30 * 60_000 },
+    async () => {
+      const results = await runScenario(
+        SCENARIO_STREAM_OVERHEAD_TEXT,
+        SO_ITERATIONS,
+        () => runSoIteration('text')
+      );
+      recordMetric(
+        'so',
+        SCENARIO_STREAM_OVERHEAD_TEXT,
+        results.map((r) => r.soMs),
+        SO_TARGETS
+      );
+    }
+  );
+
+  test(
+    'scenario: stream overhead (structured)',
+    { timeout: 30 * 60_000 },
+    async () => {
+      const results = await runScenario(
+        SCENARIO_STREAM_OVERHEAD_STRUCTURED,
+        SO_ITERATIONS,
+        () => runSoIteration('structured')
+      );
+      recordMetric(
+        'so',
+        SCENARIO_STREAM_OVERHEAD_STRUCTURED,
+        results.map((r) => r.soMs),
+        SO_TARGETS
+      );
+    }
+  );
 
   test('scenario: sequential steps', { timeout: 60 * 60_000 }, async () => {
     const results = await runScenario(

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -17,11 +17,14 @@
 //   reader's `readAt` so SL (`readAt - writtenAt`) excludes the client read
 //   path.
 // - `benchSoWorkflow` measures stream overhead (SO), reusing the SL setup but
-//   streaming a realistic LLM-shaped workload: a writer emits fake 4-byte
-//   tokens paced at a fixed rate for a fixed duration while a parallel reader
-//   drains the whole stream. The workflow returns the writer's `writtenAt` and
-//   the reader's `doneAt`; the runner subtracts the modelled generation window
-//   from `doneAt - writtenAt`, leaving the stream's overhead/backpressure.
+//   streaming a realistic LLM-shaped workload: a writer emits deterministic
+//   variable-length token deltas paced at a fixed rate for a fixed duration
+//   while a parallel reader drains the whole stream. The workflow returns the
+//   writer's `writtenAt` and the reader's `doneAt`; the runner subtracts the
+//   modelled generation window from `doneAt - writtenAt`, leaving the stream's
+//   overhead/backpressure. Two payload shapes are supported so the runner can
+//   isolate serialization cost: `'text'` (raw string fragments) and
+//   `'structured'` (AI-SDK-style `{ type: 'text-delta', id, text }` objects).
 
 import { createHook, getWorkflowMetadata, getWritable } from 'workflow';
 import { getRun } from 'workflow/api';
@@ -55,6 +58,21 @@ export interface BenchStreamOverhead {
   received: number;
 }
 
+/** AI-SDK-style structured text delta streamed by the SO structured variant. */
+export interface BenchTextDelta {
+  type: 'text-delta';
+  id: string;
+  text: string;
+}
+
+/** A single SO chunk: either a raw text fragment or a structured delta. */
+export type BenchStreamDelta = string | BenchTextDelta;
+
+/** SO payload shape. `'text'` streams raw string fragments; `'structured'`
+ * wraps each fragment in a {@link BenchTextDelta}, so the two scenarios differ
+ * only in payload shape (same fragments, count, and pacing). */
+export type BenchStreamOverheadMode = 'text' | 'structured';
+
 // Dedicated stream for the SL scenario, kept off the default output stream so
 // it never interacts with the default-stream lifecycle.
 const SL_STREAM_NAMESPACE = 'bench-sl';
@@ -71,9 +89,37 @@ const SL_READY_NAMESPACE = 'bench-sl-ready';
 // reader-ready barrier pattern SL uses.
 const SO_STREAM_NAMESPACE = 'bench-so';
 const SO_READY_NAMESPACE = 'bench-so-ready';
-// Payload for each SO chunk: 4 ASCII bytes, modelling ~one LLM token. Kept as a
-// tiny string so per-chunk framing (not payload size) dominates the overhead.
-const SO_CHUNK_PAYLOAD = 'aaaa';
+// Deterministic, variable-length text fragments cycled to approximate real
+// token-stream traffic (≈4.5 UTF-8 bytes on average, including punctuation and
+// newline "tokens") while keeping every run byte-for-byte reproducible.
+const SO_TEXT_FRAGMENTS = [
+  'The',
+  ' quick',
+  ' brown',
+  ' fox',
+  ' jumps',
+  ' over',
+  ' the',
+  ' lazy',
+  ' dog',
+  '.\n',
+];
+// AI-SDK text-delta events for a single text block share one id, so the
+// structured variant keeps `id` constant and only varies `text`.
+const SO_STRUCTURED_DELTA_ID = '0';
+
+/** Builds the `index`-th SO chunk in the requested shape. Both shapes cycle the
+ * same fragment list, so `'text'` vs `'structured'` isolates serialization
+ * cost and nothing else. */
+function soChunk(
+  mode: BenchStreamOverheadMode,
+  index: number
+): BenchStreamDelta {
+  const text = SO_TEXT_FRAGMENTS[index % SO_TEXT_FRAGMENTS.length];
+  return mode === 'structured'
+    ? { type: 'text-delta', id: SO_STRUCTURED_DELTA_ID, text }
+    : text;
+}
 
 async function timedNoopStep(index: number): Promise<BenchStepTiming> {
   'use step';
@@ -245,8 +291,10 @@ export async function benchSlWorkflow(): Promise<{ sl: BenchStreamLatency }> {
 async function soReaderStep(): Promise<{ doneAt: number; received: number }> {
   'use step';
   const { workflowRunId } = getWorkflowMetadata();
-  const reader = getRun<string>(workflowRunId)
-    .getReadable<string>({ namespace: SO_STREAM_NAMESPACE })
+  // The reader only counts chunks and stamps the drain time, so it is agnostic
+  // to the payload shape the writer chose.
+  const reader = getRun<BenchStreamDelta>(workflowRunId)
+    .getReadable<BenchStreamDelta>({ namespace: SO_STREAM_NAMESPACE })
     .getReader();
   try {
     // Initiate the read BEFORE signalling ready so the stream GET is in flight
@@ -274,15 +322,17 @@ async function soReaderStep(): Promise<{ doneAt: number; received: number }> {
 }
 
 /** Writer half of the SO scenario: blocks on the reader-ready marker (as in
- * {@link slWriterStep}), then streams `chunkCount` fixed-size chunks paced to
- * one every `intervalMs`. `writtenAt` is stamped just before the loop, and each
- * write is scheduled at `writtenAt + (i + 1) * intervalMs`, so the write phase
- * spans `chunkCount * intervalMs` by construction — the modelled generation
- * window. Pacing only sleeps while ahead of schedule; if backpressure puts the
- * writer behind, it writes immediately and that lost time surfaces as SO. */
+ * {@link slWriterStep}), then streams `chunkCount` token deltas (in the given
+ * `mode`) paced to one every `intervalMs`. `writtenAt` is stamped just before
+ * the loop, and each write is scheduled at `writtenAt + (i + 1) * intervalMs`,
+ * so the write phase spans `chunkCount * intervalMs` by construction — the
+ * modelled generation window. Pacing only sleeps while ahead of schedule; if
+ * backpressure puts the writer behind, it writes immediately and that lost time
+ * surfaces as SO. */
 async function soWriterStep(
   chunkCount: number,
-  intervalMs: number
+  intervalMs: number,
+  mode: BenchStreamOverheadMode
 ): Promise<{ writtenAt: number }> {
   'use step';
   const { workflowRunId } = getWorkflowMetadata();
@@ -295,7 +345,9 @@ async function soWriterStep(
     readyReader.cancel().catch(() => {});
   }
 
-  const writable = getWritable<string>({ namespace: SO_STREAM_NAMESPACE });
+  const writable = getWritable<BenchStreamDelta>({
+    namespace: SO_STREAM_NAMESPACE,
+  });
   const writer = writable.getWriter();
   const writtenAt = Date.now();
   for (let i = 0; i < chunkCount; i++) {
@@ -303,7 +355,7 @@ async function soWriterStep(
     if (delay > 0) {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
-    await writer.write(SO_CHUNK_PAYLOAD);
+    await writer.write(soChunk(mode, i));
   }
   writer.releaseLock();
   await writable.close();
@@ -315,21 +367,24 @@ async function soWriterStep(
  *
  * Reuses the SL scenario's dedicated-stream + reader-ready-barrier setup, but
  * models a realistic LLM streaming workload: the writer emits `chunkCount`
- * 4-byte chunks paced at one every `intervalMs` (e.g. 300 chunks at 10ms ≈ a
- * haiku-size LLM streaming ~100 tokens/s for 3s) while the reader drains the
- * whole stream in parallel. The workflow returns the writer's `writtenAt` and
- * the reader's `doneAt`; the runner subtracts the modelled generation window
- * (`chunkCount * intervalMs`) from `doneAt - writtenAt`, so SO isolates the
- * stream's write+consume overhead/backpressure on top of the token rate.
+ * variable-length token deltas (shape chosen by `mode`) paced at one every
+ * `intervalMs` (e.g. 300 chunks at 10ms ≈ a haiku-size LLM streaming ~100
+ * tokens/s for 3s) while the reader drains the whole stream in parallel. The
+ * workflow returns the writer's `writtenAt` and the reader's `doneAt`; the
+ * runner subtracts the modelled generation window (`chunkCount * intervalMs`)
+ * from `doneAt - writtenAt`, so SO isolates the stream's write+consume
+ * overhead/backpressure on top of the token rate. Running it in both `'text'`
+ * and `'structured'` mode isolates serialization cost.
  */
 export async function benchSoWorkflow(
   chunkCount: number,
-  intervalMs: number
+  intervalMs: number,
+  mode: BenchStreamOverheadMode = 'text'
 ): Promise<{ so: BenchStreamOverhead }> {
   'use workflow';
   const [reader, writer] = await Promise.all([
     soReaderStep(),
-    soWriterStep(chunkCount, intervalMs),
+    soWriterStep(chunkCount, intervalMs, mode),
   ]);
   return {
     so: {


### PR DESCRIPTION
Two independent PR-comment / benchmark polish changes, both following up on #3077.

## 1. SO benchmark payload variants
Addresses review feedback from @karthikscale3 on #3077.

- **Deterministic, variable-length text** ([comment](https://github.com/vercel/workflow/pull/3077#issuecomment-5064739528)): the SO writer cycles a fixed fragment list (`"The"`, `" quick"`, … `".\n"`, ~4.5 UTF-8 bytes avg incl. punctuation/newline tokens) instead of repeating `"aaaa"` — closer to real token-stream traffic, still byte-for-byte reproducible.
- **Structured-delta variant** ([comment](https://github.com/vercel/workflow/pull/3077#issuecomment-5064740148)): a new `mode: 'text' | 'structured'` arg on `benchSoWorkflow`; structured mode wraps each fragment as `{ type: "text-delta", id: "0", text }` (AI SDK shape). Both scenarios stream the same 300 chunks @ 100/s over 3 s and reuse the same fragments, so payload shape is the only variable and the SO gap between them isolates serialization cost.

Renders as two rows — **SO / stream overhead (text)** and **SO / stream overhead (structured)**. The text scenario was renamed from `stream overhead`, which also drops its stale fixed-payload baseline (both SO deltas start blank and re-baseline on the next `main` run; no methodology bump, so other metrics keep their baselines).

## 2. Restructured "E2E Test Results" PR comment
Reworks `.github/scripts/aggregate-e2e-results.js` (aggregate mode) and `.github/workflows/tests.yml`:

- **Failed tests first.** A renamed **"Failed E2E Tests"** section moves to the top and is hidden entirely when everything passed. Per category, failures under 10 are listed inline under a heading; only categories with ≥10 failures collapse into a `<details>`.
- **"E2E Test Summary"** section follows, with two collapsibles: the overall summary table, and a flat **"Details by Category"** breakdown (no nested collapsibles — one big list).
- **Removed the redundant "Some E2E test jobs failed" append step** (superseded by the failed-tests section) and its duplicate run link, keeping the single **"View full workflow run"** link from the script.

## Testing
- `node --test ".github/scripts/**/*.test.js"` — 29/29 pass, including new coverage for the aggregate renderer (few/many failures, all-pass, no-nested-details) and both SO rows.
- `@workflow/core` typecheck passes; `97_bench.ts` recompiles cleanly via SWC; both SO modes resolve through the workbench registry.
- Aggregate comment rendering verified locally against synthetic fixtures for the <10, ≥10, and all-pass cases.
- SO runs end-to-end in the Performance Benchmarks job on the preview deploy (the bench suite runs against Vercel only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)