### PR TITLE
feat: return the run public key from the capability probe

### DIFF
--- a/.changeset/encp-start-probe-key.md
+++ b/.changeset/encp-start-probe-key.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': minor
+'@workflow/world': minor
+---
+
+The cross-deployment capability probe now returns the target run's public key, letting `start()` seal workflow arguments without a separate key-lookup request.

--- a/.changeset/encp-start-probe-key.md
+++ b/.changeset/encp-start-probe-key.md
@@ -1,6 +1,7 @@
 ---
 '@workflow/core': minor
 '@workflow/world': minor
+'@workflow/world-vercel': minor
 ---
 
 The cross-deployment capability probe now returns the target run's public key, letting `start()` seal workflow arguments without a separate key-lookup request.

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -2,7 +2,7 @@ import { PreconditionFailedError, WorkflowWorldError } from '@workflow/errors';
 import type { Event, World } from '@workflow/world';
 import { ulid } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { deriveRunKeyPair, seal } from '../sealed-box.js';
+import { bytesToBase64, deriveRunKeyPair, seal } from '../sealed-box.js';
 import {
   decrypt,
   encodeWithFormatPrefix,
@@ -12,6 +12,7 @@ import {
 } from '../serialization.js';
 import {
   getWorkflowQueueName,
+  handleHealthCheckMessage,
   healthCheck,
   latestEventStateUpdatedAt,
   loadWorkflowRunEvents,
@@ -708,5 +709,97 @@ describe('memoizeEncryptionKey', () => {
   it('resolves undefined when encryption is not configured', async () => {
     const getKey = memoizeEncryptionKey(worldWithKey(undefined), 'wrun_1');
     await expect(getKey()).resolves.toBeUndefined();
+  });
+});
+
+describe('health check run public key', () => {
+  const MATERIAL = new Uint8Array(32).fill(0x5e);
+
+  /** Capture what the responder writes to the probe response stream. */
+  function responderWorld(getEncryptionKeyForRun?: unknown) {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const world = {
+      streams: { write, close: vi.fn().mockResolvedValue(undefined) },
+      getEncryptionKeyForRun,
+    } as unknown as World;
+    return { world, write };
+  }
+
+  function writtenResponse(write: ReturnType<typeof vi.fn>) {
+    return JSON.parse(write.mock.calls[0][2] as string);
+  }
+
+  it('returns the run public key when the probe names a run', async () => {
+    // The responder executes inside the target deployment, so it can derive
+    // the key locally — that is what lets a cross-deployment start() skip the
+    // key-lookup API request entirely.
+    const { getWorldLazy } = await import('./get-world-lazy.js');
+    const { world, write } = responderWorld(
+      vi.fn().mockResolvedValue(MATERIAL)
+    );
+    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+
+    await handleHealthCheckMessage(
+      { __healthCheck: true, correlationId: 'corr_1', runId: 'wrun_1' },
+      'workflow'
+    );
+
+    const { publicKey } = await deriveRunKeyPair(MATERIAL);
+    expect(writtenResponse(write).encryptionPublicKey).toBe(
+      bytesToBase64(publicKey)
+    );
+  });
+
+  it('omits the key when the probe names no run', async () => {
+    // Probes issued by the CLI health command or the dashboard carry no
+    // runId; they must not trigger key derivation at all.
+    const { getWorldLazy } = await import('./get-world-lazy.js');
+    const getEncryptionKeyForRun = vi.fn().mockResolvedValue(MATERIAL);
+    const { world, write } = responderWorld(getEncryptionKeyForRun);
+    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+
+    await handleHealthCheckMessage(
+      { __healthCheck: true, correlationId: 'corr_2' },
+      'workflow'
+    );
+
+    expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+    expect(writtenResponse(write).encryptionPublicKey).toBeUndefined();
+    expect(writtenResponse(write).healthy).toBe(true);
+  });
+
+  it('omits the key when encryption is not configured', async () => {
+    const { getWorldLazy } = await import('./get-world-lazy.js');
+    const { world, write } = responderWorld(undefined);
+    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+
+    await handleHealthCheckMessage(
+      { __healthCheck: true, correlationId: 'corr_3', runId: 'wrun_1' },
+      'workflow'
+    );
+
+    expect(writtenResponse(write).encryptionPublicKey).toBeUndefined();
+    expect(writtenResponse(write).healthy).toBe(true);
+  });
+
+  it('still reports healthy when key derivation fails', async () => {
+    // The probe doubles as plain capability detection, so a key problem must
+    // degrade to "no key" (caller falls back to a lookup) rather than fail
+    // the health check and lose the capability information too.
+    const { getWorldLazy } = await import('./get-world-lazy.js');
+    const { world, write } = responderWorld(
+      vi.fn().mockRejectedValue(new Error('key service down'))
+    );
+    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+
+    await handleHealthCheckMessage(
+      { __healthCheck: true, correlationId: 'corr_4', runId: 'wrun_1' },
+      'workflow'
+    );
+
+    const response = writtenResponse(write);
+    expect(response.healthy).toBe(true);
+    expect(response.encryptionPublicKey).toBeUndefined();
+    expect(response.workflowCoreVersion).toBeDefined();
   });
 });

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -20,6 +20,7 @@ import {
 } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 import { runtimeLogger } from '../logger.js';
+import { bytesToBase64, deriveRunKeyPair } from '../sealed-box.js';
 import {
   deriveRunPayloadKeys,
   type PayloadKey,
@@ -88,6 +89,15 @@ export interface HealthCheckResult {
    * or a non-JSON plain-text health response.
    */
   workflowCoreVersion?: string;
+  /**
+   * The target run's X25519 public key (base64), returned only when the probe
+   * carried a `runId` and the responding deployment has encryption enabled.
+   *
+   * Lets a cross-deployment `start()` seal the workflow arguments using a
+   * response it was already waiting on, instead of making a separate
+   * key-lookup request.
+   */
+  encryptionPublicKey?: string;
 }
 
 /**
@@ -126,11 +136,43 @@ export async function handleHealthCheckMessage(
 ): Promise<void> {
   const world = await getWorldLazy();
   const streamName = getHealthCheckStreamName(healthCheck.correlationId);
+
+  // When the probe names a run the caller is about to create, publish that
+  // run's public key. We are executing inside the target deployment, so its
+  // key material is available locally (no API call), and the caller can then
+  // seal the workflow arguments straight from this response rather than
+  // making a separate key-lookup request.
+  //
+  // Only a *public* key may travel this way: the probe response stream is
+  // deliberately unauthenticated, so anything secret would be exposed.
+  // Best-effort — a failure here must not fail the health check itself, which
+  // callers also rely on for plain capability detection.
+  let encryptionPublicKey: string | undefined;
+  if (healthCheck.runId) {
+    try {
+      const rawKey = await world.getEncryptionKeyForRun?.(healthCheck.runId);
+      if (rawKey) {
+        encryptionPublicKey = bytesToBase64(
+          (await deriveRunKeyPair(rawKey)).publicKey
+        );
+      }
+    } catch (err) {
+      runtimeLogger.warn(
+        'Health check could not derive a run public key; the caller will fall back to a key lookup',
+        {
+          correlationId: healthCheck.correlationId,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      );
+    }
+  }
+
   const response = JSON.stringify({
     healthy: true,
     correlationId: healthCheck.correlationId,
     specVersion: worldSpecVersion ?? SPEC_VERSION_CURRENT,
     workflowCoreVersion,
+    ...(encryptionPublicKey ? { encryptionPublicKey } : {}),
     timestamp: Date.now(),
   });
   // Use a deterministic fake runId derived from the correlationId so that
@@ -145,6 +187,13 @@ export interface HealthCheckOptions {
   timeout?: number;
   /** Deployment ID to send the health check to. Falls back to process.env.VERCEL_DEPLOYMENT_ID. */
   deploymentId?: string;
+  /**
+   * The run id the caller is about to create. When set, the responding
+   * deployment derives that run's public key locally and returns it as
+   * `encryptionPublicKey`, letting a cross-deployment `start()` seal the
+   * workflow arguments without a separate key lookup.
+   */
+  runId?: string;
   /**
    * Queue namespace of the target deployment (e.g. `'eve'` for topics like
    * `__eve_wkf_workflow_*`). Falls back to `WORKFLOW_QUEUE_NAMESPACE` in the
@@ -234,6 +283,7 @@ function parseHealthCheckResponse(chunks: Uint8Array[]): {
   healthy: boolean;
   specVersion?: number;
   workflowCoreVersion?: string;
+  encryptionPublicKey?: string;
 } | null {
   if (chunks.length === 0) return null;
 
@@ -273,6 +323,7 @@ function parseHealthCheckResponse(chunks: Uint8Array[]): {
     healthy: boolean;
     specVersion?: number;
     workflowCoreVersion?: string;
+    encryptionPublicKey?: string;
   } = {
     healthy: r.healthy as boolean,
   };
@@ -281,6 +332,9 @@ function parseHealthCheckResponse(chunks: Uint8Array[]): {
   }
   if (typeof r.workflowCoreVersion === 'string') {
     parsed.workflowCoreVersion = r.workflowCoreVersion;
+  }
+  if (typeof r.encryptionPublicKey === 'string') {
+    parsed.encryptionPublicKey = r.encryptionPublicKey;
   }
   return parsed;
 }
@@ -309,7 +363,11 @@ export async function healthCheck(
   try {
     await world.queue(
       queueName,
-      { __healthCheck: true, correlationId },
+      {
+        __healthCheck: true,
+        correlationId,
+        ...(options?.runId ? { runId: options.runId } : {}),
+      },
       {
         // Use JSON transport so the health check works against both
         // old (JSON-only) and new (dual) deployments.

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -14,6 +14,7 @@ import {
   it,
   vi,
 } from 'vitest';
+import { importKey } from '../encryption.js';
 import { runtimeLogger } from '../logger.js';
 import {
   base64ToBytes,
@@ -22,6 +23,12 @@ import {
   open,
   seal,
 } from '../sealed-box.js';
+import {
+  hydrateWorkflowArguments,
+  peekFormatPrefix,
+  runPayloadKeys,
+  SerializationFormat,
+} from '../serialization.js';
 import type { Run } from './run.js';
 import type { WorkflowFunction } from './start.js';
 import { _resetLatestNoOpWarnForTests, start } from './start.js';
@@ -1227,6 +1234,127 @@ describe('start', () => {
         expect.anything(),
         expect.objectContaining({ deploymentId: 'dpl_other' })
       );
+    });
+
+    describe('run public key from the capability probe', () => {
+      const MATERIAL = new Uint8Array(32).fill(0x8c);
+
+      /** A world whose probe responds with the given extra fields. */
+      function worldWithProbe(
+        extra: Record<string, unknown>,
+        getEncryptionKeyForRun?: ReturnType<typeof vi.fn>
+      ) {
+        const response = JSON.stringify({
+          healthy: true,
+          endpoint: 'workflow',
+          specVersion: SPEC_VERSION_CURRENT,
+          workflowCoreVersion: '0.0.0-test',
+          ...extra,
+        });
+        setWorld({
+          specVersion: SPEC_VERSION_CURRENT,
+          getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+          events: { create: mockEventsCreate },
+          queue: mockQueue,
+          getEncryptionKeyForRun,
+          streams: {
+            get: vi.fn(
+              async () =>
+                new ReadableStream<Uint8Array>({
+                  start(controller) {
+                    controller.enqueue(new TextEncoder().encode(response));
+                    controller.close();
+                  },
+                })
+            ),
+          },
+        });
+      }
+
+      it('asks the probe for the run it is about to create', async () => {
+        // The runId has to be minted before the probe for this to work, so
+        // this also guards the ordering.
+        worldWithProbe({});
+
+        await start(validWorkflow, [], { deploymentId: 'dpl_other' });
+
+        const probeCall = mockQueue.mock.calls.find((c) =>
+          String(c[0]).endsWith('health_check')
+        );
+        expect(probeCall?.[1]).toMatchObject({
+          __healthCheck: true,
+          runId: expect.stringMatching(/^wrun_/),
+        });
+        // ...and it is the same run that actually gets created.
+        expect(probeCall?.[1].runId).toBe(mockEventsCreate.mock.calls[0][0]);
+      });
+
+      it('seals the arguments with the probed key and skips the key lookup', async () => {
+        const { publicKey } = await deriveRunKeyPair(MATERIAL);
+        const getEncryptionKeyForRun = vi.fn().mockResolvedValue(MATERIAL);
+        worldWithProbe(
+          { encryptionPublicKey: bytesToBase64(publicKey) },
+          getEncryptionKeyForRun
+        );
+
+        await start(validWorkflow, ['hello'], { deploymentId: 'dpl_other' });
+
+        // The whole point: no key-lookup request on this path.
+        expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+
+        const eventData = mockEventsCreate.mock.calls[0][1].eventData;
+        expect(peekFormatPrefix(eventData.input)).toBe(
+          SerializationFormat.SEALED
+        );
+        // The run still advertises the key so later cross-run writers can
+        // seal to it too.
+        expect(eventData.encryptionPublicKey).toBe(bytesToBase64(publicKey));
+      });
+
+      it('produces arguments the target deployment can actually open', async () => {
+        const keyPair = await deriveRunKeyPair(MATERIAL);
+        worldWithProbe({
+          encryptionPublicKey: bytesToBase64(keyPair.publicKey),
+        });
+
+        await start(validWorkflow, ['hello', 42], {
+          deploymentId: 'dpl_other',
+        });
+
+        const { input } = mockEventsCreate.mock.calls[0][1].eventData;
+        const keys = runPayloadKeys(await importKey(MATERIAL), keyPair);
+        await expect(
+          hydrateWorkflowArguments(input, 'wrun_x', keys)
+        ).resolves.toEqual(['hello', 42]);
+      });
+
+      it('falls back to the key lookup when the probe returns no key', async () => {
+        // Older target deployment, or a probe that timed out.
+        const getEncryptionKeyForRun = vi.fn().mockResolvedValue(MATERIAL);
+        worldWithProbe({}, getEncryptionKeyForRun);
+
+        await start(validWorkflow, [], { deploymentId: 'dpl_other' });
+
+        expect(getEncryptionKeyForRun).toHaveBeenCalled();
+        expect(
+          peekFormatPrefix(mockEventsCreate.mock.calls[0][1].eventData.input)
+        ).toBe(SerializationFormat.ENCRYPTED);
+      });
+
+      it('ignores a malformed probed key and falls back', async () => {
+        const getEncryptionKeyForRun = vi.fn().mockResolvedValue(MATERIAL);
+        worldWithProbe(
+          { encryptionPublicKey: 'not-a-valid-key' },
+          getEncryptionKeyForRun
+        );
+
+        await start(validWorkflow, [], { deploymentId: 'dpl_other' });
+
+        expect(getEncryptionKeyForRun).toHaveBeenCalled();
+        expect(
+          peekFormatPrefix(mockEventsCreate.mock.calls[0][1].eventData.input)
+        ).toBe(SerializationFormat.ENCRYPTED);
+      });
     });
   });
 });

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -17,9 +17,15 @@ import { isRetryableWorldError } from '../classify-error.js';
 import { importKey } from '../encryption.js';
 import { runtimeLogger } from '../logger.js';
 import type { Serializable } from '../schemas.js';
