### PR TITLE
[world-vercel] Backport the optimized HTTP/2 transport to stable

### DIFF
--- a/.changeset/cancel-v4-frame-stream.md
+++ b/.changeset/cancel-v4-frame-stream.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Cancel the v4 event frame stream when a reader stops early, so the response body's undici connection returns to the pool instead of leaking.

--- a/.changeset/h2-events-multiplexing.md
+++ b/.changeset/h2-events-multiplexing.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Event-log requests now multiplex over a single HTTP/2 connection instead of opening one connection per in-flight request

--- a/.changeset/h2-receive-windows.md
+++ b/.changeset/h2-receive-windows.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Raise HTTP/2 receive windows on the events client, slightly decreasing read latency

--- a/.changeset/nitro-h2-noderequire.md
+++ b/.changeset/nitro-h2-noderequire.md
@@ -1,0 +1,5 @@
+---
+'@workflow/nitro': patch
+---
+
+Fix HTTP/2 requests failing in production builds (Vite/Nitro, TanStack Start) where undici's bundled `node:http2` could not load and fell back to a stub.

--- a/.changeset/stream-close-retry.md
+++ b/.changeset/stream-close-retry.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Retry stream close on retriable 5xx. Close is idempotent on the server (unlike chunk appends, which keep their no-5xx retry policy), and the server may return retriable 503s expecting the writer to close again.

--- a/.changeset/sveltekit-h2-noderequire.md
+++ b/.changeset/sveltekit-h2-noderequire.md
@@ -1,0 +1,5 @@
+---
+'@workflow/sveltekit': patch
+---
+
+Fix HTTP/2 requests failing in SvelteKit production builds (undici's bundled `node:http2` could not load, falling back to a stub).

--- a/.changeset/web-h2-noderequire.md
+++ b/.changeset/web-h2-noderequire.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Fix run and event observability pages hanging (~16s) and showing no data in the bundled server build, caused by HTTP/2 requests failing to reach `node:http2`.

--- a/.changeset/world-vercel-enable-h2.md
+++ b/.changeset/world-vercel-enable-h2.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Enable HTTP/2 for the events API and stream write requests.

--- a/.changeset/world-vercel-http-core.md
+++ b/.changeset/world-vercel-http-core.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Unify HTTP request handling into a shared core, extending OTEL client spans, trace-context propagation, and `DEBUG` logging to the v4 events, stream, and Vercel API request paths

--- a/docs/content/docs/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/deploying/world/vercel-world.mdx
@@ -113,6 +113,10 @@ Vercel team ID for API requests. Automatically detected.
 
 Custom base URL for the Vercel workflow API. Automatically detected.
 
+### `WORKFLOW_H2_MULTIPLEX`
+
+Enabled by default. Lets concurrent event-log requests share one HTTP/2 connection instead of opening one connection per in-flight request. Set to `0` to send one event request per connection.
+
 ### Programmatic configuration
 
 {/*@skip-typecheck: incomplete code sample*/}

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -9,6 +9,46 @@ import type { ModuleOptions } from './types';
 
 export type { ModuleOptions };
 
+/**
+ * Prepend a `createRequire`-backed global `require` to every server chunk so
+ * undici's bundled `require('node:http2')` resolves the real builtin instead of
+ * throwing (which would make undici fall back to a stub without
+ * `http2.connect`, breaking HTTP/2). The guard keeps it idempotent across
+ * chunks, and `node:module` is always available in the Node server runtime.
+ *
+ * This is a Node-server-runtime-only shim (callers gate it to the production
+ * server build). Note the deliberate global side effect: defining
+ * `globalThis.require` makes `typeof require` truthy for *every* bundled
+ * dependency in this ESM server output, so any library that feature-detects
+ * `require` will take its CJS path here. That is safe because (a) it never
+ * touches the client bundle, (b) the `typeof require === 'undefined'` guard
+ * makes it a no-op in CJS chunks where a real `require` already exists, and
+ * (c) the `require` we install is a working `createRequire`, so a library that
+ * switches to the require path gets a functional `require`, not a broken stub.
+ * The behavior to watch for is a bundled lib that, on seeing `require`, does
+ * `require()` of an ESM-only dependency on a Node version without `require(ESM)`
+ * support.
+ */
+function addNodeRequireBanner(config: RollupConfig): void {
+  const banner =
+    "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
+  const output = config.output;
+  if (output == null) {
+    config.output = { banner };
+    return;
+  }
+  const outputs = Array.isArray(output) ? output : [output];
+  for (const o of outputs) {
+    const existing = o.banner;
+    o.banner =
+      existing == null
+        ? banner
+        : typeof existing === 'function'
+          ? async (chunk: unknown) => `${banner}\n${await existing(chunk)}`
+          : `${banner}\n${existing}`;
+  }
+}
+
 export default {
   name: 'workflow/nitro',
   async setup(nitro: Nitro) {
@@ -29,6 +69,19 @@ export default {
           exclude: [nitroBuildDir],
         })
       );
+
+      // Nitro bundles undici (via the world adapter) into the ESM server
+      // output. undici loads most node: builtins as ESM imports, but pulls in
+      // `node:http2` lazily via a bare `require('node:http2')` inside a
+      // try/catch — which the bundler leaves un-wired, so in the ESM bundle the
+      // require throws and undici silently falls back to a stub whose
+      // `http2.connect` is undefined. That breaks any HTTP/2 request (the
+      // workflow flow-route callback fails with "fetch failed", so runs never
+      // start). Prepend a working CJS `require` to the server chunks so the
+      // real `node:http2` resolves. Skipped in dev (Vite SSR provides require).
+      if (!nitro.options.dev) {
+        addNodeRequireBanner(config);
+      }
     });
 
     // NOTE: Temporary workaround for debug unenv mock

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -21,17 +21,27 @@ export type { ModuleOptions };
  * `globalThis.require` makes `typeof require` truthy for *every* bundled
  * dependency in this ESM server output, so any library that feature-detects
  * `require` will take its CJS path here. That is safe because (a) it never
