### PR TITLE
[world-vercel] Bound HTTP timeouts and retry transport timeouts

### DIFF
--- a/.changeset/world-vercel-undici-timeouts.md
+++ b/.changeset/world-vercel-undici-timeouts.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Bound HTTP requests with a 30s headers/body timeout instead of undici's 5-minute default, and retry transport timeouts and other transient failures in-process, so a stalled connection no longer leaves a run silently paused for ~5 minutes until the queue redelivers it. Override with `WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS` / `WORKFLOW_VERCEL_BODY_TIMEOUT_MS`.

--- a/packages/world-vercel/src/event-retry.test.ts
+++ b/packages/world-vercel/src/event-retry.test.ts
@@ -1,0 +1,227 @@
+import {
+  EntityConflictError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { EventTypeSchema } from '@workflow/world';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  EVENT_RETRY_ELIGIBILITY,
+  isRetryableEventPostError,
+  MAX_EVENT_POST_RETRIES,
+  withEventPostRetry,
+} from './event-retry.js';
+
+const transportErr = (code: string) =>
+  Object.assign(new Error(`transport ${code}`), { code });
+
+// undici `fetch` wraps low-level failures in a TypeError whose `cause` carries
+// the real code — the classifier must walk the cause chain.
+const fetchFailed = (code: string) =>
+  Object.assign(new TypeError('fetch failed'), {
+    cause: Object.assign(new Error('underlying'), { code }),
+  });
+
+describe('EVENT_RETRY_ELIGIBILITY', () => {
+  it('classifies every world event type (no gaps)', () => {
+    for (const type of EventTypeSchema.options) {
+      const policy = EVENT_RETRY_ELIGIBILITY[type];
+      expect(policy, `missing policy for ${type}`).toBeDefined();
+      expect(typeof policy.retryable).toBe('boolean');
+      expect(policy.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('marks idempotent-on-retry events retryable', () => {
+    for (const type of [
+      'run_created',
+      'run_started',
+      'run_completed',
+      'run_failed',
+      'run_cancelled',
+      'step_created',
+      'step_completed',
+      'step_failed',
+      'wait_created',
+      'wait_completed',
+      'hook_created',
+      'hook_disposed',
+    ] as const) {
+      expect(EVENT_RETRY_ELIGIBILITY[type].retryable, type).toBe(true);
+    }
+  });
+
+  it('excludes events that are unsafe to blindly retry', () => {
+    // step_started double-increments attempt; step_retrying / hook_received
+    // append a duplicate event row; hook_conflict is server-originated.
+    for (const type of [
+      'step_started',
+      'step_retrying',
+      'hook_received',
+      'hook_conflict',
+    ] as const) {
+      expect(EVENT_RETRY_ELIGIBILITY[type].retryable, type).toBe(false);
+    }
+  });
+});
+
+describe('isRetryableEventPostError', () => {
+  it('retries transient 5xx', () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(
+        isRetryableEventPostError(new WorkflowWorldError('boom', { status }))
+      ).toBe(true);
+    }
+  });
+
+  it('does not retry 4xx definitive responses', () => {
+    for (const status of [400, 404]) {
+      expect(
+        isRetryableEventPostError(new WorkflowWorldError('nope', { status }))
+      ).toBe(false);
+    }
+  });
+
+  it('does not retry server-considered conflicts/terminal/too-early/throttle', () => {
+    expect(isRetryableEventPostError(new EntityConflictError('409'))).toBe(
+      false
+    );
+    expect(isRetryableEventPostError(new RunExpiredError('410'))).toBe(false);
+    expect(isRetryableEventPostError(new TooEarlyError('425'))).toBe(false);
+    expect(isRetryableEventPostError(new ThrottleError('429'))).toBe(false);
+  });
+
+  it('retries a body-parse failure (write may have landed)', () => {
+    expect(
+      isRetryableEventPostError(
+        new WorkflowWorldError('parse', { code: 'PARSE_ERROR' })
+      )
+    ).toBe(true);
+  });
+
+  it('retries raw transport errors by code', () => {
+    for (const code of [
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'UND_ERR_SOCKET',
+      'UND_ERR_REQ_RETRY',
+      'UND_ERR_HEADERS_TIMEOUT',
+    ]) {
+      expect(isRetryableEventPostError(transportErr(code)), code).toBe(true);
+    }
+  });
+
+  it('retries transport errors hidden under a `fetch failed` cause', () => {
+    expect(isRetryableEventPostError(fetchFailed('UND_ERR_SOCKET'))).toBe(true);
+  });
+
+  it('retries our own timeout (TimeoutError) but not an external abort (AbortError)', () => {
+    // Self-deadline via AbortSignal.timeout → TimeoutError → ambiguous, retry.
+    expect(
+      isRetryableEventPostError(
+        Object.assign(new Error('timed out'), { name: 'TimeoutError' })
+      )
+    ).toBe(true);
+    // Caller-requested cancellation surfaces as AbortError → must NOT be retried.
+    expect(
+      isRetryableEventPostError(
+        Object.assign(new Error('aborted'), { name: 'AbortError' })
+      )
+    ).toBe(false);
+    // Also when wrapped by makeRequest as a WorkflowWorldError(cause).
+    expect(
+      isRetryableEventPostError(
+        new WorkflowWorldError('request aborted', {
+          cause: Object.assign(new Error('aborted'), { name: 'AbortError' }),
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('does not retry an unclassified error', () => {
+    expect(isRetryableEventPostError(new Error('something else'))).toBe(false);
+  });
+});
+
+describe('withEventPostRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a retryable event past a transient blip and returns the result', async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw transportErr('ECONNRESET');
+      return 'ok';
+    });
+
+    const p = withEventPostRetry(fn, 'step_completed');
+    await vi.runAllTimersAsync();
+
+    await expect(p).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a 409 that appears on a retry (original landed)', async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw transportErr('ECONNRESET');
+      // The first attempt actually landed; the retry observes the conflict.
+      throw new EntityConflictError('already completed');
+    });
+
+    const p = withEventPostRetry(fn, 'step_completed').catch((e) => e);
+    await vi.runAllTimersAsync();
+
+    const err = await p;
+    expect(EntityConflictError.is(err)).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after MAX_EVENT_POST_RETRIES and throws the last error', async () => {
+    const fn = vi.fn(async () => {
+      throw transportErr('ECONNRESET');
+    });
+
+    const p = withEventPostRetry(fn, 'step_completed').catch((e) => e);
+    await vi.runAllTimersAsync();
+
+    const err = await p;
+    expect((err as { code?: string }).code).toBe('ECONNRESET');
+    expect(fn).toHaveBeenCalledTimes(MAX_EVENT_POST_RETRIES + 1);
+  });
+
+  it('does not retry a definitive failure even for a retryable event', async () => {
+    const fn = vi.fn(async () => {
+      throw new WorkflowWorldError('bad request', { status: 400 });
+    });
+
+    await expect(withEventPostRetry(fn, 'step_completed')).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an excluded event (step_started — protects the attempt counter)', async () => {
+    const fn = vi.fn(async () => {
+      throw transportErr('ECONNRESET');
+    });
+
+    await expect(withEventPostRetry(fn, 'step_started')).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an excluded event (hook_received — avoids double-delivery)', async () => {
+    const fn = vi.fn(async () => {
+      throw transportErr('ECONNRESET');
+    });
+
+    await expect(withEventPostRetry(fn, 'hook_received')).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/world-vercel/src/event-retry.ts
+++ b/packages/world-vercel/src/event-retry.ts
@@ -1,0 +1,297 @@
+/**
+ * In-process retry for event POSTs.
+ *
+ * undici's `RetryAgent` never retries a POST (a non-idempotent method), so a
+ * trivially-recoverable transport blip — `UND_ERR_REQ_RETRY`, `ECONNRESET`, a
+ * socket/headers timeout, a transient 5xx — bubbles straight out of an event
+ * write. For a `step_completed`/`step_failed` write that means the queue message
+ * is not acked, it redelivers, the workflow replays, and the step's user code is
+ * re-executed with `attempt++` even though it already ran to completion once.
+ *
+ * That re-execution is avoidable, because workflow-server makes event writes
+ * idempotent *in outcome*: the entity handlers run before the event-log row is
+ * inserted, and state transitions are conditional writes that exclude
+ * already-terminal states. A retry whose original already landed therefore
+ * throws before any row is written and surfaces as a 409 for most types — which
+ * the SDK maps to `EntityConflictError` and existing callers already handle (e.g.
+ * the step executor swallows it as `{ type: 'skipped' }`). The one non-conflict
+ * case still resolves as plain success the caller already handles: `run_started`
+ * early-returns the running run (200). So retrying the POST is safe: worst case
+ * we observe the outcome our own first attempt caused.
+ *
+ * This module retries the POST in-process for the event types that are provably
+ * idempotent-on-retry, and leaves the rest at a single attempt. The three
+ * excluded types are NOT safe to blindly retry:
+ *
+ *   - `step_started`  — its handler does an unconditional `attempt += 1` with a
+ *                       `.where()` that only excludes terminal states, so a
+ *                       retried start double-increments the attempt counter.
+ *   - `step_retrying` — re-applies `pending` (idempotent state) but its handler
+ *                       does NOT throw on a duplicate, so a retry appends a
+ *                       second event-log row.
+ *   - `hook_received` — has no server-side guard at all; a retry appends a
+ *                       duplicate row and can re-deliver the payload.
+ *
+ * Only transient/ambiguous transport failures are retried; definitive responses
+ * (409/410/425/429 and any other 4xx) surface immediately, exactly as before.
+ */
+
+import {
+  EntityConflictError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import type { EventTypeSchema } from '@workflow/world';
+import type { z } from 'zod';
+
+/** Every event type the world knows about (includes the server-only
+ * `hook_conflict`, which the SDK never POSTs). */
+type WorkflowEventType = z.infer<typeof EventTypeSchema>;
+
+export interface EventRetryPolicy {
+  /** Whether a failed POST of this event type may be retried in-process. */
+  retryable: boolean;
+  /** Why — kept in code so the validated classification is self-documenting. */
+  reason: string;
+}
+
+/**
+ * Validated per-event idempotency-on-retry classification, derived from reading
+ * every handler in workflow-server's event create path. `retryable: true` means
+ * a retry whose original already landed produces no duplicate event row and no
+ * double-applied state (it surfaces a 409 the SDK already handles).
+ *
+ * Declared `satisfies Record<WorkflowEventType, …>` so adding or removing a
+ * world event type without classifying it is a compile error.
+ */
+export const EVENT_RETRY_ELIGIBILITY = {
+  // Creates: conditional create → 409 EntityConflictError if it already exists.
+  run_created: {
+    retryable: true,
+    reason: 'conditional create → 409 if exists',
+  },
+  step_created: {
+    retryable: true,
+    reason: 'conditional create → 409 if exists',
+  },
+  wait_created: {
+    retryable: true,
+    reason: 'conditional create → 409 if exists',
+  },
+  hook_created: {
+    retryable: true,
+    reason: 'transactional token uniqueness → 409 if exists',
+  },
+  // Run start: early-returns if already running, writes no duplicate row.
+  run_started: {
+    retryable: true,
+    reason: 'early-returns if already running, no duplicate row',
+  },
+  // Terminal transitions: conditional `.where()` excludes terminal states →
+  // 409 before the event row is written.
+  run_completed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  run_failed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  run_cancelled: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  step_completed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  step_failed: {
+    retryable: true,
+    reason: 'terminal-state guard → 409, no duplicate row',
+  },
+  wait_completed: {
+    retryable: true,
+    reason: 'waiting-state guard → 409, no duplicate row',
+  },
+  hook_disposed: {
+    retryable: true,
+    reason: 'conditional delete (exists) → 409, no duplicate row',
+  },
+  // NOT safe to retry — see the module comment.
+  step_started: {
+    retryable: false,
+    reason: 'unconditional attempt increment → a retry double-counts attempts',
+  },
+  step_retrying: {
+    retryable: false,
+    reason: 'no duplicate guard → a retry appends a second event row',
+  },
+  hook_received: {
+    retryable: false,
+    reason:
+      'no server guard → a retry duplicates the row / re-delivers payload',
+  },
+  // Server-originated; the SDK never POSTs it.
+  hook_conflict: {
+    retryable: false,
+    reason: 'server-originated; never POSTed by the SDK',
+  },
+} satisfies Record<WorkflowEventType, EventRetryPolicy>;
+
+/** Up to this many retries after the initial attempt (3 attempts total). */
+export const MAX_EVENT_POST_RETRIES = 2;
+/** Base backoff; doubles per attempt. Kept tiny — the goal is riding out a
+ * brief blip inline, not waiting out an outage (that falls through to the
+ * queue's redelivery). */
+export const EVENT_POST_RETRY_BASE_MS = 100;
+const EVENT_POST_RETRY_JITTER_MS = 50;
+
+/** Transient transport error codes/names worth retrying. Mirrors undici's
+ * default retryable `errorCodes` plus its timeout/retry codes. */
+const TRANSIENT_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'EHOSTDOWN',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'ETIMEDOUT',
+  'UND_ERR_SOCKET',
+  'UND_ERR_REQ_RETRY',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  // Names (undici/Node surface these on the error or its cause).
+  // `TimeoutError` is our own per-request deadline (`AbortSignal.timeout` in
+  // makeRequest) — a genuinely ambiguous failure worth retrying. We deliberately
+  // do NOT include `AbortError`: that is how an external/caller-supplied
+  // cancellation surfaces (makeRequest composes the caller's signal via
+  // `AbortSignal.any`), and re-issuing a write the caller asked to cancel —
+  // stalling the abort by the full backoff budget — would be wrong.
+  'TimeoutError',
+  'RequestRetryError',
+]);
+
+/** Walk an error and its `cause` chain collecting `code`/`name` markers.
+ * `fetch()` (undici) wraps low-level failures in a `TypeError: fetch failed`
+ * whose `cause` carries the real `code`, so the chain must be inspected. */
+function collectErrorMarkers(err: unknown, depth = 0): string[] {
+  if (depth > 5 || err === null || typeof err !== 'object') return [];
+  const markers: string[] = [];
+  const e = err as { code?: unknown; name?: unknown; cause?: unknown };
+  if (typeof e.code === 'string') markers.push(e.code);
+  if (typeof e.name === 'string') markers.push(e.name);
+  if (e.cause) markers.push(...collectErrorMarkers(e.cause, depth + 1));
+  return markers;
+}
+
+/**
+ * Whether a failed event POST should be retried. Retries transient/ambiguous
+ * transport failures and transient 5xx; never retries a definitive response
+ * (409/410/425/429 and other 4xx), which surfaces immediately as today.
+ */
+export function isRetryableEventPostError(err: unknown): boolean {
+  // Definitive, server-considered outcomes — never retried in-process.
+  // (425/429 are intentionally left to the runtime's retry-after handling.)
+  if (
+    EntityConflictError.is(err) ||
+    RunExpiredError.is(err) ||
+    TooEarlyError.is(err) ||
+    ThrottleError.is(err)
+  ) {
+    return false;
+  }
+
+  if (WorkflowWorldError.is(err)) {
+    // Body parsed past the response but the write may have landed — safe to
+    // retry for eligible events (a landed original re-surfaces as 409).
+    if (err.code === 'PARSE_ERROR') return true;
+    if (typeof err.status === 'number') {
+      // Transient server errors; 4xx are definitive and not retried.
+      return err.status >= 500 && err.status <= 599;
+    }
+    // No status (e.g. a timeout wrapped by makeRequest) — fall through to the
+    // transport-marker check on the error/cause chain.
+  }
+
+  return collectErrorMarkers(err).some((m) => TRANSIENT_CODES.has(m));
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Gated like the rest of world-vercel's HTTP layer (`DEBUG=workflow:*`). Keeps
+ * in-process retries visible during a latency/outage investigation — otherwise a
+ * step that quietly rode out a blip and one that exhausted its retries and fell
+ * through to queue redelivery look identical in logs/traces. */
+const RETRY_DEBUG_ENABLED =
+  typeof process !== 'undefined' &&
+  typeof process.env.DEBUG === 'string' &&
+  (process.env.DEBUG.includes('workflow:') || process.env.DEBUG === '*');
+
+function logRetry(message: string, fields: Record<string, unknown>): void {
+  if (!RETRY_DEBUG_ENABLED) return;
+  const suffix = Object.entries(fields)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+  console.debug(`[workflow:world-vercel:event-retry] ${message} ${suffix}`);
+}
+
+/** A concise identifier for the failure, for the debug line above. */
+function errorMarker(err: unknown): string {
+  if (WorkflowWorldError.is(err)) {
+    return err.code ?? (err.status != null ? `status_${err.status}` : err.name);
+  }
+  return (
+    collectErrorMarkers(err)[0] ?? (err instanceof Error ? err.name : 'unknown')
+  );
+}
+
+/**
+ * Run an event POST, retrying transient transport failures in-process when the
+ * event type is idempotent-on-retry. Non-retryable event types and definitive
+ * responses run/throw on the first attempt, preserving existing behavior.
+ */
+export async function withEventPostRetry<T>(
+  fn: () => Promise<T>,
+  eventType: WorkflowEventType
+): Promise<T> {
+  const retryable = EVENT_RETRY_ELIGIBILITY[eventType]?.retryable ?? false;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const transient = retryable && isRetryableEventPostError(err);
+      if (transient && attempt < MAX_EVENT_POST_RETRIES) {
+        const backoff =
+          EVENT_POST_RETRY_BASE_MS * 2 ** attempt +
+          Math.floor(Math.random() * EVENT_POST_RETRY_JITTER_MS);
+        logRetry('retrying event POST after transient failure', {
+          eventType,
+          attempt: attempt + 1,
+          backoffMs: backoff,
+          error: errorMarker(err),
+        });
+        await sleep(backoff);
+        continue;
+      }
+      // Out of retries on a still-transient failure: surface it so the queue
+      // redelivers (the worst-case fallthrough the in-process retry rode against).
+      if (transient) {
+        logRetry(
+          'exhausted in-process retries; surfacing for queue redelivery',
+          {
+            eventType,
+            attempts: attempt + 1,
+            error: errorMarker(err),
+          }
+        );
+      }
+      throw err;
+    }
+  }
+}

--- a/packages/world-vercel/src/events-retry.test.ts
+++ b/packages/world-vercel/src/events-retry.test.ts
@@ -1,0 +1,140 @@
+import {
+  EntityConflictError,
+  HookNotFoundError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Integration coverage for the retry seam in `createWorkflowRunEvent`: that
+// `data.eventType` is actually threaded into `withEventPostRetry`, and that the
+// existing 404 → HookNotFoundError mapping still fires *after* the retry loop.
+// The unit tests in event-retry.test.ts cover the retry logic in isolation; a
+// refactor that wrapped the wrong layer (or passed the wrong event type) would
+// keep those green but break here. We mock the v4 wire client so we can assert
+// attempt counts and error mapping without standing up a real transport.
+const { createV4Mock } = vi.hoisted(() => ({ createV4Mock: vi.fn() }));
+
+vi.mock('./events-v4.js', () => ({
+  createWorkflowRunEventV4: createV4Mock,
+  getEventV4: vi.fn(),
+  getWorkflowRunEventsV4: vi.fn(),
+  getEventsByCorrelationIdV4: vi.fn(),
+}));
+
+import { createWorkflowRunEvent } from './events.js';
+
+const RUN_ID = 'wrun_test';
+const CONFIG = { token: 'test-token' };
+
+const stepCompleted = () => ({
+  eventType: 'step_completed' as const,
+  correlationId: 'step_1',
+  specVersion: 2,
+  eventData: {
+    stepName: 's',
+    workflowName: 'w',
+    result: new Uint8Array(),
+  },
+});
+
+const v4Success = () => ({
+  eventId: 'evnt_1',
+  runId: RUN_ID,
+  createdAt: '2020-01-01T00:00:00.000Z',
+  body: {
+    event: {
+      eventId: 'evnt_1',
+      runId: RUN_ID,
+      eventType: 'step_completed',
+      correlationId: 'step_1',
+      specVersion: 2,
+      createdAt: '2020-01-01T00:00:00.000Z',
+      eventData: { stepName: 's', workflowName: 'w' },
+    },
+  },
+});
+
+describe('createWorkflowRunEvent retry wiring', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createV4Mock.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a transient 5xx on step_completed and then succeeds', async () => {
+    let calls = 0;
+    createV4Mock.mockImplementation(async () => {
+      calls++;
+      if (calls === 1) throw new WorkflowWorldError('boom', { status: 503 });
+      return v4Success();
+    });
+
+    const p = createWorkflowRunEvent(
+      RUN_ID,
+      stepCompleted(),
+      undefined,
+      CONFIG
+    );
+    await vi.runAllTimersAsync();
+
+    const result = await p;
+    expect(result.event).toBeDefined();
+    expect(createV4Mock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a retry-time 409 as EntityConflictError', async () => {
+    let calls = 0;
+    createV4Mock.mockImplementation(async () => {
+      calls++;
+      if (calls === 1) throw new WorkflowWorldError('boom', { status: 503 });
+      throw new EntityConflictError('already completed');
+    });
+
+    const p = createWorkflowRunEvent(
+      RUN_ID,
+      stepCompleted(),
+      undefined,
+      CONFIG
+    ).catch((e) => e);
+    await vi.runAllTimersAsync();
+
+    const err = await p;
+    expect(EntityConflictError.is(err)).toBe(true);
+    expect(createV4Mock).toHaveBeenCalledTimes(2);
+  });
+
+  it('still maps a hook_disposed 404 to HookNotFoundError, after the retry loop, without retrying', async () => {
+    createV4Mock.mockImplementation(async () => {
+      throw new WorkflowWorldError('not found', { status: 404 });
+    });
+
+    await expect(
+      createWorkflowRunEvent(
+        RUN_ID,
+        { eventType: 'hook_disposed', correlationId: 'hook_1', specVersion: 2 },
+        undefined,
+        CONFIG
+      )
+    ).rejects.toBeInstanceOf(HookNotFoundError);
+    // 404 is definitive → one attempt; the mapping wraps the retry loop.
+    expect(createV4Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an excluded event type (step_started) even on a 5xx', async () => {
+    createV4Mock.mockImplementation(async () => {
+      throw new WorkflowWorldError('boom', { status: 503 });
+    });
+
+    await expect(
+      createWorkflowRunEvent(
+        RUN_ID,
+        { eventType: 'step_started', correlationId: 'step_1', specVersion: 2 },
+        undefined,
+        CONFIG
+      )
+    ).rejects.toBeInstanceOf(WorkflowWorldError);
+    expect(createV4Mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -48,6 +48,7 @@ import {
   type WorkflowRun,
 } from '@workflow/world';
 import { decode } from 'cbor-x';
+import { withEventPostRetry } from './event-retry.js';
 import {
   createWorkflowRunEventV4,
   type DecodedV4Event,
@@ -543,7 +544,18 @@ export async function createWorkflowRunEvent(
   config?: APIConfig
 ): Promise<EventResult> {
   try {
-    return await createWorkflowRunEventInner(id, data, params, config);
+    // Retry transient transport failures (UND_ERR_REQ_RETRY, ECONNRESET,
+    // socket/headers timeouts, transient 5xx) in-process for event types that
+    // are idempotent-on-retry. A write that landed but whose response was lost
+    // re-surfaces as a 409 (or plain success for run_started) the callers
+    // already handle, so this avoids a needless step re-execution on the next
+    // queue delivery. Non-retryable types (step_started, step_retrying,
+    // hook_received) run once. See ./event-retry for the validated per-event
+    // classification.
+    return await withEventPostRetry(
+      () => createWorkflowRunEventInner(id, data, params, config),
+      data.eventType
+    );
   } catch (err) {
     // 404 on hook_disposed / hook_received → already-disposed hook.
     if (

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { getDispatcher } from './http-client.js';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Agent } from 'undici';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_BODY_TIMEOUT_MS,
+  DEFAULT_HEADERS_TIMEOUT_MS,
+  getAgentOptions,
+  getDispatcher,
+  MAX_RETRIES,
+  RETRY_ERROR_CODES,
+} from './http-client.js';
 
 describe('getDispatcher', () => {
   it('returns the shared default dispatcher when none is provided', () => {
@@ -10,5 +20,100 @@ describe('getDispatcher', () => {
   it('returns the caller-supplied dispatcher when provided', () => {
     const custom = {};
     expect(getDispatcher({ dispatcher: custom })).toBe(custom);
+  });
+});
+
+describe('getAgentOptions', () => {
+  const envKeys = [
+    'WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS',
+    'WORKFLOW_VERCEL_BODY_TIMEOUT_MS',
+  ] as const;
+
+  afterEach(() => {
+    for (const key of envKeys) delete process.env[key];
+  });
+
+  it('bounds requests below undici’s 5-minute defaults', () => {
+    const { headersTimeout, bodyTimeout } = getAgentOptions();
+    expect(headersTimeout).toBe(DEFAULT_HEADERS_TIMEOUT_MS);
+    expect(bodyTimeout).toBe(DEFAULT_BODY_TIMEOUT_MS);
+    // The point of the change: a stalled socket must surface long before the
+    // queue's 300s visibility timeout lets the message redeliver, and before
+    // makeRequest's own 60s deadline turns it into an opaque abort.
+    for (const timeout of [headersTimeout, bodyTimeout]) {
+      expect(timeout).toBeLessThan(60_000);
+    }
+  });
+
+  it('honors environment overrides, including 0 (disabled)', () => {
+    process.env.WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS = '1234';
+    process.env.WORKFLOW_VERCEL_BODY_TIMEOUT_MS = '0';
+    expect(getAgentOptions().headersTimeout).toBe(1234);
+    expect(getAgentOptions().bodyTimeout).toBe(0);
+  });
+
+  it('falls back to the default for unparseable or negative overrides', () => {
+    process.env.WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS = 'not-a-number';
+    process.env.WORKFLOW_VERCEL_BODY_TIMEOUT_MS = '-1';
+    expect(getAgentOptions().headersTimeout).toBe(DEFAULT_HEADERS_TIMEOUT_MS);
+    expect(getAgentOptions().bodyTimeout).toBe(DEFAULT_BODY_TIMEOUT_MS);
+  });
+});
+
+describe('retry options', () => {
+  it('retries transport timeouts', () => {
+    // undici's default errorCodes omit these, so a socket that accepted the
+    // request and then went quiet was never retried.
+    expect(RETRY_ERROR_CODES).toContain('UND_ERR_HEADERS_TIMEOUT');
+    expect(RETRY_ERROR_CODES).toContain('UND_ERR_BODY_TIMEOUT');
+  });
+
+  it('keeps the worst-case retry budget inside the queue visibility window', () => {
+    const attempts = MAX_RETRIES + 1;
+    const { headersTimeout } = getAgentOptions();
+    // Each attempt can burn a full headers timeout. The queue client wraps its
+    // acknowledge call in its own 3 attempts, so the product must stay under
+    // the 300s visibility timeout or a hung ack still loses the lease.
+    expect(attempts * headersTimeout * 3).toBeLessThan(300_000);
+  });
+});
+
+describe('a stalled response', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    delete process.env.WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS;
+    if (server) {
+      const toClose = server;
+      server = undefined;
+      await new Promise((resolve) => toClose.close(resolve));
+    }
+  });
+
+  it('fails with UND_ERR_HEADERS_TIMEOUT instead of hanging', async () => {
+    // Accepts the request and never responds — the shape of the production
+    // failure (the request was written, the invocation then waited).
+    server = createServer(() => {});
+    await new Promise<void>((resolve) => {
+      server?.listen(0, '127.0.0.1', () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    process.env.WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS = '150';
+    const agent = new Agent(getAgentOptions());
+    try {
+      const started = Date.now();
+      await expect(
+        agent.request({
+          origin: `http://127.0.0.1:${port}`,
+          path: '/',
+          method: 'GET',
+        })
+      ).rejects.toMatchObject({ code: 'UND_ERR_HEADERS_TIMEOUT' });
+      // Well under undici's 300s default, which is what let the lease expire.
+      expect(Date.now() - started).toBeLessThan(5_000);
+    } finally {
+      await agent.close();
+    }
   });
 });

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -1,7 +1,115 @@
-import { Agent, RetryAgent } from 'undici';
+import { Agent, RetryAgent, type RetryHandler } from 'undici';
 import type { APIConfig } from './utils.js';
 
 let _dispatcher: RetryAgent | undefined;
+
+/**
+ * Time-to-first-byte cap for every request through the shared dispatcher.
+ *
+ * undici's default is 300_000 (5 minutes), which is longer than the queue's
+ * default visibility timeout — so a single connection that goes quiet after the
+ * request is written outlives the lease that the invocation is holding. The
+ * message then redelivers and the run replays, which is observable as a ~305s
+ * gap between two consecutive workflow events with no error recorded anywhere.
+ *
+ * 30s is deliberately well under both the queue's visibility-extension interval
+ * (60s) and the per-request deadline in `makeRequest` (`REQUEST_TIMEOUT_MS`,
+ * 60s), so a stalled socket surfaces as a typed, retryable
+ * `UND_ERR_HEADERS_TIMEOUT` while callers still have time to react — rather than
+ * as an opaque outer abort, or not at all.
+ *
+ * Override with `WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS`; `0` disables the timeout.
+ */
+export const DEFAULT_HEADERS_TIMEOUT_MS = 30_000;
+
+/**
+ * Gap-between-body-chunks cap for every request through the shared dispatcher.
+ * Same reasoning and same undici default (300_000) as the headers timeout. The
+ * timer resets on each chunk received, so this bounds a stalled response body,
+ * not the total transfer time — streamed event-log reads are unaffected as long
+ * as the server keeps producing chunks.
+ *
+ * Override with `WORKFLOW_VERCEL_BODY_TIMEOUT_MS`; `0` disables the timeout.
+ */
+export const DEFAULT_BODY_TIMEOUT_MS = 30_000;
+
+/**
+ * Reads a non-negative integer millisecond override from the environment.
+ * Anything unparseable or negative falls back to the default, so a typo can't
+ * silently remove the timeout.
+ */
+function envTimeoutMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/**
+ * Transport error codes retried in-process for idempotent methods.
+ *
+ * undici's defaults (everything up to `UND_ERR_SOCKET`) cover connection-level
+ * failures but omit the timeout codes, so before this list existed a stalled
+ * socket was never retried at all. The two timeout codes are ambiguous — the
+ * request may have been fully processed — which is why they stay scoped to
+ * `RetryAgent`'s default `methods` (GET/HEAD/OPTIONS/PUT/DELETE/TRACE, never
+ * POST). The PUTs that go through this dispatcher are the legacy v1/v2 entity
+ * updates (cancel run, update step), which are idempotent in outcome; stream
+ * appends — the one non-idempotent PUT — bypass the dispatcher entirely (see
+ * streamer.ts). POST event writes get their own type-aware retry instead (see
+ * event-retry.ts).
+ *
+ * Exported so a test can assert the timeout codes stay in the list.
+ */
+export const RETRY_ERROR_CODES = [
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'EHOSTDOWN',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+];
+
+/**
+ * Retries after the initial attempt. undici's default is 5, which combined with
+ * the timeout codes above would let one request burn 6 × the headers timeout
+ * before failing. Three attempts keeps the worst case (~92s including backoff)
+ * inside the queue's 300s visibility window even when a caller — e.g. the queue
+ * client's acknowledge path — wraps the call in its own bounded retries.
+ */
+export const MAX_RETRIES = 2;
+
+/**
+ * Options for the shared undici Agent. Exported (and read from the environment
+ * on each call) so tests can assert the transport configuration and exercise it
+ * against a real socket without duplicating the constants.
+ */
+export function getAgentOptions() {
+  return {
+    connections: 8,
+    keepAliveTimeout: 10_000,
+    // H2 is specifically incompatible with SvelteKit on Vercel prod. Everything else
+    // runs fine.
+    // TODO: Investigate/fix the failure on SvelteKit so we can re-enable H2.
+    allowH2: false,
+    // HTTP/1.1 pipelining is disabled (pipelining: 1) because it causes
+    // head-of-line blocking that deadlocks the webhook respondWith mechanism.
+    pipelining: 1,
+    headersTimeout: envTimeoutMs(
+      'WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS',
+      DEFAULT_HEADERS_TIMEOUT_MS
+    ),
+    bodyTimeout: envTimeoutMs(
+      'WORKFLOW_VERCEL_BODY_TIMEOUT_MS',
+      DEFAULT_BODY_TIMEOUT_MS
+    ),
+  } as const;
+}
 
 /**
  * Resolves the undici dispatcher for a request: the caller's override, or the
@@ -15,39 +123,31 @@ export function getDispatcher(config?: APIConfig): unknown {
  * Returns a shared undici RetryAgent wrapping an Agent.
  *
  * - Connection pooling (up to 8 connections per origin)
- * - Retry: Automatic retry on 5xx or network errors with exponential backoff
- *   (idempotent methods only — undici's default never retries POST), observing
- *   the `Retry-After` header when present.
+ * - Timeouts: bounded time-to-first-byte and body-stall windows, replacing
+ *   undici's 5-minute defaults
+ * - Retry: Automatic retry on 5xx, network errors, and transport timeouts with
+ *   exponential backoff (idempotent methods only — undici's default never
+ *   retries POST), observing the `Retry-After` header when present.
  */
 function getDefaultDispatcher(): RetryAgent {
   if (!_dispatcher) {
-    _dispatcher = new RetryAgent(
-      new Agent({
-        connections: 8,
-        keepAliveTimeout: 10_000,
-        // H2 is specifically incompatible with SvelteKit on Vercel prod. Everything else
-        // runs fine.
-        // TODO: Investigate/fix the failure on SvelteKit so we can re-enable H2.
-        allowH2: false,
-        // HTTP/1.1 pipelining is disabled (pipelining: 1) because it causes
-        // head-of-line blocking that deadlocks the webhook respondWith mechanism.
-        pipelining: 1,
-      }),
-      {
-        // Observe Retry-After header if received
-        retryAfter: true,
-        // Retry 5xx in-process (genuine transient blips recover fast), but NOT
-        // 429. The Vercel firewall issues a challenge as a 429: our
-        // server-to-server client cannot solve a challenge, so in-process
-        // retries just re-trigger it ~5× per request and amplify load against
-        // an already-overloaded firewall during an incident. Letting 429 pass
-        // through surfaces it immediately to makeRequest — which maps it to a
-        // ThrottleError carrying the `x-vercel-mitigated` / `x-vercel-id`
-        // headers — and the queue does the (backed-off) retry instead.
-        // (undici default is [500, 502, 503, 504, 429].)
-        statusCodes: [500, 502, 503, 504],
-      }
-    );
+    const retryOptions: RetryHandler.RetryOptions = {
+      // Observe Retry-After header if received
+      retryAfter: true,
+      // Retry 5xx in-process (genuine transient blips recover fast), but NOT
+      // 429. The Vercel firewall issues a challenge as a 429: our
+      // server-to-server client cannot solve a challenge, so in-process
+      // retries just re-trigger it ~5× per request and amplify load against
+      // an already-overloaded firewall during an incident. Letting 429 pass
+      // through surfaces it immediately to makeRequest — which maps it to a
+      // ThrottleError carrying the `x-vercel-mitigated` / `x-vercel-id`
+      // headers — and the queue does the (backed-off) retry instead.
+      // (undici default is [500, 502, 503, 504, 429].)
+      statusCodes: [500, 502, 503, 504],
+      errorCodes: RETRY_ERROR_CODES,
+      maxRetries: MAX_RETRIES,
+    };
+    _dispatcher = new RetryAgent(new Agent(getAgentOptions()), retryOptions);
   }
   return _dispatcher;
 }

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -90,6 +90,13 @@ const WORKFLOW_SERVER_URL_OVERRIDE = '';
  * Without this, a hung workflow-server response would keep the caller
  * blocked until the platform's `maxDuration` SIGTERM — burning compute
  * and defeating upstream timeout handlers (e.g. the replay timeout).
+ *
+ * This is the outer backstop, not the first line of defense: the shared
+ * dispatcher's `headersTimeout`/`bodyTimeout` fire earlier (see http-client.ts)
+ * and produce a typed, retryable `UND_ERR_*_TIMEOUT` instead of the opaque
+ * abort this deadline raises. Keep it above those so the ordering holds — it
+ * still covers the whole request (including retries the dispatcher performs
+ * internally, and time spent outside undici's own timers).
  */
 const REQUEST_TIMEOUT_MS = 60_000;
 


### PR DESCRIPTION
## Problem

The shared undici `Agent` in `world-vercel` sets no `headersTimeout`/`bodyTimeout`, so undici's **5-minute defaults** apply. That is longer than the queue's 300s visibility timeout, so a connection that accepts a request and then goes quiet outlives the lease the invocation is holding: the message redelivers, the run replays, and the whole thing is invisible — no `step_retrying`, no `errorCode`, just a **~305s gap between two consecutive workflow events**.

This was found on a production customer on 4.5.0: 56 of 33,822 runs over 4 days (0.17%) each contain exactly one gap of 302.9–308.3s. The tightness of that distribution is what identifies it as a fixed timeout rather than workload variance. Two contributing signatures showed up in the outgoing-fetch logs for the invocations that went silent:

- `UND_ERR_HEADERS_TIMEOUT` at ~300,300ms against the queue host — undici's default `headersTimeout`, on a path that has no other deadline (the queue client gets this dispatcher but does not go through `makeRequest`).
- A `POST /api/v3/runs/<wrun>/events` aborted at 60,003ms — `REQUEST_TIMEOUT_MS` in `utils.ts` — with **zero retries**, because `RetryAgent` never retries a POST.

In both cases the invocation returned HTTP 200 having renewed its queue lease but never acked it.

## Change

**Timeouts** (`http-client.ts`): `headersTimeout` and `bodyTimeout` are set to 30s. That is under both the queue's 60s visibility-extension interval and `makeRequest`'s 60s deadline, so a stalled socket surfaces as a typed, retryable `UND_ERR_*_TIMEOUT` while callers can still react — instead of as an opaque outer abort, or (off the `makeRequest` path) not until the lease is already gone. Overridable via `WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS` / `WORKFLOW_VERCEL_BODY_TIMEOUT_MS`; `0` disables.

**Retries for timeouts**: `UND_ERR_HEADERS_TIMEOUT` / `UND_ERR_BODY_TIMEOUT` are added to the `RetryAgent`'s `errorCodes` (undici's defaults omit them, so a stalled socket was never retried at all), and `maxRetries` drops from undici's 5 to 2. These codes are ambiguous — the request may have been processed — so they stay scoped to `RetryAgent`'s default `methods`, which never includes POST. The PUTs that go through this dispatcher are the legacy v1/v2 entity updates (cancel run, update step), idempotent in outcome; stream appends bypass the dispatcher entirely.

The retry budget is bounded deliberately: 3 attempts × 30s ≈ 92s with backoff, and the queue client wraps its acknowledge call in its own 3 attempts, so the product stays under the 300s visibility window. A test asserts that arithmetic so raising either constant fails.

**POST event writes**: since `RetryAgent` can't cover them, this backports the type-aware in-process retry from #2675 (`event-retry.ts`), whose transient set already includes the timeout codes. `attr_set` is dropped — it doesn't exist on this line. `step_started`, `step_retrying`, and `hook_received` stay at one attempt.

## Validation

`packages/world-vercel`: 200 unit tests pass; workspace `typecheck` clean. New tests cover the env parsing (including the `0` and unparseable cases), the presence of the timeout codes, the retry-budget arithmetic, and — against a real socket that accepts and never responds — that the request fails with `UND_ERR_HEADERS_TIMEOUT` rather than hanging.

Two out-of-band probes against a hung local server, using the built dist and the real `createWorkflowRunEvent` (not committed):

| event | attempts | outcome |
|---|---|---|
| `step_completed` | 3 | `UND_ERR_HEADERS_TIMEOUT` at 3× the configured timeout |
| `step_started` | 1 | `UND_ERR_HEADERS_TIMEOUT`, no attempt-counter double-increment |

A raw POST through the dispatcher fails at the configured timeout with exactly one request reaching the server, confirming the dispatcher itself does not re-issue POSTs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)