### PR TITLE
[benchmarks] Split STSO by inline vs queue-hop steps, add distribution diffs vs main

### DIFF
--- a/.changeset/stso-inline-vs-queue-hop.md
+++ b/.changeset/stso-inline-vs-queue-hop.md
@@ -1,0 +1,4 @@
+---
+---
+
+Split the STSO benchmark by inline vs queue-hop steps (tagged by the workflow itself), record every sample rather than percentiles only, and add per-kind histogram diffs against `main` to the benchmark comment.

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -367,10 +367,11 @@ function renderOverlayBar(base, cur, maxCount) {
   return `${'█'.repeat(baseWidth)}${'░'.repeat(notchPos - baseWidth - 1)}┃`;
 }
 
-/** Renders main vs this run as one overlay bar per bucket (a fenced code
- * block keeps bars aligned in a monospace font), so the shape of the two
- * distributions — and exactly where this run diverged from the baseline — is
- * visible at a glance instead of only as numbers in a table. */
+/** Renders main vs this run as one overlay bar per bucket, with both counts
+ * and their delta on the same line (a fenced code block keeps everything
+ * aligned in a monospace font). This is the whole histogram diff — the shape
+ * of the two distributions and the per-bucket numbers behind it, without a
+ * second table restating them. */
 function renderStsoBarChart(buckets, { selfDiff } = {}) {
   const maxCount = Math.max(1, ...buckets.map((b) => Math.max(b.base, b.cur)));
   const labelWidth = Math.max(...buckets.map((b) => b.label.length));
@@ -390,19 +391,18 @@ function renderStsoBarChart(buckets, { selfDiff } = {}) {
     ).padEnd(BAR_CHART_WIDTH);
     const counts = selfDiff
       ? `steps ${String(cur).padStart(countWidth)}`
-      : `main ${String(base).padStart(countWidth)}  this ${String(cur).padStart(countWidth)}`;
+      : `main ${String(base).padStart(countWidth)}  this ${String(cur).padStart(countWidth)}  ${formatDeltaValue(cur - base).padStart(countWidth + 1)}`;
     lines.push(`${label.padStart(labelWidth)} ms  ${bar}  ${counts}`);
   }
   lines.push('```');
   return lines.join('\n');
 }
 
-/** Renders one STSO row's cumulative-time line, an ASCII bar-chart overlay,
- * and a bucketed histogram table (this run vs main). Bin width is chosen from
- * this row's own sample range, so every scenario gets a histogram that
- * actually spreads across multiple buckets rather than overflowing into
- * one — except "inline" rows, which use a hardcoded finer width (see
- * STSO_INLINE_BIN_WIDTH_MS). */
+/** Renders one STSO row's cumulative-time line and its histogram diff (this
+ * run vs main). Bin width is chosen from this row's own sample range, so every
+ * scenario gets a histogram that actually spreads across multiple buckets
+ * rather than overflowing into one — except "inline" rows, which use a
+ * hardcoded finer width (see STSO_INLINE_BIN_WIDTH_MS). */
 function renderStsoRowDiff(row) {
   // Until this lands on `main`, no baseline run has raw samples to diff
   // against. The shape of this run's distribution is still worth showing, so
@@ -446,23 +446,7 @@ function renderStsoRowDiff(row) {
     );
   }
   if (buckets.length > 0) {
-    lines.push(renderStsoBarChart(buckets, { selfDiff }), '');
-  }
-  if (selfDiff) {
-    lines.push('| Bucket (ms) | Steps |', '|---|---:|');
-    for (const { label, cur } of buckets) {
-      lines.push(`| ${label} | ${cur} |`);
-    }
-    return lines.join('\n');
-  }
-  lines.push(
-    '| Bucket (ms) | main steps | this run steps | Δ |',
-    '|---|---:|---:|---:|'
-  );
-  for (const { label, base, cur } of buckets) {
-    lines.push(
-      `| ${label} | ${base} | ${cur} | ${formatDeltaValue(cur - base)} |`
-    );
+    lines.push(renderStsoBarChart(buckets, { selfDiff }));
   }
   return lines.join('\n');
 }

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -119,8 +119,31 @@ export function extractHistory(body) {
   return [];
 }
 
+/**
+ * Drops the per-metric raw sample arrays before embedding an entry in the
+ * comment's data block. The sequential-steps scenario records ~1000 STSO
+ * samples per run (plus the baseline's), which would blow past GitHub's
+ * comment size limit within a couple of history entries; the percentiles and
+ * baseline annotations — everything the history tables render — are kept. The
+ * histogram diff is therefore only shown for the current run.
+ */
+function stripRawSamples(entries) {
+  return entries.map((entry) => ({
+    ...entry,
+    results: (entry.results ?? []).map((result) => ({
+      ...result,
+      metrics: (result.metrics ?? []).map(
+        ({ raw, baselineRaw, ...row }) => row
+      ),
+    })),
+  }));
+}
+
 export function encodeHistory(entries) {
-  const json = JSON.stringify({ version: 1, entries });
+  const json = JSON.stringify({
+    version: 1,
+    entries: stripRawSamples(entries),
+  });
   return `<!-- ${DATA_MARKER}${Buffer.from(json, 'utf8').toString('base64')} -->`;
 }
 
@@ -203,12 +226,261 @@ export function annotateWithBaseline(results, baseline) {
       const value = from(base);
       if (typeof value === 'number') annotated[annotation] = value;
     }
+    // Raw samples (when the baseline run recorded them) drive the STSO
+    // histogram diff below the table — kept separate from BASELINE_FIELDS
+    // since it's an array, not a numeric percentile.
+    if (Array.isArray(base.raw)) annotated.baselineRaw = base.raw;
     return annotated;
   };
   return results.map((result) => ({
     ...result,
     metrics: (result.metrics ?? []).map((row) => annotate(result, row)),
   }));
