### PR TITLE
feat(world): persist the compute instance that ran each step attempt

### DIFF
--- a/.changeset/compute-instance-event-field.md
+++ b/.changeset/compute-instance-event-field.md
@@ -2,6 +2,7 @@
 '@workflow/core': minor
 '@workflow/world': minor
 '@workflow/world-vercel': minor
+'@workflow/web-shared': minor
 ---
 
-Record the compute instance that ran each step attempt: `CreateEventParams.computeInstanceId` is stamped on `step_started` writes and forwarded in the world-vercel v4 frame meta alongside `vercelId`.
+Record the compute instance that ran each step attempt: `CreateEventParams.computeInstanceId` is stamped on `step_started` writes, forwarded in the world-vercel v4 frame meta alongside `vercelId`, and surfaced as "Compute Instance ID" in the observability attribute panel.

--- a/.changeset/compute-instance-event-field.md
+++ b/.changeset/compute-instance-event-field.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'@workflow/world': minor
+'@workflow/world-vercel': minor
+---
+
+Record the compute instance that ran each step attempt: `CreateEventParams.computeInstanceId` is stamped on `step_started` writes and forwarded in the world-vercel v4 frame meta alongside `vercelId`.

--- a/.changeset/compute-instance-event-field.md
+++ b/.changeset/compute-instance-event-field.md
@@ -3,6 +3,7 @@
 '@workflow/world': minor
 '@workflow/world-vercel': minor
 '@workflow/web-shared': minor
+'@workflow/world-postgres': patch
 ---
 
 Record the compute instance that ran each step attempt: `CreateEventParams.computeInstanceId` is stamped on `step_started` writes, forwarded in the world-vercel v4 frame meta alongside `vercelId`, and surfaced as "Compute Instance ID" in the observability attribute panel.

--- a/.changeset/compute-instance-event-field.md
+++ b/.changeset/compute-instance-event-field.md
@@ -3,7 +3,6 @@
 '@workflow/world': minor
 '@workflow/world-vercel': minor
 '@workflow/web-shared': minor
-'@workflow/world-postgres': patch
 ---
 
-Record the compute instance that ran each step attempt: `CreateEventParams.computeInstanceId` is stamped on `step_started` writes, forwarded in the world-vercel v4 frame meta alongside `vercelId`, and surfaced as "Compute Instance ID" in the observability attribute panel.
+Record the compute instance that ran each step attempt: `CreateEventParams.computeInstanceId` is stamped on `step_started` writes, forwarded in the world-vercel v4 frame meta alongside `vercelId`, read back on `AnalyticsEvent` / `AnalyticsStep`, and surfaced as "Compute Instance ID" in the observability attribute panel.

--- a/packages/core/src/runtime/step-executor.test.ts
+++ b/packages/core/src/runtime/step-executor.test.ts
@@ -164,3 +164,53 @@ describe('executeStep — retry ceiling (authoritativeAttempt)', () => {
     expect(ceilingFailures).toHaveLength(0);
   });
 });
+
+describe('executeStep — compute instance stamping', () => {
+  afterEach(() => {
+    counter += 1;
+  });
+
+  it('stamps computeInstanceId on step_started without displacing the stateUpdatedAt guard', async () => {
+    const world = makeWorld();
+    const stepName = uniqueStepName();
+    const { runId, stepId } = await setupRunningStep({
+      world,
+      stepName,
+      onBody: () => {},
+    });
+
+    // computeInstanceId rides in CreateEventParams, which world-local does not
+    // persist — so observe the call itself rather than the stored event.
+    const creates: Array<{
+      eventType: string;
+      params?: { computeInstanceId?: string; stateUpdatedAt?: number };
+    }> = [];
+    const realCreate = world.events.create.bind(world.events);
+    world.events.create = ((
+      rid: Parameters<typeof realCreate>[0],
+      data: Parameters<typeof realCreate>[1],
+      params: Parameters<typeof realCreate>[2]
+    ) => {
+      creates.push({ eventType: data.eventType, params });
+      return realCreate(rid, data, params);
+    }) as typeof world.events.create;
+
+    await executeStep({
+      world,
+      workflowRunId: runId,
+      workflowName: 'wf',
+      workflowStartedAt: Date.now(),
+      stepId,
+      stepName,
+      stateUpdatedAt: 1_700_000_000_000,
+    });
+
+    const started = creates.filter((c) => c.eventType === 'step_started');
+    expect(started).toHaveLength(1);
+    expect(started[0]?.params?.computeInstanceId).toMatch(
+      /^cinst_[0-9A-HJKMNP-TV-Z]{26}$/
+    );
+    // Both ride the same params object — neither may clobber the other.
+    expect(started[0]?.params?.stateUpdatedAt).toBe(1_700_000_000_000);
+  });
+});

