### PR TITLE
fix(builders): preserve JSON import attributes in bundled output

### DIFF
--- a/.changeset/builders-json-import-attributes.md
+++ b/.changeset/builders-json-import-attributes.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Preserve JSON import attributes (`with { type: "json" }`) in bundled dependency output so local step execution works on Node 22.

--- a/packages/builders/src/apply-swc-transform.ts
+++ b/packages/builders/src/apply-swc-transform.ts
@@ -117,11 +117,21 @@ export async function applySwcTransform(
             }),
       },
       target: 'es2022',
-      experimental: mode
-        ? {
-            plugins: [[swcPluginPath, { mode, moduleSpecifier }]],
-          }
-        : undefined,
+      experimental: {
+        // Preserve `import ... with { type: 'json' }` attributes. Without
+        // this SWC silently drops them, so imports that end up externalized
+        // in the emitted bundle fail at runtime on Node's ESM loader with
+        // ERR_IMPORT_ATTRIBUTE_MISSING (see issue #3157).
+        keepImportAttributes: true,
+        ...(mode
+          ? {
+              plugins: [[swcPluginPath, { mode, moduleSpecifier }]] as [
+                string,
+                Record<string, unknown>,
+              ][],
+            }
+          : {}),
+      },
       transform: {
         react: {
           runtime: 'preserve',

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -62,6 +62,19 @@ export type { DiscoveredEntries } from './fast-discovery.js';
 const EMIT_SOURCEMAPS_FOR_DEBUGGING =
   process.env.WORKFLOW_EMIT_SOURCEMAPS_FOR_DEBUGGING === '1';
 
+/**
+ * esbuild treats import attributes (`import data from './x.json' with
+ * { type: 'json' }`) as unsupported syntax for the `es2022` target and
+ * silently strips them from the output. Any such import that ends up
+ * externalized (rather than inlined) then crashes at runtime on Node's
+ * ESM loader with ERR_IMPORT_ATTRIBUTE_MISSING (see issue #3157).
+ * All supported Node.js runtimes understand the `with` keyword, so mark
+ * the syntax as supported for every bundle that Node loads directly.
+ */
+const ESBUILD_SUPPORTED_FEATURES = {
+  'import-attributes': true,
+} as const;
+
 const VALID_SOURCEMAP_STRINGS = new Set([
   'inline',
   'linked',
@@ -1194,6 +1207,7 @@ export const __steps_registered = true;
       platform: 'node',
       conditions: ['node'],
       target: 'es2022',
+      supported: ESBUILD_SUPPORTED_FEATURES,
       write: true,
       treeShaking: true,
       keepNames: true,
@@ -1633,6 +1647,7 @@ ${createWorkflowRouteHandlersCode(`workflowEntrypoint(workflowCode${workflowEntr
           format,
           platform: 'node',
           target: 'es2022',
+          supported: ESBUILD_SUPPORTED_FEATURES,
           write: true,
           keepNames: true,
           minify: false,
@@ -1832,6 +1847,7 @@ ${createWorkflowRouteHandlersCode(`workflowEntrypoint(workflowCode${workflowEntr
         format,
         platform: 'node',
         target: 'es2022',
+        supported: ESBUILD_SUPPORTED_FEATURES,
         write: true,
         keepNames: true,
         minify: false,
@@ -2012,6 +2028,7 @@ ${createWorkflowRouteHandlersCode(`workflowEntrypoint(workflowCode${workflowEntr
       platform: 'node',
       jsx: 'preserve',
       target: 'es2022',
+      supported: ESBUILD_SUPPORTED_FEATURES,
       write: true,
       treeShaking: true,
       external: ['@workflow/core'],
@@ -2118,6 +2135,7 @@ export const OPTIONS = handler;`;
       platform: 'node',
       conditions: ['import', 'module', 'node', 'default'],
       target: 'es2022',
+      supported: ESBUILD_SUPPORTED_FEATURES,
       write: true,
       treeShaking: true,
       keepNames: true,

--- a/packages/builders/src/json-import-attributes.test.ts
+++ b/packages/builders/src/json-import-attributes.test.ts
@@ -1,0 +1,163 @@
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applySwcTransform } from './apply-swc-transform.js';
+import { BaseBuilder, type DiscoveredEntries } from './base-builder.js';
+import type { StandaloneConfig } from './types.js';
+
+class TestBuilder extends BaseBuilder {
+  async build(): Promise<void> {
+    // no-op
+  }
+
+  public createSteps(
+    inputFiles: string[],
+    outfile: string,
+    discoveredEntries: DiscoveredEntries
+  ) {
+    return this.createStepsBundle({
+      inputFiles,
+      outfile,
+      externalizeNonSteps: true,
+      bundleTransitiveLocalStepDependencies: false,
+      rewriteTsExtensions: true,
+      discoveredEntries,
+    });
+  }
+}
+
+const realTmpdir = realpathSync(tmpdir());
+
+function writeFile(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents, 'utf-8');
+}
+
+function createBuilder(workingDir: string): TestBuilder {
+  const config: StandaloneConfig = {
+    buildTarget: 'standalone',
+    workingDir,
+    dirs: ['.'],
+    stepsBundlePath: join(workingDir, '.workflow', 'steps.js'),
+    workflowsBundlePath: join(workingDir, '.workflow', 'workflows.js'),
+    webhookBundlePath: join(workingDir, '.workflow', 'webhook.js'),
+  };
+  return new TestBuilder(config);
+}
+
+describe('JSON import attributes (issue #3157)', () => {
+  let testRoot: string;
+
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(realTmpdir, 'workflow-json-attr-'));
+    writeFile(
+      join(testRoot, 'node_modules', 'workflow', 'package.json'),
+      JSON.stringify({ name: 'workflow', version: '1.0.0' })
+    );
+    writeFile(
+      join(testRoot, 'node_modules', 'workflow', 'internal', 'builtins.js'),
+      'export const __builtins = true;\n'
+    );
+  });
+
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('applySwcTransform preserves `with { type: "json" }` attributes', async () => {
+    const source = [
+      `import data from './data.json' with { type: 'json' };`,
+      `export default data;`,
+    ].join('\n');
+
+    const { code } = await applySwcTransform('index.js', source, false);
+
+    expect(code).toMatch(/with\s*\{\s*type:\s*'json'\s*\}/);
+  });
+
+  it('keeps the attribute on externalized JSON imports so the steps bundle executes', async () => {
+    const stepFile = join(testRoot, 'src', 'step.ts');
+    const jsonFile = join(testRoot, 'src', 'greeting.json');
+    const outfile = join(testRoot, '.workflow', 'steps.js');
+
+    mkdirSync(dirname(outfile), { recursive: true });
+    writeFile(jsonFile, JSON.stringify({ greeting: 'hello from json' }));
+    // A dependency-shaped module whose entry uses a JSON import attribute,
+    // mirroring `builtin-modules` from the issue report.
+    writeFile(
+      join(testRoot, 'node_modules', 'json-attr-dep', 'package.json'),
+      JSON.stringify({
+        name: 'json-attr-dep',
+        version: '1.0.0',
+        type: 'module',
+        main: 'index.js',
+      })
+    );
+    writeFile(
+      join(testRoot, 'node_modules', 'json-attr-dep', 'data.json'),
+      JSON.stringify({ fromDep: 'dep json' })
+    );
+    writeFile(
+      join(testRoot, 'node_modules', 'json-attr-dep', 'index.js'),
+      `import data from './data.json' with { type: 'json' };\nexport default data;\n`
+    );
+    writeFile(
+      stepFile,
+      `import config from './greeting.json' with { type: 'json' };
+import depData from 'json-attr-dep';
+
+export async function greet() {
+  'use step';
+  return config.greeting + ' / ' + depData.fromDep;
+}
+`
+    );
+
+    const discoveredEntries: DiscoveredEntries = {
+      discoveredSteps: new Set([stepFile]),
+      discoveredWorkflows: new Set(),
+      discoveredSerdeFiles: new Set(),
+    };
+
+    await createBuilder(testRoot).createSteps(
+      [stepFile],
+      outfile,
+      discoveredEntries
+    );
+
+    const generated = readFileSync(outfile, 'utf-8');
+
+    // The step file is bundled (and SWC-transformed) while the project-local
+    // JSON import is externalized as a relative path. The import attribute
+    // must survive both the SWC transform and esbuild's output generation,
+    // otherwise Node's ESM loader throws ERR_IMPORT_ATTRIBUTE_MISSING when
+    // the local runtime loads the steps bundle.
+    expect(generated).toMatch(
+      /import\s+\w+\s+from\s+"\.\.\/src\/greeting\.json"\s+with\s+\{\s*type:\s*"json"\s*\}/
+    );
+
+    // The bundle must actually load under Node's native ESM loader.
+    const result = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `const mod = await import(${JSON.stringify(
+          pathToFileURL(outfile).href
+        )}); console.log(JSON.stringify(mod.__steps_registered));`,
+      ],
+      { encoding: 'utf8', cwd: testRoot }
+    );
+    expect(result.trim()).toBe('true');
+  });
+});


### PR DESCRIPTION
Fixes #3157, reported by @tmatkinson.

Import attributes (`with { type: 'json' }`) were stripped at two points in the build pipeline: the SWC transform drops them unless `jsc.experimental.keepImportAttributes` is set, and esbuild treats them as unsupported syntax for the `es2022` target and removes them. Inlined JSON imports were fine, but any JSON import that ends up externalized (relative project paths, bare specifiers, or dependency-internal imports like builtin-modules' `./builtin-modules.json`) lost its attribute and crashed Node 22's ESM loader with `ERR_IMPORT_ATTRIBUTE_MISSING`, breaking local step execution.

Fix: enable `keepImportAttributes` in the SWC transform and mark `import-attributes` as supported syntax for every esbuild pass whose output Node loads directly. Includes a changeset (patch for `@workflow/builders`).

Regression tests cover both stripping points. 232 builders tests pass locally; the new tests fail without the fix.
