### PR TITLE
fix(world-postgres): skip parked runs and dedupe recovery jobs on startup

### DIFF
--- a/.changeset/world-postgres-startup-recovery.md
+++ b/.changeset/world-postgres-startup-recovery.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Skip parked runs during startup recovery and enqueue recovery jobs with a stable job key so repeated boots do not accumulate duplicate jobs.

--- a/packages/world-postgres/src/index.ts
+++ b/packages/world-postgres/src/index.ts
@@ -1,9 +1,10 @@
 import type { Storage, World } from '@workflow/world';
-import { reenqueueActiveRuns, SPEC_VERSION_CURRENT } from '@workflow/world';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { Pool } from 'pg';
 import type { PostgresWorldConfig } from './config.js';
 import { createClient, type Drizzle } from './drizzle/index.js';
 import { createQueue } from './queue.js';
+import { reenqueueRecoverableRuns } from './recovery.js';
 import {
   createEventsStorage,
   createHooksStorage,
@@ -72,12 +73,13 @@ export function createWorld(
     }),
     async start() {
       await queue.start();
-      await reenqueueActiveRuns(
-        storage.runs,
-        queue.queue,
-        'world-postgres',
-        config.namespace
-      );
+      await reenqueueRecoverableRuns({
+        runs: storage.runs,
+        drizzle,
+        enqueue: queue.queue,
+        label: 'world-postgres',
+        namespace: config.namespace,
+      });
     },
     async close() {
       await queue.close();

--- a/packages/world-postgres/src/recovery.test.ts
+++ b/packages/world-postgres/src/recovery.test.ts
@@ -1,0 +1,300 @@
+import type { Storage } from '@workflow/world';
+import { describe, expect, it, vi } from 'vitest';
+import type { Drizzle } from './drizzle/index.js';
+import * as Schema from './drizzle/schema.js';
+import {
+  reenqueueRecoverableRuns,
+  STARTUP_RECOVERY_IDEMPOTENCY_PREFIX,
+  startupRecoveryIdempotencyKey,
+} from './recovery.js';
+
+type FakeRun = { runId: string; workflowName: string };
+
+type FakePersistedState = {
+  steps?: Array<{ runId: string; status: string }>;
+  waits?: Array<{ runId: string; status: string; resumeAt: Date | null }>;
+  hooks?: Array<{ runId: string }>;
+};
+
+/**
+ * Minimal fake for the drizzle `select().from().where()` chains used by the
+ * startup-recovery classifier. Applies the same status filters the real SQL
+ * applies, keyed off the schema table identity.
+ */
+function createFakeDrizzle(state: FakePersistedState): Drizzle {
+  return {
+    select: (_fields: unknown) => ({
+      from: (table: unknown) => ({
+        where: (_condition: unknown) => {
+          if (table === Schema.steps) {
+            return Promise.resolve(
+              (state.steps ?? [])
+                .filter(
+                  (step) =>
+                    step.status === 'pending' || step.status === 'running'
+                )
+                .map(({ runId }) => ({ runId }))
+            );
+          }
+          if (table === Schema.waits) {
+            return Promise.resolve(
+              (state.waits ?? [])
+                .filter((wait) => wait.status === 'waiting')
+                .map(({ runId, resumeAt }) => ({ runId, resumeAt }))
+            );
+          }
+          if (table === Schema.hooks) {
+            return Promise.resolve(
+              (state.hooks ?? []).map(({ runId }) => ({ runId }))
+            );
+          }
+          return Promise.reject(
+            new Error('Unexpected table in recovery query')
+          );
+        },
+      }),
+    }),
+  } as unknown as Drizzle;
+}
+
+function createFakeRuns(
+  runsByStatus: Partial<Record<'pending' | 'running', FakeRun[]>>
+): Storage['runs'] {
+  return {
+    list: vi.fn(async (params: { status: 'pending' | 'running' }) => ({
+      data: (runsByStatus[params.status] ?? []).map((run) => ({
+        ...run,
+        status: params.status,
+      })),
+      hasMore: false,
+      cursor: null,
+    })),
+  } as unknown as Storage['runs'];
+}
+
+function createEnqueueSpy() {
+  return vi.fn(async () => ({ messageId: null }));
+}
+
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000);
+const PAST = new Date(Date.now() - 60 * 60 * 1000);
+
+describe('reenqueueRecoverableRuns', () => {
+  it('re-enqueues pending runs with a stable recovery idempotency key', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        pending: [{ runId: 'wrun_pending', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({}),
+      enqueue,
+      label: 'test',
+    });
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.stringContaining('wfA'),
+      { runId: 'wrun_pending' },
+      { idempotencyKey: `${STARTUP_RECOVERY_IDEMPOTENCY_PREFIX}wrun_pending` }
+    );
+  });
+
+  it('re-enqueues running runs with interrupted step work', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        running: [{ runId: 'wrun_step', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({
+        steps: [{ runId: 'wrun_step', status: 'running' }],
+      }),
+      enqueue,
+      label: 'test',
+    });
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.anything(),
+      { runId: 'wrun_step' },
+      { idempotencyKey: startupRecoveryIdempotencyKey('wrun_step') }
+    );
+  });
+
+  it('skips running runs parked solely on unresolved hooks', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        running: [{ runId: 'wrun_hook', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({
+        hooks: [{ runId: 'wrun_hook' }],
+        // Completed steps do not make a run runnable.
+        steps: [{ runId: 'wrun_hook', status: 'completed' }],
+      }),
+      enqueue,
+      label: 'test',
+    });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips running runs parked on a wait that is not due yet', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        running: [{ runId: 'wrun_sleep', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({
+        waits: [{ runId: 'wrun_sleep', status: 'waiting', resumeAt: FUTURE }],
+      }),
+      enqueue,
+      label: 'test',
+    });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips running runs parked on an indefinite wait (no resumeAt)', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        running: [{ runId: 'wrun_wait', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({
+        waits: [{ runId: 'wrun_wait', status: 'waiting', resumeAt: null }],
+      }),
+      enqueue,
+      label: 'test',
+    });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('re-enqueues running runs whose wait is already due', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        running: [{ runId: 'wrun_due', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({
+        waits: [{ runId: 'wrun_due', status: 'waiting', resumeAt: PAST }],
+      }),
+      enqueue,
+      label: 'test',
+    });
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.anything(),
+      { runId: 'wrun_due' },
+      { idempotencyKey: startupRecoveryIdempotencyKey('wrun_due') }
+    );
+  });
+
+  it('fails open for running runs with no persisted suspension state', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        running: [{ runId: 'wrun_ambiguous', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({}),
+      enqueue,
+      label: 'test',
+    });
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.anything(),
+      { runId: 'wrun_ambiguous' },
+      { idempotencyKey: startupRecoveryIdempotencyKey('wrun_ambiguous') }
+    );
+  });
+
+  it('only recovers the runnable subset of a mixed page', async () => {
+    const enqueue = createEnqueueSpy();
+    await reenqueueRecoverableRuns({
+      runs: createFakeRuns({
+        running: [
+          { runId: 'wrun_hook', workflowName: 'wfA' },
+          { runId: 'wrun_sleep', workflowName: 'wfA' },
+          { runId: 'wrun_step', workflowName: 'wfA' },
+          { runId: 'wrun_ambiguous', workflowName: 'wfA' },
+        ],
+      }),
+      drizzle: createFakeDrizzle({
+        hooks: [{ runId: 'wrun_hook' }],
+        waits: [{ runId: 'wrun_sleep', status: 'waiting', resumeAt: FUTURE }],
+        steps: [{ runId: 'wrun_step', status: 'pending' }],
+      }),
+      enqueue,
+      label: 'test',
+    });
+
+    const enqueuedRunIds = enqueue.mock.calls.map(
+      (call) => (call[1] as { runId: string }).runId
+    );
+    expect(enqueuedRunIds.sort()).toEqual(['wrun_ambiguous', 'wrun_step']);
+  });
+
+  it('uses the same idempotency key on every startup so restarts cannot accumulate duplicate jobs', async () => {
+    const enqueue = createEnqueueSpy();
+    const args = {
+      runs: createFakeRuns({
+        running: [{ runId: 'wrun_restart', workflowName: 'wfA' }],
+      }),
+      drizzle: createFakeDrizzle({
+        steps: [{ runId: 'wrun_restart', status: 'running' }],
+      }),
+      enqueue,
+      label: 'test',
+    };
+
+    // Simulate five process restarts without the job being consumed.
+    for (let boot = 0; boot < 5; boot++) {
+      await reenqueueRecoverableRuns(args);
+    }
+
+    expect(enqueue).toHaveBeenCalledTimes(5);
+    const keys = enqueue.mock.calls.map(
+      (call) => (call[2] as { idempotencyKey: string }).idempotencyKey
+    );
+    expect(new Set(keys).size).toBe(1);
+    expect(keys[0]).toBe(startupRecoveryIdempotencyKey('wrun_restart'));
+  });
+
+  it('re-enqueues the whole page when parked-state classification fails', async () => {
+    const enqueue = createEnqueueSpy();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const brokenDrizzle = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.reject(new Error('database exploded')),
+        }),
+      }),
+    } as unknown as Drizzle;
+
+    try {
+      await reenqueueRecoverableRuns({
+        runs: createFakeRuns({
+          running: [
+            { runId: 'wrun_a', workflowName: 'wfA' },
+            { runId: 'wrun_b', workflowName: 'wfA' },
+          ],
+        }),
+        drizzle: brokenDrizzle,
+        enqueue,
+        label: 'test',
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    // Fail open: both runs recovered, still with dedupe keys.
+    expect(enqueue).toHaveBeenCalledTimes(2);
+    for (const call of enqueue.mock.calls) {
+      expect((call[2] as { idempotencyKey: string }).idempotencyKey).toMatch(
+        new RegExp(`^${STARTUP_RECOVERY_IDEMPOTENCY_PREFIX}`)
+      );
+    }
+  });
+});

