### PR TITLE
[ci] Shrink the event-log race repro job 100x and add a local world-postgres runner

### DIFF
--- a/.changeset/event-log-race-repro-local.md
+++ b/.changeset/event-log-race-repro-local.md
@@ -1,0 +1,4 @@
+---
+---
+
+Shrink the event log race repro CI job and add a local world-postgres runner

--- a/.changeset/local-empty-vercel-url.md
+++ b/.changeset/local-empty-vercel-url.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Treat an empty `VERCEL_URL` as not running on Vercel, so a `.env.local` left behind by `vercel env pull` no longer makes local runs fail with `Invalid URL`

--- a/.github/workflows/event-log-race-repro.yml
+++ b/.github/workflows/event-log-race-repro.yml
@@ -4,56 +4,54 @@ on:
   pull_request:
     branches: [main, stable]
     types: [opened, reopened, synchronize, labeled]
+  # Every input below is passed straight through to the harness, and a blank one
+  # lands on the harness' own default in
+  # `packages/core/e2e/event-log-race-repro.test.ts` — which is the only place
+  # these numbers are defined. Do not reintroduce `default:` values here: a second
+  # copy drifts, and the copy CI uses would stop matching the one a local run gets.
+  #
+  # The defaults are sized for a per-PR regression check. To soak for a *rate*
+  # instead, dispatch with the historical scale: step_storm_attempts 600,
+  # hook_storm_attempts 600, attempts 200, concurrency 40, budget_ms 4500000 —
+  # and raise `timeout-minutes` below, which is sized for the default scale.
   workflow_dispatch:
     inputs:
       step_storm_attempts:
         description: 'Number of step-storm runs (racing steps vs. watchdog + poke-hook pressure)'
         required: false
-        default: '600'
       hook_storm_attempts:
         description: 'Number of hook-storm runs (racing hook deliveries vs. watchdog — the production shape)'
         required: false
-        default: '600'
       attempts:
         description: 'Number of hook-sleep control runs (calibration baseline, ~0.1% historical corruption rate)'
         required: false
-        default: '200'
       concurrency:
         description: 'Number of concurrent workflow runs'
         required: false
-        default: '40'
       rounds:
         description: 'Rounds of racing branches per storm run (longer log = more room for a divergence to surface)'
         required: false
-        default: '6'
       width:
         description: 'Racing branches per round (each one is an independent wake source, so this is the main concurrency dial)'
         required: false
-        default: '8'
       watchdog_ms:
         description: 'Per-branch watchdog timeout. Branches that time out emit an extra step, which is what shifts the correlation-ID sequence'
         required: false
-        default: '2500'
       step_delay_ms:
         description: 'step-storm: raced step duration. Must straddle watchdog_ms once jitter is applied'
         required: false
-        default: '2200'
       hook_resume_stagger_ms:
         description: 'hook-storm: per-index delay inside a round resume burst. width * this should exceed watchdog_ms'
         required: false
-        default: '400'
       poke_interval_ms:
         description: 'step-storm: cadence of out-of-band resumes to the never-read poke hook'
         required: false
-        default: '750'
       run_timeout_ms:
         description: 'Per-run timeout before classifying as stuck'
         required: false
-        default: '240000'
       budget_ms:
         description: 'Wall-clock budget for launching attempts. Must stay far enough below the job timeout to leave room for rendering the summary'
         required: false
-        default: '4500000'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,7 +61,12 @@ jobs:
   event-log-race-repro:
     name: Event Log Race Repro
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # Sized for the harness' default scale: its own test timeout is
+    # `budget_ms + run_timeout_ms + 60s` (~17 min at the defaults), and the rest is
+    # checkout, build, the deployment wait, and rendering the summary. A soak
+    # dispatch that raises `budget_ms` has to raise this too, or the runner kills
+    # the job before the summary is written.
+    timeout-minutes: 25
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'event-log-race-repro') }}
     permissions:
       contents: read
@@ -115,18 +118,21 @@ jobs:
           WORKFLOW_VERCEL_PROJECT: "prj_yjkM7UdHliv8bfxZ1sMJQf1pMpdi"
           WORKFLOW_VERCEL_PROJECT_SLUG: example-nextjs-workflow-turbopack
           VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
-          EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS: ${{ inputs.step_storm_attempts || '600' }}
-          EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS: ${{ inputs.hook_storm_attempts || '600' }}
-          EVENT_LOG_RACE_REPRO_ATTEMPTS: ${{ inputs.attempts || '200' }}
-          EVENT_LOG_RACE_REPRO_CONCURRENCY: ${{ inputs.concurrency || '40' }}
-          EVENT_LOG_RACE_REPRO_ROUNDS: ${{ inputs.rounds || '6' }}
-          EVENT_LOG_RACE_REPRO_WIDTH: ${{ inputs.width || '8' }}
-          EVENT_LOG_RACE_REPRO_WATCHDOG_MS: ${{ inputs.watchdog_ms || '2500' }}
-          EVENT_LOG_RACE_REPRO_STEP_DELAY_MS: ${{ inputs.step_delay_ms || '2200' }}
-          EVENT_LOG_RACE_REPRO_HOOK_RESUME_STAGGER_MS: ${{ inputs.hook_resume_stagger_ms || '400' }}
-          EVENT_LOG_RACE_REPRO_POKE_INTERVAL_MS: ${{ inputs.poke_interval_ms || '750' }}
-          EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms || '240000' }}
-          EVENT_LOG_RACE_REPRO_BUDGET_MS: ${{ inputs.budget_ms || '4500000' }}
+          # Deliberately unguarded pass-through: on a `pull_request` event every
+          # `inputs.*` is empty, and the harness reads an empty variable as unset
+          # and falls back to its own default. See the note on the inputs above.
+          EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS: ${{ inputs.step_storm_attempts }}
+          EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS: ${{ inputs.hook_storm_attempts }}
+          EVENT_LOG_RACE_REPRO_ATTEMPTS: ${{ inputs.attempts }}
+          EVENT_LOG_RACE_REPRO_CONCURRENCY: ${{ inputs.concurrency }}
+          EVENT_LOG_RACE_REPRO_ROUNDS: ${{ inputs.rounds }}
+          EVENT_LOG_RACE_REPRO_WIDTH: ${{ inputs.width }}
+          EVENT_LOG_RACE_REPRO_WATCHDOG_MS: ${{ inputs.watchdog_ms }}
+          EVENT_LOG_RACE_REPRO_STEP_DELAY_MS: ${{ inputs.step_delay_ms }}
+          EVENT_LOG_RACE_REPRO_HOOK_RESUME_STAGGER_MS: ${{ inputs.hook_resume_stagger_ms }}
+          EVENT_LOG_RACE_REPRO_POKE_INTERVAL_MS: ${{ inputs.poke_interval_ms }}
+          EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms }}
+          EVENT_LOG_RACE_REPRO_BUDGET_MS: ${{ inputs.budget_ms }}
 
       - name: Fetch previous repro comment
         if: always() && github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,10 @@ packages/swc-plugin-workflow/build-hash.json
 workbench/nextjs-*/public/.well-known/workflow
 workbench/sveltekit/static/.well-known/workflow
 
