### PR TITLE
Slot event identity (SDK 4/4): scope listByCorrelationId to a run

### DIFF
--- a/.changeset/correlation-id-run-scope.md
+++ b/.changeset/correlation-id-run-scope.md
@@ -1,0 +1,9 @@
+---
+'@workflow/world': minor
+'@workflow/world-local': minor
+'@workflow/world-postgres': minor
+'@workflow/world-vercel': minor
+'@workflow/web': minor
+---
+
+Let `events.listByCorrelationId` take a `runId`, so a lookup for a step or wait returns that run's events and not every run that numbered one the same.

--- a/packages/web/app/lib/client/hooks/use-events-list-data.ts
+++ b/packages/web/app/lib/client/hooks/use-events-list-data.ts
@@ -175,6 +175,7 @@ export function useEventsListData(
             sortOrder,
             limit: 100,
             withData: false,
+            runId,
           })
         );
         if (fetchError) {

--- a/packages/web/app/lib/rpc-client.ts
+++ b/packages/web/app/lib/rpc-client.ts
@@ -136,6 +136,7 @@ export async function fetchEventsByCorrelationId(
     sortOrder?: 'asc' | 'desc';
     limit?: number;
     withData?: boolean;
+    runId?: string;
   }
 ): Promise<ServerActionResult<PaginatedResult<Event>>> {
   return rpc('fetchEventsByCorrelationId', {

--- a/packages/web/app/server/workflow-server-actions.server.ts
+++ b/packages/web/app/server/workflow-server-actions.server.ts
@@ -896,9 +896,22 @@ export async function fetchEventsByCorrelationId(
     sortOrder?: 'asc' | 'desc';
     limit?: number;
     withData?: boolean;
+    /**
+     * Restricts the search to one run. A correlation id is unique per run, not
+     * globally — a slot-numbered run numbers its own steps — so a search made
+     * from a run's page passes it.
+     */
+    runId?: string;
   }
 ): Promise<ServerActionResult<PaginatedResult<Event>>> {
-  const { cursor, sortOrder = 'asc', limit = 100, withData = false } = params;
+  const {
+    cursor,
+    sortOrder = 'asc',
+    limit = 100,
+    withData = false,
+    runId,
+  } = params;
+  const runScope = runId === undefined ? {} : { runId };
   try {
     const world = await getWorldFromEnv(worldEnv);
     // Prefer the metadata-only analytics read path when the backend provides one
@@ -908,6 +921,7 @@ export async function fetchEventsByCorrelationId(
     if (world.analytics && !withData) {
       const result = await world.analytics.events.listByCorrelationId({
         correlationId,
+        ...runScope,
         pagination: { cursor, limit, sortOrder },
       });
       return createResponse({
@@ -919,6 +933,7 @@ export async function fetchEventsByCorrelationId(
     }
     const result = await world.events.listByCorrelationId({
       correlationId,
+      ...runScope,
       pagination: { cursor, limit, sortOrder },
       resolveData: withData ? 'all' : 'none',
     });

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -2984,12 +2984,21 @@ export function createEventsStorage(
     async listByCorrelationId(params) {
       const correlationId = params.correlationId;
       assertSafeEntityId('correlationId', correlationId);
+      if (params.runId !== undefined) {
+        assertSafeEntityId('runId', params.runId);
+      }
       const resolveData = params.resolveData ?? DEFAULT_RESOLVE_DATA_OPTION;
       const result = await paginatedFileSystemQuery({
         directory: path.join(basedir, 'events'),
         schema: EventSchema,
         cachedItems: eventCache,
-        // No filePrefix - search all events
+        // Scoped to one run's files when the caller named a run, since a
+        // correlation id identifies a step or wait only within its own run.
+        // Without a run it searches every event, and a slot-numbered
+        // `step_…001` legitimately matches one event per run.
+        ...(params.runId === undefined
+          ? {}
+          : { filePrefix: `${params.runId}-` }),
         filter: (event) => event.correlationId === correlationId,
         // Events in chronological order (oldest first) by default,
         // different from the default for other list calls.

--- a/packages/world-local/src/storage/slot-identity.test.ts
+++ b/packages/world-local/src/storage/slot-identity.test.ts
@@ -482,3 +482,39 @@ describe('conflict', () => {
     await expect(slotsOf(runId)).resolves.toEqual([1, 2, 3]);
   });
 });
+
+describe('correlation ids are unique per run, not globally', () => {
+  /** The id every slot-numbered run gives its own first step. */
+  const firstStep = `step_${String(FIRST_SLOT).padStart(26, '0')}`;
+
+  async function twoRunsSharingFirstStep(): Promise<[string, string]> {
+    const runIds: string[] = [];
+    for (const _ of [0, 1]) {
+      const runId = await newSlotRun();
+      await createStep(runId, firstStep);
+      runIds.push(runId);
+    }
+    return [runIds[0] as string, runIds[1] as string];
+  }
+
+  it('matches every run that numbered a step the same when unscoped', async () => {
+    // Not a bug to fix in the query — it is what a per-run counter means, and
+    // it is why a caller that knows the run has to say so.
+    const runIds = await twoRunsSharingFirstStep();
+    const { data } = await storage.events.listByCorrelationId({
+      correlationId: firstStep,
+      pagination: { limit: 10 },
+    });
+    expect(new Set(data.map((event) => event.runId))).toEqual(new Set(runIds));
+  });
+
+  it('returns one run when the caller names it', async () => {
+    const [runId] = await twoRunsSharingFirstStep();
+    const { data } = await storage.events.listByCorrelationId({
+      correlationId: firstStep,
+      runId,
+      pagination: { limit: 10 },
+    });
+    expect(data.map((event) => event.runId)).toEqual([runId]);
+  });
+});

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -2169,6 +2169,11 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         .where(
           and(
             eq(events.correlationId, params.correlationId),
+            // A correlation id names a step or wait within its run, so without
+            // a run scope this matches one event per run that allocated the
+            // same id — and the cursor, an event id, cannot tell two such rows
+            // apart. Scoped, `(run_id, id)` is the primary key, so it can.
+            map(params.runId, (runId) => eq(events.runId, runId)),
             map(params.pagination?.cursor, (c) =>
               order.compare(events.eventId, c)
             )

--- a/packages/world-postgres/test/slot-identity.test.ts
+++ b/packages/world-postgres/test/slot-identity.test.ts
@@ -423,4 +423,69 @@ describe('Slot identity (Postgres integration)', () => {
       expect(rows.map((row) => row.step_id)).toEqual(['step_out_of_band']);
     });
   });
+
+  describe('correlation ids are unique per run, not globally', () => {
+    /** The id every slot-numbered run gives its own first step. */
+    const firstStep = `step_${String(FIRST_SLOT).padStart(26, '0')}`;
+
+    async function twoRunsSharingFirstStep(): Promise<[string, string]> {
+      const runIds: string[] = [];
+      for (const _ of [0, 1]) {
+        const runId = await newSlotRun();
+        await createStep(runId, firstStep);
+        runIds.push(runId);
+      }
+      return [runIds[0] as string, runIds[1] as string];
+    }
+
+    test('matches every run that numbered a step the same when unscoped', async () => {
+      // Not a bug to fix in the query — it is what a per-run counter means, and
+      // it is why a caller that knows the run has to say so.
+      const runIds = await twoRunsSharingFirstStep();
+      const { data } = await events.listByCorrelationId({
+        correlationId: firstStep,
+        pagination: { limit: 10 },
+      });
+      expect(new Set(data.map((event) => event.runId))).toEqual(
+        new Set(runIds)
+      );
+    });
+
+    test('returns one run when the caller names it', async () => {
+      const [runId] = await twoRunsSharingFirstStep();
+      const { data } = await events.listByCorrelationId({
+        correlationId: firstStep,
+        runId,
+        pagination: { limit: 10 },
+      });
+      expect(data.map((event) => event.runId)).toEqual([runId]);
+    });
+
+    test('pages a scoped query whose event ids repeat across runs', async () => {
+      // Both runs hold the same correlation id at the same slots, so the two
+      // logs are indistinguishable by event id alone: unscoped, a cursor at one
+      // run's id silently skips the other's. The run scope is what makes the
+      // cursor a key again.
+      const [runId] = await twoRunsSharingFirstStep();
+      await events.create(runId, {
+        eventType: 'step_completed',
+        specVersion: SPEC_VERSION_SLOT_IDENTITY,
+        correlationId: firstStep,
+        eventData: { output: new Uint8Array() },
+      });
+
+      const seen: string[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = await events.listByCorrelationId({
+          correlationId: firstStep,
+          runId,
+          pagination: { limit: 1, cursor },
+        });
+        seen.push(...page.data.map((event) => event.eventType));
+        cursor = page.hasMore ? (page.cursor ?? undefined) : undefined;
+      } while (cursor);
+      expect(seen).toEqual(['step_created', 'step_completed']);
+    });
+  });
 });

--- a/packages/world-vercel/src/analytics.ts
+++ b/packages/world-vercel/src/analytics.ts
@@ -138,8 +138,17 @@ export function createAnalytics(config?: APIConfig): Analytics {
         searchParams.set('correlationId', params.correlationId);
         appendPagination(searchParams, params.pagination);
 
+        // A correlation id is unique per run, not globally — a slot-numbered
+        // run numbers its own steps, so `step_…001` names the first step of
+        // every such run. When the caller named a run, the run-scoped endpoint
+        // takes the same correlation-id filter and answers exactly.
+        const endpoint =
+          params.runId === undefined
+            ? `/v2/analytics/events${createQueryString(searchParams)}`
+            : `/v2/analytics/runs/${encodeURIComponent(params.runId)}/events${createQueryString(searchParams)}`;
+
         return makeRequest({
-          endpoint: `/v2/analytics/events${createQueryString(searchParams)}`,
+          endpoint,
           config,
           schema: PaginatedResponseSchema(AnalyticsEventSchema),
         });

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -609,8 +609,18 @@ export async function getWorkflowRunEvents(
     buildEventFromV4(listed.event, listed.body, resolveData)
   );
 
+  // A correlation id is unique per run, not globally — a slot-numbered run
+  // numbers its own steps, so `step_…001` names the first step of every such
+  // run. The backend selects by correlation id alone, so a caller that named a
+  // run gets the scope applied here. `hasMore`/`cursor` stay the backend's, so
+  // a page that filters down to nothing is still followed by the next one.
+  const runScoped =
+    'correlationId' in params && params.runId !== undefined
+      ? events.filter((event) => event.runId === params.runId)
+      : events;
+
   return {
-    data: events,
+    data: runScoped,
     // `next` is present even on the final page (it's the incremental-load
     // resume cursor), so prefer the server's explicit `hasMore`. The
     // `Boolean(next)` fallback covers older servers that don't emit it —

--- a/packages/world/src/analytics.ts
+++ b/packages/world/src/analytics.ts
@@ -189,6 +189,8 @@ export interface AnalyticsListEventsParams
 
 export interface AnalyticsListEventsByCorrelationIdParams {
   correlationId: string;
+  /** Restricts the query to one run; see `ListEventsByCorrelationIdParams`. */
+  runId?: string;
   pagination?: PaginationOptions;
 }
 

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -944,6 +944,15 @@ export interface ListEventsParams {
 
 export interface ListEventsByCorrelationIdParams {
   correlationId: string;
+  /**
+   * Restricts the query to one run. A correlation id is unique per run, not
+   * globally: a slot-numbered run counts its own steps and waits, so
+   * `step_…001` names the first step of *every* such run. Pass the run when
+   * the caller knows it — both to keep foreign runs out of the page and
+   * because `(runId, eventId)` is what makes the pagination cursor
+   * unambiguous, where an event id alone is not.
+   */
+  runId?: string;
   pagination?: PaginationOptions;
   resolveData?: ResolveData;
 }


### PR DESCRIPTION
Stacked on #3246. Review the last commit only.

## Why

A correlation id identifies a step or wait **within its run**, not across runs. Nothing enforced that while every id carried a ULID, so the distinction never mattered. It matters as soon as a run numbers its own steps: `step_…001` names the first step of *every* slot-numbered run.

Measured on the Local World before this change — two runs, each with one step, one unscoped lookup:

```
listByCorrelationId('step_…001') → 2 events, runIds [wrun_01KYTTGYF6…, wrun_01KYTTGYF9…]
```

Two consequences:

- **Foreign runs in the page.** The observability search already post-filters on `runId`, so nothing wrong is displayed — but it pages against a bounded page cap, so the run it wants can sit past the cap and the search reports nothing found.
- **An ambiguous cursor.** The Postgres query orders and resumes by `eventId`. Two runs can hold the same correlation id at the same slot, so `eventId > cursor` skips the sibling row at the equal id. Scoped, `(run_id, id)` is the primary key, so the cursor is a key again.

Nothing in the runtime reads this path — it is an observability read — so this is not a correctness regression in a run. It is a read that gets quietly wrong answers under slot identity.

## What

`ListEventsByCorrelationIdParams` (and the analytics variant) gain an optional `runId`.

| World | How it scopes |
|---|---|
| Local | Restricts the scan to the run's own event files |
| Postgres | `AND run_id = $n`, which also disambiguates the cursor |
| Vercel — analytics | Routes to the run-scoped endpoint that already takes a correlation-id filter |
| Vercel — runtime read | Applies the scope to the returned page; the backend index is keyed by correlation id alone, so the pagination cursor and `hasMore` stay the backend's |

The observability search passes the run it is already looking at, and keeps its post-filter as defence for a world that cannot scope.

Leaving the param optional keeps every existing caller working, and an unscoped lookup still means "every run that numbered one the same" — which is the honest answer to the question asked.

## Tests

Both slot-identity suites gain the pair, and Postgres gains the cursor case:

- unscoped lookup matches every run that numbered a step the same (asserts the collision rather than pretending it away)
- scoped lookup returns one run
- Postgres: paging a scoped query whose event ids repeat across runs returns both of the run's events, in order

Local 524 pass, Postgres 184 pass (real container), world 98, core 1687 + 3 expected fail, world-vercel 317, web 94.

## Follow-up

The backend index behind the Vercel runtime read is keyed by correlation id alone, so a slot-mode `step_…001` is a hot key across all runs and the scope is applied client-side. Taking a run scope there is a backend-side change, tracked separately.

---

Stack: #3228 → #3234 → #3246 → **#3247**

Paired backend stack (world-vercel side): 6 PRs, all rebased on main and stacked; `WORKFLOW_SERVER_URL_OVERRIDE` points at the top of it and **must be reverted before merge**.