--- a/packages/core/src/runtime/step-executor.test.ts
+++ b/packages/core/src/runtime/step-executor.test.ts
@@ -4,9 +4,10 @@ import { join } from 'node:path';
 import type { Event, World } from '@workflow/world';
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { createWorld } from '@workflow/world-local';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { registerStepFunction } from '../private.js';
 import { dehydrateStepArguments } from '../serialization.js';
+import { COMPUTE_INSTANCE_ID } from './compute-instance.js';
 import { executeStep } from './step-executor.js';
 
 // The retry ceiling (`authoritativeAttempt`) is what bounds a step that keeps
@@ -181,19 +182,7 @@ describe('executeStep — compute instance stamping', () => {
 
     // computeInstanceId rides in CreateEventParams, which world-local does not
     // persist — so observe the call itself rather than the stored event.
-    const creates: Array<{
-      eventType: string;
-      params?: { computeInstanceId?: string; stateUpdatedAt?: number };
-    }> = [];
-    const realCreate = world.events.create.bind(world.events);
-    world.events.create = ((
-      rid: Parameters<typeof realCreate>[0],
-      data: Parameters<typeof realCreate>[1],
-      params: Parameters<typeof realCreate>[2]
-    ) => {
-      creates.push({ eventType: data.eventType, params });
-      return realCreate(rid, data, params);
-    }) as typeof world.events.create;
+    const createSpy = vi.spyOn(world.events, 'create');
 
     await executeStep({
       world,
@@ -205,12 +194,12 @@ describe('executeStep — compute instance stamping', () => {
       stateUpdatedAt: 1_700_000_000_000,
     });
 
-    const started = creates.filter((c) => c.eventType === 'step_started');
-    expect(started).toHaveLength(1);
-    expect(started[0]?.params?.computeInstanceId).toMatch(
-      /^cinst_[0-9A-HJKMNP-TV-Z]{26}$/
+    const started = createSpy.mock.calls.filter(
+      ([, data]) => data.eventType === 'step_started'
     );
+    expect(started).toHaveLength(1);
+    expect(started[0]?.[2]?.computeInstanceId).toBe(COMPUTE_INSTANCE_ID);
     // Both ride the same params object — neither may clobber the other.
-    expect(started[0]?.params?.stateUpdatedAt).toBe(1_700_000_000_000);
+    expect(started[0]?.[2]?.stateUpdatedAt).toBe(1_700_000_000_000);
   });
 });

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -42,6 +42,7 @@ import {
   isOptimisticInlineStartEnabled,
   isOptimisticInlineStartExplicitlyDisabled,
 } from './constants.js';
+import { COMPUTE_INSTANCE_ID } from './compute-instance.js';
 import { getPortLazy } from './get-port-lazy.js';
 import { memoizeEncryptionKey } from './helpers.js';
 import {
@@ -300,22 +301,26 @@ export async function executeStep(
           if (params.runReadyBarrier) {
             await params.runReadyBarrier.catch(() => {});
           }
-          await world.events.create(workflowRunId, {
-            eventType: 'step_started',
-            specVersion: SPEC_VERSION_CURRENT,
-            correlationId: stepId,
-            eventData: {
-              stepName,
-              workflowName,
-              input: params.lazyStepInput,
-              // Stamped for consistency even though this step terminal-fails
-              // immediately below — the log should never show an unowned
-              // lazy start.
-              ...(params.ownerMessageId !== undefined
-                ? { ownerMessageId: params.ownerMessageId }
-                : {}),
+          await world.events.create(
+            workflowRunId,
+            {
+              eventType: 'step_started',
+              specVersion: SPEC_VERSION_CURRENT,
+              correlationId: stepId,
+              eventData: {
+                stepName,
+                workflowName,
+                input: params.lazyStepInput,
+                // Stamped for consistency even though this step terminal-fails
+                // immediately below — the log should never show an unowned
+                // lazy start.
+                ...(params.ownerMessageId !== undefined
+                  ? { ownerMessageId: params.ownerMessageId }
+                  : {}),
+              },
             },
-          });
+            { computeInstanceId: COMPUTE_INSTANCE_ID }
+          );
         } catch (startErr) {
           if (EntityConflictError.is(startErr)) {
             return { type: 'skipped' };
@@ -560,9 +565,12 @@ export async function executeStep(
             // (412) rejection surfaces via reconcileOptimisticStart as a
             // non-translatable error: the body result is discarded and the
             // rejection propagates to the caller.
-            params.stateUpdatedAt !== undefined
-              ? { stateUpdatedAt: params.stateUpdatedAt }
-              : undefined
+            {
+              computeInstanceId: COMPUTE_INSTANCE_ID,
+              ...(params.stateUpdatedAt !== undefined
+                ? { stateUpdatedAt: params.stateUpdatedAt }
+                : {}),
+            }
           );
         }
       );
@@ -623,9 +631,12 @@ export async function executeStep(
           // (412) rejection is intentionally NOT translated by
           // startErrorToResult below, so it propagates to the caller for a
           // fresh replay.
-          params.stateUpdatedAt !== undefined
-            ? { stateUpdatedAt: params.stateUpdatedAt }
-            : undefined
+          {
+            computeInstanceId: COMPUTE_INSTANCE_ID,
+            ...(params.stateUpdatedAt !== undefined
+              ? { stateUpdatedAt: params.stateUpdatedAt }
+              : {}),
+          }
         );
 
         if (!startResult.step) {

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -13,7 +13,13 @@ import {
   pluralize,
   stepDisplayName,
 } from '@workflow/utils';
-import type { Event, SerializedData, Step, World } from '@workflow/world';
+import type {
+  CreateEventParams,
+  Event,
+  SerializedData,
+  Step,
+  World,
+} from '@workflow/world';
 import {
   SPEC_VERSION_CURRENT,
   SPEC_VERSION_SUPPORTS_COMPRESSION,
@@ -506,6 +512,14 @@ export async function executeStep(
           !isOptimisticInlineStartExplicitlyDisabled()));
 
     let step: Step;
+    // Params for the `step_started` create on either path below: the ambient
+    // compute-instance stamp plus the optimistic-concurrency claim guard.
+    const startEventParams: CreateEventParams = {
+      computeInstanceId: COMPUTE_INSTANCE_ID,
+      ...(params.stateUpdatedAt !== undefined
+        ? { stateUpdatedAt: params.stateUpdatedAt }
+        : {}),
+    };
     // `Date.now()` taken immediately before the `step_started` create is
     // issued (either path below) — anchors RSFS's end point. See
     // StepLatencyEventData.rsfs and the call sites below.
@@ -565,12 +579,7 @@ export async function executeStep(
             // (412) rejection surfaces via reconcileOptimisticStart as a
             // non-translatable error: the body result is discarded and the
             // rejection propagates to the caller.
-            {
-              computeInstanceId: COMPUTE_INSTANCE_ID,
-              ...(params.stateUpdatedAt !== undefined
-                ? { stateUpdatedAt: params.stateUpdatedAt }
-                : {}),
-            }
+            startEventParams
           );
         }
       );
@@ -631,12 +640,7 @@ export async function executeStep(
           // (412) rejection is intentionally NOT translated by
           // startErrorToResult below, so it propagates to the caller for a
           // fresh replay.
-          {
-            computeInstanceId: COMPUTE_INSTANCE_ID,
-            ...(params.stateUpdatedAt !== undefined
-              ? { stateUpdatedAt: params.stateUpdatedAt }
-              : {}),
-          }
+          startEventParams
         );
 
         if (!startResult.step) {

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -262,6 +262,7 @@ const attributeOrder: AttributeKey[] = [
   'correlationId',
   'eventType',
   'deploymentId',
+  'computeInstanceId',
   'specVersion',
   'workflowCoreVersion',
   'ownerId',
@@ -307,6 +308,7 @@ const attributeDisplayNames: Partial<Record<AttributeKey, string>> = {
   errorCode: 'Error Code',
   correlationId: 'Correlation ID',
   deploymentId: 'Deployment ID',
+  computeInstanceId: 'Compute Instance ID',
   specVersion: 'Spec Version',
   workflowCoreVersion: '@workflow/core version',
   occurredAt: 'Occurred',
@@ -424,6 +426,7 @@ const attributeToDisplayFn: Record<
   correlationId: (value: unknown) => String(value),
   // Project details
   deploymentId: (value: unknown) => String(value),
+  computeInstanceId: (value: unknown) => String(value),
   specVersion: (value: unknown) => String(value),
   workflowCoreVersion: (value: unknown) => String(value),
   // Tenancy (we don't show these)
@@ -684,6 +687,7 @@ const copyableBasicAttributes = new Set<AttributeKey>([
   'hookId',
   'eventId',
   'deploymentId',
+  'computeInstanceId',
   'moduleSpecifier',
   'token',
 ]);

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -243,7 +243,9 @@ type AttributeKey =
   | 'lastReceivedAt'
   | 'disposedAt'
   | 'isSystem'
-  | 'errorCode';
+  | 'errorCode'
+  // Analytics-only provenance (AnalyticsEvent / AnalyticsStep), not on Event.
+  | 'computeInstanceId';
 
 const attributeOrder: AttributeKey[] = [
   'workflowName',

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -142,8 +142,15 @@ export const events = schema.table(
     eventDataJson: jsonb('payload'),
     eventData: Cbor<unknown>()('payload_cbor'),
     specVersion: integer('spec_version'),
+    // `occurredAt` and `computeInstanceId` are readable Event fields this
+    // world does not persist, so they are omitted from the column contract.
   } satisfies DrizzlishOfType<
-    Cborized<Omit<Event, 'occurredAt'> & { eventData?: undefined }, 'eventData'>
+    Cborized<
+      Omit<Event, 'occurredAt' | 'computeInstanceId'> & {
+        eventData?: undefined;
+      },
+      'eventData'
+    >
   >,
   (tb) => [
     index().on(tb.runId),

--- a/packages/world-postgres/src/drizzle/schema.ts
+++ b/packages/world-postgres/src/drizzle/schema.ts
@@ -142,15 +142,8 @@ export const events = schema.table(
     eventDataJson: jsonb('payload'),
     eventData: Cbor<unknown>()('payload_cbor'),
     specVersion: integer('spec_version'),
-    // `occurredAt` and `computeInstanceId` are readable Event fields this
-    // world does not persist, so they are omitted from the column contract.
   } satisfies DrizzlishOfType<
-    Cborized<
-      Omit<Event, 'occurredAt' | 'computeInstanceId'> & {
-        eventData?: undefined;
-      },
-      'eventData'
-    >
+    Cborized<Omit<Event, 'occurredAt'> & { eventData?: undefined }, 'eventData'>
   >,
   (tb) => [
     index().on(tb.runId),

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -109,6 +109,8 @@ export interface CreateEventV4Input {
   specVersion: number;
   correlationId?: string;
   vercelId?: string;
+  /** Compute instance that wrote this event; rides the frame meta by `vercelId`. */
+  computeInstanceId?: string;
   /** Client-side time at which the event occurred. */
   occurredAt?: Date;
   remoteRefBehavior?: 'resolve' | 'lazy';
@@ -255,6 +257,9 @@ function buildPostFrameMeta(
   if (input.correlationId !== undefined)
     meta.correlationId = input.correlationId;
   if (input.vercelId !== undefined) meta.vercelId = input.vercelId;
+  if (input.computeInstanceId !== undefined) {
+    meta.computeInstanceId = input.computeInstanceId;
+  }
   if (input.occurredAt !== undefined) meta.occurredAt = input.occurredAt;
   if (input.remoteRefBehavior !== undefined) {
     meta.remoteRefBehavior = input.remoteRefBehavior;

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -257,9 +257,8 @@ function buildPostFrameMeta(
   if (input.correlationId !== undefined)
     meta.correlationId = input.correlationId;
   if (input.vercelId !== undefined) meta.vercelId = input.vercelId;
-  if (input.computeInstanceId !== undefined) {
+  if (input.computeInstanceId !== undefined)
     meta.computeInstanceId = input.computeInstanceId;
-  }
   if (input.occurredAt !== undefined) meta.occurredAt = input.occurredAt;
   if (input.remoteRefBehavior !== undefined) {
     meta.remoteRefBehavior = input.remoteRefBehavior;

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -195,6 +195,138 @@ describe('createWorkflowRunEvent stateUpdatedAt wire field', () => {
   });
 });
 
+describe('createWorkflowRunEvent computeInstanceId wire field', () => {
+  it('includes computeInstanceId in the v4 frame meta when provided', async () => {
+    const agent = mockAgent();
+    let capturedMeta: Record<string, unknown> | undefined;
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/step_started',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          capturedMeta = decodePostedMeta(opts.body);
+          return encode({ step: { stepId: 'step_1', status: 'running' } });
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+          },
+        }
+      );
+
+    await createWorkflowRunEvent(
+      'wrun_1',
+      {
+        eventType: 'step_started',
+        specVersion: 2,
+        correlationId: 'step_1',
+      } as AnyEventRequest,
+      { computeInstanceId: 'cinst_01JZZZTESTINSTANCE00000001' },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(capturedMeta?.computeInstanceId).toBe(
+      'cinst_01JZZZTESTINSTANCE00000001'
+    );
+    agent.assertNoPendingInterceptors();
+  });
+
+  it('rides alongside requestId/vercelId rather than replacing it', async () => {
+    const agent = mockAgent();
+    let capturedMeta: Record<string, unknown> | undefined;
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/step_started',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          capturedMeta = decodePostedMeta(opts.body);
+          return encode({ step: { stepId: 'step_1', status: 'running' } });
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+          },
+        }
+      );
+
+    await createWorkflowRunEvent(
+      'wrun_1',
+      {
+        eventType: 'step_started',
+        specVersion: 2,
+        correlationId: 'step_1',
+      } as AnyEventRequest,
+      {
+        requestId: 'iad1::abc-123-def',
+        computeInstanceId: 'cinst_01JZZZTESTINSTANCE00000001',
+      },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    // Instance identity and request identity are independent dimensions: the
+    // pair is what distinguishes same-instance from same-invocation execution.
+    expect(capturedMeta?.vercelId).toBe('iad1::abc-123-def');
+    expect(capturedMeta?.computeInstanceId).toBe(
+      'cinst_01JZZZTESTINSTANCE00000001'
+    );
+    agent.assertNoPendingInterceptors();
+  });
+
+  it('omits computeInstanceId from the v4 frame meta when not provided', async () => {
+    const agent = mockAgent();
+    let capturedMeta: Record<string, unknown> | undefined;
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/step_started',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          capturedMeta = decodePostedMeta(opts.body);
+          return encode({ step: { stepId: 'step_1', status: 'running' } });
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+          },
+        }
+      );
+
+    await createWorkflowRunEvent(
+      'wrun_1',
+      {
+        eventType: 'step_started',
+        specVersion: 2,
+        correlationId: 'step_1',
+      } as AnyEventRequest,
+      undefined,
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect('computeInstanceId' in (capturedMeta ?? {})).toBe(false);
+    agent.assertNoPendingInterceptors();
+  });
+});
+
 /**
  * The split's meta allowlist IS the eventData wire contract on v4. The
  * type-level `assertEventDataWireContractExhaustive` guard in events.ts

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -1,4 +1,4 @@
-import type { AnyEventRequest } from '@workflow/world';
+import type { AnyEventRequest, CreateEventParams } from '@workflow/world';
 import { decode, encode } from 'cbor-x';
 import { ulid } from 'ulid';
 import { MockAgent } from 'undici';
@@ -195,135 +195,71 @@ describe('createWorkflowRunEvent stateUpdatedAt wire field', () => {
   });
 });
 
-describe('createWorkflowRunEvent computeInstanceId wire field', () => {
-  it('includes computeInstanceId in the v4 frame meta when provided', async () => {
-    const agent = mockAgent();
-    let capturedMeta: Record<string, unknown> | undefined;
+/** POSTs a v4 step_started with `params` and returns the decoded frame meta. */
+async function postStepStartedMeta(
+  params: CreateEventParams | undefined
+): Promise<Record<string, unknown>> {
+  const agent = mockAgent();
+  let capturedMeta: Record<string, unknown> | undefined;
 
-    agent
-      .get(ORIGIN)
-      .intercept({
-        path: '/api/v4/runs/wrun_1/events/step_started',
-        method: 'POST',
-      })
-      .reply(
-        200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
-          return encode({ step: { stepId: 'step_1', status: 'running' } });
-        },
-        {
-          headers: {
-            'x-wf-event-id': 'evnt_1',
-            'x-wf-run-id': 'wrun_1',
-            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
-          },
-        }
-      );
-
-    await createWorkflowRunEvent(
-      'wrun_1',
+  agent
+    .get(ORIGIN)
+    .intercept({
+      path: '/api/v4/runs/wrun_1/events/step_started',
+      method: 'POST',
+    })
+    .reply(
+      200,
+      (opts: { body?: unknown }) => {
+        capturedMeta = decodePostedMeta(opts.body);
+        return encode({ step: { stepId: 'step_1', status: 'running' } });
+      },
       {
-        eventType: 'step_started',
-        specVersion: 2,
-        correlationId: 'step_1',
-      } as AnyEventRequest,
-      { computeInstanceId: 'cinst_01JZZZTESTINSTANCE00000001' },
-      { token: 'test-token', dispatcher: agent }
+        headers: {
+          'x-wf-event-id': 'evnt_1',
+          'x-wf-run-id': 'wrun_1',
+          'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+        },
+      }
     );
 
-    expect(capturedMeta?.computeInstanceId).toBe(
-      'cinst_01JZZZTESTINSTANCE00000001'
-    );
-    agent.assertNoPendingInterceptors();
+  await createWorkflowRunEvent(
+    'wrun_1',
+    {
+      eventType: 'step_started',
+      specVersion: 2,
+      correlationId: 'step_1',
+    } as AnyEventRequest,
+    params,
+    { token: 'test-token', dispatcher: agent }
+  );
+
+  agent.assertNoPendingInterceptors();
+  return capturedMeta ?? {};
+}
+
+describe('createWorkflowRunEvent computeInstanceId wire field', () => {
+  const INSTANCE = 'cinst_01JZZZTESTINSTANCE00000001';
+
+  it('includes computeInstanceId in the v4 frame meta when provided', async () => {
+    const meta = await postStepStartedMeta({ computeInstanceId: INSTANCE });
+    expect(meta.computeInstanceId).toBe(INSTANCE);
   });
 
   it('rides alongside requestId/vercelId rather than replacing it', async () => {
-    const agent = mockAgent();
-    let capturedMeta: Record<string, unknown> | undefined;
-
-    agent
-      .get(ORIGIN)
-      .intercept({
-        path: '/api/v4/runs/wrun_1/events/step_started',
-        method: 'POST',
-      })
-      .reply(
-        200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
-          return encode({ step: { stepId: 'step_1', status: 'running' } });
-        },
-        {
-          headers: {
-            'x-wf-event-id': 'evnt_1',
-            'x-wf-run-id': 'wrun_1',
-            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
-          },
-        }
-      );
-
-    await createWorkflowRunEvent(
-      'wrun_1',
-      {
-        eventType: 'step_started',
-        specVersion: 2,
-        correlationId: 'step_1',
-      } as AnyEventRequest,
-      {
-        requestId: 'iad1::abc-123-def',
-        computeInstanceId: 'cinst_01JZZZTESTINSTANCE00000001',
-      },
-      { token: 'test-token', dispatcher: agent }
-    );
-
-    // Instance identity and request identity are independent dimensions: the
-    // pair is what distinguishes same-instance from same-invocation execution.
-    expect(capturedMeta?.vercelId).toBe('iad1::abc-123-def');
-    expect(capturedMeta?.computeInstanceId).toBe(
-      'cinst_01JZZZTESTINSTANCE00000001'
-    );
-    agent.assertNoPendingInterceptors();
+    // Independent dimensions: the pair is what distinguishes same-instance
+    // from same-invocation execution.
+    const meta = await postStepStartedMeta({
+      requestId: 'iad1::abc-123-def',
+      computeInstanceId: INSTANCE,
+    });
+    expect(meta.vercelId).toBe('iad1::abc-123-def');
+    expect(meta.computeInstanceId).toBe(INSTANCE);
   });
 
   it('omits computeInstanceId from the v4 frame meta when not provided', async () => {
-    const agent = mockAgent();
-    let capturedMeta: Record<string, unknown> | undefined;
-
-    agent
-      .get(ORIGIN)
-      .intercept({
-        path: '/api/v4/runs/wrun_1/events/step_started',
-        method: 'POST',
-      })
-      .reply(
-        200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
-          return encode({ step: { stepId: 'step_1', status: 'running' } });
-        },
-        {
-          headers: {
-            'x-wf-event-id': 'evnt_1',
-            'x-wf-run-id': 'wrun_1',
-            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
-          },
-        }
-      );
-
-    await createWorkflowRunEvent(
-      'wrun_1',
-      {
-        eventType: 'step_started',
-        specVersion: 2,
-        correlationId: 'step_1',
-      } as AnyEventRequest,
-      undefined,
-      { token: 'test-token', dispatcher: agent }
-    );
-
-    expect('computeInstanceId' in (capturedMeta ?? {})).toBe(false);
-    agent.assertNoPendingInterceptors();
+    const meta = await postStepStartedMeta(undefined);
+    expect('computeInstanceId' in meta).toBe(false);
   });
 });
 

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -705,6 +705,9 @@ async function createWorkflowRunEventInner(
       specVersion: data.specVersion ?? 2,
       ...(data.correlationId ? { correlationId: data.correlationId } : {}),
       ...(params?.requestId ? { vercelId: params.requestId } : {}),
+      ...(params?.computeInstanceId
+        ? { computeInstanceId: params.computeInstanceId }
+        : {}),
       ...(params?.stateUpdatedAt !== undefined
         ? { stateUpdatedAt: params.stateUpdatedAt }
         : {}),

--- a/packages/world/src/analytics.ts
+++ b/packages/world/src/analytics.ts
@@ -69,6 +69,8 @@ export const AnalyticsStepSchema = z.object({
   errorCode: NullableStringSchema,
   workflowCoreVersion: NullableStringSchema,
   workflowEncryptionEnabled: NullableBooleanSchema,
+  /** Compute instance of the latest attempt's `step_started`. */
+  computeInstanceId: NullableStringSchema,
 });
 
 export const AnalyticsEventSchema = z.object({
@@ -86,6 +88,8 @@ export const AnalyticsEventSchema = z.object({
   region: NullableStringSchema,
   vercelId: NullableStringSchema,
   requestId: NullableStringSchema,
+  /** Compute instance that wrote the event. See CreateEventParams. */
+  computeInstanceId: NullableStringSchema,
   resumeAt: NullableDateSchema,
   retryAfter: NullableDateSchema,
   errorCode: NullableStringSchema,

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -644,6 +644,8 @@ export const EventSchema = AllEventsSchema.and(
     createdAt: z.coerce.date(),
     occurredAt: z.coerce.date().optional(),
     specVersion: z.number().optional(),
+    /** Compute instance that wrote this event, when the world persists it. */
+    computeInstanceId: z.string().optional(),
   })
 );
 
@@ -706,6 +708,14 @@ export interface CreateEventParams {
   resolveData?: ResolveData;
   /** Request ID (x-vercel-id when on Vercel) for correlating request logs with workflow events. */
   requestId?: string;
+  /**
+   * Compute instance whose handler is writing this event — i.e. the instance
+   * that ran the work it records (`COMPUTE_INSTANCE_ID` in @workflow/core).
+   * Ambient per-event identity, like {@link requestId}, which distinguishes
+   * invocations *within* an instance. Worlds may persist it; observability uses
+   * the pair to tell same-instance from same-invocation execution.
+   */
+  computeInstanceId?: string;
   /**
    * Epoch ms (the ULID time of the latest event the runtime has loaded during
    * replay). Sent by replay-context creates so the backend can reject the event

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -644,8 +644,6 @@ export const EventSchema = AllEventsSchema.and(
     createdAt: z.coerce.date(),
     occurredAt: z.coerce.date().optional(),
     specVersion: z.number().optional(),
-    /** Compute instance that wrote this event, when the world persists it. */
-    computeInstanceId: z.string().optional(),
   })
 );
 
@@ -709,11 +707,10 @@ export interface CreateEventParams {
   /** Request ID (x-vercel-id when on Vercel) for correlating request logs with workflow events. */
   requestId?: string;
   /**
-   * Compute instance whose handler is writing this event — i.e. the instance
-   * that ran the work it records (`COMPUTE_INSTANCE_ID` in @workflow/core).
-   * Ambient per-event identity, like {@link requestId}, which distinguishes
-   * invocations *within* an instance. Worlds may persist it; observability uses
-   * the pair to tell same-instance from same-invocation execution.
+   * Compute instance whose handler is writing this event (`COMPUTE_INSTANCE_ID`
+   * in @workflow/core). Ambient per-event identity like {@link requestId},
+   * which distinguishes invocations *within* an instance. Read back via
+   * `AnalyticsEventSchema` / `AnalyticsStepSchema`.
    */
   computeInstanceId?: string;
   /**


### PR DESCRIPTION
### Description

Adds `computeInstanceId` to the event log so observability can tell whether two steps ran on the same compute instance — `requestId` already distinguishes invocations, but Fluid packs several concurrent invocations onto one warm instance, and Vercel exposes no native per-instance id.

- `CreateEventParams.computeInstanceId` — ambient per-event identity, modeled on `requestId`.
- `Event.computeInstanceId` — readable back out when a world persists it.
- Core stamps it on every `step_started` write; `world-vercel` forwards it in the v4 frame meta beside `vercelId`.
- Rendered as "Compute Instance ID" in the attribute panel.

### How did you test your changes?

**`world-vercel`** (`events.test.ts`, mirroring the adjacent `stateUpdatedAt` wire-field tests) — the id reaches the v4 frame meta, rides *alongside* `vercelId` rather than replacing it, and is omitted when unset.

**`core`** (`step-executor.test.ts`) — a `step_started` claim carries the id and still carries `stateUpdatedAt`; both now share one params object, so a careless edit could silently drop the precondition guard.

Verified both fail on regression rather than passing vacuously: dropping the stamp fails the first, clobbering `stateUpdatedAt` fails the second.

Suites: `@workflow/world-vercel` 313/313, `@workflow/core` 1639 passed, `@workflow/web-shared` + `@workflow/web` build clean. The 14 failures in `src/vm/uint8array-base64.test.ts` are unrelated and reproduce without this change — local Node is v26, outside the repo's supported engines, where the base64 polyfill's error semantics differ.