### PR TITLE
[e2e] Rebuild the event-log corruption repro around step-count divergence

### DIFF
--- a/.changeset/event-log-corruption-repro.md
+++ b/.changeset/event-log-corruption-repro.md
@@ -1,0 +1,4 @@
+---
+---
+
+Rebuild the event-log race CI repro around step-count-divergent racing branches.

--- a/.github/scripts/render-event-log-race-repro-results.js
+++ b/.github/scripts/render-event-log-race-repro-results.js
@@ -163,29 +163,35 @@ function renderConfig(entry) {
   const config = entry.config ?? {};
   const attempts = config.attempts ? `${config.attempts} runs` : '';
   const scenarios = [
-    config.hookSleepAttempts ? `hook ${config.hookSleepAttempts}` : '',
+    config.stepStormAttempts ? `step-storm ${config.stepStormAttempts}` : '',
+    config.hookStormAttempts ? `hook-storm ${config.hookStormAttempts}` : '',
+    config.hookSleepAttempts ? `hook-sleep ${config.hookSleepAttempts}` : '',
+    // Historical entries from the pre-storm harness, kept so an old sticky
+    // comment still renders its own configuration rather than a blank cell.
     config.stepFanoutAttempts ? `fanout ${config.stepFanoutAttempts}` : '',
     config.stepSleepRaceAttempts ? `race ${config.stepSleepRaceAttempts}` : '',
   ]
     .filter(Boolean)
     .join(', ');
   const concurrency = config.concurrency ? `c${config.concurrency}` : '';
-  const stepConcurrency = config.stepConcurrency
-    ? `step c${config.stepConcurrency}`
-    : '';
-  const iterations = config.iterations ? `${config.iterations} iters` : '';
-  return [attempts, scenarios, concurrency, stepConcurrency, iterations]
-    .filter(Boolean)
-    .join(' / ');
+  const shape =
+    config.rounds && config.width
+      ? `${config.rounds}x${config.width}`
+      : config.stepFanoutRounds && config.stepFanoutWidth
+        ? `${config.stepFanoutRounds}x${config.stepFanoutWidth}`
+        : '';
+  return [attempts, scenarios, concurrency, shape].filter(Boolean).join(' / ');
 }
 
 function renderTiming(entry) {
   const config = entry.config ?? {};
   return [
-    config.sleepMs ? `sleep ${config.sleepMs}ms` : '',
-    config.resumeDelayMs || config.resumeJitterMs
-      ? `resume ${config.resumeDelayMs ?? 0}+${config.resumeJitterMs ?? 0}ms`
+    config.watchdogMs ? `watchdog ${config.watchdogMs}ms` : '',
+    config.stepDelayMs
+      ? `step ${config.stepDelayMs}±${config.stepDelayJitterMs ?? 0}ms`
       : '',
+    config.hookResumeStaggerMs ? `stagger ${config.hookResumeStaggerMs}ms` : '',
+    config.pokeIntervalMs ? `poke ${config.pokeIntervalMs}ms` : '',
     config.runTimeoutMs ? `timeout ${config.runTimeoutMs}ms` : '',
   ]
     .filter(Boolean)
@@ -195,19 +201,26 @@ function renderTiming(entry) {
 function compactConfig(config = {}) {
   return {
     attempts: config.attempts,
+    stepStormAttempts: config.stepStormAttempts,
+    hookStormAttempts: config.hookStormAttempts,
     hookSleepAttempts: config.hookSleepAttempts,
+    concurrency: config.concurrency,
+    rounds: config.rounds,
+    width: config.width,
+    watchdogMs: config.watchdogMs,
+    stepDelayMs: config.stepDelayMs,
+    stepDelayJitterMs: config.stepDelayJitterMs,
+    reconcileBase: config.reconcileBase,
+    attrWrites: config.attrWrites,
+    pokeIntervalMs: config.pokeIntervalMs,
+    hookResumeStaggerMs: config.hookResumeStaggerMs,
+    runTimeoutMs: config.runTimeoutMs,
+    // Pre-storm harness keys, retained so history rows recorded by an older
+    // revision of this script keep rendering their own configuration.
     stepFanoutAttempts: config.stepFanoutAttempts,
     stepSleepRaceAttempts: config.stepSleepRaceAttempts,
-    concurrency: config.concurrency,
-    stepConcurrency: config.stepConcurrency,
-    iterations: config.iterations,
-    sleepMs: config.sleepMs,
-    resumeDelayMs: config.resumeDelayMs,
-    resumeJitterMs: config.resumeJitterMs,
-    runTimeoutMs: config.runTimeoutMs,
     stepFanoutRounds: config.stepFanoutRounds,
     stepFanoutWidth: config.stepFanoutWidth,
-    stepRaceRounds: config.stepRaceRounds,
   };
 }
 

--- a/.github/workflows/event-log-race-repro.yml
+++ b/.github/workflows/event-log-race-repro.yml
@@ -6,46 +6,50 @@ on:
     types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
     inputs:
+      step_storm_attempts:
+        description: 'Number of step-storm runs (racing steps vs. watchdog + poke-hook pressure)'
+        required: false
+        default: '600'
+      hook_storm_attempts:
+        description: 'Number of hook-storm runs (racing hook deliveries vs. watchdog — the production shape)'
+        required: false
+        default: '600'
       attempts:
-        description: 'Number of hook/sleep workflow runs to start'
+        description: 'Number of hook-sleep control runs (calibration baseline, ~0.1% historical corruption rate)'
         required: false
-        default: '1500'
-      step_fanout_attempts:
-        description: 'Number of parallel-step fanout workflow runs to start'
-        required: false
-        default: '250'
-      step_sleep_race_attempts:
-        description: 'Number of step/sleep race workflow runs to start'
-        required: false
-        default: '250'
+        default: '200'
       concurrency:
         description: 'Number of concurrent workflow runs'
         required: false
-        default: '50'
-      step_concurrency:
-        description: 'Number of concurrent step-heavy workflow runs'
+        default: '40'
+      rounds:
+        description: 'Rounds of racing branches per storm run (longer log = more room for a divergence to surface)'
         required: false
-        default: '50'
-      iterations:
-        description: 'Hook/sleep race iterations per workflow run (ceiling; the run returns as soon as the wake branch wins, so this mainly widens the window for the resume to land before the sleep budget is exhausted)'
+        default: '6'
+      width:
+        description: 'Racing branches per round (each one is an independent wake source, so this is the main concurrency dial)'
         required: false
         default: '8'
+      watchdog_ms:
+        description: 'Per-branch watchdog timeout. Branches that time out emit an extra step, which is what shifts the correlation-ID sequence'
+        required: false
+        default: '2500'
+      step_delay_ms:
+        description: 'step-storm: raced step duration. Must straddle watchdog_ms once jitter is applied'
+        required: false
+        default: '2200'
+      hook_resume_stagger_ms:
+        description: 'hook-storm: per-index delay inside a round resume burst. width * this should exceed watchdog_ms'
+        required: false
+        default: '400'
+      poke_interval_ms:
+        description: 'step-storm: cadence of out-of-band resumes to the never-read poke hook'
+        required: false
+        default: '750'
       run_timeout_ms:
         description: 'Per-run timeout before classifying as stuck'
         required: false
-        default: '150000'
-      sleep_ms:
-        description: 'Workflow sleep duration in the hook/sleep race'
-        required: false
-        default: '5000'
-      resume_delay_ms:
-        description: 'Base delay before resuming the hook'
-        required: false
-        default: '15000'
-      resume_jitter_ms:
-        description: 'Additional random hook resume delay'
-        required: false
-        default: '10000'
+        default: '240000'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -107,16 +111,17 @@ jobs:
           WORKFLOW_VERCEL_PROJECT: "prj_yjkM7UdHliv8bfxZ1sMJQf1pMpdi"
           WORKFLOW_VERCEL_PROJECT_SLUG: example-nextjs-workflow-turbopack
           VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
-          EVENT_LOG_RACE_REPRO_ATTEMPTS: ${{ inputs.attempts || '1500' }}
-          EVENT_LOG_RACE_REPRO_STEP_FANOUT_ATTEMPTS: ${{ inputs.step_fanout_attempts || '250' }}
-          EVENT_LOG_RACE_REPRO_STEP_SLEEP_RACE_ATTEMPTS: ${{ inputs.step_sleep_race_attempts || '250' }}
-          EVENT_LOG_RACE_REPRO_CONCURRENCY: ${{ inputs.concurrency || '50' }}
-          EVENT_LOG_RACE_REPRO_STEP_CONCURRENCY: ${{ inputs.step_concurrency || '50' }}
-          EVENT_LOG_RACE_REPRO_ITERATIONS: ${{ inputs.iterations || '8' }}
-          EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms || '150000' }}
-          EVENT_LOG_RACE_REPRO_SLEEP_MS: ${{ inputs.sleep_ms || '5000' }}
-          EVENT_LOG_RACE_REPRO_RESUME_DELAY_MS: ${{ inputs.resume_delay_ms || '15000' }}
-          EVENT_LOG_RACE_REPRO_RESUME_JITTER_MS: ${{ inputs.resume_jitter_ms || '10000' }}
+          EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS: ${{ inputs.step_storm_attempts || '600' }}
+          EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS: ${{ inputs.hook_storm_attempts || '600' }}
+          EVENT_LOG_RACE_REPRO_ATTEMPTS: ${{ inputs.attempts || '200' }}
+          EVENT_LOG_RACE_REPRO_CONCURRENCY: ${{ inputs.concurrency || '40' }}
+          EVENT_LOG_RACE_REPRO_ROUNDS: ${{ inputs.rounds || '6' }}
+          EVENT_LOG_RACE_REPRO_WIDTH: ${{ inputs.width || '8' }}
+          EVENT_LOG_RACE_REPRO_WATCHDOG_MS: ${{ inputs.watchdog_ms || '2500' }}
+          EVENT_LOG_RACE_REPRO_STEP_DELAY_MS: ${{ inputs.step_delay_ms || '2200' }}
+          EVENT_LOG_RACE_REPRO_HOOK_RESUME_STAGGER_MS: ${{ inputs.hook_resume_stagger_ms || '400' }}
+          EVENT_LOG_RACE_REPRO_POKE_INTERVAL_MS: ${{ inputs.poke_interval_ms || '750' }}
+          EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms || '240000' }}
 
       - name: Fetch previous repro comment
         if: always() && github.event_name == 'pull_request'

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -12,6 +12,29 @@ import {
 } from '../src/runtime';
 import { getWorkflowMetadata, setupWorld, trackRun } from './utils';
 
