### PR TITLE
Share error dehydration pipeline

### DIFF
--- a/.changeset/bright-errors-dehydrate.md
+++ b/.changeset/bright-errors-dehydrate.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Deduplicate step and workflow error dehydration internals.

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -3433,6 +3433,34 @@ export async function dehydrateStepReturnValue(
 }
 
 /**
+ * Serializes an error payload after its boundary-specific reducers have been
+ * selected. The caller owns error framing so step and run errors retain their
+ * existing labels.
+ */
+async function dehydrateError(
+  value: unknown,
+  reducers: Partial<Reducers>,
+  key: CryptoKey | undefined,
+  compression: boolean
+): Promise<Uint8Array> {
+  const str = stringify(value, reducers);
+  const payload = new TextEncoder().encode(str);
+  const serialized = encodeWithFormatPrefix(
+    SerializationFormat.DEVALUE_V1,
+    payload
+  ) as Uint8Array;
+  // Compress before encrypting — encrypted bytes don't compress.
+  const compressionStats: CompressionStats = {};
+  const compressed = await compress(serialized, compression, compressionStats);
+  const encrypted = (await maybeEncrypt(
+    compressed as Uint8Array,
+    key
+  )) as Uint8Array;
+  await recordCompression(compressionStats, 'serialize');
+  return encrypted;
+}
+
+/**
  * Called from the step executor when a step throws. Dehydrates the thrown
  * value from within the step execution environment into a format that can
  * be saved to the database in a `step_failed` or `step_retrying` event.
@@ -3457,25 +3485,12 @@ export async function dehydrateStepError(
   compression = false
 ): Promise<Uint8Array> {
   try {
-    const str = stringify(value, getStepReducers(global, ops, runId, key));
-    const payload = new TextEncoder().encode(str);
-    const serialized = encodeWithFormatPrefix(
-      SerializationFormat.DEVALUE_V1,
-      payload
-    ) as Uint8Array;
-    // Compress before encrypting — encrypted bytes don't compress.
-    const compressionStats: CompressionStats = {};
-    const compressed = await compress(
-      serialized,
-      compression,
-      compressionStats
+    return await dehydrateError(
+      value,
+      getStepReducers(global, ops, runId, key),
+      key,
+      compression
     );
-    const encrypted = (await maybeEncrypt(
-      compressed as Uint8Array,
-      key
-    )) as Uint8Array;
-    await recordCompression(compressionStats, 'serialize');
-    return encrypted;
   } catch (error) {
     const cause = unwrapSerializationCause(error);
     const { message, hint } = formatSerializationError('step error', cause);
@@ -3530,25 +3545,12 @@ export async function dehydrateRunError(
   compression = false
 ): Promise<Uint8Array> {
   try {
-    const str = stringify(value, getWorkflowReducers(global));
-    const payload = new TextEncoder().encode(str);
-    const serialized = encodeWithFormatPrefix(
-      SerializationFormat.DEVALUE_V1,
-      payload
-    ) as Uint8Array;
-    // Compress before encrypting — encrypted bytes don't compress.
-    const compressionStats: CompressionStats = {};
-    const compressed = await compress(
-      serialized,
-      compression,
-      compressionStats
+    return await dehydrateError(
+      value,
+      getWorkflowReducers(global),
+      key,
+      compression
     );
-    const encrypted = (await maybeEncrypt(
-      compressed as Uint8Array,
-      key
-    )) as Uint8Array;
-    await recordCompression(compressionStats, 'serialize');
-    return encrypted;
   } catch (error) {
     const cause = unwrapSerializationCause(error);
     const { message, hint } = formatSerializationError('run error', cause);


### PR DESCRIPTION
## What

Route step and workflow-run error dehydration through one private implementation while retaining their public wrappers and hydration paths.

## Why

Both pipelines performed the same reducer setup, dehydration, and fallback handling. Keeping two copies made fixes easy to apply inconsistently.

## Impact

No wire-format or public API change.

## Verification

- full serialization suite: 199 passed
- `@workflow/core` typecheck
- formatting and diff checks