### PR TITLE
[world-local] Retry transient EPERM unlink failures on Windows

### DIFF
--- a/.changeset/world-local-windows-unlink-retry.md
+++ b/.changeset/world-local-windows-unlink-retry.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Retry transient `EPERM` unlink failures on Windows when deleting hook and entity JSON files. A concurrent reader briefly holding a file open made `deleteJSON` throw a share-violation `EPERM`, which surfaced as a failed operation — for example a failed `run.cancel()` while `deleteAllHooksForRun` raced hook polling.

--- a/packages/world-local/src/fs.test.ts
+++ b/packages/world-local/src/fs.test.ts
@@ -19,6 +19,7 @@ import { UnwritableDataDirError } from './build-target-mismatch.js';
 import {
   assertSafeEntityId,
   clearCreatedFilesCache,
+  deleteJSON,
   ensureDir,
   paginatedFileSystemQuery,
   readFirstByte,
@@ -115,6 +116,67 @@ describe('fs utilities', () => {
       expect(await readFirstByte(dataPath)).toBe(1);
       expect(await readFirstByte(nonEofPath)).toBe(0);
       expect(await readFirstByte(emptyPath)).toBeUndefined();
+    });
+  });
+
+  describe('deleteJSON', () => {
+    it('deletes the file and tolerates one that is already gone', async () => {
+      const filePath = path.join(testDir, 'victim.json');
+      await fs.writeFile(filePath, '{}');
+
+      await deleteJSON(filePath);
+      await expect(fs.access(filePath)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+
+      await expect(deleteJSON(filePath)).resolves.toBeUndefined();
+    });
+
+    it('propagates non-ENOENT unlink failures', async () => {
+      const eisdir = Object.assign(new Error('EISDIR: illegal operation'), {
+        code: 'EISDIR',
+      });
+      vi.spyOn(fs, 'unlink').mockRejectedValue(eisdir);
+
+      await expect(deleteJSON(path.join(testDir, 'x.json'))).rejects.toThrow(
+        'EISDIR'
+      );
+    });
+
+    it('retries transient EPERM unlink failures on Windows', async () => {
+      // On Windows, unlink fails with EPERM while a concurrent reader briefly
+      // holds the file open (e.g. hook polling racing deleteAllHooksForRun).
+      // Re-import the module with the platform stubbed so its module-level
+      // isWindows check takes the retry path.
+      const platform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      vi.resetModules();
+      try {
+        const freshFsModule = await import('./fs.js');
+        const filePath = path.join(testDir, 'locked.json');
+        await fs.writeFile(filePath, '{}');
+
+        const eperm = Object.assign(
+          new Error('EPERM: operation not permitted, unlink'),
+          { code: 'EPERM' }
+        );
+        const unlinkSpy = vi
+          .spyOn(fs, 'unlink')
+          .mockRejectedValueOnce(eperm)
+          .mockRejectedValueOnce(eperm);
+
+        await freshFsModule.deleteJSON(filePath);
+
+        expect(unlinkSpy).toHaveBeenCalledTimes(3);
+        await expect(fs.access(filePath)).rejects.toMatchObject({
+          code: 'ENOENT',
+        });
+      } finally {
+        if (platform) {
+          Object.defineProperty(process, 'platform', platform);
+        }
+        vi.resetModules();
+      }
     });
   });
 

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -458,7 +458,12 @@ export async function readFirstByte(
 
 export async function deleteJSON(filePath: string): Promise<void> {
   try {
-    await fs.unlink(filePath);
+    // On Windows, a concurrent reader briefly holding the file open makes
+    // unlink fail with EPERM (share violation), so retry like the other
+    // mutation paths in this module. A reader's window is milliseconds;
+    // without the retry a transient EPERM surfaces as a failed operation
+    // (e.g. run cancellation via deleteAllHooksForRun).
+    await withWindowsRetry(() => fs.unlink(filePath));
   } catch (error) {
     if ((error as any).code !== 'ENOENT') throw error;
   }


### PR DESCRIPTION
## Summary

`run.cancel()` on the local world can fail with `EPERM: operation not permitted, unlink` on Windows when hook cleanup races a concurrent reader. The fs layer already owns the fix — `withWindowsRetry`, which retries `EPERM`/`EBUSY`/`EACCES` with exponential backoff — but `deleteJSON` is the one mutation path that neither uses it nor swallows the error.

## Observed failure

eve CI, `test-integration (windows-latest)` on vercel/eve#1387, world-local `5.0.0-beta.32` (the code is unchanged at current HEAD):

```
Error: EPERM: operation not permitted, unlink 'D:\a\eve\eve\packages\eve\.eve\.workflow-data\vitest-3\hooks\hook_01KYT1T0ZH4J57043XC0GRBYV0.vitest-3.json'
 ❯ deleteJSON            world-local/src/fs.ts:461
 ❯ deleteAllHooksForRun  world-local/src/storage/hooks-storage.ts:378
 ❯ createImpl            world-local/src/storage/events-storage.ts:1325
 ❯ e.cancel              (run cancellation)
```

Job: https://github.com/vercel/eve/actions/runs/30566760759/job/90953098171

The consuming test's assertions had all passed; a cleanup `run.cancel()` threw because `deleteAllHooksForRun` unlinked a hook JSON file while another handle (hook polling reading the same file) briefly held it open. On POSIX that unlink succeeds; on Windows an open handle is a share violation and `unlink` throws `EPERM` (errno -4048).

## Why deleteJSON specifically

The write pipeline consistently guards the equivalent operations — `withWindowsRetry(() => fs.rename(...))` (fs.ts:415), `withWindowsRetry(() => fs.unlink(tempPath), 3)` (fs.ts:422, 500), `withWindowsRetry(() => fs.link(...))` (fs.ts:489, 527) — and every other direct `fs.unlink` in the package swallows failures (`helpers.ts:323`, `legacy.ts:71`, `events-storage.ts:2186`, `index.ts:222`). `deleteJSON` is the only unlink that both skips the retry and propagates, and it sits under run cancellation, so a transient share violation surfaces as a failed cancel. Beyond CI, a real `run.cancel()` on a Windows dev machine hits the same race.

## Change

- Wrap `deleteJSON`'s unlink in `withWindowsRetry`. `ENOENT` is not in the retryable set, so the existing already-deleted tolerance still short-circuits.
- Tests: delete + already-gone tolerance, non-ENOENT propagation, and the Windows retry path (module re-imported with `process.platform` stubbed to `win32`, unlink rejecting `EPERM` twice before succeeding).
- Changeset: `@workflow/world-local` patch.

## Testing

- `pnpm --filter @workflow/world-local test` — 493/493
- `pnpm --filter @workflow/world-local exec tsc --noEmit`
- `biome check` clean on the touched files