### PR TITLE
Document direct Postgres queue delivery

### DIFF
--- a/.changeset/postgres-direct-delivery-docs.md
+++ b/.changeset/postgres-direct-delivery-docs.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Document direct Postgres queue delivery and worker initialization.

--- a/docs/content/worlds/v4/postgres.mdx
+++ b/docs/content/worlds/v4/postgres.mdx
@@ -73,7 +73,7 @@ The migration is idempotent and can safely be run as a post-deployment lifecycle
 
 ## Starting the World
 
-To subscribe to the graphile-worker queue, your workflow app needs to start the world on server start. Here are examples for a few frameworks:
+Register the generated flow handler before starting the World. Then Graphile Worker can deliver jobs directly in the worker process.
 
 <Callout type="warn">
 This step is specific to worlds that run a background worker, such as Postgres
@@ -91,10 +91,13 @@ Create an `instrumentation.ts` file in your project root:
 
 ```ts title="instrumentation.ts" lineNumbers
 export async function register() {
-  if (process.env.NEXT_RUNTIME !== "edge") {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { POST } = await import(
+      "./app/.well-known/workflow/v1/flow/route"
+    );
+    await POST.initialize();
     const { getWorld } = await import("workflow/runtime");
-    const world = await getWorld();
-    await world.start?.();
+    await (await getWorld()).start?.();
   }
 }
 ```
