### PR TITLE
fix(core): order step-result deliveries against wait/hook deliveries by event-log position

### DIFF
--- a/.changeset/step-delivery-ordering.md
+++ b/.changeset/step-delivery-ordering.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Deliver step results in strict event-log order relative to wait completions and hook payloads, preventing replay divergence (`CORRUPTED_EVENT_LOG`) when a step completion is adjacent in the log to a `wait_completed` or `hook_received` that a concurrent branch is awaiting.
+Deliver step results, wait completions, hook payloads and aborts in strict event-log order relative to one another, preventing replay divergence (`CORRUPTED_EVENT_LOG`) when a step completion is adjacent in the log to a `wait_completed`, `hook_received` or abort that a concurrent branch is awaiting.

--- a/.changeset/step-delivery-ordering.md
+++ b/.changeset/step-delivery-ordering.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Deliver step results in strict event-log order relative to wait completions and hook payloads, preventing replay divergence (`CORRUPTED_EVENT_LOG`) when a step completion is adjacent in the log to a `wait_completed` or `hook_received` that a concurrent branch is awaiting.

--- a/packages/core/src/delivery-barrier-coverage.test.ts
+++ b/packages/core/src/delivery-barrier-coverage.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Third companion to `step-delivery-ordering.test.ts` (the two production
+ * `CORRUPTED_EVENT_LOG` shapes) and `step-delivery-hop-count.test.ts` (a step
+ * result must not overtake the wait/hook branch the log ordered first, however
+ * many hops that branch needs). Both of those cover a step result deferring
+ * behind an earlier delivery. This file covers the three cases where the
+ * delivery-barrier registry did not yet reach:
+ *
+ *  1. STEP behind STEP, across drain windows. `DEFER_BEHIND.step` used to
+ *     exclude `'step'`, on the grounds that the serial `promiseQueue` already
+ *     orders step results. It no longer does: a step captures its outcome in
+ *     its queue slot but resolves from a detached continuation once its
+ *     barrier clears, and two steps agree on that ordering only while they
+ *     defer behind the same set.
+ *
+ *  2. WAIT / HOOK behind STEP, at varying consumer hop counts — the mirror of
+ *     `step-delivery-hop-count.test.ts`. `sleep.ts` and `hook.ts` used to read
+ *     the registry after their queue work rather than at event-consumption
+ *     time, by which point an earlier step had usually delivered and retired
+ *     its barrier. They then skipped both the gate and
+ *     `awaitEarlierDeliveries`' macrotask yield.
+ *
+ *  3. ABORT deliveries. `_setAborted` fires the signal's listeners, and a
+ *     listener may invoke a step and draw a ULID, so an abort is as
+ *     branch-deciding as any other delivery — but it resolved straight off its
+ *     `promiseQueue` slot and registered no barrier.
+ *
+ * Every case asserts the same thing: the replay allocates its follow-up step
+ * ULIDs in the order the committed log recorded. A regression surfaces as the
+ * production `ReplayDivergenceError`.
+ */
+import { WorkflowRuntimeError } from '@workflow/errors';
+import { withResolvers } from '@workflow/utils';
+import type { Event } from '@workflow/world';
+import * as nanoid from 'nanoid';
+import { monotonicFactory } from 'ulid';
+import { describe, expect, it, vi } from 'vitest';
+import { EventsConsumer } from './events-consumer.js';
+import { WorkflowSuspension } from './global.js';
+import {
+  awaitEarlierDeliveries,
+  registerDeliveryBarrier,
+  type WorkflowOrchestratorContext,
+} from './private.js';
+import { ReplayPayloadCache } from './replay-payload-cache.js';
+import { dehydrateStepReturnValue } from './serialization.js';
+import { createUseStep } from './step.js';
+import { createContext } from './vm/index.js';
+import { createCreateAbortController } from './workflow/abort-controller.js';
+import { createCreateHook } from './workflow/hook.js';
+import { createSleep } from './workflow/sleep.js';
+
+const FIXED_TIMESTAMP = 1753481739458;
+
+function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
+  const context = createContext({
+    seed: 'test',
+    fixedTimestamp: FIXED_TIMESTAMP,
+  });
+  const ulid = monotonicFactory(() => context.globalThis.Math.random());
+  const workflowStartedAt = context.globalThis.Date.now();
+  const promiseQueueHolder = { current: Promise.resolve() };
+  const ctxRef: { current?: WorkflowOrchestratorContext } = {};
+  const ctx: WorkflowOrchestratorContext = {
+    runId: 'wrun_test',
+    encryptionKey: undefined,
+    replayPayloadCache: new ReplayPayloadCache(undefined),
+    globalThis: context.globalThis,
+    eventsConsumer: new EventsConsumer(events, {
+      onUnconsumedEvent: (event) => {
+        ctxRef.current?.onWorkflowError(
+          new WorkflowRuntimeError(`Unconsumed event: ${event.eventType}`)
+        );
+      },
+      getPromiseQueue: () => promiseQueueHolder.current,
+    }),
+    invocationsQueue: new Map(),
+    generateUlid: () => ulid(workflowStartedAt),
+    generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
+      new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
+    ),
+    onWorkflowError: vi.fn(),
+    get promiseQueue() {
+      return promiseQueueHolder.current;
+    },
+    set promiseQueue(value: Promise<void>) {
+      promiseQueueHolder.current = value;
+    },
+    pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
+  };
+  ctxRef.current = ctx;
+  return ctx;
+}
+
+/**
+ * The ULIDs the seeded generator hands out, in invocation order. Correlation
+ * IDs in the fixtures below have to match what the replayed workflow draws.
+ */
+function deterministicUlids(count: number): string[] {
+  const context = createContext({
+    seed: 'test',
+    fixedTimestamp: FIXED_TIMESTAMP,
+  });
+  const ulid = monotonicFactory(() => context.globalThis.Math.random());
+  const workflowStartedAt = context.globalThis.Date.now();
+  return Array.from({ length: count }, () => ulid(workflowStartedAt));
+}
+
+const ULIDS = deterministicUlids(8);
+
+async function replay(
+  ctx: WorkflowOrchestratorContext,
+  workflowFn: () => Promise<unknown>
+): Promise<unknown> {
+  const discontinuation = withResolvers<void>();
+  ctx.onWorkflowError = discontinuation.reject;
+  try {
+    await Promise.race([workflowFn(), discontinuation.promise]);
+  } catch (err) {
+    return err;
+  }
+  return undefined;
+}
+
+/**
+ * Assert the replay stopped where the committed log says it should: the
+ * follow-up steps allocated, in the log's order, and the run suspended waiting
+ * on them. A divergent replay fails here with the production error instead.
+ */
+function expectSuspendedWithPendingSteps(
+  ctx: WorkflowOrchestratorContext,
+  error: unknown,
+  expected: string[]
+) {
+  if (!WorkflowSuspension.is(error)) {
+    throw new Error(
+      error === undefined
+        ? 'expected the replay to suspend, but it completed'
+        : error instanceof Error
+          ? error.message
+          : String(error),
+      { cause: error }
+    );
+  }
+  expect(
+    [...ctx.invocationsQueue.values()].flatMap((item) =>
+      item.type === 'step' ? [item.stepName] : []
+    )
+  ).toEqual(expected);
+}
+
+const event = (
+  eventId: string,
+  eventType: string,
+  correlationId: string,
+  eventData: Record<string, unknown>
+): Event =>
+  ({
+    eventId,
+    runId: 'wrun_test',
+    eventType,
+    correlationId,
+    eventData,
+    createdAt: new Date(),
+  }) as Event;
+
+// ─── 1. step behind step, across drain windows ────────────────────────────
+//
+// The log is one a live run legitimately produces:
+//
+//   evnt_3  wait_completed        ← the sleep branch
+//   evnt_4  step_completed stepA  ← stepA's worker wrote this just before…
+//   evnt_5  step_created   stepB  ← …the invocation resuming from the sleep
+//                                   wrote this; its own replay predated
+//                                   evnt_4, so it never delivered stepA
+//   evnt_7  step_completed stepB
+//   evnt_8  step_created   afterA ← a later invocation delivered stepA first,
+//   evnt_9  step_created   afterB   exactly as the log orders them
+//
+// On replay `stepB`'s consumer does not exist until the sleep is delivered, so
+// the drain stops at evnt_5 and the two step completions land in separate
+// windows. stepA (deferring behind the wait) is then parked on the macrotask
+// yield while stepB, which sees an empty registry, resolves on microtasks.
+describe('step result delivery ordering against an earlier step result', () => {
+  it('delivers the earlier step_completed first when only it defers', async () => {
+    const resumeAt = new Date(FIXED_TIMESTAMP + 5_000);
+    const ops: Promise<unknown>[] = [];
+    const [stepAResult, stepBResult] = await Promise.all([
+      dehydrateStepReturnValue('a', 'wrun_test', undefined, ops),
+      dehydrateStepReturnValue('b', 'wrun_test', undefined, ops),
+    ]);
+
+    const events: Event[] = [
+      event('evnt_0', 'step_created', `step_${ULIDS[0]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_1', 'wait_created', `wait_${ULIDS[1]}`, { resumeAt }),
+      event('evnt_2', 'step_started', `step_${ULIDS[0]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_3', 'wait_completed', `wait_${ULIDS[1]}`, { resumeAt }),
+      event('evnt_4', 'step_completed', `step_${ULIDS[0]}`, {
+        stepName: 'stepA',
+        result: stepAResult,
+      }),
+      event('evnt_5', 'step_created', `step_${ULIDS[2]}`, {
+        stepName: 'stepB',
+      }),
+      event('evnt_6', 'step_started', `step_${ULIDS[2]}`, {
+        stepName: 'stepB',
+      }),
+      event('evnt_7', 'step_completed', `step_${ULIDS[2]}`, {
+        stepName: 'stepB',
+        result: stepBResult,
+      }),
+      event('evnt_8', 'step_created', `step_${ULIDS[3]}`, {
+        stepName: 'afterA',
+      }),
+      event('evnt_9', 'step_created', `step_${ULIDS[4]}`, {
+        stepName: 'afterB',
+      }),
+    ];
+
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    const sleep = createSleep(ctx);
+
+    const error = await replay(ctx, async () => {
+      const stepA = useStep('stepA');
+      const afterA = useStep('afterA');
+      const stepB = useStep('stepB');
+      const afterB = useStep('afterB');
+
+      await Promise.all([
+        (async () => {
+          await stepA();
+          await afterA();
+        })(),
+        (async () => {
+          await sleep('5s');
+          await stepB();
+          await afterB();
+        })(),
+      ]);
+    });
+
+    expectSuspendedWithPendingSteps(ctx, error, ['afterA', 'afterB']);
+  });
+});
+
+// ─── 2. wait / hook behind step, at varying consumer hop counts ────────────
+//
+// The mirror of `step-delivery-hop-count.test.ts`: there a step result must
+// not overtake an earlier wait/hook branch; here a wait/hook must not overtake
+// an earlier STEP branch. The step branch is padded with extra `await`s so hop
+// count is the only variable — under a hop-count race the padded branch loses
+// and the follow-up ULIDs swap.
+const EXTRA_HOPS = [0, 1, 3, 8, 20, 50];
+
+describe('wait completion delivery ordering against an earlier step result', () => {
+  for (const extraHops of EXTRA_HOPS) {
+    it(`keeps the recorded ULID allocation with ${extraHops} extra consumer hops`, async () => {
+      const resumeAt = new Date(FIXED_TIMESTAMP + 5_000);
+      const ops: Promise<unknown>[] = [];
+      const stepAResult = await dehydrateStepReturnValue(
+        'a',
+        'wrun_test',
+        undefined,
+        ops
+      );
+
+      const events: Event[] = [
+        event('evnt_0', 'step_created', `step_${ULIDS[0]}`, {
+          stepName: 'stepA',
+        }),
+        event('evnt_1', 'wait_created', `wait_${ULIDS[1]}`, { resumeAt }),
+        event('evnt_2', 'step_started', `step_${ULIDS[0]}`, {
+          stepName: 'stepA',
+        }),
+        event('evnt_3', 'step_completed', `step_${ULIDS[0]}`, {
+          stepName: 'stepA',
+          result: stepAResult,
+        }),
+        event('evnt_4', 'wait_completed', `wait_${ULIDS[1]}`, { resumeAt }),
+        event('evnt_5', 'step_created', `step_${ULIDS[2]}`, {
+          stepName: 'afterStep',
+        }),
+        event('evnt_6', 'step_created', `step_${ULIDS[3]}`, {
+          stepName: 'afterSleep',
+        }),
+      ];
+
+      const ctx = setupWorkflowContext(events);
+      const useStep = createUseStep(ctx);
+      const sleep = createSleep(ctx);
+
+      const error = await replay(ctx, async () => {
+        const stepA = useStep('stepA');
+        const afterStep = useStep('afterStep');
+        const afterSleep = useStep('afterSleep');
+
+        await Promise.all([
+          (async () => {
+            await stepA();
+            for (let i = 0; i < extraHops; i++) {
+              await Promise.resolve();
+            }
+            await afterStep();
+          })(),
+          (async () => {
+            await sleep('5s');
+            await afterSleep();
+          })(),
+        ]);
+      });
+
+      expectSuspendedWithPendingSteps(ctx, error, ['afterStep', 'afterSleep']);
+    });
+  }
+});
+
+describe('hook payload delivery ordering against an earlier step result', () => {
+  for (const extraHops of EXTRA_HOPS) {
+    it(`keeps the recorded ULID allocation with ${extraHops} extra consumer hops`, async () => {
+      const ops: Promise<unknown>[] = [];
+      const [stepAResult, hookPayload] = await Promise.all([
+        dehydrateStepReturnValue('a', 'wrun_test', undefined, ops),
+        dehydrateStepReturnValue({ v: 1 }, 'wrun_test', undefined, ops),
+      ]);
+
+      const events: Event[] = [
+        event('evnt_0', 'step_created', `step_${ULIDS[0]}`, {
+          stepName: 'stepA',
+        }),
+        event('evnt_1', 'hook_created', `hook_${ULIDS[1]}`, {
+          token: 'tok',
+          isWebhook: false,
+        }),
+        event('evnt_2', 'step_started', `step_${ULIDS[0]}`, {
+          stepName: 'stepA',
+        }),
+        event('evnt_3', 'step_completed', `step_${ULIDS[0]}`, {
+          stepName: 'stepA',
+          result: stepAResult,
+        }),
+        event('evnt_4', 'hook_received', `hook_${ULIDS[1]}`, {
+          token: 'tok',
+          payload: hookPayload,
+        }),
+        event('evnt_5', 'step_created', `step_${ULIDS[2]}`, {
+          stepName: 'afterStep',
+        }),
+        event('evnt_6', 'step_created', `step_${ULIDS[3]}`, {
+          stepName: 'afterHook',
+        }),
+      ];
+
+      const ctx = setupWorkflowContext(events);
+      const useStep = createUseStep(ctx);
+      const createHook = createCreateHook(ctx);
+
+      const error = await replay(ctx, async () => {
+        const stepA = useStep('stepA');
+        const afterStep = useStep('afterStep');
+        const afterHook = useStep('afterHook');
+
+        await Promise.all([
+          (async () => {
+            await stepA();
+            for (let i = 0; i < extraHops; i++) {
+              await Promise.resolve();
+            }
+            await afterStep();
+          })(),
+          (async () => {
+            const hook = createHook<{ v: number }>({ token: 'tok' });
+            await hook;
+            await afterHook();
+          })(),
+        ]);
+      });
+
+      expectSuspendedWithPendingSteps(ctx, error, ['afterStep', 'afterHook']);
+    });
+  }
+});
+
+// ─── 3. abort deliveries ───────────────────────────────────────────────────
+//
+//   evnt_4  wait_completed          ← makes the step result defer
+//   evnt_5  step_completed stepA    ← deferred behind the wait
+//   evnt_6  hook_received  (abort)  ← must NOT overtake evnt_5
+describe('abort delivery ordering against an earlier step result', () => {
+  it('delivers the earlier step_completed before the abort', async () => {
+    // The controller draws two ULIDs on construction (stream id, then hook
+    // correlation id), so the sleep and stepA take the next two.
+    const abortHookToken = `abrt_${ULIDS[0]}`;
+    const abortCorrelationId = `hook_${ULIDS[1]}`;
+    const waitCorrelationId = `wait_${ULIDS[2]}`;
+    const stepACorrelationId = `step_${ULIDS[3]}`;
+
+    const resumeAt = new Date(FIXED_TIMESTAMP + 5_000);
+    const ops: Promise<unknown>[] = [];
+    const [stepAResult, abortPayload] = await Promise.all([
+      dehydrateStepReturnValue('a', 'wrun_test', undefined, ops),
+      dehydrateStepReturnValue(
+        { reason: 'cancelled' },
+        'wrun_test',
+        undefined,
+        ops
+      ),
+    ]);
+
+    const events: Event[] = [
+      event('evnt_0', 'hook_created', abortCorrelationId, {
+        token: abortHookToken,
+        isWebhook: false,
+      }),
+      event('evnt_1', 'wait_created', waitCorrelationId, { resumeAt }),
+      event('evnt_2', 'step_created', stepACorrelationId, {
+        stepName: 'stepA',
+      }),
+      event('evnt_3', 'step_started', stepACorrelationId, {
+        stepName: 'stepA',
+      }),
+      event('evnt_4', 'wait_completed', waitCorrelationId, { resumeAt }),
+      event('evnt_5', 'step_completed', stepACorrelationId, {
+        stepName: 'stepA',
+        result: stepAResult,
+      }),
+      event('evnt_6', 'hook_received', abortCorrelationId, {
+        token: abortHookToken,
+        payload: abortPayload,
+      }),
+      event('evnt_7', 'step_created', `step_${ULIDS[4]}`, {
+        stepName: 'afterStep',
+      }),
+      event('evnt_8', 'step_created', `step_${ULIDS[5]}`, {
+        stepName: 'afterAbort',
+      }),
+    ];
+
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    const sleep = createSleep(ctx);
+    const WorkflowAbortController = createCreateAbortController(ctx);
+
+    const error = await replay(ctx, async () => {
+      const controller = new WorkflowAbortController();
+      const stepA = useStep('stepA');
+      const afterStep = useStep('afterStep');
+      const afterAbort = useStep('afterAbort');
+
+      await Promise.all([
+        sleep('5s'),
+        (async () => {
+          await stepA();
+          await afterStep();
+        })(),
+        (async () => {
+          await new Promise<void>((resolveListener) => {
+            controller.signal.addEventListener('abort', resolveListener);
+          });
+          await afterAbort();
+        })(),
+      ]);
+    });
+
+    expectSuspendedWithPendingSteps(ctx, error, ['afterStep', 'afterAbort']);
+  });
+});
+
+// ─── 4. registry scan cost ─────────────────────────────────────────────────
+//
+// `resolvesOnItsOwn` walks the registry recursively: an armed hook re-checks
+// every earlier wait and step, an armed wait every earlier hook and step, and
+// so on. Unmemoized that is T(n) = Σ T(j) — exponential — and the registry is
+// not small by construction: `EventsConsumer` drains consecutively consumable
+// events synchronously while barriers only retire on microtask-driven
+// deliveries, so a fan-out of `Promise.race([hook, sleep(watchdog)])` branches
+// accumulates one barrier per branch per kind (measured: 49 live barriers for
+// 24 branches).
+//
+// The scan runs synchronously, before `awaitEarlierDeliveries` first awaits,
+// so timing the call alone measures it. Unmemoized, 40 alternating armed
+// hook/wait barriers is ~10^8 recursive calls — minutes. Memoized it is
+// linear. The bound is deliberately loose; this is an order-of-magnitude
+// guard, not a benchmark.
+describe('delivery-barrier registry scan cost', () => {
+  it('stays linear in registry size for a step delivery', () => {
+    const ctx = {
+      pendingDeliveries: 0,
+      promiseQueue: Promise.resolve(),
+      pendingDeliveryBarriers: new Map(),
+    } as unknown as WorkflowOrchestratorContext;
+
+    const BARRIERS = 40;
+    for (let index = 0; index < BARRIERS; index++) {
+      registerDeliveryBarrier(ctx, index, index % 2 ? 'hook' : 'wait');
+    }
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(BARRIERS);
+
+    const startedAt = performance.now();
+    // The floating promise never settles (nothing delivers these barriers);
+    // only the synchronous scan inside the call is under test.
+    void awaitEarlierDeliveries(ctx, BARRIERS, 'step');
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+});

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -162,26 +162,33 @@ export interface WorkflowOrchestratorContext {
   pendingDeliveries: number;
   /**
    * Ordered registry of in-flight "branch-deciding" deliveries — the
-   * resolutions a workflow typically `Promise.race`s on: buffered hook
-   * payloads (`hook_received`) and wait completions (`wait_completed`).
-   * Keyed by the delivery's position (index) in the consumed event log.
+   * resolutions a workflow typically `Promise.race`s on, or awaits from
+   * independent concurrent branches: hook payloads (`hook_received`), wait
+   * completions (`wait_completed`), and step results (`step_completed` /
+   * `step_failed`). Keyed by the delivery's position (index) in the consumed
+   * event log.
    *
-   * The problem: a buffered hook payload is observed via the async hook
-   * iterator (`yield await this`), costing extra microtask hops, while a
-   * `wait_completed` resolves with fewer hops — and a reused sleep can
-   * resolve in an entirely earlier loop iteration. Either way, the
-   * resolution that the committed event log ordered first can lose a
-   * `Promise.race` to a faster- or already-resolved competitor, diverging
-   * from the log and surfacing as `CorruptedEventLogError`.
+   * The problem: each of these resolutions reaches workflow code after a
+   * different, workload-dependent number of microtask hops. A buffered hook
+   * payload is observed via the async hook iterator (`yield await this`),
+   * costing extra hops; a `wait_completed` resolves with fewer, and a reused
+   * sleep can resolve in an entirely earlier loop iteration; a step result is
+   * gated on hydration whose cost varies between replays of the SAME
+   * invocation — the first replay pays the full decrypt/decompress/revive,
+   * while later replays sharing the invocation's `ReplayPayloadCache`
+   * memo-hit small primitive results and resolve in one or two hops. Either
+   * way, the resolution that the committed event log ordered first can lose a
+   * `Promise.race` (or a `useStep` ULID allocation) to a faster- or
+   * already-resolved competitor, diverging from the log and surfacing as
+   * `CorruptedEventLogError`.
    *
    * The fix is a strict, deterministic delivery order anchored on
    * event-log position: a delivery does not resolve to the workflow until
-   * every earlier-in-log delivery of the OPPOSITE kind has been delivered.
-   * (Opposite kind only: sequential same-kind hook payloads must not block
-   * one another, and a wait need not wait behind a later wait.) Because the
+   * every relevant earlier-in-log delivery has been delivered. Because the
    * gate is "the earlier delivery resolved", not "won a timing race", the
    * outcome is independent of microtask hops, hydration/decryption time,
-   * and `Promise.race` argument order.
+   * and `Promise.race` argument order. Which earlier kinds a delivery defers
+   * behind is spelled out on {@link awaitEarlierDeliveries}.
    *
    * Index is used rather than the `eventId` string because `eventId` is an
    * opaque, world-assigned value not guaranteed to sort in creation order
@@ -199,30 +206,111 @@ export interface WorkflowOrchestratorContext {
 }
 
 /** The kind of branch-deciding delivery a barrier represents. */
-export type DeliveryKind = 'hook' | 'wait';
+export type DeliveryKind = 'hook' | 'wait' | 'step';
 
 interface DeliveryBarrierEntry {
   kind: DeliveryKind;
   /** Resolves once this delivery has resolved to the workflow. */
   delivered: Promise<void>;
+  /**
+   * Whether this delivery is committed to reaching the workflow without any
+   * further action by workflow code. True for wait completions and step
+   * results, which always resolve from their own chain, and for a hook payload
+   * that already had a waiting consumer when it was consumed.
+   *
+   * False for a BUFFERED hook payload no consumer has claimed yet: it is
+   * delivered by `claim()`, i.e. whenever the workflow next reads the hook —
+   * which may be causally *after* a later-in-log delivery. `arm()` flips it
+   * once a consumer takes the payload.
+   */
+  armed: boolean;
 }
 
 /**
- * Awaits, in strict event-log order, every still-registered delivery whose
- * index is earlier than `eventIndex` AND whose kind is in `deferBehindKinds`,
- * so that this resolution is handed to the workflow only after all relevant
- * earlier-in-log deliveries have been. This is what keeps a `Promise.race`
- * deterministic and aligned with the committed event log, independent of
- * microtask-hop counts, hydration time, or race-argument order.
+ * Which earlier kinds each delivery kind defers behind. Chosen so that no kind
+ * blocks on a peer it does not need to:
  *
- * `deferBehindKinds` is the opposite kind(s): a hook defers behind earlier
- * WAITS (not earlier hooks — those are sequential same-entity payloads), a
- * wait defers behind earlier HOOKS.
+ *  - a hook defers behind earlier WAITS and STEPS — not earlier hooks, which
+ *    are sequential same-entity payloads and must not block one another;
+ *  - a wait defers behind earlier HOOKS and STEPS — not earlier waits, since a
+ *    wait never needs to queue behind another wait;
+ *  - a step defers behind earlier WAITS and HOOKS — not earlier steps, whose
+ *    relative order the serial `promiseQueue` already fixes (each step's
+ *    hydration slot runs, and therefore delivers, in log order).
+ *
+ * Every edge points from a later log index to a strictly earlier one, so the
+ * wait-for graph can never contain a cycle.
+ */
+const DEFER_BEHIND: Record<DeliveryKind, readonly DeliveryKind[]> = {
+  hook: ['wait', 'step'],
+  wait: ['hook', 'step'],
+  step: ['wait', 'hook'],
+};
+
+/**
+ * Whether `entry` will resolve on its own — it is armed, and every earlier
+ * delivery it defers behind will likewise resolve on its own.
+ *
+ * A step delivery is always self-resolving: it skips uncommitted deliveries
+ * (see {@link awaitEarlierDeliveries}), so nothing can hold it back.
+ *
+ * Recursion terminates because every edge points to a strictly smaller index,
+ * and the registry only ever holds the handful of deliveries currently in
+ * flight.
+ */
+function resolvesOnItsOwn(
+  barriers: Map<number, DeliveryBarrierEntry>,
+  index: number,
+  entry: DeliveryBarrierEntry
+): boolean {
+  if (!entry.armed) {
+    return false;
+  }
+  if (entry.kind === 'step') {
+    return true;
+  }
+  const deferBehind = DEFER_BEHIND[entry.kind];
+  for (const [otherIndex, other] of barriers) {
+    if (
+      otherIndex < index &&
+      deferBehind.includes(other.kind) &&
+      !resolvesOnItsOwn(barriers, otherIndex, other)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Awaits, in strict event-log order, every still-registered delivery that is
+ * earlier in the log than `eventIndex` and that a delivery of `kind` defers
+ * behind (see {@link DEFER_BEHIND}), so that this resolution is handed to the
+ * workflow only after all relevant earlier-in-log deliveries have been. This
+ * is what keeps a `Promise.race` — or the ULID a follow-up `useStep` draws on
+ * a concurrent branch — deterministic and aligned with the committed event
+ * log, independent of microtask-hop counts, hydration time, or race-argument
+ * order. When this delivery does have to wait, it also yields a macrotask
+ * afterwards so the earlier delivery's consumer can run to its own next
+ * suspension point first; see the comment at that `await` for why ordering the
+ * `resolve()` calls alone is not enough.
+ *
+ * One asymmetry: a STEP result additionally skips any earlier delivery that
+ * will not resolve on its own, i.e. one blocked (directly or transitively) on
+ * a buffered hook payload no consumer has claimed. Such a payload is delivered
+ * only when the workflow next reads the hook, and reaching that read very
+ * commonly requires the step result itself (`await stepX()` before the read).
+ * Gating the step on it would stall the workflow until the barrier's idle
+ * safety net fires, which then releases every delivery queued behind that
+ * payload at once — losing exactly the race this ordering exists to protect.
+ * Waits and hooks keep gating on unclaimed payloads: for them, waiting for the
+ * claim IS the ordering guarantee (a `wait_completed` must not preempt a
+ * payload the log ordered first).
  */
 export async function awaitEarlierDeliveries(
   ctx: WorkflowOrchestratorContext,
   eventIndex: number | undefined,
-  deferBehindKinds: readonly DeliveryKind[]
+  kind: DeliveryKind
 ): Promise<void> {
   // Defensive: tolerate contexts that predate this field (test harnesses).
   if (
@@ -232,14 +320,35 @@ export async function awaitEarlierDeliveries(
   ) {
     return;
   }
+  const barriers = ctx.pendingDeliveryBarriers;
+  const deferBehind = DEFER_BEHIND[kind];
   const earlier: Promise<void>[] = [];
-  for (const [index, entry] of ctx.pendingDeliveryBarriers) {
-    if (index < eventIndex && deferBehindKinds.includes(entry.kind)) {
-      earlier.push(entry.delivered);
+  for (const [index, entry] of barriers) {
+    if (index >= eventIndex || !deferBehind.includes(entry.kind)) {
+      continue;
     }
+    if (kind === 'step' && !resolvesOnItsOwn(barriers, index, entry)) {
+      continue;
+    }
+    earlier.push(entry.delivered);
   }
   if (earlier.length > 0) {
     await Promise.all(earlier);
+    // An earlier delivery being "delivered" only means its `resolve()` ran.
+    // The branch it woke may need an arbitrary number of further microtask
+    // hops before it reaches its next `useStep` call and draws a ULID — a
+    // `for await` over a hook, for instance, resumes the generator, settles
+    // the promise from `next()`, and only then runs the loop body. Resolving
+    // this delivery on a microtask would let it overtake that branch and
+    // reorder the ULID allocation anyway, turning the guarantee below into a
+    // hop-count race that holds only for the shortest consumers.
+    //
+    // Yielding a macrotask lets the earlier branch's entire microtask chain
+    // drain first, whatever its length, so log order survives regardless of
+    // how the workflow consumes the earlier delivery. Only deliveries that
+    // actually had to defer pay this, so the common single-delivery drain is
+    // unaffected.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
   }
 }
 
@@ -247,17 +356,26 @@ export async function awaitEarlierDeliveries(
 export interface DeliveryBarrier {
   /**
    * Mark this delivery as delivered to the workflow. Resolves its
-   * `delivered` promise so any later-in-log opposite-kind delivery gated on
-   * it (via {@link awaitEarlierDeliveries}) may proceed, and removes it from
-   * the registry. Idempotent.
+   * `delivered` promise so any later-in-log delivery gated on it (via
+   * {@link awaitEarlierDeliveries}) may proceed, and removes it from the
+   * registry. Idempotent.
    */
   markDelivered: () => void;
+  /**
+   * Mark this delivery as committed to happening, for a barrier registered
+   * unarmed (a buffered hook payload) once a consumer has claimed it. From
+   * then on a later step result may be ordered behind it. Idempotent.
+   */
+  arm: () => void;
 }
 
 /**
  * Register a branch-deciding delivery at its event-log index so that later
- * opposite-kind deliveries can be ordered strictly after it. Returns an inert
- * handle when `pendingDeliveryBarriers` is not initialized.
+ * deliveries can be ordered strictly after it. Returns an inert handle when
+ * `pendingDeliveryBarriers` is not initialized.
+ *
+ * Pass `armed: false` for a delivery whose resolution waits on workflow code
+ * asking for it (a buffered hook payload); call `arm()` when it does.
  *
  * To guarantee a later delivery gated on this one can never hang when this
  * delivery is abandoned (the workflow took a different branch or is
@@ -266,16 +384,21 @@ export interface DeliveryBarrier {
 export function registerDeliveryBarrier(
   ctx: WorkflowOrchestratorContext,
   eventIndex: number | undefined,
-  kind: DeliveryKind
+  kind: DeliveryKind,
+  options: { armed?: boolean } = {}
 ): DeliveryBarrier {
   const barriers = ctx.pendingDeliveryBarriers;
   if (!barriers || eventIndex === undefined) {
-    return { markDelivered: () => {} };
+    return { markDelivered: () => {}, arm: () => {} };
   }
 
   let done = false;
   const { promise, resolve } = withResolvers<void>();
-  const entry: DeliveryBarrierEntry = { kind, delivered: promise };
+  const entry: DeliveryBarrierEntry = {
+    kind,
+    delivered: promise,
+    armed: options.armed ?? true,
+  };
   barriers.set(eventIndex, entry);
 
   const finish = () => {
@@ -290,12 +413,18 @@ export function registerDeliveryBarrier(
   };
 
   // Safety net: if this delivery is never delivered to the workflow (its
-  // branch was not taken / the run is suspending), resolve at idle so a
-  // later opposite-kind delivery gated on it cannot deadlock and the
+  // branch was not taken / the run is suspending, or a buffered hook payload
+  // is only claimed after a later delivery the workflow is still waiting on),
+  // resolve at idle so a later delivery gated on it cannot deadlock and the
   // registry cannot leak an entry per abandoned delivery.
   scheduleWhenIdle(ctx, finish);
 
-  return { markDelivered: finish };
+  return {
+    markDelivered: finish,
+    arm: () => {
+      entry.armed = true;
+    },
+  };
 }
 
 /**

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -234,9 +234,21 @@ interface DeliveryBarrierEntry {
  *    are sequential same-entity payloads and must not block one another;
  *  - a wait defers behind earlier HOOKS and STEPS — not earlier waits, since a
  *    wait never needs to queue behind another wait;
- *  - a step defers behind earlier WAITS and HOOKS — not earlier steps, whose
- *    relative order the serial `promiseQueue` already fixes (each step's
- *    hydration slot runs, and therefore delivers, in log order).
+ *  - a step defers behind earlier WAITS, HOOKS and STEPS.
+ *
+ * The step-behind-step edge is not redundant with the serial `promiseQueue`.
+ * The queue fixes the order in which step results are HYDRATED, but a step no
+ * longer resolves inside its queue slot — it captures the outcome there and
+ * resolves from a detached continuation once its barrier clears. Two steps
+ * agree on that continuation's ordering only while they defer behind the same
+ * set, which holds when they are consumed in the same drain window but not
+ * across windows: a step consumed later can miss a wait/hook barrier that an
+ * earlier step is still parked on, because the barrier retired in between. The
+ * earlier step is then waiting out the macrotask yield below while the later
+ * one resolves on microtasks, and overtakes it — see
+ * `delivery-barrier-coverage.test.ts`. Deferring behind earlier steps
+ * closes that window structurally: the earlier step's barrier is still
+ * registered precisely because it has not delivered yet.
  *
  * Every edge points from a later log index to a strictly earlier one, so the
  * wait-for graph can never contain a cycle.
@@ -244,7 +256,7 @@ interface DeliveryBarrierEntry {
 const DEFER_BEHIND: Record<DeliveryKind, readonly DeliveryKind[]> = {
   hook: ['wait', 'step'],
   wait: ['hook', 'step'],
-  step: ['wait', 'hook'],
+  step: ['wait', 'hook', 'step'],
 };
 
 /**
@@ -252,16 +264,40 @@ const DEFER_BEHIND: Record<DeliveryKind, readonly DeliveryKind[]> = {
  * delivery it defers behind will likewise resolve on its own.
  *
  * A step delivery is always self-resolving: it skips uncommitted deliveries
- * (see {@link awaitEarlierDeliveries}), so nothing can hold it back.
+ * (see {@link awaitEarlierDeliveries}), and the earlier steps it does defer
+ * behind are self-resolving by the same argument, inducting down on index.
  *
- * Recursion terminates because every edge points to a strictly smaller index,
- * and the registry only ever holds the handful of deliveries currently in
- * flight.
+ * Recursion terminates because every edge points to a strictly smaller index.
+ * `memo` is required rather than an optimization: without it the walk is
+ * exponential in the number of live hook/wait barriers (each armed entry
+ * re-walks every earlier entry of the opposite kind, T(n) = Σ T(j)), and the
+ * registry is not small by construction — `EventsConsumer` drains
+ * consecutively consumable events synchronously while barriers only retire on
+ * microtask-driven deliveries, so a fan-out of `Promise.race([hook, sleep])`
+ * branches accumulates one barrier per branch per kind. Memoized, the walk is
+ * linear in registry size. The memo MUST be per-call: `armed` mutates between
+ * calls as buffered payloads are claimed.
  */
 function resolvesOnItsOwn(
   barriers: Map<number, DeliveryBarrierEntry>,
   index: number,
-  entry: DeliveryBarrierEntry
+  entry: DeliveryBarrierEntry,
+  memo: Map<number, boolean>
+): boolean {
+  const cached = memo.get(index);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = computeResolvesOnItsOwn(barriers, index, entry, memo);
+  memo.set(index, result);
+  return result;
+}
+
+function computeResolvesOnItsOwn(
+  barriers: Map<number, DeliveryBarrierEntry>,
+  index: number,
+  entry: DeliveryBarrierEntry,
+  memo: Map<number, boolean>
 ): boolean {
   if (!entry.armed) {
     return false;
@@ -274,7 +310,7 @@ function resolvesOnItsOwn(
     if (
       otherIndex < index &&
       deferBehind.includes(other.kind) &&
-      !resolvesOnItsOwn(barriers, otherIndex, other)
+      !resolvesOnItsOwn(barriers, otherIndex, other, memo)
     ) {
       return false;
     }
@@ -323,11 +359,16 @@ export async function awaitEarlierDeliveries(
   const barriers = ctx.pendingDeliveryBarriers;
   const deferBehind = DEFER_BEHIND[kind];
   const earlier: Promise<void>[] = [];
+  // Shared across this call only — see `resolvesOnItsOwn`.
+  const selfResolving = new Map<number, boolean>();
   for (const [index, entry] of barriers) {
     if (index >= eventIndex || !deferBehind.includes(entry.kind)) {
       continue;
     }
-    if (kind === 'step' && !resolvesOnItsOwn(barriers, index, entry)) {
+    if (
+      kind === 'step' &&
+      !resolvesOnItsOwn(barriers, index, entry, selfResolving)
+    ) {
       continue;
     }
     earlier.push(entry.delivered);

--- a/packages/core/src/step-delivery-hop-count.test.ts
+++ b/packages/core/src/step-delivery-hop-count.test.ts
@@ -1,0 +1,492 @@
+/**
+ * Companion to `step-delivery-ordering.test.ts`, which reproduces the two
+ * production `CORRUPTED_EVENT_LOG` shapes. Those two logs happen to be consumed
+ * by branches that reach their next `useStep` call in the fewest possible
+ * microtask hops, so they cannot distinguish two very different guarantees:
+ *
+ *  a) step results are DELIVERED in event-log order relative to wait and hook
+ *     deliveries, or
+ *  b) a step result merely resolves a hop or two later than before, which is
+ *     enough to lose a race against the shortest consumers and nothing more.
+ *
+ * The distinction is not academic. A branch resumed by a `wait_completed` or a
+ * hook payload may need any number of further hops before it draws its next
+ * ULID (`for await` over a hook resumes the generator, settles the promise from
+ * `next()`, and only then runs the loop body; workflow code is free to await
+ * anything in between). Under (b) a memo-warm step result overtakes such a
+ * branch and reorders the ULID allocation exactly as the unfixed runtime did.
+ *
+ * So each case here replays a log that a live run legitimately produced — the
+ * live invocation received the two events in SEPARATE deliveries, so the first
+ * branch ran to completion long before the second event existed — while the
+ * replay receives both in one drain window and must still allocate the ULIDs in
+ * the recorded order. The consumer is padded with a varying number of extra
+ * `await`s to make hop count the only variable.
+ */
+import { WorkflowRuntimeError } from '@workflow/errors';
+import { withResolvers } from '@workflow/utils';
+import type { Event } from '@workflow/world';
+import * as nanoid from 'nanoid';
+import { monotonicFactory } from 'ulid';
+import { describe, expect, it, vi } from 'vitest';
+import { EventsConsumer } from './events-consumer.js';
+import { WorkflowSuspension } from './global.js';
+import type { WorkflowOrchestratorContext } from './private.js';
+import { ReplayPayloadCache } from './replay-payload-cache.js';
+import {
+  dehydrateStepError,
+  dehydrateStepReturnValue,
+} from './serialization.js';
+import { createUseStep } from './step.js';
+import { createContext } from './vm/index.js';
+import { createCreateHook } from './workflow/hook.js';
+import { createSleep } from './workflow/sleep.js';
+
+function setupWorkflowContext(
+  events: Event[],
+  replayPayloadCache: ReplayPayloadCache = new ReplayPayloadCache(undefined)
+): WorkflowOrchestratorContext {
+  const context = createContext({
+    seed: 'test',
+    fixedTimestamp: 1753481739458,
+  });
+  const ulid = monotonicFactory(() => context.globalThis.Math.random());
+  const workflowStartedAt = context.globalThis.Date.now();
+  const promiseQueueHolder = { current: Promise.resolve() };
+  const ctxRef: { current?: WorkflowOrchestratorContext } = {};
+  const ctx: WorkflowOrchestratorContext = {
+    runId: 'wrun_test',
+    encryptionKey: undefined,
+    replayPayloadCache,
+    globalThis: context.globalThis,
+    eventsConsumer: new EventsConsumer(events, {
+      onUnconsumedEvent: (event) => {
+        ctxRef.current?.onWorkflowError(
+          new WorkflowRuntimeError(`Unconsumed event: ${event.eventType}`)
+        );
+      },
+      getPromiseQueue: () => promiseQueueHolder.current,
+    }),
+    invocationsQueue: new Map(),
+    generateUlid: () => ulid(workflowStartedAt),
+    generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
+      new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
+    ),
+    onWorkflowError: vi.fn(),
+    get promiseQueue() {
+      return promiseQueueHolder.current;
+    },
+    set promiseQueue(value: Promise<void>) {
+      promiseQueueHolder.current = value;
+    },
+    pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
+  };
+  ctxRef.current = ctx;
+  return ctx;
+}
+
+const CORR_IDS = [
+  '01K11TFZ62YS0YYFDQ3E8B9YCV',
+  '01K11TFZ62YS0YYFDQ3E8B9YCW',
+  '01K11TFZ62YS0YYFDQ3E8B9YCX',
+  '01K11TFZ62YS0YYFDQ3E8B9YCY',
+];
+
+async function runWithDiscontinuation(
+  ctx: WorkflowOrchestratorContext,
+  workflowFn: () => Promise<any>
+): Promise<{ result?: any; error?: any }> {
+  const d = withResolvers<void>();
+  ctx.onWorkflowError = d.reject;
+  let result: any;
+  let error: any;
+  try {
+    result = await Promise.race([workflowFn(), d.promise]);
+  } catch (err) {
+    error = err;
+  }
+  return { result, error };
+}
+
+function slowHydration() {
+  return (async () => {
+    const serialization = await import('./serialization.js');
+    const original = serialization.hydrateStepReturnValue;
+    return vi
+      .spyOn(serialization, 'hydrateStepReturnValue')
+      .mockImplementation(async (...args) => {
+        await new Promise((r) => setTimeout(r, 10));
+        return original(...args);
+      });
+  })();
+}
+
+async function buildEventLog(): Promise<Event[]> {
+  const ops: Promise<any>[] = [];
+  const [hookPayload, stepAResult] = await Promise.all([
+    dehydrateStepReturnValue({ kind: 'ping' }, 'wrun_test', undefined, ops),
+    dehydrateStepReturnValue('ok', 'wrun_test', undefined, ops),
+  ]);
+  return [
+    {
+      eventId: 'evnt_0',
+      runId: 'wrun_test',
+      eventType: 'hook_created',
+      correlationId: `hook_${CORR_IDS[0]}`,
+      eventData: { token: 'test-token', isWebhook: false },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_1',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[1]}`,
+      eventData: { stepName: 'stepA' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_2',
+      runId: 'wrun_test',
+      eventType: 'step_started',
+      correlationId: `step_${CORR_IDS[1]}`,
+      eventData: { stepName: 'stepA' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_3',
+      runId: 'wrun_test',
+      eventType: 'hook_received',
+      correlationId: `hook_${CORR_IDS[0]}`,
+      eventData: { token: 'test-token', payload: hookPayload },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_4',
+      runId: 'wrun_test',
+      eventType: 'step_completed',
+      correlationId: `step_${CORR_IDS[1]}`,
+      eventData: { stepName: 'stepA', result: stepAResult },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_5',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[2]}`,
+      eventData: { stepName: 'afterHook' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_6',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[3]}`,
+      eventData: { stepName: 'afterStep' },
+      createdAt: new Date(),
+    },
+  ];
+}
+
+function body(ctx: WorkflowOrchestratorContext, extraHops: number) {
+  const useStep = createUseStep(ctx);
+  const createHook = createCreateHook(ctx);
+  return async () => {
+    const stepA = useStep('stepA');
+    const afterStep = useStep('afterStep');
+    const afterHook = useStep('afterHook');
+    const hook = createHook<{ kind: string }>({ token: 'test-token' });
+    const b1 = (async () => {
+      await stepA();
+      await afterStep();
+    })();
+    const b2 = (async () => {
+      for await (const p of hook) {
+        void p;
+        for (let i = 0; i < extraHops; i++) {
+          await Promise.resolve();
+        }
+        await afterHook();
+        break;
+      }
+    })();
+    await Promise.all([b1, b2]);
+  };
+}
+
+function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
+  return [...ctx.invocationsQueue.values()]
+    .filter((i) => i.type === 'step')
+    .map((i) => (i.type === 'step' ? i.stepName : ''));
+}
+
+describe('step delivery ordering is independent of consumer hop count: hook payload', () => {
+  for (const extraHops of [0, 1, 2, 4, 8, 16]) {
+    it(`keeps the recorded ULID allocation with ${extraHops} extra consumer hops`, async () => {
+      const spy = await slowHydration();
+      try {
+        const events = await buildEventLog();
+        const cache = new ReplayPayloadCache(undefined);
+        const c1 = setupWorkflowContext(events, cache);
+        const r1 = await runWithDiscontinuation(c1, body(c1, extraHops));
+        if (!WorkflowSuspension.is(r1.error)) {
+          throw r1.error ?? new Error('replay 1 did not suspend');
+        }
+        const c2 = setupWorkflowContext(events, cache);
+        const r2 = await runWithDiscontinuation(c2, body(c2, extraHops));
+        if (!WorkflowSuspension.is(r2.error)) {
+          throw r2.error ?? new Error('replay 2 did not suspend');
+        }
+        expect(pendingStepNames(c2).sort()).toEqual(['afterHook', 'afterStep']);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  }
+});
+
+const RESUME_AT = new Date('2026-07-27T12:00:05.000Z');
+
+async function buildWaitEventLog(): Promise<Event[]> {
+  const ops: Promise<any>[] = [];
+  const stepAResult = await dehydrateStepReturnValue(
+    'ok',
+    'wrun_test',
+    undefined,
+    ops
+  );
+  return [
+    {
+      eventId: 'evnt_0',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[0]}`,
+      eventData: { stepName: 'stepA' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_1',
+      runId: 'wrun_test',
+      eventType: 'wait_created',
+      correlationId: `wait_${CORR_IDS[1]}`,
+      eventData: { resumeAt: RESUME_AT },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_2',
+      runId: 'wrun_test',
+      eventType: 'step_started',
+      correlationId: `step_${CORR_IDS[0]}`,
+      eventData: { stepName: 'stepA' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_3',
+      runId: 'wrun_test',
+      eventType: 'wait_completed',
+      correlationId: `wait_${CORR_IDS[1]}`,
+      eventData: { resumeAt: RESUME_AT },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_4',
+      runId: 'wrun_test',
+      eventType: 'step_completed',
+      correlationId: `step_${CORR_IDS[0]}`,
+      eventData: { stepName: 'stepA', result: stepAResult },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_5',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[2]}`,
+      eventData: { stepName: 'afterSleep' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_6',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[3]}`,
+      eventData: { stepName: 'afterStep' },
+      createdAt: new Date(),
+    },
+  ];
+}
+
+function waitBody(ctx: WorkflowOrchestratorContext, extraHops: number) {
+  const useStep = createUseStep(ctx);
+  const sleep = createSleep(ctx);
+  return async () => {
+    const stepA = useStep('stepA');
+    const afterStep = useStep('afterStep');
+    const afterSleep = useStep('afterSleep');
+    const b1 = (async () => {
+      await stepA();
+      await afterStep();
+    })();
+    const b2 = (async () => {
+      await sleep(RESUME_AT);
+      for (let i = 0; i < extraHops; i++) {
+        await Promise.resolve();
+      }
+      await afterSleep();
+    })();
+    await Promise.all([b1, b2]);
+  };
+}
+
+describe('step delivery ordering is independent of consumer hop count: wait completion', () => {
+  for (const extraHops of [0, 1, 2, 4, 8, 16]) {
+    it(`keeps the recorded ULID allocation with ${extraHops} extra consumer hops`, async () => {
+      const spy = await slowHydration();
+      try {
+        const events = await buildWaitEventLog();
+        const cache = new ReplayPayloadCache(undefined);
+        const c1 = setupWorkflowContext(events, cache);
+        const r1 = await runWithDiscontinuation(c1, waitBody(c1, extraHops));
+        if (!WorkflowSuspension.is(r1.error))
+          throw r1.error ?? new Error('replay 1 did not suspend');
+        const c2 = setupWorkflowContext(events, cache);
+        const r2 = await runWithDiscontinuation(c2, waitBody(c2, extraHops));
+        if (!WorkflowSuspension.is(r2.error))
+          throw r2.error ?? new Error('replay 2 did not suspend');
+        expect(pendingStepNames(c2).sort()).toEqual([
+          'afterSleep',
+          'afterStep',
+        ]);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  }
+});
+
+/**
+ * `step_failed` is as branch-deciding as `step_completed` — it decides whether
+ * a `catch` continuation runs, and therefore which ULID the follow-up
+ * `useStep` there draws — and it goes through the same barrier registration and
+ * event-consumption-time deferral capture. Covered here so a refactor cannot
+ * silently order rejections differently from results.
+ */
+async function buildFailedEventLog(): Promise<Event[]> {
+  const ops: Promise<any>[] = [];
+  const stepAError = await dehydrateStepError(
+    new Error('stepA blew up'),
+    'wrun_test',
+    undefined,
+    ops
+  );
+  return [
+    {
+      eventId: 'evnt_0',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[0]}`,
+      eventData: { stepName: 'stepA' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_1',
+      runId: 'wrun_test',
+      eventType: 'wait_created',
+      correlationId: `wait_${CORR_IDS[1]}`,
+      eventData: { resumeAt: RESUME_AT },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_2',
+      runId: 'wrun_test',
+      eventType: 'step_started',
+      correlationId: `step_${CORR_IDS[0]}`,
+      eventData: { stepName: 'stepA' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_3',
+      runId: 'wrun_test',
+      eventType: 'wait_completed',
+      correlationId: `wait_${CORR_IDS[1]}`,
+      eventData: { resumeAt: RESUME_AT },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_4',
+      runId: 'wrun_test',
+      eventType: 'step_failed',
+      correlationId: `step_${CORR_IDS[0]}`,
+      eventData: { stepName: 'stepA', error: stepAError },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_5',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[2]}`,
+      eventData: { stepName: 'afterSleep' },
+      createdAt: new Date(),
+    },
+    {
+      eventId: 'evnt_6',
+      runId: 'wrun_test',
+      eventType: 'step_created',
+      correlationId: `step_${CORR_IDS[3]}`,
+      eventData: { stepName: 'afterFailure' },
+      createdAt: new Date(),
+    },
+  ];
+}
+
+function failedBody(ctx: WorkflowOrchestratorContext, extraHops: number) {
+  const useStep = createUseStep(ctx);
+  const sleep = createSleep(ctx);
+  return async () => {
+    const stepA = useStep('stepA');
+    const afterFailure = useStep('afterFailure');
+    const afterSleep = useStep('afterSleep');
+    const branchStep = (async () => {
+      try {
+        await stepA();
+      } catch {
+        await afterFailure();
+      }
+    })();
+    const branchSleep = (async () => {
+      await sleep(RESUME_AT);
+      for (let i = 0; i < extraHops; i++) {
+        await Promise.resolve();
+      }
+      await afterSleep();
+    })();
+    await Promise.all([branchStep, branchSleep]);
+  };
+}
+
+describe('step delivery ordering is independent of consumer hop count: step failure', () => {
+  for (const extraHops of [0, 1, 2, 4, 8, 16]) {
+    it(`keeps the recorded ULID allocation with ${extraHops} extra consumer hops`, async () => {
+      const spy = await slowHydration();
+      try {
+        const events = await buildFailedEventLog();
+        const cache = new ReplayPayloadCache(undefined);
+        const c1 = setupWorkflowContext(events, cache);
+        const r1 = await runWithDiscontinuation(c1, failedBody(c1, extraHops));
+        if (!WorkflowSuspension.is(r1.error)) {
+          throw r1.error ?? new Error('replay 1 did not suspend');
+        }
+        const c2 = setupWorkflowContext(events, cache);
+        const r2 = await runWithDiscontinuation(c2, failedBody(c2, extraHops));
+        if (!WorkflowSuspension.is(r2.error)) {
+          throw r2.error ?? new Error('replay 2 did not suspend');
+        }
+        expect(pendingStepNames(c2).sort()).toEqual([
+          'afterFailure',
+          'afterSleep',
+        ]);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  }
+});

--- a/packages/core/src/step-delivery-ordering.test.ts
+++ b/packages/core/src/step-delivery-ordering.test.ts
@@ -1,0 +1,602 @@
+import { WorkflowRuntimeError } from '@workflow/errors';
+import { withResolvers } from '@workflow/utils';
+import type { Event } from '@workflow/world';
+import * as nanoid from 'nanoid';
+import { monotonicFactory } from 'ulid';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventsConsumer } from './events-consumer.js';
+import { WorkflowSuspension } from './global.js';
+import type { WorkflowOrchestratorContext } from './private.js';
+import { ReplayPayloadCache } from './replay-payload-cache.js';
+import { dehydrateStepReturnValue } from './serialization.js';
+import { createUseStep } from './step.js';
+import { createContext } from './vm/index.js';
+import { createCreateHook } from './workflow/hook.js';
+import { createSleep } from './workflow/sleep.js';
+
+/**
+ * Production incident: two o2flow runs on `@workflow/core@5.0.0-beta.36`
+ * (`wrun_41KYJENABV0GSF5YTE9EETV5DD` and `wrun_41KYJEE01S0GPC9RWT5MEKVCX8`)
+ * failed permanently with
+ *
+ *   Replay divergence: step event step_created for step_X belongs to
+ *   "countFanoutStep", but the current step consumer is
+ *   "releaseGlobalLaunchSlot"
+ *
+ * repeated at the SAME eventId across three divergence-recovery replays, and
+ * then escalated to a terminal `CorruptedEventLogError`.
+ *
+ * Mechanism reproduced here:
+ *
+ * - Each `useStep(...)` invocation draws the next deterministic ULID as its
+ *   correlation id (`step.ts`), so WHICH workflow branch resumes first decides
+ *   which correlation id each step call gets. Replay matches events to
+ *   consumers by exact correlation id and rejects a `step_created` whose
+ *   recorded `stepName` differs from the consumer's (`step.ts`, the
+ *   `eventStepName !== stepName` divergence check).
+ * - The runtime has a delivery-barrier system that pins branch-deciding
+ *   delivery order to event-log position (`pendingDeliveryBarriers` in
+ *   `private.ts`), but it only covers the kinds `'hook'` and `'wait'`.
+ *   **Step results are not in it.**
+ * - `wait_completed` resolves through a detached chain with a fixed, small
+ *   microtask-hop count (`workflow/sleep.ts`). A `step_completed` instead
+ *   resolves inside a serial `ctx.promiseQueue` slot that first hydrates the
+ *   payload via `ReplayPayloadCache.getStepResult(...)`. That hop count is not
+ *   fixed: the first hydration pays async decrypt/deserialize, while a later
+ *   replay sharing the same `ReplayPayloadCache` hits the
+ *   `primitiveStepResults` memo for small primitive results and resolves in
+ *   one or two hops.
+ *
+ * So when a `step_completed` sits adjacent in the log to a `wait_completed`
+ * (or `hook_received`) and both consumers are live, the FIRST replay of a
+ * queue delivery (cold cache) delivers the wait first — the ordering the live
+ * invocation recorded into the log — while every LATER replay in that same
+ * delivery (warm cache) delivers the step result first. The two branches then
+ * allocate each other's ULIDs and diverge, forever, at the same event.
+ *
+ * Production log shape for run 1, which the synthetic log below mirrors:
+ *
+ *   …, step_completed(finalizeTaskSandbox), wait_completed, wait_completed,
+ *   step_completed(finalizeTaskSandbox), step_created(countFanoutStep),
+ *   step_created(releaseGlobalLaunchSlot), …
+ *
+ * This is entirely core replay machinery — no World implementation is
+ * involved. Worlds only supply event I/O, so the bug is not specific to the
+ * Vercel world.
+ *
+ * These tests assert the CORRECT behavior: both replays must agree with the
+ * committed log and suspend. On `main` the second replay instead throws
+ * `ReplayDivergenceError`, which is the reproduction. The companion fix on
+ * branch `pgp/fix-step-delivery-ordering` brings step results into the
+ * delivery-barrier system and makes these pass.
+ *
+ * Scope limit, worth knowing before treating these five cases as the whole
+ * guarantee: every branch here reaches its next `useStep(...)` in the fewest
+ * possible microtask hops after being resumed. That makes them unable to
+ * distinguish "step results are delivered in event-log order relative to wait
+ * and hook deliveries" from "a step result merely resolves a hop or two later
+ * than it used to", which beats the shortest consumers and nothing else. A
+ * revision of the companion fix that only reordered the `resolve()` calls
+ * passed all five while a consumer padded with one extra `await` still
+ * diverged. Padded consumers are covered separately by
+ * `step-delivery-hop-count.test.ts` on the fix branch; both files together are
+ * what pins the ordering guarantee.
+ */
+
+/**
+ * Harness copied from `hook-sleep-interaction.test.ts`, with one addition: a
+ * `ReplayPayloadCache` can be passed in, so two sequential replays can share
+ * one cache exactly like the replay loop inside a single production queue
+ * delivery does (see the `ReplayPayloadCache` class docstring).
+ */
+function setupWorkflowContext(
+  events: Event[],
+  replayPayloadCache: ReplayPayloadCache = new ReplayPayloadCache(undefined)
+): WorkflowOrchestratorContext {
+  const context = createContext({
+    seed: 'test',
+    fixedTimestamp: 1753481739458,
+  });
+  const ulid = monotonicFactory(() => context.globalThis.Math.random());
+  const workflowStartedAt = context.globalThis.Date.now();
+  const promiseQueueHolder = { current: Promise.resolve() };
+  const ctxRef: { current?: WorkflowOrchestratorContext } = {};
+  const ctx: WorkflowOrchestratorContext = {
+    runId: 'wrun_test',
+    encryptionKey: undefined,
+    replayPayloadCache,
+    globalThis: context.globalThis,
+    eventsConsumer: new EventsConsumer(events, {
+      onUnconsumedEvent: (event) => {
+        ctxRef.current?.onWorkflowError(
+          new WorkflowRuntimeError(
+            `Unconsumed event in event log: eventType=${event.eventType}, correlationId=${event.correlationId}, eventId=${event.eventId}. This indicates a corrupted or invalid event log.`
+          )
+        );
+      },
+      getPromiseQueue: () => promiseQueueHolder.current,
+    }),
+    invocationsQueue: new Map(),
+    generateUlid: () => ulid(workflowStartedAt),
+    generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
+      new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
+    ),
+    onWorkflowError: vi.fn(),
+    get promiseQueue() {
+      return promiseQueueHolder.current;
+    },
+    set promiseQueue(value: Promise<void>) {
+      promiseQueueHolder.current = value;
+    },
+    pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
+  };
+  ctxRef.current = ctx;
+  return ctx;
+}
+
+// Deterministic correlation IDs from the ULID generator with seed 'test'
+const CORR_IDS = [
+  '01K11TFZ62YS0YYFDQ3E8B9YCV',
+  '01K11TFZ62YS0YYFDQ3E8B9YCW',
+  '01K11TFZ62YS0YYFDQ3E8B9YCX',
+  '01K11TFZ62YS0YYFDQ3E8B9YCY',
+];
+
+async function runWithDiscontinuation(
+  ctx: WorkflowOrchestratorContext,
+  workflowFn: () => Promise<any>
+): Promise<{ result?: any; error?: any }> {
+  const workflowDiscontinuation = withResolvers<void>();
+  ctx.onWorkflowError = workflowDiscontinuation.reject;
+
+  let result: any;
+  let error: any;
+  try {
+    result = await Promise.race([
+      workflowFn(),
+      workflowDiscontinuation.promise,
+    ]);
+  } catch (err) {
+    error = err;
+  }
+  return { result, error };
+}
+
+/**
+ * Models the cost of first-touch payload hydration (decrypt + deserialize).
+ * Production shares prepared bytes and memoized primitive results across the
+ * replays of one queue delivery, so the second replay of a small primitive
+ * step result never reaches this spy — which is exactly the hop-count
+ * asymmetry under test.
+ */
+function delayHydration() {
+  const hydrateSpy = vi.fn();
+  return {
+    hydrateSpy,
+    install: async () => {
+      const serialization = await import('./serialization.js');
+      const originalHydrate = serialization.hydrateStepReturnValue;
+      return vi
+        .spyOn(serialization, 'hydrateStepReturnValue')
+        .mockImplementation(async (...args) => {
+          hydrateSpy();
+          await new Promise((r) => setTimeout(r, 10));
+          return originalHydrate(...args);
+        });
+    },
+  };
+}
+
+describe('step result delivery ordering across replays', () => {
+  let spy: ReturnType<typeof vi.spyOn> | undefined;
+
+  afterEach(() => {
+    spy?.mockRestore();
+    spy = undefined;
+  });
+
+  describe('step_completed adjacent to wait_completed', () => {
+    // The wait's `resumeAt` is re-read from the `wait_created` event during
+    // replay (see `workflow/sleep.ts`), so any fixed date works here as long
+    // as `wait_created` and `wait_completed` agree.
+    const resumeAt = new Date('2026-07-27T12:00:05.000Z');
+
+    async function buildEventLog(): Promise<Event[]> {
+      const ops: Promise<any>[] = [];
+      // A short string result is a memoizable primitive, so the SECOND replay
+      // sharing the cache resolves it from `primitiveStepResults` without
+      // touching hydration at all.
+      const stepAResult = await dehydrateStepReturnValue(
+        'ok',
+        'wrun_test',
+        undefined,
+        ops
+      );
+
+      return [
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[0]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_test',
+          eventType: 'wait_created',
+          correlationId: `wait_${CORR_IDS[1]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_2',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[0]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        // The live invocation delivered the wait BEFORE the step result, so
+        // the wait branch resumed first and drew the next ULID. Everything
+        // after this point in the log encodes that ordering.
+        {
+          eventId: 'evnt_3',
+          runId: 'wrun_test',
+          eventType: 'wait_completed',
+          correlationId: `wait_${CORR_IDS[1]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_4',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[0]}`,
+          eventData: { stepName: 'stepA', result: stepAResult },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_5',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'afterSleep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_6',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'afterStep' },
+          createdAt: new Date(),
+        },
+      ];
+    }
+
+    // ULID draw order in this body: `stepA()` takes CORR_IDS[0], `sleep()`
+    // takes CORR_IDS[1], and then whichever branch is resumed FIRST takes
+    // CORR_IDS[2] while the other takes CORR_IDS[3].
+    function workflowBody(ctx: WorkflowOrchestratorContext) {
+      const useStep = createUseStep(ctx);
+      const sleep = createSleep(ctx);
+
+      return async () => {
+        const stepA = useStep('stepA');
+        const afterStep = useStep('afterStep');
+        const afterSleep = useStep('afterSleep');
+
+        const branchStep = (async () => {
+          await stepA();
+          await afterStep();
+        })();
+        const branchSleep = (async () => {
+          await sleep(resumeAt);
+          await afterSleep();
+        })();
+
+        await Promise.all([branchStep, branchSleep]);
+      };
+    }
+
+    function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
+      return [...ctx.invocationsQueue.values()]
+        .filter((item) => item.type === 'step')
+        .map((item) => (item.type === 'step' ? item.stepName : ''));
+    }
+
+    it('delivers the wait before the step result on the first replay, matching the log', async () => {
+      const hydration = delayHydration();
+      spy = await hydration.install();
+      const events = await buildEventLog();
+
+      const ctx = setupWorkflowContext(events);
+      const { error } = await runWithDiscontinuation(ctx, workflowBody(ctx));
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+
+      // The log's ordering was reproduced: the sleep branch resumed first and
+      // drew CORR_IDS[2] for `afterSleep`, so both `step_created` events at
+      // the tail matched their consumers and the run suspends with both
+      // follow-up steps pending.
+      expect(pendingStepNames(ctx).sort()).toEqual(['afterSleep', 'afterStep']);
+      expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
+    });
+
+    it('delivers the wait before the step result on a later replay sharing the payload cache', async () => {
+      const hydration = delayHydration();
+      spy = await hydration.install();
+      const events = await buildEventLog();
+
+      // One cache for both replays: production shares a single
+      // `ReplayPayloadCache` across every replay of one queue delivery.
+      const sharedCache = new ReplayPayloadCache(undefined);
+
+      const firstCtx = setupWorkflowContext(events, sharedCache);
+      const first = await runWithDiscontinuation(
+        firstCtx,
+        workflowBody(firstCtx)
+      );
+      if (!WorkflowSuspension.is(first.error)) {
+        throw first.error ?? new Error('expected the first replay to suspend');
+      }
+      expect(hydration.hydrateSpy).toHaveBeenCalled();
+
+      // Second replay, fresh VM/context, same event log, same cache. The step
+      // result is now memoized as a primitive, so it resolves in a couple of
+      // microtask hops instead of paying hydration — while the wait's hop
+      // count is unchanged.
+      const secondCtx = setupWorkflowContext(events, sharedCache);
+      const { error } = await runWithDiscontinuation(
+        secondCtx,
+        workflowBody(secondCtx)
+      );
+
+      expect(error).toBeDefined();
+      // FAILS on `main`: the step result now wins, `afterStep` draws
+      // CORR_IDS[2], and replay diverges at evnt_5 with the production error
+      // shape ("... belongs to \"afterSleep\", but the current step consumer
+      // is \"afterStep\"").
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+      expect(pendingStepNames(secondCtx).sort()).toEqual([
+        'afterSleep',
+        'afterStep',
+      ]);
+      expect(secondCtx.eventsConsumer.eventIndex).toBe(events.length);
+    });
+  });
+
+  describe('step_completed adjacent to hook_received', () => {
+    async function buildEventLog(): Promise<Event[]> {
+      const ops: Promise<any>[] = [];
+      const [hookPayload, stepAResult] = await Promise.all([
+        dehydrateStepReturnValue({ kind: 'ping' }, 'wrun_test', undefined, ops),
+        dehydrateStepReturnValue('ok', 'wrun_test', undefined, ops),
+      ]);
+
+      return [
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_created',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', isWebhook: false },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_2',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        // The live invocation delivered the hook payload BEFORE the step
+        // result, so the hook branch resumed first and drew the next ULID.
+        {
+          eventId: 'evnt_3',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'test-token', payload: hookPayload },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_4',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA', result: stepAResult },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_5',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[2]}`,
+          eventData: { stepName: 'afterHook' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_6',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'afterStep' },
+          createdAt: new Date(),
+        },
+      ];
+    }
+
+    /**
+     * ULID draw order: `createHook()` takes CORR_IDS[0], `stepA()` takes
+     * CORR_IDS[1], then the branch resumed FIRST takes CORR_IDS[2].
+     *
+     * Two ways of consuming the hook. Both subscribe before `hook_received` is
+     * consumed, so both take the same delivery path in `workflow/hook.ts` (the
+     * `promises.length > 0` branch; the buffered `claim()` path is not involved
+     * in either — entering `for await` calls `next()`, which reaches
+     * `yield await this` and registers the awaiter well before the events
+     * consumer drains the log on `process.nextTick`). What differs is how many
+     * microtask hops separate the payload RESOLVING from the branch calling
+     * `afterHook()` and thereby drawing the next ULID:
+     *
+     * - `for-await` (the idiomatic pattern, and what reproduces): resolution
+     *   resumes the async generator at `yield await this`, the yielded value
+     *   settles the promise returned by `next()`, and only then does the loop
+     *   body run. Those extra hops are enough for a memo-warm `step_completed`
+     *   — which on an unfixed runtime resolves inside its own queue slot with
+     *   no detached chain at all — to draw CORR_IDS[2] first.
+     * - `await hook` (control): resolution resumes the branch's continuation
+     *   directly, so it reaches `afterHook()` in the first microtask and stays
+     *   ahead of the step result even on a warm cache.
+     *
+     * So the hook flavour of this bug is not about payload buffering; it is the
+     * same latency race as the wait flavour, and the consumer shape only sets
+     * how much of a head start the step result needs in order to win.
+     */
+    function workflowBody(
+      ctx: WorkflowOrchestratorContext,
+      consume: 'for-await' | 'direct-await'
+    ) {
+      const useStep = createUseStep(ctx);
+      const createHook = createCreateHook(ctx);
+
+      return async () => {
+        const stepA = useStep('stepA');
+        const afterStep = useStep('afterStep');
+        const afterHook = useStep('afterHook');
+        const hook = createHook<{ kind: string }>({ token: 'test-token' });
+
+        const branchStep = (async () => {
+          await stepA();
+          await afterStep();
+        })();
+        const branchHook = (async () => {
+          if (consume === 'direct-await') {
+            await hook;
+            await afterHook();
+            return;
+          }
+          for await (const payload of hook) {
+            void payload;
+            await afterHook();
+            break;
+          }
+        })();
+
+        await Promise.all([branchStep, branchHook]);
+      };
+    }
+
+    function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
+      return [...ctx.invocationsQueue.values()]
+        .filter((item) => item.type === 'step')
+        .map((item) => (item.type === 'step' ? item.stepName : ''));
+    }
+
+    it('delivers the hook payload before the step result on the first replay, matching the log', async () => {
+      const hydration = delayHydration();
+      spy = await hydration.install();
+      const events = await buildEventLog();
+
+      const ctx = setupWorkflowContext(events);
+      const { error } = await runWithDiscontinuation(
+        ctx,
+        workflowBody(ctx, 'for-await')
+      );
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+      expect(pendingStepNames(ctx).sort()).toEqual(['afterHook', 'afterStep']);
+      expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
+    });
+
+    it('delivers the hook payload before the step result on a later replay sharing the payload cache', async () => {
+      const hydration = delayHydration();
+      spy = await hydration.install();
+      const events = await buildEventLog();
+      const sharedCache = new ReplayPayloadCache(undefined);
+
+      const firstCtx = setupWorkflowContext(events, sharedCache);
+      const first = await runWithDiscontinuation(
+        firstCtx,
+        workflowBody(firstCtx, 'for-await')
+      );
+      if (!WorkflowSuspension.is(first.error)) {
+        throw first.error ?? new Error('expected the first replay to suspend');
+      }
+      expect(hydration.hydrateSpy).toHaveBeenCalled();
+
+      // Hook payloads have no primitive memo, so the payload still re-hydrates
+      // on the second replay while the small primitive step result is served
+      // straight from `primitiveStepResults`.
+      const secondCtx = setupWorkflowContext(events, sharedCache);
+      const { error } = await runWithDiscontinuation(
+        secondCtx,
+        workflowBody(secondCtx, 'for-await')
+      );
+
+      expect(error).toBeDefined();
+      // FAILS on `main`: the step result overtakes the hook payload,
+      // `afterStep` draws CORR_IDS[2], and replay diverges at evnt_5 with the
+      // production error shape.
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+      expect(pendingStepNames(secondCtx).sort()).toEqual([
+        'afterHook',
+        'afterStep',
+      ]);
+      expect(secondCtx.eventsConsumer.eventIndex).toBe(events.length);
+    });
+
+    // Control: `await hook` keeps log order on both replays today. This is not
+    // a different delivery path — all three hook cases in this file take the
+    // same `promises.length > 0` immediate path in `workflow/hook.ts` — it is
+    // just a shorter consumer. Resolution resumes this branch's continuation
+    // directly, so it reaches `afterHook()` in the first microtask and stays
+    // ahead of a memo-warm step result. It is the shortest-consumer case here,
+    // and the fix must not regress it.
+    it('keeps log order across replays when the hook is awaited directly', async () => {
+      const hydration = delayHydration();
+      spy = await hydration.install();
+      const events = await buildEventLog();
+      const sharedCache = new ReplayPayloadCache(undefined);
+
+      for (const replay of [1, 2]) {
+        const ctx = setupWorkflowContext(events, sharedCache);
+        const { error } = await runWithDiscontinuation(
+          ctx,
+          workflowBody(ctx, 'direct-await')
+        );
+        if (!WorkflowSuspension.is(error)) {
+          throw error ?? new Error(`expected replay ${replay} to suspend`);
+        }
+        expect(pendingStepNames(ctx).sort()).toEqual([
+          'afterHook',
+          'afterStep',
+        ]);
+        expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
+      }
+    });
+  });
+});

--- a/packages/core/src/step.ts
+++ b/packages/core/src/step.ts
@@ -4,6 +4,8 @@ import { EventConsumerResult } from './events-consumer.js';
 import { type StepInvocationQueueItem, WorkflowSuspension } from './global.js';
 import { stepLogger } from './logger.js';
 import {
+  awaitEarlierDeliveries,
+  registerDeliveryBarrier,
   scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from './private.js';
@@ -165,6 +167,22 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
           // deterministic ordering of all promise resolutions/rejections.
           // Hydrate the serialized thrown value from the event log so the
           // original type identity and custom properties are preserved.
+          //
+          // The rejection is as branch-deciding as a success: it decides
+          // whether a `try`/`catch` continuation runs, and therefore which
+          // ULIDs the follow-up `useStep` calls draw. So it is ordered by
+          // event-log position exactly like `step_completed` below — see there
+          // for why the deferral is captured here, at event-consumption time,
+          // and awaited off the serial queue.
+          const eventIndex = ctx.eventsConsumer.eventIndex;
+          const barrier = registerDeliveryBarrier(ctx, eventIndex, 'step');
+          let rejection: unknown;
+          const earlierDelivered = awaitEarlierDeliveries(
+            ctx,
+            eventIndex,
+            'step'
+          );
+          ctx.pendingDeliveries++;
           ctx.promiseQueue = ctx.promiseQueue.then(async () => {
             try {
               const prepared = await ctx.replayPayloadCache.prepareEventPayload(
@@ -172,7 +190,7 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
                 'error',
                 event.eventData.error
               );
-              const hydrated = await hydrateStepError(
+              rejection = await hydrateStepError(
                 event.eventData.error,
                 ctx.runId,
                 ctx.encryptionKey,
@@ -180,7 +198,6 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
                 {},
                 prepared
               );
-              reject(hydrated);
             } catch (hydrateErr) {
               // If hydration fails for any reason, fall back to a generic
               // FatalError so the workflow doesn't hang. This should be
@@ -192,16 +209,20 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
                     ? hydrateErr.message
                     : String(hydrateErr),
               });
-              reject(
-                new FatalError(
-                  `Failed to hydrate step error: ${
-                    hydrateErr instanceof Error
-                      ? hydrateErr.message
-                      : String(hydrateErr)
-                  }`
-                )
+              rejection = new FatalError(
+                `Failed to hydrate step error: ${
+                  hydrateErr instanceof Error
+                    ? hydrateErr.message
+                    : String(hydrateErr)
+                }`
               );
+            } finally {
+              ctx.pendingDeliveries--;
             }
+            void earlierDelivered.then(() => {
+              barrier.markDelivered();
+              reject(rejection);
+            });
           });
           return EventConsumerResult.Finished;
         }
@@ -220,8 +241,58 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
           // Prepared serialized bytes are shared across replay VMs, but final
           // objects are always revived here inside this ordered queue slot.
           // Only immutable primitive final values bypass revival entirely.
+          //
+          // Hydration cost is what makes this delivery's timing unstable
+          // across replays of one invocation: the first replay pays the full
+          // decrypt/decompress/revive, later replays memo-hit a primitive
+          // result in `ReplayPayloadCache` and finish in a hop or two. A
+          // workflow awaiting this result on one branch and a `sleep()` or
+          // hook payload on another would therefore allocate its follow-up
+          // step ULIDs in a different order on a warm replay than the
+          // invocation that WROTE those `step_created` events did — a
+          // permanent `ReplayDivergenceError`. So the result is ordered by
+          // event-log position through the delivery-barrier registry (see
+          // `ctx.pendingDeliveryBarriers`):
+          //  - Register a 'step' barrier at this event's index so a
+          //    LATER-in-log wait/hook delivery is handed over only after it.
+          //  - Hydrate inside this serial queue slot (keeping async
+          //    deserialization in event-log order) but only CAPTURE the
+          //    outcome; then defer behind every EARLIER-in-log wait and hook
+          //    delivery before resolving, and mark this step delivered.
+          //
+          // The deferral is captured HERE, while consuming the event, and not
+          // inside the queue slot. Two reasons, both load-bearing:
+          //  - Determinism: the set of earlier deliveries is then a function of
+          //    log position alone. Captured later it would depend on how much
+          //    hydration the earlier deliveries had already finished — the very
+          //    coupling this barrier exists to remove.
+          //  - Coverage: an earlier delivery whose own hydration slot runs
+          //    first on this serial queue has usually already resolved (and so
+          //    deregistered its barrier) by the time a later slot starts. Read
+          //    at slot start, its barrier would be invisible and this step
+          //    would not defer at all. Every event in one drain window is
+          //    consumed before any slot runs, so capturing at consumption time
+          //    sees all of them.
+          //
+          // The deferral runs OFF the serial queue: it may wait on an earlier
+          // wait/hook delivery whose own resolution is driven by this queue,
+          // and blocking a queue slot on that would deadlock the queue (the
+          // same constraint sleep.ts and hook.ts document). `pendingDeliveries`
+          // is likewise released inside the slot, before the detached defer, so
+          // `scheduleWhenIdle` can still reach idle and retire the barriers
+          // this deferral may be waiting on.
           const completedEventId = event.eventId;
           const serializedResult = event.eventData.result;
+          const eventIndex = ctx.eventsConsumer.eventIndex;
+          const barrier = registerDeliveryBarrier(ctx, eventIndex, 'step');
+          let outcome:
+            | { ok: true; value: Result }
+            | { ok: false; error: unknown };
+          const earlierDelivered = awaitEarlierDeliveries(
+            ctx,
+            eventIndex,
+            'step'
+          );
           ctx.pendingDeliveries++;
           ctx.promiseQueue = ctx.promiseQueue.then(async () => {
             try {
@@ -244,12 +315,20 @@ export function createUseStep(ctx: WorkflowOrchestratorContext) {
                   );
                 }
               );
-              resolve(hydratedResult as Result);
+              outcome = { ok: true, value: hydratedResult as Result };
             } catch (error) {
-              reject(error);
+              outcome = { ok: false, error };
             } finally {
               ctx.pendingDeliveries--;
             }
+            void earlierDelivered.then(() => {
+              barrier.markDelivered();
+              if (outcome.ok) {
+                resolve(outcome.value);
+              } else {
+                reject(outcome.error);
+              }
+            });
           });
           return EventConsumerResult.Finished;
         }

--- a/packages/core/src/workflow/abort-controller.ts
+++ b/packages/core/src/workflow/abort-controller.ts
@@ -1,6 +1,10 @@
 import { ReplayDivergenceError } from '@workflow/errors';
 import { EventConsumerResult } from '../events-consumer.js';
-import type { WorkflowOrchestratorContext } from '../private.js';
+import {
+  awaitEarlierDeliveries,
+  registerDeliveryBarrier,
+  type WorkflowOrchestratorContext,
+} from '../private.js';
 import { hydrateStepReturnValue } from '../serialization.js';
 import { ABORT_HOOK_TOKEN, ABORT_STREAM_NAME } from '../symbols.js';
 import { getAbortStreamId } from '../util.js';
@@ -178,6 +182,32 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
           // dehydration, so `'reason' in payload` is false and reason
           // ends up undefined on replay.
           const rawPayload = event.eventData?.payload;
+          // An abort is a branch-deciding delivery: `_setAborted` fires the
+          // signal's listeners, and a listener is free to invoke a step and
+          // draw a ULID. So it registers in the delivery-barrier registry as a
+          // 'hook' — which is exactly what the event is — so that wait, hook
+          // and step deliveries order against it by event-log position rather
+          // than by whose hydration finished first. It is always ARMED: unlike
+          // a buffered user hook payload, nothing about its delivery waits on
+          // workflow code asking for it.
+          //
+          // Resolving straight off the queue slot was sufficient only while
+          // every other delivery also resolved from its slot. Step results no
+          // longer do (see step.ts), so an abort whose slot ran while a
+          // log-earlier step sat behind a barrier would overtake it — see
+          // `delivery-barrier-coverage.test.ts`.
+          //
+          // The deferral is captured HERE, at event-consumption time, for the
+          // same two reasons spelled out in step.ts: the set of earlier
+          // deliveries stays a function of log position alone, and barriers
+          // that retire before this slot runs are still seen.
+          const eventIndex = ctx.eventsConsumer.eventIndex;
+          const barrier = registerDeliveryBarrier(ctx, eventIndex, 'hook');
+          const earlierDelivered = awaitEarlierDeliveries(
+            ctx,
+            eventIndex,
+            'hook'
+          );
           // Account this abort as a pending delivery, exactly like step
           // results (step.ts) and hook payloads (workflow/hook.ts) do. The
           // suspension handler dehydrates queued step arguments only once
@@ -189,6 +219,11 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
           // (and a missing reason). Bumping the counter holds the suspension
           // until `_setAborted` has landed, so downstream serialization is
           // deterministic regardless of reason-hydration (decryption) latency.
+          //
+          // It is released inside the slot, before the detached deferral, so
+          // `scheduleWhenIdle` can still reach idle and retire the barriers
+          // that deferral may be waiting on — the same shape as the hook and
+          // step paths.
           ctx.pendingDeliveries++;
           ctx.promiseQueue = ctx.promiseQueue.then(async () => {
             let reason: unknown;
@@ -223,10 +258,16 @@ export function createCreateAbortController(ctx: WorkflowOrchestratorContext) {
                   // fallback (DOMException AbortError).
                 }
               }
-              this.signal._setAborted(reason);
             } finally {
               ctx.pendingDeliveries--;
             }
+            // Detached, like the other deliveries: `awaitEarlierDeliveries`
+            // may be waiting on a delivery this very queue drives, and
+            // blocking a slot on that would deadlock the queue.
+            void earlierDelivered.then(() => {
+              barrier.markDelivered();
+              this.signal._setAborted(reason);
+            });
           });
 
           ctx.invocationsQueue.delete(correlationId);

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -281,14 +281,32 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
         });
 
         if (hasWaitingConsumer) {
+          // A consumer is already awaiting, so this payload's delivery is
+          // pinned to this log position: capture the deferral HERE, while
+          // consuming the event, not at the end of the hydration slot below —
+          // same reasoning as step.ts. An earlier step or hook whose slot runs
+          // first on this serial queue has usually delivered, and so
+          // deregistered its barrier, before this slot ends. Read then, it
+          // would be invisible and this payload would skip both the gate AND
+          // `awaitEarlierDeliveries`' macrotask yield, letting it overtake the
+          // branch that earlier delivery just woke. Every event in one drain
+          // window is consumed before any slot runs, so capturing at
+          // consumption time sees all of them.
+          //
+          // The BUFFERED branch below deliberately does NOT do this — see the
+          // comment on `claim()`.
+          const earlierDelivered = awaitEarlierDeliveries(
+            ctx,
+            eventIndex,
+            'hook'
+          );
           const next = promises.shift();
           if (next) {
-            // A consumer is already awaiting. Hydrate through a promiseQueue
-            // slot (so async deserialization stays in event-log order), then
-            // defer behind earlier waits and steps before resolving. The
-            // deferral runs OFF the serial queue (it may wait on an earlier
-            // wait or step delivery and blocking a queue slot on that would
-            // deadlock the queue).
+            // Hydrate through a promiseQueue slot (so async deserialization
+            // stays in event-log order), then defer behind earlier waits and
+            // steps before resolving. The deferral runs OFF the serial queue
+            // (it may wait on an earlier wait or step delivery and blocking a
+            // queue slot on that would deadlock the queue).
             ctx.pendingDeliveries++;
             let hydrateOutcome:
               | { ok: true; value: T }
@@ -315,7 +333,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
               } finally {
                 ctx.pendingDeliveries--;
               }
-              void awaitEarlierDeliveries(ctx, eventIndex, 'hook').then(() => {
+              void earlierDelivered.then(() => {
                 barrier.markDelivered();
                 if (hydrateOutcome.ok) {
                   next.resolve(hydrateOutcome.value);
@@ -345,6 +363,15 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
             // waits on workflow code: later step results may now be ordered
             // behind it.
             barrier.arm();
+            // Unlike every other delivery, the deferral is evaluated HERE, at
+            // claim time, rather than when the event was consumed. A buffered
+            // payload's delivery genuinely happens when the workflow reads the
+            // hook, which may be many deliveries later; a consumption-time
+            // snapshot would make the claim wait on — and pay the macrotask
+            // yield for — barriers that were relevant to a moment this payload
+            // never participated in. That is not theoretical: it stalls the
+            // second payload in the e2e `hookWithSleepWorkflow` long enough
+            // for the run to suspend before delivering it.
             return hydrated.promise
               .then(() => awaitEarlierDeliveries(ctx, eventIndex, 'hook'))
               .then(() => {

--- a/packages/core/src/workflow/hook.ts
+++ b/packages/core/src/workflow/hook.ts
@@ -261,23 +261,34 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
 
       if (event.eventType === 'hook_received') {
         // Register a 'hook' delivery barrier at this event's log index so a
-        // later-in-log `wait_completed` is delivered only after this hook,
-        // and so this hook is delivered only after every earlier-in-log
-        // `wait_completed` — keeping any `Promise.race` against a wait
-        // deterministic and aligned with the committed event log, regardless
-        // of microtask-hop count, hydration time, or race-argument order.
+        // later-in-log `wait_completed` or step result is delivered only after
+        // this hook, and so this hook is delivered only after every
+        // earlier-in-log `wait_completed` and step result — keeping any
+        // `Promise.race` (or concurrent-branch ULID allocation) deterministic
+        // and aligned with the committed event log, regardless of
+        // microtask-hop count, hydration time, or race-argument order.
         // See `ctx.pendingDeliveryBarriers`.
+        //
+        // The barrier is registered ARMED only when a consumer is already
+        // awaiting, so this payload is committed to reaching the workflow. A
+        // buffered payload is registered unarmed and armed by `claim()`: until
+        // a consumer takes it, a later step result must not be ordered behind
+        // it (see `awaitEarlierDeliveries`).
         const eventIndex = ctx.eventsConsumer.eventIndex;
-        const barrier = registerDeliveryBarrier(ctx, eventIndex, 'hook');
+        const hasWaitingConsumer = promises.length > 0;
+        const barrier = registerDeliveryBarrier(ctx, eventIndex, 'hook', {
+          armed: hasWaitingConsumer,
+        });
 
-        if (promises.length > 0) {
+        if (hasWaitingConsumer) {
           const next = promises.shift();
           if (next) {
             // A consumer is already awaiting. Hydrate through a promiseQueue
             // slot (so async deserialization stays in event-log order), then
-            // defer behind earlier waits before resolving. The deferral runs
-            // OFF the serial queue (it may wait on an earlier wait delivery
-            // and blocking a queue slot on that would deadlock the queue).
+            // defer behind earlier waits and steps before resolving. The
+            // deferral runs OFF the serial queue (it may wait on an earlier
+            // wait or step delivery and blocking a queue slot on that would
+            // deadlock the queue).
             ctx.pendingDeliveries++;
             let hydrateOutcome:
               | { ok: true; value: T }
@@ -304,16 +315,14 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
               } finally {
                 ctx.pendingDeliveries--;
               }
-              void awaitEarlierDeliveries(ctx, eventIndex, ['wait']).then(
-                () => {
-                  barrier.markDelivered();
-                  if (hydrateOutcome.ok) {
-                    next.resolve(hydrateOutcome.value);
-                  } else {
-                    next.reject(hydrateOutcome.error);
-                  }
+              void awaitEarlierDeliveries(ctx, eventIndex, 'hook').then(() => {
+                barrier.markDelivered();
+                if (hydrateOutcome.ok) {
+                  next.resolve(hydrateOutcome.value);
+                } else {
+                  next.reject(hydrateOutcome.error);
                 }
-              );
+              });
             });
           }
         } else {
@@ -331,9 +340,13 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
             | undefined;
           const hydrated = withResolvers<void>();
 
-          const claim = (): Promise<T> =>
-            hydrated.promise
-              .then(() => awaitEarlierDeliveries(ctx, eventIndex, ['wait']))
+          const claim = (): Promise<T> => {
+            // A consumer has taken this payload, so its delivery no longer
+            // waits on workflow code: later step results may now be ordered
+            // behind it.
+            barrier.arm();
+            return hydrated.promise
+              .then(() => awaitEarlierDeliveries(ctx, eventIndex, 'hook'))
               .then(() => {
                 barrier.markDelivered();
                 if (outcome && !outcome.ok) {
@@ -341,6 +354,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
                 }
                 return (outcome as { ok: true; value: T }).value;
               });
+          };
 
           ctx.pendingDeliveries++;
           ctx.promiseQueue = ctx.promiseQueue.then(async () => {
@@ -415,7 +429,7 @@ export function createCreateHook(ctx: WorkflowOrchestratorContext) {
           // The payload was hydrated through a promiseQueue slot at its log
           // position (buffering branch above). `claim()` builds the
           // consumer-facing promise from that outcome, deferring behind any
-          // earlier-in-log wait and marking this hook delivered — so
+          // earlier-in-log wait or step and marking this hook delivered — so
           // resolution order stays anchored to the event log, not this later
           // claim site.
           return nextDelivery.claim();

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -90,24 +90,26 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
         ctx.invocationsQueue.delete(correlationId);
 
         // This `wait_completed` is a branch-deciding resolution the workflow
-        // may `Promise.race` against a hook payload. Order it deterministically
-        // by event-log position (see `pendingDeliveryBarriers`):
+        // may `Promise.race` against a hook payload, or await on a branch
+        // parallel to one awaiting a step. Order it deterministically by
+        // event-log position (see `pendingDeliveryBarriers`):
         //  - Register a 'wait' barrier at this event's index so a LATER-in-log
-        //    hook payload is delivered only after this wait.
-        //  - Before resolving, defer behind every EARLIER-in-log HOOK delivery
-        //    so this wait does not preempt a hook the committed log ordered
-        //    first. Then mark this wait delivered to release later hooks.
+        //    hook payload or step result is delivered only after this wait.
+        //  - Before resolving, defer behind every EARLIER-in-log HOOK and STEP
+        //    delivery so this wait does not preempt one the committed log
+        //    ordered first. Then mark this wait delivered to release the later
+        //    deliveries gated on it.
         const eventIndex = ctx.eventsConsumer.eventIndex;
         const barrier = registerDeliveryBarrier(ctx, eventIndex, 'wait');
         // Defer + resolve in a DETACHED promise (not chained onto the serial
         // `promiseQueue`). `awaitEarlierDeliveries` may wait on an earlier
-        // hook delivery whose own resolution is itself driven by the
+        // hook or step delivery whose own resolution is itself driven by the
         // promiseQueue; blocking a queue slot on it would deadlock the serial
         // queue. We still anchor to the queue tail first so prior queued
         // hydration/ordering work runs in event-log order.
         const queueAtCompletion = ctx.promiseQueue;
         void queueAtCompletion
-          .then(() => awaitEarlierDeliveries(ctx, eventIndex, ['hook']))
+          .then(() => awaitEarlierDeliveries(ctx, eventIndex, 'wait'))
           .then(() => {
             barrier.markDelivered();
             resolve();

--- a/packages/core/src/workflow/sleep.ts
+++ b/packages/core/src/workflow/sleep.ts
@@ -101,6 +101,20 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
         //    deliveries gated on it.
         const eventIndex = ctx.eventsConsumer.eventIndex;
         const barrier = registerDeliveryBarrier(ctx, eventIndex, 'wait');
+        // The deferral is captured HERE, while consuming the event, and not
+        // after the queue tail below — same reasoning as step.ts. An earlier
+        // step or hook whose hydration slot sits in that tail has usually
+        // delivered, and so deregistered its barrier, by the time the tail
+        // resolves. Read then, it would be invisible and this wait would skip
+        // both the gate AND `awaitEarlierDeliveries`' macrotask yield, letting
+        // it overtake the branch that earlier delivery just woke. Every event
+        // in one drain window is consumed before any slot runs, so capturing
+        // at consumption time sees all of them.
+        const earlierDelivered = awaitEarlierDeliveries(
+          ctx,
+          eventIndex,
+          'wait'
+        );
         // Defer + resolve in a DETACHED promise (not chained onto the serial
         // `promiseQueue`). `awaitEarlierDeliveries` may wait on an earlier
         // hook or step delivery whose own resolution is itself driven by the
@@ -109,7 +123,7 @@ export function createSleep(ctx: WorkflowOrchestratorContext) {
         // hydration/ordering work runs in event-log order.
         const queueAtCompletion = ctx.promiseQueue;
         void queueAtCompletion
-          .then(() => awaitEarlierDeliveries(ctx, eventIndex, 'wait'))
+          .then(() => earlierDelivered)
           .then(() => {
             barrier.markDelivered();
             resolve();


### PR DESCRIPTION
## The bug

Two production runs on `@workflow/core@5.0.0-beta.36` (o2flow) burned all three divergence-recovery replays at the **same** `eventId` and terminated with `CORRUPTED_EVENT_LOG`:

| run | shape | error |
| --- | --- | --- |
| `wrun_41KYJENABV0GSF5YTE9EETV5DD` | step vs wait | `Replay divergence: step event step_created for step_X belongs to "A", but the current step consumer is "B"` |
| `wrun_41KYJEE01S0GPC9RWT5MEKVCX8` | step vs hook | same |

### Mechanism

`useStep` proxies draw deterministic ULIDs in **invocation order** (`packages/core/src/step.ts:27`), and replay pairs events to consumers by `correlationId`, erroring on a `stepName` mismatch (`step.ts:88-100`). So the ULID→stepName allocation is a pure function of **the order in which promise resolutions are delivered to workflow code**.

The delivery-barrier registry (`ctx.pendingDeliveryBarriers`, `packages/core/src/private.ts`) exists to pin that order to event-log position — its own docstring describes this exact failure class — but it only covered hook payloads and wait completions. **Step results were outside it:** `step_completed` resolved straight from its serial `promiseQueue` slot, and that slot's latency varies wildly between replays of the *same* invocation:

- the **first** replay pays full hydration (decrypt → decompress → revive);
- **later** replays share the invocation's `ReplayPayloadCache` and memo-hit small primitive results (`replay-payload-cache.ts:125`), resolving in one or two microtask hops.

Meanwhile a `wait_completed` resolves from a detached, fixed-hop chain (`workflow/sleep.ts:100-116`) that is about four hops off the queue tail. So a step completion adjacent in the log to a `wait_completed` is delivered **wait-first on a cold replay and step-first on a warm one**. Whichever order the invocation that *wrote* the follow-up `step_created` events happened to observe became law; every replay computing the other order diverged permanently, and since the divergence is deterministic given a warm cache, all three recovery replays hit it at the same event.

## The fix

`step_completed` and `step_failed` now participate in the barrier registry, mirroring the hook-payload path exactly:

- register a `'step'` barrier at the event's log index, so later wait/hook deliveries are handed over only after it;
- hydrate **inside** the serial `promiseQueue` slot (async deserialization stays in log order) but only **capture** the outcome, releasing `pendingDeliveries` in the slot's `finally`;
- then, in a **detached** continuation, await the earlier deliveries before `markDelivered()` + `resolve`/`reject`.

Two details are what actually make the ordering hold. I found both by testing rather than by reading the code, and the first version of this PR had neither.

**The deferral set is captured while consuming the event, not at the start of the hydration slot.** Slot-start capture is not merely less deterministic — it is usually *empty*. An earlier delivery whose own slot runs first on the serial queue has typically already resolved and deregistered its barrier before the later slot begins, so the later delivery does not defer at all. Instrumenting the hook case showed exactly that: `awaitEarlier kind=step idx=4 defers=0`, with the hook's barrier already gone. Every event in one drain window is consumed before any slot runs, so consumption time sees all of them (`defers=1`).

**A delivery that had to wait yields a macrotask before resolving.** An earlier delivery being "delivered" only means its `resolve()` ran. The branch it woke may need arbitrarily many further microtask hops before it reaches its next `useStep` call and draws a ULID — a `for await` over a hook resumes the generator, settles the promise from `next()`, and only then runs the loop body; workflow code may await anything in between. Ordering the `resolve()` calls alone therefore buys a fixed hop or two of margin and leaves a hop-count race that holds only for the shortest consumers. Yielding a macrotask lets the earlier branch's whole microtask chain drain first, whatever its length. Only deliveries that actually deferred pay it, so the common single-delivery drain is unaffected.

`wait_completed` and `hook_received` deliveries symmetrically defer behind earlier step results. `step_failed` is included because a rejection is just as branch-deciding as a success — it decides whether a `catch` continuation runs, and therefore which ULIDs follow-up `useStep` calls draw. It also now holds `pendingDeliveries` across hydration, which it previously did not.

`awaitEarlierDeliveries(ctx, index, kind)` now takes the *delivering* kind instead of an explicit kind list, with a single `DEFER_BEHIND` table as the source of truth:

| delivering | defers behind earlier | why not the rest |
| --- | --- | --- |
| `hook` | `wait`, `step` | sequential same-entity payloads must not block one another |
| `wait` | `hook`, `step` | a wait never needs to queue behind another wait |
| `step` | `wait`, `hook` | step-vs-step order is already fixed by the serial `promiseQueue` |

### Deadlock / cycle analysis

- **No cycles.** Every edge points from a later log index to a strictly earlier one, so the wait-for graph is a DAG by construction.
- **Never await a barrier inside a serial queue slot.** Hydration stays in the slot; the barrier wait and the resolve run detached. Blocking a slot on a resolution the queue itself drives would deadlock the queue (the constraint `sleep.ts` already documents).
- **`pendingDeliveries` is released inside the slot,** before the detached defer — otherwise `scheduleWhenIdle` could never reach idle, and the idle safety net that retires abandoned barriers (which this deferral may be waiting on) would never fire. This is the same shape as the hook path and the reason `abort-controller.ts` bumps the counter.
- **When no earlier barrier is pending** — the overwhelmingly common case — `awaitEarlierDeliveries` resolves immediately with no macrotask, so the step's `resolve` is enqueued at the end of its own slot, *before* the next queue slot runs. Ordering against every other queue-slot-driven delivery (including `abort-controller.ts`'s `_setAborted`, which is not a barrier participant) is therefore unchanged from before the fix, and no macrotask is paid.
- **The macrotask cannot strand a delivery.** It is a `setTimeout(0)` awaited in the detached continuation, after `pendingDeliveries` has already been released in the slot, so it neither blocks the serial queue nor prevents `scheduleWhenIdle` from reaching idle.
- **A suspension cannot preempt the deferred resolve,** even though `scheduleWhenIdle` also runs on `setTimeout(0)` and `pendingDeliveries` is already 0 by then. The deferred step's macrotask is registered the moment the earlier barrier is marked delivered — i.e. before the woken branch's continuation runs at all — whereas the suspension macrotask is only registered once some branch reaches a `useStep` past the end of the log, which happens *within* that continuation's microtask chain. Registration order therefore puts the step's resolve first, and its own continuation (a microtask) draws its ULID before the suspension macrotask fires. The 18 hop-count cases exercise exactly this: each ends in a suspension and asserts that **both** follow-up steps are pending, which only holds if the deferred delivery landed before the suspension took effect. This does assume workflow continuations are microtask chains, which holds because the sandbox has no real timers — `sleep()` is a wait event, not a `setTimeout`.
- **The idle safety net still covers abandoned step deliveries** (workflow suspended before observing the resolution): `registerDeliveryBarrier` → `scheduleWhenIdle(finish)` is unchanged.

### One deviation from the obvious design, and it is load-bearing

Gating a step result behind **every** earlier hook barrier — the straightforward reading — is wrong, and the existing suite catches it. A **buffered** hook payload (no consumer awaiting when `hook_received` is consumed) is delivered by `claim()`, i.e. whenever the workflow next reads the hook — which is very commonly *downstream of the step result itself* (`await setupStep()` and only then `iterator.next()`). Gating the step on it stalls the run until the barrier's idle safety net fires, which then releases the step **and** every delivery queued behind that payload at once; the workflow installs its `Promise.race` against an already-resolved sleep and loses the very race the ordering exists to protect.

Implemented naively, that regressed 4 existing tests:

```
FAIL  src/hook-sleep-interaction.test.ts > … > should let a queued hook payload win when a reused wait completes after the step that installs the race
FAIL  src/hook-sleep-interaction.test.ts > … > should let a queued hook payload win without mapping the race promises
      (×2, once per sync/async deserialization mode)
ReplayDivergenceError: Replay divergence: step event step_created for step_01K11TFZ62YS0YYFDQ3E8B9YCY
  belongs to "drainStep", but the current step consumer is "syncNextStep"
```

So barrier entries carry an `armed` flag: `wait` and `step` are always armed, a hook payload with a waiting consumer is armed at registration, and a **buffered** payload is registered unarmed and armed by `claim()`. A step result skips any earlier delivery that will not resolve on its own — unarmed, or transitively blocked on something unarmed (`resolvesOnItsOwn`). Waits and hooks deliberately keep gating on unclaimed payloads: for them, waiting for the claim *is* the ordering guarantee (a `wait_completed` must not preempt a payload the log ordered first). Those 4 tests are now a real regression guard for this asymmetry.

## Test evidence

`packages/core/src/step-delivery-ordering.test.ts` is **byte-identical to the file in the repro-only companion PR #3137** apart from two `it.fails` markers there, which let a repro-only branch have green CI (`sed 's/it\.fails(/it(/g' | cmp` verifies it). So the tests demonstrably were not bent to fit the fix. Each case replays one committed event log **twice through a shared `ReplayPayloadCache`** (production shape: one cache per queue delivery, many replays), with `hydrateStepReturnValue` stubbed to cost 10ms so only the cold replay pays it.

Five cases, two of which fail on `main`:

| case | on `main` | mirrors |
| --- | --- | --- |
| wait vs step, cold replay | passes | — |
| **wait vs step, warm replay** | **fails** | run `wrun_41KYJENABV0GSF5YTE9EETV5DD` |
| `for await` hook vs step, cold replay | passes | — |
| **`for await` hook vs step, warm replay** | **fails** | run `wrun_41KYJEE01S0GPC9RWT5MEKVCX8` |
| direct `await hook` vs step, both replays | passes | control for the already-correct path |

The hook flavour must use `for await (… of hook)` to reproduce, but **not** because the payload is buffered — I instrumented `workflow/hook.ts` to check, and all three hook cases consume `hook_received` with an awaiter already registered (`promises.length === 1`); `claim()` never runs in any of them. Entering `for await` calls `next()`, which reaches `yield await this` and subscribes well before the events consumer drains the log on `process.nextTick`.

What actually differs is how many microtask hops separate the payload *resolving* from the branch calling `afterHook()` and drawing its next ULID. `for await` resumes the async generator at `yield await this`, settles the promise returned by `next()`, and only then runs the loop body; a memo-warm `step_completed` — which on an unfixed runtime resolves inside its own queue slot with no detached chain at all — gets there first. A directly-awaited hook resumes its continuation in the first microtask and stays ahead even on a warm cache, which is why it makes a good **control**: same delivery path, same event log, opposite outcome on `main`, and this PR changes the code it runs through (the barrier is now registered `armed` there), so it must stay green.

So the hook flavour is the same hydration-latency race as the wait flavour; the consumer shape only sets how much of a head start the step result needs in order to win. (Buffered payloads *are* central to the `armed` design below, but they are exercised by `hook-sleep-interaction.test.ts`'s queued-payload cases — verified by the same instrumentation: `promises.length === 0`, then `claim()` → `arm()` — not by these new tests.)

**Without the fix** (fix sources reverted to the branch's base commit, converged test file kept):

```
❯ src/step-delivery-ordering.test.ts (5 tests | 2 failed) 147ms
  × delivers the wait before the step result on a later replay sharing the payload cache
  × delivers the hook payload before the step result on a later replay sharing the payload cache

ReplayDivergenceError: Replay divergence: step event step_created for
  step_01K11TFZ62YS0YYFDQ3E8B9YCX belongs to "afterSleep", but the current step consumer is "afterStep"
 ❯ src/step.ts:91:15

ReplayDivergenceError: Replay divergence: step event step_created for
  step_01K11TFZ62YS0YYFDQ3E8B9YCX belongs to "afterHook", but the current step consumer is "afterStep"
 ❯ src/step.ts:91:15

 Tests  2 failed | 3 passed (5)
```

This matches the repro PR's independently observed baseline on `main` exactly — same two cases, same ULID, same error text — and it reproduces the same way in CI, on both Linux and Windows: in #3137's run the two warm-replay cases satisfy their `it.fails` markers while the other three pass, i.e. the divergence is not an artifact of one machine's timing.

### The second test file, and why these five cases are not sufficient

All five cases above are consumed by branches that reach their next `useStep` call in the fewest possible microtask hops. That makes them unable to distinguish two very different guarantees: **(a)** step results are *delivered* in event-log order relative to wait and hook deliveries, or **(b)** a step result merely resolves a hop or two later than it used to, which beats the shortest consumers and nothing else.

The distinction is not academic, and I only caught it by probing: the first version of this PR provided **(b)** and passed all five cases anyway. `packages/core/src/step-delivery-hop-count.test.ts` closes that hole. Each case replays a log a live run legitimately produced — the live invocation received the two events in *separate* deliveries, so the first branch ran to completion long before the second event existed — while the replay receives both in one drain window and must still allocate the ULIDs in the recorded order. The consumer is padded with 0, 1, 2, 4, 8, or 16 extra `await`s so hop count is the only variable, across three groups: step result vs wait completion, step result vs hook payload, and **step failure** vs wait completion (a rejection decides whether a `catch` continuation runs, and so which ULID the `useStep` there draws — `step_failed` goes through the same registration and capture, so it needs the same guard).

| version | hop-count cases passing |
| --- | --- |
| `main` (no fix) | **0 of 18** |
| resolve-ordering only (this PR's first revision) | **3 of 12** of the cases that predated the macrotask |
| this PR | **18 of 18** |

The middle row is the point: without the event-consumption-time capture and the macrotask yield, a consumer with a single extra `await` after being resumed still diverges. These cases are the regression guard for the guarantee actually being (a).

**With the fix:** `5 passed (5)` and `18 passed (18)`. The 15 ordering-sensitive files (both new files plus `hook-sleep-interaction`, `async-deserialization-ordering`, `abort-replay-ordering`, `abort-consistency`, `step-hydration-memoization`, `workflow`, `runtime`, `events-consumer`, `step`, `workflow/sleep`, `workflow/hook`, `define-hook`, `runtime/resume-hook`) were run **8× consecutively**, stable at `321 passed | 3 expected fail` every time.

**Full core suite** (74 files): `1565 passed | 3 expected fail` — the 3 expected-fails are pre-existing `it.fails` cases. Under a colour TTY, `log-format`, `logger`, and `context-errors` additionally report ANSI inline-snapshot mismatches; those fail identically on the unmodified tree and pass under `FORCE_COLOR=0`, i.e. a local artifact, not a regression. `pnpm --filter @workflow/core typecheck` is clean, and `biome check` reports only the two `noExcessiveCognitiveComplexity` warnings that `step.ts` already carries on `main` (63 and 20 there, 63 and 21 here).

**Full local e2e** against a `nextjs-turbopack` dev server, re-run after the macrotask change since it shifts real timing: `135 passed (135)` — the whole suite, including every `AbortController` case, `cancelRun`, `hookWithSleepWorkflow`, `hookWithSleepFinalStepWorkflow`, `sleepWithSequentialStepsWorkflow`, and `setAttributes`.

**CI history.** An earlier revision of this branch (`3fe83a19`, same barrier design, resolve-ordering only) went green across the whole matrix: all 13 `E2E Vercel Prod Tests` apps, `E2E Local Dev`, `E2E Local Postgres` and `E2E Local Prod` (three world backends, ~10 frameworks each), `Unit Tests` on Linux and Windows, `Lint`, `Docs Checks`, `Tarballs Checks`, `Performance Benchmarks` and `DCO` — tally `SUCCESS: 80, SKIPPED: 6, FAILURE: 3`. Revision `d4f86aa4` (converged test file) likewise passed `Unit Tests` on both Linux and Windows, with the Linux core-suite line matching my local numbers exactly.

The 3 failures in that tally were `E2E Local Prod Tests (nextjs-webpack - stable)`, `(nuxt - stable)`, and the `E2E Required Check` gate aggregating them: all the same pre-existing flake, `webhookWorkflow` hitting its 120s timeout at `1 failed | 153 passed (154)`. `main` fails identically at commit `4ada27d3` (same test, same timeout, same counts), so it is unrelated to this change. For the record, the first run on this branch also tripped the documented rotating `E2E Vercel Prod` flake on 7 apps; `main` at this branch's exact base commit `4ba223a0` tripped it on 9, and the re-run came back fully green.

CI is re-running on the current revision, which adds the event-consumption-time capture, the macrotask yield, and the hop-count test file.

The companion **repro-only** PR is #3137 (branch `pgp/repro-step-wait-divergence`): it adds this same test file without the fix, and its CI confirms on Linux and Windows that the two warm-replay cases diverge on `main` while the other three hold. Merging that first, then this, gives a red-then-green history for the bug; whoever lands them should flip those two cases back from `it.fails` to plain assertions as part of merging this PR.

## Follow-up: remaining barrier gaps (commit 2)

Review of the first commit turned up three more places the registry did not
reach. Each is fixed here, with a regression test in the new
`packages/core/src/delivery-barrier-coverage.test.ts` that reproduces the
production `ReplayDivergenceError` when — and only when — its own fix is
reverted. Verified one at a time.

### 1. A step must defer behind earlier STEP results

`DEFER_BEHIND.step` excluded `'step'` on the grounds that the serial
`promiseQueue` already orders step results. That stopped being true in this
PR: a step captures its outcome in its queue slot but resolves from a detached
continuation once its barrier clears. Two steps agree on that ordering only
while they defer behind the same set — true within one drain window, false
across windows. A step consumed later can miss a wait/hook barrier an earlier
step is still parked on, because it retired in between; the earlier step is
then waiting out the macrotask yield while the later one resolves on
microtasks.

The test log is one a live run legitimately produces: `stepA`'s worker writes
`step_completed` just before the invocation resuming from a sleep writes
`step_created stepB`, so that invocation's own replay never delivered `stepA`.
On replay `stepB`'s consumer does not exist until the sleep lands, so the two
completions fall in separate drain windows.

Cost of the extra edge, measured on a parallel step fan-out (`Promise.all` of
N steps, all completing in one drain): **+1.3 ms, flat**, not O(N) — the idle
safety net retires the chain in one timer tick rather than serializing N of
them. N=10 3.1→4.4 ms, N=50 3.1→5.2 ms, N=100 6.6→7.8 ms.

### 2. `sleep.ts` and `hook.ts` must capture their deferral at consumption time

The "Coverage" argument the first commit documents for `step.ts` applies
symmetrically, and was not applied. `sleep.ts` read the registry after the
queue tail and `hook.ts` at the end of its hydration slot — by which point an
earlier step or hook has usually delivered and deregistered its barrier. The
later delivery then skips **both** the gate and `awaitEarlierDeliveries`'
macrotask yield, and overtakes the branch that earlier delivery just woke.

This is the exact mirror of `step-delivery-hop-count.test.ts` and fails the
same way: a wait completion diverges at 8 extra consumer hops, a hook payload
at 20. Both are covered at 0/1/3/8/20/50 hops in the new file.

The **buffered** hook payload path deliberately keeps evaluating at claim
time, and now says so. A buffered payload's delivery genuinely happens when
the workflow reads the hook, potentially many deliveries later; a
consumption-time snapshot makes the claim wait on barriers from a moment it
never participated in, which stalls the second payload in the e2e
`hookWithSleepWorkflow` long enough for the run to suspend before delivering
it. Caught by the full local e2e run, not by unit tests.

### 3. Abort deliveries participate in the registry

`abort-controller.ts` resolved `_setAborted` straight off its `promiseQueue`
slot and registered no barrier. That was sufficient only while every other
delivery also resolved from its slot. `_setAborted` fires the signal's
listeners, and a listener may invoke a step and draw a ULID, so an abort is as
branch-deciding as any other delivery — a log-earlier step sitting behind a
barrier is overtaken by any abort whose slot runs in the meantime. It now
registers as a `'hook'` (which is exactly what the event is), always armed,
and resolves detached behind its deferral.

### Also: `resolvesOnItsOwn` was exponential

Each armed entry re-walked every earlier entry of the opposite kind —
`T(n) = Σ T(j)` — with no memo, on the synchronous delivery path. The registry
is not bounded: `EventsConsumer` drains consecutively consumable events
synchronously while barriers only retire on microtask-driven deliveries, so a
fan-out of `Promise.race([hook, sleep(watchdog)])` branches accumulates one
barrier per branch per kind (**49 live barriers measured for 24 branches**).

A single scan over 40 alternating armed hook/wait barriers took **92 seconds**
of blocked event loop before the fix, and is instant after. Guarded by a test
in the new file that times the synchronous scan.

## Verification (commit 2)

- `pnpm vitest run --root packages/core src/` → **75 files, 1614 passed | 3 expected fail**. Typecheck clean. Biome: same 8 pre-existing complexity/banned-type warnings as the unmodified tree, none new.
- The 14 ordering-sensitive files **8x consecutively** → `277 passed | 3 expected fail` every time.
- Full local e2e against a `nextjs-turbopack` dev server: **135 passed (135)**.
- `e2e/local-build`, `e2e/build-errors`, `e2e/route-bundle-isolation` pass individually. Run as one vitest invocation, `route-bundle-isolation` fails — identically on the unmodified tree, so it is cross-suite build interference, not a regression.

## Rollout caveat

In-flight runs whose logs were allocated under the old flipped (step-first) ordering will now deterministically diverge on replay. Those runs were already unrecoverable time bombs under the old runtime — any warm replay computed the other order, which is exactly how these two runs died — so this bounds the blast radius to windows that were already affected rather than creating a new one.

**Not a concern for SDK version drift specifically:** on Vercel a run is pinned to its originating immutable deployment, so a single run never replays across two different `@workflow/core` versions. The caveat above is only about logs already written under the old ordering, replayed by the same deployment.

## What reviewers should scrutinise

1. **The `armed` asymmetry** (`private.ts`, `resolvesOnItsOwn` + `awaitEarlierDeliveries`): is "a step never queues behind an unclaimed buffered payload" the right line, or should the wait/hook side eventually adopt it too? Today they must not, or the original hook-vs-sleep fix regresses.
2. **`arm()` timing — the thinnest part of the argument.** A buffered payload is armed at `claim()`, and a step now reads armed-ness while consuming its event, which is exactly log position and cannot depend on hydration duration. The residual sharp edge is a shape where the claim is armed by a *continuation of an earlier delivery*, i.e. where the arming itself is latency-coupled one level up, so a step consuming its event might see the entry unarmed on one replay and armed on another. I could not construct a case that diverges, and none of the existing tests exhibit it — the new tests never buffer, and `hook-sleep-interaction`'s queued-payload cases claim from a continuation downstream of a step but with only one step delivery in flight. So treat this as unproven rather than verified; it is where I would look first if a similar divergence resurfaces.
3. **Macrotask cost.** The barrier's idle safety net contributes one `setTimeout(0)` per step delivery (cheap; the poll exits the first time `pendingDeliveries` hits 0), and the new yield adds another **only when a delivery actually had to defer** — i.e. only when two or more branch-deciding events land in the same drain window, which is rare and is precisely the case that was broken. A sequential single-step workflow pays neither. Still worth a look given the active inline-step perf work, and worth challenging if anyone sees a cheaper way to let a resumed branch quiesce than a macrotask.
4. **`step_failed` now holds `pendingDeliveries` across hydration** (it did not before), so suspensions wait for a rejection to land. Intentional and consistent with `step_completed`, but it is a behaviour change beyond pure ordering.
5. **Whether the guarantee should be stated in the docs.** What this establishes is: given a fixed delivery order, the userland interleaving that follows is deterministic, so pinning delivery order to log order is sufficient for replay determinism. The hop-count tests encode that. If reviewers agree it is the intended contract, it probably belongs somewhere more discoverable than a test file docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


