### PR TITLE
fix(core): preserve Hook retention in QuickJS

### DIFF
--- a/.changeset/quickjs-hook-retention.md
+++ b/.changeset/quickjs-hook-retention.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Preserve Hook minimum-retention deadlines in QuickJS workflows.

--- a/packages/core/src/runtime/quickjs-entrypoint.ts
+++ b/packages/core/src/runtime/quickjs-entrypoint.ts
@@ -792,6 +792,17 @@ export async function runWorkflowWithQuickJS(params: {
     // Drain failures are swallowed: the workflow's own outcome is the
     // source of truth.
     if (result.completed.drainOperations?.length) {
+      // Fail loud on retained hooks the World can't support BEFORE the
+      // drain try/catch below — that catch intentionally swallows genuine
+      // drain failures ("the workflow's own outcome is the source of
+      // truth"), but the retention gate's FatalError must escape to the
+      // replay loop's catch (run_failed), mirroring the node engine. This
+      // covers the fire-and-forget case: a retained hook that was never
+      // awaited only reaches the gate through this drain.
+      assertHookRetentionSupported(
+        result.completed.drainOperations,
+        world.capabilities
+      );
       try {
         await dispatchPendingOps({
           world,
@@ -1043,6 +1054,14 @@ export async function runWorkflowWithQuickJS(params: {
     // Flush leftover pending side effects before writing run_failed —
     // same drain semantics as the completed branch.
     if (result.failed.drainOperations?.length) {
+      // Fail loud on retained hooks the World can't support BEFORE the
+      // drain try/catch below — same reasoning as the completed branch:
+      // the retention gate's FatalError must escape to the replay loop's
+      // catch rather than be swallowed as a genuine drain failure.
+      assertHookRetentionSupported(
+        result.failed.drainOperations,
+        world.capabilities
+      );
       try {
         await dispatchPendingOps({
           world,

--- a/packages/core/src/runtime/quickjs-entrypoint.ts
+++ b/packages/core/src/runtime/quickjs-entrypoint.ts
@@ -182,6 +182,10 @@ async function dispatchPendingOps(params: {
           correlationId: hook.correlationId,
           eventData: {
             token: hook.token,
+            tokenRetentionUntil:
+              hook.tokenRetentionUntil === undefined
+                ? undefined
+                : new Date(hook.tokenRetentionUntil),
             metadata: encryptedMetadata,
             // Always include isWebhook explicitly. Worlds default it to
             // `true` when absent, which would break the public webhook

--- a/packages/core/src/runtime/quickjs-entrypoint.ts
+++ b/packages/core/src/runtime/quickjs-entrypoint.ts
@@ -16,6 +16,7 @@
 import type { Span } from '@opentelemetry/api';
 import {
   EntityConflictError,
+  FatalError,
   HookNotFoundError,
   MaxEventsExceededError,
   RunExpiredError,
@@ -27,6 +28,7 @@ import {
   type RunInput,
   SPEC_VERSION_CURRENT,
   type WorkflowRun,
+  type WorldCapabilities,
 } from '@workflow/world';
 import { classifyRunError } from '../classify-error.js';
 import { runtimeLogger } from '../logger.js';
@@ -103,6 +105,40 @@ export function isFirstInvocation(
  *    drainPendingQueueItems. Steps are created but NOT queued, and the run
  *    is never requeued.
  */
+/**
+ * Rejects retained Hooks before registration when the configured World
+ * does not support `experimental_minRetention` — the same gate the node
+ * engine applies inside `createHook()` (workflow/hook.ts), where
+ * `ctx.worldCapabilities` is available to workflow code. The QuickJS VM
+ * has no capability channel into the guest, so the check runs host-side
+ * at dispatch, before any `hook_created` is written. Without it, a
+ * non-supporting world would silently persist the hook WITHOUT its
+ * retention deadline — the user asked for retention, got none, and
+ * nothing failed loud (see WorldCapabilities.hookRetention in
+ * @workflow/world: "Missing or inactive means the runtime rejects
+ * retained Hooks before registration").
+ *
+ * The FatalError escapes the entrypoint into the replay loop's catch in
+ * runtime.ts, which records run_failed — mirroring the node engine,
+ * where the same FatalError fails the run from inside the workflow.
+ */
+export function assertHookRetentionSupported(
+  pendingOperations: PendingOperation[],
+  capabilities: WorldCapabilities | undefined
+): void {
+  if (capabilities?.hookRetention?.active === true) return;
+  for (const op of pendingOperations) {
+    if (
+      op.type === 'hook' &&
+      (op as PendingHook).tokenRetentionUntil !== undefined
+    ) {
+      throw new FatalError(
+        'The configured World does not support `experimental_minRetention` for Hooks.'
+      );
+    }
+  }
+}
+
 async function dispatchPendingOps(params: {
   world: Awaited<ReturnType<typeof getWorld>>;
   runId: string;
@@ -146,6 +182,8 @@ async function dispatchPendingOps(params: {
   // same pattern as an elapsed wait.
   let createdAttributeEvent = false;
   const opsPromises: Promise<void>[] = [];
+
+  assertHookRetentionSupported(pendingOperations, world.capabilities);
 
   const processHookOp = async (hook: PendingHook): Promise<void> => {
     runtimeLogger.debug('QuickJS runtime: processing hook op', {

--- a/packages/core/src/runtime/quickjs-hook-retention-gate.test.ts
+++ b/packages/core/src/runtime/quickjs-hook-retention-gate.test.ts
@@ -1,0 +1,75 @@
+import { FatalError } from '@workflow/errors';
+import type { WorldCapabilities } from '@workflow/world';
+import { describe, expect, it } from 'vitest';
+import { assertHookRetentionSupported } from './quickjs-entrypoint.js';
+import type { PendingOperation } from './quickjs-runtime.js';
+
+/**
+ * Host-side capability gate for retained Hooks on the QuickJS engine.
+ * Mirrors the node engine's check in workflow/hook.ts: a World without
+ * hookRetention.active must reject a retained Hook BEFORE registration,
+ * not silently persist it without its retention deadline.
+ */
+describe('assertHookRetentionSupported', () => {
+  const retainedHook: PendingOperation = {
+    type: 'hook',
+    correlationId: 'hook_01TEST',
+    token: 'tok',
+    tokenRetentionUntil: Date.now() + 60_000,
+    isWebhook: false,
+    hasCreatedEvent: false,
+  } as PendingOperation;
+
+  const plainHook: PendingOperation = {
+    type: 'hook',
+    correlationId: 'hook_02TEST',
+    token: 'tok2',
+    isWebhook: false,
+    hasCreatedEvent: false,
+  } as PendingOperation;
+
+  const activeCaps: WorldCapabilities = { hookRetention: { active: true } };
+
+  it('passes retained hooks on a world with active hookRetention', () => {
+    expect(() =>
+      assertHookRetentionSupported([retainedHook], activeCaps)
+    ).not.toThrow();
+  });
+
+  it('throws FatalError for a retained hook when capabilities are absent', () => {
+    expect(() =>
+      assertHookRetentionSupported([retainedHook], undefined)
+    ).toThrow(FatalError);
+    expect(() =>
+      assertHookRetentionSupported([retainedHook], undefined)
+    ).toThrow(
+      'The configured World does not support `experimental_minRetention` for Hooks.'
+    );
+  });
+
+  it('throws when hookRetention is declared but inactive', () => {
+    expect(() =>
+      assertHookRetentionSupported([retainedHook], {
+        hookRetention: { active: false },
+      })
+    ).toThrow(FatalError);
+  });
+
+  it('ignores hooks without a retention deadline', () => {
+    expect(() =>
+      assertHookRetentionSupported([plainHook], undefined)
+    ).not.toThrow();
+  });
+
+  it('ignores non-hook operations', () => {
+    const waitOp = {
+      type: 'wait',
+      correlationId: 'wait_01TEST',
+      resumeAt: new Date().toISOString(),
+      hasCreatedEvent: false,
+    } as unknown as PendingOperation;
+    expect(() =>
+      assertHookRetentionSupported([waitOp], undefined)
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/runtime/quickjs-runtime.test.ts
+++ b/packages/core/src/runtime/quickjs-runtime.test.ts
@@ -87,6 +87,34 @@ describe('runQuickJSWorkflow', () => {
     );
   });
 
+  it('preserves a Hook minimum-retention deadline across the VM boundary', async () => {
+    const result = await runQuickJSWorkflow({
+      workflowCode: `
+        async function workflow() {
+          var hook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")]({
+            token: "retained",
+            experimental_minRetention: 60000,
+          });
+          await hook.getConflict();
+        }
+        workflow.workflowId = "workflow//test//workflow";
+        globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+      `,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: makeRun(),
+      events: [],
+    });
+
+    expect(result.suspended?.pendingOperations).toContainEqual(
+      expect.objectContaining({
+        type: 'hook',
+        token: 'retained',
+        tokenRetentionUntil:
+          new Date('2025-01-01T00:00:00Z').getTime() + 60_000,
+      })
+    );
+  });
+
   it('should complete after step resolves via full event replay', async () => {
     const code = `
       var add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//test//add");

--- a/packages/core/src/runtime/quickjs-runtime.test.ts
+++ b/packages/core/src/runtime/quickjs-runtime.test.ts
@@ -115,6 +115,36 @@ describe('runQuickJSWorkflow', () => {
     );
   });
 
+  it('accepts a Date-like object (getTime only) for minimum retention', async () => {
+    // Values that crossed the serde boundary may be Date-like rather than
+    // realm-native Date instances — parseDurationToDate accepts them on
+    // the node engine, so the VM shim must too.
+    const result = await runQuickJSWorkflow({
+      workflowCode: `
+        async function workflow() {
+          var hook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")]({
+            token: "retained-datelike",
+            experimental_minRetention: { getTime: function() { return 1234567890; } },
+          });
+          await hook.getConflict();
+        }
+        workflow.workflowId = "workflow//test//workflow";
+        globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+      `,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: makeRun(),
+      events: [],
+    });
+
+    expect(result.suspended?.pendingOperations).toContainEqual(
+      expect.objectContaining({
+        type: 'hook',
+        token: 'retained-datelike',
+        tokenRetentionUntil: 1234567890,
+      })
+    );
+  });
+
   it('rejects minimum retention for webhook Hooks', async () => {
     const result = await runQuickJSWorkflow({
       workflowCode: `

--- a/packages/core/src/runtime/quickjs-runtime.test.ts
+++ b/packages/core/src/runtime/quickjs-runtime.test.ts
@@ -115,6 +115,28 @@ describe('runQuickJSWorkflow', () => {
     );
   });
 
+  it('rejects minimum retention for webhook Hooks', async () => {
+    const result = await runQuickJSWorkflow({
+      workflowCode: `
+        async function workflow() {
+          globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")]({
+            isWebhook: true,
+            experimental_minRetention: 60000,
+          });
+        }
+        workflow.workflowId = "workflow//test//workflow";
+        globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+      `,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: makeRun(),
+      events: [],
+    });
+
+    expect(result.failed?.message).toBe(
+      'Webhook hooks do not support `experimental_minRetention`. Use a non-webhook `createHook()` with `resumeHook()`.'
+    );
+  });
+
   it('should complete after step resolves via full event replay', async () => {
     const code = `
       var add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//test//add");

--- a/packages/core/src/runtime/quickjs-runtime.ts
+++ b/packages/core/src/runtime/quickjs-runtime.ts
@@ -587,7 +587,10 @@ globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")] = function(options) {
         throw new Error('Invalid duration: "' + minRetention + '". Expected a valid duration string like "1s", "1m", "1h", etc.');
       }
       tokenRetentionUntil = Date.now() + retentionMs;
-    } else if (minRetention instanceof Date) {
+    } else if (minRetention instanceof Date || (minRetention && typeof minRetention.getTime === "function")) {
+      // Accept Date-like objects (anything with getTime), matching
+      // parseDurationToDate: values that crossed the serde boundary may
+      // not be realm-native Date instances.
       tokenRetentionUntil = minRetention.getTime();
     } else {
       throw new Error("Invalid duration parameter. Expected a duration string, number (milliseconds), or Date object.");

--- a/packages/core/src/runtime/quickjs-runtime.ts
+++ b/packages/core/src/runtime/quickjs-runtime.ts
@@ -86,6 +86,8 @@ export interface PendingHook {
   type: 'hook';
   correlationId: string;
   token: string;
+  /** Earliest token reuse time, as milliseconds since the Unix epoch. */
+  tokenRetentionUntil?: number;
   isWebhook: boolean;
   metadata?: unknown;
   hasCreatedEvent: boolean;
@@ -568,6 +570,26 @@ globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")] = function(options) {
   var correlationId = "hook_" + globalThis.__generateUlid();
   var isDisposed = false;
   var hasCreatedEvent = false;
+  var tokenRetentionUntil;
+  if (options.experimental_minRetention !== undefined) {
+    var minRetention = options.experimental_minRetention;
+    if (typeof minRetention === "number") {
+      if (minRetention < 0 || !isFinite(minRetention)) {
+        throw new Error("Invalid duration: " + minRetention + ". Expected a non-negative finite number of milliseconds.");
+      }
+      tokenRetentionUntil = Date.now() + minRetention;
+    } else if (typeof minRetention === "string") {
+      var retentionMs = globalThis.__parseDurationMs(minRetention);
+      if (typeof retentionMs !== "number" || retentionMs < 0 || !isFinite(retentionMs)) {
+        throw new Error('Invalid duration: "' + minRetention + '". Expected a valid duration string like "1s", "1m", "1h", etc.');
+      }
+      tokenRetentionUntil = Date.now() + retentionMs;
+    } else if (minRetention instanceof Date) {
+      tokenRetentionUntil = minRetention.getTime();
+    } else {
+      throw new Error("Invalid duration parameter. Expected a duration string, number (milliseconds), or Date object.");
+    }
+  }
 
   // Register in pending operations.
   // Serialize metadata inside the VM so Response/Request objects are
@@ -576,6 +598,7 @@ globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")] = function(options) {
     type: "hook",
     correlationId: correlationId,
     token: token,
+    tokenRetentionUntil: tokenRetentionUntil,
     isWebhook: !!options.isWebhook,
     metadata: options.metadata ? globalThis[Symbol.for("workflow-serialize")](options.metadata) : undefined,
     hasCreatedEvent: false,

--- a/packages/core/src/runtime/quickjs-runtime.ts
+++ b/packages/core/src/runtime/quickjs-runtime.ts
@@ -566,6 +566,9 @@ if (typeof Request === "undefined") {
 // The promise is resolved when a hook_received event arrives.
 globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")] = function(options) {
   options = options || {};
+  if (options.isWebhook === true && options.experimental_minRetention !== undefined) {
+    throw new Error('Webhook hooks do not support \`experimental_minRetention\`. Use a non-webhook \`createHook()\` with \`resumeHook()\`.');
+  }
   var token = options.token || globalThis.__generateNanoid();
   var correlationId = "hook_" + globalThis.__generateUlid();
   var isDisposed = false;


### PR DESCRIPTION
## Summary

- carry a Hook's minimum-retention deadline across the QuickJS VM boundary
- include that deadline in the resulting `hook_created` event
- add a focused QuickJS regression test

## Root cause

The QuickJS hook shim created its own pending-operation object but omitted `experimental_minRetention`. The host therefore persisted the Hook without `tokenRetentionUntil`, and terminal-run cleanup made it unavailable immediately. The node VM path already forwarded the deadline correctly.

## Testing

- `pnpm turbo run build --filter='!./workbench/*'`
- `pnpm --filter @workflow/core test` (1,905 passed; 3 expected failures)
- targeted QuickJS E2E: `hookMinRetentionWorkflow - terminal Hook cannot resume and its token stays unavailable`
