### PR TITLE
feat(world): add durable run-tree purge capability

### DIFF
--- a/.changeset/quiet-rabbits-purge-trees.md
+++ b/.changeset/quiet-rabbits-purge-trees.md
@@ -1,0 +1,7 @@
+---
+'@workflow/world': minor
+'@workflow/world-local': minor
+'@workflow/world-postgres': minor
+---
+
+Add an idempotent, lineage-scoped run-tree purge capability for framework-owned retention workflows using the local and PostgreSQL Worlds.

--- a/packages/world-local/README.md
+++ b/packages/world-local/README.md
@@ -15,3 +15,10 @@ const world = createWorld({
   dataDir: './custom-workflow-data',
 });
 ```
+
+## Run-tree purge
+
+The local World supports `purgeRunTree()`. It durably records a deletion
+manifest before removing terminal root and descendant runs, events, steps,
+hooks and indexes, waits, and stream data. The manifest fences later writes
+and allows an interrupted purge to finish after restart.

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -169,7 +169,13 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
             experimentalSetAttributes: (runId, changes, options) =>
               exclusiveMutation(async () => {
                 await ensurePurgeFencesLoaded();
-                assertRunWriteAllowed(runId);
+                const attributeSet: Record<string, string> = {};
+                for (const change of changes) {
+                  if (change.value !== null) {
+                    attributeSet[change.key] = change.value;
+                  }
+                }
+                assertRunWriteAllowed(runId, attributeSet);
                 return experimentalSetAttributes(runId, changes, options);
               }),
           }),

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -1,6 +1,10 @@
 import { promises as fs } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
+import {
+  EntityConflictError,
+  WorkflowRunNotFoundError,
+} from '@workflow/errors';
 import type { QueuePrefix, World } from '@workflow/world';
 import { reenqueueActiveRuns, SPEC_VERSION_CURRENT } from '@workflow/world';
 import type { Config } from './config.js';
@@ -13,12 +17,17 @@ import {
   listTaggedFiles,
   listTaggedFilesByExtension,
   readJSON,
+  taggedPath,
 } from './fs.js';
 import { initDataDir } from './init.js';
 import { instrumentObject } from './instrumentObject.js';
 import { createQueue, type DirectHandler } from './queue.js';
 import { hashToken, hookRecoveryMarkerPath } from './storage/helpers.js';
-import { resetHookIndexEnsureCache } from './storage/hook-index.js';
+import {
+  deleteHookByRunMarkerFile,
+  listHookByRunMarkers,
+  resetHookIndexEnsureCache,
+} from './storage/hook-index.js';
 import { createStorage } from './storage.js';
 import { createStreamer } from './streamer.js';
 
@@ -40,6 +49,29 @@ export type LocalWorld = World & {
   /** Clear all workflow data (runs, steps, events, hooks, streams). */
   clear(): Promise<void>;
 };
+
+interface PurgedTreeManifest {
+  rootRunId: string;
+  runIds: string[];
+  descendantAttribute?: { key: string; value: string };
+}
+
+function createExclusiveMutation() {
+  let tail = Promise.resolve();
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    const previous = tail;
+    let release = () => {};
+    tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  };
+}
 
 /**
  * Creates a local world instance that combines queue, storage, and streamer functionalities.
@@ -68,16 +100,355 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
     tag
   );
   const recoverActiveRuns = resolveRecoverActiveRuns(mergedConfig);
+  const streams = createStreamer(mergedConfig.dataDir, tag);
+  const exclusiveMutation = createExclusiveMutation();
+  const purgedRuns = new Set<string>();
+  const purgedTrees = new Map<string, PurgedTreeManifest>();
+  let purgeFencesLoaded = false;
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: validates durable manifests defensively
+  async function ensurePurgeFencesLoaded(): Promise<void> {
+    if (purgeFencesLoaded) return;
+    const dir = path.join(mergedConfig.dataDir, 'purged-trees');
+    const files = tag
+      ? await listTaggedFiles(dir, tag)
+      : (await fs.readdir(dir).catch(() => [] as string[])).filter(
+          (file) => file.endsWith('.json') && !file.slice(0, -5).includes('.')
+        );
+    for (const file of files) {
+      try {
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(dir, file), 'utf8')
+        ) as PurgedTreeManifest;
+        if (
+          typeof manifest.rootRunId !== 'string' ||
+          !Array.isArray(manifest.runIds)
+        ) {
+          continue;
+        }
+        purgedTrees.set(manifest.rootRunId, manifest);
+        for (const runId of manifest.runIds) purgedRuns.add(runId);
+      } catch {
+        // A partial/corrupt manifest cannot safely establish a deletion fence.
+      }
+    }
+    purgeFencesLoaded = true;
+  }
+
+  function assertRunWriteAllowed(
+    runId: string | null,
+    attributes?: Record<string, string>
+  ): void {
+    if (runId !== null && purgedRuns.has(runId)) {
+      throw new EntityConflictError(`Workflow run ${runId} was purged`);
+    }
+    if (attributes !== undefined) {
+      for (const manifest of purgedTrees.values()) {
+        const selector = manifest.descendantAttribute;
+        if (
+          selector !== undefined &&
+          attributes[selector.key] === selector.value
+        ) {
+          throw new EntityConflictError(
+            `Workflow run tree ${manifest.rootRunId} was purged`
+          );
+        }
+      }
+    }
+  }
+
+  const experimentalSetAttributes = storage.runs.experimentalSetAttributes;
+  const writeMulti = streams.streams.writeMulti;
+  const fencedStorage = {
+    ...storage,
+    runs: {
+      ...storage.runs,
+      ...(experimentalSetAttributes === undefined
+        ? {}
+        : {
+            experimentalSetAttributes: (runId, changes, options) =>
+              exclusiveMutation(async () => {
+                await ensurePurgeFencesLoaded();
+                assertRunWriteAllowed(runId);
+                return experimentalSetAttributes(runId, changes, options);
+              }),
+          }),
+    },
+    events: {
+      ...storage.events,
+      create: ((runId, data, params) =>
+        exclusiveMutation(async () => {
+          await ensurePurgeFencesLoaded();
+          const attributes =
+            data.eventType === 'run_created' || data.eventType === 'run_started'
+              ? data.eventData?.attributes
+              : undefined;
+          assertRunWriteAllowed(runId, attributes);
+          if (data.eventType === 'run_created') {
+            return storage.events.create(runId, data, params);
+          }
+          if (runId === null) {
+            throw new Error('runId is required for non-run_created events');
+          }
+          return storage.events.create(runId, data, params);
+        })) as typeof storage.events.create,
+    },
+  } satisfies typeof storage;
+  const fencedStreams = {
+    ...streams.streams,
+    write: (runId, name, chunk) =>
+      exclusiveMutation(async () => {
+        await ensurePurgeFencesLoaded();
+        assertRunWriteAllowed(await runId);
+        return streams.streams.write(runId, name, chunk);
+      }),
+    ...(writeMulti === undefined
+      ? {}
+      : {
+          writeMulti: (runId, name, chunks) =>
+            exclusiveMutation(async () => {
+              await ensurePurgeFencesLoaded();
+              assertRunWriteAllowed(await runId);
+              return writeMulti(runId, name, chunks);
+            }),
+        }),
+    close: (runId, name) =>
+      exclusiveMutation(async () => {
+        await ensurePurgeFencesLoaded();
+        assertRunWriteAllowed(await runId);
+        return streams.streams.close(runId, name);
+      }),
+  } satisfies typeof streams.streams;
   return {
     specVersion: SPEC_VERSION_CURRENT,
+    capabilities: { runTreePurge: true },
     ...queue,
-    ...storage,
+    ...fencedStorage,
     ...instrumentObject('world.streams', {
-      ...createStreamer(mergedConfig.dataDir, tag),
+      streams: fencedStreams,
       ...(mergedConfig.streamFlushIntervalMs !== undefined && {
         streamFlushIntervalMs: mergedConfig.streamFlushIntervalMs,
       }),
     }),
+    // Purge deliberately keeps discovery, terminal fencing, and removal in
+    // one method so no caller can invoke only a partial deletion phase.
+    async purgeRunTree(rootRunId, options) {
+      return exclusiveMutation(
+        // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: atomic retention boundary
+        async () => {
+          await ensurePurgeFencesLoaded();
+          const root = await storage.runs
+            .get(rootRunId, { resolveData: 'none' })
+            .catch((error: unknown) => {
+              if (WorkflowRunNotFoundError.is(error)) return null;
+              throw error;
+            });
+          if (root === null) {
+            const prior = purgedTrees.get(rootRunId);
+            if (prior !== undefined) {
+              await removeRunTreeEntities(prior.runIds);
+              return {
+                purgedRunCount: prior.runIds.length,
+                status: 'purged' as const,
+              };
+            }
+            return { purgedRunCount: 0, status: 'absent' as const };
+          }
+
+          const runIds = new Set([rootRunId]);
+          let cursor: string | undefined;
+          do {
+            const page = await storage.runs.list({
+              pagination: { cursor, limit: 1000 },
+              resolveData: 'none',
+            });
+            for (const run of page.data) {
+              const selector = options?.descendantAttribute;
+              if (
+                selector !== undefined &&
+                run.attributes[selector.key] === selector.value
+              ) {
+                runIds.add(run.runId);
+              }
+            }
+            cursor = page.hasMore ? (page.cursor ?? undefined) : undefined;
+          } while (cursor !== undefined);
+
+          for (const runId of runIds) {
+            const run = await storage.runs.get(runId, { resolveData: 'none' });
+            if (run.status === 'pending' || run.status === 'running') {
+              throw new EntityConflictError(
+                `Workflow run tree ${rootRunId} is still active`
+              );
+            }
+          }
+
+          const manifest: PurgedTreeManifest = {
+            rootRunId,
+            runIds: [...runIds],
+            ...(options?.descendantAttribute === undefined
+              ? {}
+              : { descendantAttribute: options.descendantAttribute }),
+          };
+          const manifestPath = taggedPath(
+            mergedConfig.dataDir,
+            'purged-trees',
+            rootRunId,
+            tag
+          );
+          await fs.mkdir(path.dirname(manifestPath), { recursive: true });
+          await fs.writeFile(`${manifestPath}.tmp`, JSON.stringify(manifest));
+          await fs.rename(`${manifestPath}.tmp`, manifestPath);
+          purgedTrees.set(rootRunId, manifest);
+          for (const runId of runIds) purgedRuns.add(runId);
+          await removeRunTreeEntities([...runIds]);
+          return { purgedRunCount: runIds.size, status: 'purged' as const };
+
+          // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: exhaustively removes all backend entities
+          async function removeRunTreeEntities(ids: string[]): Promise<void> {
+            for (const runId of ids) {
+              const hooks = [];
+              let hookCursor: string | undefined;
+              do {
+                const page = await storage.hooks.list({
+                  pagination: { cursor: hookCursor, limit: 1000 },
+                  resolveData: 'all',
+                  runId,
+                });
+                hooks.push(...page.data);
+                hookCursor = page.hasMore
+                  ? (page.cursor ?? undefined)
+                  : undefined;
+              } while (hookCursor !== undefined);
+              const events = [];
+              let eventCursor: string | undefined;
+              do {
+                const page = await storage.events.list({
+                  pagination: { cursor: eventCursor, limit: 1000 },
+                  resolveData: 'none',
+                  runId,
+                });
+                events.push(...page.data);
+                eventCursor = page.hasMore
+                  ? (page.cursor ?? undefined)
+                  : undefined;
+              } while (eventCursor !== undefined);
+              const steps = [];
+              let stepCursor: string | undefined;
+              do {
+                const page = await storage.steps.list({
+                  pagination: { cursor: stepCursor, limit: 1000 },
+                  resolveData: 'none',
+                  runId,
+                });
+                steps.push(...page.data);
+                stepCursor = page.hasMore
+                  ? (page.cursor ?? undefined)
+                  : undefined;
+              } while (stepCursor !== undefined);
+              const streamNames = await streams.streams.list(runId);
+              const byRunMarkers = await listHookByRunMarkers(
+                mergedConfig.dataDir,
+                runId
+              );
+              const hookCreatedEvents = events.filter(
+                (event) => event.eventType === 'hook_created'
+              );
+
+              const waitsDir = path.join(mergedConfig.dataDir, 'waits');
+              const waitFiles = (
+                await fs.readdir(waitsDir).catch(() => [] as string[])
+              )
+                .filter(
+                  (file) =>
+                    file.startsWith(`${runId}-`) && file.endsWith('.json')
+                )
+                .map((file) => path.join(waitsDir, file));
+
+              await Promise.all([
+                ...hooks.flatMap((hook) => [
+                  deleteJSON(
+                    taggedPath(mergedConfig.dataDir, 'hooks', hook.hookId, tag)
+                  ),
+                  deleteJSON(
+                    path.join(
+                      mergedConfig.dataDir,
+                      'hooks',
+                      'tokens',
+                      `${hashToken(hook.token)}.json`
+                    )
+                  ),
+                  deleteJSON(
+                    hookRecoveryMarkerPath(
+                      mergedConfig.dataDir,
+                      hook.token,
+                      runId,
+                      hook.hookId
+                    )
+                  ),
+                  ...hookCreatedEvents
+                    .filter((event) => event.correlationId === hook.hookId)
+                    .flatMap((event) => [
+                      deleteJSON(
+                        taggedPath(
+                          mergedConfig.dataDir,
+                          `hooks/token-index/${hashToken(hook.token)}`,
+                          event.eventId,
+                          tag
+                        )
+                      ),
+                      deleteJSON(
+                        taggedPath(
+                          mergedConfig.dataDir,
+                          `hooks/id-index/${hook.hookId}`,
+                          event.eventId,
+                          tag
+                        )
+                      ),
+                    ]),
+                ]),
+                ...byRunMarkers.map((marker) =>
+                  deleteHookByRunMarkerFile(mergedConfig.dataDir, marker.fileId)
+                ),
+                ...waitFiles.map((file) => deleteJSON(file)),
+                ...events.map((event) =>
+                  deleteJSON(
+                    taggedPath(
+                      mergedConfig.dataDir,
+                      'events',
+                      `${runId}-${event.eventId}`,
+                      tag
+                    )
+                  )
+                ),
+                ...steps.map((step) =>
+                  deleteJSON(
+                    taggedPath(mergedConfig.dataDir, 'steps', step.stepId, tag)
+                  )
+                ),
+                ...streamNames.map((name) =>
+                  rm(
+                    path.join(mergedConfig.dataDir, 'streams', 'chunks', name),
+                    {
+                      force: true,
+                      recursive: true,
+                    }
+                  )
+                ),
+                deleteJSON(
+                  taggedPath(mergedConfig.dataDir, 'streams/runs', runId, tag)
+                ),
+                deleteJSON(
+                  taggedPath(mergedConfig.dataDir, 'runs', runId, tag)
+                ),
+              ]);
+            }
+            clearStorageCache();
+            resetHookIndexEnsureCache();
+          }
+        }
+      );
+    },
     async start() {
       await initDataDir(mergedConfig.dataDir);
       if (!recoverActiveRuns) {
@@ -153,6 +524,7 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
           'hooks/by-run',
           'waits',
           'streams/runs',
+          'purged-trees',
         ];
         await Promise.all(
           entityDirs.map(async (dir) => {
@@ -230,6 +602,9 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
         await rm(mergedConfig.dataDir, { recursive: true, force: true });
         await initDataDir(mergedConfig.dataDir);
       }
+      purgedRuns.clear();
+      purgedTrees.clear();
+      purgeFencesLoaded = false;
     },
   };
 }

--- a/packages/world-local/src/purge.test.ts
+++ b/packages/world-local/src/purge.test.ts
@@ -128,6 +128,38 @@ describe('purgeRunTree', () => {
     ).rejects.toThrow('was purged');
   });
 
+  it('rejects re-associating a surviving run with a purged tree', async () => {
+    const root = await createRun(world, {
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    const survivor = await createRun(world, {
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    await updateRun(world, root.runId, 'run_completed', {
+      output: new Uint8Array(),
+    });
+    await world.purgeRunTree?.(root.runId, {
+      descendantAttribute: { key: 'lineageRoot', value: root.runId },
+    });
+
+    await expect(
+      world.runs.experimentalSetAttributes?.(survivor.runId, [
+        { key: 'lineageRoot', value: root.runId },
+      ])
+    ).rejects.toThrow('was purged');
+    await expect(
+      world.runs.experimentalSetAttributes?.(survivor.runId, [
+        { key: 'lineageRoot', value: 'another-root' },
+      ])
+    ).resolves.toEqual({
+      attributes: { lineageRoot: 'another-root' },
+    });
+  });
+
   it('resumes a partial purge from its durable manifest after restart', async () => {
     const root = await createRun(world, {
       deploymentId: 'deployment',

--- a/packages/world-local/src/purge.test.ts
+++ b/packages/world-local/src/purge.test.ts
@@ -1,0 +1,177 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createWorld, type LocalWorld } from './index.js';
+import {
+  createHook,
+  createRun,
+  createStep,
+  updateRun,
+  updateStep,
+} from './test-helpers.js';
+
+describe('purgeRunTree', () => {
+  let dataDir: string;
+  let world: LocalWorld;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workflow-purge-'));
+    world = createWorld({ dataDir, recoverActiveRuns: false });
+  });
+
+  afterEach(async () => {
+    await world.close();
+    await fs.rm(dataDir, { force: true, recursive: true });
+  });
+
+  it('purges terminal root and descendant entities while preserving unrelated runs', async () => {
+    const root = await createRun(world, {
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    const child = await createRun(world, {
+      attributes: { lineageRoot: root.runId },
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    const unrelated = await createRun(world, {
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    await createHook(world, child.runId, {
+      hookId: 'hook_child',
+      token: 'child-token',
+    });
+    await createStep(world, child.runId, {
+      input: new Uint8Array(),
+      stepId: 'step_child',
+      stepName: 'child',
+    });
+    await updateStep(world, child.runId, 'step_child', 'step_completed', {
+      result: new Uint8Array(),
+    });
+    await world.streams.write(child.runId, 'stream_child', 'secret');
+    await world.streams.close(child.runId, 'stream_child');
+    await updateRun(world, child.runId, 'run_completed', {
+      output: new Uint8Array(),
+    });
+    await updateRun(world, root.runId, 'run_completed', {
+      output: new Uint8Array(),
+    });
+
+    await expect(
+      world.purgeRunTree?.(root.runId, {
+        descendantAttribute: { key: 'lineageRoot', value: root.runId },
+      })
+    ).resolves.toEqual({ purgedRunCount: 2, status: 'purged' });
+    await expect(world.runs.get(root.runId)).rejects.toThrow();
+    await expect(world.runs.get(child.runId)).rejects.toThrow();
+    await expect(world.hooks.getByToken('child-token')).rejects.toThrow();
+    await expect(world.runs.get(unrelated.runId)).resolves.toMatchObject({
+      runId: unrelated.runId,
+    });
+  });
+
+  it('is idempotent for an absent root', async () => {
+    await expect(world.purgeRunTree?.('wrun_absent')).resolves.toEqual({
+      purgedRunCount: 0,
+      status: 'absent',
+    });
+  });
+
+  it('rejects an active tree without deleting it', async () => {
+    const root = await createRun(world, {
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+
+    await expect(world.purgeRunTree?.(root.runId)).rejects.toThrow(
+      'still active'
+    );
+    await expect(world.runs.get(root.runId)).resolves.toMatchObject({
+      runId: root.runId,
+    });
+  });
+
+  it('fences concurrent and later writes to a purged tree', async () => {
+    const root = await createRun(world, {
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    await updateRun(world, root.runId, 'run_completed', {
+      output: new Uint8Array(),
+    });
+
+    const purge = world.purgeRunTree?.(root.runId, {
+      descendantAttribute: { key: 'lineageRoot', value: root.runId },
+    });
+    const lateEvent = world.events.create(root.runId, {
+      eventType: 'run_cancelled',
+      eventData: { cancelReason: 'late' },
+    });
+
+    await expect(purge).resolves.toMatchObject({ status: 'purged' });
+    await expect(lateEvent).rejects.toThrow('was purged');
+    await expect(
+      createRun(world, {
+        attributes: { lineageRoot: root.runId },
+        deploymentId: 'deployment',
+        input: new Uint8Array(),
+        workflowName: 'workflow',
+      })
+    ).rejects.toThrow('was purged');
+  });
+
+  it('resumes a partial purge from its durable manifest after restart', async () => {
+    const root = await createRun(world, {
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    const child = await createRun(world, {
+      attributes: { lineageRoot: root.runId },
+      deploymentId: 'deployment',
+      input: new Uint8Array(),
+      workflowName: 'workflow',
+    });
+    await updateRun(world, child.runId, 'run_completed', {
+      output: new Uint8Array(),
+    });
+    await updateRun(world, root.runId, 'run_completed', {
+      output: new Uint8Array(),
+    });
+
+    await fs.mkdir(path.join(dataDir, 'purged-trees'), { recursive: true });
+    await fs.writeFile(
+      path.join(dataDir, 'purged-trees', `${root.runId}.json`),
+      JSON.stringify({
+        rootRunId: root.runId,
+        runIds: [root.runId, child.runId],
+        descendantAttribute: { key: 'lineageRoot', value: root.runId },
+      })
+    );
+    await fs.rm(path.join(dataDir, 'runs', `${root.runId}.json`));
+
+    await world.close();
+    world = createWorld({ dataDir, recoverActiveRuns: false });
+    await expect(world.purgeRunTree?.(root.runId)).resolves.toEqual({
+      purgedRunCount: 2,
+      status: 'purged',
+    });
+    await expect(world.runs.get(child.runId)).rejects.toThrow();
+    await expect(
+      createRun(world, {
+        attributes: { lineageRoot: root.runId },
+        deploymentId: 'deployment',
+        input: new Uint8Array(),
+        workflowName: 'workflow',
+      })
+    ).rejects.toThrow('was purged');
+  });
+});

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -170,6 +170,11 @@ Make sure your PostgreSQL database is accessible and the user has sufficient per
 - **Streaming**: Real-time event streaming capabilities
 - **Health Checks**: Built-in connection health monitoring
 - **Configurable Concurrency**: Adjustable worker concurrency for queue processing
+- **Run-tree Purge**: Transactional deletion of terminal run trees with durable write fences and idempotent retry
+
+`purgeRunTree()` removes runs, events, steps, hooks, waits, and stream chunks in
+one transaction. The migration-created tombstones and lineage fences reject
+later writes or attempts to recreate descendants of a purged tree.
 
 ## Queue Behavior
 

--- a/packages/world-postgres/src/drizzle/migrations/0016_add_run_tree_purge_fences.sql
+++ b/packages/world-postgres/src/drizzle/migrations/0016_add_run_tree_purge_fences.sql
@@ -1,0 +1,99 @@
+CREATE TABLE IF NOT EXISTS "workflow"."workflow_run_tombstones" (
+  "run_id" varchar PRIMARY KEY,
+  "root_run_id" varchar NOT NULL,
+  "purged_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflow_run_tombstones_root_run_id_index"
+  ON "workflow"."workflow_run_tombstones" ("root_run_id");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "workflow"."workflow_tree_fences" (
+  "attribute_key" varchar NOT NULL,
+  "attribute_value" varchar NOT NULL,
+  "root_run_id" varchar NOT NULL,
+  "purged_at" timestamp DEFAULT now() NOT NULL,
+  PRIMARY KEY ("attribute_key", "attribute_value")
+);
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "workflow"."guard_purged_run_write"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  guarded_run_id varchar;
+  attribute_entry record;
+BEGIN
+  IF TG_TABLE_NAME = 'workflow_runs' THEN
+    guarded_run_id := NEW.id;
+  ELSE
+    guarded_run_id := NEW.run_id;
+  END IF;
+
+  -- Run writes take selector locks before the run lock, matching purge order.
+  -- This prevents attribute updates and purges from deadlocking.
+  IF TG_TABLE_NAME = 'workflow_runs' THEN
+    FOR attribute_entry IN
+      SELECT key, value
+        FROM jsonb_each_text(COALESCE(NEW.attributes, '{}'::jsonb))
+       ORDER BY key, value
+    LOOP
+      PERFORM pg_advisory_xact_lock(
+        hashtextextended(attribute_entry.key || chr(31) || attribute_entry.value, 1)
+      );
+      IF EXISTS (
+        SELECT 1
+          FROM "workflow"."workflow_tree_fences"
+         WHERE attribute_key = attribute_entry.key
+           AND attribute_value = attribute_entry.value
+      ) THEN
+        RAISE EXCEPTION 'workflow run tree was purged'
+          USING ERRCODE = '23503';
+      END IF;
+    END LOOP;
+  END IF;
+
+  IF guarded_run_id IS NOT NULL THEN
+    PERFORM pg_advisory_xact_lock(hashtextextended(guarded_run_id, 0));
+    IF EXISTS (
+      SELECT 1
+        FROM "workflow"."workflow_run_tombstones"
+       WHERE run_id = guarded_run_id
+    ) THEN
+      RAISE EXCEPTION 'workflow run % was purged', guarded_run_id
+        USING ERRCODE = '23503';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "workflow_guard_purged_run_write" ON "workflow"."workflow_runs";
+CREATE TRIGGER "workflow_guard_purged_run_write"
+  BEFORE INSERT OR UPDATE ON "workflow"."workflow_runs"
+  FOR EACH ROW EXECUTE FUNCTION "workflow"."guard_purged_run_write"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "workflow_guard_purged_event_write" ON "workflow"."workflow_events";
+CREATE TRIGGER "workflow_guard_purged_event_write"
+  BEFORE INSERT OR UPDATE ON "workflow"."workflow_events"
+  FOR EACH ROW EXECUTE FUNCTION "workflow"."guard_purged_run_write"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "workflow_guard_purged_step_write" ON "workflow"."workflow_steps";
+CREATE TRIGGER "workflow_guard_purged_step_write"
+  BEFORE INSERT OR UPDATE ON "workflow"."workflow_steps"
+  FOR EACH ROW EXECUTE FUNCTION "workflow"."guard_purged_run_write"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "workflow_guard_purged_hook_write" ON "workflow"."workflow_hooks";
+CREATE TRIGGER "workflow_guard_purged_hook_write"
+  BEFORE INSERT OR UPDATE ON "workflow"."workflow_hooks"
+  FOR EACH ROW EXECUTE FUNCTION "workflow"."guard_purged_run_write"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "workflow_guard_purged_wait_write" ON "workflow"."workflow_waits";
+CREATE TRIGGER "workflow_guard_purged_wait_write"
+  BEFORE INSERT OR UPDATE ON "workflow"."workflow_waits"
+  FOR EACH ROW EXECUTE FUNCTION "workflow"."guard_purged_run_write"();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS "workflow_guard_purged_stream_write" ON "workflow"."workflow_stream_chunks";
+CREATE TRIGGER "workflow_guard_purged_stream_write"
+  BEFORE INSERT OR UPDATE ON "workflow"."workflow_stream_chunks"
+  FOR EACH ROW EXECUTE FUNCTION "workflow"."guard_purged_run_write"();

--- a/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
+++ b/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1782691200000,
       "tag": "0015_move_enums_to_workflow_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1785283200000,
+      "tag": "0016_add_run_tree_purge_fences",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/world-postgres/src/index.ts
+++ b/packages/world-postgres/src/index.ts
@@ -1,3 +1,4 @@
+import { EntityConflictError } from '@workflow/errors';
 import type { Storage, World } from '@workflow/world';
 import { reenqueueActiveRuns, SPEC_VERSION_CURRENT } from '@workflow/world';
 import { Pool } from 'pg';
@@ -64,9 +65,150 @@ export function createWorld(
 
   return {
     specVersion: SPEC_VERSION_CURRENT,
+    capabilities: { runTreePurge: true },
     ...storage,
     ...streamer,
     ...queue,
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: transaction owns discovery, fencing, and deletion
+    async purgeRunTree(rootRunId, options) {
+      const client = await pool.connect();
+      try {
+        await client.query('begin');
+        const selector = options?.descendantAttribute;
+        if (selector !== undefined) {
+          await client.query(
+            'select pg_advisory_xact_lock(hashtextextended($1 || chr(31) || $2, 1))',
+            [selector.key, selector.value]
+          );
+        }
+        await client.query(
+          'select pg_advisory_xact_lock(hashtextextended($1, 0))',
+          [rootRunId]
+        );
+
+        const root = await client.query<{ id: string }>(
+          'select id from workflow.workflow_runs where id = $1',
+          [rootRunId]
+        );
+        if (root.rowCount === 0) {
+          const prior = await client.query<{ run_id: string }>(
+            `select run_id
+               from workflow.workflow_run_tombstones
+              where root_run_id = $1
+              order by run_id`,
+            [rootRunId]
+          );
+          if (prior.rowCount !== 0) {
+            await deleteRunTreeEntities(prior.rows.map((row) => row.run_id));
+            await client.query('commit');
+            return {
+              purgedRunCount: prior.rows.length,
+              status: 'purged' as const,
+            };
+          }
+          await client.query('commit');
+          return { purgedRunCount: 0, status: 'absent' as const };
+        }
+
+        const selected = selector
+          ? await client.query<{ id: string; status: string }>(
+              `select id, status
+                 from workflow.workflow_runs
+                where id = $1 or attributes ->> $2 = $3
+                order by id`,
+              [rootRunId, selector.key, selector.value]
+            )
+          : await client.query<{ id: string; status: string }>(
+              `select id, status
+                 from workflow.workflow_runs
+                where id = $1
+                order by id`,
+              [rootRunId]
+            );
+
+        for (const run of selected.rows) {
+          await client.query(
+            'select pg_advisory_xact_lock(hashtextextended($1, 0))',
+            [run.id]
+          );
+        }
+        const runIds = selected.rows.map((run) => run.id);
+        const locked = await client.query<{ id: string; status: string }>(
+          `select id, status
+             from workflow.workflow_runs
+            where id = any($1::varchar[])
+            order by id
+            for update`,
+          [runIds]
+        );
+        if (
+          locked.rows.some(
+            (run) => run.status === 'pending' || run.status === 'running'
+          )
+        ) {
+          await client.query('rollback');
+          throw new EntityConflictError(
+            `Workflow run tree ${rootRunId} is still active`
+          );
+        }
+
+        if (selector !== undefined) {
+          await client.query(
+            `insert into workflow.workflow_tree_fences
+               (attribute_key, attribute_value, root_run_id)
+             values ($1, $2, $3)
+             on conflict (attribute_key, attribute_value) do update
+               set root_run_id = excluded.root_run_id`,
+            [selector.key, selector.value, rootRunId]
+          );
+        }
+        await client.query(
+          `insert into workflow.workflow_run_tombstones
+             (run_id, root_run_id)
+           select unnest($1::varchar[]), $2
+           on conflict (run_id) do nothing`,
+          [runIds, rootRunId]
+        );
+        await deleteRunTreeEntities(runIds);
+        await client.query('commit');
+        return {
+          purgedRunCount: runIds.length,
+          status: 'purged' as const,
+        };
+
+        async function deleteRunTreeEntities(runIds: string[]) {
+          await client.query(
+            'delete from workflow.workflow_stream_chunks where run_id = any($1::varchar[])',
+            [runIds]
+          );
+          await client.query(
+            'delete from workflow.workflow_waits where run_id = any($1::varchar[])',
+            [runIds]
+          );
+          await client.query(
+            'delete from workflow.workflow_hooks where run_id = any($1::varchar[])',
+            [runIds]
+          );
+          await client.query(
+            'delete from workflow.workflow_steps where run_id = any($1::varchar[])',
+            [runIds]
+          );
+          await client.query(
+            'delete from workflow.workflow_events where run_id = any($1::varchar[])',
+            [runIds]
+          );
+          await client.query(
+            'delete from workflow.workflow_runs where id = any($1::varchar[])',
+            [runIds]
+          );
+        }
+      } catch (error) {
+        await client.query('rollback').catch(() => undefined);
+        throw error;
+      } finally {
+        client.release();
+      }
+    },
     ...(config.streamFlushIntervalMs !== undefined && {
       streamFlushIntervalMs: config.streamFlushIntervalMs,
     }),

--- a/packages/world-vercel/README.md
+++ b/packages/world-vercel/README.md
@@ -6,6 +6,15 @@ Integrates with Vercel's infrastructure for storage, queuing, and authentication
 
 Used by default for deployments on Vercel. Authentication and API endpoints are configured automatically in Vercel deployments.
 
+## Run-tree purge availability
+
+This client does not advertise `runTreePurge`. Supporting it requires an
+atomic `DELETE /v2/runs/:rootRunId/tree` implementation in the separately
+owned `vercel/workflow-server`, including server-owned snapshots, blob
+references, and durable post-delete write fencing. That server source is not
+part of this repository, so the adapter must not report the capability until
+the server endpoint is implemented and deployed.
+
 ## Custom dispatcher
 
 HTTP requests (including the queue) default to a shared undici `RetryAgent` that handles connection pooling and retries. Pass a custom `dispatcher` to override it — e.g. to tune undici on newer Node runtimes:

--- a/packages/world/README.md
+++ b/packages/world/README.md
@@ -5,3 +5,12 @@ Core interfaces and types for Workflow SDK storage backends.
 This package defines the `World` interface that abstracts workflow storage, queuing, authentication, and streaming operations. Implementation packages like `@workflow/world-local` and `@workflow/world-vercel` provide concrete implementations.
 
 Used internally by `@workflow/core` and world implementations. Should not be used directly in application code.
+
+## Run-tree purge
+
+Frameworks that own a stable lineage attribute can use the optional
+`World.purgeRunTree()` retention primitive. A supporting World must fence new
+writes, reject active trees with `EntityConflictError`, remove the root,
+matching descendants, and all backend-owned entities, and make retries
+idempotent. Callers must check `world.capabilities?.runTreePurge === true`
+before relying on this operation.

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -314,6 +314,11 @@ export interface Storage {
  */
 export interface WorldCapabilities {
   /**
+   * The World can atomically fence and permanently purge a root run and every
+   * descendant selected by the supplied lineage predicate.
+   */
+  runTreePurge?: boolean;
+  /**
    * Supports `experimental_minRetention` for Hooks. Missing or inactive means
    * the runtime rejects retained Hooks before registration.
    */
@@ -353,6 +358,24 @@ export interface WorldCapabilities {
  * The "World" interface represents how Workflows are able to communicate with the outside world.
  */
 export interface World extends Queue, Streamer, Storage {
+  /**
+   * Permanently removes a workflow run tree and all of its owned entities.
+   *
+   * Implementations must fence new writes before inspecting active state,
+   * reject with EntityConflictError when active work cannot be cancelled and
+   * purged atomically, and treat an absent root as an idempotent success.
+   */
+  purgeRunTree?(
+    rootRunId: string,
+    options?: {
+      /**
+       * Reserved run attribute whose exact value identifies descendants.
+       * Frameworks should own this key and value; Worlds do not infer lineage
+       * from payload-bearing execution context.
+       */
+      descendantAttribute?: { key: string; value: string };
+    }
+  ): Promise<{ purgedRunCount: number; status: 'absent' | 'purged' }>;
   /**
    * Optional analytics read namespace for observability surfaces.
    *


### PR DESCRIPTION
## Summary

- add an explicit run-tree purge capability to the World contract
- implement durable write fencing, idempotent retry, descendant discovery, and entity removal in world-local
- implement transactional tombstones, lineage fences, triggers, and entity removal in world-postgres
- leave world-vercel unsupported and document the separately owned workflow-server operation required before it can advertise the capability

Closes #3114 only when the managed Vercel backend is implemented; this PR alone does not provide Vercel production deletion.

## Verification

- all 483 world-local tests pass, including active, absent, concurrent, restart/partial-retry, descendant, and post-delete rejection cases
- world, world-local, and world-postgres build
- world-local and world-postgres typecheck
- Biome and git diff checks pass

## Constraints

Docker is unavailable in the authoring environment, so the Postgres migration/concurrency path still needs its Testcontainers CI run. The private vercel/workflow-server source is not in this repository; it must implement atomic root-tree deletion, fencing, snapshots, and owned blob-reference cleanup before world-vercel can safely expose this capability.