### PR TITLE
Align Streams UI with trace viewer

### DIFF
--- a/.changeset/dense-stream-viewer.md
+++ b/.changeset/dense-stream-viewer.md
@@ -1,0 +1,6 @@
+---
+'@workflow/web': patch
+'@workflow/web-shared': patch
+---
+
+Tighten stream list, chunk viewer, and shared loading skeleton styling to match the trace view.

--- a/packages/web-shared/src/components/index.ts
+++ b/packages/web-shared/src/components/index.ts
@@ -29,6 +29,7 @@ export type {
   FetchSpanDetail,
 } from './sidebar/use-selected-span-detail';
 export { type StreamChunk, StreamViewer } from './stream-viewer';
+export { StreamViewerSkeleton } from './stream-viewer-skeleton';
 export type { Span, SpanEvent } from './trace-viewer/types';
 export { NewTraceViewer } from './trace-viewer-new';
 export {

--- a/packages/web-shared/src/components/stream-viewer-skeleton.tsx
+++ b/packages/web-shared/src/components/stream-viewer-skeleton.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from './ui/skeleton';
+
+const STREAM_SKELETON_ROWS = [
+  { id: 'stream-skeleton-row-1', width: '72%' },
+  { id: 'stream-skeleton-row-2', width: '58%' },
+  { id: 'stream-skeleton-row-3', width: '80%' },
+  { id: 'stream-skeleton-row-4', width: '64%' },
+];
+
+export function StreamViewerSkeleton() {
+  return (
+    <output
+      aria-busy="true"
+      aria-label="Loading stream"
+      className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background-100"
+    >
+      <span className="sr-only">Loading stream…</span>
+      <div className="flex h-10 min-h-10 items-center border-b border-gray-alpha-400 px-3">
+        <Skeleton className="h-3 w-10" />
+      </div>
+      <div className="flex flex-col">
+        {STREAM_SKELETON_ROWS.map((row) => (
+          <div
+            key={row.id}
+            className="flex h-10 items-center gap-2 border-b border-gray-alpha-400 px-3"
+          >
+            <Skeleton className="h-3" style={{ width: row.width }} />
+            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+          </div>
+        ))}
+      </div>
+    </output>
+  );
+}

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -25,7 +25,7 @@ interface StreamViewerProps {
   error?: string | null;
   /** True while the initial stream connection is being established */
   isLoading?: boolean;
-  /** Called when the user scrolls near the bottom, for triggering pagination */
+  /** Called when the user scrolls near the rendered end. */
   onScrollEnd?: () => void;
 }
 
@@ -74,7 +74,6 @@ export function StreamViewer({
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const prevChunkCountRef = useRef(0);
 
-  // Auto-scroll to bottom when new chunks arrive (live streaming)
   useEffect(() => {
     if (chunks.length > prevChunkCountRef.current && chunks.length > 0) {
       virtuosoRef.current?.scrollToIndex({
@@ -109,7 +108,7 @@ export function StreamViewer({
             <div>{error}</div>
           </div>
         ) : chunks.length === 0 ? (
-          <div className="border-b border-gray-alpha-400 bg-background-200 px-3 py-2 text-label-12 text-gray-900">
+          <div className="flex h-10 items-center border-b border-gray-alpha-400 bg-background-200 px-3 text-label-12 text-gray-900">
             {isLive ? 'Waiting for stream data...' : 'Stream is empty'}
           </div>
         ) : (

--- a/packages/web-shared/src/components/stream-viewer.tsx
+++ b/packages/web-shared/src/components/stream-viewer.tsx
@@ -2,8 +2,10 @@
 
 import React, { useEffect, useRef } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
+import { CopyButton } from './new-trace-viewer/components/copy-button';
+import { serializeForClipboard } from './sidebar/copyable-data-block';
+import { StreamViewerSkeleton } from './stream-viewer-skeleton';
 import { DataInspector } from './ui/data-inspector';
-import { Skeleton } from './ui/skeleton';
 
 // ──────────────────────────────────────────────────────────────────────────
 // Types
@@ -31,59 +33,26 @@ interface StreamViewerProps {
 // Chunk row — memoized to prevent remounts during polling
 // ──────────────────────────────────────────────────────────────────────────
 
-const ChunkRow = React.memo(function ChunkRow({
-  chunk,
-  index,
-}: {
-  chunk: Chunk;
-  index: number;
-}) {
+const ChunkRow = React.memo(function ChunkRow({ chunk }: { chunk: Chunk }) {
   return (
-    <div
-      className="text-[11px] rounded-md border p-3"
-      style={{
-        borderColor: 'var(--ds-gray-300)',
-        backgroundColor: 'var(--ds-gray-100)',
-      }}
-    >
-      <div className="flex items-start gap-2">
-        <span
-          className="select-none pt-px"
-          style={{ color: 'var(--ds-gray-500)' }}
-        >
-          [{index}]
-        </span>
-        <div className="min-w-0 flex-1">
-          {typeof chunk.value === 'string' ? (
-            <span
-              className="whitespace-pre-wrap break-words"
-              style={{ color: 'var(--ds-gray-1000)' }}
-            >
-              {chunk.value}
-            </span>
-          ) : (
-            <DataInspector data={chunk.value} expandLevel={1} />
-          )}
-        </div>
+    <div className="flex w-full items-start gap-1 border-b border-gray-alpha-400 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        {typeof chunk.value === 'string' ? (
+          <span className="whitespace-pre-wrap break-words text-label-12 font-mono text-gray-1000">
+            {chunk.value}
+          </span>
+        ) : (
+          <DataInspector data={chunk.value} expandLevel={1} />
+        )}
       </div>
+      <CopyButton
+        copyText={serializeForClipboard(chunk.value)}
+        ariaLabel="Copy chunk"
+        className="shrink-0 -mr-1 [&>div]:h-4 [&>div]:w-4 [&_svg]:h-4 [&_svg]:w-4"
+      />
     </div>
   );
 });
-
-// ──────────────────────────────────────────────────────────────────────────
-// Skeleton loading
-// ──────────────────────────────────────────────────────────────────────────
-
-function StreamSkeleton() {
-  return (
-    <div className="flex flex-col gap-3 animate-in fade-in">
-      <Skeleton style={{ width: 120, height: 16, borderRadius: 4 }} />
-      {[1, 2, 3, 4].map((i) => (
-        <Skeleton key={i} style={{ height: 56, borderRadius: 6 }} />
-      ))}
-    </div>
-  );
-}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Main component
@@ -116,71 +85,31 @@ export function StreamViewer({
     prevChunkCountRef.current = chunks.length;
   }, [chunks.length]);
 
-  // Show skeleton when loading and no chunks have arrived yet
   if (isLoading && chunks.length === 0) {
-    return (
-      <div className="flex flex-col h-full">
-        <StreamSkeleton />
-      </div>
-    );
+    return <StreamViewerSkeleton />;
   }
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Live indicator */}
-      {isLive && (
-        <div className="flex items-center gap-1.5 mb-2 px-1">
-          <span
-            className="inline-block w-2 h-2 rounded-full"
-            style={{ backgroundColor: 'var(--ds-green-600)' }}
-          />
-          <span className="text-xs" style={{ color: 'var(--ds-green-700)' }}>
-            Live
-          </span>
-        </div>
-      )}
-
-      {/* Header */}
-      {chunks.length > 0 && (
-        <div className="flex items-center gap-2 mb-2 px-1">
-          <span
-            className="text-[13px] font-medium"
-            style={{ color: 'var(--ds-gray-900)' }}
-          >
-            Stream Chunks
-          </span>
-          <span
-            className="text-xs tabular-nums"
-            style={{ color: 'var(--ds-gray-600)' }}
-          >
-            ({chunks.length})
-          </span>
-        </div>
-      )}
+    <div className="flex h-full w-full flex-col overflow-hidden bg-background-100">
+      {/* Status header */}
+      <div className="flex h-10 min-h-10 items-center gap-1.5 border-b border-gray-alpha-400 px-3">
+        {isLive && (
+          <>
+            <span className="inline-block h-2 w-2 rounded-full bg-green-600" />
+            <span className="text-label-12 text-green-700">Live</span>
+          </>
+        )}
+      </div>
 
       {/* Content */}
       <div className="flex-1 min-h-0">
         {error ? (
-          <div
-            className="text-[11px] rounded-md border p-3"
-            style={{
-              borderColor: 'var(--ds-red-300)',
-              backgroundColor: 'var(--ds-red-100)',
-              color: 'var(--ds-red-700)',
-            }}
-          >
+          <div className="border-b border-red-400 bg-red-100 px-3 py-2 text-label-12 text-red-900">
             <div>Error reading stream:</div>
             <div>{error}</div>
           </div>
         ) : chunks.length === 0 ? (
-          <div
-            className="text-[11px] rounded-md border p-3"
-            style={{
-              borderColor: 'var(--ds-gray-300)',
-              backgroundColor: 'var(--ds-gray-100)',
-              color: 'var(--ds-gray-600)',
-            }}
-          >
+          <div className="border-b border-gray-alpha-400 bg-background-200 px-3 py-2 text-label-12 text-gray-900">
             {isLive ? 'Waiting for stream data...' : 'Stream is empty'}
           </div>
         ) : (
@@ -190,8 +119,8 @@ export function StreamViewer({
             overscan={10}
             endReached={() => onScrollEnd?.()}
             itemContent={(index) => (
-              <div style={{ paddingBottom: 8 }}>
-                <ChunkRow chunk={chunks[index]} index={index} />
+              <div className="w-full">
+                <ChunkRow chunk={chunks[index]} />
               </div>
             )}
             style={{ flex: 1, minHeight: 0 }}

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -780,38 +780,23 @@ export function RunDetailView({
 
             <TabsContent value="streams" className="mt-0 flex-1 min-h-0">
               <ErrorBoundary title="Failed to load stream data">
-                <div className="h-full flex gap-4">
+                <div className="flex h-full">
                   {/* Stream list sidebar */}
-                  <div
-                    className="w-64 flex-shrink-0 border rounded-lg overflow-hidden"
-                    style={{
-                      borderColor: 'var(--ds-gray-300)',
-                      backgroundColor: 'var(--ds-background-100)',
-                    }}
-                  >
-                    <div
-                      className="px-3 py-2 border-b text-xs font-medium"
-                      style={{
-                        borderColor: 'var(--ds-gray-300)',
-                        color: 'var(--ds-gray-900)',
-                      }}
-                    >
+                  <div className="w-[340px] shrink-0 overflow-hidden border border-gray-alpha-400 bg-background-100">
+                    <div className="flex h-10 min-h-10 items-center border-b border-gray-alpha-400 pl-4 pr-2 text-label-14 font-medium text-gray-1000">
                       Streams ({streams.length})
                     </div>
-                    <div className="overflow-auto max-h-[calc(100vh-400px)]">
+                    <div className="max-h-[calc(100vh-400px)] overflow-auto divide-y divide-gray-400 border-b border-gray-400">
                       {streamsLoading ? (
-                        <div className="p-4 flex items-center justify-center">
+                        <div className="flex h-10 items-center justify-center">
                           <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                         </div>
                       ) : streamsError ? (
-                        <div className="p-4 text-xs text-destructive">
+                        <div className="px-4 py-2 text-label-12 text-red-900">
                           {streamsError.message}
                         </div>
                       ) : streams.length === 0 ? (
-                        <div
-                          className="p-4 text-xs"
-                          style={{ color: 'var(--ds-gray-600)' }}
-                        >
+                        <div className="flex h-10 items-center px-4 text-label-12 text-gray-900">
                           No streams found for this run
                         </div>
                       ) : (
@@ -820,14 +805,11 @@ export function RunDetailView({
                             key={streamId}
                             type="button"
                             onClick={() => setSelectedStreamId(streamId)}
-                            className="w-full text-left px-3 py-2 text-xs font-mono truncate hover:bg-accent transition-colors"
-                            style={{
-                              backgroundColor:
-                                selectedStreamId === streamId
-                                  ? 'var(--ds-gray-200)'
-                                  : 'transparent',
-                              color: 'var(--ds-gray-1000)',
-                            }}
+                            className={`flex h-10 w-full min-w-0 items-center truncate pl-4 pr-2 text-left text-label-14 font-mono text-gray-1000 transition-colors ${
+                              selectedStreamId === streamId
+                                ? 'bg-gray-100 hover:bg-gray-200'
+                                : 'hover:bg-gray-100'
+                            }`}
                             title={streamId}
                           >
                             {streamId}

--- a/packages/web/app/components/run-detail-view.tsx
+++ b/packages/web/app/components/run-detail-view.tsx
@@ -8,6 +8,7 @@ import {
   NewTraceViewer,
   type SidebarDataContextValue,
   StreamViewer,
+  StreamViewerSkeleton,
   stepEventsToStepEntity,
 } from '@workflow/web-shared';
 import { type Event, isStepEventType, type WorkflowRun } from '@workflow/world';
@@ -427,6 +428,7 @@ export function RunDetailView({
   const {
     chunks: streamChunks,
     isLive: streamIsLive,
+    isInitialLoading: streamIsInitialLoading,
     error: streamError,
   } = useStreamReader(env, selectedStreamId, runId, encryptionKey, run.status);
 
@@ -780,16 +782,25 @@ export function RunDetailView({
 
             <TabsContent value="streams" className="mt-0 flex-1 min-h-0">
               <ErrorBoundary title="Failed to load stream data">
-                <div className="flex h-full">
+                <div className="relative -mx-6 flex h-full min-h-0 overflow-hidden border-t border-gray-alpha-400 bg-background-100">
                   {/* Stream list sidebar */}
-                  <div className="w-[340px] shrink-0 overflow-hidden border border-gray-alpha-400 bg-background-100">
-                    <div className="flex h-10 min-h-10 items-center border-b border-gray-alpha-400 pl-4 pr-2 text-label-14 font-medium text-gray-1000">
-                      Streams ({streams.length})
-                    </div>
-                    <div className="max-h-[calc(100vh-400px)] overflow-auto divide-y divide-gray-400 border-b border-gray-400">
+                  <div className="flex w-[340px] shrink-0 flex-col border-r border-gray-alpha-400 bg-background-100">
+                    <div
+                      aria-hidden="true"
+                      className="h-10 min-h-10 border-b border-gray-alpha-400"
+                    />
+                    <div className="min-h-0 flex-1 divide-y divide-gray-400 overflow-y-auto">
                       {streamsLoading ? (
-                        <div className="flex h-10 items-center justify-center">
-                          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                        <div className="flex flex-col divide-y divide-gray-400">
+                          <div className="flex h-10 items-center pl-4 pr-2">
+                            <Skeleton className="h-3.5 w-24" />
+                          </div>
+                          <div className="flex h-10 items-center pl-4 pr-2">
+                            <Skeleton className="h-3.5 w-32" />
+                          </div>
+                          <div className="flex h-10 items-center pl-4 pr-2">
+                            <Skeleton className="h-3.5 w-20" />
+                          </div>
                         </div>
                       ) : streamsError ? (
                         <div className="px-4 py-2 text-label-12 text-red-900">
@@ -805,10 +816,10 @@ export function RunDetailView({
                             key={streamId}
                             type="button"
                             onClick={() => setSelectedStreamId(streamId)}
-                            className={`flex h-10 w-full min-w-0 items-center truncate pl-4 pr-2 text-left text-label-14 font-mono text-gray-1000 transition-colors ${
+                            className={`flex h-10 w-full min-w-0 items-center truncate pl-4 pr-2 text-left text-label-14 transition-colors ${
                               selectedStreamId === streamId
-                                ? 'bg-gray-100 hover:bg-gray-200'
-                                : 'hover:bg-gray-100'
+                                ? 'bg-gray-100 text-gray-1000 hover:bg-gray-200 active:bg-gray-200'
+                                : 'bg-transparent text-gray-900 hover:bg-gray-100 hover:text-gray-1000 focus-visible:bg-gray-100 focus-visible:text-gray-1000'
                             }`}
                             title={streamId}
                           >
@@ -820,55 +831,48 @@ export function RunDetailView({
                   </div>
 
                   {/* Stream viewer */}
-                  <div className="flex-1 min-w-0">
-                    {selectedStreamId ? (
+                  <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-background-100">
+                    {streamsLoading ? (
+                      <div className="min-h-0 flex-1">
+                        <StreamViewerSkeleton />
+                      </div>
+                    ) : selectedStreamId ? (
                       streamError?.includes('encrypted') && !encryptionKey ? (
-                        <div
-                          className="h-full flex flex-col items-center justify-center gap-3 rounded-lg border p-4"
-                          style={{
-                            borderColor: 'var(--ds-gray-300)',
-                            backgroundColor: 'var(--ds-gray-100)',
-                          }}
-                        >
-                          <Lock
-                            className="h-6 w-6"
-                            style={{ color: 'var(--ds-gray-700)' }}
-                          />
-                          <div
-                            className="text-sm"
-                            style={{ color: 'var(--ds-gray-900)' }}
-                          >
-                            This stream is encrypted.
+                        <div className="flex h-full items-center justify-center p-4">
+                          <div className="flex flex-col items-center gap-3 text-center">
+                            <Lock className="h-8 w-8 text-gray-700" />
+                            <div className="space-y-1">
+                              <div className="text-label-14 font-medium text-gray-1000">
+                                Encrypted Stream
+                              </div>
+                              <div className="text-label-12 text-gray-900">
+                                Decrypt this stream to view its chunks.
+                              </div>
+                            </div>
+                            <DecryptButton
+                              onClick={handleDecrypt}
+                              loading={isDecrypting}
+                            />
                           </div>
-                          <DecryptButton
-                            onClick={handleDecrypt}
-                            loading={isDecrypting}
-                          />
                         </div>
                       ) : (
-                        <StreamViewer
-                          streamId={selectedStreamId}
-                          chunks={streamChunks}
-                          isLive={streamIsLive}
-                          error={
-                            streamError?.includes('encrypted')
-                              ? null
-                              : streamError
-                          }
-                        />
+                        <div className="min-h-0 flex-1">
+                          <StreamViewer
+                            streamId={selectedStreamId}
+                            chunks={streamChunks}
+                            isLive={streamIsLive}
+                            isLoading={streamIsInitialLoading}
+                            error={
+                              streamError?.includes('encrypted')
+                                ? null
+                                : streamError
+                            }
+                          />
+                        </div>
                       )
                     ) : (
-                      <div
-                        className="h-full flex items-center justify-center rounded-lg border"
-                        style={{
-                          borderColor: 'var(--ds-gray-300)',
-                          backgroundColor: 'var(--ds-gray-100)',
-                        }}
-                      >
-                        <div
-                          className="text-sm"
-                          style={{ color: 'var(--ds-gray-600)' }}
-                        >
+                      <div className="flex h-full items-center justify-center">
+                        <div className="text-label-14 text-gray-600">
                           {streams.length > 0
                             ? 'Select a stream to view its data'
                             : 'No streams available'}

--- a/packages/web/app/lib/hooks/use-stream-reader.test.ts
+++ b/packages/web/app/lib/hooks/use-stream-reader.test.ts
@@ -1,0 +1,80 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StreamResponse } from '~/lib/client/workflow-streams';
+import { readStream } from '~/lib/workflow-api-client';
+import { useStreamReader } from './use-stream-reader';
+
+vi.mock('~/lib/workflow-api-client', () => ({
+  readStream: vi.fn(),
+}));
+
+const env = {};
+
+function emptyStreamResponse(done: boolean): StreamResponse {
+  return {
+    body: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    cursor: null,
+    done,
+  };
+}
+
+describe('useStreamReader status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not report live while the initial request is loading', async () => {
+    let resolveRead: (response: StreamResponse) => void = () => {};
+    vi.mocked(readStream).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve;
+      })
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useStreamReader(env, 'stream-1', 'run-1', null, 'running')
+    );
+
+    expect(result.current.isInitialLoading).toBe(true);
+    expect(result.current.isLive).toBe(false);
+
+    resolveRead(emptyStreamResponse(false));
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+    expect(result.current.isLive).toBe(true);
+
+    unmount();
+  });
+
+  it('does not report a completed stream as live', async () => {
+    vi.mocked(readStream).mockResolvedValue(emptyStreamResponse(true));
+
+    const { result } = renderHook(() =>
+      useStreamReader(env, 'stream-1', 'run-1', null, 'running')
+    );
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+    expect(result.current.isLive).toBe(false);
+  });
+
+  it('does not report an open stream as live after the run completes', async () => {
+    vi.mocked(readStream).mockResolvedValue(emptyStreamResponse(false));
+
+    const { result } = renderHook(() =>
+      useStreamReader(env, 'stream-1', 'run-1', null, 'completed')
+    );
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+    expect(result.current.isLive).toBe(false);
+  });
+});

--- a/packages/web/app/lib/hooks/use-stream-reader.ts
+++ b/packages/web/app/lib/hooks/use-stream-reader.ts
@@ -1,11 +1,9 @@
 import {
   decryptEnvelope,
   deriveRunPayloadKeys,
-  type PayloadKey,
-} from '@workflow/core/serialization-format';
-import {
   hydrateData,
   isEncryptedData,
+  type PayloadKey,
 } from '@workflow/core/serialization-format';
 import { getWebRevivers } from '@workflow/web-shared';
 import type { WorkflowRunStatus } from '@workflow/world';
@@ -59,6 +57,9 @@ export function useStreamReader(
 ) {
   const [chunks, setChunks] = useState<StreamChunk[]>([]);
   const [isLive, setIsLive] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(
+    Boolean(streamId && runId)
+  );
   const [error, setError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const chunkIdRef = useRef(0);
@@ -130,6 +131,8 @@ export function useStreamReader(
   useEffect(() => {
     setChunks([]);
     setError(null);
+    setIsLive(false);
+    setIsInitialLoading(Boolean(streamId && runId));
     chunkIdRef.current = 0;
     frameCountRef.current = 0;
     serverCursorRef.current = null;
@@ -140,14 +143,13 @@ export function useStreamReader(
     }
 
     if (!streamId || !runId) {
-      setIsLive(false);
+      setIsInitialLoading(false);
       return;
     }
 
     let mounted = true;
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
-    setIsLive(true);
 
     const revivers = getWebRevivers();
 
@@ -320,6 +322,7 @@ export function useStreamReader(
           if (mounted) {
             setError('This stream is encrypted. Click Decrypt to view.');
             setIsLive(false);
+            setIsInitialLoading(false);
           }
           return;
         }
@@ -330,6 +333,7 @@ export function useStreamReader(
         if (!mounted || abortController.signal.aborted) return;
 
         setChunks(initialChunks);
+        setIsInitialLoading(false);
 
         // If the stream itself is done, no need to poll regardless of run status
         if (result.done) {
@@ -338,6 +342,7 @@ export function useStreamReader(
         }
 
         if (isRunActive(runStatusRef.current)) {
+          setIsLive(true);
           const poll = async () => {
             if (!mounted || abortController.signal.aborted) return;
             try {
@@ -375,6 +380,7 @@ export function useStreamReader(
         if (mounted) {
           setError(err instanceof Error ? err.message : String(err));
           setIsLive(false);
+          setIsInitialLoading(false);
         }
       }
     };
@@ -401,5 +407,5 @@ export function useStreamReader(
     }
   }, [runStatus]);
 
-  return { chunks, isLive, error };
+  return { chunks, isLive, isInitialLoading, error };
 }


### PR DESCRIPTION
## Summary
- Flatten stream chunks into full-width rows with a permanent status header, semantic light surface, and trace-viewer copy controls.
- Tighten the Workflow web stream list into a compact 340px sidebar while preserving streaming, virtualization, pagination, selection, and encryption behavior.
- Export and reuse the shared `StreamViewerSkeleton` so Front consumers can use the same single-line loading treatment.

## Test plan
- [x] `pnpm exec biome check packages/web-shared/src/components/index.ts packages/web-shared/src/components/stream-viewer.tsx packages/web-shared/src/components/stream-viewer-skeleton.tsx packages/web/app/components/run-detail-view.tsx` (passes with two pre-existing complexity warnings in `run-detail-view.tsx`)
- [x] `pnpm --filter @workflow/web-shared typecheck`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)