+
+# Event log race repro output (written to the repo root by the harness and by
+# scripts/event-log-race-repro-local.sh)
+event-log-race-repro-results.json
+event-log-race-repro-summary.md
+event-log-race-repro-previous-comment.md
+event-log-race-repro-server.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,24 @@ EVENT_LOG_RACE_REPRO_BUDGET_MS=4500000 \
   pnpm run test:e2e:event-log-race-repro:local --skip-build --skip-db-setup
 ```
 
+Against world-postgres the storms bite much harder than the CI job's Vercel
+preview does: on `main`, three 14-run passes failed 8 of their 18 `step-storm`
+attempts with `CORRUPTED_EVENT_LOG` while `hook-storm` and `hook-sleep` stayed
+clean, so the script exits non-zero. That is the harness working, not a broken
+setup, and it is why the local runner is the fast signal while a fix is in
+flight — at 14 runs a green CI job means "the storms did not trip it", nowhere
+near "the rate is below X".
+
+One thing about a local run is unlike CI and is worth knowing before you read a
+result: in CI each replay gets its own Fluid invocation, while here every replay
+of every run shares one Next.js process. world-postgres gives that process (and
+the harness process) 50 embedded Graphile Worker slots each, and ~100 replays in
+one heap saturates GC — measured on a 12-core laptop, all 14 attempts came back
+`stuck` with the server at 6.4 GB RSS and Postgres idle. The script therefore
+sets `WORKFLOW_POSTGRES_WORKER_CONCURRENCY=10` (override by exporting it) and
+raises the app's old-space limit (`--heap-mb`). If a local run reports `stuck`
+rather than `CORRUPTED_EVENT_LOG`, suspect the machine before the SDK.
+
 In CI the same harness runs from `.github/workflows/event-log-race-repro.yml`,
 triggered by adding the `event-log-race-repro` label to a PR (or by
 `workflow_dispatch`, whose inputs are the soak dial — raise `timeout-minutes` in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,61 @@ VERCEL_OIDC_TOKEN="$(grep VERCEL_OIDC_TOKEN workbench/nextjs-turbopack/.env.loca
 pnpm run test:e2e
 ```
 