- * touches the client bundle, (b) the `typeof require === 'undefined'` guard
- * makes it a no-op in CJS chunks where a real `require` already exists, and
- * (c) the `require` we install is a working `createRequire`, so a library that
- * switches to the require path gets a functional `require`, not a broken stub.
- * The behavior to watch for is a bundled lib that, on seeing `require`, does
- * `require()` of an ESM-only dependency on a Node version without `require(ESM)`
- * support.
+ * touches the client bundle, (b) the guard makes it a no-op where a real
+ * `require` already exists, and (c) the `require` we install is a working
+ * `createRequire`, so a library that switches to the require path gets a
+ * functional `require`, not a broken stub. The behavior to watch for is a
+ * bundled lib that, on seeing `require`, does `require()` of an ESM-only
+ * dependency on a Node version without `require(ESM)` support.
+ *
+ * The guard reads `globalThis.require` rather than the bare identifier: a
+ * bundled module may declare its own top-level `const require` (as
+ * `@workflow/core`'s runtime world loader does), and Rollup hoists that
+ * declaration into the chunk's module scope without renaming it, since the
+ * banner isn't part of the module graph it analyzes. `typeof require` would then
+ * read a const in its temporal dead zone and throw
+ * `ReferenceError: Cannot access 'require' before initialization` on the first
+ * line of the server bundle — the server never boots. A property read is safe
+ * regardless of what the chunk declares; a chunk that has its own `require`
+ * keeps using it, because the local binding shadows the global.
  */
 function addNodeRequireBanner(config: RollupConfig): void {
   const banner =
-    "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
+    "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof globalThis.require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
   const output = config.output;
   if (output == null) {
     config.output = { banner };

--- a/packages/sveltekit/src/plugin.ts
+++ b/packages/sveltekit/src/plugin.ts
@@ -12,6 +12,54 @@ export function workflowPlugin(): Plugin[] {
     workflowTransformPlugin() as Plugin,
     {
       name: 'workflow:sveltekit',
+      // SvelteKit bundles the server (including undici, via the world adapter)
+      // into ESM output. undici loads most node: builtins as ESM imports, but
+      // pulls in `node:http2` lazily via a bare `require('node:http2')` inside a
+      // try/catch — which the bundler leaves un-wired, so in the ESM bundle the
+      // require throws and undici silently falls back to a stub whose
+      // `http2.connect` is undefined. That breaks any HTTP/2 request (observed
+      // as the workflow flow-route callback failing with "fetch failed" ->
+      // runs never start). Provide a working CJS `require` for the *server*
+      // build so the real `node:http2` resolves.
+      //
+      // Detection runs in `configResolved` (not the `config` hook): SvelteKit
+      // does not set `env.isSsrBuild` for its server pass, but `build.ssr` is
+      // set on the resolved config. We gate to the SSR build because a
+      // `node:module` import in the client/browser bundle would break it.
+      //
+      // This is a Node-server-runtime-only shim. Note the deliberate global
+      // side effect: defining `globalThis.require` makes `typeof require` truthy
+      // for *every* bundled dependency in this ESM server output, so any library
+      // that feature-detects `require` will take its CJS path here. That is safe
+      // because (a) it never touches the client bundle, (b) the `typeof require
+      // === 'undefined'` guard makes it a no-op in CJS chunks where a real
+      // `require` already exists, and (c) the `require` we install is a working
+      // `createRequire`, so a library that switches to the require path gets a
+      // functional `require`, not a broken stub. The behavior to watch for is a
+      // bundled lib that, on seeing `require`, does `require()` of an ESM-only
+      // dependency on a Node version without `require(ESM)` support.
+      configResolved(config) {
+        if (!config.build?.ssr) {
+          return;
+        }
+        const banner =
+          "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
+        const rollupOptions = config.build.rollupOptions;
+        if (rollupOptions.output == null) {
+          rollupOptions.output = {};
+        }
+        const output = rollupOptions.output;
+        const outputs = Array.isArray(output) ? output : [output];
+        for (const o of outputs) {
+          const existing = o.banner;
+          o.banner =
+            existing == null
+              ? banner
+              : typeof existing === 'function'
+                ? async (chunk) => `${banner}\n${await existing(chunk)}`
+                : `${banner}\n${existing}`;
+        }
+      },
     },
     workflowHotUpdatePlugin({
       builder,

--- a/packages/sveltekit/src/plugin.ts
+++ b/packages/sveltekit/src/plugin.ts
@@ -31,19 +31,29 @@ export function workflowPlugin(): Plugin[] {
       // side effect: defining `globalThis.require` makes `typeof require` truthy
       // for *every* bundled dependency in this ESM server output, so any library
       // that feature-detects `require` will take its CJS path here. That is safe
-      // because (a) it never touches the client bundle, (b) the `typeof require
-      // === 'undefined'` guard makes it a no-op in CJS chunks where a real
-      // `require` already exists, and (c) the `require` we install is a working
-      // `createRequire`, so a library that switches to the require path gets a
-      // functional `require`, not a broken stub. The behavior to watch for is a
-      // bundled lib that, on seeing `require`, does `require()` of an ESM-only
-      // dependency on a Node version without `require(ESM)` support.
+      // because (a) it never touches the client bundle, (b) the guard makes it a
+      // no-op where a real `require` already exists, and (c) the `require` we
+      // install is a working `createRequire`, so a library that switches to the
+      // require path gets a functional `require`, not a broken stub. The behavior
+      // to watch for is a bundled lib that, on seeing `require`, does `require()`
+      // of an ESM-only dependency on a Node version without `require(ESM)`
+      // support.
+      //
+      // The guard reads `globalThis.require` rather than the bare identifier: a
+      // bundled module may declare its own top-level `const require` (as
+      // `@workflow/core`'s runtime world loader does), and Rollup hoists that
+      // into the chunk's module scope without renaming it, since the banner isn't
+      // part of the module graph it analyzes. `typeof require` would then read a
+      // const in its temporal dead zone and throw on the bundle's first line. A
+      // property read is safe regardless of what the chunk declares; a chunk with
+      // its own `require` keeps using it, because the local binding shadows the
+      // global.
       configResolved(config) {
         if (!config.build?.ssr) {
           return;
         }
         const banner =
-          "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
+          "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof globalThis.require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
         const rollupOptions = config.build.rollupOptions;
         if (rollupOptions.output == null) {
           rollupOptions.output = {};

--- a/packages/web/vite-plugin-node-require.test.ts
+++ b/packages/web/vite-plugin-node-require.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { build, type Plugin, type Rollup } from 'vite';
+import { describe, expect, test } from 'vitest';
+import { nodeRequireBanner } from './vite-plugin-node-require';
+
+// A virtual entry so the build needs no real files on disk. The body is
+// irrelevant — we only care about the banner the plugin prepends to the chunk.
+function virtualEntry(): Plugin {
+  const id = 'virtual:entry';
+  const resolved = `\0${id}`;
+  return {
+    name: 'test:virtual-entry',
+    resolveId(source) {
+      return source === id ? resolved : null;
+    },
+    load(thisId) {
+      return thisId === resolved ? 'export const ok = true;' : null;
+    },
+  };
+}
+
+async function buildChunkCode(opts: {
+  ssr: boolean;
+  withPlugin: boolean;
+}): Promise<string> {
+  const result = (await build({
+    logLevel: 'silent',
+    configFile: false,
+    build: {
+      ssr: opts.ssr,
+      write: false,
+      minify: false,
+      rollupOptions: { input: 'virtual:entry' },
+    },
+    plugins: [
+      virtualEntry(),
+      ...(opts.withPlugin ? [nodeRequireBanner()] : []),
+    ],
+  })) as Rollup.RollupOutput;
+  const chunk = result.output.find((o) => o.type === 'chunk');
+  if (!chunk || chunk.type !== 'chunk') throw new Error('no chunk emitted');
+  return chunk.code;
+}
+
+describe('nodeRequireBanner', () => {
+  // The load-bearing assertion: without this banner, bundled undici's lazy
+  // `require('node:http2')` finds no `require` in the ESM server bundle, falls
+  // back to a stub with no `http2.connect`, and every HTTP/2 request (the v4
+  // events API + stream writes) breaks — silently degrading observability
+  // reads. See vite-plugin-node-require.ts for the full mechanism.
+  test('injects the global-require shim into the SSR server build', async () => {
+    // rollup may re-quote / reflow the banner, so assert on its semantic parts
+    // rather than the exact source string.
+    const code = await buildChunkCode({ ssr: true, withPlugin: true });
+    expect(code).toContain('__wkfCreateRequire');
+    expect(code).toContain('globalThis.require');
+    expect(code).toMatch(/createRequire[\s\S]*from ['"]node:module['"]/);
+  });
+
+  test('does not inject the shim into the client/browser build', async () => {
+    const code = await buildChunkCode({ ssr: false, withPlugin: true });
+    expect(code).not.toContain('__wkfCreateRequire');
+  });
+
+  test('the SSR build has no shim without the plugin (guards the assertion)', async () => {
+    const code = await buildChunkCode({ ssr: true, withPlugin: false });
+    expect(code).not.toContain('__wkfCreateRequire');
+  });
+});

--- a/packages/web/vite-plugin-node-require.ts
+++ b/packages/web/vite-plugin-node-require.ts
@@ -1,0 +1,56 @@
+import type { Plugin, Rollup } from 'vite';
+
+// The web server build sets `ssr.noExternal: true` (see vite.config.ts), which
+// bundles every dependency — including the world adapters and their `undici` —
+// into the ESM server output. undici loads most node: builtins as ESM imports,
+// but pulls in `node:http2` lazily via a bare `require('node:http2')` inside a
+// try/catch. The bundler leaves that `require` un-wired, so in the ESM bundle
+// there is no `require` in scope: the call throws, undici swallows it and falls
+// back to a stub whose `http2.connect` is undefined. That silently breaks every
+// HTTP/2 request — and world-vercel's events API + stream writes run over H2 —
+// so the observability reads (fetchEvents, etc.) hang on a failing H2
+// connection, retry with backoff for ~16s, then return empty.
+//
+// Prepend a `createRequire`-backed global `require` to the server chunks so the
+// real `node:http2` resolves. This mirrors the same fix the @workflow/sveltekit
+// and @workflow/nitro plugins apply for their bundled server builds.
+export const NODE_REQUIRE_BANNER =
+  "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
+
+/** Prepend NODE_REQUIRE_BANNER to an existing rollup `banner` option, which may
+ *  be absent, a string, or a per-chunk function. */
+function prependBanner(
+  existing: Rollup.OutputOptions['banner']
+): Rollup.OutputOptions['banner'] {
+  if (existing == null) return NODE_REQUIRE_BANNER;
+  if (typeof existing === 'function') {
+    return async (chunk) => `${NODE_REQUIRE_BANNER}\n${await existing(chunk)}`;
+  }
+  return `${NODE_REQUIRE_BANNER}\n${existing}`;
+}
+
+/**
+ * Vite plugin that installs a working global `require` at the top of every
+ * server chunk so bundled `undici` can reach `node:http2` (and HTTP/2 works).
+ *
+ * Gated to the SSR production build: a `node:module` import would break the
+ * client/browser bundle, and dev (`react-router dev`) loads dependencies
+ * natively via Vite's SSR runner where a real `require` already exists. The
+ * `typeof require === 'undefined'` guard keeps it a safe no-op in any CJS chunk,
+ * and `node:module` is always available in the Node server runtime.
+ */
+export function nodeRequireBanner(): Plugin {
+  return {
+    name: 'workflow-web:node-require-banner',
+    configResolved(config) {
+      if (config.command !== 'build' || !config.build?.ssr) return;
+      const rollupOptions = config.build.rollupOptions;
+      rollupOptions.output ??= {};
+      const output = rollupOptions.output;
+      const outputs = Array.isArray(output) ? output : [output];
+      for (const o of outputs) {
+        o.banner = prependBanner(o.banner);
+      }
+    },
+  };
+}

--- a/packages/web/vite-plugin-node-require.ts
+++ b/packages/web/vite-plugin-node-require.ts
@@ -14,8 +14,19 @@ import type { Plugin, Rollup } from 'vite';
 // Prepend a `createRequire`-backed global `require` to the server chunks so the
 // real `node:http2` resolves. This mirrors the same fix the @workflow/sveltekit
 // and @workflow/nitro plugins apply for their bundled server builds.
+//
+// The guard reads `globalThis.require` rather than the bare identifier: a bundled
+// module may declare its own top-level `const require` (as `@workflow/core`'s
+// runtime world loader does), and Rollup hoists that declaration into the chunk's
+// module scope without renaming it, since the banner isn't part of the module
+// graph it analyzes. `typeof require` would then read a const in its temporal
+// dead zone and throw `ReferenceError: Cannot access 'require' before
+// initialization` on the first line of the server bundle — the server never
+// boots. A property read is safe regardless of what the chunk declares; a chunk
+// that has its own `require` keeps using it, because the local binding shadows
+// the global.
 export const NODE_REQUIRE_BANNER =
-  "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
+  "import { createRequire as __wkfCreateRequire } from 'node:module'; if (typeof globalThis.require === 'undefined') { globalThis.require = __wkfCreateRequire(import.meta.url); }";
 
 /** Prepend NODE_REQUIRE_BANNER to an existing rollup `banner` option, which may
  *  be absent, a string, or a per-chunk function. */
@@ -36,8 +47,8 @@ function prependBanner(
  * Gated to the SSR production build: a `node:module` import would break the
  * client/browser bundle, and dev (`react-router dev`) loads dependencies
  * natively via Vite's SSR runner where a real `require` already exists. The
- * `typeof require === 'undefined'` guard keeps it a safe no-op in any CJS chunk,
- * and `node:module` is always available in the Node server runtime.
+ * `typeof globalThis.require === 'undefined'` guard keeps it a safe no-op in any
+ * CJS chunk, and `node:module` is always available in the Node server runtime.
  */
 export function nodeRequireBanner(): Plugin {
   return {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,6 +1,7 @@
 import { reactRouter } from '@react-router/dev/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
+import { nodeRequireBanner } from './vite-plugin-node-require';
 
 export default defineConfig(({ command, isSsrBuild }) => ({
   build: {
@@ -31,7 +32,7 @@ export default defineConfig(({ command, isSsrBuild }) => ({
     noExternal: command === 'build' ? true : undefined,
     external: ['express'],
   },
-  plugins: [tailwindcss(), reactRouter()],
+  plugins: [tailwindcss(), reactRouter(), nodeRequireBanner()],
   resolve: {
     // Ensure all workspace packages resolve React from the same location
     // to prevent duplicate React instances (which cause "Invalid hook call"

--- a/packages/world-vercel/package.json
+++ b/packages/world-vercel/package.json
@@ -52,6 +52,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-async-hooks": "1.30.1",
+    "@opentelemetry/core": "1.30.1",
+    "@opentelemetry/sdk-trace-base": "1.30.1",
     "@types/node": "catalog:",
     "@workflow/tsconfig": "workspace:*",
     "genversion": "3.2.0",

--- a/packages/world-vercel/src/encryption.ts
+++ b/packages/world-vercel/src/encryption.ts
@@ -11,10 +11,10 @@
  */
 
 import { webcrypto } from 'node:crypto';
-import { getVercelOidcToken } from '@vercel/oidc';
 import type { WorkflowRun, World } from '@workflow/world';
 import * as z from 'zod';
 import { getDispatcher } from './http-client.js';
+import { instrumentedFetch, resolveVercelApiToken } from './http-core.js';
 
 const KEY_BYTES = 32; // 256 bits = 32 bytes (AES-256)
 
@@ -101,14 +101,7 @@ export async function fetchRunKey(
     dispatcher?: unknown;
   }
 ): Promise<Uint8Array | undefined> {
-  // Authenticate via provided token (CLI/config), VERCEL_TOKEN env var
-  // (external tooling), or OIDC token (runtime) — in that order.
-  // OIDC is last to avoid an unnecessary network call when a token is
-  // already available (e.g. CLI or CI contexts).
-  const token =
-    options?.token ??
-    process.env.VERCEL_TOKEN ??
-    (await getVercelOidcToken().catch(() => null));
+  const token = await resolveVercelApiToken({ token: options?.token });
   if (!token) {
     throw new Error(
       'Cannot fetch run key: no OIDC token or VERCEL_TOKEN available'
@@ -119,30 +112,30 @@ export async function fetchRunKey(
   if (options?.teamId) {
     params.set('teamId', options.teamId);
   }
-  // 429/5xx retries are handled by the shared RetryAgent from getDispatcher()
-  const response = await fetch(
-    `https://api.vercel.com/v1/workflow/run-key/${deploymentId}?${params}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      // @ts-expect-error -- undici dispatcher is accepted by Node.js fetch but not in @types/node's RequestInit
-      dispatcher: getDispatcher({ dispatcher: options?.dispatcher }),
-    }
-  );
-
-  if (!response.ok) {
-    let body: string;
-    try {
-      body = await response.text();
-    } catch {
-      body = '<unable to read response body>';
-    }
-    throw new Error(
-      `Failed to fetch run key for ${runId} (deployment ${deploymentId}): HTTP ${response.status} ${response.statusText}${body ? ` — ${body}` : ''}`
-    );
-  }
+  // 429/5xx retries are handled by the shared RetryAgent from getDispatcher().
+  // instrumentedFetch adds the OTEL client span + DEBUG logging the v3/v4
+  // paths have.
+  const response = await instrumentedFetch({
+    method: 'GET',
+    url: `https://api.vercel.com/v1/workflow/run-key/${deploymentId}?${params}`,
+    headers: new Headers({ Authorization: `Bearer ${token}` }),
+    dispatcher: getDispatcher({ dispatcher: options?.dispatcher }),
+    peerService: 'vercel-api',
+    // Preserve the prior no-timeout behavior for this Vercel-API call; the
+    // shared RetryAgent still handles transient/5xx retries.
+    timeoutMs: null,
+    buildError: async (res) => {
+      let body: string;
+      try {
+        body = await res.text();
+      } catch {
+        body = '<unable to read response body>';
+      }
+      return new Error(
+        `Failed to fetch run key for ${runId} (deployment ${deploymentId}): HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`
+      );
+    },
+  });
 
   const data = await response.json();
   const result = z.object({ key: z.string().nullable() }).safeParse(data);

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -10,6 +10,7 @@ import { MockAgent } from 'undici';
 import { describe, expect, it } from 'vitest';
 import {
   createWorkflowRunEventV4,
+  getEventV4,
   getWorkflowRunEventsV4,
   throwForErrorResponse,
 } from './events-v4.js';
@@ -186,6 +187,52 @@ describe('getWorkflowRunEventsV4 over HTTP', () => {
         { token: 'test-token', dispatcher: agent }
       )
     ).rejects.toThrow(/end-of-stream sentinel/);
+  });
+});
+
+/**
+ * getEventV4 returns after the first frame. The early return must cancel the
+ * response body (releasing its undici socket) without corrupting the returned
+ * value or hanging — the trailing frame below is never read.
+ */
+describe('getEventV4 over HTTP', () => {
+  it('returns the first frame and stops reading the rest', async () => {
+    const origin = 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    const body = new TextEncoder().encode('event-payload');
+    const frames = Buffer.concat([
+      encodeFrame(
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_1',
+          eventType: 'run_created',
+          createdAt: '2026-06-10T00:00:00.000Z',
+          eventData: {},
+        },
+        body
+      ),
+      // Trailing bytes the reader must never need.
+      encodeFrame({ eventId: 'evnt_unused' }, new Uint8Array(8)),
+    ]);
+
+    agent
+      .get(origin)
+      .intercept({ path: '/api/v4/runs/wrun_1/events/evnt_1', method: 'GET' })
+      .reply(200, frames, {
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+
+    const { event, body: returnedBody } = await getEventV4('wrun_1', 'evnt_1', {
+      token: 'test-token',
+      dispatcher: agent,
+    });
+
+    expect(event.eventId).toBe('evnt_1');
+    expect(event.eventType).toBe('run_created');
+    expect(new Uint8Array(returnedBody)).toEqual(body);
+    agent.assertNoPendingInterceptors();
   });
 });
 

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -32,7 +32,7 @@ import {
 import { decode } from 'cbor-x';
 import { type Dispatcher, request } from 'undici';
 import { decodeFrames, encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
-import { getDispatcher } from './http-client.js';
+import { getEventsDispatcher } from './http-client.js';
 import { type APIConfig, getHttpConfig } from './utils.js';
 
 /**
@@ -266,10 +266,15 @@ export async function createWorkflowRunEventV4(
     method: 'POST',
     headers: Object.fromEntries(headers.entries()),
     body: frame,
-    // getDispatcher() is typed `unknown` (undici's Dispatcher type is
-    // version-specific across @types/node majors); cast to the undici
-    // Dispatcher this module's own `request` expects.
-    dispatcher: getDispatcher(config) as Dispatcher,
+    // The events API uses its own HTTP/2-enabled dispatcher: these
+    // reads/writes are plain request/response (or a streamed LIST response)
+    // and benefit from multiplexing, while the default dispatcher stays on
+    // HTTP/1.1 because H2 deadlocks the queue's webhook respondWith mechanism
+    // — see http-client.ts. getEventsDispatcher() is typed `unknown`
+    // (undici's Dispatcher type is version-specific across @types/node
+    // majors); cast to the undici Dispatcher this module's own `request`
+    // expects.
+    dispatcher: getEventsDispatcher(config) as Dispatcher,
   });
   if (response.statusCode < 200 || response.statusCode >= 300) {
     const errorBody = await response.body.text();
@@ -353,10 +358,15 @@ export async function getEventV4(
   const response = await request(url, {
     method: 'GET',
     headers: Object.fromEntries(headers.entries()),
-    // getDispatcher() is typed `unknown` (undici's Dispatcher type is
-    // version-specific across @types/node majors); cast to the undici
-    // Dispatcher this module's own `request` expects.
-    dispatcher: getDispatcher(config) as Dispatcher,
+    // The events API uses its own HTTP/2-enabled dispatcher: these
+    // reads/writes are plain request/response (or a streamed LIST response)
+    // and benefit from multiplexing, while the default dispatcher stays on
+    // HTTP/1.1 because H2 deadlocks the queue's webhook respondWith mechanism
+    // — see http-client.ts. getEventsDispatcher() is typed `unknown`
+    // (undici's Dispatcher type is version-specific across @types/node
+    // majors); cast to the undici Dispatcher this module's own `request`
+    // expects.
+    dispatcher: getEventsDispatcher(config) as Dispatcher,
   });
   if (response.statusCode < 200 || response.statusCode >= 300) {
     const errorBody = await response.body.text();
@@ -441,10 +451,15 @@ async function consumeListFrameStream(
   const response = await request(url, {
     method: 'GET',
     headers: Object.fromEntries(headers.entries()),
-    // getDispatcher() is typed `unknown` (undici's Dispatcher type is
-    // version-specific across @types/node majors); cast to the undici
-    // Dispatcher this module's own `request` expects.
-    dispatcher: getDispatcher(config) as Dispatcher,
+    // The events API uses its own HTTP/2-enabled dispatcher: these
+    // reads/writes are plain request/response (or a streamed LIST response)
+    // and benefit from multiplexing, while the default dispatcher stays on
+    // HTTP/1.1 because H2 deadlocks the queue's webhook respondWith mechanism
+    // — see http-client.ts. getEventsDispatcher() is typed `unknown`
+    // (undici's Dispatcher type is version-specific across @types/node
+    // majors); cast to the undici Dispatcher this module's own `request`
+    // expects.
+    dispatcher: getEventsDispatcher(config) as Dispatcher,
   });
   if (response.statusCode < 200 || response.statusCode >= 300) {
     const errorBody = await response.body.text();

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -21,19 +21,73 @@
  * bytes — this module stays at the wire-bytes layer.
  */
 
-import {
-  EntityConflictError,
-  PreconditionFailedError,
-  RunExpiredError,
-  ThrottleError,
-  TooEarlyError,
-  WorkflowWorldError,
-} from '@workflow/errors';
 import { decode } from 'cbor-x';
-import { type Dispatcher, request } from 'undici';
 import { decodeFrames, encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { getEventsDispatcher } from './http-client.js';
+import {
+  errorForResponse,
+  instrumentedFetch,
+  parseRetryAfter,
+} from './http-core.js';
 import { type APIConfig, getHttpConfig } from './utils.js';
+
+/**
+ * Issue an instrumented v4 request through the global `fetch` — NOT undici's
+ * `request`.
+ *
+ * Vercel's observability "outgoing requests" view instruments the global
+ * `fetch`. Calling `undici.request()` directly bypasses that instrumentation,
+ * so v4 event traffic disappeared from the log viewer while queue traffic
+ * (which uses `fetch`) kept showing. `instrumentedFetch` routes through the
+ * global `fetch` with the custom dispatcher, restoring visibility while also
+ * opening the OTEL client span, injecting trace context, setting the
+ * cache-bust header (see #618), and emitting `DEBUG` logs — the same envelope
+ * the v3 `makeRequest` path has always had.
+ *
+ * The events API uses its own HTTP/2-enabled dispatcher
+ * (`getEventsDispatcher`): these reads/writes are plain request/response (or a
+ * streamed LIST response) and benefit from multiplexing. The default dispatcher
+ * stays on HTTP/1.1 because H2 deadlocks the queue's webhook respondWith
+ * mechanism — see http-client.ts.
+ *
+ * No per-request timeout: a LIST response streams the full event-log page, which
+ * for a large run can legitimately take a while to drain — a whole-request
+ * deadline would abort it mid-stream.
+ */
+async function fetchV4(
+  url: string,
+  init: { method: string; headers: Headers; body?: Uint8Array },
+  config: APIConfig | undefined,
+  opName: string
+): Promise<Response> {
+  return instrumentedFetch({
+    method: init.method,
+    url,
+    headers: init.headers,
+    body: init.body,
+    dispatcher: getEventsDispatcher(config),
+    timeoutMs: null,
+    logLabel: opName,
+    buildError: async (response) =>
+      errorFromV4Response(
+        response.status,
+        headersToRecord(response.headers),
+        await response.text(),
+        opName,
+        url
+      ),
+  });
+}
+
+/** Flatten a fetch `Headers` into the record shape throwForErrorResponse
+ *  expects (it mirrors the v3 `makeRequest` error contract). */
+function headersToRecord(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+}
 
 /**
  * POST surfaces these so callers can read the created eventId without
@@ -162,29 +216,21 @@ function buildPostFrameMeta(
 }
 
 /**
- * Map a non-2xx response to the same typed-error contract the v3 client's
- * `makeRequest` used. The runtime branches on these types for core control
- * flow, so v4 must preserve every mapping:
- *
- *   - 409 → EntityConflictError (start() dedupe, terminal-state transitions)
- *   - 410 → RunExpiredError (runtime exits without retrying)
- *   - 412 → PreconditionFailedError (stale event-log snapshot; the runtime
- *     reloads + retries, then re-invokes)
- *   - 425 → TooEarlyError + retryAfter (step retry pacing — see #1806 for
- *     what happens when a 425 degrades into an untyped error)
- *   - 429 → ThrottleError + retryAfter
- *   - anything else → WorkflowWorldError with `status` (the hook 404 →
- *     HookNotFoundError translation in events.ts keys off status === 404)
- *
- * Exported for unit tests.
+ * Build the typed error for a non-2xx v4 response. Reuses the shared
+ * `errorForResponse` status → error-type contract (409→EntityConflictError,
+ * 410→RunExpiredError, 412→PreconditionFailedError, 425→TooEarlyError,
+ * 429→ThrottleError, else →WorkflowWorldError) so v3 and v4 stay in lockstep —
+ * only the message *string* is v4-specific (`v4 {opName} failed: HTTP …`,
+ * which the runtime and log tooling key on; the hook 404 →
+ * HookNotFoundError translation in events.ts keys off status === 404).
  */
-export function throwForErrorResponse(
+function errorFromV4Response(
   statusCode: number,
   responseHeaders: Record<string, string | string[] | undefined>,
   errorBody: string,
   opName: string,
   url: string
-): never {
+): Error {
   let message = `v4 ${opName} failed: HTTP ${statusCode}`;
   let code: string | undefined;
   try {
@@ -196,41 +242,37 @@ export function throwForErrorResponse(
     if (errorBody) message += ` ${errorBody}`;
   }
 
-  // Retry-After response header (seconds). Used by 425 and 429.
-  let retryAfter: number | undefined;
-  const retryAfterHeader = readHeader(responseHeaders, 'retry-after');
-  if (retryAfterHeader) {
-    const parsed = parseInt(retryAfterHeader, 10);
-    if (!Number.isNaN(parsed)) retryAfter = parsed;
-  }
-
-  if (statusCode === 409) throw new EntityConflictError(message);
-  if (statusCode === 410) throw new RunExpiredError(message);
-  if (statusCode === 412)
-    throw new PreconditionFailedError(message, { retryAfter });
-  if (statusCode === 425) throw new TooEarlyError(message, { retryAfter });
-  if (statusCode === 429) {
-    // A firewall-challenge 429 is routed to the retryable transport path (not
-    // ThrottleError) so step_started writes back off + cap rather than looping.
-    if (readHeader(responseHeaders, 'x-vercel-mitigated') === 'challenge') {
-      throw new WorkflowWorldError(
-        `${message} (x-vercel-mitigated=challenge)`,
-        {
-          status: statusCode,
-          code: 'TRANSPORT',
-          url,
-          retryAfter,
-        }
-      );
-    }
-    throw new ThrottleError(message, { retryAfter });
-  }
-  throw new WorkflowWorldError(message, {
-    status: statusCode,
+  const retryAfter = parseRetryAfter(
+    readHeader(responseHeaders, 'retry-after')
+  );
+  // A firewall-challenge 429 is routed to the retryable transport path (not
+  // ThrottleError) so step_started writes back off + cap rather than looping.
+  return errorForResponse(statusCode, message, {
+    retryAfter,
     code,
     url,
-    retryAfter,
+    mitigated: readHeader(responseHeaders, 'x-vercel-mitigated'),
   });
+}
+
+/**
+ * Throwing wrapper around `errorFromV4Response`. Exported for unit tests; the
+ * request paths throw via `instrumentedFetch`'s `buildError`.
+ */
+export function throwForErrorResponse(
+  statusCode: number,
+  responseHeaders: Record<string, string | string[] | undefined>,
+  errorBody: string,
+  opName: string,
+  url: string
+): never {
+  throw errorFromV4Response(
+    statusCode,
+    responseHeaders,
+    errorBody,
+    opName,
+    url
+  );
 }
 
 /**
@@ -262,34 +304,16 @@ export async function createWorkflowRunEventV4(
   );
 
   const url = `${baseUrl}/v4/runs/${encodeURIComponent(input.runId)}/events/${encodeURIComponent(input.eventType)}`;
-  const response = await request(url, {
-    method: 'POST',
-    headers: Object.fromEntries(headers.entries()),
-    body: frame,
-    // The events API uses its own HTTP/2-enabled dispatcher: these
-    // reads/writes are plain request/response (or a streamed LIST response)
-    // and benefit from multiplexing, while the default dispatcher stays on
-    // HTTP/1.1 because H2 deadlocks the queue's webhook respondWith mechanism
-    // — see http-client.ts. getEventsDispatcher() is typed `unknown`
-    // (undici's Dispatcher type is version-specific across @types/node
-    // majors); cast to the undici Dispatcher this module's own `request`
-    // expects.
-    dispatcher: getEventsDispatcher(config) as Dispatcher,
-  });
-  if (response.statusCode < 200 || response.statusCode >= 300) {
-    const errorBody = await response.body.text();
-    throwForErrorResponse(
-      response.statusCode,
-      response.headers,
-      errorBody,
-      'createEvent',
-      url
-    );
-  }
+  const response = await fetchV4(
+    url,
+    { method: 'POST', headers, body: frame },
+    config,
+    'createEvent'
+  );
 
-  const eventId = response.headers[V4_RESPONSE_HEADERS.eventId];
-  const runId = response.headers[V4_RESPONSE_HEADERS.runId];
-  const createdAt = response.headers[V4_RESPONSE_HEADERS.createdAt];
+  const eventId = response.headers.get(V4_RESPONSE_HEADERS.eventId);
+  const runId = response.headers.get(V4_RESPONSE_HEADERS.runId);
+  const createdAt = response.headers.get(V4_RESPONSE_HEADERS.createdAt);
   if (
     typeof eventId !== 'string' ||
     typeof runId !== 'string' ||
@@ -299,7 +323,7 @@ export async function createWorkflowRunEventV4(
   }
 
   // Decode the materialized-entity bag from the CBOR response body.
-  const bodyBytes = new Uint8Array(await response.body.arrayBuffer());
+  const bodyBytes = new Uint8Array(await response.arrayBuffer());
   const body =
     bodyBytes.byteLength > 0
       ? (decode(bodyBytes) as CreateEventV4Result['body'])
@@ -355,39 +379,24 @@ export async function getEventV4(
   const { baseUrl, headers } = await getHttpConfig(config);
 
   const url = `${baseUrl}/v4/runs/${encodeURIComponent(runId)}/events/${encodeURIComponent(eventId)}`;
-  const response = await request(url, {
-    method: 'GET',
-    headers: Object.fromEntries(headers.entries()),
-    // The events API uses its own HTTP/2-enabled dispatcher: these
-    // reads/writes are plain request/response (or a streamed LIST response)
-    // and benefit from multiplexing, while the default dispatcher stays on
-    // HTTP/1.1 because H2 deadlocks the queue's webhook respondWith mechanism
-    // — see http-client.ts. getEventsDispatcher() is typed `unknown`
-    // (undici's Dispatcher type is version-specific across @types/node
-    // majors); cast to the undici Dispatcher this module's own `request`
-    // expects.
-    dispatcher: getEventsDispatcher(config) as Dispatcher,
-  });
-  if (response.statusCode < 200 || response.statusCode >= 300) {
-    const errorBody = await response.body.text();
-    throwForErrorResponse(
-      response.statusCode,
-      response.headers,
-      errorBody,
-      'getEvent',
-      url
-    );
-  }
-  const contentType = readHeader(response.headers, 'content-type');
+  const response = await fetchV4(
+    url,
+    { method: 'GET', headers },
+    config,
+    'getEvent'
+  );
+  const contentType = response.headers.get('content-type');
   if (!contentType?.startsWith(V4_FRAME_CONTENT_TYPE)) {
     throw new Error(
       `v4 getEvent: expected ${V4_FRAME_CONTENT_TYPE}, got ${contentType ?? '(none)'}`
     );
   }
 
-  // undici's response body is an AsyncIterable of byte chunks — feed it
-  // to decodeFrames directly. Do NOT convert via node:stream
-  // Readable.toWeb: dynamic `import('node:stream')` resolves to an empty
+  // fetch's `Response.body` is a web ReadableStream, which is async-iterable
+  // on Node (readableStream async iteration, since v16.5.0) — feed it straight
+  // to decodeFrames. The cast is only because TS's lib `ReadableStream` type
+  // omits the async iterator. Do NOT round-trip through `node:stream`
+  // Readable.toWeb: a dynamic `import('node:stream')` resolves to an empty
   // module namespace in Next.js webpack server bundles and crashes.
   const chunks = response.body as unknown as AsyncIterable<Uint8Array>;
 
@@ -448,40 +457,21 @@ async function consumeListFrameStream(
   config: APIConfig | undefined,
   opName: string
 ): Promise<ListEventsV4Result> {
-  const response = await request(url, {
-    method: 'GET',
-    headers: Object.fromEntries(headers.entries()),
-    // The events API uses its own HTTP/2-enabled dispatcher: these
-    // reads/writes are plain request/response (or a streamed LIST response)
-    // and benefit from multiplexing, while the default dispatcher stays on
-    // HTTP/1.1 because H2 deadlocks the queue's webhook respondWith mechanism
-    // — see http-client.ts. getEventsDispatcher() is typed `unknown`
-    // (undici's Dispatcher type is version-specific across @types/node
-    // majors); cast to the undici Dispatcher this module's own `request`
-    // expects.
-    dispatcher: getEventsDispatcher(config) as Dispatcher,
-  });
-  if (response.statusCode < 200 || response.statusCode >= 300) {
-    const errorBody = await response.body.text();
-    throwForErrorResponse(
-      response.statusCode,
-      response.headers,
-      errorBody,
-      opName,
-      url
-    );
-  }
-  const contentType = readHeader(response.headers, 'content-type');
+  const response = await fetchV4(
+    url,
+    { method: 'GET', headers },
+    config,
+    opName
+  );
+  const contentType = response.headers.get('content-type');
   if (!contentType?.startsWith(V4_FRAME_CONTENT_TYPE)) {
     throw new Error(
       `v4 ${opName}: expected ${V4_FRAME_CONTENT_TYPE}, got ${contentType ?? '(none)'}`
     );
   }
 
-  // undici's response body is an AsyncIterable of byte chunks — feed it
-  // to decodeFrames directly. Do NOT convert via node:stream
-  // Readable.toWeb: dynamic `import('node:stream')` resolves to an empty
-  // module namespace in Next.js webpack server bundles and crashes.
+  // See getEventV4: fetch's web ReadableStream is async-iterable on Node; the
+  // cast only works around TS's lib type omitting the async iterator.
   const chunks = response.body as unknown as AsyncIterable<Uint8Array>;
 
   const events: ListedEventV4[] = [];

--- a/packages/world-vercel/src/frames.test.ts
+++ b/packages/world-vercel/src/frames.test.ts
@@ -1,4 +1,4 @@
-import { decode, encode } from 'cbor-x';
+import { decode } from 'cbor-x';
 import { describe, expect, it } from 'vitest';
 import {
   type DecodedFrame,
@@ -39,6 +39,29 @@ async function drainFrames(
   const out: DecodedFrame[] = [];
   for await (const f of decodeFrames(source)) out.push(f);
   return out;
+}
+
+/** A stream that stays open after delivering its payload (never signals EOF),
+ *  like a kept-alive HTTP socket, and records whether cancel() ran — the
+ *  signal undici uses to release the connection. highWaterMark: 0 suppresses
+ *  the pull-ahead that would otherwise auto-close a toy stream. */
+function spyStream(payload: Uint8Array) {
+  let sent = false;
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        if (sent) return;
+        controller.enqueue(payload);
+        sent = true;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    },
+    { highWaterMark: 0 }
+  );
+  return { stream, wasCancelled: () => cancelled };
 }
 
 describe('encodeFrame', () => {
@@ -207,6 +230,51 @@ describe('decodeFrames from an AsyncIterable source', () => {
     });
     expect(frames[0].body).toEqual(body);
     expect(frames[1].meta).toEqual({ _end: 1, next: 'cursor-1' });
+  });
+});
+
+describe('decodeFrames releases the stream on early exit', () => {
+  // Regression: a consumer that stops before EOF (getEventV4 returns after
+  // the first frame; consumeListFrameStream breaks at the sentinel) must
+  // cancel the body, or its undici socket stays pinned out of the pool.
+  function twoFramesThenEnd(): Uint8Array {
+    return new Uint8Array([
+      ...encodeFrame({ eventId: 'a' }, new Uint8Array([1, 2, 3])),
+      ...encodeFrame({ eventId: 'b' }, new Uint8Array([4, 5, 6])),
+      ...encodeEndFrame(),
+    ]);
+  }
+
+  it('cancels the underlying stream when the consumer breaks early', async () => {
+    const { stream, wasCancelled } = spyStream(twoFramesThenEnd());
+    for await (const f of decodeFrames(stream)) {
+      expect(f.meta).toEqual({ eventId: 'a' });
+      break; // mirrors getEventV4 returning after the first frame
+    }
+    expect(wasCancelled()).toBe(true);
+  });
+
+  it('cancels via the reader path when the source is not async-iterable', async () => {
+    const { stream, wasCancelled } = spyStream(twoFramesThenEnd());
+    // A bare { getReader } object forces the readerToIterator branch (a real
+    // ReadableStream is already async-iterable in Node).
+    const source = {
+      getReader: () => stream.getReader(),
+    } as unknown as ReadableStream<Uint8Array>;
+    for await (const f of decodeFrames(source)) {
+      expect(f.meta).toEqual({ eventId: 'a' });
+      break;
+    }
+    expect(wasCancelled()).toBe(true);
+  });
+
+  it('still decodes every frame when fully consumed', async () => {
+    const frames = await drainFrames(spyStream(twoFramesThenEnd()).stream);
+    expect(frames.map((f) => f.meta)).toEqual([
+      { eventId: 'a' },
+      { eventId: 'b' },
+      { _end: 1 },
+    ]);
   });
 });
 

--- a/packages/world-vercel/src/frames.ts
+++ b/packages/world-vercel/src/frames.ts
@@ -79,41 +79,63 @@ export async function* decodeFrames(
     return out;
   };
 
-  while (true) {
-    if (!(await refill(4))) return;
-    const metaLen = new DataView(buffer.buffer, buffer.byteOffset, 4).getUint32(
-      0,
-      false
-    );
-    take(4);
+  try {
+    while (true) {
+      if (!(await refill(4))) return;
+      const metaLen = new DataView(
+        buffer.buffer,
+        buffer.byteOffset,
+        4
+      ).getUint32(0, false);
+      take(4);
 
-    if (!(await refill(metaLen))) {
-      throw new Error('decodeFrames: truncated meta block');
-    }
-    const meta = decode(take(metaLen)) as Record<string, unknown>;
+      if (!(await refill(metaLen))) {
+        throw new Error('decodeFrames: truncated meta block');
+      }
+      const meta = decode(take(metaLen)) as Record<string, unknown>;
 
-    if (!(await refill(4))) {
-      throw new Error('decodeFrames: truncated body length');
-    }
-    const bodyLen = new DataView(buffer.buffer, buffer.byteOffset, 4).getUint32(
-      0,
-      false
-    );
-    take(4);
+      if (!(await refill(4))) {
+        throw new Error('decodeFrames: truncated body length');
+      }
+      const bodyLen = new DataView(
+        buffer.buffer,
+        buffer.byteOffset,
+        4
+      ).getUint32(0, false);
+      take(4);
 
-    if (bodyLen > 0) {
-      if (!(await refill(bodyLen))) {
+      if (bodyLen > 0 && !(await refill(bodyLen))) {
         throw new Error('decodeFrames: truncated body bytes');
       }
-      // Slice (not subarray) so the yielded body owns its bytes —
-      // subsequent reads into the buffer won't overwrite it.
+      // Slice (not subarray) so the yielded body owns its bytes — later
+      // reads into the buffer won't overwrite it; bodyLen 0 yields empty.
       yield { meta, body: buffer.slice(0, bodyLen) };
       take(bodyLen);
-    } else {
-      yield { meta, body: new Uint8Array(0) };
-    }
 
-    if (meta._end === 1) return;
+      if (meta._end === 1) return;
+    }
+  } finally {
+    // Release the source when the consumer stops before EOF (early
+    // break/return): an unconsumed body pins its undici socket out of the
+    // connection pool. No-op once the stream is already drained.
+    //
+    // Fire-and-forget, NOT awaited: on a service-backed World this cancel
+    // can hit the network (an H2 stream reset, or an H1 socket teardown),
+    // and awaiting it here would block every early-exit caller (getEventV4,
+    // every replay's list read) on that round-trip. Awaiting it previously
+    // hung indefinitely on the Next.js Vercel Function lanes specifically —
+    // same class of bug as the abort-stream reader in #2807.
+    closeQuietly(() => chunks.return?.());
+  }
+}
+
+/** Best-effort source cleanup, safe to run detached from a `finally`:
+ *  swallows errors so cleanup can't mask the original outcome. */
+function closeQuietly(close: () => unknown): void {
+  try {
+    void Promise.resolve(close()).catch(() => {});
+  } catch {
+    // best-effort
   }
 }
 
@@ -122,9 +144,15 @@ export async function* decodeFrames(
 async function* readerToIterator(
   reader: ReadableStreamDefaultReader<Uint8Array>
 ): AsyncGenerator<Uint8Array> {
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) return;
-    if (value) yield value;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      if (value) yield value;
+    }
+  } finally {
+    // Cancel on early exit so the socket is released, not just unlocked.
+    // Fire-and-forget — see closeQuietly's call site above.
+    closeQuietly(() => reader.cancel());
   }
 }

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -1,14 +1,20 @@
 import { createServer, type Server } from 'node:http';
+import { createSecureServer, type Http2SecureServer } from 'node:http2';
 import type { AddressInfo } from 'node:net';
+import type { TLSSocket } from 'node:tls';
 import { Agent } from 'undici';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
   DEFAULT_BODY_TIMEOUT_MS,
   DEFAULT_HEADERS_TIMEOUT_MS,
   getAgentOptions,
   getDispatcher,
+  getEventsAgentOptions,
+  getEventsDispatcher,
+  getStreamDispatcher,
   MAX_RETRIES,
   RETRY_ERROR_CODES,
+  STREAM_RETRY_OPTIONS,
 } from './http-client.js';
 
 describe('getDispatcher', () => {
@@ -20,6 +26,73 @@ describe('getDispatcher', () => {
   it('returns the caller-supplied dispatcher when provided', () => {
     const custom = {};
     expect(getDispatcher({ dispatcher: custom })).toBe(custom);
+  });
+});
+
+describe('getEventsDispatcher', () => {
+  it('returns its own shared dispatcher, distinct from the default', () => {
+    expect(getEventsDispatcher()).toBe(getEventsDispatcher());
+    expect(getEventsDispatcher()).not.toBe(getDispatcher());
+  });
+
+  it('returns the caller-supplied dispatcher when provided', () => {
+    const custom = {};
+    expect(getEventsDispatcher({ dispatcher: custom })).toBe(custom);
+  });
+});
+
+describe('getStreamDispatcher', () => {
+  it('returns its own shared dispatcher, distinct from default and events', () => {
+    expect(getStreamDispatcher()).toBe(getStreamDispatcher());
+    expect(getStreamDispatcher()).not.toBe(getDispatcher());
+    expect(getStreamDispatcher()).not.toBe(getEventsDispatcher());
+  });
+
+  it('returns the caller-supplied dispatcher when provided', () => {
+    const custom = {};
+    expect(getStreamDispatcher({ dispatcher: custom })).toBe(custom);
+  });
+
+  // Stream writes (PUT) append chunks and are NOT idempotent. Retrying a write
+  // the server already applied would duplicate a chunk, so the retry policy is
+  // deliberately narrowed: only transient connection errors and HTTP 429 (both
+  // of which guarantee nothing was persisted) are retryable. A 5xx must never
+  // be retried — it can mean the chunk was written but the response failed.
+  it('retries stream writes only on transient errors and 429, never on 5xx', () => {
+    expect(STREAM_RETRY_OPTIONS.methods).toEqual(['PUT']);
+    expect(STREAM_RETRY_OPTIONS.statusCodes).toEqual([429]);
+    for (const code of [500, 502, 503, 504]) {
+      expect(STREAM_RETRY_OPTIONS.statusCodes).not.toContain(code);
+    }
+  });
+
+  // The narrowed policy must also not inherit the timeout codes the default
+  // dispatcher retries: a headers/body timeout is ambiguous about whether the
+  // server persisted the chunk, so leaving errorCodes unset (undici's
+  // transient-network-error defaults) is the load-bearing part.
+  it('does not retry stream writes on transport timeouts', () => {
+    expect(STREAM_RETRY_OPTIONS.errorCodes).toBeUndefined();
+  });
+});
+
+describe('agent transport', () => {
+  // Regression guards for the deliberate HTTP/2 scoping:
+  //   - the events API opts into H2 (the hot read/write path), while
+  //   - the default agent (queue webhook respondWith, v3, streaming) stays on
+  //     H1 because H2 deadlocks the webhook mechanism.
+  // Flipping either silently would regress one side or the other.
+  it('enables HTTP/2 for the events API only', () => {
+    expect(getEventsAgentOptions().allowH2).toBe(true);
+    expect(getAgentOptions().allowH2).toBe(false);
+  });
+
+  // The bounded transport timeouts were introduced for the default agent; every
+  // agent added since must inherit them, or a stalled socket on that path
+  // outlives the queue lease again.
+  it('applies the bounded transport timeouts to the events agent too', () => {
+    const events = getEventsAgentOptions();
+    expect(events.headersTimeout).toBe(DEFAULT_HEADERS_TIMEOUT_MS);
+    expect(events.bodyTimeout).toBe(DEFAULT_BODY_TIMEOUT_MS);
   });
 });
 
@@ -115,5 +188,107 @@ describe('a stalled response', () => {
     } finally {
       await agent.close();
     }
+  });
+});
+
+// Self-signed cert for localhost, valid 100 years. Generated with:
+//   openssl req -x509 -newkey rsa:2048 -nodes -days 36500 -subj /CN=localhost
+//     -addext subjectAltName=DNS:localhost,IP:127.0.0.1
+// It only ever terminates a loopback test server, so the private key is inert.
+const TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQDH6QbH1JTD0vbo
+w4ND1gDSaHfx32D6mrXwK0RgaNP0PqyjBJWb2nTA+EN0hLq16DRahjLBIIGuOfhq
+YSoRdYbtUUpsV9Ywi7/oSxVIh+uNk0ASXqL9bGeUZZcdh5KkOMs5vZOj/MPIgYdn
+2kn2knvtR0qqpJiqkVueb3hoSdK8bUGKR+svdGyuFmquXd/iggYaPMiYZ/EhqSoE
+vTqpfCBlsDASGbsMED5LEqeyD332PkhNHnaoVofvZ96tTdk3YWe05rCfnlYSpwoi
+PNvsBbeFeU1CQw8fq0ktzkEKF+SzBS39OpjZC3NyRhVFXmBVRHyc3nd+PSDwmTkm
+g8OjmOIRAgMBAAECgf9LCgfaeXLMkDY0BiI/vYYFVMBdxvJSEfa1SzeassbMuggY
+2DlLAVR2eTuwbkJ/OQNVpAdpM7TzLUCmYmmAX4JpTH4EMpNvNGRQ21IcgVR+SWat
+/+WPlrhtxdTbTkEeO1EAHZT/wLviuuILan6ZppiYD4ZQd2g1VbO4KMwEVChCbCtX
+gu+5WAXKtn1kVd7mg9k58IP/SQBPZBzhI8uYCmjvRIVKPACq2ntRabBCu40w2Pt8
+5dIdFiU7FFGD7il4OHRmpopY67ZKsLjYvMbKKL6TXbev1zMgnglSt+4A5/JupGUs
+Z5wxeqR5HzoV/IXdDRRqXRyNpshdnRqvrqotZr0CgYEA+o0Gosh7nwIuRGiz9j9X
+m0/7Win5ozw6DgArr2joXWm/5SoVtwdSbuflaknfmolDrrlUj+lV/PPzIzkdUOC4
+o9Vd+ovTSdY87xWjZUphuALbCDQ6gy9P5B+04siP27udqXg+ZF7vOCXSsEaLp7ma
+B+YqE72xSQ79vD/UoGVQOm8CgYEAzEINa4d0pB2YQ2GqwVtb2gz49Lor7pB1MI2r
+Fn3WogQPhltrDLFj2FpYA+uYD9Mcr9jBkFEgU3RAyutaQARfftTSZRFxYLkHalM4
+ZxgC2FccPaaVe13m1ZR8nC9u0P1oAWg95W40+2epnVcCZePVF29qv4gqyljakMT0
+9CtY638CgYA8Mpn/jm+1Oo7nPMjQR1PDKypW9XLXN2czafMVB/2cRAYpBz2EZiv2
+HZ1PNkSVGpm6ZyjcEtHoHqyyL8zNW9DA/EjCI8o2GVU2lFpXwdFMptL9W58bWci2
+JLAPNOTrhF5TE2LaNrz/HodKdwii2cMaVsCRUahAx2tLSYLKrszh3QKBgQCgwvgH
+AtS1+qkFl5AqoPoZE466JvE+0am6rjXS/PX6DFIfwEHv+ooIFYsigsHq6pCwglxO
+dtuHc38vdq9QpWB31Y9GhsUCiH6im59P3OEYXu9WQo9ySoTM4xJ0ZwzEJj4+pUna
+ErRWjs87i+jSQtBLoqCU4No06lwUB0B4EMnqhwKBgAEcbz/0bEBLlsjtJi22kfib
+V20TfIk0ReiruJgNzcAUQ9zXzWUpzCyq0eNIPGbbnzu7M1PmvuRT4UwvqOIxPKDh
+sIQN52a6U6gA5KDP9rNDOkN5Bh7RSsOxY5uKqAqhPyBC+I5vTdtR5mWILf9Emc3M
+jMdHLypx4TIJ2ugeZzFv
+-----END PRIVATE KEY-----`;
+
+const TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIDJzCCAg+gAwIBAgIUPQi4xIRXRrIhXhrLbj/Dn3RY1SUwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDYyMjIxNDgwOFoYDzIxMjYw
+NTI5MjE0ODA4WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDH6QbH1JTD0vbow4ND1gDSaHfx32D6mrXwK0RgaNP0
+PqyjBJWb2nTA+EN0hLq16DRahjLBIIGuOfhqYSoRdYbtUUpsV9Ywi7/oSxVIh+uN
+k0ASXqL9bGeUZZcdh5KkOMs5vZOj/MPIgYdn2kn2knvtR0qqpJiqkVueb3hoSdK8
+bUGKR+svdGyuFmquXd/iggYaPMiYZ/EhqSoEvTqpfCBlsDASGbsMED5LEqeyD332
+PkhNHnaoVofvZ96tTdk3YWe05rCfnlYSpwoiPNvsBbeFeU1CQw8fq0ktzkEKF+Sz
+BS39OpjZC3NyRhVFXmBVRHyc3nd+PSDwmTkmg8OjmOIRAgMBAAGjbzBtMB0GA1Ud
+DgQWBBTT1aH/RgcYEpdjuvedACycPwYPtDAfBgNVHSMEGDAWgBTT1aH/RgcYEpdj
+uvedACycPwYPtDAPBgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGCCWxvY2FsaG9z
+dIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEAHpbHKTelmRfi5UV3Nox79ttqu2GM
+CIHoTJBD5hdjcE31wbHt/fK76dWknGR0wG5v5vC071lAWliQoYRlJfloy536XOXc
+zPvVs6UqXfPji6kWyHA74qM1zKjLvoPQhWuDJqepb6CYhM1iX3tV4LHWXCDASNuV
+wIaFqUOx2vU/DLcH47+VEnEtrmodMvownUojvO+eZ1aODpPyYQg4Iqt5StSLURFz
+JSsW5YzWatjMPka0HLgfbf7gv0+QFF7vGd9TqUO7ZD7NuPDuKuT5BMa6XxoQYkIO
+TTVKDw9WMB6CyIX5kV0cOG/S8OO+1l3ZPaogkzj0P5OnJaYPvpp2kpGrlQ==
+-----END CERTIFICATE-----`;
+
+// Proves the exact mechanism the v4 events path relies on: a request issued
+// through the *global* `fetch` with an `allowH2` undici dispatcher actually
+// negotiates HTTP/2 over ALPN. `fetchV4` (events-v4.ts) routes through global
+// `fetch` for observability instrumentation rather than `undici.request`, so we
+// verify h2 survives that route. The server only speaks h2 (allowHTTP1 left at
+// its default of false), so a client that fell back to HTTP/1.1 would fail to
+// connect instead of silently passing.
+describe('HTTP/2 over global fetch with an undici dispatcher', () => {
+  let server: Http2SecureServer;
+  let port: number;
+  let negotiatedAlpn: string | false | null | undefined;
+  const agent = new Agent({
+    allowH2: true,
+    connect: { rejectUnauthorized: false },
+  });
+
+  beforeAll(async () => {
+    server = createSecureServer({ key: TEST_KEY, cert: TEST_CERT });
+    // 'stream' only fires for HTTP/2 sessions.
+    server.on('stream', (stream) => {
+      negotiatedAlpn = (stream.session?.socket as TLSSocket | undefined)
+        ?.alpnProtocol;
+      stream.respond({ ':status': 200 });
+      stream.end('ok');
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await agent.close();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it('negotiates h2 (global fetch honors the dispatcher)', async () => {
+    const res = await fetch(`https://127.0.0.1:${port}/`, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+      dispatcher: agent,
+    } as any);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+    expect(negotiatedAlpn).toBe('h2');
   });
 });

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -11,9 +11,11 @@ import {
   getDispatcher,
   getEventsAgentOptions,
   getEventsDispatcher,
+  getStreamCloseDispatcher,
   getStreamDispatcher,
   MAX_RETRIES,
   RETRY_ERROR_CODES,
+  STREAM_CLOSE_RETRY_OPTIONS,
   STREAM_RETRY_OPTIONS,
 } from './http-client.js';
 
@@ -72,6 +74,28 @@ describe('getStreamDispatcher', () => {
   // transient-network-error defaults) is the load-bearing part.
   it('does not retry stream writes on transport timeouts', () => {
     expect(STREAM_RETRY_OPTIONS.errorCodes).toBeUndefined();
+  });
+
+  // Stream CLOSE is the one idempotent stream PUT: a duplicate close of a
+  // completed stream early-returns, and the server's close-barrier fence is
+  // an if_not_exists stamp a re-entered close resumes. The barrier protocol
+  // RELIES on close retrying 5xx: transient reconciliation failures (and
+  // unsafe close shapes awaiting in-flight backups) surface as retriable
+  // 503s with the stream left durably closing. Without 5xx here, that 503
+  // rejects writer.close() and the stream stays fenced until run expiry.
+  it('retries stream close on 5xx (idempotent, and the close barrier depends on it)', () => {
+    expect(STREAM_CLOSE_RETRY_OPTIONS.methods).toEqual(['PUT']);
+    for (const code of [429, 500, 502, 503, 504]) {
+      expect(STREAM_CLOSE_RETRY_OPTIONS.statusCodes).toContain(code);
+    }
+    expect(STREAM_CLOSE_RETRY_OPTIONS.retryAfter).toBe(true);
+  });
+
+  it('close uses its own shared dispatcher, distinct from the write dispatcher', () => {
+    expect(getStreamCloseDispatcher()).toBe(getStreamCloseDispatcher());
+    expect(getStreamCloseDispatcher()).not.toBe(getStreamDispatcher());
+    const custom = {};
+    expect(getStreamCloseDispatcher({ dispatcher: custom })).toBe(custom);
   });
 });
 

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -5,12 +5,15 @@ import type { TLSSocket } from 'node:tls';
 import { Agent } from 'undici';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
+  createEventsDispatcher,
+  createStreamDispatcher,
   DEFAULT_BODY_TIMEOUT_MS,
   DEFAULT_HEADERS_TIMEOUT_MS,
   getAgentOptions,
   getDispatcher,
   getEventsAgentOptions,
   getEventsDispatcher,
+  getStreamAgentOptions,
   getStreamCloseDispatcher,
   getStreamDispatcher,
   MAX_RETRIES,
@@ -107,7 +110,24 @@ describe('agent transport', () => {
   // Flipping either silently would regress one side or the other.
   it('enables HTTP/2 for the events API only', () => {
     expect(getEventsAgentOptions().allowH2).toBe(true);
+    expect(getStreamAgentOptions().allowH2).toBe(true);
     expect(getAgentOptions().allowH2).toBe(false);
+  });
+
+  // `allowH2` alone buys nothing: undici gates in-flight requests per
+  // connection on `pipelining`, so `pipelining: 1` reduces an H2 agent to H1
+  // behavior (one stream per connection). These two options are the difference
+  // between multiplexing and not — see getEventsAgentOptions.
+  it('gives the events agent a pipelining depth that permits multiplexing', () => {
+    expect(getEventsAgentOptions().pipelining).toBeGreaterThan(1);
+  });
+
+  // Inverse guard: stream appends are not idempotent, so they must NOT
+  // multiplex — one connection-level failure would fail (and retry) several
+  // appends at once. See getStreamAgentOptions.
+  it('keeps stream writes and the H1 default at one request per connection', () => {
+    expect(getStreamAgentOptions().pipelining).toBe(1);
+    expect(getAgentOptions().pipelining).toBe(1);
   });
 
   // The bounded transport timeouts were introduced for the default agent; every
@@ -117,6 +137,12 @@ describe('agent transport', () => {
     const events = getEventsAgentOptions();
     expect(events.headersTimeout).toBe(DEFAULT_HEADERS_TIMEOUT_MS);
     expect(events.bodyTimeout).toBe(DEFAULT_BODY_TIMEOUT_MS);
+  });
+
+  it('applies the bounded transport timeouts to the stream agent too', () => {
+    const stream = getStreamAgentOptions();
+    expect(stream.headersTimeout).toBe(DEFAULT_HEADERS_TIMEOUT_MS);
+    expect(stream.bodyTimeout).toBe(DEFAULT_BODY_TIMEOUT_MS);
   });
 });
 
@@ -314,5 +340,208 @@ describe('HTTP/2 over global fetch with an undici dispatcher', () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('ok');
     expect(negotiatedAlpn).toBe('h2');
+  });
+});
+
+// Negotiating h2 is not the same as using it. This measures the property the
+// events agent actually exists for: concurrent POSTs sharing ONE connection as
+// parallel H2 streams. It is the regression test the config-only assertions
+// above cannot be — before the pipelining + interceptor fix, `allowH2` was true
+// and ALPN was h2, yet 16 concurrent requests still produced 8 serialized
+// requests over 8 TCP connections, exactly like the H1 agent.
+describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
+  const CONCURRENCY = 16;
+
+  let server: Http2SecureServer;
+  let port: number;
+  let sessions: number;
+  let maxConcurrentStreams: number;
+  let inFlight: number;
+  let receivedBodies: string[];
+  let release: Array<() => void>;
+  let flakyAttempts: number;
+
+  /**
+   * Holds every request open until `CONCURRENCY` of them are in flight, so peak
+   * concurrency is observed rather than timed. A periodic flush (see `burst`)
+   * drains whatever is waiting when that target is never reached — which is the
+   * expected outcome for a non-multiplexing agent, and must fail the assertion
+   * rather than hang the test.
+   */
+  function onArrival(path: string): Promise<void> {
+    // The pool-warming request is not part of the barrier — it must complete on
+    // its own so the burst starts from an established session.
+    if (!path.startsWith('/req-')) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      inFlight++;
+      maxConcurrentStreams = Math.max(maxConcurrentStreams, inFlight);
+      release.push(resolve);
+      if (release.length >= CONCURRENCY) {
+        for (const r of release.splice(0)) r();
+      }
+    });
+  }
+
+  beforeAll(async () => {
+    server = createSecureServer({ key: TEST_KEY, cert: TEST_CERT });
+    server.on('session', (session) => {
+      sessions++;
+      // Agents are closed while the pool still holds idle sessions; the
+      // resulting resets are expected teardown noise, not test failures.
+      session.on('error', () => undefined);
+    });
+    server.on('sessionError', () => undefined);
+    server.on('clientError', () => undefined);
+    server.on('stream', (stream, headers) => {
+      stream.on('error', () => undefined);
+      const chunks: Buffer[] = [];
+      stream.on('data', (c: Buffer) => chunks.push(c));
+      stream.on('end', () => {
+        void (async () => {
+          const path = String(headers[':path']);
+          receivedBodies.push(Buffer.concat(chunks).toString());
+          await onArrival(path);
+          if (path.startsWith('/req-')) inFlight--;
+          // `/flaky` fails once so RetryAgent re-dispatches it.
+          if (path === '/flaky' && ++flakyAttempts === 1) {
+            stream.respond({ ':status': 503 });
+            stream.end('retry me');
+            return;
+          }
+          stream.respond({ ':status': 200 });
+          stream.end(path);
+        })();
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  /** Loopback TLS escape hatch — the only deviation from production wiring. */
+  const LOOPBACK = { connect: { rejectUnauthorized: false } };
+
+  async function burst(dispatcher: unknown) {
+    sessions = 0;
+    maxConcurrentStreams = 0;
+    inFlight = 0;
+    receivedBodies = [];
+    release = [];
+    flakyAttempts = 0;
+    // Warm the pool so connection setup isn't conflated with the stream gate:
+    // a cold burst races ALPN negotiation and fans out across connections.
+    await fetch(`https://127.0.0.1:${port}/warm`, {
+      dispatcher,
+      method: 'POST',
+      body: 'warm',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+    } as any);
+    const sessionsAfterWarm = sessions;
+    // Repeating, not one-shot: an agent that caps in-flight requests below
+    // CONCURRENCY delivers the burst in several waves, and every wave needs
+    // draining or the remainder blocks forever.
+    const timer = setInterval(() => {
+      for (const r of release.splice(0)) r();
+    }, 250);
+    const bodies = await Promise.all(
+      Array.from({ length: CONCURRENCY }, (_, i) =>
+        fetch(`https://127.0.0.1:${port}/req-${i}`, {
+          method: 'POST',
+          body: JSON.stringify({ i }),
+          dispatcher,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+        } as any).then((r) => r.text())
+      )
+    );
+    clearInterval(timer);
+    return { bodies, sessionsAfterWarm };
+  }
+
+  it('multiplexes concurrent event writes onto a single connection', async () => {
+    // The real production factory — so dropping the interceptor from
+    // createEventsDispatcher fails here, not just changing the options.
+    const agent = createEventsDispatcher(LOOPBACK);
+    try {
+      const { bodies, sessionsAfterWarm } = await burst(agent);
+
+      expect(maxConcurrentStreams).toBe(CONCURRENCY);
+      // No new TCP/TLS session beyond the warmed one — the whole point.
+      expect(sessions).toBe(sessionsAfterWarm);
+      // Re-buffering the body must not corrupt or cross-wire payloads.
+      expect(bodies.sort()).toEqual(
+        Array.from({ length: CONCURRENCY }, (_, i) => `/req-${i}`).sort()
+      );
+      expect(receivedBodies.filter((b) => b !== 'warm').sort()).toEqual(
+        Array.from({ length: CONCURRENCY }, (_, i) =>
+          JSON.stringify({ i })
+        ).sort()
+      );
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it('does not multiplex stream writes (non-idempotent appends stay isolated)', async () => {
+    const agent = createStreamDispatcher(STREAM_RETRY_OPTIONS, LOOPBACK);
+    try {
+      await burst(agent);
+      // Bounded by the pool size, not by CONCURRENCY: each connection carries
+      // at most one append, so a reset can only ever fail one write.
+      expect(maxConcurrentStreams).toBeLessThanOrEqual(
+        getStreamAgentOptions().connections
+      );
+      expect(maxConcurrentStreams).toBeLessThan(CONCURRENCY);
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it('resends the full body when a re-buffered request is retried', async () => {
+    // The interceptor consumes the request body to make it multiplexable, but
+    // RetryAgent re-dispatches with the *original* (now exhausted) stream. If the
+    // drained buffer were not reused, the retry would arrive with an empty body.
+    const agent = createEventsDispatcher(LOOPBACK);
+    receivedBodies = [];
+    flakyAttempts = 0;
+    const payload = JSON.stringify({ chunk: 'x'.repeat(64) });
+    try {
+      const response = await fetch(`https://127.0.0.1:${port}/flaky`, {
+        method: 'PUT',
+        body: payload,
+        dispatcher: agent,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+      } as any);
+      expect(response.status).toBe(200);
+      expect(flakyAttempts).toBe(2);
+      expect(receivedBodies).toEqual([payload, payload]);
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it('WORKFLOW_H2_MULTIPLEX=0 falls back to one request per connection', async () => {
+    const previous = process.env.WORKFLOW_H2_MULTIPLEX;
+    process.env.WORKFLOW_H2_MULTIPLEX = '0';
+    // Read when the dispatcher is built, so the kill switch only takes effect
+    // for agents created after it is set.
+    const agent = createEventsDispatcher(LOOPBACK);
+    try {
+      await burst(agent);
+      expect(maxConcurrentStreams).toBeLessThan(CONCURRENCY);
+    } finally {
+      await agent.close();
+      if (previous === undefined) {
+        delete process.env.WORKFLOW_H2_MULTIPLEX;
+      } else {
+        process.env.WORKFLOW_H2_MULTIPLEX = previous;
+      }
+    }
   });
 });

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -144,6 +144,30 @@ describe('agent transport', () => {
     expect(stream.headersTimeout).toBe(DEFAULT_HEADERS_TIMEOUT_MS);
     expect(stream.bodyTimeout).toBe(DEFAULT_BODY_TIMEOUT_MS);
   });
+
+  // Both receive windows have to clear undici's defaults (256 KiB stream,
+  // 512 KiB connection), and the connection window has to leave room for more
+  // than one stream's worth. Whichever is left at its default becomes the
+  // binding constraint by itself: a single read stalls on the stream window,
+  // concurrent reads stall on the shared connection window. See
+  // getEventsAgentOptions.
+  it('raises both H2 receive windows on the events agent', () => {
+    // undici's own defaults, not HTTP/2's 65535 — see undici
+    // lib/dispatcher/client.js, kHTTP2InitialWindowSize / kHTTP2ConnectionWindowSize.
+    const UNDICI_DEFAULT_STREAM_WINDOW = 262_144;
+    const UNDICI_DEFAULT_CONNECTION_WINDOW = 524_288;
+    const events = getEventsAgentOptions();
+
+    expect(events.initialWindowSize).toBeGreaterThan(
+      UNDICI_DEFAULT_STREAM_WINDOW
+    );
+    expect(events.connectionWindowSize).toBeGreaterThan(
+      UNDICI_DEFAULT_CONNECTION_WINDOW
+    );
+    expect(events.connectionWindowSize).toBeGreaterThan(
+      events.initialWindowSize
+    );
+  });
 });
 
 describe('getAgentOptions', () => {

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -386,6 +386,16 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
   let flakyAttempts: number;
 
   /**
+   * Paths that participate in the concurrency barrier: the synthetic burst
+   * paths, plus the real v4 event-write path (`/api/v4/...`) used by the
+   * end-to-end test. The pool-warming request and `/flaky` are excluded — they
+   * must complete on their own.
+   */
+  function isBarrierPath(path: string): boolean {
+    return path.startsWith('/req-') || path.startsWith('/api/v4/');
+  }
+
+  /**
    * Holds every request open until `CONCURRENCY` of them are in flight, so peak
    * concurrency is observed rather than timed. A periodic flush (see `burst`)
    * drains whatever is waiting when that target is never reached — which is the
@@ -395,7 +405,7 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
   function onArrival(path: string): Promise<void> {
     // The pool-warming request is not part of the barrier — it must complete on
     // its own so the burst starts from an established session.
-    if (!path.startsWith('/req-')) return Promise.resolve();
+    if (!isBarrierPath(path)) return Promise.resolve();
     return new Promise<void>((resolve) => {
       inFlight++;
       maxConcurrentStreams = Math.max(maxConcurrentStreams, inFlight);
@@ -425,11 +435,23 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
           const path = String(headers[':path']);
           receivedBodies.push(Buffer.concat(chunks).toString());
           await onArrival(path);
-          if (path.startsWith('/req-')) inFlight--;
+          if (isBarrierPath(path)) inFlight--;
           // `/flaky` fails once so RetryAgent re-dispatches it.
           if (path === '/flaky' && ++flakyAttempts === 1) {
             stream.respond({ ':status': 503 });
             stream.end('retry me');
+            return;
+          }
+          // The v4 create-event contract: the client requires these response
+          // headers and CBOR-decodes the body.
+          if (path.startsWith('/api/v4/')) {
+            stream.respond({
+              ':status': 200,
+              'x-wf-event-id': `evnt_${receivedBodies.length}`,
+              'x-wf-run-id': 'wrun_1',
+              'x-wf-created-at': '2026-06-10T00:00:00.000Z',
+            });
+            stream.end();
             return;
           }
           stream.respond({ ':status': 200 });
@@ -547,6 +569,69 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
       expect(receivedBodies).toEqual([payload, payload]);
     } finally {
       await agent.close();
+    }
+  });
+
+  it('multiplexes real v4 event writes (createWorkflowRunEventV4 end to end)', async () => {
+    // The tests above drive the transport with a synthetic `fetch`. This one
+    // drives the actual production call, which matters because the events
+    // client hands its frame to the *global* `fetch` (so v4 traffic stays
+    // visible in Vercel's outgoing-requests view). `fetch` streamifies the
+    // body, which is exactly what trips undici's second H2 busy() gate — so
+    // this is the path where the interceptor's re-buffering has to work.
+    const { createWorkflowRunEventV4 } = await import('./events-v4.js');
+    const previousUrl = process.env.VERCEL_WORKFLOW_SERVER_URL;
+    process.env.VERCEL_WORKFLOW_SERVER_URL = `https://127.0.0.1:${port}`;
+    const agent = createEventsDispatcher(LOOPBACK);
+    sessions = 0;
+    maxConcurrentStreams = 0;
+    inFlight = 0;
+    receivedBodies = [];
+    release = [];
+    // Warm the pool so ALPN negotiation isn't conflated with the stream gate.
+    await fetch(`https://127.0.0.1:${port}/warm`, {
+      dispatcher: agent,
+      method: 'POST',
+      body: 'warm',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+    } as any);
+    const sessionsAfterWarm = sessions;
+    const timer = setInterval(() => {
+      for (const r of release.splice(0)) r();
+    }, 250);
+    try {
+      const results = await Promise.all(
+        Array.from({ length: CONCURRENCY }, (_, i) =>
+          createWorkflowRunEventV4(
+            {
+              runId: 'wrun_1',
+              eventType: 'step_started',
+              payload: new TextEncoder().encode(`payload-${i}`),
+            },
+            { token: 'test-token', dispatcher: agent }
+          )
+        )
+      );
+
+      expect(results).toHaveLength(CONCURRENCY);
+      expect(maxConcurrentStreams).toBe(CONCURRENCY);
+      expect(sessions).toBe(sessionsAfterWarm);
+      // Every frame arrived whole: re-buffering must not truncate or drop the
+      // body it drained off the fetch stream.
+      const frames = receivedBodies.filter((b) => b !== 'warm');
+      expect(frames).toHaveLength(CONCURRENCY);
+      expect(frames.every((b) => b.length > 0)).toBe(true);
+      expect(frames.map((b) => b.slice(b.indexOf('payload-'))).sort()).toEqual(
+        Array.from({ length: CONCURRENCY }, (_, i) => `payload-${i}`).sort()
+      );
+    } finally {
+      clearInterval(timer);
+      await agent.close();
+      if (previousUrl === undefined) {
+        delete process.env.VERCEL_WORKFLOW_SERVER_URL;
+      } else {
+        process.env.VERCEL_WORKFLOW_SERVER_URL = previousUrl;
+      }
     }
   });
 

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -1,4 +1,4 @@
-import { Agent, RetryAgent, type RetryHandler } from 'undici';
+import { Agent, type Dispatcher, RetryAgent, type RetryHandler } from 'undici';
 import type { APIConfig } from './utils.js';
 
 let _dispatcher: RetryAgent | undefined;
@@ -93,14 +93,16 @@ export const MAX_RETRIES = 2;
  * timeouts. Read from the environment on each call so the documented overrides
  * apply to all agents, and so tests can exercise them without duplicating the
  * constants.
+ *
+ * `pipelining` is deliberately NOT set here: undici overloads that single
+ * option to mean both "H1 pipelining depth" and "max in-flight H2 streams per
+ * connection", and the two paths want opposite values. Each agent sets it
+ * explicitly below.
  */
 function getBaseAgentOptions() {
   return {
     connections: 8,
     keepAliveTimeout: 10_000,
-    // HTTP/1.1 pipelining is disabled (pipelining: 1) because it causes
-    // head-of-line blocking that deadlocks the webhook respondWith mechanism.
-    pipelining: 1,
     headersTimeout: envTimeoutMs(
       'WORKFLOW_VERCEL_HEADERS_TIMEOUT_MS',
       DEFAULT_HEADERS_TIMEOUT_MS
@@ -111,6 +113,14 @@ function getBaseAgentOptions() {
     ),
   } as const;
 }
+
+/**
+ * In-flight H2 streams allowed per connection. Matches undici's
+ * `maxConcurrentStreams` default (100), which is the real ceiling once the
+ * server's SETTINGS_MAX_CONCURRENT_STREAMS is known — so this only has to be
+ * large enough not to be the binding constraint.
+ */
+const H2_MAX_IN_FLIGHT_STREAMS = 100;
 
 /**
  * Options for the default undici Agent — the queue client (webhook
@@ -129,12 +139,15 @@ export function getAgentOptions() {
   return {
     ...getBaseAgentOptions(),
     allowH2: false,
+    // HTTP/1.1 pipelining is disabled (pipelining: 1) because it causes
+    // head-of-line blocking that deadlocks the webhook respondWith mechanism.
+    pipelining: 1,
   } as const;
 }
 
 /**
  * Options for the events API undici Agent. Exported so tests can assert that
- * HTTP/2 stays enabled.
+ * HTTP/2 stays enabled *and* that it is actually configured to multiplex.
  *
  * The v4 events endpoints are the hottest path (an event write per step
  * transition, plus event-log reads on replay) and are plain request/response —
@@ -144,11 +157,50 @@ export function getAgentOptions() {
  * Re-enabling H2 more broadly is gated on resolving those issues (notably the
  * earlier SvelteKit-on-Vercel-prod hang, which is why bundled consumers need
  * the `node:http2` require shim — see the nitro/sveltekit plugins).
+ *
+ * `pipelining` must be set for H2 to multiplex at all. undici gates in-flight
+ * requests per connection on `getPipelining(client)`, which reads
+ * `client[kPipelining] ?? httpContext.defaultPipelining ?? 1`. `client-h2.js`
+ * sets `defaultPipelining: Infinity`, but the Client constructor coerces
+ * `pipelining` to a number (`pipelining != null ? pipelining : 1`), so
+ * `kPipelining` is never nullish and H2's Infinity is unreachable — leaving one
+ * in-flight stream per connection. Before this was set, the H2 agent behaved
+ * byte-for-byte like the H1 agent: 16 concurrent requests produced 8 in-flight
+ * requests over 8 TCP connections. See nodejs/undici#4143.
  */
 export function getEventsAgentOptions() {
   return {
     ...getBaseAgentOptions(),
     allowH2: true,
+    pipelining: H2_MAX_IN_FLIGHT_STREAMS,
+  } as const;
+}
+
+/**
+ * Options for the stream write/close Agents. H2 is enabled (these send a
+ * fully-buffered body, or none, so they avoid the duplex-streaming issues that
+ * keep the long-lived live-read on plain `fetch`), but multiplexing is
+ * deliberately left OFF — `pipelining: 1`, one in-flight request per
+ * connection.
+ *
+ * Stream appends are not idempotent. Multiplexing N appends onto one connection
+ * makes a single RST_STREAM / GOAWAY / socket reset fail all N at once, and
+ * STREAM_RETRY_OPTIONS retries PUT on exactly those transient `errorCodes` — so
+ * a connection-level blip would resend chunks the server may already have
+ * applied and duplicate them. Serializing keeps the existing
+ * one-request-per-connection failure isolation that policy was written against.
+ *
+ * Note this is currently belt-and-braces: undici's H2 `busy()` check already
+ * serializes non-idempotent requests (`client-h2.js`: `if
+ * (request.idempotent === false) return true`), so PUTs would not multiplex even
+ * at a higher pipelining value. Setting it explicitly means the safety property
+ * does not silently depend on that upstream detail.
+ */
+export function getStreamAgentOptions() {
+  return {
+    ...getBaseAgentOptions(),
+    allowH2: true,
+    pipelining: 1,
   } as const;
 }
 
@@ -225,6 +277,102 @@ export const STREAM_CLOSE_RETRY_OPTIONS: RetryHandler.RetryOptions = {
 };
 
 /**
+ * Largest body the H2 multiplexing interceptor will re-buffer. Event frames are
+ * small CBOR payloads; the cap is a guard against an unexpectedly large write
+ * being held in memory twice, not a tuning knob.
+ */
+const H2_REBUFFER_MAX_BYTES = 1 << 20; // 1 MiB
+
+/** Set `WORKFLOW_H2_MULTIPLEX=0` to fall back to one request per connection. */
+function h2MultiplexEnabled(): boolean {
+  return process.env.WORKFLOW_H2_MULTIPLEX !== '0';
+}
+
+function contentLength(headers: unknown): number {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    return Number.NaN;
+  }
+  const record = headers as Record<string, unknown>;
+  const raw = record['content-length'] ?? record['Content-Length'];
+  return typeof raw === 'string' || typeof raw === 'number'
+    ? Number(raw)
+    : Number.NaN;
+}
+
+/**
+ * Undici interceptor that lets the events API actually multiplex over H2.
+ *
+ * `pipelining` (see getEventsAgentOptions) is necessary but not sufficient:
+ * undici's H2 `busy()` check reports the connection busy — serializing the
+ * request behind whatever is in flight — for two more reasons.
+ *
+ * 1. Non-idempotent method. `client-h2.js` returns busy when
+ *    `request.idempotent === false`, and undici only treats GET/HEAD as
+ *    idempotent by default (`core/request.js`), so every event-write POST
+ *    serializes. We mark them idempotent for *concurrency* purposes only: in
+ *    undici 7 the flag feeds nothing but the H1/H2 `busy()` gates — it does not
+ *    cause resends. Retries are governed solely by RetryAgent, whose
+ *    `methods` default (`['GET','HEAD','OPTIONS','PUT','DELETE','TRACE']`)
+ *    excludes POST, so an event write is still never replayed. See
+ *    nodejs/undici#5390.
+ *
+ * 2. Streamed request body. `client-h2.js` also returns busy for a body that is
+ *    a stream / async iterable, because such a body can error mid-flight and
+ *    take unrelated in-flight requests down with it. events-v4 dispatches
+ *    through undici's own `request()` with a materialized `Uint8Array`, so its
+ *    bodies already arrive buffered and skip this branch; a caller that hands
+ *    down a streamed body (as the global `fetch` does — it converts every body
+ *    into an async iterable) would otherwise stay serialized. Draining it back
+ *    into a Buffer restores the buffered-body shape undici needs, at the cost of
+ *    one copy of an already-in-memory payload. Bodies without a usable
+ *    `content-length`, or above H2_REBUFFER_MAX_BYTES, are passed through
+ *    untouched (and stay serialized) rather than buffered blind.
+ *
+ * Without both of these, `pipelining` alone leaves the events agent at one
+ * in-flight request per connection.
+ */
+export function h2MultiplexInterceptor(
+  dispatch: Dispatcher['dispatch']
+): Dispatcher['dispatch'] {
+  return (opts, handler) => {
+    const body = opts.body;
+    const isAsyncIterable =
+      !!body &&
+      typeof body !== 'string' &&
+      !Buffer.isBuffer(body) &&
+      typeof (body as unknown as Record<symbol, unknown>)[
+        Symbol.asyncIterator
+      ] === 'function';
+    const length = contentLength(opts.headers);
+
+    if (!isAsyncIterable || !(length >= 0) || length > H2_REBUFFER_MAX_BYTES) {
+      return dispatch({ ...opts, idempotent: true }, handler);
+    }
+
+    // Drain asynchronously, then dispatch. Returning `true` reports "no
+    // backpressure", which is accurate: the request is accepted, and the pool
+    // gate we are lifting is exactly the one that would have reported drain.
+    void (async () => {
+      try {
+        const chunks: Buffer[] = [];
+        for await (const chunk of body as AsyncIterable<Uint8Array>) {
+          chunks.push(Buffer.from(chunk));
+        }
+        dispatch(
+          { ...opts, body: Buffer.concat(chunks), idempotent: true },
+          handler
+        );
+      } catch (error) {
+        // Surface a drain failure the way undici would have surfaced a body
+        // error, so the awaiting caller rejects instead of hanging.
+        handler.onError?.(error as Error);
+      }
+    })();
+    return true;
+  };
+}
+
+/**
  * Resolves the undici dispatcher for a request: the caller's override, or the
  * shared default agent (HTTP/1.1).
  */
@@ -262,6 +410,73 @@ export function getStreamCloseDispatcher(config?: APIConfig): unknown {
 }
 
 /**
+ * Builds the events-API dispatcher: the H2 agent plus the interceptor that makes
+ * H2 actually multiplex. Exported (rather than only reachable through the
+ * `getEventsDispatcher` singleton) so a test can exercise this exact wiring
+ * against a loopback server via `agentOverrides` — asserting on
+ * getEventsAgentOptions() alone cannot catch the composition being dropped.
+ */
+export function createEventsDispatcher(
+  agentOverrides?: Partial<Agent.Options>
+): RetryAgent {
+  const agent = new RetryAgent(
+    new Agent({ ...getEventsAgentOptions(), ...agentOverrides }),
+    getRetryAgentOptions()
+  );
+  if (!h2MultiplexEnabled()) {
+    return agent;
+  }
+  // The interceptor wraps the RetryAgent (rather than the Agent inside it) so
+  // that retries re-send the *drained* body. RetryHandler captures its own copy
+  // of the request body up front — `wrapRequestBody` (undici core/util.js) hands
+  // an async-iterable body to a fresh `BodyAsyncIterable`. Composed inside, that
+  // copy would wrap the stream the interceptor is about to consume, so a retry
+  // would re-iterate an exhausted stream and send an empty body. Composed
+  // outside, RetryHandler captures the Buffer and replays it verbatim.
+  return withBoundLifecycle(
+    agent,
+    agent.compose(h2MultiplexInterceptor) as unknown as RetryAgent
+  );
+}
+
+/**
+ * Restores `close()`/`destroy()` on a composed dispatcher.
+ *
+ * `Dispatcher.compose()` returns `new Proxy(this, { get: (t, k) => k ===
+ * 'dispatch' ? composed : t[k] })`, so every other method comes back unbound and
+ * runs with the Proxy as `this`. For a RetryAgent that means `close()` throws
+ * `TypeError: Cannot read private member #agent from an object whose class did
+ * not declare it`. Binding the lifecycle methods to the real instance keeps the
+ * composed dispatcher disposable.
+ */
+function withBoundLifecycle(
+  agent: RetryAgent,
+  composed: RetryAgent
+): RetryAgent {
+  return new Proxy(composed, {
+    get: (target, key) =>
+      key === 'close' || key === 'destroy'
+        ? (agent[key] as (...args: unknown[]) => unknown).bind(agent)
+        : target[key as keyof RetryAgent],
+  });
+}
+
+/**
+ * Builds a stream write/close dispatcher. Exported for the same reason as
+ * `createEventsDispatcher` — so a test can assert the inverse property, that
+ * these deliberately do NOT multiplex.
+ */
+export function createStreamDispatcher(
+  retryOptions: RetryHandler.RetryOptions,
+  agentOverrides?: Partial<Agent.Options>
+): RetryAgent {
+  return new RetryAgent(
+    new Agent({ ...getStreamAgentOptions(), ...agentOverrides }),
+    retryOptions
+  );
+}
+
+/**
  * Returns a shared undici RetryAgent wrapping an Agent.
  *
  * - HTTP/1.1 (see getAgentOptions)
@@ -283,13 +498,12 @@ function getDefaultDispatcher(): RetryAgent {
 /**
  * Returns the shared HTTP/2 RetryAgent used by the v4 events API. Same retry /
  * pooling / timeout behavior as the default dispatcher, but with `allowH2`
- * enabled.
+ * enabled, a pipelining depth that lets H2 actually multiplex
+ * (getEventsAgentOptions), and the interceptor that lifts undici's remaining
+ * two per-request H2 busy gates (h2MultiplexInterceptor).
  */
 function getDefaultEventsDispatcher(): RetryAgent {
-  _eventsDispatcher ??= new RetryAgent(
-    new Agent(getEventsAgentOptions()),
-    getRetryAgentOptions()
-  );
+  _eventsDispatcher ??= createEventsDispatcher();
   return _eventsDispatcher;
 }
 
@@ -302,22 +516,18 @@ function getDefaultEventsDispatcher(): RetryAgent {
  * chunk was not persisted — and never on 5xx or other 4xx, where a retry could
  * duplicate an already-applied write. It opts into H2 (the write/close requests
  * send a fully-buffered body, or none, so they don't hit the duplex-streaming H2
- * issues that keep the long-lived live-read on plain `fetch`) by reusing the
- * events agent's H2 / pooling options.
+ * issues that keep the long-lived live-read on plain `fetch`) via
+ * getStreamAgentOptions() — which, unlike the events agent, keeps multiplexing
+ * off so one connection-level failure cannot fail (and thus retry) several
+ * appends at once.
  */
 function getDefaultStreamDispatcher(): RetryAgent {
-  _streamDispatcher ??= new RetryAgent(
-    new Agent(getEventsAgentOptions()),
-    STREAM_RETRY_OPTIONS
-  );
+  _streamDispatcher ??= createStreamDispatcher(STREAM_RETRY_OPTIONS);
   return _streamDispatcher;
 }
 
 /** Shared agent for the idempotent stream close (5xx retriable). */
 function getDefaultStreamCloseDispatcher(): RetryAgent {
-  _streamCloseDispatcher ??= new RetryAgent(
-    new Agent(getEventsAgentOptions()),
-    STREAM_CLOSE_RETRY_OPTIONS
-  );
+  _streamCloseDispatcher ??= createStreamDispatcher(STREAM_CLOSE_RETRY_OPTIONS);
   return _streamCloseDispatcher;
 }

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -2,6 +2,8 @@ import { Agent, RetryAgent, type RetryHandler } from 'undici';
 import type { APIConfig } from './utils.js';
 
 let _dispatcher: RetryAgent | undefined;
+let _eventsDispatcher: RetryAgent | undefined;
+let _streamDispatcher: RetryAgent | undefined;
 
 /**
  * Time-to-first-byte cap for every request through the shared dispatcher.
@@ -53,11 +55,12 @@ function envTimeoutMs(name: string, fallback: number): number {
  * socket was never retried at all. The two timeout codes are ambiguous — the
  * request may have been fully processed — which is why they stay scoped to
  * `RetryAgent`'s default `methods` (GET/HEAD/OPTIONS/PUT/DELETE/TRACE, never
- * POST). The PUTs that go through this dispatcher are the legacy v1/v2 entity
- * updates (cancel run, update step), which are idempotent in outcome; stream
- * appends — the one non-idempotent PUT — bypass the dispatcher entirely (see
- * streamer.ts). POST event writes get their own type-aware retry instead (see
- * event-retry.ts).
+ * POST). The PUTs that reach the default and events dispatchers are the legacy
+ * v1/v2 entity updates (cancel run, update step), which are idempotent in
+ * outcome; stream appends — the one non-idempotent PUT — get their own
+ * dispatcher whose retry policy deliberately excludes these codes (see
+ * STREAM_RETRY_OPTIONS). POST event writes get their own type-aware retry
+ * instead (see event-retry.ts).
  *
  * Exported so a test can assert the timeout codes stay in the list.
  */
@@ -85,18 +88,15 @@ export const RETRY_ERROR_CODES = [
 export const MAX_RETRIES = 2;
 
 /**
- * Options for the shared undici Agent. Exported (and read from the environment
- * on each call) so tests can assert the transport configuration and exercise it
- * against a real socket without duplicating the constants.
+ * Shared by every agent — connection pooling and the bounded transport
+ * timeouts. Read from the environment on each call so the documented overrides
+ * apply to all agents, and so tests can exercise them without duplicating the
+ * constants.
  */
-export function getAgentOptions() {
+function getBaseAgentOptions() {
   return {
     connections: 8,
     keepAliveTimeout: 10_000,
-    // H2 is specifically incompatible with SvelteKit on Vercel prod. Everything else
-    // runs fine.
-    // TODO: Investigate/fix the failure on SvelteKit so we can re-enable H2.
-    allowH2: false,
     // HTTP/1.1 pipelining is disabled (pipelining: 1) because it causes
     // head-of-line blocking that deadlocks the webhook respondWith mechanism.
     pipelining: 1,
@@ -112,16 +112,128 @@ export function getAgentOptions() {
 }
 
 /**
+ * Options for the default undici Agent — the queue client (webhook
+ * respondWith), v3 `makeRequest`, deployment resolution, and run-key fetch.
+ * Exported (and read from the environment on each call) so tests can assert the
+ * transport configuration and exercise it against a real socket without
+ * duplicating the constants.
+ *
+ * HTTP/2 is intentionally OFF here: it deadlocks the webhook respondWith
+ * mechanism and hangs duplex streaming in Vercel Functions (observed as 120s
+ * E2E timeouts on the webhook/hook workflows). Only the events API and the
+ * stream write/close path, which use neither mechanism, opt into H2 — see
+ * getEventsAgentOptions.
+ */
+export function getAgentOptions() {
+  return {
+    ...getBaseAgentOptions(),
+    allowH2: false,
+  } as const;
+}
+
+/**
+ * Options for the events API undici Agent. Exported so tests can assert that
+ * HTTP/2 stays enabled.
+ *
+ * The v4 events endpoints are the hottest path (an event write per step
+ * transition, plus event-log reads on replay) and are plain request/response —
+ * or, for LIST, a streamed *response* — none of which trip the webhook /
+ * duplex-streaming H2 issues that keep the default agent on H1. Multiplexing
+ * removes per-request connection setup and head-of-line blocking here.
+ * Re-enabling H2 more broadly is gated on resolving those issues (notably the
+ * earlier SvelteKit-on-Vercel-prod hang, which is why bundled consumers need
+ * the `node:http2` require shim — see the nitro/sveltekit plugins).
+ */
+export function getEventsAgentOptions() {
+  return {
+    ...getBaseAgentOptions(),
+    allowH2: true,
+  } as const;
+}
+
+/**
+ * Retry policy shared by the default and events dispatchers.
+ *
+ * Built on each call because it embeds MAX_RETRIES alongside the
+ * environment-sensitive timeouts the codes below react to.
+ */
+function getRetryAgentOptions(): RetryHandler.RetryOptions {
+  return {
+    // Observe Retry-After header if received
+    retryAfter: true,
+    // Retry 5xx in-process (genuine transient blips recover fast), but NOT
+    // 429. The Vercel firewall issues a challenge as a 429: our
+    // server-to-server client cannot solve a challenge, so in-process
+    // retries just re-trigger it ~5× per request and amplify load against
+    // an already-overloaded firewall during an incident. Letting 429 pass
+    // through surfaces it immediately to makeRequest — which maps it to a
+    // ThrottleError carrying the `x-vercel-mitigated` / `x-vercel-id`
+    // headers — and the queue does the (backed-off) retry instead.
+    // (undici default is [500, 502, 503, 504, 429].)
+    statusCodes: [500, 502, 503, 504],
+    errorCodes: RETRY_ERROR_CODES,
+    maxRetries: MAX_RETRIES,
+  };
+}
+
+/**
+ * Retry options for stream writes (PUT). Stream appends are NOT idempotent, so
+ * we must never retry a write the server may already have applied. We therefore
+ * narrow undici's defaults to only the conditions that guarantee the request was
+ * rejected *before* the chunk was persisted:
+ *  - transient connection errors (undici's default `errorCodes`: ECONNRESET,
+ *    ECONNREFUSED, ENOTFOUND, …) — the request never reached, or was not
+ *    accepted by, the server, and
+ *  - HTTP 429 — the server rejected the request outright (rate limited), so no
+ *    chunk was written; honoring Retry-After backs off cleanly.
+ *
+ * Crucially, 5xx is excluded from the default `[500, 502, 503, 504, 429]`: a
+ * 5xx can mean the chunk *was* written but the response failed, and a retry
+ * would duplicate it. Other 4xx are client errors a retry can't fix. `methods`
+ * is pinned to PUT (the only stream-write verb) for clarity; `errorCodes` is
+ * left at undici's transient-network-error defaults — deliberately *without*
+ * RETRY_ERROR_CODES' two timeout codes, which are ambiguous about whether the
+ * server processed the request. Exported so a test can assert that 5xx never
+ * sneaks back into the retryable set.
+ */
+export const STREAM_RETRY_OPTIONS: RetryHandler.RetryOptions = {
+  retryAfter: true,
+  methods: ['PUT'],
+  statusCodes: [429],
+};
+
+/**
  * Resolves the undici dispatcher for a request: the caller's override, or the
- * shared default agent.
+ * shared default agent (HTTP/1.1).
  */
 export function getDispatcher(config?: APIConfig): unknown {
   return config?.dispatcher ?? getDefaultDispatcher();
 }
 
 /**
+ * Resolves the dispatcher for the v4 events API: the caller's override, or the
+ * shared HTTP/2 events agent. See getEventsAgentOptions for why the events API
+ * uses H2 while the default path stays on H1.
+ */
+export function getEventsDispatcher(config?: APIConfig): unknown {
+  return config?.dispatcher ?? getDefaultEventsDispatcher();
+}
+
+/**
+ * Resolves the dispatcher for stream writes (the PUT write/close path): the
+ * caller's override, or the shared HTTP/2 stream agent. See
+ * getDefaultStreamDispatcher (and STREAM_RETRY_OPTIONS) for its deliberately
+ * narrowed retry policy — transient connection errors + HTTP 429 only, never
+ * 5xx — chosen because stream appends are not idempotent.
+ */
+export function getStreamDispatcher(config?: APIConfig): unknown {
+  return config?.dispatcher ?? getDefaultStreamDispatcher();
+}
+
+/**
  * Returns a shared undici RetryAgent wrapping an Agent.
  *
+ * - HTTP/1.1 (see getAgentOptions)
  * - Connection pooling (up to 8 connections per origin)
  * - Timeouts: bounded time-to-first-byte and body-stall windows, replacing
  *   undici's 5-minute defaults
@@ -130,24 +242,42 @@ export function getDispatcher(config?: APIConfig): unknown {
  *   retries POST), observing the `Retry-After` header when present.
  */
 function getDefaultDispatcher(): RetryAgent {
-  if (!_dispatcher) {
-    const retryOptions: RetryHandler.RetryOptions = {
-      // Observe Retry-After header if received
-      retryAfter: true,
-      // Retry 5xx in-process (genuine transient blips recover fast), but NOT
-      // 429. The Vercel firewall issues a challenge as a 429: our
-      // server-to-server client cannot solve a challenge, so in-process
-      // retries just re-trigger it ~5× per request and amplify load against
-      // an already-overloaded firewall during an incident. Letting 429 pass
-      // through surfaces it immediately to makeRequest — which maps it to a
-      // ThrottleError carrying the `x-vercel-mitigated` / `x-vercel-id`
-      // headers — and the queue does the (backed-off) retry instead.
-      // (undici default is [500, 502, 503, 504, 429].)
-      statusCodes: [500, 502, 503, 504],
-      errorCodes: RETRY_ERROR_CODES,
-      maxRetries: MAX_RETRIES,
-    };
-    _dispatcher = new RetryAgent(new Agent(getAgentOptions()), retryOptions);
-  }
+  _dispatcher ??= new RetryAgent(
+    new Agent(getAgentOptions()),
+    getRetryAgentOptions()
+  );
   return _dispatcher;
+}
+
+/**
+ * Returns the shared HTTP/2 RetryAgent used by the v4 events API. Same retry /
+ * pooling / timeout behavior as the default dispatcher, but with `allowH2`
+ * enabled.
+ */
+function getDefaultEventsDispatcher(): RetryAgent {
+  _eventsDispatcher ??= new RetryAgent(
+    new Agent(getEventsAgentOptions()),
+    getRetryAgentOptions()
+  );
+  return _eventsDispatcher;
+}
+
+/**
+ * Returns the shared HTTP/2 RetryAgent used for stream writes (PUT write/close).
+ *
+ * Stream writes append chunks and are NOT idempotent, so this dispatcher uses a
+ * deliberately narrowed retry policy (see STREAM_RETRY_OPTIONS): it retries only
+ * on transient connection errors and HTTP 429 — both of which guarantee the
+ * chunk was not persisted — and never on 5xx or other 4xx, where a retry could
+ * duplicate an already-applied write. It opts into H2 (the write/close requests
+ * send a fully-buffered body, or none, so they don't hit the duplex-streaming H2
+ * issues that keep the long-lived live-read on plain `fetch`) by reusing the
+ * events agent's H2 / pooling options.
+ */
+function getDefaultStreamDispatcher(): RetryAgent {
+  _streamDispatcher ??= new RetryAgent(
+    new Agent(getEventsAgentOptions()),
+    STREAM_RETRY_OPTIONS
+  );
+  return _streamDispatcher;
 }

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -379,15 +379,15 @@ function contentLength(headers: unknown): number {
  *
  * 2. Streamed request body. `client-h2.js` also returns busy for a body that is
  *    a stream / async iterable, because such a body can error mid-flight and
- *    take unrelated in-flight requests down with it. events-v4 dispatches
- *    through undici's own `request()` with a materialized `Uint8Array`, so its
- *    bodies already arrive buffered and skip this branch; a caller that hands
- *    down a streamed body (as the global `fetch` does — it converts every body
- *    into an async iterable) would otherwise stay serialized. Draining it back
- *    into a Buffer restores the buffered-body shape undici needs, at the cost of
- *    one copy of an already-in-memory payload. Bodies without a usable
- *    `content-length`, or above H2_REBUFFER_MAX_BYTES, are passed through
- *    untouched (and stay serialized) rather than buffered blind.
+ *    take unrelated in-flight requests down with it. events-v4 hands us a fully
+ *    materialized `Uint8Array`, but it dispatches through the global `fetch`
+ *    (deliberately — that is what keeps v4 traffic visible in Vercel's outgoing
+ *    -requests view, see events-v4.ts), and `fetch` converts every body into an
+ *    async iterable on the way down. Draining it back into a Buffer restores the
+ *    buffered-body shape undici needs, at the cost of one copy of an
+ *    already-in-memory payload. Bodies without a usable `content-length`, or
+ *    above H2_REBUFFER_MAX_BYTES, are passed through untouched (and stay
+ *    serialized) rather than buffered blind.
  *
  * Without both of these, `pipelining` alone leaves the events agent at one
  * in-flight request per connection.

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -4,6 +4,7 @@ import type { APIConfig } from './utils.js';
 let _dispatcher: RetryAgent | undefined;
 let _eventsDispatcher: RetryAgent | undefined;
 let _streamDispatcher: RetryAgent | undefined;
+let _streamCloseDispatcher: RetryAgent | undefined;
 
 /**
  * Time-to-first-byte cap for every request through the shared dispatcher.
@@ -203,6 +204,27 @@ export const STREAM_RETRY_OPTIONS: RetryHandler.RetryOptions = {
 };
 
 /**
+ * Retry options for stream CLOSE (the `X-Stream-Done` PUT). Unlike chunk
+ * appends, close is idempotent on the server: a duplicate close of a completed
+ * stream early-returns, and the close-barrier protocol's durable `closing`
+ * fence is an if_not_exists stamp that a re-entered close resumes — so a 5xx
+ * whose effect may or may not have applied is safe to retry, and the server's
+ * close barrier *relies* on it: a transient reconciliation failure (or an
+ * unsafe close shape awaiting in-flight backups) is surfaced as a retriable
+ * 503 with the stream left durably closing, expecting the writer to close
+ * again. Without 5xx here, that 503 would reject `writer.close()` outright and
+ * leave the stream fenced until run expiry. 429 keeps the same
+ * pass-through-to-queue reasoning as chunk writes not applying: close is one
+ * terminal request, so honoring Retry-After in-process is the cleaner
+ * behavior. Exported so a test can pin the close-is-retriable contract.
+ */
+export const STREAM_CLOSE_RETRY_OPTIONS: RetryHandler.RetryOptions = {
+  retryAfter: true,
+  methods: ['PUT'],
+  statusCodes: [429, 500, 502, 503, 504],
+};
+
+/**
  * Resolves the undici dispatcher for a request: the caller's override, or the
  * shared default agent (HTTP/1.1).
  */
@@ -228,6 +250,15 @@ export function getEventsDispatcher(config?: APIConfig): unknown {
  */
 export function getStreamDispatcher(config?: APIConfig): unknown {
   return config?.dispatcher ?? getDefaultStreamDispatcher();
+}
+
+/**
+ * Resolves the dispatcher for stream CLOSE: the caller's override, or the
+ * shared close agent whose retry policy includes 5xx — close is idempotent
+ * (see STREAM_CLOSE_RETRY_OPTIONS), unlike chunk appends.
+ */
+export function getStreamCloseDispatcher(config?: APIConfig): unknown {
+  return config?.dispatcher ?? getDefaultStreamCloseDispatcher();
 }
 
 /**
@@ -280,4 +311,13 @@ function getDefaultStreamDispatcher(): RetryAgent {
     STREAM_RETRY_OPTIONS
   );
   return _streamDispatcher;
+}
+
+/** Shared agent for the idempotent stream close (5xx retriable). */
+function getDefaultStreamCloseDispatcher(): RetryAgent {
+  _streamCloseDispatcher ??= new RetryAgent(
+    new Agent(getEventsAgentOptions()),
+    STREAM_CLOSE_RETRY_OPTIONS
+  );
+  return _streamCloseDispatcher;
 }

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -118,9 +118,59 @@ function getBaseAgentOptions() {
  * In-flight H2 streams allowed per connection. Matches undici's
  * `maxConcurrentStreams` default (100), which is the real ceiling once the
  * server's SETTINGS_MAX_CONCURRENT_STREAMS is known — so this only has to be
- * large enough not to be the binding constraint.
+ * large enough not to be the binding constraint. The Vercel edge advertises
+ * SETTINGS_MAX_CONCURRENT_STREAMS 160, so it isn't.
+ *
+ * Note that undici's `maxConcurrentStreams` *option* is not this gate: it only
+ * seeds `peerMaxConcurrentStreams` at connect time and is then overwritten by
+ * the server's SETTINGS. Raising it is inert — measured at ±1.6% (inside a 6.1%
+ * noise floor) across every workload shape. `pipelining` is the only knob that
+ * actually gates in-flight streams; see getEventsAgentOptions.
  */
 const H2_MAX_IN_FLIGHT_STREAMS = 100;
+
+/**
+ * H2 *receive* flow-control windows for the events agent, in bytes.
+ *
+ * undici defaults to a 256 KiB stream window and a 512 KiB connection window.
+ * Both are far below the bandwidth-delay product of this path: a Vercel Function
+ * sees roughly 9 ms RTT to the edge (measured from iad1 against
+ * edge-terminated routes), so once a response exceeds the window the origin has
+ * to stop and wait for a WINDOW_UPDATE, costing a round trip per window's worth
+ * of body. Event-log reads on replay are exactly that shape.
+ *
+ * The two windows have to be raised together, because whichever is left small
+ * becomes the binding constraint on its own:
+ *  - a single read (one in-flight stream) is capped by the *stream* window;
+ *    raising only the connection window changes nothing.
+ *  - concurrent reads share the *connection* window; raising only the stream
+ *    window just relocates the stall to the connection level, and measured
+ *    slightly *worse* than leaving both alone.
+ * Measured against a loopback H2 origin mirroring the edge's SETTINGS at 10 ms
+ * RTT, these cut read wall time by 76–86% versus undici's defaults across 1, 4
+ * and 32 concurrent reads, against noise floors of 0.3–3.9%.
+ *
+ * Sizing: the stream window is what binds a single read, and 4 MiB captures that
+ * win in full (a 4 MiB page goes from 216 ms to 17 ms; 2 MiB only reaches 29 ms).
+ * That single-read shape is the one replay actually produces, since event-log
+ * pages are read sequentially and page size is server-driven with no byte cap, so
+ * a page carrying large step payloads can be multiple MiB. The connection window
+ * has to be several times the stream window or concurrent reads stall on it
+ * instead — at 32 concurrent reads 8 MiB is no better than 1 MiB/8 MiB while
+ * 16 MiB is 25% faster, and 32 MiB adds nothing further.
+ *
+ * Cost: a receive window is a ceiling on how many unacked bytes the origin may
+ * have in flight toward this process, so 8 connections x 16 MiB bounds the
+ * transport's worst-case buffering. Under an adversarial slow consumer (8
+ * concurrent 8 MiB bodies read one chunk per ms) peak RSS measured ~60–100 MiB
+ * above the smaller settings. It is a ceiling rather than an allocation, and only
+ * fills when the origin outruns the consumer; the events readers decode a whole
+ * response body anyway, so those bytes reach app memory either way. The write
+ * path is unaffected — receive windows don't govern uploads, and with four
+ * interleaved controls every setting lands within a 1.3% noise floor.
+ */
+const H2_STREAM_WINDOW_BYTES = 4 * 1024 * 1024;
+const H2_CONNECTION_WINDOW_BYTES = 16 * 1024 * 1024;
 
 /**
  * Options for the default undici Agent — the queue client (webhook
@@ -167,12 +217,23 @@ export function getAgentOptions() {
  * in-flight stream per connection. Before this was set, the H2 agent behaved
  * byte-for-byte like the H1 agent: 16 concurrent requests produced 8 in-flight
  * requests over 8 TCP connections. See nodejs/undici#4143.
+ *
+ * Multiplexing interacts with flow control, which is why the receive windows are
+ * raised here too. Concentrating N streams onto one connection makes them share
+ * that connection's single receive window, so the download side gets *worse* as
+ * multiplexing improves unless the window grows with it: at 32 concurrent reads,
+ * `pipelining: 1` measured 70% faster than `pipelining: 100` on downloads purely
+ * because spreading streams over 8 connections gave them 8 separate windows.
+ * Raising the windows removes that trade-off — the multiplexed agent then beats
+ * both.
  */
 export function getEventsAgentOptions() {
   return {
     ...getBaseAgentOptions(),
     allowH2: true,
     pipelining: H2_MAX_IN_FLIGHT_STREAMS,
+    initialWindowSize: H2_STREAM_WINDOW_BYTES,
+    connectionWindowSize: H2_CONNECTION_WINDOW_BYTES,
   } as const;
 }
 

--- a/packages/world-vercel/src/http-core.test.ts
+++ b/packages/world-vercel/src/http-core.test.ts
@@ -1,0 +1,125 @@
+import {
+  EntityConflictError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  errorForResponse,
+  formatVercelDiagnostics,
+  getVercelDiagnostics,
+  parseRetryAfter,
+  resolveVercelApiToken,
+} from './http-core.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn().mockRejectedValue(new Error('no OIDC')),
+}));
+
+describe('errorForResponse', () => {
+  // The runtime branches on these typed errors for core control flow, so the
+  // v3 and v4 paths must map status codes to the same types — this is the
+  // single source they both delegate to.
+  it('maps 409 to EntityConflictError', () => {
+    expect(errorForResponse(409, 'boom')).toBeInstanceOf(EntityConflictError);
+  });
+
+  it('maps 410 to RunExpiredError', () => {
+    expect(errorForResponse(410, 'boom')).toBeInstanceOf(RunExpiredError);
+  });
+
+  it('maps 425 to TooEarlyError carrying retryAfter', () => {
+    const err = errorForResponse(425, 'too early', { retryAfter: 7 });
+    expect(err).toBeInstanceOf(TooEarlyError);
+    expect((err as TooEarlyError).retryAfter).toBe(7);
+  });
+
+  it('maps 429 to ThrottleError carrying retryAfter', () => {
+    const err = errorForResponse(429, 'slow down', { retryAfter: 30 });
+    expect(err).toBeInstanceOf(ThrottleError);
+    expect((err as ThrottleError).retryAfter).toBe(30);
+  });
+
+  it('maps other statuses to WorkflowWorldError with status/code', () => {
+    const err = errorForResponse(404, 'not found', {
+      code: 'not_found',
+      url: 'http://x',
+    });
+    expect(err).toBeInstanceOf(WorkflowWorldError);
+    expect((err as WorkflowWorldError).status).toBe(404);
+    expect((err as WorkflowWorldError).code).toBe('not_found');
+    expect(err.message).toBe('not found');
+  });
+
+  it('treats 5xx as WorkflowWorldError (retryable, not a typed terminal)', () => {
+    const err = errorForResponse(503, 'unavailable');
+    expect(err).toBeInstanceOf(WorkflowWorldError);
+    expect((err as WorkflowWorldError).status).toBe(503);
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('parses integer seconds', () => {
+    expect(parseRetryAfter('30')).toBe(30);
+  });
+
+  it('returns undefined for missing or non-numeric values', () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+    expect(parseRetryAfter('')).toBeUndefined();
+    expect(parseRetryAfter('soon')).toBeUndefined();
+  });
+});
+
+describe('vercel diagnostics', () => {
+  function headers(init: Record<string, string>): Headers {
+    return new Headers(init);
+  }
+
+  it('extracts x-vercel-id and x-vercel-error when present', () => {
+    const h = headers({
+      'x-vercel-id': 'sfo1::abc',
+      'x-vercel-error': 'FUNCTION_INVOCATION_FAILED',
+    });
+    expect(getVercelDiagnostics(h)).toEqual([
+      'x-vercel-id=sfo1::abc',
+      'x-vercel-error=FUNCTION_INVOCATION_FAILED',
+    ]);
+    expect(formatVercelDiagnostics(h)).toBe(
+      ' (x-vercel-id=sfo1::abc; x-vercel-error=FUNCTION_INVOCATION_FAILED)'
+    );
+  });
+
+  it('skips absent headers and formats nothing when none present', () => {
+    const h = headers({ 'x-vercel-id': 'sfo1::abc' });
+    expect(getVercelDiagnostics(h)).toEqual(['x-vercel-id=sfo1::abc']);
+    expect(formatVercelDiagnostics(headers({}))).toBe('');
+  });
+});
+
+describe('resolveVercelApiToken', () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('prefers an explicit token over env and OIDC', async () => {
+    process.env = { ...originalEnv, VERCEL_TOKEN: 'env-token' };
+    expect(await resolveVercelApiToken({ token: 'explicit' })).toBe('explicit');
+  });
+
+  it('falls back to VERCEL_TOKEN when no explicit token', async () => {
+    process.env = { ...originalEnv, VERCEL_TOKEN: 'env-token' };
+    expect(await resolveVercelApiToken()).toBe('env-token');
+  });
+
+  it('falls back to null when OIDC is unavailable and no token/env', async () => {
+    process.env = { ...originalEnv };
+    delete process.env.VERCEL_TOKEN;
+    expect(await resolveVercelApiToken()).toBeNull();
+  });
+});

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -1,0 +1,441 @@
+/**
+ * Shared HTTP request core for the world-vercel adapter.
+ *
+ * Every outgoing request from world-vercel goes through one of a few
+ * higher-level clients — the v3 `makeRequest`, the v4 events client, the
+ * streamer, and the direct Vercel-API calls (run-key / resolve-deployment).
+ * They differ in how they shape the *body* (CBOR + schema, binary frames, raw
+ * chunks, JSON), but they share the same cross-cutting envelope: an OTEL client
+ * span, trace-context injection, a cache-bust header, a request timeout,
+ * `DEBUG` logging, x-vercel diagnostic headers, and the status → typed-error
+ * mapping the runtime branches on.
+ *
+ * This module is the single source of truth for that envelope. It depends only
+ * on `telemetry.js`, `@workflow/errors`, and `@vercel/oidc` so it can be
+ * imported by both `utils.ts` and `events-v4.ts` without an import cycle —
+ * dispatchers are passed in by the caller rather than imported here.
+ */
+
+import { getVercelOidcToken } from '@vercel/oidc';
+import {
+  EntityConflictError,
+  PreconditionFailedError,
+  RunExpiredError,
+  ThrottleError,
+  TooEarlyError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import {
+  ErrorType,
+  getSpanKind,
+  HttpRequestMethod,
+  HttpResponseStatusCode,
+  injectTraceContextIntoHeaders,
+  PeerService,
+  RpcService,
+  RpcSystem,
+  ServerAddress,
+  ServerPort,
+  trace,
+  UrlFull,
+} from './telemetry.js';
+
+/**
+ * Per-request timeout for HTTP calls to workflow-server (in ms).
+ *
+ * Without this, a hung workflow-server response would keep the caller blocked
+ * until the platform's `maxDuration` SIGTERM — burning compute and defeating
+ * upstream timeout handlers (e.g. the replay timeout).
+ *
+ * This is the outer backstop, not the first line of defense: the shared
+ * dispatcher's `headersTimeout`/`bodyTimeout` fire earlier (see http-client.ts)
+ * and produce a typed, retryable `UND_ERR_*_TIMEOUT` instead of the opaque
+ * abort this deadline raises. Keep it above those so the ordering holds — it
+ * still covers the whole request (including retries the dispatcher performs
+ * internally, and time spent outside undici's own timers).
+ */
+export const REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Lightweight debug logger toggle for HTTP requests. Activated when the DEBUG
+ * env var contains "workflow:" or is "*".
+ *
+ * Note: this does not implement full `debug` module semantics (e.g.
+ * comma-separated globs, negation with `-`). It is a simple check sufficient
+ * for enabling HTTP-level debug output.
+ */
+export const HTTP_DEBUG_ENABLED =
+  typeof process !== 'undefined' &&
+  typeof process.env.DEBUG === 'string' &&
+  (process.env.DEBUG.includes('workflow:') || process.env.DEBUG === '*');
+
+/** Diagnostic response headers worth surfacing in logs and error messages.
+ * `x-vercel-mitigated` (`challenge` | `deny`) is set by the Vercel firewall
+ * when it intercepts a request in front of the backend — surfacing it makes a
+ * firewall block diagnosable from the error message and DEBUG logs. */
+const DIAGNOSTIC_HEADERS = [
+  'x-vercel-id',
+  'x-vercel-error',
+  'x-vercel-mitigated',
+] as const;
+
+/**
+ * Extract the Vercel diagnostic response headers (x-vercel-id /
+ * x-vercel-error / x-vercel-mitigated) as `key=value` strings, skipping any
+ * that are absent.
+ */
+export function getVercelDiagnostics(headers: Headers): string[] {
+  return DIAGNOSTIC_HEADERS.flatMap((header) => {
+    const value = headers.get(header);
+    return value ? [`${header}=${value}`] : [];
+  });
+}
+
+/**
+ * Format the Vercel diagnostic headers as a ` (a=b; c=d)` suffix for error
+ * messages, or an empty string when none are present.
+ */
+export function formatVercelDiagnostics(headers: Headers): string {
+  const diagnostics = getVercelDiagnostics(headers);
+  return diagnostics.length > 0 ? ` (${diagnostics.join('; ')})` : '';
+}
+
+/**
+ * One-line request log, emitted only when HTTP debug is enabled. `label` is a
+ * short request identifier (an endpoint path or full URL).
+ */
+export function httpLog(
+  method: string,
+  label: string,
+  response: Response,
+  ms: number
+): void {
+  if (!HTTP_DEBUG_ENABLED) return;
+  const diagnostics = getVercelDiagnostics(response.headers);
+  const suffix = diagnostics.length > 0 ? `; ${diagnostics.join('; ')}` : '';
+  console.debug(
+    `[workflow:world-vercel:http] ${method} ${label} -> ${response.status} (${ms}ms${suffix})`
+  );
+}
+
+/**
+ * On a failed request with `DEBUG` set, print a copy-pasteable `curl` that
+ * reproduces it (authorization header stripped). Separate from
+ * HTTP_DEBUG_ENABLED so any DEBUG value opts in, matching the original v3
+ * behavior.
+ */
+export function logCurlRepro(
+  method: string,
+  url: string,
+  headers: Headers
+): void {
+  if (!process.env.DEBUG) return;
+  const stringifiedHeaders = Array.from(headers.entries())
+    .filter(([key]) => key.toLowerCase() !== 'authorization')
+    .map(([key, value]) => `-H "${key}: ${value}"`)
+    .join(' ');
+  console.error(
+    `Failed to fetch, reproduce with:\ncurl -X ${method} ${stringifiedHeaders} "${url}"`
+  );
+}
+
+/** Parse a `Retry-After` header value (seconds). Used by 425 and 429. */
+export function parseRetryAfter(
+  value: string | null | undefined
+): number | undefined {
+  if (!value) return undefined;
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Build the typed error for a non-2xx response. This is the single source of
+ * truth for the status → error-type contract the runtime branches on:
+ *
+ *   - 409 → EntityConflictError (start() dedupe, terminal-state transitions)
+ *   - 410 → RunExpiredError (runtime exits without retrying)
+ *   - 412 → PreconditionFailedError + retryAfter (stale `stateUpdatedAt`
+ *     snapshot — the optimistic-concurrency guard on event creation)
+ *   - 425 → TooEarlyError + retryAfter (step retry pacing — see #1806 for what
+ *     happens when a 425 degrades into an untyped error)
+ *   - 429 → ThrottleError + retryAfter, EXCEPT a firewall challenge (429 +
+ *     `x-vercel-mitigated: challenge`) → retryable transport WorkflowWorldError
+ *     (`code: 'TRANSPORT'`); see isFirewallChallenge429
+ *   - anything else → WorkflowWorldError with `status` (the hook 404 →
+ *     HookNotFoundError translation in events.ts keys off status === 404)
+ *
+ * Returns the error rather than throwing so callers can `throw` it inside a
+ * span helper or pass it through a `buildError` callback.
+ */
+export function errorForResponse(
+  status: number,
+  message: string,
+  opts: {
+    retryAfter?: number;
+    code?: string;
+    url?: string;
+    mitigated?: string | null;
+  } = {}
+): Error {
+  const { retryAfter, code, url, mitigated } = opts;
+  if (status === 409) return new EntityConflictError(message);
+  if (status === 410) return new RunExpiredError(message);
+  if (status === 412)
+    return new PreconditionFailedError(message, { retryAfter });
+  if (status === 425) return new TooEarlyError(message, { retryAfter });
+  if (status === 429) {
+    // A firewall challenge can't be solved by a server-to-server client, so map
+    // it to the retryable transport path instead of ThrottleError — see
+    // isFirewallChallenge429. A genuine application 429 stays a ThrottleError.
+    if (isFirewallChallenge429(status, mitigated)) {
+      return new WorkflowWorldError(
+        `${message} (x-vercel-mitigated=challenge)`,
+        {
+          url,
+          status,
+          code: 'TRANSPORT',
+          retryAfter,
+        }
+      );
+    }
+    return new ThrottleError(message, { retryAfter });
+  }
+  return new WorkflowWorldError(message, { url, status, code, retryAfter });
+}
+
+/**
+ * The Vercel firewall answers an intercepted request with HTTP 429 and
+ * `x-vercel-mitigated: challenge`. A challenge is meant to be solved by a
+ * browser, which our server-to-server client can't do, so the 429 recurs for
+ * the life of the incident.
+ *
+ * Such a 429 must NOT surface as a `ThrottleError`: on the `step_started` write
+ * the runtime defers a `ThrottleError` by self-enqueuing a FRESH queue message,
+ * which resets the delivery count — so it never backs off past `retryAfter` and
+ * never reaches `MAX_QUEUE_DELIVERIES`, hot-looping against an already-overloaded
+ * firewall. Mapping it to a retryable transport `WorkflowWorldError` (`code:
+ * 'TRANSPORT'`) instead lets the runtime rethrow it to the queue handler —
+ * earning the delivery-count backoff AND the delivery cap.
+ */
+export function isFirewallChallenge429(
+  status: number,
+  mitigated: string | null | undefined
+): boolean {
+  return status === 429 && mitigated === 'challenge';
+}
+
+/**
+ * Resolve the auth token for a direct Vercel-API call (run-key,
+ * resolve-deployment). Prefers an explicit token (CLI / config), then
+ * `VERCEL_TOKEN` (external tooling), then the per-request OIDC token (runtime).
+ * OIDC is last to avoid an unnecessary network call when a token is already
+ * available.
+ */
+export async function resolveVercelApiToken(opts?: {
+  token?: string;
+}): Promise<string | null> {
+  return (
+    opts?.token ??
+    process.env.VERCEL_TOKEN ??
+    (await getVercelOidcToken().catch(() => null))
+  );
+}
+
+/** Parse the server address/port from a URL for OTEL span attributes. */
+function parseServer(url: string): {
+  serverAddress?: string;
+  serverPort?: number;
+} {
+  try {
+    const parsed = new URL(url);
+    return {
+      serverAddress: parsed.hostname,
+      serverPort: parsed.port
+        ? parseInt(parsed.port, 10)
+        : parsed.protocol === 'https:'
+          ? 443
+          : 80,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Standard OTEL client-span attributes for an HTTP request. Shared by
+ * `instrumentedFetch` and the v3 `makeRequest` envelope so both report the
+ * same shape. `peerService` doubles as the rpc.service label (Datadog service
+ * maps); pass 'workflow-server' for backend calls and 'vercel-api' for direct
+ * api.vercel.com calls.
+ */
+export function httpClientSpanAttributes(args: {
+  method: string;
+  url: string;
+  peerService: string;
+}): Record<string, string | number> {
+  const { method, url, peerService } = args;
+  const { serverAddress, serverPort } = parseServer(url);
+  return {
+    ...HttpRequestMethod(method),
+    ...UrlFull(url),
+    ...(serverAddress ? ServerAddress(serverAddress) : {}),
+    ...(serverPort ? ServerPort(serverPort) : {}),
+    ...PeerService(peerService),
+    ...RpcSystem('http'),
+    ...RpcService(peerService),
+  };
+}
+
+export interface InstrumentedFetchOptions {
+  method: string;
+  url: string;
+  headers: Headers;
+  body?: Uint8Array | string;
+  /** Undici dispatcher (typed `unknown`; see APIConfig.dispatcher). */
+  dispatcher: unknown;
+  /**
+   * OTEL peer/rpc service label. 'workflow-server' for backend calls (default),
+   * 'vercel-api' for direct api.vercel.com calls.
+   */
+  peerService?: string;
+  /**
+   * Per-request timeout in ms. Defaults to REQUEST_TIMEOUT_MS. Pass `null` to
+   * disable (e.g. stream writes, which buffer arbitrarily large bodies).
+   */
+  timeoutMs?: number | null;
+  /** Optional caller abort signal, composed with the timeout. */
+  signal?: AbortSignal;
+  /** Inject W3C trace context onto the request headers. Default true. */
+  injectTraceContext?: boolean;
+  /** Set the X-Request-Time cache-bust header. Default true. */
+  cacheBust?: boolean;
+  /** Short label for logs (endpoint path). Defaults to the full URL. */
+  logLabel?: string;
+  /**
+   * Build the error to throw on a non-2xx response. Receives the raw Response
+   * so the caller can read its body in the right format and craft a path-
+   * specific message (the message *strings* legitimately differ per API
+   * version). May return an Error or throw directly. When omitted, a generic
+   * WorkflowWorldError is built from the status line + body text via
+   * `errorForResponse`.
+   */
+  buildError?: (response: Response) => Error | Promise<Error>;
+}
+
+/**
+ * Issue a single instrumented request through the global `fetch` (so Vercel's
+ * observability "outgoing requests" view picks it up) with a caller-supplied
+ * undici dispatcher.
+ *
+ * Handles the shared envelope — OTEL client span + attributes, trace-context
+ * injection, cache-bust header, timeout (mapping TimeoutError/AbortError to
+ * WorkflowWorldError), `DEBUG` logging, and the non-2xx error path (span error
+ * attribute + curl-repro + typed error). Returns the raw `Response` on success
+ * so the caller can consume the body in its own format.
+ */
+export async function instrumentedFetch(
+  opts: InstrumentedFetchOptions
+): Promise<Response> {
+  const {
+    method,
+    url,
+    headers,
+    body,
+    dispatcher,
+    peerService = 'workflow-server',
+    timeoutMs = REQUEST_TIMEOUT_MS,
+    signal: callerSignal,
+    injectTraceContext = true,
+    cacheBust = true,
+    logLabel,
+    buildError,
+  } = opts;
+  const label = logLabel ?? url;
+
+  return trace(
+    `http ${method}`,
+    { kind: await getSpanKind('CLIENT') },
+    async (span) => {
+      span?.setAttributes(
+        httpClientSpanAttributes({ method, url, peerService })
+      );
+
+      // Explicitly propagate trace context so the receiving server can parent
+      // its spans to this client span — the custom undici dispatcher bypasses
+      // ambient auto-instrumentation. No-ops when no OTEL SDK is registered.
+      if (injectTraceContext) await injectTraceContextIntoHeaders(headers);
+
+      // Unique header per attempt to bypass RSC/Next fetch memoization (and to
+      // avoid replaying a memoized truncated body). See:
+      // https://github.com/vercel/workflow/issues/618
+      if (cacheBust) headers.set('X-Request-Time', Date.now().toString());
+
+      const timeoutSignal =
+        timeoutMs != null ? AbortSignal.timeout(timeoutMs) : undefined;
+      const signal =
+        callerSignal && timeoutSignal
+          ? AbortSignal.any([callerSignal, timeoutSignal])
+          : (callerSignal ?? timeoutSignal);
+
+      const start = Date.now();
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method,
+          headers,
+          body,
+          signal,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+          dispatcher,
+        } as any);
+      } catch (error) {
+        const elapsed = Date.now() - start;
+        // AbortSignal.timeout() surfaces as a DOMException named 'TimeoutError'.
+        // Map to WorkflowWorldError so existing catch sites treat it like any
+        // other world transport failure.
+        if (
+          error instanceof Error &&
+          (error.name === 'TimeoutError' || error.name === 'AbortError')
+        ) {
+          const timeoutError = new WorkflowWorldError(
+            `${method} ${label} timed out after ${elapsed}ms`,
+            { url, cause: error }
+          );
+          span?.setAttributes({ ...ErrorType('TIMEOUT') });
+          span?.recordException?.(timeoutError);
+          throw timeoutError;
+        }
+        throw error;
+      }
+      const ms = Date.now() - start;
+
+      httpLog(method, label, response, ms);
+      span?.setAttributes({ ...HttpResponseStatusCode(response.status) });
+
+      if (!response.ok) {
+        span?.setAttributes({ ...ErrorType(`HTTP ${response.status}`) });
+        logCurlRepro(method, url, headers);
+        if (buildError) {
+          const error = await buildError(response);
+          span?.recordException?.(error);
+          throw error;
+        }
+        const text = await response.text().catch(() => '');
+        const error = errorForResponse(
+          response.status,
+          `${method} ${label} -> HTTP ${response.status}: ${response.statusText}${
+            text ? ` ${text}` : ''
+          }${formatVercelDiagnostics(response.headers)}`,
+          {
+            url,
+            retryAfter: parseRetryAfter(response.headers.get('Retry-After')),
+          }
+        );
+        span?.recordException?.(error);
+        throw error;
+      }
+
+      return response;
+    }
+  );
+}

--- a/packages/world-vercel/src/resolve-latest-deployment.test.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.test.ts
@@ -53,13 +53,10 @@ describe('createResolveLatestDeploymentId', () => {
     expect(result).toBe('dpl_latest_xyz789');
     expect(mockFetch).toHaveBeenCalledWith(
       'https://api.vercel.com/v1/workflow/resolve-latest-deployment/dpl_current_abc123',
-      expect.objectContaining({
-        method: 'GET',
-        headers: expect.objectContaining({
-          Authorization: 'Bearer test-token',
-        }),
-      })
+      expect.objectContaining({ method: 'GET' })
     );
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer test-token');
   });
 
   it('should throw when VERCEL_DEPLOYMENT_ID is not set', async () => {
@@ -112,12 +109,10 @@ describe('createResolveLatestDeploymentId', () => {
     expect(result).toBe('dpl_latest_from_env');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer env-token-123',
-        }),
-      })
+      expect.anything()
     );
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer env-token-123');
   });
 
   it('should use OIDC token when config token is absent and VERCEL_TOKEN is unset', async () => {
@@ -150,12 +145,10 @@ describe('createResolveLatestDeploymentId', () => {
     expect(result).toBe('dpl_latest_from_oidc');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer oidc-token-456',
-        }),
-      })
+      expect.anything()
     );
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer oidc-token-456');
   });
 
   it('should throw on non-ok HTTP response', async () => {

--- a/packages/world-vercel/src/resolve-latest-deployment.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.ts
@@ -6,9 +6,9 @@
  * deployments) as the provided current deployment.
  */
 
-import { getVercelOidcToken } from '@vercel/oidc';
 import * as z from 'zod';
 import { getDispatcher } from './http-client.js';
+import { instrumentedFetch, resolveVercelApiToken } from './http-core.js';
 import type { APIConfig } from './utils.js';
 
 const ResolveLatestDeploymentResponseSchema = z.object({
@@ -35,14 +35,7 @@ export function createResolveLatestDeploymentId(
       );
     }
 
-    // Authenticate via provided token (CLI/config), VERCEL_TOKEN env var
-    // (external tooling), or OIDC token (runtime) — in that order.
-    // OIDC is last to avoid an unnecessary network call when a token is
-    // already available (e.g. CLI or CI contexts).
-    const token =
-      config?.token ??
-      process.env.VERCEL_TOKEN ??
-      (await getVercelOidcToken().catch(() => null));
+    const token = await resolveVercelApiToken(config);
     if (!token) {
       throw new Error(
         'Cannot resolve latest deployment: no OIDC token or VERCEL_TOKEN available'
@@ -51,27 +44,30 @@ export function createResolveLatestDeploymentId(
 
     const url = `https://api.vercel.com/v1/workflow/resolve-latest-deployment/${encodeURIComponent(currentDeploymentId)}`;
 
-    // 429/5xx retries are handled by the shared RetryAgent from getDispatcher()
-    const response = await fetch(url, {
+    // 429/5xx retries are handled by the shared RetryAgent from getDispatcher().
+    // instrumentedFetch adds the OTEL client span + DEBUG logging the v3/v4
+    // paths have.
+    const response = await instrumentedFetch({
       method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      // @ts-expect-error -- undici dispatcher is accepted by Node.js fetch but not in @types/node's RequestInit
+      url,
+      headers: new Headers({ Authorization: `Bearer ${token}` }),
       dispatcher: getDispatcher(config),
+      peerService: 'vercel-api',
+      // Preserve the prior no-timeout behavior for this Vercel-API call; the
+      // shared RetryAgent still handles transient/5xx retries.
+      timeoutMs: null,
+      buildError: async (res) => {
+        let body: string;
+        try {
+          body = await res.text();
+        } catch {
+          body = '<unable to read response body>';
+        }
+        return new Error(
+          `Failed to resolve latest deployment for ${currentDeploymentId}: HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`
+        );
+      },
     });
-
-    if (!response.ok) {
-      let body: string;
-      try {
-        body = await response.text();
-      } catch {
-        body = '<unable to read response body>';
-      }
-      throw new Error(
-        `Failed to resolve latest deployment for ${currentDeploymentId}: HTTP ${response.status} ${response.statusText}${body ? ` — ${body}` : ''}`
-      );
-    }
 
     const data = await response.json();
     const result = ResolveLatestDeploymentResponseSchema.safeParse(data);

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -5,7 +5,10 @@ import type {
   StreamInfoResponse,
 } from '@workflow/world';
 import { z } from 'zod';
-import { getStreamDispatcher } from './http-client.js';
+import {
+  getStreamCloseDispatcher,
+  getStreamDispatcher,
+} from './http-client.js';
 import {
   type APIConfig,
   getHttpConfig,
@@ -21,16 +24,20 @@ export const MAX_CHUNKS_PER_REQUEST = 1000;
 const DEFAULT_STREAM_MUTATION_TIMEOUT_MS = 30_000;
 
 // Stream writes (the PUT write/close path) go through the H2 stream
-// dispatcher (see getStreamDispatcher): they send a fully-buffered body (or
-// none), so they benefit from H2 multiplexing without hitting the duplex
-// issues that keep the long-lived live-read (GET) on plain fetch. Because
-// stream appends aren't idempotent, that stream dispatcher uses a deliberately
-// narrowed retry policy (see STREAM_RETRY_OPTIONS): it retries only on
-// transient connection errors and HTTP 429 — both of which guarantee the chunk
-// was never persisted — and never on 5xx, so a retry can't duplicate an
-// already-applied write. Snapshot reads (chunks/info) go
-// through makeRequest (default H1 dispatcher); the live-read and list use
-// plain fetch().
+// dispatchers: they send a fully-buffered body (or none), so they benefit from
+// H2 multiplexing without hitting the duplex issues that keep the long-lived
+// live-read (GET) on plain fetch. The two mutations have different retry
+// policies because they differ in idempotency:
+//  - chunk appends are NOT idempotent, so getStreamDispatcher's policy (see
+//    STREAM_RETRY_OPTIONS) retries only on transient connection errors and
+//    HTTP 429 — both of which guarantee the chunk was never persisted — and
+//    never on 5xx, so a retry can't duplicate an already-applied write.
+//  - close IS idempotent, so getStreamCloseDispatcher's policy (see
+//    STREAM_CLOSE_RETRY_OPTIONS) also retries 5xx; the server's close-barrier
+//    protocol relies on that, surfacing transient reconciliation states as
+//    retriable 503s with the stream left durably closing.
+// Snapshot reads (chunks/info) go through makeRequest (default H1 dispatcher);
+// the live-read and list use plain fetch().
 
 function getStreamUrl(
   name: string,
@@ -67,10 +74,15 @@ async function fetchStreamMutation(
     return await fetch(url, {
       ...init,
       signal: AbortSignal.timeout(timeoutMs),
-      // Stream mutations go through the dedicated H2 stream dispatcher rather
-      // than the global agent — see the note at the top of this file.
+      // Stream mutations go through the dedicated H2 stream dispatchers rather
+      // than the global agent — see the note at the top of this file. Close is
+      // idempotent (unlike chunk appends), so it gets the dispatcher that
+      // retries 5xx, which the server's close-barrier protocol depends on.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici's dispatcher option isn't in @types/node's RequestInit
-      dispatcher: getStreamDispatcher(config),
+      dispatcher:
+        operation === 'close'
+          ? getStreamCloseDispatcher(config)
+          : getStreamDispatcher(config),
     } as any);
   } catch (err) {
     if (

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -9,6 +9,7 @@ import {
   getStreamCloseDispatcher,
   getStreamDispatcher,
 } from './http-client.js';
+import { getVercelDiagnostics, instrumentedFetch } from './http-core.js';
 import {
   type APIConfig,
   getHttpConfig,
@@ -23,11 +24,15 @@ import {
 export const MAX_CHUNKS_PER_REQUEST = 1000;
 const DEFAULT_STREAM_MUTATION_TIMEOUT_MS = 30_000;
 
+// All stream requests share the instrumented envelope (`instrumentedFetch`):
+// an OTEL client span, trace-context injection, `DEBUG` logging, and the
+// x-vercel diagnostic headers — the same coverage the v3/v4 paths have.
+//
 // Stream writes (the PUT write/close path) go through the H2 stream
 // dispatchers: they send a fully-buffered body (or none), so they benefit from
 // H2 multiplexing without hitting the duplex issues that keep the long-lived
-// live-read (GET) on plain fetch. The two mutations have different retry
-// policies because they differ in idempotency:
+// live-read (GET) on the global dispatcher. The two mutations have different
+// retry policies because they differ in idempotency:
 //  - chunk appends are NOT idempotent, so getStreamDispatcher's policy (see
 //    STREAM_RETRY_OPTIONS) retries only on transient connection errors and
 //    HTTP 429 — both of which guarantee the chunk was never persisted — and
@@ -37,7 +42,9 @@ const DEFAULT_STREAM_MUTATION_TIMEOUT_MS = 30_000;
 //    protocol relies on that, surfacing transient reconciliation states as
 //    retriable 503s with the stream left durably closing.
 // Snapshot reads (chunks/info) go through makeRequest (default H1 dispatcher);
-// the live-read and list use plain fetch().
+// the live-read (GET) and list keep the global dispatcher (no custom retry) and
+// no request timeout — the live read is long-lived and a whole-request deadline
+// would truncate it.
 
 function getStreamUrl(
   name: string,
@@ -63,38 +70,41 @@ function getStreamMutationTimeoutMs() {
   return DEFAULT_STREAM_MUTATION_TIMEOUT_MS;
 }
 
+/**
+ * Issue an instrumented stream mutation (a `write` or `close` PUT), throwing on
+ * a non-2xx and draining the response body so undici can release the pooled
+ * connection.
+ *
+ * The per-request deadline is handed to `instrumentedFetch`, which raises a
+ * typed, retryable `WorkflowWorldError` on expiry instead of the opaque
+ * `AbortError` that a bare `AbortSignal.timeout` surfaces.
+ */
 async function fetchStreamMutation(
   url: URL,
-  init: RequestInit,
+  init: { method: string; headers: Headers; body?: string | Uint8Array },
   operation: 'write' | 'close',
   config?: APIConfig
-) {
-  const timeoutMs = getStreamMutationTimeoutMs();
-  try {
-    return await fetch(url, {
-      ...init,
-      signal: AbortSignal.timeout(timeoutMs),
-      // Stream mutations go through the dedicated H2 stream dispatchers rather
-      // than the global agent — see the note at the top of this file. Close is
-      // idempotent (unlike chunk appends), so it gets the dispatcher that
-      // retries 5xx, which the server's close-barrier protocol depends on.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici's dispatcher option isn't in @types/node's RequestInit
-      dispatcher:
-        operation === 'close'
-          ? getStreamCloseDispatcher(config)
-          : getStreamDispatcher(config),
-    } as any);
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      (err.name === 'AbortError' || err.name === 'TimeoutError')
-    ) {
-      throw new Error(`Stream ${operation} timed out after ${timeoutMs}ms`, {
-        cause: err,
-      });
-    }
-    throw err;
-  }
+): Promise<void> {
+  const response = await instrumentedFetch({
+    method: init.method,
+    url: url.toString(),
+    headers: init.headers,
+    body: init.body,
+    // Stream mutations go through the dedicated H2 stream dispatchers rather
+    // than the global agent — see the note at the top of this file. Close is
+    // idempotent (unlike chunk appends), so it gets the dispatcher that
+    // retries 5xx, which the server's close-barrier protocol depends on.
+    dispatcher:
+      operation === 'close'
+        ? getStreamCloseDispatcher(config)
+        : getStreamDispatcher(config),
+    timeoutMs: getStreamMutationTimeoutMs(),
+    logLabel: url.pathname,
+    buildError: async (res) =>
+      createStreamRequestError(operation, url, res, await res.text()),
+  });
+  // Drain the (empty) response so undici can release the pooled connection.
+  await response.text();
 }
 
 function createStreamRequestError(
@@ -103,13 +113,10 @@ function createStreamRequestError(
   response: Response,
   text: string
 ): Error {
-  const context = [`PUT ${url.origin}${url.pathname}`];
-  for (const header of ['x-vercel-id', 'x-vercel-error']) {
-    const value = response.headers.get(header);
-    if (value) {
-      context.push(`${header}=${value}`);
-    }
-  }
+  const context = [
+    `PUT ${url.origin}${url.pathname}`,
+    ...getVercelDiagnostics(response.headers),
+  ];
 
   return new Error(
     `Stream ${operation} failed: HTTP ${response.status} (${context.join('; ')}): ${text}`
@@ -188,7 +195,7 @@ export function createStreamer(config?: APIConfig): Streamer {
 
       const httpConfig = await getHttpConfig(config);
       const url = getStreamUrl(name, resolvedRunId, httpConfig);
-      const response = await fetchStreamMutation(
+      await fetchStreamMutation(
         url,
         {
           method: 'PUT',
@@ -198,10 +205,6 @@ export function createStreamer(config?: APIConfig): Streamer {
         'write',
         config
       );
-      const text = await response.text();
-      if (!response.ok) {
-        throw createStreamRequestError('write', url, response, text);
-      }
     },
 
     async writeToStreamMulti(
@@ -231,7 +234,7 @@ export function createStreamer(config?: APIConfig): Streamer {
         const batch = chunks.slice(i, i + MAX_CHUNKS_PER_REQUEST);
         const body = encodeMultiChunks(batch);
         const url = getStreamUrl(name, resolvedRunId, httpConfig);
-        const response = await fetchStreamMutation(
+        await fetchStreamMutation(
           url,
           {
             method: 'PUT',
@@ -241,10 +244,6 @@ export function createStreamer(config?: APIConfig): Streamer {
           'write',
           config
         );
-        const text = await response.text();
-        if (!response.ok) {
-          throw createStreamRequestError('write', url, response, text);
-        }
       }
     },
 
@@ -255,7 +254,7 @@ export function createStreamer(config?: APIConfig): Streamer {
       const httpConfig = await getHttpConfig(config);
       httpConfig.headers.set('X-Stream-Done', 'true');
       const url = getStreamUrl(name, resolvedRunId, httpConfig);
-      const response = await fetchStreamMutation(
+      await fetchStreamMutation(
         url,
         {
           method: 'PUT',
@@ -264,10 +263,6 @@ export function createStreamer(config?: APIConfig): Streamer {
         'close',
         config
       );
-      const text = await response.text();
-      if (!response.ok) {
-        throw createStreamRequestError('close', url, response, text);
-      }
     },
 
     async readFromStream(name: string, startIndex?: number) {
@@ -281,13 +276,18 @@ export function createStreamer(config?: APIConfig): Streamer {
       // actually aborts the in-flight HTTP request instead of leaving
       // the socket hanging until the server times out.
       const abortController = new AbortController();
-      const response = await fetch(url, {
+      // Live read: keep the global dispatcher and no request timeout so the
+      // long-lived, reconnecting read isn't truncated.
+      const response = await instrumentedFetch({
+        method: 'GET',
+        url: url.toString(),
         headers: httpConfig.headers,
+        dispatcher: undefined,
+        timeoutMs: null,
         signal: abortController.signal,
+        logLabel: url.pathname,
+        buildError: (res) => new Error(`Failed to fetch stream: ${res.status}`),
       });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch stream: ${response.status}`);
-      }
       if (!response.body) {
         throw new Error('No response body for stream');
       }
@@ -358,12 +358,15 @@ export function createStreamer(config?: APIConfig): Streamer {
       const url = new URL(
         `${httpConfig.baseUrl}/v2/runs/${encodeURIComponent(runId)}/streams`
       );
-      const response = await fetch(url, {
+      const response = await instrumentedFetch({
+        method: 'GET',
+        url: url.toString(),
         headers: httpConfig.headers,
+        dispatcher: undefined,
+        timeoutMs: null,
+        logLabel: url.pathname,
+        buildError: (res) => new Error(`Failed to list streams: ${res.status}`),
       });
-      if (!response.ok) {
-        throw new Error(`Failed to list streams: ${response.status}`);
-      }
       return (await response.json()) as string[];
     },
   };

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -5,6 +5,7 @@ import type {
   StreamInfoResponse,
 } from '@workflow/world';
 import { z } from 'zod';
+import { getStreamDispatcher } from './http-client.js';
 import {
   type APIConfig,
   getHttpConfig,
@@ -19,10 +20,17 @@ import {
 export const MAX_CHUNKS_PER_REQUEST = 1000;
 const DEFAULT_STREAM_MUTATION_TIMEOUT_MS = 30_000;
 
-// Streaming calls use plain fetch() without the undici dispatcher.
-// The dispatcher's retry logic doesn't apply well to streaming operations
-// (partial writes, long-lived reads), and duplex streams are incompatible
-// with undici's experimental H2 support.
+// Stream writes (the PUT write/close path) go through the H2 stream
+// dispatcher (see getStreamDispatcher): they send a fully-buffered body (or
+// none), so they benefit from H2 multiplexing without hitting the duplex
+// issues that keep the long-lived live-read (GET) on plain fetch. Because
+// stream appends aren't idempotent, that stream dispatcher uses a deliberately
+// narrowed retry policy (see STREAM_RETRY_OPTIONS): it retries only on
+// transient connection errors and HTTP 429 — both of which guarantee the chunk
+// was never persisted — and never on 5xx, so a retry can't duplicate an
+// already-applied write. Snapshot reads (chunks/info) go
+// through makeRequest (default H1 dispatcher); the live-read and list use
+// plain fetch().
 
 function getStreamUrl(
   name: string,
@@ -51,14 +59,19 @@ function getStreamMutationTimeoutMs() {
 async function fetchStreamMutation(
   url: URL,
   init: RequestInit,
-  operation: 'write' | 'close'
+  operation: 'write' | 'close',
+  config?: APIConfig
 ) {
   const timeoutMs = getStreamMutationTimeoutMs();
   try {
     return await fetch(url, {
       ...init,
       signal: AbortSignal.timeout(timeoutMs),
-    });
+      // Stream mutations go through the dedicated H2 stream dispatcher rather
+      // than the global agent — see the note at the top of this file.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici's dispatcher option isn't in @types/node's RequestInit
+      dispatcher: getStreamDispatcher(config),
+    } as any);
   } catch (err) {
     if (
       err instanceof Error &&
@@ -170,7 +183,8 @@ export function createStreamer(config?: APIConfig): Streamer {
           body: chunk,
           headers: httpConfig.headers,
         },
-        'write'
+        'write',
+        config
       );
       const text = await response.text();
       if (!response.ok) {
@@ -212,7 +226,8 @@ export function createStreamer(config?: APIConfig): Streamer {
             body,
             headers: httpConfig.headers,
           },
-          'write'
+          'write',
+          config
         );
         const text = await response.text();
         if (!response.ok) {
@@ -234,7 +249,8 @@ export function createStreamer(config?: APIConfig): Streamer {
           method: 'PUT',
           headers: httpConfig.headers,
         },
-        'close'
+        'close',
+        config
       );
       const text = await response.text();
       if (!response.ok) {

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -87,6 +87,27 @@ export async function getSpanKind(
   return otel.SpanKind[field];
 }
 
+/**
+ * Injects the active trace context into the given request headers using the
+ * registered propagator (typically W3C `traceparent`/`tracestate` plus
+ * `baggage`). Call inside an active client span so the receiving server can
+ * parent its spans to it.
+ *
+ * No-ops when `@opentelemetry/api` is unavailable or no SDK/propagator is
+ * registered (the default no-op propagator injects nothing).
+ */
+export async function injectTraceContextIntoHeaders(
+  headers: Headers
+): Promise<void> {
+  const otel = await getOtelApi();
+  if (!otel) return;
+  const carrier: Record<string, string> = {};
+  otel.propagation.inject(otel.context.active(), carrier);
+  for (const [key, value] of Object.entries(carrier)) {
+    headers.set(key, value);
+  }
+}
+
 // Semantic conventions for World/Storage tracing
 // Standard OTEL conventions: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 function SemanticConvention<T>(...names: string[]) {

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -1,0 +1,212 @@
+import { context, trace as otelTrace, propagation } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { encode } from 'cbor-x';
+import { MockAgent } from 'undici';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { z } from 'zod';
+import { getWorkflowRunEventsV4 } from './events-v4.js';
+import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
+import { createStreamer } from './streamer.js';
+import { injectTraceContextIntoHeaders } from './telemetry.js';
+import { makeRequest } from './utils.js';
+
+vi.mock('@vercel/oidc', () => ({
+  getVercelOidcToken: vi.fn().mockRejectedValue(new Error('no OIDC')),
+}));
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+const contextManager = new AsyncLocalStorageContextManager();
+
+beforeAll(() => {
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+  otelTrace.setGlobalTracerProvider(provider);
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  context.disable();
+  propagation.disable();
+  otelTrace.disable();
+});
+
+afterEach(() => {
+  exporter.reset();
+  vi.unstubAllGlobals();
+});
+
+/** Minimal 2xx CBOR response, mirroring utils.test.ts. */
+function cborResponse(data: unknown) {
+  const bytes = encode(data);
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      get: (k: string) =>
+        k.toLowerCase() === 'content-type' ? 'application/cbor' : null,
+    },
+    arrayBuffer: async () =>
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  };
+}
+
+describe('injectTraceContextIntoHeaders', () => {
+  it('injects traceparent for the active span', async () => {
+    const tracer = otelTrace.getTracer('test');
+    await tracer.startActiveSpan('client', async (span) => {
+      const headers = new Headers();
+      await injectTraceContextIntoHeaders(headers);
+      expect(headers.get('traceparent')).toBe(
+        `00-${span.spanContext().traceId}-${span.spanContext().spanId}-01`
+      );
+      span.end();
+    });
+  });
+
+  it('is a no-op when there is no active span context', async () => {
+    const headers = new Headers();
+    await injectTraceContextIntoHeaders(headers);
+    expect(headers.get('traceparent')).toBeNull();
+  });
+});
+
+describe('makeRequest trace propagation', () => {
+  const schema = z.object({ value: z.string() });
+
+  it('sends traceparent on the outgoing workflow-server request, parented to the client span', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(cborResponse({ value: 'ok' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await makeRequest({
+      endpoint: '/v3/runs/wrun_test/events',
+      options: { method: 'GET' },
+      schema,
+    });
+    expect(result).toEqual({ value: 'ok' });
+
+    const request = fetchMock.mock.calls[0][0] as Request;
+    const traceparent = request.headers.get('traceparent');
+    expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    // The injected context must be the `http GET` CLIENT span created by
+    // makeRequest, so the server's spans become its children.
+    const clientSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'http GET');
+    expect(clientSpan).toBeDefined();
+    expect(traceparent).toBe(
+      `00-${clientSpan?.spanContext().traceId}-${clientSpan?.spanContext().spanId}-01`
+    );
+  });
+});
+
+describe('v4 event requests (fetchV4) trace propagation', () => {
+  it('sends traceparent on the outgoing v4 request, propagating the active context to workflow-server', async () => {
+    const origin = 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+    agent
+      .get(origin)
+      .intercept({ path: '/api/v4/runs/wrun_1/events', method: 'GET' })
+      .reply(200, encodeFrame({ _end: 1 }, new Uint8Array(0)), {
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+
+    // Spy passes through to the real fetch (MockAgent intercepts at the
+    // dispatcher layer) so we can read the headers fetchV4 actually sent.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const tracer = otelTrace.getTracer('test');
+    let traceId = '';
+    let spanId = '';
+    await tracer.startActiveSpan('flow-invocation', async (span) => {
+      traceId = span.spanContext().traceId;
+      spanId = span.spanContext().spanId;
+      await getWorkflowRunEventsV4(
+        'wrun_1',
+        {},
+        { token: 'test-token', dispatcher: agent }
+      );
+      span.end();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledInit = fetchSpy.mock.calls[0][1];
+    const sent = new Headers(calledInit?.headers as HeadersInit);
+    const traceparent = sent.get('traceparent');
+    // The v4 path issues its request through the shared instrumented envelope,
+    // so it opens its own `http GET` CLIENT span (a child of the
+    // flow-invocation span) and injects from inside it — matching the v3
+    // makeRequest path. Without that injection the header is absent and the
+    // backend cannot parent its spans to the flow-route invocation.
+    expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    const clientSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'http GET');
+    expect(clientSpan).toBeDefined();
+    expect(clientSpan?.spanContext().traceId).toBe(traceId);
+    expect(clientSpan?.parentSpanId).toBe(spanId);
+    expect(traceparent).toBe(
+      `00-${traceId}-${clientSpan?.spanContext().spanId}-01`
+    );
+    agent.assertNoPendingInterceptors();
+    fetchSpy.mockRestore();
+  });
+});
+
+describe('streamer write trace propagation', () => {
+  it('injects traceparent on the outgoing stream write, parented to the client span', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const streamer = createStreamer({ token: 'test-token' });
+
+    const tracer = otelTrace.getTracer('test');
+    let traceId = '';
+    let spanId = '';
+    await tracer.startActiveSpan('flow-invocation', async (span) => {
+      traceId = span.spanContext().traceId;
+      spanId = span.spanContext().spanId;
+      await streamer.writeToStream('user', 'wrun_1', 'chunk');
+      span.end();
+    });
+
+    const calledInit = fetchMock.mock.calls[0][1];
+    const sent = new Headers(calledInit?.headers as HeadersInit);
+    const traceparent = sent.get('traceparent');
+    // Stream writes ride the same instrumented envelope as the event paths, so
+    // the backend can correlate a write with the run that issued it.
+    expect(traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    const clientSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === 'http PUT');
+    expect(clientSpan).toBeDefined();
+    expect(clientSpan?.spanContext().traceId).toBe(traceId);
+    expect(clientSpan?.parentSpanId).toBe(spanId);
+    expect(traceparent).toBe(
+      `00-${traceId}-${clientSpan?.spanContext().spanId}-01`
+    );
+  });
+});

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -1,79 +1,30 @@
 import os from 'node:os';
 import { inspect } from 'node:util';
 import { getVercelOidcToken } from '@vercel/oidc';
-import {
-  EntityConflictError,
-  PreconditionFailedError,
-  RunExpiredError,
-  ThrottleError,
-  TooEarlyError,
-  WorkflowWorldError,
-} from '@workflow/errors';
+import { WorkflowWorldError } from '@workflow/errors';
 import { type StructuredError, StructuredErrorSchema } from '@workflow/world';
 import { decode, encode } from 'cbor-x';
 import type { z } from 'zod';
 import { getDispatcher } from './http-client.js';
 import {
+  errorForResponse,
+  formatVercelDiagnostics,
+  HTTP_DEBUG_ENABLED,
+  httpClientSpanAttributes,
+  httpLog,
+  logCurlRepro,
+  parseRetryAfter,
+  REQUEST_TIMEOUT_MS,
+} from './http-core.js';
+import {
   ErrorType,
   getSpanKind,
-  HttpRequestMethod,
   HttpResponseStatusCode,
-  PeerService,
-  RpcService,
-  RpcSystem,
-  ServerAddress,
-  ServerPort,
+  injectTraceContextIntoHeaders,
   trace,
-  UrlFull,
   WorldParseFormat,
 } from './telemetry.js';
 import { version } from './version.js';
-
-/**
- * Lightweight debug logger for HTTP requests. Activated when the DEBUG
- * env var contains "workflow:" or is "*".
- *
- * Note: this does not implement full `debug` module semantics (e.g.
- * comma-separated globs, negation with `-`). It is a simple check
- * sufficient for enabling HTTP-level debug output.
- */
-const HTTP_DEBUG_ENABLED =
-  typeof process !== 'undefined' &&
-  typeof process.env.DEBUG === 'string' &&
-  (process.env.DEBUG.includes('workflow:') || process.env.DEBUG === '*');
-
-function httpLog(
-  method: string,
-  endpoint: string,
-  response: Response,
-  ms: number
-): void {
-  if (HTTP_DEBUG_ENABLED) {
-    const responseContext = getResponseDiagnosticHeaders(response);
-    const diagnosticSuffix =
-      responseContext.length > 0 ? `; ${responseContext.join('; ')}` : '';
-    console.debug(
-      `[workflow:world-vercel:http] ${method} ${endpoint} -> ${response.status} (${ms}ms${diagnosticSuffix})`
-    );
-  }
-}
-
-function getResponseDiagnosticHeaders(response: Response): string[] {
-  // x-vercel-mitigated (challenge | deny) is set by the Vercel firewall when it
-  // intercepts a request in front of the backend — surfacing it makes a
-  // firewall block diagnosable from the error message and DEBUG logs.
-  return ['x-vercel-id', 'x-vercel-error', 'x-vercel-mitigated'].flatMap(
-    (header) => {
-      const value = response.headers.get(header);
-      return value ? [`${header}=${value}`] : [];
-    }
-  );
-}
-
-function formatResponseDiagnostics(response: Response): string {
-  const headers = getResponseDiagnosticHeaders(response);
-  return headers.length > 0 ? ` (${headers.join('; ')})` : '';
-}
 
 /**
  * Hard-coded workflow-server URL override for testing.
@@ -83,22 +34,6 @@ function formatResponseDiagnostics(response: Response): string {
  * Example: 'https://workflow-server-git-branch-name.vercel.sh'
  */
 const WORKFLOW_SERVER_URL_OVERRIDE = '';
-
-/**
- * Per-request timeout for HTTP calls to workflow-server (in ms).
- *
- * Without this, a hung workflow-server response would keep the caller
- * blocked until the platform's `maxDuration` SIGTERM — burning compute
- * and defeating upstream timeout handlers (e.g. the replay timeout).
- *
- * This is the outer backstop, not the first line of defense: the shared
- * dispatcher's `headersTimeout`/`bodyTimeout` fire earlier (see http-client.ts)
- * and produce a typed, retryable `UND_ERR_*_TIMEOUT` instead of the opaque
- * abort this deadline raises. Keep it above those so the ordering holds — it
- * still covers the whole request (including retries the dispatcher performs
- * internally, and time spent outside undici's own timers).
- */
-const REQUEST_TIMEOUT_MS = 60_000;
 
 /**
  * HTTP methods that are safe to transparently re-issue inside the adapter.
@@ -456,21 +391,6 @@ export async function makeRequest<T>({
   const { baseUrl, headers } = await getHttpConfig(config);
   const url = `${baseUrl}${endpoint}`;
 
-  // Parse server address and port from URL for OTEL attributes
-  let serverAddress: string | undefined;
-  let serverPort: number | undefined;
-  try {
-    const parsedUrl = new URL(url);
-    serverAddress = parsedUrl.hostname;
-    serverPort = parsedUrl.port
-      ? parseInt(parsedUrl.port, 10)
-      : parsedUrl.protocol === 'https:'
-        ? 443
-        : 80;
-  } catch {
-    // URL parsing failed, skip these attributes
-  }
-
   // Standard OTEL span name for HTTP client: "{method}"
   // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
   return trace(
@@ -478,18 +398,22 @@ export async function makeRequest<T>({
     { kind: await getSpanKind('CLIENT') },
     async (span) => {
       // Set standard OTEL HTTP client attributes
-      span?.setAttributes({
-        ...HttpRequestMethod(method),
-        ...UrlFull(url),
-        ...(serverAddress && ServerAddress(serverAddress)),
-        ...(serverPort && ServerPort(serverPort)),
-        // Peer service for Datadog service maps
-        ...PeerService('workflow-server'),
-        ...RpcSystem('http'),
-        ...RpcService('workflow-server'),
-      });
+      span?.setAttributes(
+        httpClientSpanAttributes({
+          method,
+          url,
+          peerService: 'workflow-server',
+        })
+      );
 
       headers.set('Accept', 'application/cbor');
+
+      // Explicitly propagate the active trace context (traceparent /
+      // tracestate / baggage) onto the outgoing request so the backend can
+      // parent its spans to this client span — without relying on the customer
+      // app having undici auto-instrumentation. No-ops when no OTEL SDK is
+      // registered.
+      await injectTraceContextIntoHeaders(headers);
 
       // Encode body as CBOR if data is provided
       let body: Buffer | undefined;
@@ -579,7 +503,7 @@ export async function makeRequest<T>({
         }
         const fetchMs = Date.now() - fetchStart;
 
-        responseDiagnostics = formatResponseDiagnostics(response);
+        responseDiagnostics = formatVercelDiagnostics(response.headers);
         httpLog(method, endpoint, response, fetchMs);
 
         span?.setAttributes({
@@ -591,87 +515,33 @@ export async function makeRequest<T>({
             await parseResponseBody(response)
               .then((r) => r.data as { message?: string; code?: string })
               .catch(() => ({}));
-          if (process.env.DEBUG) {
-            const stringifiedHeaders = Array.from(headers.entries())
-              .filter(([key]) => key.toLowerCase() !== 'authorization')
-              .map(([key, value]: [string, string]) => `-H "${key}: ${value}"`)
-              .join(' ');
-            console.error(
-              `Failed to fetch, reproduce with:\ncurl -X ${request.method} ${stringifiedHeaders} "${url}"`
-            );
-          }
+          logCurlRepro(request.method, url, headers);
 
-          // Parse Retry-After header (value is in seconds).
-          // Used by both 425 (TooEarlyError) and 429 (ThrottleError).
-          // The RetryAgent no longer retries 429 in-process (see
-          // http-client.ts), so every 429 reaches here.
-          let retryAfter: number | undefined;
-          const retryAfterHeader = response.headers.get('Retry-After');
-          if (retryAfterHeader) {
-            const parsed = parseInt(retryAfterHeader, 10);
-            if (!Number.isNaN(parsed)) {
-              retryAfter = parsed;
-            }
-          }
+          // Used by 425 and 429. The RetryAgent no longer retries 429
+          // in-process (see http-client.ts), so every 429 reaches here.
+          const retryAfter = parseRetryAfter(
+            response.headers.get('Retry-After')
+          );
 
           const defaultMessage =
             (errorData.message ||
               `${request.method} ${endpoint} -> HTTP ${response.status}: ${response.statusText}`) +
             responseDiagnostics;
 
-          // Map specific HTTP status codes to semantic error types
-          const throwWithTrace = (error: Error): never => {
-            span?.setAttributes({
-              ...ErrorType(errorData.code || `HTTP ${response.status}`),
-            });
-            span?.recordException?.(error);
-            throw error;
-          };
-
-          if (response.status === 409) {
-            throwWithTrace(new EntityConflictError(defaultMessage));
-          }
-          if (response.status === 410) {
-            throwWithTrace(new RunExpiredError(defaultMessage));
-          }
-          if (response.status === 412) {
-            throwWithTrace(
-              new PreconditionFailedError(defaultMessage, { retryAfter })
-            );
-          }
-          if (response.status === 425) {
-            throwWithTrace(new TooEarlyError(defaultMessage, { retryAfter }));
-          }
-          if (response.status === 429) {
-            // A firewall-challenge 429 (x-vercel-mitigated: challenge) can't be
-            // solved by a server-to-server client, so route it to the retryable
-            // transport path (TRANSPORT) instead of ThrottleError so the runtime
-            // backs off + caps rather than self-enqueuing a fresh message. A
-            // genuine application 429 stays a ThrottleError.
-            if (response.headers.get('x-vercel-mitigated') === 'challenge') {
-              throwWithTrace(
-                new WorkflowWorldError(
-                  `${defaultMessage} (x-vercel-mitigated=challenge)`,
-                  {
-                    url,
-                    status: response.status,
-                    code: 'TRANSPORT',
-                    retryAfter,
-                  }
-                )
-              );
-            }
-            throwWithTrace(new ThrottleError(defaultMessage, { retryAfter }));
-          }
-
-          throwWithTrace(
-            new WorkflowWorldError(defaultMessage, {
-              url,
-              status: response.status,
-              code: errorData.code,
-              retryAfter,
-            })
-          );
+          // Map the status to the typed error the runtime branches on (shared
+          // with the v4 path via errorForResponse). A firewall-challenge 429 is
+          // routed to the retryable transport path via `mitigated`.
+          const error = errorForResponse(response.status, defaultMessage, {
+            url,
+            code: errorData.code,
+            retryAfter,
+            mitigated: response.headers.get('x-vercel-mitigated'),
+          });
+          span?.setAttributes({
+            ...ErrorType(errorData.code || `HTTP ${response.status}`),
+          });
+          span?.recordException?.(error);
+          throw error;
         }
 
         // Expose response headers to caller before consuming the body

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -198,6 +198,13 @@ export interface APIConfig {
    * bundled with each `@types/node` major), so a concrete type would reject a
    * dispatcher from a different undici version. Callers may pass any undici
    * version's dispatcher, or any object implementing the dispatcher contract.
+   *
+   * Note: when provided, this dispatcher replaces *every* default — including
+   * the one used for stream writes (the `PUT` write/close path). Stream appends
+   * are not idempotent, and undici's `RetryAgent` retries `PUT` on 5xx by
+   * default, which can duplicate a chunk the server already persisted. A custom
+   * dispatcher used with stream writes should therefore not retry `PUT` on 5xx
+   * (the built-in stream dispatcher retries only on transient errors and 429).
    */
   dispatcher?: unknown;
   projectConfig?: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1296,6 +1296,15 @@ importers:
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
+      '@opentelemetry/context-async-hooks':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.0
@@ -4684,6 +4693,12 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/core@1.30.1':
     resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
@@ -17971,6 +17986,10 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -22335,7 +22354,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.6.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.3(@types/node@24.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.3(@types/node@22.19.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:


### PR DESCRIPTION
Backports the full HTTP/2 stack from `main` onto `stable`, so `stable` gets a working *and* optimized H2 transport rather than just the two most recent tuning PRs.

The two requested PRs (#3190, #3212) are no-ops without the groundwork — `stable` never had H2 enabled on the events path at all — so the prerequisite commits are included here.

## Commits (oldest first)

| Upstream | Change |
|---|---|
| #2573 | Enable HTTP/2 for the events API and stream writes; `node:http2` require shim for bundled consumers (`@workflow/nitro`, `@workflow/sveltekit`) |
| #2632 | Same `node:http2` shim for `@workflow/web`'s bundled server build (observability reads hung ~16s without it) |
| #2873 | Cancel the v4 event frame stream on early exit so the response body's connection returns to the pool |
| #3038 | Idempotent retry policy for stream close (5xx retriable; chunk appends keep their no-5xx policy) |
| #3190 | Make H2 actually multiplex on the events path |
| #3212 | Raise H2 receive windows on the events agent |
| — | Guard the `node:http2` require banner on `globalThis` (see below) |
| #2631 | Unify HTTP request handling into a shared `http-core` |

## Why the groundwork is needed

`allowH2: true` alone left the events agent behaving byte-for-byte like the H1 agent: 16 concurrent requests produced 8 serialized requests over 8 TCP connections. Three undici gates had to be lifted together (#3190):

1. `pipelining` — undici reads `client[kPipelining] ?? httpContext.defaultPipelining ?? 1`, and the `Client` constructor coerces `pipelining` to a number, so H2's `defaultPipelining: Infinity` is unreachable (nodejs/undici#4143).
2. `request.idempotent === false` marks the H2 connection busy for every POST (nodejs/undici#5390). An interceptor sets the flag for concurrency purposes only — `RetryAgent`'s default `methods` excludes POST, so event writes are still never replayed.
3. A streamed request body also marks the connection busy; the interceptor drains async-iterable bodies under 1 MiB back into a `Buffer`.

The interceptor is composed **outside** the `RetryAgent`, not inside: `RetryHandler` captures its own `wrapRequestBody` copy up front, so composed inside, a retry would re-iterate an exhausted stream and send an empty body. A test covers exactly that (`resends the full body when a re-buffered request is retried`).

Then #3212: multiplexing makes N streams share one connection's receive window, so the download side gets *worse* as multiplexing improves unless the window grows with it. Both windows are raised together (4 MiB stream / 16 MiB connection) — whichever is left at undici's default becomes the binding constraint on its own.

Kill switch: `WORKFLOW_H2_MULTIPLEX=0` reverts to one request per connection (documented in `docs/content/docs/deploying/world/vercel-world.mdx`).

## The require-banner guard

The H2 shim's banner tested `typeof require === 'undefined'` to decide whether to install a `createRequire` fallback. `stable`'s `packages/core/src/runtime/world.ts` declares a module-scope `const require = createRequire(...)`, which Rollup hoists into chunk scope, so the banner read it inside its TDZ and every Nitro-built workbench crashed at boot with `ReferenceError: Cannot access 'require' before initialization` (17 CI failures). Reading `typeof globalThis.require` instead cannot hit a TDZ. Verified by rebuilding `workbench/express` with the hoisted `const` still present and booting `.output/server/index.mjs` (manifest 200).

## #2631: included, not skipped

An earlier revision of this PR left #2631 out on the grounds that it was a pure refactor with no H2 benefit. That was wrong: on `stable` the v4 events path and the stream write path emit **no** OTEL client span and inject **no** `traceparent`, because they bypass the instrumented global `fetch` (`propagation.inject` is called nowhere in `world-vercel` on `stable`). Moving them onto the shared envelope is the mechanism that fixes that, so it is included here.

`http-core.ts` now owns the request envelope — CLIENT span + attributes, trace-context injection, `X-Request-Time` cache bust, the per-request deadline, `DEBUG` logging with a curl repro, and the status → typed-error mapping — and `utils.ts` / `events-v4.ts` / `streamer.ts` / `encryption.ts` / `resolve-latest-deployment.ts` delegate to it. That also removes the duplicated 412 → `PreconditionFailedError` and firewall-challenge-429 → retryable `TRANSPORT` mappings, which previously had to be kept in sync by hand between `utils.ts` and `events-v4.ts`.

Adapted rather than cherry-picked: `stable` keeps #3169's bounded headers/body timeouts (now documented as firing *ahead* of the outer `REQUEST_TIMEOUT_MS` backstop), its body-parse retry loop, and #3038's write-vs-close stream dispatcher split. Only `injectTraceContextIntoHeaders` is taken from #2363, not its `WORKFLOW_TRACE_MODE` machinery.

Side effect worth calling out: routing v4 through the global `fetch` makes interceptor gate 3 **live** on the event-write path (fetch streamifies every request body), where before it was defensive. `trace-propagation.test.ts` is authored for `stable` rather than picked, since `stable` has neither #2363's trace modes nor #2857's stream spans.

## Adaptations for `stable`

Every `http-client.ts` change is a hand-merge, not a clean pick: #3169 (bounded headers/body timeouts, `RETRY_ERROR_CODES`, `MAX_RETRIES`) exists only on `stable`, which keeps function-shaped, env-read-per-call agent options (`getAgentOptions()`, `getEventsAgentOptions()`, `getStreamAgentOptions()`) where `main` has frozen consts. Tests assert against those functions instead.

Two smaller drops: `packages/nitro`'s unused `isNitroV2` helper (unreferenced on `stable`), and the `v4 transport uses global fetch (observability)` test from #2873's diff (superseded — the v4 path now genuinely uses global fetch, and `trace-propagation.test.ts` asserts it).

## Verification

- `packages/world-vercel`: 242 tests pass across 16 files.
- New end-to-end multiplexing test drives the real `createWorkflowRunEventV4` (not a synthetic `fetch`) 16-wide against a loopback H2 server: **16 concurrent streams on one session** with the interceptor, **8** with `WORKFLOW_H2_MULTIPLEX=0` — i.e. the production call path, not just the transport, is covered.
- The rest of the multiplexing suite runs the same loopback server with an arrival barrier and asserts peak concurrent streams, that no new TLS session opens beyond the warmed one, and that stream-write appends stay bounded by the pool size (the inverse guard).
- `pnpm typecheck`: 40/40 tasks green.
- `biome check` clean on all touched files. The 3 remaining `noExcessiveCognitiveComplexity` warnings all pre-exist upstream — and `utils.ts`'s drops from 84 on `stable` to 45 here.
