### PR TITLE
Remove @ijjk from CODEOWNERS default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owners for the entire repository
-* @ijjk @vercel/workflow
+* @vercel/workflow
 
-/docs @ijjk @vercel/workflow @vercel/team-python
+/docs @vercel/workflow @vercel/team-python


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`@ijjk` was listed as a default CODEOWNER for the whole repo (and `/docs`), so GitHub requested JJ as a reviewer on every PR.

This removes `@ijjk` from both entries and leaves team ownership (`@vercel/workflow`, and `@vercel/team-python` for docs).

## Test plan

- [ ] Confirm CODEOWNERS no longer includes `@ijjk`
- [ ] After merge, open a test PR and verify JJ is not auto-requested as a reviewer

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2577dd4-974e-4570-8c6e-0e03fea0dc30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2577dd4-974e-4570-8c6e-0e03fea0dc30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