+### Event Log Race Repro
+
+`packages/core/e2e/event-log-race-repro.test.ts` is a dedicated harness for
+`CORRUPTED_EVENT_LOG`. It drives three scenarios against one deployment:
+`step-storm` and `hook-storm` (concurrent replays of a single run racing the
+per-branch watchdog — `hook-storm` is the production shape), plus a `hook-sleep`
+control that provides the calibration baseline. Any outcome other than
+`completed` fails the run, except `infra`, which means the harness could not
+reach the deployment.
+
+Run it locally against `@workflow/world-postgres` and a locally started
+workbench app — no Vercel deployment, no credentials:
+
+```bash
+pnpm run test:e2e:event-log-race-repro:local
+```
+
+The script (`scripts/event-log-race-repro-local.sh`, `--help` for flags) brings up
+the world-postgres container, applies migrations, builds and starts
+`workbench/nextjs-turbopack` with `WORKFLOW_TARGET_WORLD` and
+`WORKFLOW_PUBLIC_MANIFEST=1` set **at build time** (both are build-time inputs;
+missing either silently yields a world-local app or a 404 manifest), runs the
+harness, prints the same summary table CI posts, and tears the server down.
+Postgres is left running for the next iteration unless `--teardown` is passed.
+
+Scale is controlled entirely by `EVENT_LOG_RACE_REPRO_*` environment variables.
+Their defaults live only in `event-log-race-repro.test.ts` — neither the CI
+workflow nor the local script defines a second copy. The default scale (14 runs)
+is a per-PR regression check, not a rate measurement; a clean run means "the
+storms did not trip it", not "the rate is below X". To soak for a *rate*, use the
+historical scale:
+
+```bash
+EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS=600 \
+EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS=600 \
+EVENT_LOG_RACE_REPRO_ATTEMPTS=200 \
+EVENT_LOG_RACE_REPRO_CONCURRENCY=40 \
+EVENT_LOG_RACE_REPRO_BUDGET_MS=4500000 \
+  pnpm run test:e2e:event-log-race-repro:local --skip-build --skip-db-setup
+```
+
+In CI the same harness runs from `.github/workflows/event-log-race-repro.yml`,
+triggered by adding the `event-log-race-repro` label to a PR (or by
+`workflow_dispatch`, whose inputs are the soak dial — raise `timeout-minutes` in
+that dispatch's branch if you raise `budget_ms`). Results land in a sticky PR
+comment that keeps a history of previous runs and their configs.
+
+To poke at a run afterwards, the CLI reads the same world from the environment:
+
+```bash
+WORKFLOW_TARGET_WORLD=@workflow/world-postgres \
+WORKFLOW_POSTGRES_URL=postgres://world:world@localhost:5432/world \
+  pnpm wf inspect <run-id>
+```
+
 ### Example App Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typecheck": "turbo typecheck",
     "test:e2e": "vitest run packages/core/e2e/e2e.test.ts packages/core/e2e/e2e-agent.test.ts",
     "test:e2e:event-log-race-repro": "vitest run packages/core/e2e/event-log-race-repro.test.ts",
+    "test:e2e:event-log-race-repro:local": "bash scripts/event-log-race-repro-local.sh",
     "test:e2e:nextjs-webpack:staged": "node scripts/test-staged-nextjs-webpack.mjs",
     "test:docs": "pnpm --filter @workflow/docs-typecheck test:docs",
     "bench": "vitest run packages/core/e2e/benchmark.test.ts",

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -25,14 +25,23 @@ import { getWorkflowMetadata, setupWorld, trackRun } from './utils';
  *
  * The `step-storm` and `hook-storm` scenarios supply all three by construction
  * (see `workflows/103_event_log_corruption_repro.ts`). `hook-sleep` is retained
- * as a low-attempt calibration control: it is the shape that has historically
- * produced a nonzero — but very low, ~0.1% — corruption rate, so its rate is the
- * yardstick the storms are meant to beat.
+ * as a calibration control: it is the shape that has historically produced a
+ * nonzero — but very low, ~0.1% — corruption rate, so its rate is the yardstick
+ * the storms are meant to beat.
  *
- * This job is a *measurement*, not a pass/fail gate on the SDK's happy path:
- * every non-`completed`, non-`infra` outcome is reported and fails the test, so
- * a corruption shows up loudly and the sticky PR comment can be diffed between a
+ * Every non-`completed`, non-`infra` outcome is reported and fails the test, so a
+ * corruption shows up loudly and the sticky PR comment can be diffed between a
  * baseline run and a fix run.
+ *
+ * At its default scale this is a *regression check*, not a rate measurement: a
+ * few tens of runs cannot resolve a per-run corruption rate, so a clean run means
+ * "the storms did not trip it", not "the rate is below X". Measuring a rate — or
+ * comparing one against the `hook-sleep` baseline — needs the soak scale, which
+ * is what the `workflow_dispatch` inputs on `event-log-race-repro.yml` exist for.
+ * The default is deliberately small because the storms are per-run amplifiers:
+ * each run's own `rounds` x `width` fan-out supplies the concurrency, so a
+ * regression that the shape can catch at all usually shows up in a handful of
+ * runs, and the attempt count buys resolution rather than sensitivity.
  */
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
@@ -145,15 +154,25 @@ function envBoolean(name: string, fallback: boolean) {
   return fallback;
 }
 
+// These are the only copy of the harness' scale. The CI workflow passes its
+// `workflow_dispatch` inputs straight through and `envNumber` treats an unset or
+// empty variable as absent, so a blank input lands on the value below rather
+// than on a second default maintained in YAML.
 const config: ReproConfig = {
-  stepStormAttempts: envNumber('EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS', 600),
-  hookStormAttempts: envNumber('EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS', 600),
-  hookSleepAttempts: envNumber('EVENT_LOG_RACE_REPRO_ATTEMPTS', 200),
-  concurrency: envNumber('EVENT_LOG_RACE_REPRO_CONCURRENCY', 40),
-  // 75 min leaves ~20 min of the job's 120-min cap for checkout, build, the
-  // deployment wait, and rendering the summary, even at the worst case of one
-  // in-flight attempt draining its full `runTimeoutMs` after the budget ends.
-  budgetMs: envNumber('EVENT_LOG_RACE_REPRO_BUDGET_MS', 75 * 60_000),
+  stepStormAttempts: envNumber('EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS', 6),
+  hookStormAttempts: envNumber('EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS', 6),
+  hookSleepAttempts: envNumber('EVENT_LOG_RACE_REPRO_ATTEMPTS', 2),
+  // Cross-run concurrency is throughput only — the race being reproduced is
+  // between concurrent replays *within* one run, driven by `rounds`/`width` and
+  // the watchdog timings. So this is set to clear the default attempt count in a
+  // couple of waves, not to maximize pressure.
+  concurrency: envNumber('EVENT_LOG_RACE_REPRO_CONCURRENCY', 8),
+  // Headroom, not a target: the default attempt count needs a few minutes, and a
+  // budget that fires before the job's `timeout-minutes` is what lets the
+  // summary be rendered at all. It has to stay far enough below that cap to
+  // absorb the worst case of one in-flight attempt draining its full
+  // `runTimeoutMs` after the budget ends (see `testTimeoutMs` below).
+  budgetMs: envNumber('EVENT_LOG_RACE_REPRO_BUDGET_MS', 12 * 60_000),
   runTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS', 240_000),
   hookTimeoutMs: envNumber('EVENT_LOG_RACE_REPRO_HOOK_TIMEOUT_MS', 60_000),
   rounds: envNumber('EVENT_LOG_RACE_REPRO_ROUNDS', 6),

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -263,7 +263,11 @@ export async function executeStep(
     stepId,
     stepName,
   } = params;
-  const isVercel = process.env.VERCEL_URL !== undefined;
+  // Truthiness, not presence: `vercel env pull` writes `VERCEL_URL=""` into
+  // `.env.local`, and a framework that loads that file locally would otherwise
+  // put us on the Vercel branch with nothing to build a host from, making
+  // `https://` the base URL of every step.
+  const isVercel = Boolean(process.env.VERCEL_URL);
   // Gate payload compression on the run's specVersion.
   const compression =
     (params.runSpecVersion ?? 0) >= SPEC_VERSION_SUPPORTS_COMPRESSION;

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -159,7 +159,11 @@ export async function runWorkflow(
     const fixedTimestamp =
       runIdCreatedAt(workflowRun.runId) ?? +workflowRun.createdAt;
 
-    const isVercel = process.env.VERCEL_URL !== undefined;
+    // Truthiness, not presence: `vercel env pull` writes `VERCEL_URL=""` into
+    // `.env.local`, and a framework that loads that file locally would otherwise
+    // put us on the Vercel branch with nothing to build a host from, making
+    // `https://` the base URL of every run.
+    const isVercel = Boolean(process.env.VERCEL_URL);
     // Load getPort lazily to prevent Turbopack from tracing get-port's
     // fs ops (readdir, readFile) into the flow route bundle. The resolved
     // port is cached per process (see get-port-lazy.ts), so this is cheap

--- a/scripts/event-log-race-repro-local.sh
+++ b/scripts/event-log-race-repro-local.sh
@@ -45,6 +45,18 @@ KEEP_QUEUE="0"
 # enough to exceed Node's default old-space limit (~4 GB) and take the server
 # down mid-run with an OOM, which then shows up as unrelated `stuck` outcomes.
 SERVER_HEAP_MB="8192"
+# world-postgres runs an embedded Graphile Worker in every process that loads it,
+# so the app and the harness each get this many slots. The package default is 50,
+# i.e. ~100 replays in flight against one Next.js process. Measured on a 12-core
+# laptop at the default: next-server pegged at ~120% CPU and 6.4 GB RSS against
+# an 8 GB old space while Postgres sat idle (1 active connection), all 100 slots
+# stayed locked, and every one of the 14 attempts came back `stuck` — GC
+# saturation, not a database or a queue limit. Bounded, the same 14 attempts run
+# to completion with no `stuck` at all. 10 is also world-postgres's pool size, so
+# Graphile Worker stops warning that concurrency outruns maxPoolSize. Bounding
+# replays per process does not weaken the repro: the race is between a handful of
+# concurrent replays of one run, not a throughput effect.
+LOCAL_WORKER_CONCURRENCY="10"
 
 COMPOSE_FILE="packages/world-postgres/docker-compose.yaml"
 # Matches the compose file and the `e2e-local-postgres` job in tests.yml.
@@ -99,9 +111,11 @@ This script deliberately sets none of them. Their defaults — and the full list
 live in packages/core/e2e/event-log-race-repro.test.ts, which is the single
 source of truth the CI workflow also defers to.
 
-WORKFLOW_POSTGRES_WORKER_CONCURRENCY (default 50) caps how many replays the app
-and the harness each run at once. Lowering it lowers the pressure the storms
-apply, so prefer --heap-mb for memory problems and treat this as a last resort.
+The one knob this script does set is WORKFLOW_POSTGRES_WORKER_CONCURRENCY, which
+caps how many replays the app and the harness each run at once. world-postgres
+defaults it to 50, i.e. ~100 replays sharing one Next.js process, which on a
+12-core laptop saturates GC and reports all 14 attempts as `stuck`. It is set to
+10 here instead, matching the pool size. Export your own value to override.
 
 Examples:
   # Default scale (a regression check, a few minutes).
@@ -156,6 +170,7 @@ done
 export WORKFLOW_POSTGRES_URL="${WORKFLOW_POSTGRES_URL:-$DEFAULT_POSTGRES_URL}"
 export WORKFLOW_TARGET_WORLD="@workflow/world-postgres"
 export WORKFLOW_PUBLIC_MANIFEST="1"
+export WORKFLOW_POSTGRES_WORKER_CONCURRENCY="${WORKFLOW_POSTGRES_WORKER_CONCURRENCY:-$LOCAL_WORKER_CONCURRENCY}"
 export PORT="$PORT"
 DEPLOYMENT_URL="http://localhost:$PORT"
 MANIFEST_URL="$DEPLOYMENT_URL/.well-known/workflow/v1/manifest.json"
@@ -182,9 +197,23 @@ cleanup() {
     # the port — a process-group kill is not portable here (macOS has no setsid).
     pkill -P "$SERVER_PID" >/dev/null 2>&1
     kill "$SERVER_PID" >/dev/null 2>&1
-    local pids
-    pids="$(port_pids)"
-    [ -n "$pids" ] && echo "$pids" | xargs kill >/dev/null 2>&1
+    # Then wait for the port to actually come free rather than just asking. The
+    # listener takes a moment to unbind, and the next run's up-front port check
+    # runs long before that — back-to-back runs otherwise die on "port in use".
+    local pids i
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+      pids="$(port_pids)"
+      [ -n "$pids" ] || break
+      # SIGTERM first, SIGKILL from the third try on.
+      if [ "$i" -lt 3 ]; then
+        echo "$pids" | xargs kill >/dev/null 2>&1
+      else
+        echo "$pids" | xargs kill -9 >/dev/null 2>&1
+      fi
+      sleep 1
+    done
+    [ -z "$(port_pids)" ] ||
+      log "Port $PORT is still held by $(port_pids | tr '\n' ' ')— the next run needs --port or a manual kill."
   fi
   if [ "$TEARDOWN" = "1" ] && [ "$USE_DOCKER" = "1" ]; then
     log "Removing the Postgres container"

--- a/scripts/event-log-race-repro-local.sh
+++ b/scripts/event-log-race-repro-local.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+#
+# Run the event-log race repro harness locally, against @workflow/world-postgres
+# and a workbench app started on this machine. No Vercel deployment, no GitHub
+# Actions, no VERCEL_* credentials.
+#
+# This is the same harness `.github/workflows/event-log-race-repro.yml` runs
+# (`packages/core/e2e/event-log-race-repro.test.ts`), pointed at a local backend.
+# It exists because the ordering here is easy to get wrong in ways that fail
+# silently rather than loudly:
+#
+#   * WORKFLOW_PUBLIC_MANIFEST=1 must be set at *build* time — the Next.js builder
+#     emits the manifest as a static file during the build, and without it the
+#     harness cannot resolve workflow IDs.
+#   * WORKFLOW_TARGET_WORLD must be set at *build* time too. `withWorkflow()`
+#     defaults it to `local` when VERCEL_DEPLOYMENT_ID is absent, which bakes the
+#     filesystem backend into the app and leaves the harness talking to a
+#     different world than the app is.
+#   * The schema has to exist before the app boots, or Graphile Worker starts
+#     against an unmigrated database.
+#   * The queue has to be empty before the app boots. Postgres outlives the app
+#     here, so an interrupted run leaves its unfinished flow messages behind and
+#     the next boot resumes all of them — thousands of stale jobs starving the
+#     run you actually care about. See clear_queue below.
+#
+# Usage: scripts/event-log-race-repro-local.sh [options]
+# Run with --help for options.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+APP_NAME="nextjs-turbopack"
+PORT="3000"
+USE_DEV="0"
+SKIP_BUILD="0"
+SKIP_DB_SETUP="0"
+USE_DOCKER="1"
+TEARDOWN="0"
+KEEP_QUEUE="0"
+# In CI every replay of a run lands in its own Fluid invocation; here they all
+# land in one Next.js process, and a storm run has tens of replays in flight at
+# once, each holding a VM sandbox and its own copy of the event log. That is
+# enough to exceed Node's default old-space limit (~4 GB) and take the server
+# down mid-run with an OOM, which then shows up as unrelated `stuck` outcomes.
+SERVER_HEAP_MB="8192"
+
+COMPOSE_FILE="packages/world-postgres/docker-compose.yaml"
+# Matches the compose file and the `e2e-local-postgres` job in tests.yml.
+DEFAULT_POSTGRES_URL="postgres://world:world@localhost:5432/world"
+RESULTS_FILE="event-log-race-repro-results.json"
+SERVER_LOG="event-log-race-repro-server.log"
+RENDERER=".github/scripts/render-event-log-race-repro-results.js"
+
+usage() {
+  cat <<'EOF'
+Run the event-log race repro harness against world-postgres + a local workbench app.
+
+Options:
+  --app NAME         Workbench app to drive (default: nextjs-turbopack).
+                     The repro workflow fixtures (101_hook_sleep_repro.ts,
+                     103_event_log_corruption_repro.ts) only exist in
+                     workbench/nextjs-turbopack; another app needs them copied
+                     or symlinked in first.
+  --port N           Port for the app (default: 3000).
+  --heap-mb N        Old-space limit for the app process (default: 8192). The
+                     server holds every concurrent replay of every run, so the
+                     default heap is not enough; lower this only if the machine
+                     cannot spare it, and expect OOM-induced `stuck` outcomes.
+  --dev              Use `pnpm dev` instead of a production build + `pnpm start`.
+                     Faster to iterate on workflow fixtures; less like CI.
+  --skip-build       Skip `pnpm build` and the app build. Use when only the
+                     harness or the driver changed.
+  --skip-db-setup    Skip applying migrations (schema already set up).
+  --no-docker        Do not manage Postgres. Point WORKFLOW_POSTGRES_URL at your
+                     own instance; the schema still needs to exist.
+  --keep-queue       Leave queued Graphile Worker jobs in place. By default they
+                     are deleted before the app boots: an interrupted earlier run
+                     leaves its flow messages queued, and resuming those abandoned
+                     runs saturates the app so this run reports `stuck` for
+                     reasons that have nothing to do with the event log. Only
+                     useful if you are inspecting the leftovers themselves.
+  --teardown         Stop and delete the Postgres container on exit. Off by
+                     default so repeat runs skip container startup.
+  -h, --help         Show this help.
+
+Scale knobs are read from the environment by the harness itself, so anything
+already exported is passed through untouched:
+
+  EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS   EVENT_LOG_RACE_REPRO_ROUNDS
+  EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS   EVENT_LOG_RACE_REPRO_WIDTH
+  EVENT_LOG_RACE_REPRO_ATTEMPTS              EVENT_LOG_RACE_REPRO_WATCHDOG_MS
+  EVENT_LOG_RACE_REPRO_CONCURRENCY           EVENT_LOG_RACE_REPRO_STEP_DELAY_MS
+  EVENT_LOG_RACE_REPRO_BUDGET_MS             EVENT_LOG_RACE_REPRO_POKE_INTERVAL_MS
+  EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS        EVENT_LOG_RACE_REPRO_HOOK_RESUME_STAGGER_MS
+
+This script deliberately sets none of them. Their defaults — and the full list —
+live in packages/core/e2e/event-log-race-repro.test.ts, which is the single
+source of truth the CI workflow also defers to.
+
+WORKFLOW_POSTGRES_WORKER_CONCURRENCY (default 50) caps how many replays the app
+and the harness each run at once. Lowering it lowers the pressure the storms
+apply, so prefer --heap-mb for memory problems and treat this as a last resort.
+
+Examples:
+  # Default scale (a regression check, a few minutes).
+  scripts/event-log-race-repro-local.sh
+
+  # One run per scenario, to smoke the plumbing.
+  EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS=1 \
+  EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS=1 \
+  EVENT_LOG_RACE_REPRO_ATTEMPTS=1 \
+    scripts/event-log-race-repro-local.sh
+
+  # Soak for a rate, reusing an already-built app and database.
+  EVENT_LOG_RACE_REPRO_STEP_STORM_ATTEMPTS=600 \
+  EVENT_LOG_RACE_REPRO_HOOK_STORM_ATTEMPTS=600 \
+  EVENT_LOG_RACE_REPRO_ATTEMPTS=200 \
+  EVENT_LOG_RACE_REPRO_CONCURRENCY=40 \
+  EVENT_LOG_RACE_REPRO_BUDGET_MS=4500000 \
+    scripts/event-log-race-repro-local.sh --skip-build --skip-db-setup
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --app) APP_NAME="${2:?--app needs a value}"; shift 2 ;;
+    --port) PORT="${2:?--port needs a value}"; shift 2 ;;
+    --heap-mb) SERVER_HEAP_MB="${2:?--heap-mb needs a value}"; shift 2 ;;
+    --dev) USE_DEV="1"; shift ;;
+    --skip-build) SKIP_BUILD="1"; shift ;;
+    --skip-db-setup) SKIP_DB_SETUP="1"; shift ;;
+    --no-docker) USE_DOCKER="0"; shift ;;
+    --keep-queue) KEEP_QUEUE="1"; shift ;;
+    --teardown) TEARDOWN="1"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; echo >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '\n\033[1m[repro]\033[0m %s\n' "$*"; }
+die() { printf '\n\033[1;31m[repro]\033[0m %s\n' "$*" >&2; exit 1; }
+
+APP_DIR="workbench/$APP_NAME"
+[ -d "$APP_DIR" ] || die "No such workbench app: $APP_DIR"
+
+# The harness resolves these two workflow files through the deployment's
+# manifest, so an app without them fails one attempt at a time with opaque
+# harness errors instead of up front.
+for fixture in 101_hook_sleep_repro.ts 103_event_log_corruption_repro.ts; do
+  [ -e "$APP_DIR/workflows/$fixture" ] ||
+    die "$APP_DIR/workflows/$fixture is missing — the repro fixtures live in workbench/nextjs-turbopack."
+done
+
+export WORKFLOW_POSTGRES_URL="${WORKFLOW_POSTGRES_URL:-$DEFAULT_POSTGRES_URL}"
+export WORKFLOW_TARGET_WORLD="@workflow/world-postgres"
+export WORKFLOW_PUBLIC_MANIFEST="1"
+export PORT="$PORT"
+DEPLOYMENT_URL="http://localhost:$PORT"
+MANIFEST_URL="$DEPLOYMENT_URL/.well-known/workflow/v1/manifest.json"
+
+# --- port ---------------------------------------------------------------------
+
+port_pids() { lsof -ti "tcp:$PORT" 2>/dev/null || true; }
+
+if [ -n "$(port_pids)" ]; then
+  die "Port $PORT is already in use (pids: $(port_pids | tr '\n' ' ')). Stop it or pass --port."
+fi
+
+# --- cleanup ------------------------------------------------------------------
+
+SERVER_PID=""
+
+cleanup() {
+  local status=$?
+  set +e
+  if [ -n "$SERVER_PID" ]; then
+    log "Stopping the app (pid $SERVER_PID)"
+    # `pnpm start` is a wrapper around `next start`, so the pnpm pid is not the
+    # listener. Kill the wrapper, then its children, then anything still holding
+    # the port — a process-group kill is not portable here (macOS has no setsid).
+    pkill -P "$SERVER_PID" >/dev/null 2>&1
+    kill "$SERVER_PID" >/dev/null 2>&1
+    local pids
+    pids="$(port_pids)"
+    [ -n "$pids" ] && echo "$pids" | xargs kill >/dev/null 2>&1
+  fi
+  if [ "$TEARDOWN" = "1" ] && [ "$USE_DOCKER" = "1" ]; then
+    log "Removing the Postgres container"
+    docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1
+  fi
+  set -e
+  return $status
+}
+trap cleanup EXIT
+
+# --- postgres -----------------------------------------------------------------
+
+if [ "$USE_DOCKER" = "1" ]; then
+  command -v docker >/dev/null 2>&1 || die "docker not found. Install Docker, or use --no-docker with your own Postgres."
+  log "Starting Postgres ($COMPOSE_FILE)"
+  docker compose -f "$COMPOSE_FILE" up -d
+
+  log "Waiting for Postgres to accept connections"
+  for _ in $(seq 1 60); do
+    if docker compose -f "$COMPOSE_FILE" exec -T postgres pg_isready -U world -d world >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+  docker compose -f "$COMPOSE_FILE" exec -T postgres pg_isready -U world -d world >/dev/null 2>&1 ||
+    die "Postgres did not become ready. Check: docker compose -f $COMPOSE_FILE logs postgres"
+else
+  log "Using the Postgres at WORKFLOW_POSTGRES_URL (not managed by this script)"
+fi
+
+# --- queue ---------------------------------------------------------------------
+
+# Runs a single statement as the `world` user. Prefers the container's own psql so
+# no local Postgres client is required.
+pg_exec() {
+  if [ "$USE_DOCKER" = "1" ]; then
+    docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U world -d world -At -c "$1" 2>/dev/null
+  else
+    psql "$WORKFLOW_POSTGRES_URL" -At -c "$1" 2>/dev/null
+  fi
+}
+
+# The jobs table is private to graphile-worker and has been renamed across its
+# versions, so resolve it instead of hardcoding one name, and no-op when the
+# schema does not exist yet (a fresh database).
+QUEUE_TABLE_SQL="select coalesce(to_regclass('graphile_worker._private_jobs')::text, to_regclass('graphile_worker.jobs')::text, '')"
+
+clear_queue() {
+  local table count
+  table="$(pg_exec "$QUEUE_TABLE_SQL" || true)"
+  [ -n "$table" ] || return 0
+  count="$(pg_exec "select count(*) from $table" || echo "0")"
+  [ "${count:-0}" -gt 0 ] || return 0
+  pg_exec "delete from $table" >/dev/null ||
+    die "Could not clear $table. Pass --keep-queue to skip this, or reset the database."
+  # Loud on purpose: a backlog here means the previous run was interrupted, which
+  # is worth knowing when comparing results between runs.
+  log "Discarded $count queued job(s) left over from an earlier run ($table)"
+}
+
+if [ "$KEEP_QUEUE" = "0" ]; then
+  if [ "$USE_DOCKER" = "0" ] && ! command -v psql >/dev/null 2>&1; then
+    log "psql not found — leaving the queue as it is. Stale jobs from an interrupted run will compete with this one."
+  else
+    clear_queue
+  fi
+fi
+
+# --- build --------------------------------------------------------------------
+
+if [ "$SKIP_BUILD" = "0" ]; then
+  # Turbo-cached, so this is cheap on repeat runs. Needed before the migration
+  # step, which loads packages/world-postgres/dist/cli.js.
+  log "Building packages"
+  pnpm build
+fi
+
+if [ "$SKIP_DB_SETUP" = "0" ]; then
+  log "Applying the world-postgres schema"
+  ./packages/world-postgres/bin/setup.js
+fi
+
+if [ "$SKIP_BUILD" = "0" ] && [ "$USE_DEV" = "0" ]; then
+  # WORKFLOW_PUBLIC_MANIFEST and WORKFLOW_TARGET_WORLD are exported above, so
+  # they apply to this build as well as to the server started below. Both are
+  # build-time inputs — see the header comment.
+  log "Building $APP_NAME"
+  pnpm --filter "$APP_NAME" build
+fi
+
+# --- server -------------------------------------------------------------------
+
+if [ "$USE_DEV" = "1" ]; then
+  SERVER_CMD="dev"
+else
+  SERVER_CMD="start"
+fi
+
+log "Starting $APP_NAME ($SERVER_CMD) on $DEPLOYMENT_URL — logging to $SERVER_LOG"
+: > "$SERVER_LOG"
+(
+  cd "$APP_DIR" &&
+    NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=$SERVER_HEAP_MB" \
+      pnpm "$SERVER_CMD" >> "$REPO_ROOT/$SERVER_LOG" 2>&1
+) &
+SERVER_PID=$!
+
+# A 200 on the manifest proves both that the server is up and that the public
+# manifest the harness depends on was actually emitted — a build without
+# WORKFLOW_PUBLIC_MANIFEST=1 serves the app fine and 404s here.
+log "Waiting for the workflow manifest at $MANIFEST_URL"
+ready="0"
+for _ in $(seq 1 180); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    tail -40 "$SERVER_LOG" >&2
+    die "The app exited before serving the manifest. Full log: $SERVER_LOG"
+  fi
+  if curl -fsS -o /dev/null "$MANIFEST_URL" 2>/dev/null; then
+    ready="1"
+    break
+  fi
+  sleep 1
+done
+[ "$ready" = "1" ] || {
+  tail -40 "$SERVER_LOG" >&2
+  die "Timed out waiting for $MANIFEST_URL. Full log: $SERVER_LOG"
+}
+
+# --- harness ------------------------------------------------------------------
+
+log "Running the repro harness"
+rm -f "$RESULTS_FILE"
+set +e
+DEPLOYMENT_URL="$DEPLOYMENT_URL" \
+APP_NAME="$APP_NAME" \
+NODE_OPTIONS="--enable-source-maps" \
+  pnpm run test:e2e:event-log-race-repro --reporter=default
+harness_status=$?
+set -e
+
+# A server that died mid-run makes every remaining attempt time out, so the
+# harness reports a wall of `stuck` runs with no hint of why. Say so plainly —
+# an OOM or a crash here is a local-environment problem, not a repro.
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+  log "The app is no longer running — it died during the harness. Last lines:"
+  tail -20 "$SERVER_LOG" >&2
+  SERVER_PID=""
+  harness_status=1
+fi
+
+# --- summary ------------------------------------------------------------------
+
+if [ -f "$RESULTS_FILE" ]; then
+  log "Summary"
+  # Same renderer the CI job uses for its sticky comment; with no --run-url it
+  # just prints the tables.
+  node "$RENDERER" "$RESULTS_FILE"
+  log "Full results: $RESULTS_FILE / app log: $SERVER_LOG"
+else
+  log "No $RESULTS_FILE was written — the harness died before its first checkpoint."
+fi
+
+if [ "$USE_DOCKER" = "1" ] && [ "$TEARDOWN" = "0" ]; then
+  log "Postgres is still running. Stop it with: docker compose -f $COMPOSE_FILE down -v"
+fi
+
+# The harness' own exit code is the gate: it fails on any non-`completed`,
+# non-`infra` outcome, which is the same rule as the renderer's --check.
+exit "$harness_status"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     testTimeout: 60_000,
+    // Positional file arguments are regex filters, not paths, so
+    // `vitest run packages/core/e2e/x.test.ts` also matches
+    // `.claude/worktrees/<name>/packages/core/e2e/x.test.ts` when agent
+    // worktrees live inside the repo (see .gitignore). Those copies belong to
+    // other branches: they would run their own version of the suite against the
+    // same backend and overwrite the same result files.
+    exclude: [...configDefaults.exclude, '**/.claude/**'],
   },
 });


