### PR TITLE
feat(core): resume hooks from stored resumeContext and seal to the run key

### DIFF
--- a/.changeset/hook-resume-context.md
+++ b/.changeset/hook-resume-context.md
@@ -1,0 +1,8 @@
+---
+"@workflow/world": patch
+"@workflow/world-postgres": patch
+"@workflow/core": patch
+"@workflow/web-shared": patch
+---
+
+Hooks can carry an optional `resumeContext`; when present, `resumeHook`/`resumeWebhook` resume from it directly instead of fetching the full run, saving a round trip per resume. When the context also carries the run's `encryptionPublicKey`, the resume seals its payload (`encp`) directly to that key, so a default webhook resume needs neither a run read nor a run-key lookup. These two optimizations fall back independently: it fetches the full run when the context is absent, and uses symmetric encryption when no usable public key is available.

--- a/packages/core/src/runtime/resume-hook.fast-path.test.ts
+++ b/packages/core/src/runtime/resume-hook.fast-path.test.ts
@@ -1,0 +1,270 @@
+import {
+  EntityConflictError,
+  HookNotFoundError,
+  RunExpiredError,
+} from '@workflow/errors';
+import {
+  type Hook,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+  type World,
+} from '@workflow/world';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resumeHook, resumeWebhook } from './resume-hook.js';
+import { setWorld } from './world.js';
+
+vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }));
+vi.mock('../telemetry.js', () => ({
+  linkToTraceCarrier: vi.fn(),
+  trace: vi.fn((_name, fn) => fn(undefined)),
+}));
+// Stub payload (de)serialization so these control-flow tests don't depend on
+// devalue/encryption/Request framing — SerializationFormat is kept real for
+// the capability checks. Byte-level sealing is covered by the sibling
+// `resume-hook.test.ts`, which runs serialization for real.
+vi.mock('../serialization.js', async (importActual) => {
+  const actual = await importActual<typeof import('../serialization.js')>();
+  return {
+    ...actual,
+    dehydrateStepReturnValue: vi.fn(async () => 'serialized'),
+    hydrateStepArguments: vi.fn(async (value: unknown) => value),
+  };
+});
+
+describe('resumeHook (resumeContext fast path)', () => {
+  afterEach(() => setWorld(undefined));
+
+  const baseHook = {
+    runId: 'wrun_ctx',
+    hookId: 'hook_ctx',
+    token: 'order:ctx',
+    ownerId: 'owner_1',
+    projectId: 'project_1',
+    environment: 'production',
+    createdAt: new Date(),
+  } satisfies Hook;
+
+  const resumeContext = {
+    deploymentId: 'deployment_ctx',
+    workflowName: 'processOrder',
+    runSpecVersion: SPEC_VERSION_CURRENT,
+    workflowCoreVersion: '5.0.0',
+  };
+
+  // A syntactically valid 32-byte X25519 public key (base64). Enough for
+  // `decodeRunPublicKey` to accept it and route resumeHook down the seal
+  // branch; byte-level sealing is verified with real serialization in
+  // resume-hook.test.ts.
+  const resumeContextWithKey = {
+    ...resumeContext,
+    encryptionPublicKey: 'AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=',
+  };
+
+  const makeWorld = (
+    hook: Hook,
+    overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}
+  ) => {
+    const runsGet = overrides.runsGet ?? vi.fn();
+    const getEncryptionKeyForRun =
+      overrides.getEncryptionKeyForRun ?? vi.fn().mockResolvedValue(undefined);
+    const createEvent = overrides.createEvent ?? vi.fn();
+    const queue = overrides.queue ?? vi.fn();
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      hooks: { getByToken: vi.fn().mockResolvedValue(hook) },
+      runs: { get: runsGet },
+      events: { create: createEvent },
+      getEncryptionKeyForRun,
+      queue,
+    } as unknown as World);
+    return { runsGet, getEncryptionKeyForRun, createEvent, queue };
+  };
+
+  it('resumes from stored resumeContext without fetching the run', async () => {
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const { runsGet, getEncryptionKeyForRun, createEvent, queue } =
+      makeWorld(hook);
+
+    await resumeHook(hook.token, { foo: 'bar' });
+
+    // Fast path: no run read.
+    expect(runsGet).not.toHaveBeenCalled();
+    // Key resolved by runId + deploymentId, not a run entity.
+    expect(getEncryptionKeyForRun).toHaveBeenCalledWith(hook.runId, {
+      deploymentId: resumeContext.deploymentId,
+    });
+    expect(createEvent).toHaveBeenCalledTimes(1);
+    // Queue routing comes from the stored context.
+    expect(queue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ runId: hook.runId }),
+      expect.objectContaining({
+        deploymentId: resumeContext.deploymentId,
+        specVersion: SPEC_VERSION_CURRENT,
+      })
+    );
+  });
+
+  it('uses the fast path when given a Hook object carrying resumeContext', async () => {
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const { runsGet, queue } = makeWorld(hook);
+
+    await resumeHook(hook, { foo: 'bar' });
+
+    expect(runsGet).not.toHaveBeenCalled();
+    expect(queue).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to runs.get when the hook has no resumeContext', async () => {
+    const hook = { ...baseHook } satisfies Hook;
+    const run = {
+      runId: hook.runId,
+      status: 'running',
+      deploymentId: 'deployment_fallback',
+      workflowName: 'processOrder',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      attributes: {},
+      specVersion: SPEC_VERSION_CURRENT,
+    } as unknown as WorkflowRun;
+    const runsGet = vi.fn().mockResolvedValue(run);
+    const { queue } = makeWorld(hook, { runsGet });
+
+    await resumeHook(hook.token, { foo: 'bar' });
+
+    expect(runsGet).toHaveBeenCalledWith(hook.runId);
+    expect(queue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ runId: hook.runId }),
+      expect.objectContaining({ deploymentId: 'deployment_fallback' })
+    );
+  });
+
+  it('surfaces a terminal-run rejection from the server on the fast path (no re-trigger)', async () => {
+    // The fast path does not pre-check the run's terminal status; the server
+    // rejects hook_received for an ended run, and resumeHook must re-key that
+    // rejection to HookNotFoundError(token). Model that: events.create rejects,
+    // and the queue must not be re-triggered.
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    // A genuinely missing hook maps to HookNotFoundError keyed on the hook ID
+    // (the event correlationId), NOT the token — resumeHook must re-key it.
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new HookNotFoundError(hook.hookId));
+    const { runsGet, queue } = makeWorld(hook, { createEvent });
+
+    await expect(resumeHook(hook.token, { foo: 'bar' })).rejects.toSatisfy(
+      (err: unknown) =>
+        HookNotFoundError.is(err) &&
+        // Byte-for-byte contract: `.token` is the hook token, not the ID.
+        (err as HookNotFoundError).token === hook.token
+    );
+    expect(runsGet).not.toHaveBeenCalled();
+    expect(queue).not.toHaveBeenCalled();
+  });
+
+  it('re-keys an EntityConflictError (compat / conflict-shaped rejection) from events.create to HookNotFoundError(token)', async () => {
+    // Current Vercel behavior returns 404 for a terminal run (mapped to
+    // HookNotFoundError, covered above). EntityConflictError is kept for
+    // compatibility with older / conflict-shaped (HTTP 409) rejection
+    // behavior. On the fast path it surfaces from events.create and must be
+    // re-keyed to HookNotFoundError(token), matching the pre-fast-path
+    // contract where resumeHook threw HookNotFoundError.
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new EntityConflictError('run has already ended'));
+    const { runsGet, queue } = makeWorld(hook, { createEvent });
+
+    await expect(resumeHook(hook.token, { foo: 'bar' })).rejects.toSatisfy(
+      (err: unknown) =>
+        HookNotFoundError.is(err) &&
+        (err as HookNotFoundError).token === hook.token
+    );
+    expect(runsGet).not.toHaveBeenCalled();
+    expect(queue).not.toHaveBeenCalled();
+  });
+
+  it('re-keys a RunExpiredError (world-local / world-postgres terminal run) from events.create to HookNotFoundError(token)', async () => {
+    // world-local and world-postgres reject hook_received for a terminal run
+    // with RunExpiredError. Same re-keying requirement as the compat case.
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new RunExpiredError('run has expired'));
+    const { runsGet, queue } = makeWorld(hook, { createEvent });
+
+    await expect(resumeHook(hook.token, { foo: 'bar' })).rejects.toSatisfy(
+      (err: unknown) =>
+        HookNotFoundError.is(err) &&
+        (err as HookNotFoundError).token === hook.token
+    );
+    expect(runsGet).not.toHaveBeenCalled();
+    expect(queue).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve the key again when one is passed in (resumeHook override)', async () => {
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const { runsGet, getEncryptionKeyForRun } = makeWorld(hook);
+    const override = {} as unknown as Awaited<
+      ReturnType<typeof import('../encryption.js').importKey>
+    >;
+
+    await resumeHook(hook, { foo: 'bar' }, override);
+
+    expect(runsGet).not.toHaveBeenCalled();
+    // Override supplied → the world key resolver is never consulted.
+    expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+  });
+
+  it('resumeWebhook default (no metadata) pays no key lookup and seals to the run', async () => {
+    // The common default webhook — createWebhook() with no `respondWith` —
+    // stores no metadata, so getHookByTokenWithKey resolves no key and
+    // resumeHook seals to the run's public key carried in the resume context.
+    // Zero run reads, zero `run-key` API round trips. (Byte-level `encp` is
+    // asserted with real serialization in resume-hook.test.ts.)
+    const hook = {
+      ...baseHook,
+      isWebhook: true,
+      resumeContext: resumeContextWithKey,
+    } satisfies Hook;
+    const getEncryptionKeyForRun = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32));
+    const { runsGet, queue } = makeWorld(hook, { getEncryptionKeyForRun });
+
+    const response = await resumeWebhook(hook.token, new Request('http://x'));
+
+    expect(response.status).toBe(202);
+    expect(runsGet).not.toHaveBeenCalled();
+    // The P1 fix: the default webhook must not pay the run-key lookup.
+    expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+    expect(queue).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumeWebhook with metadata resolves the run key exactly once', async () => {
+    // A webhook that stored metadata genuinely needs the symmetric key to
+    // hydrate it. That single lookup (in getHookByTokenWithKey) is then reused
+    // for the payload write, so the key is resolved exactly once end-to-end.
+    const hook = {
+      ...baseHook,
+      isWebhook: true,
+      resumeContext: resumeContextWithKey,
+      metadata: { note: 'stored' } as unknown as Hook['metadata'],
+    } satisfies Hook;
+    const getEncryptionKeyForRun = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32));
+    const { runsGet, queue } = makeWorld(hook, { getEncryptionKeyForRun });
+
+    const response = await resumeWebhook(hook.token, new Request('http://x'));
+
+    expect(response.status).toBe(202);
+    expect(runsGet).not.toHaveBeenCalled();
+    expect(getEncryptionKeyForRun).toHaveBeenCalledTimes(1);
+    expect(getEncryptionKeyForRun).toHaveBeenCalledWith(hook.runId, {
+      deploymentId: resumeContext.deploymentId,
+    });
+    expect(queue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/runtime/resume-hook.test.ts
+++ b/packages/core/src/runtime/resume-hook.test.ts
@@ -14,7 +14,7 @@ import {
   runPayloadKeys,
   SerializationFormat,
 } from '../serialization.js';
-import { resumeHook } from './resume-hook.js';
+import { resumeHook, resumeWebhook } from './resume-hook.js';
 import { setWorld } from './world.js';
 
 vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }));