+}
+
+// ============================================================================
+// STSO distribution diff (histogram + cumulative time, vs main)
+// ============================================================================
+
+const sum = (values) => values.reduce((total, v) => total + v, 0);
+
+const maxOf = (values) => values.reduce((m, v) => (v > m ? v : m), 0);
+
+/** Buckets samples into fixed-width ms bins. Anything past `binWidth *
+ * maxBins` is folded into a single overflow bucket, so a handful of outliers
+ * don't blow up the table width. Negative samples get their own bucket rather
+ * than joining that overflow: step timestamps come from two different step
+ * bodies, so a gap can come out slightly negative under clock skew, and
+ * lumping those in with the slowest samples would invert what the tail
+ * bucket means. */
+function buildHistogram(samples, binWidth, maxBins) {
+  const counts = new Array(maxBins).fill(0);
+  let overflow = 0;
+  let underflow = 0;
+  for (const v of samples) {
+    const idx = Math.floor(v / binWidth);
+    if (idx >= 0 && idx < maxBins) counts[idx]++;
+    else if (idx < 0) underflow++;
+    else overflow++;
+  }
+  return { counts, overflow, underflow };
+}
+
+// Target bin count for the STSO histogram diff — the actual bin *width* is
+// derived per-row from the observed sample range (see chooseBinWidth), since
+// a fixed width picked for one scenario's typical latency (e.g. sub-100ms)
+// silently dumps every sample into a single overflow bucket for another
+// (e.g. a colder run at 200-500ms/step).
+const STSO_HISTOGRAM_TARGET_BINS = 12;
+
+// "Inline" steps (same warm process as the step before them) cluster tightly,
+// and the adaptive width above is coarse enough (~500ms bins on a run whose
+// samples top out in the seconds) to hide structure inside that cluster —
+// e.g. a bimodal split between a fast ~150-250ms mode and a slower ~350ms+
+// one. Hardcode a finer width for those rows; queue-hop steps (dispatch +
+// cold reinit, much larger and far sparser) keep the adaptive width.
+const STSO_INLINE_BIN_WIDTH_MS = 50;
+
+/** Rounds a raw bin width up to a "nice" 1/2/5 * 10^n step, so bucket
+ * boundaries read cleanly (e.g. 20ms, 50ms) instead of arbitrary fractions. */
+function chooseBinWidth(maxValue, targetBins) {
+  if (!Number.isFinite(maxValue) || maxValue <= 0) return 1;
+  const raw = maxValue / targetBins;
+  const magnitude = 10 ** Math.floor(Math.log10(raw));
+  const normalized = raw / magnitude;
+  const niceNormalized =
+    normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return niceNormalized * magnitude;
+}
+
+function formatDeltaValue(delta, unit = '') {
+  return `${delta >= 0 ? '+' : ''}${Math.round(delta)}${unit}`;
+}
+
+/** Non-empty (bucket label, main count, this-run count) triples for a
+ * histogram, including the overflow bucket (labeled `${max}+`) when either
+ * side has samples there. Shared by the bar chart and the table so both
+ * render from the exact same bucketing. */
+function nonEmptyBuckets(current, baseline, binWidth, binCount) {
+  const buckets = [];
+  if (current.underflow > 0 || baseline.underflow > 0) {
+    buckets.push({
+      label: '<0 (skew)',
+      base: baseline.underflow,
+      cur: current.underflow,
+    });
+  }
+  for (let i = 0; i < binCount; i++) {
+    if (current.counts[i] === 0 && baseline.counts[i] === 0) continue;
+    buckets.push({
+      label: `${i * binWidth}-${(i + 1) * binWidth}`,
+      base: baseline.counts[i],
+      cur: current.counts[i],
+    });
+  }
+  if (current.overflow > 0 || baseline.overflow > 0) {
+    buckets.push({
+      label: `${binCount * binWidth}+`,
+      base: baseline.overflow,
+      cur: current.overflow,
+    });
+  }
+  return buckets;
+}
+
+// Bar width (characters) for the ASCII histogram overlay.
+const BAR_CHART_WIDTH = 24;
+
+/**
+ * Renders one bucket as a single overlay bar: a solid `█` run for the
+ * baseline's (main's) count, a `┃` notch marking exactly where this run's
+ * count lands, and — only when this run exceeds the baseline — a lighter `░`
+ * run bridging the gap between them so the extension past the base bar is
+ * visually distinct from the base itself. One glance shows both the
+ * baseline's magnitude (bar length) and this run's relative position (the
+ * notch) without needing two separate bars.
+ */
+function renderOverlayBar(base, cur, maxCount) {
+  if (maxCount <= 0) return '';
+  const scale = (count) =>
+    count <= 0
+      ? 0
+      : Math.max(1, Math.round((count / maxCount) * BAR_CHART_WIDTH));
+  const baseWidth = scale(base);
+  const notchPos = scale(cur);
+  if (notchPos <= baseWidth) {
+    // Notch sits inside (or right at the end of) the solid base bar.
+    const notchIndex = Math.max(0, notchPos - 1);
+    return (
+      '█'.repeat(notchIndex) +
+      '┃' +
+      '█'.repeat(Math.max(0, baseWidth - notchIndex - 1))
+    );
+  }
+  // This run exceeds the baseline: extend past the base in a lighter shade,
+  // capped by the notch marking this run's exact value.
+  return `${'█'.repeat(baseWidth)}${'░'.repeat(notchPos - baseWidth - 1)}┃`;
+}
+
+/** Renders main vs this run as one overlay bar per bucket (a fenced code
+ * block keeps bars aligned in a monospace font), so the shape of the two
+ * distributions — and exactly where this run diverged from the baseline — is
+ * visible at a glance instead of only as numbers in a table. */
+function renderStsoBarChart(buckets, { selfDiff } = {}) {
+  const maxCount = Math.max(1, ...buckets.map((b) => Math.max(b.base, b.cur)));
+  const labelWidth = Math.max(...buckets.map((b) => b.label.length));
+  const countWidth = Math.max(
+    ...buckets.map((b) => String(Math.max(b.base, b.cur)).length)
+  );
+  const lines = ['```'];
+  for (const { label, base, cur } of buckets) {
+    // Without a baseline the two counts are the same series; render one solid
+    // bar rather than an overlay of a run against itself.
+    const bar = (
+      selfDiff
+        ? '█'.repeat(
+            Math.max(1, Math.round((cur / maxCount) * BAR_CHART_WIDTH))
+          )
+        : renderOverlayBar(base, cur, maxCount)
+    ).padEnd(BAR_CHART_WIDTH);
+    const counts = selfDiff
+      ? `steps ${String(cur).padStart(countWidth)}`
+      : `main ${String(base).padStart(countWidth)}  this ${String(cur).padStart(countWidth)}`;
+    lines.push(`${label.padStart(labelWidth)} ms  ${bar}  ${counts}`);
+  }
+  lines.push('```');
+  return lines.join('\n');
+}
+
+/** Renders one STSO row's cumulative-time line, an ASCII bar-chart overlay,
+ * and a bucketed histogram table (this run vs main). Bin width is chosen from
+ * this row's own sample range, so every scenario gets a histogram that
+ * actually spreads across multiple buckets rather than overflowing into
+ * one — except "inline" rows, which use a hardcoded finer width (see
+ * STSO_INLINE_BIN_WIDTH_MS). */
+function renderStsoRowDiff(row) {
+  // Until this lands on `main`, no baseline run has raw samples to diff
+  // against. The shape of this run's distribution is still worth showing, so
+  // fall back to rendering it as a single series rather than diffing it
+  // against itself (which would label this run's own numbers as `main`).
+  const selfDiff = !Array.isArray(row.baselineRaw);
+  const baselineRaw = selfDiff ? row.raw : row.baselineRaw;
+
+  const maxValue = Math.max(maxOf(row.raw), maxOf(baselineRaw));
+  const binWidth = row.scenario.includes('(inline)')
+    ? STSO_INLINE_BIN_WIDTH_MS
+    : chooseBinWidth(maxValue, STSO_HISTOGRAM_TARGET_BINS);
+  // +1 bin of headroom so the max sample lands inside the range rather than
+  // exactly on (and thus overflowing) the last edge.
+  const binCount = Math.ceil(maxValue / binWidth) + 1;
+
+  const current = buildHistogram(row.raw, binWidth, binCount);
+  const baseline = buildHistogram(baselineRaw, binWidth, binCount);
+  const currentTotal = sum(row.raw);
+  const baselineTotal = sum(baselineRaw);
+  const totalDelta = currentTotal - baselineTotal;
+  const totalPct =
+    baselineTotal > 0 ? (totalDelta / baselineTotal) * 100 : undefined;
+  const pctSuffix =
+    totalPct === undefined ? '' : `, ${formatDeltaValue(totalPct)}%`;
+
+  const buckets = nonEmptyBuckets(current, baseline, binWidth, binCount);
+
+  const lines = ['', `_${row.scenario}_`, ''];
+  if (selfDiff) {
+    lines.push(
+      `Cumulative STSO time: ${Math.round(currentTotal)}ms over ${row.samples} samples`,
+      '',
+      "<sub>No `main` baseline with raw samples yet — showing this run's distribution on its own; the diff appears once a run on `main` has recorded them.</sub>",
+      ''
+    );
+  } else {
+    lines.push(
+      `Cumulative STSO time: main ${Math.round(baselineTotal)}ms → this run ${Math.round(currentTotal)}ms (Δ ${formatDeltaValue(totalDelta, 'ms')}${pctSuffix})`,
+      ''
+    );
+  }
+  if (buckets.length > 0) {
+    lines.push(renderStsoBarChart(buckets, { selfDiff }), '');
+  }
+  if (selfDiff) {
+    lines.push('| Bucket (ms) | Steps |', '|---|---:|');
+    for (const { label, cur } of buckets) {
+      lines.push(`| ${label} | ${cur} |`);
+    }
+    return lines.join('\n');
+  }
+  lines.push(
+    '| Bucket (ms) | main steps | this run steps | Δ |',
+    '|---|---:|---:|---:|'
+  );
+  for (const { label, base, cur } of buckets) {
+    lines.push(
+      `| ${label} | ${base} | ${cur} | ${formatDeltaValue(cur - base)} |`
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Renders a per-scenario histogram diff (bucketed step counts) and a
+ * cumulative-time diff (sum of all STSO samples) against `main`, for every
+ * STSO row that recorded raw samples — i.e. one for inline steps and one for
+ * queue-hop steps. This is a complement to the Best/P75/P90/P99 table:
+ * percentiles hide *how many* samples moved and by how much in aggregate,
+ * which is exactly where this benchmark's run-to-run variance shows up.
+ */
+function renderStsoDiffSection(result) {
+  const rows = (result.metrics ?? []).filter(
+    (row) => row.metric === 'stso' && Array.isArray(row.raw)
+  );
+  if (rows.length === 0) return '';
+  const anyBaseline = rows.some((row) => Array.isArray(row.baselineRaw));
+  return [
+    '',
+    anyBaseline ? '**STSO distribution vs `main`**' : '**STSO distribution**',
+    ...rows.map(renderStsoRowDiff),
+  ].join('\n');
 }
 
 // Deltas beyond ±this vs main get a directional marker: 🔻 for a regression,
@@ -300,6 +572,12 @@ function renderEntry(entry, { heading }) {
       lines.push(`Backend: \`${result.backend}\` · app: \`${result.app}\``, '');
     }
     lines.push(renderResultTable(result), '');
+    // Only the latest entry carries raw samples (they are stripped before
+    // being embedded in the comment's data block, see stripRawSamples), so
+    // this renders for the current run and is silently skipped for the
+    // collapsed history entries.
+    const stsoDiff = renderStsoDiffSection(result);
+    if (stsoDiff) lines.push(stsoDiff, '');
   }
   return lines.join('\n');
 }
@@ -352,7 +630,19 @@ function renderFooter(entries) {
     )
   );
 