### PR DESCRIPTION
The `event-log-race-repro` label currently launches **1400 workflow runs** (600 step-storm + 600 hook-storm + 200 hook-sleep) at concurrency 40, with a 75-minute launch budget inside a 120-minute job, against a live preview deployment. That was the right scale while hunting an unknown ~0.1% corruption rate. As a per-PR regression signal it costs two hours of runner time and 1400 preview-deployment runs.

## Scale: 1400 → 14 runs

| knob | before | after |
|:--|--:|--:|
| `stepStormAttempts` | 600 | 6 |
| `hookStormAttempts` | 600 | 6 |
| `hookSleepAttempts` | 200 | 2 |
| **total runs** | **1400** | **14** |
| `concurrency` | 40 | 8 |
| `budgetMs` | 75 min | 12 min |
| `timeout-minutes` | 120 | 25 |

The **per-run shape is unchanged** — `rounds` 6 × `width` 8 and every timing (`watchdogMs`, `stepDelayMs`, `hookResumeStaggerMs`, `pokeIntervalMs`) stays as-is. Those are the amplifier: a missing event shifts the step count, which renames every later correlation ID. Shrinking them would weaken each run instead of running fewer of them. All three scenarios are kept, including the `hook-sleep` control the calibration baseline is built on.

At 14 runs this is a regression check, not a rate measurement — a clean run means "the storms did not trip it", not "the rate is below X". The soak scale stays available via `workflow_dispatch`, and its values are recorded once in `AGENTS.md`.

