### PR TITLE
Remove deprecated experimental setAttributes aliases

### DIFF
--- a/.changeset/remove-experimental-set-attributes.md
+++ b/.changeset/remove-experimental-set-attributes.md
@@ -1,0 +1,6 @@
+---
+"@workflow/core": major
+"workflow": major
+---
+
+**BREAKING CHANGE**: Remove the deprecated `experimental_setAttributes` and `ExperimentalSetAttributesOptions` aliases; use `setAttributes` and `SetAttributesOptions` instead.

--- a/docs/content/docs/v5/api-reference/workflow/set-attributes.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/set-attributes.mdx
@@ -59,7 +59,3 @@ Validation errors throw [`FatalError`](/docs/api-reference/workflow/fatal-error)
 Calls from both workflow and step bodies append a native `attr_set` event, which the World materializes onto `run.attributes`. Workflow-originated events record a workflow writer; step-originated events record the originating step ID and attempt.
 
 Native attributes require spec version 4 or later. Step-body storage errors throw from `setAttributes`; catch them inside the step if the write should be best-effort. Workflow-body writes are committed when the workflow suspends: transient storage errors are retried with the suspension, while a write the World rejects as invalid — such as exceeding the per-run attribute cap across multiple calls — fails the run with the validation error.
-
-<Callout>
-This function was previously exported as `experimental_setAttributes`. The old name still works as a deprecated alias — update imports to `setAttributes`.
-</Callout>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,7 +26,6 @@ export {
 } from './create-hook.js';
 export { defineHook, type TypedHook } from './define-hook.js';
 export {
-  experimental_setAttributes,
   type SetAttributesOptions,
   setAttributes,
 } from './set-attributes.js';

--- a/packages/core/src/set-attributes.test.ts
+++ b/packages/core/src/set-attributes.test.ts
@@ -1,7 +1,7 @@
 import { FatalError } from '@workflow/errors';
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { experimental_setAttributes, setAttributes } from './set-attributes.js';
+import { setAttributes } from './set-attributes.js';
 import { contextStorage, type StepContext } from './step/context-storage.js';
 
 const WORLD_CACHE = Symbol.for('@workflow/world//cache');
@@ -165,10 +165,6 @@ describe('setAttributes (host-side)', () => {
     // Barrier rejection is swallowed for ordering only — the write still fires
     // and would surface a genuine run-not-found error from the World itself.
     expect(create).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps the deprecated experimental_setAttributes alias working', async () => {
-    expect(experimental_setAttributes).toBe(setAttributes);
   });
 
   it('rejects validation errors before posting from a step', async () => {

--- a/packages/core/src/set-attributes.ts
+++ b/packages/core/src/set-attributes.ts
@@ -3,12 +3,9 @@ import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { normalizeAttributeChanges } from './attribute-changes.js';
 import { getWorldLazy } from './runtime/get-world-lazy.js';
 import { contextStorage } from './step/context-storage.js';
-import type {
-  ExperimentalSetAttributesOptions,
-  SetAttributesOptions,
-} from './workflow/set-attributes.js';
+import type { SetAttributesOptions } from './workflow/set-attributes.js';
 
-export type { ExperimentalSetAttributesOptions, SetAttributesOptions };
+export type { SetAttributesOptions };
 
 /**
  * Host-side implementation for `setAttributes`. Workflow bodies resolve
@@ -66,9 +63,3 @@ export async function setAttributes(
     },
   });
 }
-
-/**
- * @deprecated The feature is no longer experimental — use
- * {@link setAttributes} instead.
- */
-export const experimental_setAttributes = setAttributes;

--- a/packages/core/src/workflow/index.ts
+++ b/packages/core/src/workflow/index.ts
@@ -15,7 +15,6 @@ export { createHook, createWebhook } from './create-hook.js';
 export { defineHook } from './define-hook.js';
 export { getWorkflowMetadata } from './get-workflow-metadata.js';
 export {
-  experimental_setAttributes,
   type SetAttributesOptions,
   setAttributes,
 } from './set-attributes.js';

--- a/packages/core/src/workflow/set-attributes.test.ts
+++ b/packages/core/src/workflow/set-attributes.test.ts
@@ -1,7 +1,7 @@
 import { FatalError } from '@workflow/errors';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WORKFLOW_SET_ATTRIBUTES } from '../symbols.js';
-import { experimental_setAttributes, setAttributes } from './set-attributes.js';
+import { setAttributes } from './set-attributes.js';
 
 describe('workflow.setAttributes', () => {
   const dispatchCalls: Array<{
@@ -91,14 +91,6 @@ describe('workflow.setAttributes', () => {
       )
     ).rejects.toBeInstanceOf(FatalError);
     expect(dispatchCalls).toHaveLength(0);
-  });
-
-  it('keeps the deprecated experimental_setAttributes alias working', async () => {
-    expect(experimental_setAttributes).toBe(setAttributes);
-    await experimental_setAttributes({ phase: 'init' });
-    expect(dispatchCalls).toEqual([
-      { changes: [{ key: 'phase', value: 'init' }], options: {} },
-    ]);
   });
 
   it('throws FatalError when called with a non-object', async () => {

--- a/packages/core/src/workflow/set-attributes.ts
+++ b/packages/core/src/workflow/set-attributes.ts
@@ -27,11 +27,6 @@ export interface SetAttributesOptions {
 }
 
 /**
- * @deprecated Use {@link SetAttributesOptions} instead.
- */
-export type ExperimentalSetAttributesOptions = SetAttributesOptions;
-
-/**
  * Attach plaintext string key/value metadata to the current workflow run.
  *
  * Callable only from a workflow body (`'use workflow'`). The call is
@@ -101,9 +96,3 @@ export async function setAttributes(
     allowReservedAttributes ? { allowReservedAttributes: true } : {}
   );
 }
-
-/**
- * @deprecated The feature is no longer experimental — use
- * {@link setAttributes} instead.
- */
-export const experimental_setAttributes = setAttributes;


### PR DESCRIPTION
## What

- remove the deprecated `experimental_setAttributes` host and workflow aliases
- remove the compatibility-only `ExperimentalSetAttributesOptions` type
- remove alias-specific tests and the deprecated API callout

## Why

The experimental entry points are exact aliases of the stable `setAttributes` API. Keeping both expands the public surface and duplicates tests without preserving distinct behavior.

## Impact

This is a deliberate breaking cleanup for callers still using the experimental names. The stable replacement is `setAttributes`; its behavior is unchanged.

## Verification

- focused host and workflow attribute tests: 14 passed
- `@workflow/core` typecheck
- Biome check on changed files
- diff check

## Docs Preview

| Page | Preview |
| :--- | :--- |
| v5 `setAttributes` | [Preview](https://workflow-docs-git-codex-remove-experimental-set-attributes.vercel.sh/v5/docs/api-reference/workflow/set-attributes) |