### PR TITLE
feat: publish each run's X25519 public key on the run entity

### DIFF
--- a/.changeset/encp-run-public-key-core.md
+++ b/.changeset/encp-run-public-key-core.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Derive each run's X25519 public key at `start()` and stamp it on the run, so cross-run writers can seal payloads to the run without fetching its symmetric key.

--- a/.changeset/encp-run-public-key-postgres.md
+++ b/.changeset/encp-run-public-key-postgres.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': minor
+---
+
+Add an `encryption_public_key` column to `workflow_runs` (migration `0016`) to store each run's X25519 public key.

--- a/.changeset/encp-run-public-key-web-shared.md
+++ b/.changeset/encp-run-public-key-web-shared.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Hide the run's `encryptionPublicKey` in the attribute panel — internal encryption plumbing, not user-facing.

--- a/.changeset/encp-run-public-key-worlds.md
+++ b/.changeset/encp-run-public-key-worlds.md
@@ -1,0 +1,7 @@
+---
+'@workflow/world': minor
+'@workflow/world-local': minor
+'@workflow/world-vercel': minor
+---
+
+Persist and transport the new optional `encryptionPublicKey` field on workflow runs, carried on `run_created` (and `run_started` for resilient start).

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -15,6 +15,13 @@ import {
   vi,
 } from 'vitest';
 import { runtimeLogger } from '../logger.js';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  deriveRunKeyPair,
+  open,
+  seal,
+} from '../sealed-box.js';
 import type { Run } from './run.js';
 import type { WorkflowFunction } from './start.js';
 import { _resetLatestNoOpWarnForTests, start } from './start.js';
@@ -460,6 +467,97 @@ describe('start', () => {
           deploymentId: 'deploy_explicit',
         })
       );
+    });
+
+    describe('encryptionPublicKey stamping', () => {
+      const validWorkflow = Object.assign(() => Promise.resolve('result'), {
+        workflowId: 'test-workflow',
+      });
+
+      function stampedKey(): string | undefined {
+        return mockEventsCreate.mock.calls[0][1].eventData.encryptionPublicKey;
+      }
+
+      it('stamps the run public key derived from the per-run key material', async () => {
+        const material = new Uint8Array(32).fill(0x5a);
+        mockGetEncryptionKeyForRun.mockResolvedValue(material);
+
+        await start(validWorkflow, []);
+
+        const runId = mockEventsCreate.mock.calls[0][0];
+        const expected = bytesToBase64(
+          (await deriveRunKeyPair(material)).publicKey
+        );
+
+        // The stamped key must be exactly what the owning deployment will
+        // re-derive from the same material at resume time — otherwise sealed
+        // payloads would be addressed to a key nobody holds the scalar for.
+        expect(stampedKey()).toBe(expected);
+        expect(runId).toMatch(/^wrun_/);
+      });
+
+      it('publishes a key that actually opens payloads sealed to it', async () => {
+        // End-to-end proof that the published key is usable: seal to the
+        // stamped value, then open with the keypair the run's own deployment
+        // would derive.
+        const material = new Uint8Array(32).fill(0x11);
+        mockGetEncryptionKeyForRun.mockResolvedValue(material);
+
+        await start(validWorkflow, []);
+
+        const publicKey = base64ToBytes(stampedKey()!);
+        expect(publicKey).toBeDefined();
+
+        const plaintext = new TextEncoder().encode('sealed by a stranger');
+        const sealed = await seal(publicKey!, plaintext);
+        const opened = await open(await deriveRunKeyPair(material), sealed);
+        expect(new TextDecoder().decode(opened)).toBe('sealed by a stranger');
+      });
+
+      it('omits the public key when encryption is disabled', async () => {
+        // No key material means encryption is off for this run; stamping a
+        // key would advertise a sealing capability the run cannot honor.
+        mockGetEncryptionKeyForRun.mockResolvedValue(undefined);
+
+        await start(validWorkflow, []);
+
+        expect(stampedKey()).toBeUndefined();
+        expect(
+          'encryptionPublicKey' in mockEventsCreate.mock.calls[0][1].eventData
+        ).toBe(false);
+      });
+
+      it('mirrors the public key onto the queued runInput for resilient start', async () => {
+        // If the run_created write fails, the server recreates the run from
+        // the queue payload. Without the key there, such a run would silently
+        // lose the ability to receive sealed writes.
+        const material = new Uint8Array(32).fill(0x77);
+        mockGetEncryptionKeyForRun.mockResolvedValue(material);
+
+        await start(validWorkflow, []);
+
+        const queuePayload = mockQueue.mock.calls[0][1];
+        expect(queuePayload.runInput.encryptionPublicKey).toBe(stampedKey());
+      });
+
+      it('derives distinct public keys for distinct runs', async () => {
+        // Per-run isolation: two runs on the same deployment get different
+        // key material, so their public keys must differ too.
+        mockGetEncryptionKeyForRun.mockImplementation(async (runId: string) => {
+          const material = new Uint8Array(32);
+          material.set(new TextEncoder().encode(runId.slice(-8)));
+          return material;
+        });
+
+        await start(validWorkflow, []);
+        await start(validWorkflow, []);
+
+        const first = mockEventsCreate.mock.calls[0][1].eventData;
+        const second = mockEventsCreate.mock.calls[1][1].eventData;
+        expect(first.encryptionPublicKey).toBeDefined();
+        expect(second.encryptionPublicKey).toBeDefined();
+        expect(first.encryptionPublicKey).not.toBe(second.encryptionPublicKey);
+      });
     });
   });
 

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -17,6 +17,7 @@ import { isRetryableWorldError } from '../classify-error.js';
 import { importKey } from '../encryption.js';
 import { runtimeLogger } from '../logger.js';
 import type { Serializable } from '../schemas.js';
