### PR TITLE
chore(deps): upgrade undici to 7.29.0

### DIFF
--- a/.changeset/bump-undici-7-29-0.md
+++ b/.changeset/bump-undici-7-29-0.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-local': patch
+'@workflow/world-vercel': patch
+---
+
+Update undici to 7.29.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ~3.0.1
       version: 3.0.1
     undici:
-      specifier: 7.28.0
-      version: 7.28.0
+      specifier: 7.29.0
+      version: 7.29.0
     vitest:
       specifier: ^4.1.10
       version: 4.1.10
@@ -1379,7 +1379,7 @@ importers:
         version: 3.0.1
       undici:
         specifier: 'catalog:'
-        version: 7.28.0
+        version: 7.29.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1538,7 +1538,7 @@ importers:
         version: 3.0.1
       undici:
         specifier: 'catalog:'
-        version: 7.28.0
+        version: 7.29.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -16476,12 +16476,12 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -34956,7 +34956,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.1
       tmp: 0.2.5
-      undici: 7.22.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -35244,9 +35244,9 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@7.22.0: {}
-
   undici@7.28.0: {}
+
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   semver: 7.7.4
   typescript: ^6.0.3
   ulid: ~3.0.1
-  undici: 7.28.0
+  undici: 7.29.0
   vitest: ^4.1.10
   zod: ~4.3.6
 


### PR DESCRIPTION
Upgrades `undici` from 7.28.0 to 7.29.0 in the workspace catalog, consumed by `@workflow/world-local` and `@workflow/world-vercel`.

- Unit tests pass for both packages (world-local 508, world-vercel 334)
- Changeset included (patch bump for both packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)