### PR TITLE
feat(core): seal hook payloads to the target run's public key

### DIFF
--- a/.changeset/encp-resume-hook-seal.md
+++ b/.changeset/encp-resume-hook-seal.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+`resumeHook()` now seals its payload to the target run's published public key when one is present, removing the cross-deployment `run-key` API round trip from hook resumption. Readers resolve the full key capability so they can open sealed payloads.

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -4,7 +4,7 @@
 
 import { withResolvers } from '@workflow/utils';
 import type { WorldCapabilities } from '@workflow/world';
-import type { CryptoKey } from './encryption.js';
+import type { PayloadKey } from './serialization/encryption.js';
 import type { EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
 import type { ReplayPayloadCache } from './replay-payload-cache.js';
@@ -132,7 +132,7 @@ export function getStepFunction(stepId: string): StepFunction | undefined {
 
 export interface WorkflowOrchestratorContext {
   runId: string;
-  encryptionKey: CryptoKey | undefined;
+  encryptionKey: PayloadKey | undefined;
   worldCapabilities?: WorldCapabilities;
   globalThis: typeof globalThis;
   eventsConsumer: EventsConsumer;

--- a/packages/core/src/replay-payload-cache.ts
+++ b/packages/core/src/replay-payload-cache.ts
@@ -1,5 +1,5 @@
 import type { Event, WorkflowRun } from '@workflow/world';
-import type { CryptoKey } from './encryption.js';
+import type { PayloadKey } from './serialization/encryption.js';
 import {
   type PreparedReplayPayload,
   prepareReplayPayload,
@@ -43,7 +43,7 @@ export class ReplayPayloadCache {
   private nextUnscannedEventIndex = 0;
 
   constructor(
-    private readonly encryptionKey: CryptoKey | undefined,
+    private readonly encryptionKey: PayloadKey | undefined,
     private readonly preparer: ReplayPayloadPreparer = prepareReplayPayload
   ) {}
 

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -2,11 +2,20 @@ import { PreconditionFailedError, WorkflowWorldError } from '@workflow/errors';
 import type { Event, World } from '@workflow/world';
 import { ulid } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { deriveRunKeyPair, seal } from '../sealed-box.js';
+import {
+  decrypt,
+  encodeWithFormatPrefix,
+  encrypt,
+  peekFormatPrefix,
+  SerializationFormat,
+} from '../serialization.js';
 import {
   getWorkflowQueueName,
   healthCheck,
   latestEventStateUpdatedAt,
   loadWorkflowRunEvents,
+  memoizeEncryptionKey,
   type MutableEventLog,
   withPreconditionRetry,
 } from './helpers.js';
@@ -636,5 +645,68 @@ describe('withPreconditionRetry', () => {
     );
     expect(op).toHaveBeenCalledTimes(1);
     expect(eventsListMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('memoizeEncryptionKey', () => {
+  const MATERIAL = new Uint8Array(32).fill(0x6b);
+
+  function worldWithKey(getEncryptionKeyForRun: unknown): World {
+    return { getEncryptionKeyForRun } as unknown as World;
+  }
+
+  it('resolves a key that can open payloads sealed to the run', async () => {
+    // A run reading its own event log may find sealed ('encp') payloads that
+    // another run wrote to it — a cross-deployment hook resumption, say. If
+    // this resolved only the symmetric key, those payloads would fail to open
+    // and wedge the run, so the sealed capability must be part of what every
+    // reader gets by default.
+    const getKey = memoizeEncryptionKey(
+      worldWithKey(vi.fn().mockResolvedValue(MATERIAL)),
+      'wrun_1'
+    );
+    const resolved = await getKey();
+    expect(resolved).toBeDefined();
+
+    const { publicKey } = await deriveRunKeyPair(MATERIAL);
+    const sealed = await seal(publicKey, new TextEncoder().encode('"hi"'));
+    const prefixed = encodeWithFormatPrefix(
+      SerializationFormat.SEALED,
+      sealed
+    ) as Uint8Array;
+
+    await expect(decrypt(prefixed, resolved)).resolves.toEqual(
+      new TextEncoder().encode('"hi"')
+    );
+  });
+
+  it("resolves a key that still opens the run's own symmetric payloads", async () => {
+    const getKey = memoizeEncryptionKey(
+      worldWithKey(vi.fn().mockResolvedValue(MATERIAL)),
+      'wrun_1'
+    );
+    const resolved = await getKey();
+
+    const encrypted = await encrypt(new TextEncoder().encode('"hi"'), resolved);
+    expect(peekFormatPrefix(encrypted)).toBe(SerializationFormat.ENCRYPTED);
+    await expect(decrypt(encrypted, resolved)).resolves.toEqual(
+      new TextEncoder().encode('"hi"')
+    );
+  });
+
+  it('memoizes so the key is derived once per run', async () => {
+    // Derivation now costs several Web Crypto round trips (HKDF + a PKCS#8
+    // import + a JWK export), so re-deriving per payload would be wasteful.
+    const spy = vi.fn().mockResolvedValue(MATERIAL);
+    const getKey = memoizeEncryptionKey(worldWithKey(spy), 'wrun_1');
+
+    const [a, b] = await Promise.all([getKey(), getKey()]);
+    expect(a).toBe(b);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves undefined when encryption is not configured', async () => {
+    const getKey = memoizeEncryptionKey(worldWithKey(undefined), 'wrun_1');
+    await expect(getKey()).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -19,12 +19,11 @@ import {
   ulidToDate,
 } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
-
+import { runtimeLogger } from '../logger.js';
 import {
   deriveRunPayloadKeys,
   type PayloadKey,
 } from '../serialization/encryption.js';
-import { runtimeLogger } from '../logger.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanKind, trace } from '../telemetry.js';
 import { version as workflowCoreVersion } from '../version.js';
@@ -795,13 +794,21 @@ export function getQueueOverhead(message: { requestedAt?: Date }) {
 }
 
 /**
- * Returns a memoized accessor for the per-run AES-256 encryption key.
+ * Returns a memoized accessor for a run's full encryption capability.
  *
- * The first call resolves the key via `world.getEncryptionKeyForRun` (which
- * may do HKDF derivation locally on Vercel, or a network fetch from
- * external contexts) and imports it as a `CryptoKey`; subsequent calls
- * await the same cached promise. If the world doesn't support encryption
- * or the run has no key configured, the cached value is `undefined`.
+ * The first call resolves the run's key material via
+ * `world.getEncryptionKeyForRun` (which may do HKDF derivation locally on
+ * Vercel, or a network fetch from external contexts) and derives a
+ * {@link PayloadKey} from it; subsequent calls await the same cached promise.
+ * If the world doesn't support encryption or the run has no key configured,
+ * the cached value is `undefined`.
+ *
+ * The resolved value is deliberately the *full* capability — the symmetric AES
+ * key plus the run's X25519 keypair — not just a `CryptoKey`. A run reading
+ * its own event log can encounter sealed (`encp`) payloads that another run
+ * wrote to it (a cross-deployment hook resumption, say), and opening those
+ * needs the keypair. Resolving only the symmetric key would leave those
+ * payloads unopenable and wedge the run.
  *
  * Used by step / workflow handlers to defer the (potentially expensive)
  * key fetch until the first code path that actually needs it — typically

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -20,7 +20,10 @@ import {
 } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 
-import { type CryptoKey, importKey } from '../encryption.js';
+import {
+  deriveRunPayloadKeys,
+  type PayloadKey,
+} from '../serialization/encryption.js';
 import { runtimeLogger } from '../logger.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getSpanKind, trace } from '../telemetry.js';
@@ -816,8 +819,8 @@ export function getQueueOverhead(message: { requestedAt?: Date }) {
 export function memoizeEncryptionKey(
   world: World,
   runOrId: WorkflowRun | string
-): () => Promise<CryptoKey | undefined> {
-  let cached: Promise<CryptoKey | undefined> | undefined;
+): () => Promise<PayloadKey | undefined> {
+  let cached: Promise<PayloadKey | undefined> | undefined;
   return () => {
     if (!cached) {
       cached = (async () => {
@@ -828,7 +831,11 @@ export function memoizeEncryptionKey(
           typeof runOrId === 'string'
             ? await world.getEncryptionKeyForRun?.(runOrId)
             : await world.getEncryptionKeyForRun?.(runOrId);
-        return rawKey ? await importKey(rawKey) : undefined;
+        // Resolve the *full* capability, not just the symmetric key: a run
+        // reading its own event log may encounter sealed (`encp`) payloads
+        // that another run wrote to it, and opening those needs the run's
+        // X25519 scalar as well.
+        return rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
       })();
     }
     return cached;

--- a/packages/core/src/runtime/resume-hook.test.ts
+++ b/packages/core/src/runtime/resume-hook.test.ts
@@ -6,6 +6,14 @@ import {
   type World,
 } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { importKey } from '../encryption.js';
+import { bytesToBase64, deriveRunKeyPair } from '../sealed-box.js';
+import {
+  hydrateStepReturnValue,
+  peekFormatPrefix,
+  runPayloadKeys,
+  SerializationFormat,
+} from '../serialization.js';
 import { resumeHook } from './resume-hook.js';
 import { setWorld } from './world.js';
 
@@ -58,5 +66,192 @@ describe('resumeHook', () => {
     expect(createEvent).not.toHaveBeenCalled();
     expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
     expect(queue).not.toHaveBeenCalled();
+  });
+
+  describe('payload encryption', () => {
+    const RUN_KEY_MATERIAL = new Uint8Array(32).fill(0x4d);
+
+    function makeHook(): Hook {
+      return {
+        runId: 'wrun_1',
+        hookId: 'hook_1',
+        token: 'order:1',
+        ownerId: 'owner_1',
+        projectId: 'project_1',
+        environment: 'production',
+        createdAt: new Date(),
+        specVersion: SPEC_VERSION_CURRENT,
+      } as Hook;
+    }
+
+    function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+      return {
+        runId: 'wrun_1',
+        status: 'running',
+        deploymentId: 'deployment_1',
+        workflowName: 'processOrder',
+        specVersion: SPEC_VERSION_CURRENT,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        attributes: {},
+        executionContext: { workflowCoreVersion: '5.0.0-beta.40' },
+        ...overrides,
+      } as WorkflowRun;
+    }
+
+    /** Wire up a world and return the spies plus the captured event. */
+    function setupWorld(run: WorkflowRun) {
+      const createEvent = vi.fn().mockResolvedValue(undefined);
+      const getEncryptionKeyForRun = vi
+        .fn()
+        .mockResolvedValue(RUN_KEY_MATERIAL);
+      const queue = vi.fn().mockResolvedValue(undefined);
+
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        hooks: { getByToken: vi.fn().mockResolvedValue(makeHook()) },
+        runs: { get: vi.fn().mockResolvedValue(run) },
+        events: { create: createEvent },
+        getEncryptionKeyForRun,
+        queue,
+        getDeploymentId: vi.fn().mockResolvedValue('deployment_2'),
+      } as unknown as World);
+
+      return { createEvent, getEncryptionKeyForRun, queue };
+    }
+
+    function capturedPayload(
+      createEvent: ReturnType<typeof vi.fn>
+    ): Uint8Array {
+      return createEvent.mock.calls[0][1].eventData.payload as Uint8Array;
+    }
+
+    it('seals the payload to the run public key without fetching a key', async () => {
+      // This is the whole point of the change: a cross-deployment resume
+      // should not need `getEncryptionKeyForRun` at all, because that is the
+      // ~350ms `run-key` API round trip.
+      const { publicKey } = await deriveRunKeyPair(RUN_KEY_MATERIAL);
+      const run = makeRun({ encryptionPublicKey: bytesToBase64(publicKey) });
+      const { createEvent, getEncryptionKeyForRun } = setupWorld(run);
+
+      await resumeHook('order:1', { approved: true });
+
+      expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+      expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+        SerializationFormat.SEALED
+      );
+    });
+
+    it('produces a payload the owning run can actually open', async () => {
+      // End-to-end: seal as the resumer, then hydrate exactly as the owning
+      // deployment would after re-deriving its own key material.
+      const keyPair = await deriveRunKeyPair(RUN_KEY_MATERIAL);
+      const run = makeRun({
+        encryptionPublicKey: bytesToBase64(keyPair.publicKey),
+      });
+      const { createEvent } = setupWorld(run);
+
+      await resumeHook('order:1', { approved: true, count: 7 });
+
+      const keys = runPayloadKeys(await importKey(RUN_KEY_MATERIAL), keyPair);
+      const hydrated = await hydrateStepReturnValue(
+        capturedPayload(createEvent),
+        'wrun_1',
+        keys
+      );
+      expect(hydrated).toEqual({ approved: true, count: 7 });
+    });
+
+    it('falls back to the symmetric path when the run has no public key', async () => {
+      // Runs created by older SDKs carry no public key; those must keep
+      // working exactly as before.
+      const run = makeRun();
+      const { createEvent, getEncryptionKeyForRun } = setupWorld(run);
+
+      await resumeHook('order:1', { approved: true });
+
+      expect(getEncryptionKeyForRun).toHaveBeenCalledWith(run);
+      expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+        SerializationFormat.ENCRYPTED
+      );
+    });
+
+    it('falls back to the symmetric path when the public key is malformed', async () => {
+      // A corrupt stored value must degrade to the previous behavior rather
+      // than fail the resumption.
+      for (const bad of ['not-base64!!', bytesToBase64(new Uint8Array(31))]) {
+        const run = makeRun({ encryptionPublicKey: bad });
+        const { createEvent, getEncryptionKeyForRun } = setupWorld(run);
+
+        await resumeHook('order:1', { approved: true });
+
+        expect(getEncryptionKeyForRun).toHaveBeenCalled();
+        expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+          SerializationFormat.ENCRYPTED
+        );
+        setWorld(undefined);
+      }
+    });
+
+    it('seals even when the target reports a core version predating encp', async () => {
+      // Presence of the public key is the gate, deliberately not the version
+      // table: a run only has a key if the runtime that created it could open
+      // one, which is a stronger attestation than a version compare and stays
+      // correct when package versions drift.
+      const { publicKey } = await deriveRunKeyPair(RUN_KEY_MATERIAL);
+      const run = makeRun({
+        encryptionPublicKey: bytesToBase64(publicKey),
+        executionContext: { workflowCoreVersion: '4.2.0-beta.64' },
+      });
+      const { createEvent, getEncryptionKeyForRun } = setupWorld(run);
+
+      await resumeHook('order:1', { approved: true });
+
+      expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+      expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+        SerializationFormat.SEALED
+      );
+    });
+
+    it('reuses a caller-supplied symmetric key instead of sealing', async () => {
+      // resumeWebhook already had to fetch the symmetric key to hydrate hook
+      // metadata, so sealing would add an ECDH without saving a round trip.
+      const keyPair = await deriveRunKeyPair(RUN_KEY_MATERIAL);
+      const run = makeRun({
+        encryptionPublicKey: bytesToBase64(keyPair.publicKey),
+      });
+      const { createEvent, getEncryptionKeyForRun } = setupWorld(run);
+
+      await resumeHook(
+        makeHook(),
+        { approved: true },
+        await importKey(RUN_KEY_MATERIAL)
+      );
+
+      expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+      expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+        SerializationFormat.ENCRYPTED
+      );
+    });
+
+    it('writes plaintext when encryption is disabled entirely', async () => {
+      const run = makeRun();
+      const createEvent = vi.fn().mockResolvedValue(undefined);
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        hooks: { getByToken: vi.fn().mockResolvedValue(makeHook()) },
+        runs: { get: vi.fn().mockResolvedValue(run) },
+        events: { create: createEvent },
+        // No getEncryptionKeyForRun at all — encryption not configured.
+        queue: vi.fn().mockResolvedValue(undefined),
+        getDeploymentId: vi.fn().mockResolvedValue('deployment_2'),
+      } as unknown as World);
+
+      await resumeHook('order:1', { approved: true });
+
+      expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+        SerializationFormat.DEVALUE_V1
+      );
+    });
   });
 });

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -14,11 +14,15 @@ import {
   type WorkflowRun,
 } from '@workflow/world';
 import { getRunCapabilities } from '../capabilities.js';
