### PR TITLE
perf(core): avoid resolving background coordination events

### DIFF
--- a/.changeset/lazy-background-event-scan.md
+++ b/.changeset/lazy-background-event-scan.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Avoid resolving event payloads while checking for pending background steps.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -855,18 +855,20 @@ export function workflowEntrypoint(
                         stepResult.type === 'failed' ||
                         stepResult.type === 'skipped'
                       ) {
-                        // Load events to check if all parallel steps are done.
-                        // Use cursor-based loading so the main loop can continue
-                        // incrementally from here.
-                        const loaded = await loadWorkflowRunEvents(runId);
-                        cachedEvents = loaded.events;
-                        eventsCursor = loaded.cursor;
+                        // This coordination check only needs event metadata.
+                        // Avoid resolving payload refs for handlers that will
+                        // return because another parallel step is still pending.
+                        const eventMetadata = await loadWorkflowRunEvents(
+                          runId,
+                          undefined,
+                          'none'
+                        );
 
                         // Check for pending steps: any step_created without
                         // a matching step_completed or step_failed.
                         const stepCreatedIds = new Set<string | undefined>();
                         const stepTerminalIds = new Set<string | undefined>();
-                        for (const e of cachedEvents) {
+                        for (const e of eventMetadata.events) {
                           if (e.eventType === 'step_created') {
                             stepCreatedIds.add(e.correlationId);
                           } else if (
@@ -895,7 +897,7 @@ export function workflowEntrypoint(
                           if (
                             isInlineOwnershipEnabled() &&
                             hasPendingStepOwnedByMessage(
-                              cachedEvents,
+                              eventMetadata.events,
                               pendingStepIds,
                               metadata.messageId
                             )
@@ -915,6 +917,12 @@ export function workflowEntrypoint(
                             return;
                           }
                         }
+
+                        // This invocation will continue into replay, which
+                        // requires resolved payloads and a reusable cursor.
+                        const loaded = await loadWorkflowRunEvents(runId);
+                        cachedEvents = loaded.events;
+                        eventsCursor = loaded.cursor;
 
                         // All steps done — fall through to the main replay loop.
                         // Set up shared state so the loop can continue.

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -6,6 +6,7 @@ import {
 import type {
   Event,
   HealthCheckPayload,
+  ResolveData,
   ValidQueueName,
   WorkflowRun,
   World,
@@ -460,10 +461,12 @@ function shouldRetryWithoutEventCursor(
  *   returned (incremental load). If omitted, all events are returned.
  *   The returned cursor can be passed back in on a subsequent call for
  *   incremental loading.
+ * @param resolveData - Whether event payloads should be resolved.
  */
 export async function loadWorkflowRunEvents(
   runId: string,
-  afterCursor?: string
+  afterCursor?: string,
+  resolveData?: ResolveData
 ): Promise<{ events: Event[]; cursor: string | null }> {
   const incremental = afterCursor !== undefined;
   return trace(
@@ -495,6 +498,7 @@ export async function loadWorkflowRunEvents(
         try {
           response = await world.events.list({
             runId,
+            ...(resolveData ? { resolveData } : {}),
             pagination: {
               sortOrder: 'asc',
               cursor: requestedCursor ?? undefined,


### PR DESCRIPTION
## Summary

- Load event metadata without resolving payloads when a background step checks whether parallel siblings are still pending.
- Preserve ownership metadata for owned-step recovery.
- Reload the fully resolved event log only for the invocation that continues into workflow replay.

## Why

Every completed background step currently loads and resolves the run event history before deciding whether another parallel step is still pending. Most handlers immediately return, so resolving inputs, outputs, and errors only adds Redis/S3 reads and response bytes.

`resolveData: none` strips only payload fields; the coordination check still receives `eventType`, `correlationId`, `ownerMessageId`, and retry metadata. The winning invocation retains the existing resolved load before it reads `run_created.input` or replays the workflow.

## Impact

This avoids payload hydration for non-winning background-step handlers without changing DynamoDB pagination, event ordering, ownership decisions, or replay behavior.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/core test` — 1,526 passed, 3 expected failures
- `pnpm exec biome check packages/core/src/runtime.ts packages/core/src/runtime/helpers.ts`