### PR TITLE
Deliver Postgres queue messages in process

### DIFF
--- a/.changeset/framework-direct-queue-bootstrap.md
+++ b/.changeset/framework-direct-queue-bootstrap.md
@@ -1,0 +1,10 @@
+---
+'@workflow/astro': patch
+'@workflow/nest': patch
+'@workflow/nitro': patch
+'@workflow/next': patch
+'@workflow/sveltekit': patch
+'@workflow/world-testing': patch
+---
+
+Initialize generated flow handlers before starting direct-delivery Worlds.

--- a/.changeset/postgres-direct-delivery.md
+++ b/.changeset/postgres-direct-delivery.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Deliver Postgres workflow queue messages directly to the in-process handler and create runs atomically with their first event.

--- a/.changeset/postgres-direct-execution.md
+++ b/.changeset/postgres-direct-execution.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-postgres': minor
+'@workflow/world-testing': patch
+---
+
+`@workflow/world-postgres` now executes queue jobs by calling the registered in-process workflow handler directly instead of POSTing to the app's own HTTP routes. The HTTP loopback path is removed entirely — including `WORKFLOW_LOCAL_BASE_URL`/`PORT` handling, port detection, and TCP readiness probing. The graphile-worker runner starts only once a workflow handler is registered, so jobs are never consumed by a process that cannot execute them (enqueue-only processes stay inert). Load the generated workflow route module in the worker process before/alongside `world.start()`. Graphile task names and job payloads are unchanged, so in-flight and suspended runs survive the upgrade.

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -84,10 +84,11 @@ export class LocalBuilder extends BaseBuilder {
     workflowsRouteContent = workflowsRouteContent.replace(
       /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
       (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const workflowHandler = workflowEntrypoint(workflowCode${options});
+export const POST = Object.assign(async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode${options})(normalRequest);
-}
+  return workflowHandler(normalRequest);
+}, { initialize: workflowHandler.initialize });
 
 export const prerender = false;`
     );

--- a/packages/nest/src/workflow.controller.ts
+++ b/packages/nest/src/workflow.controller.ts
@@ -91,6 +91,12 @@ function getOutDir(): string {
   return controllerConfig.outDir;
 }
 
+export async function loadWorkflowHandler() {
+  const outDir = getOutDir();
+  await import(pathToFileURL(join(outDir, 'steps.mjs')).href);
+  return import(pathToFileURL(join(outDir, 'workflows.mjs')).href);
+}
+
 /**
  * Controller that handles the well-known workflow endpoints.
  * Dynamically imports the generated bundles and handles request/response conversion.
@@ -99,12 +105,7 @@ function getOutDir(): string {
 export class WorkflowController {
   @Post('flow')
   async handleFlow(@Req() req: any, @Res() res: any) {
-    const outDir = getOutDir();
-    // Import step registrations (side effects) before the combined handler
-    await import(pathToFileURL(join(outDir, 'steps.mjs')).href);
-    const { POST } = await import(
-      pathToFileURL(join(outDir, 'workflows.mjs')).href
-    );
+    const { POST } = await loadWorkflowHandler();
     const webRequest = toWebRequest(req);
     const webResponse = await POST(webRequest);
     await sendWebResponse(res, webResponse);

--- a/packages/nest/src/workflow.module.ts
+++ b/packages/nest/src/workflow.module.ts
@@ -9,6 +9,7 @@ import { join } from 'pathe';
 import type { NestBuilderOptions } from './builder.js';
 import {
   configureWorkflowController,
+  loadWorkflowHandler,
   WorkflowController,
 } from './workflow.controller.js';
 
@@ -86,19 +87,23 @@ export class WorkflowModule implements OnModuleInit, OnModuleDestroy {
 
   async onModuleInit() {
     const options = WorkflowModule.state.options;
-    if (!options || options.skipBuild) {
-      return;
+    const outDir = WorkflowModule.state.outDir;
+    if (!options || !outDir) return;
+
+    if (!options.skipBuild) {
+      // Lazy-load the toolchain so it never enters the runtime bundle.
+      const [{ NestLocalBuilder }, { createBuildQueue }] = await Promise.all([
+        import('./builder.js'),
+        import('@workflow/builders'),
+      ]);
+      const builder = new NestLocalBuilder({ ...options, outDir });
+      await createBuildQueue()(() => builder.build());
     }
-    // Lazy-load the toolchain so it never enters the runtime bundle.
-    const [{ NestLocalBuilder }, { createBuildQueue }] = await Promise.all([
-      import('./builder.js'),
-      import('@workflow/builders'),
-    ]);
-    const builder = new NestLocalBuilder({
-      ...options,
-      outDir: WorkflowModule.state.outDir ?? undefined,
-    });
-    await createBuildQueue()(() => builder.build());
+
+    if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+      const { POST } = await loadWorkflowHandler();
+      await POST.initialize();
+    }
   }
 
   async onModuleDestroy() {

--- a/packages/next/src/index.test.ts
+++ b/packages/next/src/index.test.ts
@@ -144,6 +144,30 @@ describe('withWorkflow builder config', () => {
     expect(prewarmWorkflowSwcPluginCacheMock).not.toHaveBeenCalled();
   });
 
+  it('inlines the selected World during development', async () => {
+    process.env.WORKFLOW_TARGET_WORLD = '@workflow/world-postgres';
+    const config = withWorkflow({ env: { EXISTING: 'value' } });
+
+    const nextConfig = await config('phase-development-server', {
+      defaultConfig: {},
+    });
+
+    expect(nextConfig.env).toEqual({
+      EXISTING: 'value',
+      WORKFLOW_TARGET_WORLD: '@workflow/world-postgres',
+    });
+  });
+
+  it('keeps World selection dynamic in production', async () => {
+    const config = withWorkflow({ env: { EXISTING: 'value' } });
+
+    const nextConfig = await config('phase-production-build', {
+      defaultConfig: {},
+    });
+
+    expect(nextConfig.env).toEqual({ EXISTING: 'value' });
+  });
+
   it('configures diagnostics inside the default Next.js dist dir', async () => {
     const config = withWorkflow({});
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -488,6 +488,12 @@ export function withWorkflow(
     }
     // shallow clone to avoid read-only on top-level
     nextConfig = Object.assign({}, nextConfig);
+    if (phase === 'phase-development-server') {
+      nextConfig.env = {
+        ...nextConfig.env,
+        WORKFLOW_TARGET_WORLD: process.env.WORKFLOW_TARGET_WORLD,
+      };
+    }
     const workflowBasePath = nextConfig.basePath;
     setWorkflowBasePath(workflowBasePath);
     nextConfig.serverExternalPackages = [

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -476,6 +476,18 @@ function addVirtualHandler(
     'workflow/webhook.mjs': '',
     'workflow/workflows.mjs': `await import(/* @vite-ignore */ pathToFileURL(${stepsImportPath}).href + "?t=" + version);`,
   };
+  const initializeWorkflow: Record<VirtualHandlerPath, string> = {
+    'workflow/webhook.mjs': '',
+    'workflow/workflows.mjs': `
+      export async function initializeWorkflow() {
+        await (await loadHandler()).POST.initialize();
+      }`,
+  };
+  const handlerImports: Record<VirtualHandlerPath, string> = {
+    'workflow/webhook.mjs': `import { POST } from ${handlerImportPath};`,
+    'workflow/workflows.mjs': `import { POST } from ${handlerImportPath};
+    export const initializeWorkflow = POST.initialize;`,
+  };
 
   if (nitro.options.dev) {
     // Dev mode: load generated workflow bundles from disk at request time.
@@ -492,19 +504,21 @@ function addVirtualHandler(
       let currentVersion = "";
       let currentImportPath = "";
 
-      async function loadPOST() {
+      async function loadHandler() {
         const version = String(statSync(handlerPath).mtimeMs);
         if (version !== currentVersion) {
           currentVersion = version;
           currentImportPath = pathToFileURL(handlerPath).href + "?t=" + version;
           ${preloadSteps[buildPath]}
         }
-        return (await import(currentImportPath)).POST;
+        return import(currentImportPath);
       }
 
+      ${initializeWorkflow[buildPath]}
+
       export default fromWebHandler(async (request, context) => {
-        const POST = await loadPOST();
-        return POST(request, context);
+        const handler = await loadHandler();
+        return handler.POST(request, context);
       });
     `;
     } else {
@@ -516,20 +530,22 @@ function addVirtualHandler(
       let currentVersion = "";
       let currentImportPath = "";
 
-      async function loadPOST() {
+      async function loadHandler() {
         const version = String(statSync(handlerPath).mtimeMs);
         if (version !== currentVersion) {
           currentVersion = version;
           currentImportPath = pathToFileURL(handlerPath).href + "?t=" + version;
           ${preloadSteps[buildPath]}
         }
-        return (await import(currentImportPath)).POST;
+        return import(currentImportPath);
       }
+
+      ${initializeWorkflow[buildPath]}
 
       export default async ({ req }) => {
         try {
-          const POST = await loadPOST();
-          return await POST(req);
+          const handler = await loadHandler();
+          return await handler.POST(req);
         } catch (error) {
           console.error('Handler error:', error);
           return new Response('Internal Server Error', { status: 500 });
@@ -550,14 +566,14 @@ function addVirtualHandler(
     nitro.options.virtual[`#${buildPath}`] = /* js */ `
     import ${handlerImportPath};
     import { fromWebHandler } from "h3";
-    import { POST } from ${handlerImportPath};
+    ${handlerImports[buildPath]}
     export default fromWebHandler(POST);
   `;
   } else {
     // Nitro v3+ (native web handlers)
     nitro.options.virtual[`#${buildPath}`] = /* js */ `
     import ${handlerImportPath};
-    import { POST } from ${handlerImportPath};
+    ${handlerImports[buildPath]}
     export default async ({ req }) => {
       try {
         return await POST(req);

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -94,10 +94,11 @@ export class SvelteKitBuilder extends BaseBuilder {
     workflowsRouteContent = workflowsRouteContent.replace(
       /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
       (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const workflowHandler = workflowEntrypoint(workflowCode${options});
+export const POST = Object.assign(async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode${options})(normalRequest);
-}`
+  return workflowHandler(normalRequest);
+}, { initialize: workflowHandler.initialize });`
     );
     // These files are generated into the SvelteKit routes directory, which
     // Vite watches in dev, so an identical rewrite would still invalidate the

--- a/packages/world-postgres/HOW_IT_WORKS.md
+++ b/packages/world-postgres/HOW_IT_WORKS.md
@@ -12,13 +12,16 @@ If you want to use any other ORM, query builder or underlying database client, y
 graph LR
     Client --> PG[graphile-worker queue]
     PG --> Worker[Embedded Worker]
-    Worker --> HTTP[Combined flow HTTP route]
-    HTTP --> Handler[Workflow Handler]
+    Worker --> Handler[Registered Workflow Handler]
 
     PG -.-> F["${prefix}flows<br/>(orchestration and steps)"]
 ```
 
-Jobs include retry logic (3 attempts), idempotency keys, durable delayed rescheduling, and configurable worker concurrency (default: 10).
+Jobs include retry logic (3 attempts), idempotency keys, durable delayed rescheduling, and configurable worker concurrency (default: 50).
+
+When the workflow runtime's generated flow route module loads, it calls `world.createQueueHandler(prefix, handler)`. The Postgres world stores that handler in a process-global registry and the embedded graphile-worker runner invokes it **directly in-process** for every job — there is no HTTP loopback, port detection, or base-URL configuration. The returned HTTP wrapper keeps the generated flow route functional (e.g. for health checks), but it is not on the job execution path.
+
+When the handler returns `{ timeoutSeconds }`, the worker schedules a replacement Graphile job with a future `runAt` time (carrying the incremented logical attempt) before acknowledging the current one, so a crash cannot lose the wake-up.
 
 ## Streaming
 
@@ -32,23 +35,19 @@ Real-time data streaming via **PostgreSQL LISTEN/NOTIFY**:
 
 ## Setup
 
-Call `world.start()` to initialize graphile-worker workers. When `.start()` is called, workers begin listening to graphile-worker queues. When a job arrives, the worker executes the queue message over the workflow HTTP routes and awaits completion before acknowledging the Graphile job.
+Call `world.start()` to initialize graphile-worker. The runner begins consuming jobs only once a workflow handler is registered — jobs stay in PostgreSQL until the process can execute them, and a process that only enqueues (e.g. a CLI) never consumes. If `start()` was called and no handler registers within 10 seconds, a warning is logged.
 
-When the runtime returns `{ timeoutSeconds }`, the worker schedules a new Graphile job with a future `runAt` time before finishing the current task.
-
-The worker sends workflow orchestration and queued step messages to the combined `.well-known/workflow/v1/flow` endpoint.
-
-In **Next.js**, the `world.start()` call needs to be added to `instrumentation.ts|js` to ensure workers start before request handling. Use `workflow/runtime` for `getWorld` (same as the testing server and other framework plugins):
+Make sure the generated workflow route module is loaded in the worker process (it registers the handler as a module-load side effect), then call `world.start()`. In **Next.js**, do both from `instrumentation.ts|js`:
 
 ```ts
 // instrumentation.ts
-
-if (process.env.NEXT_RUNTIME !== "edge") {
-  import("workflow/runtime").then(async ({ getWorld }) => {
-    // start listening to the jobs.
-    const world = await getWorld();
-    await world.start?.();
-  });
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Registers the workflow handler as a side effect.
+    await import("./app/.well-known/workflow/v1/flow/route");
+    const { getWorld } = await import("workflow/runtime");
+    await getWorld().then((world) => world.start?.());
+  }
 }
 ```
 
@@ -56,6 +55,6 @@ if (process.env.NEXT_RUNTIME !== "edge") {
 
 `world.close()` first stops Graphile Worker from claiming new jobs, then waits for active jobs before closing the streamer and any internally owned pool.
 
-Graphile Worker gives active tasks a grace period, then aborts their task signal. The Postgres world forwards that signal to both the workflow HTTP request and its response body. If the request aborts, Graphile Worker unlocks the same Postgres job row through its normal failure handling. The already-claimed delivery consumes an attempt and is retried only if its Graphile attempt budget remains; the shutdown handler does not insert a successor row.
+Graphile Worker gives active tasks a grace period, then unlocks their job rows through its normal failure handling. The already-claimed delivery consumes an attempt and is retried only if its Graphile attempt budget remains; the shutdown handler does not insert a successor row. Unlocking a row does not stop the in-process handler that is still executing it, so workflow and step handlers need to tolerate at-least-once execution.
 
-Applications that manage a broader shutdown sequence should set `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` for the standard package target or `applicationManagedShutdown: true` for a programmatic World, await `world.close()`, and only then close the workflow HTTP routes and any caller-owned pool. This prevents Graphile Worker's default handler from terminating the process as soon as its queue stops. Because aborting a client request does not prove that its server handler stopped, workflow and step handlers still need to tolerate at-least-once execution.
+Applications that manage a broader shutdown sequence should set `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` for the standard package target or `applicationManagedShutdown: true` for a programmatic World, await `world.close()`, and only then close any caller-owned pool. This prevents Graphile Worker's default handler from terminating the process as soon as its queue stops.

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -82,11 +82,11 @@ const world = createWorld({
 await world.start();
 ```
 
-Use this option only when your application or framework has its own shutdown hook. Handle cleanup errors there and await `world.close()` first, then close the workflow HTTP server and any caller-owned `pg.Pool`.
+Use this option only when your application or framework has its own shutdown hook. Handle cleanup errors there and await `world.close()` first, then close any caller-owned `pg.Pool`.
 
-Closing the world stops the queue from accepting new jobs and waits for active jobs. After Graphile Worker's graceful-shutdown timeout (5 seconds by default), it aborts any workflow HTTP request that is still pending. Graphile Worker then unlocks the same row through its normal failure handling. Graphile counts a delivery attempt when it claims the row, so the aborted delivery consumes that attempt and is retried only if its Graphile attempt budget remains. A one-attempt or final-attempt job is unlocked but not retried. The shutdown handler does not create a replacement row.
+Closing the world stops the queue from accepting new jobs and waits for active jobs. After Graphile Worker's graceful-shutdown timeout (5 seconds by default), it unlocks any job row that is still executing through its normal failure handling. Graphile counts a delivery attempt when it claims the row, so the interrupted delivery consumes that attempt and is retried only if its Graphile attempt budget remains. A one-attempt or final-attempt job is unlocked but not retried. The shutdown handler does not create a replacement row.
 
-An aborted HTTP request does not guarantee that its server-side handler stopped, so workflow and step handlers must continue to tolerate at-least-once execution. Keep the workflow HTTP routes and any caller-owned pool available until `world.close()` resolves.
+An unlocked job row does not stop the in-process handler that is still executing it, so workflow and step handlers must continue to tolerate at-least-once execution. Keep any caller-owned pool available until `world.close()` resolves.
 
 ## Configuration Options
 
@@ -176,18 +176,25 @@ and its token can be reused. If the token is never reused, the expired
 ## Features
 
 - **Durable Storage**: Stores workflow runs, events, steps, hooks, and webhooks in PostgreSQL
-- **Queue Processing**: Uses graphile-worker as the durable queue and executes jobs over the workflow HTTP routes
+- **Queue Processing**: Uses graphile-worker as the durable queue and executes jobs in-process through the registered workflow handler — no HTTP loopback
 - **Durable Delays**: Re-schedules waits and retries in PostgreSQL
 - **Streaming**: Real-time event streaming capabilities
 - **Health Checks**: Built-in connection health monitoring
 - **Configurable Concurrency**: Adjustable worker concurrency for queue processing
+
+## Execution Model
+
+A worker is any Node.js process that has loaded the generated workflow route module (which registers the workflow handler) and called `world.start()`. Jobs are executed by calling that handler directly in-process — there is no HTTP hop. Scale out by running more such processes against the same database; graphile-worker's row locking distributes jobs between them.
+
+- `world.start()` starts consuming jobs only once a workflow handler is registered. If none is registered after 10 seconds, a warning is logged.
+- A process that only enqueues runs (e.g. a CLI) never registers a handler, so it never consumes jobs — they stay in PostgreSQL until a worker picks them up.
 
 ## Queue Behavior
 
 - Graphile jobs are acknowledged only after execution finishes, or after the worker durably schedules a delayed follow-up job
 - Backlog stays in PostgreSQL when all execution slots are busy
 - Retry and sleep-style delays use Graphile `runAt` scheduling
-- Workflow orchestration and queued step execution are both sent through `/.well-known/workflow/v1/flow`
+- Workflow orchestration and queued step execution are both dispatched through the single registered workflow queue handler
 
 ## Development
 

--- a/packages/world-postgres/package.json
+++ b/packages/world-postgres/package.json
@@ -46,11 +46,9 @@
     "db:push": "node dist/cli.js"
   },
   "dependencies": {
-    "@vercel/queue": "catalog:",
     "@workflow/errors": "workspace:*",
     "@workflow/utils": "workspace:*",
     "@workflow/world": "workspace:*",
-    "@workflow/world-local": "workspace:*",
     "cbor-x": "1.6.0",
     "dotenv": "17.3.1",
     "drizzle-orm": "0.45.2",

--- a/packages/world-postgres/src/index.ts
+++ b/packages/world-postgres/src/index.ts
@@ -75,6 +75,7 @@ export function createWorld(
   return {
     specVersion: mintedSpecVersion(),
     capabilities: {
+      directQueueDelivery: true,
       hookRetention: { active: true },
     },
     ...storage,

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -3,7 +3,6 @@ import {
   parseQueueName,
   type QueueHandler,
   type QueuePayload,
-  type QueuePrefix,
   serializeQueueMessage,
 } from '@workflow/world';
 import {
@@ -14,7 +13,7 @@ import {
 } from 'graphile-worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageData } from './message.js';
-import { createQueue } from './queue.js';
+import { createQueue, handlerRegistry } from './queue.js';
 
 const createdQueues: Array<ReturnType<typeof createQueue>> = [];
 
@@ -25,14 +24,6 @@ vi.mock('graphile-worker', () => ({
   makeWorkerUtils: vi.fn(),
   run: vi.fn(),
 }));
-
-// The handler registry is process-global (shared across module copies), so
-// tests must reset it between runs.
-const registry = (
-  globalThis as {
-    [key: symbol]: { handlers: Map<QueuePrefix, QueueHandler> };
-  }
-)[Symbol.for('@workflow/world-postgres//queueHandlers')];
 
 describe('postgres queue direct execution', () => {
   const workerUtilsMock = {
@@ -50,7 +41,9 @@ describe('postgres queue direct execution', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    registry.handlers.clear();
+    // The handler registry is process-global (shared across module copies),
+    // so tests must reset it between runs.
+    handlerRegistry.handlers.clear();
 
     vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
     vi.mocked(run).mockResolvedValue(runnerMock as unknown as Runner);

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -1,10 +1,9 @@
-import { createServer, type Server } from 'node:http';
-import { setWorkflowBasePath } from '@workflow/utils';
-import { getWorkflowPort } from '@workflow/utils/get-port';
 import {
   MessageId,
   parseQueueName,
+  type QueueHandler,
   type QueuePayload,
+  type QueuePrefix,
   serializeQueueMessage,
 } from '@workflow/world';
 import {
@@ -18,7 +17,6 @@ import { MessageData } from './message.js';
 import { createQueue } from './queue.js';
 
 const createdQueues: Array<ReturnType<typeof createQueue>> = [];
-const createdServers: Server[] = [];
 
 vi.mock('graphile-worker', () => ({
   Logger: class Logger {
@@ -28,11 +26,15 @@ vi.mock('graphile-worker', () => ({
   run: vi.fn(),
 }));
 
-vi.mock('@workflow/utils/get-port', () => ({
-  getWorkflowPort: vi.fn(),
-}));
+// The handler registry is process-global (shared across module copies), so
+// tests must reset it between runs.
+const registry = (
+  globalThis as {
+    [key: symbol]: { handlers: Map<QueuePrefix, QueueHandler> };
+  }
+)[Symbol.for('@workflow/world-postgres//queueHandlers')];
 
-describe('postgres queue http execution', () => {
+describe('postgres queue direct execution', () => {
   const workerUtilsMock = {
     addJob: vi.fn(),
     migrate: vi.fn(),
@@ -48,94 +50,41 @@ describe('postgres queue http execution', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    registry.handlers.clear();
 
     vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
-    vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
     vi.mocked(run).mockResolvedValue(runnerMock as unknown as Runner);
   });
 
   afterEach(async () => {
     await Promise.all(createdQueues.splice(0).map((queue) => queue.close()));
-    await Promise.all(
-      createdServers.splice(0).map(
-        (server) =>
-          new Promise<void>((resolve, reject) => {
-            server.close((err) => (err ? reject(err) : resolve()));
-            server.closeAllConnections();
-          })
-      )
-    );
     vi.useRealTimers();
-    delete process.env.WORKFLOW_LOCAL_BASE_URL;
-    delete process.env.PORT;
-    setWorkflowBasePath(undefined);
   });
 
-  it('uses a late-detected local port when the queue starts before PORT is available', async () => {
-    const requests: Array<{
-      method: string | undefined;
-      url: string | undefined;
-      headers: Record<string, string | string[] | undefined>;
-      body: string;
-    }> = [];
-    const port = await getUnusedLoopbackPort();
-    vi.mocked(getWorkflowPort).mockResolvedValue(port);
-
+  it('does not start the runner until a workflow handler is registered', async () => {
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
     await queue.start();
 
     expect(run).not.toHaveBeenCalled();
 
-    await startWorkflowHttpServer(requests, port);
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
     await vi.waitFor(() => {
       expect(run).toHaveBeenCalledTimes(1);
     });
-
-    const task = getTaskHandler('workflow_flows');
-    const message = {
-      runId: 'run_01ABC',
-      stepId: 'step_01ABC',
-      stepName: 'test-step',
-    } satisfies QueuePayload;
-    const payload = buildMessageData('__wkf_workflow_test-step', message, {
-      headers: { traceparent: 'trace-parent' },
-      idempotencyKey: 'step_01ABC',
-    });
-
-    await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-    expect(getWorkflowPort).toHaveBeenCalled();
-    expect(requests).toEqual([
-      expect.objectContaining({
-        method: 'POST',
-        url: '/.well-known/workflow/v1/flow',
-      }),
-    ]);
   });
 
-  it('keeps the base-url error when env vars and local port detection cannot resolve a target', async () => {
+  it('starts the runner immediately when a handler is already registered', async () => {
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
+
     await queue.start();
 
-    const task = getTaskHandler('workflow_flows');
-    const message = {
-      runId: 'run_01ABC',
-      stepId: 'step_01ABC',
-      stepName: 'test-step',
-    } satisfies QueuePayload;
-    const payload = buildMessageData('__wkf_workflow_test-step', message, {
-      idempotencyKey: 'step_01ABC',
-    });
-
-    await expect(task(payload, {} as any)).rejects.toThrow(
-      'Unable to resolve base URL for workflow queue.'
-    );
-
-    expect(getWorkflowPort).toHaveBeenCalled();
+    expect(run).toHaveBeenCalledTimes(1);
   });
 
   it('keeps Graphile Worker automatic shutdown by default', async () => {
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
 
     await queue.start();
 
@@ -152,6 +101,7 @@ describe('postgres queue http execution', () => {
       },
       pool
     );
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
 
     await queue.start();
 
@@ -160,360 +110,252 @@ describe('postgres queue http execution', () => {
     );
   });
 
-  it('aborts while waiting for an HTTP response without scheduling a replacement', async () => {
-    const server = await startHangingWorkflowHttpServer('headers');
-    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
-
+  it('executes jobs by invoking the registered handler directly', async () => {
+    const handler = vi.fn<QueueHandler>(async () => undefined);
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    queue.createQueueHandler('__wkf_workflow_', handler);
     await queue.start();
 
-    const controller = new AbortController();
-    const execution = getTaskHandler('workflow_flows')(
-      buildMessageData('__wkf_workflow_test-step', {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      }),
-      {
-        abortSignal: controller.signal,
-        job: { attempts: 1 },
-      }
-    );
-    const outcome = execution.then(
-      () => ({ status: 'fulfilled' as const }),
-      (error: unknown) => ({ status: 'rejected' as const, error })
-    );
-
-    await server.requestReceived;
-    controller.abort();
-
-    await expect(settleWithin(outcome)).resolves.toMatchObject({
-      status: 'rejected',
-      error: expect.objectContaining({ name: 'AbortError' }),
+    const message = {
+      runId: 'run_01ABC',
+      stepId: 'step_01ABC',
+      stepName: 'test-step',
+    } satisfies QueuePayload;
+    const payload = buildMessageData('__wkf_workflow_test-step', message, {
+      idempotencyKey: 'step_01ABC',
     });
-    expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
+
+    await expect(
+      getTaskHandler()(payload, { job: { attempts: 1 } })
+    ).resolves.toBeUndefined();
+
+    expect(handler).toHaveBeenCalledWith(message, {
+      attempt: 1,
+      queueName: '__wkf_workflow_test-step',
+      messageId: 'msg_01ABC',
+    });
   });
 
-  it('aborts while reading an HTTP response body without scheduling a replacement', async () => {
-    const server = await startHangingWorkflowHttpServer('body');
-    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
-    const nativeFetch = globalThis.fetch;
-    let resolveResponseReceived!: () => void;
-    const responseReceived = new Promise<void>((resolve) => {
-      resolveResponseReceived = resolve;
-    });
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (...args: Parameters<typeof fetch>) => {
-        const response = await nativeFetch(...args);
-        resolveResponseReceived();
-        return response;
-      })
-    );
-
-    try {
-      const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-      await queue.start();
-
-      const controller = new AbortController();
-      const execution = getTaskHandler('workflow_flows')(
-        buildMessageData('__wkf_workflow_test-step', {
-          runId: 'run_01ABC',
-          stepId: 'step_01ABC',
-          stepName: 'test-step',
-        }),
-        {
-          abortSignal: controller.signal,
-          job: { attempts: 1 },
-        }
-      );
-      const outcome = execution.then(
-        () => ({ status: 'fulfilled' as const }),
-        (error: unknown) => ({ status: 'rejected' as const, error })
-      );
-
-      await responseReceived;
-      // Let executeMessageOverHttp enter response.text() before aborting.
-      await Promise.resolve();
-      controller.abort();
-
-      await expect(settleWithin(outcome)).resolves.toMatchObject({
-        status: 'rejected',
-        error: expect.objectContaining({ name: 'AbortError' }),
-      });
-      expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('serializes workflow queue execution for the same runId', async () => {
-    let resolveFirstRequestStarted!: () => void;
-    const firstRequestStarted = new Promise<void>((resolve) => {
-      resolveFirstRequestStarted = resolve;
-    });
-    let resolveReleaseFirstRequest!: () => void;
-    const releaseFirstRequest = new Promise<void>((resolve) => {
-      resolveReleaseFirstRequest = resolve;
-    });
-    let requestCount = 0;
-    let activeRequests = 0;
-    let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
-      requestCount += 1;
-      activeRequests += 1;
-      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-
-      if (requestCount === 1) {
-        resolveFirstRequestStarted();
-        await releaseFirstRequest;
-      }
-
-      activeRequests -= 1;
-      return Response.json({ ok: true });
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = {
-        runId: 'wrun_01ABC',
-      };
-      const firstExecution = task(
-        buildMessageData('__wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABC'),
-        }),
-        {} as any
-      );
-      const secondExecution = task(
-        buildMessageData('__wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABD'),
-        }),
-        {} as any
-      );
-
-      await firstRequestStarted;
-      await Promise.resolve();
-      expect(requestCount).toBe(1);
-      expect(maxActiveRequests).toBe(1);
-
-      resolveReleaseFirstRequest();
-      await Promise.all([firstExecution, secondExecution]);
-
-      expect(requestCount).toBe(2);
-      expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('serializes namespaced workflow queue execution for the same runId', async () => {
-    let resolveFirstRequestStarted!: () => void;
-    const firstRequestStarted = new Promise<void>((resolve) => {
-      resolveFirstRequestStarted = resolve;
-    });
-    let resolveReleaseFirstRequest!: () => void;
-    const releaseFirstRequest = new Promise<void>((resolve) => {
-      resolveReleaseFirstRequest = resolve;
-    });
-    let requestCount = 0;
-    let activeRequests = 0;
-    let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
-      requestCount += 1;
-      activeRequests += 1;
-      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-
-      if (requestCount === 1) {
-        resolveFirstRequestStarted();
-        await releaseFirstRequest;
-      }
-
-      activeRequests -= 1;
-      return Response.json({ ok: true });
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
+  it('routes namespaced jobs to the namespaced handler', async () => {
+    const handler = vi.fn<QueueHandler>(async () => undefined);
     const queue = buildQueue(
       { connectionString: 'postgres://test', namespace: 'custom' },
       pool
     );
-    try {
-      await queue.start();
+    queue.createQueueHandler('__custom_wkf_workflow_', handler);
+    await queue.start();
 
-      const task = getTaskHandler('workflow_flows');
-      const payload = {
-        runId: 'wrun_01ABC',
-      };
-      const firstExecution = task(
-        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABC'),
-        }),
-        {} as any
-      );
-      const secondExecution = task(
-        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABD'),
-        }),
-        {} as any
-      );
+    const message = { runId: 'run_01ABC' } satisfies QueuePayload;
+    await getTaskHandler()(
+      buildMessageData('__custom_wkf_workflow_test-workflow', message),
+      { job: { attempts: 1 } }
+    );
 
-      await firstRequestStarted;
-      await Promise.resolve();
-      expect(requestCount).toBe(1);
-      expect(maxActiveRequests).toBe(1);
-
-      resolveReleaseFirstRequest();
-      await Promise.all([firstExecution, secondExecution]);
-
-      expect(requestCount).toBe(2);
-      expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    expect(handler).toHaveBeenCalledWith(
+      message,
+      expect.objectContaining({
+        queueName: '__custom_wkf_workflow_test-workflow',
+      })
+    );
   });
 
-  it('does not require a runId for workflow health-check payloads', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
+  it('executes health-check payloads that carry no runId', async () => {
+    const handler = vi.fn<QueueHandler>(async () => undefined);
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
 
-      const task = getTaskHandler('workflow_flows');
-      const payload = buildMessageData('__wkf_workflow_health_check', {
-        __healthCheck: true,
-        correlationId: 'hc_01ABC',
-      });
+    const message = { __healthCheck: true, correlationId: 'hc_01ABC' };
+    await getTaskHandler()(
+      buildMessageData('__wkf_workflow_health_check', message as QueuePayload),
+      { job: { attempts: 1 } }
+    );
 
-      await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://workflow.example.test/.well-known/workflow/v1/flow',
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'x-vqs-queue-name': '__wkf_workflow_health_check',
-          }),
-        })
-      );
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    expect(handler).toHaveBeenCalledWith(message, expect.anything());
   });
 
-  it('uses basePath for local postgres queue HTTP delivery', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
-    const port = await getUnusedLoopbackPort();
-    await startWorkflowHttpServer([], port);
-    process.env.PORT = String(port);
-    setWorkflowBasePath('/v2');
-
+  it('schedules a replacement job when the handler reschedules', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
+    queue.createQueueHandler('__wkf_workflow_', async () => ({
+      timeoutSeconds: 30,
+    }));
+    await queue.start();
 
-      const task = getTaskHandler('workflow_flows');
-      const payload = buildMessageData('__wkf_workflow_test-step', {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      });
+    await getTaskHandler()(
+      buildMessageData(
+        '__wkf_workflow_test-step',
+        { runId: 'run_01ABC', stepId: 'step_01ABC', stepName: 'test-step' },
+        { idempotencyKey: 'step_01ABC' }
+      ),
+      { job: { attempts: 1 } }
+    );
 
-      await expect(task(payload, {} as any)).resolves.toBeUndefined();
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'workflow_flows',
+      expect.objectContaining({
+        attempt: 2,
+        id: 'test-step',
+        idempotencyKey: 'step_01ABC',
+        messageId: 'msg_01ABC',
+      }),
+      expect.objectContaining({
+        jobKey: 'step_01ABC',
+        maxAttempts: 3,
+        runAt: new Date('2024-01-01T00:00:30.000Z'),
+      })
+    );
+  });
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        `http://localhost:${port}/v2/.well-known/workflow/v1/flow`,
-        expect.objectContaining({ method: 'POST' })
-      );
-      expect(getWorkflowPort).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllGlobals();
-    }
+  it('sums the stored attempt with graphile retry attempts', async () => {
+    const handler = vi.fn<QueueHandler>(async () => undefined);
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+
+    await getTaskHandler()(
+      buildMessageData(
+        '__wkf_workflow_test-workflow',
+        { runId: 'run_01ABC' },
+        { attempt: 3 }
+      ),
+      { job: { attempts: 2 } }
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ attempt: 4 })
+    );
+  });
+
+  it('propagates handler errors so graphile retries the job', async () => {
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    queue.createQueueHandler('__wkf_workflow_', async () => {
+      throw new Error('replay failed');
+    });
+    await queue.start();
+
+    await expect(
+      getTaskHandler()(
+        buildMessageData('__wkf_workflow_test-workflow', {
+          runId: 'run_01ABC',
+        }),
+        { job: { attempts: 1 } }
+      )
+    ).rejects.toThrow('replay failed');
+
+    expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates completed idempotency keys', async () => {
+    const handler = vi.fn<QueueHandler>(async () => undefined);
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+
+    const payload = buildMessageData(
+      '__wkf_workflow_test-step',
+      { runId: 'run_01ABC', stepId: 'step_01ABC', stepName: 'test-step' },
+      { idempotencyKey: 'step_01ABC' }
+    );
+    const task = getTaskHandler();
+    await task(payload, { job: { attempts: 1 } });
+    await task(payload, { job: { attempts: 2 } });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes workflow replays for the same runId', async () => {
+    let resolveFirstExecution!: () => void;
+    const firstExecutionStarted = Promise.withResolvers<void>();
+    let activeExecutions = 0;
+    let maxActiveExecutions = 0;
+    const handler = vi.fn<QueueHandler>(async () => {
+      activeExecutions += 1;
+      maxActiveExecutions = Math.max(maxActiveExecutions, activeExecutions);
+      if (handler.mock.calls.length === 1) {
+        firstExecutionStarted.resolve();
+        await new Promise<void>((resolve) => {
+          resolveFirstExecution = resolve;
+        });
+      }
+      activeExecutions -= 1;
+      return undefined;
+    });
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+
+    const task = getTaskHandler();
+    const message = { runId: 'wrun_01ABC' };
+    const first = task(
+      buildMessageData('__wkf_workflow_test-workflow', message, {
+        messageId: MessageId.parse('msg_01ABC'),
+      }),
+      { job: { attempts: 1 } }
+    );
+    const second = task(
+      buildMessageData('__wkf_workflow_test-workflow', message, {
+        messageId: MessageId.parse('msg_01ABD'),
+      }),
+      { job: { attempts: 1 } }
+    );
+
+    await firstExecutionStarted.promise;
+    await Promise.resolve();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    resolveFirstExecution();
+    await Promise.all([first, second]);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(maxActiveExecutions).toBe(1);
   });
 
   it('queues producer delays and headers in graphile job metadata', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
-
-    try {
-      const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-      await queue.start();
-
-      await queue.queue(
-        '__wkf_workflow_test-step',
-        {
-          runId: 'run_01ABC',
-          stepId: 'step_01ABC',
-          stepName: 'test-step',
-        },
-        {
-          delaySeconds: 5,
-          headers: { traceparent: 'trace-parent' },
-          idempotencyKey: 'step_01ABC',
-        }
-      );
-
-      expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
-        'workflow_flows',
-        expect.objectContaining({
-          attempt: 1,
-          headers: { traceparent: 'trace-parent' },
-          id: 'test-step',
-          idempotencyKey: 'step_01ABC',
-        }),
-        expect.objectContaining({
-          jobKey: 'step_01ABC',
-          maxAttempts: 3,
-          runAt: new Date('2024-01-01T00:00:05.000Z'),
-        })
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('queues namespaced producer messages in graphile job metadata', async () => {
-    const queue = buildQueue(
-      { connectionString: 'postgres://test', namespace: 'custom' },
-      pool
-    );
-    await queue.start();
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
 
     await queue.queue(
-      '__custom_wkf_workflow_test-step',
+      '__wkf_workflow_test-step',
       {
         runId: 'run_01ABC',
         stepId: 'step_01ABC',
         stepName: 'test-step',
       },
       {
+        delaySeconds: 5,
+        headers: { traceparent: 'trace-parent' },
         idempotencyKey: 'step_01ABC',
       }
     );
 
+    expect(run).not.toHaveBeenCalled();
     expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
       'workflow_flows',
       expect.objectContaining({
         attempt: 1,
+        headers: { traceparent: 'trace-parent' },
         id: 'test-step',
         idempotencyKey: 'step_01ABC',
       }),
       expect.objectContaining({
         jobKey: 'step_01ABC',
         maxAttempts: 3,
+        runAt: new Date('2024-01-01T00:00:05.000Z'),
       })
     );
+  });
+
+  it('rejects queueing after close', async () => {
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    await queue.close();
+
+    await expect(
+      queue.queue('__wkf_workflow_test-workflow', { runId: 'run_01ABC' })
+    ).rejects.toThrow('closed');
   });
 });
 
@@ -548,131 +390,9 @@ function buildMessageData(
   });
 }
 
