### PR TITLE
Initialize direct queue delivery before workers

### DIFF
--- a/.changeset/eager-direct-queue-registration.md
+++ b/.changeset/eager-direct-queue-registration.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+'workflow': patch
+---
+
+Allow generated flow routes to register direct queue handlers before workers start.

--- a/.changeset/framework-direct-queue-bootstrap.md
+++ b/.changeset/framework-direct-queue-bootstrap.md
@@ -1,0 +1,9 @@
+---
+'@workflow/astro': patch
+'@workflow/nest': patch
+'@workflow/nitro': patch
+'@workflow/sveltekit': patch
+'@workflow/world-testing': patch
+---
+
+Initialize generated flow handlers before starting direct-delivery Worlds.

--- a/.changeset/postgres-direct-delivery.md
+++ b/.changeset/postgres-direct-delivery.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Deliver Postgres workflow queue messages directly to the in-process handler.

--- a/.changeset/postgres-worker-integrations.md
+++ b/.changeset/postgres-worker-integrations.md
@@ -1,0 +1,6 @@
+---
+'@workflow/nitro': patch
+'@workflow/nest': patch
+---
+
+Load the generated workflow flow module at server boot so its queue handler registers without an HTTP request — required for worlds like `@workflow/world-postgres` that execute queue jobs in-process. Nitro dev now boot-loads the flow bundle (production already loads it eagerly), and the Nest `WorkflowModule` imports the generated bundles in `onModuleInit`.

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -84,10 +84,11 @@ export class LocalBuilder extends BaseBuilder {
     workflowsRouteContent = workflowsRouteContent.replace(
       /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
       (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const workflowHandler = workflowEntrypoint(workflowCode${options});
+export const POST = Object.assign(async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode${options})(normalRequest);
-}
+  return workflowHandler(normalRequest);
+}, { initialize: workflowHandler.initialize });
 
 export const prerender = false;`
     );

--- a/packages/core/src/runtime-world-singleton.test.ts
+++ b/packages/core/src/runtime-world-singleton.test.ts
@@ -1,3 +1,4 @@
+import { withResolvers } from '@workflow/utils';
 import { SPEC_VERSION_CURRENT, type World } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getWorld, setWorld } from './runtime/world.js';
@@ -36,5 +37,65 @@ describe('workflowEntrypoint world initialization', () => {
     expect(response.status).toBe(204);
     await expect(getWorld()).resolves.toBe(world);
     expect(createLocalWorld).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers a handler before the first request when initialized', async () => {
+    const entrypoint = workflowEntrypoint('');
+
+    await entrypoint.initialize();
+
+    expect(world.createQueueHandler).toHaveBeenCalledOnce();
+  });
+
+  it('does not expose the public health response for direct delivery', async () => {
+    const directWorld = {
+      ...world,
+      capabilities: { directQueueDelivery: true },
+    } as unknown as World;
+    createLocalWorld.mockResolvedValue(directWorld);
+
+    const response = await workflowEntrypoint('')(
+      new Request('https://example.test/?__health')
+    );
+
+    expect(response.status).toBe(204);
+  });
+
+  it('rebinds an initialized entrypoint after setWorld()', async () => {
+    const entrypoint = workflowEntrypoint('');
+    await entrypoint.initialize();
+    const nextWorld = {
+      ...world,
+      createQueueHandler: vi.fn(
+        () => async () => new Response(null, { status: 204 })
+      ),
+    } as unknown as World;
+
+    setWorld(nextWorld);
+    await entrypoint.initialize();
+
+    expect(nextWorld.createQueueHandler).toHaveBeenCalledOnce();
+  });
+
+  it('uses a direct World that replaces in-flight initialization', async () => {
+    const pendingWorld = withResolvers<World>();
+    createLocalWorld.mockReturnValueOnce(pendingWorld.promise);
+    const directWorld = {
+      ...world,
+      capabilities: { directQueueDelivery: true },
+      createQueueHandler: vi.fn(
+        () => async () => new Response(null, { status: 404 })
+      ),
+    } as unknown as World;
+    const response = workflowEntrypoint('')(
+      new Request('https://example.test/?__health')
+    );
+    await vi.waitFor(() => expect(createLocalWorld).toHaveBeenCalledOnce());
+
+    setWorld(directWorld);
+    pendingWorld.resolve(world);
+
+    await expect(response).resolves.toMatchObject({ status: 404 });
+    expect(directWorld.createQueueHandler).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -118,7 +118,11 @@ import {
 } from './runtime/suspension-handler.js';
 import { useQuickJSVm } from './runtime/vm-mode.js';
 import { getWaitContinuationDispatch } from './runtime/wait-continuation.js';
-import { getWorld, type WorldHandlers } from './runtime/world.js';
+import {
+  getWorld,
+  getWorldGeneration,
+  type WorldHandlers,
+} from './runtime/world.js';
 import { dehydrateRunError } from './serialization.js';
 import { remapErrorStack } from './source-map.js';
 import * as Attribute from './telemetry/semantic-conventions.js';
@@ -681,6 +685,11 @@ async function getMaxInlineDurationMs(
  * @param workflowCode - The workflow bundle code containing all workflow functions
  * @returns A function that can be used as a Vercel API route
  */
+export interface WorkflowEntrypoint {
+  (req: Request): Promise<Response>;
+  initialize(): Promise<void>;
+}
+
 export function workflowEntrypoint(
   workflowCode: string,
   options?: {
@@ -688,7 +697,7 @@ export function workflowEntrypoint(
     routeModuleBodyStartedAt?: number;
     basePath?: string;
   }
-): (req: Request) => Promise<Response> {
+): WorkflowEntrypoint {
   setWorkflowBasePath(options?.basePath);
 
   const namespace = resolveQueueNamespace(options?.namespace);
@@ -4856,7 +4865,13 @@ export function workflowEntrypoint(
       }
     );
 
-  let cachedHandler: ((req: Request) => Promise<Response>) | undefined;
+  type InitializedHandler = (req: Request) => Promise<Response>;
+  type HandlerCache = {
+    generation: number;
+    promise: Promise<InitializedHandler>;
+  };
+
+  let handlerCache: HandlerCache | undefined;
   let invocationCount = 0;
   const entrypointCreatedAt = Date.now();
   const routeModuleBodyInitMs =
@@ -4864,9 +4879,41 @@ export function workflowEntrypoint(
       ? entrypointCreatedAt - options.routeModuleBodyStartedAt
       : undefined;
 
-  return withHealthCheck(async (req) => {
+  async function initializeHandler(): Promise<InitializedHandler> {
+    const generation = getWorldGeneration();
+    let cache = handlerCache;
+    if (!cache || cache.generation !== generation) {
+      const promise = trace('workflow.route.init', async () => {
+        const worldHandlers = await trace(
+          'workflow.route.get_world_handlers',
+          async () => getWorld()
+        );
+        if (generation !== getWorldGeneration()) return initializeHandler();
+        const queueHandler = handler(worldHandlers);
+        return worldHandlers.capabilities?.directQueueDelivery === true
+          ? queueHandler
+          : withHealthCheck(queueHandler);
+      });
+      cache = { generation, promise };
+      handlerCache = cache;
+    }
+
+    try {
+      const initialized = await cache.promise;
+      if (cache.generation !== getWorldGeneration()) {
+        if (handlerCache === cache) handlerCache = undefined;
+        return initializeHandler();
+      }
+      return initialized;
+    } catch (error) {
+      if (handlerCache === cache) handlerCache = undefined;
+      throw error;
+    }
+  }
+
+  const invokeQueueHandler = async (req: Request): Promise<Response> => {
     invocationCount += 1;
-    const handlerCached = cachedHandler !== undefined;
+    const handlerCached = handlerCache?.generation === getWorldGeneration();
     const spanKind = await getSpanKind('SERVER');
 
     return trace(
@@ -4889,27 +4936,8 @@ export function workflowEntrypoint(
         },
       },
       async (span) => {
-        if (!cachedHandler) {
-          cachedHandler = await trace('workflow.route.init', async () => {
-            // The full runtime World, not `getWorldHandlers()`. That accessor
-            // owns a second, build-time-safe cache, so calling it here built a
-            // second World in the same process: duplicate connection pools and
-            // queue workers for a stateful World, plus a second copy of that
-            // world package's modules once it is bundled, which is what
-            // silently demoted the events WebSocket transport to HTTP. #3665.
-            //
-            // The span keeps its original name. It is a distinct span from the
-            // per-request `workflow.route.get_world` at the top of the flow
-            // route, and renaming it would collide with that one.
-            const worldHandlers = await trace(
-              'workflow.route.get_world_handlers',
-              async () => getWorld()
-            );
-            return handler(worldHandlers);
-          });
-        }
-
-        const response = await cachedHandler(req);
+        const initializedHandler = await initializeHandler();
+        const response = await initializedHandler(req);
         if (response instanceof Response) {
           span?.setAttributes(
             Attribute.HttpResponseStatusCode(response.status)
@@ -4918,5 +4946,11 @@ export function workflowEntrypoint(
         return response;
       }
     );
+  };
+  const entrypoint: WorkflowEntrypoint = Object.assign(invokeQueueHandler, {
+    initialize: async () => {
+      await initializeHandler();
+    },
   });
+  return entrypoint;
 }

--- a/packages/core/src/runtime/world.ts
+++ b/packages/core/src/runtime/world.ts
@@ -45,13 +45,19 @@ const WorldCachePromise = Symbol.for('@workflow/world//cachePromise');
 const StubbedWorldCachePromise = Symbol.for(
   '@workflow/world//stubbedCachePromise'
 );
+const WorldCacheGeneration = Symbol.for('@workflow/world//cacheGeneration');
 
 const globalSymbols: typeof globalThis & {
   [WorldCache]?: World;
   [StubbedWorldCache]?: World;
   [WorldCachePromise]?: Promise<World>;
   [StubbedWorldCachePromise]?: Promise<World>;
+  [WorldCacheGeneration]?: number;
 } = globalThis;
+
+export function getWorldGeneration(): number {
+  return globalSymbols[WorldCacheGeneration] ?? 0;
+}
 
 export type WorldFactoryModule = {
   createWorld?: () => World | Promise<World>;
@@ -243,14 +249,21 @@ export const getWorld = async (): Promise<World> => {
   // Store the promise immediately to prevent race conditions with concurrent calls.
   // Clear on rejection so subsequent calls can retry instead of caching the failure.
   if (!globalSymbols[WorldCachePromise]) {
-    globalSymbols[WorldCachePromise] = createWorld().catch((err) => {
-      globalSymbols[WorldCachePromise] = undefined;
+    let pendingWorld!: Promise<World>;
+    pendingWorld = createWorld().catch((err) => {
+      if (globalSymbols[WorldCachePromise] === pendingWorld) {
+        globalSymbols[WorldCachePromise] = undefined;
+      }
       throw err;
     });
+    globalSymbols[WorldCachePromise] = pendingWorld;
   }
-  globalSymbols[WorldCache] = await globalSymbols[WorldCachePromise];
-  assertWorldSupportsRuntimeProtocol(globalSymbols[WorldCache]);
-  return globalSymbols[WorldCache];
+  const worldPromise = globalSymbols[WorldCachePromise];
+  const world = await worldPromise;
+  if (globalSymbols[WorldCachePromise] !== worldPromise) return getWorld();
+  globalSymbols[WorldCache] = world;
+  assertWorldSupportsRuntimeProtocol(world);
+  return world;
 };
 
 /**
@@ -258,6 +271,7 @@ export const getWorld = async (): Promise<World> => {
  * variables change and you need to reinitialize the world with new config.
  */
 export const setWorld = (world: World | undefined): void => {
+  globalSymbols[WorldCacheGeneration] = getWorldGeneration() + 1;
   globalSymbols[WorldCache] = world;
   globalSymbols[StubbedWorldCache] = world;
   globalSymbols[WorldCachePromise] = undefined;

--- a/packages/nest/src/workflow.controller.ts
+++ b/packages/nest/src/workflow.controller.ts
@@ -91,6 +91,12 @@ function getOutDir(): string {
   return controllerConfig.outDir;
 }
 
+export async function loadWorkflowHandler() {
+  const outDir = getOutDir();
+  await import(pathToFileURL(join(outDir, 'steps.mjs')).href);
+  return import(pathToFileURL(join(outDir, 'workflows.mjs')).href);
+}
+
 /**
  * Controller that handles the well-known workflow endpoints.
  * Dynamically imports the generated bundles and handles request/response conversion.
@@ -99,12 +105,7 @@ function getOutDir(): string {
 export class WorkflowController {
   @Post('flow')
   async handleFlow(@Req() req: any, @Res() res: any) {
-    const outDir = getOutDir();
-    // Import step registrations (side effects) before the combined handler
-    await import(pathToFileURL(join(outDir, 'steps.mjs')).href);
-    const { POST } = await import(
-      pathToFileURL(join(outDir, 'workflows.mjs')).href
-    );
+    const { POST } = await loadWorkflowHandler();
     const webRequest = toWebRequest(req);
     const webResponse = await POST(webRequest);
     await sendWebResponse(res, webResponse);

--- a/packages/nest/src/workflow.module.ts
+++ b/packages/nest/src/workflow.module.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import {
   type DynamicModule,
   Module,
@@ -74,19 +75,24 @@ export class WorkflowModule implements OnModuleInit, OnModuleDestroy {
 
   async onModuleInit() {
     const options = WorkflowModule.options;
-    if (!options || options.skipBuild) {
+    const outDir = WorkflowModule.outDir;
+    if (!options || !outDir) {
       return;
     }
-    // Lazy-load the toolchain so it never enters the runtime bundle.
-    const [{ NestLocalBuilder }, { createBuildQueue }] = await Promise.all([
-      import('./builder.js'),
-      import('@workflow/builders'),
-    ]);
-    const builder = new NestLocalBuilder({
-      ...options,
-      outDir: WorkflowModule.outDir ?? undefined,
-    });
-    await createBuildQueue()(() => builder.build());
+    if (!options.skipBuild) {
+      // Lazy-load the toolchain so it never enters the runtime bundle.
+      const [{ NestLocalBuilder }, { createBuildQueue }] = await Promise.all([
+        import('./builder.js'),
+        import('@workflow/builders'),
+      ]);
+      const builder = new NestLocalBuilder({ ...options, outDir });
+      await createBuildQueue()(() => builder.build());
+    }
+    // Load the generated bundles so the workflow queue handler registers at
+    // boot — worlds like @workflow/world-postgres execute queue jobs
+    // in-process and only start consuming once a handler is registered.
+    await import(pathToFileURL(join(outDir, 'steps.mjs')).href);
+    await import(pathToFileURL(join(outDir, 'workflows.mjs')).href);
   }
 
   async onModuleDestroy() {

--- a/packages/nest/src/workflow.module.ts
+++ b/packages/nest/src/workflow.module.ts
@@ -35,8 +35,10 @@ const DEFAULT_OUT_DIR = '.nestjs/workflow';
  */
 @Module({})
 export class WorkflowModule implements OnModuleInit, OnModuleDestroy {
-  private static options: WorkflowModuleOptions | null = null;
-  private static outDir: string | null = null;
+  private static config: {
+    options: WorkflowModuleOptions;
+    outDir: string;
+  } | null = null;
 
   /**
    * Configure the WorkflowModule with options.
@@ -57,8 +59,7 @@ export class WorkflowModule implements OnModuleInit, OnModuleDestroy {
     // Configure the controller with the output directory
     configureWorkflowController(outDir);
 
-    WorkflowModule.options = options;
-    WorkflowModule.outDir = outDir;
+    WorkflowModule.config = { options, outDir };
 
     return {
       module: WorkflowModule,
@@ -74,11 +75,10 @@ export class WorkflowModule implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleInit() {
-    const options = WorkflowModule.options;
-    const outDir = WorkflowModule.outDir;
-    if (!options || !outDir) {
+    if (!WorkflowModule.config) {
       return;
     }
+    const { options, outDir } = WorkflowModule.config;
     if (!options.skipBuild) {
       // Lazy-load the toolchain so it never enters the runtime bundle.
       const [{ NestLocalBuilder }, { createBuildQueue }] = await Promise.all([
@@ -97,6 +97,6 @@ export class WorkflowModule implements OnModuleInit, OnModuleDestroy {
 
   async onModuleDestroy() {
     // Cleanup if needed
-    WorkflowModule.options = null;
+    WorkflowModule.config = null;
   }
 }

--- a/packages/nest/src/workflow.module.ts
+++ b/packages/nest/src/workflow.module.ts
@@ -9,6 +9,7 @@ import { join } from 'pathe';
 import type { NestBuilderOptions } from './builder.js';
 import {
   configureWorkflowController,
+  loadWorkflowHandler,
   WorkflowController,
 } from './workflow.controller.js';
 
@@ -86,19 +87,23 @@ export class WorkflowModule implements OnModuleInit, OnModuleDestroy {
 
   async onModuleInit() {
     const options = WorkflowModule.state.options;
-    if (!options || options.skipBuild) {
-      return;
+    const outDir = WorkflowModule.state.outDir;
+    if (!options || !outDir) return;
+
+    if (!options.skipBuild) {
+      // Lazy-load the toolchain so it never enters the runtime bundle.
+      const [{ NestLocalBuilder }, { createBuildQueue }] = await Promise.all([
+        import('./builder.js'),
+        import('@workflow/builders'),
+      ]);
+      const builder = new NestLocalBuilder({ ...options, outDir });
+      await createBuildQueue()(() => builder.build());
     }
-    // Lazy-load the toolchain so it never enters the runtime bundle.
-    const [{ NestLocalBuilder }, { createBuildQueue }] = await Promise.all([
-      import('./builder.js'),
-      import('@workflow/builders'),
-    ]);
-    const builder = new NestLocalBuilder({
-      ...options,
-      outDir: WorkflowModule.state.outDir ?? undefined,
-    });
-    await createBuildQueue()(() => builder.build());
+
+    if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+      const { POST } = await loadWorkflowHandler();
+      await POST.initialize();
+    }
   }
 
   async onModuleDestroy() {

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -484,13 +484,20 @@ function addVirtualHandler(
     'workflow/webhook.mjs': '',
     'workflow/workflows.mjs': /* js */ `
       (async () => {
+        let lastError;
         for (let attempt = 0; attempt < 60; attempt++) {
           try {
             await loadPOST();
             return;
-          } catch {}
-          await new Promise((resolve) => setTimeout(resolve, 500));
+          } catch (error) {
+            lastError = error;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 500).unref?.());
         }
