### PR TITLE
docs: add inbound cross-links to orphaned docs pages

### DIFF
--- a/docs/content/docs/v4/ai/index.mdx
+++ b/docs/content/docs/v4/ai/index.mdx
@@ -427,7 +427,10 @@ A complete example that includes all of the above, plus all of the "next steps" 
 ## Related Documentation
 
 - [Tools](/docs/ai/defining-tools) - Patterns for defining tools for your agent
+- [Human-in-the-Loop](/docs/ai/human-in-the-loop) - Pause agent workflows for human approval, then resume on input
+- [Sleep, Suspense, and Scheduling](/docs/ai/sleep-and-delays) - Pause agent execution for scheduling, rate limiting, and waiting on external state
 - [`WorkflowAgent`](https://ai-sdk.dev/v7/docs/agents/workflow-agent#workflowagent) - AI SDK API for durable, resumable agents
+- [`@workflow/ai`](/docs/api-reference/workflow-ai) - API reference for the AI SDK integration helpers
 - [Workflows and Steps](/docs/foundations/workflows-and-steps) - Core concepts
 - [Streaming](/docs/foundations/streaming) - In-depth streaming guide
 - [Errors and Retries](/docs/foundations/errors-and-retries) - Error handling patterns

--- a/docs/content/docs/v4/api-reference/workflow-api/get-run.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-api/get-run.mdx
@@ -45,6 +45,8 @@ export default Run;`}
 showSections={["returns"]}
 />
 
+`run.returnValue` polls until the run completes, handling [`WorkflowRunNotCompletedError`](/docs/api-reference/workflow-errors/workflow-run-not-completed-error) internally, and throws [`WorkflowRunCancelledError`](/docs/api-reference/workflow-errors/workflow-run-cancelled-error) if the run was cancelled.
+
 #### WorkflowReadableStream
 
 `run.getReadable()` returns a `WorkflowReadableStream` — a standard `ReadableStream` extended with a `getTailIndex()` helper:
@@ -85,7 +87,7 @@ export default StopSleepResult;`}
 
 ### Check if a Run Exists
 
-Use the `exists` getter to check whether a workflow run exists without throwing when the run is not found:
+Use the `exists` getter to check whether a workflow run exists without throwing a [`WorkflowRunNotFoundError`](/docs/api-reference/workflow-errors/workflow-run-not-found-error) when the run is not found:
 
 ```typescript lineNumbers
 import { getRun } from "workflow/api";

--- a/docs/content/docs/v4/api-reference/workflow-errors/index.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-errors/index.mdx
@@ -9,7 +9,7 @@ related:
 
 API reference for the error classes exported from the `workflow/errors` package.
 
-All errors extend [`WorkflowError`](/docs/api-reference/workflow-errors/workflow-error), so you can catch any SDK error with a single `instanceof` check, or narrow to a specific class for fine-grained handling.
+All errors extend [`WorkflowError`](/docs/api-reference/workflow-errors/workflow-error), so you can catch any SDK error with a single `instanceof` check, or narrow to a specific class for fine-grained handling. Failures from workflow storage backends extend [`WorkflowWorldError`](/docs/api-reference/workflow-errors/workflow-world-error).
 
 ## Base Classes
 

--- a/docs/content/docs/v4/api-reference/workflow-nitro/index.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-nitro/index.mdx
@@ -56,3 +56,5 @@ export default defineConfig({
 ## Vite-based Nitro
 
 If you use Nitro through its Vite plugin (`nitro/vite`) instead of a standalone `nitro.config.ts`, use the [`workflow/vite`](/docs/api-reference/workflow-vite) entry point, which wraps this module as a Vite plugin and accepts the same `ModuleOptions`.
+
+Nuxt apps use the [`workflow/nuxt`](/docs/api-reference/workflow-nuxt) module instead, which registers this module on Nuxt's Nitro server.

--- a/docs/content/docs/v4/api-reference/workflow-observability/observability-revivers.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-observability/observability-revivers.mdx
@@ -10,7 +10,7 @@ related:
 
 A set of reviver functions that handle the workflow serialization format's workflow-specific types — streams, step/workflow function references, class instances, `AbortController`/`AbortSignal`, and `DOMException` — reviving them as display-friendly marker objects or strings. Built-in JavaScript types (`Date`, `Map`, `Set`, `RegExp`, etc.) are handled by the devalue format itself and need no revivers.
 
-Pass it as the `revivers` argument to [`hydrateResourceIO()`](/docs/api-reference/workflow-observability/hydrate-resource-io) or [`hydrateData()`](/docs/api-reference/workflow-observability/hydrate-data).
+Pass it as the `revivers` argument to [`hydrateResourceIO()`](/docs/api-reference/workflow-observability/hydrate-resource-io) or [`hydrateData()`](/docs/api-reference/workflow-observability/hydrate-data). Use [`parseClassName()`](/docs/api-reference/workflow-observability/parse-class-name) to turn the machine-readable class IDs on revived class-instance markers into display-friendly names.
 
 ```typescript lineNumbers
 import { hydrateResourceIO, observabilityRevivers } from "workflow/observability"; // [!code highlight]

