### PR TITLE
fix(world-local): queue - bound stalled delivery timeouts

### DIFF
--- a/.changeset/world-local-bounded-deliveries.md
+++ b/.changeset/world-local-bounded-deliveries.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Bound stalled local queue deliveries and redeliver their durable messages instead of waiting indefinitely.

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -86,6 +86,18 @@ The Local World is the default outside Vercel and is intended for development.
 - Default: unlimited
 - Maximum seconds a local queue message stays hidden before the handler rechecks the run.
 
+### `WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS`
+
+- Factory option: none
+- Default: `30000`
+- Maximum milliseconds to wait for a local queue handler to begin responding before the durable message is redelivered. Set to `0` to disable.
+
+### `WORKFLOW_LOCAL_BODY_TIMEOUT_MS`
+
+- Factory option: none
+- Default: `30000`
+- Maximum gap in milliseconds between response body chunks from a local queue handler before the durable message is redelivered. Set to `0` to disable.
+
 ### `recoverActiveRuns`
 
 - Environment variable: `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS`

--- a/docs/content/worlds/v5/local.mdx
+++ b/docs/content/worlds/v5/local.mdx
@@ -62,6 +62,14 @@ Maximum number of concurrent queue message handlers. Default: `1000`
 
 Maximum number of seconds a local queue message can stay hidden before the handler rechecks the run. Default: unlimited.
 
+### `WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS`
+
+Maximum time in milliseconds to wait for a local queue handler to begin responding before redelivering the durable message. Default: `30000`. Set to `0` to disable.
+
+### `WORKFLOW_LOCAL_BODY_TIMEOUT_MS`
+
+Maximum gap in milliseconds between response body chunks from a local queue handler before redelivering the durable message. Default: `30000`. Set to `0` to disable.
+
 ### `WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS`
 
 Whether pending and running runs found in the data directory are re-enqueued when the world starts. Set to `0` or `false` to skip recovery and leave stale runs untouched. Default: `true`

--- a/packages/world-local/src/queue.test.ts
+++ b/packages/world-local/src/queue.test.ts
@@ -1,9 +1,16 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { setWorkflowBasePath } from '@workflow/utils';
 import type { WorkflowInvokePayload } from '@workflow/world';
 import { MessageId, ValidQueueName } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { createQueue } from './queue';
