### PR TITLE
fix(builders): bundle Markdown imports in Workflow and Next

### DIFF
--- a/.changeset/bundled-markdown-prompts.md
+++ b/.changeset/bundled-markdown-prompts.md
@@ -1,0 +1,6 @@
+---
+'@workflow/builders': patch
+'@workflow/next': patch
+---
+
+Bundle static Markdown imports as text in Workflow and Next builds.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -1118,6 +1118,7 @@ export const __steps_registered = true;
       bundle: true,
       format,
       platform: 'node',
+      loader: { '.md': 'text' },
       conditions: ['node'],
       target: 'es2022',
       write: true,
@@ -1348,6 +1349,7 @@ export const __steps_registered = true;
       absWorkingDir: this.config.workingDir,
       format: 'cjs', // Runs inside the VM which expects cjs
       platform: 'neutral', // The platform is neither node nor browser
+      loader: { '.md': 'text' },
       mainFields: ['module', 'main'], // To support npm style imports
       conditions: ['workflow'], // Allow packages to export 'workflow' compliant versions
       target: 'es2022',

--- a/packages/builders/src/markdown-loader.test.ts
+++ b/packages/builders/src/markdown-loader.test.ts
@@ -1,0 +1,118 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BaseBuilder } from './base-builder.js';
+import type { StandaloneConfig } from './types.js';
+
+const realTmpdir = realpathSync(tmpdir());
+
+class TestBuilder extends BaseBuilder {
+  async build(): Promise<void> {
+    // no-op
+  }
+
+  public bundleSteps(inputFiles: string[], outfile: string) {
+    return this.createStepsBundle({ inputFiles, outfile });
+  }
+
+  public bundleWorkflows(inputFiles: string[], outfile: string) {
+    return this.createWorkflowsBundle({ inputFiles, outfile });
+  }
+}
+
+function writeFile(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents, 'utf-8');
+}
+
+function createBuilder(workingDir: string): TestBuilder {
+  const config: StandaloneConfig = {
+    buildTarget: 'standalone',
+    workingDir,
+    dirs: ['.'],
+    stepsBundlePath: join(workingDir, '.workflow', 'steps.js'),
+    workflowsBundlePath: join(workingDir, '.workflow', 'workflows.js'),
+    webhookBundlePath: join(workingDir, '.workflow', 'webhook.js'),
+  };
+  return new TestBuilder(config);
+}
+
+describe('Markdown loader', () => {
+  let testRoot: string;
+
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(realTmpdir, 'workflow-markdown-loader-'));
+    const workflowPackageDir = join(testRoot, 'node_modules', 'workflow');
+    mkdirSync(join(workflowPackageDir, 'internal'), { recursive: true });
+    writeFile(
+      join(workflowPackageDir, 'package.json'),
+      JSON.stringify({
+        name: 'workflow',
+        type: 'module',
+        exports: {
+          './internal/builtins': './internal/builtins.js',
+          './runtime': './runtime.js',
+        },
+      })
+    );
+    writeFile(
+      join(workflowPackageDir, 'internal', 'builtins.js'),
+      'export {};'
+    );
+    writeFile(
+      join(workflowPackageDir, 'runtime.js'),
+      'export const workflowEntrypoint = (handler) => handler;'
+    );
+  });
+
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('embeds a static Markdown import in both step and workflow bundles', async () => {
+    const entryFile = join(testRoot, 'src', 'entry.ts');
+    const promptFile = join(testRoot, 'src', 'instructions.md');
+    const stepsOutfile = join(testRoot, '.workflow', 'steps.js');
+    const workflowsOutfile = join(testRoot, '.workflow', 'workflows.js');
+
+    mkdirSync(dirname(stepsOutfile), { recursive: true });
+    writeFile(promptFile, '# Bundled instruction\n');
+    writeFile(
+      entryFile,
+      `import instructions from './instructions.md';
+
+console.log(instructions);
+
+export async function runStep() {
+  'use step';
+  return instructions;
+}
+
+export async function runWorkflow() {
+  'use workflow';
+  return instructions;
+}
+`
+    );
+
+    const builder = createBuilder(testRoot);
+    await builder.bundleSteps([entryFile], stepsOutfile);
+    const workflows = await builder.bundleWorkflows(
+      [entryFile],
+      workflowsOutfile
+    );
+
+    expect(readFileSync(stepsOutfile, 'utf-8')).toContain(
+      '# Bundled instruction'
+    );
+    expect(workflows.interimBundleText).toContain('# Bundled instruction');
+  });
+});

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -40,7 +40,8 @@
     "@workflow/swc-plugin": "workspace:*",
     "chokidar": "4.0.3",
     "ignore": "7.0.5",
-    "semver": "catalog:"
+    "semver": "catalog:",
+    "tinyglobby": "0.2.17"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -16,6 +16,7 @@ import type {
 } from '@workflow/builders';
 import chokidar from 'chokidar';
 import type { NextConfig as ProjectNextConfig } from 'next';
+import { glob } from 'tinyglobby';
 import { createWatchIgnorePredicate } from './watch-ignore.js';
 import {
   classifyRebuild,
@@ -162,6 +163,7 @@ export async function getNextBuilderEager(
           '.cts',
           '.cjs',
           '.mjs',
+          '.md',
         ]);
         const normalizedGeneratedDir = workflowGeneratedDir.replace(/\\/g, '/');
         const normalizedDistDir = normalizePath(this.config.distDir);
