### PR TITLE
feat(core): add `encp` sealed-box encryption primitive

### DIFF
--- a/.changeset/encp-sealed-box.md
+++ b/.changeset/encp-sealed-box.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Add the `encp` sealed-box encryption primitive: X25519 keypairs derived from the existing per-run key material, letting cross-run writers encrypt with only a public key. Not yet wired into any write path.

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -31,6 +31,12 @@
  * - `gzip` (gzip payload compression): added in `5.0.0-beta.18`
  * - `zstd` (zstd payload compression, preferred codec): added in `5.0.0-beta.18`
  *   alongside gzip — they co-ship, so any run that can read one can read both.
+ * - `encp` (X25519 sealed-box encryption for cross-run writes): added in
+ *   `5.0.0-beta.37`. Note that producers do **not** gate `encp` on this table:
+ *   they gate on the presence of `encryptionPublicKey` on the target run,
+ *   which a run only carries if the deployment that created it could also
+ *   open `encp`. The entry exists so the capability set stays a complete,
+ *   auditable description of a run's decoding ability.
  */
 
 import semver from 'semver';
@@ -79,6 +85,12 @@ const FORMAT_VERSION_TABLE: ReadonlyArray<{
   // they share a min version — a run that can read one can read both.
   { format: SerializationFormat.GZIP, minVersion: '5.0.0-beta.18' },
   { format: SerializationFormat.ZSTD, minVersion: '5.0.0-beta.18' },
+  // TODO(release): verify this matches the actual version that ships sealed-box
+  // encryption. If a "Version Packages (beta)" PR merges before this change,
+  // bump to the next beta. Unlike the entries above, a wrong cutoff here is
+  // not a correctness hazard: producers gate `encp` on the target run carrying
+  // an `encryptionPublicKey`, not on this table (see History above).
+  { format: SerializationFormat.SEALED, minVersion: '5.0.0-beta.37' },
   // Future entries:
   // { format: SerializationFormat.CBOR, minVersion: '5.x.y' },
   // { format: SerializationFormat.ENCRYPTED_V2, minVersion: '5.x.y' },

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -23,8 +23,12 @@ import { RuntimeDecryptionError, WorkflowRuntimeError } from '@workflow/errors';
 // so consumers can reference it without adding `dom` lib.
 export type CryptoKey = import('node:crypto').webcrypto.CryptoKey;
 
-const NONCE_LENGTH = 12;
-const TAG_LENGTH = 128; // bits
+/** AES-GCM nonce length in bytes. */
+export const NONCE_LENGTH = 12;
+/** AES-GCM authentication tag length in bits. */
+export const TAG_LENGTH = 128;
+/** AES-GCM authentication tag length in bytes. */
+export const TAG_BYTES = TAG_LENGTH / 8;
 const KEY_LENGTH = 32; // bytes (AES-256)
 
 /**

--- a/packages/core/src/encryption.ts
+++ b/packages/core/src/encryption.ts
@@ -68,17 +68,27 @@ export async function importKey(
  *
  * @param key - CryptoKey from `importKey()`
  * @param data - Plaintext to encrypt
+ * @param aad - Optional additional authenticated data. Not encrypted, but
+ *   covered by the GCM auth tag: decryption fails unless the exact same
+ *   bytes are supplied. Used by the sealed-box layer to bind ciphertext to
+ *   a `projectId|runId` context. Omit for no AAD (the legacy behavior).
  * @returns `[nonce (12 bytes)][ciphertext + GCM auth tag]`
  */
 export async function encrypt(
   key: CryptoKey,
-  data: Uint8Array
+  data: Uint8Array,
+  aad?: Uint8Array
 ): Promise<Uint8Array> {
   const nonce = globalThis.crypto.getRandomValues(new Uint8Array(NONCE_LENGTH));
   let ciphertext: ArrayBuffer;
   try {
     ciphertext = await globalThis.crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
+      {
+        name: 'AES-GCM',
+        iv: nonce,
+        tagLength: TAG_LENGTH,
+        ...(aad ? { additionalData: aad } : {}),
+      },
       key,
       data
     );
@@ -123,11 +133,15 @@ export async function encrypt(
  *
  * @param key - CryptoKey from `importKey()`
  * @param data - `[nonce (12 bytes)][ciphertext + GCM auth tag]`
+ * @param aad - Optional additional authenticated data. Must match the bytes
+ *   passed to {@link encrypt} exactly, otherwise the GCM tag fails to verify
+ *   and a {@link RuntimeDecryptionError} is thrown.
  * @returns Decrypted plaintext
  */
 export async function decrypt(
   key: CryptoKey,
-  data: Uint8Array
+  data: Uint8Array,
+  aad?: Uint8Array
 ): Promise<Uint8Array> {
   const minLength = NONCE_LENGTH + TAG_LENGTH / 8; // nonce + auth tag
   if (data.byteLength < minLength) {
@@ -146,7 +160,12 @@ export async function decrypt(
   let plaintext: ArrayBuffer;
   try {
     plaintext = await globalThis.crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv: nonce, tagLength: TAG_LENGTH },
+      {
+        name: 'AES-GCM',
+        iv: nonce,
+        tagLength: TAG_LENGTH,
+        ...(aad ? { additionalData: aad } : {}),
+      },
       key,
       ciphertext
     );

--- a/packages/core/src/sealed-box.test.ts
+++ b/packages/core/src/sealed-box.test.ts
@@ -1,0 +1,404 @@
+import { RuntimeDecryptionError, WorkflowRuntimeError } from '@workflow/errors';
+import { describe, expect, it } from 'vitest';
+import {
+  decrypt as aesGcmDecrypt,
+  encrypt as aesGcmEncrypt,
+} from './encryption.js';
+import {
+  decapsulate,
+  deriveRunKeyPair,
+  encapsulate,
+  open,
+  type RunKeyPair,
+  runAad,
+  seal,
+} from './sealed-box.js';
+
+const K = new Uint8Array(32).fill(7);
+const OTHER_K = new Uint8Array(32).fill(8);
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function plaintext(value = 'hello, workflow'): Uint8Array {
+  return encoder.encode(value);
+}
+
+describe('sealed-box', () => {
+  describe('deriveRunKeyPair', () => {
+    it('is deterministic for the same run key material', async () => {
+      const a = await deriveRunKeyPair(K);
+      const b = await deriveRunKeyPair(K);
+      expect(a.scalar).toEqual(b.scalar);
+      expect(a.publicKey).toEqual(b.publicKey);
+    });
+
+    it('derives different keypairs for different run key material', async () => {
+      const a = await deriveRunKeyPair(K);
+      const b = await deriveRunKeyPair(OTHER_K);
+      expect(a.scalar).not.toEqual(b.scalar);
+      expect(a.publicKey).not.toEqual(b.publicKey);
+    });
+
+    it('produces 32-byte scalars and public keys', async () => {
+      const { scalar, publicKey } = await deriveRunKeyPair(K);
+      expect(scalar.byteLength).toBe(32);
+      expect(publicKey.byteLength).toBe(32);
+    });
+
+    it('does not leak the run key material into either half', async () => {
+      const { scalar, publicKey } = await deriveRunKeyPair(K);
+      expect(scalar).not.toEqual(K);
+      expect(publicKey).not.toEqual(K);
+      expect(publicKey).not.toEqual(scalar);
+    });
+
+    it('rejects run key material that is not exactly 32 bytes', async () => {
+      await expect(deriveRunKeyPair(new Uint8Array(16))).rejects.toThrow(
+        /must be exactly 32 bytes, got 16/
+      );
+    });
+  });
+
+  describe('seal/open round-trip', () => {
+    it('opens a payload sealed to the run public key', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(keyPair.publicKey, plaintext());
+
+      // 32-byte ephemeral public key + 12-byte nonce + 16-byte GCM tag.
+      expect(sealed.byteLength).toBe(plaintext().byteLength + 32 + 12 + 16);
+
+      const opened = await open(keyPair, sealed);
+      expect(decoder.decode(opened)).toBe('hello, workflow');
+    });
+
+    it('round-trips empty payloads', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(keyPair.publicKey, new Uint8Array(0));
+      expect(await open(keyPair, sealed)).toEqual(new Uint8Array(0));
+    });
+
+    it('round-trips large payloads', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      // `getRandomValues` accepts at most 64KiB per call, so fill in chunks.
+      const large = new Uint8Array(128 * 1024);
+      for (let offset = 0; offset < large.length; offset += 32 * 1024) {
+        globalThis.crypto.getRandomValues(
+          large.subarray(offset, offset + 32 * 1024)
+        );
+      }
+      const sealed = await seal(keyPair.publicKey, large);
+      expect(await open(keyPair, sealed)).toEqual(large);
+    });
+
+    it('produces a distinct ephemeral key and ciphertext on every call', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const a = await seal(keyPair.publicKey, plaintext());
+      const b = await seal(keyPair.publicKey, plaintext());
+
+      // Identical plaintext, but the ephemeral public keys (first 32 bytes)
+      // and therefore the whole envelope must differ — this is what makes
+      // nonce reuse impossible across one-shot seals.
+      expect(a.subarray(0, 32)).not.toEqual(b.subarray(0, 32));
+      expect(a).not.toEqual(b);
+      expect(await open(keyPair, a)).toEqual(await open(keyPair, b));
+    });
+  });
+
+  describe('encrypt-only guarantee', () => {
+    it('gives the sealer a content key that cannot decrypt', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const { contentKey } = await encapsulate(keyPair.publicKey);
+
+      expect(contentKey.usages).toEqual(['encrypt']);
+
+      const encrypted = await aesGcmEncrypt(contentKey, plaintext());
+      // Even holding the very content key it just used, the writer cannot
+      // reverse the operation: the CryptoKey carries no 'decrypt' usage.
+      await expect(aesGcmDecrypt(contentKey, encrypted)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+
+    it('gives the recipient a content key that cannot encrypt', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const { ephemeralPublicKey } = await encapsulate(keyPair.publicKey);
+      const contentKey = await decapsulate(keyPair, ephemeralPublicKey);
+
+      expect(contentKey.usages).toEqual(['decrypt']);
+      await expect(aesGcmEncrypt(contentKey, plaintext())).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+
+    it('cannot be opened with only the public key (no scalar)', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(keyPair.publicKey, plaintext());
+
+      // Simulate a writer that knows only the public key: give `open` a
+      // keypair whose "scalar" is the public key. This models the
+      // type-confusion hazard where a public key is mistaken for secret
+      // key material — it must never yield the plaintext.
+      const publicOnly: RunKeyPair = {
+        scalar: keyPair.publicKey,
+        publicKey: keyPair.publicKey,
+      };
+      await expect(open(publicOnly, sealed)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+  });
+
+  describe('key separation', () => {
+    it('cannot be opened by a different run', async () => {
+      const recipient = await deriveRunKeyPair(K);
+      const other = await deriveRunKeyPair(OTHER_K);
+      const sealed = await seal(recipient.publicKey, plaintext());
+
+      await expect(open(other, sealed)).rejects.toThrow(RuntimeDecryptionError);
+    });
+
+    it('binds the content key to the recipient public key', async () => {
+      const recipient = await deriveRunKeyPair(K);
+      const other = await deriveRunKeyPair(OTHER_K);
+      const sealed = await seal(recipient.publicKey, plaintext());
+
+      // Splice the correct scalar together with the wrong public key. The
+      // X25519 agreement still succeeds (the scalar matches the ephemeral
+      // key), but the KDF `info` binds both public keys, so the derived
+      // content key differs and the GCM tag fails. This is the
+      // key-substitution defense.
+      const spliced: RunKeyPair = {
+        scalar: recipient.scalar,
+        publicKey: other.publicKey,
+      };
+      await expect(open(spliced, sealed)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+  });
+
+  describe('additional authenticated data', () => {
+    it('round-trips when the AAD matches', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const aad = runAad('prj_123', 'wrun_abc');
+      const sealed = await seal(keyPair.publicKey, plaintext(), aad);
+      expect(decoder.decode(await open(keyPair, sealed, aad))).toBe(
+        'hello, workflow'
+      );
+    });
+
+    it('rejects a payload replayed against a different run', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(
+        keyPair.publicKey,
+        plaintext(),
+        runAad('prj_123', 'wrun_abc')
+      );
+
+      await expect(
+        open(keyPair, sealed, runAad('prj_123', 'wrun_different'))
+      ).rejects.toThrow(RuntimeDecryptionError);
+    });
+
+    it('rejects a payload whose AAD is dropped', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(
+        keyPair.publicKey,
+        plaintext(),
+        runAad('prj_123', 'wrun_abc')
+      );
+
+      await expect(open(keyPair, sealed)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+
+    it('distinguishes projects with identical run ids', async () => {
+      expect(runAad('prj_a', 'wrun_1')).not.toEqual(runAad('prj_b', 'wrun_1'));
+    });
+  });
+
+  describe('tamper detection', () => {
+    it('rejects a flipped ciphertext bit', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(keyPair.publicKey, plaintext());
+      const tampered = new Uint8Array(sealed);
+      tampered[tampered.length - 1] ^= 0x01;
+
+      await expect(open(keyPair, tampered)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+
+    it('rejects a swapped ephemeral public key', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(keyPair.publicKey, plaintext());
+      const other = await seal(keyPair.publicKey, plaintext());
+
+      const tampered = new Uint8Array(sealed);
+      tampered.set(other.subarray(0, 32), 0);
+
+      await expect(open(keyPair, tampered)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+
+    it('rejects a truncated envelope', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(keyPair.publicKey, plaintext());
+
+      await expect(open(keyPair, sealed.subarray(0, 50))).rejects.toThrow(
+        /Sealed payload too short/
+      );
+    });
+
+    it('rejects an envelope that is all ephemeral key and no ciphertext', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      await expect(open(keyPair, new Uint8Array(32))).rejects.toThrow(
+        /Sealed payload too short/
+      );
+    });
+  });
+
+  describe('malformed public keys', () => {
+    it('rejects public keys that are not 32 bytes', async () => {
+      await expect(seal(new Uint8Array(31), plaintext())).rejects.toThrow(
+        WorkflowRuntimeError
+      );
+      await expect(seal(new Uint8Array(33), plaintext())).rejects.toThrow(
+        /must be exactly 32 bytes, got 33/
+      );
+    });
+
+    it('rejects low-order public keys', async () => {
+      // An all-zero public key is a low-order point: X25519 agreement with it
+      // yields an all-zero shared secret, which Web Crypto rejects. Surfacing
+      // this as a hard error gives us HPKE's contributory-behavior check.
+      await expect(seal(new Uint8Array(32), plaintext())).rejects.toThrow(
+        /not a valid curve point/
+      );
+    });
+
+    it('rejects a malformed ephemeral public key on open', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const sealed = await seal(keyPair.publicKey, plaintext());
+      const tampered = new Uint8Array(sealed);
+      // Zero out the ephemeral key — a low-order point.
+      tampered.fill(0, 0, 32);
+
+      await expect(open(keyPair, tampered)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+  });
+
+  describe('cross-implementation validation', () => {
+    it('derives the same public key as node:crypto for the same scalar', async () => {
+      // `derivePublicKeyFromScalar` reads the public half out of a JWK export
+      // because Web Crypto exposes no scalar-multiplication primitive. That is
+      // subtle enough to be worth checking against an independent
+      // implementation: Node's native X25519, reached through the same PKCS#8
+      // wrapper. A mismatch would mean we publish public keys that do not
+      // correspond to the scalars we decrypt with.
+      const { createPrivateKey, createPublicKey } = await import('node:crypto');
+      const { scalar, publicKey } = await deriveRunKeyPair(K);
+
+      const pkcs8 = new Uint8Array(16 + 32);
+      pkcs8.set(
+        [
+          0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
+          0x6e, 0x04, 0x22, 0x04, 0x20,
+        ],
+        0
+      );
+      pkcs8.set(scalar, 16);
+
+      const nodePrivate = createPrivateKey({
+        key: Buffer.from(pkcs8),
+        format: 'der',
+        type: 'pkcs8',
+      });
+      const nodePublicRaw = createPublicKey(nodePrivate).export({
+        format: 'jwk',
+      }).x as string;
+
+      expect(new Uint8Array(Buffer.from(nodePublicRaw, 'base64url'))).toEqual(
+        publicKey
+      );
+    });
+  });
+
+  describe('streaming (amortized KEM)', () => {
+    it('encrypts many frames under one encapsulation', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const { ephemeralPublicKey, contentKey } = await encapsulate(
+        keyPair.publicKey
+      );
+
+      const frames = ['alpha', 'beta', 'gamma'].map((f) => plaintext(f));
+      const encrypted = [];
+      for (const frame of frames) {
+        encrypted.push(await aesGcmEncrypt(contentKey, frame));
+      }
+
+      const readerKey = await decapsulate(keyPair, ephemeralPublicKey);
+      const decrypted = [];
+      for (const frame of encrypted) {
+        decrypted.push(decoder.decode(await aesGcmDecrypt(readerKey, frame)));
+      }
+      expect(decrypted).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('never repeats a (content key, nonce) pair across frames', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const { contentKey } = await encapsulate(keyPair.publicKey);
+
+      // Identical plaintext on every frame: any nonce reuse would show up as
+      // byte-identical ciphertext, which under AES-GCM leaks the plaintext
+      // XOR and the auth subkey.
+      const nonces = new Set<string>();
+      for (let i = 0; i < 200; i++) {
+        const frame = await aesGcmEncrypt(contentKey, plaintext('same'));
+        nonces.add(Array.from(frame.subarray(0, 12)).join(','));
+      }
+      expect(nonces.size).toBe(200);
+    });
+
+    it('derives a fresh content key per encapsulation, so reconnects and replays cannot collide', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+
+      // Model a writer that reconnects (or replays) 25 times. Every
+      // incarnation must get its own ephemeral key and content key so that
+      // restarting frame numbering at zero is harmless.
+      const ephemeralKeys = new Set<string>();
+      const firstFrames = new Set<string>();
+      for (let i = 0; i < 25; i++) {
+        const { ephemeralPublicKey, contentKey } = await encapsulate(
+          keyPair.publicKey
+        );
+        ephemeralKeys.add(Array.from(ephemeralPublicKey).join(','));
+        const frame = await aesGcmEncrypt(contentKey, plaintext('frame-0'));
+        firstFrames.add(Array.from(frame).join(','));
+      }
+      expect(ephemeralKeys.size).toBe(25);
+      expect(firstFrames.size).toBe(25);
+    });
+
+    it('cannot decrypt frames from a different encapsulation', async () => {
+      const keyPair = await deriveRunKeyPair(K);
+      const first = await encapsulate(keyPair.publicKey);
+      const second = await encapsulate(keyPair.publicKey);
+
+      const frame = await aesGcmEncrypt(first.contentKey, plaintext());
+      const wrongReaderKey = await decapsulate(
+        keyPair,
+        second.ephemeralPublicKey
+      );
+
+      await expect(aesGcmDecrypt(wrongReaderKey, frame)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+  });
+});

--- a/packages/core/src/sealed-box.test.ts
+++ b/packages/core/src/sealed-box.test.ts
@@ -1,5 +1,5 @@
 import { RuntimeDecryptionError, WorkflowRuntimeError } from '@workflow/errors';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   decrypt as aesGcmDecrypt,
   encrypt as aesGcmEncrypt,
@@ -51,6 +51,32 @@ describe('sealed-box', () => {
       expect(scalar).not.toEqual(K);
       expect(publicKey).not.toEqual(K);
       expect(publicKey).not.toEqual(scalar);
+    });
+
+    it('validates the length of the JWK-derived public key', async () => {
+      // The public key is read out of a JWK export, the one place this module
+      // trusts an external encoding. A short value must be rejected here
+      // rather than surfacing later inside key agreement.
+      const subtle = globalThis.crypto.subtle;
+      const realExport = subtle.exportKey.bind(subtle);
+      const spy = vi
+        .spyOn(subtle, 'exportKey')
+        .mockImplementation(async (format: any, key: any) => {
+          const jwk = await realExport(format, key);
+          if (format === 'jwk') {
+            // 31 bytes of base64url instead of 32.
+            (jwk as { x?: string }).x = 'A'.repeat(41);
+          }
+          return jwk;
+        });
+
+      try {
+        await expect(deriveRunKeyPair(K)).rejects.toThrow(
+          /produced a \d+-byte public key, expected 32/
+        );
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it('rejects run key material that is not exactly 32 bytes', async () => {

--- a/packages/core/src/sealed-box.ts
+++ b/packages/core/src/sealed-box.ts
@@ -1,0 +1,540 @@
+import { RuntimeDecryptionError, WorkflowRuntimeError } from '@workflow/errors';
+import {
+  decrypt as aesGcmDecrypt,
+  encrypt as aesGcmEncrypt,
+  type CryptoKey,
+} from './encryption.js';
+
+/**
+ * Browser-compatible sealed-box (asymmetric) encryption for cross-run writes.
+ *
+ * ## Why this exists
+ *
+ * The symmetric `encr` path requires the writer to hold the recipient run's
+ * key — which also grants decrypt capability. For *cross-run* writes (a hook
+ * resumption targeting another run, or a child workflow writing into a
+ * parent's forwarded `WritableStream`) that is more authority than the writer
+ * needs, and obtaining the symmetric key across a deployment boundary costs a
+ * round trip to the Vercel API.
+ *
+ * A sealed box fixes both: the writer needs only the recipient's **public**
+ * key, which is not secret and therefore travels on the run entity (and in
+ * stream descriptors) at no cost. "Encrypt-only" stops being an honor-system
+ * convention enforced by `importKey(raw, ['encrypt'])` and becomes a
+ * cryptographic guarantee — a writer holding just the public key provably
+ * cannot read anything.
+ *
+ * ## Key hierarchy
+ *
+ * Both keys descend from the same per-run key material `K` that
+ * `World.getEncryptionKeyForRun()` already returns today, so nothing about
+ * key acquisition, the World interface, or the Vercel API changes:
+ *
+ * ```
+ * K  (32 bytes, per-run, = HKDF(VERCEL_DEPLOYMENT_KEY, "projectId|runId"))
+ * ├── AES-256 key = K used directly            → 'encr' envelopes (unchanged)
+ * └── X25519 scalar = HKDF(K, SCALAR_INFO)     → 'encp' envelopes
+ *     └── public key = X25519 basepoint · scalar   (published, not secret)
+ * ```
+ *
+ * `K` is therefore both an AEAD key and a key-derivation key. This is sound:
+ * AES-GCM never exposes its key, and HKDF-SHA256 output is computationally
+ * independent of the AES keystream. A strict reading of NIST SP 800-108
+ * prefers these roles be separated, but `K`'s direct AES use is fixed by
+ * backward compatibility with every `encr` payload already written.
+ *
+ * ## Construction
+ *
+ * An ECIES-style sealed box using the same primitives as HPKE (RFC 9180)
+ * base mode with DHKEM(X25519, HKDF-SHA256) and AES-256-GCM, but without the
+ * full `LabeledExtract`/`LabeledExpand` suite-ID ceremony:
+ *
+ * ```
+ * ephemeral    = X25519 keypair, freshly generated per encryption context
+ * sharedSecret = X25519(ephemeralPrivate, recipientPublic)
+ * contentKey   = HKDF-SHA256(
+ *                  ikm  = sharedSecret,
+ *                  salt = zeros(32),
+ *                  info = CONTENT_KEY_INFO ‖ ephemeralPublic ‖ recipientPublic,
+ *                )
+ * ```
+ *
+ * Binding both public keys into `info` is the security-critical part (it is
+ * HPKE's `kem_context`): it prevents key-substitution/unknown-key-share
+ * attacks in which an adversary replays a ciphertext as though it had been
+ * sealed to a different recipient. Deviating from strict RFC 9180 framing is
+ * a deliberate, documented choice — the envelope is versioned via its format
+ * prefix and the HKDF labels below, so a conformant profile can be added
+ * later as a new version without touching existing payloads.
+ *
+ * Wire format (the `encp` format prefix is attached by the serialization
+ * layer, not by this module):
+ *
+ * ```
+ * [ephemeral public key (32 bytes)][nonce (12 bytes)][ciphertext + GCM tag (16 bytes)]
+ * ```
+ *
+ * ## Nonce discipline
+ *
+ * One-shot {@link seal} generates a fresh ephemeral keypair — and therefore a
+ * fresh content key — for every call, so nonce reuse is impossible.
+ *
+ * Streaming callers amortize the KEM across many frames via
+ * {@link encapsulate}, which makes the content key long-lived and nonce
+ * discipline *their* responsibility. Frames MUST use a fresh random nonce
+ * each (which `aesGcmEncrypt` does) rather than a counter: a counter would
+ * restart at zero after a stream reconnect or a durable replay, reusing
+ * `(contentKey, nonce)` and catastrophically breaking AES-GCM. Callers must
+ * additionally re-run {@link encapsulate} per connection attempt so that
+ * replayed or reconnected writers never share a content key with a previous
+ * incarnation. See `getSerializeStream` for the enforcement.
+ */
+
+/** Length of an X25519 private scalar and public key, in bytes. */
+const X25519_KEY_LENGTH = 32;
+
+/** Length of the AES-256 content key derived from the shared secret. */
+const CONTENT_KEY_LENGTH = 32;
+
+/**
+ * HKDF `info` label for deriving the per-run X25519 scalar from the per-run
+ * key material.
+ *
+ * Versioned and namespaced so that any future derivation from the same `K`
+ * (a second keypair, a MAC key, a different curve) can never collide with
+ * this one.
+ */
+const SCALAR_INFO = 'workflow/encp/x25519/v1';
+
+/**
+ * HKDF `info` prefix for deriving the AES-256-GCM content key from an X25519
+ * shared secret. The ephemeral and recipient public keys are appended to this
+ * label to form the full `info` (HPKE's `kem_context`).
+ */
+const CONTENT_KEY_INFO = 'workflow/encp/aes256gcm/v1';
+
+/**
+ * DER prefix for an RFC 8410 `PrivateKeyInfo` wrapping a raw X25519 scalar.
+ *
+ * Web Crypto cannot import a raw X25519 private key (`importKey('raw', ...)`
+ * is only defined for public keys on the Secure Curves algorithms), so a
+ * derived scalar has to be wrapped in PKCS#8 before it can be used. The
+ * structure is fully determined for a 32-byte X25519 key:
+ *
+ * ```
+ * SEQUENCE (46 bytes)                         30 2e
+ *   INTEGER 0                                 02 01 00
+ *   SEQUENCE (5 bytes)                        30 05
+ *     OBJECT IDENTIFIER 1.3.101.110 (X25519)  06 03 2b 65 6e
+ *   OCTET STRING (34 bytes)                   04 22
+ *     OCTET STRING (32 bytes)                 04 20
+ *       <scalar>
+ * ```
+ */
+const PKCS8_X25519_PREFIX = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x04,
+  0x22, 0x04, 0x20,
+]);
+
+const infoEncoder = new TextEncoder();
+
+/**
+ * A per-run X25519 keypair, derived from the run's key material.
+ *
+ * Callers should derive this once per run and memoize it alongside the
+ * symmetric key — derivation costs several Web Crypto round trips.
+ */
+export interface RunKeyPair {
+  /** Raw 32-byte X25519 private scalar. Secret. */
+  readonly scalar: Uint8Array;
+  /** Raw 32-byte X25519 public key. Safe to publish. */
+  readonly publicKey: Uint8Array;
+}
+
+function assertKeyMaterialLength(runKeyMaterial: Uint8Array): void {
+  if (runKeyMaterial.byteLength !== CONTENT_KEY_LENGTH) {
+    throw new WorkflowRuntimeError(
+      `Run key material must be exactly ${CONTENT_KEY_LENGTH} bytes, got ${runKeyMaterial.byteLength}`
+    );
+  }
+}
+
+function assertPublicKeyLength(publicKey: Uint8Array, label: string): void {
+  if (publicKey.byteLength !== X25519_KEY_LENGTH) {
+    throw new WorkflowRuntimeError(
+      `${label} must be exactly ${X25519_KEY_LENGTH} bytes, got ${publicKey.byteLength}`
+    );
+  }
+}
+
+/**
+ * Derive the per-run X25519 keypair from the run's 32-byte key material.
+ *
+ * Deterministic: the same key material always yields the same keypair, which
+ * is what lets the owning deployment re-derive its private scalar on demand
+ * (from `VERCEL_DEPLOYMENT_KEY`) instead of storing it anywhere.
+ *
+ * @param runKeyMaterial - The 32 bytes returned by `World.getEncryptionKeyForRun()`
+ * @returns The run's X25519 scalar and public key
+ */
+export async function deriveRunKeyPair(
+  runKeyMaterial: Uint8Array
+): Promise<RunKeyPair> {
+  assertKeyMaterialLength(runKeyMaterial);
+
+  const hkdfKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    runKeyMaterial,
+    'HKDF',
+    false,
+    ['deriveBits']
+  );
+
+  // Zero salt is acceptable per RFC 5869 §3.1: the IKM here is itself HKDF
+  // output (or a high-entropy BYOK value), so it is already uniform. The
+  // `info` label provides domain separation.
+  const scalarBits = await globalThis.crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(32),
+      info: infoEncoder.encode(SCALAR_INFO),
+    },
+    hkdfKey,
+    X25519_KEY_LENGTH * 8
+  );
+  const scalar = new Uint8Array(scalarBits);
+
+  // Any 32-byte string is a valid X25519 scalar (the low/high bits are
+  // clamped during scalar multiplication), so the HKDF output needs no
+  // rejection sampling.
+  const publicKey = await derivePublicKeyFromScalar(scalar);
+  return { scalar, publicKey };
+}
+
+/**
+ * Recover the raw public key for a scalar.
+ *
+ * Web Crypto exposes no scalar-multiplication primitive, so the scalar is
+ * imported as a PKCS#8 private key and its public half read back out of the
+ * JWK export (`x`), which the Secure Curves spec defines as the base64url
+ * raw public key.
+ */
+async function derivePublicKeyFromScalar(
+  scalar: Uint8Array
+): Promise<Uint8Array> {
+  const privateKey = await importScalar(scalar, /* extractable */ true);
+  const jwk = await globalThis.crypto.subtle.exportKey('jwk', privateKey);
+  if (!jwk.x) {
+    throw new WorkflowRuntimeError(
+      'X25519 JWK export did not include a public key component ("x")'
+    );
+  }
+  return base64UrlToBytes(jwk.x);
+}
+
+async function importScalar(
+  scalar: Uint8Array,
+  extractable: boolean
+): Promise<CryptoKey> {
+  const pkcs8 = new Uint8Array(PKCS8_X25519_PREFIX.length + scalar.byteLength);
+  pkcs8.set(PKCS8_X25519_PREFIX, 0);
+  pkcs8.set(scalar, PKCS8_X25519_PREFIX.length);
+  return globalThis.crypto.subtle.importKey(
+    'pkcs8',
+    pkcs8,
+    { name: 'X25519' },
+    extractable,
+    ['deriveBits']
+  );
+}
+
+function importPublicKey(publicKey: Uint8Array): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.importKey(
+    'raw',
+    publicKey,
+    { name: 'X25519' },
+    /* extractable */ true,
+    // Public keys carry no usages for X25519 — the private key does the
+    // deriving; the public key is only ever an argument to it.
+    []
+  );
+}
+
+const BASE64URL_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+/**
+ * Decode a base64url string (JWK encoding) to bytes.
+ *
+ * Hand-rolled rather than using `atob` or `Buffer`: this module also runs
+ * inside the workflow VM, whose global surface is deliberately minimal and
+ * does not include either. The inputs here are fixed-size JWK key components,
+ * so a compact decoder is sufficient — it accepts unpadded base64url only,
+ * which is what RFC 7515 §2 mandates for JWK members.
+ */
+function base64UrlToBytes(value: string): Uint8Array {
+  let accumulator = 0;
+  let bitCount = 0;
+  const bytes: number[] = [];
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === '=') break;
+    const index = BASE64URL_CHARS.indexOf(char);
+    if (index === -1) {
+      throw new WorkflowRuntimeError(
+        `Invalid base64url character "${char}" in X25519 JWK key component`
+      );
+    }
+    accumulator = (accumulator << 6) | index;
+    bitCount += 6;
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      bytes.push((accumulator >> bitCount) & 0xff);
+    }
+  }
+
+  return new Uint8Array(bytes);
+}
+
+/**
+ * Derive the AES-256-GCM content key from an X25519 shared secret, binding
+ * it to both public keys (HPKE's `kem_context`).
+ */
+async function deriveContentKey(
+  sharedSecret: Uint8Array,
+  ephemeralPublicKey: Uint8Array,
+  recipientPublicKey: Uint8Array,
+  usages: ReadonlyArray<'encrypt' | 'decrypt'>
+): Promise<CryptoKey> {
+  const label = infoEncoder.encode(CONTENT_KEY_INFO);
+  const info = new Uint8Array(
+    label.length + ephemeralPublicKey.length + recipientPublicKey.length
+  );
+  info.set(label, 0);
+  info.set(ephemeralPublicKey, label.length);
+  info.set(recipientPublicKey, label.length + ephemeralPublicKey.length);
+
+  const hkdfKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    sharedSecret,
+    'HKDF',
+    false,
+    ['deriveBits']
+  );
+  const contentKeyBits = await globalThis.crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(32), info },
+    hkdfKey,
+    CONTENT_KEY_LENGTH * 8
+  );
+
+  return globalThis.crypto.subtle.importKey(
+    'raw',
+    new Uint8Array(contentKeyBits),
+    'AES-GCM',
+    false,
+    // `KeyUsage` is a DOM-lib type that is not in scope under `es2022`; the
+    // parameter type is a strict subset of it, so this cast is sound.
+    usages as ('encrypt' | 'decrypt')[]
+  );
+}
+
+/**
+ * The writer half of the KEM: generate an ephemeral keypair and derive a
+ * content key for a recipient's public key.
+ *
+ * Use this when many payloads share one KEM operation — i.e. stream frames.
+ * The returned `contentKey` can only encrypt, so a stream writer provably
+ * cannot read the recipient run's data even by mistake.
+ *
+ * **Callers own nonce discipline.** Encrypt each frame with a fresh random
+ * nonce, and call this function again for every new connection attempt or
+ * replay so that a restarted writer never reuses a content key. For one-shot
+ * payloads prefer {@link seal}, which handles this automatically.
+ *
+ * @param recipientPublicKey - The recipient run's raw 32-byte X25519 public key
+ * @returns The ephemeral public key to publish alongside the ciphertext, and
+ *   the encrypt-only content key
+ */
+export async function encapsulate(recipientPublicKey: Uint8Array): Promise<{
+  ephemeralPublicKey: Uint8Array;
+  contentKey: CryptoKey;
+}> {
+  assertPublicKeyLength(recipientPublicKey, 'Recipient public key');
+
+  let recipientKey: CryptoKey;
+  try {
+    recipientKey = await importPublicKey(recipientPublicKey);
+  } catch (cause) {
+    throw new WorkflowRuntimeError(
+      `Invalid X25519 recipient public key: ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause }
+    );
+  }
+
+  const ephemeral = (await globalThis.crypto.subtle.generateKey(
+    { name: 'X25519' },
+    /* extractable */ true,
+    ['deriveBits']
+  )) as { privateKey: CryptoKey; publicKey: CryptoKey };
+
+  const ephemeralPublicKey = new Uint8Array(
+    await globalThis.crypto.subtle.exportKey('raw', ephemeral.publicKey)
+  );
+
+  let sharedSecretBits: ArrayBuffer;
+  try {
+    sharedSecretBits = await globalThis.crypto.subtle.deriveBits(
+      { name: 'X25519', public: recipientKey },
+      ephemeral.privateKey,
+      X25519_KEY_LENGTH * 8
+    );
+  } catch (cause) {
+    // Web Crypto throws OperationError when the shared secret is all-zero,
+    // which happens exactly when the recipient public key is a low-order
+    // point. This is the platform giving us HPKE's contributory-behavior
+    // check for free.
+    throw new WorkflowRuntimeError(
+      'X25519 key agreement failed: the recipient public key is not a valid ' +
+        'curve point (low-order point or corrupted key material)',
+      { cause }
+    );
+  }
+
+  const contentKey = await deriveContentKey(
+    new Uint8Array(sharedSecretBits),
+    ephemeralPublicKey,
+    recipientPublicKey,
+    ['encrypt']
+  );
+
+  return { ephemeralPublicKey, contentKey };
+}
+
+/**
+ * The recipient half of the KEM: recover the content key for a sealed
+ * payload from the run's own keypair and the sender's ephemeral public key.
+ *
+ * @param keyPair - The recipient run's keypair, from {@link deriveRunKeyPair}
+ * @param ephemeralPublicKey - The sender's raw 32-byte X25519 public key,
+ *   read from the head of the sealed envelope
+ * @returns A decrypt-only content key
+ */
+export async function decapsulate(
+  keyPair: RunKeyPair,
+  ephemeralPublicKey: Uint8Array
+): Promise<CryptoKey> {
+  if (ephemeralPublicKey.byteLength !== X25519_KEY_LENGTH) {
+    throw new RuntimeDecryptionError(
+      `Sealed payload has a malformed ephemeral public key: expected ${X25519_KEY_LENGTH} bytes, got ${ephemeralPublicKey.byteLength}`,
+      {
+        context: {
+          operation: 'decrypt',
+          byteLength: ephemeralPublicKey.byteLength,
+        },
+      }
+    );
+  }
+
+  let sharedSecretBits: ArrayBuffer;
+  try {
+    const [privateKey, senderKey] = await Promise.all([
+      importScalar(keyPair.scalar, /* extractable */ false),
+      importPublicKey(ephemeralPublicKey),
+    ]);
+    sharedSecretBits = await globalThis.crypto.subtle.deriveBits(
+      { name: 'X25519', public: senderKey },
+      privateKey,
+      X25519_KEY_LENGTH * 8
+    );
+  } catch (cause) {
+    throw new RuntimeDecryptionError(
+      `X25519 key agreement failed while opening a sealed payload: ${cause instanceof Error ? cause.message : String(cause)}`,
+      {
+        cause,
+        context: {
+          operation: 'decrypt',
+          byteLength: ephemeralPublicKey.byteLength,
+        },
+      }
+    );
+  }
+
+  return deriveContentKey(
+    new Uint8Array(sharedSecretBits),
+    ephemeralPublicKey,
+    keyPair.publicKey,
+    ['decrypt']
+  );
+}
+
+/**
+ * Seal a payload to a run's public key.
+ *
+ * Each call performs its own KEM operation, so every sealed payload gets an
+ * independent content key — nonce reuse across calls is impossible by
+ * construction.
+ *
+ * @param recipientPublicKey - The recipient run's raw 32-byte X25519 public key
+ * @param data - Plaintext to seal
+ * @param aad - Optional additional authenticated data, covered by the GCM tag
+ *   but not encrypted. Callers pass the recipient's `projectId|runId` so a
+ *   sealed payload cannot be replayed against a different run.
+ * @returns `[ephemeral public key (32)][nonce (12)][ciphertext + tag]`
+ */
+export async function seal(
+  recipientPublicKey: Uint8Array,
+  data: Uint8Array,
+  aad?: Uint8Array
+): Promise<Uint8Array> {
+  const { ephemeralPublicKey, contentKey } =
+    await encapsulate(recipientPublicKey);
+  const encrypted = await aesGcmEncrypt(contentKey, data, aad);
+
+  const result = new Uint8Array(
+    ephemeralPublicKey.byteLength + encrypted.byteLength
+  );
+  result.set(ephemeralPublicKey, 0);
+  result.set(encrypted, ephemeralPublicKey.byteLength);
+  return result;
+}
+
+/**
+ * Open a payload sealed to this run's public key.
+ *
+ * @param keyPair - The recipient run's keypair, from {@link deriveRunKeyPair}
+ * @param sealed - `[ephemeral public key (32)][nonce (12)][ciphertext + tag]`
+ * @param aad - The exact additional authenticated data passed to {@link seal}
+ * @returns The decrypted plaintext
+ */
+export async function open(
+  keyPair: RunKeyPair,
+  sealed: Uint8Array,
+  aad?: Uint8Array
+): Promise<Uint8Array> {
+  // 32-byte ephemeral public key + 12-byte nonce + 16-byte GCM tag.
+  const minLength = X25519_KEY_LENGTH + 12 + 16;
+  if (sealed.byteLength < minLength) {
+    throw new RuntimeDecryptionError(
+      `Sealed payload too short: expected at least ${minLength} bytes, got ${sealed.byteLength}`,
+      { context: { operation: 'decrypt', byteLength: sealed.byteLength } }
+    );
+  }
+
+  const ephemeralPublicKey = sealed.subarray(0, X25519_KEY_LENGTH);
+  const encrypted = sealed.subarray(X25519_KEY_LENGTH);
+  const contentKey = await decapsulate(keyPair, ephemeralPublicKey);
+  return aesGcmDecrypt(contentKey, encrypted, aad);
+}
+
+/**
+ * Build the additional authenticated data that binds a sealed payload to a
+ * specific run.
+ *
+ * Mirrors the `info` used for symmetric per-run key derivation so the two
+ * schemes agree on what "this run" means.
+ */
+export function runAad(projectId: string, runId: string): Uint8Array {
+  return infoEncoder.encode(`${projectId}|${runId}`);
+}

--- a/packages/core/src/sealed-box.ts
+++ b/packages/core/src/sealed-box.ts
@@ -3,6 +3,8 @@ import {
   decrypt as aesGcmDecrypt,
   encrypt as aesGcmEncrypt,
   type CryptoKey,
+  NONCE_LENGTH,
+  TAG_BYTES,
 } from './encryption.js';
 
 /**
@@ -79,15 +81,19 @@ import {
  * One-shot {@link seal} generates a fresh ephemeral keypair — and therefore a
  * fresh content key — for every call, so nonce reuse is impossible.
  *
- * Streaming callers amortize the KEM across many frames via
- * {@link encapsulate}, which makes the content key long-lived and nonce
- * discipline *their* responsibility. Frames MUST use a fresh random nonce
- * each (which `aesGcmEncrypt` does) rather than a counter: a counter would
- * restart at zero after a stream reconnect or a durable replay, reusing
- * `(contentKey, nonce)` and catastrophically breaking AES-GCM. Callers must
- * additionally re-run {@link encapsulate} per connection attempt so that
- * replayed or reconnected writers never share a content key with a previous
- * incarnation. See `getSerializeStream` for the enforcement.
+ * Callers that amortize the KEM across many frames via {@link encapsulate}
+ * take on nonce discipline themselves, because the content key then outlives a
+ * single message. Two rules apply:
+ *
+ * 1. Every frame MUST use a fresh random nonce (which `aesGcmEncrypt` does).
+ *    Never a counter: a counter restarts at zero after a stream reconnect or a
+ *    durable replay, reusing `(contentKey, nonce)` — which under AES-GCM leaks
+ *    the plaintext XOR of the two frames and the GCM auth subkey.
+ * 2. A writer must not inherit a previous incarnation's content key, so
+ *    {@link encapsulate} is re-run per writer instance.
+ *
+ * Nothing in this module enforces either rule; it is the streaming caller's
+ * contract.
  */
 
 /** Length of an X25519 private scalar and public key, in bytes. */
@@ -230,7 +236,16 @@ async function derivePublicKeyFromScalar(
       'X25519 JWK export did not include a public key component ("x")'
     );
   }
-  return base64UrlToBytes(jwk.x);
+  const publicKey = base64UrlToBytes(jwk.x);
+  // Guard the one step in this module that trusts an external encoding. A
+  // short or malformed value here would otherwise flow onward and fail much
+  // later, inside key agreement, with a far less obvious message.
+  if (publicKey.byteLength !== X25519_KEY_LENGTH) {
+    throw new WorkflowRuntimeError(
+      `X25519 JWK export produced a ${publicKey.byteLength}-byte public key, expected ${X25519_KEY_LENGTH}`
+    );
+  }
+  return publicKey;
 }
 
 async function importScalar(
@@ -513,8 +528,8 @@ export async function open(
   sealed: Uint8Array,
   aad?: Uint8Array
 ): Promise<Uint8Array> {
-  // 32-byte ephemeral public key + 12-byte nonce + 16-byte GCM tag.
-  const minLength = X25519_KEY_LENGTH + 12 + 16;
+  // Ephemeral public key + AES-GCM nonce + AES-GCM tag.
+  const minLength = X25519_KEY_LENGTH + NONCE_LENGTH + TAG_BYTES;
   if (sealed.byteLength < minLength) {
     throw new RuntimeDecryptionError(
       `Sealed payload too short: expected at least ${minLength} bytes, got ${sealed.byteLength}`,

--- a/packages/core/src/serialization-format.test.ts
+++ b/packages/core/src/serialization-format.test.ts
@@ -11,6 +11,7 @@ import {
   isClassInstanceRef,
   isEncryptedData,
   isExpiredStub,
+  isSealedData,
   isStreamId,
   isStreamRef,
   observabilityRevivers,
@@ -536,6 +537,16 @@ describe('encrypted data handling', () => {
     return result;
   }
 
+  /** Create a fake sealed cross-run payload: "encp" prefix + random bytes */
+  function makeSealedPayload(): Uint8Array {
+    const prefix = new TextEncoder().encode('encp');
+    const fakeSealedBody = new Uint8Array(60).fill(9);
+    const result = new Uint8Array(prefix.length + fakeSealedBody.length);
+    result.set(prefix, 0);
+    result.set(fakeSealedBody, prefix.length);
+    return result;
+  }
+
   describe('isEncryptedData', () => {
     it('should detect encr-prefixed Uint8Array', () => {
       expect(isEncryptedData(makeEncryptedPayload())).toBe(true);
@@ -556,6 +567,32 @@ describe('encrypted data handling', () => {
 
     it('should return false for Uint8Array shorter than 4 bytes', () => {
       expect(isEncryptedData(new Uint8Array([1, 2, 3]))).toBe(false);
+    });
+
+    it('should detect encp-prefixed (sealed) Uint8Array as ciphertext', () => {
+      // Display layers treat both schemes identically — a sealed cross-run
+      // payload is just as opaque as a symmetrically encrypted one.
+      expect(isEncryptedData(makeSealedPayload())).toBe(true);
+    });
+  });
+
+  describe('isSealedData', () => {
+    it('should detect encp-prefixed Uint8Array', () => {
+      expect(isSealedData(makeSealedPayload())).toBe(true);
+    });
+
+    it('should not detect encr-prefixed Uint8Array', () => {
+      expect(isSealedData(makeEncryptedPayload())).toBe(false);
+    });
+
+    it('should not detect devl-prefixed Uint8Array', () => {
+      expect(isSealedData(makeDevlPayload('hello'))).toBe(false);
+    });
+
+    it('should return false for non-Uint8Array and short values', () => {
+      expect(isSealedData('hello')).toBe(false);
+      expect(isSealedData(null)).toBe(false);
+      expect(isSealedData(new Uint8Array([1, 2, 3]))).toBe(false);
     });
   });
 
@@ -672,6 +709,34 @@ describe('encrypted data handling', () => {
         key
       );
       expect(result).toEqual(original);
+    });
+
+    it('should pass sealed payloads through untouched even when a key is present', async () => {
+      // A sealed payload is encrypted to the run's X25519 public key, so the
+      // symmetric key this function receives cannot open it. Attempting an
+      // AES-GCM decrypt would fail the auth tag and surface a spurious
+      // decryption error, so it must fall through as ciphertext instead.
+      const sealed = makeSealedPayload();
+      const key = await getTestKey();
+
+      const result = await hydrateDataWithKey(
+        sealed,
+        observabilityRevivers,
+        key
+      );
+      expect(result).toBe(sealed);
+      expect(isEncryptedData(result)).toBe(true);
+    });
+
+    it('should not throw "Unsupported serialization format" for sealed payloads', async () => {
+      // Regression guard: before `encp` was recognized, o11y hydration hit the
+      // unknown-format branch and threw, breaking the CLI/dashboard entirely
+      // for any run that received a sealed cross-run write.
+      const sealed = makeSealedPayload();
+      await expect(
+        hydrateDataWithKey(sealed, observabilityRevivers, undefined)
+      ).resolves.toBe(sealed);
+      expect(() => hydrateData(sealed, {})).not.toThrow();
     });
 
     it('should handle non-Uint8Array values (legacy specVersion 1 data)', async () => {

--- a/packages/core/src/serialization-format.ts
+++ b/packages/core/src/serialization-format.ts
@@ -18,6 +18,17 @@ export const SerializationFormat = {
   DEVALUE_V1: 'devl',
   /** Encrypted payload (inner payload has its own format prefix after decryption) */
   ENCRYPTED: 'encr',
+  /**
+   * Sealed payload — asymmetrically encrypted to a run's X25519 public key
+   * (inner payload has its own format prefix after opening).
+   *
+   * Written by cross-run writers that hold only the recipient run's public
+   * key. Opening it requires the run's private scalar rather than the
+   * symmetric per-run key, so o11y display treats it as ciphertext via
+   * {@link isEncryptedData} but {@link hydrateDataWithKey} does not attempt
+   * an AES-GCM decrypt on it.
+   */
+  SEALED: 'encp',
   /** Gzip-compressed payload (inner payload has its own format prefix after decompression) */
   GZIP: 'gzip',
   /** Zstandard-compressed payload (inner payload has its own format prefix after decompression) */
@@ -140,7 +151,15 @@ export function isExpiredStub(data: unknown): boolean {
 }
 
 /**
- * Check if a binary value has the 'encr' format prefix indicating encryption.
+ * Check if a binary value is ciphertext — either a symmetrically encrypted
+ * payload ('encr') or a sealed cross-run payload ('encp').
+ *
+ * This is the predicate display layers want: both schemes are opaque bytes
+ * that must not be fed to the devalue parser, and both render as the same
+ * "Encrypted" affordance in the CLI and web UI. Use {@link isSealedData} when
+ * the *scheme* matters — notably when choosing a decryption path, since a
+ * sealed payload needs the run's private scalar rather than its symmetric key.
+ *
  * Browser-safe — does not depend on the full serialization module.
  */
 export function isEncryptedData(data: unknown): boolean {
@@ -148,7 +167,24 @@ export function isEncryptedData(data: unknown): boolean {
     return false;
   }
   const prefix = formatDecoder.decode(data.subarray(0, FORMAT_PREFIX_LENGTH));
-  return prefix === SerializationFormat.ENCRYPTED;
+  return (
+    prefix === SerializationFormat.ENCRYPTED ||
+    prefix === SerializationFormat.SEALED
+  );
+}
+
+/**
+ * Check if a binary value has the 'encp' format prefix, indicating a sealed
+ * (asymmetrically encrypted) cross-run payload.
+ *
+ * Browser-safe — does not depend on the full serialization module.
+ */
+export function isSealedData(data: unknown): boolean {
+  if (!(data instanceof Uint8Array) || data.length < FORMAT_PREFIX_LENGTH) {
+    return false;
+  }
+  const prefix = formatDecoder.decode(data.subarray(0, FORMAT_PREFIX_LENGTH));
+  return prefix === SerializationFormat.SEALED;
 }
 
 /**
@@ -362,8 +398,19 @@ export async function hydrateDataWithKey(
   key: import('./encryption.js').CryptoKey | undefined
 ): Promise<unknown> {
   let data = value;
-  if (data instanceof Uint8Array && isEncryptedData(data) && key) {
-    // Decrypt: strip 'encr' prefix, AES-GCM decrypt, then hydrate the result
+  if (
+    data instanceof Uint8Array &&
+    isEncryptedData(data) &&
+    !isSealedData(data) &&
+    key
+  ) {
+    // Decrypt: strip 'encr' prefix, AES-GCM decrypt, then hydrate the result.
+    //
+    // Sealed ('encp') payloads are deliberately excluded: they are encrypted
+    // to the run's X25519 public key, so opening them needs the private
+    // scalar, not the symmetric key this function receives. Feeding them to
+    // AES-GCM would fail the auth tag and surface as a spurious decryption
+    // error, so they fall through untouched and render as ciphertext instead.
     const { decrypt } = await import('./encryption.js');
     const { payload } = decodeFormatPrefix(data);
     data = await decrypt(key, payload);

--- a/packages/core/src/serialization/types.ts
+++ b/packages/core/src/serialization/types.ts
@@ -32,6 +32,16 @@ export const SerializationFormat = {
   DEVALUE_V1: 'devl' as FormatPrefix,
   /** Encrypted payload (inner payload has its own format prefix) */
   ENCRYPTED: 'encr' as FormatPrefix,
+  /**
+   * Sealed payload — asymmetrically encrypted to a run's X25519 public key
+   * (inner payload has its own format prefix).
+   *
+   * Used for *cross-run* writes (hook payloads, forwarded stream frames),
+   * where the writer holds only the recipient run's public key and therefore
+   * cannot decrypt. A run's own payloads continue to use {@link ENCRYPTED}.
+   * See `sealed-box.ts` for the construction.
+   */
+  SEALED: 'encp' as FormatPrefix,
   /** Gzip-compressed payload (inner payload has its own format prefix) */
   GZIP: 'gzip' as FormatPrefix,
   /** Zstandard-compressed payload (inner payload has its own format prefix) */


### PR DESCRIPTION
**PR 1 of 7** in a stack that removes the ~350ms cross-deployment encryption-key lookup from every hot path.

- **#3093 (this PR)** — the `encp` sealed-box primitive
- #3094 — route sealed envelopes through the serialization layer
- #3095 — publish each run's public key on the run entity
- #3096 — `resumeHook()` seals instead of fetching the key ← the payoff
- #3097 — decrypt sealed payloads in observability tooling
- #3098 — seal forwarded stream writes
- #3099 — `start()` gets the key from the probe it already awaits

## Why

Cross-run writes — a hook resumption targeting another run, a child writing into a parent's forwarded stream — currently require the writer to hold the recipient's *symmetric* key. That grants decrypt capability the writer doesn't need, and obtaining it across a deployment boundary costs a `run-key` API round trip.

A sealed box fixes both: the writer needs only a **public** key, which isn't secret and can therefore travel on the run entity for free.

## Key hierarchy

Both keys descend from the per-run key material `K` that `World.getEncryptionKeyForRun()` already returns, so **key acquisition, the World interface, and the Vercel API are all untouched**:

```
K  (32 bytes, per-run, = HKDF(VERCEL_DEPLOYMENT_KEY, "projectId|runId"))
├── AES-256 key = K used directly            → 'encr' envelopes (unchanged)
└── X25519 scalar = HKDF(K, versioned label) → 'encp' envelopes
    └── public key = basepoint · scalar          (published, not secret)
```

## Construction

ECIES-style over the same primitives as HPKE base mode (DHKEM(X25519), HKDF-SHA256, AES-256-GCM), binding **both** public keys into the KDF `info` as HPKE's `kem_context` does — that's the part that prevents key-substitution/unknown-key-share attacks. The deviation from strict RFC 9180 framing is documented, and the HKDF labels are versioned so a conformant profile can be added later without touching existing payloads.

Wire format (`encp` prefix attached by the serialization layer in #3094):
```
[ephemeral public key (32)][nonce (12)][ciphertext + GCM tag (16)]
```

## Nothing produces `encp` yet

This PR is the primitive only. The o11y layer is hardened defensively so sealed payloads render as ciphertext rather than throwing `Unsupported serialization format`, and `hydrateDataWithKey` skips the AES path for them (opening a sealed payload needs the private scalar, not the symmetric key).

## Notes for reviewers

- `encapsulate`/`decapsulate` are split out so stream writers can amortize the KEM across frames. The docs state the obligation that comes with that: keep **random per-frame nonces** and re-encapsulate per connection attempt. A long-lived content key plus counter nonces would repeat `(key, nonce)` after a reconnect or a durable replay — catastrophic for AES-GCM. Enforced in #3094.
- Web Crypto cannot import a raw X25519 private key, so a derived scalar is wrapped in a fixed `PKCS#8` prefix (RFC 8410) and its public half read from a JWK export. That's subtle enough that the test suite **cross-validates the derived public key against `node:crypto`'s native X25519**.
- Low-order public keys and wrong-length keys are rejected by the platform (`OperationError` on all-zero shared secret), giving us HPKE's contributory-behavior check for free — asserted in tests.
- Optional AAD added to the AES helpers; passing no AAD is byte-identical to previous behavior.

30 new tests. Full core unit suite passes; workspace typecheck clean.