-import { type CryptoKey, importKey } from '../encryption.js';
+import { importKey } from '../encryption.js';
 import { runtimeLogger } from '../logger.js';
+import { decodeRunPublicKey } from '../sealed-box.js';
+import { deriveRunPayloadKeys } from '../serialization/encryption.js';
 import {
   dehydrateStepReturnValue,
   hydrateStepArguments,
+  type PayloadKey,
+  sealTo,
   SerializationFormat,
 } from '../serialization.js';
 import { WEBHOOK_RESPONSE_WRITABLE } from '../symbols.js';
@@ -41,11 +45,11 @@ async function getHookAndRun(token: string): Promise<{
 
 async function getHookByTokenWithKey(token: string): Promise<{
   hook: Hook;
-  encryptionKey: CryptoKey | undefined;
+  encryptionKey: PayloadKey | undefined;
 }> {
   const { hook, run } = await getHookAndRun(token);
   const rawKey = await (await getWorldLazy()).getEncryptionKeyForRun?.(run);
-  const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+  const encryptionKey = rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
   if (typeof hook.metadata !== 'undefined') {
     hook.metadata = await hydrateStepArguments(
       hook.metadata as any,
@@ -103,7 +107,7 @@ export async function getHookByToken(token: string): Promise<Hook> {
 export async function resumeHook<T = any>(
   tokenOrHook: string | Hook,
   payload: T,
-  encryptionKeyOverride?: CryptoKey
+  encryptionKeyOverride?: PayloadKey
 ): Promise<Hook> {
   return await waitedUntil(() => {
     return trace('hook.resume', async (span) => {
@@ -131,12 +135,6 @@ export async function resumeHook<T = any>(
           throw new HookNotFoundError(hook.token);
         }
 
-        let encryptionKey = encryptionKeyOverride;
-        if (!encryptionKey) {
-          const rawKey = await world.getEncryptionKeyForRun?.(workflowRun);
-          encryptionKey = rawKey ? await importKey(rawKey) : undefined;
-        }
-
         // Check the target run's capabilities to ensure we encode the
         // payload in a format the run's deployment can decode. For example,
         // runs created before encryption support was added cannot decode
@@ -146,8 +144,47 @@ export async function resumeHook<T = any>(
         const capabilities = getRunCapabilities(
           typeof rawVersion === 'string' ? rawVersion : undefined
         );
-        if (!capabilities.supportedFormats.has(SerializationFormat.ENCRYPTED)) {
-          encryptionKey = undefined;
+
+        // Resolve how to encrypt the payload for the target run.
+        //
+        // Preferred path: the run published an X25519 public key, so seal to
+        // it. This needs nothing beyond the run entity we already fetched —
+        // no `getEncryptionKeyForRun`, which for a cross-deployment resume
+        // means a ~350ms `run-key` API round trip. That call dominates
+        // cross-deployment hook resumption latency, and sealing removes it.
+        //
+        // Sealing also drops privilege: the resumer ends up able to write a
+        // payload for the run without being able to read anything of the
+        // run's, where fetching the symmetric key grants both.
+        //
+        // Deliberately NOT gated on `capabilities.supportedFormats` the way
+        // `encr` is above: presence of the public key is itself the gate. A
+        // run only carries one if the runtime that created it could also open
+        // a sealed payload, and runs are pinned to their creating deployment,
+        // so presence is a more reliable attestation than a version compare
+        // — and it stays correct even when package versions drift.
+        let payloadKey: PayloadKey | undefined;
+        const runPublicKey = encryptionKeyOverride
+          ? // The caller already holds the symmetric key (resumeWebhook had
+            // to fetch it to hydrate hook metadata), so sealing would add an
+            // ECDH for no saved round trip. Reuse what it resolved.
+            undefined
+          : decodeRunPublicKey(workflowRun.encryptionPublicKey);
+
+        if (runPublicKey) {
+          payloadKey = sealTo(runPublicKey);
+        } else {
+          let encryptionKey = encryptionKeyOverride;
+          if (!encryptionKey) {
+            const rawKey = await world.getEncryptionKeyForRun?.(workflowRun);
+            encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+          }
+          if (
+            !capabilities.supportedFormats.has(SerializationFormat.ENCRYPTED)
+          ) {
+            encryptionKey = undefined;
+          }
+          payloadKey = encryptionKey;
         }
 
         // Compress only when the target run and its deployment support the
@@ -162,7 +199,7 @@ export async function resumeHook<T = any>(
         const dehydratedPayload = await dehydrateStepReturnValue(
           payload,
           hook.runId,
-          encryptionKey,
+          payloadKey,
           ops,
           globalThis,
           v1Compat,

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -22,8 +22,8 @@ import {
   dehydrateStepReturnValue,
   hydrateStepArguments,
   type PayloadKey,
-  sealTo,
   SerializationFormat,
+  sealTo,
 } from '../serialization.js';
 import { WEBHOOK_RESPONSE_WRITABLE } from '../symbols.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
@@ -158,11 +158,12 @@ export async function resumeHook<T = any>(
         // run's, where fetching the symmetric key grants both.
         //
         // Deliberately NOT gated on `capabilities.supportedFormats` the way
-        // `encr` is above: presence of the public key is itself the gate. A
-        // run only carries one if the runtime that created it could also open
-        // a sealed payload, and runs are pinned to their creating deployment,
-        // so presence is a more reliable attestation than a version compare
-        // — and it stays correct even when package versions drift.
+        // the symmetric fallback below gates `encr`: presence of the public key
+        // is itself the gate. A run only carries one if the runtime that
+        // created it could also open a sealed payload, and runs are pinned to
+        // their creating deployment, so presence is a more reliable attestation
+        // than a version compare — and it stays correct even when package
+        // versions drift.
         let payloadKey: PayloadKey | undefined;
         const runPublicKey = encryptionKeyOverride
           ? // The caller already holds the symmetric key (resumeWebhook had

--- a/packages/core/src/runtime/run.ts
+++ b/packages/core/src/runtime/run.ts
@@ -10,7 +10,10 @@ import {
   type WorkflowRunStatus,
   type World,
 } from '@workflow/world';
-import { type CryptoKey, importKey } from '../encryption.js';
+import {
+  deriveRunPayloadKeys,
+  type PayloadKey,
+} from '../serialization/encryption.js';
 import {
   getExternalRevivers,
   hydrateRunError,
@@ -103,7 +106,7 @@ export class Run<TResult> {
    * reused for returnValue, getReadable(), etc.
    * @internal
    */
-  #encryptionKeyPromise: Promise<CryptoKey | undefined> | null = null;
+  #encryptionKeyPromise: Promise<PayloadKey | undefined> | null = null;
 
   /**
    * When true, run_created failed and the run may not exist yet (the
@@ -125,13 +128,13 @@ export class Run<TResult> {
    * to be resolved once.
    * @internal
    */
-  #getEncryptionKey(): Promise<CryptoKey | undefined> {
+  #getEncryptionKey(): Promise<PayloadKey | undefined> {
     if (!this.#encryptionKeyPromise) {
       this.#encryptionKeyPromise = (async () => {
         const world = await this.#lazyWorldPromise;
         const run = await world.runs.get(this.runId);
         const rawKey = await world.getEncryptionKeyForRun?.(run);
-        return rawKey ? await importKey(rawKey) : undefined;
+        return rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
       })();
     }
     return this.#encryptionKeyPromise;
@@ -143,7 +146,7 @@ export class Run<TResult> {
    * unobserved run lookup.
    * @internal
    */
-  #getEncryptionKeyLazily(): () => Promise<CryptoKey | undefined> {
+  #getEncryptionKeyLazily(): () => Promise<PayloadKey | undefined> {
     return () => this.#getEncryptionKey();
   }
 

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -5,7 +5,7 @@ import {
   SPEC_VERSION_LEGACY,
   type World,
 } from '@workflow/world';
-import { importKey } from '../encryption.js';
+import { deriveRunPayloadKeys } from '../serialization/encryption.js';
 import { hydrateWorkflowArguments } from '../serialization.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { start } from './start.js';
@@ -85,7 +85,9 @@ export async function recreateRunFromExisting(
   try {
     const run = await world.runs.get(runId, { resolveData: 'all' });
     const rawKey = await world.getEncryptionKeyForRun?.(run);
-    const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+    const encryptionKey = rawKey
+      ? await deriveRunPayloadKeys(rawKey)
+      : undefined;
     const workflowArgs = normalizeWorkflowArgs(
       await hydrateWorkflowArguments(
         run.input,

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -18,7 +18,7 @@ import {
   SPEC_VERSION_CURRENT,
   SPEC_VERSION_SUPPORTS_COMPRESSION,
 } from '@workflow/world';
-import type { CryptoKey } from '../encryption.js';
+import type { PayloadKey } from '../serialization/encryption.js';
 import { runtimeLogger, stepLogger } from '../logger.js';
 import { getStepFunction } from '../private.js';
 import {
@@ -85,7 +85,7 @@ export interface StepExecutorParams {
   rootRunId?: string;
   stepId: string;
   stepName: string;
-  encryptionKey?: CryptoKey;
+  encryptionKey?: PayloadKey;
   /**
    * The workflow run's specVersion, used to gate payload compression.
    * Step outputs/errors are only compressed when the run is marked as

--- a/packages/core/src/sealed-box.test.ts
+++ b/packages/core/src/sealed-box.test.ts
@@ -8,6 +8,7 @@ import {
   base64ToBytes,
   bytesToBase64,
   decapsulate,
+  decodeRunPublicKey,
   deriveRunKeyPair,
   encapsulate,
   open,
@@ -477,6 +478,21 @@ describe('base64 helpers', () => {
         `expected ${bad} to be rejected`
       ).toBeUndefined();
     }
+  });
+
+  it('rejects a malformed public key at the decode boundary', () => {
+    // decodeRunPublicKey is the funnel every caller uses, so the strictness
+    // has to show up there rather than only in the raw decoder.
+    expect(decodeRunPublicKey('AAAAA')).toBeUndefined();
+    expect(decodeRunPublicKey('AA=A')).toBeUndefined();
+    expect(decodeRunPublicKey(undefined)).toBeUndefined();
+    // Right encoding, wrong length.
+    expect(
+      decodeRunPublicKey(bytesToBase64(new Uint8Array(31)))
+    ).toBeUndefined();
+    // And the happy path still resolves.
+    const valid = bytesToBase64(new Uint8Array(32).fill(3));
+    expect(decodeRunPublicKey(valid)).toEqual(new Uint8Array(32).fill(3));
   });
 
   it('accepts every canonical encoding Buffer produces', () => {

--- a/packages/core/src/sealed-box.ts
+++ b/packages/core/src/sealed-box.ts
@@ -735,7 +735,32 @@ function keyCacheId(publicKey: Uint8Array): string {
  *
  * Mirrors the `info` used for symmetric per-run key derivation so the two
  * schemes agree on what "this run" means.
+ *
+ * Note that the sealed-box construction already binds a payload to its
+ * recipient without any AAD: the content key is derived over
+ * `ephemeralPublicKey ‖ recipientPublicKey`, and a recipient public key is
+ * unique per (deployment key × project × run). Replaying a sealed payload at
+ * a different run therefore fails at key agreement regardless. AAD is
+ * available for callers that want an additional, KDF-independent binding —
+ * both sides must supply byte-identical values or the payload will not open.
  */
 export function runAad(projectId: string, runId: string): Uint8Array {
   return infoEncoder.encode(`${projectId}|${runId}`);
+}
+
+/**
+ * Decode a run's published public key, validating both encoding and length.
+ *
+ * Returns `undefined` when the value is absent, not valid base64, or not
+ * exactly 32 bytes. Callers treat that as "this run has no usable public key"
+ * and fall back to the symmetric path, so a corrupt or truncated stored value
+ * degrades to the pre-existing behavior instead of failing a resumption.
+ */
+export function decodeRunPublicKey(
+  value: string | undefined
+): Uint8Array | undefined {
+  if (!value) return undefined;
+  const bytes = base64ToBytes(value);
+  if (!bytes || bytes.byteLength !== X25519_KEY_LENGTH) return undefined;
+  return bytes;
 }

--- a/packages/core/src/step/context-storage.ts
+++ b/packages/core/src/step/context-storage.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type { CryptoKey } from '../encryption.js';
+import type { PayloadKey } from '../serialization/encryption.js';
 import type { FlushableStreamState } from '../flushable-stream.js';
 import type { WorkflowMetadata } from '../workflow/get-workflow-metadata.js';
 import type { StepMetadata } from './get-step-metadata.js';
@@ -57,7 +57,7 @@ export type StepContext = {
    */
   preCompletionOps: Promise<void>[];
   closureVars?: Record<string, any>;
-  encryptionKey?: CryptoKey;
+  encryptionKey?: PayloadKey;
   writables?: Map<string, CachedWritable>;
   /**
    * Turbo mode only: a promise that resolves once the backgrounded

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -10,7 +10,7 @@ import type { Event, WorkflowRun, WorldCapabilities } from '@workflow/world';
 import { SPEC_VERSION_SUPPORTS_COMPRESSION } from '@workflow/world';
 import * as nanoid from 'nanoid';
 import { monotonicFactory } from 'ulid';
-import type { CryptoKey } from './encryption.js';
+import type { PayloadKey } from './serialization/encryption.js';
 import { EventConsumerResult, EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
 import { ENOTSUP, WorkflowSuspension } from './global.js';
@@ -116,7 +116,7 @@ export async function runWorkflow(
   workflowCode: string,
   workflowRun: WorkflowRun,
   events: Event[],
-  encryptionKey: CryptoKey | undefined,
+  encryptionKey: PayloadKey | undefined,
   /**
    * Optional per-run cache for replay payload preparation and immutable final
    * values. Owned by the inline replay loop so it survives fresh VM contexts


### PR DESCRIPTION
**PR 4 of 7 — the payoff.** Stacked on #3095; review the stack in order, starting from #3093.

- #3093 — the `encp` sealed-box primitive
- #3094 — route sealed envelopes through the serialization layer
- #3095 — publish each run's public key on the run entity
- **#3096 (this PR)** — `resumeHook()` seals instead of fetching the key ← the payoff
- #3097 — decrypt sealed payloads in observability tooling
- #3098 — seal forwarded stream writes
- #3099 — `start()` gets the key from the probe it already awaits

## Impact

Cross-deployment `resumeHook()` no longer calls `getEncryptionKeyForRun`, which on Vercel means a ~350ms `run-key` API round trip — Cosmos reads, a 50–75KB `encrypted_env.json` fetch from S3, up to three KMS decrypts — **to recover 32 bytes**. When the target run publishes a public key, the resumer seals to it using only the run entity it already fetched.

More than half of `resumeHook()` calls miss the same-deployment fast path, so this is the dominant term in hook-resumption latency. For Eve, hook resumption is what an agent turn waits on.

Also removes the sfo1 single-region dependency, the S3/KMS load, and the 2000 req/min/owner rate-limit exposure from the resumption hot path.

## It also *reduces* privilege

Fetching the symmetric key grants read access to everything in the run. Sealing grants only the ability to write one payload to it. A resumer is now **cryptographically unable** to read the run it resumes — upgrading the previous honor-system `importKey(raw, ['encrypt'])` restriction to a real guarantee.

## ⚠️ The read path was the hidden requirement

Sealing is useless if the run can't open the result — and **every reader previously resolved a bare symmetric `CryptoKey`, which by construction cannot open `encp`**. Shipping the seal path alone would have wedged the first sealed hook payload with `RuntimeDecryptionError`.

Key resolution now yields the full capability (symmetric key + X25519 keypair) at all four read sites: `memoizeEncryptionKey`, the `Run` class, `runs.ts`, and `getHookByTokenWithKey`. Holder types widen from `CryptoKey` to `PayloadKey` — a pure widening. This is most of the diff, and it's why this PR is bigger than "make resumeHook seal".

## Gating

Sealing is gated on **presence of `encryptionPublicKey`**, deliberately *not* on the capability version table the way `encr` and `gzip` are — see #3095 for why presence is the stronger attestation. `resumeWebhook` keeps using the symmetric key it already had to fetch (to hydrate hook metadata); sealing there would add an ECDH without saving a round trip.

Falls back to the symmetric path when the run has no public key (older SDKs), when the stored value is malformed, or when encryption is off.

## 🔍 Open decision: no AAD on sealed payloads

An earlier iteration of this design specified additional authenticated data of `projectId|runId` on every sealed payload. **This PR seals with no AAD**, because:

- The content key is already derived over `ephemeralPublicKey ‖ recipientPublicKey`, and a recipient public key is unique per (deployment key × project × run). Replaying a sealed payload at a different run therefore already fails at key agreement.
- AAD would add a second binding of the *same* property while introducing a real hazard: any writer/reader mismatch is an unrecoverable wedge, for zero security gain.

The `aad` parameter remains available in the sealed-box API for callers that want a KDF-independent binding, and the reasoning is documented in `sealed-box.ts`. **Flagging it explicitly because it reverses an earlier design decision — it should be a review call, not mine.**

## Tests

8 tests on `resumeHook` covering: no key fetch when a public key is present, an **end-to-end assertion that the sealed payload hydrates with the keys the owning deployment re-derives**, all three fallback paths, presence-gating overriding an old reported core version, and the webhook override path. Plus 4 on `memoizeEncryptionKey` asserting the resolved key opens both schemes.

Full core suite (1596) passes; workspace typecheck clean; zero new lint diagnostics (verified against a stashed baseline).



