### PR TITLE
Report replay divergence recovery episodes

### DIFF
--- a/.changeset/report-replay-recovery.md
+++ b/.changeset/report-replay-recovery.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+'@workflow/world-vercel': patch
+---
+
+Report replay-divergence counts on event writes that recover or exhaust replay retries.

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -53,6 +53,7 @@ async function runWorkflowHandlerWithEvents(
   options: {
     attempt?: number;
     createdEvents?: unknown[];
+    createdEventParams?: unknown[];
     queuedMessages?: unknown[];
     replayDivergence?: { eventId: string; count: number };
     /**
@@ -66,27 +67,30 @@ async function runWorkflowHandlerWithEvents(
   } = {}
 ) {
   const createdEvents = options.createdEvents ?? [];
-  const eventsCreate = vi.fn(async (_runId: string, data: any) => {
-    createdEvents.push(data);
+  const eventsCreate = vi.fn(
+    async (_runId: string, data: any, params?: any) => {
+      createdEvents.push(data);
+      options.createdEventParams?.push(params);
 
-    if (data.eventType === 'run_started') {
-      return {
-        run: workflowRun,
-        events,
+      if (data.eventType === 'run_started') {
+        return {
+          run: workflowRun,
+          events,
+        };
+      }
+
+      const event = {
+        eventId: `event-${createdEvents.length}`,
+        runId: workflowRun.runId,
+        createdAt: new Date(),
+        ...data,
       };
+      if (options.dynamicEventLog) {
+        events.push(event as Event);
+      }
+      return { event };
     }
-
-    const event = {
-      eventId: `event-${createdEvents.length}`,
-      runId: workflowRun.runId,
-      createdAt: new Date(),
-      ...data,
-    };
-    if (options.dynamicEventLog) {
-      events.push(event as Event);
-    }
-    return { event };
-  });
+  );
 
   setWorld({
     specVersion: SPEC_VERSION_CURRENT,
@@ -614,7 +618,9 @@ describe('workflowEntrypoint replay guards', () => {
       })
     );
 
-    const terminalAttemptEvents = await runWorkflowHandlerWithEvents(
+    const terminalAttemptEvents: unknown[] = [];
+    const terminalAttemptParams: unknown[] = [];
+    await runWorkflowHandlerWithEvents(
       `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
       async function workflow() {
         await sleep('5s');
@@ -623,6 +629,8 @@ describe('workflowEntrypoint replay guards', () => {
       workflowRun,
       events,
       {
+        createdEvents: terminalAttemptEvents,
+        createdEventParams: terminalAttemptParams,
         replayDivergence: {
           eventId: 'different-event',
           count: REPLAY_DIVERGENCE_MAX_RETRIES,
@@ -630,12 +638,67 @@ describe('workflowEntrypoint replay guards', () => {
       }
     );
 
-    expect(terminalAttemptEvents).toContainEqual(
+    const failedIndex = terminalAttemptEvents.findIndex(
+      (event) => (event as { eventType?: string }).eventType === 'run_failed'
+    );
+    expect(failedIndex).toBeGreaterThanOrEqual(0);
+    expect(terminalAttemptEvents[failedIndex]).toEqual(
       expect.objectContaining({
         eventType: 'run_failed',
         eventData: expect.objectContaining({
           errorCode: RUN_ERROR_CODES.CORRUPTED_EVENT_LOG,
         }),
+      })
+    );
+    expect(terminalAttemptParams[failedIndex]).toEqual(
+      expect.objectContaining({
+        replayDivergenceCount: REPLAY_DIVERGENCE_MAX_RETRIES + 1,
+      })
+    );
+  });
+
+  it('reports a recovered divergence episode on the next natural event write', async () => {
+    const workflowRun: WorkflowRun = {
+      runId: 'wrun_runtime_replay_recovered',
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments(
+        [],
+        'wrun_runtime_replay_recovered',
+        undefined,
+        []
+      ),
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      startedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deploymentId: 'test-deployment',
+    };
+    const createdEvents: any[] = [];
+    const createdEventParams: any[] = [];
+
+    await runWorkflowHandlerWithEvents(
+      `async function workflow() {
+        return 'recovered';
+      }${getWorkflowTransformCode('workflow')}`,
+      workflowRun,
+      [],
+      {
+        createdEvents,
+        createdEventParams,
+        replayDivergence: {
+          eventId: 'event-diverged',
+          count: 2,
+        },
+      }
+    );
+
+    const completedIndex = createdEvents.findIndex(
+      (event) => event.eventType === 'run_completed'
+    );
+    expect(completedIndex).toBeGreaterThanOrEqual(0);
+    expect(createdEventParams[completedIndex]).toEqual(
+      expect.objectContaining({
+        replayDivergenceCount: 2,
       })
     );
   });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -49,6 +49,7 @@ import {
 import { countStepStartedEvents } from './runtime/count-step-started-events.js';
 import {
   appendUniqueEvents,
+  type EventCreator,
   getQueueOverhead,
   getWorkflowQueueName,
   handleHealthCheckMessage,
@@ -66,6 +67,7 @@ import {
   handleReplayBudgetExhausted,
   ReplayBudget,
 } from './runtime/replay-budget.js';
+import { ReplayRecoveryReporter } from './runtime/replay-recovery-reporter.js';
 import { runIdCreatedAt } from './runtime/run-id-time.js';
 import {
   DEFAULT_STEP_MAX_RETRIES,
@@ -518,6 +520,13 @@ export function workflowEntrypoint(
 
                   const invocationStartTime = Date.now();
                   let loopIteration = 0;
+                  const replayRecoveryReporter = replayDivergence
+                    ? new ReplayRecoveryReporter(replayDivergence.count)
+                    : ReplayRecoveryReporter.inert();
+                  const createEvent: EventCreator = (data, params) =>
+                    replayRecoveryReporter.withEventCreate(params, (p) =>
+                      world.events.create(runId, data, p)
+                    );
 
                   // Event cache: keep loaded events in memory across loop iterations.
                   // On the first iteration we do a full load; on subsequent iterations
@@ -998,8 +1007,7 @@ export function workflowEntrypoint(
                       // handler, optimistic step_started, terminal run writes) so
                       // nothing is written before the run exists.
                       recordRunStartedCreateStart(true);
-                      const startedPromise = world.events.create(
-                        runId,
+                      const startedPromise = createEvent(
                         runStartedEvent,
                         // We background this purely as a write barrier and
                         // never read its preloaded events (preloadedEvents is
@@ -1076,11 +1084,9 @@ export function workflowEntrypoint(
                     } else {
                       try {
                         recordRunStartedCreateStart(false);
-                        const result = await world.events.create(
-                          runId,
-                          runStartedEvent,
-                          { requestId }
-                        );
+                        const result = await createEvent(runStartedEvent, {
+                          requestId,
+                        });
                         if (!result.run) {
                           throw new WorkflowRuntimeError(
                             `Event creation for 'run_started' did not return the run entity for run "${runId}"`
@@ -1373,7 +1379,7 @@ export function workflowEntrypoint(
                             runId,
                             waitLog,
                             (stateUpdatedAt) =>
-                              world.events.create(runId, waitEvent, {
+                              createEvent(waitEvent, {
                                 requestId,
                                 stateUpdatedAt,
                               })
@@ -1522,6 +1528,7 @@ export function workflowEntrypoint(
                         loopIteration,
                         replayMs: Date.now() - replayStart,
                       });
+                      replayRecoveryReporter.activate();
 
                       // Workflow completed. Send the snapshot but do NOT
                       // reload-and-retry the create in place: `result` was
@@ -1535,8 +1542,7 @@ export function workflowEntrypoint(
                         // here before the backgrounded run_started; order the
                         // terminal write after it so the run exists.
                         await awaitRunReady();
-                        await world.events.create(
-                          runId,
+                        await createEvent(
                           {
                             eventType: 'run_completed',
                             specVersion: SPEC_VERSION_CURRENT,
@@ -1567,6 +1573,7 @@ export function workflowEntrypoint(
                       return;
                     } catch (err) {
                       if (WorkflowSuspension.is(err)) {
+                        replayRecoveryReporter.activate();
                         // Synchronous `runWorkflow` duration for THIS
                         // suspension only — anchors the `finalSchedulingReplay`
                         // telemetry field below (see
@@ -1645,6 +1652,7 @@ export function workflowEntrypoint(
                             requestId,
                             eventLog: suspensionLog,
                             runReadyBarrier,
+                            replayRecoveryReporter,
                           });
                         } catch (suspensionError) {
                           // A suspension create whose stale (412) rejection
@@ -1687,8 +1695,7 @@ export function workflowEntrypoint(
                             // Turbo: order the terminal write after the
                             // backgrounded run_started so the run exists.
                             await awaitRunReady();
-                            await world.events.create(
-                              runId,
+                            await createEvent(
                               {
                                 eventType: 'run_failed',
                                 specVersion: SPEC_VERSION_CURRENT,
@@ -2353,6 +2360,7 @@ export function workflowEntrypoint(
                                         preInlineWriteCursor,
                                     }
                                   : {}),
+                                replayRecoveryReporter,
                               });
                             // Invariant bookkeeping: this invocation owns
                             // these bodies until they settle — see
@@ -2633,6 +2641,7 @@ export function workflowEntrypoint(
                         }
 
                         let terminalError = err;
+                        let replayDivergenceCountForFailure: number | undefined;
                         if (ReplayDivergenceError.is(err)) {
                           const divergenceCount =
                             (replayDivergence?.count ?? 0) + 1;
@@ -2669,10 +2678,13 @@ export function workflowEntrypoint(
                             return;
                           }
 
+                          replayDivergenceCountForFailure = divergenceCount;
                           terminalError = new CorruptedEventLogError(
                             `Workflow replay diverged ${divergenceCount} times after ${maxRecoveryReplays} recovery replays; latest divergent event was ${err.eventId}. Last divergence: ${err.message}`,
                             { cause: err }
                           );
+                        } else if (replayStart > 0) {
+                          replayRecoveryReporter.activate();
                         }
 
                         // User code errors and terminal runtime errors fail the run.
@@ -2742,8 +2754,7 @@ export function workflowEntrypoint(
                           // Turbo: order the terminal write after the
                           // backgrounded run_started so the run exists.
                           await awaitRunReady();
-                          await world.events.create(
-                            runId,
+                          await createEvent(
                             {
                               eventType: 'run_failed',
                               specVersion: SPEC_VERSION_CURRENT,
@@ -2759,7 +2770,15 @@ export function workflowEntrypoint(
                                 errorCode,
                               },
                             },
-                            { requestId }
+                            {
+                              requestId,
+                              ...(replayDivergenceCountForFailure !== undefined
+                                ? {
+                                    replayDivergenceCount:
+                                      replayDivergenceCountForFailure,
+                                  }
+                                : {}),
+                            }
                           );
                         } catch (failErr) {
                           if (

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -4,7 +4,10 @@ import {
   WorkflowWorldError,
 } from '@workflow/errors';
 import type {
+  CreateEventParams,
+  CreateEventRequest,
   Event,
+  EventResult,
   HealthCheckPayload,
   ValidQueueName,
   WorkflowRun,
@@ -761,6 +764,12 @@ export async function withPreconditionRetry<T>(
     }
   }
 }
+
+/** Creates one event on a bound run, carrying replay-recovery telemetry. */
+export type EventCreator = (
+  data: CreateEventRequest,
+  params?: CreateEventParams
+) => Promise<EventResult>;
 
 /**
  * CORS headers for health check responses.

--- a/packages/core/src/runtime/replay-recovery-reporter.test.ts
+++ b/packages/core/src/runtime/replay-recovery-reporter.test.ts
@@ -1,0 +1,68 @@
+import type { CreateEventParams } from '@workflow/world';
+import { describe, expect, it, vi } from 'vitest';
+import { ReplayRecoveryReporter } from './replay-recovery-reporter.js';
+
+describe('ReplayRecoveryReporter', () => {
+  it('stays dormant until replay reaches a deterministic outcome', async () => {
+    const create = vi.fn(async (_params: CreateEventParams) => 'created');
+    const reporter = new ReplayRecoveryReporter(2);
+
+    await reporter.withEventCreate({ requestId: 'req_1' }, create);
+
+    expect(create).toHaveBeenCalledWith({ requestId: 'req_1' });
+  });
+
+  it('attaches telemetry to only the first successful natural write', async () => {
+    const create = vi.fn(async (_params: CreateEventParams) => 'created');
+    const reporter = new ReplayRecoveryReporter(2);
+    reporter.activate();
+
+    await reporter.withEventCreate({ requestId: 'req_1' }, create);
+    await reporter.withEventCreate({ requestId: 'req_2' }, create);
+
+    expect(create).toHaveBeenNthCalledWith(1, {
+      requestId: 'req_1',
+      replayDivergenceCount: 2,
+    });
+    expect(create).toHaveBeenNthCalledWith(2, { requestId: 'req_2' });
+  });
+
+  it('releases a failed write so the next natural write can report', async () => {
+    const reporter = new ReplayRecoveryReporter(2);
+    reporter.activate();
+
+    await expect(
+      reporter.withEventCreate({}, async () => {
+        throw new Error('write failed');
+      })
+    ).rejects.toThrow('write failed');
+    const create = vi.fn(async (_params: CreateEventParams) => 'created');
+    await reporter.withEventCreate({}, create);
+
+    expect(create).toHaveBeenCalledWith({ replayDivergenceCount: 2 });
+  });
+
+  describe('inert()', () => {
+    it('cannot be armed, so it never stamps a count', async () => {
+      const create = vi.fn(async (_params: CreateEventParams) => 'created');
+      const reporter = ReplayRecoveryReporter.inert();
+      reporter.activate();
+
+      await reporter.withEventCreate({ requestId: 'req_1' }, create);
+
+      // A zero count would be rejected as out-of-range by the server, so the
+      // inert reporter must not report at all rather than report zero.
+      expect(create).toHaveBeenCalledWith({ requestId: 'req_1' });
+    });
+
+    it('passes undefined params straight through', async () => {
+      const create = vi.fn(async (_params?: CreateEventParams) => 'created');
+      const reporter = ReplayRecoveryReporter.inert();
+      reporter.activate();
+
+      await reporter.withEventCreate(undefined, create);
+
+      expect(create).toHaveBeenCalledWith(undefined);
+    });
+  });
+});

--- a/packages/core/src/runtime/replay-recovery-reporter.ts
+++ b/packages/core/src/runtime/replay-recovery-reporter.ts
@@ -1,0 +1,70 @@
+import type { CreateEventParams } from '@workflow/world';
+
+/**
+ * Invocation-scoped, one-shot reporter for a replay-divergence recovery.
+ *
+ * The reporter stays dormant until replay reaches a valid deterministic
+ * boundary. The first subsequent event write carries the telemetry for free.
+ * A recovered invocation with no natural event write intentionally reports
+ * nothing.
+ */
+export class ReplayRecoveryReporter {
+  private active = false;
+  private reported = false;
+
+  constructor(private readonly divergenceCount: number) {}
+
+  /**
+   * A reporter for an invocation that never diverged: `activate()` cannot arm
+   * it, so `withEventCreate` always passes writes through untouched. Lets every
+   * call site hold a non-optional reporter instead of branching on one.
+   *
+   * Structurally inert rather than a zero-count reporter on purpose — the
+   * server rejects a count below 1 as out-of-range and emits a
+   * `telemetry_rejected` metric, so a reporter that *can* report zero is a
+   * live footgun.
+   */
+  static inert(): ReplayRecoveryReporter {
+    return new InertReplayRecoveryReporter();
+  }
+
+  activate(): void {
+    this.active = true;
+  }
+
+  /**
+   * Decorate one natural event write with recovery telemetry.
+   *
+   * The claim is taken synchronously, so concurrent suspension writes cannot
+   * all carry the same count. A failed request releases it for a later natural
+   * write in the same invocation.
+   */
+  async withEventCreate<T>(
+    params: CreateEventParams | undefined,
+    create: (params: CreateEventParams | undefined) => Promise<T>
+  ): Promise<T> {
+    if (!this.active || this.reported) return create(params);
+
+    this.reported = true;
+    try {
+      return await create({
+        ...params,
+        replayDivergenceCount: this.divergenceCount,
+      });
+    } catch (error) {
+      this.reported = false;
+      throw error;
+    }
+  }
+}
+
+/** See {@link ReplayRecoveryReporter.inert}. */
+class InertReplayRecoveryReporter extends ReplayRecoveryReporter {
+  constructor() {
+    super(0);
+  }
+
+  override activate(): void {
+    // Deliberately empty: nothing to report, so nothing can arm.
+  }
+}

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -16,6 +16,7 @@ import {
 import type {
   CreateEventParams,
   Event,
+  EventResult,
   SerializedData,
   Step,
   World,
@@ -49,7 +50,8 @@ import {
   isOptimisticInlineStartExplicitlyDisabled,
 } from './constants.js';
 import { getPortLazy } from './get-port-lazy.js';
-import { memoizeEncryptionKey } from './helpers.js';
+import { type EventCreator, memoizeEncryptionKey } from './helpers.js';
+import { ReplayRecoveryReporter } from './replay-recovery-reporter.js';
 import {
   computeStepLatencyEventData,
   type StepLatencyEventData,
@@ -198,6 +200,8 @@ export interface StepExecutorParams {
    *   (`metadata.attempt`), which increments on every redelivery.
    */
   authoritativeAttempt?: number;
+  /** One-shot recovery telemetry activated by the orchestrator replay. */
+  replayRecoveryReporter?: ReplayRecoveryReporter;
 }
 
 /**
@@ -259,6 +263,12 @@ export async function executeStep(
   // Gate payload compression on the run's specVersion.
   const compression =
     (params.runSpecVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION;
+  const replayRecoveryReporter =
+    params.replayRecoveryReporter ?? ReplayRecoveryReporter.inert();
+  const createEvent: EventCreator = (data, eventParams) =>
+    replayRecoveryReporter.withEventCreate(eventParams, (p) =>
+      world.events.create(workflowRunId, data, p)
+    );
 
   const spanName = `step.execute ${stepDisplayName(stepName)}`;
   return trace(spanName, {}, async (span) => {
@@ -306,8 +316,7 @@ export async function executeStep(
           if (params.runReadyBarrier) {
             await params.runReadyBarrier.catch(() => {});
           }
-          await world.events.create(
-            workflowRunId,
+          await createEvent(
             {
               eventType: 'step_started',
               specVersion: SPEC_VERSION_CURRENT,
@@ -337,7 +346,7 @@ export async function executeStep(
         }
       }
       try {
-        await world.events.create(workflowRunId, {
+        await createEvent({
           eventType: 'step_failed',
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
@@ -393,7 +402,7 @@ export async function executeStep(
         maxRetries,
       });
       try {
-        await world.events.create(workflowRunId, {
+        await createEvent({
           eventType: 'step_failed',
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
@@ -558,8 +567,7 @@ export async function executeStep(
           // RSFS measures the run_started-to-POST stretch, and the barrier
           // wait IS part of that stretch under turbo.
           stepStartPostSentAtMs = Date.now();
-          return world.events.create(
-            workflowRunId,
+          return createEvent(
             {
               eventType: 'step_started',
               specVersion: SPEC_VERSION_CURRENT,
@@ -619,8 +627,7 @@ export async function executeStep(
             ? { ownerMessageId: params.ownerMessageId }
             : {};
         stepStartPostSentAtMs = Date.now();
-        const startResult = await world.events.create(
-          workflowRunId,
+        const startResult = await createEvent(
           {
             eventType: 'step_started',
             specVersion: SPEC_VERSION_CURRENT,
@@ -699,7 +706,7 @@ export async function executeStep(
         }
       }
       try {
-        await world.events.create(workflowRunId, {
+        await createEvent({
           eventType: 'step_failed',
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
@@ -1081,7 +1088,7 @@ export async function executeStep(
           (effectiveErr as Error).stack = normalizedStack;
         }
         try {
-          await world.events.create(workflowRunId, {
+          await createEvent({
             eventType: 'step_failed',
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: stepId,
@@ -1150,7 +1157,7 @@ export async function executeStep(
         (wrappedError as Error).cause = err;
         if (normalizedStack) wrappedError.stack = normalizedStack;
         try {
-          await world.events.create(workflowRunId, {
+          await createEvent({
             eventType: 'step_failed',
             specVersion: SPEC_VERSION_CURRENT,
             correlationId: stepId,
@@ -1213,7 +1220,7 @@ export async function executeStep(
         (err as Error).stack = normalizedStack;
       }
       try {
-        await world.events.create(workflowRunId, {
+        await createEvent({
           eventType: 'step_retrying',
           specVersion: SPEC_VERSION_CURRENT,
           correlationId: stepId,
@@ -1264,10 +1271,9 @@ export async function executeStep(
     // Create step_completed event outside the step execution failure path:
     // persistence failures are infrastructure errors and should redeliver the
     // queue message, not become user step_retrying/step_failed events.
-    let completedResult: Awaited<ReturnType<typeof world.events.create>>;
+    let completedResult: EventResult;
     try {
-      completedResult = await world.events.create(
-        workflowRunId,
+      completedResult = await createEvent(
         {
           eventType: 'step_completed',
           specVersion: SPEC_VERSION_CURRENT,

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -1,6 +1,7 @@
 import type { WorkflowRun, World } from '@workflow/world';
 import { describe, expect, it, vi } from 'vitest';
 import { WorkflowSuspension } from '../global.js';
+import { ReplayRecoveryReporter } from './replay-recovery-reporter.js';
 import { handleSuspension } from './suspension-handler.js';
 
 vi.mock('../version.js', () => ({ version: '0.0.0-test' }));
@@ -30,6 +31,41 @@ function createWorld(eventsCreate: ReturnType<typeof vi.fn>): World {
 }
 
 describe('handleSuspension', () => {
+  it('stamps recovery telemetry on a suspension write', async () => {
+    // Covers the wiring, not the claim mechanics (see
+    // replay-recovery-reporter.test.ts): an activated reporter reaching
+    // handleSuspension must actually reach its event writes.
+    const eventsCreate = vi.fn().mockImplementation(async (_runId, event) => ({
+      event,
+    }));
+    const world = createWorld(eventsCreate);
+    const reporter = new ReplayRecoveryReporter(2);
+    reporter.activate();
+    const pending = new Map([
+      [
+        'hook_recovered',
+        {
+          type: 'hook' as const,
+          correlationId: 'hook_recovered',
+          token: 'order:123',
+        },
+      ],
+    ]);
+
+    await handleSuspension({
+      suspension: new WorkflowSuspension(pending, globalThis),
+      world,
+      run,
+      replayRecoveryReporter: reporter,
+    });
+
+    expect(eventsCreate).toHaveBeenCalledWith(
+      run.runId,
+      expect.objectContaining({ eventType: 'hook_created' }),
+      expect.objectContaining({ replayDivergenceCount: 2 })
+    );
+  });
+
   it('persists the token retention deadline on hook_created', async () => {
     const eventsCreate = vi.fn().mockImplementation(async (_runId, event) => ({
       event,

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -8,9 +8,7 @@ import {
 } from '@workflow/errors';
 import {
   AttributeValidationError,
-  type CreateEventParams,
   type CreateEventRequest,
-  type EventResult,
   type SerializedData,
   SPEC_VERSION_CURRENT,
   SPEC_VERSION_SUPPORTS_COMPRESSION,
@@ -30,7 +28,12 @@ import { dehydrateStepArguments } from '../serialization.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { getAbortStreamIdFromToken } from '../util.js';
 import { getMaxInlineSteps } from './constants.js';
-import { type MutableEventLog, withPreconditionRetry } from './helpers.js';
+import {
+  type EventCreator,
+  type MutableEventLog,
+  withPreconditionRetry,
+} from './helpers.js';
+import { ReplayRecoveryReporter } from './replay-recovery-reporter.js';
 
 export interface SuspensionHandlerParams {
   suspension: WorkflowSuspension;
@@ -56,6 +59,8 @@ export interface SuspensionHandlerParams {
    * where `run_started` was already awaited up front.
    */
   runReadyBarrier?: Promise<unknown>;
+  /** One-shot telemetry reporter, activated only after replay has recovered. */
+  replayRecoveryReporter?: ReplayRecoveryReporter;
 }
 
 /**
@@ -134,10 +139,7 @@ async function createHookEvent({
   hookEvent: CreateEventRequest;
   queueItem: HookInvocationQueueItem;
   requestId?: string;
-  createEvent: (
-    data: CreateEventRequest,
-    params?: CreateEventParams
-  ) => Promise<EventResult>;
+  createEvent: EventCreator;
 }): Promise<{
   hasHookConflict: boolean;
   hasAwaitedHookCreation: boolean;
@@ -205,6 +207,7 @@ export async function handleSuspension({
   requestId,
   eventLog,
   runReadyBarrier,
+  replayRecoveryReporter,
 }: SuspensionHandlerParams): Promise<SuspensionHandlerResult> {
   const runId = run.runId;
 
@@ -226,22 +229,26 @@ export async function handleSuspension({
     }
   };
 
-  // Create an event with the optimistic-concurrency guard when the caller
-  // supplied a loaded event log; otherwise create it directly (callers without
-  // a replay snapshot, e.g. tests). The guard reloads + retries on a stale
-  // (412) rejection, keeping `eventLog` current in place. All suspension events
-  // are non-run_created events on this run's `runId`.
-  const createGuarded = (
-    data: CreateEventRequest,
-    params?: CreateEventParams
-  ): Promise<EventResult> => {
-    if (!eventLog) {
-      return world.events.create(runId, data, params);
-    }
-    return withPreconditionRetry(runId, eventLog, (stateUpdatedAt) =>
-      world.events.create(runId, data, { ...params, stateUpdatedAt })
+  // Every suspension write carries replay-recovery telemetry on the first one
+  // that commits after replay recovered. All suspension events are
+  // non-run_created events on this run's `runId`.
+  const reporter = replayRecoveryReporter ?? ReplayRecoveryReporter.inert();
+  const createEvent: EventCreator = (data, params) =>
+    reporter.withEventCreate(params, (p) =>
+      world.events.create(runId, data, p)
     );
-  };
+  // Adds the optimistic-concurrency guard when the caller supplied a loaded
+  // event log; without one it creates directly (callers with no replay
+  // snapshot, e.g. tests). The guard reloads + retries on a stale (412)
+  // rejection, keeping `eventLog` current in place. It wraps `createEvent`
+  // rather than the reverse so a retried attempt re-takes the telemetry claim,
+  // matching how the wait-completion writes in `runtime.ts` compose the two.
+  const createGuarded: EventCreator = (data, params) =>
+    eventLog
+      ? withPreconditionRetry(runId, eventLog, (stateUpdatedAt) =>
+          createEvent(data, { ...params, stateUpdatedAt })
+        )
+      : createEvent(data, params);
   // Separate queue items by type
   const stepItems = suspension.steps.filter(
     (item): item is StepInvocationQueueItem => item.type === 'step'
@@ -614,8 +621,7 @@ export async function handleSuspension({
       (async () => {
         try {
           await ensureRunReady();
-          await world.events.create(
-            runId,
+          await createEvent(
             {
               eventType: 'attr_set',
               specVersion: SPEC_VERSION_CURRENT,

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -209,6 +209,8 @@ export interface CreateEventV4Input {
    * without a loaded event log; older servers ignore it entirely.
    */
   stateUpdatedAt?: number;
+  /** Number of consecutive replay divergences resolved by this write. */
+  replayDivergenceCount?: number;
 }
 
 export interface CreateEventV4Result {
@@ -308,6 +310,9 @@ function buildPostFrameMeta(
   if (input.skipPreload !== undefined) meta.skipPreload = input.skipPreload;
   if (input.stateUpdatedAt !== undefined) {
     meta.stateUpdatedAt = input.stateUpdatedAt;
+  }
+  if (input.replayDivergenceCount !== undefined) {
+    meta.replayDivergenceCount = input.replayDivergenceCount;
   }
   return meta;
 }

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -263,6 +263,51 @@ describe('createWorkflowRunEvent computeInstanceId wire field', () => {
   });
 });
 
+describe('createWorkflowRunEvent replayDivergenceCount wire field', () => {
+  it('carries recovery telemetry in v4 frame metadata', async () => {
+    const agent = mockAgent();
+    let capturedMeta: Record<string, unknown> | undefined;
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/run_completed',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          capturedMeta = decodePostedMeta(opts.body);
+          return encode({ run: { runId: 'wrun_1', status: 'completed' } });
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+          },
+        }
+      );
+
+    await createWorkflowRunEvent(
+      'wrun_1',
+      {
+        eventType: 'run_completed',
+        specVersion: 2,
+        eventData: { result: 'ok' },
+      } as AnyEventRequest,
+      {
+        replayDivergenceCount: 2,
+      },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(capturedMeta?.replayDivergenceCount).toBe(2);
+    expect(capturedMeta?.eventData).toBeUndefined();
+    agent.assertNoPendingInterceptors();
+  });
+});
+
 /**
  * The split's meta allowlist IS the eventData wire contract on v4. The
  * type-level `assertEventDataWireContractExhaustive` guard in events.ts

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -711,6 +711,9 @@ async function createWorkflowRunEventInner(
       ...(params?.stateUpdatedAt !== undefined
         ? { stateUpdatedAt: params.stateUpdatedAt }
         : {}),
+      ...(params?.replayDivergenceCount !== undefined
+        ? { replayDivergenceCount: params.replayDivergenceCount }
+        : {}),
       occurredAt: params?.occurredAt ?? new Date(),
       // Opt-in inline-delta: forward the cursor the runtime held before
       // this write so the server can return the authoritative event-log

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -738,6 +738,14 @@ export interface CreateEventParams {
    */
   occurredAt?: Date;
   /**
+   * Number of consecutive replay divergences resolved by this event write.
+   *
+   * This is request telemetry, not workflow state. Worlds may use it for
+   * metrics and diagnostics, but must not require it for event
+   * materialization or persist it into the event log.
+   */
+  replayDivergenceCount?: number;
+  /**
    * Inline-delta optimization (opt-in). When set, the World MAY return,
    * on the resulting {@link EventResult}, the first page of events written
    * strictly after this cursor (via `events`/`cursor`/`hasMore`) — the


### PR DESCRIPTION
## Summary & Motivation

Adds an optional `replayDivergenceCount` on event writes, making replay-divergence outcomes observable without GET-side effects or VQS changes.

- Set once per invocation, on the first natural write after replay reaches a deterministic boundary — recovery and retry-exhaustion both land on a real event write, so no extra request is needed to surface either.
- Reporting is managed by a stateful `ReplayRecoveryReporter`, which claims that write so an invocation reports its recovery exactly once even when several suspension writes race, and releases the claim if the write fails.
- Request telemetry only: worlds may report it, but must not persist it into the event log.

## Test Plan

Unit tests added for the reporter, the runtime and suspension paths, and the v4 wire field; typecheck and the core/world-vercel suites pass locally.
