### PR TITLE
Fix false-positive serde registration warnings after tree shaking

### DIFF
--- a/.changeset/calm-models-register.md
+++ b/.changeset/calm-models-register.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Avoid serde registration warnings for classes removed from workflow bundles by dead-code elimination.

--- a/packages/builders/src/serde-checker.test.ts
+++ b/packages/builders/src/serde-checker.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowManifest } from './apply-swc-transform.js';
+import { analyzeSerdeCompliance } from './serde-checker.js';
+
+const classId = 'class//models.ts//GatewayLanguageModel';
+
+function manifestFor(
+  classes: Record<string, { classId: string }>
+): WorkflowManifest {
+  return {
+    classes: {
+      'models.ts': classes,
+    },
+  };
+}
+
+function registrationFor(className: string, registeredClassId: string): string {
+  return `
+    class ${className} {}
+    (function(__wf_cls, __wf_id) {
+      var __wf_sym = Symbol.for("workflow-class-registry");
+      var __wf_reg =
+        globalThis[__wf_sym] || (globalThis[__wf_sym] = new Map());
+      __wf_reg.set(__wf_id, __wf_cls);
+    })(${className}, "${registeredClassId}");
+  `;
+}
+
+describe('analyzeSerdeCompliance', () => {
+  it('ignores manifest classes removed from the workflow bundle', () => {
+    const result = analyzeSerdeCompliance({
+      sourceCode: '',
+      workflowCode: 'globalThis.__private_workflows = new Map();',
+      manifest: manifestFor({
+        GatewayLanguageModel: { classId },
+      }),
+    });
+
+    expect(result.classes).toEqual([]);
+    expect(result.hasSerdeClasses).toBe(false);
+  });
+
+  it('ignores removed classes mentioned only in an inline source map', () => {
+    const sourceMap = encodeURIComponent(
+      JSON.stringify({
+        version: 3,
+        sources: ['models.ts'],
+        sourcesContent: ['class GatewayLanguageModel {}'],
+        mappings: '',
+      })
+    );
+    const result = analyzeSerdeCompliance({
+      sourceCode: '',
+      workflowCode: [
+        'globalThis.__private_workflows = new Map();',
+        `//${'#'} sourceMappingURL=data:application/json,${sourceMap}`,
+      ].join('\n'),
+      manifest: manifestFor({
+        GatewayLanguageModel: { classId },
+      }),
+    });
+
+    expect(result.classes).toEqual([]);
+    expect(result.hasSerdeClasses).toBe(false);
+  });
+
+  it('warns when a surviving class has no registration', () => {
+    const result = analyzeSerdeCompliance({
+      sourceCode: '',
+      workflowCode: 'var GatewayLanguageModel = class {};',
+      manifest: manifestFor({
+        GatewayLanguageModel: { classId },
+      }),
+    });
+
+    expect(result.classes).toMatchObject([
+      {
+        className: 'GatewayLanguageModel',
+        registered: false,
+        compliant: false,
+      },
+    ]);
+    expect(result.classes[0].issues).toContain(
+      'No class registration IIFE was generated. Ensure WORKFLOW_SERIALIZE and WORKFLOW_DESERIALIZE are defined as static methods inside the class body using computed property syntax: static [WORKFLOW_SERIALIZE](...) { ... }'
+    );
+    expect(result.hasSerdeClasses).toBe(true);
+  });
+
+  it('checks registration for each surviving class', () => {
+    const otherClassId = 'class//models.ts//OtherModel';
+    const result = analyzeSerdeCompliance({
+      sourceCode: '',
+      workflowCode: `
+        ${registrationFor('GatewayLanguageModel', classId)}
+        var OtherModel = class {};
+      `,
+      manifest: manifestFor({
+        GatewayLanguageModel: { classId },
+        OtherModel: { classId: otherClassId },
+      }),
+    });
+
+    expect(result.classes).toMatchObject([
+      {
+        className: 'GatewayLanguageModel',
+        registered: true,
+        compliant: true,
+      },
+      {
+        className: 'OtherModel',
+        registered: false,
+        compliant: false,
+      },
+    ]);
+  });
+});

