### PR TITLE
feat(web,web-shared): redesign Streams view on the run detail page

### DIFF
--- a/.changeset/streams-chunk-copy.md
+++ b/.changeset/streams-chunk-copy.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': minor
+---
+
+Add copy buttons to the Streams view: per-chunk copy on hover in the chunk ledger, and copy on non-text JSON blocks in the Text view.

--- a/.changeset/streams-header-bar-back.md
+++ b/.changeset/streams-header-bar-back.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Restore the Streams viewer header bar with the live indicator and view toggle; the floating overlay read as detached chrome.

--- a/.changeset/streams-header-simplify.md
+++ b/.changeset/streams-header-simplify.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Drop the stream identity cluster from the Streams viewer header — the sidebar owns identity and selection, so the header keeps only live state, chunk count, and the view toggle.

--- a/.changeset/streams-id-copy-truncate.md
+++ b/.changeset/streams-id-copy-truncate.md
@@ -1,0 +1,6 @@
+---
+'@workflow/web-shared': minor
+'@workflow/web': patch
+---
+
+Render stream IDs middle-truncated at the same size as their labels, with copy actions in the Streams sidebar and viewer header; export `CopyButton` and `MiddleTruncate` from `@workflow/web-shared`.

--- a/.changeset/streams-no-chunk-index.md
+++ b/.changeset/streams-no-chunk-index.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Drop the numeric index gutter from the chunk ledger and the `[n]` prefix from non-text JSON blocks in the Streams view.

--- a/.changeset/streams-remove-counts.md
+++ b/.changeset/streams-remove-counts.md
@@ -1,0 +1,6 @@
+---
+'@workflow/web-shared': patch
+'@workflow/web': patch
+---
+
+Remove the stream count from the Streams sidebar header and the chunk count from the Streams viewer header.

--- a/.changeset/streams-remove-header-bar.md
+++ b/.changeset/streams-remove-header-bar.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Remove the Streams viewer header bar; the live indicator and view toggle now float at the top-right of the content, which runs edge to edge.

--- a/.changeset/streams-sidebar-labels.md
+++ b/.changeset/streams-sidebar-labels.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': minor
+---
+
+Show decoded stream names in the run detail Streams sidebar and auto-select the first stream when the tab opens.

--- a/.changeset/streams-trace-design-match.md
+++ b/.changeset/streams-trace-design-match.md
@@ -1,0 +1,6 @@
+---
+'@workflow/web-shared': patch
+'@workflow/web': patch
+---
+
+Align the Streams tab chrome with the trace view: full-bleed flat panels, hairline `gray-alpha-400` borders, `h-10` header bars, and flat sidebar rows without card rounding or filled surfaces.

--- a/.changeset/streams-view-redesign.md
+++ b/.changeset/streams-view-redesign.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': minor
+---
+
+Redesign the stream viewer: decoded stream identity in the header, a reassembled Text view for text streams with follow-scroll and a jump-to-latest action, and a quieter hairline chunk ledger.

