### PR TITLE
Pass the webhook request through without buffering its body

### DIFF
--- a/.changeset/webhook-request-passthrough.md
+++ b/.changeset/webhook-request-passthrough.md
@@ -1,0 +1,6 @@
+---
+'@workflow/astro': patch
+'@workflow/sveltekit': patch
+---
+
+The generated webhook route now passes the incoming request directly to its handler instead of copying it into a new `Request`, so the request body is no longer read before the handler runs.

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -146,13 +146,15 @@ export const prerender = false;\n`
       ''
     );
 
-    // Normalize request, needed for preserving request through astro
+    // Astro's `request` is already a standard `Request`, so it is handed to
+    // the webhook handler as-is. Notably it must NOT be copied via a
+    // normalizer that buffers the body: this is a public route where the
+    // token is checked inside `handler`, so the body must stay unread until
+    // the token has been accepted.
     webhookRouteContent = webhookRouteContent.replace(
       /export const GET = handler;\nexport const POST = handler;\nexport const PUT = handler;\nexport const PATCH = handler;\nexport const DELETE = handler;\nexport const HEAD = handler;\nexport const OPTIONS = handler;/,
-      `${NORMALIZE_REQUEST_CODE}
-const createHandler = (method) => async ({ request, params, platform }) => {
-  const normalRequest = await normalizeRequest(request);
-  const response = await handler(normalRequest, params.token);
+      `const createHandler = (method) => async ({ request, params, platform }) => {
+  const response = await handler(request, params.token);
   return response;
 };
 

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -171,13 +171,16 @@ export const POST = async ({request}) => {
       ''
     );
 
-    // Replace all HTTP method exports with SvelteKit-compatible handlers
+    // Replace all HTTP method exports with SvelteKit-compatible handlers.
+    // The `request` from SvelteKit is already a standard `Request`, so it is
+    // handed to the webhook handler as-is. Notably it must NOT be copied via
+    // a normalizer that buffers the body: this is a public route where the
+    // token is checked inside `handler`, so the body must stay unread until
+    // the token has been accepted.
     webhookRouteContent = webhookRouteContent.replace(
       /export const GET = handler;\nexport const POST = handler;\nexport const PUT = handler;\nexport const PATCH = handler;\nexport const DELETE = handler;\nexport const HEAD = handler;\nexport const OPTIONS = handler;/,
-      `${NORMALIZE_REQUEST_CODE}
-const createSvelteKitHandler = (method) => async ({ request, params, platform }) => {
-  const normalRequest = await normalizeRequest(request);
-  const response = await handler(normalRequest, params.token);
+      `const createSvelteKitHandler = (method) => async ({ request, params, platform }) => {
+  const response = await handler(request, params.token);
   return response;
 };
 


### PR DESCRIPTION
## Problem

The Astro and SvelteKit webhook wrappers copied the incoming request via `normalizeRequest()` — which reads the whole body with `arrayBuffer()` — before calling the handler. That read happened before the handler had a chance to look at the token, so requests carrying an unknown token did unnecessary work before being rejected.

## Fix

The copy turns out to be unnecessary. Both frameworks already hand the route a standard `Request`, so the wrappers now pass it straight through:

```js
const createHandler = (method) => async ({ request, params, platform }) => {
  const response = await handler(request, params.token);
  return response;
};
```

The body is left untouched until `resumeWebhook()` has accepted the token. This deletes code rather than adding a second normalizer — an earlier revision of this PR added a streaming variant of `normalizeRequest`, but with the body read removed that wrapper was just an identity copy of the request, so it's gone.

The **flow route keeps `normalizeRequest()`**: it authenticates via the queue trigger rather than a URL token, so the ordering doesn't matter there. Whether the shim is needed there at all is a separate question — see below.

## On the origin of the shim

Per prior discussion, `normalizeRequest` was introduced to get an e2e test passing before a launch, and the specific failure is no longer remembered. For the webhook route I can confirm it is not needed: with it removed, the full `e2e.test.ts` passes on both frameworks, including the webhook cases that assert exact received bodies across the default, static and manual `respondWith` paths.

I have **not** tested removing it from the flow route. That's a larger change and unrelated to this one, so it's left for a follow-up rather than folded in.

## Verification

| | Astro | SvelteKit |
|---|---|---|
| full `e2e.test.ts` | 128 passed, 7 skipped | 128 passed, 7 skipped |
| unknown-token request | rejected without the body being read | rejected without the body being read |

## Notes for reviewers

**Astro dev server.** It reads request bodies upstream of the route handler — a route that never touches the body behaves the same way — so the change is only observable in built output (node adapter / Vercel), which is what gets deployed.

**No automated regression guard.** The property "the webhook wrapper must not read the body" is currently enforced only by the comment in each builder. Making it testable would mean extracting the wrapper template into an exported constant so a unit test could assert it; happy to add that if reviewers want it.