### PR TITLE
Surface a Request ID in the run sidebar attribute panel

### DIFF
--- a/.changeset/attribute-order-indexof.md
+++ b/.changeset/attribute-order-indexof.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Sort sidebar Metadata rows missing from the panel's explicit order list after the listed ones instead of ahead of them, and give `errorCode`, `isWebhook`, and `isSystem` a position — a failed step's Error Code no longer renders above the step's own name.

--- a/.changeset/attribute-order-indexof.md
+++ b/.changeset/attribute-order-indexof.md
@@ -1,5 +1,0 @@
----
-'@workflow/web-shared': patch
----
-
-Sort sidebar Metadata rows missing from the panel's explicit order list after the listed ones instead of ahead of them, and give `errorCode`, `isWebhook`, and `isSystem` a position — a failed step's Error Code no longer renders above the step's own name.

--- a/.changeset/sidebar-request-id.md
+++ b/.changeset/sidebar-request-id.md
@@ -2,4 +2,4 @@
 '@workflow/web-shared': minor
 ---
 
-Surface an analytics event's `vercelId` in the run sidebar's Metadata list as a copyable "Request ID", and stop rendering the literal text `null` for a provenance id the analytics contract left empty.
+Surface an analytics event's `vercelId` in the run sidebar's Metadata list as a copyable "Request ID", and stop rendering the literal text `null` for a provenance id the analytics contract left empty. Also order Metadata rows missing from the panel's explicit order list after the listed ones instead of ahead of them, so a failed step's Error Code no longer renders above the step's own name.

--- a/.changeset/sidebar-request-id.md
+++ b/.changeset/sidebar-request-id.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': minor
+---
+
+Surface an analytics event's `vercelId` in the run sidebar's Metadata list as a copyable "Request ID", and stop rendering the literal text `null` for a provenance id the analytics contract left empty.

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -245,7 +245,12 @@ type AttributeKey =
   | 'isSystem'
   | 'errorCode'
   // Analytics-only provenance (AnalyticsEvent / AnalyticsStep), not on Event.