+/**
+ * Deliberate reproduction harness for `CORRUPTED_EVENT_LOG`.
+ *
+ * A corrupted event log needs three things at once: several invocations
+ * replaying one run concurrently, at least one write derived from an event load
+ * that is missing a committed event, and control flow whose *step count* depends
+ * on the missing event. The last one is the amplifier — correlation IDs are
+ * positional ordinals of one seeded sequence, so a replay that emits a different
+ * number of steps renames every entity after that point and the divergence
+ * becomes unrecoverable rather than a benign retry.
+ *
+ * The `step-storm` and `hook-storm` scenarios supply all three by construction
+ * (see `workflows/103_event_log_corruption_repro.ts`). `hook-sleep` is retained
+ * as a low-attempt calibration control: it is the shape that has historically
+ * produced a nonzero — but very low, ~0.1% — corruption rate, so its rate is the
+ * yardstick the storms are meant to beat.
+ *
+ * This job is a *measurement*, not a pass/fail gate on the SDK's happy path:
+ * every non-`completed`, non-`infra` outcome is reported and fails the test, so
+ * a corruption shows up loudly and the sticky PR comment can be diffed between a
+ * baseline run and a fix run.
+ */
+
 const deploymentUrl = process.env.DEPLOYMENT_URL;
 if (!deploymentUrl) {
   throw new Error('`DEPLOYMENT_URL` environment variable is not set');
@@ -21,13 +44,10 @@ const RESULT_PATH = path.resolve(
   process.cwd(),
   'event-log-race-repro-results.json'
 );
-const WORKFLOW_FILE = 'workflows/101_hook_sleep_repro.ts';
+const STORM_WORKFLOW_FILE = 'workflows/103_event_log_corruption_repro.ts';
+const CONTROL_WORKFLOW_FILE = 'workflows/101_hook_sleep_repro.ts';
 
-type Scenario =
-  | 'hook-sleep'
-  | 'step-fanout'
-  | 'step-sleep-race-step-biased'
-  | 'step-sleep-race-sleep-biased';
+type Scenario = 'step-storm' | 'hook-storm' | 'hook-sleep';
 
 type Outcome =
   | 'completed'
@@ -37,42 +57,49 @@ type Outcome =
   | 'stuck'
   | 'other'
   // Harness-side, non-gating outcomes: timing races in the repro driver
-  // itself (hook resume vs. the workflow's sleep budget) and transport
+  // itself (hook resume vs. the workflow's watchdog budget) and transport
   // errors talking to the deployment. These are NOT event-log regressions,
   // so they are reported but never fail the job. See `infra` handling in
   // `.github/scripts/render-event-log-race-repro-results.js`.
   | 'infra';
 
 interface ReproConfig {
+  stepStormAttempts: number;
+  hookStormAttempts: number;
   hookSleepAttempts: number;
-  stepFanoutAttempts: number;
-  stepSleepRaceAttempts: number;
   concurrency: number;
-  stepConcurrency: number;
+  runTimeoutMs: number;
+  hookTimeoutMs: number;
+  /** Rounds of racing branches per run. More rounds = more chances for a bad
+   *  write, and a longer log so a divergence has room to surface. */
+  rounds: number;
+  /** Racing branches per round. Each one is an independent wake source, so this
+   *  is the main dial on how many invocations replay the run at once. */
+  width: number;
+  watchdogMs: number;
+  stepDelayMs: number;
+  stepDelayJitterMs: number;
+  jitterBuckets: number;
+  betweenRoundSleepMs: number;
+  reconcileBase: number;
+  attrWrites: number;
+  /** `step-storm`: cadence of resumes to the never-read poke hook. Each one is
+   *  an out-of-band `hook_received` write plus an extra invocation. */
+  pokeIntervalMs: number;
+  pokeJitterMs: number;
+  /** `hook-storm`: per-index delay between resumes inside a round's burst. Set
+   *  so the burst straddles `watchdogMs` and the straggler count varies. */
+  hookResumeStaggerMs: number;
+  hookResumeOffsetMs: number;
+  /** `hook-sleep` control knobs. */
   iterations: number;
   sleepMs: number;
   resumeDelayMs: number;
   resumeJitterMs: number;
-  runTimeoutMs: number;
-  hookTimeoutMs: number;
   sleepBranchWaitCount: number;
   sleepBranchWaitMs: number;
   sleepBranchWaitSpacingMs: number;
   returnOnWake: boolean;
-  drainDelayMs: number;
-  finalDelayMs: number;
-  stepFanoutRounds: number;
-  stepFanoutWidth: number;
-  stepFanoutDelayMs: number;
-  stepFanoutDelayJitterMs: number;
-  stepFanoutAggregateDelayMs: number;
-  stepFanoutBetweenRoundSleepMs: number;
-  stepRaceRounds: number;
-  stepRaceStepWinDelayMs: number;
-  stepRaceStepWinSleepMs: number;
-  stepRaceSleepWinDelayMs: number;
-  stepRaceSleepWinSleepMs: number;
-  stepRacePostSleepMs: number;
 }
 
 interface ReproRunResult {
@@ -84,8 +111,17 @@ interface ReproRunResult {
   status?: string;
   errorCode?: string;
   errorMessage?: string;
+  errorName?: string;
   durationMs: number;
   dashboardUrl?: string;
+  /** Diagnostics from the driver: how much racing pressure the attempt actually
+   *  applied. A run that corrupts with `stragglers: 0` in every round would mean
+   *  the step-count amplifier was not the trigger. */
+  pressure?: {
+    resumesSent: number;
+    resumesFailed: number;
+    stragglers?: number;
+  };
 }
 
 function envNumber(name: string, fallback: number) {
@@ -104,30 +140,41 @@ function envBoolean(name: string, fallback: boolean) {
 }
 
 const config: ReproConfig = {
-  hookSleepAttempts: envNumber('EVENT_LOG_RACE_REPRO_ATTEMPTS', 1500),
-  stepFanoutAttempts: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_FANOUT_ATTEMPTS',
+  stepStormAttempts: envNumber('EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS', 600),
+  hookStormAttempts: envNumber('EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS', 600),
+  hookSleepAttempts: envNumber('EVENT_LOG_RACE_REPRO_ATTEMPTS', 200),
+  concurrency: envNumber('EVENT_LOG_RACE_REPRO_CONCURRENCY', 40),
+  runTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS', 240_000),
+  hookTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_HOOK_TIMEOUT_MS', 60_000),
+  rounds: envNumber('EVENT_LOG_RACE_REPRO_ROUNDS', 6),
+  width: envNumber('EVENT_LOG_RACE_REPRO_WIDTH', 8),
+  watchdogMs: envNumber('EVENT_LOG_RACE_REPRO_WATCHDOG_MS', 2500),
+  stepDelayMs: envNumber('EVENT_LOG_RACE_REPRO_STEP_DELAY_MS', 2200),
+  stepDelayJitterMs: envNumber(
+    'EVENT_LOG_RACE_REPRO_STEP_DELAY_JITTER_MS',
     250
   ),
-  stepSleepRaceAttempts: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_SLEEP_RACE_ATTEMPTS',
-    250
+  jitterBuckets: envNumber('EVENT_LOG_RACE_REPRO_JITTER_BUCKETS', 5),
+  betweenRoundSleepMs: envNumber(
+    'EVENT_LOG_RACE_REPRO_BETWEEN_ROUND_SLEEP_MS',
+    1000
   ),
-  concurrency: envNumber('EVENT_LOG_RACE_REPRO_CONCURRENCY', 50),
-  stepConcurrency: envNumber('EVENT_LOG_RACE_REPRO_STEP_CONCURRENCY', 50),
-  // Ceiling on hook/sleep race iterations. The run short-circuits via
-  // `returnOnWake` as soon as the hook wins, so a higher ceiling does not add
-  // runtime — it widens the window for the delayed hook resume
-  // (resumeDelayMs + resumeJitterMs, up to ~25s) to land before the workflow
-  // exhausts its sleep budget (iterations * sleepMs) and exits via the no-wake
-  // path. Keep iterations * sleepMs comfortably above the resume ceiling so the
-  // wake branch is actually exercised instead of being lost to a timing race.
+  reconcileBase: envNumber('EVENT_LOG_RACE_REPRO_RECONCILE_BASE', 2),
+  attrWrites: envNumber('EVENT_LOG_RACE_REPRO_ATTR_WRITES', 1),
+  pokeIntervalMs: envNumber('EVENT_LOG_RACE_REPRO_POKE_INTERVAL_MS', 750),
+  pokeJitterMs: envNumber('EVENT_LOG_RACE_REPRO_POKE_JITTER_MS', 250),
+  hookResumeStaggerMs: envNumber(
+    'EVENT_LOG_RACE_REPRO_HOOK_RESUME_STAGGER_MS',
+    400
+  ),
+  hookResumeOffsetMs: envNumber(
+    'EVENT_LOG_RACE_REPRO_HOOK_RESUME_OFFSET_MS',
+    0
+  ),
   iterations: envNumber('EVENT_LOG_RACE_REPRO_ITERATIONS', 8),
   sleepMs: envNumber('EVENT_LOG_RACE_REPRO_SLEEP_MS', 5000),
   resumeDelayMs: envNumber('EVENT_LOG_RACE_REPRO_RESUME_DELAY_MS', 15_000),
   resumeJitterMs: envNumber('EVENT_LOG_RACE_REPRO_RESUME_JITTER_MS', 10_000),
-  runTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS', 150_000),
-  hookTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_HOOK_TIMEOUT_MS', 60_000),
   sleepBranchWaitCount: envNumber(
     'EVENT_LOG_RACE_REPRO_SLEEP_BRANCH_WAIT_COUNT',
     2
@@ -141,48 +188,26 @@ const config: ReproConfig = {
     250
   ),
   returnOnWake: envBoolean('EVENT_LOG_RACE_REPRO_RETURN_ON_WAKE', true),
-  drainDelayMs: envNumber('EVENT_LOG_RACE_REPRO_DRAIN_DELAY_MS', 0),
-  finalDelayMs: envNumber('EVENT_LOG_RACE_REPRO_FINAL_DELAY_MS', 0),
-  stepFanoutRounds: envNumber('EVENT_LOG_RACE_REPRO_STEP_FANOUT_ROUNDS', 4),
-  stepFanoutWidth: envNumber('EVENT_LOG_RACE_REPRO_STEP_FANOUT_WIDTH', 4),
-  stepFanoutDelayMs: envNumber('EVENT_LOG_RACE_REPRO_STEP_FANOUT_DELAY_MS', 0),
-  stepFanoutDelayJitterMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_FANOUT_DELAY_JITTER_MS',
-    75
-  ),
-  stepFanoutAggregateDelayMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_FANOUT_AGGREGATE_DELAY_MS',
-    0
-  ),
-  stepFanoutBetweenRoundSleepMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_FANOUT_BETWEEN_ROUND_SLEEP_MS',
-    250
-  ),
-  stepRaceRounds: envNumber('EVENT_LOG_RACE_REPRO_STEP_RACE_ROUNDS', 4),
-  stepRaceStepWinDelayMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_RACE_STEP_WIN_DELAY_MS',
-    0
-  ),
-  stepRaceStepWinSleepMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_RACE_STEP_WIN_SLEEP_MS',
-    5000
-  ),
-  stepRaceSleepWinDelayMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_RACE_SLEEP_WIN_DELAY_MS',
-    5000
-  ),
-  stepRaceSleepWinSleepMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_RACE_SLEEP_WIN_SLEEP_MS',
-    500
-  ),
-  stepRacePostSleepMs: envNumber(
-    'EVENT_LOG_RACE_REPRO_STEP_RACE_POST_SLEEP_MS',
-    1500
-  ),
 };
