### PR TITLE
feat(core): route sealed envelopes through the serialization layer

### DIFF
--- a/.changeset/encp-payload-key-union.md
+++ b/.changeset/encp-payload-key-union.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Teach the serialization layer to read and write `encp` sealed envelopes via a `PayloadKey` union, so a cross-run writer can encrypt with only a public key. Existing symmetric call sites are unaffected.

--- a/packages/core/src/sealed-box.ts
+++ b/packages/core/src/sealed-box.ts
@@ -544,6 +544,112 @@ export async function open(
 }
 
 /**
+ * A writer-side session that amortizes one KEM operation across many sealed
+ * payloads — use it for streams, where one-shot {@link seal} would perform a
+ * fresh keygen + ECDH + HKDF for every frame.
+ *
+ * Safety rests on two properties:
+ *
+ * - Every payload still gets a **fresh random nonce** from `aesGcmEncrypt`, so
+ *   sharing the content key does not risk `(key, nonce)` reuse. (A counter
+ *   would: it restarts at zero whenever a writer restarts.)
+ * - The session is bound to one writer instance. A reconnect or a durable
+ *   replay constructs a new session, so a restarted writer never inherits a
+ *   previous incarnation's content key.
+ *
+ * The envelope layout is byte-identical to {@link seal}, so a reader cannot
+ * tell which was used and needs no matching session.
+ */
+export function createSealSession(
+  recipientPublicKey: Uint8Array,
+  aad?: Uint8Array
+): { seal(data: Uint8Array): Promise<Uint8Array> } {
+  let encapsulation:
+    | Promise<{ ephemeralPublicKey: Uint8Array; contentKey: CryptoKey }>
+    | undefined;
+
+  return {
+    async seal(data: Uint8Array): Promise<Uint8Array> {
+      // Lazily, so constructing a session for a stream that is never written
+      // to costs nothing.
+      encapsulation ??= encapsulate(recipientPublicKey);
+      const { ephemeralPublicKey, contentKey } = await encapsulation;
+      const encrypted = await aesGcmEncrypt(contentKey, data, aad);
+
+      const result = new Uint8Array(
+        ephemeralPublicKey.byteLength + encrypted.byteLength
+      );
+      result.set(ephemeralPublicKey, 0);
+      result.set(encrypted, ephemeralPublicKey.byteLength);
+      return result;
+    },
+  };
+}
+
+/**
+ * A reader-side session that caches decapsulation per sender.
+ *
+ * The mirror of {@link createSealSession}: because every frame from one writer
+ * carries the same ephemeral public key, this turns an ECDH per frame into an
+ * ECDH per writer. Correctness does not depend on the writer having used a
+ * session — a stream of independently sealed payloads simply misses the cache
+ * on each new ephemeral key.
+ *
+ * The cache is keyed by the ephemeral public key and holds one entry, which is
+ * the common case (one writer per stream). A second writer evicts the first
+ * rather than growing without bound.
+ */
+export function createOpenSession(
+  keyPair: RunKeyPair,
+  aad?: Uint8Array
+): { open(sealed: Uint8Array): Promise<Uint8Array> } {
+  let cachedSender: string | undefined;
+  let cachedKey: Promise<CryptoKey> | undefined;
+
+  return {
+    async open(sealed: Uint8Array): Promise<Uint8Array> {
+      const minLength = X25519_KEY_LENGTH + NONCE_LENGTH + TAG_BYTES;
+      if (sealed.byteLength < minLength) {
+        throw new RuntimeDecryptionError(
+          `Sealed payload too short: expected at least ${minLength} bytes, got ${sealed.byteLength}`,
+          { context: { operation: 'decrypt', byteLength: sealed.byteLength } }
+        );
+      }
+
+      const ephemeralPublicKey = sealed.subarray(0, X25519_KEY_LENGTH);
+      const encrypted = sealed.subarray(X25519_KEY_LENGTH);
+
+      const sender = keyCacheId(ephemeralPublicKey);
+      if (sender !== cachedSender || !cachedKey) {
+        cachedSender = sender;
+        cachedKey = decapsulate(keyPair, ephemeralPublicKey);
+      }
+
+      let contentKey: CryptoKey;
+      try {
+        contentKey = await cachedKey;
+      } catch (error) {
+        // Do not let one bad frame poison the cache for subsequent frames.
+        cachedSender = undefined;
+        cachedKey = undefined;
+        throw error;
+      }
+
+      return aesGcmDecrypt(contentKey, encrypted, aad);
+    },
+  };
+}
+
+/** Stable cache key for a 32-byte public key. */
+function keyCacheId(publicKey: Uint8Array): string {
+  let id = '';
+  for (let i = 0; i < publicKey.length; i++) {
+    id += publicKey[i].toString(16).padStart(2, '0');
+  }
+  return id;
+}
+
+/**
  * Build the additional authenticated data that binds a sealed payload to a
  * specific run.
  *

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -5145,6 +5145,27 @@ describe('stream sealing round-trip (encp)', () => {
     ).toEqual([{ data: 'split me' }]);
   });
 
+  it('amortizes one KEM across all frames of a stream', async () => {
+    // Sealing per frame would mean a keygen + ECDH + HKDF per chunk. The
+    // session reuses one encapsulation, so every frame carries the same
+    // ephemeral public key — that is the observable signal of amortization.
+    const frames = await serializeWith(
+      sealTo(keyPair.publicKey),
+      Array.from({ length: 25 }, (_, i) => ({ i }))
+    );
+
+    // Ephemeral public key sits after [4-byte length][encp].
+    const ephemerals = new Set(
+      frames.map((f) => Array.from(f.subarray(8, 40)).join(','))
+    );
+    expect(ephemerals.size).toBe(1);
+
+    // ...and it still round-trips.
+    expect(await deserializeWith(runKeys, frames)).toEqual(
+      Array.from({ length: 25 }, (_, i) => ({ i }))
+    );
+  });
+
   it('never repeats a (content key, nonce) pair across frames', async () => {
     // Regression guard for the nonce-reuse hazard: every frame carries
     // identical plaintext, so any reuse of a (key, nonce) pair would show up
@@ -5181,6 +5202,60 @@ describe('stream sealing round-trip (encp)', () => {
     for (const frames of runs) {
       expect(await deserializeWith(runKeys, frames)).toEqual([{ frame: 0 }]);
     }
+  });
+
+  it('decodes frames from multiple writers despite the single-entry cache', async () => {
+    // The reader caches one decapsulation, keyed by ephemeral public key. Two
+    // writers on one stream means alternating keys and therefore cache
+    // eviction on every frame — correctness must not depend on hit rate.
+    const a = await serializeWith(sealTo(keyPair.publicKey), [
+      { writer: 'a', n: 1 },
+      { writer: 'a', n: 2 },
+    ]);
+    const b = await serializeWith(sealTo(keyPair.publicKey), [
+      { writer: 'b', n: 1 },
+      { writer: 'b', n: 2 },
+    ]);
+
+    // Sanity: the two writers really did use different ephemeral keys.
+    expect(Array.from(a[0].subarray(8, 40)).join(',')).not.toBe(
+      Array.from(b[0].subarray(8, 40)).join(',')
+    );
+
+    // Interleave them so the cache is evicted on each frame.
+    const interleaved = [a[0], b[0], a[1], b[1]];
+    expect(await deserializeWith(runKeys, interleaved)).toEqual([
+      { writer: 'a', n: 1 },
+      { writer: 'b', n: 1 },
+      { writer: 'a', n: 2 },
+      { writer: 'b', n: 2 },
+    ]);
+  });
+
+  it('keeps decoding after a corrupt sealed frame poisons nothing', async () => {
+    // A failed decapsulation must not leave a broken entry cached, or one bad
+    // frame would take out every later frame from the same writer.
+    const good = await serializeWith(sealTo(keyPair.publicKey), [{ ok: true }]);
+    const corrupt = new Uint8Array(good[0]);
+    // Corrupt the ephemeral key into a low-order point so decapsulation fails
+    // (as opposed to merely failing the auth tag).
+    corrupt.fill(0, 8, 40);
+
+    const deserialize = getDeserializeStream(revivers, runKeys);
+    const readPromise = (async () => {
+      const reader = deserialize.readable.getReader();
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    })();
+    const writer = deserialize.writable.getWriter();
+    await writer.write(corrupt).catch(() => {});
+    await writer.close().catch(() => {});
+    await expect(readPromise).rejects.toThrow(RuntimeDecryptionError);
+
+    // A fresh reader with the same keys still works.
+    expect(await deserializeWith(runKeys, good)).toEqual([{ ok: true }]);
   });
 
   it('errors when sealed frames arrive without a run keypair', async () => {

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -11,6 +11,8 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { registerSerializationClass } from './class-serialization.js';
 import { decrypt, encrypt, importKey } from './encryption.js';
 import { getStepFunction, registerStepFunction } from './private.js';
+import { deriveRunKeyPair } from './sealed-box.js';
+import { runPayloadKeys, sealTo } from './serialization/encryption.js';
 import {
   cancelAbortReaders,
   decodeFormatPrefix,
@@ -5027,6 +5029,220 @@ describe('stream encryption round-trip', () => {
 
     expect(results).toHaveLength(1);
     expect(results[0]).toEqual(largeArray);
+  });
+});
+
+describe('stream sealing round-trip (encp)', () => {
+  const K = new Uint8Array(32).fill(0x33);
+  const reducers = {} as any;
+  const revivers = getCommonRevivers(globalThis) as any;
+
+  let keyPair: Awaited<ReturnType<typeof deriveRunKeyPair>>;
+  let runKeys: ReturnType<typeof runPayloadKeys>;
+  beforeAll(async () => {
+    keyPair = await deriveRunKeyPair(K);
+    runKeys = runPayloadKeys(await importKey(K), keyPair);
+  });
+
+  /** Drive a serialize stream with the given key, collecting frames. */
+  async function serializeWith(
+    key: Parameters<typeof getSerializeStream>[1],
+    values: unknown[]
+  ): Promise<Uint8Array[]> {
+    const serialize = getSerializeStream(reducers, key);
+    const results: Uint8Array[] = [];
+    const readPromise = (async () => {
+      const reader = serialize.readable.getReader();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        results.push(value);
+      }
+    })();
+    const writer = serialize.writable.getWriter();
+    for (const value of values) await writer.write(value);
+    await writer.close();
+    await readPromise;
+    return results;
+  }
+
+  async function deserializeWith(
+    key: Parameters<typeof getDeserializeStream>[1],
+    chunks: Uint8Array[]
+  ): Promise<unknown[]> {
+    const deserialize = getDeserializeStream(revivers, key);
+    const results: unknown[] = [];
+    const readPromise = (async () => {
+      const reader = deserialize.readable.getReader();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        results.push(value);
+      }
+    })();
+    const writer = deserialize.writable.getWriter();
+    for (const chunk of chunks) await writer.write(chunk);
+    await writer.close();
+    await readPromise;
+    return results;
+  }
+
+  it('emits encp-prefixed frames with the length header in the clear', async () => {
+    const frames = await serializeWith(sealTo(keyPair.publicKey), [
+      { hello: 'world' },
+    ]);
+    expect(frames).toHaveLength(1);
+
+    const frame = frames[0];
+    const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+    // Frame boundaries must stay readable without any key so a reader can
+    // still find them regardless of transport chunking.
+    expect(view.getUint32(0, false)).toBe(frame.length - 4);
+    expect(new TextDecoder().decode(frame.subarray(4, 8))).toBe('encp');
+  });
+
+  it('round-trips: cross-run writer seals frames, owning run opens them', async () => {
+    const original = [
+      { message: 'secret', count: 42 },
+      [1, 2, 3],
+      'plain',
+      null,
+    ];
+    const sealed = await serializeWith(sealTo(keyPair.publicKey), original);
+    expect(await deserializeWith(runKeys, sealed)).toEqual(original);
+  });
+
+  it('handles sealed frames coalesced into one transport chunk', async () => {
+    const sealed = await serializeWith(sealTo(keyPair.publicKey), [
+      { a: 1 },
+      { b: 2 },
+      { c: 3 },
+    ]);
+    const total = sealed.reduce((sum, c) => sum + c.length, 0);
+    const concatenated = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of sealed) {
+      concatenated.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    expect(await deserializeWith(runKeys, [concatenated])).toEqual([
+      { a: 1 },
+      { b: 2 },
+      { c: 3 },
+    ]);
+  });
+
+  it('handles a sealed frame split across transport chunks', async () => {
+    const sealed = await serializeWith(sealTo(keyPair.publicKey), [
+      { data: 'split me' },
+    ]);
+    const frame = sealed[0];
+    const mid = Math.floor(frame.length / 2);
+
+    expect(
+      await deserializeWith(runKeys, [frame.slice(0, mid), frame.slice(mid)])
+    ).toEqual([{ data: 'split me' }]);
+  });
+
+  it('never repeats a (content key, nonce) pair across frames', async () => {
+    // Regression guard for the nonce-reuse hazard: every frame carries
+    // identical plaintext, so any reuse of a (key, nonce) pair would show up
+    // as byte-identical ciphertext. Under AES-GCM that leaks the plaintext
+    // XOR and the auth subkey, which would let anyone with read access forge
+    // frames.
+    const frames = await serializeWith(
+      sealTo(keyPair.publicKey),
+      Array.from({ length: 100 }, () => ({ same: 'payload' }))
+    );
+
+    const bodies = new Set(frames.map((f) => Array.from(f).join(',')));
+    expect(bodies.size).toBe(100);
+  });
+
+  it('never reuses a content key across writers, so reconnects and replays are safe', async () => {
+    // Each stream instance is a fresh writer — modelling a reconnect or a
+    // durable replay. Every incarnation must derive its own content key, so
+    // that restarting frame numbering at zero can never collide.
+    const runs = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        serializeWith(sealTo(keyPair.publicKey), [{ frame: 0 }])
+      )
+    );
+
+    // The ephemeral public key sits right after the 4-byte length header and
+    // the 4-byte 'encp' prefix.
+    const ephemeralKeys = new Set(
+      runs.map((frames) => Array.from(frames[0].subarray(8, 40)).join(','))
+    );
+    expect(ephemeralKeys.size).toBe(10);
+
+    // Every replay still decodes correctly.
+    for (const frames of runs) {
+      expect(await deserializeWith(runKeys, frames)).toEqual([{ frame: 0 }]);
+    }
+  });
+
+  it('errors when sealed frames arrive without a run keypair', async () => {
+    const sealed = await serializeWith(sealTo(keyPair.publicKey), [
+      { secret: true },
+    ]);
+
+    // A bare symmetric key cannot open sealed frames.
+    const deserialize = getDeserializeStream(revivers, await importKey(K));
+    const readPromise = (async () => {
+      const reader = deserialize.readable.getReader();
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    })();
+    const writer = deserialize.writable.getWriter();
+    for (const chunk of sealed) await writer.write(chunk).catch(() => {});
+    await writer.close().catch(() => {});
+
+    const error = await readPromise.catch((e) => e);
+    expect(RuntimeDecryptionError.is(error)).toBe(true);
+    expect(error.message).toMatch(/no run keypair is available/);
+    expect(error.context).toMatchObject({
+      operation: 'decrypt',
+      formatPrefix: 'encp',
+    });
+  });
+
+  it('errors with the encp prefix in context when a sealed frame is tampered', async () => {
+    const sealed = await serializeWith(sealTo(keyPair.publicKey), [
+      { secret: true },
+    ]);
+    const tampered = new Uint8Array(sealed[0]);
+    tampered[tampered.length - 1] ^= 0xff;
+
+    const deserialize = getDeserializeStream(revivers, runKeys);
+    const readPromise = (async () => {
+      const reader = deserialize.readable.getReader();
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    })();
+    const writer = deserialize.writable.getWriter();
+    await writer.write(tampered).catch(() => {});
+    await writer.close().catch(() => {});
+
+    const error = await readPromise.catch((e) => e);
+    expect(RuntimeDecryptionError.is(error)).toBe(true);
+    expect(error.context).toMatchObject({
+      operation: 'decrypt',
+      formatPrefix: 'encp',
+    });
+  });
+
+  it("still writes symmetric frames for a run's own stream", async () => {
+    // Same-run streams keep using `encr` even though the holder of
+    // RunPayloadKeys could seal — see the PayloadKey docs.
+    const frames = await serializeWith(runKeys, [{ own: true }]);
+    expect(new TextDecoder().decode(frames[0].subarray(4, 8))).toBe('encr');
+    expect(await deserializeWith(runKeys, frames)).toEqual([{ own: true }]);
   });
 });
 

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -6,12 +6,7 @@ import {
 import { envNumber } from '@workflow/world';
 import { parse, stringify, unflatten } from 'devalue';
 import { monotonicFactory } from 'ulid';
-import {
-  decrypt as aesGcmDecrypt,
-  encrypt as aesGcmEncrypt,
-  type CryptoKey,
-  importKey,
-} from './encryption.js';
+import { type CryptoKey, importKey } from './encryption.js';
 import {
   createFlushableState,
   flushablePipe,
@@ -37,9 +32,12 @@ import {
   decompress,
 } from './serialization/compression.js';
 import {
+  aesKeyOf,
   decrypt,
   type EncryptionKeyParam,
   encrypt,
+  isRunPayloadKeys,
+  type PayloadKey,
   resolveEncryptionKey,
 } from './serialization/encryption.js';
 import {
@@ -221,7 +219,10 @@ export function getSerializeStream(
   // Note: if resolving cryptoKey rejects (e.g., network error fetching
   // the derived key), the rejection won't surface until the first chunk
   // is processed — not at stream construction time.
-  const keyState = { resolved: false, key: undefined as CryptoKey | undefined };
+  const keyState = {
+    resolved: false,
+    key: undefined as PayloadKey | undefined,
+  };
   const stream = new TransformStream<any, Uint8Array>({
     async transform(chunk, controller) {
       try {
@@ -239,12 +240,13 @@ export function getSerializeStream(
         // Encrypt the frame payload if a key is provided.
         // The length header remains in the clear so the deserializer can
         // find frame boundaries regardless of transport chunking.
+        //
+        // Each frame gets its own random nonce (and, on the sealed path, its
+        // own ephemeral keypair). Never switch this to a counter: a stream
+        // reconnect or a durable replay restarts the writer, which would
+        // repeat `(key, nonce)` and catastrophically break AES-GCM.
         if (keyState.key) {
-          const encrypted = await aesGcmEncrypt(keyState.key, prefixed);
-          prefixed = encodeWithFormatPrefix(
-            SerializationFormat.ENCRYPTED,
-            encrypted
-          ) as Uint8Array;
+          prefixed = (await encrypt(prefixed, keyState.key)) as Uint8Array;
         }
 
         // Write length-prefixed frame: [4-byte length][prefixed data]
@@ -280,7 +282,10 @@ export function getDeserializeStream(
   const decoder = new TextDecoder();
   let buffer = new Uint8Array(0);
   // Resolve the key input once on first use and cache the result.
-  const keyState = { resolved: false, key: undefined as CryptoKey | undefined };
+  const keyState = {
+    resolved: false,
+    key: undefined as PayloadKey | undefined,
+  };
 
   function appendToBuffer(data: Uint8Array) {
     const newBuffer = new Uint8Array(buffer.length + data.length);
@@ -318,20 +323,33 @@ export function getDeserializeStream(
 
       let { format, payload } = decodeFormatPrefix(frameData);
 
-      // If the frame payload is encrypted, decrypt it first to reveal
-      // the inner format-prefixed data (e.g., 'devl' + serialized text),
-      // then fall through to the normal deserialization path.
-      if (format === SerializationFormat.ENCRYPTED) {
-        if (!keyState.key) {
+      // If the frame payload is encrypted or sealed, recover it first to
+      // reveal the inner format-prefixed data (e.g., 'devl' + serialized
+      // text), then fall through to the normal deserialization path.
+      if (
+        format === SerializationFormat.ENCRYPTED ||
+        format === SerializationFormat.SEALED
+      ) {
+        const sealed = format === SerializationFormat.SEALED;
+        // A sealed frame needs the run's keypair; a symmetric frame needs an
+        // AES key. Report the shortfall precisely — "no key at all" and "the
+        // wrong kind of key" have very different causes.
+        const usable = sealed
+          ? isRunPayloadKeys(keyState.key)
+          : aesKeyOf(keyState.key) !== undefined;
+        if (!usable) {
           controller.error(
             new RuntimeDecryptionError(
-              'Encrypted stream data encountered but no encryption key is available. ' +
-                'Encryption is not configured or no key was provided for this run.',
+              sealed
+                ? 'Sealed stream data encountered but no run keypair is available. ' +
+                    "Opening a sealed frame requires the run's own encryption key material."
+                : 'Encrypted stream data encountered but no encryption key is available. ' +
+                    'Encryption is not configured or no key was provided for this run.',
               {
                 context: {
                   operation: 'decrypt',
                   byteLength: payload.byteLength,
-                  formatPrefix: 'encr',
+                  formatPrefix: sealed ? 'encp' : 'encr',
                 },
               }
             )
@@ -340,12 +358,14 @@ export function getDeserializeStream(
         }
         let decrypted: Uint8Array;
         try {
-          decrypted = await aesGcmDecrypt(keyState.key, payload);
+          // Delegate to the shared envelope layer so the two schemes stay in
+          // lockstep with the one-shot path.
+          decrypted = (await decrypt(frameData, keyState.key)) as Uint8Array;
         } catch (error) {
-          // The low-level AES layer only sees the stripped payload, so it
-          // cannot record the outer envelope prefix. We peeked it here
-          // (`encr`), so enrich the diagnostic context with the real format
-          // prefix before propagating — mirroring serialization/encryption.ts.
+          // The low-level crypto layer only sees the stripped payload, so it
+          // cannot record the outer envelope prefix. We peeked it here, so
+          // enrich the diagnostic context with the real format prefix before
+          // propagating — mirroring serialization/encryption.ts.
           if (RuntimeDecryptionError.is(error) && error.context) {
             error.context.formatPrefix = format;
           }
@@ -3044,7 +3064,7 @@ function getStepRevivers(
  */
 export async function maybeEncrypt(
   data: Uint8Array,
-  key: CryptoKey | undefined
+  key: PayloadKey | undefined
 ): Promise<Uint8Array> {
   return (await encrypt(data, key)) as Uint8Array;
 }
@@ -3056,7 +3076,7 @@ export async function maybeEncrypt(
  */
 export async function maybeDecrypt(
   data: Uint8Array | unknown,
-  key: CryptoKey | undefined
+  key: PayloadKey | undefined
 ): Promise<Uint8Array | unknown> {
   return decrypt(data, key);
 }
@@ -3084,7 +3104,7 @@ export interface PreparedReplayPayload {
  */
 export type ReplayPayloadPreparer = (
   value: unknown,
-  key: CryptoKey | undefined
+  key: PayloadKey | undefined
 ) => PreparedReplayPayload | Promise<PreparedReplayPayload>;
 
 /**
@@ -3179,7 +3199,7 @@ export function deserializePreparedStepError(
 export async function dehydrateWorkflowArguments(
   value: unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   ops: Promise<void>[] = [],
   global: Record<string, any> = globalThis,
   v1Compat = false,
@@ -3223,7 +3243,7 @@ export async function dehydrateWorkflowArguments(
 export async function hydrateWorkflowArguments(
   value: Uint8Array | unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {},
   prepared?: PreparedReplayPayload
@@ -3241,7 +3261,7 @@ export async function hydrateWorkflowArguments(
 export async function dehydrateWorkflowReturnValue(
   value: unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   global: Record<string, any> = globalThis,
   v1Compat = false,
   compression = false
@@ -3277,7 +3297,7 @@ export async function dehydrateWorkflowReturnValue(
 export async function hydrateWorkflowReturnValue(
   value: Uint8Array | unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   ops: Promise<void>[] = [],
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {}
@@ -3304,7 +3324,7 @@ export async function hydrateWorkflowReturnValue(
 export async function dehydrateStepArguments(
   value: unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   global: Record<string, any> = globalThis,
   v1Compat = false,
   compression = false
@@ -3337,7 +3357,7 @@ export async function dehydrateStepArguments(
 export async function hydrateStepArguments(
   value: Uint8Array | unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   ops: Promise<any>[] = [],
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {},
@@ -3378,7 +3398,7 @@ export async function hydrateStepArguments(
 export async function dehydrateStepReturnValue(
   value: unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   ops: Promise<any>[] = [],
   global: Record<string, any> = globalThis,
   v1Compat = false,
@@ -3451,7 +3471,7 @@ export async function dehydrateStepReturnValue(
 export async function dehydrateStepError(
   value: unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   ops: Promise<any>[] = [],
   global: Record<string, any> = globalThis,
   compression = false
@@ -3499,7 +3519,7 @@ export async function dehydrateStepError(
 export async function hydrateStepError(
   value: Uint8Array | unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {},
   prepared?: PreparedReplayPayload
@@ -3525,7 +3545,7 @@ export async function hydrateStepError(
 export async function dehydrateRunError(
   value: unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   global: Record<string, any> = globalThis,
   compression = false
 ): Promise<Uint8Array> {
@@ -3571,7 +3591,7 @@ export async function dehydrateRunError(
 export async function hydrateRunError(
   value: Uint8Array | unknown,
   runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   ops: Promise<void>[] = [],
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {}
@@ -3624,7 +3644,7 @@ export async function hydrateRunError(
 export async function hydrateStepReturnValue(
   value: Uint8Array | unknown,
   _runId: string,
-  key: CryptoKey | undefined,
+  key: PayloadKey | undefined,
   global: Record<string, any> = globalThis,
   extraRevivers: Record<string, (value: any) => any> = {},
   prepared?: PreparedReplayPayload

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -25,6 +25,7 @@ import { getStepFunction } from './private.js';
 // "Turbopack NFT Tracing Errors in V2 Combined Flow Route" section of
 // `docs/content/docs/changelog/eager-processing.mdx`.
 import { getWorldLazy } from './runtime/get-world-lazy.js';
+import { createOpenSession, createSealSession } from './sealed-box.js';
 import * as clientModule from './serialization/client.js';
 import {
   type CompressionStats,
@@ -37,6 +38,7 @@ import {
   type EncryptionKeyParam,
   encrypt,
   isRunPayloadKeys,
+  isSealTarget,
   type PayloadKey,
   resolveEncryptionKey,
 } from './serialization/encryption.js';
@@ -223,12 +225,21 @@ export function getSerializeStream(
     resolved: false,
     key: undefined as PayloadKey | undefined,
   };
+  // Set when the resolved key is a seal target; amortizes the KEM across all
+  // frames this stream instance writes.
+  let sealSession: ReturnType<typeof createSealSession> | undefined;
   const stream = new TransformStream<any, Uint8Array>({
     async transform(chunk, controller) {
       try {
         if (!keyState.resolved) {
           keyState.key = await resolveEncryptionKey(cryptoKey);
           keyState.resolved = true;
+          if (isSealTarget(keyState.key)) {
+            sealSession = createSealSession(
+              keyState.key.recipientPublicKey,
+              keyState.key.aad
+            );
+          }
         }
         const serialized = stringify(chunk, reducers);
         const payload = encoder.encode(serialized);
@@ -241,11 +252,22 @@ export function getSerializeStream(
         // The length header remains in the clear so the deserializer can
         // find frame boundaries regardless of transport chunking.
         //
-        // Each frame gets its own random nonce (and, on the sealed path, its
-        // own ephemeral keypair). Never switch this to a counter: a stream
-        // reconnect or a durable replay restarts the writer, which would
-        // repeat `(key, nonce)` and catastrophically break AES-GCM.
-        if (keyState.key) {
+        // Every frame gets a fresh random nonce. Never switch this to a
+        // counter: a stream reconnect or a durable replay restarts the writer,
+        // which would repeat `(key, nonce)` and catastrophically break
+        // AES-GCM.
+        //
+        // On the sealed path the KEM is amortized across the stream via a
+        // session (one ECDH per writer instead of one per frame). That is safe
+        // precisely because the nonces stay random, and because the session is
+        // scoped to this stream instance — a replayed or reconnected writer
+        // builds a new one and never inherits a previous content key.
+        if (sealSession) {
+          prefixed = encodeWithFormatPrefix(
+            SerializationFormat.SEALED,
+            await sealSession.seal(prefixed)
+          ) as Uint8Array;
+        } else if (keyState.key) {
           prefixed = (await encrypt(prefixed, keyState.key)) as Uint8Array;
         }
 
@@ -286,6 +308,10 @@ export function getDeserializeStream(
     resolved: false,
     key: undefined as PayloadKey | undefined,
   };
+  // Mirror of the writer's seal session: every frame from one writer carries
+  // the same ephemeral public key, so this turns an ECDH per frame into an
+  // ECDH per writer.
+  let openSession: ReturnType<typeof createOpenSession> | undefined;
 
   function appendToBuffer(data: Uint8Array) {
     const newBuffer = new Uint8Array(buffer.length + data.length);
@@ -301,6 +327,9 @@ export function getDeserializeStream(
     if (!keyState.resolved) {
       keyState.key = await resolveEncryptionKey(cryptoKey);
       keyState.resolved = true;
+      if (isRunPayloadKeys(keyState.key)) {
+        openSession = createOpenSession(keyState.key.keyPair, keyState.key.aad);
+      }
     }
 
     // Try to extract complete length-prefixed frames
@@ -358,9 +387,13 @@ export function getDeserializeStream(
         }
         let decrypted: Uint8Array;
         try {
-          // Delegate to the shared envelope layer so the two schemes stay in
-          // lockstep with the one-shot path.
-          decrypted = (await decrypt(frameData, keyState.key)) as Uint8Array;
+          // Sealed frames go through the session so repeated frames from one
+          // writer reuse a single decapsulation. Everything else delegates to
+          // the shared envelope layer, keeping the two schemes in lockstep
+          // with the one-shot path.
+          decrypted = sealed
+            ? await openSession!.open(decodeFormatPrefix(frameData).payload)
+            : ((await decrypt(frameData, keyState.key)) as Uint8Array);
         } catch (error) {
           // The low-level crypto layer only sees the stripped payload, so it
           // cannot record the outer envelope prefix. We peeked it here, so

--- a/packages/core/src/serialization/client.ts
+++ b/packages/core/src/serialization/client.ts
@@ -10,9 +10,9 @@ import type { CodecOptions } from './codec.js';
 import { devalueCodec } from './codec-devalue.js';
 import { compress, decompress } from './compression.js';
 import {
-  type CryptoKey,
   decrypt as decryptData,
   encrypt as encryptData,
+  type PayloadKey,
 } from './encryption.js';
 import { formatSerializationError, rethrowIfRuntimeError } from './errors.js';
 import { decodeFormatPrefix, encodeWithFormatPrefix } from './format.js';
@@ -23,7 +23,7 @@ import { SerializationFormat } from './types.js';
  */
 export async function serialize(
   value: unknown,
-  encryptionKey?: CryptoKey,
+  encryptionKey?: PayloadKey,
   options?: CodecOptions
 ): Promise<Uint8Array | unknown> {
   try {
@@ -51,7 +51,7 @@ export async function serialize(
  */
 export async function deserialize(
   data: Uint8Array | unknown,
-  encryptionKey?: CryptoKey,
+  encryptionKey?: PayloadKey,
   options?: CodecOptions
 ): Promise<unknown> {
   const decrypted = await decompress(

--- a/packages/core/src/serialization/encryption.ts
+++ b/packages/core/src/serialization/encryption.ts
@@ -1,8 +1,10 @@
 /**
  * Composable encryption layer for serialized data.
  *
- * Wraps/unwraps serialized payloads with AES-256-GCM encryption,
- * using the format prefix system to mark encrypted data.
+ * Wraps/unwraps serialized payloads with either symmetric AES-256-GCM
+ * encryption (`encr`) or an asymmetric sealed box (`encp`), using the format
+ * prefix system to mark which. See {@link PayloadKey} for how a caller
+ * declares which capabilities it holds.
  */
 
 import { RuntimeDecryptionError } from '@workflow/errors';
@@ -12,66 +14,253 @@ import {
   type CryptoKey,
 } from '../encryption.js';
 import {
+  open as openSealed,
+  type RunKeyPair,
+  seal as sealToPublicKey,
+} from '../sealed-box.js';
+import {
   decodeFormatPrefix,
   encodeWithFormatPrefix,
   peekFormatPrefix,
 } from './format.js';
 import { SerializationFormat } from './types.js';
 
-export type { CryptoKey };
+export type { CryptoKey, RunKeyPair };
+
+/**
+ * Brands distinguishing the structured key variants from a bare `CryptoKey`.
+ *
+ * `Symbol.for` rather than `Symbol()` because these values cross realm
+ * boundaries (host ↔ workflow VM), and the global symbol registry is shared
+ * across realms while unique symbols are not.
+ */
+const SEAL_TARGET_BRAND = Symbol.for('workflow.serialization.sealTarget');
+const RUN_KEYS_BRAND = Symbol.for('workflow.serialization.runKeys');
+
+/**
+ * A write-only capability: seal payloads to a run's X25519 public key.
+ *
+ * This is what a *cross-run* writer holds — a hook resumption targeting
+ * another run, or a child workflow writing into a parent's forwarded stream.
+ * It carries no ability to decrypt anything, and because it is a distinct
+ * nominal type it cannot be mistaken for symmetric key material.
+ *
+ * That last property matters more than it looks: a raw 32-byte X25519 public
+ * key is a *structurally valid* AES-256 key, so handing one to
+ * `importKey(..., 'AES-GCM')` succeeds and silently produces ciphertext that
+ * nobody can ever open. Routing public keys exclusively through
+ * {@link sealTo} makes that mistake unrepresentable rather than merely
+ * discouraged.
+ */
+export interface SealTarget {
+  readonly [SEAL_TARGET_BRAND]: true;
+  /** The recipient run's raw 32-byte X25519 public key. */
+  readonly recipientPublicKey: Uint8Array;
+  /** Additional authenticated data binding the payload to the recipient run. */
+  readonly aad?: Uint8Array;
+}
+
+/**
+ * The full key capability of a run's *own* runtime (and of o11y tooling
+ * acting on its behalf): the symmetric key for its own payloads, plus the
+ * keypair needed to open sealed payloads that other runs wrote to it.
+ */
+export interface RunPayloadKeys {
+  readonly [RUN_KEYS_BRAND]: true;
+  /** Symmetric AES-256-GCM key — the run's own `encr` payloads. */
+  readonly aes: CryptoKey;
+  /** X25519 keypair — opens `encp` payloads sealed to this run. */
+  readonly keyPair: RunKeyPair;
+  /** Additional authenticated data expected on sealed payloads. */
+  readonly aad?: Uint8Array;
+}
+
+/**
+ * A resolved key for reading or writing a serialized payload.
+ *
+ * The bare `CryptoKey` variant is the historical shape and remains valid: it
+ * means "symmetric only", which is exactly right for a run that predates
+ * sealed boxes or for any same-run payload. The structured variants are
+ * additive:
+ *
+ * | Variant            | Writes  | Reads          | Held by                  |
+ * | ------------------ | ------- | -------------- | ------------------------ |
+ * | `CryptoKey`        | `encr`  | `encr`         | same-run (legacy shape)  |
+ * | {@link RunPayloadKeys} | `encr`  | `encr`, `encp` | the owning run, o11y     |
+ * | {@link SealTarget} | `encp`  | —              | cross-run writers        |
+ *
+ * A run's own payloads deliberately stay symmetric even when the writer could
+ * seal: sealing costs a fresh ECDH per envelope and 32 extra bytes, and buys
+ * nothing when the writer already holds the decryption key.
+ */
+export type PayloadKey = CryptoKey | SealTarget | RunPayloadKeys;
+
+/**
+ * Build a write-only seal capability for a recipient run's public key.
+ *
+ * @param recipientPublicKey - The recipient run's raw 32-byte X25519 public key
+ * @param aad - Additional authenticated data, conventionally `runAad(projectId, runId)`
+ */
+export function sealTo(
+  recipientPublicKey: Uint8Array,
+  aad?: Uint8Array
+): SealTarget {
+  return { [SEAL_TARGET_BRAND]: true, recipientPublicKey, aad };
+}
+
+/**
+ * Bundle a run's symmetric key with the keypair that opens payloads sealed
+ * to it.
+ */
+export function runPayloadKeys(
+  aes: CryptoKey,
+  keyPair: RunKeyPair,
+  aad?: Uint8Array
+): RunPayloadKeys {
+  return { [RUN_KEYS_BRAND]: true, aes, keyPair, aad };
+}
+
+export function isSealTarget(value: unknown): value is SealTarget {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Partial<SealTarget>)[SEAL_TARGET_BRAND] === true
+  );
+}
+
+export function isRunPayloadKeys(value: unknown): value is RunPayloadKeys {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Partial<RunPayloadKeys>)[RUN_KEYS_BRAND] === true
+  );
+}
+
+/**
+ * The symmetric key to use for `encr` operations, or undefined when this key
+ * has no symmetric capability (i.e. it is a seal-only target).
+ */
+export function aesKeyOf(key: PayloadKey | undefined): CryptoKey | undefined {
+  if (!key) return undefined;
+  if (isRunPayloadKeys(key)) return key.aes;
+  if (isSealTarget(key)) return undefined;
+  return key;
+}
 
 /**
  * Encryption key parameter type. Accepts a resolved key, undefined (no encryption),
  * a promise, or a resolver that can defer fetching the key until data needs it.
  */
 export type EncryptionKeyParam =
-  | CryptoKey
+  | PayloadKey
   | undefined
-  | Promise<CryptoKey | undefined>
-  | (() => Promise<CryptoKey | undefined>);
+  | Promise<PayloadKey | undefined>
+  | (() => Promise<PayloadKey | undefined>);
 
 export async function resolveEncryptionKey(
   key: EncryptionKeyParam
-): Promise<CryptoKey | undefined> {
+): Promise<PayloadKey | undefined> {
   return typeof key === 'function' ? key() : key;
 }
 
 /**
  * Encrypt a format-prefixed payload if a key is provided.
- * Wraps the data with the 'encr' format prefix.
+ *
+ * Wraps the data with the `encr` prefix for symmetric keys, or the `encp`
+ * prefix when handed a {@link SealTarget} — a cross-run writer that holds only
+ * the recipient's public key.
  *
  * @param data - The format-prefixed serialized data
  * @param key - Encryption key (undefined to skip encryption)
- * @returns The encrypted data with 'encr' prefix, or the original data if no key
+ * @returns The encrypted data with its format prefix, or the original data if no key
  */
 export async function encrypt(
   data: Uint8Array | unknown,
-  key: CryptoKey | undefined
+  key: PayloadKey | undefined
 ): Promise<Uint8Array | unknown> {
   if (!key || !(data instanceof Uint8Array)) return data;
-  const encrypted = await aesGcmEncrypt(key, data);
+
+  if (isSealTarget(key)) {
+    const sealed = await sealToPublicKey(key.recipientPublicKey, data, key.aad);
+    return encodeWithFormatPrefix(SerializationFormat.SEALED, sealed);
+  }
+
+  // Symmetric path — a run's own payloads, including when the caller holds
+  // the full `RunPayloadKeys` bundle and *could* seal. See `PayloadKey`.
+  const aesKey = isRunPayloadKeys(key) ? key.aes : key;
+  const encrypted = await aesGcmEncrypt(aesKey, data);
   return encodeWithFormatPrefix(SerializationFormat.ENCRYPTED, encrypted);
 }
 
 /**
- * Decrypt a format-prefixed payload if it's encrypted.
- * Strips the 'encr' format prefix and decrypts the inner payload.
+ * Decrypt a format-prefixed payload if it's encrypted or sealed.
+ *
+ * Strips the `encr`/`encp` format prefix and recovers the inner payload.
+ * Opening a sealed (`encp`) payload requires the run's X25519 keypair, so the
+ * caller must supply {@link RunPayloadKeys} — a bare symmetric key cannot do
+ * it, and neither can a {@link SealTarget} (which is write-only by design).
  *
  * @param data - The potentially encrypted data
  * @param key - Encryption key (undefined to skip decryption)
  * @returns The decrypted inner payload, or the original data if not encrypted
  */
+/**
+ * Open a sealed (`encp`) envelope. Split out from {@link decrypt} to keep
+ * each scheme's error handling readable on its own.
+ */
+async function openSealedEnvelope(
+  data: Uint8Array,
+  key: PayloadKey | undefined
+): Promise<Uint8Array> {
+  // Sealed payloads need the private scalar. Anything else — no key, a bare
+  // symmetric key, or a write-only seal target — cannot open them.
+  if (!isRunPayloadKeys(key)) {
+    throw new RuntimeDecryptionError(
+      'Sealed data encountered but no run keypair is available. ' +
+        "Opening a sealed payload requires the run's own encryption key " +
+        'material; a symmetric key or a seal-only target cannot decrypt it.',
+      {
+        context: {
+          operation: 'decrypt',
+          byteLength: data.byteLength,
+          formatPrefix: 'encp',
+        },
+      }
+    );
+  }
+
+  const { payload } = decodeFormatPrefix(data);
+  try {
+    return await openSealed(key.keyPair, payload, key.aad);
+  } catch (error) {
+    // The sealed-box layer only sees the stripped payload, so it cannot
+    // record the outer envelope prefix. Enrich it here before rethrowing.
+    if (RuntimeDecryptionError.is(error) && error.context) {
+      error.context.formatPrefix = SerializationFormat.SEALED;
+    }
+    throw error;
+  }
+}
+
 export async function decrypt(
   data: Uint8Array | unknown,
-  key: CryptoKey | undefined
+  key: PayloadKey | undefined
 ): Promise<Uint8Array | unknown> {
   // Non-binary data is returned as-is.
   if (!(data instanceof Uint8Array)) return data;
 
   const format = peekFormatPrefix(data);
 
-  // If the data is encrypted but no key was provided, fail fast.
-  if (format === SerializationFormat.ENCRYPTED && !key) {
+  if (format === SerializationFormat.SEALED) {
+    return openSealedEnvelope(data, key);
+  }
+
+  // If the data is not encrypted, return it unchanged.
+  if (format !== SerializationFormat.ENCRYPTED) return data;
+
+  // If the data is encrypted but no symmetric key is available, fail fast.
+  const aesKey = aesKeyOf(key);
+  if (!aesKey) {
     throw new RuntimeDecryptionError(
       'Encrypted data encountered but no encryption key is available. ' +
         'Encryption is not configured or no key was provided for this run.',
@@ -85,12 +274,9 @@ export async function decrypt(
     );
   }
 
-  // If the data is not encrypted, return it unchanged.
-  if (format !== SerializationFormat.ENCRYPTED) return data;
-
   const { payload } = decodeFormatPrefix(data);
   try {
-    return await aesGcmDecrypt(key!, payload);
+    return await aesGcmDecrypt(aesKey, payload);
   } catch (error) {
     // The low-level AES layer only sees the stripped payload, so it cannot
     // record the outer envelope prefix. This layer peeked it (`encr`), so

--- a/packages/core/src/serialization/serialization.test.ts
+++ b/packages/core/src/serialization/serialization.test.ts
@@ -3,9 +3,18 @@ import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { describe, expect, it, vi } from 'vitest';
 import { registerSerializationClass } from '../class-serialization.js';
 import { importKey } from '../encryption.js';
+import { deriveRunKeyPair, runAad } from '../sealed-box.js';
 import * as client from './client.js';
 import { devalueCodec } from './codec-devalue.js';
-import { decrypt, encrypt } from './encryption.js';
+import {
+  aesKeyOf,
+  decrypt,
+  encrypt,
+  isRunPayloadKeys,
+  isSealTarget,
+  runPayloadKeys,
+  sealTo,
+} from './encryption.js';
 import {
   decodeFormatPrefix,
   encodeWithFormatPrefix,
@@ -360,6 +369,170 @@ describe('decrypt', () => {
     expect(error.context).toMatchObject({
       operation: 'decrypt',
       formatPrefix: 'encr',
+    });
+  });
+});
+
+// ============================================================================
+// encryption.ts — sealed ('encp') envelopes and the PayloadKey variants
+// ============================================================================
+
+describe('sealed envelopes', () => {
+  const K = new Uint8Array(32).fill(0x21);
+
+  /** The key bundle a run's own runtime holds: symmetric key + keypair. */
+  async function makeRunKeys(material = K) {
+    const [aes, keyPair] = await Promise.all([
+      importKey(material),
+      deriveRunKeyPair(material),
+    ]);
+    return { keys: runPayloadKeys(aes, keyPair), keyPair, aes };
+  }
+
+  const payload = () =>
+    encodeWithFormatPrefix(
+      SerializationFormat.DEVALUE_V1,
+      new TextEncoder().encode('"secret"')
+    ) as Uint8Array;
+
+  it('seals with a SealTarget and emits the encp prefix', async () => {
+    const { keyPair } = await makeRunKeys();
+    const sealed = (await encrypt(
+      payload(),
+      sealTo(keyPair.publicKey)
+    )) as Uint8Array;
+
+    expect(peekFormatPrefix(sealed)).toBe(SerializationFormat.SEALED);
+    // Sealed data must not be mistaken for symmetrically encrypted data by
+    // anything dispatching on the prefix.
+    expect(isEncrypted(sealed)).toBe(false);
+  });
+
+  it('round-trips: cross-run writer seals, owning run opens', async () => {
+    const { keys, keyPair } = await makeRunKeys();
+
+    // The writer holds only the public key.
+    const sealed = await encrypt(payload(), sealTo(keyPair.publicKey));
+    // The owning run holds the full bundle.
+    const opened = await decrypt(sealed, keys);
+
+    expect(opened).toEqual(payload());
+  });
+
+  it("keeps a run's own payloads symmetric even when it could seal", async () => {
+    // RunPayloadKeys can seal, but writing own payloads with it must still
+    // produce `encr` — sealing to yourself costs an ECDH and 32 bytes for no
+    // security benefit.
+    const { keys } = await makeRunKeys();
+    const encrypted = (await encrypt(payload(), keys)) as Uint8Array;
+
+    expect(peekFormatPrefix(encrypted)).toBe(SerializationFormat.ENCRYPTED);
+    expect(await decrypt(encrypted, keys)).toEqual(payload());
+  });
+
+  it('honors AAD binding a sealed payload to its recipient run', async () => {
+    const { aes, keyPair } = await makeRunKeys();
+    const aad = runAad('prj_1', 'wrun_1');
+
+    const sealed = await encrypt(payload(), sealTo(keyPair.publicKey, aad));
+    expect(await decrypt(sealed, runPayloadKeys(aes, keyPair, aad))).toEqual(
+      payload()
+    );
+
+    // Same keys, different run context — must not open.
+    const wrongAad = runAad('prj_1', 'wrun_2');
+    await expect(
+      decrypt(sealed, runPayloadKeys(aes, keyPair, wrongAad))
+    ).rejects.toThrow(RuntimeDecryptionError);
+  });
+
+  describe('capability enforcement', () => {
+    it('refuses to open a sealed payload with only a symmetric key', async () => {
+      const { aes, keyPair } = await makeRunKeys();
+      const sealed = await encrypt(payload(), sealTo(keyPair.publicKey));
+
+      // A bare CryptoKey is the legacy "symmetric only" shape. It has no
+      // scalar, so it cannot open a sealed payload — and must say so clearly
+      // rather than failing an auth tag somewhere deeper.
+      const error = await decrypt(sealed, aes).catch((e) => e);
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      expect(error.message).toMatch(/no run keypair is available/);
+      expect(error.context).toMatchObject({
+        operation: 'decrypt',
+        formatPrefix: 'encp',
+      });
+    });
+
+    it('refuses to open a sealed payload with a write-only seal target', async () => {
+      const { keyPair } = await makeRunKeys();
+      const sealed = await encrypt(payload(), sealTo(keyPair.publicKey));
+
+      await expect(decrypt(sealed, sealTo(keyPair.publicKey))).rejects.toThrow(
+        /no run keypair is available/
+      );
+    });
+
+    it('refuses to open a sealed payload with no key at all', async () => {
+      const { keyPair } = await makeRunKeys();
+      const sealed = await encrypt(payload(), sealTo(keyPair.publicKey));
+
+      await expect(decrypt(sealed, undefined)).rejects.toThrow(
+        /no run keypair is available/
+      );
+    });
+
+    it('refuses to open a symmetric payload with a write-only seal target', async () => {
+      const { aes, keyPair } = await makeRunKeys();
+      const encrypted = await encrypt(payload(), aes);
+
+      // A seal target carries no symmetric capability, so it must be treated
+      // exactly like "no key" rather than silently coerced.
+      const error = await decrypt(encrypted, sealTo(keyPair.publicKey)).catch(
+        (e) => e
+      );
+      expect(RuntimeDecryptionError.is(error)).toBe(true);
+      expect(error.message).toMatch(/no encryption key is available/);
+    });
+
+    it('cannot be opened by a different run', async () => {
+      const recipient = await makeRunKeys();
+      const other = await makeRunKeys(new Uint8Array(32).fill(0x99));
+      const sealed = await encrypt(
+        payload(),
+        sealTo(recipient.keyPair.publicKey)
+      );
+
+      await expect(decrypt(sealed, other.keys)).rejects.toThrow(
+        RuntimeDecryptionError
+      );
+    });
+  });
+
+  describe('type-confusion guards', () => {
+    it('distinguishes a seal target from a symmetric key at runtime', async () => {
+      const { aes, keyPair } = await makeRunKeys();
+      const target = sealTo(keyPair.publicKey);
+
+      expect(isSealTarget(target)).toBe(true);
+      expect(isSealTarget(aes)).toBe(false);
+      expect(isRunPayloadKeys(target)).toBe(false);
+      expect(isRunPayloadKeys(runPayloadKeys(aes, keyPair))).toBe(true);
+
+      // `aesKeyOf` is the single funnel every symmetric operation goes
+      // through, so a seal target can never reach AES-GCM as a key.
+      expect(aesKeyOf(target)).toBeUndefined();
+      expect(aesKeyOf(aes)).toBe(aes);
+      expect(aesKeyOf(runPayloadKeys(aes, keyPair))).toBe(aes);
+      expect(aesKeyOf(undefined)).toBeUndefined();
+    });
+
+    it('does not treat plain objects as key variants', () => {
+      expect(isSealTarget({ recipientPublicKey: new Uint8Array(32) })).toBe(
+        false
+      );
+      expect(isSealTarget(null)).toBe(false);
+      expect(isSealTarget(new Uint8Array(32))).toBe(false);
+      expect(isRunPayloadKeys({ aes: 1, keyPair: 2 })).toBe(false);
     });
   });
 });

--- a/packages/core/src/serialization/step.ts
+++ b/packages/core/src/serialization/step.ts
@@ -10,9 +10,9 @@ import type { CodecOptions } from './codec.js';
 import { devalueCodec } from './codec-devalue.js';
 import { compress, decompress } from './compression.js';
 import {
-  type CryptoKey,
   decrypt as decryptData,
   encrypt as encryptData,
+  type PayloadKey,
 } from './encryption.js';
 import { formatSerializationError, rethrowIfRuntimeError } from './errors.js';
 import { decodeFormatPrefix, encodeWithFormatPrefix } from './format.js';
@@ -23,7 +23,7 @@ import { SerializationFormat } from './types.js';
  */
 export async function serialize(
   value: unknown,
-  encryptionKey?: CryptoKey,
+  encryptionKey?: PayloadKey,
   options?: CodecOptions
 ): Promise<Uint8Array | unknown> {
   try {
@@ -51,7 +51,7 @@ export async function serialize(
  */
 export async function deserialize(
   data: Uint8Array | unknown,
-  encryptionKey?: CryptoKey,
+  encryptionKey?: PayloadKey,
   options?: CodecOptions
 ): Promise<unknown> {
   const decrypted = await decompress(


### PR DESCRIPTION
**PR 2 of 7.** Stacked on #3093; review the stack in order, starting from #3093.

- #3093 — the `encp` sealed-box primitive
- **#3094 (this PR)** — route sealed envelopes through the serialization layer
- #3095 — publish each run's public key on the run entity
- #3096 — `resumeHook()` seals instead of fetching the key ← the payoff
- #3097 — decrypt sealed payloads in observability tooling
- #3098 — seal forwarded stream writes
- #3099 — `start()` gets the key from the probe it already awaits

## The gap this closes

The serialization layer had no way to express "seal to this public key": every consumer expected a symmetric `CryptoKey`, and the encrypt primitive was unconditionally AES-GCM.

That gap was also a live footgun. **A 32-byte X25519 public key is a structurally valid AES-256 key**, so `importKey(pubkey, 'AES-GCM')` succeeds and silently produces ciphertext nobody can ever open — no compile error, no runtime error, just unreadable data. Making public keys reachable only through `sealTo()` turns that from "avoided by convention" into "unrepresentable".

## `PayloadKey` is a widening, not a replacement

This is why the diff touches ~6 files instead of ~60, and why **no existing call site or test needed to change**:

| Variant | Writes | Reads | Held by |
| --- | --- | --- | --- |
| `CryptoKey` | `encr` | `encr` | same-run (legacy shape) |
| `RunPayloadKeys` | `encr` | `encr`, `encp` | the owning run, o11y |
| `SealTarget` | `encp` | — | cross-run writers |

A run's own payloads deliberately stay symmetric even when the holder *could* seal: sealing costs a fresh ECDH and 32 bytes per envelope and buys nothing when the writer already holds the decryption key. The dual `encr`/`encp` model is the intended steady state, not a migration step — the `encr` read path has to exist forever for already-written payloads regardless, and readers dispatch on the 4-byte format prefix, so converging on one scheme would delete no code.

The variants are branded with `Symbol.for` rather than `Symbol()` because these values cross the host ↔ workflow VM realm boundary, where only the global symbol registry is shared.

## Streams

Both directions handle sealed frames, keeping the length header in the clear so frame boundaries stay findable without a key.

Frames keep **per-frame random nonces** rather than a counter. Regression tests assert:
- 100 frames of identical plaintext → 100 distinct ciphertexts
- 10 writer incarnations (modelling reconnect / durable replay) → 10 distinct content keys

## Error quality

Capability shortfalls fail loudly and specifically. Opening a sealed payload with a symmetric key (or a write-only seal target, or nothing) reports *"no run keypair is available"* rather than surfacing as a mysterious auth-tag failure further down.

## Design note: why no new `World` method

An obvious alternative is to add a `World.getEncryptionPublicKeyForRun()` accessor so callers can ask the world for a run's public key. This PR deliberately does not.

The public key is **data, not a capability**: it arrives on the `WorkflowRun` entity that `resumeHook` already fetches, and (in a later PR) in the serialized stream descriptor. Nothing needs to *ask* for it. Keeping it out of the interface means the `World` contract is unchanged and custom `World` implementations get sealed-envelope support for free, with no new method to implement.

**Worth a second opinion on that call**, since it is the main structural choice in this PR.

20 new tests. Full core unit suite (1576) passes; workspace typecheck clean.