+import { bytesToBase64, deriveRunKeyPair } from '../sealed-box.js';
 import {
   dehydrateWorkflowArguments,
   SerializationFormat,
@@ -434,6 +435,21 @@ export async function start<TArgs extends unknown[], TResult>(
       });
       const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
 
+      // Derive and publish the run's X25519 public key so that cross-run
+      // writers (a hook resumption from another deployment, a sibling writing
+      // into a forwarded stream) can seal payloads *to* this run without
+      // holding its symmetric key — and without paying a `run-key` API call.
+      //
+      // Presence of this field is the writer-side gate for sealed envelopes,
+      // so it must only be stamped when this runtime could itself open one.
+      // That holds by construction here: derivation and `encp` dispatch live
+      // in the same package, so any core that can stamp can also open. Runs
+      // are pinned to their creating deployment, so the capability this
+      // attests to is still accurate at resume time.
+      const encryptionPublicKey = rawKey
+        ? bytesToBase64((await deriveRunKeyPair(rawKey)).publicKey)
+        : undefined;
+
       // Create run via run_created event (event-sourced architecture)
       // Pass client-generated runId - server will accept and use it
       // Compress workflow arguments only when the run itself is marked as
@@ -477,6 +493,7 @@ export async function start<TArgs extends unknown[], TResult>(
               workflowName: workflowName,
               input: workflowArguments,
               executionContext,
+              ...(encryptionPublicKey ? { encryptionPublicKey } : {}),
               ...attributeSeed,
             },
           },
@@ -495,6 +512,7 @@ export async function start<TArgs extends unknown[], TResult>(
                     workflowName,
                     specVersion,
                     executionContext,
+                    ...(encryptionPublicKey ? { encryptionPublicKey } : {}),
                     ...attributeSeed,
                   },
                 }

--- a/packages/core/src/sealed-box.test.ts
+++ b/packages/core/src/sealed-box.test.ts
@@ -459,6 +459,41 @@ describe('base64 helpers', () => {
     expect(base64ToBytes('****')).toBeUndefined();
   });
 
+  it('rejects malformed shapes instead of returning a truncated key', () => {
+    // A lenient decoder is worse than a throwing one here: silently returning
+    // a short key makes a corrupt value look *present*, so the caller seals to
+    // garbage rather than taking the symmetric fallback.
+    for (const bad of [
+      'AAAAA', // length % 4 === 1: the trailing char encodes no byte
+      'AA=A', // padding in the middle
+      'A=AA',
+      'AAA=A', // characters after padding
+      'AB', // final quantum with non-zero unused bits
+      'AAB',
+      'AAAA=', // padding that does not land on a 4-char boundary
+    ]) {
+      expect(
+        base64ToBytes(bad),
+        `expected ${bad} to be rejected`
+      ).toBeUndefined();
+    }
+  });
+
+  it('accepts every canonical encoding Buffer produces', () => {
+    // Guard against the strictness overshooting into false negatives.
+    for (let length = 0; length <= 48; length++) {
+      const bytes = new Uint8Array(length);
+      globalThis.crypto.getRandomValues(bytes);
+      const encoded = Buffer.from(bytes).toString('base64');
+      expect(base64ToBytes(encoded), `length ${length}`).toEqual(bytes);
+      // Unpadded form must decode identically.
+      expect(
+        base64ToBytes(encoded.replace(/=+$/, '')),
+        `length ${length}`
+      ).toEqual(bytes);
+    }
+  });
+
   it('tolerates missing padding', () => {
     const bytes = new Uint8Array([1, 2, 3, 4, 5]);
     const padded = bytesToBase64(bytes);

--- a/packages/core/src/sealed-box.test.ts
+++ b/packages/core/src/sealed-box.test.ts
@@ -5,6 +5,8 @@ import {
   encrypt as aesGcmEncrypt,
 } from './encryption.js';
 import {
+  base64ToBytes,
+  bytesToBase64,
   decapsulate,
   deriveRunKeyPair,
   encapsulate,
@@ -426,5 +428,40 @@ describe('sealed-box', () => {
         RuntimeDecryptionError
       );
     });
+  });
+});
+
+describe('base64 helpers', () => {
+  it('matches node:crypto Buffer encoding for random byte strings', () => {
+    // Hand-rolled because the module must run in the browser and the VM; that
+    // makes an independent cross-check worthwhile.
+    for (const length of [0, 1, 2, 3, 4, 31, 32, 33, 64, 255]) {
+      const bytes = new Uint8Array(length);
+      globalThis.crypto.getRandomValues(bytes);
+      const expected = Buffer.from(bytes).toString('base64');
+      expect(bytesToBase64(bytes)).toBe(expected);
+      expect(base64ToBytes(expected)).toEqual(bytes);
+    }
+  });
+
+  it('round-trips a derived public key', async () => {
+    const { publicKey } = await deriveRunKeyPair(K);
+    const encoded = bytesToBase64(publicKey);
+    // 32 bytes -> 44 base64 chars including padding.
+    expect(encoded).toHaveLength(44);
+    expect(base64ToBytes(encoded)).toEqual(publicKey);
+  });
+
+  it('returns undefined for malformed base64 rather than throwing', () => {
+    // A corrupt public key read from storage must degrade to "no usable key"
+    // (falling back to the symmetric path), not crash a resumption.
+    expect(base64ToBytes('not valid base64!!')).toBeUndefined();
+    expect(base64ToBytes('****')).toBeUndefined();
+  });
+
+  it('tolerates missing padding', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const padded = bytesToBase64(bytes);
+    expect(base64ToBytes(padded.replace(/=+$/, ''))).toEqual(bytes);
   });
 });

