### PR TITLE
[e2e] Report partial results when the event-log race repro is cut short

### DIFF
--- a/.changeset/repro-partial-results.md
+++ b/.changeset/repro-partial-results.md
@@ -1,0 +1,4 @@
+---
+---
+
+Report partial results when the event-log race CI repro job is cut short.

--- a/.github/scripts/render-event-log-race-repro-results.js
+++ b/.github/scripts/render-event-log-race-repro-results.js
@@ -154,9 +154,15 @@ function renderResult(entry) {
   }
   const infra = entry.infraCount ?? infraCount(entry.distribution ?? {});
   const infraSuffix = infra > 0 ? ` (+${infra} infra)` : '';
+  // A partial run's rates are still meaningful but its totals are not
+  // comparable to a full run's, so the row says so rather than letting a
+  // short run read as a clean one.
+  const partialSuffix = entry.partial
+    ? ` — partial${entry.plannedAttempts ? ` (${entry.total} of ${entry.plannedAttempts} planned)` : ''}`
+    : '';
   return entry.failedCount === 0
-    ? `no regressions${infraSuffix}`
-    : `${entry.failedCount}/${entry.total} regressions${infraSuffix}`;
+    ? `no regressions${infraSuffix}${partialSuffix}`
+    : `${entry.failedCount}/${entry.total} regressions${infraSuffix}${partialSuffix}`;
 }
 
 function renderConfig(entry) {
@@ -231,6 +237,9 @@ function compactHistoryEntry(entry, keepFailures = false) {
     runUrl: entry.runUrl,
     deploymentUrl: entry.deploymentUrl,
     missingResults: entry.missingResults,
+    partial: entry.partial ?? false,
+    budgetExhausted: entry.budgetExhausted ?? false,
+    plannedAttempts: entry.plannedAttempts ?? 0,
     distribution: entry.distribution ?? emptyDistribution(),
     scenarioDistribution: entry.scenarioDistribution ?? {},
     failedCount: entry.failedCount ?? 0,
@@ -252,6 +261,9 @@ function buildEntry(resultsFile) {
       runUrl,
       deploymentUrl: '',
       missingResults: true,
+      partial: false,
+      budgetExhausted: false,
+      plannedAttempts: 0,
       distribution: emptyDistribution(),
       failedCount: 1,
       total: 0,
@@ -294,6 +306,12 @@ function buildEntry(resultsFile) {
     runUrl,
     deploymentUrl: resultsFile.deploymentUrl,
     missingResults: false,
+    // The harness checkpoints the file as it goes and only stamps
+    // `partial: false` on its final write, so a job killed by cancellation or
+    // its own `timeout-minutes` still reports whatever landed.
+    partial: resultsFile.partial ?? false,
+    budgetExhausted: resultsFile.budgetExhausted ?? false,
+    plannedAttempts: resultsFile.plannedAttempts ?? 0,
     distribution,
     scenarioDistribution,
     failedCount,
@@ -408,14 +426,20 @@ function render(resultsFile, previousComment) {
         'these are reported but do not fail the job.'
       : '';
 
+  const partialNote = latest.partial
+    ? ` Results are **partial**: ${latest.total} of ${latest.plannedAttempts || 'the'} planned runs completed` +
+      `${latest.budgetExhausted ? ', because the launch budget was spent' : ', because the job ended before the harness finished'}` +
+      '. Rates are still comparable; totals are not.'
+    : '';
+
   console.log('<!-- event-log-race-repro-results -->');
   console.log('## Event Log Race Repro\n');
   console.log(
     latest.missingResults
       ? 'No result file was produced by the latest repro job.'
       : latest.failedCount === 0
-        ? `No event-log regressions in the latest repro job.${infraNote}`
-        : `${latest.failedCount} of ${latest.total} latest repro runs hit event-log regressions.${infraNote}`
+        ? `No event-log regressions in the latest repro job.${partialNote}${infraNote}`
+        : `${latest.failedCount} of ${latest.total} latest repro runs hit event-log regressions.${partialNote}${infraNote}`
   );
   console.log('');
   console.log(historyMarkerStart);

--- a/.github/scripts/render-event-log-race-repro-results.test.js
+++ b/.github/scripts/render-event-log-race-repro-results.test.js
@@ -31,6 +31,10 @@ function runCheck(file) {
   }
 }
 
+function runRender(file) {
+  return execFileSync('node', [SCRIPT, file], { encoding: 'utf8' });
+}
+
 test('infra is not a gating outcome', () => {
   assert.ok(!gatingOutcomes.includes('infra'));
   assert.ok(!gatingOutcomes.includes('completed'));
@@ -146,6 +150,50 @@ test('--check exits 1 on a corruption-class regression', () => {
       { outcome: 'infra', errorCode: 'HOOK_RESUME_FAILED' },
       { outcome: 'CORRUPTED_EVENT_LOG', errorCode: 'CORRUPTED_EVENT_LOG' },
     ],
+  });
+  assert.strictEqual(runCheck(file), 1);
+});
+
+test('buildEntry carries partial-run metadata through to the summary', () => {
+  const entry = buildEntry({
+    partial: true,
+    budgetExhausted: true,
+    plannedAttempts: 1400,
+    results: [{ outcome: 'completed' }, { outcome: 'CORRUPTED_EVENT_LOG' }],
+  });
+  assert.strictEqual(entry.missingResults, false);
+  assert.strictEqual(entry.partial, true);
+  assert.strictEqual(entry.budgetExhausted, true);
+  assert.strictEqual(entry.plannedAttempts, 1400);
+  assert.strictEqual(entry.total, 2);
+});
+
+test('buildEntry defaults a complete file to non-partial', () => {
+  const entry = buildEntry({ results: [{ outcome: 'completed' }] });
+  assert.strictEqual(entry.partial, false);
+  assert.strictEqual(entry.budgetExhausted, false);
+  assert.strictEqual(entry.plannedAttempts, 0);
+});
+
+test('a partial result file renders as partial, not as a missing file', () => {
+  const file = writeTempResults({
+    partial: true,
+    budgetExhausted: true,
+    plannedAttempts: 1400,
+    results: [{ outcome: 'completed' }, { outcome: 'CORRUPTED_EVENT_LOG' }],
+  });
+  const output = runRender(file);
+  assert.ok(!output.includes('No result file was produced'));
+  assert.ok(output.includes('partial'));
+  assert.ok(output.includes('1400'));
+});
+
+test('--check still gates on regressions in a partial result file', () => {
+  const file = writeTempResults({
+    partial: true,
+    budgetExhausted: true,
+    plannedAttempts: 1400,
+    results: [{ outcome: 'completed' }, { outcome: 'CORRUPTED_EVENT_LOG' }],
   });
   assert.strictEqual(runCheck(file), 1);
 });

--- a/.github/workflows/event-log-race-repro.yml
+++ b/.github/workflows/event-log-race-repro.yml
@@ -50,6 +50,10 @@ on:
         description: 'Per-run timeout before classifying as stuck'
         required: false
         default: '240000'
+      budget_ms:
+        description: 'Wall-clock budget for launching attempts. Must stay far enough below the job timeout to leave room for rendering the summary'
+        required: false
+        default: '4500000'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -122,6 +126,7 @@ jobs:
           EVENT_LOG_RACE_REPRO_HOOK_RESUME_STAGGER_MS: ${{ inputs.hook_resume_stagger_ms || '400' }}
           EVENT_LOG_RACE_REPRO_POKE_INTERVAL_MS: ${{ inputs.poke_interval_ms || '750' }}
           EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms || '240000' }}
+          EVENT_LOG_RACE_REPRO_BUDGET_MS: ${{ inputs.budget_ms || '4500000' }}
 
       - name: Fetch previous repro comment
         if: always() && github.event_name == 'pull_request'

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -68,6 +68,12 @@ interface ReproConfig {
   hookStormAttempts: number;
   hookSleepAttempts: number;
   concurrency: number;
+  /** Wall-clock budget for *launching* attempts. Once it is spent no new
+   *  attempt is claimed, in-flight ones are allowed to finish, and whatever
+   *  landed is reported. This is what keeps the job inside its own
+   *  `timeout-minutes`: a cap that fires before the runner's leaves time to
+   *  render the summary, while one that fires after it discards the whole run. */
+  budgetMs: number;
   runTimeoutMs: number;
   hookTimeoutMs: number;
   /** Rounds of racing branches per run. More rounds = more chances for a bad
@@ -144,6 +150,10 @@ const config: ReproConfig = {
   hookStormAttempts: envNumber('EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS', 600),
   hookSleepAttempts: envNumber('EVENT_LOG_RACE_REPRO_ATTEMPTS', 200),
   concurrency: envNumber('EVENT_LOG_RACE_REPRO_CONCURRENCY', 40),
+  // 75 min leaves ~20 min of the job's 120-min cap for checkout, build, the
+  // deployment wait, and rendering the summary, even at the worst case of one
+  // in-flight attempt draining its full `runTimeoutMs` after the budget ends.
+  budgetMs: envNumber('EVENT_LOG_RACE_REPRO_BUDGET_MS', 75 * 60_000),
   runTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS', 240_000),
   hookTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_HOOK_TIMEOUT_MS', 60_000),
   rounds: envNumber('EVENT_LOG_RACE_REPRO_ROUNDS', 6),
@@ -816,6 +826,13 @@ async function mapLimit<T, R>(
 
   async function worker() {
     while (index < items.length) {
+      // Checked before claiming, never mid-attempt: an attempt that has already
+      // started owns a real workflow run, and abandoning it would report a
+      // stuck run the harness itself caused.
+      if (Date.now() >= launchDeadline) {
+        budgetExhausted = true;
+        return;
+      }
       const currentIndex = index;
       index += 1;
       const item = items[currentIndex];
@@ -865,13 +882,37 @@ function summarizeByScenario(results: ReproRunResult[]) {
   );
 }
 
-function writeResults(results: ReproRunResult[]) {
+/** Minimum gap between checkpoint writes. The file is rewritten whole, so this
+ *  trades staleness on a kill against re-serializing every landing attempt. */
+const CHECKPOINT_INTERVAL_MS = 10_000;
+
+/** Everything that has landed so far, across all scenarios. Attempts push here
+ *  as they settle rather than being collected at the end, so a cancelled or
+ *  timed-out job still reports the runs it paid for. */
+const collected: ReproRunResult[] = [];
+const plannedAttempts =
+  config.stepStormAttempts +
+  config.hookStormAttempts +
+  config.hookSleepAttempts;
+let overallDeadline = Number.POSITIVE_INFINITY;
+let launchDeadline = Number.POSITIVE_INFINITY;
+let remainingPlanned = plannedAttempts;
+let budgetExhausted = false;
+let lastCheckpointAt = 0;
+
+function writeResults(results: ReproRunResult[], complete: boolean) {
   fs.writeFileSync(
     RESULT_PATH,
     JSON.stringify(
       {
         completedAt: new Date().toISOString(),
         deploymentUrl,
+        // `partial` is the renderer's signal that the distribution below counts
+        // fewer runs than were planned, so its rates are still meaningful but
+        // its totals are not comparable to a full run's.
+        partial: !complete,
+        budgetExhausted,
+        plannedAttempts,
         config: { ...config, attempts: results.length },
         distribution: summarize(results),
         scenarioDistribution: summarizeByScenario(results),
@@ -881,6 +922,14 @@ function writeResults(results: ReproRunResult[]) {
       2
     )
   );
+  lastCheckpointAt = Date.now();
+}
+
+function recordResult(result: ReproRunResult) {
+  collected.push(result);
+  if (Date.now() - lastCheckpointAt >= CHECKPOINT_INTERVAL_MS) {
+    writeResults(collected, false);
+  }
 }
 
 async function runScenario(
@@ -891,19 +940,36 @@ async function runScenario(
   if (attempts <= 0) {
     return [];
   }
+  // Each scenario gets the share of the remaining budget its remaining planned
+  // attempts represent, so a truncated run still carries data for every
+  // scenario — including the `hook-sleep` control, which runs last and would
+  // otherwise be the first thing a single global deadline dropped. A scenario
+  // that finishes under its slice hands the surplus to the next one, since the
+  // slice is recomputed from the wall-clock left until `overallDeadline`.
+  const now = Date.now();
+  launchDeadline = Math.min(
+    overallDeadline,
+    now + ((overallDeadline - now) * attempts) / remainingPlanned
+  );
+  remainingPlanned -= attempts;
   const attemptNumbers = Array.from(
     { length: attempts },
     (_, index) => index + 1
   );
-  return await mapLimit(attemptNumbers, concurrency, run);
+  return await mapLimit(attemptNumbers, concurrency, async (attempt) => {
+    const result = await run(attempt);
+    recordResult(result);
+    return result;
+  });
 }
 
-const totalAttempts =
-  config.stepStormAttempts +
-  config.hookStormAttempts +
-  config.hookSleepAttempts;
-const testTimeoutMs =
-  config.runTimeoutMs * Math.ceil(totalAttempts / config.concurrency) + 60_000;
+// Derived from the launch budget, not from the attempt count: the budget is
+// what actually bounds the run, and the tail is one in-flight attempt draining
+// at its own timeout plus the final write. Deriving it from
+// `runTimeoutMs * ceil(attempts / concurrency)` instead produces a timeout
+// longer than the job's own `timeout-minutes`, so the runner kills the job
+// first and no summary is ever rendered.
+const testTimeoutMs = config.budgetMs + config.runTimeoutMs + 60_000;
 
 describe('event log race repro', () => {
   beforeAll(() => {
@@ -957,24 +1023,36 @@ describe('event log race repro', () => {
     'event log races do not corrupt, stall, or take stale branches',
     { timeout: testTimeoutMs },
     async () => {
-      const results = [
-        ...(await runScenario(
-          config.stepStormAttempts,
-          config.concurrency,
-          runStepStormAttempt
-        )),
-        ...(await runScenario(
-          config.hookStormAttempts,
-          config.concurrency,
-          runHookStormAttempt
-        )),
-        ...(await runScenario(
-          config.hookSleepAttempts,
-          config.concurrency,
-          runHookSleepAttempt
-        )),
-      ];
-      writeResults(results);
+      overallDeadline = Date.now() + config.budgetMs;
+      // Written up front so a kill before the first checkpoint still produces a
+      // file the renderer can report against, rather than nothing at all.
+      writeResults(collected, false);
+
+      await runScenario(
+        config.stepStormAttempts,
+        config.concurrency,
+        runStepStormAttempt
+      );
+      await runScenario(
+        config.hookStormAttempts,
+        config.concurrency,
+        runHookStormAttempt
+      );
+      await runScenario(
+        config.hookSleepAttempts,
+        config.concurrency,
+        runHookSleepAttempt
+      );
+
+      const results = collected;
+      writeResults(results, true);
+      if (budgetExhausted) {
+        console.warn(
+          `[event-log-race-repro] launch budget (${config.budgetMs}ms) spent after ` +
+            `${results.length} of ${plannedAttempts} planned attempts. Reported rates ` +
+            `are still valid; totals are not comparable to a full run.`
+        );
+      }
 
       // Only event-log regressions fail the job. `infra` outcomes are
       // harness-side timing races (hook resume vs. watchdog budget) and

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -1045,7 +1045,10 @@ describe('event log race repro', () => {
       );
 
       const results = collected;
-      writeResults(results, true);
+      // A budget-exhausted run launched fewer than `plannedAttempts` attempts,
+      // so its totals are short of a full run. Stamp it `partial` so the
+      // renderer surfaces that (its rates stay valid; its totals do not).
+      writeResults(results, !budgetExhausted);
       if (budgetExhausted) {
         console.warn(
           `[event-log-race-repro] launch budget (${config.budgetMs}ms) spent after ` +


### PR DESCRIPTION
The event-log race repro job posted **"No result file was produced by the latest repro job."** on both of its last two runs, discarding every attempt that had completed.

## Cause

Two things compounded:

1. `writeResults` ran **once**, after all planned attempts had landed. A job that ends any other way produces no file at all. The `always()` reporting steps do run on cancellation — they just find nothing.
2. The vitest timeout was derived from the attempt count: `runTimeoutMs * ceil(attempts / concurrency) + 60s` = **141 min** at the current defaults (1400 attempts, c40, 240s), above the job's own `timeout-minutes: 120`. So the runner always won the race and vitest never reached its final write.

## Fix

- **Wall-clock launch budget.** `EVENT_LOG_RACE_REPRO_BUDGET_MS` (new `budget_ms` dispatch input, default 75 min) is checked before an attempt is *claimed*, never mid-attempt — an attempt that has started owns a real workflow run, and abandoning it would report a stuck run the harness itself caused. It is sliced per scenario in proportion to remaining planned attempts, so a truncated run still carries `hook-sleep` control data instead of dropping the last scenario entirely; a scenario finishing under its slice hands the surplus to the next. The vitest timeout now derives from the budget (`budget + runTimeoutMs + 60s` = 80 min), so the harness finishes and reports well inside the job cap.
- **Checkpointing.** Attempts push into a shared array as they settle and the result file is rewritten at most every 10s, plus once up front. A cancellation or timeout now reports the runs it paid for.
- **Honest rendering.** The file carries `partial`, `budgetExhausted` and `plannedAttempts`; the renderer surfaces that in the headline and in the history row (`… — partial (N of M planned)`) so a short run cannot read as a clean one. `--check` still gates on regressions in a partial file.

## Tests

`node --test .github/scripts/render-event-log-race-repro-results.test.js` — 12/12, including four new cases: partial metadata passes through `buildEntry`, a complete file defaults to non-partial, a partial file renders as partial rather than missing, and `--check` still exits 1 on a regression in a partial file.

## Note

Branches that already have repro runs in flight (e.g. #3139) check out their own head SHA, so they need to merge `main` before this affects their runs.