@@ -110,12 +113,17 @@ Learn more about [Next.js Instrumentation](https://nextjs.org/docs/app/guides/in
 Create a `src/hooks.server.ts` file:
 
 ```ts title="src/hooks.server.ts" lineNumbers
+import { building } from "$app/environment";
 import type { ServerInit } from "@sveltejs/kit";
 
 export const init: ServerInit = async () => {
+  if (building) return;
+  const { POST } = await import(
+    "./routes/.well-known/workflow/v1/flow/+server.js"
+  );
+  await POST.initialize();
   const { getWorld } = await import("workflow/runtime");
-  const world = await getWorld();
-  await world.start?.();
+  await (await getWorld()).start?.();
 };
 ```
 
@@ -133,9 +141,10 @@ Create a plugin to start the world on server initialization:
 import { defineNitroPlugin } from "nitro/~internal/runtime/plugin";
 
 export default defineNitroPlugin(async () => {
+  const { initializeWorkflow } = await import("#workflow/workflows.mjs");
+  await initializeWorkflow();
   const { getWorld } = await import("workflow/runtime");
-  const world = await getWorld();
-  await world.start?.();
+  await (await getWorld()).start?.();
 });
 ```
 
@@ -157,6 +166,10 @@ Learn more about [Nitro Plugins](https://v3.nitro.build/docs/plugins).
 </Tab>
 
 </Tabs>
+
+<Callout type="warn">
+Do not warm the flow route with an HTTP request. With Postgres active, every external request to `/.well-known/workflow/v1/flow` returns 404, including `?__health`.
+</Callout>
 
 <Callout type="info">
 The Postgres World requires a long-lived worker process that polls the database for jobs. This does not work on serverless environments. For Vercel deployments, use the [Vercel World](/worlds/vercel) instead.
@@ -231,7 +244,7 @@ const world = createWorld({
 The Postgres World uses PostgreSQL as a durable backend:
 
 - **Storage**: Workflow runs, events, steps, and hooks are stored in PostgreSQL tables.
-- **Job queue**: [graphile-worker](https://github.com/graphile/worker) handles reliable job processing with retries.
+- **Job queue**: [graphile-worker](https://github.com/graphile/worker) handles retries and calls the registered flow handler directly.
 - **Streaming**: PostgreSQL NOTIFY/LISTEN enables real-time event distribution.
 
 This architecture ensures workflows survive application restarts with all state reliably persisted. For implementation details, see the [source code](https://github.com/vercel/workflow/tree/main/packages/world-postgres).
@@ -249,7 +262,7 @@ Ensure your deployment has:
 
 - Network access to your PostgreSQL database
 - Environment variables configured correctly
-- The `start()` function called on server initialization
+- The flow handler initialized before `start()` on server initialization
 
 <Callout type="info">
 The Postgres World is not compatible with Vercel deployments. On Vercel, workflows automatically use the [Vercel World](/worlds/vercel) with zero configuration.
@@ -257,7 +270,7 @@ The Postgres World is not compatible with Vercel deployments. On Vercel, workflo
 
 ## Limitations
 
-- **Requires long-running process**: Must call `start()` on server initialization; not compatible with serverless platforms
+- **Requires long-running process**: Must initialize the flow handler and call `start()` on server initialization; not compatible with serverless platforms
 - **PostgreSQL infrastructure**: Requires a PostgreSQL database (self-hosted or managed)
 - **Not compatible with Vercel**: Use the [Vercel World](/worlds/vercel) for Vercel deployments
 

--- a/docs/content/worlds/v5/postgres.mdx
+++ b/docs/content/worlds/v5/postgres.mdx
@@ -23,9 +23,9 @@ Install the Postgres World package in your workflow project:
 ```
 
 <Callout type="info">
-Use the same release channel for `workflow` and `@workflow/world-postgres`. If
-your app uses a beta or other prerelease Workflow version, install the matching
-prerelease Postgres World package, such as
+Use the same release channel for `workflow` and `@workflow/world-postgres`, and
+upgrade them together. If your app uses a beta or other prerelease Workflow
+version, install the matching prerelease Postgres World package, such as
 `npm install @workflow/world-postgres@beta`. Mismatched versions fail before
 starting a run with an error that says the runtime requires a World with a
 matching spec version.
@@ -82,17 +82,22 @@ The migration is idempotent and can safely be run as a post-deployment lifecycle
 
 ## Starting the World
 
-To subscribe to the graphile-worker queue, your workflow app needs to start the world on server start. Here are examples for a few frameworks:
+The Postgres World executes queue jobs in-process: any Node.js process that has loaded the generated workflow flow module (which registers the workflow queue handler as a module-load side effect) and called `world.start()` is a worker. There is no HTTP hop between the queue and your workflow code. Scale out by running more app instances against the same database — graphile-worker's row locking distributes jobs between them.
+
+`world.start()` begins consuming jobs only once the workflow handler is registered, and logs a warning if none registers within 10 seconds. A process that only enqueues runs (such as a CLI) never registers a handler and therefore never consumes jobs — they stay in PostgreSQL until a worker picks them up.
+
+Start the world on server start. Here are examples for a few frameworks:
 
 <Tabs items={["Next.js", "SvelteKit", "Nitro"]}>
 
 <Tab value="Next.js">
 
-Create an `instrumentation.ts` file in your project root:
+Create an `instrumentation.ts` file in your project root. Import the generated flow route module first so its queue handler is registered in the server process:
 
 ```ts title="instrumentation.ts" lineNumbers
 export async function register() {
-  if (process.env.NEXT_RUNTIME !== "edge") {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./app/.well-known/workflow/v1/flow/route");
     const { getWorld } = await import("workflow/runtime");
     const world = await getWorld();
     await world.start?.();
@@ -104,16 +109,21 @@ export async function register() {
 Learn more about [Next.js Instrumentation](https://nextjs.org/docs/app/guides/instrumentation).
 </Callout>
 
+<Callout type="warn">
+In `next dev`, instrumentation is compiled once at server start, so the embedded worker keeps executing the workflow code it loaded at boot — restart the dev server after editing workflows. For local development we recommend the [Local World](/worlds/local), which always executes fresh code.
+</Callout>
+
 </Tab>
 
 <Tab value="SvelteKit">
 
-Create a `src/hooks.server.ts` file:
+Create a `src/hooks.server.ts` file that imports the generated flow route module before starting the world:
 
 ```ts title="src/hooks.server.ts" lineNumbers
 import type { ServerInit } from "@sveltejs/kit";
 
 export const init: ServerInit = async () => {
+  await import("./routes/.well-known/workflow/v1/flow/+server.js");
   const { getWorld } = await import("workflow/runtime");
   const world = await getWorld();
   await world.start?.();
@@ -128,7 +138,7 @@ Learn more about [SvelteKit Hooks](https://svelte.dev/docs/kit/hooks).
 
 <Tab value="Nitro">
 
-Create a plugin to start the world on server initialization:
+Create a plugin to start the world on server initialization (the `workflow/nitro` module loads the flow module at boot, so no extra import is needed):
 
 ```ts title="plugins/start-pg-world.ts" lineNumbers
 import { defineNitroPlugin } from "nitro/~internal/runtime/plugin";
@@ -216,7 +226,7 @@ For higher worker concurrency, Graphile Worker recommends setting `maxPoolSize` 
 
 ### `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN`
 
-Set to `1` when the application or framework coordinates shutdown and awaits `world.close()` before closing its workflow HTTP server and any caller-owned pool. Default: unset (`false`).
+Set to `1` when the application or framework coordinates shutdown and awaits `world.close()` before closing its HTTP server and any caller-owned pool. Default: unset (`false`).
 
 ### `WORKFLOW_POSTGRES_HOOK_RETENTION_LIMIT_DAYS`
 
@@ -263,17 +273,17 @@ WORKFLOW_TARGET_WORLD="./my-world.ts"
 Graphile Worker responds automatically when the application is asked to shut down. If your application or framework already coordinates a broader shutdown sequence, set `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` when selecting the package directly with `WORKFLOW_TARGET_WORLD`, or set `applicationManagedShutdown: true` in a programmatic World. Use the application's normal shutdown hook. This prevents Graphile Worker's default handler from terminating the process as soon as its queue stops. The hook must handle cleanup errors and await resources in this order:
 
 1. `world.close()`
-2. The workflow HTTP server
+2. The application's HTTP server
 3. Any caller-owned `pg.Pool`
 
-Closing the world stops new queue claims and waits for active jobs. After Graphile Worker's grace period, a pending workflow HTTP request is aborted. Graphile Worker unlocks that same row through its normal failure handling. The already-claimed delivery consumes a Graphile attempt and is retried only if its attempt budget remains; a one-attempt or final-attempt job is not retried. The shutdown handler does not insert a successor row. Because a client abort does not prove the server handler stopped, workflow and step handlers must tolerate at-least-once execution.
+Closing the world stops new queue claims and waits for active jobs. After Graphile Worker's grace period, it unlocks the rows of jobs that are still executing through its normal failure handling. The already-claimed delivery consumes a Graphile attempt and is retried only if its attempt budget remains; a one-attempt or final-attempt job is not retried. The shutdown handler does not insert a successor row. Because unlocking a row does not stop the in-process handler still executing it, workflow and step handlers must tolerate at-least-once execution.
 
 ## How It Works
 
 The Postgres World uses PostgreSQL as a durable backend:
 
 - **Storage** - Workflow runs, events, steps, and hooks are stored in PostgreSQL tables
-- **Job Queue** - [graphile-worker](https://github.com/graphile/worker) handles reliable job processing with retries
+- **Job Queue** - [graphile-worker](https://github.com/graphile/worker) handles reliable job processing with retries; jobs execute by calling the registered workflow handler directly in-process, with no HTTP loopback
 - **Streaming** - PostgreSQL NOTIFY/LISTEN enables real-time event distribution
 
 This architecture ensures workflows survive application restarts with all state reliably persisted. For implementation details, see the [source code](https://github.com/vercel/workflow/tree/main/packages/world-postgres).

--- a/docs/content/worlds/v5/postgres.mdx
+++ b/docs/content/worlds/v5/postgres.mdx
@@ -80,7 +80,7 @@ The migration is idempotent and can safely be run as a post-deployment lifecycle
 
 ## Starting the World
 
-To subscribe to the graphile-worker queue, your workflow app needs to start the world on server start. Here are examples for a few frameworks:
+Register the generated flow handler before starting the World. Then Graphile Worker can deliver jobs directly in the worker process.
 
 <Callout type="warn">
 This step is specific to worlds that run a background worker, such as Postgres
@@ -98,10 +98,13 @@ Create an `instrumentation.ts` file in your project root:
 
 ```ts title="instrumentation.ts" lineNumbers
 export async function register() {
-  if (process.env.NEXT_RUNTIME !== "edge") {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { POST } = await import(
+      "./app/.well-known/workflow/v1/flow/route"
+    );
+    await POST.initialize();
     const { getWorld } = await import("workflow/runtime");
-    const world = await getWorld();
-    await world.start?.();
+    await (await getWorld()).start?.();
   }
 }
 ```
@@ -117,12 +120,17 @@ Learn more about [Next.js Instrumentation](https://nextjs.org/docs/app/guides/in
 Create a `src/hooks.server.ts` file:
 
 ```ts title="src/hooks.server.ts" lineNumbers
+import { building } from "$app/environment";
 import type { ServerInit } from "@sveltejs/kit";
 
 export const init: ServerInit = async () => {
+  if (building) return;
+  const { POST } = await import(
+    "./routes/.well-known/workflow/v1/flow/+server.js"
+  );
+  await POST.initialize();
   const { getWorld } = await import("workflow/runtime");
-  const world = await getWorld();
-  await world.start?.();
+  await (await getWorld()).start?.();
 };
 ```
 
@@ -140,9 +148,10 @@ Create a plugin to start the world on server initialization:
 import { defineNitroPlugin } from "nitro/~internal/runtime/plugin";
 
 export default defineNitroPlugin(async () => {
+  const { initializeWorkflow } = await import("#workflow/workflows.mjs");
+  await initializeWorkflow();
   const { getWorld } = await import("workflow/runtime");
-  const world = await getWorld();
-  await world.start?.();
+  await (await getWorld()).start?.();
 });
 ```
 
@@ -164,6 +173,10 @@ Learn more about [Nitro Plugins](https://v3.nitro.build/docs/plugins).
 </Tab>
 
 </Tabs>
+
+<Callout type="warn">
+Do not warm the flow route with an HTTP request. With Postgres active, every external request to `/.well-known/workflow/v1/flow` returns 404, including `?__health`.
+</Callout>
 
 <Callout type="info">
 The Postgres World requires a long-lived worker process that polls the database for jobs. This does not work on serverless environments. For Vercel deployments, use the [Vercel World](/worlds/vercel) instead.
@@ -275,17 +288,16 @@ WORKFLOW_TARGET_WORLD="./my-world.ts"
 Graphile Worker responds automatically when the application is asked to shut down. If your application or framework already coordinates a broader shutdown sequence, set `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` when selecting the package directly with `WORKFLOW_TARGET_WORLD`, or set `applicationManagedShutdown: true` in a programmatic World. Use the application's normal shutdown hook. This prevents Graphile Worker's default handler from terminating the process as soon as its queue stops. The hook must handle cleanup errors and await resources in this order:
 
 1. `world.close()`
-2. The workflow HTTP server
-3. Any caller-owned `pg.Pool`
+2. Any caller-owned `pg.Pool`
 
-Closing the world stops new queue claims and waits for active jobs. After Graphile Worker's grace period, a pending workflow HTTP request is aborted. Graphile Worker unlocks that same row through its normal failure handling. The already-claimed delivery consumes a Graphile attempt and is retried only if its attempt budget remains; a one-attempt or final-attempt job is not retried. The shutdown handler does not insert a successor row. Because a client abort does not prove the server handler stopped, workflow and step handlers must tolerate at-least-once execution.
+Closing the World stops new queue claims and waits for active jobs. After Graphile Worker's grace period, it aborts the delivery wait and unlocks that row through its normal failure handling. The delivery consumes an attempt and is retried only if its attempt budget remains. Because aborting a delivery does not prove that application code in its handler stopped, workflow and step handlers must tolerate at-least-once execution.
 
 ## How it works
 
 The Postgres World uses PostgreSQL as a durable backend:
 
 - **Storage**: Workflow runs, events, steps, and hooks are stored in PostgreSQL tables.
-- **Job queue**: [graphile-worker](https://github.com/graphile/worker) handles reliable job processing with retries.
+- **Job queue**: [graphile-worker](https://github.com/graphile/worker) handles retries and calls the registered flow handler directly.
 - **Streaming**: PostgreSQL NOTIFY/LISTEN enables real-time event distribution.
 
 This architecture ensures workflows survive application restarts with all state reliably persisted. For implementation details, see the [source code](https://github.com/vercel/workflow/tree/main/packages/world-postgres).
@@ -303,7 +315,7 @@ Ensure your deployment has:
 
 - Network access to your PostgreSQL database
 - Environment variables configured correctly
-- The `start()` function called on server initialization
+- The flow handler initialized before `start()` on server initialization
 
 <Callout type="info">
 The Postgres World is not compatible with Vercel deployments. On Vercel, workflows automatically use the [Vercel World](/worlds/vercel) with zero configuration.
@@ -311,7 +323,7 @@ The Postgres World is not compatible with Vercel deployments. On Vercel, workflo
 
 ## Limitations
 
-- **Requires long-running process**: Must call `start()` on server initialization; not compatible with serverless platforms
+- **Requires long-running process**: Must initialize the flow handler and call `start()` on server initialization; not compatible with serverless platforms
 - **PostgreSQL infrastructure**: Requires a PostgreSQL database (self-hosted or managed)
 - **Not compatible with Vercel**: Use the [Vercel World](/worlds/vercel) for Vercel deployments
 

--- a/packages/world-postgres/HOW_IT_WORKS.md
+++ b/packages/world-postgres/HOW_IT_WORKS.md
@@ -31,7 +31,7 @@ Real-time data streaming via **PostgreSQL LISTEN/NOTIFY**:
 - `pg_notify` triggers sent on writes to `workflow_event_chunk` topic
 - Subscribers receive notifications and fetch chunk data
 - ULID-based ordering ensures correct sequence
-- One long-lived dedicated `LISTEN` client, with an in-process EventEmitter for distributing events to multiple subscribers
+- One long-lived dedicated `LISTEN` client (connected lazily on the first stream read — constructing a world opens no connections), with an in-process EventEmitter for distributing events to multiple subscribers
 
 ## Setup
 

--- a/packages/world-postgres/HOW_IT_WORKS.md
+++ b/packages/world-postgres/HOW_IT_WORKS.md
@@ -12,13 +12,12 @@ If you want to use any other ORM, query builder or underlying database client, y
 graph LR
     Client --> PG[graphile-worker queue]
     PG --> Worker[Embedded Worker]
-    Worker --> HTTP[Combined flow HTTP route]
-    HTTP --> Handler[Workflow Handler]
+    Worker --> Handler[Registered flow handler]
 
     PG -.-> F["${prefix}flows<br/>(orchestration and steps)"]
 ```
 
-Jobs include retry logic (3 attempts), idempotency keys, durable delayed rescheduling, and configurable worker concurrency (default: 10).
+Jobs include retry logic, idempotency keys, durable delayed rescheduling, and configurable worker concurrency (default: 50).
 
 ## Streaming
 
@@ -32,23 +31,24 @@ Real-time data streaming via **PostgreSQL LISTEN/NOTIFY**:
 
 ## Setup
 
-Call `world.start()` to initialize graphile-worker workers. When `.start()` is called, workers begin listening to graphile-worker queues. When a job arrives, the worker executes the queue message over the workflow HTTP routes and awaits completion before acknowledging the Graphile job.
+Call the generated flow handler's `initialize()` method before `world.start()`. This registers the handler before Graphile Worker begins claiming jobs. The worker invokes it directly and acknowledges each Graphile job only after it finishes.
 
 When the runtime returns `{ timeoutSeconds }`, the worker schedules a new Graphile job with a future `runAt` time before finishing the current task.
 
-The worker sends workflow orchestration and queued step messages to the combined `.well-known/workflow/v1/flow` endpoint.
+The generated `.well-known/workflow/v1/flow` route returns 404 for every external request when Postgres is active, including `?__health`.
 
 In **Next.js**, the `world.start()` call needs to be added to `instrumentation.ts|js` to ensure workers start before request handling. Use `workflow/runtime` for `getWorld` (same as the testing server and other framework plugins):
 
 ```ts
 // instrumentation.ts
 
-if (process.env.NEXT_RUNTIME !== "edge") {
-  import("workflow/runtime").then(async ({ getWorld }) => {
-    // start listening to the jobs.
-    const world = await getWorld();
-    await world.start?.();
-  });
+if (process.env.NEXT_RUNTIME === "nodejs") {
+  const { POST } = await import(
+    "./app/.well-known/workflow/v1/flow/route"
+  );
+  await POST.initialize();
+  const { getWorld } = await import("workflow/runtime");
+  await (await getWorld()).start?.();
 }
 ```
 
@@ -56,6 +56,6 @@ if (process.env.NEXT_RUNTIME !== "edge") {
 
 `world.close()` first stops Graphile Worker from claiming new jobs, then waits for active jobs before closing the streamer and any internally owned pool.
 
-Graphile Worker gives active tasks a grace period, then aborts their task signal. The Postgres world forwards that signal to both the workflow HTTP request and its response body. If the request aborts, Graphile Worker unlocks the same Postgres job row through its normal failure handling. The already-claimed delivery consumes an attempt and is retried only if its Graphile attempt budget remains; the shutdown handler does not insert a successor row.
+Graphile Worker gives active tasks a grace period, then aborts their task signal. The Postgres World stops waiting for the handler and Graphile Worker unlocks the same Postgres job row through its normal failure handling. The already-claimed delivery consumes an attempt and is retried only if its Graphile attempt budget remains; the shutdown handler does not insert a successor row.
 
-Applications that manage a broader shutdown sequence should set `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` for the standard package target or `applicationManagedShutdown: true` for a programmatic World, await `world.close()`, and only then close the workflow HTTP routes and any caller-owned pool. This prevents Graphile Worker's default handler from terminating the process as soon as its queue stops. Because aborting a client request does not prove that its server handler stopped, workflow and step handlers still need to tolerate at-least-once execution.
+Applications that manage a broader shutdown sequence should set `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` for the standard package target or `applicationManagedShutdown: true` for a programmatic World, await `world.close()`, and only then close any caller-owned pool. This prevents Graphile Worker's default handler from terminating the process as soon as its queue stops. Because aborting a delivery does not prove that application code in its handler stopped, workflow and step handlers still need to tolerate at-least-once execution.

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -33,8 +33,8 @@ export WORKFLOW_POSTGRES_URL="postgres://username:password@localhost:5432/databa
 # Optional: Job prefix for queue operations
 export WORKFLOW_POSTGRES_JOB_PREFIX="myapp"
 
-# Optional: Worker concurrency (default: 10)
-export WORKFLOW_POSTGRES_WORKER_CONCURRENCY="10"
+# Optional: Worker concurrency (default: 50)
+export WORKFLOW_POSTGRES_WORKER_CONCURRENCY="50"
 
 # Optional: Internal pg.Pool max size (default: 10)
 export WORKFLOW_POSTGRES_MAX_POOL_SIZE="10"
@@ -67,6 +67,29 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const worldFromPool = createWorld({ pool });
 ```
 
+### Starting the embedded worker
+
+Load the generated flow handler before starting the World. For example, in
+Next.js:
+
+```typescript
+// instrumentation.ts
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { POST } = await import(
+      './app/.well-known/workflow/v1/flow/route'
+    );
+    await POST.initialize();
+    const { getWorld } = await import('workflow/runtime');
+    await (await getWorld()).start?.();
+  }
+}
+```
+
+Postgres calls this handler directly in the worker process. Its generated HTTP
+route returns 404 for every request, including `?__health`, so it is not an
+unauthenticated queue or health endpoint.
+
 ### Application-managed shutdown
 
 By default, Graphile Worker responds automatically when the application is asked to shut down. If your application already coordinates shutdown, set `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` when selecting the package with `WORKFLOW_TARGET_WORLD`, or set `applicationManagedShutdown: true` when calling `createWorld()` directly. Await `world.close()` from your shutdown path so Graphile Worker cannot terminate the process as soon as its queue stops, before your application finishes closing dependent resources:
@@ -82,11 +105,11 @@ const world = createWorld({
 await world.start();
 ```
 
-Use this option only when your application or framework has its own shutdown hook. Handle cleanup errors there and await `world.close()` first, then close the workflow HTTP server and any caller-owned `pg.Pool`.
+Use this option only when your application or framework has its own shutdown hook. Handle cleanup errors there and await `world.close()` before closing any caller-owned `pg.Pool`.
 
-Closing the world stops the queue from accepting new jobs and waits for active jobs. After Graphile Worker's graceful-shutdown timeout (5s by default), it aborts any workflow HTTP request that is still pending. Graphile Worker then unlocks the same row through its normal failure handling. Graphile counts a delivery attempt when it claims the row, so the aborted delivery consumes that attempt and is retried only if its Graphile attempt budget remains. A one-attempt or final-attempt job is unlocked but not retried. The shutdown handler does not create a replacement row.
+Closing the World stops the queue from accepting new jobs and waits for active jobs. After Graphile Worker's graceful-shutdown timeout (5s by default), it aborts the delivery wait. Graphile Worker then unlocks the same row through its normal failure handling. Graphile counts a delivery attempt when it claims the row, so the aborted delivery consumes that attempt and is retried only if its Graphile attempt budget remains. A one-attempt or final-attempt job is unlocked but not retried. The shutdown handler does not create a replacement row.
 
-An aborted HTTP request does not guarantee that its server-side handler stopped, so workflow and step handlers must continue to tolerate at-least-once execution. Keep the workflow HTTP routes and any caller-owned pool available until `world.close()` resolves.
+Aborting a delivery does not guarantee that application code already running in its handler stopped, so workflow and step handlers must continue to tolerate at-least-once execution. Keep any caller-owned pool available until `world.close()` resolves.
 
 ## Configuration options
 
@@ -176,10 +199,9 @@ and its token can be reused. If the token is never reused, the expired
 ## Features
 
 - **Durable storage**: Stores workflow runs, events, steps, hooks, and webhooks in PostgreSQL
-- **Queue processing**: Uses Graphile Worker as the durable queue and executes jobs over the workflow HTTP routes
+- **Queue processing**: Uses Graphile Worker as the durable queue and executes jobs directly in the worker process
 - **Durable delays**: Reschedules waits and retries in PostgreSQL
 - **Streaming**: Real-time event streaming capabilities
-- **Health checks**: Built-in connection health monitoring
 - **Configurable concurrency**: Adjustable worker concurrency for queue processing
 
 ## Queue behavior
@@ -187,7 +209,7 @@ and its token can be reused. If the token is never reused, the expired
 - Graphile jobs are acknowledged only after execution finishes, or after the worker durably schedules a delayed follow-up job
 - Backlog stays in PostgreSQL when all execution slots are busy
 - Retry and sleep-style delays use Graphile `runAt` scheduling
-- Workflow orchestration and queued step execution are both sent through `/.well-known/workflow/v1/flow`
+- Workflow orchestration and queued step execution use the registered flow handler; the generated HTTP route is disabled for this World
 
 ## Development
 


### PR DESCRIPTION
## Summary

Update both maintained Postgres World guides for the smaller direct-delivery architecture.

- Show `POST.initialize()` before `world.start()`.
- Explain that Graphile Worker invokes the registered handler in process.
- Document that the public flow route always returns `404`, including `?__health`.
- Clarify enqueue-only processes and shutdown behavior.

## Docs Preview

| Version | Page |
| --- | --- |
| v4 / stable | [Postgres World](https://workflow-docs-git-nathanc-postgres-world-docs.vercel.sh/worlds/postgres) |
| v5 / beta | [Postgres World](https://workflow-docs-git-nathanc-postgres-world-docs.vercel.sh/v5/worlds/postgres) |

Preview links require Vercel team access.

## Validation

- Documentation production build: 908 static pages

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>