### PR TITLE
feat(core): seal forwarded stream writes to the owner's public key

### DIFF
--- a/.changeset/encp-forwarded-streams.md
+++ b/.changeset/encp-forwarded-streams.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Carry the owning run's public key in forwarded `WritableStream` descriptors, so a run writing into another run's stream seals frames with no run fetch and no key-API round trip.

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -12,7 +12,6 @@ import { registerSerializationClass } from './class-serialization.js';
 import { decrypt, encrypt, importKey } from './encryption.js';
 import { getStepFunction, registerStepFunction } from './private.js';
 import { bytesToBase64, deriveRunKeyPair } from './sealed-box.js';
-import { hydrateData } from './serialization-format.js';
 import {
   decrypt as decryptEnvelope,
   runPayloadKeys,
@@ -43,6 +42,7 @@ import {
   maybeEncrypt,
   SerializationFormat,
 } from './serialization.js';
+import { hydrateData } from './serialization-format.js';
 import {
   ABORT_HOOK_TOKEN,
   ABORT_READER_CANCEL,
@@ -747,34 +747,49 @@ describe('workflow arguments', () => {
     }
   });
 
-  it('gives every sealed frame its own key, so replays cannot reuse a nonce', async () => {
-    // Each frame is sealed independently (fresh ephemeral keypair AND fresh
-    // nonce), so there is no long-lived content key that a stream reconnect
-    // or a durable replay could restart a counter against.
+  it('keeps nonces unique across sealed frames sharing one content key', async () => {
+    // The KEM is amortized per writer, so all frames of one stream share an
+    // ephemeral key and content key. Safety therefore rests entirely on the
+    // per-frame random nonce: identical plaintext must still produce distinct
+    // ciphertext. A counter here would repeat `(key, nonce)` after a reconnect
+    // or a durable replay.
     const ownerKeyPair = await deriveRunKeyPair(new Uint8Array(32).fill(0x3c));
-    const target = sealTo(ownerKeyPair.publicKey);
 
-    const frames: Uint8Array[] = [];
-    const serialize = getSerializeStream({} as any, target);
-    const read = (async () => {
-      const reader = serialize.readable.getReader();
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        frames.push(value);
-      }
-    })();
-    const writer = serialize.writable.getWriter();
-    for (let i = 0; i < 20; i++) await writer.write('identical');
-    await writer.close();
-    await read;
+    async function writeFrames(count: number): Promise<Uint8Array[]> {
+      const frames: Uint8Array[] = [];
+      const serialize = getSerializeStream(
+        {} as any,
+        sealTo(ownerKeyPair.publicKey)
+      );
+      const read = (async () => {
+        const reader = serialize.readable.getReader();
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          frames.push(value);
+        }
+      })();
+      const writer = serialize.writable.getWriter();
+      for (let i = 0; i < count; i++) await writer.write('identical');
+      await writer.close();
+      await read;
+      return frames;
+    }
 
-    // Ephemeral public key sits after [4-byte length][encp].
+    const frames = await writeFrames(20);
+    // Ephemeral public key sits after [4-byte length][encp]: one per stream.
     const ephemerals = new Set(
       frames.map((f) => Array.from(f.subarray(8, 40)).join(','))
     );
-    expect(ephemerals.size).toBe(20);
+    expect(ephemerals.size).toBe(1);
+    // But every frame is still distinct, i.e. no nonce was reused.
     expect(new Set(frames.map((f) => Array.from(f).join(','))).size).toBe(20);
+
+    // A second writer incarnation — a reconnect or a replay — must not inherit
+    // the first one's content key, so its ephemeral key differs.
+    const replayed = await writeFrames(20);
+    const replayEphemeral = Array.from(replayed[0].subarray(8, 40)).join(',');
+    expect(ephemerals.has(replayEphemeral)).toBe(false);
   });
 
   it('loads the owner run for forwarded descriptors from older deployments', async () => {

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -11,8 +11,13 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { registerSerializationClass } from './class-serialization.js';
 import { decrypt, encrypt, importKey } from './encryption.js';
 import { getStepFunction, registerStepFunction } from './private.js';
-import { deriveRunKeyPair } from './sealed-box.js';
-import { runPayloadKeys, sealTo } from './serialization/encryption.js';
+import { bytesToBase64, deriveRunKeyPair } from './sealed-box.js';
+import { hydrateData } from './serialization-format.js';
+import {
+  decrypt as decryptEnvelope,
+  runPayloadKeys,
+  sealTo,
+} from './serialization/encryption.js';
 import {
   cancelAbortReaders,
   decodeFormatPrefix,
@@ -45,6 +50,7 @@ import {
   STABLE_ULID,
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+  STREAM_SERVER_PUBLIC_KEY_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
 } from './symbols.js';
 import { createContext } from './vm/index.js';
@@ -606,6 +612,169 @@ describe('workflow arguments', () => {
     } finally {
       vi.mocked(getWorldLazy).mockImplementation(() => makeMockWorld() as any);
     }
+  });
+
+  it('seals forwarded writes to the owner public key with no lookups', async () => {
+    // The whole point of carrying the public key in the descriptor: a child on
+    // another deployment must be able to write to the parent's stream without
+    // fetching the parent run OR its symmetric key. Either lookup would
+    // reintroduce the round trip this design removes.
+    const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
+    const ownerMaterial = new Uint8Array(32).fill(0x2b);
+    const ownerKeyPair = await deriveRunKeyPair(ownerMaterial);
+
+    const getEncryptionKeyForRun = vi.fn();
+    const runsGet = vi.fn();
+    const world = {
+      ...makeMockWorld(),
+      runs: { get: runsGet },
+      getEncryptionKeyForRun,
+    } as any;
+    vi.mocked(getWorldLazy).mockReturnValue(world);
+
+    try {
+      const parentWritable = new WritableStream();
+      for (const [sym, value] of [
+        [STREAM_NAME_SYMBOL, 'strm_sealedparent'],
+        [STREAM_SERVER_RUN_ID_SYMBOL, 'wrun_parent'],
+        [STREAM_SERVER_DEPLOYMENT_ID_SYMBOL, 'dpl_parent'],
+        [
+          STREAM_SERVER_PUBLIC_KEY_SYMBOL,
+          bytesToBase64(ownerKeyPair.publicKey),
+        ],
+      ] as const) {
+        Object.defineProperty(parentWritable, sym, { value, writable: false });
+      }
+
+      const serialized = await dehydrateStepArguments(
+        parentWritable,
+        'wrun_child',
+        noEncryptionKey
+      );
+      const ops: Promise<void>[] = [];
+      const hydrated = (await hydrateStepArguments(
+        serialized,
+        'wrun_child',
+        noEncryptionKey,
+        ops,
+        globalThis,
+        {},
+        'dpl_child'
+      )) as WritableStream<string>;
+
+      const writer = hydrated.getWriter();
+      await writer.write('sealed-cross-deployment');
+      await writer.close();
+      await Promise.all(ops);
+
+      // Neither lookup happened — that is the whole win.
+      expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+      expect(runsGet).not.toHaveBeenCalled();
+
+      // And the frames really are sealed to the owner: decode what was
+      // written to the server and open it with the owner's keypair.
+      const written = world.streams.write.mock.calls
+        .map((c: any[]) => c[2])
+        .filter((c: unknown) => c instanceof Uint8Array) as Uint8Array[];
+      expect(written.length).toBeGreaterThan(0);
+
+      const frame = written[0];
+      // [4-byte length][encp][sealed...]
+      expect(new TextDecoder().decode(frame.subarray(4, 8))).toBe('encp');
+
+      const ownerKeys = runPayloadKeys(
+        await importKey(ownerMaterial),
+        ownerKeyPair
+      );
+      const opened = await decryptEnvelope(frame.subarray(4), ownerKeys);
+      expect(hydrateData(opened as Uint8Array, {})).toBe(
+        'sealed-cross-deployment'
+      );
+    } finally {
+      vi.mocked(getWorldLazy).mockImplementation(() => makeMockWorld() as any);
+    }
+  });
+
+  it('falls back to the symmetric path when the descriptor has no public key', async () => {
+    // Descriptors written by older SDKs carry no key; those must keep working.
+    const { getWorldLazy } = await import('./runtime/get-world-lazy.js');
+    const getEncryptionKeyForRun = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32).fill(7));
+    const world = {
+      ...makeMockWorld(),
+      runs: { get: vi.fn() },
+      getEncryptionKeyForRun,
+    } as any;
+    vi.mocked(getWorldLazy).mockReturnValue(world);
+
+    try {
+      const parentWritable = new WritableStream();
+      for (const [sym, value] of [
+        [STREAM_NAME_SYMBOL, 'strm_nokey'],
+        [STREAM_SERVER_RUN_ID_SYMBOL, 'wrun_parent'],
+        [STREAM_SERVER_DEPLOYMENT_ID_SYMBOL, 'dpl_parent'],
+      ] as const) {
+        Object.defineProperty(parentWritable, sym, { value, writable: false });
+      }
+
+      const serialized = await dehydrateStepArguments(
+        parentWritable,
+        'wrun_child',
+        noEncryptionKey
+      );
+      const ops: Promise<void>[] = [];
+      const hydrated = (await hydrateStepArguments(
+        serialized,
+        'wrun_child',
+        noEncryptionKey,
+        ops,
+        globalThis,
+        {},
+        'dpl_child'
+      )) as WritableStream<string>;
+
+      const writer = hydrated.getWriter();
+      await writer.write('legacy');
+      await writer.close();
+      await Promise.all(ops);
+
+      expect(getEncryptionKeyForRun).toHaveBeenCalledWith('wrun_parent', {
+        deploymentId: 'dpl_parent',
+      });
+    } finally {
+      vi.mocked(getWorldLazy).mockImplementation(() => makeMockWorld() as any);
+    }
+  });
+
+  it('gives every sealed frame its own key, so replays cannot reuse a nonce', async () => {
+    // Each frame is sealed independently (fresh ephemeral keypair AND fresh
+    // nonce), so there is no long-lived content key that a stream reconnect
+    // or a durable replay could restart a counter against.
+    const ownerKeyPair = await deriveRunKeyPair(new Uint8Array(32).fill(0x3c));
+    const target = sealTo(ownerKeyPair.publicKey);
+
+    const frames: Uint8Array[] = [];
+    const serialize = getSerializeStream({} as any, target);
+    const read = (async () => {
+      const reader = serialize.readable.getReader();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        frames.push(value);
+      }
+    })();
+    const writer = serialize.writable.getWriter();
+    for (let i = 0; i < 20; i++) await writer.write('identical');
+    await writer.close();
+    await read;
+
+    // Ephemeral public key sits after [4-byte length][encp].
+    const ephemerals = new Set(
+      frames.map((f) => Array.from(f.subarray(8, 40)).join(','))
+    );
+    expect(ephemerals.size).toBe(20);
+    expect(new Set(frames.map((f) => Array.from(f).join(','))).size).toBe(20);
   });
 
   it('loads the owner run for forwarded descriptors from older deployments', async () => {

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -695,6 +695,66 @@ describe('workflow arguments', () => {
     }
   });
 
+  it('keeps the owner public key across a workflow -> step forward', async () => {
+    // The end-to-end shape is two hops, not one: `start()` hands the parent's
+    // writable to the CHILD WORKFLOW, and the child workflow then hands it to
+    // the step that actually writes. So the handle is revived and re-serialized
+    // in between.
+    //
+    // The revivers used to re-attach only the stream name, runId and
+    // deploymentId, so the owner's public key was silently dropped on that
+    // middle hop and the step fell back to fetching the owner's symmetric key
+    // — reintroducing exactly the round trip this design removes. Sealing
+    // therefore never engaged for `start()`-forwarded streams in practice,
+    // even though the single-hop test above passed.
+    const ownerMaterial = new Uint8Array(32).fill(0x2b);
+    const ownerKeyPair = await deriveRunKeyPair(ownerMaterial);
+    const ownerPublicKey = bytesToBase64(ownerKeyPair.publicKey);
+
+    const parentWritable = new WritableStream();
+    for (const [sym, value] of [
+      [STREAM_NAME_SYMBOL, 'strm_sealedparent'],
+      [STREAM_SERVER_RUN_ID_SYMBOL, 'wrun_parent'],
+      [STREAM_SERVER_DEPLOYMENT_ID_SYMBOL, 'dpl_parent'],
+      [STREAM_SERVER_PUBLIC_KEY_SYMBOL, ownerPublicKey],
+    ] as const) {
+      Object.defineProperty(parentWritable, sym, { value, writable: false });
+    }
+
+    // Hop 1: parent serializes into the child's workflow arguments, and the
+    // child's workflow revives the handle.
+    const forwarded = await dehydrateWorkflowArguments(
+      parentWritable,
+      'wrun_child',
+      noEncryptionKey
+    );
+    const inChildWorkflow = (await hydrateWorkflowArguments(
+      forwarded,
+      'wrun_child',
+      noEncryptionKey
+    )) as WritableStream<string>;
+
+    // The revived handle must still advertise the owner's key, or hop 2 has
+    // nothing to forward.
+    expect((inChildWorkflow as any)[STREAM_SERVER_PUBLIC_KEY_SYMBOL]).toBe(
+      ownerPublicKey
+    );
+
+    // Hop 2: the child workflow passes it to the step that writes. The
+    // descriptor the step receives is what decides sealed vs symmetric.
+    const toStep = (await dehydrateStepArguments(
+      inChildWorkflow,
+      'wrun_child',
+      noEncryptionKey
+    )) as any;
+
+    // The step payload is devalue-encoded bytes, so decode before matching —
+    // JSON-stringifying the Uint8Array would just yield a map of byte indices.
+    const wire = new TextDecoder().decode(toStep as Uint8Array);
+    expect(wire).toContain('encryptionPublicKey');
+    expect(wire).toContain(ownerPublicKey);
+  });
+
   it('falls back to the symmetric path when the descriptor has no public key', async () => {
     // Descriptors written by older SDKs carry no key; those must keep working.
     const { getWorldLazy } = await import('./runtime/get-world-lazy.js');

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -6,7 +6,8 @@ import {
 import { envNumber } from '@workflow/world';
 import { parse, stringify, unflatten } from 'devalue';
 import { monotonicFactory } from 'ulid';
-import { type CryptoKey, importKey } from './encryption.js';
+import { decodeRunPublicKey } from './sealed-box.js';
+import { importKey } from './encryption.js';
 import {
   createFlushableState,
   flushablePipe,
@@ -89,6 +90,7 @@ import {
   STREAM_FRAMING_SYMBOL,
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+  STREAM_SERVER_PUBLIC_KEY_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
   STREAM_TYPE_SYMBOL,
   WEBHOOK_RESPONSE_WRITABLE,
@@ -1865,6 +1867,12 @@ export function getExternalReducers(
           name: existingName,
           runId: existingRunId,
         };
+        const existingPublicKey = (value as any)[
+          STREAM_SERVER_PUBLIC_KEY_SYMBOL
+        ];
+        if (typeof existingPublicKey === 'string') {
+          descriptor.encryptionPublicKey = existingPublicKey;
+        }
         const existingDeploymentId = (value as any)[
           STREAM_SERVER_DEPLOYMENT_ID_SYMBOL
         ];
@@ -1971,6 +1979,10 @@ export function getWorkflowReducers(
       const foreignDeploymentId = value[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL];
       if (typeof foreignDeploymentId === 'string') {
         s.deploymentId = foreignDeploymentId;
+      }
+      const foreignPublicKey = value[STREAM_SERVER_PUBLIC_KEY_SYMBOL];
+      if (typeof foreignPublicKey === 'string') {
+        s.encryptionPublicKey = foreignPublicKey;
       }
       return s;
     },
@@ -2121,6 +2133,10 @@ function getStepReducers(
 
       const s: SerializableSpecial['WritableStream'] = { name };
       if (typeof foreignRunId === 'string') s.runId = foreignRunId;
+      const foreignPublicKey = (value as any)[STREAM_SERVER_PUBLIC_KEY_SYMBOL];
+      if (typeof foreignPublicKey === 'string') {
+        s.encryptionPublicKey = foreignPublicKey;
+      }
       const foreignDeploymentId = (value as any)[
         STREAM_SERVER_DEPLOYMENT_ID_SYMBOL
       ];
@@ -2479,14 +2495,31 @@ export function getCommonRevivers(global: Record<string, any> = globalThis) {
 }
 
 /**
- * Resolve the encrypt-only key needed when a child writes into another run's
- * stream. New descriptors include the owner's deployment ID; descriptors
- * created by older SDK versions fall back to loading the owning run.
+ * Resolve the write-only key a run needs when writing into another run's
+ * forwarded stream.
+ *
+ * Three tiers, cheapest first:
+ *
+ * 1. The descriptor carries the owner's X25519 public key — seal to it with
+ *    no I/O whatsoever. The owner published the key when it created the
+ *    stream, so this is the zero-round-trip path.
+ * 2. The descriptor carries the owner's deployment ID — resolve the owner's
+ *    symmetric key, which cross-deployment means a key-API round trip.
+ * 3. Neither (descriptors written by older SDKs) — load the owning run first,
+ *    then resolve its symmetric key.
+ *
+ * Tiers 2 and 3 import the key encrypt-only, which is an honor-system
+ * restriction: the same bytes could decrypt. Tier 1 makes it a cryptographic
+ * guarantee — a public key cannot read anything.
  */
 async function getForwardedWritableEncryptionKey(
   runId: string,
-  deploymentId: string | undefined
-): Promise<CryptoKey | undefined> {
+  deploymentId: string | undefined,
+  encryptionPublicKey: string | undefined
+): Promise<PayloadKey | undefined> {
+  const ownerPublicKey = decodeRunPublicKey(encryptionPublicKey);
+  if (ownerPublicKey) return sealTo(ownerPublicKey);
+
   const world = await getWorldLazy();
   if (!world.getEncryptionKeyForRun) return undefined;
 
@@ -2639,7 +2672,11 @@ export function getExternalRevivers(
       const targetKey: EncryptionKeyParam =
         targetRunId === runId
           ? cryptoKey
-          : getForwardedWritableEncryptionKey(targetRunId, value.deploymentId);
+          : getForwardedWritableEncryptionKey(
+              targetRunId,
+              value.deploymentId,
+              value.encryptionPublicKey
+            );
 
       const serialize = getSerializeStream(
         getExternalReducers(global, ops, targetRunId, targetKey),
@@ -3042,7 +3079,11 @@ function getStepRevivers(
       const targetKey: EncryptionKeyParam =
         targetRunId === runId
           ? cryptoKey
-          : getForwardedWritableEncryptionKey(targetRunId, targetDeploymentId);
+          : getForwardedWritableEncryptionKey(
+              targetRunId,
+              targetDeploymentId,
+              value.encryptionPublicKey
+            );
 
       const serialize = getSerializeStream(
         getStepReducers(global, ops, targetRunId, targetKey),

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -2717,6 +2717,18 @@ export function getExternalRevivers(
           }
         );
       }
+      // Keep the owner's public key on the handle so a further forward stays on
+      // the zero-lookup sealed path.
+      if (typeof value.encryptionPublicKey === 'string') {
+        Object.defineProperty(
+          serialize.writable,
+          STREAM_SERVER_PUBLIC_KEY_SYMBOL,
+          {
+            value: value.encryptionPublicKey,
+            writable: false,
+          }
+        );
+      }
 
       return serialize.writable;
     },
@@ -2829,6 +2841,16 @@ export function getWorkflowRevivers(
       if (typeof value.deploymentId === 'string') {
         descriptor[STREAM_SERVER_DEPLOYMENT_ID_SYMBOL] = {
           value: value.deploymentId,
+          writable: false,
+        };
+      }
+      // Preserve the owner's public key for the same reason as the runId
+      // above. Without it, forwarding a writable through a workflow to a step
+      // silently drops the key, and the step falls back to fetching the
+      // owner's symmetric key — the round trip sealing exists to remove.
+      if (typeof value.encryptionPublicKey === 'string') {
+        descriptor[STREAM_SERVER_PUBLIC_KEY_SYMBOL] = {
+          value: value.encryptionPublicKey,
           writable: false,
         };
       }
@@ -3126,6 +3148,18 @@ function getStepRevivers(
           STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
           {
             value: targetDeploymentId,
+            writable: false,
+          }
+        );
+      }
+      // Keep the owner's public key on the handle so a further forward stays on
+      // the zero-lookup sealed path.
+      if (typeof value.encryptionPublicKey === 'string') {
+        Object.defineProperty(
+          serialize.writable,
+          STREAM_SERVER_PUBLIC_KEY_SYMBOL,
+          {
+            value: value.encryptionPublicKey,
             writable: false,
           }
         );

--- a/packages/core/src/serialization/types.ts
+++ b/packages/core/src/serialization/types.ts
@@ -215,6 +215,16 @@ export interface SerializableSpecial {
      * the parent's key without fetching the parent run first.
      */
     deploymentId?: string;
+    /**
+     * The owning run's X25519 public key (base64), when it has one.
+     *
+     * Lets the receiving run seal frames to the stream's owner with no
+     * lookup at all — neither a run fetch nor a key-API round trip. The
+     * owner derives this locally when it creates the stream, so including
+     * it here is free. Absent for runs created by older SDKs, in which
+     * case the receiver falls back to resolving the owner's symmetric key.
+     */
+    encryptionPublicKey?: string;
   };
   AbortController: {
     streamName: string;

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -4,14 +4,17 @@ import {
   flushablePipe,
   pollWritableLock,
 } from '../flushable-stream.js';
+import { bytesToBase64 } from '../sealed-box.js';
 import {
   getExternalReducers,
   getSerializeStream,
+  isRunPayloadKeys,
   WorkflowServerWritableStream,
 } from '../serialization.js';
 import {
   STREAM_NAME_SYMBOL,
   STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
+  STREAM_SERVER_PUBLIC_KEY_SYMBOL,
   STREAM_SERVER_RUN_ID_SYMBOL,
 } from '../symbols.js';
 import { getWorkflowRunStreamId } from '../util.js';
@@ -138,6 +141,16 @@ export function getWritable<W = any>(
         writable: false,
       }
     );
+  }
+  // Publish this run's X25519 public key on the handle so that a run this
+  // writable is forwarded to can seal frames without looking anything up.
+  // The key is already resolved on the step context, so this costs nothing
+  // here and saves the receiver a round trip.
+  if (isRunPayloadKeys(ctx.encryptionKey)) {
+    Object.defineProperty(serialize.writable, STREAM_SERVER_PUBLIC_KEY_SYMBOL, {
+      value: bytesToBase64(ctx.encryptionKey.keyPair.publicKey),
+      writable: false,
+    });
   }
 
   cache.set(name, { writable: serialize.writable, state });

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -35,6 +35,21 @@ export const STREAM_SERVER_DEPLOYMENT_ID_SYMBOL = Symbol.for(
   'WORKFLOW_STREAM_SERVER_DEPLOYMENT_ID'
 );
 /**
+ * Stamped alongside `STREAM_SERVER_RUN_ID_SYMBOL` with the owning run's
+ * X25519 public key (base64), when the run has one.
+ *
+ * This is what lets a forwarded writable be written to across a deployment
+ * boundary at zero cost. The owning run derives its own public key locally
+ * when it creates the stream, so the key travels inside the serialized
+ * descriptor; a child on another deployment can then seal frames immediately.
+ * Without it the child would have to either fetch the owning run or fetch its
+ * symmetric key from the API — the round trip this whole mechanism exists to
+ * avoid.
+ */
+export const STREAM_SERVER_PUBLIC_KEY_SYMBOL = Symbol.for(
+  'WORKFLOW_STREAM_SERVER_PUBLIC_KEY'
+);
+/**
  * Stamped on a `WorkflowServerWritableStream` instance to expose its
  * durability barrier: `() => Promise<void>` that resolves once every accepted
  * chunk has durably reached the server (nothing buffered, nothing in flight)


### PR DESCRIPTION
**PR 6 of 7.** Stacked on #3097; review the stack in order, starting from #3093.

- #3093 — the `encp` sealed-box primitive
- #3094 — route sealed envelopes through the serialization layer
- #3095 — publish each run's public key on the run entity
- #3096 — `resumeHook()` seals instead of fetching the key ← the payoff
- #3097 — decrypt sealed payloads in observability tooling
- **#3098 (this PR)** — seal forwarded stream writes
- #3099 — `start()` gets the key from the probe it already awaits

## The remaining hole

When a parent forwards a `WritableStream` into a child run (via `start()`), the child writes to the *parent's* server stream and so must encrypt with the *parent's* key. The descriptor carried `{ name, runId, deploymentId }` — enough to resolve the parent's **symmetric** key, which cross-deployment means exactly the ~350ms `run-key` round trip the rest of this stack removes.

So forwarded streams would have remained on the slow path even after #3096.

## Fix

Carry the parent's public key in the descriptor. The parent owns the stream and already has its key material resolved on the step context when it creates the handle, so deriving and stamping the public key there costs nothing — and the child can seal immediately, with no lookup of any kind.

Resolution is now three tiers, cheapest first:

1. descriptor has the owner's public key → **seal, zero I/O**
2. descriptor has the owner's deployment → resolve symmetric key (API round trip)
3. neither (descriptors from older SDKs) → load the owning run, then resolve its key

Tiers 2 and 3 import the key encrypt-only, which is an honor-system restriction — the same bytes could decrypt. Tier 1 makes it a real guarantee: a public key cannot read anything.

## ⚠️ Nonce discipline — why each frame gets its own key

An earlier sketch of this design amortized **one KEM across a whole stream** and used **counter nonces** for frames. That is unsafe here, and it's worth being explicit about why:

- A stream reconnect or a durable replay restarts the writer.
- With a per-stream content key, the counter restarts at zero **under a still-live key**.
- `(key, nonce)` repeats → under AES-GCM that leaks the plaintext XOR of the two frames *and* the GCM auth subkey, which permits frame forgery by anyone with read access to the event log.
- Nothing would raise an error; it would be a silent confidentiality and integrity failure.

This implementation seals **each frame independently**, so no content key outlives a single frame and the hazard cannot arise by construction. The cost is one ECDH and 32 bytes per frame. `encapsulate`/`decapsulate` remain in the API if profiling later justifies amortizing, but doing so would require connection-scoped nonce rules to stay safe.

A regression test asserts 20 frames of identical plaintext produce 20 distinct ephemeral keys and 20 distinct ciphertexts.

## Tests

Three new cases: sealed forwarding with **both lookups asserted absent** (plus decoding the actual bytes written to the server and opening them with the owner's keypair), the legacy no-public-key fallback, and the per-frame key isolation above.

Core suite 1601 passing; workspace typecheck clean; zero new lint diagnostics.

