### PR TITLE
Snapshot environment per workflow delivery

### DIFF
--- a/.changeset/snapshot-workflow-delivery-environment.md
+++ b/.changeset/snapshot-workflow-delivery-environment.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Keep workflow environment variables stable across inline replays in one queue delivery.

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -18,6 +18,7 @@ import { workflowEntrypoint } from './runtime.js';
 import {
   dehydrateStepReturnValue,
   dehydrateWorkflowArguments,
+  hydrateWorkflowReturnValue,
 } from './serialization.js';
 
 // Capture every promise handed to `waitUntil` so tests can assert that
@@ -63,6 +64,8 @@ async function runWorkflowHandlerWithEvents(
      * pin the log's contents keep full control.
      */
     dynamicEventLog?: boolean;
+    /** Invoked after an event is made durable by the test World. */
+    afterEventCreated?: (event: Event) => void;
   } = {}
 ) {
   const createdEvents = options.createdEvents ?? [];
@@ -85,6 +88,7 @@ async function runWorkflowHandlerWithEvents(
     if (options.dynamicEventLog) {
       events.push(event as Event);
     }
+    options.afterEventCreated?.(event as Event);
     return { event };
   });
 
@@ -760,6 +764,86 @@ describe('workflowEntrypoint replay guards', () => {
     expect(createdEvents).not.toContainEqual(
       expect.objectContaining({ eventType: 'step_started' })
     );
+  });
+
+  it('keeps the environment stable across inline replays in one delivery', async () => {
+    const environmentKey = 'WORKFLOW_DELIVERY_ENV_SNAPSHOT_TEST';
+    const originalEnvironmentValue = process.env[environmentKey];
+    process.env[environmentKey] = 'before-replay';
+
+    try {
+      const workflowRun: WorkflowRun = {
+        runId: 'wrun_delivery_environment',
+        workflowName: 'workflow',
+        status: 'running',
+        input: await dehydrateWorkflowArguments(
+          [],
+          'wrun_delivery_environment',
+          undefined,
+          []
+        ),
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+        startedAt: new Date('2024-01-01T00:00:00.000Z'),
+        deploymentId: 'test-deployment',
+      };
+      const createdEvents: unknown[] = [];
+
+      await runWorkflowHandlerWithEvents(
+        `const setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
+        async function workflow() {
+          const environment = process.env.${environmentKey};
+          await setAttributes([{ key: 'environment', value: environment }]);
+          return environment;
+        }${getWorkflowTransformCode('workflow')}`,
+        workflowRun,
+        [],
+        {
+          createdEvents,
+          dynamicEventLog: true,
+          afterEventCreated: (event) => {
+            if (event.eventType === 'attr_set') {
+              process.env[environmentKey] = 'after-replay';
+            }
+          },
+        }
+      );
+
+      expect(createdEvents).toContainEqual(
+        expect.objectContaining({
+          eventType: 'attr_set',
+          eventData: expect.objectContaining({
+            changes: [{ key: 'environment', value: 'before-replay' }],
+          }),
+        })
+      );
+      expect(createdEvents).toContainEqual(
+        expect.objectContaining({ eventType: 'run_completed' })
+      );
+      const completedEvent = createdEvents.find(
+        (event): event is { eventData: { output: Uint8Array } } =>
+          typeof event === 'object' &&
+          event !== null &&
+          'eventType' in event &&
+          event.eventType === 'run_completed'
+      );
+      if (!completedEvent) {
+        throw new Error('Expected the delivery to complete the workflow');
+      }
+      expect(
+        await hydrateWorkflowReturnValue(
+          completedEvent.eventData.output,
+          workflowRun.runId,
+          undefined
+        )
+      ).toBe('before-replay');
+    } finally {
+      if (originalEnvironmentValue === undefined) {
+        delete process.env[environmentKey];
+      } else {
+        process.env[environmentKey] = originalEnvironmentValue;
+      }
+    }
   });
 
   it('fails the run when the World rejects an attr_set event as invalid', async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -99,6 +99,7 @@ import {
 } from './telemetry.js';
 import { getErrorName, getErrorStack, normalizeUnknownError } from './types.js';
 import { buildWorkflowSuspensionMessage } from './util.js';
+import { snapshotEnvironment } from './vm/index.js';
 import { runWorkflow } from './workflow.js';
 
 export type { Event, WorkflowRun };
@@ -375,6 +376,10 @@ export function workflowEntrypoint(
           replayDivergence,
           runInput,
         } = WorkflowInvokePayloadSchema.parse(message_);
+        // A delivery may replay the workflow several times while executing
+        // inline steps. Capture the environment before any async work so each
+        // fresh VM and its derived base URL see one consistent snapshot.
+        const environment = snapshotEnvironment();
         // `start()` always attaches a trace carrier, but
         // serializeTraceCarrier() returns `{}` when no OTEL SDK is registered
         // or no span is active — treat an empty carrier the same as an
@@ -783,6 +788,7 @@ export function workflowEntrypoint(
                               stepId: incomingStepId,
                               stepName: incomingStepName,
                               runSpecVersion: bgRun.specVersion,
+                              environment,
                               // Retry ceiling: the queue delivery count as a fast
                               // gate, verified against the recorded step_started
                               // count once it crosses the ceiling (see above).
@@ -1540,7 +1546,8 @@ export function workflowEntrypoint(
                         // `awaitRunReady()` below, so gate those writes on the
                         // backgrounded run_started too. Undefined outside turbo.
                         runReadyBarrier,
-                        world.capabilities
+                        world.capabilities,
+                        environment
                       );
                       await payloadPrewarm;
                       runtimeLogger.debug('Workflow replay completed', {
@@ -2310,6 +2317,7 @@ export function workflowEntrypoint(
                                 stepId: s.correlationId,
                                 stepName: s.stepName,
                                 runSpecVersion: workflowRun.specVersion,
+                                environment,
                                 // Attempt number = prior step_started count + 1
                                 // (this execution's start), counting only THIS
                                 // message's own starts: the owned-recovery

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -37,6 +37,7 @@ import {
   normalizeUnknownError,
   promoteAbortErrorToFatal,
 } from '../types.js';
+import { type EnvironmentSnapshot, snapshotEnvironment } from '../vm/index.js';
 
 import {
   isOptimisticInlineStartEnabled,
@@ -85,6 +86,8 @@ export interface StepExecutorParams {
   rootRunId?: string;
   stepId: string;
   stepName: string;
+  /** Immutable environment captured at the start of this queue delivery. */
+  environment?: EnvironmentSnapshot;
   encryptionKey?: CryptoKey;
   /**
    * The workflow run's specVersion, used to gate payload compression.
@@ -249,7 +252,8 @@ export async function executeStep(
     stepId,
     stepName,
   } = params;
-  const isVercel = process.env.VERCEL_URL !== undefined;
+  const environment = params.environment ?? snapshotEnvironment();
+  const isVercel = environment.VERCEL_URL !== undefined;
   // Gate payload compression on the run's specVersion.
   const compression =
     (params.runSpecVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION;
@@ -798,7 +802,7 @@ export async function executeStep(
       const thisVal = hydratedInput.thisVal ?? null;
       const workflowBaseUrl = createWorkflowBaseUrl(
         isVercel
-          ? `https://${process.env.VERCEL_URL}`
+          ? `https://${environment.VERCEL_URL}`
           : `http://localhost:${(await getPortLazy()) ?? 3000}`
       );
 

--- a/packages/core/src/vm/index.test.ts
+++ b/packages/core/src/vm/index.test.ts
@@ -27,6 +27,26 @@ describe('createContext', () => {
     expect(vm.runInContext('Date.now()', context)).toEqual(fixedTimestamp);
   });
 
+  it('uses the supplied immutable environment snapshot directly', () => {
+    const environment = Object.freeze({
+      WORKFLOW_ENV_TEST: 'captured',
+    });
+    const { context } = createContext({ seed, fixedTimestamp, environment });
+
+    const vmEnvironment = vm.runInContext('process.env', context);
+    expect(vmEnvironment).toBe(environment);
+    expect(vm.runInContext('process.env.WORKFLOW_ENV_TEST', context)).toBe(
+      'captured'
+    );
+    expect(vm.runInContext('Object.isFrozen(process.env)', context)).toBe(true);
+    expect(
+      vm.runInContext(
+        "process.env.hasOwnProperty('WORKFLOW_ENV_TEST')",
+        context
+      )
+    ).toBe(true);
+  });
+
   it('should have deterministic `Date` constructor when called without arguments', () => {
     const fixedTimestamp = 1234567890000;
     const { context } = createContext({ seed, fixedTimestamp });

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -10,6 +10,19 @@ export interface CreateContextOptions {
   seed: string;
   // Fixed timestamp for deterministic Date operations
   fixedTimestamp: number;
+  /**
+   * Immutable environment captured for this workflow delivery. Supplying it
+   * lets fresh replay VMs observe the same environment without exposing the
+   * host `process` object.
+   */
+  environment?: EnvironmentSnapshot;
+}
+
+export type EnvironmentSnapshot = Readonly<NodeJS.ProcessEnv>;
+
+/** Capture the host environment once for deterministic workflow replays. */
+export function snapshotEnvironment(): EnvironmentSnapshot {
+  return Object.freeze({ ...process.env });
 }
 
 // WebCrypto digest algorithm names → node:crypto (OpenSSL) names.
@@ -51,7 +64,7 @@ function toDigestInput(
  */
 export function createContext(options: CreateContextOptions) {
   let { fixedTimestamp } = options;
-  const { seed } = options;
+  const { seed, environment = snapshotEnvironment() } = options;
   const rng = seedrandom(seed);
   const context = vmCreateContext();
 
@@ -171,7 +184,7 @@ export function createContext(options: CreateContextOptions) {
 
   // Propagate environment variables
   (g as any).process = {
-    env: Object.freeze({ ...process.env }),
+    env: environment,
   };
 
   // Stateless + synchronous Web APIs that are made available inside the sandbox

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -38,7 +38,11 @@ import {
 import * as Attribute from './telemetry/semantic-conventions.js';
 import { trace } from './telemetry.js';
 import { getWorkflowRunStreamId } from './util.js';
-import { createContext } from './vm/index.js';
+import {
+  createContext,
+  type EnvironmentSnapshot,
+  snapshotEnvironment,
+} from './vm/index.js';
 import { runCachedWorkflowScript } from './vm/script-cache.js';
 import {
   createAbortSignalStatics,
@@ -136,7 +140,12 @@ export async function runWorkflow(
    * Features supported by the World executing this workflow. Missing
    * capabilities are treated as unsupported.
    */
-  worldCapabilities?: WorldCapabilities
+  worldCapabilities?: WorldCapabilities,
+  /**
+   * Immutable environment captured at the start of the queue delivery. It is
+   * shared by every fresh VM replay in that delivery.
+   */
+  environment: EnvironmentSnapshot = snapshotEnvironment()
 ): Promise<Uint8Array | unknown> {
   return trace(`workflow.run ${workflowRun.workflowName}`, async (span) => {
     span?.setAttributes({
@@ -159,14 +168,14 @@ export async function runWorkflow(
     const fixedTimestamp =
       runIdCreatedAt(workflowRun.runId) ?? +workflowRun.createdAt;
 
-    const isVercel = process.env.VERCEL_URL !== undefined;
+    const isVercel = environment.VERCEL_URL !== undefined;
     // Load getPort lazily to prevent Turbopack from tracing get-port's
     // fs ops (readdir, readFile) into the flow route bundle. The resolved
     // port is cached per process (see get-port-lazy.ts), so this is cheap
     // on replays after the first.
     const workflowBaseUrl = createWorkflowBaseUrl(
       isVercel
-        ? `https://${process.env.VERCEL_URL}`
+        ? `https://${environment.VERCEL_URL}`
         : `http://localhost:${(await getPortLazy()) ?? 3000}`
     );
 
@@ -177,6 +186,7 @@ export async function runWorkflow(
     } = createContext({
       seed: `${workflowRun.runId}:${workflowRun.workflowName}:${workflowRun.deploymentId}`,
       fixedTimestamp,
+      environment,
     });
 
     const workflowDiscontinuation = withResolvers<void>();


### PR DESCRIPTION
## What

Capture one frozen, normal-object snapshot of `process.env` when a workflow delivery begins and pass it through workflow, VM, step, and base-URL setup.

## Why

The same delivery repeatedly copied and reread the ambient process environment. A single snapshot makes the input stable and avoids redundant work.

## Impact

Each delivery sees a consistent environment while separate deliveries still receive fresh snapshots.

## Verification

- focused runtime and VM tests: 12 passed
- `@workflow/core` typecheck
- Biome and diff checks