### PR TITLE
[docs] upgrade geistdocs to 1.19.4

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "@types/react-dom": "^19.1.9",
     "@vercel/analytics": "^1.6.1",
     "@vercel/edge-config": "^1.4.0",
-    "@vercel/geistdocs": "1.19.2",
+    "@vercel/geistdocs": "1.19.4",
     "@vercel/speed-insights": "1.3.1",
     "@workflow/ai": "workspace:*",
     "@workflow/cli": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@opentelemetry/api@1.9.1)
       '@vercel/geistdocs':
-        specifier: 1.19.2
-        version: 1.19.2(ca06f1362f0431b858b9a3959a4ee660)
+        specifier: 1.19.4
+        version: 1.19.4(ca06f1362f0431b858b9a3959a4ee660)
       '@vercel/speed-insights':
         specifier: 1.3.1
         version: 1.3.1(@sveltejs/kit@2.69.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.46.4))(vite@7.3.6(@types/node@22.19.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.46.4))(typescript@6.0.3)(vite@7.3.6(@types/node@22.19.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)))(next@16.2.11(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(svelte@5.56.4(@typescript-eslint/types@8.46.4))(vue-router@4.6.3(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
@@ -9702,8 +9702,8 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
-  '@vercel/geistdocs@1.19.2':
-    resolution: {integrity: sha512-LOxbVHAVsfWIkBIo98TUNL2pRKBL/XrthAxgGm3eYP57G9xlKSTRsA43mpnZ1k80rUz1IzhLrGFffOIV6UR7oQ==}
+  '@vercel/geistdocs@1.19.4':
+    resolution: {integrity: sha512-aV6K8VAgFeqGTxjyE6EmlwX7FoSoDFBSDpvwtL252eiqecWbJqwUp6xd3Qam0YIEg2ipdNpho7BmJ1etEPffvA==}
     hasBin: true
     peerDependencies:
       next: ^16.2.11
@@ -26091,7 +26091,7 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
 
-  '@vercel/geistdocs@1.19.2(ca06f1362f0431b858b9a3959a4ee660)':
+  '@vercel/geistdocs@1.19.4(ca06f1362f0431b858b9a3959a4ee660)':
     dependencies:
       '@ai-sdk/react': 3.0.221(react@19.2.4)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
Bumps `@vercel/geistdocs` in the docs app from 1.19.2 to 1.19.4 to fix safari logo bug