## One source of truth for scale

Scale lived in three places: `envNumber(...)` fallbacks in the test, `default:` values on the `workflow_dispatch` inputs, and `${{ inputs.x || '600' }}` in the job's `env:`. `envNumber` treats an empty string as unset and GitHub passes `''` for an untouched input, so the YAML now passes inputs through bare and `event-log-race-repro.test.ts` is the only place a number lives. The renderer needs no change; it is scale-agnostic and its history rows keep rendering their own recorded config.

## Local runner

`scripts/event-log-race-repro-local.sh` (aliased as `pnpm run test:e2e:event-log-race-repro:local`) runs the same harness against `@workflow/world-postgres` plus a locally started `workbench/nextjs-turbopack` — no deployment, no `VERCEL_*` credentials, no Actions. It exists as a script rather than docs because every ordering constraint here fails *silently*:

- `WORKFLOW_PUBLIC_MANIFEST=1` and `WORKFLOW_TARGET_WORLD` are **build-time** inputs. Missing the first 404s the manifest; missing the second bakes world-local into the app, so the harness and the app talk to different worlds.
- The schema must exist before the app boots, or Graphile Worker starts against an unmigrated database.
- Postgres outlives the app, so an interrupted run leaves its flow messages queued and the next boot resumes all of them. Measured on this branch: an interrupted run left **2743** queued jobs, which starved the following run into 14/14 `stuck`. The script deletes them before boot (`--keep-queue` opts out) and says how many it discarded.

