### PR TITLE
feat(cli): bulk-cancel runs in a single operation

### DIFF
--- a/.changeset/bulk-cancel-cli.md
+++ b/.changeset/bulk-cancel-cli.md
@@ -1,0 +1,5 @@
+---
+'@workflow/cli': minor
+---
+
+`workflow cancel` now bulk-cancels runs matched by `--status` (pending/running) or `--workflowName` in a single operation. Prints a compact outcome summary and exits nonzero only when a run genuinely fails.

--- a/docs/content/docs/v5/configuration/cli-and-web-ui.mdx
+++ b/docs/content/docs/v5/configuration/cli-and-web-ui.mdx
@@ -2,7 +2,7 @@
 title: CLI and Web UI
 description: CLI flags and environment variables for inspecting local, Postgres, and Vercel Workflow runs.
 type: reference
-summary: Configure workflow inspect, workflow web, workflow health, and observability tooling.
+summary: Configure workflow inspect, workflow cancel, workflow web, workflow health, and observability tooling.
 related:
   - /docs/observability
   - /docs/configuration/worlds
@@ -114,6 +114,34 @@ Vercel project and auth settings can often be inferred from `.vercel/project.jso
 - Environment variable: none
 - Default: disabled
 - Enables keyboard-controlled pagination for supported list commands.
+
+## Bulk cancel
+
+`workflow cancel <run-id>` cancels one run. Given a filter instead, it bulk-cancels a batch; bulk mode requires `--status` or `--workflowName`.
+
+### `--status`
+
+- Command: `workflow cancel`
+- Default: unset
+- Restricts the batch to this status. Only `pending` and `running` are accepted — terminal runs cannot be cancelled.
+
+### `--workflowName` / `-n`
+
+- Command: `workflow cancel`
+- Default: unset
+- Restricts the batch to one workflow. Expects the generated workflow ID from `workflow inspect runs`, not the short function name.
+
+### `--limit` (cancel)
+
+- Command: `workflow cancel`
+- Default: `50`
+- Maximum runs to cancel in one batch (1–500). Only one batch is cancelled per invocation; re-run to cancel the next.
+
+### `--confirm` / `-y`
+
+- Command: `workflow cancel`
+- Default: disabled
+- Skips the interactive confirmation prompt.
 
 ## Health checks
 

--- a/packages/cli/src/commands/cancel.ts
+++ b/packages/cli/src/commands/cancel.ts
@@ -1,11 +1,14 @@
 import readline from 'node:readline';
 import { Args, Flags } from '@oclif/core';
 import { cancelRun } from '@workflow/core/runtime';
-import { parseWorkflowName } from '@workflow/utils/parse-name';
 import { WorkflowRunStatusSchema } from '@workflow/world';
 import chalk from 'chalk';
-import Table from 'easy-table';
 import { BaseCommand } from '../base.js';
+import {
+  CANCELLABLE_STATUSES,
+  performBulkCancel,
+  validateBulkCancelLimit,
+} from '../lib/bulk-cancel.js';
 import { LOGGING_CONFIG, logger } from '../lib/config/log.js';
 import {
   getObservabilityUpgradeRequiredMessage,
@@ -13,7 +16,6 @@ import {
 } from '../lib/inspect/errors.js';
 import { cliFlags } from '../lib/inspect/flags.js';
 import { setupCliWorld } from '../lib/inspect/setup.js';
-import { planWindowStartFromResponse } from '../lib/inspect/time-window.js';
 
 export default class Cancel extends BaseCommand {
   static description =
@@ -48,9 +50,12 @@ export default class Cancel extends BaseCommand {
   static flags = {
     ...cliFlags,
     status: Flags.string({
-      description: 'Filter runs by status for bulk cancel',
+      // Only cancellable statuses are offered: cancelling a terminal run
+      // (completed / failed / cancelled) is a no-op, so pinning one would list
+      // the same page on every rerun and never advance.
+      description: 'Filter runs by status for bulk cancel (pending or running)',
       required: false,
-      options: [...WorkflowRunStatusSchema.options],
+      options: [...CANCELLABLE_STATUSES],
       helpGroup: 'Bulk Cancel',
       helpLabel: '--status',
     }),
@@ -62,7 +67,7 @@ export default class Cancel extends BaseCommand {
       helpLabel: '-n, --workflowName',
     }),
     limit: Flags.integer({
-      description: 'Max runs to cancel in bulk mode',
+      description: 'Max runs to cancel in bulk mode (1-500)',
       required: false,
       default: 50,
       helpGroup: 'Bulk Cancel',
@@ -108,112 +113,30 @@ export default class Cancel extends BaseCommand {
       process.exit(1);
     }
 
-    // Fetch matching runs. Only metadata is needed to display and cancel, so
-    // prefer the analytics read path when the backend provides one.
+    const limit = flags.limit ?? 50;
+    const limitError = validateBulkCancelLimit(limit);
+    if (limitError) {
+      logger.error(limitError);
+      process.exit(1);
+    }
+
     const status = flags.status
       ? WorkflowRunStatusSchema.parse(flags.status)
       : undefined;
-    const limit = flags.limit || 50;
-    const analytics = world.analytics;
-    const fetchMatches = async () => {
-      if (!analytics) {
-        return world.runs.list({
-          status,
-          workflowName: flags.workflowName,
-          pagination: { limit },
-          resolveData: 'none',
-        });
-      }
-      // The analytics backend defaults its listing to a recent window
-      // (trailing 24h on the Vercel backend), but bulk cancel must match
-      // across the plan's whole observability window — a run can sleep or
-      // wait on a hook for days without emitting recent events. Probe for
-      // the plan window bounds first, then match across them.
-      const probe = await analytics.runs.list({
-        status,
-        workflowName: flags.workflowName,
-        pagination: { limit: 1 },
-      });
-      const windowStart = planWindowStartFromResponse(probe);
-      return analytics.runs.list({
-        status,
-        workflowName: flags.workflowName,
-        ...(windowStart
-          ? { startTime: windowStart, endTime: new Date().toISOString() }
-          : {}),
-        pagination: { limit },
-      });
-    };
-    const runList = await fetchMatches();
-    const runs = {
-      data: runList.data.map((run) => ({
-        runId: run.runId,
-        workflowName: run.workflowName,
-        status: run.status,
-        startedAt: run.startedAt,
-      })),
-      hasMore: runList.hasMore,
-    };
 
-    if (runs.data.length === 0) {
-      logger.warn('No matching runs found.');
-      return;
+    const { exitCode } = await performBulkCancel({
+      world,
+      status,
+      workflowName: flags.workflowName,
+      limit,
+      confirm: flags.confirm,
+      logger,
+      promptConfirm,
+    });
+
+    if (exitCode !== 0) {
+      process.exit(exitCode);
     }
-
-    // Display what will be cancelled
-    const table = new Table();
-    for (const run of runs.data) {
-      const shortName =
-        parseWorkflowName(run.workflowName)?.shortName || run.workflowName;
-      table.cell('runId', run.runId);
-      table.cell('workflow', chalk.blueBright(shortName));
-      table.cell('status', run.status);
-      table.cell(
-        'startedAt',
-        run.startedAt ? new Date(run.startedAt).toISOString() : '-'
-      );
-      table.newRow();
-    }
-    logger.log(`\nFound ${chalk.bold(runs.data.length)} runs to cancel:\n`);
-    logger.log(table.toString());
-
-    if (runs.hasMore) {
-      logger.warn(
-        `More runs match these filters. Increase --limit (currently ${flags.limit || 50}) or re-run to cancel additional runs.`
-      );
-    }
-
-    // Confirm unless --confirm/-y
-    if (!flags.confirm) {
-      const confirmed = await promptConfirm(
-        `Cancel ${runs.data.length} run${runs.data.length === 1 ? '' : 's'}?`
-      );
-      if (!confirmed) {
-        logger.log('Aborted.');
-        return;
-      }
-    }
-
-    // Cancel each run with progress
-    let cancelled = 0;
-    let failed = 0;
-    for (const run of runs.data) {
-      try {
-        await cancelRun(world, run.runId);
-        cancelled++;
-        logger.log(
-          chalk.green(`  ✓ ${run.runId}`) +
-            chalk.gray(` (${cancelled}/${runs.data.length})`)
-        );
-      } catch (err: any) {
-        failed++;
-        logger.warn(`  ✗ ${run.runId}: ${err.message || String(err)}`);
-      }
-    }
-
-    logger.log(
-      `\nDone: ${chalk.green(`${cancelled} cancelled`)}${failed > 0 ? `, ${chalk.red(`${failed} failed`)}` : ''}`
-    );
   }
 }
 

--- a/packages/cli/src/commands/cancel.ts
+++ b/packages/cli/src/commands/cancel.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { BaseCommand } from '../base.js';
 import {
   CANCELLABLE_STATUSES,
+  CLI_CANCEL_REASON,
   performBulkCancel,
   validateBulkCancelLimit,
 } from '../lib/bulk-cancel.js';
@@ -96,7 +97,9 @@ export default class Cancel extends BaseCommand {
 
     // Single-run cancel (existing behavior)
     if (args.runId) {
-      await cancelRun(world, args.runId);
+      await cancelRun(world, args.runId, {
+        cancelReason: CLI_CANCEL_REASON,
+      });
       logger.log(chalk.green(`Cancelled run ${args.runId}`));
       return;
     }

--- a/packages/cli/src/lib/bulk-cancel.test.ts
+++ b/packages/cli/src/lib/bulk-cancel.test.ts
@@ -1,0 +1,377 @@
+import type {
+  BulkCancelWorkflowRunsRequest,
+  BulkCancelWorkflowRunsResult,
+  World,
+} from '@workflow/world';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  bulkCancelFailureLines,
+  formatBulkCancelSummary,
+  HAS_MORE_GUIDANCE,
+  performBulkCancel,
+  validateBulkCancelLimit,
+} from './bulk-cancel.js';
+
+interface FakeRun {
+  runId: string;
+  workflowName: string;
+  status: string;
+  startedAt?: string;
+}
+
+/** Collects logger output so assertions can inspect what the user saw. */
+function makeLogger() {
+  const logs: string[] = [];
+  const warns: string[] = [];
+  const errors: string[] = [];
+  return {
+    logger: {
+      log: (m: string) => logs.push(m),
+      warn: (m: string) => warns.push(m),
+      error: (m: string) => errors.push(m),
+    },
+    logs,
+    warns,
+    errors,
+  };
+}
+
+/**
+ * Build a minimal fake world. `cancelMany` is attached only when provided,
+ * which is how {@link performBulkCancel} (via `cancelRuns`) decides between
+ * the single-request fast path and the per-run fallback.
+ */
+function makeWorld(opts: {
+  runs: FakeRun[];
+  hasMore?: boolean;
+  cancelMany?: (
+    request: BulkCancelWorkflowRunsRequest
+  ) => Promise<BulkCancelWorkflowRunsResult>;
+  eventsCreate?: (runId: string) => Promise<unknown>;
+}): World {
+  const runsById = new Map(opts.runs.map((r) => [r.runId, r]));
+  const world: any = {
+    analytics: undefined,
+    runs: {
+      // Status-aware so tests can seed mixed-status runs and assert that only
+      // the requested status is matched. performBulkCancel always passes a
+      // concrete status per call (the pinned one, or each cancellable status).
+      list: vi.fn(async (params: { status?: string } = {}) => ({
+        data: params.status
+          ? opts.runs.filter((r) => r.status === params.status)
+          : opts.runs,
+        hasMore: opts.hasMore ?? false,
+      })),
+      get: vi.fn(async (runId: string) => {
+        const run = runsById.get(runId);
+        if (!run) throw new Error(`run ${runId} not found`);
+        return run;
+      }),
+    },
+    events: {
+      create: vi.fn(async (runId: string) => opts.eventsCreate?.(runId)),
+    },
+  };
+  if (opts.cancelMany) {
+    world.runs.cancelMany = vi.fn(opts.cancelMany);
+  }
+  return world as World;
+}
+
+describe('validateBulkCancelLimit', () => {
+  it('accepts integers within [1, 500]', () => {
+    expect(validateBulkCancelLimit(1)).toBeUndefined();
+    expect(validateBulkCancelLimit(50)).toBeUndefined();
+    expect(validateBulkCancelLimit(500)).toBeUndefined();
+  });
+
+  it('rejects out-of-range and non-integer values', () => {
+    expect(validateBulkCancelLimit(0)).toMatch(/between 1 and 500/);
+    expect(validateBulkCancelLimit(501)).toMatch(/between 1 and 500/);
+    expect(validateBulkCancelLimit(-5)).toMatch(/between 1 and 500/);
+    expect(validateBulkCancelLimit(1.5)).toMatch(/between 1 and 500/);
+  });
+});
+
+describe('formatBulkCancelSummary', () => {
+  it('renders every outcome category so counts add up to requested', () => {
+    const summary = formatBulkCancelSummary({
+      summary: {
+        requested: 7,
+        cancelled: 2,
+        alreadyCancelled: 1,
+        notCancellable: 1,
+        notFound: 3,
+        failed: 0,
+      },
+      results: [],
+    });
+    expect(summary).toBe(
+      [
+        'Done:',
+        '  2 cancelled',
+        '  1 already cancelled',
+        '  1 not cancellable',
+        '  3 not found',
+        '  0 failed',
+      ].join('\n')
+    );
+  });
+});
+
+describe('bulkCancelFailureLines', () => {
+  it('surfaces only not_found, not_cancellable, and failed runs', () => {
+    const lines = bulkCancelFailureLines({
+      summary: {
+        requested: 5,
+        cancelled: 1,
+        alreadyCancelled: 1,
+        notCancellable: 1,
+        notFound: 1,
+        failed: 1,
+      },
+      results: [
+        { runId: 'a', outcome: 'cancelled' },
+        { runId: 'b', outcome: 'already_cancelled' },
+        { runId: 'c', outcome: 'not_cancellable', status: 'completed' },
+        { runId: 'd', outcome: 'not_found' },
+        {
+          runId: 'e',
+          outcome: 'failed',
+          code: 'internal_error',
+          retryable: true,
+        },
+      ],
+    });
+    expect(lines).toEqual([
+      '  ✗ c: not cancellable (completed)',
+      '  ✗ d: not found',
+      '  ✗ e: failed (internal_error, retryable)',
+    ]);
+  });
+});
+
+describe('performBulkCancel', () => {
+  it('warns and exits 0 when no runs match', async () => {
+    const { logger, warns } = makeLogger();
+    const world = makeWorld({ runs: [] });
+
+    const { exitCode, result } = await performBulkCancel({
+      world,
+      limit: 50,
+      confirm: true,
+      logger,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(result).toBeUndefined();
+    expect(warns).toContain('No matching runs found.');
+  });
+
+  it('restricts to cancellable statuses and excludes terminal runs when no status is pinned', async () => {
+    const { logger } = makeLogger();
+    const cancelMany = vi.fn(
+      async (
+        req: BulkCancelWorkflowRunsRequest
+      ): Promise<BulkCancelWorkflowRunsResult> => ({
+        summary: {
+          requested: req.runIds.length,
+          cancelled: req.runIds.length,
+          alreadyCancelled: 0,
+          notCancellable: 0,
+          notFound: 0,
+          failed: 0,
+        },
+        results: req.runIds.map((runId) => ({
+          runId,
+          outcome: 'cancelled' as const,
+        })),
+      })
+    );
+    const world = makeWorld({
+      runs: [
+        { runId: 'p1', workflowName: 'wf', status: 'pending' },
+        { runId: 'r1', workflowName: 'wf', status: 'running' },
+        // Terminal — must never be fetched or cancelled.
+        { runId: 'done', workflowName: 'wf', status: 'completed' },
+      ],
+      cancelMany,
+    });
+
+    const { exitCode } = await performBulkCancel({
+      world,
+      limit: 50,
+      confirm: true,
+      logger,
+    });
+
+    expect(exitCode).toBe(0);
+    const requestedStatuses = (world.runs.list as any).mock.calls.map(
+      (c: [{ status?: string }]) => c[0]?.status
+    );
+    expect(requestedStatuses).toContain('pending');
+    expect(requestedStatuses).toContain('running');
+    expect(requestedStatuses).not.toContain('completed');
+    // Only the cancellable runs reach cancelMany; the completed run is excluded.
+    expect(cancelMany).toHaveBeenCalledTimes(1);
+    expect([...cancelMany.mock.calls[0][0].runIds].sort()).toEqual([
+      'p1',
+      'r1',
+    ]);
+  });
+
+  it('uses the cancelMany fast path in a single call and skips per-run events', async () => {
+    const { logger } = makeLogger();
+    const cancelMany = vi.fn(
+      async (): Promise<BulkCancelWorkflowRunsResult> => ({
+        summary: {
+          requested: 2,
+          cancelled: 2,
+          alreadyCancelled: 0,
+          notCancellable: 0,
+          notFound: 0,
+          failed: 0,
+        },
+        results: [
+          { runId: 'r1', outcome: 'cancelled' },
+          { runId: 'r2', outcome: 'cancelled' },
+        ],
+      })
+    );
+    const world = makeWorld({
+      runs: [
+        { runId: 'r1', workflowName: 'wf', status: 'running' },
+        { runId: 'r2', workflowName: 'wf', status: 'running' },
+      ],
+      cancelMany,
+    });
+
+    const { exitCode } = await performBulkCancel({
+      world,
+      status: 'running',
+      limit: 50,
+      confirm: true,
+      logger,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(cancelMany).toHaveBeenCalledTimes(1);
+    expect(cancelMany).toHaveBeenCalledWith({ runIds: ['r1', 'r2'] });
+    // Fast path must not fall back to per-run event creation.
+    expect(world.events.create as any).not.toHaveBeenCalled();
+  });
+
+  it('falls back to per-run cancellation when cancelMany is absent', async () => {
+    const { logger, logs } = makeLogger();
+    const world = makeWorld({
+      runs: [
+        { runId: 'r1', workflowName: 'wf', status: 'running' },
+        { runId: 'r2', workflowName: 'wf', status: 'running' },
+      ],
+    });
+
+    const { exitCode, result } = await performBulkCancel({
+      world,
+      status: 'running',
+      limit: 50,
+      confirm: true,
+      logger,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(world.events.create as any).toHaveBeenCalledTimes(2);
+    expect(result?.summary.cancelled).toBe(2);
+    expect(logs.join('\n')).toContain('2 cancelled');
+  });
+
+  it('prints rerun guidance when more runs match than were fetched', async () => {
+    const { logger, warns } = makeLogger();
+    const world = makeWorld({
+      runs: [{ runId: 'r1', workflowName: 'wf', status: 'running' }],
+      hasMore: true,
+      cancelMany: async () => ({
+        summary: {
+          requested: 1,
+          cancelled: 1,
+          alreadyCancelled: 0,
+          notCancellable: 0,
+          notFound: 0,
+          failed: 0,
+        },
+        results: [{ runId: 'r1', outcome: 'cancelled' }],
+      }),
+    });
+
+    await performBulkCancel({
+      world,
+      status: 'running',
+      limit: 1,
+      confirm: true,
+      logger,
+    });
+
+    expect(warns).toContain(HAS_MORE_GUIDANCE);
+  });
+
+  it('exits 1 and surfaces per-run failures when a run fails', async () => {
+    const { logger, warns } = makeLogger();
+    const world = makeWorld({
+      runs: [
+        { runId: 'r1', workflowName: 'wf', status: 'running' },
+        { runId: 'r2', workflowName: 'wf', status: 'running' },
+      ],
+      cancelMany: async () => ({
+        summary: {
+          requested: 2,
+          cancelled: 1,
+          alreadyCancelled: 0,
+          notCancellable: 0,
+          notFound: 0,
+          failed: 1,
+        },
+        results: [
+          { runId: 'r1', outcome: 'cancelled' },
+          {
+            runId: 'r2',
+            outcome: 'failed',
+            code: 'internal_error',
+            retryable: true,
+          },
+        ],
+      }),
+    });
+
+    const { exitCode } = await performBulkCancel({
+      world,
+      status: 'running',
+      limit: 50,
+      confirm: true,
+      logger,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(warns).toContain('  ✗ r2: failed (internal_error, retryable)');
+  });
+
+  it('aborts without cancelling when confirmation is declined', async () => {
+    const { logger, logs } = makeLogger();
+    const cancelMany = vi.fn();
+    const world = makeWorld({
+      runs: [{ runId: 'r1', workflowName: 'wf', status: 'running' }],
+      cancelMany: cancelMany as any,
+    });
+
+    const { exitCode } = await performBulkCancel({
+      world,
+      status: 'running',
+      limit: 50,
+      confirm: false,
+      logger,
+      promptConfirm: async () => false,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(logs).toContain('Aborted.');
+    expect(cancelMany).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/lib/bulk-cancel.test.ts
+++ b/packages/cli/src/lib/bulk-cancel.test.ts
@@ -6,6 +6,7 @@ import type {
 import { describe, expect, it, vi } from 'vitest';
 import {
   bulkCancelFailureLines,
+  CLI_CANCEL_REASON,
   formatBulkCancelSummary,
   HAS_MORE_GUIDANCE,
   performBulkCancel,
@@ -220,6 +221,56 @@ describe('performBulkCancel', () => {
     ]);
   });
 
+  it('round-robins status pages before applying the batch limit', async () => {
+    const { logger } = makeLogger();
+    const cancelMany = vi.fn(
+      async (
+        req: BulkCancelWorkflowRunsRequest
+      ): Promise<BulkCancelWorkflowRunsResult> => ({
+        summary: {
+          requested: req.runIds.length,
+          cancelled: req.runIds.length,
+          alreadyCancelled: 0,
+          notCancellable: 0,
+          notFound: 0,
+          failed: 0,
+        },
+        results: req.runIds.map((runId) => ({
+          runId,
+          outcome: 'cancelled' as const,
+        })),
+      })
+    );
+    const world = makeWorld({
+      runs: [
+        ...Array.from({ length: 5 }, (_, index) => ({
+          runId: `r${index + 1}`,
+          workflowName: 'wf',
+          status: 'running',
+          startedAt: new Date(2026, 0, index + 1).toISOString(),
+        })),
+        ...Array.from({ length: 3 }, (_, index) => ({
+          runId: `p${index + 1}`,
+          workflowName: 'wf',
+          status: 'pending',
+        })),
+      ],
+      cancelMany,
+    });
+
+    await performBulkCancel({
+      world,
+      limit: 5,
+      confirm: true,
+      logger,
+    });
+
+    expect(cancelMany).toHaveBeenCalledWith({
+      runIds: ['p1', 'r1', 'p2', 'r2', 'p3'],
+      cancelReason: CLI_CANCEL_REASON,
+    });
+  });
+
   it('uses the cancelMany fast path in a single call and skips per-run events', async () => {
     const { logger } = makeLogger();
     const cancelMany = vi.fn(
@@ -256,7 +307,10 @@ describe('performBulkCancel', () => {
 
     expect(exitCode).toBe(0);
     expect(cancelMany).toHaveBeenCalledTimes(1);
-    expect(cancelMany).toHaveBeenCalledWith({ runIds: ['r1', 'r2'] });
+    expect(cancelMany).toHaveBeenCalledWith({
+      runIds: ['r1', 'r2'],
+      cancelReason: CLI_CANCEL_REASON,
+    });
     // Fast path must not fall back to per-run event creation.
     expect(world.events.create as any).not.toHaveBeenCalled();
   });
@@ -280,6 +334,13 @@ describe('performBulkCancel', () => {
 
     expect(exitCode).toBe(0);
     expect(world.events.create as any).toHaveBeenCalledTimes(2);
+    expect(world.events.create as any).toHaveBeenCalledWith(
+      'r1',
+      expect.objectContaining({
+        eventData: { cancelReason: CLI_CANCEL_REASON },
+      }),
+      expect.anything()
+    );
     expect(result?.summary.cancelled).toBe(2);
     expect(logs.join('\n')).toContain('2 cancelled');
   });

--- a/packages/cli/src/lib/bulk-cancel.ts
+++ b/packages/cli/src/lib/bulk-cancel.ts
@@ -1,0 +1,267 @@
+import { cancelRuns } from '@workflow/core/runtime';
+import { parseWorkflowName } from '@workflow/utils/parse-name';
+import type {
+  BulkCancelWorkflowRunsResult,
+  WorkflowRunStatus,
+  World,
+} from '@workflow/world';
+import chalk from 'chalk';
+import Table from 'easy-table';
+import { planWindowStartFromResponse } from './inspect/time-window.js';
+
+export const BULK_CANCEL_MIN_LIMIT = 1;
+export const BULK_CANCEL_MAX_LIMIT = 500;
+
+/**
+ * Statuses a run can still be cancelled from. When the caller doesn't pin a
+ * `--status`, bulk cancel restricts matching to these so terminal runs
+ * (including the ones a prior batch just cancelled) don't crowd out reachable
+ * active runs. Otherwise, listing every status returns the same newest
+ * terminal page on each rerun and older active runs are never reached. The
+ * list API filters by a single status, so we fan out across these and merge.
+ */
+export const CANCELLABLE_STATUSES = [
+  'pending',
+  'running',
+] as const satisfies readonly WorkflowRunStatus[];
+
+/**
+ * Guidance printed when more runs match the filters than were fetched. Bulk
+ * cancel is deliberately single-batch and user-paced — no cursors or async
+ * jobs — so the user re-runs to cancel the next batch.
+ */
+export const HAS_MORE_GUIDANCE =
+  'More runs match these filters. Re-run this command to cancel the next batch,\n' +
+  'or use --limit up to 500.';
+
+export interface CancelLogger {
+  log(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
+ * Validate the `--limit` flag. Returns an error message when invalid, or
+ * `undefined` when the value is an integer within [1, 500].
+ */
+export function validateBulkCancelLimit(limit: number): string | undefined {
+  if (
+    !Number.isInteger(limit) ||
+    limit < BULK_CANCEL_MIN_LIMIT ||
+    limit > BULK_CANCEL_MAX_LIMIT
+  ) {
+    return `--limit must be an integer between ${BULK_CANCEL_MIN_LIMIT} and ${BULK_CANCEL_MAX_LIMIT}.`;
+  }
+  return undefined;
+}
+
+/**
+ * Build the compact multi-line "Done:" summary block. Lists every outcome
+ * category so the counts add up to the number of runs requested; individual
+ * `not_found`, `not_cancellable`, and `failed` runs are additionally surfaced
+ * per-run via {@link bulkCancelFailureLines}.
+ */
+export function formatBulkCancelSummary(
+  result: BulkCancelWorkflowRunsResult
+): string {
+  const { summary } = result;
+  return [
+    'Done:',
+    `  ${summary.cancelled} cancelled`,
+    `  ${summary.alreadyCancelled} already cancelled`,
+    `  ${summary.notCancellable} not cancellable`,
+    `  ${summary.notFound} not found`,
+    `  ${summary.failed} failed`,
+  ].join('\n');
+}
+
+/**
+ * Per-run lines for outcomes worth calling out individually: `not_found`,
+ * `not_cancellable`, and `failed`. Cancelled and already-cancelled runs are
+ * left to the summary.
+ */
+export function bulkCancelFailureLines(
+  result: BulkCancelWorkflowRunsResult
+): string[] {
+  const lines: string[] = [];
+  for (const r of result.results) {
+    switch (r.outcome) {
+      case 'not_found':
+        lines.push(`  ✗ ${r.runId}: not found`);
+        break;
+      case 'not_cancellable':
+        lines.push(`  ✗ ${r.runId}: not cancellable (${r.status})`);
+        break;
+      case 'failed':
+        lines.push(
+          `  ✗ ${r.runId}: failed (${r.code}${r.retryable ? ', retryable' : ''})`
+        );
+        break;
+    }
+  }
+  return lines;
+}
+
+export interface BulkCancelParams {
+  world: World;
+  status?: WorkflowRunStatus;
+  workflowName?: string;
+  /** Max runs to fetch and cancel in this batch (already validated). */
+  limit: number;
+  /** When true, skip the interactive confirmation prompt. */
+  confirm: boolean;
+  logger: CancelLogger;
+  /**
+   * Confirmation prompt. Omitted in non-interactive contexts (and tests),
+   * in which case an unconfirmed run aborts.
+   */
+  promptConfirm?: (message: string) => Promise<boolean>;
+}
+
+export interface BulkCancelOutcome {
+  /** Process exit code: 1 when any run failed, otherwise 0. */
+  exitCode: number;
+  /** The structured result, or undefined when nothing matched / aborted. */
+  result?: BulkCancelWorkflowRunsResult;
+}
+
+/**
+ * Fetch matching runs (up to `limit`), confirm, and cancel them in a single
+ * bulk operation. Prints a table of what will be cancelled, rerun guidance
+ * when more runs match than were fetched, a compact summary, and per-run
+ * lines for surfaced failures.
+ *
+ * Does not traverse pages: exactly one page of at most `limit` runs is
+ * cancelled per invocation.
+ */
+export async function performBulkCancel(
+  params: BulkCancelParams
+): Promise<BulkCancelOutcome> {
+  const { world, status, workflowName, limit, confirm, logger, promptConfirm } =
+    params;
+
+  // Fetch matching runs. Only metadata is needed to display and cancel, so
+  // prefer the analytics read path when the backend provides one.
+  //
+  // When the caller pins a status, match exactly that. Otherwise restrict to
+  // the cancellable statuses so rerunning makes progress instead of returning
+  // the same terminal page forever. The list API takes a single status, so
+  // fan out across the target statuses and merge the pages below.
+  const analytics = world.analytics;
+  const targetStatuses: WorkflowRunStatus[] = status
+    ? [status]
+    : [...CANCELLABLE_STATUSES];
+
+  const fetchPage = async (pageStatus: WorkflowRunStatus) => {
+    if (!analytics) {
+      return world.runs.list({
+        status: pageStatus,
+        workflowName,
+        pagination: { limit },
+        resolveData: 'none',
+      });
+    }
+    // The analytics backend defaults its listing to a recent window
+    // (trailing 24h on the Vercel backend), but bulk cancel must match
+    // across the plan's whole observability window — a run can sleep or
+    // wait on a hook for days without emitting recent events. Probe for
+    // the plan window bounds first, then match across them.
+    const probe = await analytics.runs.list({
+      status: pageStatus,
+      workflowName,
+      pagination: { limit: 1 },
+    });
+    const windowStart = planWindowStartFromResponse(probe);
+    return analytics.runs.list({
+      status: pageStatus,
+      workflowName,
+      ...(windowStart
+        ? { startTime: windowStart, endTime: new Date().toISOString() }
+        : {}),
+      pagination: { limit },
+    });
+  };
+
+  const pages = await Promise.all(targetStatuses.map(fetchPage));
+
+  // Merge the per-status pages: project to display fields, dedupe by runId,
+  // and sort newest-first. Cap at `limit`; `hasMore` is true if any page
+  // reported more or the merge overflowed the cap — never claim "no more"
+  // when runs remain.
+  const projected = pages.flatMap((page) =>
+    page.data.map((run) => ({
+      runId: run.runId,
+      workflowName: run.workflowName,
+      status: run.status,
+      startedAt: run.startedAt,
+    }))
+  );
+  const byRunId = new Map<string, (typeof projected)[number]>();
+  for (const run of projected) {
+    if (!byRunId.has(run.runId)) byRunId.set(run.runId, run);
+  }
+  const merged = [...byRunId.values()].sort((a, b) => {
+    const ta = a.startedAt ? new Date(a.startedAt).getTime() : 0;
+    const tb = b.startedAt ? new Date(b.startedAt).getTime() : 0;
+    return tb - ta;
+  });
+  const runs = {
+    data: merged.slice(0, limit),
+    hasMore: pages.some((page) => page.hasMore) || merged.length > limit,
+  };
+
+  if (runs.data.length === 0) {
+    logger.warn('No matching runs found.');
+    return { exitCode: 0 };
+  }
+
+  // Display what will be cancelled.
+  const table = new Table();
+  for (const run of runs.data) {
+    const shortName =
+      parseWorkflowName(run.workflowName)?.shortName || run.workflowName;
+    table.cell('runId', run.runId);
+    table.cell('workflow', chalk.blueBright(shortName));
+    table.cell('status', run.status);
+    table.cell(
+      'startedAt',
+      run.startedAt ? new Date(run.startedAt).toISOString() : '-'
+    );
+    table.newRow();
+  }
+  logger.log(`\nFound ${chalk.bold(runs.data.length)} runs to cancel:\n`);
+  logger.log(table.toString());
+
+  if (runs.hasMore) {
+    logger.warn(HAS_MORE_GUIDANCE);
+  }
+
+  // Confirm unless --confirm/-y.
+  if (!confirm) {
+    const confirmed = promptConfirm
+      ? await promptConfirm(
+          `Cancel ${runs.data.length} run${runs.data.length === 1 ? '' : 's'}?`
+        )
+      : false;
+    if (!confirmed) {
+      logger.log('Aborted.');
+      return { exitCode: 0 };
+    }
+  }
+
+  // One bulk operation: a single backend request on Vercel, or bounded
+  // fallback concurrency on local / community worlds.
+  const result = await cancelRuns(
+    world,
+    runs.data.map((run) => run.runId)
+  );
+
+  for (const line of bulkCancelFailureLines(result)) {
+    logger.warn(line);
+  }
+  logger.log(`\n${formatBulkCancelSummary(result)}`);
+
+  // Already-cancelled and terminal runs are valid partial outcomes; only a
+  // genuine failure is a nonzero exit.
+  return { exitCode: result.summary.failed > 0 ? 1 : 0, result };
+}

--- a/packages/cli/src/lib/bulk-cancel.ts
+++ b/packages/cli/src/lib/bulk-cancel.ts
@@ -11,6 +11,7 @@ import { planWindowStartFromResponse } from './inspect/time-window.js';
 
 export const BULK_CANCEL_MIN_LIMIT = 1;
 export const BULK_CANCEL_MAX_LIMIT = 500;
+export const CLI_CANCEL_REASON = 'Cancelled via Workflow CLI';
 
 /**
  * Statuses a run can still be cancelled from. When the caller doesn't pin a
@@ -184,11 +185,11 @@ export async function performBulkCancel(
 
   const pages = await Promise.all(targetStatuses.map(fetchPage));
 
-  // Merge the per-status pages: project to display fields, dedupe by runId,
-  // and sort newest-first. Cap at `limit`; `hasMore` is true if any page
-  // reported more or the merge overflowed the cap — never claim "no more"
-  // when runs remain.
-  const projected = pages.flatMap((page) =>
+  // Merge the per-status pages round-robin so a full page of running runs
+  // cannot crowd pending runs (which do not have a startedAt timestamp) out
+  // of every batch. Preserve each page's backend order and dedupe by runId in
+  // case a run changes status while the pages are fetched.
+  const projectedPages = pages.map((page) =>
     page.data.map((run) => ({
       runId: run.runId,
       workflowName: run.workflowName,
@@ -196,15 +197,21 @@ export async function performBulkCancel(
       startedAt: run.startedAt,
     }))
   );
-  const byRunId = new Map<string, (typeof projected)[number]>();
-  for (const run of projected) {
-    if (!byRunId.has(run.runId)) byRunId.set(run.runId, run);
+  const merged: (typeof projectedPages)[number][number][] = [];
+  const seenRunIds = new Set<string>();
+  const maxPageLength = Math.max(
+    0,
+    ...projectedPages.map((page) => page.length)
+  );
+  for (let index = 0; index < maxPageLength; index++) {
+    for (const page of projectedPages) {
+      const run = page[index];
+      if (run && !seenRunIds.has(run.runId)) {
+        seenRunIds.add(run.runId);
+        merged.push(run);
+      }
+    }
   }
-  const merged = [...byRunId.values()].sort((a, b) => {
-    const ta = a.startedAt ? new Date(a.startedAt).getTime() : 0;
-    const tb = b.startedAt ? new Date(b.startedAt).getTime() : 0;
-    return tb - ta;
-  });
   const runs = {
     data: merged.slice(0, limit),
     hasMore: pages.some((page) => page.hasMore) || merged.length > limit,
@@ -253,7 +260,8 @@ export async function performBulkCancel(
   // fallback concurrency on local / community worlds.
   const result = await cancelRuns(
     world,
-    runs.data.map((run) => run.runId)
+    runs.data.map((run) => run.runId),
+    { cancelReason: CLI_CANCEL_REASON }
   );
 
   for (const line of bulkCancelFailureLines(result)) {


### PR DESCRIPTION
## What
`workflow cancel` gains a bulk mode: cancel runs matched by `--status` (pending or running) or `--workflowName` in one operation. Adds `--limit` (1–500), an interactive confirmation prompt (`-y`/`--confirm` to skip), a compact outcome summary, and a nonzero exit only when a run genuinely fails.

## Why
Operators need to cancel batches of stuck or runaway runs without scripting one CLI call per run.

## Docs
This API is v5-only; only v5 docs are updated (`configuration/cli-and-web-ui.mdx`). No v4 docs are changed.

Stacked on #3347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)