+import {
+  createQueue,
+  DEFAULT_BODY_TIMEOUT_MS,
+  DEFAULT_HEADERS_TIMEOUT_MS,
+  getQueueAgentOptions,
+} from './queue';
 
 // Mock node:timers/promises so setTimeout resolves immediately
 vi.mock('node:timers/promises', () => ({
@@ -472,5 +479,121 @@ describe('transport-level delivery failures are retried (regression)', () => {
 
     await vi.waitFor(() => expect(attempts.length).toBe(1));
     expect(attempts[0]).toBe(1);
+  });
+});
+
+describe('queue transport timeouts', () => {
+  const envKeys = [
+    'WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS',
+    'WORKFLOW_LOCAL_BODY_TIMEOUT_MS',
+  ] as const;
+
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    for (const key of envKeys) delete process.env[key];
+    if (server !== undefined) {
+      const toClose = server;
+      server = undefined;
+      toClose.closeAllConnections();
+      await new Promise((resolve) => toClose.close(resolve));
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('bounds queue requests by default', () => {
+    expect(getQueueAgentOptions()).toMatchObject({
+      bodyTimeout: DEFAULT_BODY_TIMEOUT_MS,
+      headersTimeout: DEFAULT_HEADERS_TIMEOUT_MS,
+    });
+  });
+
+  it('honors environment overrides, including 0', () => {
+    process.env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS = '1234';
+    process.env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS = '0';
+    expect(getQueueAgentOptions()).toMatchObject({
+      bodyTimeout: 0,
+      headersTimeout: 1234,
+    });
+  });
+
+  it('falls back for invalid environment overrides', () => {
+    process.env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS = 'not-a-number';
+    process.env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS = '-1';
+    expect(getQueueAgentOptions()).toMatchObject({
+      bodyTimeout: DEFAULT_BODY_TIMEOUT_MS,
+      headersTimeout: DEFAULT_HEADERS_TIMEOUT_MS,
+    });
+  });
+
+  it('redelivers when a handler accepts a request but never responds', async () => {
+    let requests = 0;
+    server = createServer((_request, response) => {
+      requests++;
+      if (requests === 1) return;
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) => {
+      server?.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+
+    process.env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS = '150';
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const localQueue = createQueue({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+    try {
+      await localQueue.queue('__wkf_workflow_test' as any, workflowPayload);
+      await vi.waitFor(() => expect(requests).toBe(2), { timeout: 5_000 });
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Queue delivery failed at the transport'),
+        expect.objectContaining({
+          error: expect.stringContaining('fetch failed'),
+        })
+      );
+    } finally {
+      await localQueue.close();
+    }
+  });
+
+  it('redelivers when a handler response body stalls', async () => {
+    let requests = 0;
+    server = createServer((_request, response) => {
+      requests++;
+      response.setHeader('content-type', 'application/json');
+      if (requests === 1) {
+        response.write('{"ok":');
+        return;
+      }
+      response.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) => {
+      server?.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+
+    process.env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS = '150';
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const localQueue = createQueue({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+    try {
+      await localQueue.queue('__wkf_workflow_test' as any, workflowPayload);
+      await vi.waitFor(() => expect(requests).toBe(2), { timeout: 5_000 });
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Queue delivery failed at the transport'),
+        expect.objectContaining({
+          error: expect.stringMatching(/terminated|fetch failed/),
+        })
+      );
+    } finally {
+      await localQueue.close();
+    }
   });
 });

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -61,6 +61,39 @@ const WORKFLOW_LOCAL_QUEUE_CONCURRENCY =
   parseInt(process.env.WORKFLOW_LOCAL_QUEUE_CONCURRENCY ?? '0', 10) ||
   DEFAULT_CONCURRENCY_LIMIT;
 
+/** Default time-to-first-byte deadline for local queue deliveries. */
+export const DEFAULT_HEADERS_TIMEOUT_MS = 30_000;
+
+/** Default maximum gap between response body chunks for local deliveries. */
+export const DEFAULT_BODY_TIMEOUT_MS = 30_000;
+
+function envTimeoutMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/**
+ * Bounds a stalled delivery below the queue handler's retry horizon. A
+ * transport timeout is retried by the delivery loop with the same durable
+ * message; `0` remains available for applications that need unbounded calls.
+ */
+export function getQueueAgentOptions() {
+  return {
+    bodyTimeout: envTimeoutMs(
+      'WORKFLOW_LOCAL_BODY_TIMEOUT_MS',
+      DEFAULT_BODY_TIMEOUT_MS
+    ),
+    connections: 1000,
+    headersTimeout: envTimeoutMs(
+      'WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS',
+      DEFAULT_HEADERS_TIMEOUT_MS
+    ),
+    keepAliveTimeout: 30_000,
+  } as const;
+}
+
 export type DirectHandler = (req: Request) => Promise<Response>;
 
 export type LocalQueue = Queue & {
@@ -95,16 +128,7 @@ function isDetachedArrayBufferQueueError(error: unknown): boolean {
 }
 
 export function createQueue(config: Partial<Config>): LocalQueue {
-  // Create a custom agent optimized for high-concurrency local workflows:
-  // - headersTimeout: 0 allows long-running steps
-  // - connections: 1000 allows many parallel connections to the same host
-  // - pipelining: 1 (default) for HTTP/1.1 compatibility
-  // - keepAliveTimeout: 30s keeps connections warm for rapid step execution
-  const httpAgent = new Agent({
-    headersTimeout: 0,
-    connections: 1000,
-    keepAliveTimeout: 30_000,
-  });
+  const httpAgent = new Agent(getQueueAgentOptions());
   const transport = new TypedJsonTransport();
   const generateId = monotonicFactory();
   const semaphore = new Sema(WORKFLOW_LOCAL_QUEUE_CONCURRENCY);
@@ -180,10 +204,8 @@ export function createQueue(config: Partial<Config>): LocalQueue {
       // ok, a timeoutSeconds re-delivery, or an HTTP error response). This —
       // not the loop counter — is the attempt the handler sees via
       // `x-vqs-message-attempt`, which it counts against MAX_QUEUE_DELIVERIES.
-      // Transport-level failures (below) never reach the handler, so they must
-      // not advance this, or a burst of "fetch failed"/ETIMEDOUT timeouts under
-      // local load would exhaust the handler's delivery budget before its first
-      // real execution.
+      // Failures before response headers do not advance this; body failures do,
+      // because the handler has already accepted that delivery.
       let delivery = 0;
       try {
         for (let loop = 0; loop < MAX_LOCAL_SAFETY_LIMIT; loop++) {
@@ -196,6 +218,7 @@ export function createQueue(config: Partial<Config>): LocalQueue {
           };
           const directHandler = directHandlers.get(prefix);
           let response: Response;
+          let text: string;
 
           try {
             if (directHandler) {
@@ -220,14 +243,13 @@ export function createQueue(config: Partial<Config>): LocalQueue {
                 } as any
               );
             }
+            delivery++;
+            text = await response.text();
           } catch (err) {
-            // The delivery never reached the handler: undici threw before a
-            // response. Under heavy local concurrency the single-process dev
-            // server can't accept every connection, so undici reports
-            // `TypeError: fetch failed` with an ETIMEDOUT/ECONNRESET cause.
-            // These are transient — back off and retry the *same* delivery
-            // rather than dropping the message (which would leave the step
-            // never started, with no retry). Two failures are not retryable:
+            // A transport can fail before response headers or while consuming
+            // the body. Both are transient — back off and retry the same
+            // durable message rather than leaving its run stalled. Two
+            // failures are not retryable:
             //  - shutdown: close() aborted the agent / the backoff sleep.
             //  - a detached-ArrayBuffer proxy misconfig, which never succeeds —
             //    rethrow so the outer catch surfaces the actionable guidance.
@@ -254,9 +276,6 @@ export function createQueue(config: Partial<Config>): LocalQueue {
             await setTimeout(5000, undefined, { signal: closeSignal });
             continue;
           }
-
-          delivery++;
-          const text = await response.text();
 
           if (response.ok) {
             try {


### PR DESCRIPTION
### Description

Two intermittent eve e2e failures timed out with no events while local-world queue deliveries remained in flight:

- https://github.com/vercel/eve/actions/runs/30638901448/job/91183675933?pr=1459
- https://github.com/vercel/eve/actions/runs/30639275992/job/91184813210

`@workflow/world-local` configured undici with `headersTimeout: 0` and no body timeout. If a delivery handler accepted a connection and then stopped making progress, the transport never rejected, so the durable message could not be retried. The `socket hang up` errors seen during teardown were pending deliveries being terminated, not the initiating failure.

This intentionally brings world-local on `main` in line with the transport resilience policy recently added to world-vercel on `stable` in #3169: 30-second header and body stall limits, environment overrides, and `0` as an explicit unbounded opt-out. The retry implementation is different by design: world-vercel uses `RetryAgent` and event-specific POST retries, while world-local already owns a durable delivery loop, so transport timeouts redeliver the same queued message there.

This change bounds response-header and response-body waits at 30 seconds by default, keeps body consumption inside the retry boundary, and redelivers stalled durable messages. Both limits can be overridden with `WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS` and `WORKFLOW_LOCAL_BODY_TIMEOUT_MS`; setting either to `0` preserves an explicit unbounded opt-out.

### How did you test your changes?

- `pnpm --filter @workflow/world-local build`
- `pnpm --filter @workflow/world-local typecheck`
- `pnpm --filter @workflow/world-local test` (12 files, 498 tests)
- Added real HTTP socket tests proving header and body stalls are redelivered.
- `pnpm test:docs` was attempted, but this fresh checkout cannot complete the required workspace build because Rust/`wasm32-unknown-unknown` is not installed; CI remains the full docs check.

### PR Checklist - Required to merge

- [x] 📦 Added a patch changeset for `@workflow/world-local`
- [x] 🔒 Commit includes DCO sign-off
- [x] 📝 Pinged `@vercel/workflow` for review