+  const hasStsoDistribution = results.some((result) =>
+    (result.metrics ?? []).some(
+      (row) => row.metric === 'stso' && Array.isArray(row.raw)
+    )
+  );
+
   const smallprint = [
+    ...(hasStsoDistribution
+      ? [
+          '<sub>The **STSO distribution** section buckets every step gap of the sequential-steps run (not a sampled window), split by whether the step ending the gap ran **inline** — in the same warm process as the step before it, so the gap is pure framework overhead — or after a **queue-hop** — the first step of a fresh process, which pays queue dispatch, client reinit and event-log replay. Bars overlay the two runs: `█` is `main`, `┃` marks where this run lands, `░` bridges the gap when this run has more samples in a bucket.</sub>',
+          '',
+        ]
+      : []),
     ...(hasBaseline
       ? [
           '<sub>Best/P75/P90/P99 deltas compare against the most recent benchmark run on `main` at the time of this run. 🔻 flags a delta worse than +15%, 💚 one better than −15%.</sub>',

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -124,8 +124,13 @@ export function extractHistory(body) {
  * comment's data block. The sequential-steps scenario records ~1000 STSO
  * samples per run (plus the baseline's), which would blow past GitHub's
  * comment size limit within a couple of history entries; the percentiles and
- * baseline annotations — everything the history tables render — are kept. The
- * histogram diff is therefore only shown for the current run.
+ * baseline annotations — everything the history tables render — are kept.
+ *
+ * This does not affect the histogram diff against `main`: that reads its
+ * baseline from the artifacts the workflow downloads into --baseline-dir,
+ * which keep their raw samples. What it costs is the collapsed "Previous
+ * results" entries, re-rendered from this block on a later commit of the same
+ * PR — they show their tables but not their histograms.
  */
 function stripRawSamples(entries) {
   return entries.map((entry) => ({

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -458,6 +458,10 @@ function renderStsoRowDiff(row) {
  * queue-hop steps. This is a complement to the Best/P75/P90/P99 table:
  * percentiles hide *how many* samples moved and by how much in aggregate,
  * which is exactly where this benchmark's run-to-run variance shows up.
+ *
+ * Collapsed by default, like the methodology footer — it is a drill-down for
+ * when the table shows something worth explaining, not the headline. The
+ * blank line after <summary> lets GitHub render the markdown inside.
  */
 function renderStsoDiffSection(result) {
   const rows = (result.metrics ?? []).filter(
@@ -467,8 +471,12 @@ function renderStsoDiffSection(result) {
   const anyBaseline = rows.some((row) => Array.isArray(row.baselineRaw));
   return [
     '',
-    anyBaseline ? '**STSO distribution vs `main`**' : '**STSO distribution**',
+    '<details>',
+    `<summary>📈 STSO distribution${anyBaseline ? ' vs main' : ''} (inline / queue-hop histograms)</summary>`,
+    '',
     ...rows.map(renderStsoRowDiff),
+    '',
+    '</details>',
   ].join('\n');
 }
 
@@ -628,7 +636,7 @@ function renderFooter(entries) {
   const smallprint = [
     ...(hasStsoDistribution
       ? [
-          '<sub>The **STSO distribution** section buckets every step gap of the sequential-steps run (not a sampled window), split by whether the step ending the gap ran **inline** — in the same warm process as the step before it, so the gap is pure framework overhead — or after a **queue-hop** — the first step of a fresh process, which pays queue dispatch, client reinit and event-log replay. Bars overlay the two runs: `█` is `main`, `┃` marks where this run lands, `░` bridges the gap when this run has more samples in a bucket.</sub>',
+          '<sub>The collapsed **STSO distribution** section above buckets every step gap of the sequential-steps run (not a sampled window), split by whether the step ending the gap ran **inline** — in the same warm process as the step before it, so the gap is pure framework overhead — or after a **queue-hop** — the first step of a fresh process, which pays queue dispatch, client reinit and event-log replay. Bars overlay the two runs: `█` is `main`, `┃` marks where this run lands, `░` bridges the gap when this run has more samples in a bucket.</sub>',
           '',
         ]
       : []),

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -532,7 +532,7 @@ test('renders inline and queue-hop STSO histogram diffs against main', async () 
   assert.match(body, /█+┃/);
   assert.match(
     body,
-    /<sub>The \*\*STSO distribution\*\* section buckets every/
+    /<sub>The collapsed \*\*STSO distribution\*\* section above buckets every/
   );
 });
 

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -515,16 +515,17 @@ test('renders inline and queue-hop STSO histogram diffs against main', async () 
     /Cumulative STSO time: main 1440ms → this run 1070ms \(Δ -370ms, -26%\)/
   );
   // Inline rows are bucketed at a hardcoded 50ms, so the two fast samples
-  // land in 150-200 and the bucket the baseline occupied loses them.
-  assert.match(body, /\| 150-200 \| 0 \| 2 \| \+2 \|/);
-  assert.match(body, /\| 350-400 \| 4 \| 2 \| -2 \|/);
+  // land in 150-200 and the bucket the baseline occupied loses them. Counts
+  // and the per-bucket delta ride on the bar line; there is no second table.
+  assert.match(body, /^ *150-200 ms .*main 0 +this 2 +\+2$/m);
+  assert.match(body, /^ *350-400 ms .*main 4 +this 2 +-2$/m);
+  assert.doesNotMatch(body, /Bucket \(ms\)/);
   // Queue-hop rows keep the adaptive (much coarser) bin width.
-  assert.doesNotMatch(body, /\| 2100-2150 \|/);
-  assert.match(body, /\| 2000-2500 \| 2 \| 1 \| -1 \|/);
-  assert.match(body, /\| 2500-3000 \| 0 \| 1 \| \+1 \|/);
+  assert.doesNotMatch(body, /2100-2150 ms/);
+  assert.match(body, /^ *2000-2500 ms .*main 2 +this 1 +-1$/m);
+  assert.match(body, /^ *2500-3000 ms .*main 0 +this 1 +\+1$/m);
   // Overlay bars: solid run for main, notch for this run.
   assert.match(body, /█+┃/);
-  assert.match(body, /main \d+ +this \d+/);
   assert.match(
     body,
     /<sub>The \*\*STSO distribution\*\* section buckets every/
@@ -550,10 +551,10 @@ test('shows the STSO distribution alone when main has no raw samples', async () 
   assert.doesNotMatch(body, /STSO distribution vs `main`/);
   assert.match(body, /No `main` baseline with raw samples yet/);
   assert.match(body, /Cumulative STSO time: 520ms over 2 samples/);
-  // Single-series rendering: no main/this columns, no Δ column.
-  assert.match(body, /\| Bucket \(ms\) \| Steps \|/);
-  assert.match(body, /\| 150-200 \| 1 \|/);
-  assert.doesNotMatch(body, /this run steps/);
+  // Single-series rendering: one count per bucket, no main/this or delta.
+  assert.match(body, /^ *150-200 ms .*steps 1$/m);
+  assert.doesNotMatch(body, /this \d/);
+  assert.doesNotMatch(body, /Bucket \(ms\)/);
 });
 
 test('strips raw samples from the embedded history data block', async () => {
@@ -603,7 +604,7 @@ test('buckets negative STSO gaps separately from the slow tail', async () => {
     commit: 'abcdef1234567890',
   });
 
-  assert.match(body, /\| <0 \(skew\) \| 0 \| 1 \| \+1 \|/);
+  assert.match(body, /^ *<0 \(skew\) ms .*main 0 +this 1 +\+1$/m);
   // ...and the top bucket still reflects only genuinely slow samples.
-  assert.match(body, /\| 350-400 \| 1 \| 1 \| \+0 \|/);
+  assert.match(body, /^ *350-400 ms .*main 1 +this 1 +\+0$/m);
 });

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -506,7 +506,11 @@ test('renders inline and queue-hop STSO histogram diffs against main', async () 
     commit: 'abcdef1234567890',
   });
 
-  assert.match(body, /\*\*STSO distribution vs `main`\*\*/);
+  // Collapsed by default — a drill-down, not the headline.
+  assert.match(
+    body,
+    /<details>\n<summary>📈 STSO distribution vs main \(inline \/ queue-hop histograms\)<\/summary>/
+  );
   assert.match(body, /_1020 steps \(inline\)_/);
   assert.match(body, /_1020 steps \(queue-hop\)_/);
   // Cumulative time diff: inline 1440ms → 1070ms.
@@ -547,8 +551,12 @@ test('shows the STSO distribution alone when main has no raw samples', async () 
     commit: 'abcdef1234567890',
   });
 
-  assert.match(body, /\*\*STSO distribution\*\*/);
-  assert.doesNotMatch(body, /STSO distribution vs `main`/);
+  // Summary drops the "vs main" qualifier when there is nothing to diff.
+  assert.match(
+    body,
+    /<summary>📈 STSO distribution \(inline \/ queue-hop histograms\)<\/summary>/
+  );
+  assert.doesNotMatch(body, /STSO distribution vs main/);
   assert.match(body, /No `main` baseline with raw samples yet/);
   assert.match(body, /Cumulative STSO time: 520ms over 2 samples/);
   // Single-series rendering: one count per bucket, no main/this or delta.
@@ -569,7 +577,7 @@ test('strips raw samples from the embedded history data block', async () => {
   });
 
   // The histogram renders for the current run...
-  assert.match(body, /\*\*STSO distribution vs `main`\*\*/);
+  assert.match(body, /<summary>📈 STSO distribution vs main/);
   // ...but the ~1000 samples behind it never reach the embedded data block,
   // which would otherwise blow past GitHub's comment size limit as history
   // accumulates.

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -458,3 +458,152 @@ test('CLI fails when completed with no results', async () => {
     )
   );
 });
+
+/** A sequential-steps result whose STSO rows carry raw samples, as the
+ * benchmark runner now records them (every gap, not a sampled window). */
+function sequentialResult({ inline, queueHop }) {
+  const stsoRow = (scenario, raw) => ({
+    metric: 'stso',
+    scenario,
+    unit: 'ms',
+    best: Math.min(...raw),
+    avg: raw.reduce((a, b) => a + b, 0) / raw.length,
+    p75: raw[Math.ceil(0.75 * raw.length) - 1],
+    p90: raw[Math.ceil(0.9 * raw.length) - 1],
+    p99: raw[Math.ceil(0.99 * raw.length) - 1],
+    samples: raw.length,
+    raw,
+  });
+  return sampleResult({
+    scenarios: [
+      { name: '1020 steps', description: 'trivial sequential steps' },
+    ],
+    metrics: [
+      stsoRow('1020 steps (inline)', inline),
+      stsoRow('1020 steps (queue-hop)', queueHop),
+    ],
+  });
+}
+
+test('renders inline and queue-hop STSO histogram diffs against main', async () => {
+  const { renderComment } = await loadModule();
+  const body = renderComment({
+    status: 'completed',
+    // Two inline steps move from the 350-400ms bucket down to 150-200ms.
+    results: [
+      sequentialResult({
+        inline: [160, 190, 360, 360],
+        queueHop: [2100, 2600],
+      }),
+    ],
+    baseline: [
+      sequentialResult({
+        inline: [360, 360, 360, 360],
+        queueHop: [2100, 2100],
+      }),
+    ],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+
+  assert.match(body, /\*\*STSO distribution vs `main`\*\*/);
+  assert.match(body, /_1020 steps \(inline\)_/);
+  assert.match(body, /_1020 steps \(queue-hop\)_/);
+  // Cumulative time diff: inline 1440ms → 1070ms.
+  assert.match(
+    body,
+    /Cumulative STSO time: main 1440ms → this run 1070ms \(Δ -370ms, -26%\)/
+  );
+  // Inline rows are bucketed at a hardcoded 50ms, so the two fast samples
+  // land in 150-200 and the bucket the baseline occupied loses them.
+  assert.match(body, /\| 150-200 \| 0 \| 2 \| \+2 \|/);
+  assert.match(body, /\| 350-400 \| 4 \| 2 \| -2 \|/);
+  // Queue-hop rows keep the adaptive (much coarser) bin width.
+  assert.doesNotMatch(body, /\| 2100-2150 \|/);
+  assert.match(body, /\| 2000-2500 \| 2 \| 1 \| -1 \|/);
+  assert.match(body, /\| 2500-3000 \| 0 \| 1 \| \+1 \|/);
+  // Overlay bars: solid run for main, notch for this run.
+  assert.match(body, /█+┃/);
+  assert.match(body, /main \d+ +this \d+/);
+  assert.match(
+    body,
+    /<sub>The \*\*STSO distribution\*\* section buckets every/
+  );
+});
+
+test('shows the STSO distribution alone when main has no raw samples', async () => {
+  const { renderComment } = await loadModule();
+  const run = sequentialResult({ inline: [160, 360], queueHop: [2100] });
+  // A pre-raw-samples baseline: same rows, percentiles only.
+  const baseline = sequentialResult({ inline: [160, 360], queueHop: [2100] });
+  for (const row of baseline.metrics) delete row.raw;
+
+  const body = renderComment({
+    status: 'completed',
+    results: [run],
+    baseline: [baseline],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+
+  assert.match(body, /\*\*STSO distribution\*\*/);
+  assert.doesNotMatch(body, /STSO distribution vs `main`/);
+  assert.match(body, /No `main` baseline with raw samples yet/);
+  assert.match(body, /Cumulative STSO time: 520ms over 2 samples/);
+  // Single-series rendering: no main/this columns, no Δ column.
+  assert.match(body, /\| Bucket \(ms\) \| Steps \|/);
+  assert.match(body, /\| 150-200 \| 1 \|/);
+  assert.doesNotMatch(body, /this run steps/);
+});
+
+test('strips raw samples from the embedded history data block', async () => {
+  const { renderComment, extractHistory } = await loadModule();
+  const inline = Array.from({ length: 1000 }, (_, i) => 200 + (i % 300));
+  const body = renderComment({
+    status: 'completed',
+    results: [sequentialResult({ inline, queueHop: [2100, 2600] })],
+    baseline: [sequentialResult({ inline, queueHop: [2100, 2600] })],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+
+  // The histogram renders for the current run...
+  assert.match(body, /\*\*STSO distribution vs `main`\*\*/);
+  // ...but the ~1000 samples behind it never reach the embedded data block,
+  // which would otherwise blow past GitHub's comment size limit as history
+  // accumulates.
+  const history = extractHistory(body);
+  const row = history[0].results[0].metrics[0];
+  assert.strictEqual(row.raw, undefined);
+  assert.strictEqual(row.baselineRaw, undefined);
+  assert.strictEqual(row.samples, 1000);
+  assert.ok(body.length < 20_000, `comment is ${body.length} chars`);
+
+  // Re-rendering from that history keeps the table but drops the histogram.
+  const rerendered = renderComment({
+    status: 'running',
+    results: [],
+    history,
+    commit: 'ffffff1234567890',
+  });
+  assert.match(rerendered, /1020 steps \(inline\)/);
+  assert.doesNotMatch(rerendered, /STSO distribution/);
+});
+
+test('buckets negative STSO gaps separately from the slow tail', async () => {
+  const { renderComment } = await loadModule();
+  // Consecutive step timestamps come from different step bodies, so a gap can
+  // come out slightly negative under clock skew — it must not be counted with
+  // the slowest samples.
+  const body = renderComment({
+    status: 'completed',
+    results: [sequentialResult({ inline: [-40, 160, 360], queueHop: [2100] })],
+    baseline: [sequentialResult({ inline: [160, 360], queueHop: [2100] })],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+
+  assert.match(body, /\| <0 \(skew\) \| 0 \| 1 \| \+1 \|/);
+  // ...and the top bucket still reflects only genuinely slow samples.
+  assert.match(body, /\| 350-400 \| 1 \| 1 \| \+0 \|/);
+});

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -31,9 +31,13 @@
  * - STSO  (step-to-step overhead): gap between consecutive step body
  *          executions (`steps[i].start - steps[i-1].end`) in a workflow with
  *          many trivial sequential steps. Both timestamps come from step
- *          bodies on the deployment. Reported per step-index range (see
- *          STSO_BUCKETS) because early steps behave differently from late ones
- *          (first-invocation fast paths, growing event log).
+ *          bodies on the deployment. Reported split by whether the step
+ *          ending the gap was 'inline' (same warm process as the step before
+ *          it) or a 'queue-hop' (first step of a fresh process — cold start
+ *          or a redispatch after the prior invocation's duration limit) —
+ *          the two have very different cost profiles and averaging them
+ *          together hides that. The workflow itself tags each step's kind
+ *          (see workflows/97_bench.ts's `stepKind`).
  * - WO    (workflow overhead): total time the run spends outside of step
  *          bodies over the whole sequential run, from the in-deployment
  *          `clientStart` to the end of the last step body:
@@ -146,15 +150,6 @@ const SO_NOMINAL_DURATION_MS = SO_CHUNK_COUNT * SO_INTERVAL_MS;
 // Provisional, like TTFS/SL above: re-tighten once in-deployment baselines land.
 const SO_TARGETS = { p75: 250, p90: 500, p99: 1000 };
 
-// STSO percentiles are reported for sampled step-index windows: the gap
-// between steps k and k+1 counts toward the window where `from <= k < to`.
-// The early window captures first-invocation behavior; the later ones capture
-// steady state with an increasingly large event log.
-const STSO_BUCKETS = [
-  { from: 1, to: 20, targets: { p75: 20, p90: 30, p99: 60 } },
-  { from: 101, to: 120, targets: { p75: 30, p90: 45, p99: 90 } },
-  { from: 1001, to: 1020, targets: { p75: 40, p90: 60, p99: 120 } },
-];
 // Guard timeouts so a single stuck run fails fast instead of eating the job.
 const RUN_TIMEOUT_MS = envInt('BENCH_RUN_TIMEOUT_MS', 120_000);
 // Preflight guard: a trivial 1-step run must complete within this window
@@ -172,6 +167,11 @@ const ZERO_SUCCESS_ABORT_ATTEMPTS = 3;
 interface BenchStepTiming {
   start: number;
   end: number;
+  /** 'queue-hop' if this was the first step body executed in its process
+   * (cold start or a fresh dispatch after the prior invocation ended);
+   * 'inline' for later steps in the same warm process. Set by the workflow
+   * itself (see workflows/97_bench.ts) — ground truth, not inferred. */
+  kind: 'inline' | 'queue-hop';
 }
 
 interface BenchStreamLatency {
@@ -193,8 +193,13 @@ interface StreamIterationResult {
 
 interface SequentialIterationResult {
   runId: string;
-  /** stsoMs[i] is the gap between steps i+1 and i+2 (1-indexed). */
-  stsoMs: number[];
+  /** STSO gaps preceding an 'inline' step (same warm process as the step
+   * before it) — the framework's pure step-to-step overhead. */
+  stsoInlineMs: number[];
+  /** STSO gaps preceding a 'queue-hop' step (first step of a fresh process:
+   * cold start or a redispatch via the queue after the prior invocation's
+   * duration limit) — dispatch + reinit overhead, not step-body cost. */
+  stsoQueueHopMs: number[];
   /** Whole-run workflow overhead, anchored on the in-deployment clientStart. */
   woMs: number;
 }
@@ -352,14 +357,17 @@ async function runSequentialIteration(
       );
     }
 
-    const stsoMs: number[] = [];
+    const stsoInlineMs: number[] = [];
+    const stsoQueueHopMs: number[] = [];
     for (let i = 1; i < steps.length; i++) {
-      stsoMs.push(steps[i].start - steps[i - 1].end);
+      const gap = steps[i].start - steps[i - 1].end;
+      (steps[i].kind === 'queue-hop' ? stsoQueueHopMs : stsoInlineMs).push(gap);
     }
 
     return {
       runId,
-      stsoMs,
+      stsoInlineMs,
+      stsoQueueHopMs,
       woMs: workflowOverheadMs(clientStart, steps),
     };
   } catch (error) {
@@ -508,6 +516,10 @@ interface MetricStats {
   p90: number;
   p99: number;
   samples: number;
+  /** Every sample (ms, ascending), not just the percentiles above: the PR
+   * comment diffs the whole STSO distribution against `main`, and
+   * percentiles alone hide *how many* samples moved and by how much. */
+  raw: number[];
 }
 
 interface MetricTargets {
@@ -533,6 +545,7 @@ function computeStats(samples: number[]): MetricStats {
     p90: round(percentile(90)),
     p99: round(percentile(99)),
     samples: sorted.length,
+    raw: sorted,
   };
 }
 
@@ -764,17 +777,23 @@ describe('workflow benchmarks', () => {
         extraAttempts: Math.max(2, Math.ceil(SEQUENTIAL_ITERATIONS * 0.5)),
       }
     );
-    // Report STSO per step-index window. Gap k (between steps k and k+1,
-    // 1-indexed) lives at stsoMs[k - 1].
-    for (const { from, to, targets } of STSO_BUCKETS) {
-      if (from >= SEQUENTIAL_STEP_COUNT) continue;
-      recordMetric(
-        'stso',
-        `${SCENARIO_SEQUENTIAL} (${from}-${Math.min(to, SEQUENTIAL_STEP_COUNT)})`,
-        results.flatMap((r) => r.stsoMs.slice(from - 1, to - 1)),
-        targets
-      );
-    }
+    // Report STSO split by whether the step that ends the gap was 'inline'
+    // (same warm process as the step before it — pure framework overhead) or
+    // a 'queue-hop' (first step of a fresh process — dispatch + reinit cost).
+    // Ground truth from the workflow itself (see workflows/97_bench.ts), not
+    // inferred from step index or trace timestamps. No targets yet: the two
+    // populations are new, and the old per-index-window targets described a
+    // different (index-bucketed) grouping.
+    recordMetric(
+      'stso',
+      `${SCENARIO_SEQUENTIAL} (inline)`,
+      results.flatMap((r) => r.stsoInlineMs)
+    );
+    recordMetric(
+      'stso',
+      `${SCENARIO_SEQUENTIAL} (queue-hop)`,
+      results.flatMap((r) => r.stsoQueueHopMs)
+    );
     // WO: whole-run overhead outside step bodies, anchored on the in-deployment
     // clientStart. Measured here rather than on the stream scenarios, where a
     // single step makes WO algebraically identical to TTFS.

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -34,6 +34,24 @@ export interface BenchStepTiming {
   start: number;
   /** Date.now() at step body exit (just before step_completed is sent) */
   end: number;
+  /** 'queue-hop' if this is the first step body executed in this process
+   * (module state persists across warm invocations, so a fresh process means
+   * a cold start or a fresh dispatch from the queue after the previous
+   * invocation ended); 'inline' for every subsequent step in the same
+   * process. See {@link stepKind}. */
+  kind: 'inline' | 'queue-hop';
+}
+
+// Process-global, initialized once per process. A fresh process (cold start,
+// or redispatch via the queue after the prior invocation's ~duration limit)
+// resets this to false, so the first step body it runs is tagged
+// 'queue-hop'; every step after that in the same warm process is 'inline'.
+let hasExecutedStepInProcess = false;
+
+function stepKind(): 'inline' | 'queue-hop' {
+  const kind = hasExecutedStepInProcess ? 'inline' : 'queue-hop';
+  hasExecutedStepInProcess = true;
+  return kind;
 }
 
 export interface BenchStreamChunk {
@@ -123,15 +141,17 @@ function soChunk(
 
 async function timedNoopStep(index: number): Promise<BenchStepTiming> {
   'use step';
+  const kind = stepKind();
   const start = Date.now();
   // No body work: `end - start` is ~0, so the gap between consecutive step
   // timings is pure framework overhead.
   void index;
-  return { start, end: Date.now() };
+  return { start, end: Date.now(), kind };
 }
 
 async function timedStreamingStep(chunks: number): Promise<BenchStepTiming> {
   'use step';
+  const kind = stepKind();
   const start = Date.now();
   const writable = getWritable<BenchStreamChunk>();
   const writer = writable.getWriter();
@@ -141,7 +161,7 @@ async function timedStreamingStep(chunks: number): Promise<BenchStepTiming> {
   writer.releaseLock();
   // Close so the benchmark reader's read loop terminates.
   await writable.close();
-  return { start, end: Date.now() };
+  return { start, end: Date.now(), kind };
 }
 
 /**


### PR DESCRIPTION
## Why

The sequential-steps benchmark's STSO metric mixed two unrelated phenomena:

- **inline** gaps — steps running back-to-back in the same warm process (pure framework overhead, ~200-500ms)
- **queue-hop** gaps — steps across an invocation boundary, paying queue dispatch + client reinit + event-log replay (~2-3s, roughly 10x more)

The old step-index windows (`1-20` / `101-120` / `1001-1020`) sampled 19 gaps each and captured neither cleanly. A 1020-step run crosses ~3 invocation boundaries at non-deterministic step indices, so *whether a boundary happened to land inside a window* moved that window's P99 by hundreds of percent between two runs of the same commit against the same deployment. That was most of the run-to-run variance the benchmark comment has been reporting.

Diagnosed on `shalabhc/benchmarks-variance`, where separating the two categories showed inline STSO to be stable within ~3% across runs while the visible "regressions" were entirely boundary placement.

## What changed

**Ground-truth tagging.** `97_bench.ts` tags each step with whether it was the first step body executed in its process (`queue-hop`) or a later one in the same warm process (`inline`), via a process-global. Not inferred from step index or trace timestamps.

**Two STSO rows over every gap** instead of three sampled 19-gap windows. No targets on the new rows — the old ones described the index-bucketed grouping.

**Full sample retention.** `computeStats` keeps the sorted sample array alongside the percentiles.

**Histogram + cumulative-time diff vs `main`**, one per STSO kind, rendered under the existing table (which is unchanged). Percentiles hide *how many* samples moved and by how much, which is exactly where the variance lives.

No changes to `benchmarks.yml` — this is still one run diffed against the `main` baseline the workflow already downloads.

## Sample output

```
**STSO distribution vs `main`**

_1020 steps (inline)_

Cumulative STSO time: main 369664ms → this run 333174ms (Δ -36490ms, -10%)

200-250 ms  █┃                        main   2  this  35   +33
250-300 ms  ███░░░░░░░░┃              main  59  this 227  +168
300-350 ms  █████████████████░░░░░░┃  main 322  this 445  +123
350-400 ms  █████████████┃█████████   main 433  this 254  -179
400-450 ms  ██┃███████                main 185  this  54  -131
450-500 ms  ┃                         main  15  this   1   -14
```

`█` is `main`, `┃` marks where this run lands, `░` bridges the gap when this run has more samples in a bucket. Per-bucket counts and deltas ride on the bar line — no second table restating them.

## Notes for review

- **This PR's own comment will show the distributions without deltas.** No run on `main` has recorded raw samples yet, so the section renders as a single series (with a note) rather than diffing this run against itself. Deltas start on the next PR.
- **Raw samples are stripped from the comment's embedded data block.** ~1000 samples × current + baseline would exceed GitHub's 65k comment limit within a couple of history entries. The histogram therefore renders for the current run only; collapsed history keeps its tables. Simulated 12 successive runs → 15.9 KB comment with a full 10-entry history.
- **Inline rows use a fixed 50ms bin width**; the adaptive width is coarse enough to hide structure inside that cluster (a bimodal split was invisible behind ~500ms bins). Queue-hop rows keep the adaptive width.
- **Negative gaps get their own `<0 (skew)` bucket.** Step timestamps come from two different step bodies, so a gap can come out slightly negative under clock skew; counting those with the slowest samples inverts what the tail bucket means.
- Empty changeset, matching #3080 which touched the same file set.

Draft until the benchmark job runs on it and the rendered comment is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