--- a/packages/core/src/sealed-box.ts
+++ b/packages/core/src/sealed-box.ts
@@ -276,8 +276,67 @@ function importPublicKey(publicKey: Uint8Array): Promise<CryptoKey> {
   );
 }
 
+const BASE64_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
 const BASE64URL_CHARS =
   'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+/**
+ * Encode bytes as standard (padded) base64.
+ *
+ * Hand-rolled for the same reason as {@link base64UrlToBytes}: this module
+ * runs in the browser (o11y decryption) and inside the workflow VM, so neither
+ * `Buffer` nor `btoa` can be assumed. Used for the wire encoding of run public
+ * keys, matching the base64 convention already used for `VERCEL_DEPLOYMENT_KEY`
+ * and the `run-key` API response.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i];
+    const b1 = i + 1 < bytes.length ? bytes[i + 1] : 0;
+    const b2 = i + 2 < bytes.length ? bytes[i + 2] : 0;
+
+    out += BASE64_CHARS[(b0 >> 2) & 0x3f];
+    out += BASE64_CHARS[((b0 & 0x03) << 4) | ((b1 >> 4) & 0x0f)];
+    out +=
+      i + 1 < bytes.length
+        ? BASE64_CHARS[((b1 & 0x0f) << 2) | ((b2 >> 6) & 0x03)]
+        : '=';
+    out += i + 2 < bytes.length ? BASE64_CHARS[b2 & 0x3f] : '=';
+  }
+  return out;
+}
+
+/**
+ * Decode standard base64 (padding optional) to bytes.
+ *
+ * Returns `undefined` for malformed input rather than throwing: callers decode
+ * public keys that arrive from storage or over the wire, where a corrupt value
+ * should degrade to "this run has no usable public key" (and fall back to the
+ * symmetric path) rather than crash a resumption.
+ */
+export function base64ToBytes(value: string): Uint8Array | undefined {
+  let accumulator = 0;
+  let bitCount = 0;
+  const bytes: number[] = [];
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === '=') break;
+    const index = BASE64_CHARS.indexOf(char);
+    if (index === -1) return undefined;
+    accumulator = (accumulator << 6) | index;
+    bitCount += 6;
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      bytes.push((accumulator >> bitCount) & 0xff);
+    }
+  }
+
+  return new Uint8Array(bytes);
+}
 
 /**
  * Decode a base64url string (JWK encoding) to bytes.

--- a/packages/core/src/sealed-box.ts
+++ b/packages/core/src/sealed-box.ts
@@ -316,16 +316,32 @@ export function bytesToBase64(bytes: Uint8Array): string {
  * public keys that arrive from storage or over the wire, where a corrupt value
  * should degrade to "this run has no usable public key" (and fall back to the
  * symmetric path) rather than crash a resumption.
+ *
+ * Validation is strict, because a lenient decoder is worse than a throwing one
+ * here — silently returning a short or truncated key makes a corrupt value look
+ * *present*, so the caller seals to garbage instead of taking the fallback.
+ * Rejected: characters outside the alphabet, a length that cannot describe a
+ * whole number of bytes (`length % 4 === 1`), padding anywhere but the end, and
+ * a final quantum whose unused low bits are not zero.
  */
 export function base64ToBytes(value: string): Uint8Array | undefined {
+  // Strip trailing padding, then require what remains to be padding-free.
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '=') end--;
+  const body = value.slice(0, end);
+  if (body.includes('=')) return undefined;
+
+  // 4 chars -> 3 bytes; 3 -> 2; 2 -> 1. A remainder of 1 encodes no byte.
+  if (body.length % 4 === 1) return undefined;
+  // Padding, when present, must bring the total to a multiple of 4.
+  if (end !== value.length && value.length % 4 !== 0) return undefined;
+
   let accumulator = 0;
   let bitCount = 0;
   const bytes: number[] = [];
 
