### PR TITLE
feat(world-vercel): support Hook minimum retention

### DIFF
--- a/.changeset/fatal-hook-world-validation.md
+++ b/.changeset/fatal-hook-world-validation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fail a workflow when its World deterministically rejects Hook creation.

--- a/.changeset/vercel-hook-min-retention.md
+++ b/.changeset/vercel-hook-min-retention.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': minor
+---
+
+Support Hook minimum retention on Vercel.

--- a/docs/content/worlds/v5/vercel.mdx
+++ b/docs/content/worlds/v5/vercel.mdx
@@ -91,6 +91,7 @@ const run = await start(myWorkflow, [input], { region: "sfo1" });
 ## Limitations
 
 - **No run migration** - A run's region is fixed at creation. Existing runs cannot be moved to a different region.
+- **Hook minimum retention** - [`experimental_minRetention`](/docs/api-reference/workflow/create-hook#keep-a-token-unavailable-after-the-run-ends) cannot exceed 30 days.
 
 ## Observability
 

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2099,7 +2099,7 @@ describe('e2e', () => {
     }
   );
 
-  test.skipIf(!isLocalDeployment())(
+  test(
     'hookMinRetentionWorkflow - terminal Hook cannot resume and its token stays unavailable',
     { timeout: 60_000 },
     async () => {

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -1,5 +1,9 @@
 import { runInNewContext } from 'node:vm';
-import { PreconditionFailedError } from '@workflow/errors';
+import {
+  FatalError,
+  PreconditionFailedError,
+  WorkflowWorldError,
+} from '@workflow/errors';
 import type { WorkflowRun, World } from '@workflow/world';
 import { describe, expect, it, vi } from 'vitest';
 import { WorkflowSuspension } from '../global.js';
@@ -103,6 +107,36 @@ describe('handleSuspension', () => {
       }),
       expect.anything()
     );
+  });
+
+  it('fails the run when the World rejects Hook retention', async () => {
+    const worldError = new WorkflowWorldError('Retention exceeds 30 days', {
+      status: 400,
+    });
+    const world = createWorld(vi.fn().mockRejectedValue(worldError));
+    const pending = new Map([
+      [
+        'hook_with_invalid_retention',
+        {
+          type: 'hook' as const,
+          correlationId: 'hook_with_invalid_retention',
+          token: 'order:123',
+          tokenRetentionUntil: new Date('2026-09-01T00:00:00.000Z'),
+        },
+      ],
+    ]);
+
+    await expect(
+      handleSuspension({
+        suspension: new WorkflowSuspension(pending, globalThis),
+        world,
+        run,
+      })
+    ).rejects.toMatchObject({
+      name: FatalError.name,
+      message: 'createHook failed World validation: Retention exceeds 30 days',
+      cause: worldError,
+    });
   });
 
   it('marks hook.getConflict()-awaited creations without converting them into wait timeouts', async () => {

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -197,6 +197,16 @@ async function createHookEvent({
       };
     }
 
+    if (isWorldValidationFailure(err)) {
+      const fatal = new FatalError(
+        `createHook failed World validation: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      fatal.cause = err;
+      throw fatal;
+    }
+
     throw err;
   }
 }
@@ -711,7 +721,7 @@ export async function handleSuspension({
                 message: err.message,
               }
             );
-          } else if (isAttributeValidationFailure(err)) {
+          } else if (isWorldValidationFailure(err)) {
             // Deterministic validation rejection from the World — e.g. the
             // cumulative per-run attribute cap, which only the World can
             // check against the run's existing attributes. Redelivering the
@@ -806,15 +816,15 @@ export async function handleSuspension({
 }
 
 /**
- * Whether an `events.create` rejection is a deterministic attribute
- * validation failure rather than a transient/storage error. Local Worlds
+ * Whether an `events.create` rejection is deterministic World validation
+ * rather than a transient/storage error. Local Worlds
  * (world-local, world-postgres) throw `AttributeValidationError` directly;
  * remote Worlds surface the equivalent server-side rejection as a
  * `WorkflowWorldError` with HTTP status 400. The name check covers
  * `AttributeValidationError` instances from a different copy of
  * `@workflow/world` than the one this package resolved.
  */
-function isAttributeValidationFailure(err: unknown): boolean {
+function isWorldValidationFailure(err: unknown): boolean {
   if (err instanceof AttributeValidationError) return true;
   if (err instanceof Error && err.name === 'AttributeValidationError') {
     return true;

--- a/packages/world-vercel/src/index.ts
+++ b/packages/world-vercel/src/index.ts
@@ -33,6 +33,7 @@ export function createWorld(config?: APIConfig): World {
     // those payloads opaquely, and v5 remains a superset of v4 attributes.
     specVersion: SPEC_VERSION_SUPPORTS_COMPRESSION,
     capabilities: {
+      hookRetention: { active: true },
       // workflow-server enforces the `stateUpdatedAt` optimistic-concurrency
       // guard: creations carrying a stale snapshot are rejected with 412
       // (PreconditionFailedError) when the run's outside-event marker is


### PR DESCRIPTION
# The backend PR must be merged and deployed first

## Summary

- advertise Hook minimum-retention support from the Vercel World
- run the existing Hook-retention end-to-end case against Vercel deployments
- document the Vercel World's fixed 30-day maximum
- turn deterministic World validation failures into `FatalError` so workflows do not retry invalid Hook requests

The SDK remains unaware of the 30-day limit. `workflow-server` enforces it at the event-persistence boundary and returns HTTP 400. Core recognizes that deterministic response, including the existing Local World validation error, and stops the workflow instead of retrying it.

## Limits

- every Vercel project may request up to 30 days
- the limit does not depend on plan or Observability Plus
- requests beyond 30 days fail before event payload upload or entity materialization

The wire field already flows through world-vercel. The capability is enabled only after the backend implements and deploys the storage semantics.

## Stack

- Base: `main`
- Backend: [vercel/workflow-server#691](https://github.com/vercel/workflow-server/pull/691)

## Verification

- `@workflow/core` build passed
- focused suspension-handler tests: 19 passed
- dependency build for the Local, Postgres, and Vercel World stack passed
- world-vercel TypeScript check passed
- all 39 world-vercel event tests passed
- workflow-server production build and TypeScript check passed
- focused V2 and V4 backend integration tests passed against the rebuilt server

## Docs Preview

| Page | Preview |
| --- | --- |
| `createHook()` minimum retention | [v5](https://workflow-docs-git-codex-hook-retention-vercel.vercel.sh/v5/docs/api-reference/workflow/create-hook#keep-a-token-unavailable-after-the-run-ends) |
| Vercel World limitation | [v5](https://workflow-docs-git-codex-hook-retention-vercel.vercel.sh/worlds/vercel#limitations) |