@@ -136,6 +136,87 @@ describe('resumeHook', () => {
 
       await resumeHook('order:1', { approved: true });
 
+      expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+      expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+        SerializationFormat.SEALED
+      );
+    });
+
+    it('seals via the stored resume context without reading the run or a key', async () => {
+      // Option 1 fast path: when the hook carries a resumeContext with the
+      // run's public key inline, a resume needs neither `runs.get` NOR
+      // `getEncryptionKeyForRun` — a single `hooks.getByToken`, then seal. This
+      // is what folds the public-key hop into the same read that already
+      // skips the run fetch.
+      const { publicKey } = await deriveRunKeyPair(RUN_KEY_MATERIAL);
+      const hook = {
+        ...makeHook(),
+        resumeContext: {
+          deploymentId: 'deployment_1',
+          workflowName: 'processOrder',
+          runSpecVersion: SPEC_VERSION_CURRENT,
+          workflowCoreVersion: '5.0.0-beta.40',
+          encryptionPublicKey: bytesToBase64(publicKey),
+        },
+      } as Hook;
+      const runsGet = vi.fn();
+      const createEvent = vi.fn().mockResolvedValue(undefined);
+      const getEncryptionKeyForRun = vi.fn();
+
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        hooks: { getByToken: vi.fn().mockResolvedValue(hook) },
+        runs: { get: runsGet },
+        events: { create: createEvent },
+        getEncryptionKeyForRun,
+        queue: vi.fn().mockResolvedValue(undefined),
+        getDeploymentId: vi.fn().mockResolvedValue('deployment_2'),
+      } as unknown as World);
+
+      await resumeHook('order:1', { approved: true });
+
+      // Single read: no run fetch and no run-key API round trip.
+      expect(runsGet).not.toHaveBeenCalled();
+      expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
+      expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
+        SerializationFormat.SEALED
+      );
+    });
+
+    it('resumeWebhook default seals the payload with no key lookup', async () => {
+      // End-to-end through the webhook entrypoint: a default webhook (no
+      // metadata) must resolve no key and still emit a sealed (`encp`) payload,
+      // keyed off the run's public key in the resume context. This is the P1
+      // fix observed at the byte level.
+      const { publicKey } = await deriveRunKeyPair(RUN_KEY_MATERIAL);
+      const hook = {
+        ...makeHook(),
+        isWebhook: true,
+        resumeContext: {
+          deploymentId: 'deployment_1',
+          workflowName: 'processOrder',
+          runSpecVersion: SPEC_VERSION_CURRENT,
+          workflowCoreVersion: '5.0.0-beta.40',
+          encryptionPublicKey: bytesToBase64(publicKey),
+        },
+      } as Hook;
+      const runsGet = vi.fn();
+      const createEvent = vi.fn().mockResolvedValue(undefined);
+      const getEncryptionKeyForRun = vi.fn();
+      setWorld({
+        specVersion: SPEC_VERSION_CURRENT,
+        hooks: { getByToken: vi.fn().mockResolvedValue(hook) },
+        runs: { get: runsGet },
+        events: { create: createEvent },
+        getEncryptionKeyForRun,
+        queue: vi.fn().mockResolvedValue(undefined),
+        getDeploymentId: vi.fn().mockResolvedValue('deployment_2'),
+      } as unknown as World);
+
+      const response = await resumeWebhook('order:1', new Request('http://x'));
+
+      expect(response.status).toBe(202);
+      expect(runsGet).not.toHaveBeenCalled();
       expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
       expect(peekFormatPrefix(capturedPayload(createEvent))).toBe(
         SerializationFormat.SEALED

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -1,10 +1,13 @@
 import {
+  EntityConflictError,
   ERROR_SLUGS,
   HookNotFoundError,
+  RunExpiredError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import {
   type Hook,
+  type HookResumeContext,
   isLegacySpecVersion,
   isTerminalWorkflowRunStatus,
   SPEC_VERSION_CURRENT,
@@ -32,25 +35,103 @@ import { getWorldLazy } from './get-world-lazy.js';
 import { getWorkflowQueueName } from './helpers.js';
 import { safeWaitUntil, waitedUntil } from './wait-until.js';
 
-/** Get a Hook and its owning run without hydrating payload data. */
-async function getHookAndRun(token: string): Promise<{
-  hook: Hook;
-  run: WorkflowRun;
-}> {
+/**
+ * The resume context for a hook plus where it came from. `run` is present only
+ * on the fallback path (pre-`resumeContext` hooks), where it also carries the
+ * run's mutable status for the terminal-run check. Key resolution is kept
+ * separate so callers can gate it behind that check.
+ */
+interface HookResumeInfo {
+  resumeContext: HookResumeContext;
+  source: 'hook' | 'run_fallback';
+  run?: WorkflowRun;
+}
+
+/** Derive a resume context from a full run (fallback for pre-`resumeContext` hooks). */
+function resumeContextFromRun(run: WorkflowRun): HookResumeContext {
+  const coreVersion = run.executionContext?.workflowCoreVersion;
+  const traceCarrier = run.executionContext?.traceCarrier;
+  return {
+    deploymentId: run.deploymentId,
+    workflowName: run.workflowName,
+    runSpecVersion: run.specVersion,
+    workflowCoreVersion:
+      typeof coreVersion === 'string' ? coreVersion : undefined,
+    traceCarrier:
+      traceCarrier && typeof traceCarrier === 'object'
+        ? (traceCarrier as HookResumeContext['traceCarrier'])
+        : undefined,
+    encryptionPublicKey: run.encryptionPublicKey,
+  };
+}
+
+/**
+ * Resolve resume context for a hook. Uses the stored `resumeContext` when
+ * present (fast path — no run read); otherwise fetches the run and synthesizes
+ * it. Does NOT resolve the encryption key — callers do that separately. Only
+ * the fallback path can gate key work behind a local terminal-run check (it
+ * has the fetched run); the fast path's stored context carries no status, so
+ * seal/serialization work may run before the receiving side rejects
+ * `hook_received` for an ended run.
+ */
+async function resolveHookResumeInfo(hook: Hook): Promise<HookResumeInfo> {
+  if (hook.resumeContext) {
+    return { resumeContext: hook.resumeContext, source: 'hook' };
+  }
+  const run = await (await getWorldLazy()).runs.get(hook.runId);
+  return {
+    resumeContext: resumeContextFromRun(run),
+    source: 'run_fallback',
+    run,
+  };
+}
+
+/**
+ * Resolve the run's symmetric key for a payload WRITE, as a bare `CryptoKey`
+ * (`importKey`) — the `encr` write fallback used when the run published no
+ * public key to seal to. Writing needs only the AES key, not the read-side
+ * keypair. On the fast path this needs only `runId` + `deploymentId` (no run
+ * entity); on the fallback path the already fetched run is reused.
+ */
+async function resolveHookEncryptionKey(
+  hook: Hook,
+  info: HookResumeInfo
+): Promise<Awaited<ReturnType<typeof importKey>> | undefined> {
   const world = await getWorldLazy();
-  const hook = await world.hooks.getByToken(token);
-  const run = await world.runs.get(hook.runId);
-  return { hook, run };
+  const rawKey = info.run
+    ? await world.getEncryptionKeyForRun?.(info.run)
+    : await world.getEncryptionKeyForRun?.(hook.runId, {
+        deploymentId: info.resumeContext.deploymentId,
+      });
+  return rawKey ? await importKey(rawKey) : undefined;
 }
 
 async function getHookByTokenWithKey(token: string): Promise<{
   hook: Hook;
   encryptionKey: PayloadKey | undefined;
 }> {
-  const { hook, run } = await getHookAndRun(token);
-  const rawKey = await (await getWorldLazy()).getEncryptionKeyForRun?.(run);
-  const encryptionKey = rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
+  const world = await getWorldLazy();
+  const hook = await world.hooks.getByToken(token);
+
+  // Only a hook that actually carries metadata needs the run's key resolved
+  // here: hydrating that metadata is a READ, so derive the full RunPayloadKeys
+  // (which opens sealed `encp` metadata, not just symmetric `encr`). The common
+  // default webhook — createWebhook() with no `respondWith` — stores no
+  // metadata, so it skips this entirely: no ~350ms `run-key` API round trip,
+  // and, crucially, no resolved key handed to `resumeHook`, leaving it free to
+  // seal the payload to the run's published public key instead. Metadata-
+  // bearing webhooks still legitimately pay one lookup to hydrate.
+  let encryptionKey: PayloadKey | undefined;
   if (typeof hook.metadata !== 'undefined') {
+    const info = await resolveHookResumeInfo(hook);
+    // On the fast path this resolves the key by runId + deploymentId (no run
+    // read); on the fallback path it reuses the already-fetched run.
+    const rawKey = info.run
+      ? await world.getEncryptionKeyForRun?.(info.run)
+      : await world.getEncryptionKeyForRun?.(hook.runId, {
+          deploymentId: info.resumeContext.deploymentId,
+        });
+    encryptionKey = rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
     hook.metadata = await hydrateStepArguments(
       hook.metadata as any,
       hook.runId,
@@ -114,24 +195,28 @@ export async function resumeHook<T = any>(
       const world = await getWorldLazy();
 
       try {
-        let hook: Hook;
-        let workflowRun: WorkflowRun;
-        if (typeof tokenOrHook === 'string') {
-          const result = await getHookAndRun(tokenOrHook);
-          hook = result.hook;
-          workflowRun = result.run;
-        } else {
-          hook = tokenOrHook;
-          workflowRun = await world.runs.get(hook.runId);
-        }
+        const hook: Hook =
+          typeof tokenOrHook === 'string'
+            ? await world.hooks.getByToken(tokenOrHook)
+            : tokenOrHook;
+
+        const info = await resolveHookResumeInfo(hook);
+        const { resumeContext } = info;
 
         span?.setAttributes({
           ...Attribute.HookToken(hook.token),
           ...Attribute.HookId(hook.hookId),
           ...Attribute.WorkflowRunId(hook.runId),
+          'workflow.hook.resume_context_source': info.source,
         });
 
-        if (isTerminalWorkflowRunStatus(workflowRun.status)) {
+        // The stored `resumeContext` intentionally omits the run's mutable
+        // status, so this early client-side rejection only runs on the
+        // fallback path (which fetched the run). On the fast path the terminal
+        // check happens server-side: `hook_received` against an ended run is
+        // rejected, which the catch around `world.events.create` below re-keys
+        // to HookNotFoundError — same public contract, no run pre-fetch.
+        if (info.run && isTerminalWorkflowRunStatus(info.run.status)) {
           throw new HookNotFoundError(hook.token);
         }
 
@@ -140,18 +225,18 @@ export async function resumeHook<T = any>(
         // runs created before encryption support was added cannot decode
         // the 'encr' serialization format, and runs created before
         // byte-stream framing support cannot decode framed byte streams.
-        const rawVersion = workflowRun.executionContext?.workflowCoreVersion;
         const capabilities = getRunCapabilities(
-          typeof rawVersion === 'string' ? rawVersion : undefined
+          resumeContext.workflowCoreVersion
         );
 
-        // Resolve how to encrypt the payload for the target run.
+        // Resolve how to encrypt the payload for the target run (a WRITE).
         //
-        // Preferred path: the run published an X25519 public key, so seal to
-        // it. This needs nothing beyond the run entity we already fetched —
-        // no `getEncryptionKeyForRun`, which for a cross-deployment resume
-        // means a ~350ms `run-key` API round trip. That call dominates
-        // cross-deployment hook resumption latency, and sealing removes it.
+        // Preferred path: seal to the run's published X25519 public key, which
+        // the stored `resumeContext` carries inline. On the fast path this is
+        // the whole win — no run read AND no `getEncryptionKeyForRun`, whose
+        // ~350ms `run-key` API round trip dominates cross-deployment hook
+        // resumption latency. (On the fallback path the key is synthesized
+        // from the fetched run, which also carries it.)
         //
         // Sealing also drops privilege: the resumer ends up able to write a
         // payload for the run without being able to read anything of the
@@ -166,20 +251,21 @@ export async function resumeHook<T = any>(
         // versions drift.
         let payloadKey: PayloadKey | undefined;
         const runPublicKey = encryptionKeyOverride
-          ? // The caller already holds the symmetric key (resumeWebhook had
-            // to fetch it to hydrate hook metadata), so sealing would add an
-            // ECDH for no saved round trip. Reuse what it resolved.
+          ? // The caller already holds a key (resumeWebhook resolved one to
+            // hydrate hook metadata), so sealing would add an ECDH for no
+            // saved round trip. Reuse what it resolved.
             undefined
-          : decodeRunPublicKey(workflowRun.encryptionPublicKey);
+          : decodeRunPublicKey(resumeContext.encryptionPublicKey);
 
         if (runPublicKey) {
           payloadKey = sealTo(runPublicKey);
         } else {
-          let encryptionKey = encryptionKeyOverride;
-          if (!encryptionKey) {
-            const rawKey = await world.getEncryptionKeyForRun?.(workflowRun);
-            encryptionKey = rawKey ? await importKey(rawKey) : undefined;
-          }
+          // Symmetric `encr` write fallback: needs only the AES key
+          // (a bare CryptoKey via `resolveHookEncryptionKey`), not the
+          // read-side RunPayloadKeys.
+          let encryptionKey =
+            encryptionKeyOverride ??
+            (await resolveHookEncryptionKey(hook, info));
           if (
             !capabilities.supportedFormats.has(SerializationFormat.ENCRYPTED)
           ) {
@@ -191,7 +277,8 @@ export async function resumeHook<T = any>(
         // Compress only when the target run and its deployment support the
         // compression formats introduced with spec version 5.
         const compression =
-          (workflowRun.specVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION &&
+          (resumeContext.runSpecVersion ?? 0) >=
+            SPEC_VERSION_SUPPORTS_COMPRESSION &&
           capabilities.supportedFormats.has(SerializationFormat.GZIP);
 
         // Dehydrate the payload for storage
@@ -223,29 +310,51 @@ export async function resumeHook<T = any>(
         });
 
         // Create a hook_received event with the payload
-        await world.events.create(
-          hook.runId,
-          {
-            eventType: 'hook_received',
-            specVersion: SPEC_VERSION_CURRENT,
-            correlationId: hook.hookId,
-            eventData: {
-              ...(v1Compat ? {} : { token: hook.token }),
-              payload: dehydratedPayload,
+        try {
+          await world.events.create(
+            hook.runId,
+            {
+              eventType: 'hook_received',
+              specVersion: SPEC_VERSION_CURRENT,
+              correlationId: hook.hookId,
+              eventData: {
+                ...(v1Compat ? {} : { token: hook.token }),
+                payload: dehydratedPayload,
+              },
             },
-          },
-          { v1Compat }
-        );
+            { v1Compat }
+          );
+        } catch (err) {
+          // Re-key any "hook can no longer be received" rejection to
+          // HookNotFoundError(hook.token) so `.token` matches the
+          // pre-fast-path contract, where resumeHook threw
+          // `HookNotFoundError(hook.token)` after its own terminal check.
+          // The specific error depends on the World:
+          //   - a genuinely missing hook maps to HookNotFoundError (keyed on
+          //     the event correlationId / hook ID);
+          //   - a terminal run on Vercel rejects hook_received with 404, which
+          //     world-vercel maps to HookNotFoundError;
+          //   - a terminal run on world-local / world-postgres rejects with
+          //     RunExpiredError.
+          // EntityConflictError (HTTP 409) is kept for compatibility with
+          // older / conflict-shaped rejection behavior.
+          if (
+            HookNotFoundError.is(err) ||
+            EntityConflictError.is(err) ||
+            RunExpiredError.is(err)
+          ) {
+            throw new HookNotFoundError(hook.token);
+          }
+          throw err;
+        }
 
         span?.setAttributes({
-          ...Attribute.WorkflowName(workflowRun.workflowName),
+          ...Attribute.WorkflowName(resumeContext.workflowName),
         });
 
-        // Link to the run-origin context from the workflow run's stored
-        // trace carrier (skipped when absent or invalid).
-        const originLink = await linkToTraceCarrier(
-          workflowRun.executionContext?.traceCarrier
-        );
+        // Link to the run-origin context from the stored trace carrier
+        // (skipped when absent or invalid).
+        const originLink = await linkToTraceCarrier(resumeContext.traceCarrier);
         if (originLink) {
           span?.addLink?.(originLink);
         }
@@ -253,16 +362,15 @@ export async function resumeHook<T = any>(
         // Re-trigger the workflow against the deployment ID associated
         // with the workflow run that the hook belongs to
         await world.queue(
-          getWorkflowQueueName(workflowRun.workflowName),
+          getWorkflowQueueName(resumeContext.workflowName),
           {
             runId: hook.runId,
-            // attach the trace carrier from the workflow run
-            traceCarrier:
-              workflowRun.executionContext?.traceCarrier ?? undefined,
+            // attach the trace carrier from the run's resume context
+            traceCarrier: resumeContext.traceCarrier ?? undefined,
           } satisfies WorkflowInvokePayload,
           {
-            deploymentId: workflowRun.deploymentId,
-            specVersion: workflowRun.specVersion ?? SPEC_VERSION_LEGACY,
+            deploymentId: resumeContext.deploymentId,
+            specVersion: resumeContext.runSpecVersion ?? SPEC_VERSION_LEGACY,
           }
         );
 

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -417,6 +417,8 @@ const attributeToDisplayFn: Record<
   receivedCount: (value: unknown) => String(value),
   lastReceivedAt: localMillisecondTimeOrNull,
   disposedAt: localMillisecondTimeOrNull,
+  // Internal resume plumbing — not surfaced in the UI
+  resumeContext: (_value: unknown) => null,
   // Event details
   eventType: (value: unknown) => String(value),
   correlationId: (value: unknown) => String(value),

--- a/packages/world-postgres/src/drizzle/migrations/0017_add_hook_resume_context.sql
+++ b/packages/world-postgres/src/drizzle/migrations/0017_add_hook_resume_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflow"."workflow_hooks" ADD COLUMN "resume_context" bytea;

--- a/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
+++ b/packages/world-postgres/src/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1784937600000,
       "tag": "0016_add_encryption_public_key",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1785283200000,
+      "tag": "0017_add_hook_resume_context",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -222,6 +222,9 @@ export const hooks = schema.table(
     specVersion: integer('spec_version'),
     isWebhook: boolean('is_webhook').default(true),
     isSystem: boolean('is_system').default(false),
+    // Server-synthesized resume slice. Not carried by the hook_created event,
+    // so this backend leaves it null; reads fall back to runs.get.
+    resumeContext: Cbor<NonNullable<Hook['resumeContext']>>()('resume_context'),
   } satisfies DrizzlishOfType<Cborized<Hook, 'metadata'>>,
   (tb) => [index().on(tb.runId), index().on(tb.token)]
 );

--- a/packages/world-vercel/src/encryption.test.ts
+++ b/packages/world-vercel/src/encryption.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockFetch } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
@@ -8,7 +8,11 @@ vi.mock('./http-client.js', () => ({
   getDispatcher: vi.fn().mockReturnValue({}),
 }));
 
-import { deriveRunKey, fetchRunKey } from './encryption.js';
+import {
+  createGetEncryptionKeyForRun,
+  deriveRunKey,
+  fetchRunKey,
+} from './encryption.js';
 
 const testProjectId = 'prj_test123';
 const testRunId = 'wrun_abc123';
@@ -136,5 +140,67 @@ describe('fetchRunKey', () => {
         token: 'test-token',
       })
     ).rejects.toThrow('HTTP 404');
+  });
+});
+
+describe('createGetEncryptionKeyForRun (runId, { deploymentId }) overload', () => {
+  const projectId = 'prj_test123';
+  const runId = 'wrun_xdeploy';
+  const currentDeployment = 'dpl_A';
+  const otherDeployment = 'dpl_B';
+
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      VERCEL: process.env.VERCEL,
+      VERCEL_DEPLOYMENT_ID: process.env.VERCEL_DEPLOYMENT_ID,
+      VERCEL_DEPLOYMENT_KEY: process.env.VERCEL_DEPLOYMENT_KEY,
+    };
+    // Serverless runtime with a local deployment key for the current deployment.
+    process.env.VERCEL = '1';
+    process.env.VERCEL_DEPLOYMENT_ID = currentDeployment;
+    process.env.VERCEL_DEPLOYMENT_KEY =
+      Buffer.from(testDeploymentKey).toString('base64');
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    mockFetch.mockReset();
+  });
+
+  it('derives locally and does not fetch when the context deployment is the current one', async () => {
+    const getKey = createGetEncryptionKeyForRun(projectId, undefined, 'tok');
+    if (!getKey) throw new Error('expected getEncryptionKeyForRun to exist');
+    const key = await getKey(runId, { deploymentId: currentDeployment });
+
+    expect(key).toBeInstanceOf(Uint8Array);
+    expect(key?.byteLength).toBe(32);
+    expect(key).toEqual(
+      await deriveRunKey(testDeploymentKey, projectId, runId)
+    );
+    // Same-deployment key work stays local — no cross-deployment API call.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches the run key for a different context deployment', async () => {
+    const keyBase64 = Buffer.from(testDeploymentKey).toString('base64');
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ key: keyBase64 }), { status: 200 })
+    );
+
+    const getKey = createGetEncryptionKeyForRun(projectId, undefined, 'tok');
+    if (!getKey) throw new Error('expected getEncryptionKeyForRun to exist');
+    const key = await getKey(runId, { deploymentId: otherDeployment });
+
+    expect(key).toEqual(Buffer.from(keyBase64, 'base64'));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // The fetch targets the OTHER deployment's run-key endpoint.
+    const callArgs = JSON.stringify(mockFetch.mock.calls[0]);
+    expect(callArgs).toContain(`run-key/${otherDeployment}`);
+    expect(callArgs).not.toContain(`run-key/${currentDeployment}`);
   });
 });

--- a/packages/world/src/hooks.test.ts
+++ b/packages/world/src/hooks.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { HookSchema } from './hooks.js';
+
+const baseHook = {
+  runId: 'wrun_1',
+  hookId: 'hook_1',
+  token: 'order:1',
+  ownerId: 'owner_1',
+  projectId: 'project_1',
+  environment: 'production',
+  createdAt: new Date(),
+};
+
+const resumeContext = {
+  deploymentId: 'deployment_1',
+  workflowName: 'processOrder',
+  runSpecVersion: 5,
+  workflowCoreVersion: '5.0.0',
+  traceCarrier: { traceparent: '00-abc-def-01' },
+  encryptionPublicKey: 'ZmFrZS1wdWJsaWMta2V5',
+};
+
+describe('HookSchema resumeContext', () => {
+  it('parses and preserves a resumeContext', () => {
+    const parsed = HookSchema.parse({ ...baseHook, resumeContext });
+    expect(parsed.resumeContext).toEqual(resumeContext);
+  });
+
+  it('is optional — a hook without it still parses', () => {
+    const parsed = HookSchema.parse(baseHook);
+    expect(parsed.resumeContext).toBeUndefined();
+  });
+
+  it('an old client (schema without resumeContext) strips the unknown field, other fields intact', () => {
+    // Model a pre-`resumeContext` client's schema: Zod strips unknown keys by
+    // default, so the enriched response is parsed without failing and the new
+    // field is simply dropped.
+    const legacyHookSchema = HookSchema.omit({ resumeContext: true });
+    const parsed = legacyHookSchema.parse({ ...baseHook, resumeContext });
+    expect('resumeContext' in parsed).toBe(false);
+    expect(parsed).toMatchObject({
+      runId: baseHook.runId,
+      hookId: baseHook.hookId,
+      token: baseHook.token,
+    });
+  });
+});

--- a/packages/world/src/hooks.ts
+++ b/packages/world/src/hooks.ts
@@ -1,7 +1,35 @@
 import { z } from 'zod';
+import { TraceCarrierSchema } from './queue.js';
 import type { SerializedData } from './serialization.js';
 import { SerializedDataSchema } from './serialization.js';
 import type { PaginationOptions, ResolveData } from './shared.js';
+
+/**
+ * Minimal, immutable slice of a hook's owning run needed to resume it —
+ * enough for encryption-key resolution, serialization/compression capability
+ * selection, queue routing, and trace linking, without fetching the full run.
+ *
+ * Persisted on new hook records (workflow-server) and also returned inline by
+ * `getByToken`, so a resume can skip the separate `runs.get`. Deliberately
+ * excludes the run's mutable state (e.g. status), inputs/outputs, attributes,
+ * and any secret — only fields that are fixed at hook-creation time.
+ */
+export const HookResumeContextSchema = z.object({
+  deploymentId: z.string(),
+  workflowName: z.string(),
+  // Named `runSpecVersion` to distinguish it from the hook's own `specVersion`.
+  runSpecVersion: z.number().optional(),
+  workflowCoreVersion: z.string().optional(),
+  traceCarrier: TraceCarrierSchema.optional(),
+  // The run's published X25519 public key (base64), mirrored from the run
+  // entity. Lets a resume seal (`encp`) its payload to the run without reading
+  // the run or fetching its symmetric key. Absent on runs created before
+  // sealed envelopes and on projects with encryption disabled, where the
+  // resume falls back to the symmetric per-run key.
+  encryptionPublicKey: z.string().optional(),
+});
+
+export type HookResumeContext = z.infer<typeof HookResumeContextSchema>;
 
 /**
  * Schema for workflow hooks.
@@ -24,6 +52,10 @@ export const HookSchema = z.object({
   specVersion: z.number().optional(),
   isWebhook: z.boolean().optional(),
   isSystem: z.boolean().optional(),
+  // Present when the server stored it (new hooks) or synthesized it from the
+  // run (old hooks). Absent only against an old server, where the resume path
+  // falls back to `runs.get`.
+  resumeContext: HookResumeContextSchema.optional(),
 });
 
 /**


### PR DESCRIPTION
## What
Hooks can carry an optional `resumeContext` — the immutable slice of the owning run needed to route and decrypt a resume: deployment ID, workflow name, run spec version, core version, trace carrier, and (when the run publishes one) its X25519 `encryptionPublicKey`. `resumeHook`/`resumeWebhook` use it to resume a hook directly.

## Why
Resuming a hook previously always fetched the full run to recover its routing and encryption context, adding a run round trip to every resume — including on the hot webhook path. Sealed payloads made this worse: a resume would additionally fetch the run's symmetric key (~350ms cross-deployment `run-key` hop) to write its payload.

## How
- When `resumeContext` is present, route the resume from the stored context and skip `runs.get` entirely.
- When the context also carries `encryptionPublicKey`, seal the payload (`encp`) directly to that key — no symmetric-key material required. Building on the sealed-envelope work (#3093–#3096), a **default webhook resume then needs neither a run read nor a run-key lookup**.
- The symmetric key is resolved (and derived) **only** when the hook actually stores `metadata` that must be hydrated — the one case that genuinely needs it. Webhooks with stored metadata keep a single key lookup; the common metadata-less webhook pays none.
- When the context is absent (older hook records), or when it carries no public key, transparently fall back to the previous `runs.get` + symmetric-key path — no behavior change for existing hooks.
- Terminal-run resumes preserve the `HookNotFoundError` contract (error keyed to the hook token). On the fast path the terminal check happens on the receiving side and the backend-specific rejection is re-keyed to `HookNotFoundError`: current Vercel returns 404 (world-vercel maps it to `HookNotFoundError`), world-local / world-postgres reject with `RunExpiredError`, and `EntityConflictError` (HTTP 409) is caught for compatibility with older / conflict-shaped behavior.

Backwards compatible: `resumeContext` and its `encryptionPublicKey` are optional on both the schema and the resume path, so new clients interoperate with older records and vice versa.

## Tests
- The resume-hook suite is split into a control-flow suite (mocked serialization) and a real-serialization crypto suite, so the fast path is asserted to produce a genuine `encp`-sealed payload end-to-end and the default webhook is asserted to make **zero** key lookups while a metadata-bearing webhook makes exactly one.
- `world-vercel` covers the `getEncryptionKeyForRun(runId, { deploymentId })` overload the fast path relies on (derive locally for the current deployment, fetch for a different one).

## Note
The `world-postgres` migration (`0017_add_hook_resume_context`) adds a `resume_context` column. Reads are safe (nullable); population of the column is a separate data-only change requiring no migration coordination. The journal numbering is clean — `0017` follows `0016` with no gap.

The web attribute panel gains a small renderer so a hook's `resumeContext` is inspectable in the UI.