--- a/packages/world-postgres/src/recovery.ts
+++ b/packages/world-postgres/src/recovery.ts
@@ -1,0 +1,267 @@
+import type { Queue, Storage, ValidQueueName } from '@workflow/world';
+import { getQueueTopicPrefix, resolveQueueNamespace } from '@workflow/world';
+import { and, eq, inArray } from 'drizzle-orm';
+import type { Drizzle } from './drizzle/index.js';
+import * as Schema from './drizzle/schema.js';
+
+/**
+ * Prefix for the idempotency key attached to startup-recovery enqueues.
+ *
+ * The Postgres queue uses the idempotency key as the graphile-worker
+ * `job_key` (see `queue.ts`), and graphile-worker's default `replace`
+ * job-key mode updates the existing pending job instead of inserting a
+ * new one. Deriving the key from the run ID therefore guarantees at most
+ * one outstanding startup-recovery job per run, no matter how many times
+ * the process restarts before the job is consumed. Once the job completes
+ * the key is released, so later legitimate wake-ups are never suppressed.
+ */
+export const STARTUP_RECOVERY_IDEMPOTENCY_PREFIX = 'startup-recovery:';
+
+export function startupRecoveryIdempotencyKey(runId: string): string {
+  return `${STARTUP_RECOVERY_IDEMPOTENCY_PREFIX}${runId}`;
+}
+
+/** Step statuses that represent interrupted, still-runnable work. */
+const RUNNABLE_STEP_STATUSES = ['pending', 'running'] as const;
+
+/**
+ * Classify a page of `running` runs into runnable vs. durably parked using
+ * only persisted state.
+ *
+ * A run counts as runnable (i.e. worth replaying on startup) when:
+ * - it has a step in a non-terminal state (interrupted step work), or
+ * - it has a `waiting` wait whose `resumeAt` is already due, or
+ * - it has no persisted suspension state at all (no open hooks, no waiting
+ *   waits, no runnable steps). Such a run crashed between making progress
+ *   and suspending, so it must be replayed to continue; we fail open for
+ *   this ambiguous case because the enqueue is deduplicated.
+ *
+ * A run counts as parked (skipped) when its only live state is open hooks
+ * and/or waits that are not yet due: hook deliveries and due timers enqueue
+ * their own wake-up jobs, and those jobs live durably in the same Postgres
+ * database as this queue, so they survive restarts and do not need to be
+ * recreated on boot.
+ */
+async function classifyRunnableRuns(
+  drizzle: Drizzle,
+  runIds: string[],
+  now: Date
+): Promise<Set<string>> {
+  const [stepRows, waitRows, hookRows] = await Promise.all([
+    drizzle
+      .select({ runId: Schema.steps.runId })
+      .from(Schema.steps)
+      .where(
+        and(
+          inArray(Schema.steps.runId, runIds),
+          inArray(Schema.steps.status, [...RUNNABLE_STEP_STATUSES])
+        )
+      ),
+    drizzle
+      .select({ runId: Schema.waits.runId, resumeAt: Schema.waits.resumeAt })
+      .from(Schema.waits)
+      .where(
+        and(
+          inArray(Schema.waits.runId, runIds),
+          eq(Schema.waits.status, 'waiting')
+        )
+      ),
+    drizzle
+      .select({ runId: Schema.hooks.runId })
+      .from(Schema.hooks)
+      .where(inArray(Schema.hooks.runId, runIds)),
+  ]);
+
+  const runnableStepRunIds = new Set(stepRows.map((row) => row.runId));
+  const waitingRunIds = new Set(waitRows.map((row) => row.runId));
+  const dueWaitRunIds = new Set(
+    waitRows
+      .filter(
+        (row) => row.resumeAt != null && row.resumeAt.getTime() <= now.getTime()
+      )
+      .map((row) => row.runId)
+  );
+  const openHookRunIds = new Set(hookRows.map((row) => row.runId));
+
+  const runnable = new Set<string>();
+  for (const runId of runIds) {
+    if (runnableStepRunIds.has(runId) || dueWaitRunIds.has(runId)) {
+      runnable.add(runId);
+      continue;
+    }
+    if (openHookRunIds.has(runId) || waitingRunIds.has(runId)) {
+      // Durably parked: only live state is an unresolved hook and/or a wait
+      // that is not due yet. Replaying it on boot would be pure overhead.
+      continue;
+    }
+    // No persisted suspension state — cannot be classified as parked, so
+    // fail open and recover it. The stable idempotency key keeps this from
+    // accumulating jobs across restarts.
+    runnable.add(runId);
+  }
+  return runnable;
+}
+
+type RecoverableRun = { runId: string; workflowName: string };
+
+/**
+ * Classify a page of runs with fail-open semantics: pending runs are always
+ * runnable, and if the persisted-state queries fail the whole page is
+ * treated as runnable (the stable idempotency key still prevents duplicate
+ * job accumulation across restarts).
+ */
+async function classifyPageSafe(
+  drizzle: Drizzle,
+  status: 'pending' | 'running',
+  runIds: string[],
+  label: string
+): Promise<Set<string> | null> {
+  if (status !== 'running' || runIds.length === 0) {
+    return null;
+  }
+  try {
+    return await classifyRunnableRuns(drizzle, runIds, new Date());
+  } catch (err) {
+    console.warn(
+      `[${label}] Failed to classify parked runs during startup recovery, ` +
+        `re-enqueueing all active runs in page: ${err}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Enqueue one startup-recovery job for a run, keyed by the run ID so
+ * repeated restarts replace the outstanding job instead of adding another.
+ * Returns whether the enqueue succeeded.
+ */
+async function enqueueRecoveryJob(
+  enqueue: Queue['queue'],
+  workflowQueuePrefix: string,
+  run: RecoverableRun,
+  label: string
+): Promise<boolean> {
+  try {
+    const queueName: ValidQueueName =
+      `${workflowQueuePrefix}${run.workflowName}` as ValidQueueName;
+    await enqueue(
+      queueName,
+      { runId: run.runId },
+      { idempotencyKey: startupRecoveryIdempotencyKey(run.runId) }
+    );
+    return true;
+  } catch (err) {
+    console.warn(`[${label}] Failed to re-enqueue run ${run.runId}: ${err}`);
+    return false;
+  }
+}
+
+/**
+ * Re-enqueue persisted runnable workflow runs so they resume processing
+ * after a world restart.
+ *
+ * Unlike the generic `reenqueueActiveRuns` helper in `@workflow/world`,
+ * this Postgres-specific variant:
+ * - skips runs that are durably parked on unresolved hooks or future waits
+ *   (their wake-up jobs are persisted in the same database and survive the
+ *   restart), and
+ * - attaches a stable per-run idempotency key so repeated restarts replace
+ *   the outstanding recovery job instead of accumulating duplicates.
+ *
+ * See https://github.com/vercel/workflow/issues/3119.
+ *
+ * @param runs - Storage runs interface for listing active runs
+ * @param drizzle - Drizzle client for querying persisted suspension state
+ * @param enqueue - Queue's enqueue method
+ * @param label - Log prefix identifying the world implementation
+ * @param namespace - Optional queue namespace. Defaults to WORKFLOW_QUEUE_NAMESPACE.
+ */
+/**
+ * Recover one page of active runs: skip the durably parked ones and
+ * enqueue the rest with the stable per-run recovery key.
+ */
+async function recoverPage(
+  ctx: {
+    drizzle: Drizzle;
+    enqueue: Queue['queue'];
+    workflowQueuePrefix: string;
+    label: string;
+  },
+  status: 'pending' | 'running',
+  pageRuns: RecoverableRun[]
+): Promise<{ reenqueued: number; skippedParked: number }> {
+  // Pending runs have not started yet and are always runnable. Running
+  // runs are filtered down to the ones with persisted runnable work.
+  const runnableRunIds = await classifyPageSafe(
+    ctx.drizzle,
+    status,
+    pageRuns.map((run) => run.runId),
+    ctx.label
+  );
+
+  let reenqueued = 0;
+  let skippedParked = 0;
+  for (const run of pageRuns) {
+    if (runnableRunIds && !runnableRunIds.has(run.runId)) {
+      skippedParked++;
+      continue;
+    }
+    if (
+      await enqueueRecoveryJob(
+        ctx.enqueue,
+        ctx.workflowQueuePrefix,
+        run,
+        ctx.label
+      )
+    ) {
+      reenqueued++;
+    }
+  }
+  return { reenqueued, skippedParked };
+}
+
+export async function reenqueueRecoverableRuns({
+  runs,
+  drizzle,
+  enqueue,
+  label,
+  namespace,
+}: {
+  runs: Storage['runs'];
+  drizzle: Drizzle;
+  enqueue: Queue['queue'];
+  label: string;
+  namespace?: string;
+}): Promise<void> {
+  const workflowQueuePrefix = getQueueTopicPrefix(
+    'workflow',
+    resolveQueueNamespace(namespace)
+  );
+  const ctx = { drizzle, enqueue, workflowQueuePrefix, label };
+  let reenqueued = 0;
+  let skippedParked = 0;
+  for (const status of ['pending', 'running'] as const) {
+    let cursor: string | undefined;
+    let hasMore = true;
+    while (hasMore) {
+      const page = await runs.list({
+        status,
+        resolveData: 'none',
+        pagination: { cursor },
+      });
+      const counts = await recoverPage(ctx, status, page.data);
+      reenqueued += counts.reenqueued;
+      skippedParked += counts.skippedParked;
+      hasMore = page.hasMore;
+      cursor = page.cursor ?? undefined;
+    }
+  }
+  if (reenqueued > 0 || skippedParked > 0) {
+    console.log(
+      `[${label}] Re-enqueued ${reenqueued} active run(s) on startup` +
+        (skippedParked > 0
+          ? ` (skipped ${skippedParked} durably parked run(s))`
+          : '')
+    );
+  }
+}

--- a/packages/world-postgres/src/reenqueue.test.ts
+++ b/packages/world-postgres/src/reenqueue.test.ts
@@ -41,6 +41,52 @@ vi.mock('@workflow/world-local', async (importOriginal) => {
   };
 });
 
+// Persisted suspension state consulted by startup recovery (recovery.ts)
+// through the drizzle client. Reset in beforeEach; tests push rows to mark
+// runs as parked (hooks / waits) or runnable (non-terminal steps).
+const drizzleState = vi.hoisted(() => ({
+  steps: [] as Array<{ runId: string; status: string }>,
+  waits: [] as Array<{
+    runId: string;
+    status: string;
+    resumeAt: Date | null;
+  }>,
+  hooks: [] as Array<{ runId: string }>,
+}));
+
+vi.mock('./drizzle/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./drizzle/index.js')>();
+  const Schema = actual.Schema;
+  return {
+    ...actual,
+    createClient: vi.fn(() => ({
+      select: () => ({
+        from: (table: unknown) => ({
+          where: async () => {
+            if (table === Schema.steps) {
+              return drizzleState.steps
+                .filter(
+                  (step) =>
+                    step.status === 'pending' || step.status === 'running'
+                )
+                .map(({ runId }) => ({ runId }));
+            }
+            if (table === Schema.waits) {
+              return drizzleState.waits
+                .filter((wait) => wait.status === 'waiting')
+                .map(({ runId, resumeAt }) => ({ runId, resumeAt }));
+            }
+            if (table === Schema.hooks) {
+              return drizzleState.hooks.map(({ runId }) => ({ runId }));
+            }
+            throw new Error('Unexpected table in recovery query');
+          },
+        }),
+      }),
+    })),
+  };
+});
+
 vi.mock('./storage.js', () => ({
   createRunsStorage: vi.fn(),
   createEventsStorage: vi.fn(),
@@ -103,6 +149,9 @@ describe('re-enqueue active runs on start', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    drizzleState.steps = [];
+    drizzleState.waits = [];
+    drizzleState.hooks = [];
     runnerMock.promise = Promise.resolve();
     vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
     vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
@@ -252,6 +301,64 @@ describe('re-enqueue active runs on start', () => {
     expect(workerUtilsMock.addJob).toHaveBeenCalledTimes(2);
 
     await world.close();
+  });
+
+  it('skips runs durably parked on hooks or future waits during startup recovery', async () => {
+    mockRunsList({
+      running: [
+        { runId: 'wrun_hooked', workflowName: 'wfHook' },
+        { runId: 'wrun_sleeping', workflowName: 'wfSleep' },
+        { runId: 'wrun_active', workflowName: 'wfActive' },
+      ],
+    });
+    // wrun_hooked is suspended on an unresolved hook, wrun_sleeping on a
+    // wait that is not due for another hour. Only wrun_active has
+    // interrupted step work.
+    drizzleState.hooks.push({ runId: 'wrun_hooked' });
+    drizzleState.waits.push({
+      runId: 'wrun_sleeping',
+      status: 'waiting',
+      resumeAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    drizzleState.steps.push({ runId: 'wrun_active', status: 'running' });
+
+    const world = createWorld({ connectionString: 'postgres://test', pool });
+    await world.start();
+
+    expect(workerUtilsMock.addJob).toHaveBeenCalledTimes(1);
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'workflow_flows',
+      expect.objectContaining({ id: 'wfActive' }),
+      expect.anything()
+    );
+
+    await world.close();
+  });
+
+  it('recovers runs with a stable graphile job key so repeated boots do not accumulate duplicate jobs', async () => {
+    mockRunsList({
+      pending: [{ runId: 'wrun_AAA', workflowName: 'wfA' }],
+    });
+
+    // Boot the world twice without the recovery job being consumed,
+    // simulating repeated process restarts against the same database.
+    const world1 = createWorld({ connectionString: 'postgres://test', pool });
+    await world1.start();
+    await world1.close();
+
+    const world2 = createWorld({ connectionString: 'postgres://test', pool });
+    await world2.start();
+    await world2.close();
+
+    expect(workerUtilsMock.addJob).toHaveBeenCalledTimes(2);
+    const jobKeys = vi
+      .mocked(workerUtilsMock.addJob)
+      .mock.calls.map((call) => (call[2] as { jobKey?: string })?.jobKey);
+    // Same persisted job key on every boot: graphile-worker's job_key
+    // replace semantics collapse these into a single outstanding job,
+    // instead of the pre-fix behavior of a fresh message ID per boot.
+    expect(jobKeys[0]).toBe('startup-recovery:wrun_AAA');
+    expect(jobKeys[1]).toBe('startup-recovery:wrun_AAA');
   });
 
   it('closes owned resources in dependency order', async () => {


### PR DESCRIPTION
Fixes #3119, reported by @Jiarui-Ni.

Startup recovery re-enqueued every non-terminal run, including parked runs, and enqueued recovery jobs without a stable job key. Two problems followed: parked runs were woken up when the world restarted, and repeated boots accumulated duplicate recovery jobs for the same run.

Fix: skip parked runs during startup recovery, and enqueue recovery jobs with a stable `startup-recovery:<runId>` job key so graphile-worker dedupes them across boots. Includes a changeset (patch for `@workflow/world-postgres`).

All 38 world-postgres tests pass locally; the new parked-run and dedupe tests fail without the fix.
