### PR TITLE
Reduce Vercel E2E polling load

### DIFF
--- a/.changeset/five-second-e2e-polling.md
+++ b/.changeset/five-second-e2e-polling.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Allow configuring the polling interval used by `Run.returnValue` with `WORKFLOW_RETURN_VALUE_POLL_INTERVAL_MS`.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -330,7 +330,6 @@ jobs:
       statuses: read
     strategy:
       fail-fast: false
-      max-parallel: 6
       matrix:
         # Workflow VM engines: node:vm (default) and the opt-in QuickJS
         # WASM engine. The env var is set on the e2e test runner, which is

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -330,6 +330,7 @@ jobs:
       statuses: read
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix:
         # Workflow VM engines: node:vm (default) and the opt-in QuickJS
         # WASM engine. The env var is set on the e2e test runner, which is
@@ -381,6 +382,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       WORKFLOW_PUBLIC_MANIFEST: '1'
+      WORKFLOW_RETURN_VALUE_POLL_INTERVAL_MS: '5000'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -522,6 +524,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       WORKFLOW_PUBLIC_MANIFEST: '1'
+      WORKFLOW_RETURN_VALUE_POLL_INTERVAL_MS: '5000'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/docs/content/docs/v5/configuration/runtime-tuning.mdx
+++ b/docs/content/docs/v5/configuration/runtime-tuning.mdx
@@ -10,6 +10,16 @@ related:
 
 Runtime variables are read where workflows execute. Set them on the deployment or dev server.
 
+## Client polling
+
+### `WORKFLOW_RETURN_VALUE_POLL_INTERVAL_MS`
+
+- Default: `1000`
+- Minimum: `1`
+- Delay between status requests made by [`Run.returnValue`](/docs/api-reference/workflow-api/get-run) while a workflow run is not yet complete.
+- Increase it to reduce polling traffic at the cost of noticing completion later.
+- This variable is read by the process awaiting `Run.returnValue`, such as an E2E test runner, rather than by the workflow deployment.
+
 ## Replay and queue delivery
 
 ### `WORKFLOW_REPLAY_TIMEOUT_MS`

--- a/packages/core/src/runtime/run.ts
+++ b/packages/core/src/runtime/run.ts
@@ -6,6 +6,7 @@ import {
 } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import {
+  envNumber,
   SPEC_VERSION_CURRENT,
   type WorkflowRunStatus,
   type World,
@@ -27,6 +28,17 @@ import {
   type StopSleepResult,
   wakeUpRun,
 } from './runs.js';
+
+const RETURN_VALUE_POLL_INTERVAL_MS = 1_000;
+
+/** @internal */
+export function getReturnValuePollIntervalMs(): number {
+  return envNumber(
+    'WORKFLOW_RETURN_VALUE_POLL_INTERVAL_MS',
+    RETURN_VALUE_POLL_INTERVAL_MS,
+    { integer: true, min: 1 }
+  );
+}
 
 /**
  * A `ReadableStream` extended with workflow-specific helpers.
@@ -307,7 +319,7 @@ export class Run<TResult> {
   }
 
   /**
-   * Polls the workflow return value every 1 second until it is completed.
+   * Polls the workflow return value until it is completed.
    * @internal
    * @returns The workflow return value.
    */
@@ -374,7 +386,9 @@ export class Run<TResult> {
         throw new WorkflowRunNotCompletedError(this.runId, run.status);
       } catch (error) {
         if (WorkflowRunNotCompletedError.is(error)) {
-          await new Promise((resolve) => setTimeout(resolve, 1_000));
+          await new Promise((resolve) =>
+            setTimeout(resolve, getReturnValuePollIntervalMs())
+          );
           continue;
         }
         if (

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -30,7 +30,7 @@ import {
   dehydrateStepReturnValue,
   hydrateStepReturnValue,
 } from '../serialization.js';
-import { Run } from './run.js';
+import { getReturnValuePollIntervalMs, Run } from './run.js';
 import { recreateRunFromExisting, reenqueueRun, wakeUpRun } from './runs.js';
 import { start } from './start.js';
 import { setWorld } from './world.js';
@@ -393,6 +393,31 @@ describe('Run custom serialization', () => {
 
     expect(hydrated).toBeInstanceOf(Run);
     expect((hydrated as Run<unknown>).runId).toBe('wrun_roundtrip');
+  });
+});
+
+describe('Run.returnValue polling interval', () => {
+  const envName = 'WORKFLOW_RETURN_VALUE_POLL_INTERVAL_MS';
+  const originalValue = process.env[envName];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[envName];
+    } else {
+      process.env[envName] = originalValue;
+    }
+  });
+
+  it('defaults to one second', () => {
+    delete process.env[envName];
+
+    expect(getReturnValuePollIntervalMs()).toBe(1_000);
+  });
+
+  it('accepts a runtime override', () => {
+    process.env[envName] = '5000';
+
+    expect(getReturnValuePollIntervalMs()).toBe(5_000);
   });
 });
 


### PR DESCRIPTION
## Summary

- make the `Run.returnValue` polling interval configurable with `WORKFLOW_RETURN_VALUE_POLL_INTERVAL_MS`
- set all Vercel E2E jobs to poll every 5 seconds
- document and test the new runtime setting

## Why

The Vercel E2E matrix was running many test variants concurrently, and each active `Run.returnValue` waited for completion by polling the Workflow API every second. That combined fan-out produced the recent `api-workflow` traffic spike attributed to Vercel Labs CI.

This keeps the SDK default at 1 second for existing users while reducing CI polling frequency. The tradeoff is up to roughly 4 seconds of additional completion-detection latency in these E2E jobs.

## Validation

- `pnpm vitest run packages/core/src/runtime/runs.test.ts` (22 tests)
- `pnpm --filter @workflow/core build`
- `pnpm --filter @workflow/core typecheck`
- parsed `.github/workflows/tests.yml` as YAML
- `git diff --check`

> Note: validation ran on Node 25, while the repository declares support for Node 18/20/22/24; pnpm emitted an engine warning, but all checks above passed.
