### PR TITLE
Reuse serialization format constants

### DIFF
--- a/.changeset/calm-formats-share.md
+++ b/.changeset/calm-formats-share.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Reuse the canonical serialization format constants in browser-safe helpers.

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -10,7 +10,7 @@
  * ## Adding a new format
  *
  * When a new serialization format is introduced:
- * 1. Add the format constant to `SerializationFormat` in `serialization.ts`
+ * 1. Add the format constant to `SerializationFormat` in `serialization/types.ts`
  * 2. Add an entry to `FORMAT_VERSION_TABLE` below with the minimum
  *    `@workflow/core` version that supports it
  * 3. The `getRunCapabilities()` function will automatically include it

--- a/packages/core/src/serialization-format.test.ts
+++ b/packages/core/src/serialization-format.test.ts
@@ -17,6 +17,7 @@ import {
   observabilityRevivers,
   type Revivers,
   SerializationFormat,
+  type SerializationFormatType,
   STREAM_REF_TYPE,
   truncateId,
 } from './serialization-format.js';
@@ -59,10 +60,8 @@ const testRevivers: Revivers = {
 describe('encodeWithFormatPrefix', () => {
   it('should prepend the format prefix to a Uint8Array payload', () => {
     const payload = new Uint8Array([1, 2, 3]);
-    const encoded = encodeWithFormatPrefix(
-      SerializationFormat.DEVALUE_V1,
-      payload
-    ) as Uint8Array;
+    const format: SerializationFormatType = 'devl';
+    const encoded = encodeWithFormatPrefix(format, payload) as Uint8Array;
 
     expect(encoded).toBeInstanceOf(Uint8Array);
     expect(encoded.length).toBe(4 + 3); // "devl" (4 bytes) + payload (3 bytes)

--- a/packages/core/src/serialization-format.ts
+++ b/packages/core/src/serialization-format.ts
@@ -8,35 +8,24 @@
 
 import { getEventDataRefFields } from '@workflow/world';
 import { parse, unflatten } from 'devalue';
+import { SerializationFormat } from './serialization/types.js';
 
 // ---------------------------------------------------------------------------
 // Format prefix constants and encoding/decoding
 // ---------------------------------------------------------------------------
 
-export const SerializationFormat = {
-  /** devalue stringify/parse with TextEncoder/TextDecoder */
-  DEVALUE_V1: 'devl',
-  /** Encrypted payload (inner payload has its own format prefix after decryption) */
-  ENCRYPTED: 'encr',
-  /**
-   * Sealed payload — asymmetrically encrypted to a run's X25519 public key
-   * (inner payload has its own format prefix after opening).
-   *
-   * Written by cross-run writers that hold only the recipient run's public
-   * key. Opening it requires the run's private scalar rather than the
-   * symmetric per-run key, so o11y display treats it as ciphertext via
-   * {@link isEncryptedData} but {@link hydrateDataWithKey} does not attempt
-   * an AES-GCM decrypt on it.
-   */
-  SEALED: 'encp',
-  /** Gzip-compressed payload (inner payload has its own format prefix after decompression) */
-  GZIP: 'gzip',
-  /** Zstandard-compressed payload (inner payload has its own format prefix after decompression) */
-  ZSTD: 'zstd',
-} as const;
+export { SerializationFormat };
 
+/**
+ * Public literal union retained for compatibility with callers that pass a
+ * validated format directly instead of reading it from `SerializationFormat`.
+ */
 export type SerializationFormatType =
-  (typeof SerializationFormat)[keyof typeof SerializationFormat];
+  | 'devl'
+  | 'encr'
+  | 'encp'
+  | 'gzip'
+  | 'zstd';
 
 /** Length of the format prefix in bytes */
 const FORMAT_PREFIX_LENGTH = 4;
@@ -77,7 +66,7 @@ export function decodeFormatPrefix(data: Uint8Array | unknown): {
 } {
   if (!(data instanceof Uint8Array)) {
     return {
-      format: SerializationFormat.DEVALUE_V1,
+      format: SerializationFormat.DEVALUE_V1 as SerializationFormatType,
       payload: new TextEncoder().encode(JSON.stringify(data)),
     };
   }


### PR DESCRIPTION
## What

Use the canonical runtime serialization-format constants from `serialization/types.ts` instead of maintaining a second value object in `serialization-format.ts`.

## Why

The duplicate definitions could drift as formats are added. The public literal-union type remains explicit so raw format literals stay assignable.

## Impact

No format values, public type compatibility, or serialization behavior changes.

## Verification

- serialization-format and capabilities tests: 218 passed
- `@workflow/core` typecheck
- Biome and diff checks