-import { bytesToBase64, deriveRunKeyPair } from '../sealed-box.js';
+import {
+  bytesToBase64,
+  decodeRunPublicKey,
+  deriveRunKeyPair,
+} from '../sealed-box.js';
 import {
   dehydrateWorkflowArguments,
+  type PayloadKey,
+  sealTo,
   SerializationFormat,
 } from '../serialization.js';
 import { contextStorage } from '../step/context-storage.js';
@@ -317,29 +323,6 @@ export async function start<TArgs extends unknown[], TResult>(
       //
       // Worlds that don't expose the `streams` API (e.g. minimal test
       // mocks) can't service health checks, so we skip the probe for them.
-      let framedByteStreams: boolean;
-      let targetSupportsCompression: boolean;
-      if (deploymentId === currentDeploymentId) {
-        framedByteStreams = true;
-        targetSupportsCompression = true;
-      } else if (typeof world.streams?.get !== 'function') {
-        framedByteStreams = false;
-        targetSupportsCompression = false;
-      } else {
-        const probe = await healthCheck(world, {
-          deploymentId,
-          timeout: CROSS_DEPLOYMENT_CAPABILITY_PROBE_TIMEOUT_MS,
-          namespace: opts.namespace,
-        }).catch(() => undefined);
-        const capabilities = getRunCapabilities(probe?.workflowCoreVersion);
-        framedByteStreams = capabilities.framedByteStreams;
-        targetSupportsCompression = capabilities.supportedFormats.has(
-          SerializationFormat.GZIP
-        );
-      }
-
-      const ops: Promise<void>[] = [];
-
       // Generate runId client-side so we have it before serialization
       // (required for future E2E encryption where runId is part of the
       // encryption context). When the World provides a `createRunId()`
@@ -352,6 +335,41 @@ export async function start<TArgs extends unknown[], TResult>(
           ? world.createRunId(opts as Readonly<Record<string, unknown>>)
           : ulid()
       }`;
+
+      let framedByteStreams: boolean;
+      let targetSupportsCompression: boolean;
+      // Public key of the target run, when the capability probe was able to
+      // supply one (cross-deployment only).
+      let probedRunPublicKey: string | undefined;
+      if (deploymentId === currentDeploymentId) {
+        framedByteStreams = true;
+        targetSupportsCompression = true;
+      } else if (typeof world.streams?.get !== 'function') {
+        framedByteStreams = false;
+        targetSupportsCompression = false;
+      } else {
+        // Ask for this run's public key while we're here. The probe already
+        // blocks `start()` on every cross-deployment call, and the responder
+        // executes inside the target deployment where the key material is
+        // local — so the key comes back for free on a response we are
+        // already awaiting, and we can skip the key-lookup API request
+        // entirely. Best-effort: on timeout or an older target, no key comes
+        // back and we fall through to the regular lookup below.
+        const probe = await healthCheck(world, {
+          deploymentId,
+          runId,
+          timeout: CROSS_DEPLOYMENT_CAPABILITY_PROBE_TIMEOUT_MS,
+          namespace: opts.namespace,
+        }).catch(() => undefined);
+        probedRunPublicKey = probe?.encryptionPublicKey;
+        const capabilities = getRunCapabilities(probe?.workflowCoreVersion);
+        framedByteStreams = capabilities.framedByteStreams;
+        targetSupportsCompression = capabilities.supportedFormats.has(
+          SerializationFormat.GZIP
+        );
+      }
+
+      const ops: Promise<void>[] = [];
 
       // Serialize current trace context to propagate across queue boundary
       const traceCarrier = await serializeTraceCarrier();
@@ -429,26 +447,45 @@ export async function start<TArgs extends unknown[], TResult>(
       // deploymentId (not just the raw opts) so the World can use it for
       // key resolution even when deploymentId was inferred from the environment
       // rather than explicitly provided in opts (e.g., in e2e test runners).
-      const rawKey = await world.getEncryptionKeyForRun?.(runId, {
-        ...opts,
-        deploymentId,
-      });
-      const encryptionKey = rawKey ? await importKey(rawKey) : undefined;
-
-      // Derive and publish the run's X25519 public key so that cross-run
-      // writers (a hook resumption from another deployment, a sibling writing
-      // into a forwarded stream) can seal payloads *to* this run without
-      // holding its symmetric key — and without paying a `run-key` API call.
+      // Resolve how to encrypt the workflow arguments.
       //
-      // Presence of this field is the writer-side gate for sealed envelopes,
-      // so it must only be stamped when this runtime could itself open one.
-      // That holds by construction here: derivation and `encp` dispatch live
-      // in the same package, so any core that can stamp can also open. Runs
-      // are pinned to their creating deployment, so the capability this
-      // attests to is still accurate at resume time.
-      const encryptionPublicKey = rawKey
-        ? bytesToBase64((await deriveRunKeyPair(rawKey)).publicKey)
-        : undefined;
+      // Preferred: the capability probe already told us this run's public
+      // key, so seal to it. That skips `getEncryptionKeyForRun`, which for a
+      // cross-deployment start is a `run-key` API request — the last one left
+      // on this path. It is also a privilege reduction: the caller ends up
+      // able to write the arguments but not read them back, whereas fetching
+      // the symmetric key grants full read access to a run it merely
+      // launched.
+      const probedPublicKey = decodeRunPublicKey(probedRunPublicKey);
+
+      let encryptionKey: PayloadKey | undefined;
+      let encryptionPublicKey: string | undefined;
+
+      if (probedPublicKey) {
+        encryptionKey = sealTo(probedPublicKey);
+        encryptionPublicKey = probedRunPublicKey;
+      } else {
+        const rawKey = await world.getEncryptionKeyForRun?.(runId, {
+          ...opts,
+          deploymentId,
+        });
+        encryptionKey = rawKey ? await importKey(rawKey) : undefined;
+
+        // Publish the run's X25519 public key so that cross-run writers (a
+        // hook resumption from another deployment, a sibling writing into a
+        // forwarded stream) can seal payloads *to* this run without holding
+        // its symmetric key.
+        //
+        // Presence of this field is the writer-side gate for sealed
+        // envelopes, so it must only be stamped when this runtime could
+        // itself open one. That holds by construction here: derivation and
+        // `encp` dispatch live in the same package, so any core that can
+        // stamp can also open. Runs are pinned to their creating deployment,
+        // so the capability this attests to is still accurate at resume time.
+        encryptionPublicKey = rawKey
+          ? bytesToBase64((await deriveRunKeyPair(rawKey)).publicKey)
+          : undefined;
+      }
 
       // Create run via run_created event (event-sourced architecture)
       // Pass client-generated runId - server will accept and use it

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -523,6 +523,32 @@ describe('createQueue', () => {
       );
     });
 
+    it('keeps a per-probe topic for a health check that carries a runId', async () => {
+      process.env.WORKFLOW_SEQUENTIAL_REPLAYS = '1';
+
+      const queue = createQueue();
+      // A probe issued to prepare a cross-deployment `start()` carries the run
+      // id it is about to create. It must still get its per-probe topic rather
+      // than being routed to that run's serialized replay topic, which would
+      // queue the probe behind the run it is trying to prepare.
+      await queue.queue('__wkf_workflow_health_check', {
+        __healthCheck: true as const,
+        correlationId: 'corr_123',
+        runId: 'wrun_abc',
+      });
+
+      expect(mockSend.mock.calls[0][0]).toBe(
+        '__wkf_workflow_health_check_corr_123'
+      );
+      // The payload must survive intact so the handler dispatches it as a
+      // health check rather than as a workflow invoke.
+      expect(mockSend.mock.calls[0][1].payload).toEqual({
+        __healthCheck: true,
+        correlationId: 'corr_123',
+        runId: 'wrun_abc',
+      });
+    });
+
     it('does not rewrite health check topics when the flag is unset', async () => {
       delete process.env.WORKFLOW_SEQUENTIAL_REPLAYS;
 

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -175,7 +175,12 @@ const FALLBACK_REGION = 'iad1';
 
 /**
  * Extract the workflow run ID from a queue payload, returning `undefined` for
- * payloads that don't carry one (e.g. health-check messages).
+ * payloads that don't carry one.
+ *
+ * Health-check payloads usually have no run ID, but a probe issued to prepare a
+ * cross-deployment `start()` carries the run id it is about to create. Reading
+ * it here is intentional: it routes the probe to the region the run will live
+ * in, matching the invoke that follows.
  */
 function getRunIdFromPayload(payload: QueuePayload): string | undefined {
   if ('runId' in payload && typeof payload.runId === 'string') {
@@ -312,6 +317,13 @@ function getPhysicalQueueName(
       '[workflow] WORKFLOW_SEQUENTIAL_REPLAYS=1: routing flow messages to per-run queue topics'
     );
   }
+  // Health checks are matched before the runId branch: a probe issued to
+  // prepare a cross-deployment `start()` carries the run id it is about to
+  // create, and must still get its per-probe topic rather than being routed to
+  // that run's serialized replay topic.
+  if ('__healthCheck' in payload && typeof payload.correlationId === 'string') {
+    return `${queueName}_${payload.correlationId}`;
+  }
   if ('runId' in payload && typeof payload.runId === 'string') {
     // Inline step execution: full parallelism via a per-step topic.
     if ('stepId' in payload && typeof payload.stepId === 'string') {
@@ -319,9 +331,6 @@ function getPhysicalQueueName(
     }
     // Orchestrator replay: serialize per run.
     return `${queueName}_${payload.runId}`;
-  }
-  if ('__healthCheck' in payload && typeof payload.correlationId === 'string') {
-    return `${queueName}_${payload.correlationId}`;
   }
   return queueName;
 }

--- a/packages/world/src/queue.test.ts
+++ b/packages/world/src/queue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getQueueTopicPrefix,
   parseQueueName,
+  QueuePayloadSchema,
   QueuePrefix,
   ValidQueueName,
 } from './queue.js';
@@ -121,5 +122,42 @@ describe('parseQueueName', () => {
       prefix: '__custom_wkf_workflow_',
       id: 'myFlow',
     });
+  });
+});
+
+describe('QueuePayloadSchema', () => {
+  // A probe issued to prepare a cross-deployment `start()` carries the run id
+  // it is about to create, which also makes it satisfy
+  // `WorkflowInvokePayloadSchema` (whose only required field is `runId`). Zod
+  // unions return the first matching member and strip keys that member doesn't
+  // declare, so if the invoke member were matched first the discriminator would
+  // be dropped and the runtime would reinterpret the probe as a run replay.
+  it('preserves the health-check discriminator on a probe that carries a runId', () => {
+    const parsed = QueuePayloadSchema.parse({
+      __healthCheck: true,
+      correlationId: 'corr_123',
+      runId: 'wrun_01ABC',
+    });
+
+    expect(parsed).toEqual({
+      __healthCheck: true,
+      correlationId: 'corr_123',
+      runId: 'wrun_01ABC',
+    });
+  });
+
+  it('preserves health-check payloads that carry no runId', () => {
+    expect(
+      QueuePayloadSchema.parse({
+        __healthCheck: true,
+        correlationId: 'corr_123',
+      })
+    ).toEqual({ __healthCheck: true, correlationId: 'corr_123' });
+  });
+
+  it('still resolves workflow invoke payloads', () => {
+    expect(
+      QueuePayloadSchema.parse({ runId: 'wrun_01ABC', stepId: 'step_1' })
+    ).toEqual({ runId: 'wrun_01ABC', stepId: 'step_1' });
   });
 });

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -146,6 +146,17 @@ export type HealthCheckPayload = z.infer<typeof HealthCheckPayloadSchema>;
 export const HealthCheckPayloadSchema = z.object({
   __healthCheck: z.literal(true),
   correlationId: z.string(),
+  /**
+   * The run id the caller is about to create, when the probe is being used to
+   * prepare a cross-deployment `start()`.
+   *
+   * The responder runs inside the target deployment, so it can derive that
+   * run's public key locally from its own key material and return it in the
+   * probe response. That lets the caller seal the workflow arguments without
+   * a separate key lookup. Absent for probes issued for other reasons (CLI
+   * health command, dashboard), in which case no key is returned.
+   */
+  runId: z.string().optional(),
 });
 
 export const QueuePayloadSchema = z.union([

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -159,9 +159,26 @@ export const HealthCheckPayloadSchema = z.object({
   runId: z.string().optional(),
 });
 
+/**
+ * Health check MUST come first.
+ *
+ * Zod unions return the first matching member's output, and `z.object` strips
+ * keys the matching member doesn't declare. `HealthCheckPayloadSchema` carries
+ * an optional `runId`, so a probe payload also satisfies
+ * `WorkflowInvokePayloadSchema` (whose only required field is `runId`). With
+ * the invoke member first, parsing a runId-bearing probe silently dropped
+ * `__healthCheck` and `correlationId`, and the runtime — which dispatches on
+ * `__healthCheck` before falling through to the invoke schema — reinterpreted
+ * the probe as "replay this run". That made the queue handler POST
+ * `run_started` for a run that doesn't exist yet (404), fail, and retry
+ * forever, so the probe never answered and `start()` timed out.
+ *
+ * Ordering health check first is safe in the other direction: it requires
+ * `__healthCheck: true`, which an invoke payload never carries.
+ */
 export const QueuePayloadSchema = z.union([
-  WorkflowInvokePayloadSchema,
   HealthCheckPayloadSchema,
+  WorkflowInvokePayloadSchema,
 ]);
 export type QueuePayload = z.infer<typeof QueuePayloadSchema>;
 


### PR DESCRIPTION
**PR 7 of 7.** Stacked on #3098; review the stack in order, starting from #3093.

- #3093 — the `encp` sealed-box primitive
- #3094 — route sealed envelopes through the serialization layer
- #3095 — publish each run's public key on the run entity
- #3096 — `resumeHook()` seals instead of fetching the key ← the payoff
- #3097 — decrypt sealed payloads in observability tooling
- #3098 — seal forwarded stream writes
- **#3099 (this PR)** — `start()` gets the key from the probe it already awaits

## The last lookup

After #3096 and #3098, cross-deployment `resumeHook()` and forwarded stream writes no longer hit the key API. Cross-deployment `start()` still did — the run doesn't exist yet, so there's no run entity to read a public key from.

But `start()` **already blocks on a capability probe** for every cross-deployment call, and the probe responder executes *inside the target deployment*, where the run's key material is local. So the public key can ride back on a response the caller is already awaiting.

## Why this beats keeping the request

- **The wait is already being paid.** Folding the key into the existing response removes the request outright rather than relocating it.
- **A public key is exactly what this channel can carry.** The probe response stream is deliberately unauthenticated — that would disqualify shipping the symmetric key over it, but a public key isn't secret. The constraint costs nothing.
- **It reduces privilege.** The caller ends up able to seal the workflow arguments but *not* read them back. Fetching the symmetric key granted full read access to a run it merely launched.

## Ordering change

`runId` is now minted **before** the probe instead of just after. `createRunId()` reads only `opts`, which is fully resolved at that point, so the move has no other dependency. A test asserts the id sent to the probe is the one actually created, so the ordering can't silently regress.

## Everything is best-effort

The probe is already failure-tolerant (2s timeout, errors swallowed) and is skipped entirely for same-deployment starts and for worlds without a streams API. When no key comes back — old target, timeout, encryption disabled, or a malformed value — `start()` falls back to the existing lookup plus symmetric encryption.

Key derivation failures inside the responder are caught and logged so the probe still reports health and capabilities, which callers rely on for reasons unrelated to encryption.

## ⚠️ Trust-model note for reviewers

This widens the recipient-substitution surface slightly. The key-lookup API is strongly authenticated and audit-logged; the probe response stream is not. An attacker able to write to that stream — which requires tenant-scoped stream write access — could substitute a public key and read arguments subsequently sealed to it.

That is the same class and roughly the same prerequisite as substituting the key on the run entity (which #3095 already introduces), but it is a **second instance** of it, and worth weighing explicitly if we later decide public-key attestation is warranted.

## Tests

Responder side: key returned when the probe names a run, omitted when it doesn't (with no derivation attempted), omitted when encryption is off, and health still reported when derivation throws.

Caller side: the probe is asked about the run that actually gets created, the arguments are sealed with the probed key and **no lookup happens**, the sealed arguments **actually open** with the keys the target re-derives, and both fallbacks (no key, malformed key) work.

Core suite 1610 passing; world 78; workspace typecheck clean; zero new lint diagnostics.

