### PR TITLE
fix(world-postgres): remove stream reader listeners on EOF, query failure, and close

### DIFF
--- a/packages/world-postgres/src/streamer.test.ts
+++ b/packages/world-postgres/src/streamer.test.ts
@@ -1,0 +1,163 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Drizzle } from './drizzle/index.js';
+import { createStreamer } from './streamer.js';
+
+vi.mock('pg', () => ({
+  Client: vi.fn(function Client() {
+    return {
+      connect: vi.fn(async () => {}),
+      query: vi.fn(async () => {}),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      end: vi.fn(async () => {}),
+    };
+  }),
+  Pool: vi.fn(),
+}));
+
+const fakePool = {
+  options: {},
+  query: vi.fn(async () => ({ rows: [] })),
+} as any;
+
+/**
+ * Minimal fake for the drizzle query chain used by `streams.get()`:
+ * `drizzle.select(...).from(...).where(...).orderBy(...)`.
+ */
+function createFakeDrizzle(
+  rows: () => Promise<Array<{ id: string; eof: boolean; data: Buffer }>>
+): Drizzle {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => rows(),
+          limit: () => rows(),
+        }),
+      }),
+    }),
+  } as unknown as Drizzle;
+}
+
+describe('postgres streamer reader listener cleanup', () => {
+  // `createStreamer()` keeps its EventEmitter private, so capture any
+  // emitter that receives a `strm:*` listener via a prototype spy.
+  let streamEmitters: Set<EventEmitter>;
+
+  const listenerCount = (name: string) => {
+    let count = 0;
+    for (const emitter of streamEmitters) {
+      count += emitter.listenerCount(`strm:${name}`);
+    }
+    return count;
+  };
+
+  beforeEach(() => {
+    streamEmitters = new Set();
+    const originalOn = EventEmitter.prototype.on;
+    vi.spyOn(EventEmitter.prototype, 'on').mockImplementation(function (
+      this: EventEmitter,
+      eventName,
+      listener
+    ) {
+      if (typeof eventName === 'string' && eventName.startsWith('strm:')) {
+        streamEmitters.add(this);
+      }
+      return originalOn.call(this, eventName, listener);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes the listener when a persisted EOF closes the stream', async () => {
+    const drizzle = createFakeDrizzle(async () => [
+      { id: 'chnk_00000000000000000000000001', eof: false, data: Buffer.from('hello') },
+      { id: 'chnk_00000000000000000000000002', eof: true, data: Buffer.from([]) },
+    ]);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    const warnings: Error[] = [];
+    const onWarning = (warning: Error) => warnings.push(warning);
+    process.on('warning', onWarning);
+
+    try {
+      // Repeated reads of the same completed stream must not accumulate
+      // listeners (issue reproduction uses 12 readers to trip the default
+      // max-listeners threshold of 10).
+      for (let i = 0; i < 12; i++) {
+        const stream = await streamer.streams.get('run_1', 'stream-eof');
+        const reader = stream.getReader();
+        let done = false;
+        while (!done) {
+          ({ done } = await reader.read());
+        }
+        expect(listenerCount('stream-eof')).toBe(0);
+      }
+
+      // Warnings are emitted via process.nextTick; flush before asserting.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(
+        warnings.filter((w) => w.name === 'MaxListenersExceededWarning')
+      ).toEqual([]);
+    } finally {
+      process.removeListener('warning', onWarning);
+      await streamer.close();
+    }
+  });
+
+  it('removes the listener when the initial chunk query rejects', async () => {
+    const drizzle = createFakeDrizzle(async () => {
+      throw new Error('initial query failed');
+    });
+    const streamer = createStreamer(fakePool, drizzle);
+
+    try {
+      for (let i = 0; i < 12; i++) {
+        const stream = await streamer.streams.get('run_1', 'stream-err');
+        const reader = stream.getReader();
+        await expect(reader.read()).rejects.toThrow('initial query failed');
+      }
+      expect(listenerCount('stream-err')).toBe(0);
+    } finally {
+      await streamer.close();
+    }
+  });
+
+  it('detaches active readers when the streamer is closed', async () => {
+    // No EOF chunk: readers stay open, tailing live events.
+    const drizzle = createFakeDrizzle(async () => [
+      { id: 'chnk_00000000000000000000000001', eof: false, data: Buffer.from('hello') },
+    ]);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    const readers: ReadableStreamDefaultReader<Uint8Array>[] = [];
+    for (let i = 0; i < 10; i++) {
+      const stream = await streamer.streams.get('run_1', 'stream-open');
+      readers.push(stream.getReader());
+      // Consume the persisted chunk; the reader keeps waiting for more.
+      await readers[i].read();
+    }
+    expect(listenerCount('stream-open')).toBe(10);
+
+    await streamer.close();
+    expect(listenerCount('stream-open')).toBe(0);
+  });
+
+  it('still cleans up on explicit consumer cancellation', async () => {
+    const drizzle = createFakeDrizzle(async () => []);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    try {
+      const stream = await streamer.streams.get('run_1', 'stream-cancel');
+      const reader = stream.getReader();
+      expect(listenerCount('stream-cancel')).toBe(1);
+      await reader.cancel();
+      expect(listenerCount('stream-cancel')).toBe(0);
+    } finally {
+      await streamer.close();
+    }
+  });
+});

--- a/packages/world-postgres/src/streamer.ts
+++ b/packages/world-postgres/src/streamer.ts
@@ -93,6 +93,9 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
   const { streams } = Schema;
   const genChunkId = () => `chnk_${ulid()}` as const;
   const mutexes = new Map<string, Rc<{ drop(): void; mutex: Mutex }>>();
+  // Idempotent cleanup functions for active stream readers, so that
+  // `close()` can detach any listeners still registered on `events`.
+  const readerCleanups = new Set<() => void>();
   const getMutex = (key: string) => {
     let mutex = mutexes.get(key);
     if (!mutex) {
@@ -353,6 +356,14 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
         startIndex?: number
       ): Promise<ReadableStream<Uint8Array>> {
         const cleanups: (() => void)[] = [];
+        let cleanedUp = false;
+        const cleanup = () => {
+          if (cleanedUp) return;
+          cleanedUp = true;
+          readerCleanups.delete(cleanup);
+          cleanups.forEach((fn) => void fn());
+        };
+        readerCleanups.add(cleanup);
 
         return new ReadableStream<Uint8Array>({
           async start(controller) {
@@ -381,6 +392,7 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
                 controller.enqueue(new Uint8Array(msg.data));
               }
               if (msg.eof) {
+                cleanup();
                 controller.close();
               }
               lastChunkId = msg.id;
@@ -398,15 +410,21 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
               events.off(`strm:${name}`, onData);
             });
 
-            const chunks = await drizzle
-              .select({
-                id: streams.chunkId,
-                eof: streams.eof,
-                data: streams.chunkData,
-              })
-              .from(streams)
-              .where(and(eq(streams.streamId, name)))
-              .orderBy(streams.chunkId);
+            let chunks: StreamChunkEvent[];
+            try {
+              chunks = await drizzle
+                .select({
+                  id: streams.chunkId,
+                  eof: streams.eof,
+                  data: streams.chunkData,
+                })
+                .from(streams)
+                .where(and(eq(streams.streamId, name)))
+                .orderBy(streams.chunkId);
+            } catch (err) {
+              cleanup();
+              throw err;
+            }
 
             // Resolve negative offset relative to the data chunk count
             // (excluding the trailing EOF marker, if present)
@@ -424,7 +442,7 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
             buffer = null;
           },
           cancel() {
-            cleanups.forEach((fn) => void fn());
+            cleanup();
           },
         });
       },
@@ -441,6 +459,9 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
     },
 
     async close() {
+      for (const cleanup of [...readerCleanups]) {
+        cleanup();
+      }
       const sub = await listenSubscription.catch(() => undefined);
       if (sub) await sub.close();
     },


### PR DESCRIPTION
Fixes #3120

## What

`world-postgres` stream readers registered an `events.on('strm:<name>', onData)` listener whose cleanup only ran on explicit `ReadableStream.cancel()`. EOF close, initial-query rejection, and `createStreamer().close()` all left listeners attached, so repeated reads of a completed or failing stream accumulated listeners until `MaxListenersExceededWarning`, and closed readers were retained.

Each reader now owns a single idempotent cleanup invoked from all four terminal paths, and the streamer tracks active reader cleanups so `close()` detaches everything that remains. No public API changes.

## Tests

Mock-based unit tests (fake pg client, no live Postgres) assert listener counts return to zero on all four paths, including 12 repeated EOF reads with no warnings. With the fix stashed, 3 of the 4 new tests fail with exactly the leaked counts; with it, the package suite is 30/30. Typecheck and biome clean.

Credit to @Jiarui-Ni for the detailed report in #3120.