-function getTaskHandler(name: 'workflow_flows') {
+function getTaskHandler() {
   const taskList = vi.mocked(run).mock.calls[0]?.[0]?.taskList;
-  const task = taskList?.[name];
+  const task = taskList?.workflow_flows;
   expect(task).toBeTypeOf('function');
   return task as (payload: unknown, helpers: unknown) => Promise<void>;
-}
-
-async function startWorkflowHttpServer(
-  requests: Array<{
-    method: string | undefined;
-    url: string | undefined;
-    headers: Record<string, string | string[] | undefined>;
-    body: string;
-  }>,
-  port = 0
-) {
-  const server = createServer(async (req, res) => {
-    const body = await new Promise<string>((resolve, reject) => {
-      let chunks = '';
-      req.setEncoding('utf8');
-      req.on('data', (chunk) => {
-        chunks += chunk;
-      });
-      req.on('end', () => resolve(chunks));
-      req.on('error', reject);
-    });
-
-    const request = {
-      method: req.method,
-      url: req.url,
-      headers: req.headers,
-      body,
-    };
-    requests.push(request);
-
-    if (req.method === 'POST' && req.url === '/.well-known/workflow/v1/flow') {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ ok: true }));
-      return;
-    }
-
-    res.writeHead(404, { 'content-type': 'text/plain' });
-    res.end('not found');
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(port, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-
-  createdServers.push(server);
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to determine test server address');
-  }
-
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-  };
-}
-
-async function startHangingWorkflowHttpServer(stage: 'headers' | 'body') {
-  let resolveRequestReceived!: () => void;
-  const requestReceived = new Promise<void>((resolve) => {
-    resolveRequestReceived = resolve;
-  });
-  const server = createServer((req, res) => {
-    req.resume();
-    resolveRequestReceived();
-
-    if (stage === 'body') {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.write('{"ok":');
-    }
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-
-  createdServers.push(server);
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to determine test server address');
-  }
-
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-    requestReceived,
-  };
-}
-
-async function settleWithin<T>(
-  promise: Promise<T>,
-  timeoutMs = 250
-): Promise<T | { status: 'pending' }> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<{ status: 'pending' }>((resolve) => {
-        timeout = setTimeout(() => resolve({ status: 'pending' }), timeoutMs);
-        timeout.unref();
-      }),
-    ]);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-async function getUnusedLoopbackPort(): Promise<number> {
-  const server = createServer();
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-  const address = server.address();
-  await new Promise<void>((resolve, reject) => {
-    server.close((err) => (err ? reject(err) : resolve()));
-  });
-
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to reserve a loopback port');
-  }
-
-  return address.port;
 }

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -1,22 +1,17 @@
-import { createServer, type Server } from 'node:http';
-import { JsonTransport } from '@vercel/queue';
-import { setWorkflowBasePath } from '@workflow/utils';
-import { getWorkflowPort } from '@workflow/utils/get-port';
 import { MessageId, parseQueueName, type QueuePayload } from '@workflow/world';
