### PR TITLE
[repro] main + WORKFLOW_H2_MULTIPLEX=0

### DIFF
--- a/workbench/nextjs-turbopack/app/api/e2e-h2-flag/route.ts
+++ b/workbench/nextjs-turbopack/app/api/e2e-h2-flag/route.ts
@@ -1,0 +1,18 @@
+/**
+ * Repro-branch probe. Proves that `WORKFLOW_H2_MULTIPLEX`, set in this app's
+ * `vercel.json` `env` block, actually reaches the deployed function's *runtime*
+ * environment — which is where `@workflow/world-vercel` reads it, lazily, in
+ * `createEventsDispatcher()` (packages/world-vercel/src/http-client.ts).
+ *
+ * Without this probe a flag-off storm that measures no change is ambiguous
+ * between "multiplexing is not the cause" and "the flag never arrived".
+ */
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return Response.json({
+    WORKFLOW_H2_MULTIPLEX: process.env.WORKFLOW_H2_MULTIPLEX ?? null,
+    // Mirrors `h2MultiplexEnabled()` in world-vercel's http-client.
+    multiplexEnabled: process.env.WORKFLOW_H2_MULTIPLEX !== '0',
+  });
+}

--- a/workbench/nextjs-turbopack/app/api/e2e-h2-flag/route.ts
+++ b/workbench/nextjs-turbopack/app/api/e2e-h2-flag/route.ts
@@ -14,5 +14,8 @@ export function GET() {
     WORKFLOW_H2_MULTIPLEX: process.env.WORKFLOW_H2_MULTIPLEX ?? null,
     // Mirrors `h2MultiplexEnabled()` in world-vercel's http-client.
     multiplexEnabled: process.env.WORKFLOW_H2_MULTIPLEX !== '0',
+    // 'vercel.json' if the deployment supplied it, 'instrumentation' if the
+    // fallback in instrumentation.ts had to.
+    source: process.env.WORKFLOW_H2_MULTIPLEX_SOURCE ?? null,
   });
 }

--- a/workbench/nextjs-turbopack/instrumentation.ts
+++ b/workbench/nextjs-turbopack/instrumentation.ts
@@ -1,5 +1,21 @@
 import { registerOTel } from '@vercel/otel';
 
+// Repro branch only. `vercel.json`'s `env` block is the documented way to give
+// the deployed functions a runtime variable, but Vercel marks it deprecated, so
+// this is the belt to that suspenders: if the block were ignored, a storm here
+// would measure stock main and read as "multiplexing is not the cause".
+// `@workflow/world-vercel` reads the variable lazily in
+// `createEventsDispatcher()`, which always runs after instrumentation, so
+// setting it here reaches the same code path.
+// Recorded so the probe route can also tell us whether the deprecated
+// `vercel.json` block still works — that decides where the real mitigation
+// advice should point if #3190 turns out to own the regression.
+process.env.WORKFLOW_H2_MULTIPLEX_SOURCE =
+  process.env.WORKFLOW_H2_MULTIPLEX === undefined
+    ? 'instrumentation'
+    : 'vercel.json';
+process.env.WORKFLOW_H2_MULTIPLEX ??= '0';
+
 export function register() {
   registerOTel({
     serviceName: 'nextjs-turbopack',

--- a/workbench/nextjs-turbopack/vercel.json
+++ b/workbench/nextjs-turbopack/vercel.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "WORKFLOW_PUBLIC_MANIFEST": "1"
+    "WORKFLOW_PUBLIC_MANIFEST": "1",
+    "WORKFLOW_H2_MULTIPLEX": "0"
   },
   "regions": [
     "iad1",


### PR DESCRIPTION
**Not for merge.** Disposable isolation experiment for the hook-storm regression.

## What this branch is

Current `main` (`32ac8e73f`) with exactly one behavioral change: the workbench app the storm runs against sets `WORKFLOW_H2_MULTIPLEX=0` in its `vercel.json` `env` block. That is the documented kill switch for #3190 (*[world-vercel] Make HTTP/2 actually multiplex on the events path*). `world-vercel` reads the variable lazily at runtime inside `createEventsDispatcher()`, so a deployment-level env var reaches it — no build-time inlining is involved.

Nothing is reverted and no package source is touched, so a storm here measures events-path multiplexing and nothing else.

## Why

The hook-storm corruption rate steps from ~115–145 / 600 to saturation somewhere in `e8934ade9..b12f248b6`, and it does not come from #3196 — two independent branches flipped on the same `main` merge (evidence in #3196). Fresh measurement on current `main`, same night, preview environment: **hook-storm 195 corrupted / 0 completed of 200**, hook-sleep control 50/50 clean ([run 30588748635](https://github.com/vercel/workflow/actions/runs/30588748635)).

#3190 is the prime suspect on mechanism. Before it, undici capped the events H2 agent at one in-flight request per connection — the `Client` constructor coerces `pipelining`, so H2's `defaultPipelining: Infinity` was unreachable ([nodejs/undici#4143](https://github.com/nodejs/undici/issues/4143)). After it, up to 100 streams multiplex per connection. That is a step change in how concurrently one run's event reads and writes hit the wire, which is precisely the input distribution every hydration-latency race in the replay engine is sensitive to.

## Registered prediction (written before the run)

- If #3190 owns the regression, hook-storm returns to roughly **100–145 per 600**, i.e. **~33–48 corrupted of 200**.
- If it does not, hook-storm stays at **saturation, ~195 of 200**.
- Anything in between is not a clean verdict, and it gets reported as "not a clean verdict" rather than rounded toward whichever side is convenient.

The comparison is against run 30588748635 — same night, same preview environment, same 200/50 shape. Not against the older 600-attempt baselines, which differ in both size and day.

## The probe route

`GET /api/e2e-h2-flag` echoes the runtime value of the flag. A flag that silently failed to reach the deployed function would produce a "no change" result indistinguishable from "multiplexing is not the cause", so the flag is verified on the deployment before the storm is dispatched.

## How it is being run

Dispatched as a hook-first short run (`step_storm_attempts=0`, `hook_storm_attempts=200`, `attempts=50`) rather than by label, so the answer lands in ~20 minutes instead of holding runners for a two-hour full storm. Label this PR `event-log-race-repro` if a full storm is ever wanted here.

## Runs

- [30589591922](https://github.com/vercel/workflow/actions/runs/30589591922) — the measurement, on `5cc453ae7`.
- [30589448906](https://github.com/vercel/workflow/actions/runs/30589448906) — cancelled deliberately. It was dispatched on `2bb0858bb`, before the instrumentation fallback existed, so a null result from it could not have been distinguished from the flag never arriving.