Readiness is a 200 on `/.well-known/workflow/v1/manifest.json`, which proves both that the server is up and that the public manifest was emitted. The app runs with `--max-old-space-size=8192` because every replay of every run shares one Node process here (CI gives each its own invocation) and the default ~4 GB limit OOMs mid-run, surfacing as unrelated `stuck` outcomes. Postgres is left running between runs unless `--teardown`.

The script sets no `EVENT_LOG_RACE_REPRO_*` variable, so the test file's defaults remain the only copy.

## Also included

- `fix(core)`: `VERCEL_URL=""` (what `vercel env pull` writes into `.env.local`, which Next.js loads for a local `next start`) took the Vercel branch on a presence check, so `createWorkflowBaseUrl` received `https://` and every run failed with `TypeError: Invalid URL`. Now a truthiness check. Found by the local runner.
- `vitest.config.ts`: exclude `**/.claude/**`. Positional args are regex filters, not paths, so `vitest run packages/core/e2e/event-log-race-repro.test.ts` also collected copies under `.claude/worktrees/*` — other branches' versions of the suite, running against the same backend and overwriting the same results file.

## Local worker concurrency

world-postgres starts an embedded Graphile Worker in **every process that loads it**, so the app and the harness get 50 slots each by default — ~100 replays sharing one Next.js heap. At that default all 14 attempts came back `stuck`, with `next-server` at ~120% CPU and 6.4 GB RSS against an 8 GB old space while Postgres sat idle at one active connection: GC saturation, not a database or queue limit. The script sets `WORKFLOW_POSTGRES_WORKER_CONCURRENCY=10` (export your own to override), which is also world-postgres's pool size, so Graphile stops warning that concurrency outruns `maxPoolSize`. Bounding replays per process doesn't weaken the repro — the race is between a handful of concurrent replays of *one* run, not a throughput effect.

