### PR TITLE
Add SurrealDB as a community world

### DIFF
--- a/.changeset/add-surrealdb-world.md
+++ b/.changeset/add-surrealdb-world.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add SurrealDB to `worlds-manifest.json` as a community world, and add optional `args` support to the community-world CI's generic `docker` service runner so a manifest service can pass command arguments to its container image (SurrealDB's image entrypoint needs the `start` subcommand). The E2E job remains gated by the existing `if: false` on `e2e-community`.

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -124,6 +124,14 @@ jobs:
               done <<< "$env_lines"
             fi
             args+=("$image")
+            # Optional command args passed to the image entrypoint (e.g. a
+            # `start` subcommand for images whose entrypoint is the bare binary).
+            cmd_args=$(echo "$svc" | jq -r '.args // [] | .[]')
+            if [ -n "$cmd_args" ]; then
+              while IFS= read -r line; do
+                args+=("$line")
+              done <<< "$cmd_args"
+            fi
 
             echo "Starting $name ($image)..."
             "${args[@]}"

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -130,6 +130,48 @@
       ]
     },
     {
+      "id": "surrealdb",
+      "type": "community",
+      "package": "workflow-world-surrealdb",
+      "name": "SurrealDB",
+      "description": "SurrealDB world using LIVE SELECT for queueing and real-time streaming",
+      "repository": "https://github.com/sepcnt/workflow-world-surrealdb",
+      "docs": "https://github.com/sepcnt/workflow-world-surrealdb",
+      "features": [],
+      "env": {
+        "WORKFLOW_TARGET_WORLD": "workflow-world-surrealdb",
+        "WORKFLOW_SURREAL_URL": "ws://127.0.0.1:8000/rpc",
+        "WORKFLOW_SURREAL_NAMESPACE": "workflow",
+        "WORKFLOW_SURREAL_DATABASE": "workflow",
+        "WORKFLOW_SURREAL_USERNAME": "root",
+        "WORKFLOW_SURREAL_PASSWORD": "root"
+      },
+      "services": [
+        {
+          "name": "surrealdb",
+          "image": "surrealdb/surrealdb:v3",
+          "args": [
+            "start",
+            "--user",
+            "root",
+            "--pass",
+            "root",
+            "--bind",
+            "0.0.0.0:8000",
+            "memory"
+          ],
+          "ports": ["8000:8000"],
+          "healthCheck": {
+            "cmd": "curl -sf http://localhost:8000/health || exit 1",
+            "interval": "5s",
+            "timeout": "3s",
+            "retries": 10
+          }
+        }
+      ],
+      "setup": "pnpm exec workflow-surreal-setup"
+    },
+    {
       "id": "jazz",
       "type": "community",
       "package": "workflow-world-jazz",


### PR DESCRIPTION
Adopts #1579 by @sepcnt so CI can run — fork PRs never receive repo secrets, so the required `e2e-vercel-prod` lane can structurally never pass there. The commit is authored by @sepcnt with their DCO sign-off preserved.

## What this adds

- `worlds-manifest.json`: SurrealDB community world entry ([workflow-world-surrealdb](https://github.com/sepcnt/workflow-world-surrealdb)), with its container declared in the manifest's `services` array (generic `docker` service type)
- `e2e-community-world.yml`: optional `args` support in the generic docker service runner — the `surrealdb/surrealdb:v3` image has `Entrypoint: ["/surreal"]` and no default command, so a service definition must be able to pass the `start` subcommand and flags
- Empty changeset (no packages changed), same pattern as the Platformatic world PR

The community-world e2e lane remains disabled (`if: false`) until community worlds implement the `world.streams.*` interface, so the SurrealDB job won't execute yet either way.

Closes #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)