### PR TITLE
fix(core): don't observe idle while a committed delivery is parked behind its deferral

### DIFF
--- a/.changeset/idle-check-parked-deliveries.md
+++ b/.changeset/idle-check-parked-deliveries.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Don't observe idle — and raise a `WorkflowSuspension` — while a delivery that is committed to reaching the workflow is still parked between its serial queue slot and its detached `resolve()`. A run with an outstanding `sleep()` replaying a batch of parallel step results could suspend inside that gap with none of the batch's follow-up work queued, going dormant until an unrelated timer fired.

--- a/packages/core/src/delivery-barrier-coverage.test.ts
+++ b/packages/core/src/delivery-barrier-coverage.test.ts
@@ -25,9 +25,19 @@
  *     branch-deciding as any other delivery — but it resolved straight off its
  *     `promiseQueue` slot and registered no barrier.
  *
- * Every case asserts the same thing: the replay allocates its follow-up step
+ * Cases 1-4 assert the same thing: the replay allocates its follow-up step
  * ULIDs in the order the committed log recorded. A regression surfaces as the
  * production `ReplayDivergenceError`.
+ *
+ * The final section covers the SUSPENSION side of the registry
+ * (vercel/workflow#3183): an idle check must not observe idle — and raise a
+ * `WorkflowSuspension` — while a delivery that is committed to reaching the
+ * workflow is still parked between its queue slot (which releases
+ * `pendingDeliveries`) and its detached `resolve()` (which pays
+ * `awaitEarlierDeliveries`' macrotask yield whenever it deferred). A
+ * suspension raised inside that gap predates the workflow's own
+ * continuations, carries none of the follow-up work they were about to
+ * create, and schedules nothing — leaving the run dormant.
  */
 import { WorkflowRuntimeError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
@@ -506,5 +516,156 @@ describe('delivery-barrier registry scan cost', () => {
     // only the synchronous scan inside the call is under test.
     void awaitEarlierDeliveries(ctx, BARRIERS, 'step');
     expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+});
+
+// ─── 5. suspension timing: idle must wait out parked deliveries ────────────
+//
+// Field shape from vercel/workflow#3183: a fire-and-forget `sleep()` (a
+// watchdog — never awaited, never completing in-run) plus a parallel batch of
+// step results. The sleep's subscriber reaches the end of the log on every
+// replay and arms `scheduleWhenIdle`; the batch's step results release
+// `pendingDeliveries` inside their serial queue slots but resolve from
+// detached continuations, and every one after the first pays the
+// step-behind-step deferral's macrotask yield. The armed idle check races
+// exactly that yield.
+//
+// The assertions here are against the `WorkflowSuspension`'s OWN snapshot of
+// the invocation queue (taken at raise time), not the live queue: the parked
+// deliveries still resolve after a premature suspension, so the live queue
+// eventually contains the follow-up step even when the suspension that the
+// runtime acted on did not. A premature suspension surfaces as `[]` — zero
+// invocations, nothing scheduled, a dormant run.
+function expectSuspensionSnapshotSteps(error: unknown, expected: string[]) {
+  if (!WorkflowSuspension.is(error)) {
+    throw new Error(
+      error === undefined
+        ? 'expected the replay to suspend, but it completed'
+        : error instanceof Error
+          ? error.message
+          : String(error),
+      { cause: error }
+    );
+  }
+  expect(
+    (error as WorkflowSuspension).steps.flatMap((item) =>
+      item.type === 'step' ? [item.stepName] : []
+    )
+  ).toEqual(expected);
+}
+
+describe('suspension timing against parked step deliveries', () => {
+  // Draw order: sleep -> ULIDS[0]; the three parallel steps -> 1..3; the
+  // follow-up step (never run, so only allocated) -> 4.
+  const RESUME_AT = new Date(FIXED_TIMESTAMP + 25 * 60_000);
+
+  it('a parallel batch with a pending sleep suspends carrying the follow-up step', async () => {
+    const ops: Promise<unknown>[] = [];
+    const results = await Promise.all(
+      ['a', 'b', 'c'].map((value) =>
+        dehydrateStepReturnValue(value, 'wrun_test', undefined, ops)
+      )
+    );
+
+    const events: Event[] = [
+      event('evnt_0', 'wait_created', `wait_${ULIDS[0]}`, {
+        resumeAt: RESUME_AT,
+      }),
+      event('evnt_1', 'step_created', `step_${ULIDS[1]}`, {
+        stepName: 'parallelA',
+      }),
+      event('evnt_2', 'step_created', `step_${ULIDS[2]}`, {
+        stepName: 'parallelB',
+      }),
+      event('evnt_3', 'step_created', `step_${ULIDS[3]}`, {
+        stepName: 'parallelC',
+      }),
+      event('evnt_4', 'step_started', `step_${ULIDS[1]}`, {
+        stepName: 'parallelA',
+      }),
+      event('evnt_5', 'step_started', `step_${ULIDS[2]}`, {
+        stepName: 'parallelB',
+      }),
+      event('evnt_6', 'step_started', `step_${ULIDS[3]}`, {
+        stepName: 'parallelC',
+      }),
+      event('evnt_7', 'step_completed', `step_${ULIDS[1]}`, {
+        stepName: 'parallelA',
+        result: results[0],
+      }),
+      event('evnt_8', 'step_completed', `step_${ULIDS[2]}`, {
+        stepName: 'parallelB',
+        result: results[1],
+      }),
+      event('evnt_9', 'step_completed', `step_${ULIDS[3]}`, {
+        stepName: 'parallelC',
+        result: results[2],
+      }),
+    ];
+
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    const sleep = createSleep(ctx);
+
+    const error = await replay(ctx, async () => {
+      // Watchdog: arms the idle check on every replay, completes on none.
+      sleep('25m').catch(() => {});
+
+      const parallelA = useStep('parallelA');
+      const parallelB = useStep('parallelB');
+      const parallelC = useStep('parallelC');
+      const followUp = useStep('followUp');
+
+      await Promise.all([parallelA(), parallelB(), parallelC()]);
+      await followUp();
+    });
+
+    expectSuspensionSnapshotSteps(error, ['followUp']);
+  });
+
+  // Control from the same field data: 121 single-step rounds never stalled. A
+  // lone step result defers behind nothing, resolves on microtasks ahead of
+  // the idle check's macrotask, and needs no barrier awareness in the idle
+  // check at all.
+  it('control: a single-step round with a pending sleep is unaffected', async () => {
+    const ops: Promise<unknown>[] = [];
+    const result = await dehydrateStepReturnValue(
+      'a',
+      'wrun_test',
+      undefined,
+      ops
+    );
+
+    const events: Event[] = [
+      event('evnt_0', 'wait_created', `wait_${ULIDS[0]}`, {
+        resumeAt: RESUME_AT,
+      }),
+      event('evnt_1', 'step_created', `step_${ULIDS[1]}`, {
+        stepName: 'only',
+      }),
+      event('evnt_2', 'step_started', `step_${ULIDS[1]}`, {
+        stepName: 'only',
+      }),
+      event('evnt_3', 'step_completed', `step_${ULIDS[1]}`, {
+        stepName: 'only',
+        result,
+      }),
+    ];
+
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    const sleep = createSleep(ctx);
+
+    const error = await replay(ctx, async () => {
+      sleep('25m').catch(() => {});
+
+      const only = useStep('only');
+      const followUp = useStep('followUp');
+
+      await only();
+      await followUp();
+    });
+
+    expectSuspensionSnapshotSteps(error, ['followUp']);
   });
 });

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -4,11 +4,11 @@
 
 import { withResolvers } from '@workflow/utils';
 import type { WorldCapabilities } from '@workflow/world';
-import type { PayloadKey } from './serialization/encryption.js';
 import type { EventsConsumer } from './events-consumer.js';
 import type { QueueItem } from './global.js';
 import type { ReplayPayloadCache } from './replay-payload-cache.js';
 import type { Serializable } from './schemas.js';
+import type { PayloadKey } from './serialization/encryption.js';
 
 export type StepFunction<
   Args extends Serializable[] = any[],
@@ -421,6 +421,16 @@ export interface DeliveryBarrier {
  * To guarantee a later delivery gated on this one can never hang when this
  * delivery is abandoned (the workflow took a different branch or is
  * suspending and never observes it), the barrier auto-resolves at idle.
+ *
+ * INVARIANT required of every call site: a barrier that is ever `armed` must
+ * be paired with a delivery chain that runs unconditionally — attached when
+ * the event is consumed (waits, step results, waiting-consumer hook payloads,
+ * aborts), or by the `claim()` whose invocation is what arms it (buffered
+ * hook payloads). The idle check ({@link scheduleWhenIdle}) refuses to
+ * observe idle while an armed, self-resolving barrier is undelivered, and the
+ * safety net below is itself idle-gated — so an armed barrier with no
+ * unconditional chain would livelock every idle check in the run, including
+ * its own retirement.
  */
 export function registerDeliveryBarrier(
   ctx: WorkflowOrchestratorContext,
@@ -469,12 +479,61 @@ export function registerDeliveryBarrier(
 }
 
 /**
+ * Whether some registered branch-deciding delivery is going to reach the
+ * workflow without any further help (it is armed and not transitively parked
+ * behind an unclaimed buffered payload — see {@link resolvesOnItsOwn}) but
+ * has not been handed over yet.
+ *
+ * This is the delivery state `pendingDeliveries` cannot see. That counter
+ * covers the hydration window inside a serial `promiseQueue` slot and is
+ * released there, while the delivery's `resolve()` runs later, from a
+ * detached continuation behind {@link awaitEarlierDeliveries} — including its
+ * macrotask yield whenever the delivery had to defer. Replaying a batch of N
+ * parallel step results consumed in one drain window leaves N-1 of them
+ * parked on that yield with `pendingDeliveries` already at 0. An idle check
+ * armed during the same window (a pending `sleep()` arms one on every replay)
+ * could then observe "idle" mid-deferral and raise a `WorkflowSuspension`
+ * BEFORE the workflow's own continuations ran — a suspension carrying none of
+ * the follow-up work the batch was about to create, which the runtime
+ * dutifully schedules as nothing, leaving the run dormant until an unrelated
+ * timer fires (vercel/workflow#3183).
+ *
+ * Deliveries that do NOT resolve on their own must be excluded, not for
+ * accuracy but for termination: an unclaimed buffered hook payload is retired
+ * BY the idle safety net in {@link registerDeliveryBarrier}, so counting it
+ * here would gate its own retirement. Self-resolving deliveries always
+ * deliver from their own chains (see the INVARIANT on
+ * {@link registerDeliveryBarrier}) and never need that net, so waiting on
+ * them is deadlock-free.
+ */
+function hasParkedCommittedDelivery(ctx: WorkflowOrchestratorContext): boolean {
+  const barriers = ctx.pendingDeliveryBarriers;
+  if (!barriers || barriers.size === 0) {
+    return false;
+  }
+  // Shared across this call only — see `resolvesOnItsOwn`.
+  const selfResolving = new Map<number, boolean>();
+  for (const [index, entry] of barriers) {
+    if (resolvesOnItsOwn(barriers, index, entry, selfResolving)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Schedule a callback to fire only after all pending data deliveries
  * (step results, hook payloads) and async deserialization have completed.
- * Uses a polling loop: setTimeout(0) → check pendingDeliveries →
- * if > 0, wait for promiseQueue → repeat. This handles the multi-round
- * delivery pattern where each hook payload delivery cycle appends new
- * async work to the promiseQueue.
+ * Uses a polling loop: setTimeout(0) → check pendingDeliveries and the
+ * barrier registry → if anything is still in flight, wait for promiseQueue →
+ * repeat. This handles the multi-round delivery pattern where each hook
+ * payload delivery cycle appends new async work to the promiseQueue.
+ *
+ * "In flight" is two distinct windows, each with its own guard:
+ * `pendingDeliveries > 0` covers hydration inside the serial queue slots, and
+ * {@link hasParkedCommittedDelivery} covers the detached gap between a slot
+ * releasing that counter and the delivery's `resolve()` actually running —
+ * deliberately outside `pendingDeliveries` (see step.ts), and invisible to it.
  *
  * The initial `setTimeout(0)` macrotask is load-bearing and must NOT be
  * downgraded to a microtask (`queueMicrotask`/`Promise.resolve().then`).
@@ -493,8 +552,10 @@ export function scheduleWhenIdle(
   fn: () => void
 ): void {
   const check = () => {
-    if (ctx.pendingDeliveries > 0) {
-      // Still delivering data — wait for queue to drain, then re-check
+    if (ctx.pendingDeliveries > 0 || hasParkedCommittedDelivery(ctx)) {
+      // A delivery is still hydrating, or is committed but parked behind its
+      // deferral (whose resolve runs on a detached timer, not this queue).
+      // Either way: let the queue drain, then re-check a timer tick later.
       ctx.promiseQueue.then(() => {
         setTimeout(check, 0);
       });


### PR DESCRIPTION
Fixes #3183 — thank you @shtefcs for an unusually precise report; the mechanism analysis in it is correct on every point and this fix is implemented from it.

## The bug

#3139 (first published in `beta.37`) moved every branch-deciding delivery's `resolve()` off its serial `promiseQueue` slot into a detached continuation gated by `awaitEarlierDeliveries`, which ends in a **macrotask yield** whenever the delivery had to defer. `pendingDeliveries` is deliberately released inside the slot — the idle safety net that retires abandoned barriers depends on idle being reachable — which opened a gap the idle check could not see:

- Replaying a batch of **N parallel step results** consumed in one drain window leaves N−1 of them hydrated but parked on that yield, with `pendingDeliveries` already at 0 (the step-behind-step edge in `DEFER_BEHIND` makes every step after the first defer).
- An idle check armed during the same window observes "idle" mid-deferral. A fire-and-forget `sleep()` arms one on **every** replay: its subscriber reaches the end of the log and calls `scheduleWhenIdle(… WorkflowSuspension …)`.
- The suspension therefore fires **before the workflow's own continuations run**. It carries zero invocations, `runtime.ts` hits `inlineExecutions.length === 0` and returns without queueing anything, and the run is dormant until an unrelated timer fires.

The field data in #3183 matches the mechanism exactly: a single-step round defers behind nothing, resolves on microtasks ahead of the idle check's macrotask, and is unaffected (121/121 clean); parallel batches stalled 5 of 6 times, each rescued only by the very watchdog `sleep()` that armed the premature check.

For the record of how #3139's own testing missed this: every ordering test asserts *which* work the suspension carries on log shapes where the deferral chain has already unwound before any idle check fires. None raced an **armed idle check** against the deferral window — a pending `wait_created` with no `wait_completed`, plus a multi-step batch. That's exactly the shape added here.

## The fix

`scheduleWhenIdle` now refuses to observe idle while any registered barrier is **armed and self-resolving (`resolvesOnItsOwn`) but undelivered** — the delivery state `pendingDeliveries` structurally cannot see, since it lives between the slot releasing the counter and the detached `resolve()` running.

The exclusion of non-self-resolving barriers is load-bearing, not an optimization: an unclaimed buffered hook payload is retired **by** the idle safety net, so counting it would gate its own retirement. Termination therefore rests on an invariant that previously lived implicitly across four files, now documented as an **INVARIANT** on `registerDeliveryBarrier`: a barrier that is ever armed must have a delivery chain that runs unconditionally. Audited at every call site — `sleep.ts` chains off the queue tail unconditionally; both `step.ts` paths reach their detached continuation past a try/finally; `hook.ts`'s waiting-consumer branch is guarded by `promises.length > 0`; buffered payloads register unarmed and only arm inside `claim()`, whose chain *is* the delivery; `abort-controller.ts` mirrors sleep. An armed barrier with no unconditional chain would livelock every idle check in the run, including its own — which is why the invariant is now written where the next call site will read it.

Cost on the happy path: one `O(live barriers)` memoized scan per idle-poll iteration, on a loop that already runs on timer ticks.

## Tests

Added as a fifth section of `delivery-barrier-coverage.test.ts` (same harness, no fourth copy of the boilerplate), covering the suspension side of the barrier registry:

- **Parallel repro** — fire-and-forget `sleep('25m')` + `Promise.all` of three steps + a follow-up step. Without the fix it fails **5/5 runs** with the exact dormant signature: `expected [] to deeply equal ['followUp']`, a suspension carrying zero invocations.
- **Serial control** — single step, same sleep; passes with or without the fix, matching the 121/0 field split.

Both assert against the `WorkflowSuspension`'s **own snapshot** rather than the live invocation queue. That distinction is what makes the repro sound: the parked deliveries still resolve after a premature suspension, so the live queue *heals* and eventually contains `followUp` even when the suspension the runtime acted on carried nothing.

## Verification

- Full core suite: **75 files, 1652 passed | 3 expected fail** (pre-existing). Typecheck clean, biome clean.
- The 12 ordering/suspension-sensitive files (including `hook-sleep-interaction`, which exercises the idle safety net this constrains) run **8× consecutively**: identical results every run.
- **Full local e2e** against a `nextjs-turbopack` dev server: **135/135**.

## Release sequencing

- This blocks the v5 stable release: `beta.37` is the first affected version.
- #3173 (the `stable` backport of #3139) is **on hold** and must take this fix along when it lands — `stable` does not carry the regression today only because that PR hasn't merged. The fix has no abort-controller dependency, so it applies to the `stable` adaptation without changes.

## Follow-up (separate issue)

#3183's "cheap second layer" is worth doing regardless: when a suspension carries zero pending work and the handler queues nothing, `runtime.ts` returns silently and the run can only be revived externally. Re-invoking once in that case turns any future bug of this class into a latency blip instead of indefinite dormancy.