--- a/packages/builders/src/serde-checker.ts
+++ b/packages/builders/src/serde-checker.ts
@@ -29,6 +29,10 @@ const nodeImportExtractRegex = new RegExp(
 const registrationIifeRegex =
   /Symbol\.for\s*\(\s*["']workflow-class-registry["']\s*\)/;
 
+// Source maps may contain source text for classes that esbuild removed.
+const sourceMapCommentRegex =
+  /(?:\/\/[#@]\s*sourceMappingURL=[^\r\n]*|\/\*[#@]\s*sourceMappingURL=[\s\S]*?\*\/)/g;
+
 /**
  * Result of checking a single class for serde compliance.
  */
@@ -81,18 +85,36 @@ export function analyzeSerdeCompliance(options: {
 }): SerdeCheckResult {
   const { sourceCode, workflowCode, manifest } = options;
 
+  const workflowCodeWithoutSourceMaps = workflowCode.replace(
+    sourceMapCommentRegex,
+    ''
+  );
+
   // 1. Extract all Node.js built-in imports from the workflow output
-  const globalNodeImports = extractNodeImports(workflowCode);
+  const globalNodeImports = extractNodeImports(workflowCodeWithoutSourceMaps);
 
   // 2. Check if the manifest contains any serde-registered classes
   const classEntries = extractClassEntries(manifest);
-  const hasSerdeClasses = classEntries.length > 0;
 
   // 3. Check if the workflow output contains registration IIFEs
-  const hasRegistration = registrationIifeRegex.test(workflowCode);
+  const hasRegistration = registrationIifeRegex.test(
+    workflowCodeWithoutSourceMaps
+  );
 
-  // 4. Analyze each class
-  const classes: SerdeClassCheckResult[] = classEntries.map((entry) => {
+  // 4. Analyze each class that survived dead-code elimination. The manifest is
+  // collected before esbuild tree-shakes the workflow bundle, so it can include
+  // classes that are only used inside step bodies and cannot need registration
+  // in the workflow runtime.
+  const classes: SerdeClassCheckResult[] = classEntries.flatMap((entry) => {
+    const registered =
+      hasRegistration &&
+      containsQuotedValue(workflowCodeWithoutSourceMaps, entry.classId);
+    const present =
+      registered ||
+      containsClassDefinition(workflowCodeWithoutSourceMaps, entry.className);
+
+    if (!present) return [];
+
     const issues: string[] = [];
 
     // Check for Node.js imports (these will fail in the workflow sandbox)
@@ -105,7 +127,7 @@ export function analyzeSerdeCompliance(options: {
     }
 
     // Check for registration
-    if (!hasRegistration) {
+    if (!registered) {
       issues.push(
         `No class registration IIFE was generated. ` +
           `Ensure WORKFLOW_SERIALIZE and WORKFLOW_DESERIALIZE are defined as static methods ` +
@@ -113,16 +135,19 @@ export function analyzeSerdeCompliance(options: {
       );
     }
 
-    return {
-      className: entry.className,
-      classId: entry.classId,
-      detected: true,
-      registered: hasRegistration,
-      nodeImports: globalNodeImports,
-      compliant: globalNodeImports.length === 0 && hasRegistration,
-      issues,
-    };
+    return [
+      {
+        className: entry.className,
+        classId: entry.classId,
+        detected: true,
+        registered,
+        nodeImports: globalNodeImports,
+        compliant: globalNodeImports.length === 0 && registered,
+        issues,
+      },
+    ];
   });
+  const hasSerdeClasses = classes.length > 0;
 
   // 5. Check for classes that have serde patterns in source but weren't detected by SWC
   const sourceHasSerdePatterns =
@@ -154,6 +179,22 @@ export function analyzeSerdeCompliance(options: {
     hasSerdeClasses,
     manifest,
   };
+}
+
+function containsClassDefinition(code: string, className: string): boolean {
+  const escapedClassName = escapeRegex(className);
+  return new RegExp(
+    `(?:\\bclass\\s+_?${escapedClassName}\\b|` +
+      `\\b(?:const|let|var)\\s+${escapedClassName}\\s*=\\s*class\\b)`
+  ).test(code);
+}
+
+function containsQuotedValue(code: string, value: string): boolean {
+  return new RegExp(`["']${escapeRegex(value)}["']`).test(code);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**


### PR DESCRIPTION
## Summary

- ignore serde-capable classes that are present in the pre-DCE manifest but absent from the final workflow bundle
- match registration IIFEs to each surviving class by class ID instead of treating one registration as valid for every class
- add regression coverage for tree-shaken AI SDK-style classes, inline source maps, missing registrations, and mixed registered/unregistered classes

## Root cause

The serde manifest is collected before esbuild performs dead-code elimination, while the compliance checker runs against the post-DCE workflow bundle. Classes used only inside `"use step"` bodies therefore remained in the manifest after their definitions and registration IIFEs were correctly removed from the workflow bundle, producing a false warning.

The checker now analyzes only classes whose definitions or registrations survive in the bundle. Source-map comments are removed before checking so embedded source text cannot make a removed class appear present.

Fixes #2956.

## Validation

- `pnpm --filter @workflow/builders build`
- `pnpm --filter @workflow/builders test` (18 files, 222 tests)
- `pnpm exec biome check packages/builders/src/serde-checker.ts packages/builders/src/serde-checker.test.ts`
- `pnpm changeset status --since=main`