+
+function stormInput(token: string) {
+  return {
+    attrWrites: config.attrWrites,
+    betweenRoundSleepMs: config.betweenRoundSleepMs,
+    jitterBuckets: config.jitterBuckets,
+    reconcileBase: config.reconcileBase,
+    rounds: config.rounds,
+    stepDelayJitterMs: config.stepDelayJitterMs,
+    stepDelayMs: config.stepDelayMs,
+    token,
+    watchdogMs: config.watchdogMs,
+    width: config.width,
+  };
+}
 
 async function start(
   scenario: Scenario,
+  workflowFile: string,
   workflowFn: string,
   workflow: { workflowId: string },
   args: unknown[]
@@ -190,16 +215,28 @@ async function start(
   const run = await rawStart(workflow, args);
   trackRun(run, {
     testName: `event-log-race-repro:${scenario}`,
-    workflowFile: WORKFLOW_FILE,
+    workflowFile,
     workflowFn,
   });
   return run;
 }
 
-async function waitForHook(token: string, runId: string) {
-  const deadline = Date.now() + config.hookTimeoutMs;
+/** Set once the run reaches a terminal state, so driver pumps stop pushing. */
+interface DriverState {
+  done: boolean;
+  resumesSent: number;
+  resumesFailed: number;
+}
+
+async function waitForHook(
+  token: string,
+  runId: string,
+  state: DriverState,
+  timeoutMs = config.hookTimeoutMs
+) {
+  const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
-  while (Date.now() < deadline) {
+  while (Date.now() < deadline && !state.done) {
     try {
       const hook = await getHookByToken(token);
       if (hook.runId === runId) {
@@ -238,90 +275,92 @@ function classifyFailure(errorCode: string | undefined): Outcome {
   return 'other';
 }
 
-function hasWakeBranch(value: unknown) {
-  if (!value || typeof value !== 'object' || !('branches' in value)) {
-    return false;
-  }
-  const branches = (value as { branches?: unknown }).branches;
-  return (
-    Array.isArray(branches) &&
-    branches.some(
-      (branch) =>
-        branch &&
-        typeof branch === 'object' &&
-        'branch' in branch &&
-        branch.branch === 'wake'
-    )
-  );
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object';
 }
 
-function validateFanoutReturn(value: unknown) {
-  if (!isRecord(value)) {
-    return 'Run returned a non-object value.';
-  }
-
-  const records = value.roundRecords;
-  if (!Array.isArray(records)) {
-    return 'Run did not return roundRecords.';
-  }
-
-  if (records.length !== config.stepFanoutRounds) {
-    return `Expected ${config.stepFanoutRounds} fanout rounds, got ${records.length}.`;
-  }
-
-  for (const [index, record] of records.entries()) {
-    if (!isRecord(record)) {
-      return `Round ${index} record was not an object.`;
-    }
-    if (record.round !== index) {
-      return `Round ${index} returned unexpected round ${String(record.round)}.`;
-    }
-    if (record.count !== config.stepFanoutWidth) {
-      return `Round ${index} aggregated ${String(record.count)} steps instead of ${config.stepFanoutWidth}.`;
-    }
-    if (typeof record.checksum !== 'string') {
-      return `Round ${index} did not return a checksum.`;
-    }
-  }
+function hasWakeBranch(value: unknown) {
+  if (!isRecord(value)) return false;
+  const branches = value.branches;
+  return (
+    Array.isArray(branches) &&
+    branches.some((branch) => isRecord(branch) && branch.branch === 'wake')
+  );
 }
 
-function validateStepRaceReturn(value: unknown) {
+/**
+ * Consistency check for one round of a storm ledger. Returns the round's
+ * observed straggler count, or the first disagreement found.
+ */
+function validateStormRound(
+  record: unknown,
+  index: number
+): { error?: string; stragglers?: number } {
+  if (!isRecord(record)) {
+    return { error: `Round ${index} record was not an object.` };
+  }
+  if (record.round !== index) {
+    return {
+      error: `Round ${index} returned unexpected round ${String(record.round)}.`,
+    };
+  }
+
+  const branches = record.branches;
+  if (!Array.isArray(branches) || branches.length !== config.width) {
+    return {
+      error: `Round ${index} recorded ${Array.isArray(branches) ? branches.length : 'no'} branches instead of ${config.width}.`,
+    };
+  }
+
+  const stragglers = branches.filter(
+    (branch) => isRecord(branch) && branch.winner === 'watchdog'
+  ).length;
+  if (record.stragglers !== stragglers) {
+    return {
+      error: `Round ${index} reported ${String(record.stragglers)} stragglers but recorded ${stragglers} watchdog branches.`,
+    };
+  }
+  if (record.reconciled !== config.reconcileBase + stragglers) {
+    return {
+      error: `Round ${index} reconciled ${String(record.reconciled)} steps instead of ${config.reconcileBase + stragglers}.`,
+    };
+  }
+
+  return { stragglers };
+}
+
+/**
+ * Checks the storm ledger for internal consistency. This is the *silent*
+ * corruption detector: a run whose replay diverged but still reached
+ * `completed` will usually disagree with itself here — a round whose reconcile
+ * width does not match its own straggler count, or a missing round/branch.
+ */
+function validateStormReturn(value: unknown): {
+  error?: string;
+  stragglers?: number;
+} {
   if (!isRecord(value)) {
-    return 'Run returned a non-object value.';
+    return { error: 'Run returned a non-object value.' };
   }
 
-  const branches = value.branches;
-  if (!Array.isArray(branches)) {
-    return 'Run did not return branches.';
+  const ledger = value.ledger;
+  if (!Array.isArray(ledger)) {
+    return { error: 'Run did not return a ledger.' };
+  }
+  if (ledger.length !== config.rounds) {
+    return {
+      error: `Expected ${config.rounds} rounds, got ${ledger.length}.`,
+    };
   }
 
-  if (branches.length !== config.stepRaceRounds) {
-    return `Expected ${config.stepRaceRounds} race rounds, got ${branches.length}.`;
+  let stragglers = 0;
+  for (const [index, record] of ledger.entries()) {
+    const round = validateStormRound(record, index);
+    if (round.error) return { error: round.error };
+    stragglers += round.stragglers ?? 0;
   }
 
-  for (const [index, branch] of branches.entries()) {
-    if (!isRecord(branch)) {
-      return `Race round ${index} record was not an object.`;
-    }
-    if (branch.round !== index) {
-      return `Race round ${index} returned unexpected round ${String(branch.round)}.`;
-    }
-    if (branch.branch !== 'sleep' && branch.branch !== 'step') {
-      return `Race round ${index} took unexpected ${String(branch.branch)} branch.`;
-    }
-
-    const marker = branch.marker;
-    if (!isRecord(marker)) {
-      return `Race round ${index} marker was not an object.`;
-    }
-    if (marker.branch !== branch.branch) {
-      return `Race round ${index} marker branch ${String(marker.branch)} did not match returned branch ${String(branch.branch)}.`;
-    }
-  }
+  return { stragglers };
 }
 
 async function pollTerminalRun(
@@ -332,6 +371,13 @@ async function pollTerminalRun(
   const world = await getWorld();
   const deadline = startedAt + config.runTimeoutMs;
   let lastStatus: string | undefined;
+  const base = {
+    attempt: -1,
+    scenario,
+    token: '',
+    runId: run.runId,
+    dashboardUrl: getDashboardUrl(run.runId),
+  };
 
   while (Date.now() < deadline) {
     const runData = await world.runs.get(run.runId);
@@ -339,50 +385,41 @@ async function pollTerminalRun(
 
     if (runData.status === 'completed') {
       return {
-        attempt: -1,
-        scenario,
-        token: '',
-        runId: run.runId,
+        ...base,
         outcome: 'completed',
         status: runData.status,
         durationMs: Date.now() - startedAt,
-        dashboardUrl: getDashboardUrl(run.runId),
       };
     }
 
     if (runData.status === 'failed') {
-      // A failed WorkflowRun carries its reason in `error: { code, message }`
-      // — the run has no top-level `errorCode`. Reading the structured error
-      // is what lets us classify USER_ERROR/RUNTIME_ERROR/CORRUPTED_EVENT_LOG
-      // (vs. uncategorised `other`) and surface *why* it failed in the summary.
-      const structuredError = (
-        runData as { error?: { code?: string; message?: string } }
-      ).error;
+      // The machine-readable reason is the plaintext top-level `errorCode`.
+      // `error` is rehydrated into an `Error` instance carrying only
+      // `name`/`message`, so reading `error.code` misclassifies every real
+      // failure as `other` — which is exactly how earlier runs of this job
+      // reported corruptions.
+      const failure = runData as {
+        errorCode?: string;
+        error?: { name?: string; message?: string };
+      };
       return {
-        attempt: -1,
-        scenario,
-        token: '',
-        runId: run.runId,
-        outcome: classifyFailure(structuredError?.code),
+        ...base,
+        outcome: classifyFailure(failure.errorCode),
         status: runData.status,
-        errorCode: structuredError?.code,
-        errorMessage: structuredError?.message,
+        errorCode: failure.errorCode,
+        errorMessage: failure.error?.message,
+        errorName: failure.error?.name,
         durationMs: Date.now() - startedAt,
-        dashboardUrl: getDashboardUrl(run.runId),
       };
     }
 
     if (runData.status === 'cancelled') {
       return {
-        attempt: -1,
-        scenario,
-        token: '',
-        runId: run.runId,
+        ...base,
         outcome: 'infra',
         status: runData.status,
         errorCode: 'CANCELLED',
         durationMs: Date.now() - startedAt,
-        dashboardUrl: getDashboardUrl(run.runId),
       };
     }
 
@@ -390,14 +427,10 @@ async function pollTerminalRun(
   }
 
   return {
-    attempt: -1,
-    scenario,
-    token: '',
-    runId: run.runId,
+    ...base,
     outcome: 'stuck',
     status: lastStatus,
     durationMs: Date.now() - startedAt,
-    dashboardUrl: getDashboardUrl(run.runId),
   };
 }
 
@@ -412,71 +445,333 @@ async function withTimeout<T>(
   return await Promise.race([promise, timeout]);
 }
 
-async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
-  const scenario: Scenario = 'hook-sleep';
+function harnessFailure(
+  scenario: Scenario,
+  attempt: number,
+  token: string,
+  startedAt: number,
+  err: unknown
+): ReproRunResult {
+  if (WorkflowRunFailedError.is(err)) {
+    return {
+      attempt,
+      scenario,
+      token,
+      runId: err.runId,
+      outcome: classifyFailure(err.errorCode),
+      status: 'failed',
+      errorCode: err.errorCode,
+      errorMessage: err.message,
+      durationMs: Date.now() - startedAt,
+      dashboardUrl: getDashboardUrl(err.runId),
+    };
+  }
+
+  return {
+    attempt,
+    scenario,
+    token,
+    // A non-WorkflowRunFailedError thrown in the driver is a transport /
+    // harness problem (deployment unreachable, hook never appeared, resume
+    // or return-value read timed out), not an event-log regression.
+    outcome: 'infra',
+    errorCode: 'HARNESS_ERROR',
+    errorMessage: err instanceof Error ? err.message : String(err),
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Runs a driver pump alongside the terminal-state poll. The pump keeps applying
+ * pressure (hook resumes) for as long as the run is alive, and is torn down as
+ * soon as the run is terminal so a pending hook wait cannot outlive it.
+ *
+ * Pump failures never fail the attempt: a resume racing the hook's disposal is
+ * the expected outcome for a branch whose watchdog already fired, and counting
+ * those is more useful than treating them as regressions.
+ */
+async function drive(
+  run: Run<unknown>,
+  startedAt: number,
+  scenario: Scenario,
+  pump: (state: DriverState) => Promise<void>
+) {
+  const state: DriverState = { done: false, resumesFailed: 0, resumesSent: 0 };
+  const pumpPromise = pump(state).catch(() => {
+    // Swallowed by design — see the note above.
+  });
+  try {
+    return {
+      runResult: await pollTerminalRun(run, startedAt, scenario),
+      state,
+    };
+  } finally {
+    state.done = true;
+    await pumpPromise;
+  }
+}
+
+async function tryResume(
+  state: DriverState,
+  hook: Awaited<ReturnType<typeof getHookByToken>>,
+  payload: unknown
+) {
+  state.resumesSent += 1;
+  try {
+    await resumeHook(hook, payload);
+  } catch {
+    // A resume landing after the workflow disposed the hook is expected.
+    state.resumesFailed += 1;
+  }
+}
+
+/**
+ * `step-storm`: the racing branches settle on their own (a step completion beats
+ * or loses to the watchdog), and the driver's only job is to keep resuming the
+ * never-read poke hook. Each poke is an out-of-band `hook_received` — a write
+ * with no replay snapshot behind it — plus one more invocation replaying the run
+ * concurrently with whatever the branches are doing.
+ */
+async function runStepStormAttempt(attempt: number): Promise<ReproRunResult> {
+  const scenario: Scenario = 'step-storm';
   const startedAt = Date.now();
-  const token = `event-log-race-${scenario}-${Date.now()}-${attempt}-${Math.random()
-    .toString(36)
-    .slice(2)}`;
+  const token = makeToken(scenario, attempt);
 
   try {
     const workflow = await getWorkflowMetadata(
       deploymentUrl,
-      WORKFLOW_FILE,
+      STORM_WORKFLOW_FILE,
+      'stepStormReproWorkflow'
+    );
+    const run = await start(
+      scenario,
+      STORM_WORKFLOW_FILE,
+      'stepStormReproWorkflow',
+      workflow,
+      [stormInput(token)]
+    );
+
+    const { runResult, state } = await drive(
+      run,
+      startedAt,
+      scenario,
+      async (driverState) => {
+        const hook = await waitForHook(`${token}:poke`, run.runId, driverState);
+        while (!driverState.done) {
+          await tryResume(driverState, hook, {
+            index: -1,
+            round: -1,
+            sentAt: Date.now(),
+          });
+          const jitter =
+            config.pokeJitterMs > 0
+              ? Math.floor(Math.random() * config.pokeJitterMs)
+              : 0;
+          await sleep(config.pokeIntervalMs + jitter);
+        }
+      }
+    );
+
+    return await finishStormAttempt(
+      run,
+      runResult,
+      state,
+      attempt,
+      scenario,
+      token
+    );
+  } catch (err) {
+    return harnessFailure(scenario, attempt, token, startedAt, err);
+  }
+}
+
+/**
+ * `hook-storm`: the production shape. Each branch waits for its own hook
+ * delivery with a watchdog timeout, so every resume both settles a branch and
+ * wakes its own invocation. A round's `width` hooks are all created by one
+ * suspension, so waiting for index 0 to exist is enough to know the rest do —
+ * the driver then staggers resumes across the watchdog deadline so some branches
+ * settle and some straggle, and the reconcile width differs per round.
+ */
+async function runHookStormAttempt(attempt: number): Promise<ReproRunResult> {
+  const scenario: Scenario = 'hook-storm';
+  const startedAt = Date.now();
+  const token = makeToken(scenario, attempt);
+
+  try {
+    const workflow = await getWorkflowMetadata(
+      deploymentUrl,
+      STORM_WORKFLOW_FILE,
+      'hookStormReproWorkflow'
+    );
+    const run = await start(
+      scenario,
+      STORM_WORKFLOW_FILE,
+      'hookStormReproWorkflow',
+      workflow,
+      [stormInput(token)]
+    );
+
+    const { runResult, state } = await drive(
+      run,
+      startedAt,
+      scenario,
+      async (driverState) => {
+        for (let round = 0; round < config.rounds; round += 1) {
+          if (driverState.done) return;
+
+          // Round `n`'s hooks only exist once round `n - 1` finished, so this
+          // wait doubles as the round barrier.
+          await waitForHook(`${token}:${round}:0`, run.runId, driverState);
+          if (config.hookResumeOffsetMs > 0) {
+            await sleep(config.hookResumeOffsetMs);
+          }
+
+          await Promise.all(
+            Array.from({ length: config.width }, async (_, index) => {
+              if (index > 0) {
+                await sleep(index * config.hookResumeStaggerMs);
+              }
+              if (driverState.done) return;
+              let hook: Awaited<ReturnType<typeof getHookByToken>>;
+              try {
+                hook = await waitForHook(
+                  `${token}:${round}:${index}`,
+                  run.runId,
+                  driverState,
+                  5000
+                );
+              } catch {
+                // The branch's watchdog already fired and disposed the hook.
+                driverState.resumesFailed += 1;
+                return;
+              }
+              await tryResume(driverState, hook, {
+                index,
+                round,
+                sentAt: Date.now(),
+              });
+            })
+          );
+        }
+      }
+    );
+
+    return await finishStormAttempt(
+      run,
+      runResult,
+      state,
+      attempt,
+      scenario,
+      token
+    );
+  } catch (err) {
+    return harnessFailure(scenario, attempt, token, startedAt, err);
+  }
+}
+
+async function finishStormAttempt(
+  run: Run<unknown>,
+  runResult: ReproRunResult,
+  state: DriverState,
+  attempt: number,
+  scenario: Scenario,
+  token: string
+): Promise<ReproRunResult> {
+  const pressure = {
+    resumesFailed: state.resumesFailed,
+    resumesSent: state.resumesSent,
+  };
+
+  if (runResult.outcome !== 'completed') {
+    return { ...runResult, attempt, pressure, scenario, token };
+  }
+
+  const returnValue = await withTimeout(
+    run.returnValue,
+    30_000,
+    `Timed out reading return value for run ${run.runId}`
+  );
+  const validation = validateStormReturn(returnValue);
+  if (validation.error) {
+    return {
+      ...runResult,
+      attempt,
+      errorCode: 'BAD_STORM_LEDGER',
+      errorMessage: validation.error,
+      outcome: 'other',
+      pressure,
+      scenario,
+      token,
+    };
+  }
+
+  return {
+    ...runResult,
+    attempt,
+    pressure: { ...pressure, stragglers: validation.stragglers },
+    scenario,
+    token,
+  };
+}
+
+/**
+ * The calibration control, unchanged in shape from the original harness: a
+ * single hook read raced against a single sleep, resumed once after a jittered
+ * delay. Kept at low attempt counts purely so each run reports a rate for the
+ * one scenario with a known historical baseline (~0.1%).
+ */
+async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
+  const scenario: Scenario = 'hook-sleep';
+  const startedAt = Date.now();
+  const token = makeToken(scenario, attempt);
+
+  try {
+    const workflow = await getWorkflowMetadata(
+      deploymentUrl,
+      CONTROL_WORKFLOW_FILE,
       'hookSleepReproWorkflow'
     );
-    const run = await start(scenario, 'hookSleepReproWorkflow', workflow, [
-      {
-        token,
-        iterations: config.iterations,
-        sleepMs: config.sleepMs,
-        returnOnWake: config.returnOnWake,
-        drainDelayMs: config.drainDelayMs,
-        finalDelayMs: config.finalDelayMs,
-        sleepBranchWaitCount: config.sleepBranchWaitCount,
-        sleepBranchWaitMs: config.sleepBranchWaitMs,
-        sleepBranchWaitSpacingMs: config.sleepBranchWaitSpacingMs,
-      },
-    ]);
-
-    const hook = await waitForHook(token, run.runId);
-    const jitter =
-      config.resumeJitterMs > 0
-        ? Math.floor(Math.random() * config.resumeJitterMs)
-        : 0;
-    const resumeDelayMs = config.resumeDelayMs + jitter;
-    const resumePromise = sleep(resumeDelayMs).then(() =>
-      resumeHook(hook, { attempt, sentAt: Date.now() })
-    );
-
-    const runResult = await pollTerminalRun(run, startedAt, scenario);
-    const resumeResult = await Promise.allSettled([
-      withTimeout(
-        resumePromise,
-        30_000,
-        `Timed out resuming hook ${token} for run ${run.runId}`
-      ),
-    ]);
-
-    const resumeFailure = resumeResult.find(
-      (result) => result.status === 'rejected'
-    );
-    if (runResult.outcome === 'completed') {
-      if (resumeFailure?.status === 'rejected') {
-        return {
-          ...runResult,
-          attempt,
-          scenario,
+    const run = await start(
+      scenario,
+      CONTROL_WORKFLOW_FILE,
+      'hookSleepReproWorkflow',
+      workflow,
+      [
+        {
+          iterations: config.iterations,
+          returnOnWake: config.returnOnWake,
+          sleepBranchWaitCount: config.sleepBranchWaitCount,
+          sleepBranchWaitMs: config.sleepBranchWaitMs,
+          sleepBranchWaitSpacingMs: config.sleepBranchWaitSpacingMs,
+          sleepMs: config.sleepMs,
           token,
-          // The run completed; only the harness's own resume call failed
-          // (typically because the sleep branch already finished the run and
-          // disposed the hook). Harness timing, not an SDK regression.
-          outcome: 'infra',
-          errorCode: 'HOOK_RESUME_FAILED',
-          errorMessage: String(resumeFailure.reason),
-        };
-      }
+        },
+      ]
+    );
 
+    const { runResult, state } = await drive(
+      run,
+      startedAt,
+      scenario,
+      async (driverState) => {
+        const hook = await waitForHook(token, run.runId, driverState);
+        const jitter =
+          config.resumeJitterMs > 0
+            ? Math.floor(Math.random() * config.resumeJitterMs)
+            : 0;
+        await sleep(config.resumeDelayMs + jitter);
+        if (driverState.done) return;
+        await tryResume(driverState, hook, { attempt, sentAt: Date.now() });
+      }
+    );
+
+    const pressure = {
+      resumesFailed: state.resumesFailed,
+      resumesSent: state.resumesSent,
+    };
+
+    if (runResult.outcome === 'completed') {
       const returnValue = await withTimeout(
         run.returnValue,
         30_000,
@@ -486,253 +781,29 @@ async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
         return {
           ...runResult,
           attempt,
-          scenario,
-          token,
+          errorCode: 'NO_WAKE_BRANCH',
+          errorMessage: 'Run completed without taking the hook wake branch.',
           // The run completed cleanly but the sleep branch won the race before
           // the resume landed, so the wake branch was never taken. This means
           // the attempt lost its intended coverage, not that the log is wrong.
           outcome: 'infra',
-          errorCode: 'NO_WAKE_BRANCH',
-          errorMessage: 'Run completed without taking the hook wake branch.',
-        };
-      }
-    }
-
-    return {
-      ...runResult,
-      attempt,
-      scenario,
-      token,
-      errorMessage:
-        runResult.errorMessage ??
-        (resumeFailure?.status === 'rejected'
-          ? String(resumeFailure.reason)
-          : undefined),
-    };
-  } catch (err) {
-    if (WorkflowRunFailedError.is(err)) {
-      return {
-        attempt,
-        scenario,
-        token,
-        runId: err.runId,
-        outcome: classifyFailure(err.errorCode),
-        status: 'failed',
-        errorCode: err.errorCode,
-        errorMessage: err.message,
-        durationMs: Date.now() - startedAt,
-        dashboardUrl: getDashboardUrl(err.runId),
-      };
-    }
-
-    return {
-      attempt,
-      scenario,
-      token,
-      // A non-WorkflowRunFailedError thrown in the driver is a transport /
-      // harness problem (deployment unreachable, hook never appeared, resume
-      // or return-value read timed out), not an event-log regression.
-      outcome: 'infra',
-      errorCode: 'HARNESS_ERROR',
-      errorMessage: err instanceof Error ? err.message : String(err),
-      durationMs: Date.now() - startedAt,
-    };
-  }
-}
-
-async function resumeGate(
-  scenario: Scenario,
-  attempt: number,
-  token: string,
-  runId: string
-) {
-  const hook = await waitForHook(token, runId);
-  await resumeHook(hook, { attempt, scenario, sentAt: Date.now() });
-}
-
-async function runStepFanoutAttempt(attempt: number): Promise<ReproRunResult> {
-  const scenario: Scenario = 'step-fanout';
-  const startedAt = Date.now();
-  const token = `event-log-race-${scenario}-${Date.now()}-${attempt}-${Math.random()
-    .toString(36)
-    .slice(2)}`;
-
-  try {
-    const workflow = await getWorkflowMetadata(
-      deploymentUrl,
-      WORKFLOW_FILE,
-      'stepFanoutReplayReproWorkflow'
-    );
-    const run = await start(
-      scenario,
-      'stepFanoutReplayReproWorkflow',
-      workflow,
-      [
-        {
-          aggregateDelayMs: config.stepFanoutAggregateDelayMs,
-          betweenRoundSleepMs: config.stepFanoutBetweenRoundSleepMs,
-          rounds: config.stepFanoutRounds,
-          stepDelayJitterMs: config.stepFanoutDelayJitterMs,
-          stepDelayMs: config.stepFanoutDelayMs,
-          token,
-          width: config.stepFanoutWidth,
-        },
-      ]
-    );
-
-    await resumeGate(scenario, attempt, token, run.runId);
-
-    const runResult = await pollTerminalRun(run, startedAt, scenario);
-    if (runResult.outcome === 'completed') {
-      const returnValue = await withTimeout(
-        run.returnValue,
-        30_000,
-        `Timed out reading return value for run ${run.runId}`
-      );
-      const validationError = validateFanoutReturn(returnValue);
-      if (validationError) {
-        return {
-          ...runResult,
-          attempt,
+          pressure,
           scenario,
           token,
-          outcome: 'other',
-          errorCode: 'BAD_FANOUT_RETURN',
-          errorMessage: validationError,
         };
       }
     }
 
-    return {
-      ...runResult,
-      attempt,
-      scenario,
-      token,
-    };
+    return { ...runResult, attempt, pressure, scenario, token };
   } catch (err) {
-    if (WorkflowRunFailedError.is(err)) {
-      return {
-        attempt,
-        scenario,
-        token,
-        runId: err.runId,
-        outcome: classifyFailure(err.errorCode),
-        status: 'failed',
-        errorCode: err.errorCode,
-        errorMessage: err.message,
-        durationMs: Date.now() - startedAt,
-        dashboardUrl: getDashboardUrl(err.runId),
-      };
-    }
-
-    return {
-      attempt,
-      scenario,
-      token,
-      // A non-WorkflowRunFailedError thrown in the driver is a transport /
-      // harness problem (deployment unreachable, hook never appeared, resume
-      // or return-value read timed out), not an event-log regression.
-      outcome: 'infra',
-      errorCode: 'HARNESS_ERROR',
-      errorMessage: err instanceof Error ? err.message : String(err),
-      durationMs: Date.now() - startedAt,
-    };
+    return harnessFailure(scenario, attempt, token, startedAt, err);
   }
 }
 
-async function runStepSleepRaceAttempt(
-  attempt: number,
-  bias: 'sleep' | 'step'
-): Promise<ReproRunResult> {
-  const scenario: Scenario =
-    bias === 'step'
-      ? 'step-sleep-race-step-biased'
-      : 'step-sleep-race-sleep-biased';
-  const startedAt = Date.now();
-  const token = `event-log-race-${scenario}-${Date.now()}-${attempt}-${Math.random()
+function makeToken(scenario: Scenario, attempt: number) {
+  return `event-log-race-${scenario}-${Date.now()}-${attempt}-${Math.random()
     .toString(36)
     .slice(2)}`;
-
-  try {
-    const workflow = await getWorkflowMetadata(
-      deploymentUrl,
-      WORKFLOW_FILE,
-      'stepSleepRaceReproWorkflow'
-    );
-    const run = await start(scenario, 'stepSleepRaceReproWorkflow', workflow, [
-      {
-        postRaceSleepMs: config.stepRacePostSleepMs,
-        rounds: config.stepRaceRounds,
-        sleepMs:
-          bias === 'step'
-            ? config.stepRaceStepWinSleepMs
-            : config.stepRaceSleepWinSleepMs,
-        stepDelayMs:
-          bias === 'step'
-            ? config.stepRaceStepWinDelayMs
-            : config.stepRaceSleepWinDelayMs,
-        token,
-      },
-    ]);
-
-    await resumeGate(scenario, attempt, token, run.runId);
-
-    const runResult = await pollTerminalRun(run, startedAt, scenario);
-    if (runResult.outcome === 'completed') {
-      const returnValue = await withTimeout(
-        run.returnValue,
-        30_000,
-        `Timed out reading return value for run ${run.runId}`
-      );
-      const validationError = validateStepRaceReturn(returnValue);
-      if (validationError) {
-        return {
-          ...runResult,
-          attempt,
-          scenario,
-          token,
-          outcome: 'other',
-          errorCode: 'BAD_STEP_RACE_RETURN',
-          errorMessage: validationError,
-        };
-      }
-    }
-
-    return {
-      ...runResult,
-      attempt,
-      scenario,
-      token,
-    };
-  } catch (err) {
-    if (WorkflowRunFailedError.is(err)) {
-      return {
-        attempt,
-        scenario,
-        token,
-        runId: err.runId,
-        outcome: classifyFailure(err.errorCode),
-        status: 'failed',
-        errorCode: err.errorCode,
-        errorMessage: err.message,
-        durationMs: Date.now() - startedAt,
-        dashboardUrl: getDashboardUrl(err.runId),
-      };
-    }
-
-    return {
-      attempt,
-      scenario,
-      token,
-      // A non-WorkflowRunFailedError thrown in the driver is a transport /
-      // harness problem (deployment unreachable, hook never appeared, resume
-      // or return-value read timed out), not an event-log regression.
-      outcome: 'infra',
-      errorCode: 'HARNESS_ERROR',
-      errorMessage: err instanceof Error ? err.message : String(err),
-      durationMs: Date.now() - startedAt,
-    };
-  }
 }
 
 async function mapLimit<T, R>(
@@ -761,24 +832,6 @@ async function mapLimit<T, R>(
   return results;
 }
 
-function summarize(results: ReproRunResult[]) {
-  return results.reduce<Record<Outcome, number>>(
-    (acc, result) => {
-      acc[result.outcome] += 1;
-      return acc;
-    },
-    {
-      completed: 0,
-      CORRUPTED_EVENT_LOG: 0,
-      USER_ERROR: 0,
-      RUNTIME_ERROR: 0,
-      stuck: 0,
-      other: 0,
-      infra: 0,
-    }
-  );
-}
-
 function emptyOutcomeCounts(): Record<Outcome, number> {
   return {
     completed: 0,
@@ -791,6 +844,13 @@ function emptyOutcomeCounts(): Record<Outcome, number> {
   };
 }
 
+function summarize(results: ReproRunResult[]) {
+  return results.reduce<Record<Outcome, number>>((acc, result) => {
+    acc[result.outcome] += 1;
+    return acc;
+  }, emptyOutcomeCounts());
+}
+
 function summarizeByScenario(results: ReproRunResult[]) {
   return results.reduce<Record<Scenario, Record<Outcome, number>>>(
     (acc, result) => {
@@ -798,19 +858,11 @@ function summarizeByScenario(results: ReproRunResult[]) {
       return acc;
     },
     {
+      'step-storm': emptyOutcomeCounts(),
+      'hook-storm': emptyOutcomeCounts(),
       'hook-sleep': emptyOutcomeCounts(),
-      'step-fanout': emptyOutcomeCounts(),
-      'step-sleep-race-step-biased': emptyOutcomeCounts(),
-      'step-sleep-race-sleep-biased': emptyOutcomeCounts(),
     }
   );
-}
-
-function buildResultConfig(results: ReproRunResult[]) {
-  return {
-    ...config,
-    attempts: results.length,
-  };
 }
 
 function writeResults(results: ReproRunResult[]) {
@@ -820,7 +872,7 @@ function writeResults(results: ReproRunResult[]) {
       {
         completedAt: new Date().toISOString(),
         deploymentUrl,
-        config: buildResultConfig(results),
+        config: { ...config, attempts: results.length },
         distribution: summarize(results),
         scenarioDistribution: summarizeByScenario(results),
         results,
@@ -846,39 +898,57 @@ async function runScenario(
   return await mapLimit(attemptNumbers, concurrency, run);
 }
 
+const totalAttempts =
+  config.stepStormAttempts +
+  config.hookStormAttempts +
+  config.hookSleepAttempts;
 const testTimeoutMs =
-  config.runTimeoutMs *
-    Math.ceil(config.hookSleepAttempts / config.concurrency) +
-  config.runTimeoutMs *
-    Math.ceil(config.stepFanoutAttempts / config.stepConcurrency) +
-  config.runTimeoutMs *
-    Math.ceil(
-      Math.ceil(config.stepSleepRaceAttempts / 2) / config.stepConcurrency
-    ) +
-  config.runTimeoutMs *
-    Math.ceil(
-      Math.floor(config.stepSleepRaceAttempts / 2) / config.stepConcurrency
-    ) +
-  60_000;
+  config.runTimeoutMs * Math.ceil(totalAttempts / config.concurrency) + 60_000;
 
 describe('event log race repro', () => {
   beforeAll(() => {
     setupWorld(deploymentUrl);
 
-    // The hook resume must land before the workflow exhausts its sleep budget,
-    // otherwise the sleep branch wins and the run exits via the no-wake path,
-    // recording an `infra` outcome (NO_WAKE_BRANCH / HOOK_RESUME_FAILED) and
-    // losing the wake-branch coverage this scenario exists to exercise.
+    // The storms only produce the step-count divergence they exist for when
+    // branches land on both sides of the watchdog deadline. If the step delay
+    // spread sits entirely under (or over) the watchdog, every branch takes the
+    // same path, the reconcile width is constant, and a missing event no longer
+    // shifts the correlation-ID sequence.
+    const spreadMs =
+      config.jitterBuckets > 1
+        ? Math.floor(config.jitterBuckets / 2) * config.stepDelayJitterMs
+        : 0;
+    if (
+      config.stepDelayMs + spreadMs <= config.watchdogMs ||
+      config.stepDelayMs - spreadMs >= config.watchdogMs
+    ) {
+      console.warn(
+        `[event-log-race-repro] step delay spread (${config.stepDelayMs} ± ${spreadMs}ms) ` +
+          `does not straddle watchdogMs (${config.watchdogMs}). Every step-storm ` +
+          `branch will take the same path, so the reconcile fan-out width will be ` +
+          `constant and the step-count amplifier is disabled.`
+      );
+    }
+
+    // Same requirement for hook-storm, where the driver's stagger — not a step
+    // delay — decides which branches settle before their watchdog.
+    const burstSpanMs = (config.width - 1) * config.hookResumeStaggerMs;
+    if (config.hookResumeOffsetMs + burstSpanMs <= config.watchdogMs) {
+      console.warn(
+        `[event-log-race-repro] hook resume burst (offset ${config.hookResumeOffsetMs}ms + ` +
+          `span ${burstSpanMs}ms over ${config.width} branches) finishes before ` +
+          `watchdogMs (${config.watchdogMs}). Every hook-storm branch will settle, ` +
+          `so no branch takes the extra-step recovery path.`
+      );
+    }
+
     const sleepBudgetMs = config.iterations * config.sleepMs;
     const resumeCeilingMs = config.resumeDelayMs + config.resumeJitterMs;
     if (resumeCeilingMs >= sleepBudgetMs) {
       console.warn(
-        `[event-log-race-repro] resume ceiling (${resumeCeilingMs}ms = ` +
-          `resumeDelayMs ${config.resumeDelayMs} + resumeJitterMs ${config.resumeJitterMs}) ` +
-          `is not below the hook-sleep budget (${sleepBudgetMs}ms = iterations ` +
-          `${config.iterations} * sleepMs ${config.sleepMs}). Many hook-sleep ` +
-          `attempts will lose the wake branch to the sleep race and be recorded ` +
-          `as infra. Raise iterations/sleepMs or lower the resume delay.`
+        `[event-log-race-repro] hook-sleep resume ceiling (${resumeCeilingMs}ms) is not ` +
+          `below its sleep budget (${sleepBudgetMs}ms). Most control attempts will ` +
+          `lose the wake branch and be recorded as infra.`
       );
     }
   });
@@ -887,36 +957,29 @@ describe('event log race repro', () => {
     'event log races do not corrupt, stall, or take stale branches',
     { timeout: testTimeoutMs },
     async () => {
-      const stepBiasedAttempts = Math.ceil(config.stepSleepRaceAttempts / 2);
-      const sleepBiasedAttempts = Math.floor(config.stepSleepRaceAttempts / 2);
       const results = [
+        ...(await runScenario(
+          config.stepStormAttempts,
+          config.concurrency,
+          runStepStormAttempt
+        )),
+        ...(await runScenario(
+          config.hookStormAttempts,
+          config.concurrency,
+          runHookStormAttempt
+        )),
         ...(await runScenario(
           config.hookSleepAttempts,
           config.concurrency,
           runHookSleepAttempt
         )),
-        ...(await runScenario(
-          config.stepFanoutAttempts,
-          config.stepConcurrency,
-          runStepFanoutAttempt
-        )),
-        ...(await runScenario(
-          stepBiasedAttempts,
-          config.stepConcurrency,
-          (attempt) => runStepSleepRaceAttempt(attempt, 'step')
-        )),
-        ...(await runScenario(
-          sleepBiasedAttempts,
-          config.stepConcurrency,
-          (attempt) => runStepSleepRaceAttempt(attempt, 'sleep')
-        )),
       ];
       writeResults(results);
 
       // Only event-log regressions fail the job. `infra` outcomes are
-      // harness-side timing races (hook resume vs. sleep budget) and transport
-      // errors — they are recorded and surfaced in the summary, but do not
-      // gate, matching `--check` in the renderer script.
+      // harness-side timing races (hook resume vs. watchdog budget) and
+      // transport errors — they are recorded and surfaced in the summary, but do
+      // not gate, matching `--check` in the renderer script.
       const regressions = results.filter(
         (result) => result.outcome !== 'completed' && result.outcome !== 'infra'
       );

--- a/workbench/nextjs-turbopack/workflows/103_event_log_corruption_repro.ts
+++ b/workbench/nextjs-turbopack/workflows/103_event_log_corruption_repro.ts
@@ -1,0 +1,426 @@
+import {
+  createHook,
+  getWorkflowMetadata,
+  setAttributes,
+  sleep,
+} from 'workflow';
+
+/**
+ * Workflows purpose-built to reproduce `CORRUPTED_EVENT_LOG`.
+ *
+ * A corrupted event log needs three things to line up, and these workflows are
+ * shaped to supply all three at once rather than leaving any of them to luck:
+ *
+ * 1. **Concurrent writers on one run.** Every wake source (a raced step
+ *    completing, a watchdog timer elapsing, an out-of-band `hook_received`)
+ *    delivers its own queue message, so a run with many simultaneous wake
+ *    sources is replayed by several invocations at the same time. Each one
+ *    loads the event log, replays, and writes.
+ * 2. **A write derived from an incomplete log.** With writers overlapping, one
+ *    replay's event load can miss an event a sibling has already committed.
+ * 3. **Control flow that depends on the missing event, by step *count*.** This
+ *    is the amplifier, and it is what the older repro scenarios lacked. Because
+ *    correlation IDs are positional ordinals of one seeded sequence, a replay
+ *    that emits a different *number* of steps renames every entity after that
+ *    point, turning one missing event into an unrecoverable divergence instead
+ *    of a benign retry.
+ *
+ * Both workflows below race a settle path that emits one step against a
+ * recovery path that emits two, then fan out a reconcile batch whose width is
+ * derived from how many branches took the recovery path. They differ only in
+ * what the branch races against the watchdog: an in-run step completion
+ * (`stepStormReproWorkflow`) or an out-of-band hook delivery
+ * (`hookStormReproWorkflow`, the shape seen corrupting production runs).
+ */
+
+interface StormInput {
+  token: string;
+  rounds?: number;
+  width?: number;
+  watchdogMs?: number;
+  stepDelayMs?: number;
+  stepDelayJitterMs?: number;
+  jitterBuckets?: number;
+  betweenRoundSleepMs?: number;
+  reconcileBase?: number;
+  attrWrites?: number;
+}
+
+type Winner = 'settled' | 'watchdog';
+
+interface BranchRecord {
+  round: number;
+  index: number;
+  winner: Winner;
+}
+
+interface RoundRecord {
+  round: number;
+  branches: BranchRecord[];
+  stragglers: number;
+  reconciled: number;
+}
+
+interface StormResult {
+  runId: string;
+  rounds: number;
+  width: number;
+  ledger: RoundRecord[];
+}
+
+interface WakePayload {
+  round: number;
+  index: number;
+  sentAt: number;
+}
+
+const WATCHDOG = Symbol.for('event-log-corruption-repro:watchdog');
+
+/**
+ * The raced step. Its `delayMs` is chosen to land near the watchdog deadline,
+ * so which branch wins is decided by real wall-clock timing — the legitimate
+ * nondeterminism the event log exists to freeze. A replay that cannot see this
+ * step's `step_completed` takes the recovery path instead.
+ *
+ * `attrWrites` issues `setAttributes` calls from inside the step body. Those
+ * are genuinely out-of-band writes (no replay snapshot backs them, so they
+ * carry no precondition), which both widens the window in which a concurrent
+ * replay's loaded log is incomplete and forces the reader into an extra
+ * in-process replay.
+ */
+async function settleStep(input: {
+  delayMs: number;
+  runId: string;
+  round: number;
+  index: number;
+  attrWrites: number;
+}) {
+  'use step';
+  // One fixed key, overwritten by every branch of every round, so the run never
+  // accumulates attribute keys. The value is never asserted on — the point is
+  // the `attr_set` event, not what it says.
+  for (let write = 0; write < input.attrWrites; write += 1) {
+    await setAttributes({
+      settle: `r${input.round}b${input.index}w${write}`,
+    });
+  }
+  if (input.delayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, input.delayMs));
+  }
+  return {
+    runId: input.runId,
+    round: input.round,
+    index: input.index,
+    settledAt: Date.now(),
+  };
+}
+
+/**
+ * Emitted only on the watchdog path, ahead of `finalizeStep`. The recovery path
+ * therefore writes two steps where the settle path writes one, so a replay that
+ * disagrees about the winner also disagrees about how many correlation IDs the
+ * branch consumes.
+ */
+async function recoverStep(input: {
+  runId: string;
+  round: number;
+  index: number;
+}) {
+  'use step';
+  return { ...input, recoveredAt: Date.now() };
+}
+
+async function finalizeStep(input: {
+  runId: string;
+  round: number;
+  index: number;
+  winner: Winner;
+}) {
+  'use step';
+  return { ...input, finalizedAt: Date.now() };
+}
+
+/** Runs in the branch's `finally`, so every branch ends on a write. */
+async function releaseStep(input: {
+  runId: string;
+  round: number;
+  index: number;
+}) {
+  'use step';
+  return { ...input, releasedAt: Date.now() };
+}
+
+/**
+ * One member of the round's reconcile batch. The batch's *width* is derived
+ * from the round's race outcomes, so this is where a one-event disagreement
+ * becomes a shifted correlation-ID sequence for the whole remainder of the run.
+ */
+async function reconcileStep(input: {
+  runId: string;
+  round: number;
+  index: number;
+  stragglers: number;
+}) {
+  'use step';
+  return { ...input, reconciledAt: Date.now() };
+}
+
+/**
+ * Deterministic per-branch delay spread around the watchdog deadline. It must
+ * not use `Math.random()` (the workflow body has to replay identically), but it
+ * does need to put different branches on either side of the deadline so the
+ * straggler count — and therefore the reconcile width — varies from round to
+ * round.
+ */
+function branchDelayMs(
+  round: number,
+  index: number,
+  base: number,
+  jitterMs: number,
+  buckets: number
+) {
+  if (jitterMs <= 0 || buckets <= 1) return base;
+  const bucket = (round * 3 + index * 5) % buckets;
+  // Centre the spread on `base` so roughly half the branches beat the watchdog.
+  return Math.max(0, base + (bucket - Math.floor(buckets / 2)) * jitterMs);
+}
+
+function normalize(input: StormInput) {
+  return {
+    rounds: input.rounds ?? 6,
+    width: input.width ?? 8,
+    watchdogMs: input.watchdogMs ?? 2500,
+    // Slightly under `watchdogMs`: the sleep starts when the branch suspends,
+    // while this delay only starts once the step body is dispatched, so the two
+    // deadlines land on top of each other and the jitter decides the winner.
+    stepDelayMs: input.stepDelayMs ?? 2200,
+    stepDelayJitterMs: input.stepDelayJitterMs ?? 250,
+    jitterBuckets: input.jitterBuckets ?? 5,
+    betweenRoundSleepMs: input.betweenRoundSleepMs ?? 1000,
+    reconcileBase: input.reconcileBase ?? 2,
+    attrWrites: input.attrWrites ?? 1,
+  };
+}
+
+export async function stepStormReproWorkflow(
+  input: StormInput
+): Promise<StormResult> {
+  'use workflow';
+
+  const metadata = getWorkflowMetadata();
+  const config = normalize(input);
+  const ledger: RoundRecord[] = [];
+
+  // A hook the workflow creates but never reads. The driver resumes it on a
+  // cadence for the whole run, so every replay is racing a stream of
+  // `hook_received` events written with no snapshot behind them — the
+  // out-of-band write the guard was built for, and the same shape as a sandbox
+  // callback arriving after its watchdog already fired.
+  const pokeHook = createHook<WakePayload>({ token: `${input.token}:poke` });
+
+  try {
+    for (let round = 0; round < config.rounds; round += 1) {
+      // Every branch in the round suspends together, so the round's step creates
+      // land in one batch sharing one snapshot, and their completions land within
+      // a few milliseconds of each other and of the watchdog wake.
+      const branches = await Promise.all(
+        Array.from({ length: config.width }, (_, index) =>
+          (async (): Promise<BranchRecord> => {
+            try {
+              const winner = await Promise.race([
+                settleStep({
+                  attrWrites: config.attrWrites,
+                  delayMs: branchDelayMs(
+                    round,
+                    index,
+                    config.stepDelayMs,
+                    config.stepDelayJitterMs,
+                    config.jitterBuckets
+                  ),
+                  index,
+                  round,
+                  runId: metadata.workflowRunId,
+                }),
+                sleep(config.watchdogMs).then(() => WATCHDOG),
+              ]);
+
+              if (winner === WATCHDOG) {
+                await recoverStep({
+                  index,
+                  round,
+                  runId: metadata.workflowRunId,
+                });
+                await finalizeStep({
+                  index,
+                  round,
+                  runId: metadata.workflowRunId,
+                  winner: 'watchdog',
+                });
+                return { index, round, winner: 'watchdog' };
+              }
+
+              await finalizeStep({
+                index,
+                round,
+                runId: metadata.workflowRunId,
+                winner: 'settled',
+              });
+              return { index, round, winner: 'settled' };
+            } finally {
+              await releaseStep({
+                index,
+                round,
+                runId: metadata.workflowRunId,
+              });
+            }
+          })()
+        )
+      );
+
+      const stragglers = branches.filter(
+        (branch) => branch.winner === 'watchdog'
+      ).length;
+      const reconciled = await Promise.all(
+        Array.from({ length: config.reconcileBase + stragglers }, (_, index) =>
+          reconcileStep({
+            index,
+            round,
+            runId: metadata.workflowRunId,
+            stragglers,
+          })
+        )
+      );
+
+      ledger.push({
+        branches,
+        reconciled: reconciled.length,
+        round,
+        stragglers,
+      });
+
+      if (config.betweenRoundSleepMs > 0) {
+        await sleep(config.betweenRoundSleepMs);
+      }
+    }
+  } finally {
+    pokeHook.dispose();
+  }
+
+  return {
+    ledger,
+    rounds: config.rounds,
+    runId: metadata.workflowRunId,
+    width: config.width,
+  };
+}
+
+/**
+ * The production shape: each branch races an out-of-band hook delivery against
+ * a watchdog timer, exactly like a task waiting for a sandbox callback with a
+ * timeout. Hook tokens are derived from `(round, index)` so the driver can
+ * resume all of a round's hooks in one burst without discovering them
+ * individually — every hook in a round is created by the same suspension, so
+ * the first one existing implies the rest do.
+ *
+ * Compared with `stepStormReproWorkflow`, the writes racing the replay are
+ * `hook_received` events written by the backend rather than step completions
+ * written by a sibling invocation, and each delivery wakes its own invocation.
+ */
+export async function hookStormReproWorkflow(
+  input: StormInput
+): Promise<StormResult> {
+  'use workflow';
+
+  const metadata = getWorkflowMetadata();
+  const config = normalize(input);
+  const ledger: RoundRecord[] = [];
+
+  for (let round = 0; round < config.rounds; round += 1) {
+    const hooks = Array.from({ length: config.width }, (_, index) =>
+      createHook<WakePayload>({
+        token: `${input.token}:${round}:${index}`,
+      })
+    );
+
+    try {
+      const branches = await Promise.all(
+        hooks.map((hook, index) =>
+          (async (): Promise<BranchRecord> => {
+            const iterator = hook[Symbol.asyncIterator]();
+            try {
+              const winner = await Promise.race([
+                iterator.next().then(() => 'settled' as const),
+                sleep(config.watchdogMs).then(() => WATCHDOG),
+              ]);
+
+              if (winner === WATCHDOG) {
+                await recoverStep({
+                  index,
+                  round,
+                  runId: metadata.workflowRunId,
+                });
+                await finalizeStep({
+                  index,
+                  round,
+                  runId: metadata.workflowRunId,
+                  winner: 'watchdog',
+                });
+                return { index, round, winner: 'watchdog' };
+              }
+
+              await finalizeStep({
+                index,
+                round,
+                runId: metadata.workflowRunId,
+                winner: 'settled',
+              });
+              return { index, round, winner: 'settled' };
+            } finally {
+              await releaseStep({
+                index,
+                round,
+                runId: metadata.workflowRunId,
+              });
+            }
+          })()
+        )
+      );
+
+      const stragglers = branches.filter(
+        (branch) => branch.winner === 'watchdog'
+      ).length;
+      const reconciled = await Promise.all(
+        Array.from({ length: config.reconcileBase + stragglers }, (_, index) =>
+          reconcileStep({
+            index,
+            round,
+            runId: metadata.workflowRunId,
+            stragglers,
+          })
+        )
+      );
+
+      ledger.push({
+        branches,
+        reconciled: reconciled.length,
+        round,
+        stragglers,
+      });
+    } finally {
+      for (const hook of hooks) {
+        hook.dispose();
+      }
+    }
+
+    if (config.betweenRoundSleepMs > 0) {
+      await sleep(config.betweenRoundSleepMs);
+    }
+  }
+
+  return {
+    ledger,
+    rounds: config.rounds,
+    runId: metadata.workflowRunId,
+    width: config.width,
+  };
+}


### PR DESCRIPTION
## Why

The `event-log-race-repro` job exists to give us a measurable `CORRUPTED_EVENT_LOG` rate to test event-guard changes against. Its last full run produced **2 corruptions / 2000 runs (0.1%)**, all in the `hook-sleep` scenario (2/1498); `step-fanout` was 0/250 and both `step-sleep-race-*` were 0/125. That rate is too low to tell a fix from noise, while real user workloads hit it repeatedly.

A corrupted event log needs three things to line up. The old scenarios supplied at most two:

1. **Concurrent writers on one run.** The old scenarios had roughly one wake source per run. Parallel `sleep()`s do not help — the suspension handler schedules only the *soonest* pending wait as a single delayed re-invocation, so N parallel sleeps produce one wake, not N.
2. **A write derived from an incomplete event load.** Needs (1) to be true first.
3. **Control flow that depends on the missing event by step *count*.** This was entirely absent. Every old branch emitted the same number of steps whichever way it resolved, so a replay working from a stale log still minted the same correlation IDs — a benign retry, not a divergence.

Item 3 is the amplifier. Correlation IDs are positional ordinals of one seeded sequence, so a replay that emits a *different number* of steps renames every entity after that point, turning one missing event into an unrecoverable divergence. The corrupted production runs we traced diverged at ordinals 1337 and 901, deep into long logs.

## What

Two new storm workflows (`workbench/nextjs-turbopack/workflows/103_event_log_corruption_repro.ts`) supply all three by construction. Each round fans out `width` branches; every branch races a settle path that emits **one** step against a recovery path that emits **two**, and then the round fans out a reconcile batch whose *width* is derived from how many branches took the recovery path.

- **`step-storm`** races an in-run step completion against a per-branch watchdog timer. The step body also issues `setAttributes`, which is a genuinely out-of-band write, and the driver resumes a hook the workflow creates but never reads on a continuous cadence, so every replay is racing a stream of `hook_received` events written with no snapshot behind them.
- **`hook-storm`** races an out-of-band hook delivery against the watchdog, with the round's deliveries staggered so they straddle the deadline. This is the shape seen corrupting production runs: a task waiting on a callback with a timeout.
- **`hook-sleep`** is retained at low attempt counts (200) as a calibration control, since its historical ~0.1% rate is our only baseline.

Defaults: 600 step-storm + 600 hook-storm + 200 control at concurrency 40, 6 rounds x 8 branches, watchdog 2500 ms against a 2200 ms +/- 250 ms step delay so the jitter decides each winner. Every knob is a `workflow_dispatch` input.

Two other changes matter for reading the results:

- **The classifier now reads the top-level `errorCode`.** `error` is rehydrated into an `Error` carrying only `name`/`message`, so `error.code` was always `undefined` and every real failure was bucketed as `other`. The previous artifact's `other: 2` and this branch's `CORRUPTED_EVENT_LOG: 2` would be the same outcome reported differently — worth remembering when diffing against the old sticky comment.
- **A ledger consistency check** (`validateStormReturn`) catches *silent* corruption: a run that diverged but still reached `completed` will normally disagree with itself about its own straggler count or reconcile width. That reports as `BAD_STORM_LEDGER`.

## Result

First full run on this branch (plain `main` SDK, no guard), [run 30316814473](https://github.com/vercel/workflow/actions/runs/30316814473):

| scenario | runs | `CORRUPTED_EVENT_LOG` | rate | stuck |
|:--|--:|--:|--:|--:|
| step-storm | 600 | 544 | **90.7%** | 0 |
| hook-storm | 600 | 362 | **60.3%** | 22 |
| hook-sleep (control) | 200 | 0 | 0% | 0 |
| **total** | **1400** | **906** | **64.7%** | 22 |

0 `USER_ERROR` (the poke-hook risk below did not materialise), 0 `RUNTIME_ERROR`, 0 `BAD_STORM_LEDGER`, 0 infra. Against the previous harness's 2/2000 (0.1%), that is a ~650x increase, and the retained `hook-sleep` control stayed at 0/200 in the same run — so the gain comes from the step-count-divergent shape, not from load.

The `Event Log Race Repro` check failing is the corruption gate firing as designed; every other check on this PR passes, including `E2E Required Check`.

The 22 stuck runs are all `hook-storm`, all still `running` at the 240 s timeout, spread evenly across attempts and not correlated with failed hook resumes (some have 8/8 resumes delivered). That is a separate signal from divergence and worth a look on its own.

## Acceptance bar

Label a PR `event-log-race-repro` and the job runs. Met: 906 corruptions in one run, with step-storm alone at 90.7%. The knobs are still there if a future backend change suppresses the rate and it needs re-tuning: `width`, `watchdog_ms` vs `step_delay_ms` separation, `rounds`, then attempt counts.

## Known risk

A step-storm run accumulates roughly 40 unread `hook_received` events on the poke hook. If the backend capped pending hook events this would surface as `USER_ERROR` rather than a corruption. The first full run reported 0 `USER_ERROR`, so it does not.
