### PR TITLE
Improve workflow runs table hierarchy and usability

### DIFF
--- a/.changeset/calm-runs-table.md
+++ b/.changeset/calm-runs-table.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web": patch
+---
+
+Improve the workflow runs page hierarchy, filtering, timing, and responsive table layout.

--- a/packages/web/app/components/display-utils/status-badge.tsx
+++ b/packages/web/app/components/display-utils/status-badge.tsx
@@ -30,6 +30,25 @@ interface StatusBadgeProps {
   durationMs?: number;
 }
 
+function getStatusLabel(status: StatusBadgeProps['status']): string {
+  switch (status) {
+    case 'running':
+      return 'Active';
+    case 'completed':
+      return 'Completed';
+    case 'failed':
+      return 'Errored';
+    case 'cancelled':
+      return 'Canceled';
+    case 'pending':
+      return 'Pending';
+    default: {
+      const exhaustiveStatus: never = status;
+      return exhaustiveStatus;
+    }
+  }
+}
+
 export function StatusBadge({
   status,
   context,
@@ -39,17 +58,19 @@ export function StatusBadge({
   const getCircleColor = () => {
     switch (status) {
       case 'running':
-        return 'bg-blue-500';
+        return 'bg-amber-500';
       case 'completed':
         return 'bg-emerald-500';
       case 'failed':
         return 'bg-red-500';
       case 'cancelled':
-        return 'bg-yellow-500';
+        return 'bg-gray-400';
       case 'pending':
         return 'bg-gray-400';
-      default:
-        return 'bg-gray-400';
+      default: {
+        const exhaustiveStatus: never = status;
+        return exhaustiveStatus;
+      }
     }
   };
 
@@ -59,8 +80,8 @@ export function StatusBadge({
         <span
           className={cn('size-2 rounded-full shrink-0', getCircleColor())}
         />
-        <span className="text-muted-foreground text-xs font-medium capitalize">
-          {status}
+        <span className="text-muted-foreground text-xs font-medium">
+          {getStatusLabel(status)}
         </span>
       </span>
       {durationMs !== undefined && (

--- a/packages/web/app/components/runs-table.tsx
+++ b/packages/web/app/components/runs-table.tsx
@@ -4,6 +4,8 @@ import {
   AlertCircle,
   ArrowDown,
   ArrowUp,
+  CirclePause,
+  CirclePlay,
   Loader2,
   MoreHorizontal,
   RefreshCw,
@@ -49,7 +51,7 @@ import {
 import { useTableSelection } from '~/lib/hooks/use-table-selection';
 import { fetchEvents, fetchRun } from '~/lib/rpc-client';
 import type { EnvMap } from '~/lib/types';
-import { formatDuration } from '~/lib/utils';
+import { formatDuration, LIVE_UPDATE_INTERVAL_MS } from '~/lib/utils';
 import {
   cancelRun,
   getErrorMessage,
@@ -166,10 +168,10 @@ interface RunsTableProps {
 
 const statusMap: Record<WorkflowRunStatus, { label: string; color: string }> = {
   pending: { label: 'Pending', color: 'bg-neutral-600 dark:bg-neutral-400' },
-  running: { label: 'Running', color: 'bg-blue-600 dark:bg-blue-400' },
+  running: { label: 'Active', color: 'bg-amber-500' },
   completed: { label: 'Completed', color: 'bg-green-600 dark:bg-green-400' },
-  failed: { label: 'Failed', color: 'bg-red-600 dark:bg-red-400' },
-  cancelled: { label: 'Cancelled', color: 'bg-gray-600 dark:bg-gray-400' },
+  failed: { label: 'Errored', color: 'bg-red-600 dark:bg-red-400' },
+  cancelled: { label: 'Canceled', color: 'bg-gray-600 dark:bg-gray-400' },
 };
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -310,8 +312,8 @@ interface FilterControlsProps {
   workflowNameFilter: string | 'all';
   status: WorkflowRunStatus | 'all' | undefined;
   seenWorkflowNames: Set<string>;
-  sortOrder: 'asc' | 'desc';
   loading: boolean;
+  liveUpdates: boolean;
   period: PeriodId;
   /** Whether the backend supports listing windows (analytics read path). */
   showPeriodPicker: boolean;
@@ -321,7 +323,7 @@ interface FilterControlsProps {
   onWorkflowChange: (value: string) => void;
   onStatusChange: (value: string) => void;
   onPeriodChange: (value: string) => void;
-  onSortToggle: () => void;
+  onLiveUpdatesChange: (enabled: boolean) => void;
   onRefresh: () => void;
   onClearFilters: () => void;
   hasActiveFilters: boolean;
@@ -332,8 +334,8 @@ function FilterControls({
   workflowNameFilter,
   status,
   seenWorkflowNames,
-  sortOrder,
   loading,
+  liveUpdates,
   period,
   showPeriodPicker,
   planWindowMs,
@@ -341,7 +343,7 @@ function FilterControls({
   onWorkflowChange,
   onStatusChange,
   onPeriodChange,
-  onSortToggle,
+  onLiveUpdatesChange,
   onRefresh,
   onClearFilters,
   hasActiveFilters,
@@ -468,21 +470,27 @@ function FilterControls({
             <Button
               variant="outline"
               size="sm"
-              onClick={onSortToggle}
-              disabled={loading}
+              aria-pressed={liveUpdates}
+              aria-label={
+                liveUpdates ? 'Pause live updates' : 'Resume live updates'
+              }
+              className={
+                liveUpdates
+                  ? 'border-blue-500 text-blue-700 dark:text-blue-400'
+                  : undefined
+              }
+              onClick={() => onLiveUpdatesChange(!liveUpdates)}
             >
-              {sortOrder === 'desc' ? (
-                <ArrowDown className="h-4 w-4" />
+              {liveUpdates ? (
+                <CirclePause className="h-4 w-4" />
               ) : (
-                <ArrowUp className="h-4 w-4" />
+                <CirclePlay className="h-4 w-4" />
               )}
-              {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
+              {liveUpdates ? 'Live' : 'Paused'}
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            {sortOrder === 'desc'
-              ? 'Showing newest first'
-              : 'Showing oldest first'}
+            {liveUpdates ? 'Pause live updates' : 'Resume live updates'}
           </TooltipContent>
         </Tooltip>
         {hasActiveFilters && (
@@ -544,6 +552,7 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
     PERIOD_PRESETS.find((preset) => preset.id === period) ?? PERIOD_PRESETS[2];
   const handlePeriodFilter = usePeriodFilter();
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [liveUpdates, setLiveUpdates] = useState(true);
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(
     () => new Date()
   );
@@ -776,18 +785,25 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
     setSortOrder((prev) => (prev === 'desc' ? 'asc' : 'desc'));
   };
 
-  // Only for local env and while we don't already have data,
-  // we periodically refresh the data to check for new runs.
-  // This is both to improve UX slightly, while also ensuring that
-  // we react to a workflow data directory being created after the first run.
+  // Match the hosted Workflows view's live mode while avoiding refreshes in
+  // background tabs or while another page request is in flight.
   useEffect(() => {
-    if (isLocalAndHasMissingData) {
-      const interval = setInterval(() => {
-        onRefresh();
-      }, 5000);
-      return () => clearInterval(interval);
+    if (!liveUpdates) {
+      return;
     }
-  }, [isLocalAndHasMissingData, onRefresh]);
+
+    const interval = setInterval(() => {
+      if (
+        document.visibilityState === 'visible' &&
+        !loading &&
+        !isLoadingMore
+      ) {
+        onRefresh();
+      }
+    }, LIVE_UPDATE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [isLoadingMore, liveUpdates, loading, onRefresh]);
 
   // Refresh when tab regains focus after a delay, to prevent stale UI.
   // TODO: We should generally move to using SWR or similar for _all_ API calls here.
@@ -819,8 +835,8 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
         workflowNameFilter={workflowNameFilter}
         status={status}
         seenWorkflowNames={seenWorkflowNames}
-        sortOrder={sortOrder}
         loading={loading}
+        liveUpdates={liveUpdates}
         period={period}
         showPeriodPicker={isVercelBackend}
         planWindowMs={planWindowMs}
@@ -828,7 +844,7 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
         onWorkflowChange={handleWorkflowFilter}
         onStatusChange={handleStatusFilter}
         onPeriodChange={handlePeriodFilter}
-        onSortToggle={toggleSortOrder}
+        onLiveUpdatesChange={setLiveUpdates}
         onRefresh={onReload}
         onClearFilters={handleClearFilters}
         hasActiveFilters={hasActiveFilters}
@@ -838,11 +854,11 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
       <Card className="overflow-hidden bg-background shadow-none">
         <CardContent
           ref={setScrollRoot}
-          className="min-h-80 max-h-[calc(100vh-340px)] overflow-auto p-0"
+          className="min-h-80 max-h-[calc(100vh-280px)] overflow-auto p-0"
         >
-          <Table className="min-w-[920px]">
+          <Table className="min-w-[860px]">
             <TableCaption className="sr-only">
-              Workflow runs, ordered{' '}
+              Workflow runs, ordered by creation time{' '}
               {sortOrder === 'desc' ? 'newest first' : 'oldest first'}
             </TableCaption>
             <TableHeader>
@@ -856,20 +872,39 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                     disabled={!runs.length}
                   />
                 </TableHead>
-                <TableHead className="sticky top-0 z-10 h-10 w-[42%] border-b bg-muted/60 text-xs">
-                  Run
+                <TableHead className="sticky top-0 z-10 h-10 w-[34%] border-b bg-muted/60 text-xs">
+                  ID
                 </TableHead>
-                <TableHead className="sticky top-0 z-10 h-10 w-[16%] border-b bg-muted/60 text-xs">
+                <TableHead className="sticky top-0 z-10 h-10 w-[24%] border-b bg-muted/60 text-xs">
+                  Workflow
+                </TableHead>
+                <TableHead className="sticky top-0 z-10 h-10 w-[14%] border-b bg-muted/60 text-xs">
                   Status
                 </TableHead>
-                <TableHead className="sticky top-0 z-10 h-10 w-[14%] border-b bg-muted/60 text-xs">
-                  Started
-                </TableHead>
-                <TableHead className="sticky top-0 z-10 h-10 w-[14%] border-b bg-muted/60 text-xs">
-                  Completed
-                </TableHead>
-                <TableHead className="sticky top-0 z-10 h-10 w-24 border-b bg-muted/60 text-right text-xs">
+                <TableHead className="sticky top-0 z-10 h-10 w-[12%] border-b bg-muted/60 text-right text-xs">
                   Duration
+                </TableHead>
+                <TableHead
+                  className="sticky top-0 z-10 h-10 w-[16%] border-b bg-muted/60 text-right text-xs"
+                  aria-sort={sortOrder === 'desc' ? 'descending' : 'ascending'}
+                >
+                  <button
+                    type="button"
+                    className="ml-auto flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={toggleSortOrder}
+                    aria-label={
+                      sortOrder === 'desc'
+                        ? 'Sort by oldest created first'
+                        : 'Sort by newest created first'
+                    }
+                  >
+                    Created
+                    {sortOrder === 'desc' ? (
+                      <ArrowDown className="h-3 w-3" />
+                    ) : (
+                      <ArrowUp className="h-3 w-3" />
+                    )}
+                  </button>
                 </TableHead>
                 <TableHead className="sticky top-0 z-10 h-10 w-12 border-b bg-muted/60">
                   <span className="sr-only">Actions</span>
@@ -956,6 +991,15 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                         aria-label={`Select run ${run.runId}`}
                       />
                     </TableCell>
+                    <TableCell className="min-w-0 py-3 font-mono text-xs">
+                      <CopyableText
+                        text={run.runId}
+                        overlay
+                        className="block max-w-full pr-6 text-foreground"
+                      >
+                        <span className="block truncate">{run.runId}</span>
+                      </CopyableText>
+                    </TableCell>
                     <TableCell className="min-w-0 py-3">
                       <CopyableText
                         text={run.workflowName}
@@ -966,49 +1010,21 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                             '?'}
                         </span>
                       </CopyableText>
-                      <CopyableText
-                        text={run.runId}
-                        overlay
-                        className="mt-1 block max-w-full pr-6 font-mono text-xs text-muted-foreground"
-                      >
-                        <span className="block truncate">{run.runId}</span>
-                      </CopyableText>
                     </TableCell>
                     <TableCell className="py-3">
                       <StatusBadge status={run.status} context={run} />
-                    </TableCell>
-                    <TableCell className="py-3 text-xs text-muted-foreground">
-                      {run.startedAt ? (
-                        <RelativeTime
-                          date={run.startedAt}
-                          type="distance"
-                          className="whitespace-nowrap"
-                        />
-                      ) : (
-                        <span>
-                          <span aria-hidden="true">—</span>
-                          <span className="sr-only">Not started</span>
-                        </span>
-                      )}
-                    </TableCell>
-                    <TableCell className="py-3 text-xs text-muted-foreground">
-                      {run.completedAt ? (
-                        <RelativeTime
-                          date={run.completedAt}
-                          type="distance"
-                          className="whitespace-nowrap"
-                        />
-                      ) : (
-                        <span>
-                          <span aria-hidden="true">—</span>
-                          <span className="sr-only">Not completed</span>
-                        </span>
-                      )}
                     </TableCell>
                     <TableCell className="py-3 text-right font-mono text-xs tabular-nums text-muted-foreground">
                       <RunDuration
                         startedAt={run.startedAt}
                         completedAt={run.completedAt}
+                      />
+                    </TableCell>
+                    <TableCell className="py-3 text-right text-xs text-muted-foreground">
+                      <RelativeTime
+                        date={run.createdAt}
+                        type="distance"
+                        className="whitespace-nowrap"
                       />
                     </TableCell>
                     <TableCell className="py-3 text-right">

--- a/packages/web/app/components/runs-table.tsx
+++ b/packages/web/app/components/runs-table.tsx
@@ -2,8 +2,8 @@ import { parseWorkflowName } from '@workflow/utils/parse-name';
 import type { Event, WorkflowRun, WorkflowRunStatus } from '@workflow/world';
 import {
   AlertCircle,
-  ArrowDownAZ,
-  ArrowUpAZ,
+  ArrowDown,
+  ArrowUp,
   Loader2,
   MoreHorizontal,
   RefreshCw,
@@ -31,6 +31,7 @@ import {
 import {
   Table,
   TableBody,
+  TableCaption,
   TableCell,
   TableHead,
   TableHeader,
@@ -48,6 +49,7 @@ import {
 import { useTableSelection } from '~/lib/hooks/use-table-selection';
 import { fetchEvents, fetchRun } from '~/lib/rpc-client';
 import type { EnvMap } from '~/lib/types';
+import { formatDuration } from '~/lib/utils';
 import {
   cancelRun,
   getErrorMessage,
@@ -139,6 +141,7 @@ function LazyDropdownMenu({
           size="icon"
           className="h-8 w-8"
           onClick={(e) => e.stopPropagation()}
+          aria-label={`Actions for run ${runId}`}
         >
           <MoreHorizontal className="h-4 w-4" />
         </Button>
@@ -205,7 +208,6 @@ function useWorkflowFilter() {
       const params = new URLSearchParams(searchParams.toString());
       if (value === 'all') {
         params.delete('workflow');
-        params.delete('status');
       } else {
         params.set('workflow', value);
       }
@@ -255,6 +257,49 @@ function usePeriodFilter() {
   );
 }
 
+// Helper: Clear all list filters
+function useClearFilters() {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
+
+  return useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('workflow');
+    params.delete('status');
+    params.delete('period');
+    navigate(`${pathname}?${params.toString()}`);
+  }, [navigate, pathname, searchParams]);
+}
+
+function RunDuration({
+  startedAt,
+  completedAt,
+}: {
+  startedAt: Date | string | undefined;
+  completedAt: Date | string | undefined;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!startedAt || completedAt) {
+      return;
+    }
+
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [completedAt, startedAt]);
+
+  if (!startedAt) {
+    return <span aria-label="Not started">—</span>;
+  }
+
+  const endTime = completedAt ? new Date(completedAt).getTime() : now;
+  const durationMs = Math.max(0, endTime - new Date(startedAt).getTime());
+
+  return <span>{formatDuration(durationMs)}</span>;
+}
+
 // Filter controls component
 interface FilterControlsProps {
   workflowNameFilter: string | 'all';
@@ -273,6 +318,8 @@ interface FilterControlsProps {
   onPeriodChange: (value: string) => void;
   onSortToggle: () => void;
   onRefresh: () => void;
+  onClearFilters: () => void;
+  hasActiveFilters: boolean;
   lastRefreshTime: Date | null;
 }
 
@@ -291,21 +338,26 @@ function FilterControls({
   onPeriodChange,
   onSortToggle,
   onRefresh,
+  onClearFilters,
+  hasActiveFilters,
   lastRefreshTime,
 }: FilterControlsProps) {
   return (
-    <div className="flex items-center justify-between">
-      <div className="flex items-end gap-2">
-        <p className="text-sm text-muted-foreground">Last refreshed</p>
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex min-h-9 items-center gap-1.5 text-sm text-muted-foreground">
+        <span>Updated</span>
         {lastRefreshTime && (
           <RelativeTime
             date={lastRefreshTime}
-            className="text-sm text-muted-foreground"
+            className="text-sm"
             type="distance"
           />
         )}
       </div>
-      <div className="flex items-center gap-4">
+      <div
+        className="flex flex-wrap items-center gap-2"
+        aria-label="Run filters and controls"
+      >
         {showPeriodPicker && (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -315,7 +367,10 @@ function FilterControls({
                   onValueChange={onPeriodChange}
                   disabled={loading}
                 >
-                  <SelectTrigger className="w-[150px] h-9">
+                  <SelectTrigger
+                    className="h-9 w-[150px]"
+                    aria-label="Time window"
+                  >
                     <SelectValue placeholder="Time window" />
                   </SelectTrigger>
                   <SelectContent>
@@ -355,11 +410,11 @@ function FilterControls({
           onValueChange={onWorkflowChange}
           disabled={loading}
         >
-          <SelectTrigger className="w-[180px] h-9">
+          <SelectTrigger className="h-9 w-[180px]" aria-label="Workflow">
             <SelectValue placeholder="Filter by workflow" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All Workflows</SelectItem>
+            <SelectItem value="all">All workflows</SelectItem>
             {Array.from(seenWorkflowNames)
               .sort()
               .map((name) => (
@@ -377,7 +432,10 @@ function FilterControls({
                 onValueChange={onStatusChange}
                 disabled={loading}
               >
-                <SelectTrigger className="w-[140px] h-9">
+                <SelectTrigger
+                  className="h-9 w-[140px]"
+                  aria-label="Run status"
+                >
                   <SelectValue placeholder="Filter by status" />
                 </SelectTrigger>
                 <SelectContent>
@@ -409,11 +467,11 @@ function FilterControls({
               disabled={loading}
             >
               {sortOrder === 'desc' ? (
-                <ArrowDownAZ className="h-4 w-4" />
+                <ArrowDown className="h-4 w-4" />
               ) : (
-                <ArrowUpAZ className="h-4 w-4" />
+                <ArrowUp className="h-4 w-4" />
               )}
-              {sortOrder === 'desc' ? 'Newest' : 'Oldest'}
+              {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -422,6 +480,16 @@ function FilterControls({
               : 'Showing oldest first'}
           </TooltipContent>
         </Tooltip>
+        {hasActiveFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearFilters}
+            disabled={loading}
+          >
+            Clear filters
+          </Button>
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -434,7 +502,7 @@ function FilterControls({
               Refresh
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Note that this resets pages</TooltipContent>
+          <TooltipContent>Refresh runs and reset loaded pages</TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -453,6 +521,7 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
   const [searchParams] = useSearchParams();
   const handleWorkflowFilter = useWorkflowFilter();
   const handleStatusFilter = useStatusFilter();
+  const handleClearFilters = useClearFilters();
   const { serverConfig } = useServerConfig();
 
   // Validate status parameter - only allow known valid statuses or 'all'
@@ -463,7 +532,7 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
     (rawStatus && validStatuses.includes(rawStatus as WorkflowRunStatus))
       ? (rawStatus as WorkflowRunStatus | 'all')
       : undefined;
-  const workflowNameFilter = searchParams.get('workflow') as string | 'all';
+  const workflowNameFilter = searchParams.get('workflow') ?? 'all';
   const rawPeriod = searchParams.get('period');
   const period: PeriodId = isPeriodId(rawPeriod) ? rawPeriod : DEFAULT_PERIOD;
   const periodPreset =
@@ -493,6 +562,10 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
   // window entirely — this also keeps the SWR cache key stable across the
   // local backend's empty-data poll.
   const isVercelBackend = serverConfig.backendId?.includes('vercel') ?? false;
+  const hasActiveFilters =
+    workflowNameFilter !== 'all' ||
+    (status !== undefined && status !== 'all') ||
+    (isVercelBackend && period !== DEFAULT_PERIOD);
 
   // Frozen listing window per period so every cursor page shares the same
   // bounds. Read from a module-scope store (not component state) so the SWR
@@ -530,6 +603,7 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
     startTime: listingWindow?.startTime,
     endTime: listingWindow?.endTime,
   });
+  const loading = isLoading;
 
   // Remember the plan window across period changes (a 402 response for an
   // out-of-plan window carries no pageInfo, but the picker should stay
@@ -562,7 +636,9 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
   const [isBulkReenqueuing, setIsBulkReenqueuing] = useState(false);
 
   const isLocalAndHasMissingData =
-    isLocal && (!localDataDirPath || !runs.length);
+    isLocal &&
+    !hasActiveFilters &&
+    (!localDataDirPath || (!loading && !runs.length));
 
   // Track seen workflow names from loaded data
   useEffect(() => {
@@ -578,8 +654,6 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
     }
   }, [runs]);
 
-  const loading = isLoading;
-
   // Track when we've completed the initial load
   useEffect(() => {
     if (!loading && !hasLoadedOnce) {
@@ -588,10 +662,9 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
   }, [loading, hasLoadedOnce]);
 
   // Reset hasLoadedOnce when filters change
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Want to reset on any filter change
   useEffect(() => {
     setHasLoadedOnce(false);
-  }, [workflowNameFilter, status, sortOrder]);
+  }, [period, sortOrder, status, workflowNameFilter]);
 
   const onReload = useCallback(() => {
     setLastRefreshTime(() => new Date());
@@ -735,7 +808,7 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
   );
 
   return (
-    <div>
+    <div className="space-y-4">
       <FilterControls
         workflowNameFilter={workflowNameFilter}
         status={status}
@@ -751,18 +824,24 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
         onPeriodChange={handlePeriodFilter}
         onSortToggle={toggleSortOrder}
         onRefresh={onReload}
+        onClearFilters={handleClearFilters}
+        hasActiveFilters={hasActiveFilters}
         lastRefreshTime={lastRefreshTime}
       />
 
-      <Card className="overflow-hidden mt-4 bg-background">
+      <Card className="overflow-hidden bg-background shadow-none">
         <CardContent
           ref={setScrollRoot}
-          className="p-0 max-h-[calc(100vh-280px)] overflow-auto"
+          className="min-h-80 max-h-[calc(100vh-340px)] overflow-auto p-0"
         >
-          <Table>
+          <Table className="min-w-[920px]">
+            <TableCaption className="sr-only">
+              Workflow runs, ordered{' '}
+              {sortOrder === 'desc' ? 'newest first' : 'oldest first'}
+            </TableCaption>
             <TableHeader>
               <TableRow>
-                <TableHead className="sticky top-0 bg-background z-10 border-b shadow-sm h-10 w-10">
+                <TableHead className="sticky top-0 z-10 h-10 w-12 border-b bg-muted/60">
                   <Checkbox
                     checked={selection.isAllSelected(runs)}
                     indeterminate={selection.isSomeSelected(runs)}
@@ -771,29 +850,31 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                     disabled={!runs.length}
                   />
                 </TableHead>
-                <TableHead className="sticky top-0 bg-background z-10 border-b shadow-sm h-10">
-                  Workflow
+                <TableHead className="sticky top-0 z-10 h-10 w-[42%] border-b bg-muted/60 text-xs">
+                  Run
                 </TableHead>
-                <TableHead className="sticky top-0 bg-background z-10 border-b shadow-sm h-10">
-                  Run ID
-                </TableHead>
-                <TableHead className="sticky top-0 bg-background z-10 border-b shadow-sm h-10">
+                <TableHead className="sticky top-0 z-10 h-10 w-[16%] border-b bg-muted/60 text-xs">
                   Status
                 </TableHead>
-                <TableHead className="sticky top-0 bg-background z-10 border-b shadow-sm h-10">
+                <TableHead className="sticky top-0 z-10 h-10 w-[14%] border-b bg-muted/60 text-xs">
                   Started
                 </TableHead>
-                <TableHead className="sticky top-0 bg-background z-10 border-b shadow-sm h-10">
+                <TableHead className="sticky top-0 z-10 h-10 w-[14%] border-b bg-muted/60 text-xs">
                   Completed
                 </TableHead>
-                <TableHead className="sticky top-0 bg-background z-10 border-b shadow-sm h-10 w-10"></TableHead>
+                <TableHead className="sticky top-0 z-10 h-10 w-24 border-b bg-muted/60 text-right text-xs">
+                  Duration
+                </TableHead>
+                <TableHead className="sticky top-0 z-10 h-10 w-12 border-b bg-muted/60">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {error ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="h-[400px]">
-                    <div className="flex items-center justify-center h-full">
+                  <TableCell colSpan={7} className="h-80">
+                    <div className="flex h-full items-center justify-center">
                       <Alert variant="destructive" className="max-w-md">
                         <AlertCircle className="h-4 w-4" />
                         <AlertTitle>
@@ -808,29 +889,46 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                 </TableRow>
               ) : loading && !hasLoadedOnce ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="h-[400px]">
-                    <div className="flex items-center justify-center h-full">
+                  <TableCell colSpan={7} className="h-80">
+                    <div
+                      className="flex h-full items-center justify-center"
+                      aria-live="polite"
+                    >
                       <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                      <span className="sr-only">Loading workflow runs</span>
                     </div>
                   </TableCell>
                 </TableRow>
               ) : runs.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="h-[400px]">
-                    <div className="text-sm text-center text-muted-foreground flex flex-col items-center justify-center gap-3 h-full">
-                      <span className="text-sm">
-                        No workflow runs found
-                        {isLocalAndHasMissingData ? (
-                          <> in {localDirText}</>
+                  <TableCell colSpan={7} className="h-80">
+                    <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+                      <p className="font-medium text-foreground">
+                        {hasActiveFilters
+                          ? 'No runs match these filters'
+                          : 'No workflow runs yet'}
+                      </p>
+                      <p>
+                        {hasActiveFilters ? (
+                          'Change or clear the filters to see more runs.'
+                        ) : isLocalAndHasMissingData ? (
+                          <>
+                            Run a workflow in {localDirText}. This view will
+                            update automatically.
+                          </>
                         ) : (
-                          ''
+                          'New workflow runs will appear here.'
                         )}
-                        .
-                      </span>
-                      {isLocalAndHasMissingData && (
-                        <span className="text-sm flex items-center gap-2">
-                          This view will update once you run a workflow.
-                        </span>
+                      </p>
+                      {hasActiveFilters && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="mt-2"
+                          onClick={handleClearFilters}
+                        >
+                          Clear filters
+                        </Button>
                       )}
                     </div>
                   </TableCell>
@@ -839,56 +937,69 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                 runs.map((run) => (
                   <TableRow
                     key={run.runId}
-                    className="cursor-pointer group relative"
+                    className="group relative cursor-pointer"
                     onClick={() => onRunClick(run.runId)}
-                    data-selected={selection.isSelected(run)}
+                    data-state={
+                      selection.isSelected(run) ? 'selected' : undefined
+                    }
                   >
-                    <TableCell className="py-2">
+                    <TableCell className="py-3">
                       <Checkbox
                         checked={selection.isSelected(run)}
                         onCheckedChange={() => selection.toggleSelection(run)}
                         aria-label={`Select run ${run.runId}`}
                       />
                     </TableCell>
-                    <TableCell className="py-2">
-                      <CopyableText text={run.workflowName} overlay>
-                        {parseWorkflowName(run.workflowName)?.shortName || '?'}
+                    <TableCell className="min-w-0 py-3">
+                      <CopyableText
+                        text={run.workflowName}
+                        className="min-w-0 gap-1.5"
+                      >
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {parseWorkflowName(run.workflowName)?.shortName ||
+                            '?'}
+                        </span>
+                      </CopyableText>
+                      <CopyableText
+                        text={run.runId}
+                        overlay
+                        className="mt-1 block max-w-full pr-6 font-mono text-xs text-muted-foreground"
+                      >
+                        <span className="block truncate">{run.runId}</span>
                       </CopyableText>
                     </TableCell>
-                    <TableCell className="font-mono text-xs py-2">
-                      <CopyableText text={run.runId} overlay>
-                        {run.runId}
-                      </CopyableText>
+                    <TableCell className="py-3">
+                      <StatusBadge status={run.status} context={run} />
                     </TableCell>
-                    <TableCell className="py-2">
-                      <StatusBadge
-                        status={run.status}
-                        context={run}
-                        durationMs={
-                          run.startedAt
-                            ? (run.completedAt
-                                ? new Date(run.completedAt).getTime()
-                                : Date.now()) -
-                              new Date(run.startedAt).getTime()
-                            : undefined
-                        }
+                    <TableCell className="py-3 text-xs text-muted-foreground">
+                      {run.startedAt ? (
+                        <RelativeTime
+                          date={run.startedAt}
+                          type="distance"
+                          className="whitespace-nowrap"
+                        />
+                      ) : (
+                        <span aria-label="Not started">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="py-3 text-xs text-muted-foreground">
+                      {run.completedAt ? (
+                        <RelativeTime
+                          date={run.completedAt}
+                          type="distance"
+                          className="whitespace-nowrap"
+                        />
+                      ) : (
+                        <span aria-label="Not completed">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="py-3 text-right font-mono text-xs tabular-nums text-muted-foreground">
+                      <RunDuration
+                        startedAt={run.startedAt}
+                        completedAt={run.completedAt}
                       />
                     </TableCell>
-                    <TableCell className="py-2 text-muted-foreground text-xs">
-                      {run.startedAt ? (
-                        <RelativeTime date={run.startedAt} />
-                      ) : (
-                        '-'
-                      )}
-                    </TableCell>
-                    <TableCell className="py-2 text-muted-foreground text-xs">
-                      {run.completedAt ? (
-                        <RelativeTime date={run.completedAt} />
-                      ) : (
-                        '-'
-                      )}
-                    </TableCell>
-                    <TableCell className="py-2">
+                    <TableCell className="py-3 text-right">
                       <LazyDropdownMenu
                         env={env}
                         runId={run.runId}
@@ -915,26 +1026,22 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
               so the next page is fetched before the user reaches the end. */}
           <div ref={sentinelRef} aria-hidden className="h-px" />
         </CardContent>
-      </Card>
-
-      <div className="flex items-center justify-between mt-4 text-sm text-muted-foreground">
-        <div>
-          {runs.length > 0 && (
-            <>
-              Showing {runs.length} run{runs.length === 1 ? '' : 's'}
-              {!hasMore && !loading ? ' · end of list' : ''}
-            </>
+        <div className="flex min-h-11 items-center justify-between gap-4 border-t bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
+          <div>
+            {runs.length > 0
+              ? `${runs.length} run${runs.length === 1 ? '' : 's'}${!hasMore && !loading ? ' · end of list' : ''}`
+              : 'No runs to show'}
+          </div>
+          {isVercelBackend && (
+            <div className="text-right">
+              {periodPreset.label}
+              {planInfo?.upgradeAvailable
+                ? ` · plan window ${planInfo.currentLookbackDays} day${planInfo.currentLookbackDays === 1 ? '' : 's'}`
+                : ''}
+            </div>
           )}
         </div>
-        {isVercelBackend && (
-          <div>
-            {periodPreset.label}
-            {planInfo?.upgradeAvailable
-              ? ` · plan window ${planInfo.currentLookbackDays} day${planInfo.currentLookbackDays === 1 ? '' : 's'}`
-              : ''}
-          </div>
-        )}
-      </div>
+      </Card>
 
       <SelectionBar
         selectionCount={selection.selectionCount}

--- a/packages/web/app/components/runs-table.tsx
+++ b/packages/web/app/components/runs-table.tsx
@@ -359,9 +359,8 @@ function FilterControls({
           />
         )}
       </div>
-      <div
+      <fieldset
         className="flex flex-wrap items-center gap-2"
-        role="group"
         aria-label="Run filters and controls"
       >
         {showPeriodPicker && (
@@ -510,7 +509,7 @@ function FilterControls({
           </TooltipTrigger>
           <TooltipContent>Refresh runs and reset loaded pages</TooltipContent>
         </Tooltip>
-      </div>
+      </fieldset>
     </div>
   );
 }

--- a/packages/web/app/components/runs-table.tsx
+++ b/packages/web/app/components/runs-table.tsx
@@ -291,7 +291,12 @@ function RunDuration({
   }, [completedAt, startedAt]);
 
   if (!startedAt) {
-    return <span aria-label="Not started">—</span>;
+    return (
+      <span>
+        <span aria-hidden="true">—</span>
+        <span className="sr-only">Not started</span>
+      </span>
+    );
   }
 
   const endTime = completedAt ? new Date(completedAt).getTime() : now;
@@ -356,6 +361,7 @@ function FilterControls({
       </div>
       <div
         className="flex flex-wrap items-center gap-2"
+        role="group"
         aria-label="Run filters and controls"
       >
         {showPeriodPicker && (
@@ -662,6 +668,7 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
   }, [loading, hasLoadedOnce]);
 
   // Reset hasLoadedOnce when filters change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset when any list key changes
   useEffect(() => {
     setHasLoadedOnce(false);
   }, [period, sortOrder, status, workflowNameFilter]);
@@ -979,7 +986,10 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                           className="whitespace-nowrap"
                         />
                       ) : (
-                        <span aria-label="Not started">—</span>
+                        <span>
+                          <span aria-hidden="true">—</span>
+                          <span className="sr-only">Not started</span>
+                        </span>
                       )}
                     </TableCell>
                     <TableCell className="py-3 text-xs text-muted-foreground">
@@ -990,7 +1000,10 @@ export function RunsTable({ onRunClick }: RunsTableProps) {
                           className="whitespace-nowrap"
                         />
                       ) : (
-                        <span aria-label="Not completed">—</span>
+                        <span>
+                          <span aria-hidden="true">—</span>
+                          <span className="sr-only">Not completed</span>
+                        </span>
                       )}
                     </TableCell>
                     <TableCell className="py-3 text-right font-mono text-xs tabular-nums text-muted-foreground">

--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -178,13 +178,13 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         <div className="sticky top-0 z-50 bg-background border-b px-6 py-4">
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-4">
-              <Link to="/">
-                <h1
-                  className="flex items-center gap-2"
-                  title="Workflow Observability"
-                >
-                  <Logo />
-                </h1>
+              <Link
+                to="/"
+                className="flex items-center gap-2"
+                aria-label="Workflow activity home"
+                title="Workflow activity"
+              >
+                <Logo />
               </Link>
               <div className="h-6 w-px bg-border" aria-hidden="true" />
               <ConnectionStatus />

--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -178,13 +178,13 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         <div className="sticky top-0 z-50 bg-background border-b px-6 py-4">
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-4">
-              <Link
-                to="/"
-                className="flex items-center gap-2"
-                aria-label="Workflow activity home"
-                title="Workflow activity"
-              >
-                <Logo />
+              <Link to="/">
+                <h1
+                  className="flex items-center gap-2"
+                  title="Workflow Observability"
+                >
+                  <Logo />
+                </h1>
               </Link>
               <div className="h-6 w-px bg-border" aria-hidden="true" />
               <ConnectionStatus />

--- a/packages/web/app/routes/home.tsx
+++ b/packages/web/app/routes/home.tsx
@@ -49,13 +49,47 @@ export default function Home() {
   };
 
   return (
-    <div className="max-w-7xl mx-auto px-4">
-      <Tabs value={tab} onValueChange={setTab} className="w-full">
-        <TabsList className="mb-4">
-          <TabsTrigger value="runs">Runs</TabsTrigger>
-          <TabsTrigger value="hooks">Hooks</TabsTrigger>
+    <main
+      className="mx-auto w-full max-w-[1400px]"
+      aria-labelledby="workflow-activity-heading"
+    >
+      <header className="mb-5">
+        <h1
+          id="workflow-activity-heading"
+          className="text-heading-24 text-foreground"
+        >
+          Workflow activity
+        </h1>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          Inspect executions, resolve hooks, and review available workflow
+          definitions.
+        </p>
+      </header>
+
+      <Tabs value={tab} onValueChange={setTab} className="w-full gap-0">
+        <TabsList
+          className="mb-5 h-auto w-full justify-start gap-6 rounded-none border-0 border-b bg-transparent p-0"
+          aria-label="Workflow activity views"
+        >
+          <TabsTrigger
+            value="runs"
+            className="rounded-none border-b-2 border-transparent px-0 py-3 shadow-none data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+          >
+            Runs
+          </TabsTrigger>
+          <TabsTrigger
+            value="hooks"
+            className="rounded-none border-b-2 border-transparent px-0 py-3 shadow-none data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+          >
+            Hooks
+          </TabsTrigger>
           {isLocalBackend && (
-            <TabsTrigger value="workflows">Workflows</TabsTrigger>
+            <TabsTrigger
+              value="workflows"
+              className="rounded-none border-b-2 border-transparent px-0 py-3 shadow-none data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+            >
+              Workflows
+            </TabsTrigger>
           )}
         </TabsList>
         <TabsContent value="runs">
@@ -79,6 +113,6 @@ export default function Home() {
           </TabsContent>
         )}
       </Tabs>
-    </div>
+    </main>
   );
 }

--- a/packages/web/app/routes/home.tsx
+++ b/packages/web/app/routes/home.tsx
@@ -49,23 +49,7 @@ export default function Home() {
   };
 
   return (
-    <main
-      className="mx-auto w-full max-w-[1400px]"
-      aria-labelledby="workflow-activity-heading"
-    >
-      <header className="mb-5">
-        <h1
-          id="workflow-activity-heading"
-          className="text-heading-24 text-foreground"
-        >
-          Workflow activity
-        </h1>
-        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-          Inspect executions, resolve hooks, and review available workflow
-          definitions.
-        </p>
-      </header>
-
+    <main className="mx-auto w-full max-w-[1400px]">
       <Tabs value={tab} onValueChange={setTab} className="w-full gap-0">
         <TabsList
           className="mb-5 h-auto w-full justify-start gap-6 rounded-none border-0 border-b bg-transparent p-0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

- Align the runs list with the hosted Vercel Workflows experience: live updates, ID-first rows, hosted status labels, and `ID / Workflow / Status / Duration / Created` columns.
- Move creation-time sorting into the Created column header.
- Keep the lightweight local Runs / Hooks / Workflows navigation and improve filtering, empty states, responsive layout, and accessibility.

### How did you test your changes?

- `pnpm --filter @workflow/web test` (94 tests passed)
- `pnpm --filter @workflow/web build`
- Focused Biome check on changed source files (passes with existing complexity warnings)
- Browser verification in light, dark, and narrow layouts with representative local runs

[Workflow runs list aligned with hosted Vercel Workflows](https://cursor.com/agents/bc-994e5358-acd7-4dc6-b5ae-ed545eb53566/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fworkflow-runs-table.png)

### PR Checklist - Required to merge

- [x] 📦 Added a patch changeset for `@workflow/web`
- [ ] 🔒 DCO sign-off passes
- [ ] 📝 Ping `@vercel/workflow` once ready

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-994e5358-acd7-4dc6-b5ae-ed545eb53566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-994e5358-acd7-4dc6-b5ae-ed545eb53566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