--- a/docs/content/docs/v4/api-reference/workflow-runtime/workflow-entrypoint.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-runtime/workflow-entrypoint.mdx
@@ -9,7 +9,7 @@ related:
   - /docs/api-reference/workflow-runtime/health-check
 ---
 
-Creates the HTTP route handler that executes workflow runs. The handler receives queue messages, replays the workflow from its event log, executes steps inline where possible, and suspends when the workflow waits on sleeps or hooks.
+Creates the HTTP route handler that executes workflow runs. The handler receives [queue messages](/docs/api-reference/workflow-runtime/world/queue), replays the workflow from its event log, executes steps inline where possible, and suspends when the workflow waits on sleeps or hooks.
 
 Framework adapters (Next.js, Nitro, SvelteKit, etc.) call this for you and mount the result at `/.well-known/workflow/v1/flow` — you only need it when wiring workflow support into a custom server environment.
 
@@ -39,4 +39,5 @@ Returns a fetch-style request handler: `(req: Request) => Promise<Response>`.
 ## Related Functions
 
 - [`getWorldHandlers()`](/docs/api-reference/workflow-runtime/get-world-handlers) - The build-time World access this handler is built on.
+- [`stepEntrypoint`](/docs/api-reference/workflow-runtime/step-entrypoint) - The equivalent route handler for executing step functions.
 - [`healthCheck()`](/docs/api-reference/workflow-runtime/health-check) - Verify the entrypoint processes queue messages end-to-end.