@@ -558,18 +560,31 @@ export async function getNextBuilderEager(
           scheduleFileChanges(fileChanges);
         };
 
-        const watcher = chokidar.watch(this.config.workingDir, {
-          ignoreInitial: true,
-          followSymlinks: true,
-          ignored: (pathname) => {
-            const normalizedPath = normalizePath(String(pathname));
-            const extension = extname(normalizedPath);
-            if (extension && !watchableExtensions.has(extension)) {
-              return true;
-            }
-            return hasIgnoredPathFragment(normalizedPath);
-          },
-        });
+        // Workspace prompt assets may be outside the Next app directory. Watch
+        // Markdown files individually under the transform root rather than
+        // recursively watching that whole monorepo and exhausting file handles.
+        const markdownFiles = (
+          await glob('**/*.md', {
+            cwd: this.transformProjectRoot,
+            absolute: true,
+          })
+        ).filter((file) => !hasIgnoredPathFragment(normalizePath(file)));
+
+        const watcher = chokidar.watch(
+          [this.config.workingDir, ...markdownFiles],
+          {
+            ignoreInitial: true,
+            followSymlinks: true,
+            ignored: (pathname) => {
+              const normalizedPath = normalizePath(String(pathname));
+              const extension = extname(normalizedPath);
+              if (extension && !watchableExtensions.has(extension)) {
+                return true;
+              }
+              return hasIgnoredPathFragment(normalizedPath);
+            },
+          }
+        );
 
         watcher.on('add', (pathname) => {
           void handleFileAdded(pathname);

--- a/packages/next/src/watch-rebuild.test.ts
+++ b/packages/next/src/watch-rebuild.test.ts
@@ -187,4 +187,28 @@ export const allWorkflows = {} as const;
 
     expect(decision.kind).toBe('none');
   });
+
+  test('forces a full rebuild when a bundled Markdown asset changes', async () => {
+    const markdownFile = '/workspace/packages/prompts/instructions.md';
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set(),
+          discoveredSerdeFiles: new Set(),
+        },
+        fileChanges: {
+          addedFiles: [],
+          modifiedFiles: [markdownFile],
+          removedFiles: [],
+        },
+        inputFiles: [],
+        parentHasChild: () => false,
+        readSnapshot: async () =>
+          createSourceSnapshotFromSource('', detectWorkflowPatterns),
+        sourceSnapshots: new Map(),
+      })
+    ).resolves.toEqual({ kind: 'full' });
+  });
 });

--- a/packages/next/src/watch-rebuild.ts
+++ b/packages/next/src/watch-rebuild.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
 
 export interface DiscoveredEntriesLike {
   discoveredSteps: Set<string>;
@@ -548,6 +549,19 @@ export const classifyRebuild = async ({
   readSnapshot: (file: string) => Promise<SourceSnapshot>;
   sourceSnapshots: Map<string, SourceSnapshot>;
 }): Promise<RebuildDecision> => {
+  // Markdown has no workflow definition/import signature for the snapshot
+  // classifier to compare. Its content is nevertheless embedded in a bundle,
+  // so any change must rebuild instead of being treated as unrelated source.
+  if (
+    [
+      ...fileChanges.addedFiles,
+      ...fileChanges.modifiedFiles,
+      ...fileChanges.removedFiles,
+    ].some((file) => extname(file) === '.md')
+  ) {
+    return { kind: 'full' };
+  }
+
   const prunedAddedFiles = await pruneStaleAddedFiles({
     addedFiles: fileChanges.addedFiles,
     readSnapshot,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,9 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.7.4
+      tinyglobby:
+        specifier: 0.2.17
+        version: 0.2.17
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
## Description

Fixes #3353.

Static `.md` imports now use esbuild’s text loader in both step and workflow bundles, so instructions are embedded as default-exported strings instead of requiring runtime `node:fs` access in the Workflow VM. The Next integration watches existing Markdown files under the configured transform root (including workspace packages), while preserving its ignored-path rules and avoiding a recursive monorepo watch. Markdown changes request full workflow rediscovery because source snapshots do not describe asset content.

Minimal repro:

```ts
import instructions from './instructions.md';

export async function verify() {
  'use workflow';
  return instructions;
}
```

Import attributes are intentionally not used: Next’s SWC transform removes them before the Workflow esbuild pass resolves the Markdown module.

## Testing

- `pnpm exec vitest run packages/builders/src/markdown-loader.test.ts packages/next/src/watch-rebuild.test.ts --reporter=dot`
  - Passes: static Markdown text is embedded in both step and workflow bundles; Markdown changes force a full dev rebuild.
- `pnpm run typecheck --filter @workflow/builders`
  - Passes.
- `pnpm run build --filter @workflow/next`
  - Passes.
- `pnpm --dir workbench/nextjs-turbopack build`
  - Passes: Workflow discovery/bundling and the production Turbopack build complete.
- `pnpm lint`
  - Reports pre-existing repository-wide Biome diagnostics outside this change; the changed files pass targeted Biome formatting and checks.

## Checklist

- [x] Added a changeset
- [x] Signed off the commit for DCO
- [x] Targeted `main`
- [ ] Review ping (intentionally omitted while this PR is a draft)