### PR TITLE
fix(core): seal forwarded writes for workflow-body writables

### DIFF
--- a/.changeset/encp-workflow-body-writable.md
+++ b/.changeset/encp-workflow-body-writable.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Seal forwarded writes to streams taken with `getWritable()` in a workflow body, which previously fell back to fetching the owner's symmetric key because the workflow VM has no key material to publish on the handle.

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -755,6 +755,103 @@ describe('workflow arguments', () => {
     expect(wire).toContain(ownerPublicKey);
   });
 
+  it('publishes this run public key when a step revives a workflow-body writable', async () => {
+    // `getWritable()` in a workflow body returns a handle with only a name: the
+    // workflow VM holds no key material, so nothing can publish the owner key
+    // there. The handle reaches a step, and reviving it is the first moment the
+    // run's own key is in scope — so that is where the key gets attached.
+    //
+    // It cannot be done later at serialization time: `start()` dehydrates its
+    // arguments with the CHILD's runId and key, so the owner's key is gone by
+    // then. This is the shape eve uses — a driver workflow takes a writable in
+    // its workflow body and forwards it into per-turn child runs.
+    const material = new Uint8Array(32).fill(0x5c);
+    const keys = runPayloadKeys(
+      await importKey(material),
+      await deriveRunKeyPair(material)
+    );
+
+    const handle = new WritableStream();
+    Object.defineProperty(handle, STREAM_NAME_SYMBOL, {
+      value: 'strm_fromworkflowbody',
+      writable: false,
+    });
+    // Deliberately no public-key symbol — that is the case under test.
+
+    const toStep = await dehydrateStepArguments(
+      handle,
+      'wrun_owner',
+      noEncryptionKey
+    );
+    const ops: Promise<void>[] = [];
+    const revived = (await hydrateStepArguments(
+      toStep,
+      'wrun_owner',
+      keys,
+      ops,
+      globalThis,
+      {},
+      'dpl_owner'
+    )) as WritableStream<string>;
+
+    expect((revived as any)[STREAM_SERVER_PUBLIC_KEY_SYMBOL]).toBe(
+      bytesToBase64(keys.keyPair.publicKey)
+    );
+
+    // And it survives the forward that `start()` performs, which is what puts
+    // the receiving run on the sealed path.
+    const forwarded = new TextDecoder().decode(
+      (await dehydrateWorkflowArguments(
+        revived,
+        'wrun_child',
+        noEncryptionKey
+      )) as Uint8Array
+    );
+    expect(forwarded).toContain(bytesToBase64(keys.keyPair.publicKey));
+  });
+
+  it('does NOT publish its own key when reviving another run stream', async () => {
+    // The guard that matters. Advertising our key on a stream someone else owns
+    // would make the receiver seal to us, and the real owner could never open
+    // what was written.
+    const material = new Uint8Array(32).fill(0x5c);
+    const keys = runPayloadKeys(
+      await importKey(material),
+      await deriveRunKeyPair(material)
+    );
+
+    const handle = new WritableStream();
+    for (const [sym, v] of [
+      [STREAM_NAME_SYMBOL, 'strm_someoneelse'],
+      [STREAM_SERVER_RUN_ID_SYMBOL, 'wrun_a_different_run'],
+    ] as const) {
+      Object.defineProperty(handle, sym, { value: v, writable: false });
+    }
+
+    const toStep = await dehydrateStepArguments(
+      handle,
+      'wrun_owner',
+      noEncryptionKey
+    );
+    const ops: Promise<void>[] = [];
+    const revived = (await hydrateStepArguments(
+      toStep,
+      'wrun_owner',
+      keys,
+      ops,
+      globalThis,
+      {},
+      'dpl_owner'
+    )) as WritableStream<string>;
+
+    // Sanity: the foreign owner really did survive, so the assertion below is
+    // about the guard and not about a handle that lost its identity.
+    expect((revived as any)[STREAM_SERVER_RUN_ID_SYMBOL]).toBe(
+      'wrun_a_different_run'
+    );
+    expect((revived as any)[STREAM_SERVER_PUBLIC_KEY_SYMBOL]).toBeUndefined();
+  });
+
   it('falls back to the symmetric path when the descriptor has no public key', async () => {
     // Descriptors written by older SDKs carry no key; those must keep working.
     const { getWorldLazy } = await import('./runtime/get-world-lazy.js');

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -6,7 +6,7 @@ import {
 import { envNumber } from '@workflow/world';
 import { parse, stringify, unflatten } from 'devalue';
 import { monotonicFactory } from 'ulid';
-import { decodeRunPublicKey } from './sealed-box.js';
+import { bytesToBase64, decodeRunPublicKey } from './sealed-box.js';
 import { importKey } from './encryption.js';
 import {
   createFlushableState,
@@ -3154,6 +3154,35 @@ function getStepRevivers(
       }
       // Keep the owner's public key on the handle so a further forward stays on
       // the zero-lookup sealed path.
+      //
+      // When the descriptor carries no key and the stream belongs to THIS run,
+      // derive it. A writable taken with `getWritable()` in a workflow body has
+      // only a name on it — the workflow VM holds no key material by design —
+      // so nothing could publish the key when the handle was created. Reviving
+      // happens in a step, which does hold this run's key, and any later
+      // forward then just copies the symbol.
+      //
+      // It has to happen here rather than at serialization time: `start()`
+      // dehydrates its arguments with the CHILD's runId and the CHILD's key, so
+      // the owning run's key is no longer in scope by then.
+      //
+      // `targetRunId === runId` is the guard that matters. For a stream another
+      // run owns we must not advertise our key — the receiver would seal to us
+      // and the real owner could never open what it wrote.
+      if (
+        typeof value.encryptionPublicKey !== 'string' &&
+        targetRunId === runId &&
+        isRunPayloadKeys(cryptoKey)
+      ) {
+        Object.defineProperty(
+          serialize.writable,
+          STREAM_SERVER_PUBLIC_KEY_SYMBOL,
+          {
+            value: bytesToBase64(cryptoKey.keyPair.publicKey),
+            writable: false,
+          }
+        );
+      }
       if (typeof value.encryptionPublicKey === 'string') {
         Object.defineProperty(
           serialize.writable,


### PR DESCRIPTION
Follow-up to #3098. That PR made forwarded stream writes seal to the owner's public key, but the sealed path only engaged when the writable was taken **inside a step**. A writable taken in a **workflow body** still fell back to the symmetric path — which is the shape [eve](https://github.com/vercel/eve) actually uses, so the optimization was not engaging for the workload that motivated it.

## Why it happened

`getWritable()` resolves to two different functions depending on execution context:

- **step** (`step/writable-stream.ts`) — publishes the run's X25519 public key on the handle
- **workflow body** (`workflow/writable-stream.ts`) — returns a handle carrying only a name

The asymmetry is forced, not an oversight: the workflow VM holds no key material by design, so there is nothing to publish at creation time.

Forwarding such a handle produced a descriptor with no public key, so the receiving run fell to tier 2/3 of `getForwardedWritableEncryptionKey` and fetched the owner's symmetric key over the `run-key` API. Two costs:

- the round trip #3098 exists to remove is still paid
- the writer gets material that could also **decrypt**. The tiers 2/3 comment is explicit that this is *"an honor-system restriction: the same bytes could decrypt"*, where tier 1 makes it cryptographic. That privilege reduction silently disappeared.

Nothing warned. Data was correct, results were correct — the only signal was an `encr` rather than `encp` prefix in storage.

## The fix

Publish the key when a **step revives** such a handle. That's the first point where the owning run's key is in scope.

It deliberately is *not* done at serialization time, which was my first attempt and doesn't work: `start()` dehydrates its arguments with the **child's** runId and the **child's** key, so the owning run's key is out of scope by then.

Guarded on `targetRunId === runId`. Stamping our key onto a stream another run owns would make the receiver seal to the wrong recipient, and the real owner could never open what was written. There's a test for that direction specifically, and it fails if the guard is removed.

## Verified in production

Two deployments, cross-deployment forward, raw frames read back off the server.

Before, workflow-body writable:
```
frame 0..3: len=57  prefix=encr        <- symmetric, key fetched
```

After:
```
frame 0..3: len=89  prefix=encp
distinct ephemeral keys: 1  -> KEM amortized
```

Step-side writables re-checked for regression — still `encp`, still one shared ephemeral key.

## eve

Confirmed the pattern at `f736533`:

```
workflow-entry.ts:72   "use workflow"
workflow-entry.ts:89   const driverWritable = getWritable<Uint8Array>()
        ↓ parentWritable
workflow-steps.ts:578  dispatchTurnStep  "use step"
workflow-steps.ts:582  startWorkflowPreferLatest(turnWorkflowReference, [...])
workflow-runtime.ts:310  start(workflow, args, { ...options, deploymentId: "latest" })
```

A driver workflow takes a writable in its workflow body and forwards it into per-turn child runs started with `deploymentId: "latest"` — cross-deployment by construction, and previously unsealed on every turn.