-  for (let i = 0; i < value.length; i++) {
-    const char = value[i];
-    if (char === '=') break;
-    const index = BASE64_CHARS.indexOf(char);
+  for (let i = 0; i < body.length; i++) {
+    const index = BASE64_CHARS.indexOf(body[i]);
     if (index === -1) return undefined;
     accumulator = (accumulator << 6) | index;
     bitCount += 6;
@@ -333,6 +349,11 @@ export function base64ToBytes(value: string): Uint8Array | undefined {
       bitCount -= 8;
       bytes.push((accumulator >> bitCount) & 0xff);
     }
+  }
+
+  // Leftover bits belong to no byte and must be zero in canonical base64.
+  if (bitCount > 0 && (accumulator & ((1 << bitCount) - 1)) !== 0) {
+    return undefined;
   }
 
   return new Uint8Array(bytes);

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -638,6 +638,10 @@ const attributeToDisplayFn: Record<
     if (typeof value !== 'string' || value.length === 0) return null;
     return String(value);
   },
+  // Internal encryption plumbing: the run's X25519 public key, used by
+  // cross-run writers to seal payloads to this run. Not actionable for users
+  // and not secret — hidden rather than rendered as 44 opaque base64 chars.
+  encryptionPublicKey: (_value: unknown) => null,
 };
 
 const resolvableAttributes = [

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -270,6 +270,65 @@ describe('Storage', () => {
       });
     });
 