-  | 'computeInstanceId';
+  | 'computeInstanceId'
+  // Analytics-only, and event-grained: only AnalyticsEvent carries it. The key
+  // is `vercelId` because that is the name the backend stores the SDK's
+  // `requestId` under; AnalyticsEvent's sibling `requestId` column is never
+  // written, so reading that one would always be empty.
+  | 'vercelId';
 
 const attributeOrder: AttributeKey[] = [
   'workflowName',
@@ -264,6 +269,7 @@ const attributeOrder: AttributeKey[] = [
   'correlationId',
   'eventType',
   'deploymentId',
+  'vercelId',
   'computeInstanceId',
   'specVersion',
   'workflowCoreVersion',
@@ -310,6 +316,7 @@ const attributeDisplayNames: Partial<Record<AttributeKey, string>> = {
   errorCode: 'Error Code',
   correlationId: 'Correlation ID',
   deploymentId: 'Deployment ID',
+  vercelId: 'Request ID',
   computeInstanceId: 'Compute Instance ID',
   specVersion: 'Spec Version',
   workflowCoreVersion: '@workflow/core version',
@@ -392,6 +399,14 @@ const timestampWithTooltipOrNull = (value: unknown): ReactNode | null => {
   );
 };
 
+/**
+ * Renders an opaque provenance id. The analytics read contract types these as
+ * nullable, and only a `null` return is filtered out of the panel, so a bare
+ * `String()` would surface the literal text "null" as the value.
+ */
+const opaqueIdOrNull = (value: unknown): string | null =>
+  hasDisplayContent(value) ? String(value) : null;
+
 interface DisplayContext {
   stepName?: string;
   sectionOpen?: boolean;
@@ -428,7 +443,8 @@ const attributeToDisplayFn: Record<
   correlationId: (value: unknown) => String(value),
   // Project details
   deploymentId: (value: unknown) => String(value),
-  computeInstanceId: (value: unknown) => String(value),
+  vercelId: opaqueIdOrNull,
+  computeInstanceId: opaqueIdOrNull,
   specVersion: (value: unknown) => String(value),
   workflowCoreVersion: (value: unknown) => String(value),
   // Tenancy (we don't show these)
@@ -689,6 +705,7 @@ const copyableBasicAttributes = new Set<AttributeKey>([
   'hookId',
   'eventId',
   'deploymentId',
+  'vercelId',
   'computeInstanceId',
   'moduleSpecifier',
   'token',

--- a/packages/web-shared/src/components/sidebar/attribute-panel.tsx
+++ b/packages/web-shared/src/components/sidebar/attribute-panel.tsx
@@ -263,6 +263,8 @@ const attributeOrder: AttributeKey[] = [
   'runId',
   'attempt',
   'token',
+  'isWebhook',
+  'isSystem',
   'receivedCount',
   'lastReceivedAt',
   'disposedAt',
@@ -284,6 +286,7 @@ const attributeOrder: AttributeKey[] = [
   'completedAt',
   'expiredAt',
   'retryAfter',
+  'errorCode',
   'error',
   'metadata',
   'eventData',
@@ -293,11 +296,18 @@ const attributeOrder: AttributeKey[] = [
   'resumeAt',
 ];
 
-const sortByAttributeOrder = (a: string, b: string): number => {
-  const aIndex = attributeOrder.indexOf(a as AttributeKey) || 0;
-  const bIndex = attributeOrder.indexOf(b as AttributeKey) || 0;
-  return aIndex - bIndex;
+/**
+ * Rank of an attribute in {@link attributeOrder}. Keys absent from that list
+ * sort after every listed one rather than before them — `indexOf` reports a
+ * miss as `-1`, which is truthy, so a `|| 0` fallback never fires.
+ */
+const attributeOrderIndex = (attribute: string): number => {
+  const index = attributeOrder.indexOf(attribute as AttributeKey);
+  return index === -1 ? attributeOrder.length : index;
 };
+
+const sortByAttributeOrder = (a: string, b: string): number =>
+  attributeOrderIndex(a) - attributeOrderIndex(b);
 
 /**
  * Display names for attributes that should render differently from their key.

--- a/packages/web-shared/test/attribute-panel.test.ts
+++ b/packages/web-shared/test/attribute-panel.test.ts
@@ -1,0 +1,60 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { AttributePanel } from '../src/components/sidebar/attribute-panel.js';
+
+const render = (data: Record<string, unknown>): string =>
+  renderToStaticMarkup(createElement(AttributePanel, { data }));
+
+/**
+ * `vercelId` is the key the analytics read contract stores a flow-function
+ * invocation's request id under (the SDK sends it as `requestId`). The panel
+ * surfaces it as "Request ID" to match what Vercel Logs calls the value, since
+ * this panel's View Logs button is where a reader takes it next.
+ */
+describe('AttributePanel request id', () => {
+  it('renders vercelId as a copyable "Request ID" row', () => {
+    const markup = render({
+      stepId: 'step_1',
+      vercelId: 'iad1::abc-123-def',
+    });
+
+    expect(markup).toContain('Request ID');
+    expect(markup).toContain('iad1::abc-123-def');
+    // Copy affordance, matching the other opaque ids in this section.
+    expect(markup).toContain('aria-label="Copy Request ID"');
+  });
+
+  it('places Request ID above the coarser Compute Instance ID', () => {
+    const markup = render({
+      stepId: 'step_1',
+      deploymentId: 'dpl_1',
+      computeInstanceId: 'cinst_01JQ',
+      vercelId: 'iad1::abc-123-def',
+    });
+
+    expect(markup.indexOf('Request ID')).toBeGreaterThan(
+      markup.indexOf('Deployment ID')
+    );
+    expect(markup.indexOf('Request ID')).toBeLessThan(
+      markup.indexOf('Compute Instance ID')
+    );
+  });
+
+  /**
+   * The analytics schemas type both provenance ids as nullable, and the panel
+   * only drops a row whose display fn returns `null` — so stringifying an
+   * absent value would render the literal text "null" beside the label.
+   */
+  it('omits provenance rows whose analytics value is null', () => {
+    const markup = render({
+      stepId: 'step_1',
+      vercelId: null,
+      computeInstanceId: null,
+    });
+
+    expect(markup).not.toContain('Request ID');
+    expect(markup).not.toContain('Compute Instance ID');
+    expect(markup).toContain('step_1');
+  });
+});

--- a/packages/web-shared/test/attribute-panel.test.ts
+++ b/packages/web-shared/test/attribute-panel.test.ts
@@ -58,3 +58,44 @@ describe('AttributePanel request id', () => {
     expect(markup).toContain('step_1');
   });
 });
+
+/**
+ * Rows are ordered by their position in the panel's explicit `attributeOrder`
+ * list. Keys missing from that list sorted ahead of every listed key, because
+ * `indexOf`'s `-1` miss is truthy and so defeated the `|| 0` fallback meant to
+ * catch it — which put a failed step's Error Code above its own name.
+ */
+describe('AttributePanel row ordering', () => {
+  it("keeps a failed step's Error Code below its identity rows", () => {
+    const markup = render({
+      stepId: 'step_1',
+      stepName: 'step//./src/workflows/order//processPayment',
+      status: 'failed',
+      errorCode: 'USER_ERROR',
+    });
+
+    expect(markup).toContain('Error Code');
+    expect(markup.indexOf('Error Code')).toBeGreaterThan(
+      markup.indexOf('Module')
+    );
+    expect(markup.indexOf('Error Code')).toBeGreaterThan(
+      markup.indexOf('Step ID')
+    );
+  });
+
+  it('keeps a hook’s classification flags below its token', () => {
+    const markup = render({
+      hookId: 'hook_1',
+      token: 'tok_1',
+      isWebhook: true,
+      isSystem: false,
+    });
+
+    expect(markup.indexOf('isWebhook')).toBeGreaterThan(
+      markup.indexOf('Token')
+    );
+    expect(markup.indexOf('isWebhook')).toBeGreaterThan(
+      markup.indexOf('Hook ID')
+    );
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

One warm compute instance serves many invocations, so the Compute Instance ID already in this panel can't distinguish steps that ran inline within a single flow-function invocation — sibling steps sharing a Request ID did. It's also the value Vercel Logs indexes by, and this panel's View Logs button is where a reader takes it next.

The key is `vercelId`, not `requestId`: that's the name world-vercel stores the SDK's request id under crossing the wire, and AnalyticsEvent's sibling `requestId` field is declared but never written. Nothing in this repository populates `vercelId` on the object the panel receives yet — only AnalyticsEvent carries it, and grouping steps by invocation needs a step-level aggregation in workflow-server first — so the row ships as forward-compatible plumbing in the slot next to Compute Instance ID.

The second commit is an independent fix: `sortByAttributeOrder` guarded `indexOf` with `|| 0`, but a miss returns -1, which is truthy, so any key absent from `attributeOrder` sorted ahead of every listed key. It can be dropped on its own.

## Test Plan

Unit tests added; the two ordering assertions fail against the unfixed comparator. The new row could not be verified by hand — no local code path populates it.