-import { createWorld } from '@workflow/world-local';
 import {
+  type JobHelpers,
   makeWorkerUtils,
   type Runner,
   run,
+  type Task,
   type WorkerUtils,
 } from 'graphile-worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageData } from './message.js';
-import { createQueue } from './queue.js';
+import { createQueue, encodeQueueMessage } from './queue.js';
 
-const transport = new JsonTransport();
-const createdQueues: Array<ReturnType<typeof createQueue>> = [];
-const createdServers: Server[] = [];
+const queues: Array<ReturnType<typeof createQueue>> = [];
 
 vi.mock('graphile-worker', () => ({
   Logger: class Logger {
@@ -26,146 +21,154 @@ vi.mock('graphile-worker', () => ({
   run: vi.fn(),
 }));
 
-vi.mock('@workflow/utils/get-port', () => ({
-  getWorkflowPort: vi.fn(),
-}));
-
-vi.mock('@workflow/world-local', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@workflow/world-local')>();
-
-  return {
-    ...actual,
-    createWorld: vi.fn(actual.createWorld),
-  };
-});
-
-describe('postgres queue http execution', () => {
-  const workerUtilsMock = {
+describe('postgres queue', () => {
+  const workerUtils = {
     addJob: vi.fn(),
-    migrate: vi.fn(),
     release: vi.fn(),
   } as unknown as WorkerUtils;
-  const runnerMock = {
+  const runner = {
     stop: vi.fn(),
     promise: Promise.resolve(),
-  };
-  const wrappedHandler = vi.fn(async () => Response.json({ ok: true }));
-  const localWorldClose = vi.fn();
-  const createQueueHandler = vi.fn(() => wrappedHandler);
+  } as unknown as Runner;
   const pool = {
     query: vi.fn(async () => ({ rows: [{ exists: false }] })),
-  } as any;
+  } as never;
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
-    vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
-    vi.mocked(run).mockResolvedValue(runnerMock as unknown as Runner);
-    vi.mocked(createWorld).mockReturnValue({
-      createQueueHandler,
-      close: localWorldClose,
-    } as any);
+    vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtils);
+    vi.mocked(run).mockResolvedValue(runner);
   });
 
   afterEach(async () => {
-    await Promise.all(createdQueues.splice(0).map((queue) => queue.close()));
-    await Promise.all(
-      createdServers.splice(0).map(
-        (server) =>
-          new Promise<void>((resolve, reject) => {
-            server.close((err) => (err ? reject(err) : resolve()));
-            server.closeAllConnections();
-          })
-      )
-    );
-    vi.useRealTimers();
-    delete process.env.WORKFLOW_LOCAL_BASE_URL;
-    delete process.env.PORT;
-    setWorkflowBasePath(undefined);
+    await Promise.all(queues.splice(0).map((queue) => queue.close()));
   });
 
-  it('uses a late-detected local port when the queue starts before PORT is available', async () => {
-    const requests: Array<{
-      method: string | undefined;
-      url: string | undefined;
-      headers: Record<string, string | string[] | undefined>;
-      body: string;
-    }> = [];
-    const port = await getUnusedLoopbackPort();
-    vi.mocked(getWorkflowPort).mockResolvedValue(port);
+  it('requires handler registration before starting', async () => {
+    const queue = buildQueue(pool);
 
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    await queue.start();
-
+    await expect(queue.start()).rejects.toThrow(
+      'Import the generated flow route'
+    );
     expect(run).not.toHaveBeenCalled();
+  });
 
-    await startWorkflowHttpServer(requests, port);
-    await vi.waitFor(() => {
-      expect(run).toHaveBeenCalledTimes(1);
+  it('registers one direct handler and leaves the HTTP route inert', async () => {
+    const queue = buildQueue(pool);
+    const handler = vi.fn(async () => undefined);
+
+    const httpHandler = queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+
+    await expect(
+      httpHandler(new Request('https://example.test/?__health'))
+    ).resolves.toMatchObject({ status: 404 });
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('passes messages and logical attempts directly to the handler', async () => {
+    const queue = buildQueue(pool);
+    const handler = vi.fn(async () => undefined);
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+    const message = stepMessage();
+
+    await task()(
+      messageData('__wkf_workflow_test-step', message, { attempt: 4 }),
+      jobHelpers(3)
+    );
+
+    expect(handler).toHaveBeenCalledWith(message, {
+      attempt: 6,
+      messageId: 'msg_01ABC',
+      queueName: '__wkf_workflow_test-step',
     });
+  });
 
-    const task = getTaskHandler('workflow_flows');
-    const message = {
-      runId: 'run_01ABC',
-      stepId: 'step_01ABC',
-      stepName: 'test-step',
-    } satisfies QueuePayload;
-    const payload = buildMessageData('__wkf_workflow_test-step', message, {
-      headers: { traceparent: 'trace-parent' },
-      idempotencyKey: 'step_01ABC',
-    });
+  it('writes a timeout successor before completing the delivery', async () => {
+    const queue = buildQueue(pool);
+    queue.createQueueHandler('__wkf_workflow_', async () => ({
+      timeoutSeconds: 5,
+    }));
+    await queue.start();
 
-    await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-    expect(getWorkflowPort).toHaveBeenCalled();
-    expect(requests).toEqual([
-      expect.objectContaining({
-        method: 'POST',
-        url: '/.well-known/workflow/v1/flow',
+    await task()(
+      messageData('__wkf_workflow_test-step', stepMessage(), {
+        attempt: 2,
+        idempotencyKey: 'step_01ABC',
       }),
-    ]);
+      jobHelpers(2)
+    );
+
+    expect(workerUtils.addJob).toHaveBeenCalledWith(
+      'workflow_flows',
+      expect.objectContaining({ attempt: 4 }),
+      expect.objectContaining({ jobKey: 'step_01ABC' })
+    );
   });
 
-  it('keeps the base-url error when env vars and local port detection cannot resolve a target', async () => {
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+  it('propagates handler failures for Graphile to retry', async () => {
+    const queue = buildQueue(pool);
+    const failure = new Error('handler failed');
+    queue.createQueueHandler('__wkf_workflow_', async () => {
+      throw failure;
+    });
     await queue.start();
 
-    const task = getTaskHandler('workflow_flows');
-    const message = {
-      runId: 'run_01ABC',
-      stepId: 'step_01ABC',
-      stepName: 'test-step',
-    } satisfies QueuePayload;
-    const payload = buildMessageData('__wkf_workflow_test-step', message, {
-      idempotencyKey: 'step_01ABC',
+    await expect(
+      task()(
+        messageData('__wkf_workflow_test-step', stepMessage()),
+        jobHelpers()
+      )
+    ).rejects.toBe(failure);
+    expect(workerUtils.addJob).not.toHaveBeenCalled();
+  });
+
+  it('does not start a worker in enqueue-only processes', async () => {
+    const queue = buildQueue(pool);
+
+    await queue.queue('__wkf_workflow_test-step', stepMessage());
+
+    expect(workerUtils.addJob).toHaveBeenCalledOnce();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('preserves same-run replay serialization', async () => {
+    const queue = buildQueue(pool);
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const handler = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => blocked)
+      .mockResolvedValue(undefined);
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+    const payload = messageData('__wkf_workflow_test-workflow', {
+      runId: 'wrun_01ABC',
     });
 
-    await expect(task(payload, {} as any)).rejects.toThrow(
-      'Unable to resolve base URL for workflow queue.'
-    );
+    const first = task()(payload, jobHelpers());
+    const second = task()(payload, jobHelpers());
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+    release();
+    await Promise.all([first, second]);
 
-    expect(getWorkflowPort).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps Graphile Worker automatic shutdown by default', async () => {
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+  it('rejects a handler for another namespace', () => {
+    const queue = buildQueue(pool, { namespace: 'custom' });
 
-    await queue.start();
-
-    expect(run).toHaveBeenCalledWith(
-      expect.not.objectContaining({ noHandleSignals: true })
-    );
+    expect(() =>
+      queue.createQueueHandler('__wkf_workflow_', async () => undefined)
+    ).toThrow();
   });
 
-  it('allows the application to manage shutdown', async () => {
-    const queue = buildQueue(
-      {
-        connectionString: 'postgres://test',
-        applicationManagedShutdown: true,
-      },
-      pool
-    );
+  it('passes application-managed shutdown to Graphile', async () => {
+    const queue = buildQueue(pool, { applicationManagedShutdown: true });
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
 
     await queue.start();
 
@@ -174,519 +177,65 @@ describe('postgres queue http execution', () => {
     );
   });
 
-  it('aborts while waiting for an HTTP response without scheduling a replacement', async () => {
-    const server = await startHangingWorkflowHttpServer('headers');
-    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+  it('closes once when called concurrently', async () => {
+    const queue = buildQueue(pool);
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
     await queue.start();
 
-    const controller = new AbortController();
-    const execution = getTaskHandler('workflow_flows')(
-      buildMessageData('__wkf_workflow_test-step', {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      }),
-      {
-        abortSignal: controller.signal,
-        job: { attempts: 1 },
-      }
-    );
-    const outcome = execution.then(
-      () => ({ status: 'fulfilled' as const }),
-      (error: unknown) => ({ status: 'rejected' as const, error })
-    );
+    await Promise.all([queue.close(), queue.close()]);
 
-    await server.requestReceived;
-    controller.abort();
-
-    await expect(settleWithin(outcome)).resolves.toMatchObject({
-      status: 'rejected',
-      error: expect.objectContaining({ name: 'AbortError' }),
-    });
-    expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
-  });
-
-  it('aborts while reading an HTTP response body without scheduling a replacement', async () => {
-    const server = await startHangingWorkflowHttpServer('body');
-    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
-    const nativeFetch = globalThis.fetch;
-    let resolveResponseReceived!: () => void;
-    const responseReceived = new Promise<void>((resolve) => {
-      resolveResponseReceived = resolve;
-    });
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (...args: Parameters<typeof fetch>) => {
-        const response = await nativeFetch(...args);
-        resolveResponseReceived();
-        return response;
-      })
-    );
-
-    try {
-      const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-      await queue.start();
-
-      const controller = new AbortController();
-      const execution = getTaskHandler('workflow_flows')(
-        buildMessageData('__wkf_workflow_test-step', {
-          runId: 'run_01ABC',
-          stepId: 'step_01ABC',
-          stepName: 'test-step',
-        }),
-        {
-          abortSignal: controller.signal,
-          job: { attempts: 1 },
-        }
-      );
-      const outcome = execution.then(
-        () => ({ status: 'fulfilled' as const }),
-        (error: unknown) => ({ status: 'rejected' as const, error })
-      );
-
-      await responseReceived;
-      // Let executeMessageOverHttp enter response.text() before aborting.
-      await Promise.resolve();
-      controller.abort();
-
-      await expect(settleWithin(outcome)).resolves.toMatchObject({
-        status: 'rejected',
-        error: expect.objectContaining({ name: 'AbortError' }),
-      });
-      expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('serializes workflow queue execution for the same runId', async () => {
-    let resolveFirstRequestStarted!: () => void;
-    const firstRequestStarted = new Promise<void>((resolve) => {
-      resolveFirstRequestStarted = resolve;
-    });
-    let resolveReleaseFirstRequest!: () => void;
-    const releaseFirstRequest = new Promise<void>((resolve) => {
-      resolveReleaseFirstRequest = resolve;
-    });
-    let requestCount = 0;
-    let activeRequests = 0;
-    let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
-      requestCount += 1;
-      activeRequests += 1;
-      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-
-      if (requestCount === 1) {
-        resolveFirstRequestStarted();
-        await releaseFirstRequest;
-      }
-
-      activeRequests -= 1;
-      return Response.json({ ok: true });
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = {
-        runId: 'wrun_01ABC',
-      };
-      const firstExecution = task(
-        buildMessageData('__wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABC'),
-        }),
-        {} as any
-      );
-      const secondExecution = task(
-        buildMessageData('__wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABD'),
-        }),
-        {} as any
-      );
-
-      await firstRequestStarted;
-      await Promise.resolve();
-      expect(requestCount).toBe(1);
-      expect(maxActiveRequests).toBe(1);
-
-      resolveReleaseFirstRequest();
-      await Promise.all([firstExecution, secondExecution]);
-
-      expect(requestCount).toBe(2);
-      expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('serializes namespaced workflow queue execution for the same runId', async () => {
-    let resolveFirstRequestStarted!: () => void;
-    const firstRequestStarted = new Promise<void>((resolve) => {
-      resolveFirstRequestStarted = resolve;
-    });
-    let resolveReleaseFirstRequest!: () => void;
-    const releaseFirstRequest = new Promise<void>((resolve) => {
-      resolveReleaseFirstRequest = resolve;
-    });
-    let requestCount = 0;
-    let activeRequests = 0;
-    let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
-      requestCount += 1;
-      activeRequests += 1;
-      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-
-      if (requestCount === 1) {
-        resolveFirstRequestStarted();
-        await releaseFirstRequest;
-      }
-
-      activeRequests -= 1;
-      return Response.json({ ok: true });
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
-    const queue = buildQueue(
-      { connectionString: 'postgres://test', namespace: 'custom' },
-      pool
-    );
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = {
-        runId: 'wrun_01ABC',
-      };
-      const firstExecution = task(
-        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABC'),
-        }),
-        {} as any
-      );
-      const secondExecution = task(
-        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABD'),
-        }),
-        {} as any
-      );
-
-      await firstRequestStarted;
-      await Promise.resolve();
-      expect(requestCount).toBe(1);
-      expect(maxActiveRequests).toBe(1);
-
-      resolveReleaseFirstRequest();
-      await Promise.all([firstExecution, secondExecution]);
-
-      expect(requestCount).toBe(2);
-      expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('does not require a runId for workflow health-check payloads', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = buildMessageData('__wkf_workflow_health_check', {
-        __healthCheck: true,
-        correlationId: 'hc_01ABC',
-      });
-
-      await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://workflow.example.test/.well-known/workflow/v1/flow',
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'x-vqs-queue-name': '__wkf_workflow_health_check',
-          }),
-        })
-      );
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('uses basePath for local postgres queue HTTP delivery', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
-    const port = await getUnusedLoopbackPort();
-    await startWorkflowHttpServer([], port);
-    process.env.PORT = String(port);
-    setWorkflowBasePath('/v2');
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = buildMessageData('__wkf_workflow_test-step', {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      });
-
-      await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        `http://localhost:${port}/v2/.well-known/workflow/v1/flow`,
-        expect.objectContaining({ method: 'POST' })
-      );
-      expect(getWorkflowPort).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('queues producer delays and headers in graphile job metadata', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
-
-    try {
-      const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-      await queue.start();
-
-      await queue.queue(
-        '__wkf_workflow_test-step',
-        {
-          runId: 'run_01ABC',
-          stepId: 'step_01ABC',
-          stepName: 'test-step',
-        },
-        {
-          delaySeconds: 5,
-          headers: { traceparent: 'trace-parent' },
-          idempotencyKey: 'step_01ABC',
-        }
-      );
-
-      expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
-        'workflow_flows',
-        expect.objectContaining({
-          attempt: 1,
-          headers: { traceparent: 'trace-parent' },
-          id: 'test-step',
-          idempotencyKey: 'step_01ABC',
-        }),
-        expect.objectContaining({
-          jobKey: 'step_01ABC',
-          maxAttempts: 49,
-          runAt: new Date('2024-01-01T00:00:05.000Z'),
-        })
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('queues namespaced producer messages in graphile job metadata', async () => {
-    const queue = buildQueue(
-      { connectionString: 'postgres://test', namespace: 'custom' },
-      pool
-    );
-    await queue.start();
-
-    await queue.queue(
-      '__custom_wkf_workflow_test-step',
-      {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      },
-      {
-        idempotencyKey: 'step_01ABC',
-      }
-    );
-
-    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
-      'workflow_flows',
-      expect.objectContaining({
-        attempt: 1,
-        id: 'test-step',
-        idempotencyKey: 'step_01ABC',
-      }),
-      expect.objectContaining({
-        jobKey: 'step_01ABC',
-        maxAttempts: 49,
-      })
-    );
+    expect(runner.stop).toHaveBeenCalledOnce();
+    expect(workerUtils.release).toHaveBeenCalledOnce();
   });
 });
 
 function buildQueue(
-  config: Parameters<typeof createQueue>[0],
-  pgPool: Parameters<typeof createQueue>[1]
+  pool: Parameters<typeof createQueue>[1],
+  config: Partial<Parameters<typeof createQueue>[0]> = {}
 ) {
-  const queue = createQueue(config, pgPool);
-  createdQueues.push(queue);
+  const queue = createQueue(
+    { connectionString: 'postgres://test', ...config },
+    pool
+  );
+  queues.push(queue);
   return queue;
 }
 
-function buildMessageData(
+function stepMessage(): QueuePayload {
+  return {
+    runId: 'run_01ABC',
+    stepId: 'step_01ABC',
+    stepName: 'test-step',
+  };
+}
+
+function messageData(
   queueName: string,
   payload: QueuePayload,
-  opts?: {
+  options: {
     attempt?: number;
-    headers?: Record<string, string>;
     idempotencyKey?: string;
-    messageId?: MessageId;
-  }
+  } = {}
 ) {
   const { id } = parseQueueName(queueName);
-
   return MessageData.encode({
     id,
-    data: transport.serialize(payload),
-    attempt: opts?.attempt ?? 1,
-    headers: opts?.headers,
-    idempotencyKey: opts?.idempotencyKey,
-    messageId: opts?.messageId ?? MessageId.parse('msg_01ABC'),
+    data: encodeQueueMessage(payload),
+    attempt: options.attempt ?? 1,
+    idempotencyKey: options.idempotencyKey,
+    messageId: MessageId.parse('msg_01ABC'),
   });
 }
 
-function getTaskHandler(name: 'workflow_flows') {
-  const taskList = vi.mocked(run).mock.calls[0]?.[0]?.taskList;
-  const task = taskList?.[name];
-  expect(task).toBeTypeOf('function');
-  return task as (payload: unknown, helpers: unknown) => Promise<void>;
-}
-
-async function startWorkflowHttpServer(
-  requests: Array<{
-    method: string | undefined;
-    url: string | undefined;
-    headers: Record<string, string | string[] | undefined>;
-    body: string;
-  }>,
-  port = 0
-) {
-  const server = createServer(async (req, res) => {
-    const body = await new Promise<string>((resolve, reject) => {
-      let chunks = '';
-      req.setEncoding('utf8');
-      req.on('data', (chunk) => {
-        chunks += chunk;
-      });
-      req.on('end', () => resolve(chunks));
-      req.on('error', reject);
-    });
-
-    const request = {
-      method: req.method,
-      url: req.url,
-      headers: req.headers,
-      body,
-    };
-    requests.push(request);
-
-    if (req.method === 'POST' && req.url === '/.well-known/workflow/v1/flow') {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ ok: true }));
-      return;
-    }
-
-    res.writeHead(404, { 'content-type': 'text/plain' });
-    res.end('not found');
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(port, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-
-  createdServers.push(server);
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to determine test server address');
-  }
-
+function jobHelpers(attempts = 1): JobHelpers {
   return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-  };
+    abortSignal: new AbortController().signal,
+    job: { attempts },
+  } as JobHelpers;
 }
 
-async function startHangingWorkflowHttpServer(stage: 'headers' | 'body') {
-  let resolveRequestReceived!: () => void;
-  const requestReceived = new Promise<void>((resolve) => {
-    resolveRequestReceived = resolve;
-  });
-  const server = createServer((req, res) => {
-    req.resume();
-    resolveRequestReceived();
-
-    if (stage === 'body') {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.write('{"ok":');
-    }
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-
-  createdServers.push(server);
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to determine test server address');
-  }
-
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-    requestReceived,
-  };
-}
-
-async function settleWithin<T>(
-  promise: Promise<T>,
-  timeoutMs = 250
-): Promise<T | { status: 'pending' }> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<{ status: 'pending' }>((resolve) => {
-        timeout = setTimeout(() => resolve({ status: 'pending' }), timeoutMs);
-        timeout.unref();
-      }),
-    ]);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-async function getUnusedLoopbackPort(): Promise<number> {
-  const server = createServer();
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-  const address = server.address();
-  await new Promise<void>((resolve, reject) => {
-    server.close((err) => (err ? reject(err) : resolve()));
-  });
-
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to reserve a loopback port');
-  }
-
-  return address.port;
+function task(): Task {
+  const handler = vi.mocked(run).mock.calls[0]?.[0]?.taskList?.workflow_flows;
+  expect(handler).toBeTypeOf('function');
+  return handler as Task;
 }

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -57,20 +57,24 @@ const GraphileHelpers = z.object({
  * Queue handlers registered by the workflow runtime, keyed by queue prefix.
  * Held on globalThis so every copy of this module in the process (e.g. one
  * bundled into a route module and one loaded by instrumentation) shares a
- * single registry. The latest registration for a prefix wins, so a reloaded
- * route module (dev) replaces its predecessor.
+ * single registry. The latest registration for a prefix wins (a reloaded
+ * route module in dev replaces its predecessor), and handlers are never
+ * unregistered: they delegate to the runtime's global world resolution, so a
+ * world created later in the same process reuses them.
+ *
+ * Exported for tests.
  */
-type HandlerRegistry = {
+export type HandlerRegistry = {
   handlers: Map<QueuePrefix, QueueHandler>;
   onRegister: Set<() => void>;
 };
 const RegistryKey = Symbol.for('@workflow/world-postgres//queueHandlers');
 const globalScope = globalThis as { [RegistryKey]?: HandlerRegistry };
-const registry: HandlerRegistry = globalScope[RegistryKey] ?? {
+export const handlerRegistry: HandlerRegistry = globalScope[RegistryKey] ?? {
   handlers: new Map(),
   onRegister: new Set(),
 };
-globalScope[RegistryKey] = registry;
+globalScope[RegistryKey] = handlerRegistry;
 
 /**
  * Registers the runtime's queue handler for direct in-process execution by
@@ -78,8 +82,8 @@ globalScope[RegistryKey] = registry;
  * for the generated flow route.
  */
 const createQueueHandler: Queue['createQueueHandler'] = (prefix, handler) => {
-  registry.handlers.set(prefix, handler);
-  for (const notify of [...registry.onRegister]) notify();
+  handlerRegistry.handlers.set(prefix, handler);
+  for (const notify of [...handlerRegistry.onRegister]) notify();
   return createFetchQueueHandler(prefix, handler);
 };
 
@@ -110,10 +114,9 @@ export function createQueue(
     Promise<'completed' | 'rescheduled'>
   >();
   let workerUtilsPromise: Promise<WorkerUtils> | null = null;
-  let runnerPromise: Promise<void> | null = null;
-  let runner: Runner | null = null;
-  let closed = false;
+  let runnerPromise: Promise<Runner | null> | null = null;
   const closeController = new AbortController();
+  const closeSignal = closeController.signal;
 
   function ensureWorkerUtils(): Promise<WorkerUtils> {
     workerUtilsPromise ??= (async () => {
@@ -150,7 +153,6 @@ export function createQueue(
     idempotencyKey,
     headers,
     delaySeconds,
-    jobKey,
   }: {
     queueId: string;
     body: Buffer | Uint8Array;
@@ -159,7 +161,6 @@ export function createQueue(
     idempotencyKey?: string;
     headers?: Record<string, string>;
     delaySeconds?: number;
-    jobKey: string;
   }) {
     const utils = await ensureWorkerUtils();
     const runAt =
@@ -178,7 +179,9 @@ export function createQueue(
         headers,
       }),
       {
-        jobKey,
+        // One durable row per logical message: retries and timeoutSeconds
+        // reschedules replace the job instead of adding a second row.
+        jobKey: idempotencyKey ?? messageId,
         ...(runAt ? { runAt } : {}),
         maxAttempts: 3,
       }
@@ -234,7 +237,9 @@ export function createQueue(
 
   /** Resolves once a handler for this queue's prefix is registered, or on close. */
   function waitForHandler(): Promise<void> {
-    if (registry.handlers.has(workflowPrefix)) return Promise.resolve();
+    if (handlerRegistry.handlers.has(workflowPrefix) || closeSignal.aborted) {
+      return Promise.resolve();
+    }
 
     const warnTimer = setTimeout(() => {
       console.warn(
@@ -247,22 +252,23 @@ export function createQueue(
     return new Promise((resolve) => {
       const check = () => {
         if (
-          !registry.handlers.has(workflowPrefix) &&
-          !closeController.signal.aborted
+          !handlerRegistry.handlers.has(workflowPrefix) &&
+          !closeSignal.aborted
         ) {
           return;
         }
-        registry.onRegister.delete(check);
+        handlerRegistry.onRegister.delete(check);
+        closeSignal.removeEventListener('abort', check);
         clearTimeout(warnTimer);
         resolve();
       };
-      registry.onRegister.add(check);
-      closeController.signal.addEventListener('abort', check, { once: true });
+      handlerRegistry.onRegister.add(check);
+      closeSignal.addEventListener('abort', check);
     });
   }
 
   async function start(): Promise<void> {
-    if (closed) return;
+    if (closeSignal.aborted) return;
     await ensureWorkerUtils();
 
     // The runner starts only once a workflow handler is registered: jobs stay
@@ -270,10 +276,10 @@ export function createQueue(
     // by an enqueue-only process. Armed in the background so start() does not
     // block boot when the route module loads after instrumentation.
     if (!runnerPromise) {
-      runnerPromise = (async () => {
+      const armed = (async (): Promise<Runner | null> => {
         await waitForHandler();
-        if (closed) return;
-        runner = await run({
+        if (closeSignal.aborted) return null;
+        return run({
           pgPool: pool,
           // Default of 50 is high enough to avoid worker-pool exhaustion in
           // workflows that use parent→child polling patterns (e.g. awaiting a
@@ -290,18 +296,21 @@ export function createQueue(
           taskList: { [jobQueueName]: handleFlowJob },
         });
       })();
-      runnerPromise.catch((err) => {
-        runnerPromise = null;
+      armed.catch((err) => {
+        if (runnerPromise === armed) runnerPromise = null;
         console.error('[world-postgres] Queue runner failed to start:', err);
       });
+      runnerPromise = armed;
     }
-    if (registry.handlers.has(workflowPrefix)) {
+    if (handlerRegistry.handlers.has(workflowPrefix)) {
       await runnerPromise;
     }
   }
 
   const queue: Queue['queue'] = async (queueName, message, opts) => {
-    if (closed) throw new Error('[world-postgres] The queue is closed');
+    if (closeSignal.aborted) {
+      throw new Error('[world-postgres] The queue is closed');
+    }
     const { id: queueId } = parseQueueName(queueName);
     const messageId = MessageId.parse(`msg_${generateMessageId()}`);
     await addGraphileJob({
@@ -312,7 +321,6 @@ export function createQueue(
       idempotencyKey: opts?.idempotencyKey,
       headers: opts?.headers,
       delaySeconds: opts?.delaySeconds,
-      jobKey: opts?.idempotencyKey ?? messageId,
     });
     return { messageId };
   };
@@ -322,13 +330,11 @@ export function createQueue(
     helpers: unknown
   ): Promise<void> {
     const messageData = MessageData.parse(payload);
-    const graphileHelpers = GraphileHelpers.safeParse(helpers);
+    const { job } = GraphileHelpers.parse(helpers);
     // messageData.attempt is the first logical delivery this graphile job
     // represents; graphile's own `attempts` counts retries of this job. Their
     // sum survives timeoutSeconds reschedules, which create replacement jobs.
-    const attempt =
-      messageData.attempt +
-      (graphileHelpers.success ? graphileHelpers.data.job.attempts - 1 : 0);
+    const attempt = messageData.attempt + job.attempts - 1;
     const queueName = `${workflowPrefix}${messageData.id}` as ValidQueueName;
     const message = deserializeQueueMessage(messageData.data);
     QueuePayloadSchema.parse(message);
@@ -339,7 +345,7 @@ export function createQueue(
         : undefined;
 
     const executeTask = async (): Promise<'completed' | 'rescheduled'> => {
-      const handler = registry.handlers.get(workflowPrefix);
+      const handler = handlerRegistry.handlers.get(workflowPrefix);
       if (!handler) {
         // The runner only starts after registration; throwing hands the job
         // back to graphile for redelivery.
@@ -364,7 +370,6 @@ export function createQueue(
           idempotencyKey: messageData.idempotencyKey,
           headers: messageData.headers,
           delaySeconds: result.timeoutSeconds,
-          jobKey: messageData.idempotencyKey ?? messageData.messageId,
         });
         return 'rescheduled';
       }
@@ -426,9 +431,8 @@ export function createQueue(
     queue,
     start,
     async close() {
-      closed = true;
       closeController.abort();
-      await runnerPromise?.catch(() => {});
+      const runner = await runnerPromise?.catch(() => null);
       if (runner) {
         try {
           await runner.stop();
@@ -441,7 +445,7 @@ export function createQueue(
           }
         }
         await runner.promise.catch(() => {});
-        runner = null;
+        runnerPromise = null;
       }
       if (workerUtilsPromise) {
         const utils = await workerUtilsPromise.catch(() => null);

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -1,11 +1,3 @@
-import { connect } from 'node:net';
-import { setTimeout as sleep } from 'node:timers/promises';
-import {
-  createWorkflowBaseUrl,
-  createWorkflowHealthEndpoint,
-  createWorkflowUrl,
-} from '@workflow/utils';
-import { getWorkflowPort } from '@workflow/utils/get-port';
 import {
   createFetchQueueHandler,
   deserializeQueueMessage,
@@ -13,6 +5,7 @@ import {
   MessageId,
   parseQueueName,
   type Queue,
+  type QueueHandler,
   QueuePayloadSchema,
   type QueuePrefix,
   resolveQueueNamespace,
@@ -53,28 +46,46 @@ function createGraphileLogger() {
 
 const graphileLogger = createGraphileLogger();
 const COMPLETED_IDEMPOTENCY_CACHE_LIMIT = 10_000;
+const HANDLER_WAIT_WARNING_MS = 10_000;
 const GraphileHelpers = z.object({
-  abortSignal: z.instanceof(AbortSignal).optional(),
   job: z.object({
     attempts: z.number().int().positive(),
   }),
 });
 
-type HttpExecutionResult =
-  | { type: 'completed' }
-  | { type: 'reschedule'; timeoutSeconds: number }
-  | {
-      type: 'error';
-      status: number;
-      text: string;
-      headers: Record<string, string>;
-    };
-
-type RunnerStart = { controller: AbortController; promise: Promise<void> };
-type LoopbackTarget = { hosts: string[]; port: number };
+/**
+ * Queue handlers registered by the workflow runtime, keyed by queue prefix.
+ * Held on globalThis so every copy of this module in the process (e.g. one
+ * bundled into a route module and one loaded by instrumentation) shares a
+ * single registry. The latest registration for a prefix wins, so a reloaded
+ * route module (dev) replaces its predecessor.
+ */
+type HandlerRegistry = {
+  handlers: Map<QueuePrefix, QueueHandler>;
+  onRegister: Set<() => void>;
+};
+const RegistryKey = Symbol.for('@workflow/world-postgres//queueHandlers');
+const globalScope = globalThis as { [RegistryKey]?: HandlerRegistry };
+const registry: HandlerRegistry = globalScope[RegistryKey] ?? {
+  handlers: new Map(),
+  onRegister: new Set(),
+};
+globalScope[RegistryKey] = registry;
 
 /**
- * The Postgres queue stores messages under one graphile-worker flow task.
+ * Registers the runtime's queue handler for direct in-process execution by
+ * the embedded graphile-worker runner, and returns the standard HTTP wrapper
+ * for the generated flow route.
+ */
+const createQueueHandler: Queue['createQueueHandler'] = (prefix, handler) => {
+  registry.handlers.set(prefix, handler);
+  for (const notify of [...registry.onRegister]) notify();
+  return createFetchQueueHandler(prefix, handler);
+};
+
+/**
+ * The Postgres queue stores messages under one graphile-worker flow task and
+ * executes them by calling the registered in-process queue handler directly.
  */
 export type PostgresQueue = Queue & {
   start(): Promise<void>;
@@ -85,17 +96,12 @@ export function createQueue(
   config: PostgresWorldConfig,
   pool: Pool
 ): PostgresQueue {
-  const port = process.env.PORT ? Number(process.env.PORT) : undefined;
   const generateMessageId = monotonicFactory();
-
-  function getJobQueueName(): string {
-    const jobPrefix = config.jobPrefix || 'workflow_';
-    return `${jobPrefix}flows`;
-  }
-
-  const getDeploymentId: Queue['getDeploymentId'] = async () => {
-    return 'postgres';
-  };
+  const jobQueueName = `${config.jobPrefix || 'workflow_'}flows`;
+  const workflowPrefix = getQueueTopicPrefix(
+    'workflow',
+    resolveQueueNamespace(config.namespace)
+  );
 
   const completedMessages = new Set<string>();
   const inflightMessages = new Map<string, Promise<void>>();
@@ -103,11 +109,27 @@ export function createQueue(
     string,
     Promise<'completed' | 'rescheduled'>
   >();
-  let workerUtils: WorkerUtils | null = null;
+  let workerUtilsPromise: Promise<WorkerUtils> | null = null;
+  let runnerPromise: Promise<void> | null = null;
   let runner: Runner | null = null;
-  let runnerStart: RunnerStart | null = null;
-  let closing = false;
-  let startPromise: Promise<void> | null = null;
+  let closed = false;
+  const closeController = new AbortController();
+
+  function ensureWorkerUtils(): Promise<WorkerUtils> {
+    workerUtilsPromise ??= (async () => {
+      const utils = await makeWorkerUtils({
+        pgPool: pool,
+        logger: graphileLogger,
+      });
+      await utils.migrate();
+      await migratePgBossJobs(utils);
+      return utils;
+    })().catch((err) => {
+      workerUtilsPromise = null;
+      throw err;
+    });
+    return workerUtilsPromise;
+  }
 
   function markMessageCompleted(idempotencyKey: string) {
     completedMessages.delete(idempotencyKey);
@@ -137,20 +159,16 @@ export function createQueue(
     idempotencyKey?: string;
     headers?: Record<string, string>;
     delaySeconds?: number;
-    jobKey?: string;
+    jobKey: string;
   }) {
-    const utils = workerUtils;
-    if (!utils) {
-      throw new Error('Postgres queue worker utils are not initialized');
-    }
-
+    const utils = await ensureWorkerUtils();
     const runAt =
       typeof delaySeconds === 'number' && delaySeconds > 0
         ? new Date(Date.now() + delaySeconds * 1000)
         : undefined;
 
     await utils.addJob(
-      getJobQueueName(),
+      jobQueueName,
       MessageData.encode({
         id: queueId,
         data: Buffer.from(body),
@@ -160,185 +178,11 @@ export function createQueue(
         headers,
       }),
       {
-        ...(jobKey ? { jobKey } : {}),
+        jobKey,
         ...(runAt ? { runAt } : {}),
         maxAttempts: 3,
       }
     );
-  }
-
-  async function getExecutionBaseUrl(): Promise<string | undefined> {
-    if (process.env.WORKFLOW_LOCAL_BASE_URL) {
-      return process.env.WORKFLOW_LOCAL_BASE_URL;
-    }
-
-    if (typeof port === 'number') {
-      return createWorkflowBaseUrl(`http://localhost:${port}`);
-    }
-
-    if (process.env.PORT) {
-      return createWorkflowBaseUrl(`http://localhost:${process.env.PORT}`);
-    }
-
-    const detectedPort = await getWorkflowPort({
-      endpoint: createWorkflowHealthEndpoint(),
-    });
-    if (typeof detectedPort === 'number') {
-      return createWorkflowBaseUrl(`http://localhost:${detectedPort}`);
-    }
-
-    return undefined;
-  }
-
-  function getLoopbackHosts(hostname: string): string[] {
-    if (hostname === 'localhost') {
-      return ['127.0.0.1', '::1'];
-    }
-    if (hostname === '[::1]') {
-      return ['::1'];
-    }
-    return hostname === '127.0.0.1' || hostname === '::1' ? [hostname] : [];
-  }
-
-  function getLoopbackTarget(baseUrl: string | undefined) {
-    if (!baseUrl) {
-      return undefined;
-    }
-
-    const url = new URL(baseUrl);
-    const hosts = getLoopbackHosts(url.hostname);
-    if (hosts.length === 0) {
-      return undefined;
-    }
-
-    return {
-      hosts,
-      port: Number(url.port || (url.protocol === 'https:' ? 443 : 80)),
-    };
-  }
-
-  async function canConnectToLoopbackTarget(
-    target: LoopbackTarget
-  ): Promise<boolean> {
-    for (const host of target.hosts) {
-      const reachable = await new Promise<boolean>((resolve) => {
-        const socket = connect({ host, port: target.port });
-        socket.unref();
-        const finish = (isReachable: boolean) => {
-          socket.destroy();
-          resolve(isReachable);
-        };
-
-        socket.setTimeout(200, () => finish(false));
-        socket.once('connect', () => finish(true));
-        socket.once('error', () => finish(false));
-      });
-
-      if (reachable) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  async function startRunnerUnlessAborted(controller: AbortController) {
-    if (controller.signal.aborted) {
-      return;
-    }
-
-    await setupListeners();
-  }
-
-  async function waitForLoopbackAndStartRunner(
-    controller: AbortController,
-    target: LoopbackTarget
-  ) {
-    while (
-      !controller.signal.aborted &&
-      !(await canConnectToLoopbackTarget(target))
-    ) {
-      await sleep(50, undefined, {
-        ref: false,
-      });
-    }
-
-    await startRunnerUnlessAborted(controller);
-  }
-
-  function deferRunnerStart(
-    controller: AbortController,
-    target: LoopbackTarget
-  ) {
-    const promise = waitForLoopbackAndStartRunner(controller, target)
-      .catch((err) => {
-        if (!controller.signal.aborted) {
-          console.warn(
-            '[world-postgres] Failed to start Graphile Worker after local workflow executor became reachable:',
-            err
-          );
-        }
-      })
-      .finally(() => {
-        if (runnerStart?.promise === promise) {
-          runnerStart = null;
-        }
-      });
-    runnerStart = { controller, promise };
-  }
-
-  async function executeMessageOverHttp({
-    queueName,
-    messageId,
-    attempt,
-    body,
-    headers: extraHeaders,
-    abortSignal,
-  }: {
-    queueName: ValidQueueName;
-    messageId: MessageId;
-    attempt: number;
-    body: Uint8Array;
-    headers?: Record<string, string>;
-    abortSignal?: AbortSignal;
-  }): Promise<HttpExecutionResult> {
-    const headers: Record<string, string> = {
-      ...extraHeaders,
-      'content-type': 'application/json',
-      'x-vqs-queue-name': queueName,
-      'x-vqs-message-id': messageId,
-      'x-vqs-message-attempt': String(attempt),
-    };
-    const baseUrl = await getExecutionBaseUrl();
-    if (!baseUrl) {
-      throw new Error('Unable to resolve base URL for workflow queue.');
-    }
-    const response = await fetch(createWorkflowUrl(baseUrl, { type: 'flow' }), {
-      method: 'POST',
-      duplex: 'half',
-      headers,
-      body,
-      signal: abortSignal,
-    } as any);
-    const text = await response.text();
-
-    if (!response.ok) {
-      return {
-        type: 'error',
-        status: response.status,
-        text,
-        headers: Object.fromEntries(response.headers.entries()),
-      };
-    }
-
-    try {
-      const timeoutSeconds = Number(JSON.parse(text).timeoutSeconds);
-      if (Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0) {
-        return { type: 'reschedule', timeoutSeconds };
-      }
-    } catch {}
-
-    return { type: 'completed' };
   }
 
   async function migratePgBossJobs(utils: WorkerUtils): Promise<void> {
@@ -388,73 +232,81 @@ export function createQueue(
     }
   }
 
-  async function startRunnerWhenExecutorIsReady(): Promise<void> {
-    if (closing || runner || runnerStart) {
-      return;
-    }
+  /** Resolves once a handler for this queue's prefix is registered, or on close. */
+  function waitForHandler(): Promise<void> {
+    if (registry.handlers.has(workflowPrefix)) return Promise.resolve();
 
-    const controller = new AbortController();
-    const promise = (async () => {
-      const target = getLoopbackTarget(await getExecutionBaseUrl());
-      if (!target) {
-        await startRunnerUnlessAborted(controller);
-        return;
-      }
+    const warnTimer = setTimeout(() => {
+      console.warn(
+        `[world-postgres] Waiting for a workflow handler for "${workflowPrefix}" before consuming queue jobs. ` +
+          'Import the generated workflow route module in this process so it can register its handler.'
+      );
+    }, HANDLER_WAIT_WARNING_MS);
+    warnTimer.unref();
 
-      if (await canConnectToLoopbackTarget(target)) {
-        await startRunnerUnlessAborted(controller);
-        return;
-      }
-
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      deferRunnerStart(controller, target);
-    })().finally(() => {
-      if (runnerStart?.promise === promise) {
-        runnerStart = null;
-      }
+    return new Promise((resolve) => {
+      const check = () => {
+        if (
+          !registry.handlers.has(workflowPrefix) &&
+          !closeController.signal.aborted
+        ) {
+          return;
+        }
+        registry.onRegister.delete(check);
+        clearTimeout(warnTimer);
+        resolve();
+      };
+      registry.onRegister.add(check);
+      closeController.signal.addEventListener('abort', check, { once: true });
     });
-    runnerStart = { controller, promise };
-    await promise;
   }
 
   async function start(): Promise<void> {
-    if (closing) {
-      return;
-    }
+    if (closed) return;
+    await ensureWorkerUtils();
 
-    if (!startPromise) {
-      startPromise = (async () => {
-        try {
-          workerUtils = await makeWorkerUtils({
-            pgPool: pool,
-            logger: graphileLogger,
-          });
-          await workerUtils.migrate();
-          await migratePgBossJobs(workerUtils);
-          await startRunnerWhenExecutorIsReady();
-        } catch (err) {
-          startPromise = null;
-          throw err;
-        }
+    // The runner starts only once a workflow handler is registered: jobs stay
+    // in Postgres until this process can execute them, and are never consumed
+    // by an enqueue-only process. Armed in the background so start() does not
+    // block boot when the route module loads after instrumentation.
+    if (!runnerPromise) {
+      runnerPromise = (async () => {
+        await waitForHandler();
+        if (closed) return;
+        runner = await run({
+          pgPool: pool,
+          // Default of 50 is high enough to avoid worker-pool exhaustion in
+          // workflows that use parent→child polling patterns (e.g. awaiting a
+          // child workflow via `childRun.returnValue` inside the parent).
+          // Every such poll holds a worker slot for the duration of the child
+          // run. See packages/core/src/runtime/run.ts and
+          // docs/content/docs/changelog/eager-processing.mdx for context.
+          concurrency: config.queueConcurrency || 50,
+          logger: graphileLogger,
+          ...(config.applicationManagedShutdown === true && {
+            noHandleSignals: true,
+          }),
+          pollInterval: 500, // graphile-worker uses LISTEN/NOTIFY when available
+          taskList: { [jobQueueName]: handleFlowJob },
+        });
       })();
+      runnerPromise.catch((err) => {
+        runnerPromise = null;
+        console.error('[world-postgres] Queue runner failed to start:', err);
+      });
     }
-    await startPromise;
-    if (!closing && !runner && !runnerStart) {
-      await startRunnerWhenExecutorIsReady();
+    if (registry.handlers.has(workflowPrefix)) {
+      await runnerPromise;
     }
   }
 
-  const queue: Queue['queue'] = async (queue, message, opts) => {
-    await start();
-    const { id: queueId } = parseQueueName(queue);
-    const body = serializeQueueMessage(message);
+  const queue: Queue['queue'] = async (queueName, message, opts) => {
+    if (closed) throw new Error('[world-postgres] The queue is closed');
+    const { id: queueId } = parseQueueName(queueName);
     const messageId = MessageId.parse(`msg_${generateMessageId()}`);
     await addGraphileJob({
       queueId,
-      body,
+      body: serializeQueueMessage(message),
       messageId,
       attempt: 1,
       idempotencyKey: opts?.idempotencyKey,
@@ -465,157 +317,121 @@ export function createQueue(
     return { messageId };
   };
 
-  function createTaskHandler(queue: QueuePrefix) {
-    return async (payload: unknown, helpers: unknown) => {
-      const messageData = MessageData.parse(payload);
-      const graphileHelpers = GraphileHelpers.safeParse(helpers);
-      const attempt = graphileHelpers.success
-        ? graphileHelpers.data.job.attempts
-        : messageData.attempt;
-      const queueName = `${queue}${messageData.id}` as ValidQueueName;
-      const body = deserializeQueueMessage(messageData.data);
-      QueuePayloadSchema.parse(body);
-      const workflowInvoke = WorkflowInvokePayloadSchema.safeParse(body);
-      const workflowRunSerializationKey =
-        workflowInvoke.success && !workflowInvoke.data.stepId
-          ? `workflow:${workflowInvoke.data.runId}`
-          : undefined;
-      const executeTask = async (): Promise<'completed' | 'rescheduled'> => {
-        const result = await executeMessageOverHttp({
-          queueName,
-          messageId: messageData.messageId,
-          attempt,
-          body: messageData.data,
-          headers: messageData.headers,
-          abortSignal: graphileHelpers.success
-            ? graphileHelpers.data.abortSignal
-            : undefined,
-        });
+  async function handleFlowJob(
+    payload: unknown,
+    helpers: unknown
+  ): Promise<void> {
+    const messageData = MessageData.parse(payload);
+    const graphileHelpers = GraphileHelpers.safeParse(helpers);
+    // messageData.attempt is the first logical delivery this graphile job
+    // represents; graphile's own `attempts` counts retries of this job. Their
+    // sum survives timeoutSeconds reschedules, which create replacement jobs.
+    const attempt =
+      messageData.attempt +
+      (graphileHelpers.success ? graphileHelpers.data.job.attempts - 1 : 0);
+    const queueName = `${workflowPrefix}${messageData.id}` as ValidQueueName;
+    const message = deserializeQueueMessage(messageData.data);
+    QueuePayloadSchema.parse(message);
+    const workflowInvoke = WorkflowInvokePayloadSchema.safeParse(message);
+    const workflowRunSerializationKey =
+      workflowInvoke.success && !workflowInvoke.data.stepId
+        ? `workflow:${workflowInvoke.data.runId}`
+        : undefined;
 
-        if (result.type === 'completed') {
-          return 'completed';
-        }
-
-        if (result.type === 'reschedule') {
-          // Schedule the follow-up job before we return so a crash cannot
-          // lose the wake-up request.
-          await addGraphileJob({
-            queueId: messageData.id,
-            body: messageData.data,
-            messageId: messageData.messageId,
-            attempt: attempt + 1,
-            idempotencyKey: messageData.idempotencyKey,
-            headers: messageData.headers,
-            delaySeconds: result.timeoutSeconds,
-            jobKey: messageData.idempotencyKey ?? messageData.messageId,
-          });
-          return 'rescheduled';
-        }
-
+    const executeTask = async (): Promise<'completed' | 'rescheduled'> => {
+      const handler = registry.handlers.get(workflowPrefix);
+      if (!handler) {
+        // The runner only starts after registration; throwing hands the job
+        // back to graphile for redelivery.
         throw new Error(
-          `[postgres world] Queue execution failed (${result.status}): ${result.text}`
+          `[world-postgres] No workflow handler registered for "${workflowPrefix}"`
         );
-      };
-
-      const idempotencyKey = messageData.idempotencyKey;
-      if (!idempotencyKey) {
-        if (workflowRunSerializationKey) {
-          // Preserve step fan-out while preventing two workflow replays from
-          // mutating the same run's event log at the same time.
-          const previous = inflightWorkflowRuns.get(
-            workflowRunSerializationKey
-          );
-          const execution = (previous ?? Promise.resolve())
-            .catch(() => {})
-            .then(() => executeTask())
-            .finally(() => {
-              if (
-                inflightWorkflowRuns.get(workflowRunSerializationKey) ===
-                execution
-              ) {
-                inflightWorkflowRuns.delete(workflowRunSerializationKey);
-              }
-            });
-          inflightWorkflowRuns.set(workflowRunSerializationKey, execution);
-          await execution;
-          return;
-        }
-
-        await executeTask();
-        return;
       }
 
-      if (completedMessages.has(idempotencyKey)) {
-        return;
-      }
-
-      const existing = inflightMessages.get(idempotencyKey);
-      if (existing) {
-        await existing;
-        return;
-      }
-
-      const execution = executeTask()
-        .then((result) => {
-          if (result === 'completed') {
-            markMessageCompleted(idempotencyKey);
-          }
-        })
-        .finally(() => {
-          inflightMessages.delete(idempotencyKey);
+      const result = await handler(message, {
+        attempt,
+        queueName,
+        messageId: messageData.messageId,
+      });
+      if (result) {
+        // Schedule the follow-up job before we return so a crash cannot
+        // lose the wake-up request.
+        await addGraphileJob({
+          queueId: messageData.id,
+          body: messageData.data,
+          messageId: messageData.messageId,
+          attempt: attempt + 1,
+          idempotencyKey: messageData.idempotencyKey,
+          headers: messageData.headers,
+          delaySeconds: result.timeoutSeconds,
+          jobKey: messageData.idempotencyKey ?? messageData.messageId,
         });
-      inflightMessages.set(idempotencyKey, execution);
-      await execution;
+        return 'rescheduled';
+      }
+      return 'completed';
     };
-  }
 
-  async function setupListeners() {
-    const taskList: Record<
-      string,
-      (payload: unknown, helpers: unknown) => Promise<void>
-    > = {};
-    const namespace = resolveQueueNamespace(config.namespace);
-    const workflowPrefix = getQueueTopicPrefix('workflow', namespace);
-    taskList[getJobQueueName()] = createTaskHandler(workflowPrefix);
+    const idempotencyKey = messageData.idempotencyKey;
+    if (!idempotencyKey) {
+      if (workflowRunSerializationKey) {
+        // Preserve step fan-out while preventing two workflow replays from
+        // mutating the same run's event log at the same time.
+        const previous = inflightWorkflowRuns.get(workflowRunSerializationKey);
+        const execution = (previous ?? Promise.resolve())
+          .catch(() => {})
+          .then(() => executeTask())
+          .finally(() => {
+            if (
+              inflightWorkflowRuns.get(workflowRunSerializationKey) ===
+              execution
+            ) {
+              inflightWorkflowRuns.delete(workflowRunSerializationKey);
+            }
+          });
+        inflightWorkflowRuns.set(workflowRunSerializationKey, execution);
+        await execution;
+        return;
+      }
 
-    runner = await run({
-      pgPool: pool,
-      // Default of 50 is high enough to avoid worker-pool exhaustion in
-      // workflows that use parent→child polling patterns (e.g. awaiting a
-      // child workflow via `childRun.returnValue` inside the parent).
-      // Every such poll holds a worker slot for the duration of the child
-      // run. Recursive workflows like `fibonacciWorkflow` fan out quickly
-      // — fib(6) produces ~24 concurrent polling steps at peak, and at
-      // concurrency=10 (the previous default) it would deadlock on the
-      // default Postgres setup. See packages/core/src/runtime/run.ts and
-      // docs/content/docs/changelog/eager-processing.mdx for context.
-      concurrency: config.queueConcurrency || 50,
-      logger: graphileLogger,
-      ...(config.applicationManagedShutdown === true && {
-        noHandleSignals: true,
-      }),
-      pollInterval: 500, // 500ms = 0.5s (graphile-worker uses LISTEN/NOTIFY when available)
-      taskList,
-    });
+      await executeTask();
+      return;
+    }
+
+    if (completedMessages.has(idempotencyKey)) {
+      return;
+    }
+
+    const existing = inflightMessages.get(idempotencyKey);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const execution = executeTask()
+      .then((result) => {
+        if (result === 'completed') {
+          markMessageCompleted(idempotencyKey);
+        }
+      })
+      .finally(() => {
+        inflightMessages.delete(idempotencyKey);
+      });
+    inflightMessages.set(idempotencyKey, execution);
+    await execution;
   }
 
   return {
-    createQueueHandler: createFetchQueueHandler,
-    getDeploymentId,
+    createQueueHandler,
+    getDeploymentId: async () => 'postgres',
     queue,
     start,
     async close() {
-      closing = true;
-      if (runnerStart) {
-        runnerStart.controller.abort();
-        await runnerStart.promise;
-        runnerStart = null;
-      }
-      await startPromise?.catch(() => {});
-      const activeRunner = runner;
-      if (activeRunner) {
+      closed = true;
+      closeController.abort();
+      await runnerPromise?.catch(() => {});
+      if (runner) {
         try {
-          await activeRunner.stop();
+          await runner.stop();
         } catch (error) {
           if (
             !(error instanceof Error) ||
@@ -624,14 +440,14 @@ export function createQueue(
             throw error;
           }
         }
-        await activeRunner.promise.catch(() => {});
+        await runner.promise.catch(() => {});
         runner = null;
       }
-      if (workerUtils) {
-        await workerUtils.release();
-        workerUtils = null;
+      if (workerUtilsPromise) {
+        const utils = await workerUtilsPromise.catch(() => null);
+        if (utils) await utils.release();
+        workerUtilsPromise = null;
       }
-      startPromise = null;
     },
   };
 }

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -1,13 +1,4 @@
-import { connect } from 'node:net';
-import * as Stream from 'node:stream';
-import { setTimeout as sleep } from 'node:timers/promises';
-import type { Transport } from '@vercel/queue';
-import {
-  createWorkflowBaseUrl,
-  createWorkflowHealthEndpoint,
-  createWorkflowUrl,
-} from '@workflow/utils';
-import { getWorkflowPort } from '@workflow/utils/get-port';
+import assert from 'node:assert/strict';
 import {
   getQueueTopicPrefix,
   MessageId,
@@ -17,19 +8,18 @@ import {
   type QueuePrefix,
   resolveQueueNamespace,
   type ValidQueueName,
-  WorkflowInvokePayloadSchema,
 } from '@workflow/world';
-import { createWorld } from '@workflow/world-local';
 import {
+  type JobHelpers,
   Logger,
   makeWorkerUtils,
   type Runner,
   run,
+  type Task,
   type WorkerUtils,
 } from 'graphile-worker';
 import type { Pool } from 'pg';
 import { monotonicFactory } from 'ulid';
-import { z } from 'zod/v4';
 import type { PostgresWorldConfig } from './config.js';
 import { MessageData } from './message.js';
 
@@ -55,25 +45,37 @@ const graphileLogger = createGraphileLogger();
 const COMPLETED_IDEMPOTENCY_CACHE_LIMIT = 10_000;
 // Core records MAX_DELIVERIES_EXCEEDED on delivery 49.
 const MAX_GRAPHILE_JOB_ATTEMPTS = 49;
-const GraphileHelpers = z.object({
-  abortSignal: z.instanceof(AbortSignal).optional(),
-  job: z.object({
-    attempts: z.number().int().positive(),
-  }),
-});
+type QueueHandler = Parameters<Queue['createQueueHandler']>[1];
+type ConsumerState =
+  | { status: 'idle' }
+  | { status: 'starting'; promise: Promise<Runner> }
+  | { status: 'running'; runner: Runner }
+  | { status: 'closing'; promise: Promise<void> }
+  | { status: 'closed' };
 
-type HttpExecutionResult =
-  | { type: 'completed' }
-  | { type: 'reschedule'; timeoutSeconds: number }
-  | {
-      type: 'error';
-      status: number;
-      text: string;
-      headers: Record<string, string>;
-    };
+export function encodeQueueMessage(value: unknown): Buffer {
+  return Buffer.from(
+    JSON.stringify(value, (_key, item) =>
+      item instanceof Uint8Array
+        ? {
+            __type: 'Uint8Array',
+            data: Buffer.from(item).toString('base64'),
+          }
+        : item
+    )
+  );
+}
 
-type RunnerStart = { controller: AbortController; promise: Promise<void> };
-type LoopbackTarget = { hosts: string[]; port: number };
+function decodeQueueMessage(data: Buffer): unknown {
+  return JSON.parse(data.toString(), (_key, item) =>
+    item !== null &&
+    typeof item === 'object' &&
+    item.__type === 'Uint8Array' &&
+    typeof item.data === 'string'
+      ? new Uint8Array(Buffer.from(item.data, 'base64'))
+      : item
+  );
+}
 
 /**
  * The Postgres queue stores messages under one graphile-worker flow task.
@@ -87,50 +89,12 @@ export function createQueue(
   config: PostgresWorldConfig,
   pool: Pool
 ): PostgresQueue {
-  const port = process.env.PORT ? Number(process.env.PORT) : undefined;
-  const localWorld = createWorld({ dataDir: undefined, port });
-
-  // JSON transport that preserves Uint8Array values via a tagged
-  // envelope ({ __type: 'Uint8Array', data: '<base64>' }).  Required
-  // for the resilient start path where runInput.input (a Uint8Array)
-  // is sent through the queue.
-  const transport: Transport<unknown> = {
-    contentType: 'application/json',
-    serialize(value: unknown): Buffer {
-      return Buffer.from(
-        JSON.stringify(value, (_key, v) =>
-          v instanceof Uint8Array
-            ? { __type: 'Uint8Array', data: Buffer.from(v).toString('base64') }
-            : v
-        )
-      );
-    },
-    async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
-      const chunks: Uint8Array[] = [];
-      const reader = stream.getReader();
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (value) chunks.push(value);
-      }
-      return JSON.parse(Buffer.concat(chunks).toString(), (_key, v) =>
-        v !== null &&
-        typeof v === 'object' &&
-        v.__type === 'Uint8Array' &&
-        typeof v.data === 'string'
-          ? new Uint8Array(Buffer.from(v.data, 'base64'))
-          : v
-      );
-    },
-  };
   const generateMessageId = monotonicFactory();
-
-  function getJobQueueName(): string {
-    const jobPrefix = config.jobPrefix || 'workflow_';
-    return `${jobPrefix}flows`;
-  }
-
-  const createQueueHandler = localWorld.createQueueHandler;
+  const jobQueueName = `${config.jobPrefix || 'workflow_'}flows`;
+  const workflowPrefix = getQueueTopicPrefix(
+    'workflow',
+    resolveQueueNamespace(config.namespace)
+  );
 
   const getDeploymentId: Queue['getDeploymentId'] = async () => {
     return 'postgres';
@@ -142,11 +106,9 @@ export function createQueue(
     string,
     Promise<'completed' | 'rescheduled'>
   >();
-  let workerUtils: WorkerUtils | null = null;
-  let runner: Runner | null = null;
-  let runnerStart: RunnerStart | null = null;
-  let closing = false;
-  let startPromise: Promise<void> | null = null;
+  let consumer: ConsumerState = { status: 'idle' };
+  let registeredHandler: QueueHandler | undefined;
+  let workerUtilsPromise: Promise<WorkerUtils> | undefined;
 
   function markMessageCompleted(idempotencyKey: string) {
     completedMessages.delete(idempotencyKey);
@@ -157,6 +119,29 @@ export function createQueue(
         completedMessages.delete(oldestKey);
       }
     }
+  }
+
+  function ensureWorkerUtils(): Promise<WorkerUtils> {
+    assert.notEqual(consumer.status, 'closed', 'Postgres queue is closed');
+    if (!workerUtilsPromise) {
+      let initialization!: Promise<WorkerUtils>;
+      initialization = makeWorkerUtils({
+        pgPool: pool,
+        logger: graphileLogger,
+      })
+        .then(async (utils) => {
+          await migratePgBossJobs(utils);
+          return utils;
+        })
+        .catch((error) => {
+          if (workerUtilsPromise === initialization) {
+            workerUtilsPromise = undefined;
+          }
+          throw error;
+        });
+      workerUtilsPromise = initialization;
+    }
+    return workerUtilsPromise;
   }
 
   async function addGraphileJob({
@@ -170,7 +155,7 @@ export function createQueue(
     jobKey,
   }: {
     queueId: string;
-    body: Buffer | Uint8Array;
+    body: Buffer;
     messageId: MessageId;
     attempt: number;
     idempotencyKey?: string;
@@ -178,10 +163,7 @@ export function createQueue(
     delaySeconds?: number;
     jobKey?: string;
   }) {
-    const utils = workerUtils;
-    if (!utils) {
-      throw new Error('Postgres queue worker utils are not initialized');
-    }
+    const utils = await ensureWorkerUtils();
 
     const runAt =
       typeof delaySeconds === 'number' && delaySeconds > 0
@@ -189,10 +171,10 @@ export function createQueue(
         : undefined;
 
     await utils.addJob(
-      getJobQueueName(),
+      jobQueueName,
       MessageData.encode({
         id: queueId,
-        data: Buffer.from(body),
+        data: body,
         attempt,
         messageId,
         idempotencyKey,
@@ -204,180 +186,6 @@ export function createQueue(
         maxAttempts: MAX_GRAPHILE_JOB_ATTEMPTS,
       }
     );
-  }
-
-  async function getExecutionBaseUrl(): Promise<string | undefined> {
-    if (process.env.WORKFLOW_LOCAL_BASE_URL) {
-      return process.env.WORKFLOW_LOCAL_BASE_URL;
-    }
-
-    if (typeof port === 'number') {
-      return createWorkflowBaseUrl(`http://localhost:${port}`);
-    }
-
-    if (process.env.PORT) {
-      return createWorkflowBaseUrl(`http://localhost:${process.env.PORT}`);
-    }
-
-    const detectedPort = await getWorkflowPort({
-      endpoint: createWorkflowHealthEndpoint(),
-    });
-    if (typeof detectedPort === 'number') {
-      return createWorkflowBaseUrl(`http://localhost:${detectedPort}`);
-    }
-
-    return undefined;
-  }
-
-  function getLoopbackHosts(hostname: string): string[] {
-    if (hostname === 'localhost') {
-      return ['127.0.0.1', '::1'];
-    }
-    if (hostname === '[::1]') {
-      return ['::1'];
-    }
-    return hostname === '127.0.0.1' || hostname === '::1' ? [hostname] : [];
-  }
-
-  function getLoopbackTarget(baseUrl: string | undefined) {
-    if (!baseUrl) {
-      return undefined;
-    }
-
-    const url = new URL(baseUrl);
-    const hosts = getLoopbackHosts(url.hostname);
-    if (hosts.length === 0) {
-      return undefined;
-    }
-
-    return {
-      hosts,
-      port: Number(url.port || (url.protocol === 'https:' ? 443 : 80)),
-    };
-  }
-
-  async function canConnectToLoopbackTarget(
-    target: LoopbackTarget
-  ): Promise<boolean> {
-    for (const host of target.hosts) {
-      const reachable = await new Promise<boolean>((resolve) => {
-        const socket = connect({ host, port: target.port });
-        socket.unref();
-        const finish = (isReachable: boolean) => {
-          socket.destroy();
-          resolve(isReachable);
-        };
-
-        socket.setTimeout(200, () => finish(false));
-        socket.once('connect', () => finish(true));
-        socket.once('error', () => finish(false));
-      });
-
-      if (reachable) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  async function startRunnerUnlessAborted(controller: AbortController) {
-    if (controller.signal.aborted) {
-      return;
-    }
-
-    await setupListeners();
-  }
-
-  async function waitForLoopbackAndStartRunner(
-    controller: AbortController,
-    target: LoopbackTarget
-  ) {
-    while (
-      !controller.signal.aborted &&
-      !(await canConnectToLoopbackTarget(target))
-    ) {
-      await sleep(50, undefined, {
-        ref: false,
-      });
-    }
-
-    await startRunnerUnlessAborted(controller);
-  }
-
-  function deferRunnerStart(
-    controller: AbortController,
-    target: LoopbackTarget
-  ) {
-    const promise = waitForLoopbackAndStartRunner(controller, target)
-      .catch((err) => {
-        if (!controller.signal.aborted) {
-          console.warn(
-            '[world-postgres] Failed to start Graphile Worker after local workflow executor became reachable:',
-            err
-          );
-        }
-      })
-      .finally(() => {
-        if (runnerStart?.promise === promise) {
-          runnerStart = null;
-        }
-      });
-    runnerStart = { controller, promise };
-  }
-
-  async function executeMessageOverHttp({
-    queueName,
-    messageId,
-    attempt,
-    body,
-    headers: extraHeaders,
-    abortSignal,
-  }: {
-    queueName: ValidQueueName;
-    messageId: MessageId;
-    attempt: number;
-    body: Uint8Array;
-    headers?: Record<string, string>;
-    abortSignal?: AbortSignal;
-  }): Promise<HttpExecutionResult> {
-    const headers: Record<string, string> = {
-      ...extraHeaders,
-      'content-type': 'application/json',
-      'x-vqs-queue-name': queueName,
-      'x-vqs-message-id': messageId,
-      'x-vqs-message-attempt': String(attempt),
-    };
-    const baseUrl = await getExecutionBaseUrl();
-    if (!baseUrl) {
-      throw new Error('Unable to resolve base URL for workflow queue.');
-    }
-    const response = await fetch(createWorkflowUrl(baseUrl, { type: 'flow' }), {
-      method: 'POST',
-      duplex: 'half',
-      headers,
-      body,
-      signal: abortSignal,
-    } as any);
-    const text = await response.text();
-
-    if (!response.ok) {
-      return {
-        type: 'error',
-        status: response.status,
-        text,
-        headers: Object.fromEntries(response.headers.entries()),
-      };
-    }
-
-    try {
-      const timeoutSeconds = Number(JSON.parse(text).timeoutSeconds);
-      if (Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0) {
-        return { type: 'reschedule', timeoutSeconds };
-      }
-    } catch {}
-
-    return { type: 'completed' };
   }
 
   async function migratePgBossJobs(utils: WorkerUtils): Promise<void> {
@@ -434,69 +242,47 @@ export function createQueue(
     }
   }
 
-  async function startRunnerWhenExecutorIsReady(): Promise<void> {
-    if (closing || runner || runnerStart) {
-      return;
-    }
-
-    const controller = new AbortController();
-    const promise = (async () => {
-      const target = getLoopbackTarget(await getExecutionBaseUrl());
-      if (!target) {
-        await startRunnerUnlessAborted(controller);
-        return;
-      }
-
-      if (await canConnectToLoopbackTarget(target)) {
-        await startRunnerUnlessAborted(controller);
-        return;
-      }
-
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      deferRunnerStart(controller, target);
-    })().finally(() => {
-      if (runnerStart?.promise === promise) {
-        runnerStart = null;
-      }
-    });
-    runnerStart = { controller, promise };
-    await promise;
-  }
-
   async function start(): Promise<void> {
-    if (closing) {
+    if (consumer.status === 'closed' || consumer.status === 'closing') {
+      throw new Error('Postgres queue is closed');
+    }
+    if (!registeredHandler) {
+      throw new Error(
+        'Import the generated flow route before starting the Postgres World'
+      );
+    }
+    if (consumer.status === 'running') {
+      return;
+    }
+    if (consumer.status === 'starting') {
+      await consumer.promise;
       return;
     }
 
-    if (!startPromise) {
-      startPromise = (async () => {
-        try {
-          workerUtils = await makeWorkerUtils({
-            pgPool: pool,
-            logger: graphileLogger,
-          });
-          await workerUtils.migrate();
-          await migratePgBossJobs(workerUtils);
-          await startRunnerWhenExecutorIsReady();
-        } catch (err) {
-          startPromise = null;
-          throw err;
+    let starting!: Promise<Runner>;
+    starting = ensureWorkerUtils()
+      .then(() => startRunner())
+      .then(
+        (runner) => {
+          if (consumer.status === 'starting' && consumer.promise === starting) {
+            consumer = { status: 'running', runner };
+          }
+          return runner;
+        },
+        (error) => {
+          if (consumer.status === 'starting' && consumer.promise === starting) {
+            consumer = { status: 'idle' };
+          }
+          throw error;
         }
-      })();
-    }
-    await startPromise;
-    if (!closing && !runner && !runnerStart) {
-      await startRunnerWhenExecutorIsReady();
-    }
+      );
+    consumer = { status: 'starting', promise: starting };
+    await starting;
   }
 
   const queue: Queue['queue'] = async (queue, message, opts) => {
-    await start();
     const { id: queueId } = parseQueueName(queue);
-    const body = transport.serialize(message) as Buffer;
+    const body = encodeQueueMessage(message);
     const messageId = MessageId.parse(`msg_${generateMessageId()}`);
     await addGraphileJob({
       queueId,
@@ -511,61 +297,40 @@ export function createQueue(
     return { messageId };
   };
 
-  async function deserializeMessageBody(data: Buffer): Promise<unknown> {
-    const bodyStream = Stream.Readable.toWeb(Stream.Readable.from([data]));
-    return transport.deserialize(bodyStream as ReadableStream<Uint8Array>);
-  }
-
-  function createTaskHandler(queue: QueuePrefix) {
-    return async (payload: unknown, helpers: unknown) => {
+  function createTaskHandler(queue: QueuePrefix): Task {
+    return async (payload: unknown, helpers: JobHelpers) => {
       const messageData = MessageData.parse(payload);
-      const graphileHelpers = GraphileHelpers.safeParse(helpers);
-      const attempt = graphileHelpers.success
-        ? graphileHelpers.data.job.attempts
-        : messageData.attempt;
+      const attempt = messageData.attempt + helpers.job.attempts - 1;
       const queueName = `${queue}${messageData.id}` as ValidQueueName;
-      const body = await deserializeMessageBody(messageData.data);
-      QueuePayloadSchema.parse(body);
-      const workflowInvoke = WorkflowInvokePayloadSchema.safeParse(body);
+      const message = QueuePayloadSchema.parse(
+        decodeQueueMessage(messageData.data)
+      );
       const workflowRunSerializationKey =
-        workflowInvoke.success && !workflowInvoke.data.stepId
-          ? `workflow:${workflowInvoke.data.runId}`
+        !('__healthCheck' in message) && !message.stepId
+          ? `workflow:${message.runId}`
           : undefined;
       const executeTask = async (): Promise<'completed' | 'rescheduled'> => {
-        const result = await executeMessageOverHttp({
+        assert.ok(registeredHandler, 'Postgres queue handler is missing');
+        const result = await registeredHandler(message, {
+          attempt,
           queueName,
           messageId: messageData.messageId,
-          attempt,
-          body: messageData.data,
-          headers: messageData.headers,
-          abortSignal: graphileHelpers.success
-            ? graphileHelpers.data.abortSignal
-            : undefined,
         });
+        if (!result) return 'completed';
 
-        if (result.type === 'completed') {
-          return 'completed';
-        }
-
-        if (result.type === 'reschedule') {
-          // Schedule the follow-up job before we return so a crash cannot
-          // lose the wake-up request.
-          await addGraphileJob({
-            queueId: messageData.id,
-            body: messageData.data,
-            messageId: messageData.messageId,
-            attempt: attempt + 1,
-            idempotencyKey: messageData.idempotencyKey,
-            headers: messageData.headers,
-            delaySeconds: result.timeoutSeconds,
-            jobKey: messageData.idempotencyKey ?? messageData.messageId,
-          });
-          return 'rescheduled';
-        }
-
-        throw new Error(
-          `[postgres world] Queue execution failed (${result.status}): ${result.text}`
-        );
+        // Schedule the follow-up job before we return so a crash cannot lose
+        // the wake-up request.
+        await addGraphileJob({
+          queueId: messageData.id,
+          body: messageData.data,
+          messageId: messageData.messageId,
+          attempt: attempt + 1,
+          idempotencyKey: messageData.idempotencyKey,
+          headers: messageData.headers,
+          delaySeconds: result.timeoutSeconds,
+          jobKey: messageData.idempotencyKey ?? messageData.messageId,
+        });
+        return 'rescheduled';
       };
 
       const idempotencyKey = messageData.idempotencyKey;
@@ -620,16 +385,8 @@ export function createQueue(
     };
   }
 
-  async function setupListeners() {
-    const taskList: Record<
-      string,
-      (payload: unknown, helpers: unknown) => Promise<void>
-    > = {};
-    const namespace = resolveQueueNamespace(config.namespace);
-    const workflowPrefix = getQueueTopicPrefix('workflow', namespace);
-    taskList[getJobQueueName()] = createTaskHandler(workflowPrefix);
-
-    runner = await run({
+  async function startRunner(): Promise<Runner> {
+    return run({
       pgPool: pool,
       // Default of 50 is high enough to avoid worker-pool exhaustion in
       // workflows that use parent→child polling patterns (e.g. awaiting a
@@ -646,9 +403,65 @@ export function createQueue(
         noHandleSignals: true,
       }),
       pollInterval: 500, // 500ms = 0.5s (graphile-worker uses LISTEN/NOTIFY when available)
-      taskList,
+      taskList: { [jobQueueName]: createTaskHandler(workflowPrefix) },
     });
   }
+
+  async function stopRunner(runner: Runner): Promise<void> {
+    try {
+      await runner.stop();
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        error.message !== 'Runner is already stopped'
+      ) {
+        throw error;
+      }
+    }
+    await runner.promise.catch(() => {});
+  }
+
+  async function closeConsumer(
+    previous: Extract<
+      ConsumerState,
+      { status: 'idle' | 'starting' | 'running' }
+    >
+  ): Promise<void> {
+    let runner: Runner | undefined;
+    try {
+      if (previous.status === 'starting') {
+        runner = await previous.promise.catch(() => undefined);
+      } else if (previous.status === 'running') {
+        runner = previous.runner;
+      }
+      if (runner) await stopRunner(runner);
+
+      const workerUtils = await workerUtilsPromise;
+      await workerUtils?.release();
+      workerUtilsPromise = undefined;
+      consumer = { status: 'closed' };
+    } catch (error) {
+      consumer = runner ? { status: 'running', runner } : { status: 'idle' };
+      throw error;
+    }
+  }
+
+  const createQueueHandler: Queue['createQueueHandler'] = (prefix, handler) => {
+    assert.equal(prefix, workflowPrefix);
+    switch (consumer.status) {
+      case 'idle':
+      case 'starting':
+      case 'running':
+        registeredHandler = handler;
+        break;
+      case 'closing':
+      case 'closed':
+        throw new Error('Postgres queue is closed');
+      default:
+        consumer satisfies never;
+    }
+    return async () => new Response(null, { status: 404 });
+  };
 
   return {
     createQueueHandler,
@@ -656,34 +469,13 @@ export function createQueue(
     queue,
     start,
     async close() {
-      closing = true;
-      if (runnerStart) {
-        runnerStart.controller.abort();
-        await runnerStart.promise;
-        runnerStart = null;
-      }
-      await startPromise?.catch(() => {});
-      const activeRunner = runner;
-      if (activeRunner) {
-        try {
-          await activeRunner.stop();
-        } catch (error) {
-          if (
-            !(error instanceof Error) ||
-            error.message !== 'Runner is already stopped'
-          ) {
-            throw error;
-          }
-        }
-        await activeRunner.promise.catch(() => {});
-        runner = null;
-      }
-      if (workerUtils) {
-        await workerUtils.release();
-        workerUtils = null;
-      }
-      startPromise = null;
-      await localWorld.close?.();
+      if (consumer.status === 'closed') return;
+      if (consumer.status === 'closing') return consumer.promise;
+
+      const previous = consumer;
+      const closing = closeConsumer(previous);
+      consumer = { status: 'closing', promise: closing };
+      await closing;
     },
   };
 }

--- a/packages/world-postgres/src/reenqueue.test.ts
+++ b/packages/world-postgres/src/reenqueue.test.ts
@@ -1,4 +1,3 @@
-import { getWorkflowPort } from '@workflow/utils/get-port';
 import { makeWorkerUtils, run, type WorkerUtils } from 'graphile-worker';
 import { Pool } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -26,10 +25,6 @@ vi.mock('pg', () => ({
       end: vi.fn(),
     };
   }),
-}));
-
-vi.mock('@workflow/utils/get-port', () => ({
-  getWorkflowPort: vi.fn(),
 }));
 
 vi.mock('./storage.js', () => ({
@@ -93,7 +88,6 @@ describe('re-enqueue active runs on start', () => {
     vi.clearAllMocks();
     runnerMock.promise = Promise.resolve();
     vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
-    vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
     vi.mocked(run).mockResolvedValue(runnerMock as any);
     vi.mocked(createEventsStorage).mockReturnValue({} as any);
     vi.mocked(createHooksStorage).mockReturnValue({} as any);
@@ -142,6 +136,7 @@ describe('re-enqueue active runs on start', () => {
 
   it('keeps automatic shutdown in createWorld() by default', async () => {
     const world = createWorld();
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
 
     expect(run).toHaveBeenCalledWith(
@@ -155,6 +150,7 @@ describe('re-enqueue active runs on start', () => {
     process.env.WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN = '1';
 
     const world = createWorld();
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
 
     expect(run).toHaveBeenCalledWith(
@@ -171,6 +167,7 @@ describe('re-enqueue active runs on start', () => {
     });
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
 
     expect(workerUtilsMock.addJob).toHaveBeenCalledTimes(2);
@@ -192,6 +189,7 @@ describe('re-enqueue active runs on start', () => {
     mockRunsList({});
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
 
     // addJob should only have been called for pgboss migration check, not for
@@ -227,6 +225,7 @@ describe('re-enqueue active runs on start', () => {
     } as any);
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
 
     // Should have 4 list calls: 2 statuses × 2 pages each
@@ -245,6 +244,7 @@ describe('re-enqueue active runs on start', () => {
       resolveRunnerFinished = resolve;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
     const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
     const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
@@ -282,6 +282,7 @@ describe('re-enqueue active runs on start', () => {
       resolveRunnerFinished = resolve;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
 
     const closePromise = world.close();
@@ -303,6 +304,7 @@ describe('re-enqueue active runs on start', () => {
       rejectRunnerFinished = reject;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
     const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
     const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
@@ -324,6 +326,7 @@ describe('re-enqueue active runs on start', () => {
       .mockRejectedValueOnce(new Error('transient release error'))
       .mockResolvedValueOnce(undefined);
     const world = createWorld({ connectionString: 'postgres://test' });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
     const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
     const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
@@ -341,6 +344,7 @@ describe('re-enqueue active runs on start', () => {
 
   it('does not close a caller-owned pool', async () => {
     const world = createWorld({ pool });
+    world.createQueueHandler('__wkf_workflow_', async () => undefined);
     await world.start();
 
     await world.close();

--- a/packages/world-postgres/src/reenqueue.test.ts
+++ b/packages/world-postgres/src/reenqueue.test.ts
@@ -1,5 +1,4 @@
-import { getWorkflowPort } from '@workflow/utils/get-port';
-import { createWorld as createLocalTestWorld } from '@workflow/world-local';
+import type { World } from '@workflow/world';
 import { makeWorkerUtils, run, type WorkerUtils } from 'graphile-worker';
 import { Pool } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -28,18 +27,6 @@ vi.mock('pg', () => ({
     };
   }),
 }));
-
-vi.mock('@workflow/utils/get-port', () => ({
-  getWorkflowPort: vi.fn(),
-}));
-
-vi.mock('@workflow/world-local', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@workflow/world-local')>();
-  return {
-    ...actual,
-    createWorld: vi.fn(actual.createWorld),
-  };
-});
 
 vi.mock('./storage.js', () => ({
   createRunsStorage: vi.fn(),
@@ -73,9 +60,6 @@ describe('re-enqueue active runs on start', () => {
     stop: vi.fn(),
     promise: Promise.resolve(),
   };
-  const localWorldClose = vi.fn();
-  const wrappedHandler = vi.fn(async () => Response.json({ ok: true }));
-  const createQueueHandler = vi.fn(() => wrappedHandler);
   const pool = {
     query: vi.fn(async () => ({ rows: [{ exists: false }] })),
     end: vi.fn(),
@@ -105,12 +89,7 @@ describe('re-enqueue active runs on start', () => {
     vi.clearAllMocks();
     runnerMock.promise = Promise.resolve();
     vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
-    vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
     vi.mocked(run).mockResolvedValue(runnerMock as any);
-    vi.mocked(createLocalTestWorld).mockReturnValue({
-      createQueueHandler,
-      close: localWorldClose,
-    } as any);
     vi.mocked(createEventsStorage).mockReturnValue({} as any);
     vi.mocked(createHooksStorage).mockReturnValue({} as any);
     vi.mocked(createStepsStorage).mockReturnValue({} as any);
@@ -158,7 +137,7 @@ describe('re-enqueue active runs on start', () => {
 
   it('keeps automatic shutdown in createWorld() by default', async () => {
     const world = createWorld();
-    await world.start();
+    await startWorld(world);
 
     expect(run).toHaveBeenCalledWith(
       expect.not.objectContaining({ noHandleSignals: true })
@@ -171,7 +150,7 @@ describe('re-enqueue active runs on start', () => {
     process.env.WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN = '1';
 
     const world = createWorld();
-    await world.start();
+    await startWorld(world);
 
     expect(run).toHaveBeenCalledWith(
       expect.objectContaining({ noHandleSignals: true })
@@ -187,7 +166,7 @@ describe('re-enqueue active runs on start', () => {
     });
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
-    await world.start();
+    await startWorld(world);
 
     expect(workerUtilsMock.addJob).toHaveBeenCalledTimes(2);
     expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
@@ -208,7 +187,7 @@ describe('re-enqueue active runs on start', () => {
     mockRunsList({});
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
-    await world.start();
+    await startWorld(world);
 
     // addJob should only have been called for pgboss migration check, not for
     // any workflow runs. The migration check uses pool.query, not addJob.
@@ -243,7 +222,7 @@ describe('re-enqueue active runs on start', () => {
     } as any);
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
-    await world.start();
+    await startWorld(world);
 
     // Should have 4 list calls: 2 statuses × 2 pages each
     expect(callCount).toBe(4);
@@ -261,7 +240,7 @@ describe('re-enqueue active runs on start', () => {
       resolveRunnerFinished = resolve;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
+    await startWorld(world);
     const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
     const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
     let resolveStreamerClose!: () => void;
@@ -298,7 +277,7 @@ describe('re-enqueue active runs on start', () => {
       resolveRunnerFinished = resolve;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
+    await startWorld(world);
 
     const closePromise = world.close();
     await vi.waitFor(() => {
@@ -319,7 +298,7 @@ describe('re-enqueue active runs on start', () => {
       rejectRunnerFinished = reject;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
+    await startWorld(world);
     const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
     const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
 
@@ -331,40 +310,21 @@ describe('re-enqueue active runs on start', () => {
 
     await expect(closePromise).resolves.toBeUndefined();
     expect(workerUtilsMock.release).toHaveBeenCalledOnce();
-    expect(localWorldClose).toHaveBeenCalledOnce();
-    expect(streamer?.close).toHaveBeenCalledOnce();
-    expect(internalPool?.end).toHaveBeenCalledOnce();
-  });
-
-  it('allows close to be retried after queue cleanup fails', async () => {
-    localWorldClose
-      .mockRejectedValueOnce(new Error('transient local shutdown error'))
-      .mockResolvedValueOnce(undefined);
-    const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
-    const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
-    const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
-
-    await expect(world.close()).rejects.toThrow(
-      'transient local shutdown error'
-    );
-    expect(streamer?.close).not.toHaveBeenCalled();
-    expect(internalPool?.end).not.toHaveBeenCalled();
-
-    await expect(world.close()).resolves.toBeUndefined();
-    expect(runnerMock.stop).toHaveBeenCalledOnce();
-    expect(workerUtilsMock.release).toHaveBeenCalledOnce();
-    expect(localWorldClose).toHaveBeenCalledTimes(2);
     expect(streamer?.close).toHaveBeenCalledOnce();
     expect(internalPool?.end).toHaveBeenCalledOnce();
   });
 
   it('does not close a caller-owned pool', async () => {
     const world = createWorld({ pool });
-    await world.start();
+    await startWorld(world);
 
     await world.close();
 
     expect(pool.end).not.toHaveBeenCalled();
   });
 });
+
+async function startWorld(world: World & { start(): Promise<void> }) {
+  world.createQueueHandler('__wkf_workflow_', async () => undefined);
+  await world.start();
+}

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -823,6 +823,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
       // committed: on a slot-numbered run the position is chosen inside the
       // INSERT, so there is nothing to read before it.
       let eventId: string | undefined;
+      let value: { createdAt: Date } | undefined;
       // Lazy, because on a legacy run this mints a ULID and on a slot run it
       // reads which of the two schemes applies. Every caller below awaits it
       // immediately before its insert. A caller that has already fixed the id
@@ -909,11 +910,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             allowReservedAttributes?: true;
             encryptionPublicKey?: string;
           };
-          if (
-            runInputData.deploymentId &&
-            runInputData.workflowName &&
-            runInputData.input !== undefined
-          ) {
+          const { deploymentId, input, workflowName } = runInputData;
+          if (deploymentId && workflowName && input !== undefined) {
             validateAttributeChanges(
               Object.entries(runInputData.attributes ?? {}).map(
                 ([key, value]) => ({ key, value })
@@ -926,42 +924,43 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             // Create run + run_created event atomically. The
             // transaction ensures we never have an orphaned run
             // without its run_created event.
-            const [inserted] = await drizzle
-              .insert(Schema.runs)
-              .values({
-                runId: effectiveRunId,
-                deploymentId: runInputData.deploymentId,
-                workflowName: runInputData.workflowName,
-                specVersion: effectiveSpecVersion,
-                input: runInputData.input as SerializedContent,
-                executionContext: runInputData.executionContext as
-                  | SerializedContent
-                  | undefined,
-                attributes: runInputData.attributes,
-                // Must be mirrored here too: this is the path that recreates a
-                // run from the queued message, which is exactly when the key
-                // would otherwise be lost for the rest of the run's life.
-                encryptionPublicKey: runInputData.encryptionPublicKey,
-                status: 'pending',
-              })
-              .onConflictDoNothing()
-              .returning();
+            const createdRun = await drizzle.transaction(async (tx) => {
+              const [inserted] = await tx
+                .insert(Schema.runs)
+                .values({
+                  runId: effectiveRunId,
+                  deploymentId,
+                  workflowName,
+                  specVersion: effectiveSpecVersion,
+                  input: input as SerializedContent,
+                  executionContext: runInputData.executionContext as
+                    | SerializedContent
+                    | undefined,
+                  attributes: runInputData.attributes,
+                  // Must be mirrored here too: this is the path that recreates a
+                  // run from the queued message, which is exactly when the key
+                  // would otherwise be lost for the rest of the run's life.
+                  encryptionPublicKey: runInputData.encryptionPublicKey,
+                  status: 'pending',
+                })
+                .onConflictDoNothing()
+                .returning();
+              if (!inserted) return;
 
-            if (inserted) {
               // This synthetic run_created is the run's first event, so it
               // opens the slot counter the rest of the run allocates from.
               const runCreatedEventId = await openEventSlots(
-                drizzle,
+                tx,
                 effectiveRunId
               );
-              await drizzle.insert(events).values({
+              await tx.insert(events).values({
                 runId: effectiveRunId,
                 eventId: runCreatedEventId,
                 eventType: 'run_created',
                 eventData: {
-                  deploymentId: runInputData.deploymentId,
-                  workflowName: runInputData.workflowName,
-                  input: runInputData.input,
+                  deploymentId,
+                  workflowName,
+                  input,
                   executionContext: runInputData.executionContext,
                   attributes: runInputData.attributes,
                   allowReservedAttributes: runInputData.allowReservedAttributes,
@@ -969,8 +968,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
                 },
                 specVersion: effectiveSpecVersion,
               });
-            }
-            const createdRun = inserted;
+              return inserted;
+            }, SLOT_INSERT_TRANSACTION);
 
             if (createdRun) {
               currentRun = {
@@ -1219,39 +1218,53 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             allowReservedAttributes: eventData.allowReservedAttributes === true,
           }
         );
-        const [runValue] = await drizzle
-          .insert(Schema.runs)
-          .values({
-            runId: effectiveRunId,
-            deploymentId: eventData.deploymentId,
-            workflowName: eventData.workflowName,
-            // Propagate specVersion from the event to the run entity
-            specVersion: effectiveSpecVersion,
-            input: eventData.input as SerializedContent,
-            executionContext: eventData.executionContext as
-              | SerializedContent
-              | undefined,
-            attributes: eventData.attributes,
-            encryptionPublicKey: eventData.encryptionPublicKey,
-            status: 'pending',
-          })
-          .onConflictDoNothing()
-          .returning();
+        const created = await drizzle.transaction(async (tx) => {
+          const [runValue] = await tx
+            .insert(Schema.runs)
+            .values({
+              runId: effectiveRunId,
+              deploymentId: eventData.deploymentId,
+              workflowName: eventData.workflowName,
+              // Propagate specVersion from the event to the run entity
+              specVersion: effectiveSpecVersion,
+              input: eventData.input as SerializedContent,
+              executionContext: eventData.executionContext as
+                | SerializedContent
+                | undefined,
+              attributes: eventData.attributes,
+              encryptionPublicKey: eventData.encryptionPublicKey,
+              status: 'pending',
+            })
+            .onConflictDoNothing()
+            .returning();
+          if (!runValue) return;
+
+          const runCreatedEventId = await openEventSlots(tx, effectiveRunId);
+          const [eventValue] = await tx
+            .insert(events)
+            .values({
+              runId: effectiveRunId,
+              eventId: runCreatedEventId,
+              eventType: data.eventType,
+              eventData,
+              specVersion: effectiveSpecVersion,
+            })
+            .returning({ createdAt: events.createdAt });
+          return { eventId: runCreatedEventId, eventValue, runValue };
+        }, SLOT_INSERT_TRANSACTION);
         // No row back means the run already exists: the resilient start path
         // (run_started on a non-existent run) won a TOCTOU race and created
         // it. Surface the conflict rather than returning `{ run: undefined }`.
         // start() already treats EntityConflictError as benign, and falling
         // through would append a duplicate run_created event to the log.
-        if (!runValue) {
+        if (!created) {
           throw new EntityConflictError(
             `Workflow run "${effectiveRunId}" already exists`
           );
         }
-        // Open the run's slot counter. Doing it here, rather than lazily on
-        // first allocation, is what makes "no row" mean "created before slots
-        // existed" for the rest of the run's life.
-        eventId = await openEventSlots(drizzle, effectiveRunId);
-        run = deserializeRunError(compact(runValue));
+        eventId = created.eventId;
+        value = { createdAt: created.eventValue.createdAt };
+        run = deserializeRunError(compact(created.runValue));
       }
 
       // Handle run_started event: update run status
@@ -1525,8 +1538,6 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
       } else {
         storedEventData = undefined;
       }
-
-      let value: { createdAt: Date } | undefined;
 
       // Handle step_started event: increment attempt and set the step to
       // running, then write the matching event log entry in the same

--- a/packages/world-postgres/test/spec.test.ts
+++ b/packages/world-postgres/test/spec.test.ts
@@ -5,7 +5,7 @@ import {
   FIRST_EVENT_SLOT,
   SPEC_VERSION_CURRENT,
 } from '@workflow/world';
-import { createTestSuite } from '@workflow/world-testing';
+import { createTestSuite, flowRouteSecurity } from '@workflow/world-testing';
 import { afterAll, beforeAll, expect, test } from 'vitest';
 
 // Skip these tests on Windows since it relies on a docker container
@@ -101,8 +101,14 @@ if (process.platform === 'win32') {
       FIRST_EVENT_SLOT + 2,
       FIRST_EVENT_SLOT + 3,
     ]);
+    await world.events.create(runId, {
+      eventType: 'run_completed',
+      specVersion: SPEC_VERSION_CURRENT,
+      eventData: { output: serialized(null) },
+    } as any);
     await pool.end();
   }, 60_000);
 
   createTestSuite('./dist/index.js');
+  flowRouteSecurity('./dist/index.js');
 }

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -1854,6 +1854,86 @@ describe('Storage (Postgres integration)', () => {
       expect(result.data.map((e) => eventIdToSlot(e.eventId))).toEqual([1, 2]);
     });
 
+    it('does not expose a run before its first event', async () => {
+      const racePool = new Pool({
+        connectionString: container.getConnectionUri(),
+        max: 3,
+      });
+      const blocker = await racePool.connect();
+      const raceEvents = createEventsStorage(createClient(racePool));
+      const lock = 762_841;
+
+      try {
+        await racePool.query(`
+          CREATE OR REPLACE FUNCTION workflow.pause_event_slots()
+          RETURNS trigger AS $$
+          BEGIN
+            PERFORM pg_advisory_xact_lock(${lock});
+            RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql;
+          CREATE TRIGGER pause_event_slots
+          BEFORE INSERT ON workflow.workflow_event_slots
+          FOR EACH ROW EXECUTE FUNCTION workflow.pause_event_slots();
+        `);
+        await blocker.query('SELECT pg_advisory_lock($1)', [lock]);
+
+        const runId = `wrun_${ulid()}`;
+        const runData = {
+          deploymentId: 'deployment-123',
+          workflowName: 'test-workflow',
+          input: new Uint8Array(),
+        };
+        const created = raceEvents.create(runId, {
+          eventType: 'run_created',
+          eventData: runData,
+        });
+
+        await vi.waitFor(async () => {
+          const { rows } = await racePool.query<{ waiting: boolean }>(`
+            SELECT EXISTS (
+              SELECT 1 FROM pg_stat_activity
+              WHERE datname = current_database()
+                AND wait_event_type = 'Lock'
+                AND query LIKE 'insert into "workflow"."workflow_event_slots"%'
+            ) AS waiting
+          `);
+          expect(rows[0]?.waiting).toBe(true);
+        });
+
+        const { rows } = await racePool.query<{
+          eventVisible: boolean;
+          runVisible: boolean;
+        }>(
+          `
+            SELECT
+              EXISTS (
+                SELECT 1 FROM workflow.workflow_runs WHERE id = $1
+              ) AS "runVisible",
+              EXISTS (
+                SELECT 1 FROM workflow.workflow_events
+                WHERE run_id = $1
+              ) AS "eventVisible"
+          `,
+          [runId]
+        );
+        expect(rows).toEqual([{ eventVisible: false, runVisible: false }]);
+
+        await blocker.query('SELECT pg_advisory_unlock($1)', [lock]);
+        await created;
+      } finally {
+        await blocker.query('SELECT pg_advisory_unlock($1)', [lock]);
+        blocker.release();
+        await racePool.query(
+          'DROP TRIGGER IF EXISTS pause_event_slots ON workflow.workflow_event_slots'
+        );
+        await racePool.query(
+          'DROP FUNCTION IF EXISTS workflow.pause_event_slots()'
+        );
+        await racePool.end();
+      }
+    });
+
     it('gives concurrent writers distinct, dense slots', async () => {
       const writers = 8;
       // The suite's own pool is `max: 1`, which would serialize these writes

--- a/packages/world-testing/scripts/generate-well-known-dts.mjs
+++ b/packages/world-testing/scripts/generate-well-known-dts.mjs
@@ -6,19 +6,22 @@
  * to the .mjs files makes TypeScript use the declarations instead of
  * parsing the bundled JavaScript.
  */
-import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 
 const dir = '.well-known/workflow/v1';
-const stub =
+const handler =
   'export declare const POST: (req: Request) => Response | Promise<Response>;\n';
+const stubs = {
+  flow: `import type { WorkflowEntrypoint } from 'workflow/runtime';
+export declare const POST: WorkflowEntrypoint;
+`,
+  webhook: handler,
+};
 
 // Remove the declaration generated for the retired standalone step route. This
 // also cleans stale build output in worktrees that were built before its removal.
 rmSync(`${dir}/step.d.mts`, { force: true });
 
 for (const name of ['flow', 'webhook']) {
-  const dts = `${dir}/${name}.d.mts`;
-  if (!existsSync(dts)) {
-    writeFileSync(dts, stub);
-  }
+  writeFileSync(`${dir}/${name}.d.mts`, stubs[name]);
 }

--- a/packages/world-testing/src/flow-route-security.mts
+++ b/packages/world-testing/src/flow-route-security.mts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { startServer } from './util.mjs';
+
+export function flowRouteSecurity(world: string) {
+  test('does not expose the flow handler over HTTP', async () => {
+    const server = await startServer({ world });
+    const url = `http://localhost:${server.info.port}/.well-known/workflow/v1/flow`;
+
+    const [delivery, health] = await Promise.all([
+      fetch(url, { method: 'POST', body: '{}' }),
+      fetch(`${url}?__health`, { method: 'POST' }),
+    ]);
+
+    expect(delivery.status).toBe(404);
+    expect(health.status).toBe(404);
+  });
+}

--- a/packages/world-testing/src/index.mts
+++ b/packages/world-testing/src/index.mts
@@ -1,6 +1,9 @@
 import { addition } from './addition.mjs';
 import { errors } from './errors.mjs';
 import { eventIds } from './event-ids.mjs';
+
+export { flowRouteSecurity } from './flow-route-security.mjs';
+
 import { hooks } from './hooks.mjs';
 import { idempotency } from './idempotency.mjs';
 import { inlineExecution } from './inline-execution.mjs';

--- a/packages/world-testing/src/server.mts
+++ b/packages/world-testing/src/server.mts
@@ -1,10 +1,14 @@
 import fs from 'node:fs';
 import { serve } from '@hono/node-server';
+import { createWorld } from '@workflow/core/runtime';
+import {
+  HealthCheckPayloadSchema,
+  WorkflowInvokePayloadSchema,
+} from '@workflow/world';
 import { Hono } from 'hono';
 import { getHookByToken, getRun, resumeHook, start } from 'workflow/api';
-import { getWorld } from 'workflow/runtime';
+import { getWorld, setWorld } from 'workflow/runtime';
 import * as z from 'zod';
-import { POST as flowPOST } from '../.well-known/workflow/v1/flow.mjs';
 import manifest from '../.well-known/workflow/v1/manifest.json' with {
   type: 'json',
 };
@@ -15,6 +19,28 @@ if (!process.env.WORKFLOW_TARGET_WORLD) {
   );
   process.exit(1);
 }
+
+// Track flow handler invocations per run for testing inline execution. The
+// counting wraps createQueueHandler (not the HTTP route) because worlds like
+// @workflow/world-postgres execute queue messages in-process without HTTP.
+const flowInvocationCounts = new Map<string, number>();
+
+const world = await createWorld();
+const createQueueHandler = world.createQueueHandler.bind(world);
+world.createQueueHandler = (prefix, handler) =>
+  createQueueHandler(prefix, async (message, metadata) => {
+    if (!HealthCheckPayloadSchema.safeParse(message).success) {
+      const { runId } = WorkflowInvokePayloadSchema.parse(message);
+      flowInvocationCounts.set(
+        runId,
+        (flowInvocationCounts.get(runId) ?? 0) + 1
+      );
+    }
+    return handler(message, metadata);
+  });
+setWorld(world);
+
+const { POST: flowPOST } = await import('../.well-known/workflow/v1/flow.mjs');
 
 type Files = keyof typeof manifest.workflows;
 type Workflows<F extends Files> = keyof (typeof manifest.workflows)[F];
@@ -41,38 +67,8 @@ const Invoke = z
     };
   });
 
-// Track flow handler invocations per run for testing inline execution
-const flowInvocationCounts = new Map<string, number>();
-
 const app = new Hono()
-  .post('/.well-known/workflow/v1/flow', async (ctx) => {
-    // Clone the request to read the body for tracking without consuming it.
-    // We must increment the invocation counter *before* awaiting flowPOST,
-    // otherwise the workflow may complete (and the test may observe the
-    // completed status) before the counter is bumped, producing a flaky
-    // `expected 0 to be 1` failure when the test immediately queries
-    // /_flow-invocations after seeing the run as completed.
-    const cloned = ctx.req.raw.clone();
-    try {
-      const body = (await cloned.json()) as Record<string, unknown>;
-      const runId =
-        typeof body?.runId === 'string'
-          ? body.runId
-          : typeof (body.payload as Record<string, unknown> | undefined)
-                ?.runId === 'string'
-            ? ((body.payload as Record<string, unknown>).runId as string)
-            : undefined;
-      if (runId) {
-        flowInvocationCounts.set(
-          runId,
-          (flowInvocationCounts.get(runId) ?? 0) + 1
-        );
-      }
-    } catch {
-      // Health check or non-JSON messages — ignore
-    }
-    return flowPOST(ctx.req.raw);
-  })
+  .post('/.well-known/workflow/v1/flow', (ctx) => flowPOST(ctx.req.raw))
   .get('/_flow-invocations/:runId', (ctx) => {
     const count = flowInvocationCounts.get(ctx.req.param('runId')) ?? 0;
     return ctx.json({ count });

--- a/packages/world-testing/src/server.mts
+++ b/packages/world-testing/src/server.mts
@@ -47,6 +47,22 @@ const Invoke = z
 // host bundler to compile it into several layers.
 const flowInvocationCounts = new Map<string, number>();
 
+function countFlowInvocation(message: unknown): void {
+  if (!message || typeof message !== 'object') return;
+  const runId =
+    'runId' in message && typeof message.runId === 'string'
+      ? message.runId
+      : 'payload' in message &&
+          message.payload &&
+          typeof message.payload === 'object' &&
+          'runId' in message.payload &&
+          typeof message.payload.runId === 'string'
+        ? message.payload.runId
+        : undefined;
+  if (!runId) return;
+  flowInvocationCounts.set(runId, (flowInvocationCounts.get(runId) ?? 0) + 1);
+}
+
 const app = new Hono()
   .post('/.well-known/workflow/v1/flow', async (ctx) => {
     // Clone the request to read the body for tracking without consuming it.
@@ -57,20 +73,7 @@ const app = new Hono()
     // /_flow-invocations after seeing the run as completed.
     const cloned = ctx.req.raw.clone();
     try {
-      const body = (await cloned.json()) as Record<string, unknown>;
-      const runId =
-        typeof body?.runId === 'string'
-          ? body.runId
-          : typeof (body.payload as Record<string, unknown> | undefined)
-                ?.runId === 'string'
-            ? ((body.payload as Record<string, unknown>).runId as string)
-            : undefined;
-      if (runId) {
-        flowInvocationCounts.set(
-          runId,
-          (flowInvocationCounts.get(runId) ?? 0) + 1
-        );
-      }
+      countFlowInvocation(await cloned.json());
     } catch {
       // Health check or non-JSON messages — ignore
     }
@@ -172,6 +175,15 @@ serve(
     }
 
     const world = await getWorld();
+    if (world.capabilities?.directQueueDelivery === true) {
+      const createQueueHandler = world.createQueueHandler.bind(world);
+      world.createQueueHandler = (prefix, handler) =>
+        createQueueHandler(prefix, async (message, metadata) => {
+          countFlowInvocation(message);
+          return handler(message, metadata);
+        });
+    }
+    await flowPOST.initialize();
     if (world.start) {
       console.log(`starting background tasks...`);
       await world.start().then(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2397,6 +2397,9 @@ importers:
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
+      undici:
+        specifier: 'catalog:'
+        version: 7.29.0
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1442,9 +1442,6 @@ importers:
 
   packages/world-postgres:
     dependencies:
-      '@vercel/queue':
-        specifier: 'catalog:'
-        version: 0.5.0(@opentelemetry/api@1.9.1)
       '@workflow/errors':
         specifier: workspace:*
         version: link:../errors
@@ -1454,9 +1451,6 @@ importers:
       '@workflow/world':
         specifier: workspace:*
         version: link:../world
-      '@workflow/world-local':
-        specifier: workspace:*
-        version: link:../world-local
       cbor-x:
         specifier: 1.6.0
         version: 1.6.0

--- a/workbench/astro/scripts/start-with-pg.mjs
+++ b/workbench/astro/scripts/start-with-pg.mjs
@@ -7,6 +7,10 @@
 async function main() {
   if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
     console.log('Starting Postgres World...');
+    const { POST } = await import(
+      '../src/pages/.well-known/workflow/v1/flow.js'
+    );
+    await POST.initialize();
     const { getWorld } = await import('workflow/runtime');
     const world = await getWorld();
     if (world.start) {

--- a/workbench/nest/src/main.ts
+++ b/workbench/nest/src/main.ts
@@ -4,16 +4,6 @@ import type { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
-  // Start the Postgres World if configured
-  if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
-    const { getWorld } = await import('workflow/runtime');
-    const world = await getWorld();
-    if (world.start) {
-      console.log('Starting World workers...');
-      await world.start();
-    }
-  }
-
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bodyParser: false,
   });
@@ -24,6 +14,13 @@ async function bootstrap() {
   app.use(expressModule.json());
   app.use(expressModule.text({ type: 'text/*' }));
   app.use(expressModule.raw({ type: 'application/octet-stream' }));
+
+  await app.init();
+  if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+    const { getWorld } = await import('workflow/runtime');
+    console.log('Starting World workers...');
+    await (await getWorld()).start?.();
+  }
 
   const port = process.env.PORT ?? 3000;
   await app.listen(port);

--- a/workbench/nextjs-turbopack/instrumentation.ts
+++ b/workbench/nextjs-turbopack/instrumentation.ts
@@ -1,6 +1,6 @@
 import { registerOTel } from '@vercel/otel';
 
-export function register() {
+export async function register() {
   registerOTel({
     serviceName: 'nextjs-turbopack',
     instrumentationConfig: {
@@ -17,4 +17,14 @@ export function register() {
       },
     },
   });
+
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    const { POST } = await import('./app/.well-known/workflow/v1/flow/route');
+    await POST.initialize();
+    const { getWorld } = await import('workflow/runtime');
+    await (await getWorld()).start?.();
+  }
 }

--- a/workbench/nextjs-webpack/instrumentation.ts
+++ b/workbench/nextjs-webpack/instrumentation.ts
@@ -1,6 +1,6 @@
 import { registerOTel } from '@vercel/otel';
 
-export function register() {
+export async function register() {
   registerOTel({
     serviceName: 'nextjs-webpack',
     instrumentationConfig: {
@@ -17,4 +17,14 @@ export function register() {
       },
     },
   });
+
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    const { POST } = await import('./app/.well-known/workflow/v1/flow/route');
+    await POST.initialize();
+    const { getWorld } = await import('workflow/runtime');
+    await (await getWorld()).start?.();
+  }
 }

--- a/workbench/nitro-v3/plugins/start-pg-world.ts
+++ b/workbench/nitro-v3/plugins/start-pg-world.ts
@@ -4,12 +4,10 @@ import { definePlugin } from 'nitro';
 // Needed since we test this in CI
 export default definePlugin(async () => {
   if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
-    import('workflow/runtime').then(async ({ getWorld }) => {
-      const world = await getWorld();
-      if (world.start) {
-        console.log('Starting World workers...');
-        await world.start();
-      }
-    });
+    const { initializeWorkflow } = await import('#workflow/workflows.mjs');
+    await initializeWorkflow();
+    const { getWorld } = await import('workflow/runtime');
+    console.log('Starting World workers...');
+    await (await getWorld()).start?.();
   }
 });

--- a/workbench/nuxt/server/plugins/start-pg-world.ts
+++ b/workbench/nuxt/server/plugins/start-pg-world.ts
@@ -4,12 +4,10 @@ import { defineNitroPlugin } from '#imports';
 // Needed since we test this in CI
 export default defineNitroPlugin(async () => {
   if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
-    import('workflow/runtime').then(async ({ getWorld }) => {
-      const world = await getWorld();
-      if (world.start) {
-        console.log('Starting World workers...');
-        await world.start();
-      }
-    });
+    const { initializeWorkflow } = await import('#workflow/workflows.mjs');
+    await initializeWorkflow();
+    const { getWorld } = await import('workflow/runtime');
+    console.log('Starting World workers...');
+    await (await getWorld()).start?.();
   }
 });

--- a/workbench/sveltekit/package.json
+++ b/workbench/sveltekit/package.json
@@ -36,6 +36,7 @@
     "ai": "catalog:",
     "exsolve": "^1.0.7",
     "lodash.chunk": "^4.2.0",
+    "undici": "catalog:",
     "workflow": "workspace:*",
     "zod": "catalog:"
   }

--- a/workbench/sveltekit/src/hooks.server.ts
+++ b/workbench/sveltekit/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import type { ServerInit } from '@sveltejs/kit';
 import { registerOTel } from '@vercel/otel';
+import { building } from '$app/environment';
 
 registerOTel({
   serviceName: 'example-sveltekit',
@@ -21,7 +22,14 @@ registerOTel({
 export const init: ServerInit = async () => {
   // Start the Postgres World
   // Needed since we test this in CI
-  if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+  if (
+    !building &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    const { POST } = await import(
+      './routes/.well-known/workflow/v1/flow/+server.js'
+    );
+    await POST.initialize();
     const { getWorld } = await import('workflow/runtime');
     const world = await getWorld();
     if (world.start) {


### PR DESCRIPTION
## Summary

Replace the Postgres World HTTP loopback with direct Graphile Worker delivery and start it only after each framework has registered the generated handler.

- Register the Core queue handler and call it directly from the Graphile task.
- Encode the existing queue message as JSON bytes instead of reconstructing HTTP requests and responses.
- Initialize the generated handler before Next.js, SvelteKit, Astro, Nest, Nitro, and Nuxt start background workers.
- Preserve the callable handler and its `initialize` property through framework wrappers.
- Keep enqueue-only processes producer-only; workers start only after handler registration.
- Remove the local World and Vercel Queue transport dependencies.
- Return `404` from the generated flow route for every Postgres request, including `?__health`.

Stored task names and message payloads remain compatible with queued work. `WORKFLOW_LOCAL_BASE_URL` no longer affects the Postgres World.

Refs #2658 #2656

## Validation

- `@workflow/world-postgres`: 195 passing tests
- `@workflow/core`: 2,335 passing tests, 3 expected failures, 1 skipped
- Nest, Nitro, and SvelteKit: 72 passing tests
- Next.js webpack flow-route HMR fuzz test against a staged tarball workbench
- Monorepo package build and typecheck

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>