+        console.warn(
+          '[workflow/nitro] Could not load the workflow flow bundle at boot; the queue handler is not registered:',
+          lastError
+        );
       })();`,
   };
 

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -476,6 +476,23 @@ function addVirtualHandler(
     'workflow/webhook.mjs': '',
     'workflow/workflows.mjs': `await import(/* @vite-ignore */ pathToFileURL(${stepsImportPath}).href + "?t=" + version);`,
   };
+  // Load the flow module at boot so its queue handler registers without an
+  // HTTP request — worlds like @workflow/world-postgres execute queue jobs
+  // in-process and only start consuming once a handler is registered.
+  // Retries because the dev builder may still be writing the bundle.
+  const bootLoad: Record<VirtualHandlerPath, string> = {
+    'workflow/webhook.mjs': '',
+    'workflow/workflows.mjs': /* js */ `
+      (async () => {
+        for (let attempt = 0; attempt < 60; attempt++) {
+          try {
+            await loadPOST();
+            return;
+          } catch {}
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+      })();`,
+  };
 
   if (nitro.options.dev) {
     // Dev mode: load generated workflow bundles from disk at request time.
@@ -501,6 +518,7 @@ function addVirtualHandler(
         }
         return (await import(currentImportPath)).POST;
       }
+      ${bootLoad[buildPath]}
 
       export default fromWebHandler(async (request, context) => {
         const POST = await loadPOST();
@@ -525,6 +543,7 @@ function addVirtualHandler(
         }
         return (await import(currentImportPath)).POST;
       }
+      ${bootLoad[buildPath]}
 
       export default async ({ req }) => {
         try {

--- a/packages/nitro/src/index.ts
+++ b/packages/nitro/src/index.ts
@@ -476,6 +476,18 @@ function addVirtualHandler(
     'workflow/webhook.mjs': '',
     'workflow/workflows.mjs': `await import(/* @vite-ignore */ pathToFileURL(${stepsImportPath}).href + "?t=" + version);`,
   };
+  const initializeWorkflow: Record<VirtualHandlerPath, string> = {
+    'workflow/webhook.mjs': '',
+    'workflow/workflows.mjs': `
+      export async function initializeWorkflow() {
+        await (await loadHandler()).POST.initialize();
+      }`,
+  };
+  const handlerImports: Record<VirtualHandlerPath, string> = {
+    'workflow/webhook.mjs': `import { POST } from ${handlerImportPath};`,
+    'workflow/workflows.mjs': `import { POST } from ${handlerImportPath};
+    export const initializeWorkflow = POST.initialize;`,
+  };
 
   if (nitro.options.dev) {
     // Dev mode: load generated workflow bundles from disk at request time.
@@ -492,19 +504,21 @@ function addVirtualHandler(
       let currentVersion = "";
       let currentImportPath = "";
 
-      async function loadPOST() {
+      async function loadHandler() {
         const version = String(statSync(handlerPath).mtimeMs);
         if (version !== currentVersion) {
           currentVersion = version;
           currentImportPath = pathToFileURL(handlerPath).href + "?t=" + version;
           ${preloadSteps[buildPath]}
         }
-        return (await import(currentImportPath)).POST;
+        return import(currentImportPath);
       }
 
+      ${initializeWorkflow[buildPath]}
+
       export default fromWebHandler(async (request, context) => {
-        const POST = await loadPOST();
-        return POST(request, context);
+        const handler = await loadHandler();
+        return handler.POST(request, context);
       });
     `;
     } else {
@@ -516,20 +530,22 @@ function addVirtualHandler(
       let currentVersion = "";
       let currentImportPath = "";
 
-      async function loadPOST() {
+      async function loadHandler() {
         const version = String(statSync(handlerPath).mtimeMs);
         if (version !== currentVersion) {
           currentVersion = version;
           currentImportPath = pathToFileURL(handlerPath).href + "?t=" + version;
           ${preloadSteps[buildPath]}
         }
-        return (await import(currentImportPath)).POST;
+        return import(currentImportPath);
       }
+
+      ${initializeWorkflow[buildPath]}
 
       export default async ({ req }) => {
         try {
-          const POST = await loadPOST();
-          return await POST(req);
+          const handler = await loadHandler();
+          return await handler.POST(req);
         } catch (error) {
           console.error('Handler error:', error);
           return new Response('Internal Server Error', { status: 500 });
@@ -550,14 +566,14 @@ function addVirtualHandler(
     nitro.options.virtual[`#${buildPath}`] = /* js */ `
     import ${handlerImportPath};
     import { fromWebHandler } from "h3";
-    import { POST } from ${handlerImportPath};
+    ${handlerImports[buildPath]}
     export default fromWebHandler(POST);
   `;
   } else {
     // Nitro v3+ (native web handlers)
     nitro.options.virtual[`#${buildPath}`] = /* js */ `
     import ${handlerImportPath};
-    import { POST } from ${handlerImportPath};
+    ${handlerImports[buildPath]}
     export default async ({ req }) => {
       try {
         return await POST(req);

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -94,10 +94,11 @@ export class SvelteKitBuilder extends BaseBuilder {
     workflowsRouteContent = workflowsRouteContent.replace(
       /export const POST = workflowEntrypoint\(workflowCode(?<options>[^)]*)\);?$/m,
       (_match, options = '') => `${NORMALIZE_REQUEST_CODE}
-export const POST = async ({request}) => {
+const workflowHandler = workflowEntrypoint(workflowCode${options});
+export const POST = Object.assign(async ({request}) => {
   const normalRequest = await normalizeRequest(request);
-  return workflowEntrypoint(workflowCode${options})(normalRequest);
-}`
+  return workflowHandler(normalRequest);
+}, { initialize: workflowHandler.initialize });`
     );
     // These files are generated into the SvelteKit routes directory, which
     // Vite watches in dev, so an identical rewrite would still invalidate the

--- a/packages/workflow/src/runtime.ts
+++ b/packages/workflow/src/runtime.ts
@@ -10,5 +10,6 @@ export {
   type HealthCheckResult,
   healthCheck,
   setWorld,
+  type WorkflowEntrypoint,
   workflowEntrypoint,
 } from '@workflow/core/runtime';

--- a/packages/world-postgres/package.json
+++ b/packages/world-postgres/package.json
@@ -46,11 +46,9 @@
     "db:push": "node dist/cli.js"
   },
   "dependencies": {
-    "@vercel/queue": "catalog:",
     "@workflow/errors": "workspace:*",
     "@workflow/utils": "workspace:*",
     "@workflow/world": "workspace:*",
-    "@workflow/world-local": "workspace:*",
     "cbor-x": "1.6.0",
     "dotenv": "17.3.1",
     "drizzle-orm": "0.45.2",

--- a/packages/world-postgres/src/index.ts
+++ b/packages/world-postgres/src/index.ts
@@ -75,6 +75,7 @@ export function createWorld(
   return {
     specVersion: mintedSpecVersion(),
     capabilities: {
+      directQueueDelivery: true,
       hookRetention: { active: true },
     },
     ...storage,

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -1,22 +1,17 @@
-import { createServer, type Server } from 'node:http';
-import { JsonTransport } from '@vercel/queue';
-import { setWorkflowBasePath } from '@workflow/utils';
-import { getWorkflowPort } from '@workflow/utils/get-port';
 import { MessageId, parseQueueName, type QueuePayload } from '@workflow/world';
-import { createWorld } from '@workflow/world-local';
 import {
+  type JobHelpers,
   makeWorkerUtils,
   type Runner,
   run,
+  type Task,
   type WorkerUtils,
 } from 'graphile-worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageData } from './message.js';
-import { createQueue } from './queue.js';
+import { createQueue, encodeQueueMessage } from './queue.js';
 
-const transport = new JsonTransport();
-const createdQueues: Array<ReturnType<typeof createQueue>> = [];
-const createdServers: Server[] = [];
+const queues: Array<ReturnType<typeof createQueue>> = [];
 
 vi.mock('graphile-worker', () => ({
   Logger: class Logger {
@@ -26,146 +21,154 @@ vi.mock('graphile-worker', () => ({
   run: vi.fn(),
 }));
 
-vi.mock('@workflow/utils/get-port', () => ({
-  getWorkflowPort: vi.fn(),
-}));
-
-vi.mock('@workflow/world-local', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@workflow/world-local')>();
-
-  return {
-    ...actual,
-    createWorld: vi.fn(actual.createWorld),
-  };
-});
-
-describe('postgres queue http execution', () => {
-  const workerUtilsMock = {
+describe('postgres queue', () => {
+  const workerUtils = {
     addJob: vi.fn(),
-    migrate: vi.fn(),
     release: vi.fn(),
   } as unknown as WorkerUtils;
-  const runnerMock = {
+  const runner = {
     stop: vi.fn(),
     promise: Promise.resolve(),
-  };
-  const wrappedHandler = vi.fn(async () => Response.json({ ok: true }));
-  const localWorldClose = vi.fn();
-  const createQueueHandler = vi.fn(() => wrappedHandler);
+  } as unknown as Runner;
   const pool = {
     query: vi.fn(async () => ({ rows: [{ exists: false }] })),
-  } as any;
+  } as never;
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
-    vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
-    vi.mocked(run).mockResolvedValue(runnerMock as unknown as Runner);
-    vi.mocked(createWorld).mockReturnValue({
-      createQueueHandler,
-      close: localWorldClose,
-    } as any);
+    vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtils);
+    vi.mocked(run).mockResolvedValue(runner);
   });
 
   afterEach(async () => {
-    await Promise.all(createdQueues.splice(0).map((queue) => queue.close()));
-    await Promise.all(
-      createdServers.splice(0).map(
-        (server) =>
-          new Promise<void>((resolve, reject) => {
-            server.close((err) => (err ? reject(err) : resolve()));
-            server.closeAllConnections();
-          })
-      )
-    );
-    vi.useRealTimers();
-    delete process.env.WORKFLOW_LOCAL_BASE_URL;
-    delete process.env.PORT;
-    setWorkflowBasePath(undefined);
+    await Promise.all(queues.splice(0).map((queue) => queue.close()));
   });
 
-  it('uses a late-detected local port when the queue starts before PORT is available', async () => {
-    const requests: Array<{
-      method: string | undefined;
-      url: string | undefined;
-      headers: Record<string, string | string[] | undefined>;
-      body: string;
-    }> = [];
-    const port = await getUnusedLoopbackPort();
-    vi.mocked(getWorkflowPort).mockResolvedValue(port);
+  it('requires handler registration before starting', async () => {
+    const queue = buildQueue(pool);
 
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    await queue.start();
-
+    await expect(queue.start()).rejects.toThrow(
+      'Import the generated flow route'
+    );
     expect(run).not.toHaveBeenCalled();
+  });
 
-    await startWorkflowHttpServer(requests, port);
-    await vi.waitFor(() => {
-      expect(run).toHaveBeenCalledTimes(1);
+  it('registers one direct handler and leaves the HTTP route inert', async () => {
+    const queue = buildQueue(pool);
+    const handler = vi.fn(async () => undefined);
+
+    const httpHandler = queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+
+    await expect(
+      httpHandler(new Request('https://example.test/?__health'))
+    ).resolves.toMatchObject({ status: 404 });
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('passes messages and logical attempts directly to the handler', async () => {
+    const queue = buildQueue(pool);
+    const handler = vi.fn(async () => undefined);
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+    const message = stepMessage();
+
+    await task()(
+      messageData('__wkf_workflow_test-step', message, { attempt: 4 }),
+      jobHelpers(3)
+    );
+
+    expect(handler).toHaveBeenCalledWith(message, {
+      attempt: 6,
+      messageId: 'msg_01ABC',
+      queueName: '__wkf_workflow_test-step',
     });
+  });
 
-    const task = getTaskHandler('workflow_flows');
-    const message = {
-      runId: 'run_01ABC',
-      stepId: 'step_01ABC',
-      stepName: 'test-step',
-    } satisfies QueuePayload;
-    const payload = buildMessageData('__wkf_workflow_test-step', message, {
-      headers: { traceparent: 'trace-parent' },
-      idempotencyKey: 'step_01ABC',
-    });
+  it('writes a timeout successor before completing the delivery', async () => {
+    const queue = buildQueue(pool);
+    queue.createQueueHandler('__wkf_workflow_', async () => ({
+      timeoutSeconds: 5,
+    }));
+    await queue.start();
 
-    await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-    expect(getWorkflowPort).toHaveBeenCalled();
-    expect(requests).toEqual([
-      expect.objectContaining({
-        method: 'POST',
-        url: '/.well-known/workflow/v1/flow',
+    await task()(
+      messageData('__wkf_workflow_test-step', stepMessage(), {
+        attempt: 2,
+        idempotencyKey: 'step_01ABC',
       }),
-    ]);
+      jobHelpers(2)
+    );
+
+    expect(workerUtils.addJob).toHaveBeenCalledWith(
+      'workflow_flows',
+      expect.objectContaining({ attempt: 4 }),
+      expect.objectContaining({ jobKey: 'step_01ABC' })
+    );
   });
 
-  it('keeps the base-url error when env vars and local port detection cannot resolve a target', async () => {
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+  it('propagates handler failures for Graphile to retry', async () => {
+    const queue = buildQueue(pool);
+    const failure = new Error('handler failed');
+    queue.createQueueHandler('__wkf_workflow_', async () => {
+      throw failure;
+    });
     await queue.start();
 
-    const task = getTaskHandler('workflow_flows');
-    const message = {
-      runId: 'run_01ABC',
-      stepId: 'step_01ABC',
-      stepName: 'test-step',
-    } satisfies QueuePayload;
-    const payload = buildMessageData('__wkf_workflow_test-step', message, {
-      idempotencyKey: 'step_01ABC',
+    await expect(
+      task()(
+        messageData('__wkf_workflow_test-step', stepMessage()),
+        jobHelpers()
+      )
+    ).rejects.toBe(failure);
+    expect(workerUtils.addJob).not.toHaveBeenCalled();
+  });
+
+  it('does not start a worker in enqueue-only processes', async () => {
+    const queue = buildQueue(pool);
+
+    await queue.queue('__wkf_workflow_test-step', stepMessage());
+
+    expect(workerUtils.addJob).toHaveBeenCalledOnce();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('preserves same-run replay serialization', async () => {
+    const queue = buildQueue(pool);
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const handler = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => blocked)
+      .mockResolvedValue(undefined);
+    queue.createQueueHandler('__wkf_workflow_', handler);
+    await queue.start();
+    const payload = messageData('__wkf_workflow_test-workflow', {
+      runId: 'wrun_01ABC',
     });
 
-    await expect(task(payload, {} as any)).rejects.toThrow(
-      'Unable to resolve base URL for workflow queue.'
-    );
+    const first = task()(payload, jobHelpers());
+    const second = task()(payload, jobHelpers());
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+    release();
+    await Promise.all([first, second]);
 
-    expect(getWorkflowPort).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps Graphile Worker automatic shutdown by default', async () => {
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+  it('rejects a handler for another namespace', () => {
+    const queue = buildQueue(pool, { namespace: 'custom' });
 
-    await queue.start();
-
-    expect(run).toHaveBeenCalledWith(
-      expect.not.objectContaining({ noHandleSignals: true })
-    );
+    expect(() =>
+      queue.createQueueHandler('__wkf_workflow_', async () => undefined)
+    ).toThrow();
   });
 
-  it('allows the application to manage shutdown', async () => {
-    const queue = buildQueue(
-      {
-        connectionString: 'postgres://test',
-        applicationManagedShutdown: true,
-      },
-      pool
-    );
+  it('passes application-managed shutdown to Graphile', async () => {
+    const queue = buildQueue(pool, { applicationManagedShutdown: true });
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
 
     await queue.start();
 
@@ -174,519 +177,82 @@ describe('postgres queue http execution', () => {
     );
   });
 
-  it('aborts while waiting for an HTTP response without scheduling a replacement', async () => {
-    const server = await startHangingWorkflowHttpServer('headers');
-    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+  it('stops waiting for a handler when Graphile aborts delivery', async () => {
+    const queue = buildQueue(pool);
+    const handler = vi.fn(() => new Promise<void>(() => {}));
+    queue.createQueueHandler('__wkf_workflow_', handler);
     await queue.start();
-
     const controller = new AbortController();
-    const execution = getTaskHandler('workflow_flows')(
-      buildMessageData('__wkf_workflow_test-step', {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      }),
-      {
-        abortSignal: controller.signal,
-        job: { attempts: 1 },
-      }
+
+    const delivery = task()(
+      messageData('__wkf_workflow_test-step', stepMessage()),
+      jobHelpers(1, controller.signal)
     );
-    const outcome = execution.then(
-      () => ({ status: 'fulfilled' as const }),
-      (error: unknown) => ({ status: 'rejected' as const, error })
-    );
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    controller.abort(new Error('worker shutdown'));
 
-    await server.requestReceived;
-    controller.abort();
-
-    await expect(settleWithin(outcome)).resolves.toMatchObject({
-      status: 'rejected',
-      error: expect.objectContaining({ name: 'AbortError' }),
-    });
-    expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
+    await expect(delivery).rejects.toThrow('worker shutdown');
   });
 
-  it('aborts while reading an HTTP response body without scheduling a replacement', async () => {
-    const server = await startHangingWorkflowHttpServer('body');
-    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
-    const nativeFetch = globalThis.fetch;
-    let resolveResponseReceived!: () => void;
-    const responseReceived = new Promise<void>((resolve) => {
-      resolveResponseReceived = resolve;
-    });
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (...args: Parameters<typeof fetch>) => {
-        const response = await nativeFetch(...args);
-        resolveResponseReceived();
-        return response;
-      })
-    );
-
-    try {
-      const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-      await queue.start();
-
-      const controller = new AbortController();
-      const execution = getTaskHandler('workflow_flows')(
-        buildMessageData('__wkf_workflow_test-step', {
-          runId: 'run_01ABC',
-          stepId: 'step_01ABC',
-          stepName: 'test-step',
-        }),
-        {
-          abortSignal: controller.signal,
-          job: { attempts: 1 },
-        }
-      );
-      const outcome = execution.then(
-        () => ({ status: 'fulfilled' as const }),
-        (error: unknown) => ({ status: 'rejected' as const, error })
-      );
-
-      await responseReceived;
-      // Let executeMessageOverHttp enter response.text() before aborting.
-      await Promise.resolve();
-      controller.abort();
-
-      await expect(settleWithin(outcome)).resolves.toMatchObject({
-        status: 'rejected',
-        error: expect.objectContaining({ name: 'AbortError' }),
-      });
-      expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('serializes workflow queue execution for the same runId', async () => {
-    let resolveFirstRequestStarted!: () => void;
-    const firstRequestStarted = new Promise<void>((resolve) => {
-      resolveFirstRequestStarted = resolve;
-    });
-    let resolveReleaseFirstRequest!: () => void;
-    const releaseFirstRequest = new Promise<void>((resolve) => {
-      resolveReleaseFirstRequest = resolve;
-    });
-    let requestCount = 0;
-    let activeRequests = 0;
-    let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
-      requestCount += 1;
-      activeRequests += 1;
-      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-
-      if (requestCount === 1) {
-        resolveFirstRequestStarted();
-        await releaseFirstRequest;
-      }
-
-      activeRequests -= 1;
-      return Response.json({ ok: true });
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = {
-        runId: 'wrun_01ABC',
-      };
-      const firstExecution = task(
-        buildMessageData('__wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABC'),
-        }),
-        {} as any
-      );
-      const secondExecution = task(
-        buildMessageData('__wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABD'),
-        }),
-        {} as any
-      );
-
-      await firstRequestStarted;
-      await Promise.resolve();
-      expect(requestCount).toBe(1);
-      expect(maxActiveRequests).toBe(1);
-
-      resolveReleaseFirstRequest();
-      await Promise.all([firstExecution, secondExecution]);
-
-      expect(requestCount).toBe(2);
-      expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('serializes namespaced workflow queue execution for the same runId', async () => {
-    let resolveFirstRequestStarted!: () => void;
-    const firstRequestStarted = new Promise<void>((resolve) => {
-      resolveFirstRequestStarted = resolve;
-    });
-    let resolveReleaseFirstRequest!: () => void;
-    const releaseFirstRequest = new Promise<void>((resolve) => {
-      resolveReleaseFirstRequest = resolve;
-    });
-    let requestCount = 0;
-    let activeRequests = 0;
-    let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
-      requestCount += 1;
-      activeRequests += 1;
-      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-
-      if (requestCount === 1) {
-        resolveFirstRequestStarted();
-        await releaseFirstRequest;
-      }
-
-      activeRequests -= 1;
-      return Response.json({ ok: true });
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
-    const queue = buildQueue(
-      { connectionString: 'postgres://test', namespace: 'custom' },
-      pool
-    );
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = {
-        runId: 'wrun_01ABC',
-      };
-      const firstExecution = task(
-        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABC'),
-        }),
-        {} as any
-      );
-      const secondExecution = task(
-        buildMessageData('__custom_wkf_workflow_test-workflow', payload, {
-          messageId: MessageId.parse('msg_01ABD'),
-        }),
-        {} as any
-      );
-
-      await firstRequestStarted;
-      await Promise.resolve();
-      expect(requestCount).toBe(1);
-      expect(maxActiveRequests).toBe(1);
-
-      resolveReleaseFirstRequest();
-      await Promise.all([firstExecution, secondExecution]);
-
-      expect(requestCount).toBe(2);
-      expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('does not require a runId for workflow health-check payloads', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = buildMessageData('__wkf_workflow_health_check', {
-        __healthCheck: true,
-        correlationId: 'hc_01ABC',
-      });
-
-      await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://workflow.example.test/.well-known/workflow/v1/flow',
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'x-vqs-queue-name': '__wkf_workflow_health_check',
-          }),
-        })
-      );
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('uses basePath for local postgres queue HTTP delivery', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
-    const port = await getUnusedLoopbackPort();
-    await startWorkflowHttpServer([], port);
-    process.env.PORT = String(port);
-    setWorkflowBasePath('/v2');
-
-    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-    try {
-      await queue.start();
-
-      const task = getTaskHandler('workflow_flows');
-      const payload = buildMessageData('__wkf_workflow_test-step', {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      });
-
-      await expect(task(payload, {} as any)).resolves.toBeUndefined();
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        `http://localhost:${port}/v2/.well-known/workflow/v1/flow`,
-        expect.objectContaining({ method: 'POST' })
-      );
-      expect(getWorkflowPort).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it('queues producer delays and headers in graphile job metadata', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
-
-    try {
-      const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
-      await queue.start();
-
-      await queue.queue(
-        '__wkf_workflow_test-step',
-        {
-          runId: 'run_01ABC',
-          stepId: 'step_01ABC',
-          stepName: 'test-step',
-        },
-        {
-          delaySeconds: 5,
-          headers: { traceparent: 'trace-parent' },
-          idempotencyKey: 'step_01ABC',
-        }
-      );
-
-      expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
-        'workflow_flows',
-        expect.objectContaining({
-          attempt: 1,
-          headers: { traceparent: 'trace-parent' },
-          id: 'test-step',
-          idempotencyKey: 'step_01ABC',
-        }),
-        expect.objectContaining({
-          jobKey: 'step_01ABC',
-          maxAttempts: 49,
-          runAt: new Date('2024-01-01T00:00:05.000Z'),
-        })
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('queues namespaced producer messages in graphile job metadata', async () => {
-    const queue = buildQueue(
-      { connectionString: 'postgres://test', namespace: 'custom' },
-      pool
-    );
+  it('closes once when called concurrently', async () => {
+    const queue = buildQueue(pool);
+    queue.createQueueHandler('__wkf_workflow_', async () => undefined);
     await queue.start();
 
-    await queue.queue(
-      '__custom_wkf_workflow_test-step',
-      {
-        runId: 'run_01ABC',
-        stepId: 'step_01ABC',
-        stepName: 'test-step',
-      },
-      {
-        idempotencyKey: 'step_01ABC',
-      }
-    );
+    await Promise.all([queue.close(), queue.close()]);
 
-    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
-      'workflow_flows',
-      expect.objectContaining({
-        attempt: 1,
-        id: 'test-step',
-        idempotencyKey: 'step_01ABC',
-      }),
-      expect.objectContaining({
-        jobKey: 'step_01ABC',
-        maxAttempts: 49,
-      })
-    );
+    expect(runner.stop).toHaveBeenCalledOnce();
+    expect(workerUtils.release).toHaveBeenCalledOnce();
   });
 });
 
 function buildQueue(
-  config: Parameters<typeof createQueue>[0],
-  pgPool: Parameters<typeof createQueue>[1]
+  pool: Parameters<typeof createQueue>[1],
+  config: Partial<Parameters<typeof createQueue>[0]> = {}
 ) {
-  const queue = createQueue(config, pgPool);
-  createdQueues.push(queue);
+  const queue = createQueue(
+    { connectionString: 'postgres://test', ...config },
+    pool
+  );
+  queues.push(queue);
   return queue;
 }
 
-function buildMessageData(
+function stepMessage(): QueuePayload {
+  return {
+    runId: 'run_01ABC',
+    stepId: 'step_01ABC',
+    stepName: 'test-step',
+  };
+}
+
+function messageData(
   queueName: string,
   payload: QueuePayload,
-  opts?: {
+  options: {
     attempt?: number;
-    headers?: Record<string, string>;
     idempotencyKey?: string;
-    messageId?: MessageId;
-  }
+  } = {}
 ) {
   const { id } = parseQueueName(queueName);
-
   return MessageData.encode({
     id,
-    data: transport.serialize(payload),
-    attempt: opts?.attempt ?? 1,
-    headers: opts?.headers,
-    idempotencyKey: opts?.idempotencyKey,
-    messageId: opts?.messageId ?? MessageId.parse('msg_01ABC'),
+    data: encodeQueueMessage(payload),
+    attempt: options.attempt ?? 1,
+    idempotencyKey: options.idempotencyKey,
+    messageId: MessageId.parse('msg_01ABC'),
   });
 }
 
-function getTaskHandler(name: 'workflow_flows') {
-  const taskList = vi.mocked(run).mock.calls[0]?.[0]?.taskList;
-  const task = taskList?.[name];
-  expect(task).toBeTypeOf('function');
-  return task as (payload: unknown, helpers: unknown) => Promise<void>;
+function jobHelpers(
+  attempts = 1,
+  abortSignal = new AbortController().signal
+): JobHelpers {
+  return { abortSignal, job: { attempts } } as JobHelpers;
 }
 
-async function startWorkflowHttpServer(
-  requests: Array<{
-    method: string | undefined;
-    url: string | undefined;
-    headers: Record<string, string | string[] | undefined>;
-    body: string;
-  }>,
-  port = 0
-) {
-  const server = createServer(async (req, res) => {
-    const body = await new Promise<string>((resolve, reject) => {
-      let chunks = '';
-      req.setEncoding('utf8');
-      req.on('data', (chunk) => {
-        chunks += chunk;
-      });
-      req.on('end', () => resolve(chunks));
-      req.on('error', reject);
-    });
-
-    const request = {
-      method: req.method,
-      url: req.url,
-      headers: req.headers,
-      body,
-    };
-    requests.push(request);
-
-    if (req.method === 'POST' && req.url === '/.well-known/workflow/v1/flow') {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ ok: true }));
-      return;
-    }
-
-    res.writeHead(404, { 'content-type': 'text/plain' });
-    res.end('not found');
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(port, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-
-  createdServers.push(server);
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to determine test server address');
-  }
-
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-  };
-}
-
-async function startHangingWorkflowHttpServer(stage: 'headers' | 'body') {
-  let resolveRequestReceived!: () => void;
-  const requestReceived = new Promise<void>((resolve) => {
-    resolveRequestReceived = resolve;
-  });
-  const server = createServer((req, res) => {
-    req.resume();
-    resolveRequestReceived();
-
-    if (stage === 'body') {
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.write('{"ok":');
-    }
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-
-  createdServers.push(server);
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to determine test server address');
-  }
-
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-    requestReceived,
-  };
-}
-
-async function settleWithin<T>(
-  promise: Promise<T>,
-  timeoutMs = 250
-): Promise<T | { status: 'pending' }> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<{ status: 'pending' }>((resolve) => {
-        timeout = setTimeout(() => resolve({ status: 'pending' }), timeoutMs);
-        timeout.unref();
-      }),
-    ]);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-async function getUnusedLoopbackPort(): Promise<number> {
-  const server = createServer();
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
-    server.on('error', reject);
-  });
-  const address = server.address();
-  await new Promise<void>((resolve, reject) => {
-    server.close((err) => (err ? reject(err) : resolve()));
-  });
-
-  if (!address || typeof address === 'string') {
-    throw new Error('Failed to reserve a loopback port');
-  }
-
-  return address.port;
+function task(): Task {
+  const handler = vi.mocked(run).mock.calls[0]?.[0]?.taskList?.workflow_flows;
+  expect(handler).toBeTypeOf('function');
+  return handler as Task;
 }

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -1,13 +1,4 @@
-import { connect } from 'node:net';
-import * as Stream from 'node:stream';
-import { setTimeout as sleep } from 'node:timers/promises';
-import type { Transport } from '@vercel/queue';
-import {
-  createWorkflowBaseUrl,
-  createWorkflowHealthEndpoint,
-  createWorkflowUrl,
-} from '@workflow/utils';
-import { getWorkflowPort } from '@workflow/utils/get-port';
+import assert from 'node:assert/strict';
 import {
   getQueueTopicPrefix,
   MessageId,
@@ -17,19 +8,18 @@ import {
   type QueuePrefix,
   resolveQueueNamespace,
   type ValidQueueName,
-  WorkflowInvokePayloadSchema,
 } from '@workflow/world';
-import { createWorld } from '@workflow/world-local';
 import {
+  type JobHelpers,
   Logger,
   makeWorkerUtils,
   type Runner,
   run,
+  type Task,
   type WorkerUtils,
 } from 'graphile-worker';
 import type { Pool } from 'pg';
 import { monotonicFactory } from 'ulid';
-import { z } from 'zod/v4';
 import type { PostgresWorldConfig } from './config.js';
 import { MessageData } from './message.js';
 
@@ -55,25 +45,55 @@ const graphileLogger = createGraphileLogger();
 const COMPLETED_IDEMPOTENCY_CACHE_LIMIT = 10_000;
 // Core records MAX_DELIVERIES_EXCEEDED on delivery 49.
 const MAX_GRAPHILE_JOB_ATTEMPTS = 49;
-const GraphileHelpers = z.object({
-  abortSignal: z.instanceof(AbortSignal).optional(),
-  job: z.object({
-    attempts: z.number().int().positive(),
-  }),
-});
+type QueueHandler = Parameters<Queue['createQueueHandler']>[1];
+type ConsumerState =
+  | { status: 'idle' }
+  | { status: 'starting'; promise: Promise<Runner> }
+  | { status: 'running'; runner: Runner }
+  | { status: 'closing'; promise: Promise<void> }
+  | { status: 'closed' };
 
-type HttpExecutionResult =
-  | { type: 'completed' }
-  | { type: 'reschedule'; timeoutSeconds: number }
-  | {
-      type: 'error';
-      status: number;
-      text: string;
-      headers: Record<string, string>;
-    };
+export function encodeQueueMessage(value: unknown): Buffer {
+  return Buffer.from(
+    JSON.stringify(value, (_key, item) =>
+      item instanceof Uint8Array
+        ? {
+            __type: 'Uint8Array',
+            data: Buffer.from(item).toString('base64'),
+          }
+        : item
+    )
+  );
+}
 
-type RunnerStart = { controller: AbortController; promise: Promise<void> };
-type LoopbackTarget = { hosts: string[]; port: number };
+function decodeQueueMessage(data: Buffer): unknown {
+  return JSON.parse(data.toString(), (_key, item) =>
+    item !== null &&
+    typeof item === 'object' &&
+    item.__type === 'Uint8Array' &&
+    typeof item.data === 'string'
+      ? new Uint8Array(Buffer.from(item.data, 'base64'))
+      : item
+  );
+}
+
+function callHandler(
+  handler: QueueHandler,
+  message: unknown,
+  metadata: Parameters<QueueHandler>[1],
+  signal: AbortSignal | undefined
+): ReturnType<QueueHandler> {
+  signal?.throwIfAborted();
+  const execution = handler(message, metadata);
+  if (!signal) return execution;
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    void execution.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
 
 /**
  * The Postgres queue stores messages under one graphile-worker flow task.
@@ -87,50 +107,12 @@ export function createQueue(
   config: PostgresWorldConfig,
   pool: Pool
 ): PostgresQueue {
-  const port = process.env.PORT ? Number(process.env.PORT) : undefined;
-  const localWorld = createWorld({ dataDir: undefined, port });
-
-  // JSON transport that preserves Uint8Array values via a tagged
-  // envelope ({ __type: 'Uint8Array', data: '<base64>' }).  Required
-  // for the resilient start path where runInput.input (a Uint8Array)
-  // is sent through the queue.
-  const transport: Transport<unknown> = {
-    contentType: 'application/json',
-    serialize(value: unknown): Buffer {
-      return Buffer.from(
-        JSON.stringify(value, (_key, v) =>
-          v instanceof Uint8Array
-            ? { __type: 'Uint8Array', data: Buffer.from(v).toString('base64') }
-            : v
-        )
-      );
-    },
-    async deserialize(stream: ReadableStream<Uint8Array>): Promise<unknown> {
-      const chunks: Uint8Array[] = [];
-      const reader = stream.getReader();
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (value) chunks.push(value);
-      }
-      return JSON.parse(Buffer.concat(chunks).toString(), (_key, v) =>
-        v !== null &&
-        typeof v === 'object' &&
-        v.__type === 'Uint8Array' &&
-        typeof v.data === 'string'
-          ? new Uint8Array(Buffer.from(v.data, 'base64'))
-          : v
-      );
-    },
-  };
   const generateMessageId = monotonicFactory();
-
-  function getJobQueueName(): string {
-    const jobPrefix = config.jobPrefix || 'workflow_';
-    return `${jobPrefix}flows`;
-  }
-
-  const createQueueHandler = localWorld.createQueueHandler;
+  const jobQueueName = `${config.jobPrefix || 'workflow_'}flows`;
+  const workflowPrefix = getQueueTopicPrefix(
+    'workflow',
+    resolveQueueNamespace(config.namespace)
+  );
 
   const getDeploymentId: Queue['getDeploymentId'] = async () => {
     return 'postgres';
@@ -142,11 +124,9 @@ export function createQueue(
     string,
     Promise<'completed' | 'rescheduled'>
   >();
-  let workerUtils: WorkerUtils | null = null;
-  let runner: Runner | null = null;
-  let runnerStart: RunnerStart | null = null;
-  let closing = false;
-  let startPromise: Promise<void> | null = null;
+  let consumer: ConsumerState = { status: 'idle' };
+  let registeredHandler: QueueHandler | undefined;
+  let workerUtilsPromise: Promise<WorkerUtils> | undefined;
 
   function markMessageCompleted(idempotencyKey: string) {
     completedMessages.delete(idempotencyKey);
@@ -157,6 +137,29 @@ export function createQueue(
         completedMessages.delete(oldestKey);
       }
     }
+  }
+
+  function ensureWorkerUtils(): Promise<WorkerUtils> {
+    assert.notEqual(consumer.status, 'closed', 'Postgres queue is closed');
+    if (!workerUtilsPromise) {
+      let initialization!: Promise<WorkerUtils>;
+      initialization = makeWorkerUtils({
+        pgPool: pool,
+        logger: graphileLogger,
+      })
+        .then(async (utils) => {
+          await migratePgBossJobs(utils);
+          return utils;
+        })
+        .catch((error) => {
+          if (workerUtilsPromise === initialization) {
+            workerUtilsPromise = undefined;
+          }
+          throw error;
+        });
+      workerUtilsPromise = initialization;
+    }
+    return workerUtilsPromise;
   }
 
   async function addGraphileJob({
@@ -170,7 +173,7 @@ export function createQueue(
     jobKey,
   }: {
     queueId: string;
-    body: Buffer | Uint8Array;
+    body: Buffer;
     messageId: MessageId;
     attempt: number;
     idempotencyKey?: string;
@@ -178,10 +181,7 @@ export function createQueue(
     delaySeconds?: number;
     jobKey?: string;
   }) {
-    const utils = workerUtils;
-    if (!utils) {
-      throw new Error('Postgres queue worker utils are not initialized');
-    }
+    const utils = await ensureWorkerUtils();
 
     const runAt =
       typeof delaySeconds === 'number' && delaySeconds > 0
@@ -189,10 +189,10 @@ export function createQueue(
         : undefined;
 
     await utils.addJob(
-      getJobQueueName(),
+      jobQueueName,
       MessageData.encode({
         id: queueId,
-        data: Buffer.from(body),
+        data: body,
         attempt,
         messageId,
         idempotencyKey,
@@ -204,180 +204,6 @@ export function createQueue(
         maxAttempts: MAX_GRAPHILE_JOB_ATTEMPTS,
       }
     );
-  }
-
-  async function getExecutionBaseUrl(): Promise<string | undefined> {
-    if (process.env.WORKFLOW_LOCAL_BASE_URL) {
-      return process.env.WORKFLOW_LOCAL_BASE_URL;
-    }
-
-    if (typeof port === 'number') {
-      return createWorkflowBaseUrl(`http://localhost:${port}`);
-    }
-
-    if (process.env.PORT) {
-      return createWorkflowBaseUrl(`http://localhost:${process.env.PORT}`);
-    }
-
-    const detectedPort = await getWorkflowPort({
-      endpoint: createWorkflowHealthEndpoint(),
-    });
-    if (typeof detectedPort === 'number') {
-      return createWorkflowBaseUrl(`http://localhost:${detectedPort}`);
-    }
-
-    return undefined;
-  }
-
-  function getLoopbackHosts(hostname: string): string[] {
-    if (hostname === 'localhost') {
-      return ['127.0.0.1', '::1'];
-    }
-    if (hostname === '[::1]') {
-      return ['::1'];
-    }
-    return hostname === '127.0.0.1' || hostname === '::1' ? [hostname] : [];
-  }
-
-  function getLoopbackTarget(baseUrl: string | undefined) {
-    if (!baseUrl) {
-      return undefined;
-    }
-
-    const url = new URL(baseUrl);
-    const hosts = getLoopbackHosts(url.hostname);
-    if (hosts.length === 0) {
-      return undefined;
-    }
-
-    return {
-      hosts,
-      port: Number(url.port || (url.protocol === 'https:' ? 443 : 80)),
-    };
-  }
-
-  async function canConnectToLoopbackTarget(
-    target: LoopbackTarget
-  ): Promise<boolean> {
-    for (const host of target.hosts) {
-      const reachable = await new Promise<boolean>((resolve) => {
-        const socket = connect({ host, port: target.port });
-        socket.unref();
-        const finish = (isReachable: boolean) => {
-          socket.destroy();
-          resolve(isReachable);
-        };
-
-        socket.setTimeout(200, () => finish(false));
-        socket.once('connect', () => finish(true));
-        socket.once('error', () => finish(false));
-      });
-
-      if (reachable) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  async function startRunnerUnlessAborted(controller: AbortController) {
-    if (controller.signal.aborted) {
-      return;
-    }
-
-    await setupListeners();
-  }
-
-  async function waitForLoopbackAndStartRunner(
-    controller: AbortController,
-    target: LoopbackTarget
-  ) {
-    while (
-      !controller.signal.aborted &&
-      !(await canConnectToLoopbackTarget(target))
-    ) {
-      await sleep(50, undefined, {
-        ref: false,
-      });
-    }
-
-    await startRunnerUnlessAborted(controller);
-  }
-
-  function deferRunnerStart(
-    controller: AbortController,
-    target: LoopbackTarget
-  ) {
-    const promise = waitForLoopbackAndStartRunner(controller, target)
-      .catch((err) => {
-        if (!controller.signal.aborted) {
-          console.warn(
-            '[world-postgres] Failed to start Graphile Worker after local workflow executor became reachable:',
-            err
-          );
-        }
-      })
-      .finally(() => {
-        if (runnerStart?.promise === promise) {
-          runnerStart = null;
-        }
-      });
-    runnerStart = { controller, promise };
-  }
-
-  async function executeMessageOverHttp({
-    queueName,
-    messageId,
-    attempt,
-    body,
-    headers: extraHeaders,
-    abortSignal,
-  }: {
-    queueName: ValidQueueName;
-    messageId: MessageId;
-    attempt: number;
-    body: Uint8Array;
-    headers?: Record<string, string>;
-    abortSignal?: AbortSignal;
-  }): Promise<HttpExecutionResult> {
-    const headers: Record<string, string> = {
-      ...extraHeaders,
-      'content-type': 'application/json',
-      'x-vqs-queue-name': queueName,
-      'x-vqs-message-id': messageId,
-      'x-vqs-message-attempt': String(attempt),
-    };
-    const baseUrl = await getExecutionBaseUrl();
-    if (!baseUrl) {
-      throw new Error('Unable to resolve base URL for workflow queue.');
-    }
-    const response = await fetch(createWorkflowUrl(baseUrl, { type: 'flow' }), {
-      method: 'POST',
-      duplex: 'half',
-      headers,
-      body,
-      signal: abortSignal,
-    } as any);
-    const text = await response.text();
-
-    if (!response.ok) {
-      return {
-        type: 'error',
-        status: response.status,
-        text,
-        headers: Object.fromEntries(response.headers.entries()),
-      };
-    }
-
-    try {
-      const timeoutSeconds = Number(JSON.parse(text).timeoutSeconds);
-      if (Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0) {
-        return { type: 'reschedule', timeoutSeconds };
-      }
-    } catch {}
-
-    return { type: 'completed' };
   }
 
   async function migratePgBossJobs(utils: WorkerUtils): Promise<void> {
@@ -434,69 +260,47 @@ export function createQueue(
     }
   }
 
-  async function startRunnerWhenExecutorIsReady(): Promise<void> {
-    if (closing || runner || runnerStart) {
-      return;
-    }
-
-    const controller = new AbortController();
-    const promise = (async () => {
-      const target = getLoopbackTarget(await getExecutionBaseUrl());
-      if (!target) {
-        await startRunnerUnlessAborted(controller);
-        return;
-      }
-
-      if (await canConnectToLoopbackTarget(target)) {
-        await startRunnerUnlessAborted(controller);
-        return;
-      }
-
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      deferRunnerStart(controller, target);
-    })().finally(() => {
-      if (runnerStart?.promise === promise) {
-        runnerStart = null;
-      }
-    });
-    runnerStart = { controller, promise };
-    await promise;
-  }
-
   async function start(): Promise<void> {
-    if (closing) {
+    if (consumer.status === 'closed' || consumer.status === 'closing') {
+      throw new Error('Postgres queue is closed');
+    }
+    if (!registeredHandler) {
+      throw new Error(
+        'Import the generated flow route before starting the Postgres World'
+      );
+    }
+    if (consumer.status === 'running') {
+      return;
+    }
+    if (consumer.status === 'starting') {
+      await consumer.promise;
       return;
     }
 
-    if (!startPromise) {
-      startPromise = (async () => {
-        try {
-          workerUtils = await makeWorkerUtils({
-            pgPool: pool,
-            logger: graphileLogger,
-          });
-          await workerUtils.migrate();
-          await migratePgBossJobs(workerUtils);
-          await startRunnerWhenExecutorIsReady();
-        } catch (err) {
-          startPromise = null;
-          throw err;
+    let starting!: Promise<Runner>;
+    starting = ensureWorkerUtils()
+      .then(() => startRunner())
+      .then(
+        (runner) => {
+          if (consumer.status === 'starting' && consumer.promise === starting) {
+            consumer = { status: 'running', runner };
+          }
+          return runner;
+        },
+        (error) => {
+          if (consumer.status === 'starting' && consumer.promise === starting) {
+            consumer = { status: 'idle' };
+          }
+          throw error;
         }
-      })();
-    }
-    await startPromise;
-    if (!closing && !runner && !runnerStart) {
-      await startRunnerWhenExecutorIsReady();
-    }
+      );
+    consumer = { status: 'starting', promise: starting };
+    await starting;
   }
 
   const queue: Queue['queue'] = async (queue, message, opts) => {
-    await start();
     const { id: queueId } = parseQueueName(queue);
-    const body = transport.serialize(message) as Buffer;
+    const body = encodeQueueMessage(message);
     const messageId = MessageId.parse(`msg_${generateMessageId()}`);
     await addGraphileJob({
       queueId,
@@ -511,61 +315,45 @@ export function createQueue(
     return { messageId };
   };
 
-  async function deserializeMessageBody(data: Buffer): Promise<unknown> {
-    const bodyStream = Stream.Readable.toWeb(Stream.Readable.from([data]));
-    return transport.deserialize(bodyStream as ReadableStream<Uint8Array>);
-  }
-
-  function createTaskHandler(queue: QueuePrefix) {
-    return async (payload: unknown, helpers: unknown) => {
+  function createTaskHandler(queue: QueuePrefix): Task {
+    return async (payload: unknown, helpers: JobHelpers) => {
       const messageData = MessageData.parse(payload);
-      const graphileHelpers = GraphileHelpers.safeParse(helpers);
-      const attempt = graphileHelpers.success
-        ? graphileHelpers.data.job.attempts
-        : messageData.attempt;
+      const attempt = messageData.attempt + helpers.job.attempts - 1;
       const queueName = `${queue}${messageData.id}` as ValidQueueName;
-      const body = await deserializeMessageBody(messageData.data);
-      QueuePayloadSchema.parse(body);
-      const workflowInvoke = WorkflowInvokePayloadSchema.safeParse(body);
+      const message = QueuePayloadSchema.parse(
+        decodeQueueMessage(messageData.data)
+      );
       const workflowRunSerializationKey =
-        workflowInvoke.success && !workflowInvoke.data.stepId
-          ? `workflow:${workflowInvoke.data.runId}`
+        !('__healthCheck' in message) && !message.stepId
+          ? `workflow:${message.runId}`
           : undefined;
       const executeTask = async (): Promise<'completed' | 'rescheduled'> => {
-        const result = await executeMessageOverHttp({
-          queueName,
-          messageId: messageData.messageId,
-          attempt,
-          body: messageData.data,
-          headers: messageData.headers,
-          abortSignal: graphileHelpers.success
-            ? graphileHelpers.data.abortSignal
-            : undefined,
-        });
-
-        if (result.type === 'completed') {
-          return 'completed';
-        }
-
-        if (result.type === 'reschedule') {
-          // Schedule the follow-up job before we return so a crash cannot
-          // lose the wake-up request.
-          await addGraphileJob({
-            queueId: messageData.id,
-            body: messageData.data,
+        assert.ok(registeredHandler, 'Postgres queue handler is missing');
+        const result = await callHandler(
+          registeredHandler,
+          message,
+          {
+            attempt,
+            queueName,
             messageId: messageData.messageId,
-            attempt: attempt + 1,
-            idempotencyKey: messageData.idempotencyKey,
-            headers: messageData.headers,
-            delaySeconds: result.timeoutSeconds,
-            jobKey: messageData.idempotencyKey ?? messageData.messageId,
-          });
-          return 'rescheduled';
-        }
-
-        throw new Error(
-          `[postgres world] Queue execution failed (${result.status}): ${result.text}`
+          },
+          helpers.abortSignal
         );
+        if (!result) return 'completed';
+
+        // Schedule the follow-up job before we return so a crash cannot lose
+        // the wake-up request.
+        await addGraphileJob({
+          queueId: messageData.id,
+          body: messageData.data,
+          messageId: messageData.messageId,
+          attempt: attempt + 1,
+          idempotencyKey: messageData.idempotencyKey,
+          headers: messageData.headers,
+          delaySeconds: result.timeoutSeconds,
+          jobKey: messageData.idempotencyKey ?? messageData.messageId,
+        });
+        return 'rescheduled';
       };
 
       const idempotencyKey = messageData.idempotencyKey;
@@ -620,16 +408,8 @@ export function createQueue(
     };
   }
 
-  async function setupListeners() {
-    const taskList: Record<
-      string,
-      (payload: unknown, helpers: unknown) => Promise<void>
-    > = {};
-    const namespace = resolveQueueNamespace(config.namespace);
-    const workflowPrefix = getQueueTopicPrefix('workflow', namespace);
-    taskList[getJobQueueName()] = createTaskHandler(workflowPrefix);
-
-    runner = await run({
+  async function startRunner(): Promise<Runner> {
+    return run({
       pgPool: pool,
       // Default of 50 is high enough to avoid worker-pool exhaustion in
       // workflows that use parent→child polling patterns (e.g. awaiting a
@@ -646,9 +426,65 @@ export function createQueue(
         noHandleSignals: true,
       }),
       pollInterval: 500, // 500ms = 0.5s (graphile-worker uses LISTEN/NOTIFY when available)
-      taskList,
+      taskList: { [jobQueueName]: createTaskHandler(workflowPrefix) },
     });
   }
+
+  async function stopRunner(runner: Runner): Promise<void> {
+    try {
+      await runner.stop();
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        error.message !== 'Runner is already stopped'
+      ) {
+        throw error;
+      }
+    }
+    await runner.promise.catch(() => {});
+  }
+
+  async function closeConsumer(
+    previous: Extract<
+      ConsumerState,
+      { status: 'idle' | 'starting' | 'running' }
+    >
+  ): Promise<void> {
+    let runner: Runner | undefined;
+    try {
+      if (previous.status === 'starting') {
+        runner = await previous.promise.catch(() => undefined);
+      } else if (previous.status === 'running') {
+        runner = previous.runner;
+      }
+      if (runner) await stopRunner(runner);
+
+      const workerUtils = await workerUtilsPromise;
+      await workerUtils?.release();
+      workerUtilsPromise = undefined;
+      consumer = { status: 'closed' };
+    } catch (error) {
+      consumer = runner ? { status: 'running', runner } : { status: 'idle' };
+      throw error;
+    }
+  }
+
+  const createQueueHandler: Queue['createQueueHandler'] = (prefix, handler) => {
+    assert.equal(prefix, workflowPrefix);
+    switch (consumer.status) {
+      case 'idle':
+      case 'starting':
+      case 'running':
+        registeredHandler = handler;
+        break;
+      case 'closing':
+      case 'closed':
+        throw new Error('Postgres queue is closed');
+      default:
+        consumer satisfies never;
+    }
+    return async () => new Response(null, { status: 404 });
+  };
 
   return {
     createQueueHandler,
@@ -656,34 +492,13 @@ export function createQueue(
     queue,
     start,
     async close() {
-      closing = true;
-      if (runnerStart) {
-        runnerStart.controller.abort();
-        await runnerStart.promise;
-        runnerStart = null;
-      }
-      await startPromise?.catch(() => {});
-      const activeRunner = runner;
-      if (activeRunner) {
-        try {
-          await activeRunner.stop();
-        } catch (error) {
-          if (
-            !(error instanceof Error) ||
-            error.message !== 'Runner is already stopped'
-          ) {
-            throw error;
-          }
-        }
-        await activeRunner.promise.catch(() => {});
-        runner = null;
-      }
-      if (workerUtils) {
-        await workerUtils.release();
-        workerUtils = null;
-      }
-      startPromise = null;
-      await localWorld.close?.();
+      if (consumer.status === 'closed') return;
+      if (consumer.status === 'closing') return consumer.promise;
+
+      const previous = consumer;
+      const closing = closeConsumer(previous);
+      consumer = { status: 'closing', promise: closing };
+      await closing;
     },
   };
 }

--- a/packages/world-postgres/src/reenqueue.test.ts
+++ b/packages/world-postgres/src/reenqueue.test.ts
@@ -1,5 +1,4 @@
-import { getWorkflowPort } from '@workflow/utils/get-port';
-import { createWorld as createLocalTestWorld } from '@workflow/world-local';
+import type { World } from '@workflow/world';
 import { makeWorkerUtils, run, type WorkerUtils } from 'graphile-worker';
 import { Pool } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -28,18 +27,6 @@ vi.mock('pg', () => ({
     };
   }),
 }));
-
-vi.mock('@workflow/utils/get-port', () => ({
-  getWorkflowPort: vi.fn(),
-}));
-
-vi.mock('@workflow/world-local', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@workflow/world-local')>();
-  return {
-    ...actual,
-    createWorld: vi.fn(actual.createWorld),
-  };
-});
 
 vi.mock('./storage.js', () => ({
   createRunsStorage: vi.fn(),
@@ -73,9 +60,6 @@ describe('re-enqueue active runs on start', () => {
     stop: vi.fn(),
     promise: Promise.resolve(),
   };
-  const localWorldClose = vi.fn();
-  const wrappedHandler = vi.fn(async () => Response.json({ ok: true }));
-  const createQueueHandler = vi.fn(() => wrappedHandler);
   const pool = {
     query: vi.fn(async () => ({ rows: [{ exists: false }] })),
     end: vi.fn(),
@@ -105,12 +89,7 @@ describe('re-enqueue active runs on start', () => {
     vi.clearAllMocks();
     runnerMock.promise = Promise.resolve();
     vi.mocked(makeWorkerUtils).mockResolvedValue(workerUtilsMock);
-    vi.mocked(getWorkflowPort).mockResolvedValue(undefined);
     vi.mocked(run).mockResolvedValue(runnerMock as any);
-    vi.mocked(createLocalTestWorld).mockReturnValue({
-      createQueueHandler,
-      close: localWorldClose,
-    } as any);
     vi.mocked(createEventsStorage).mockReturnValue({} as any);
     vi.mocked(createHooksStorage).mockReturnValue({} as any);
     vi.mocked(createStepsStorage).mockReturnValue({} as any);
@@ -158,7 +137,7 @@ describe('re-enqueue active runs on start', () => {
 
   it('keeps automatic shutdown in createWorld() by default', async () => {
     const world = createWorld();
-    await world.start();
+    await startWorld(world);
 
     expect(run).toHaveBeenCalledWith(
       expect.not.objectContaining({ noHandleSignals: true })
@@ -171,7 +150,7 @@ describe('re-enqueue active runs on start', () => {
     process.env.WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN = '1';
 
     const world = createWorld();
-    await world.start();
+    await startWorld(world);
 
     expect(run).toHaveBeenCalledWith(
       expect.objectContaining({ noHandleSignals: true })
@@ -187,7 +166,7 @@ describe('re-enqueue active runs on start', () => {
     });
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
-    await world.start();
+    await startWorld(world);
 
     expect(workerUtilsMock.addJob).toHaveBeenCalledTimes(2);
     expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
@@ -208,7 +187,7 @@ describe('re-enqueue active runs on start', () => {
     mockRunsList({});
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
-    await world.start();
+    await startWorld(world);
 
     // addJob should only have been called for pgboss migration check, not for
     // any workflow runs. The migration check uses pool.query, not addJob.
@@ -243,7 +222,7 @@ describe('re-enqueue active runs on start', () => {
     } as any);
 
     const world = createWorld({ connectionString: 'postgres://test', pool });
-    await world.start();
+    await startWorld(world);
 
     // Should have 4 list calls: 2 statuses × 2 pages each
     expect(callCount).toBe(4);
@@ -261,7 +240,7 @@ describe('re-enqueue active runs on start', () => {
       resolveRunnerFinished = resolve;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
+    await startWorld(world);
     const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
     const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
     let resolveStreamerClose!: () => void;
@@ -298,7 +277,7 @@ describe('re-enqueue active runs on start', () => {
       resolveRunnerFinished = resolve;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
+    await startWorld(world);
 
     const closePromise = world.close();
     await vi.waitFor(() => {
@@ -319,7 +298,7 @@ describe('re-enqueue active runs on start', () => {
       rejectRunnerFinished = reject;
     });
     const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
+    await startWorld(world);
     const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
     const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
 
@@ -331,40 +310,21 @@ describe('re-enqueue active runs on start', () => {
 
     await expect(closePromise).resolves.toBeUndefined();
     expect(workerUtilsMock.release).toHaveBeenCalledOnce();
-    expect(localWorldClose).toHaveBeenCalledOnce();
-    expect(streamer?.close).toHaveBeenCalledOnce();
-    expect(internalPool?.end).toHaveBeenCalledOnce();
-  });
-
-  it('allows close to be retried after queue cleanup fails', async () => {
-    localWorldClose
-      .mockRejectedValueOnce(new Error('transient local shutdown error'))
-      .mockResolvedValueOnce(undefined);
-    const world = createWorld({ connectionString: 'postgres://test' });
-    await world.start();
-    const streamer = vi.mocked(createStreamer).mock.results.at(-1)?.value;
-    const internalPool = vi.mocked(Pool).mock.results.at(-1)?.value;
-
-    await expect(world.close()).rejects.toThrow(
-      'transient local shutdown error'
-    );
-    expect(streamer?.close).not.toHaveBeenCalled();
-    expect(internalPool?.end).not.toHaveBeenCalled();
-
-    await expect(world.close()).resolves.toBeUndefined();
-    expect(runnerMock.stop).toHaveBeenCalledOnce();
-    expect(workerUtilsMock.release).toHaveBeenCalledOnce();
-    expect(localWorldClose).toHaveBeenCalledTimes(2);
     expect(streamer?.close).toHaveBeenCalledOnce();
     expect(internalPool?.end).toHaveBeenCalledOnce();
   });
 
   it('does not close a caller-owned pool', async () => {
     const world = createWorld({ pool });
-    await world.start();
+    await startWorld(world);
 
     await world.close();
 
     expect(pool.end).not.toHaveBeenCalled();
   });
 });
+
+async function startWorld(world: World & { start(): Promise<void> }) {
+  world.createQueueHandler('__wkf_workflow_', async () => undefined);
+  await world.start();
+}

--- a/packages/world-postgres/test/spec.test.ts
+++ b/packages/world-postgres/test/spec.test.ts
@@ -5,7 +5,7 @@ import {
   FIRST_EVENT_SLOT,
   SPEC_VERSION_CURRENT,
 } from '@workflow/world';
-import { createTestSuite } from '@workflow/world-testing';
+import { createTestSuite, flowRouteSecurity } from '@workflow/world-testing';
 import { afterAll, beforeAll, expect, test } from 'vitest';
 
 // Skip these tests on Windows since it relies on a docker container
@@ -101,8 +101,14 @@ if (process.platform === 'win32') {
       FIRST_EVENT_SLOT + 2,
       FIRST_EVENT_SLOT + 3,
     ]);
+    await world.events.create(runId, {
+      eventType: 'run_completed',
+      specVersion: SPEC_VERSION_CURRENT,
+      eventData: { output: serialized(null) },
+    } as any);
     await pool.end();
   }, 60_000);
 
   createTestSuite('./dist/index.js');
+  flowRouteSecurity('./dist/index.js');
 }

--- a/packages/world-testing/scripts/generate-well-known-dts.mjs
+++ b/packages/world-testing/scripts/generate-well-known-dts.mjs
@@ -6,19 +6,22 @@
  * to the .mjs files makes TypeScript use the declarations instead of
  * parsing the bundled JavaScript.
  */
-import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 
 const dir = '.well-known/workflow/v1';
-const stub =
+const handler =
   'export declare const POST: (req: Request) => Response | Promise<Response>;\n';
+const stubs = {
+  flow: `import type { WorkflowEntrypoint } from 'workflow/runtime';
+export declare const POST: WorkflowEntrypoint;
+`,
+  webhook: handler,
+};
 
 // Remove the declaration generated for the retired standalone step route. This
 // also cleans stale build output in worktrees that were built before its removal.
 rmSync(`${dir}/step.d.mts`, { force: true });
 
 for (const name of ['flow', 'webhook']) {
-  const dts = `${dir}/${name}.d.mts`;
-  if (!existsSync(dts)) {
-    writeFileSync(dts, stub);
-  }
+  writeFileSync(`${dir}/${name}.d.mts`, stubs[name]);
 }

--- a/packages/world-testing/src/flow-route-security.mts
+++ b/packages/world-testing/src/flow-route-security.mts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { startServer } from './util.mjs';
+
+export function flowRouteSecurity(world: string) {
+  test('does not expose the flow handler over HTTP', async () => {
+    const server = await startServer({ world });
+    const url = `http://localhost:${server.info.port}/.well-known/workflow/v1/flow`;
+
+    const [delivery, health] = await Promise.all([
+      fetch(url, { method: 'POST', body: '{}' }),
+      fetch(`${url}?__health`, { method: 'POST' }),
+    ]);
+
+    expect(delivery.status).toBe(404);
+    expect(health.status).toBe(404);
+  });
+}

--- a/packages/world-testing/src/index.mts
+++ b/packages/world-testing/src/index.mts
@@ -1,6 +1,9 @@
 import { addition } from './addition.mjs';
 import { errors } from './errors.mjs';
 import { eventIds } from './event-ids.mjs';
+
+export { flowRouteSecurity } from './flow-route-security.mjs';
+
 import { hooks } from './hooks.mjs';
 import { idempotency } from './idempotency.mjs';
 import { inlineExecution } from './inline-execution.mjs';

--- a/packages/world-testing/src/server.mts
+++ b/packages/world-testing/src/server.mts
@@ -47,6 +47,22 @@ const Invoke = z
 // host bundler to compile it into several layers.
 const flowInvocationCounts = new Map<string, number>();
 
+function countFlowInvocation(message: unknown): void {
+  if (!message || typeof message !== 'object') return;
+  const runId =
+    'runId' in message && typeof message.runId === 'string'
+      ? message.runId
+      : 'payload' in message &&
+          message.payload &&
+          typeof message.payload === 'object' &&
+          'runId' in message.payload &&
+          typeof message.payload.runId === 'string'
+        ? message.payload.runId
+        : undefined;
+  if (!runId) return;
+  flowInvocationCounts.set(runId, (flowInvocationCounts.get(runId) ?? 0) + 1);
+}
+
 const app = new Hono()
   .post('/.well-known/workflow/v1/flow', async (ctx) => {
     // Clone the request to read the body for tracking without consuming it.
@@ -57,20 +73,7 @@ const app = new Hono()
     // /_flow-invocations after seeing the run as completed.
     const cloned = ctx.req.raw.clone();
     try {
-      const body = (await cloned.json()) as Record<string, unknown>;
-      const runId =
-        typeof body?.runId === 'string'
-          ? body.runId
-          : typeof (body.payload as Record<string, unknown> | undefined)
-                ?.runId === 'string'
-            ? ((body.payload as Record<string, unknown>).runId as string)
-            : undefined;
-      if (runId) {
-        flowInvocationCounts.set(
-          runId,
-          (flowInvocationCounts.get(runId) ?? 0) + 1
-        );
-      }
+      countFlowInvocation(await cloned.json());
     } catch {
       // Health check or non-JSON messages — ignore
     }
@@ -172,6 +175,15 @@ serve(
     }
 
     const world = await getWorld();
+    if (world.capabilities?.directQueueDelivery === true) {
+      const createQueueHandler = world.createQueueHandler.bind(world);
+      world.createQueueHandler = (prefix, handler) =>
+        createQueueHandler(prefix, async (message, metadata) => {
+          countFlowInvocation(message);
+          return handler(message, metadata);
+        });
+    }
+    await flowPOST.initialize();
     if (world.start) {
       console.log(`starting background tasks...`);
       await world.start().then(

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -467,6 +467,12 @@ export interface Storage {
  */
 export interface WorldCapabilities {
   /**
+   * Queue messages are delivered to an in-process handler. Core must not add
+   * its unauthenticated HTTP health response to the generated flow route.
+   */
+  directQueueDelivery?: boolean;
+
+  /**
    * Supports `experimental_minRetention` for Hooks. Missing or inactive means
    * the runtime rejects retained Hooks before registration.
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2397,6 +2397,9 @@ importers:
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
+      undici:
+        specifier: 'catalog:'
+        version: 7.29.0
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1442,9 +1442,6 @@ importers:
 
   packages/world-postgres:
     dependencies:
-      '@vercel/queue':
-        specifier: 'catalog:'
-        version: 0.5.0(@opentelemetry/api@1.9.1)
       '@workflow/errors':
         specifier: workspace:*
         version: link:../errors
@@ -1454,9 +1451,6 @@ importers:
       '@workflow/world':
         specifier: workspace:*
         version: link:../world
-      '@workflow/world-local':
-        specifier: workspace:*
-        version: link:../world-local
       cbor-x:
         specifier: 1.6.0
         version: 1.6.0

--- a/workbench/astro/scripts/start-with-pg.mjs
+++ b/workbench/astro/scripts/start-with-pg.mjs
@@ -5,7 +5,10 @@
 // Astro doesn't have a hook for starting the Postgres World in production
 
 async function main() {
-  if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+  const usePostgres =
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres';
+
+  if (usePostgres) {
     console.log('Starting Postgres World...');
     const { getWorld } = await import('workflow/runtime');
     const world = await getWorld();
@@ -17,6 +20,20 @@ async function main() {
 
   // Now start the Astro server
   await import('../dist/server/entry.mjs');
+
+  if (usePostgres) {
+    // Astro loads route modules lazily, so hit the flow route's health
+    // endpoint once to load it — its module registers the queue handler the
+    // Postgres world needs for in-process execution.
+    const url = `http://localhost:${process.env.PORT || 4321}/.well-known/workflow/v1/flow?__health`;
+    for (let attempt = 0; attempt < 50; attempt++) {
+      try {
+        if ((await fetch(url)).ok) return;
+      } catch {}
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    console.warn(`Could not reach ${url} to load the workflow flow route.`);
+  }
 }
 
 main().catch((error) => {

--- a/workbench/astro/scripts/start-with-pg.mjs
+++ b/workbench/astro/scripts/start-with-pg.mjs
@@ -7,6 +7,10 @@
 async function main() {
   if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
     console.log('Starting Postgres World...');
+    const { POST } = await import(
+      '../src/pages/.well-known/workflow/v1/flow.js'
+    );
+    await POST.initialize();
     const { getWorld } = await import('workflow/runtime');
     const world = await getWorld();
     if (world.start) {

--- a/workbench/nest/src/main.ts
+++ b/workbench/nest/src/main.ts
@@ -4,16 +4,6 @@ import type { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
-  // Start the Postgres World if configured
-  if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
-    const { getWorld } = await import('workflow/runtime');
-    const world = await getWorld();
-    if (world.start) {
-      console.log('Starting World workers...');
-      await world.start();
-    }
-  }
-
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bodyParser: false,
   });
@@ -24,6 +14,13 @@ async function bootstrap() {
   app.use(expressModule.json());
   app.use(expressModule.text({ type: 'text/*' }));
   app.use(expressModule.raw({ type: 'application/octet-stream' }));
+
+  await app.init();
+  if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+    const { getWorld } = await import('workflow/runtime');
+    console.log('Starting World workers...');
+    await (await getWorld()).start?.();
+  }
 
   const port = process.env.PORT ?? 3000;
   await app.listen(port);

--- a/workbench/nextjs-turbopack/instrumentation.ts
+++ b/workbench/nextjs-turbopack/instrumentation.ts
@@ -1,6 +1,6 @@
 import { registerOTel } from '@vercel/otel';
 
-export function register() {
+export async function register() {
   registerOTel({
     serviceName: 'nextjs-turbopack',
     instrumentationConfig: {
@@ -17,4 +17,17 @@ export function register() {
       },
     },
   });
+
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    // Load the generated flow route module so it registers its queue handler
+    // (the Postgres world executes queue jobs in-process), then start the
+    // world's embedded queue worker.
+    await import('./app/.well-known/workflow/v1/flow/route');
+    const { getWorld } = await import('workflow/runtime');
+    const world = await getWorld();
+    await world.start?.();
+  }
 }

--- a/workbench/nextjs-turbopack/instrumentation.ts
+++ b/workbench/nextjs-turbopack/instrumentation.ts
@@ -1,6 +1,6 @@
 import { registerOTel } from '@vercel/otel';
 
-export function register() {
+export async function register() {
   registerOTel({
     serviceName: 'nextjs-turbopack',
     instrumentationConfig: {
@@ -17,4 +17,14 @@ export function register() {
       },
     },
   });
+
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    const { POST } = await import('./app/.well-known/workflow/v1/flow/route');
+    await POST.initialize();
+    const { getWorld } = await import('workflow/runtime');
+    await (await getWorld()).start?.();
+  }
 }

--- a/workbench/nextjs-webpack/instrumentation.ts
+++ b/workbench/nextjs-webpack/instrumentation.ts
@@ -1,6 +1,6 @@
 import { registerOTel } from '@vercel/otel';
 
-export function register() {
+export async function register() {
   registerOTel({
     serviceName: 'nextjs-webpack',
     instrumentationConfig: {
@@ -17,4 +17,17 @@ export function register() {
       },
     },
   });
+
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    // Load the generated flow route module so it registers its queue handler
+    // (the Postgres world executes queue jobs in-process), then start the
+    // world's embedded queue worker.
+    await import('./app/.well-known/workflow/v1/flow/route');
+    const { getWorld } = await import('workflow/runtime');
+    const world = await getWorld();
+    await world.start?.();
+  }
 }

--- a/workbench/nextjs-webpack/instrumentation.ts
+++ b/workbench/nextjs-webpack/instrumentation.ts
@@ -1,6 +1,6 @@
 import { registerOTel } from '@vercel/otel';
 
-export function register() {
+export async function register() {
   registerOTel({
     serviceName: 'nextjs-webpack',
     instrumentationConfig: {
@@ -17,4 +17,14 @@ export function register() {
       },
     },
   });
+
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    const { POST } = await import('./app/.well-known/workflow/v1/flow/route');
+    await POST.initialize();
+    const { getWorld } = await import('workflow/runtime');
+    await (await getWorld()).start?.();
+  }
 }

--- a/workbench/nitro-v3/plugins/start-pg-world.ts
+++ b/workbench/nitro-v3/plugins/start-pg-world.ts
@@ -4,12 +4,10 @@ import { definePlugin } from 'nitro';
 // Needed since we test this in CI
 export default definePlugin(async () => {
   if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
-    import('workflow/runtime').then(async ({ getWorld }) => {
-      const world = await getWorld();
-      if (world.start) {
-        console.log('Starting World workers...');
-        await world.start();
-      }
-    });
+    const { initializeWorkflow } = await import('#workflow/workflows.mjs');
+    await initializeWorkflow();
+    const { getWorld } = await import('workflow/runtime');
+    console.log('Starting World workers...');
+    await (await getWorld()).start?.();
   }
 });

--- a/workbench/nuxt/server/plugins/start-pg-world.ts
+++ b/workbench/nuxt/server/plugins/start-pg-world.ts
@@ -4,12 +4,10 @@ import { defineNitroPlugin } from '#imports';
 // Needed since we test this in CI
 export default defineNitroPlugin(async () => {
   if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
-    import('workflow/runtime').then(async ({ getWorld }) => {
-      const world = await getWorld();
-      if (world.start) {
-        console.log('Starting World workers...');
-        await world.start();
-      }
-    });
+    const { initializeWorkflow } = await import('#workflow/workflows.mjs');
+    await initializeWorkflow();
+    const { getWorld } = await import('workflow/runtime');
+    console.log('Starting World workers...');
+    await (await getWorld()).start?.();
   }
 });

--- a/workbench/sveltekit/package.json
+++ b/workbench/sveltekit/package.json
@@ -36,6 +36,7 @@
     "ai": "catalog:",
     "exsolve": "^1.0.7",
     "lodash.chunk": "^4.2.0",
+    "undici": "catalog:",
     "workflow": "workspace:*",
     "zod": "catalog:"
   }

--- a/workbench/sveltekit/src/hooks.server.ts
+++ b/workbench/sveltekit/src/hooks.server.ts
@@ -22,6 +22,9 @@ export const init: ServerInit = async () => {
   // Start the Postgres World
   // Needed since we test this in CI
   if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+    // Load the generated flow route module so it registers its queue handler
+    // (the Postgres world executes queue jobs in-process).
+    await import('./routes/.well-known/workflow/v1/flow/+server.js');
     const { getWorld } = await import('workflow/runtime');
     const world = await getWorld();
     if (world.start) {

--- a/workbench/sveltekit/src/hooks.server.ts
+++ b/workbench/sveltekit/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import type { ServerInit } from '@sveltejs/kit';
 import { registerOTel } from '@vercel/otel';
+import { building } from '$app/environment';
 
 registerOTel({
   serviceName: 'example-sveltekit',
@@ -21,7 +22,14 @@ registerOTel({
 export const init: ServerInit = async () => {
   // Start the Postgres World
   // Needed since we test this in CI
-  if (process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres') {
+  if (
+    !building &&
+    process.env.WORKFLOW_TARGET_WORLD === '@workflow/world-postgres'
+  ) {
+    const { POST } = await import(
+      './routes/.well-known/workflow/v1/flow/+server.js'
+    );
+    await POST.initialize();
     const { getWorld } = await import('workflow/runtime');
     const world = await getWorld();
     if (world.start) {


### PR DESCRIPTION
## Summary

Call the generated handler initialization hook before framework integrations start background workers.

- Next.js, SvelteKit, Astro, Nest, Nitro, and Nuxt initialize `POST` before `world.start()`.
- Preserve the callable handler and its `initialize` property through framework wrappers.
- Reuse the public `WorkflowEntrypoint` type in generated declarations.
- Add shared conformance coverage proving the Postgres flow route returns `404` for normal and health requests.

The generated route stays in place for framework compatibility, but Postgres execution no longer depends on public HTTP traffic.

## Validation

- `@workflow/nest`: 35 passing tests
- `@workflow/nitro`: 30 passing tests
- `@workflow/sveltekit`: 7 passing tests
- Production builds for Next.js Turbopack, Next.js Webpack, SvelteKit, Astro, Nest, Nitro, and Nuxt with the Postgres World

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>