### PR TITLE
fix(core): don't suspend while a committed delivery is parked behind its deferral

### DIFF
--- a/.changeset/parallel-batch-dormant-run.md
+++ b/.changeset/parallel-batch-dormant-run.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Don't raise a suspension while a step, wait, or hook delivery that is committed to reaching the workflow is still parked behind `awaitEarlierDeliveries`' macrotask yield. A run with an outstanding `sleep()` that replayed a batch of parallel step results could observe idle between `pendingDeliveries` releasing and the deferred `resolve()` running, suspend with none of the batch's follow-up work queued, and go dormant until an unrelated timer fired.

--- a/packages/core/src/parallel-batch-suspension.test.ts
+++ b/packages/core/src/parallel-batch-suspension.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Companion to `delivery-barrier-coverage.test.ts`, covering the suspension
+ * side of the delivery-barrier registry: a `WorkflowSuspension` must not be
+ * raised while a delivery that is committed to reaching the workflow (see
+ * `resolvesOnItsOwn` in `private.ts`) has not yet been delivered.
+ *
+ * The regression shape is a run with an outstanding fire-and-forget `sleep()`
+ * that replays a batch of PARALLEL step results. Each `step_completed` in the
+ * batch releases `pendingDeliveries` inside its serial queue slot, but the
+ * `resolve()` runs from a detached continuation behind
+ * `awaitEarlierDeliveries` — and every step after the first pays that
+ * deferral's macrotask yield (the step-behind-step edge in `DEFER_BEHIND`).
+ * The pending sleep reaches the end of the log and arms `scheduleWhenIdle`
+ * during the same drain window, so its idle check can observe
+ * `pendingDeliveries === 0` while those step results are hydrated but still
+ * parked. The suspension then fires before the workflow's `Promise.all`
+ * continuation has run: it carries no step invocations, the runtime queues
+ * nothing, and the run goes dormant until an unrelated timer (the sleep
+ * itself) happens to revive it.
+ *
+ * A single-step batch never defers (`earlier.length === 0`), resolves on
+ * microtasks before the idle check's own macrotask, and is unaffected — which
+ * is why the serial control below passes either way.
+ */
+import { WorkflowRuntimeError } from '@workflow/errors';
+import { withResolvers } from '@workflow/utils';
+import type { Event } from '@workflow/world';
+import * as nanoid from 'nanoid';
+import { monotonicFactory } from 'ulid';
+import { describe, expect, it, vi } from 'vitest';
+import { EventsConsumer } from './events-consumer.js';
+import { WorkflowSuspension } from './global.js';
+import type { WorkflowOrchestratorContext } from './private.js';
+import { ReplayPayloadCache } from './replay-payload-cache.js';
+import { dehydrateStepReturnValue } from './serialization.js';
+import { createUseStep } from './step.js';
+import { createContext } from './vm/index.js';
+import { createSleep } from './workflow/sleep.js';
+
+const FIXED_TIMESTAMP = 1753481739458;
+
+function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
+  const context = createContext({
+    seed: 'test',
+    fixedTimestamp: FIXED_TIMESTAMP,
+  });
+  const ulid = monotonicFactory(() => context.globalThis.Math.random());
+  const workflowStartedAt = context.globalThis.Date.now();
+  const promiseQueueHolder = { current: Promise.resolve() };
+  const ctxRef: { current?: WorkflowOrchestratorContext } = {};
+  const ctx: WorkflowOrchestratorContext = {
+    runId: 'wrun_test',
+    encryptionKey: undefined,
+    replayPayloadCache: new ReplayPayloadCache(undefined),
+    globalThis: context.globalThis,
+    eventsConsumer: new EventsConsumer(events, {
+      onUnconsumedEvent: (event) => {
+        ctxRef.current?.onWorkflowError(
+          new WorkflowRuntimeError(`Unconsumed event: ${event.eventType}`)
+        );
+      },
+      getPromiseQueue: () => promiseQueueHolder.current,
+    }),
+    invocationsQueue: new Map(),
+    generateUlid: () => ulid(workflowStartedAt),
+    generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
+      new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
+    ),
+    onWorkflowError: vi.fn(),
+    get promiseQueue() {
+      return promiseQueueHolder.current;
+    },
+    set promiseQueue(value: Promise<void>) {
+      promiseQueueHolder.current = value;
+    },
+    pendingDeliveries: 0,
+    pendingDeliveryBarriers: new Map(),
+  };
+  ctxRef.current = ctx;
+  return ctx;
+}
+
+/**
+ * The ULIDs the seeded generator hands out, in invocation order. Correlation
+ * IDs in the fixtures below have to match what the replayed workflow draws.
+ */
+function deterministicUlids(count: number): string[] {
+  const context = createContext({
+    seed: 'test',
+    fixedTimestamp: FIXED_TIMESTAMP,
+  });
+  const ulid = monotonicFactory(() => context.globalThis.Math.random());
+  const workflowStartedAt = context.globalThis.Date.now();
+  return Array.from({ length: count }, () => ulid(workflowStartedAt));
+}
+
+const ULIDS = deterministicUlids(8);
+
+async function replay(
+  ctx: WorkflowOrchestratorContext,
+  workflowFn: () => Promise<unknown>
+): Promise<unknown> {
+  const discontinuation = withResolvers<void>();
+  ctx.onWorkflowError = discontinuation.reject;
+  try {
+    await Promise.race([workflowFn(), discontinuation.promise]);
+  } catch (err) {
+    return err;
+  }
+  return undefined;
+}
+
+/**
+ * Assert the replay suspended AND that the suspension itself carries the
+ * expected step invocations. The snapshot is taken from the
+ * `WorkflowSuspension` (constructed from the invocations queue at raise
+ * time), not from the live queue, so a suspension raised before the batch's
+ * continuations queued their follow-up work fails here with `[]` — exactly
+ * what the runtime would see before deciding it has nothing to schedule.
+ */
+function expectSuspensionCarryingSteps(error: unknown, expected: string[]) {
+  if (!WorkflowSuspension.is(error)) {
+    throw new Error(
+      error === undefined
+        ? 'expected the replay to suspend, but it completed'
+        : error instanceof Error
+          ? error.message
+          : String(error),
+      { cause: error }
+    );
+  }
+  expect(
+    (error as WorkflowSuspension).steps.flatMap((item) =>
+      item.type === 'step' ? [item.stepName] : []
+    )
+  ).toEqual(expected);
+}
+
+const event = (
+  eventId: string,
+  eventType: string,
+  correlationId: string,
+  eventData: Record<string, unknown>
+): Event =>
+  ({
+    eventId,
+    runId: 'wrun_test',
+    eventType,
+    correlationId,
+    eventData,
+    createdAt: new Date(),
+  }) as Event;
+
+describe('suspension with a pending sleep and a parallel step batch', () => {
+  it('carries the follow-up step queued after the batch resolves', async () => {
+    const resumeAt = new Date(FIXED_TIMESTAMP + 25 * 60_000);
+    const ops: Promise<unknown>[] = [];
+    const [stepAResult, stepBResult, stepCResult] = await Promise.all([
+      dehydrateStepReturnValue('a', 'wrun_test', undefined, ops),
+      dehydrateStepReturnValue('b', 'wrun_test', undefined, ops),
+      dehydrateStepReturnValue('c', 'wrun_test', undefined, ops),
+    ]);
+
+    const events: Event[] = [
+      event('evnt_0', 'wait_created', `wait_${ULIDS[0]}`, { resumeAt }),
+      event('evnt_1', 'step_created', `step_${ULIDS[1]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_2', 'step_created', `step_${ULIDS[2]}`, {
+        stepName: 'stepB',
+      }),
+      event('evnt_3', 'step_created', `step_${ULIDS[3]}`, {
+        stepName: 'stepC',
+      }),
+      event('evnt_4', 'step_started', `step_${ULIDS[1]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_5', 'step_started', `step_${ULIDS[2]}`, {
+        stepName: 'stepB',
+      }),
+      event('evnt_6', 'step_started', `step_${ULIDS[3]}`, {
+        stepName: 'stepC',
+      }),
+      event('evnt_7', 'step_completed', `step_${ULIDS[1]}`, {
+        stepName: 'stepA',
+        result: stepAResult,
+      }),
+      event('evnt_8', 'step_completed', `step_${ULIDS[2]}`, {
+        stepName: 'stepB',
+        result: stepBResult,
+      }),
+      event('evnt_9', 'step_completed', `step_${ULIDS[3]}`, {
+        stepName: 'stepC',
+        result: stepCResult,
+      }),
+    ];
+
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    const sleep = createSleep(ctx);
+
+    const error = await replay(ctx, async () => {
+      // Fire-and-forget watchdog: never awaited, never completes in-run. Its
+      // subscriber reaches the end of the log and arms the idle check on
+      // every replay.
+      sleep('25m').catch(() => {});
+
+      const stepA = useStep('stepA');
+      const stepB = useStep('stepB');
+      const stepC = useStep('stepC');
+      const stepD = useStep('stepD');
+
+      await Promise.all([stepA(), stepB(), stepC()]);
+      await stepD();
+    });
+
+    expectSuspensionCarryingSteps(error, ['stepD']);
+  });
+
+  it('control: a serial batch still carries its follow-up step', async () => {
+    const resumeAt = new Date(FIXED_TIMESTAMP + 25 * 60_000);
+    const ops: Promise<unknown>[] = [];
+    const stepAResult = await dehydrateStepReturnValue(
+      'a',
+      'wrun_test',
+      undefined,
+      ops
+    );
+
+    const events: Event[] = [
+      event('evnt_0', 'wait_created', `wait_${ULIDS[0]}`, { resumeAt }),
+      event('evnt_1', 'step_created', `step_${ULIDS[1]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_2', 'step_started', `step_${ULIDS[1]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_3', 'step_completed', `step_${ULIDS[1]}`, {
+        stepName: 'stepA',
+        result: stepAResult,
+      }),
+    ];
+
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    const sleep = createSleep(ctx);
+
+    const error = await replay(ctx, async () => {
+      sleep('25m').catch(() => {});
+
+      const stepA = useStep('stepA');
+      const stepD = useStep('stepD');
+
+      await stepA();
+      await stepD();
+    });
+
+    expectSuspensionCarryingSteps(error, ['stepD']);
+  });
+});

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -469,12 +469,56 @@ export function registerDeliveryBarrier(
 }
 
 /**
+ * Whether any registered branch-deciding delivery is committed to reaching
+ * the workflow on its own (see {@link resolvesOnItsOwn}) but has not been
+ * delivered yet. `pendingDeliveries` alone cannot see these: a delivery
+ * releases that counter inside its serial queue slot, while its `resolve()`
+ * runs from a detached continuation behind `awaitEarlierDeliveries` — which
+ * ends with a macrotask yield whenever the delivery had to defer. For a
+ * parallel batch of N step results consumed in one drain window, N-1 of them
+ * are parked on that yield with `pendingDeliveries` already at 0, so an idle
+ * check racing them can observe "idle" and raise a suspension that predates
+ * the workflow's own continuation. The suspension then carries none of the
+ * follow-up work the batch was about to queue, the runtime schedules
+ * nothing, and the run goes dormant until an unrelated timer fires.
+ *
+ * Only deliveries that resolve on their own are counted: they always deliver
+ * from their own detached chains (never needing the idle safety net in
+ * {@link registerDeliveryBarrier}), so waiting for them cannot deadlock the
+ * idle check. A barrier that does NOT resolve on its own — an unclaimed
+ * buffered hook payload, or a delivery parked behind one — must not block
+ * idle, because idle is exactly what retires it.
+ */
+function hasUndeliveredCommittedDeliveries(
+  ctx: WorkflowOrchestratorContext
+): boolean {
+  const barriers = ctx.pendingDeliveryBarriers;
+  if (!barriers || barriers.size === 0) {
+    return false;
+  }
+  // Shared across this call only — see `resolvesOnItsOwn`.
+  const memo = new Map<number, boolean>();
+  for (const [index, entry] of barriers) {
+    if (resolvesOnItsOwn(barriers, index, entry, memo)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Schedule a callback to fire only after all pending data deliveries
  * (step results, hook payloads) and async deserialization have completed.
- * Uses a polling loop: setTimeout(0) → check pendingDeliveries →
- * if > 0, wait for promiseQueue → repeat. This handles the multi-round
- * delivery pattern where each hook payload delivery cycle appends new
- * async work to the promiseQueue.
+ * Uses a polling loop: setTimeout(0) → check pendingDeliveries and
+ * committed-but-undelivered barriers → if any, wait for promiseQueue →
+ * repeat. This handles the multi-round delivery pattern where each hook
+ * payload delivery cycle appends new async work to the promiseQueue.
+ *
+ * `pendingDeliveries` guards the hydration window inside the serial queue
+ * slots; {@link hasUndeliveredCommittedDeliveries} guards the detached
+ * deferral window between a slot completing and the delivery's `resolve()`
+ * actually running, which `pendingDeliveries` deliberately does not cover
+ * (see step.ts for why it is released inside the slot).
  *
  * The initial `setTimeout(0)` macrotask is load-bearing and must NOT be
  * downgraded to a microtask (`queueMicrotask`/`Promise.resolve().then`).
@@ -493,7 +537,7 @@ export function scheduleWhenIdle(
   fn: () => void
 ): void {
   const check = () => {
-    if (ctx.pendingDeliveries > 0) {
+    if (ctx.pendingDeliveries > 0 || hasUndeliveredCommittedDeliveries(ctx)) {
       // Still delivering data — wait for queue to drain, then re-check
       ctx.promiseQueue.then(() => {
         setTimeout(check, 0);


### PR DESCRIPTION
Fixes #3183, reported by @shtefcs.

Reproduced deterministically in the unit harness: a fire-and-forget `sleep()` plus a 3-wide parallel step batch suspends with zero queued steps, and the run goes dormant with no error. Root cause: #3139 moved step-result `resolve()` into a detached continuation behind `awaitEarlierDeliveries`, whose macrotask yield N-1 steps of a parallel batch must pay, while `ctx.pendingDeliveries` is released inside the serial queue slot. `scheduleWhenIdle` checked only `pendingDeliveries`, so the idle check could win the race mid-deferral and raise a `WorkflowSuspension` carrying zero steps, which the runtime queues as nothing.

The fix makes `scheduleWhenIdle` also defer while any registered delivery barrier resolves on its own but is undelivered, restoring the pre-beta.37 guarantee that a suspension never preempts a delivery already committed to reaching the workflow. Barriers that do not self-resolve (unclaimed hook payloads) still do not block idle, so the idle safety net cannot deadlock. Patch changeset for `@workflow/core` included.

Two new tests: the parallel repro (fails deterministically without the fix with the dormant signature, `expected [] to deeply equal ['stepD']`) and a serial control (passes either way, matching the reported parallel-only split). Core suite: 1638 passed with an unchanged pre-existing environmental failure set; typecheck clean.
