### PR TITLE
feat: decrypt sealed payloads in the dashboard and CLI

### DIFF
--- a/.changeset/encp-o11y-decrypt.md
+++ b/.changeset/encp-o11y-decrypt.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'@workflow/web-shared': patch
+'@workflow/cli': patch
+---
+
+Let observability tooling decrypt sealed (`encp`) payloads: key resolution now yields the run's full key capability, and `hydrateDataWithKey` dispatches on the envelope format.

--- a/.changeset/encp-o11y-decrypt.md
+++ b/.changeset/encp-o11y-decrypt.md
@@ -1,6 +1,7 @@
 ---
 '@workflow/core': minor
 '@workflow/web-shared': patch
+'@workflow/web': patch
 '@workflow/cli': patch
 ---
 

--- a/packages/cli/src/lib/inspect/hydration.ts
+++ b/packages/cli/src/lib/inspect/hydration.ts
@@ -338,8 +338,13 @@ async function maybeDecryptFields<
 
   try {
     const rawKey = await resolver(runId);
-    const { importKey } = await import('@workflow/core/encryption');
-    const k = rawKey ? await importKey(rawKey) : undefined;
+    // Resolve the full key capability so `--decrypt` can open sealed
+    // ('encp') payloads that other runs wrote to this one, not just the
+    // run's own symmetric ('encr') payloads.
+    const { deriveRunPayloadKeys } = await import(
+      '@workflow/core/serialization'
+    );
+    const k = rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
 
     // Decrypt input/output/error fields (WorkflowRun, Step)
     result.input = await maybeDecrypt(result.input, k);

--- a/packages/cli/src/lib/inspect/output.ts
+++ b/packages/cli/src/lib/inspect/output.ts
@@ -1,5 +1,5 @@
-import { importKey } from '@workflow/core/encryption';
 import {
+  deriveRunPayloadKeys,
   type EncryptionKeyParam,
   getDeserializeStream,
   getExternalRevivers,
@@ -1039,7 +1039,9 @@ export const showStream = async (
     encryptionKey = (async () => {
       const run = await world.runs.get(opts.runId!);
       const rawKey = await world.getEncryptionKeyForRun?.(run);
-      return rawKey ? await importKey(rawKey) : undefined;
+      // Full capability, so sealed ('encp') stream frames written by other
+      // runs are readable too — not just the run's own symmetric frames.
+      return rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
     })();
   } else if (opts.decrypt && !opts.runId) {
     logger.warn(

--- a/packages/core/src/serialization-format.test.ts
+++ b/packages/core/src/serialization-format.test.ts
@@ -711,6 +711,37 @@ describe('encrypted data handling', () => {
       expect(result).toEqual(original);
     });
 
+    it('rejects a write-only seal target at the type level', async () => {
+      // A seal target holds only a public key, so it can open neither scheme.
+      // Accepting it here would compile into a guaranteed runtime failure, so
+      // the signature takes a read capability instead.
+      const { sealTo, deriveRunPayloadKeys } = await import(
+        './serialization/encryption.js'
+      );
+      const target = sealTo(new Uint8Array(32).fill(1));
+
+      // @ts-expect-error - SealTarget is write-only and must not be accepted
+      void hydrateDataWithKey(
+        makeSealedPayload(),
+        observabilityRevivers,
+        target
+      );
+
+      // Both read capabilities remain accepted: the run's full key bundle...
+      const keys = await deriveRunPayloadKeys(testKeyRaw);
+      await expect(
+        hydrateDataWithKey(makeSealedPayload(), observabilityRevivers, keys)
+      ).rejects.toThrow(); // fake ciphertext, but it type-checks and is attempted
+      // ...and a bare symmetric key (which simply cannot open sealed data).
+      await expect(
+        hydrateDataWithKey(
+          makeSealedPayload(),
+          observabilityRevivers,
+          await getTestKey()
+        )
+      ).resolves.toBeInstanceOf(Uint8Array);
+    });
+
     it('should pass sealed payloads through untouched even when a key is present', async () => {
       // A sealed payload is encrypted to the run's X25519 public key, so the
       // symmetric key this function receives cannot open it. Attempting an

--- a/packages/core/src/serialization-format.test.ts
+++ b/packages/core/src/serialization-format.test.ts
@@ -728,6 +728,44 @@ describe('encrypted data handling', () => {
       expect(isEncryptedData(result)).toBe(true);
     });
 
+    it('should open a real sealed payload when given the run keypair', async () => {
+      // The o11y decrypt path must handle payloads that other runs sealed to
+      // this one — a cross-deployment hook resumption, say. Without this the
+      // dashboard and CLI would show a lock icon on data the user is entitled
+      // to read and has supplied the key for.
+      const { deriveRunKeyPair, seal } = await import('./sealed-box.js');
+      const { deriveRunPayloadKeys } = await import(
+        './serialization/encryption.js'
+      );
+
+      const original = { approved: true, note: 'sealed by another run' };
+      const keyPair = await deriveRunKeyPair(testKeyRaw);
+      const sealed = encodeWithFormatPrefix(
+        SerializationFormat.SEALED,
+        await seal(keyPair.publicKey, makeDevlPayload(original))
+      ) as Uint8Array;
+
+      const keys = await deriveRunPayloadKeys(testKeyRaw);
+      await expect(
+        hydrateDataWithKey(sealed, observabilityRevivers, keys)
+      ).resolves.toEqual(original);
+    });
+
+    it('should still open symmetric payloads when given the run keypair', async () => {
+      // The same resolved key must serve both schemes — a run's event log
+      // mixes its own 'encr' payloads with 'encp' payloads written to it.
+      const { deriveRunPayloadKeys } = await import(
+        './serialization/encryption.js'
+      );
+      const original = { message: 'own payload' };
+      const encrypted = await encryptPayload(original);
+      const keys = await deriveRunPayloadKeys(testKeyRaw);
+
+      await expect(
+        hydrateDataWithKey(encrypted, observabilityRevivers, keys)
+      ).resolves.toEqual(original);
+    });
+
     it('should not throw "Unsupported serialization format" for sealed payloads', async () => {
       // Regression guard: before `encp` was recognized, o11y hydration hit the
       // unknown-format branch and threw, breaking the CLI/dashboard entirely

--- a/packages/core/src/serialization-format.ts
+++ b/packages/core/src/serialization-format.ts
@@ -23,16 +23,17 @@ import { parse, unflatten } from 'devalue';
  * `encryption.ts` and `sealed-box.ts` are all free of Node dependencies.
  */
 export {
+  type DecryptionKey,
   decrypt as decryptEnvelope,
   deriveRunPayloadKeys,
   encrypt as encryptEnvelope,
   isRunPayloadKeys,
   isSealTarget,
   type PayloadKey,
-  runPayloadKeys,
   type RunPayloadKeys,
-  sealTo,
+  runPayloadKeys,
   type SealTarget,
+  sealTo,
 } from './serialization/encryption.js';
 
 // ---------------------------------------------------------------------------
@@ -419,11 +420,13 @@ export function hydrateData(value: unknown, revivers: Revivers): unknown {
  * @param key - The run's key material. Pass `RunPayloadKeys` (from
  *   `deriveRunPayloadKeys`) to open both symmetric (`encr`) and sealed
  *   (`encp`) payloads; a bare `CryptoKey` opens only the symmetric ones.
+ *   Typed as a read capability so a write-only seal target — which could open
+ *   neither scheme — is rejected at compile time rather than failing here.
  */
 export async function hydrateDataWithKey(
   value: unknown,
   revivers: Revivers,
-  key: import('./serialization/encryption.js').PayloadKey | undefined
+  key: import('./serialization/encryption.js').DecryptionKey | undefined
 ): Promise<unknown> {
   let data = value;
   if (data instanceof Uint8Array && isEncryptedData(data) && key) {

--- a/packages/core/src/serialization-format.ts
+++ b/packages/core/src/serialization-format.ts
@@ -10,6 +10,32 @@ import { getEventDataRefFields } from '@workflow/world';
 import { parse, unflatten } from 'devalue';
 
 // ---------------------------------------------------------------------------
+// Key material (browser-safe re-exports)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-exported from the envelope layer so browser consumers (web dashboard,
+ * web-shared) can resolve key material without importing
+ * `@workflow/core/serialization`, whose module graph reaches Node built-ins
+ * (`node:util`, `node:async_hooks`) and cannot be bundled for the browser.
+ *
+ * Everything below is Web Crypto only: `serialization/encryption.ts`,
+ * `encryption.ts` and `sealed-box.ts` are all free of Node dependencies.
+ */
+export {
+  decrypt as decryptEnvelope,
+  deriveRunPayloadKeys,
+  encrypt as encryptEnvelope,
+  isRunPayloadKeys,
+  isSealTarget,
+  type PayloadKey,
+  runPayloadKeys,
+  type RunPayloadKeys,
+  sealTo,
+  type SealTarget,
+} from './serialization/encryption.js';
+
+// ---------------------------------------------------------------------------
 // Format prefix constants and encoding/decoding
 // ---------------------------------------------------------------------------
 
@@ -388,32 +414,32 @@ export function hydrateData(value: unknown, revivers: Revivers): unknown {
  * decryption. Used by o11y tooling (web UI, CLI) when the user requests
  * decryption.
  *
- * @param value - The value to hydrate (may be encrypted)
+ * @param value - The value to hydrate (may be encrypted or sealed)
  * @param revivers - Devalue revivers for deserialization
- * @param key - AES-256 encryption key (if provided, encrypted data will be decrypted)
+ * @param key - The run's key material. Pass `RunPayloadKeys` (from
+ *   `deriveRunPayloadKeys`) to open both symmetric (`encr`) and sealed
+ *   (`encp`) payloads; a bare `CryptoKey` opens only the symmetric ones.
  */
 export async function hydrateDataWithKey(
   value: unknown,
   revivers: Revivers,
-  key: import('./encryption.js').CryptoKey | undefined
+  key: import('./serialization/encryption.js').PayloadKey | undefined
 ): Promise<unknown> {
   let data = value;
-  if (
-    data instanceof Uint8Array &&
-    isEncryptedData(data) &&
-    !isSealedData(data) &&
-    key
-  ) {
-    // Decrypt: strip 'encr' prefix, AES-GCM decrypt, then hydrate the result.
-    //
-    // Sealed ('encp') payloads are deliberately excluded: they are encrypted
-    // to the run's X25519 public key, so opening them needs the private
-    // scalar, not the symmetric key this function receives. Feeding them to
-    // AES-GCM would fail the auth tag and surface as a spurious decryption
-    // error, so they fall through untouched and render as ciphertext instead.
-    const { decrypt } = await import('./encryption.js');
-    const { payload } = decodeFormatPrefix(data);
-    data = await decrypt(key, payload);
+  if (data instanceof Uint8Array && isEncryptedData(data) && key) {
+    // Envelope-aware decrypt: handles both `encr` (AES-GCM under the run's
+    // symmetric key) and `encp` (sealed to the run's X25519 public key by
+    // some other run), dispatching on the format prefix.
+    const { decrypt, isRunPayloadKeys } = await import(
+      './serialization/encryption.js'
+    );
+    // Opening a sealed payload needs the run's private scalar. If the caller
+    // supplied only a symmetric key, leave the bytes as ciphertext so the UI
+    // keeps showing its "Encrypted" affordance, rather than surfacing a
+    // decryption error for something that was never openable with this key.
+    if (!isSealedData(data) || isRunPayloadKeys(key)) {
+      data = await decrypt(data, key);
+    }
   }
   if (data instanceof Uint8Array && isCompressedData(data)) {
     // Decompress: strip the codec prefix and inflate. gzip uses the

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -35,12 +35,17 @@ import {
 import {
   aesKeyOf,
   decrypt,
+  deriveRunPayloadKeys,
   type EncryptionKeyParam,
   encrypt,
   isRunPayloadKeys,
   isSealTarget,
   type PayloadKey,
   resolveEncryptionKey,
+  type RunPayloadKeys,
+  runPayloadKeys,
+  type SealTarget,
+  sealTo,
 } from './serialization/encryption.js';
 import {
   formatSerializationError,
@@ -108,6 +113,16 @@ export {
   compress,
   decompress,
   type EncryptionKeyParam,
+  // Sealed-box ('encp') key variants — see serialization/encryption.ts.
+  type PayloadKey,
+  type RunPayloadKeys,
+  type SealTarget,
+  sealTo,
+  runPayloadKeys,
+  deriveRunPayloadKeys,
+  isSealTarget,
+  isRunPayloadKeys,
+  aesKeyOf,
 };
 
 // Re-export the legacy SerializationFormatType for backwards compatibility.

--- a/packages/core/src/serialization/encryption.ts
+++ b/packages/core/src/serialization/encryption.ts
@@ -12,8 +12,10 @@ import {
   decrypt as aesGcmDecrypt,
   encrypt as aesGcmEncrypt,
   type CryptoKey,
+  importKey as importAesKey,
 } from '../encryption.js';
 import {
+  deriveRunKeyPair,
   open as openSealed,
   type RunKeyPair,
   seal as sealToPublicKey,
@@ -118,6 +120,25 @@ export function runPayloadKeys(
   aad?: Uint8Array
 ): RunPayloadKeys {
   return { [RUN_KEYS_BRAND]: true, aes, keyPair, aad };
+}
+
+/**
+ * Build the full key capability for a run from its raw 32-byte key material —
+ * the value `World.getEncryptionKeyForRun()` returns.
+ *
+ * Use this anywhere a run reads its own event log: it yields a key that opens
+ * both its own symmetric (`encr`) payloads and sealed (`encp`) payloads other
+ * runs wrote to it. Resolving only `importKey(material)` would leave the
+ * reader unable to open sealed writes.
+ */
+export async function deriveRunPayloadKeys(
+  runKeyMaterial: Uint8Array
+): Promise<RunPayloadKeys> {
+  const [aes, keyPair] = await Promise.all([
+    importAesKey(runKeyMaterial),
+    deriveRunKeyPair(runKeyMaterial),
+  ]);
+  return runPayloadKeys(aes, keyPair);
 }
 
 export function isSealTarget(value: unknown): value is SealTarget {

--- a/packages/core/src/serialization/encryption.ts
+++ b/packages/core/src/serialization/encryption.ts
@@ -98,6 +98,17 @@ export interface RunPayloadKeys {
 export type PayloadKey = CryptoKey | SealTarget | RunPayloadKeys;
 
 /**
+ * The subset of {@link PayloadKey} that can actually *read* a payload.
+ *
+ * Excludes {@link SealTarget}, which is write-only by construction: it holds a
+ * public key, so it can open neither `encp` (needs the private scalar) nor
+ * `encr` (needs the symmetric key). Decrypt-side signatures should take this
+ * rather than `PayloadKey`, so passing a seal target is a compile error instead
+ * of a guaranteed runtime failure.
+ */
+export type DecryptionKey = CryptoKey | RunPayloadKeys;
+
+/**
  * Build a write-only seal capability for a recipient run's public key.
  *
  * @param recipientPublicKey - The recipient run's raw 32-byte X25519 public key

--- a/packages/web-shared/src/lib/hydration.ts
+++ b/packages/web-shared/src/lib/hydration.ts
@@ -497,9 +497,14 @@ export async function hydrateResourceIOAsync<T>(
     './zstd-browser-decoder.js'
   );
   ensureZstdDecoderRegistered();
+  // Resolve the *full* key capability, not just the symmetric key: a run's
+  // event log can contain sealed ('encp') payloads that another run wrote to
+  // it (a cross-deployment hook resumption, say), and opening those needs the
+  // run's X25519 scalar in addition to its AES key. Both are derived from the
+  // same 32 bytes the key-retrieval endpoint returns.
   const cryptoKey = key
-    ? await import('@workflow/core/encryption').then(({ importKey }) =>
-        importKey(key)
+    ? await import('@workflow/core/serialization-format').then(
+        ({ deriveRunPayloadKeys }) => deriveRunPayloadKeys(key)
       )
     : undefined;
   const revivers = getRevivers();

--- a/packages/web-shared/src/lib/hydration.ts
+++ b/packages/web-shared/src/lib/hydration.ts
@@ -487,7 +487,7 @@ export async function hydrateResourceIOAsync<T>(
   resource: T,
   key?: Uint8Array
 ): Promise<T> {
-  const { hydrateDataWithKey } = await import(
+  const { hydrateDataWithKey, deriveRunPayloadKeys } = await import(
     '@workflow/core/serialization-format'
   );
   // Payloads may be zstd-compressed (the Web DecompressionStream has no zstd);
@@ -502,11 +502,12 @@ export async function hydrateResourceIOAsync<T>(
   // it (a cross-deployment hook resumption, say), and opening those needs the
   // run's X25519 scalar in addition to its AES key. Both are derived from the
   // same 32 bytes the key-retrieval endpoint returns.
-  const cryptoKey = key
-    ? await import('@workflow/core/serialization-format').then(
-        ({ deriveRunPayloadKeys }) => deriveRunPayloadKeys(key)
-      )
-    : undefined;
+  // Resolve the *full* key capability, not just the symmetric key: a run's
+  // event log can contain sealed ('encp') payloads that another run wrote to
+  // it (a cross-deployment hook resumption, say), and opening those needs the
+  // run's X25519 scalar in addition to its AES key. Both derive from the same
+  // 32 bytes the key-retrieval endpoint returns.
+  const cryptoKey = key ? await deriveRunPayloadKeys(key) : undefined;
   const revivers = getRevivers();
 
   async function hydrateField(value: unknown): Promise<unknown> {

--- a/packages/web/app/lib/hooks/use-stream-reader.ts
+++ b/packages/web/app/lib/hooks/use-stream-reader.ts
@@ -1,4 +1,8 @@
-import { decrypt as aesGcmDecrypt, importKey } from '@workflow/core/encryption';
+import {
+  decryptEnvelope,
+  deriveRunPayloadKeys,
+  type PayloadKey,
+} from '@workflow/core/serialization-format';
 import {
   hydrateData,
   isEncryptedData,
@@ -67,7 +71,7 @@ export function useStreamReader(
   const processFrame = useCallback(
     async (
       rawFrame: Uint8Array,
-      cryptoKey: CryptoKey | undefined,
+      cryptoKey: PayloadKey | undefined,
       revivers: ReturnType<typeof getWebRevivers>
     ): Promise<
       { encrypted: true } | { encrypted: false; chunk: StreamChunk }
@@ -102,9 +106,12 @@ export function useStreamReader(
           if (!cryptoKey) {
             return { encrypted: true };
           }
-          const payload = frameData.slice(4);
+          // Envelope-aware: frames may be symmetric ('encr', written by the
+          // run itself) or sealed ('encp', written by another run into a
+          // forwarded stream). `decryptEnvelope` dispatches on the prefix and
+          // strips it, so no manual slice here.
           hydrated = hydrateData(
-            await aesGcmDecrypt(cryptoKey, payload),
+            (await decryptEnvelope(frameData, cryptoKey)) as Uint8Array,
             revivers
           );
         } else {
@@ -164,7 +171,7 @@ export function useStreamReader(
      */
     const fetchAndParse = async (
       targetBuffer: StreamChunk[],
-      cryptoKey: CryptoKey | undefined,
+      cryptoKey: PayloadKey | undefined,
       options?: { skipFrames?: number; cursor?: string | null }
     ): Promise<
       | { encrypted: true }
@@ -300,8 +307,10 @@ export function useStreamReader(
 
     const readStreamData = async () => {
       try {
+        // Full capability so sealed ('encp') frames written by other runs
+        // decrypt too, not just this run's own symmetric frames.
         const cryptoKey = encryptionKey
-          ? await importKey(encryptionKey)
+          ? await deriveRunPayloadKeys(encryptionKey)
           : undefined;
 
         const initialChunks: StreamChunk[] = [];


### PR DESCRIPTION
> **Replaces #3097.** That PR was force-closed as "merged" by GitHub when I
> force-pushed its base branch to a commit that happened to contain its head —
> GitHub concluded it had merged into its base. Its code never reached `main`.
> It cannot be reopened, so this PR carries the identical work. Review history
> on #3097 still applies.

**Ordering change:** this now targets `main` directly and should land **before**
#3096, per the review there. #3096 begins emitting sealed (`encp`) hook payloads
while `workflow inspect --decrypt` can only build a symmetric key, so merging it
first would leave those payloads showing as ciphertext placeholders. Landing the
reader first closes that window.

To make this PR stand alone, `deriveRunPayloadKeys` moved here from #3096 — it
is the capability the reader needs, and its own doc says to use it "anywhere a
run reads its own event log", so it belongs on this side regardless.

---

**PR 5 of 7.** Stacked on #3096; review the stack in order, starting from #3093.

- #3093 — the `encp` sealed-box primitive
- #3094 — route sealed envelopes through the serialization layer
- #3095 — publish each run's public key on the run entity
- #3096 — `resumeHook()` seals instead of fetching the key ← the payoff
- **#3097 (this PR)** — decrypt sealed payloads in observability tooling
- #3098 — seal forwarded stream writes
- #3099 — `start()` gets the key from the probe it already awaits

## Why this is required, not optional

Once #3096 lands, a hook resumption from another deployment writes a sealed payload into the run's event log. Observability tooling can't open it: `hydrateDataWithKey` only ever ran AES-GCM. So the dashboard and CLI would render a 🔒 placeholder on data the user is entitled to read **and has already supplied the key for** — a visible debugging regression on exactly the runs this work speeds up.

## What changed

`hydrateDataWithKey` delegates to the envelope layer, which dispatches on the 4-byte format prefix, instead of unconditionally decrypting with AES-GCM.

All four o11y key-resolution sites now resolve the run's *full* key capability rather than just its symmetric key:

| Site | Path |
| --- | --- |
| `@workflow/web-shared` | `hydrateResourceIOAsync` |
| `@workflow/web` | `use-stream-reader` (hand-rolled frame decode) |
| `@workflow/cli` | `--decrypt` field hydration |
| `@workflow/cli` | `--decrypt` stream output |

Each already had the raw 32 bytes in hand, so this costs one extra key derivation and **no additional requests or round trips**.

A caller that supplies only a symmetric key still gets the ciphertext placeholder for sealed payloads rather than a decryption error — that key never could have opened them, so surfacing a failure would be misleading.

## Browser bundling

The natural import for the new helper is `@workflow/core/serialization`, but that module graph reaches `node:util` and `node:async_hooks` and cannot be bundled for the browser — which is precisely what the `@workflow/core/serialization-format` entrypoint exists to avoid. I hit this as a build failure and moved the key helpers to a re-export from that browser-safe entrypoint; the two browser consumers import from there, while the CLI keeps the direct import since it runs on Node.

Verified by walking the built import graph: `serialization-format.js` reaches 6 modules and **zero** Node built-ins.

## Tests

Two new cases assert the o11y path opens a *real* sealed payload with the derived keypair, and that the same resolved key still opens the run's own symmetric payloads — a run's event log mixes both.

Core suite 1598 passing, web-shared 160, CLI 78. Zero new lint diagnostics (diffed against a stashed baseline).