--- a/docs/content/docs/v4/api-reference/workflow-runtime/world/storage.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-runtime/world/storage.mdx
@@ -233,7 +233,7 @@ const result = await world.steps.list({ // [!code highlight]
 </Callout>
 
 <Callout type="warn">
-  `stepName` is a machine-readable identifier like `step//./src/workflows/order//processPayment`. Use `parseStepName()` from `workflow/observability` to extract the `shortName` for UI display.
+  `stepName` is a machine-readable identifier like `step//./src/workflows/order//processPayment`. Use [`parseStepName()`](/docs/api-reference/workflow-observability/parse-step-name) from `workflow/observability` to extract the `shortName` for UI display.
 </Callout>
 
 ---

--- a/docs/content/docs/v4/api-reference/workflow-vite/index.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-vite/index.mdx
@@ -7,7 +7,7 @@ related:
   - /docs/getting-started/vite
 ---
 
-Vite integration for Workflow SDK. It wraps the [`workflow/nitro`](/docs/api-reference/workflow-nitro) module as a Vite plugin, for apps using Nitro's Vite plugin (`nitro/vite`).
+Vite integration for Workflow SDK. It wraps the [`workflow/nitro`](/docs/api-reference/workflow-nitro) module as a Vite plugin, for apps using Nitro's Vite plugin (`nitro/vite`). The package exports a single [`workflow()`](/docs/api-reference/workflow-vite/workflow) plugin function.
 
 ## Functions
 

--- a/docs/content/docs/v4/api-reference/workflow/create-webhook.mdx
+++ b/docs/content/docs/v4/api-reference/workflow/create-webhook.mdx
@@ -58,7 +58,7 @@ The returned `Webhook` object has:
 - `getConflict()`: A promise that resolves with `{ runId }` identifying the conflicting run if another active hook already owns this token, or `null` once the webhook endpoint has been registered
 - Implements `AsyncIterable<T>` for handling multiple requests, where `T` is `Request` (default) or `RequestWithResponse` (manual mode)
 
-When using `createWebhook({ respondWith: 'manual' })`, the resolved request type is `RequestWithResponse`, which extends the standard `Request` interface with a `respondWith(response: Response): Promise<void>` method for sending custom responses back to the caller.
+When using `createWebhook({ respondWith: 'manual' })`, the resolved request type is `RequestWithResponse`, which extends the standard `Request` interface with a `respondWith(response: Response): Promise<void>` method for sending custom responses back to the caller. Passing any other `respondWith` value fails with the [webhook-invalid-respond-with-value](/docs/errors/webhook-invalid-respond-with-value) error.
 
 <Callout type="info">
 Use the simplest option that satisfies the prompt:
@@ -105,7 +105,7 @@ export async function basicWebhookWorkflow() {
 
 Use this section only when the caller requires a non-default HTTP response. If `202 Accepted` is acceptable, use `createWebhook()` without `respondWith: "manual"`.
 
-Pass `{ respondWith: "manual" }` to get a `RequestWithResponse` object with a `respondWith()` method. Note that `respondWith()` must be called from within a step function:
+Pass `{ respondWith: "manual" }` to get a `RequestWithResponse` object with a `respondWith()` method. If a code path finishes without sending a response, the webhook fails with the [webhook-response-not-sent](/docs/errors/webhook-response-not-sent) error. Note that `respondWith()` must be called from within a step function:
 
 ```typescript lineNumbers
 import { createWebhook, type RequestWithResponse } from "workflow"

--- a/docs/content/docs/v4/api-reference/workflow/get-step-metadata.mdx
+++ b/docs/content/docs/v4/api-reference/workflow/get-step-metadata.mdx
@@ -15,6 +15,8 @@ You may want to use this function when you need to:
 - Access timing information of a step and execution metadata
 - Generate idempotency keys for external APIs
 
+For metadata about the current workflow run, use [`getWorkflowMetadata()`](/docs/api-reference/workflow/get-workflow-metadata) instead.
+
 <Callout type="warn">
   This function can only be called inside a step function.
 </Callout>

--- a/docs/content/docs/v4/changelog/index.mdx
+++ b/docs/content/docs/v4/changelog/index.mdx
@@ -12,4 +12,5 @@ Stay up to date with the latest changes to Workflow SDK.
 
 ## 2026
 
+- [Resilient run start](/docs/changelog/resilient-start) — April 2026
 - Serializable AbortController and AbortSignal — March 12, 2026

--- a/docs/content/docs/v4/errors/hook-conflict.mdx
+++ b/docs/content/docs/v4/errors/hook-conflict.mdx
@@ -79,7 +79,7 @@ export async function processPayment() {
 
 ## Handling Hook Conflicts
 
-When a hook conflict occurs, awaiting the hook will throw a `HookConflictError`. The error exposes the token that conflicted and, for current worlds, the run ID that currently owns it. `conflictingRunId` remains optional for compatibility with older persisted events and world implementations, so guard it before delegating:
+When a hook conflict occurs, awaiting the hook will throw a [`HookConflictError`](/docs/api-reference/workflow-errors/hook-conflict-error). The error exposes the token that conflicted and, for current worlds, the run ID that currently owns it. `conflictingRunId` remains optional for compatibility with older persisted events and world implementations, so guard it before delegating:
 
 ```typescript lineNumbers
 import { createHook } from "workflow";

--- a/docs/content/docs/v4/errors/step-not-registered.mdx
+++ b/docs/content/docs/v4/errors/step-not-registered.mdx
@@ -10,7 +10,7 @@ related:
   - /docs/api-reference/workflow-errors/step-not-registered-error
 ---
 
-This error occurs when the Workflow runtime tries to execute a step function that is not registered in the current deployment. When this happens, the step fails (like a `FatalError`) and control is passed back to the workflow function, which can optionally handle the failure.
+This error occurs when the Workflow runtime tries to execute a step function that is not registered in the current deployment. When this happens, the step fails (like a `FatalError`) and control is passed back to the workflow function, which can optionally handle the failure. The runtime surfaces this as a [`StepNotRegisteredError`](/docs/api-reference/workflow-errors/step-not-registered-error).
 
 ## Error Message
 

--- a/docs/content/docs/v4/errors/workflow-not-registered.mdx
+++ b/docs/content/docs/v4/errors/workflow-not-registered.mdx
@@ -10,7 +10,7 @@ related:
   - /docs/api-reference/workflow-errors/workflow-not-registered-error
 ---
 
-This error occurs when the Workflow runtime tries to execute a workflow function that is not registered in the current deployment. When this happens, the run fails with a `RUNTIME_ERROR` error code.
+This error occurs when the Workflow runtime tries to execute a workflow function that is not registered in the current deployment. When this happens, the run fails with a `RUNTIME_ERROR` error code. The underlying error class is [`WorkflowNotRegisteredError`](/docs/api-reference/workflow-errors/workflow-not-registered-error).
 
 ## Error Message
 

--- a/docs/content/docs/v4/foundations/idempotency.mdx
+++ b/docs/content/docs/v4/foundations/idempotency.mdx
@@ -53,6 +53,8 @@ Why this works:
 - **Stable across retries**: `stepId` does not change between attempts.
 - **Globally unique per step**: Fulfills the uniqueness requirement for an idempotency key.
 
+A step can also run more than once when its function invocation crashes before reporting a result — see [Step executed multiple times](/docs/errors/step-executed-multiple-times) for how to diagnose duplicate step executions.
+
 ## Run idempotency
 
 Step idempotency protects side effects **inside** a workflow run. Run idempotency answers a different question: if the same API request is sent twice, should it create one workflow run or two?

--- a/docs/content/docs/v4/foundations/serialization.mdx
+++ b/docs/content/docs/v4/foundations/serialization.mdx
@@ -9,7 +9,7 @@ related:
   - /docs/errors/serialization-failed
 ---
 
-All function arguments and return values passed between workflow and step functions must be serializable. Workflow SDK uses a custom serialization system built on top of [devalue](https://github.com/sveltejs/devalue). This system supports standard JSON types, as well as a few additional popular Web API types.
+All function arguments and return values passed between workflow and step functions must be serializable. Workflow SDK uses a custom serialization system built on top of [devalue](https://github.com/sveltejs/devalue). This system supports standard JSON types, as well as a few additional popular Web API types. Non-serializable values surface as a [`WorkflowRuntimeError`](/docs/api-reference/workflow-errors/workflow-runtime-error) — see the [serialization-failed](/docs/errors/serialization-failed) error guide for common causes and fixes.
 
 <Callout type="info">
 The serialization system ensures that all data persists correctly across workflow suspensions and resumptions, enabling durable execution.
@@ -223,9 +223,9 @@ async function doublePoint(point: Point) {
 
 ### How It Works
 
-1. **`WORKFLOW_SERIALIZE`**: A static method that receives a class instance and returns serializable data (primitives, plain objects, arrays, etc.)
+1. **[`WORKFLOW_SERIALIZE`](/docs/api-reference/workflow-serde/workflow-serialize)**: A static method that receives a class instance and returns serializable data (primitives, plain objects, arrays, etc.)
 
-2. **`WORKFLOW_DESERIALIZE`**: A static method that receives the serialized data and returns a new class instance
+2. **[`WORKFLOW_DESERIALIZE`](/docs/api-reference/workflow-serde/workflow-deserialize)**: A static method that receives the serialized data and returns a new class instance
 
 3. **Automatic Registration**: The SWC compiler plugin automatically detects classes that implement these symbols and registers them for serialization. Each class receives a deterministic `classId` derived from its file path and class name, and is registered into the global `Symbol.for("workflow-class-registry")` registry at build time — no manual registration step is required
 

--- a/docs/content/docs/v4/foundations/versioning.mdx
+++ b/docs/content/docs/v4/foundations/versioning.mdx
@@ -118,6 +118,8 @@ export async function POST(request: Request) {
 `deploymentId: "latest"` is currently a Vercel-specific feature. Other Worlds may implement this option differently to match their own deployment runtimes, and the World spec may rename it from `deploymentId` to `version` in a future SDK version. On Vercel, `"latest"` resolves to the most recent deployment matching your current environment. Because the caller and target deployment can be different, keep the [workflow function name and file path](/docs/errors/workflow-not-registered), arguments, and return value backward-compatible across the deployments you plan to bridge.
 </Callout>
 
+SDK versions can also differ across deployments. Reading a run whose data was written by a newer version of the `workflow` package throws [`RunNotSupportedError`](/docs/api-reference/workflow-errors/run-not-supported-error) — upgrade the package to process those runs.
+
 ## Self upgrading workflows
 
 Some workflows are expected to run for a very long time. Scheduled loops, recurring jobs, agents, and chat sessions often should not stay on one deployment forever.

--- a/docs/content/docs/v4/foundations/workflows-and-steps.mdx
+++ b/docs/content/docs/v4/foundations/workflows-and-steps.mdx
@@ -130,6 +130,8 @@ There are multiple ways a workflow can suspend:
 - Using `sleep()` to pause for some fixed duration.
 - Awaiting on a promise returned by [`createWebhook()`](/docs/api-reference/workflow/create-webhook), which resumes the workflow when an external system passes data into the workflow.
 
+These suspension primitives, along with the rest of the core API, are documented in the [`workflow` package reference](/docs/api-reference/workflow).
+
 ```typescript lineNumbers
 import { sleep, createWebhook } from "workflow";
 

--- a/docs/content/docs/v4/getting-started/astro.mdx
+++ b/docs/content/docs/v4/getting-started/astro.mdx
@@ -55,7 +55,7 @@ export default defineConfig({
 });
 ```
 
-`workflow()` accepts an options object:
+[`workflow()`](/docs/api-reference/workflow-astro/workflow) accepts an options object:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -266,4 +266,5 @@ See [start-invalid-workflow-function](/docs/errors/start-invalid-workflow-functi
 
 * Learn more about the [Foundations](/docs/foundations).
 * Check [Errors](/docs/errors) if you encounter issues.
+* See the [`workflow/astro` reference](/docs/api-reference/workflow-astro) for integration options.
 * Explore the [API Reference](/docs/api-reference).

--- a/docs/content/docs/v4/getting-started/index.mdx
+++ b/docs/content/docs/v4/getting-started/index.mdx
@@ -10,6 +10,8 @@ related:
 
 import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStack, Vite, Express, Nest, Fastify, Python } from "@/app/[lang]/(home)/components/frameworks";
 
+Guides are available for [Next.js](/docs/getting-started/next), [Vite](/docs/getting-started/vite), [Astro](/docs/getting-started/astro), [Express](/docs/getting-started/express), [Fastify](/docs/getting-started/fastify), [Hono](/docs/getting-started/hono), [Nitro](/docs/getting-started/nitro), [Nuxt](/docs/getting-started/nuxt), [SvelteKit](/docs/getting-started/sveltekit), [TanStack Start](/docs/getting-started/tanstack-start), and [Python](/docs/getting-started/python).
+
 <Cards>
     <Card href="/docs/getting-started/next">
       <div  className="flex flex-col items-center justify-center gap-2"> <Next className="size-16" /> <span className="font-medium">Next.js</span> </div>
@@ -84,3 +86,5 @@ import { Next, Nitro, SvelteKit, Nuxt, Hono, Bun, AstroDark, AstroLight, TanStac
       </div>
     </Card>
 </Cards>
+
+To see how Workflow SDK compares to Temporal, Inngest, and other durable execution tools, see [Comparisons](/docs/comparisons).

--- a/docs/content/docs/v4/getting-started/nestjs.mdx
+++ b/docs/content/docs/v4/getting-started/nestjs.mdx
@@ -47,7 +47,7 @@ npm i workflow @workflow/nest
 
 ### Choose Your Module Format
 
-NestJS projects using `@workflow/nest` can compile as either ESM or CommonJS. Choose the setup that matches your SWC output instead of assuming ESM is required.
+NestJS projects using [`@workflow/nest`](/docs/api-reference/workflow-nest) can compile as either ESM or CommonJS. Choose the setup that matches your SWC output instead of assuming ESM is required.
 
 #### ESM (default)
 

--- a/docs/content/docs/v4/getting-started/next.mdx
+++ b/docs/content/docs/v4/getting-started/next.mdx
@@ -330,4 +330,5 @@ See [start-invalid-workflow-function](/docs/errors/start-invalid-workflow-functi
 
 * Learn more about the [Foundations](/docs/foundations).
 * Check [Errors](/docs/errors) if you encounter issues.
+* See the [`workflow/next` reference](/docs/api-reference/workflow-next) for integration options.
 * Explore the [API Reference](/docs/api-reference).

--- a/docs/content/docs/v4/getting-started/sveltekit.mdx
+++ b/docs/content/docs/v4/getting-started/sveltekit.mdx
@@ -50,7 +50,7 @@ export default defineConfig({
 });
 ```
 
-`workflowPlugin()` accepts an options object:
+[`workflowPlugin()`](/docs/api-reference/workflow-sveltekit/workflow-plugin) accepts an options object:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -259,4 +259,5 @@ See [start-invalid-workflow-function](/docs/errors/start-invalid-workflow-functi
 
 * Learn more about the [Foundations](/docs/foundations).
 * Check [Errors](/docs/errors) if you encounter issues.
+* See the [`workflow/sveltekit` reference](/docs/api-reference/workflow-sveltekit) for plugin options.
 * Explore the [API Reference](/docs/api-reference).

--- a/docs/content/docs/v4/how-it-works/encryption.mdx
+++ b/docs/content/docs/v4/how-it-works/encryption.mdx
@@ -48,6 +48,8 @@ Data is encrypted using **AES-256-GCM** via the [Web Crypto API](https://develop
 - The GCM authentication tag provides integrity verification — any tampering with the ciphertext is detected
 - The same plaintext produces different ciphertext each time due to the random nonce
 
+If the ciphertext, nonce, or auth tag fails verification, the run fails with a [runtime-decryption-failed](/docs/errors/runtime-decryption-failed) error.
+
 ## Decrypting Data
 
 When viewing workflow runs through the observability tools, encrypted fields display as locked placeholders until you explicitly choose to decrypt them.

--- a/docs/content/docs/v4/how-it-works/event-sourcing.mdx
+++ b/docs/content/docs/v4/how-it-works/event-sourcing.mdx
@@ -28,6 +28,8 @@ Event sourcing is a persistence pattern where state changes are stored as a sequ
 - **Consistency**: Events provide a single source of truth for all entity state
 - **Recoverability**: State can be reconstructed from the event log after failures
 
+When a replay can't consume the recorded events, the runtime recovers automatically where possible (see [replay-divergence](/docs/errors/replay-divergence)), and fails the run with a [corrupted-event-log](/docs/errors/corrupted-event-log) error when it can't.
+
 In the Workflow SDK, the following entity types are managed through events:
 
 - **Runs**: Workflow execution instances (materialized in storage)


### PR DESCRIPTION
These docs pages had no inbound links from other pages, so they're only reachable via the sidebar. Adds minimal cross-links from their parent or related pages.

Skipped intentionally:
- `/docs/internal` — preview-only page, not visible in production
- The api-reference orphans are hand-written MDX (not generated), so they were cross-linked directly from related pages.