Cleanup also waits for the port to be released now. It used to fire the kills and exit, but the listener unbinds after `kill` returns, so a second run started right after the first died on its own up-front port check.

## Verification

All of the below was run from a worktree on `origin/main` with this branch applied, against world-postgres + `workbench/nextjs-turbopack`.

| check | result |
|:--|:--|
| Full build-and-run, default scale | 14 attempts, **0 stuck**, 13 completed, 1 `CORRUPTED_EVENT_LOG`, exit 1 |
| Second pass (`--skip-build`) | 10 completed, 4 `CORRUPTED_EVENT_LOG`, 0 stuck |
| Third pass (worker concurrency 10) | 11 completed, 3 `CORRUPTED_EVENT_LOG`, 0 stuck, no pool warning |
| Negative path (`RUN_TIMEOUT_MS=1000`) | 14/14 `stuck`, script exit **1** — the gate is wired |
| Renderer `--check` | exit 1 on the 14-stuck results file, exit 0 on an all-completed copy |
| `node --test ".github/scripts/**/*.test.js"` | 37 pass, 0 fail |
| `pnpm lint` / `pnpm typecheck` | no errors on touched files / exit 0 |

The harness reproduces the bug locally: **8 of 18 `step-storm` attempts** across those three passes failed with `CORRUPTED_EVENT_LOG`, while `hook-storm` (0/18) and `hook-sleep` (0/6) stayed clean and nothing came back `stuck` (0/42). So a local run on `main` exits non-zero today — that is the harness working, not a broken setup.

The label was applied to this PR to exercise the shrunken job itself. It finished in **3m48s** against the new 25-minute cap (177s of that in-test) and reported **9 of 14 regressions**: `step-storm` 5/6 and `hook-storm` 4/6 `CORRUPTED_EVENT_LOG`, `hook-sleep` 0/2, with 0 `stuck` and 0 `infra`. The sticky comment rendered the new config row and the per-scenario table.

That is worth stating plainly: 14 runs is not a marginal sample for this bug as it stands today. The 1400-run scale was sized for a ~0.1% rate; the preview deployment currently reproduces at ~64% at this shape, so the shrunken job caught it nine times in under four minutes.

The amplifier is armed: `pressure.stragglers` runs 3–25 on storm attempts, with no `beforeAll` calibration warnings about the step delay failing to straddle `watchdogMs`. Env pass-through was confirmed by reading `config.stepStormAttempts` back out of the results JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