--- a/.changeset/streams-width-padding.md
+++ b/.changeset/streams-width-padding.md
@@ -1,0 +1,6 @@
+---
+'@workflow/web-shared': patch
+'@workflow/web': patch
+---
+
+Widen the Streams sidebar to 340px (the trace event list's default width) and align the Streams tab's header bars and content padding to the page's 24px grid.

--- a/packages/web-shared/src/components/index.ts
+++ b/packages/web-shared/src/components/index.ts
@@ -13,6 +13,8 @@ export {
   ResolveHookModal,
   useHookActions,
 } from './hook-actions';
+export { CopyButton } from './new-trace-viewer/components/copy-button';
+export { MiddleTruncate } from './new-trace-viewer/components/middle-truncate/middle-truncate';
 export { TraceViewerSkeleton } from './new-trace-viewer/components/trace-viewer-skeleton';
 export { RunTraceView } from './run-trace-view';
 export { ConversationView } from './sidebar/conversation-view';

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -96,7 +96,7 @@ function ViewToggle({
     { id: 'text', label: 'Text' },
   ];
   return (
-    <div className="flex overflow-hidden rounded-md border border-gray-alpha-400 divide-x divide-gray-alpha-400 bg-background-100 shadow-sm">
+    <div className="flex overflow-hidden rounded-md border border-gray-alpha-400 divide-x divide-gray-alpha-400">
       {modes.map((mode) => {
         const active = view === mode.id;
         return (
@@ -411,10 +411,10 @@ function ErrorState({ error }: { error: string }) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Floating view controls — top-right overlay so the content runs edge to edge
+// Header bar — stream state and view controls; identity lives in the sidebar
 // ──────────────────────────────────────────────────────────────────────────
 
-function ViewControls({
+function StreamHeader({
   isLive,
   showViewToggle,
   view,
@@ -425,9 +425,8 @@ function ViewControls({
   view: ViewMode;
   onViewChange: (view: ViewMode) => void;
 }) {
-  if (!isLive && !showViewToggle) return null;
   return (
-    <div className="absolute right-4 top-2 z-10 flex items-center gap-3">
+    <div className="flex h-10 min-h-10 flex-none items-center justify-end gap-3 border-b border-gray-alpha-400 pl-4 pr-2">
       {isLive && <LiveIndicator />}
       {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}
     </div>
@@ -501,8 +500,14 @@ export function StreamViewer({
   const view = chosenView ?? defaultView;
 
   return (
-    <div className="relative h-full">
-      <div className="h-full min-h-0">
+    <div className="flex flex-col h-full">
+      <StreamHeader
+        isLive={isLive}
+        showViewToggle={hasTextChunks}
+        view={view}
+        onViewChange={setChosenView}
+      />
+      <div className="flex-1 min-h-0">
         <StreamContent
           error={error}
           isInitialLoad={Boolean(isLoading) && chunks.length === 0}
@@ -513,14 +518,6 @@ export function StreamViewer({
           onScrollEnd={onScrollEnd}
         />
       </div>
-      {chunks.length > 0 && (
-        <ViewControls
-          isLive={isLive}
-          showViewToggle={hasTextChunks}
-          view={view}
-          onViewChange={setChosenView}
-        />
-      )}
     </div>
   );
 }

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -97,11 +97,8 @@ function ViewToggle({
     { id: 'text', label: 'Text' },
   ];
   return (
-    <div
-      className="flex overflow-hidden rounded-md border"
-      style={{ borderColor: 'var(--ds-gray-300)' }}
-    >
-      {modes.map((mode, i) => {
+    <div className="flex overflow-hidden rounded-md border border-gray-alpha-400 divide-x divide-gray-alpha-400">
+      {modes.map((mode) => {
         const active = view === mode.id;
         return (
           <button
@@ -111,10 +108,9 @@ function ViewToggle({
             onClick={() => onChange(mode.id)}
             className="px-2 py-1 text-[11px] transition-colors"
             style={{
-              backgroundColor: active ? 'var(--ds-gray-200)' : 'transparent',
+              backgroundColor: active ? 'var(--ds-gray-100)' : 'transparent',
               color: active ? 'var(--ds-gray-1000)' : 'var(--ds-gray-700)',
               fontWeight: active ? 500 : 400,
-              borderLeft: i > 0 ? '1px solid var(--ds-gray-300)' : undefined,
             }}
           >
             {mode.label}
@@ -134,11 +130,8 @@ function JumpToLatest({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[11px] font-medium"
+      className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full border border-gray-alpha-400 px-3 py-1.5 text-[11px] font-medium bg-background-100 text-gray-1000"
       style={{
-        borderColor: 'var(--ds-gray-300)',
-        backgroundColor: 'var(--ds-background-100)',
-        color: 'var(--ds-gray-1000)',
         boxShadow: 'var(--ds-shadow-small)',
       }}
     >
@@ -163,7 +156,7 @@ const ChunkRow = React.memo(function ChunkRow({
 }) {
   return (
     <div
-      className="group flex items-start gap-3 px-1 py-2"
+      className="group flex items-start gap-3 pl-4 pr-2 py-2"
       style={
         isLast ? undefined : { borderBottom: '1px solid var(--ds-gray-200)' }
       }
@@ -320,7 +313,7 @@ function TextView({ chunks }: { chunks: Chunk[] }) {
         className="h-full overflow-auto"
       >
         <div
-          className="whitespace-pre-wrap break-words py-1 pr-3 text-[13px] leading-[1.65]"
+          className="whitespace-pre-wrap break-words py-2 pl-4 pr-3 text-[13px] leading-[1.65]"
           style={{ color: 'var(--ds-gray-1000)' }}
         >
           {chunks.map((chunk, index) =>
@@ -329,11 +322,7 @@ function TextView({ chunks }: { chunks: Chunk[] }) {
             ) : (
               <div
                 key={chunk.id}
-                className="my-2 rounded-md border px-3 py-2"
-                style={{
-                  borderColor: 'var(--ds-gray-300)',
-                  backgroundColor: 'var(--ds-background-200)',
-                }}
+                className="my-2 border border-gray-alpha-400 px-3 py-2"
               >
                 <div className="mb-1 flex items-center justify-between gap-2">
                   <span
@@ -369,9 +358,9 @@ function TextView({ chunks }: { chunks: Chunk[] }) {
 
 function StreamSkeleton() {
   return (
-    <div className="flex flex-col gap-4 animate-in fade-in pt-1">
+    <div className="flex flex-col gap-4 animate-in fade-in pt-2 pl-4 pr-2">
       {[1, 2, 3, 4].map((i) => (
-        <div key={i} className="flex items-start gap-3 px-1">
+        <div key={i} className="flex items-start gap-3">
           <Skeleton style={{ width: 36, height: 12, borderRadius: 4 }} />
           <Skeleton style={{ flex: 1, height: 12, borderRadius: 4 }} />
         </div>
@@ -410,10 +399,9 @@ function EmptyState({ isLive }: { isLive: boolean }) {
 function ErrorState({ error }: { error: string }) {
   return (
     <div
-      className="text-[11px] rounded-md border p-3"
+      className="text-[11px] border p-3 mx-4 mt-2"
       style={{
         borderColor: 'var(--ds-red-300)',
-        backgroundColor: 'var(--ds-red-100)',
         color: 'var(--ds-red-700)',
       }}
     >
@@ -444,30 +432,25 @@ function StreamHeader({
 }) {
   const description = describeStreamId(streamId);
   return (
-    <div className="flex flex-none items-center justify-between gap-4 pb-2">
-      <div className="min-w-0">
-        <div
-          className={`truncate text-[13px] font-medium ${description.kind === 'user-named' ? 'font-mono' : ''}`}
-          style={{ color: 'var(--ds-gray-1000)' }}
+    <div className="flex h-10 min-h-10 flex-none items-center justify-between gap-4 border-b border-gray-alpha-400 pl-4 pr-2">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <span
+          className={`truncate text-label-14 text-gray-1000 ${description.kind === 'user-named' ? 'font-mono' : ''}`}
         >
           {description.label}
-        </div>
+        </span>
         {description.label !== streamId && (
-          <div
-            className="mt-0.5 truncate font-mono text-[11px]"
-            style={{ color: 'var(--ds-gray-700)' }}
+          <span
+            className="truncate font-mono text-[11px] text-gray-700"
             title={streamId}
           >
             {streamId}
-          </div>
+          </span>
         )}
       </div>
       <div className="flex flex-none items-center gap-3">
         {isLive && <LiveIndicator />}
-        <span
-          className="text-xs tabular-nums"
-          style={{ color: 'var(--ds-gray-900)' }}
-        >
+        <span className="text-xs tabular-nums text-gray-900">
           {chunkCount} {chunkCount === 1 ? 'chunk' : 'chunks'}
         </span>
         {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import { ArrowDown } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
+import { describeStreamId } from '../lib/stream-id';
 import { DataInspector } from './ui/data-inspector';
 import { Skeleton } from './ui/skeleton';
 
@@ -16,6 +18,8 @@ export interface StreamChunk {
 
 type Chunk = StreamChunk;
 
+type ViewMode = 'chunks' | 'text';
+
 interface StreamViewerProps {
   streamId: string;
   chunks: Chunk[];
@@ -27,6 +31,122 @@ interface StreamViewerProps {
   onScrollEnd?: () => void;
 }
 
+const DOT_PULSE_KEYFRAMES = `@keyframes workflow-dot-pulse{0%{transform:scale(1);opacity:.7}70%,100%{transform:scale(2.2);opacity:0}}@media (prefers-reduced-motion:reduce){.workflow-dot-pulse-ring{animation:none!important}}`;
+const DOT_PULSE_ANIMATION =
+  'workflow-dot-pulse 1.25s cubic-bezier(0, 0, 0.2, 1) infinite';
+const AT_BOTTOM_THRESHOLD_PX = 32;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+function stringifyChunkValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    const json = JSON.stringify(value, null, 2);
+    if (json !== undefined) return json;
+  } catch {
+    // Fall through to String() for unserializable values
+  }
+  return String(value);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Live indicator
+// ──────────────────────────────────────────────────────────────────────────
+
+function LiveIndicator() {
+  return (
+    <span className="flex items-center gap-1.5">
+      <style>{DOT_PULSE_KEYFRAMES}</style>
+      <span className="relative inline-block h-2 w-2">
+        <span
+          className="workflow-dot-pulse-ring absolute inset-0 rounded-full"
+          style={{
+            backgroundColor: 'var(--ds-green-600)',
+            opacity: 0.75,
+            animation: DOT_PULSE_ANIMATION,
+          }}
+        />
+        <span
+          className="relative block h-2 w-2 rounded-full"
+          style={{ backgroundColor: 'var(--ds-green-700)' }}
+        />
+      </span>
+      <span className="text-xs" style={{ color: 'var(--ds-green-700)' }}>
+        Live
+      </span>
+    </span>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// View toggle
+// ──────────────────────────────────────────────────────────────────────────
+
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: ViewMode;
+  onChange: (view: ViewMode) => void;
+}) {
+  const modes: { id: ViewMode; label: string }[] = [
+    { id: 'chunks', label: 'Chunks' },
+    { id: 'text', label: 'Text' },
+  ];
+  return (
+    <div
+      className="flex overflow-hidden rounded-md border"
+      style={{ borderColor: 'var(--ds-gray-300)' }}
+    >
+      {modes.map((mode, i) => {
+        const active = view === mode.id;
+        return (
+          <button
+            key={mode.id}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(mode.id)}
+            className="px-2 py-1 text-[11px] transition-colors"
+            style={{
+              backgroundColor: active ? 'var(--ds-gray-200)' : 'transparent',
+              color: active ? 'var(--ds-gray-1000)' : 'var(--ds-gray-700)',
+              fontWeight: active ? 500 : 400,
+              borderLeft: i > 0 ? '1px solid var(--ds-gray-300)' : undefined,
+            }}
+          >
+            {mode.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Jump-to-latest floating action
+// ──────────────────────────────────────────────────────────────────────────
+
+function JumpToLatest({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[11px] font-medium"
+      style={{
+        borderColor: 'var(--ds-gray-300)',
+        backgroundColor: 'var(--ds-background-100)',
+        color: 'var(--ds-gray-1000)',
+        boxShadow: 'var(--ds-shadow-small)',
+      }}
+    >
+      <ArrowDown className="h-3 w-3" />
+      New chunks
+    </button>
+  );
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Chunk row — memoized to prevent remounts during polling
 // ──────────────────────────────────────────────────────────────────────────
@@ -34,41 +154,202 @@ interface StreamViewerProps {
 const ChunkRow = React.memo(function ChunkRow({
   chunk,
   index,
+  isLast,
 }: {
   chunk: Chunk;
   index: number;
+  isLast: boolean;
 }) {
   return (
     <div
-      className="text-[11px] rounded-md border p-3"
-      style={{
-        borderColor: 'var(--ds-gray-300)',
-        backgroundColor: 'var(--ds-gray-100)',
-      }}
+      className="flex items-start gap-3 px-1 py-2"
+      style={
+        isLast ? undefined : { borderBottom: '1px solid var(--ds-gray-200)' }
+      }
     >
-      <div className="flex items-start gap-2">
-        <span
-          className="select-none pt-px"
-          style={{ color: 'var(--ds-gray-500)' }}
-        >
-          [{index}]
-        </span>
-        <div className="min-w-0 flex-1">
-          {typeof chunk.value === 'string' ? (
-            <span
-              className="whitespace-pre-wrap break-words"
-              style={{ color: 'var(--ds-gray-1000)' }}
-            >
-              {chunk.value}
-            </span>
-          ) : (
-            <DataInspector data={chunk.value} expandLevel={1} />
-          )}
-        </div>
+      <span
+        className="w-9 flex-none select-none pt-0.5 text-right font-mono text-[11px] tabular-nums"
+        style={{ color: 'var(--ds-gray-600)' }}
+      >
+        {index}
+      </span>
+      <div className="min-w-0 flex-1 text-xs leading-[1.55]">
+        {typeof chunk.value === 'string' ? (
+          <span
+            className="whitespace-pre-wrap break-words"
+            style={{ color: 'var(--ds-gray-1000)' }}
+          >
+            {chunk.value}
+          </span>
+        ) : (
+          <DataInspector data={chunk.value} expandLevel={1} />
+        )}
       </div>
     </div>
   );
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// Chunks view — virtualized ledger of raw chunks
+// ──────────────────────────────────────────────────────────────────────────
+
+function ChunksView({
+  chunks,
+  onScrollEnd,
+}: {
+  chunks: Chunk[];
+  onScrollEnd?: () => void;
+}) {
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const atBottomRef = useRef(true);
+  const prevChunkCountRef = useRef(0);
+  const [showJumpToLatest, setShowJumpToLatest] = useState(false);
+
+  // Follow the tail only while the reader is already at the bottom; when
+  // they have scrolled up to inspect earlier chunks, offer a jump action
+  // instead of yanking the scroll position.
+  useEffect(() => {
+    const grew = chunks.length > prevChunkCountRef.current;
+    prevChunkCountRef.current = chunks.length;
+    if (!grew || chunks.length === 0) return;
+    if (atBottomRef.current) {
+      virtuosoRef.current?.scrollToIndex({
+        index: chunks.length - 1,
+        align: 'end',
+      });
+    } else {
+      setShowJumpToLatest(true);
+    }
+  }, [chunks.length]);
+
+  const scrollToLatest = () => {
+    virtuosoRef.current?.scrollToIndex({
+      index: chunks.length - 1,
+      align: 'end',
+    });
+    setShowJumpToLatest(false);
+  };
+
+  return (
+    <div className="relative h-full">
+      <Virtuoso
+        ref={virtuosoRef}
+        totalCount={chunks.length}
+        overscan={10}
+        endReached={() => onScrollEnd?.()}
+        atBottomStateChange={(atBottom) => {
+          atBottomRef.current = atBottom;
+          if (atBottom) setShowJumpToLatest(false);
+        }}
+        itemContent={(index) => (
+          <ChunkRow
+            chunk={chunks[index]}
+            index={index}
+            isLast={index === chunks.length - 1}
+          />
+        )}
+        style={{ height: '100%' }}
+      />
+      {showJumpToLatest && <JumpToLatest onClick={scrollToLatest} />}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Text view — string chunks reassembled into a readable transcript;
+// non-text chunks stay inspectable as quiet JSON blocks
+// ──────────────────────────────────────────────────────────────────────────
+
+function TextView({ chunks }: { chunks: Chunk[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const atBottomRef = useRef(true);
+  const prevChunkCountRef = useRef(0);
+  const [showJumpToLatest, setShowJumpToLatest] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) {
+      atBottomRef.current =
+        el.scrollHeight - el.scrollTop - el.clientHeight <
+        AT_BOTTOM_THRESHOLD_PX;
+    }
+  }, []);
+
+  useEffect(() => {
+    const prevCount = prevChunkCountRef.current;
+    prevChunkCountRef.current = chunks.length;
+    // The first content batch is the initial load, not new data: stay at
+    // the reading position instead of prompting or scrolling.
+    if (prevCount === 0) return;
+    if (chunks.length <= prevCount) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    if (atBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    } else {
+      setShowJumpToLatest(true);
+    }
+  }, [chunks.length]);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight < AT_BOTTOM_THRESHOLD_PX;
+    atBottomRef.current = atBottom;
+    if (atBottom) setShowJumpToLatest(false);
+  };
+
+  const scrollToLatest = () => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+    setShowJumpToLatest(false);
+  };
+
+  return (
+    <div className="relative h-full">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="h-full overflow-auto"
+      >
+        <div
+          className="whitespace-pre-wrap break-words py-1 pr-3 text-[13px] leading-[1.65]"
+          style={{ color: 'var(--ds-gray-1000)' }}
+        >
+          {chunks.map((chunk, index) =>
+            typeof chunk.value === 'string' ? (
+              <React.Fragment key={chunk.id}>{chunk.value}</React.Fragment>
+            ) : (
+              <div
+                key={chunk.id}
+                className="my-2 rounded-md border px-3 py-2"
+                style={{
+                  borderColor: 'var(--ds-gray-300)',
+                  backgroundColor: 'var(--ds-background-200)',
+                }}
+              >
+                <div
+                  className="mb-1 font-mono text-[11px] tabular-nums"
+                  style={{ color: 'var(--ds-gray-600)' }}
+                >
+                  [{index}] non-text chunk
+                </div>
+                <pre
+                  className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[1.55]"
+                  style={{ color: 'var(--ds-gray-900)' }}
+                >
+                  {stringifyChunkValue(chunk.value)}
+                </pre>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+      {showJumpToLatest && <JumpToLatest onClick={scrollToLatest} />}
+    </div>
+  );
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Skeleton loading
@@ -76,13 +357,147 @@ const ChunkRow = React.memo(function ChunkRow({
 
 function StreamSkeleton() {
   return (
-    <div className="flex flex-col gap-3 animate-in fade-in">
-      <Skeleton style={{ width: 120, height: 16, borderRadius: 4 }} />
+    <div className="flex flex-col gap-4 animate-in fade-in pt-1">
       {[1, 2, 3, 4].map((i) => (
-        <Skeleton key={i} style={{ height: 56, borderRadius: 6 }} />
+        <div key={i} className="flex items-start gap-3 px-1">
+          <Skeleton style={{ width: 36, height: 12, borderRadius: 4 }} />
+          <Skeleton style={{ flex: 1, height: 12, borderRadius: 4 }} />
+        </div>
       ))}
     </div>
   );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Empty state
+// ──────────────────────────────────────────────────────────────────────────
+
+function EmptyState({ isLive }: { isLive: boolean }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      {isLive ? (
+        <span
+          className="flex items-center gap-1.5 text-xs"
+          style={{ color: 'var(--ds-gray-700)' }}
+        >
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: 'var(--ds-green-600)' }}
+          />
+          Waiting for stream data…
+        </span>
+      ) : (
+        <span className="text-xs" style={{ color: 'var(--ds-gray-600)' }}>
+          Stream is empty
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ErrorState({ error }: { error: string }) {
+  return (
+    <div
+      className="text-[11px] rounded-md border p-3"
+      style={{
+        borderColor: 'var(--ds-red-300)',
+        backgroundColor: 'var(--ds-red-100)',
+        color: 'var(--ds-red-700)',
+      }}
+    >
+      <div>Error reading stream:</div>
+      <div>{error}</div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Header — stream identity on the left, state and view controls on the right
+// ──────────────────────────────────────────────────────────────────────────
+
+function StreamHeader({
+  streamId,
+  chunkCount,
+  isLive,
+  showViewToggle,
+  view,
+  onViewChange,
+}: {
+  streamId: string;
+  chunkCount: number;
+  isLive: boolean;
+  showViewToggle: boolean;
+  view: ViewMode;
+  onViewChange: (view: ViewMode) => void;
+}) {
+  const description = describeStreamId(streamId);
+  return (
+    <div className="flex flex-none items-center justify-between gap-4 pb-2">
+      <div className="min-w-0">
+        <div
+          className={`truncate text-[13px] font-medium ${description.kind === 'user-named' ? 'font-mono' : ''}`}
+          style={{ color: 'var(--ds-gray-1000)' }}
+        >
+          {description.label}
+        </div>
+        {description.label !== streamId && (
+          <div
+            className="mt-0.5 truncate font-mono text-[11px]"
+            style={{ color: 'var(--ds-gray-700)' }}
+            title={streamId}
+          >
+            {streamId}
+          </div>
+        )}
+      </div>
+      <div className="flex flex-none items-center gap-3">
+        {isLive && <LiveIndicator />}
+        <span
+          className="text-xs tabular-nums"
+          style={{ color: 'var(--ds-gray-900)' }}
+        >
+          {chunkCount} {chunkCount === 1 ? 'chunk' : 'chunks'}
+        </span>
+        {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Content routing
+// ──────────────────────────────────────────────────────────────────────────
+
+function StreamContent({
+  error,
+  isInitialLoad,
+  isLive,
+  chunks,
+  view,
+  hasTextChunks,
+  onScrollEnd,
+}: {
+  error?: string | null;
+  isInitialLoad: boolean;
+  isLive: boolean;
+  chunks: Chunk[];
+  view: ViewMode;
+  hasTextChunks: boolean;
+  onScrollEnd?: () => void;
+}) {
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+  if (isInitialLoad) {
+    return <StreamSkeleton />;
+  }
+  if (chunks.length === 0) {
+    return <EmptyState isLive={isLive} />;
+  }
+  if (view === 'text' && hasTextChunks) {
+    return <TextView chunks={chunks} />;
+  }
+  return <ChunksView chunks={chunks} onScrollEnd={onScrollEnd} />;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -95,108 +510,46 @@ function StreamSkeleton() {
  * of complex types (Map, Set, Date, custom classes, etc.).
  */
 export function StreamViewer({
-  streamId: _streamId,
+  streamId,
   chunks,
   isLive,
   error,
   isLoading,
   onScrollEnd,
 }: StreamViewerProps) {
-  const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const prevChunkCountRef = useRef(0);
+  const hasTextChunks = chunks.some((chunk) => typeof chunk.value === 'string');
 
-  // Auto-scroll to bottom when new chunks arrive (live streaming)
-  useEffect(() => {
-    if (chunks.length > prevChunkCountRef.current && chunks.length > 0) {
-      virtuosoRef.current?.scrollToIndex({
-        index: chunks.length - 1,
-        align: 'end',
-      });
-    }
-    prevChunkCountRef.current = chunks.length;
-  }, [chunks.length]);
-
-  // Show skeleton when loading and no chunks have arrived yet
-  if (isLoading && chunks.length === 0) {
-    return (
-      <div className="flex flex-col h-full">
-        <StreamSkeleton />
-      </div>
-    );
-  }
+  // Text-first default for streams that open with string chunks (the common
+  // AI text-streaming case); the reader can always switch back to the raw
+  // chunk ledger. Evaluated from the first chunk so the default never
+  // flips while reading.
+  const [chosenView, setChosenView] = useState<ViewMode | null>(null);
+  const defaultView: ViewMode =
+    chunks.length > 0 && typeof chunks[0].value === 'string'
+      ? 'text'
+      : 'chunks';
+  const view = chosenView ?? defaultView;
 
   return (
     <div className="flex flex-col h-full">
-      {/* Live indicator */}
-      {isLive && (
-        <div className="flex items-center gap-1.5 mb-2 px-1">
-          <span
-            className="inline-block w-2 h-2 rounded-full"
-            style={{ backgroundColor: 'var(--ds-green-600)' }}
-          />
-          <span className="text-xs" style={{ color: 'var(--ds-green-700)' }}>
-            Live
-          </span>
-        </div>
-      )}
-
-      {/* Header */}
-      {chunks.length > 0 && (
-        <div className="flex items-center gap-2 mb-2 px-1">
-          <span
-            className="text-[13px] font-medium"
-            style={{ color: 'var(--ds-gray-900)' }}
-          >
-            Stream Chunks
-          </span>
-          <span
-            className="text-xs tabular-nums"
-            style={{ color: 'var(--ds-gray-600)' }}
-          >
-            ({chunks.length})
-          </span>
-        </div>
-      )}
-
-      {/* Content */}
+      <StreamHeader
+        streamId={streamId}
+        chunkCount={chunks.length}
+        isLive={isLive}
+        showViewToggle={hasTextChunks}
+        view={view}
+        onViewChange={setChosenView}
+      />
       <div className="flex-1 min-h-0">
-        {error ? (
-          <div
-            className="text-[11px] rounded-md border p-3"
-            style={{
-              borderColor: 'var(--ds-red-300)',
-              backgroundColor: 'var(--ds-red-100)',
-              color: 'var(--ds-red-700)',
-            }}
-          >
-            <div>Error reading stream:</div>
-            <div>{error}</div>
-          </div>
-        ) : chunks.length === 0 ? (
-          <div
-            className="text-[11px] rounded-md border p-3"
-            style={{
-              borderColor: 'var(--ds-gray-300)',
-              backgroundColor: 'var(--ds-gray-100)',
-              color: 'var(--ds-gray-600)',
-            }}
-          >
-            {isLive ? 'Waiting for stream data...' : 'Stream is empty'}
-          </div>
-        ) : (
-          <Virtuoso
-            ref={virtuosoRef}
-            totalCount={chunks.length}
-            overscan={10}
-            endReached={() => onScrollEnd?.()}
-            itemContent={(index) => (
-              <div style={{ paddingBottom: 8 }}>
-                <ChunkRow chunk={chunks[index]} index={index} />
-              </div>
-            )}
-            style={{ flex: 1, minHeight: 0 }}
-          />
-        )}
+        <StreamContent
+          error={error}
+          isInitialLoad={Boolean(isLoading) && chunks.length === 0}
+          isLive={isLive}
+          chunks={chunks}
+          view={view}
+          hasTextChunks={hasTextChunks}
+          onScrollEnd={onScrollEnd}
+        />
       </div>
     </div>
   );

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -96,7 +96,7 @@ function ViewToggle({
     { id: 'text', label: 'Text' },
   ];
   return (
-    <div className="flex overflow-hidden rounded-md border border-gray-alpha-400 divide-x divide-gray-alpha-400">
+    <div className="flex overflow-hidden rounded-md border border-gray-alpha-400 divide-x divide-gray-alpha-400 bg-background-100 shadow-sm">
       {modes.map((mode) => {
         const active = view === mode.id;
         return (
@@ -411,10 +411,10 @@ function ErrorState({ error }: { error: string }) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Header bar — stream state and view controls; identity lives in the sidebar
+// Floating view controls — top-right overlay so the content runs edge to edge
 // ──────────────────────────────────────────────────────────────────────────
 
-function StreamHeader({
+function ViewControls({
   isLive,
   showViewToggle,
   view,
@@ -425,8 +425,9 @@ function StreamHeader({
   view: ViewMode;
   onViewChange: (view: ViewMode) => void;
 }) {
+  if (!isLive && !showViewToggle) return null;
   return (
-    <div className="flex h-10 min-h-10 flex-none items-center justify-end gap-3 border-b border-gray-alpha-400 pl-4 pr-2">
+    <div className="absolute right-4 top-2 z-10 flex items-center gap-3">
       {isLive && <LiveIndicator />}
       {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}
     </div>
@@ -500,14 +501,8 @@ export function StreamViewer({
   const view = chosenView ?? defaultView;
 
   return (
-    <div className="flex flex-col h-full">
-      <StreamHeader
-        isLive={isLive}
-        showViewToggle={hasTextChunks}
-        view={view}
-        onViewChange={setChosenView}
-      />
-      <div className="flex-1 min-h-0">
+    <div className="relative h-full">
+      <div className="h-full min-h-0">
         <StreamContent
           error={error}
           isInitialLoad={Boolean(isLoading) && chunks.length === 0}
@@ -518,6 +513,14 @@ export function StreamViewer({
           onScrollEnd={onScrollEnd}
         />
       </div>
+      {chunks.length > 0 && (
+        <ViewControls
+          isLive={isLive}
+          showViewToggle={hasTextChunks}
+          view={view}
+          onViewChange={setChosenView}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -160,12 +160,6 @@ const ChunkRow = React.memo(function ChunkRow({
         isLast ? undefined : { borderBottom: '1px solid var(--ds-gray-200)' }
       }
     >
-      <span
-        className="w-9 flex-none select-none pt-0.5 text-right font-mono text-[11px] tabular-nums"
-        style={{ color: 'var(--ds-gray-600)' }}
-      >
-        {index}
-      </span>
       <div className="min-w-0 flex-1 text-xs leading-[1.55]">
         {typeof chunk.value === 'string' ? (
           <span
@@ -325,10 +319,10 @@ function TextView({ chunks }: { chunks: Chunk[] }) {
               >
                 <div className="mb-1 flex items-center justify-between gap-2">
                   <span
-                    className="font-mono text-[11px] tabular-nums"
+                    className="font-mono text-[11px]"
                     style={{ color: 'var(--ds-gray-600)' }}
                   >
-                    [{index}] non-text chunk
+                    Non-text chunk
                   </span>
                   <CopyButton
                     copyText={stringifyChunkValue(chunk.value)}
@@ -359,10 +353,10 @@ function StreamSkeleton() {
   return (
     <div className="flex flex-col gap-4 animate-in fade-in pt-2 pl-6 pr-2">
       {[1, 2, 3, 4].map((i) => (
-        <div key={i} className="flex items-start gap-3">
-          <Skeleton style={{ width: 36, height: 12, borderRadius: 4 }} />
-          <Skeleton style={{ flex: 1, height: 12, borderRadius: 4 }} />
-        </div>
+        <Skeleton
+          key={i}
+          style={{ height: 12, borderRadius: 4, width: `${85 - i * 10}%` }}
+        />
       ))}
     </div>
   );

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -415,13 +415,11 @@ function ErrorState({ error }: { error: string }) {
 // ──────────────────────────────────────────────────────────────────────────
 
 function StreamHeader({
-  chunkCount,
   isLive,
   showViewToggle,
   view,
   onViewChange,
 }: {
-  chunkCount: number;
   isLive: boolean;
   showViewToggle: boolean;
   view: ViewMode;
@@ -430,9 +428,6 @@ function StreamHeader({
   return (
     <div className="flex h-10 min-h-10 flex-none items-center justify-end gap-3 border-b border-gray-alpha-400 pl-4 pr-2">
       {isLive && <LiveIndicator />}
-      <span className="text-xs tabular-nums text-gray-900">
-        {chunkCount} {chunkCount === 1 ? 'chunk' : 'chunks'}
-      </span>
       {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}
     </div>
   );
@@ -507,7 +502,6 @@ export function StreamViewer({
   return (
     <div className="flex flex-col h-full">
       <StreamHeader
-        chunkCount={chunks.length}
         isLive={isLive}
         showViewToggle={hasTextChunks}
         view={view}

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -4,6 +4,7 @@ import { ArrowDown } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { describeStreamId } from '../lib/stream-id';
+import { CopyButton } from './new-trace-viewer/components/copy-button';
 import { DataInspector } from './ui/data-inspector';
 import { Skeleton } from './ui/skeleton';
 
@@ -162,7 +163,7 @@ const ChunkRow = React.memo(function ChunkRow({
 }) {
   return (
     <div
-      className="flex items-start gap-3 px-1 py-2"
+      className="group flex items-start gap-3 px-1 py-2"
       style={
         isLast ? undefined : { borderBottom: '1px solid var(--ds-gray-200)' }
       }
@@ -185,6 +186,11 @@ const ChunkRow = React.memo(function ChunkRow({
           <DataInspector data={chunk.value} expandLevel={1} />
         )}
       </div>
+      <CopyButton
+        copyText={stringifyChunkValue(chunk.value)}
+        ariaLabel={`Copy chunk ${index}`}
+        className="mt-0.5 flex-none opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+      />
     </div>
   );
 });
@@ -329,11 +335,17 @@ function TextView({ chunks }: { chunks: Chunk[] }) {
                   backgroundColor: 'var(--ds-background-200)',
                 }}
               >
-                <div
-                  className="mb-1 font-mono text-[11px] tabular-nums"
-                  style={{ color: 'var(--ds-gray-600)' }}
-                >
-                  [{index}] non-text chunk
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <span
+                    className="font-mono text-[11px] tabular-nums"
+                    style={{ color: 'var(--ds-gray-600)' }}
+                  >
+                    [{index}] non-text chunk
+                  </span>
+                  <CopyButton
+                    copyText={stringifyChunkValue(chunk.value)}
+                    ariaLabel={`Copy chunk ${index} as JSON`}
+                  />
                 </div>
                 <pre
                   className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[1.55]"

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { describeStreamId } from '../lib/stream-id';
 import { CopyButton } from './new-trace-viewer/components/copy-button';
+import { MiddleTruncate } from './new-trace-viewer/components/middle-truncate/middle-truncate';
 import { DataInspector } from './ui/data-inspector';
 import { Skeleton } from './ui/skeleton';
 
@@ -440,11 +441,15 @@ function StreamHeader({
           {description.label}
         </span>
         {description.label !== streamId && (
-          <span
-            className="truncate font-mono text-[11px] text-gray-700"
-            title={streamId}
-          >
-            {streamId}
+          <span className="flex min-w-0 items-center gap-1 font-mono text-[11px] text-gray-700">
+            <span className="min-w-0">
+              <MiddleTruncate value={streamId} />
+            </span>
+            <CopyButton
+              copyText={streamId}
+              ariaLabel={`Copy stream ID ${streamId}`}
+              className="flex-none"
+            />
           </span>
         )}
       </div>

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -3,9 +3,7 @@
 import { ArrowDown } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
-import { describeStreamId } from '../lib/stream-id';
 import { CopyButton } from './new-trace-viewer/components/copy-button';
-import { MiddleTruncate } from './new-trace-viewer/components/middle-truncate/middle-truncate';
 import { DataInspector } from './ui/data-inspector';
 import { Skeleton } from './ui/skeleton';
 
@@ -413,53 +411,29 @@ function ErrorState({ error }: { error: string }) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Header — stream identity on the left, state and view controls on the right
+// Header bar — stream state and view controls; identity lives in the sidebar
 // ──────────────────────────────────────────────────────────────────────────
 
 function StreamHeader({
-  streamId,
   chunkCount,
   isLive,
   showViewToggle,
   view,
   onViewChange,
 }: {
-  streamId: string;
   chunkCount: number;
   isLive: boolean;
   showViewToggle: boolean;
   view: ViewMode;
   onViewChange: (view: ViewMode) => void;
 }) {
-  const description = describeStreamId(streamId);
   return (
-    <div className="flex h-10 min-h-10 flex-none items-center justify-between gap-4 border-b border-gray-alpha-400 pl-4 pr-2">
-      <div className="flex min-w-0 items-baseline gap-2">
-        <span
-          className={`truncate text-label-14 text-gray-1000 ${description.kind === 'user-named' ? 'font-mono' : ''}`}
-        >
-          {description.label}
-        </span>
-        {description.label !== streamId && (
-          <span className="flex min-w-0 items-center gap-1 font-mono text-[11px] text-gray-700">
-            <span className="min-w-0">
-              <MiddleTruncate value={streamId} />
-            </span>
-            <CopyButton
-              copyText={streamId}
-              ariaLabel={`Copy stream ID ${streamId}`}
-              className="flex-none"
-            />
-          </span>
-        )}
-      </div>
-      <div className="flex flex-none items-center gap-3">
-        {isLive && <LiveIndicator />}
-        <span className="text-xs tabular-nums text-gray-900">
-          {chunkCount} {chunkCount === 1 ? 'chunk' : 'chunks'}
-        </span>
-        {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}
-      </div>
+    <div className="flex h-10 min-h-10 flex-none items-center justify-end gap-3 border-b border-gray-alpha-400 pl-4 pr-2">
+      {isLive && <LiveIndicator />}
+      <span className="text-xs tabular-nums text-gray-900">
+        {chunkCount} {chunkCount === 1 ? 'chunk' : 'chunks'}
+      </span>
+      {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}
     </div>
   );
 }
@@ -510,7 +484,7 @@ function StreamContent({
  * of complex types (Map, Set, Date, custom classes, etc.).
  */
 export function StreamViewer({
-  streamId,
+  streamId: _streamId,
   chunks,
   isLive,
   error,
@@ -533,7 +507,6 @@ export function StreamViewer({
   return (
     <div className="flex flex-col h-full">
       <StreamHeader
-        streamId={streamId}
         chunkCount={chunks.length}
         isLive={isLive}
         showViewToggle={hasTextChunks}

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -155,7 +155,7 @@ const ChunkRow = React.memo(function ChunkRow({
 }) {
   return (
     <div
-      className="group flex items-start gap-3 pl-4 pr-2 py-2"
+      className="group flex items-start gap-3 pl-6 pr-2 py-2"
       style={
         isLast ? undefined : { borderBottom: '1px solid var(--ds-gray-200)' }
       }
@@ -312,7 +312,7 @@ function TextView({ chunks }: { chunks: Chunk[] }) {
         className="h-full overflow-auto"
       >
         <div
-          className="whitespace-pre-wrap break-words py-2 pl-4 pr-3 text-[13px] leading-[1.65]"
+          className="whitespace-pre-wrap break-words py-2 pl-6 pr-3 text-[13px] leading-[1.65]"
           style={{ color: 'var(--ds-gray-1000)' }}
         >
           {chunks.map((chunk, index) =>
@@ -357,7 +357,7 @@ function TextView({ chunks }: { chunks: Chunk[] }) {
 
 function StreamSkeleton() {
   return (
-    <div className="flex flex-col gap-4 animate-in fade-in pt-2 pl-4 pr-2">
+    <div className="flex flex-col gap-4 animate-in fade-in pt-2 pl-6 pr-2">
       {[1, 2, 3, 4].map((i) => (
         <div key={i} className="flex items-start gap-3">
           <Skeleton style={{ width: 36, height: 12, borderRadius: 4 }} />
@@ -398,7 +398,7 @@ function EmptyState({ isLive }: { isLive: boolean }) {
 function ErrorState({ error }: { error: string }) {
   return (
     <div
-      className="text-[11px] border p-3 mx-4 mt-2"
+      className="text-[11px] border p-3 mx-6 mt-2"
       style={{
         borderColor: 'var(--ds-red-300)',
         color: 'var(--ds-red-700)',
@@ -426,7 +426,7 @@ function StreamHeader({
   onViewChange: (view: ViewMode) => void;
 }) {
   return (
-    <div className="flex h-10 min-h-10 flex-none items-center justify-end gap-3 border-b border-gray-alpha-400 pl-4 pr-2">
+    <div className="flex h-10 min-h-10 flex-none items-center justify-end gap-3 border-b border-gray-alpha-400 px-6">
       {isLive && <LiveIndicator />}
       {showViewToggle && <ViewToggle view={view} onChange={onViewChange} />}
     </div>

--- a/packages/web-shared/src/index.ts
+++ b/packages/web-shared/src/index.ts
@@ -56,6 +56,8 @@ export {
   truncateId,
 } from './lib/hydration';
 export type { DecodedStreamChunkSource } from './lib/stream-display';
+export type { StreamIdDescription, StreamIdKind } from './lib/stream-id';
+export { describeStreamId } from './lib/stream-id';
 export type { ToastAdapter } from './lib/toast';
 export { ToastProvider, useToast } from './lib/toast';
 export type { StreamStep } from './lib/utils';

--- a/packages/web-shared/src/lib/stream-id.test.ts
+++ b/packages/web-shared/src/lib/stream-id.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { describeStreamId } from './stream-id';
+
+function encodeBase64Url(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+describe('describeStreamId', () => {
+  it('labels the default user stream', () => {
+    expect(describeStreamId('strm_01JXYZABCDEFGHIJKLMNOP_user')).toEqual({
+      kind: 'user-default',
+      label: 'Default stream',
+    });
+  });
+
+  it('decodes the namespace of a named user stream', () => {
+    const id = `strm_01JXYZABCDEFGHIJKLMNOP_user_${encodeBase64Url('my-namespace')}`;
+    expect(describeStreamId(id)).toEqual({
+      kind: 'user-named',
+      label: 'my-namespace',
+      namespace: 'my-namespace',
+    });
+  });
+
+  it('decodes namespaces with characters outside base64', () => {
+    const namespace = 'namespace:with/special@chars é 🎉';
+    const id = `strm_abc123_user_${encodeBase64Url(namespace)}`;
+    expect(describeStreamId(id)).toEqual({
+      kind: 'user-named',
+      label: namespace,
+      namespace,
+    });
+  });
+
+  it('labels abort-signal backing streams as system streams', () => {
+    expect(
+      describeStreamId('strm_01JXYZABCDEFGHIJKLMNOP_system_abort')
+    ).toEqual({
+      kind: 'system',
+      label: 'Abort signal',
+    });
+  });
+
+  it('passes through unrecognized formats verbatim', () => {
+    expect(describeStreamId('__health_check__abc123')).toEqual({
+      kind: 'unknown',
+      label: '__health_check__abc123',
+    });
+    expect(describeStreamId('strm_known')).toEqual({
+      kind: 'unknown',
+      label: 'strm_known',
+    });
+  });
+
+  it('passes through user streams whose namespace fails to decode', () => {
+    expect(describeStreamId('strm_abc123_user_%%%')).toEqual({
+      kind: 'unknown',
+      label: 'strm_abc123_user_%%%',
+    });
+  });
+});

--- a/packages/web-shared/src/lib/stream-id.ts
+++ b/packages/web-shared/src/lib/stream-id.ts
@@ -1,0 +1,70 @@
+/**
+ * Describes opaque stream IDs for display in the observability UI.
+ *
+ * Stream IDs written by the runtime carry a decodable structure
+ * (see `getWorkflowRunStreamId` / `getAbortStreamId` in `@workflow/core`):
+ *
+ * - `strm_<ulid>_user` — the run's default user stream
+ * - `strm_<ulid>_user_<base64url(namespace)>` — a named user stream
+ * - `strm_<id>_system_abort` — a hook's abort-signal backing stream
+ *
+ * Anything else is reported verbatim so future or foreign formats stay
+ * inspectable instead of being mislabeled.
+ */
+
+export type StreamIdKind = 'user-default' | 'user-named' | 'system' | 'unknown';
+
+export interface StreamIdDescription {
+  kind: StreamIdKind;
+  /**
+   * Short human-meaningful name for the stream: the decoded namespace for
+   * named user streams, otherwise a fixed label ("Default stream",
+   * "Abort signal") or the raw ID when the format is unrecognized.
+   */
+  label: string;
+  /** Decoded namespace, present only for `user-named` streams. */
+  namespace?: string;
+}
+
+const STREAM_ID_PATTERN = /^strm_(?<id>[^_]+)_(?<rest>.+)$/;
+const USER_SEGMENT = 'user';
+const ABORT_SUFFIX = 'system_abort';
+
+function decodeBase64Url(encoded: string): string | null {
+  try {
+    const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+export function describeStreamId(streamId: string): StreamIdDescription {
+  const match = STREAM_ID_PATTERN.exec(streamId);
+  if (!match?.groups) {
+    return { kind: 'unknown', label: streamId };
+  }
+
+  const { rest } = match.groups;
+
+  if (rest === ABORT_SUFFIX) {
+    return { kind: 'system', label: 'Abort signal' };
+  }
+
+  if (rest === USER_SEGMENT) {
+    return { kind: 'user-default', label: 'Default stream' };
+  }
+
+  if (rest.startsWith(`${USER_SEGMENT}_`)) {
+    const encoded = rest.slice(USER_SEGMENT.length + 1);
+    const namespace = decodeBase64Url(encoded);
+    if (namespace) {
+      return { kind: 'user-named', label: namespace, namespace };
+    }
+  }
+
+  return { kind: 'unknown', label: streamId };
+}

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -824,23 +824,23 @@ export function RunDetailView({
                 <div className="relative h-full -mx-6 bg-background-100 border-t border-gray-alpha-400 overflow-hidden">
                   <div className="h-full flex min-h-0">
                     {/* Stream list sidebar */}
-                    <div className="w-64 flex-shrink-0 flex flex-col min-h-0 border-r border-gray-alpha-400">
-                      <div className="flex h-10 min-h-10 flex-none items-center border-b border-gray-alpha-400 pl-4 pr-2">
+                    <div className="w-[340px] flex-shrink-0 flex flex-col min-h-0 border-r border-gray-alpha-400">
+                      <div className="flex h-10 min-h-10 flex-none items-center border-b border-gray-alpha-400 pl-6 pr-2">
                         <span className="text-label-14 text-gray-1000">
                           Streams
                         </span>
                       </div>
                       <div className="flex-1 min-h-0 overflow-auto">
                         {streamsLoading ? (
-                          <div className="p-4 flex items-center justify-center">
+                          <div className="px-6 py-3 flex items-center justify-center">
                             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                           </div>
                         ) : streamsError ? (
-                          <div className="p-4 text-xs text-destructive">
+                          <div className="px-6 py-3 text-xs text-destructive">
                             {streamsError.message}
                           </div>
                         ) : streams.length === 0 ? (
-                          <div className="p-4 text-label-13 text-gray-600">
+                          <div className="px-6 py-3 text-label-13 text-gray-600">
                             No streams found for this run
                           </div>
                         ) : (
@@ -865,7 +865,7 @@ export function RunDetailView({
                                       setSelectedStreamId(streamId);
                                     }
                                   }}
-                                  className="group cursor-pointer pl-4 pr-2 py-2 transition-colors hover:bg-gray-100 aria-selected:bg-gray-100 aria-selected:hover:bg-gray-200 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--ds-focus-color)]"
+                                  className="group cursor-pointer pl-6 pr-2 py-2 transition-colors hover:bg-gray-100 aria-selected:bg-gray-100 aria-selected:hover:bg-gray-200 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--ds-focus-color)]"
                                 >
                                   {description.label !== streamId ? (
                                     <>

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -1,11 +1,13 @@
 import { parseWorkflowName } from '@workflow/utils/parse-name';
 import type { FetchSpanDetail } from '@workflow/web-shared';
 import {
+  CopyButton,
   DecryptButton,
   describeStreamId,
   ErrorBoundary,
   EventListView,
   hydrateResourceIOAsync,
+  MiddleTruncate,
   NewTraceViewer,
   type SidebarDataContextValue,
   StreamViewer,
@@ -194,6 +196,35 @@ function GraphTabContent({
       execution={execution || undefined}
       env={env}
     />
+  );
+}
+
+/**
+ * A stream ID rendered with middle truncation, plus a hover-revealed copy
+ * action that always copies the full untruncated ID.
+ */
+function StreamIdLine({
+  streamId,
+  primary,
+}: {
+  streamId: string;
+  primary?: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-1 text-label-14-mono ${
+        primary ? 'text-gray-1000' : 'mt-0.5 text-gray-700'
+      }`}
+    >
+      <span className="min-w-0 flex-1">
+        <MiddleTruncate value={streamId} />
+      </span>
+      <CopyButton
+        copyText={streamId}
+        ariaLabel={`Copy stream ID ${streamId}`}
+        className="flex-none opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+      />
+    </div>
   );
 }
 
@@ -825,32 +856,36 @@ export function RunDetailView({
                               const description = describeStreamId(streamId);
                               const isSelected = selectedStreamId === streamId;
                               return (
-                                <div key={streamId} role="presentation">
-                                  <button
-                                    type="button"
-                                    role="option"
-                                    aria-selected={isSelected}
-                                    onClick={() =>
-                                      setSelectedStreamId(streamId)
+                                <div
+                                  key={streamId}
+                                  role="option"
+                                  aria-selected={isSelected}
+                                  tabIndex={0}
+                                  onClick={() => setSelectedStreamId(streamId)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault();
+                                      setSelectedStreamId(streamId);
                                     }
-                                    className="block w-full text-left pl-4 pr-2 py-2 transition-colors hover:bg-gray-100 aria-selected:bg-gray-100 aria-selected:hover:bg-gray-200"
-                                    title={streamId}
-                                  >
-                                    <div
-                                      className={`truncate text-label-14 text-gray-1000 ${
-                                        description.kind === 'user-named'
-                                          ? 'font-mono'
-                                          : ''
-                                      }`}
-                                    >
-                                      {description.label}
-                                    </div>
-                                    {description.label !== streamId && (
-                                      <div className="truncate text-[11px] font-mono mt-0.5 text-gray-700">
-                                        {streamId}
+                                  }}
+                                  className="group cursor-pointer pl-4 pr-2 py-2 transition-colors hover:bg-gray-100 aria-selected:bg-gray-100 aria-selected:hover:bg-gray-200 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--ds-focus-color)]"
+                                >
+                                  {description.label !== streamId ? (
+                                    <>
+                                      <div
+                                        className={`truncate text-label-14 text-gray-1000 ${
+                                          description.kind === 'user-named'
+                                            ? 'font-mono'
+                                            : ''
+                                        }`}
+                                      >
+                                        {description.label}
                                       </div>
-                                    )}
-                                  </button>
+                                      <StreamIdLine streamId={streamId} />
+                                    </>
+                                  ) : (
+                                    <StreamIdLine streamId={streamId} primary />
+                                  )}
                                 </div>
                               );
                             })}

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -2,6 +2,7 @@ import { parseWorkflowName } from '@workflow/utils/parse-name';
 import type { FetchSpanDetail } from '@workflow/web-shared';
 import {
   DecryptButton,
+  describeStreamId,
   ErrorBoundary,
   EventListView,
   hydrateResourceIOAsync,
@@ -19,7 +20,7 @@ import {
   Loader2,
   Lock,
 } from 'lucide-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert';
@@ -430,6 +431,15 @@ export function RunDetailView({
     error: streamError,
   } = useStreamReader(env, selectedStreamId, runId, encryptionKey, run.status);
 
+  // Auto-select the first stream when the Streams tab opens without a
+  // streamId in the URL, so the first viewport shows data instead of a
+  // placeholder.
+  useEffect(() => {
+    if (activeTab === 'streams' && !selectedStreamId && streams.length > 0) {
+      setSelectedStreamId(streams[0]);
+    }
+  }, [activeTab, selectedStreamId, streams, setSelectedStreamId]);
+
   const handleCancelClick = () => {
     setShowCancelDialog(true);
   };
@@ -783,22 +793,28 @@ export function RunDetailView({
                 <div className="h-full flex gap-4">
                   {/* Stream list sidebar */}
                   <div
-                    className="w-64 flex-shrink-0 border rounded-lg overflow-hidden"
+                    className="w-64 flex-shrink-0 flex flex-col border rounded-lg overflow-hidden"
                     style={{
                       borderColor: 'var(--ds-gray-300)',
                       backgroundColor: 'var(--ds-background-100)',
                     }}
                   >
                     <div
-                      className="px-3 py-2 border-b text-xs font-medium"
+                      className="flex flex-none items-baseline justify-between px-3 py-2 border-b text-xs font-medium"
                       style={{
                         borderColor: 'var(--ds-gray-300)',
                         color: 'var(--ds-gray-900)',
                       }}
                     >
-                      Streams ({streams.length})
+                      Streams
+                      <span
+                        className="tabular-nums font-normal"
+                        style={{ color: 'var(--ds-gray-600)' }}
+                      >
+                        {streams.length}
+                      </span>
                     </div>
-                    <div className="overflow-auto max-h-[calc(100vh-400px)]">
+                    <div className="flex-1 min-h-0 overflow-auto">
                       {streamsLoading ? (
                         <div className="p-4 flex items-center justify-center">
                           <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
@@ -815,24 +831,44 @@ export function RunDetailView({
                           No streams found for this run
                         </div>
                       ) : (
-                        streams.map((streamId) => (
-                          <button
-                            key={streamId}
-                            type="button"
-                            onClick={() => setSelectedStreamId(streamId)}
-                            className="w-full text-left px-3 py-2 text-xs font-mono truncate hover:bg-accent transition-colors"
-                            style={{
-                              backgroundColor:
-                                selectedStreamId === streamId
+                        streams.map((streamId) => {
+                          const description = describeStreamId(streamId);
+                          const isSelected = selectedStreamId === streamId;
+                          return (
+                            <button
+                              key={streamId}
+                              type="button"
+                              aria-current={isSelected || undefined}
+                              onClick={() => setSelectedStreamId(streamId)}
+                              className="w-full text-left px-3 py-2 hover:bg-accent transition-colors"
+                              style={{
+                                backgroundColor: isSelected
                                   ? 'var(--ds-gray-200)'
                                   : 'transparent',
-                              color: 'var(--ds-gray-1000)',
-                            }}
-                            title={streamId}
-                          >
-                            {streamId}
-                          </button>
-                        ))
+                              }}
+                              title={streamId}
+                            >
+                              <div
+                                className={`truncate text-xs ${
+                                  description.kind === 'user-named'
+                                    ? 'font-mono'
+                                    : ''
+                                }`}
+                                style={{ color: 'var(--ds-gray-1000)' }}
+                              >
+                                {description.label}
+                              </div>
+                              {description.label !== streamId && (
+                                <div
+                                  className="truncate text-[11px] font-mono mt-0.5"
+                                  style={{ color: 'var(--ds-gray-700)' }}
+                                >
+                                  {streamId}
+                                </div>
+                              )}
+                            </button>
+                          );
+                        })
                       )}
                     </div>
                   </div>
@@ -877,10 +913,9 @@ export function RunDetailView({
                       )
                     ) : (
                       <div
-                        className="h-full flex items-center justify-center rounded-lg border"
+                        className="h-full flex items-center justify-center rounded-lg border border-dashed"
                         style={{
                           borderColor: 'var(--ds-gray-300)',
-                          backgroundColor: 'var(--ds-gray-100)',
                         }}
                       >
                         <div

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -790,144 +790,106 @@ export function RunDetailView({
 
             <TabsContent value="streams" className="mt-0 flex-1 min-h-0">
               <ErrorBoundary title="Failed to load stream data">
-                <div className="h-full flex gap-4">
-                  {/* Stream list sidebar */}
-                  <div
-                    className="w-64 flex-shrink-0 flex flex-col border rounded-lg overflow-hidden"
-                    style={{
-                      borderColor: 'var(--ds-gray-300)',
-                      backgroundColor: 'var(--ds-background-100)',
-                    }}
-                  >
-                    <div
-                      className="flex flex-none items-baseline justify-between px-3 py-2 border-b text-xs font-medium"
-                      style={{
-                        borderColor: 'var(--ds-gray-300)',
-                        color: 'var(--ds-gray-900)',
-                      }}
-                    >
-                      Streams
-                      <span
-                        className="tabular-nums font-normal"
-                        style={{ color: 'var(--ds-gray-600)' }}
-                      >
-                        {streams.length}
-                      </span>
+                <div className="relative h-full -mx-6 bg-background-100 border-t border-gray-alpha-400 overflow-hidden">
+                  <div className="h-full flex min-h-0">
+                    {/* Stream list sidebar */}
+                    <div className="w-64 flex-shrink-0 flex flex-col min-h-0 border-r border-gray-alpha-400">
+                      <div className="flex h-10 min-h-10 flex-none items-center justify-between border-b border-gray-alpha-400 pl-4 pr-2">
+                        <span className="text-label-14 text-gray-1000">
+                          Streams
+                        </span>
+                        <span className="text-label-12 text-gray-900 tabular-nums">
+                          {streams.length}
+                        </span>
+                      </div>
+                      <div className="flex-1 min-h-0 overflow-auto">
+                        {streamsLoading ? (
+                          <div className="p-4 flex items-center justify-center">
+                            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                          </div>
+                        ) : streamsError ? (
+                          <div className="p-4 text-xs text-destructive">
+                            {streamsError.message}
+                          </div>
+                        ) : streams.length === 0 ? (
+                          <div className="p-4 text-label-13 text-gray-600">
+                            No streams found for this run
+                          </div>
+                        ) : (
+                          <ul className="divide-y divide-gray-400">
+                            {streams.map((streamId) => {
+                              const description = describeStreamId(streamId);
+                              const isSelected = selectedStreamId === streamId;
+                              return (
+                                <li key={streamId}>
+                                  <button
+                                    type="button"
+                                    aria-selected={isSelected}
+                                    onClick={() =>
+                                      setSelectedStreamId(streamId)
+                                    }
+                                    className="block w-full text-left pl-4 pr-2 py-2 transition-colors hover:bg-gray-100 aria-selected:bg-gray-100 aria-selected:hover:bg-gray-200"
+                                    title={streamId}
+                                  >
+                                    <div
+                                      className={`truncate text-label-14 text-gray-1000 ${
+                                        description.kind === 'user-named'
+                                          ? 'font-mono'
+                                          : ''
+                                      }`}
+                                    >
+                                      {description.label}
+                                    </div>
+                                    {description.label !== streamId && (
+                                      <div className="truncate text-[11px] font-mono mt-0.5 text-gray-700">
+                                        {streamId}
+                                      </div>
+                                    )}
+                                  </button>
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        )}
+                      </div>
                     </div>
-                    <div className="flex-1 min-h-0 overflow-auto">
-                      {streamsLoading ? (
-                        <div className="p-4 flex items-center justify-center">
-                          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                        </div>
-                      ) : streamsError ? (
-                        <div className="p-4 text-xs text-destructive">
-                          {streamsError.message}
-                        </div>
-                      ) : streams.length === 0 ? (
-                        <div
-                          className="p-4 text-xs"
-                          style={{ color: 'var(--ds-gray-600)' }}
-                        >
-                          No streams found for this run
-                        </div>
+
+                    {/* Stream viewer */}
+                    <div className="flex-1 min-w-0 min-h-0 flex flex-col">
+                      {selectedStreamId ? (
+                        streamError?.includes('encrypted') && !encryptionKey ? (
+                          <div className="h-full flex flex-col items-center justify-center gap-3 p-4">
+                            <Lock className="h-6 w-6 text-gray-700" />
+                            <div className="text-sm text-gray-900">
+                              This stream is encrypted.
+                            </div>
+                            <DecryptButton
+                              onClick={handleDecrypt}
+                              loading={isDecrypting}
+                            />
+                          </div>
+                        ) : (
+                          <StreamViewer
+                            streamId={selectedStreamId}
+                            chunks={streamChunks}
+                            isLive={streamIsLive}
+                            error={
+                              streamError?.includes('encrypted')
+                                ? null
+                                : streamError
+                            }
+                          />
+                        )
                       ) : (
-                        streams.map((streamId) => {
-                          const description = describeStreamId(streamId);
-                          const isSelected = selectedStreamId === streamId;
-                          return (
-                            <button
-                              key={streamId}
-                              type="button"
-                              aria-current={isSelected || undefined}
-                              onClick={() => setSelectedStreamId(streamId)}
-                              className="w-full text-left px-3 py-2 hover:bg-accent transition-colors"
-                              style={{
-                                backgroundColor: isSelected
-                                  ? 'var(--ds-gray-200)'
-                                  : 'transparent',
-                              }}
-                              title={streamId}
-                            >
-                              <div
-                                className={`truncate text-xs ${
-                                  description.kind === 'user-named'
-                                    ? 'font-mono'
-                                    : ''
-                                }`}
-                                style={{ color: 'var(--ds-gray-1000)' }}
-                              >
-                                {description.label}
-                              </div>
-                              {description.label !== streamId && (
-                                <div
-                                  className="truncate text-[11px] font-mono mt-0.5"
-                                  style={{ color: 'var(--ds-gray-700)' }}
-                                >
-                                  {streamId}
-                                </div>
-                              )}
-                            </button>
-                          );
-                        })
+                        <div className="h-full flex items-center justify-center">
+                          <div className="text-sm text-gray-600">
+                            {streams.length > 0
+                              ? 'Select a stream to view its data'
+                              : 'No streams available'}
+                          </div>
+                        </div>
                       )}
                     </div>
-                  </div>
-
-                  {/* Stream viewer */}
-                  <div className="flex-1 min-w-0">
-                    {selectedStreamId ? (
-                      streamError?.includes('encrypted') && !encryptionKey ? (
-                        <div
-                          className="h-full flex flex-col items-center justify-center gap-3 rounded-lg border p-4"
-                          style={{
-                            borderColor: 'var(--ds-gray-300)',
-                            backgroundColor: 'var(--ds-gray-100)',
-                          }}
-                        >
-                          <Lock
-                            className="h-6 w-6"
-                            style={{ color: 'var(--ds-gray-700)' }}
-                          />
-                          <div
-                            className="text-sm"
-                            style={{ color: 'var(--ds-gray-900)' }}
-                          >
-                            This stream is encrypted.
-                          </div>
-                          <DecryptButton
-                            onClick={handleDecrypt}
-                            loading={isDecrypting}
-                          />
-                        </div>
-                      ) : (
-                        <StreamViewer
-                          streamId={selectedStreamId}
-                          chunks={streamChunks}
-                          isLive={streamIsLive}
-                          error={
-                            streamError?.includes('encrypted')
-                              ? null
-                              : streamError
-                          }
-                        />
-                      )
-                    ) : (
-                      <div
-                        className="h-full flex items-center justify-center rounded-lg border border-dashed"
-                        style={{
-                          borderColor: 'var(--ds-gray-300)',
-                        }}
-                      >
-                        <div
-                          className="text-sm"
-                          style={{ color: 'var(--ds-gray-600)' }}
-                        >
-                          {streams.length > 0
-                            ? 'Select a stream to view its data'
-                            : 'No streams available'}
-                        </div>
-                      </div>
-                    )}
                   </div>
                 </div>
               </ErrorBoundary>

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -825,12 +825,9 @@ export function RunDetailView({
                   <div className="h-full flex min-h-0">
                     {/* Stream list sidebar */}
                     <div className="w-64 flex-shrink-0 flex flex-col min-h-0 border-r border-gray-alpha-400">
-                      <div className="flex h-10 min-h-10 flex-none items-center justify-between border-b border-gray-alpha-400 pl-4 pr-2">
+                      <div className="flex h-10 min-h-10 flex-none items-center border-b border-gray-alpha-400 pl-4 pr-2">
                         <span className="text-label-14 text-gray-1000">
                           Streams
-                        </span>
-                        <span className="text-label-12 text-gray-900 tabular-nums">
-                          {streams.length}
                         </span>
                       </div>
                       <div className="flex-1 min-h-0 overflow-auto">

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -816,14 +816,19 @@ export function RunDetailView({
                             No streams found for this run
                           </div>
                         ) : (
-                          <ul className="divide-y divide-gray-400">
+                          <div
+                            className="divide-y divide-gray-400"
+                            role="listbox"
+                            aria-label="Streams"
+                          >
                             {streams.map((streamId) => {
                               const description = describeStreamId(streamId);
                               const isSelected = selectedStreamId === streamId;
                               return (
-                                <li key={streamId}>
+                                <div key={streamId} role="presentation">
                                   <button
                                     type="button"
+                                    role="option"
                                     aria-selected={isSelected}
                                     onClick={() =>
                                       setSelectedStreamId(streamId)
@@ -846,10 +851,10 @@ export function RunDetailView({
                                       </div>
                                     )}
                                   </button>
-                                </li>
+                                </div>
                               );
                             })}
-                          </ul>
+                          </div>
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesigns the Streams tab on the workflow run detail page so the reader can find the right stream, read what was written to it, and tell whether it is still producing data.

**Stream identity** (`@workflow/web-shared`, new `describeStreamId` helper)
- Decodes opaque stream IDs into human-meaningful labels: `strm_<ulid>_user` → "Default stream", `strm_<ulid>_user_<base64url(ns)>` → the decoded namespace, `strm_<id>_system_abort` → "Abort signal". Unrecognized formats pass through verbatim.
- The sidebar shows the label with the full stream ID beneath it (mono, truncated, full ID in the tooltip) instead of one truncated raw ID per row.

**Stream viewer** (`@workflow/web-shared`)
- Unified header: stream identity + full ID on the left; live indicator, chunk count, and view controls on the right, replacing the two conditional stacked rows.
- New **Text view** that reassembles string chunks into a readable transcript — the default for text-oriented streams (e.g. AI token streaming). Non-text chunks stay inspectable as quiet JSON blocks labeled by index; the **Chunks** view remains the lossless inspector (DataInspector).
- Chunk ledger restyled from boxed cards into hairline-separated rows with a right-aligned tabular index gutter.
- Follow-scroll preserves the reader's position: the tail is followed only while at the bottom; when new chunks arrive while scrolled up, a "New chunks" jump action appears instead of yanking the scroll position. Initial loads no longer prompt or scroll in Text view (starts at reading position).

**Run detail page** (`@workflow/web`)
- The Streams sidebar fills the available panel height (drops the hard-coded `max-h-[calc(100vh-400px)]`), and the selected row gets `aria-current`.
- The first stream auto-selects when the tab opens without a `streamId` URL param, so the first viewport shows data instead of an empty placeholder.

All styling stays on the existing Geist `--ds-*` tokens, works in light and dark themes, and the pulse animation respects `prefers-reduced-motion`.

## Test plan

- `packages/web-shared`: `pnpm build`, `pnpm test` (new `stream-id.test.ts` covers default/named/system/unknown/undecodable IDs; the two `zstd-decoder` failures are pre-existing on Node 22 — `node:zlib` lacks `zstdCompressSync`).
- `packages/web`: `pnpm build`, `pnpm test` (94 passing).
- Biome clean on all changed files (two pre-existing complexity warnings in `run-detail-view.tsx` unchanged).
- Manual verification against a seeded local world (`@workflow/web` + `world-local`): screenshots in light and dark themes for default/named/system/live streams, narrow-viewport reflow, and scripted follow-scroll checks (pinned-at-bottom follows, scrolled-up prompts "New chunks", jump-to-latest works, initial load stays at reading position).

## Changesets

Two changesets included (`minor`): `@workflow/web-shared` (viewer redesign) and `@workflow/web` (sidebar labels + auto-select).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-585359f7-12b8-4396-9067-a0071cce1fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-585359f7-12b8-4396-9067-a0071cce1fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