+    describe('encryptionPublicKey', () => {
+      const PUBLIC_KEY = `${'A'.repeat(43)}=`;
+
+      it('persists the public key from run_created', async () => {
+        const result = await storage.events.create(null, {
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'test-workflow',
+            input: new Uint8Array(),
+            encryptionPublicKey: PUBLIC_KEY,
+          },
+        } as never);
+        expect(result.run?.encryptionPublicKey).toBe(PUBLIC_KEY);
+
+        const reread = await storage.runs.get(result.run!.runId);
+        expect(reread.encryptionPublicKey).toBe(PUBLIC_KEY);
+      });
+
+      it('carries the public key through resilient-start run creation', async () => {
+        // run_started for a run that was never created rebuilds it from the
+        // queued message. This is the one path where losing the key is
+        // permanent — the run would silently stop accepting sealed cross-run
+        // writes for the rest of its life, with no error anywhere.
+        const runId = `wrun_${monotonicFactory()()}`;
+        const result = await storage.events.create(runId, {
+          eventType: 'run_started',
+          specVersion: SPEC_VERSION_CURRENT,
+          eventData: {
+            deploymentId: 'deployment-123',
+            workflowName: 'resilient-test',
+            input: new Uint8Array(),
+            encryptionPublicKey: PUBLIC_KEY,
+          },
+        } as never);
+
+        expect(result.run?.encryptionPublicKey).toBe(PUBLIC_KEY);
+
+        // The synthesized run_created event must carry it too, so a replay
+        // rebuilding state from the log sees the same key.
+        const events = await storage.events.list({ runId });
+        const created = events.data.find((e) => e.eventType === 'run_created');
+        expect(
+          (created?.eventData as { encryptionPublicKey?: string })
+            ?.encryptionPublicKey
+        ).toBe(PUBLIC_KEY);
+      });
+
+      it('leaves the field unset when the SDK does not supply it', async () => {
+        const created = await createRun(storage, {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array(),
+        });
+        expect(created.encryptionPublicKey).toBeUndefined();
+      });
+    });
+
     describe('update via events', () => {
       it('should update run status to running via run_started event', async () => {
         const created = await createRun(storage, {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -50,9 +50,9 @@ import {
   jsonReviver,
   listJSONFiles,
   paginatedFileSystemQuery,
+  promoteExclusive,
   readJSON,
   readJSONWithFallback,
-  promoteExclusive,
   resolveWithinBase,
   taggedPath,
   write,
@@ -70,8 +70,8 @@ import {
   mintRunDominantEventKey,
   monotonicUlid,
   pendingHookEventPath,
-  releaseHookTokenClaimIfOwnedBy,
   reapPendingHookEvents,
+  releaseHookTokenClaimIfOwnedBy,
   runTerminalMarkerPath,
 } from './helpers.js';
 import {
@@ -1140,6 +1140,7 @@ export function createEventsStorage(
             executionContext?: Record<string, any>;
             attributes?: Record<string, string>;
             allowReservedAttributes?: true;
+            encryptionPublicKey?: string;
           };
           validateAttributeChanges(
             Object.entries(runData.attributes ?? {}).map(([key, value]) => ({
@@ -1164,6 +1165,7 @@ export function createEventsStorage(
             startedAt: undefined,
             completedAt: undefined,
             attributes: runData.attributes ?? {},
+            encryptionPublicKey: runData.encryptionPublicKey,
             createdAt: now,
             updatedAt: now,
           };

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -753,6 +753,7 @@ export function createEventsStorage(
               executionContext?: Record<string, any>;
               attributes?: Record<string, string>;
               allowReservedAttributes?: true;
+              encryptionPublicKey?: string;
             };
             if (
               runInputData.deploymentId &&
@@ -785,6 +786,10 @@ export function createEventsStorage(
                 startedAt: undefined,
                 completedAt: undefined,
                 attributes: runInputData.attributes ?? {},
+                // Must be mirrored here too: this is the path that recreates a
+                // run from the queued message, which is exactly when the key
+                // would otherwise be lost for the rest of the run's life.
+                encryptionPublicKey: runInputData.encryptionPublicKey,
                 createdAt: now,
                 updatedAt: now,
               };
@@ -811,6 +816,7 @@ export function createEventsStorage(
                     attributes: runInputData.attributes,
                     allowReservedAttributes:
                       runInputData.allowReservedAttributes,
+                    encryptionPublicKey: runInputData.encryptionPublicKey,
                   },
                 };
                 await storeEvent(runCreatedEvent);
@@ -1215,6 +1221,7 @@ export function createEventsStorage(
                 startedAt: currentRun.startedAt ?? now,
                 updatedAt: now,
                 attributes: currentRun.attributes,
+                encryptionPublicKey: currentRun.encryptionPublicKey,
               }
             );
           }
@@ -1242,6 +1249,7 @@ export function createEventsStorage(
                 completedAt: now,
                 updatedAt: now,
                 attributes: currentRun.attributes,
+                encryptionPublicKey: currentRun.encryptionPublicKey,
               }
             );
             await Promise.all([
@@ -1280,6 +1288,7 @@ export function createEventsStorage(
                 completedAt: now,
                 updatedAt: now,
                 attributes: currentRun.attributes,
+                encryptionPublicKey: currentRun.encryptionPublicKey,
               }
             );
             await Promise.all([
@@ -1310,6 +1319,7 @@ export function createEventsStorage(
                 completedAt: now,
                 updatedAt: now,
                 attributes: currentRun.attributes,
+                encryptionPublicKey: currentRun.encryptionPublicKey,
               }
             );
             await Promise.all([

--- a/packages/world-postgres/src/drizzle/migrations/0016_add_encryption_public_key.sql
+++ b/packages/world-postgres/src/drizzle/migrations/0016_add_encryption_public_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflow"."workflow_runs" ADD COLUMN "encryption_public_key" varchar;

--- a/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
+++ b/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1782691200000,
       "tag": "0015_move_enums_to_workflow_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1784937600000,
+      "tag": "0016_add_encryption_public_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -105,6 +105,14 @@ export const runs = schema.table(
       .$type<Record<string, string>>()
       .default({})
       .notNull(),
+    /**
+     * The run's X25519 public key (base64), stamped at creation by SDKs that
+     * support sealed (`encp`) envelopes. Lets cross-run writers seal payloads
+     * to this run without holding its symmetric key. Not secret — the private
+     * scalar is re-derived on demand and never stored. Null on runs created by
+     * older SDKs, which fall back to the symmetric path.
+     */
+    encryptionPublicKey: varchar('encryption_public_key'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at')
       .defaultNow()

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -544,6 +544,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             executionContext?: Record<string, any>;
             attributes?: Record<string, string>;
             allowReservedAttributes?: true;
+            encryptionPublicKey?: string;
           };
           if (
             runInputData.deploymentId &&
@@ -574,6 +575,10 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
                   | SerializedContent
                   | undefined,
                 attributes: runInputData.attributes,
+                // Must be mirrored here too: this is the path that recreates a
+                // run from the queued message, which is exactly when the key
+                // would otherwise be lost for the rest of the run's life.
+                encryptionPublicKey: runInputData.encryptionPublicKey,
                 status: 'pending',
               })
               .onConflictDoNothing()
@@ -592,6 +597,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
                   executionContext: runInputData.executionContext,
                   attributes: runInputData.attributes,
                   allowReservedAttributes: runInputData.allowReservedAttributes,
+                  encryptionPublicKey: runInputData.encryptionPublicKey,
                 },
                 specVersion: effectiveSpecVersion,
               });

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -821,6 +821,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
           executionContext?: Record<string, any>;
           attributes?: Record<string, string>;
           allowReservedAttributes?: true;
+          encryptionPublicKey?: string;
         };
         validateAttributeChanges(
           Object.entries(eventData.attributes ?? {}).map(([key, value]) => ({
@@ -844,6 +845,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
               | SerializedContent
               | undefined,
             attributes: eventData.attributes,
+            encryptionPublicKey: eventData.encryptionPublicKey,
             status: 'pending',
           })
           .onConflictDoNothing()

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -14,6 +14,7 @@ import {
   getWorkflowRunEventsV4,
   throwForErrorResponse,
 } from './events-v4.js';
+import { splitEventDataForV4 } from './events.js';
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
 
@@ -607,5 +608,135 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
     expect(capturedMeta?.eventType).toBe('wait_created');
     expect('stateUpdatedAt' in (capturedMeta ?? {})).toBe(false);
     agent.assertNoPendingInterceptors();
+  });
+});
+
+/**
+ * `splitEventDataForV4` lifts allowlisted `eventData` fields into the frame
+ * meta, and `buildPostFrameMeta` copies them onto the wire field-by-field.
+ * `events.ts` spreads that meta into `CreateEventV4Input` (`...meta`), and a
+ * spread bypasses TypeScript's excess-property check — so a field that
+ * `buildPostFrameMeta` forgets to forward is dropped silently, with no build
+ * error and no runtime warning.
+ *
+ * That is exactly how `encryptionPublicKey` went missing: the run's public key
+ * was computed, put in the meta, spread into the v4 input, and then never
+ * written to the frame. The server therefore never saw it, never stored it on
+ * the run entity, and every cross-run writer fell back to the symmetric
+ * envelope. The failure looked like "the server hasn't shipped the feature".
+ */
+describe('v4 POST frame meta forwards every field the splitter produces', () => {
+  /** Decode `[u32_be meta_len][cbor_meta][u32_be body_len][body]`. */
+  function decodeFrameMeta(body: unknown): Record<string, unknown> {
+    const bytes =
+      body instanceof Uint8Array
+        ? body
+        : new Uint8Array(body as ArrayBufferLike);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const metaLen = view.getUint32(0, false);
+    return decode(bytes.subarray(4, 4 + metaLen)) as Record<string, unknown>;
+  }
+
+  async function postAndCaptureMeta(
+    data: Parameters<typeof splitEventDataForV4>[0]
+  ) {
+    const origin =
+      WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    let captured: Record<string, unknown> | undefined;
+    agent
+      .get(origin)
+      .intercept({
+        path: `/api/v4/runs/wrun_1/events/${data.eventType}`,
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          captured = decodeFrameMeta(opts.body);
+          return encode({});
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+          },
+        }
+      );
+
+    const { payload, meta } = splitEventDataForV4(data);
+    await createWorkflowRunEventV4(
+      {
+        runId: 'wrun_1',
+        eventType: data.eventType,
+        specVersion: 5,
+        payload,
+        ...meta,
+      },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    return { meta, wireMeta: captured ?? {} };
+  }
+
+  it('carries encryptionPublicKey on run_created', async () => {
+    const key = 'ozGYxJP2piL8HTY0EukzPVQsyjo8x4L5ZA1xsFWllmA=';
+    const { meta, wireMeta } = await postAndCaptureMeta({
+      eventType: 'run_created',
+      specVersion: 5,
+      eventData: {
+        deploymentId: 'dpl_1',
+        workflowName: 'myWorkflow',
+        encryptionPublicKey: key,
+        input: new TextEncoder().encode('"in"'),
+      },
+    } as unknown as Parameters<typeof splitEventDataForV4>[0]);
+
+    expect(meta.encryptionPublicKey).toBe(key);
+    expect(wireMeta.encryptionPublicKey).toBe(key);
+  });
+
+  it('carries encryptionPublicKey on a resilient-start run_started', async () => {
+    const key = 'QJI1dJ/7ZK8npKmpxjvCYPso0tS92pqjwTS3uAajd0E=';
+    const { meta, wireMeta } = await postAndCaptureMeta({
+      eventType: 'run_started',
+      specVersion: 5,
+      eventData: {
+        deploymentId: 'dpl_1',
+        workflowName: 'myWorkflow',
+        encryptionPublicKey: key,
+      },
+    } as unknown as Parameters<typeof splitEventDataForV4>[0]);
+
+    expect(meta.encryptionPublicKey).toBe(key);
+    expect(wireMeta.encryptionPublicKey).toBe(key);
+  });
+
+  // Generic guard: whatever the splitter decides belongs in the frame meta must
+  // actually reach the wire. This fails for ANY field a future change adds to
+  // the splitter but forgets in buildPostFrameMeta, not just this one.
+  it('drops no meta field between the splitter and the wire', async () => {
+    const { meta, wireMeta } = await postAndCaptureMeta({
+      eventType: 'run_created',
+      specVersion: 5,
+      eventData: {
+        deploymentId: 'dpl_1',
+        workflowName: 'myWorkflow',
+        encryptionPublicKey: 'ozGYxJP2piL8HTY0EukzPVQsyjo8x4L5ZA1xsFWllmA=',
+        attributes: { foo: 'bar' },
+        allowReservedAttributes: true,
+        executionContext: { traceCarrier: {} },
+        input: new TextEncoder().encode('"in"'),
+      },
+    } as unknown as Parameters<typeof splitEventDataForV4>[0]);
+
+    const metaKeys = Object.keys(meta);
+    // Guard the guard: if the splitter stops producing fields this test is
+    // vacuous, so require it to have produced a meaningful set.
+    expect(metaKeys.length).toBeGreaterThan(3);
+    expect(Object.keys(wireMeta)).toEqual(expect.arrayContaining(metaKeys));
   });
 });

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -156,6 +156,11 @@ export interface CreateEventV4Input {
   /** Opt-in for framework-level callers to write `$`-prefixed reserved
    *  attribute keys (attr_set / run_created / run_started). */
   allowReservedAttributes?: boolean;
+  /** The run's X25519 public key, base64 (run_created / resilient-start
+   *  run_started). Plaintext metadata, not a payload: the server stores it on
+   *  the run entity so cross-run writers can seal to it without holding the
+   *  run's symmetric key. */
+  encryptionPublicKey?: string;
   /** Client-measured time-to-first-step ms, riding on the run's first
    *  step_completed / step_failed. Consumed server-side for latency
    *  metrics; not read back. */
@@ -280,6 +285,9 @@ function buildPostFrameMeta(
   if (input.writer !== undefined) meta.writer = input.writer;
   if (input.allowReservedAttributes !== undefined) {
     meta.allowReservedAttributes = input.allowReservedAttributes;
+  }
+  if (input.encryptionPublicKey !== undefined) {
+    meta.encryptionPublicKey = input.encryptionPublicKey;
   }
   if (input.ttfs !== undefined) meta.ttfs = input.ttfs;
   if (input.stso !== undefined) meta.stso = input.stso;

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -153,6 +153,13 @@ interface SplitEventData {
     writer?: Record<string, unknown>;
     /** Reserved-attribute-key opt-in (attr_set / run_created / run_started). */
     allowReservedAttributes?: boolean;
+    /**
+     * The run's X25519 public key, base64 (run_created / resilient-start
+     * run_started). Plaintext metadata, not a payload: it is not secret, and
+     * the server stores it on the run entity so cross-run writers can seal to
+     * it without holding the run's symmetric key.
+     */
+    encryptionPublicKey?: string;
     /** Client-measured time-to-first-step ms (step_completed / step_failed). */
     ttfs?: number;
     /** Client-measured step-to-step overhead ms (step_completed / step_failed). */
@@ -199,6 +206,7 @@ type MetaSourceField =
   | 'changes'
   | 'writer'
   | 'allowReservedAttributes'
+  | 'encryptionPublicKey'
   | 'ttfs'
   | 'stso'
   | 'stepCount'
@@ -353,6 +361,9 @@ export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
   }
   if (typeof eventData.allowReservedAttributes === 'boolean') {
     meta.allowReservedAttributes = eventData.allowReservedAttributes;
+  }
+  if (typeof eventData.encryptionPublicKey === 'string') {
+    meta.encryptionPublicKey = eventData.encryptionPublicKey;
   }
   // Client-measured latency telemetry on step terminal events (TTFS / STSO).
   // The server consumes these for metrics; they are not read back.

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -499,6 +499,13 @@ const RunCreatedEventSchema = BaseEventSchema.extend({
     executionContext: z.record(z.string(), z.any()).optional(),
     attributes: z.record(z.string(), z.string()).optional(),
     allowReservedAttributes: z.literal(true).optional(),
+    /**
+     * The run's X25519 public key (base64), stamped by SDKs that support
+     * sealed (`encp`) envelopes. Persisted onto the run entity so that
+     * cross-run writers can seal payloads to this run without holding its
+     * symmetric key. Not secret — see `WorkflowRunBaseSchema`.
+     */
+    encryptionPublicKey: z.string().optional(),
   }),
 });
 
@@ -521,6 +528,13 @@ const RunStartedEventSchema = BaseEventSchema.extend({
       executionContext: z.record(z.string(), z.any()).optional(),
       attributes: z.record(z.string(), z.string()).optional(),
       allowReservedAttributes: z.literal(true).optional(),
+      /**
+       * Mirrors `run_created.eventData.encryptionPublicKey`. Carried here for
+       * the resilient-start path: when the `run_created` write failed, the
+       * server creates the run from this event instead, and without the key
+       * the run would silently lose its ability to receive sealed writes.
+       */
+      encryptionPublicKey: z.string().optional(),
     })
     .optional(),
 });

--- a/packages/world/src/runs.ts
+++ b/packages/world/src/runs.ts
@@ -100,6 +100,26 @@ export const WorkflowRunBaseSchema = z.object({
    * the attributes-mvp changelog entry.
    */
   attributes: z.record(z.string(), z.string()).default({}),
+  /**
+   * The run's X25519 public key, base64-encoded (~44 chars).
+   *
+   * Lets any party that can read this run seal a payload *to* it without
+   * being able to read the run's data — used for cross-run writes such as a
+   * hook resumption from another deployment, or a child workflow writing into
+   * a forwarded stream. The matching private scalar is never stored: it is
+   * re-derived on demand from the deployment's own key material, so this
+   * field is not secret and its presence does not weaken the run's
+   * confidentiality.
+   *
+   * Stamped at run creation by SDKs that support sealed (`encp`) envelopes.
+   * **Presence is the writer-side gate**: a run only carries a public key if
+   * the runtime that created it could also open sealed payloads, and runs are
+   * pinned to their creating deployment. Writers therefore seal iff this
+   * field is set, and otherwise fall back to fetching the symmetric per-run
+   * key. Absent on runs created by older SDKs, and on worlds that do not
+   * implement `getEncryptionKeyForRun` (encryption disabled).
+   */
+  encryptionPublicKey: z.string().optional(),
   expiredAt: z.coerce.date().optional(),
   startedAt: z.coerce.date().optional(),
   completedAt: z.coerce.date().optional(),


### PR DESCRIPTION
**PR 3 of 7.** Stacked on #3094; review the stack in order, starting from #3093.

- #3093 — the `encp` sealed-box primitive
- #3094 — route sealed envelopes through the serialization layer
- **#3095 (this PR)** — publish each run's public key on the run entity
- #3096 — `resumeHook()` seals instead of fetching the key ← the payoff
- #3097 — decrypt sealed payloads in observability tooling
- #3098 — seal forwarded stream writes
- #3099 — `start()` gets the key from the probe it already awaits

## What

A cross-run writer needs the recipient run's public key to seal to it. Derive that key at `start()` and stamp it on the run, so a hook resumption or forwarded-stream writer finds it on a run fetch **it was already making** instead of spending ~350ms on `run-key`.

Derived from the per-run key material `getEncryptionKeyForRun()` already returns, so nothing about key acquisition changes.

## Why storing it is safe

It is **not secret**. The matching private scalar is never stored anywhere — only re-derived on demand from the deployment's own env seed. So this does not violate the requirement that no key material live beside run metadata (that requirement is about secrets), and the server remains zero-knowledge: it stores and serves 32 public bytes it cannot use to decrypt anything.

Anyone with tenant-scoped read access to a run gains **encryption** capability for it, and nothing more.

## Presence is the writer-side gate

A run only carries a public key if the runtime that created it could also *open* a sealed payload. That holds by construction: derivation and `encp` dispatch both live in `@workflow/core`, so any core that can stamp can also open. Runs are pinned to their creating deployment, so the capability this attests to is still accurate at resume time.

This matters because `@workflow/core` and `@workflow/world-vercel` are versioned independently and do drift in practice. A gate that consulted only one of them would wedge runs under one drift direction or the other:

- If a deployment could *stamp* a key but its core could not *dispatch* `encp`, a writer would seal a payload the target cannot decode — run wedged. Locating derivation, stamping and dispatch all in `@workflow/core` makes this combination impossible to construct.
- If a deployment's core supports `encp` but its world package never persisted the field, the run simply has no public key, and writers fall back to the symmetric path — degraded, not broken.

Presence therefore attests to both halves at once, which a version comparison cannot.

## Resilient start

The field rides on `run_created` **and** is mirrored onto the queued `runInput`, because the resilient-start path recreates the run from the queue message when the `run_created` write failed. Without that mirror, a run recovered that way would silently lose the ability to receive sealed writes.

## Surface

| Package | Change |
| --- | --- |
| `@workflow/core` | derive + stamp at `start()`; browser/VM-safe base64 helpers |
| `@workflow/world` | optional `encryptionPublicKey` on the run schema + `run_created`/`run_started` |
| `@workflow/world-local` | materialize onto the run entity |
| `@workflow/world-postgres` | `encryption_public_key` column + migration `0016` |
| `@workflow/world-vercel` | route into the v4 frame meta block |
| `@workflow/web-shared` | hide the field in the attribute panel (internal plumbing) |

## Notes for reviewers

- **world-vercel's compile-time wire-contract guard caught the new field before it could be silently dropped on the v4 path**, exactly as designed — it failed the build naming `encryptionPublicKey`. Nice.
- Base64 helpers are hand-rolled because `sealed-box.ts` runs in the browser (o11y) and inside the workflow VM, where neither `Buffer` nor `btoa` can be assumed. They're **cross-validated against `Buffer` in tests** across a range of lengths.
- `base64ToBytes` returns `undefined` on malformed input rather than throwing, so a corrupt stored key degrades to "no usable public key" → symmetric fallback, instead of crashing a resumption.
- Tests include an end-to-end assertion that the *published* key actually opens a payload sealed to it, plus per-run isolation and the encryption-disabled case.

Postgres migration is additive and nullable. Full core suite (1585) passes; all world suites pass; workspace typecheck clean.




