### PR TITLE
world-local: converge redelivered hook_received re-ensure on its committed resumeId claim

### DIFF
--- a/.changeset/world-local-resume-redelivery-converge.md
+++ b/.changeset/world-local-resume-redelivery-converge.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Converge a redelivered `hook_received` re-ensure on its already-committed `(runId, resumeId)` claim instead of rejecting with `HookNotFoundError` when the hook was disposed after the resume was recorded. The rejection made the queue consumer ack the redelivery as "nothing left to resume", silently dropping any continuation the message carried.

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -1026,6 +1026,43 @@ export function createEventsStorage(
           isHookEventRequiringExistence(data.eventType) &&
           data.correlationId
         ) {
+          // Redelivery convergence — checked BEFORE the disposal/existence
+          // rejections below: if this resume's `(runId, resumeId)` claim is
+          // already committed AND its pinned event is journaled, return that
+          // event as success. The claim proves this exact resume was accepted
+          // while the hook was alive, and the event is already in the log, so
+          // replay observes it either way. Without this, a queue redelivery
+          // of the consumer's re-ensure after the workflow disposed the hook
+          // (dispose → sleep) is rejected with HookNotFound — which the
+          // consumer treats as "nothing left to resume" and acks, losing
+          // whatever continuation the message carried. A claim with a
+          // mismatched hookId or payload digest is NOT converged here; it
+          // falls through to the full validation below, which rejects it the
+          // same way it always has.
+          if (data.eventType === 'hook_received' && params?.resumeId) {
+            const committedClaim = await readJSON(
+              hookResumeClaimPath(basedir, effectiveRunId, params.resumeId),
+              HookResumeClaimSchema
+            );
+            if (
+              committedClaim &&
+              committedClaim.hookId === data.correlationId &&
+              (!params.resumePayloadDigest ||
+                !committedClaim.payloadDigest ||
+                committedClaim.payloadDigest === params.resumePayloadDigest)
+            ) {
+              const committedEvent = await readJSONWithFallback(
+                basedir,
+                'events',
+                `${effectiveRunId}-${committedClaim.eventId}`,
+                EventSchema,
+                tag
+              );
+              if (committedEvent) {
+                return { event: committedEvent };
+              }
+            }
+          }
           // A resume must never be journaled after the hook's disposal.
           // The disposer's durable order is: dispose lock → claim/entity
           // delete → `hook_disposed` append, so the hook entity can still

--- a/packages/world-local/src/storage/hook-resume-dedup.test.ts
+++ b/packages/world-local/src/storage/hook-resume-dedup.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { SPEC_VERSION_CURRENT, type Storage } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createHook, createRun } from '../test-helpers.js';
+import { createHook, createRun, disposeHook } from '../test-helpers.js';
 import { createStorage } from './index.js';
 
 // When a run carries the `hookResumeInputVersion` marker, the parallel resume
@@ -116,6 +116,36 @@ describe('world-local hook_received resume dedup', () => {
       resume(runId, hook, 'resume_1', 'digest_2', new Uint8Array([2]))
     ).rejects.toThrow();
     expect(await countHookReceived(runId)).toBe(1);
+  });
+
+  it('converges a committed resume re-ensured AFTER the hook was disposed', async () => {
+    const { runId, hook } = await setup();
+    const payload = new Uint8Array([1, 2, 3]);
+
+    // Delivery 1: the consumer's re-ensure commits the resume while the
+    // hook is alive.
+    const first = await resume(runId, hook, 'resume_1', 'digest_1', payload);
+
+    // The workflow receives the payload and disposes the hook (e.g. the
+    // dispose → sleep pattern), releasing its token.
+    await disposeHook(storage, runId, hook.hookId);
+
+    // Delivery 2: the SAME message is redelivered (queue retry, or a
+    // visibility-timeout continuation riding the resume message) and
+    // re-ensures the same (resumeId, digest). The resume is already
+    // committed — this must converge on the existing event as success, NOT
+    // reject with HookNotFound. A rejection makes the consumer ack the
+    // message as "nothing left to resume", silently dropping whatever
+    // continuation it carried and wedging the run.
+    const second = await resume(runId, hook, 'resume_1', 'digest_1', payload);
+
+    expect(second.event.eventId).toBe(first.event.eventId);
+    expect(await countHookReceived(runId)).toBe(1);
+
+    // A genuinely NEW resume after disposal is still rejected.
+    await expect(
+      resume(runId, hook, 'resume_2', 'digest_2', new Uint8Array([9]))
+    ).rejects.toThrow();
   });
 
   it('rejects a reused resumeId + digest that belongs to a DIFFERENT hook', async () => {


### PR DESCRIPTION
## Problem

world-local's `events.create('hook_received', …)` runs its disposal-committed and hook-existence rejections **before** the `(runId, resumeId)` claim convergence added for lazy hook resumption (#3230). A queue redelivery of the consumer's re-ensure — after the workflow has disposed the hook (e.g. the `using hook = createHook(…)` → dispose → `sleep()` pattern, which releases the token while the run continues) — therefore gets `HookNotFoundError` even though **this exact resume is already committed**.

The consumer contract (runtime.ts lazy-resume prologue) treats `HookNotFoundError` as "the run went terminal / nothing left to resume" and **acks the delivery**. Any continuation the redelivered message was carrying is silently dropped and the run wedges. Natural triggers include a consumer crash after the re-ensure but before ack, a queue retry racing the dispose, or an engine that reschedules via visibility-timeout redelivery of the resume message (where this was found: the QuickJS engine branch, #3048).

## Fix

Check the `(runId, resumeId)` claim **first**: a committed claim whose pinned event is journaled proves this exact resume was accepted while the hook was alive — return that event as success (idempotent convergence, matching the documented server behavior). Everything else is unchanged:

- claims with a mismatched `hookId` or payload digest still fall through to full validation and are rejected as before
- genuinely **new** resumes of a disposed hook are still rejected with `HookNotFoundError`
- a claim whose pinned event is not yet visible (crash between claim write and append) still goes through the disposal/existence checks

## Notes

- world-postgres is unaffected: it deliberately does not advertise lazy hook-resume dedup (no `resumeId` column) and stays on the sequential single-writer path, so the re-ensure redelivery shape never occurs there.
- New regression test in `hook-resume-dedup.test.ts` covers converge-after-dispose plus the still-rejected new-resume case.
- Backport candidate: correctness/wedge fix to existing functionality.