### PR TITLE
feat(core): mirror replay lineage into a reserved $replayedFromRunId attribute

### DIFF
--- a/.changeset/replay-lineage-attribute-core.md
+++ b/.changeset/replay-lineage-attribute-core.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Mirror replay lineage into the reserved `$replayedFromRunId` run attribute on worlds with native attributes (spec version 4+), alongside the existing `executionContext.replayedFromRunId` record, so attribute-indexed observability stores can surface replays in list queries.

--- a/.changeset/replay-lineage-attribute-world.md
+++ b/.changeset/replay-lineage-attribute-world.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world': minor
+---
+
+Add the reserved `REPLAYED_FROM_RUN_ID_ATTRIBUTE` (`$replayedFromRunId`) lineage attribute key.

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -937,7 +937,7 @@ describe('start', () => {
     });
   });
 
-  describe('replay lineage (executionContext.replayedFromRunId)', () => {
+  describe('replay lineage (replayedFromRunId)', () => {
     let mockEventsCreate: ReturnType<typeof vi.fn>;
     let mockQueue: ReturnType<typeof vi.fn>;
 
@@ -984,6 +984,65 @@ describe('start', () => {
       );
     });
 
+    it('seeds the reserved $replayedFromRunId attribute on both payloads', async () => {
+      const sourceRunId = 'wrun_01ARZ3NDEKTSV4RRFFQ69G5FAV';
+      await start(validWorkflow, [], { replayedFromRunId: sourceRunId });
+
+      // run_created carries the attribute plus the reserved-keys flag, so
+      // server-side validation permits it the same way the client did.
+      expect(mockEventsCreate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          eventData: expect.objectContaining({
+            attributes: { $replayedFromRunId: sourceRunId },
+            allowReservedAttributes: true,
+          }),
+        }),
+        expect.anything()
+      );
+      // The resilient-start queue input carries both too, so a run
+      // bootstrapped from run_started keeps its replay lineage.
+      expect(mockQueue.mock.calls[0]?.[1].runInput).toEqual(
+        expect.objectContaining({
+          attributes: { $replayedFromRunId: sourceRunId },
+          allowReservedAttributes: true,
+        })
+      );
+    });
+
+    it('merges the replay attribute with caller attributes, caller keys last', async () => {
+      const sourceRunId = 'wrun_01ARZ3NDEKTSV4RRFFQ69G5FAV';
+      await start(validWorkflow, [], {
+        replayedFromRunId: sourceRunId,
+        attributes: { tenant: 't1' },
+      });
+
+      expect(mockEventsCreate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          eventData: expect.objectContaining({
+            attributes: { $replayedFromRunId: sourceRunId, tenant: 't1' },
+            allowReservedAttributes: true,
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('skips the attribute on pre-attributes spec versions but keeps the executionContext record', async () => {
+      const sourceRunId = 'wrun_01ARZ3NDEKTSV4RRFFQ69G5FAV';
+      await start(validWorkflow, [], {
+        specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+        replayedFromRunId: sourceRunId,
+      });
+
+      const eventData = mockEventsCreate.mock.calls[0]?.[1]?.eventData;
+      expect(eventData).not.toHaveProperty('attributes');
+      expect(eventData.executionContext).toEqual(
+        expect.objectContaining({ replayedFromRunId: sourceRunId })
+      );
+    });
+
     it('omits replayedFromRunId from executionContext when not provided', async () => {
       await start(validWorkflow, []);
 
@@ -991,6 +1050,9 @@ describe('start', () => {
       expect(eventData.executionContext).not.toHaveProperty(
         'replayedFromRunId'
       );
+      // No replay and no caller attributes: the seed must stay absent
+      // entirely, not become an empty attributes object.
+      expect(eventData).not.toHaveProperty('attributes');
     });
 
     it('rejects a replayedFromRunId without the wrun_ prefix', async () => {

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -56,25 +56,38 @@ const CROSS_DEPLOYMENT_CAPABILITY_PROBE_TIMEOUT_MS = 2_000;
 const ulid = monotonicFactory();
 
 /**
- * Cross-run lineage for a run being started from inside another run.
+ * Cross-run lineage attributes for a new run.
  *
- * The ambient step context carries the parent run id and the root of its
- * lineage; the runtime fills both from the run it already has loaded, so this
- * is a pure context read with no I/O. The new run records `$parentRunId` (the
- * edge) and inherits the parent's `$rootRunId` (the parent itself when it is a
- * root), so a daisy chain or fan-out of any depth groups under one root id.
- * Returns `undefined` for a top-level `start()`, which has no context, so
- * standalone runs carry no lineage.
+ * Parent lineage: the ambient step context carries the parent run id and the
+ * root of its lineage; the runtime fills both from the run it already has
+ * loaded, so this is a pure context read with no I/O. The new run records
+ * `$parentRunId` (the edge) and inherits the parent's `$rootRunId` (the
+ * parent itself when it is a root), so a daisy chain or fan-out of any depth
+ * groups under one root id.
+ *
+ * Replay lineage: a run created as a replay records `$replayedFromRunId` — a
+ * queryable mirror of the `executionContext.replayedFromRunId` record, so
+ * attribute-indexed observability stores can serve "which runs are replays"
+ * in list queries.
+ *
+ * Returns `undefined` for a run with no lineage at all (a top-level,
+ * non-replay `start()`), so standalone runs carry no lineage attributes.
  */
-function resolveLineageAttributes(): Record<string, string> | undefined {
+function resolveLineageAttributes(
+  replayedFromRunId: string | undefined
+): Record<string, string> | undefined {
   const store = contextStorage.getStore();
   const parentRunId = store?.workflowMetadata?.workflowRunId;
-  if (!parentRunId) return undefined;
 
-  return {
-    [ROOT_RUN_ID_ATTRIBUTE]: store.rootRunId ?? parentRunId,
-    [PARENT_RUN_ID_ATTRIBUTE]: parentRunId,
-  };
+  const lineage: Record<string, string> = {};
+  if (parentRunId) {
+    lineage[ROOT_RUN_ID_ATTRIBUTE] = store?.rootRunId ?? parentRunId;
+    lineage[PARENT_RUN_ID_ATTRIBUTE] = parentRunId;
+  }
+  if (replayedFromRunId) {
+    lineage[REPLAYED_FROM_RUN_ID_ATTRIBUTE] = replayedFromRunId;
+  }
+  return Object.keys(lineage).length > 0 ? lineage : undefined;
 }
 
 // `deploymentId: 'latest'` is a no-op in Worlds without atomic deployments.
@@ -439,26 +452,17 @@ export async function start<TArgs extends unknown[], TResult>(
         );
       }
 
-      // Cross-run lineage: the reserved keys ride on the run's existing
-      // attributes, so they add no extra write. Replay lineage rides the same
-      // way — a queryable `$replayedFromRunId` mirror of the executionContext
-      // record below, so attribute-indexed observability stores can serve
-      // "which runs are replays" in list queries. Runs on pre-attributes spec
-      // versions skip the attributes silently (the executionContext record is
-      // unconditional) rather than fail the start. Caller attributes are
-      // spread last, so a caller with allowReservedAttributes can
-      // deliberately re-parent.
+      // Cross-run lineage (parent and replay): the reserved keys ride on the
+      // run's existing attributes, so they add no extra write. Runs on
+      // pre-attributes spec versions skip the attributes silently (the
+      // executionContext record below is unconditional) rather than fail the
+      // start. Caller attributes are spread last, so a caller with
+      // allowReservedAttributes can deliberately re-parent.
       const lineage =
         specVersion >= SPEC_VERSION_SUPPORTS_ATTRIBUTES
-          ? {
-              ...resolveLineageAttributes(),
-              ...(opts.replayedFromRunId
-                ? { [REPLAYED_FROM_RUN_ID_ATTRIBUTE]: opts.replayedFromRunId }
-                : {}),
-            }
+          ? resolveLineageAttributes(opts.replayedFromRunId)
           : undefined;
-      const hasLineage = lineage != null && Object.keys(lineage).length > 0;
-      const runAttributes = hasLineage
+      const runAttributes = lineage
         ? { ...lineage, ...attributes }
         : attributes;
 
@@ -466,7 +470,7 @@ export async function start<TArgs extends unknown[], TResult>(
       const attributeSeed = runAttributes
         ? {
             attributes: runAttributes,
-            ...(allowReservedAttributes || hasLineage
+            ...(allowReservedAttributes || lineage != null
               ? { allowReservedAttributes: true as const }
               : {}),
           }

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -5,6 +5,7 @@ import {
   HOOK_RESUME_INPUT_VERSION,
   isLegacySpecVersion,
   PARENT_RUN_ID_ATTRIBUTE,
+  REPLAYED_FROM_RUN_ID_ATTRIBUTE,
   ROOT_RUN_ID_ATTRIBUTE,
   SPEC_VERSION_SUPPORTS_ATTRIBUTES,
   SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
@@ -141,9 +142,11 @@ export interface StartOptionsBase {
   /**
    * The ID of an existing run this run is being replayed from, if any.
    *
-   * Recorded on the new run's `executionContext` as `replayedFromRunId` so
-   * tooling (e.g. the dashboard runs list) can show that a run originated as
-   * a replay and link back to its source. Set automatically by
+   * Recorded on the new run's `executionContext` as `replayedFromRunId` —
+   * and, on worlds with native attributes (spec version 4 and later), also
+   * as the reserved `$replayedFromRunId` attribute — so tooling (e.g. the
+   * dashboard runs list) can show that a run originated as a replay and link
+   * back to its source. Set automatically by
    * {@link recreateRunFromExisting}; there's usually no reason to pass it
    * directly.
    *
@@ -422,30 +425,9 @@ export async function start<TArgs extends unknown[], TResult>(
         );
       }
 
-      // Cross-run lineage: the reserved keys ride on the run's existing
-      // attributes, so they add no extra write. Caller attributes are spread
-      // last, so a caller with allowReservedAttributes can deliberately
-      // re-parent.
-      const lineage =
-        specVersion >= SPEC_VERSION_SUPPORTS_ATTRIBUTES
-          ? resolveLineageAttributes()
-          : undefined;
-      const runAttributes = lineage
-        ? { ...lineage, ...attributes }
-        : attributes;
-
-      // Shared by the run_created event and the resilient-start queue input.
-      const attributeSeed = runAttributes
-        ? {
-            attributes: runAttributes,
-            ...(allowReservedAttributes || lineage != null
-              ? { allowReservedAttributes: true as const }
-              : {}),
-          }
-        : {};
-
       // `replayedFromRunId` is a foreign key to the source run; reject anything
       // that isn't a real run ID so the lineage link can't point at garbage.
+      // Validated before the attribute seed below, which mirrors the value.
       if (
         opts.replayedFromRunId !== undefined &&
         !workflowRunIdSchema.safeParse(opts.replayedFromRunId).success
@@ -456,6 +438,39 @@ export async function start<TArgs extends unknown[], TResult>(
           )}.`
         );
       }
+
+      // Cross-run lineage: the reserved keys ride on the run's existing
+      // attributes, so they add no extra write. Replay lineage rides the same
+      // way — a queryable `$replayedFromRunId` mirror of the executionContext
+      // record below, so attribute-indexed observability stores can serve
+      // "which runs are replays" in list queries. Runs on pre-attributes spec
+      // versions skip the attributes silently (the executionContext record is
+      // unconditional) rather than fail the start. Caller attributes are
+      // spread last, so a caller with allowReservedAttributes can
+      // deliberately re-parent.
+      const lineage =
+        specVersion >= SPEC_VERSION_SUPPORTS_ATTRIBUTES
+          ? {
+              ...resolveLineageAttributes(),
+              ...(opts.replayedFromRunId
+                ? { [REPLAYED_FROM_RUN_ID_ATTRIBUTE]: opts.replayedFromRunId }
+                : {}),
+            }
+          : undefined;
+      const hasLineage = lineage != null && Object.keys(lineage).length > 0;
+      const runAttributes = hasLineage
+        ? { ...lineage, ...attributes }
+        : attributes;
+
+      // Shared by the run_created event and the resilient-start queue input.
+      const attributeSeed = runAttributes
+        ? {
+            attributes: runAttributes,
+            ...(allowReservedAttributes || hasLineage
+              ? { allowReservedAttributes: true as const }
+              : {}),
+          }
+        : {};
 
       // Resolve encryption key for the new run. The runId has already been
       // generated above (client-generated ULID) and will be used for both

--- a/packages/world/src/attributes.ts
+++ b/packages/world/src/attributes.ts
@@ -15,6 +15,15 @@ export const RESERVED_ATTRIBUTE_KEY_PREFIX = '$';
 export const ROOT_RUN_ID_ATTRIBUTE = `${RESERVED_ATTRIBUTE_KEY_PREFIX}rootRunId`;
 export const PARENT_RUN_ID_ATTRIBUTE = `${RESERVED_ATTRIBUTE_KEY_PREFIX}parentRunId`;
 
+/**
+ * Reserved attribute key recording replay lineage. `start()` sets it on a run
+ * created as a replay of another run (see `recreateRunFromExisting`), mirroring
+ * the `replayedFromRunId` record on the run's `executionContext` so
+ * attribute-indexed observability stores can mark replays and link back to the
+ * source run in list queries without reading each run's `executionContext`.
+ */
+export const REPLAYED_FROM_RUN_ID_ATTRIBUTE = `${RESERVED_ATTRIBUTE_KEY_PREFIX}replayedFromRunId`;
+
 /** Max length of an attribute key, in characters. */
 export const ATTRIBUTE_KEY_MAX_LENGTH = 256;
 

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -17,6 +17,7 @@ export {
   AttributeValidationError,
   applyAttributeChanges,
   PARENT_RUN_ID_ATTRIBUTE,
+  REPLAYED_FROM_RUN_ID_ATTRIBUTE,
   RESERVED_ATTRIBUTE_KEY_PREFIX,
   ROOT_RUN_ID_ATTRIBUTE,
   validateAttributeChanges,


### PR DESCRIPTION
## Summary

`recreateRunFromExisting` records its source run only on the new run's `executionContext` (`replayedFromRunId`, #2872). Attribute-indexed observability stores never see `executionContext` — the ClickHouse `workflow_run_attributes` table behind the Vercel dashboard's runs list only carries run *attributes* — so surfacing "which runs are replays" in a list currently requires a per-run world read (see vercel/front#79769, which fans out `runs.getMany` for every listed page).

This mirrors the replay lineage into the reserved `$replayedFromRunId` attribute, riding the exact mechanism `$rootRunId`/`$parentRunId` already use:

- `@workflow/world`: export `REPLAYED_FROM_RUN_ID_ATTRIBUTE` (`$replayedFromRunId`) alongside the existing lineage attribute keys.
- `@workflow/core` `start()`: when `replayedFromRunId` is set and the spec version supports native attributes (v4+), seed the attribute on both the `run_created` event and the resilient-start queue input (with `allowReservedAttributes`, like parent lineage). Pre-v4 runs skip the attribute silently and keep the unconditional `executionContext` record, so replaying an old run never fails.
- Validation of `replayedFromRunId` now runs before the attribute seed is composed; behavior is otherwise unchanged (a plain `start()` still emits no `attributes` field at all).

Once ingested, the dashboard's runs list can serve replay lineage straight from the attributes table and drop the per-run world fan-out.

## Testing

- `packages/core`: `pnpm vitest run src/runtime/start.test.ts src/runtime/runs.test.ts` — 82 passed, including new coverage: attribute seeded on both payloads, merges with caller attributes (caller keys last), skipped on pre-v4 spec with `executionContext` intact, and no empty `attributes` object on plain starts.
- `packages/world`: full unit suite — 84 passed.
- Biome and `tsc` show no new findings (the `quickjs-runtime.ts` typecheck errors and complexity warnings exist on `main`).

Made with [Cursor](https://cursor.com)