### PR TITLE
Prototype WebSocket stream transport

### DIFF
--- a/.changeset/quiet-streams-wave.md
+++ b/.changeset/quiet-streams-wave.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': minor
+---
+
+Add an opt-in WebSocket transport for stream writes.

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -303,3 +303,10 @@ When enabled (the default), a suspension's eager `step_created` and `wait_create
 - Default: `ws`
 - Ships workflow run events to the Vercel World over a WebSocket instead of one HTTP request each. Set to exactly `http` to opt out; any other value, including unset or empty, uses the WebSocket.
 - Ignored when the World is configured with `projectConfig` and routes through the `api-workflow` proxy: that endpoint is an HTTP-only REST gateway and does not forward a WebSocket upgrade, so events stay on HTTP.
+
+### `WORKFLOW_STREAMS_TRANSPORT`
+
+- Factory option: none
+- CLI flag: none
+- Default: `http`
+- Experimental. Set to `ws` to write and close streams over a stream-scoped WebSocket instead of HTTP. Reads remain on HTTP.

--- a/docs/content/worlds/v5/vercel.mdx
+++ b/docs/content/worlds/v5/vercel.mdx
@@ -207,6 +207,9 @@ Workflow run events ship to the Vercel World over a WebSocket instead of one HTT
 Set `WORKFLOW_EVENTS_TRANSPORT=http` to opt out. Only that exact value disables the WebSocket — any other value, including unset or empty, takes it — so a typo fails toward the default rather than silently pinning a deployment to HTTP.
 
 The setting is ignored when the World is configured with `projectConfig` and therefore routes through the `api-workflow` proxy: that endpoint is an HTTP-only REST gateway and does not forward a WebSocket upgrade, so events stay on HTTP and a warning is logged once per process.
+### `WORKFLOW_STREAMS_TRANSPORT`
+
+Experimental. Set `WORKFLOW_STREAMS_TRANSPORT=ws` to write and close streams over a stream-scoped WebSocket instead of HTTP. Reads remain on HTTP. Default: `http`.
 
 Tracing is unaffected by the choice. Each event write emits an `http POST` client span against the same `url.full`, regardless of which transport carries it. On the WebSocket path, the span is synthesized around the frame because no HTTP request is made. Attributes distinguish the transports:
 

--- a/packages/world-vercel/src/__fixtures__/ws-stream-frames.json
+++ b/packages/world-vercel/src/__fixtures__/ws-stream-frames.json
@@ -1,0 +1,49 @@
+{
+  "format": "u32_be(meta_len) || cbor_meta || u32_be(body_len) || body_bytes",
+  "frames": [
+    {
+      "protocol": "events",
+      "direction": "client_to_server",
+      "meta": {
+        "reqId": 1,
+        "type": "event",
+        "event": { "eventType": "run_started", "specVersion": 4 }
+      },
+      "bodyHex": "0102",
+      "frameHex": "00000041b90003657265714964016474797065656576656e74656576656e74b90002696576656e74547970656b72756e5f737461727465646b7370656356657273696f6e04000000020102"
+    },
+    {
+      "protocol": "stream-write",
+      "direction": "client_to_server",
+      "meta": { "reqId": 2, "type": "stream_write", "count": 2 },
+      "bodyHex": "6869",
+      "frameHex": "00000023b900036572657149640264747970656c73747265616d5f777269746565636f756e7402000000026869"
+    },
+    {
+      "protocol": "stream-write",
+      "direction": "client_to_server",
+      "meta": { "reqId": 3, "type": "stream_close" },
+      "bodyHex": "",
+      "frameHex": "0000001cb900026572657149640364747970656c73747265616d5f636c6f736500000000"
+    },
+    {
+      "protocol": "stream-write",
+      "direction": "server_to_client",
+      "meta": {
+        "reqId": 2,
+        "type": "stream_ack",
+        "status": 200,
+        "nextIndex": 8
+      },
+      "bodyHex": "",
+      "frameHex": "0000002eb900046572657149640264747970656a73747265616d5f61636b6673746174757318c8696e657874496e6465780800000000"
+    },
+    {
+      "protocol": "stream-write",
+      "direction": "server_to_client",
+      "meta": { "reqId": 9, "type": "error", "status": 400 },
+      "bodyHex": "7b226d657373616765223a22626164227d",
+      "frameHex": "0000001fb90003657265714964096474797065656572726f7266737461747573190190000000117b226d657373616765223a22626164227d"
+    }
+  ]
+}

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -27,6 +27,7 @@ import {
   type HttpConfig,
   makeRequest,
 } from './utils.js';
+import { isWsStreamsTransportEnabled } from './ws-transport-enabled.js';
 
 /**
  * Maximum number of chunks per request, matching the server-side
@@ -39,7 +40,7 @@ export const MAX_CHUNKS_PER_REQUEST = 1000;
  * `WORKFLOW_MAX_CHUNKS_PER_REQUEST`. Lower it (paired with the server's
  * `MAX_CHUNKS_PER_BATCH` override) to exercise the batch-splitting path.
  */
-const getMaxChunksPerRequest = (): number =>
+export const getMaxChunksPerRequest = (): number =>
   envNumber('WORKFLOW_MAX_CHUNKS_PER_REQUEST', MAX_CHUNKS_PER_REQUEST, {
     integer: true,
     min: 1,
@@ -201,6 +202,89 @@ const StreamChunksResponseSchema = z.object({
   done: z.boolean(),
 });
 
+async function writeStreamOverHttp(
+  runId: string,
+  name: string,
+  chunk: string | Uint8Array,
+  config?: APIConfig
+): Promise<void> {
+  const httpConfig = await getHttpConfig(config);
+  const url = getStreamUrl(name, runId, httpConfig);
+  const response = await instrumentedFetch({
+    method: 'PUT',
+    url: url.toString(),
+    body: chunk,
+    headers: httpConfig.headers,
+    dispatcher: getStreamDispatcher(config),
+    timeoutMs: null,
+    logLabel: url.pathname,
+    spanName: 'workflow.stream.write',
+    durationAttribute: 'workflow.stream.write.chunk_rtt',
+    attributes: streamSpanAttributes({ runId, name, operation: 'write' }),
+    buildError: async (res) =>
+      createStreamRequestError('write', url, res, await res.text()),
+  });
+  await response.text();
+}
+
+async function writeMultiStreamOverHttp(
+  runId: string,
+  name: string,
+  chunks: (string | Uint8Array)[],
+  config?: APIConfig
+): Promise<void> {
+  const httpConfig = await getHttpConfig(config);
+  httpConfig.headers.set('X-Stream-Multi', 'true');
+  const maxChunksPerRequest = getMaxChunksPerRequest();
+  for (let i = 0; i < chunks.length; i += maxChunksPerRequest) {
+    const batch = chunks.slice(i, i + maxChunksPerRequest);
+    const url = getStreamUrl(name, runId, httpConfig);
+    const response = await instrumentedFetch({
+      method: 'PUT',
+      url: url.toString(),
+      body: encodeMultiChunks(batch),
+      headers: httpConfig.headers,
+      dispatcher: getStreamDispatcher(config),
+      timeoutMs: null,
+      logLabel: url.pathname,
+      spanName: 'workflow.stream.write',
+      durationAttribute: 'workflow.stream.write.chunk_rtt',
+      attributes: streamSpanAttributes({
+        runId,
+        name,
+        operation: 'write_multi',
+      }),
+      buildError: async (res) =>
+        createStreamRequestError('write', url, res, await res.text()),
+    });
+    await response.text();
+  }
+}
+
+async function closeStreamOverHttp(
+  runId: string,
+  name: string,
+  config?: APIConfig
+): Promise<void> {
+  const httpConfig = await getHttpConfig(config);
+  httpConfig.headers.set('X-Stream-Done', 'true');
+  const url = getStreamUrl(name, runId, httpConfig);
+  const response = await instrumentedFetch({
+    method: 'PUT',
+    url: url.toString(),
+    headers: httpConfig.headers,
+    dispatcher: getStreamCloseDispatcher(config),
+    timeoutMs: null,
+    logLabel: url.pathname,
+    spanName: 'workflow.stream.write',
+    durationAttribute: 'workflow.stream.write.chunk_rtt',
+    attributes: streamSpanAttributes({ runId, name, operation: 'close' }),
+    buildError: async (res) =>
+      createStreamRequestError('close', url, res, await res.text()),
+  });
+  await response.text();
+}
+
 /** Creates the HTTP-backed streamer that talks to workflow-server. */
 export function createStreamer(config?: APIConfig): Streamer {
   return {
@@ -213,28 +297,14 @@ export function createStreamer(config?: APIConfig): Streamer {
         // Await runId if it's a promise to ensure proper flushing
         const resolvedRunId = await runId;
 
-        const httpConfig = await getHttpConfig(config);
-        const url = getStreamUrl(name, resolvedRunId, httpConfig);
-        const response = await instrumentedFetch({
-          method: 'PUT',
-          url: url.toString(),
-          body: chunk,
-          headers: httpConfig.headers,
-          dispatcher: getStreamDispatcher(config),
-          timeoutMs: null,
-          logLabel: url.pathname,
-          spanName: 'workflow.stream.write',
-          durationAttribute: 'workflow.stream.write.chunk_rtt',
-          attributes: streamSpanAttributes({
-            runId: resolvedRunId,
-            name,
-            operation: 'write',
-          }),
-          buildError: async (res) =>
-            createStreamRequestError('write', url, res, await res.text()),
-        });
-        // Drain the (empty) response so undici can release the pooled connection.
-        await response.text();
+        if (isWsStreamsTransportEnabled()) {
+          const { writeStreamOverWs } = await import('./ws-streamer.js');
+          return writeStreamOverWs(resolvedRunId, name, chunk, config, () =>
+            writeStreamOverHttp(resolvedRunId, name, chunk, config)
+          );
+        }
+
+        return writeStreamOverHttp(resolvedRunId, name, chunk, config);
       },
 
       async writeMulti(
@@ -247,77 +317,32 @@ export function createStreamer(config?: APIConfig): Streamer {
         // Await runId if it's a promise to ensure proper flushing
         const resolvedRunId = await runId;
 
-        const httpConfig = await getHttpConfig(config);
-
-        // Signal to server that this is a multi-chunk batch
-        httpConfig.headers.set('X-Stream-Multi', 'true');
-
-        // Send in pages of MAX_CHUNKS_PER_REQUEST to stay within the
-        // server's per-batch limit (MAX_CHUNKS_PER_BATCH).
-        // Note: for batches spanning multiple pages, atomicity is relaxed.
-        // earlier pages may persist while a later page fails. The caller
-        // retains the full buffer on error, so chunks from successful pages
-        // will be re-sent on retry, producing duplicates. This is acceptable
-        // because the alternative (400 on all >1000 chunk flushes) is worse,
-        // and the scenario requires a network failure mid-batch.
-        const maxChunksPerRequest = getMaxChunksPerRequest();
-        for (let i = 0; i < chunks.length; i += maxChunksPerRequest) {
-          const batch = chunks.slice(i, i + maxChunksPerRequest);
-          const body = encodeMultiChunks(batch);
-          const url = getStreamUrl(name, resolvedRunId, httpConfig);
-          const response = await instrumentedFetch({
-            method: 'PUT',
-            url: url.toString(),
-            body,
-            headers: httpConfig.headers,
-            dispatcher: getStreamDispatcher(config),
-            timeoutMs: null,
-            logLabel: url.pathname,
-            spanName: 'workflow.stream.write',
-            durationAttribute: 'workflow.stream.write.chunk_rtt',
-            attributes: streamSpanAttributes({
-              runId: resolvedRunId,
-              name,
-              operation: 'write_multi',
-            }),
-            buildError: async (res) =>
-              createStreamRequestError('write', url, res, await res.text()),
-          });
-          // Drain so undici can release the pooled connection between pages.
-          await response.text();
+        if (isWsStreamsTransportEnabled()) {
+          const { writeMultiStreamOverWs } = await import('./ws-streamer.js');
+          return writeMultiStreamOverWs(
+            resolvedRunId,
+            name,
+            chunks,
+            config,
+            () => writeMultiStreamOverHttp(resolvedRunId, name, chunks, config)
+          );
         }
+
+        return writeMultiStreamOverHttp(resolvedRunId, name, chunks, config);
       },
 
       async close(runId: string | Promise<string>, name: string) {
         // Await runId if it's a promise to ensure proper flushing
         const resolvedRunId = await runId;
 
-        const httpConfig = await getHttpConfig(config);
-        httpConfig.headers.set('X-Stream-Done', 'true');
-        const url = getStreamUrl(name, resolvedRunId, httpConfig);
-        const response = await instrumentedFetch({
-          method: 'PUT',
-          url: url.toString(),
-          headers: httpConfig.headers,
-          // Close is idempotent (unlike chunk appends), so its dispatcher
-          // retries 5xx, as required by the server's close-barrier protocol,
-          // which surfaces transient reconciliation states as retriable
-          // 503s with the stream left durably closing.
-          dispatcher: getStreamCloseDispatcher(config),
-          timeoutMs: null,
-          logLabel: url.pathname,
-          spanName: 'workflow.stream.write',
-          durationAttribute: 'workflow.stream.write.chunk_rtt',
-          attributes: streamSpanAttributes({
-            runId: resolvedRunId,
-            name,
-            operation: 'close',
-          }),
-          buildError: async (res) =>
-            createStreamRequestError('close', url, res, await res.text()),
-        });
-        // Drain the (empty) response so undici can release the pooled connection.
-        await response.text();
+        if (isWsStreamsTransportEnabled()) {
+          const { closeStreamOverWs } = await import('./ws-streamer.js');
+          return closeStreamOverWs(resolvedRunId, name, config, () =>
+            closeStreamOverHttp(resolvedRunId, name, config)
+          );
+        }
+
+        return closeStreamOverHttp(resolvedRunId, name, config);
       },
 
       async get(runId: string, name: string, startIndex?: number) {

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -29,6 +29,10 @@ import {
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { injectTraceContextIntoHeaders } from './telemetry.js';
 import { makeRequest, WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
+import {
+  resetWsStreamWritersForTest,
+  writeStreamOverWs,
+} from './ws-streamer.js';
 
 vi.mock('@vercel/oidc', () => ({
   getVercelOidcToken: vi.fn().mockRejectedValue(new Error('no OIDC')),
@@ -51,6 +55,9 @@ vi.mock('ws', () => ({
       wsUpgrades.push({ url, headers: options?.headers ?? {} });
     }
     on() {
+      return this;
+    }
+    once() {
       return this;
     }
     send() {}
@@ -124,6 +131,37 @@ describe('injectTraceContextIntoHeaders', () => {
     const headers = new Headers();
     await injectTraceContextIntoHeaders(headers);
     expect(headers.get('traceparent')).toBeNull();
+  });
+});
+
+describe('stream WebSocket trace propagation', () => {
+  afterEach(() => {
+    resetWsStreamWritersForTest();
+    wsUpgrades.length = 0;
+  });
+
+  it('injects the active trace context on the per-stream upgrade', async () => {
+    const tracer = otelTrace.getTracer('test');
+    let traceId = '';
+    await tracer.startActiveSpan('stream-writer', async (span) => {
+      traceId = span.spanContext().traceId;
+      await writeStreamOverWs(
+        'wrun_trace',
+        'output',
+        new Uint8Array([1]),
+        { baseUrl: 'https://example.test/api', token: 'test-token' },
+        async () => {}
+      );
+      await vi.waitFor(() => expect(wsUpgrades).toHaveLength(1));
+      span.end();
+    });
+
+    expect(wsUpgrades[0].url).toMatch(
+      /\/api\/websockets\/v1\/runs\/wrun_trace\/streams\/output$/
+    );
+    expect(wsUpgrades[0].headers.traceparent).toMatch(
+      new RegExp(`^00-${traceId}-[0-9a-f]{16}-0[01]$`)
+    );
   });
 });
 

--- a/packages/world-vercel/src/ws-stream-frames-interop.test.ts
+++ b/packages/world-vercel/src/ws-stream-frames-interop.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import fixture from './__fixtures__/ws-stream-frames.json';
+import { decodeFrames, encodeFrame } from './frames.js';
+
+function fromHex(hex: string): Uint8Array {
+  return new Uint8Array(Buffer.from(hex, 'hex'));
+}
+
+async function decodeOne(raw: Uint8Array) {
+  const source = (async function* () {
+    yield raw;
+  })();
+  for await (const frame of decodeFrames(source)) return frame;
+  throw new Error('fixture contained no frame');
+}
+
+describe('workflow-server WS stream frame fixture', () => {
+  it.each(
+    fixture.frames
+  )('decodes and reproduces $direction $meta.type byte-for-byte', async ({
+    meta,
+    bodyHex,
+    frameHex,
+  }) => {
+    const decoded = await decodeOne(fromHex(frameHex));
+    expect(decoded.meta).toEqual(meta);
+    expect(decoded.body).toEqual(fromHex(bodyHex));
+    expect(encodeFrame(meta, fromHex(bodyHex))).toEqual(fromHex(frameHex));
+  });
+});

--- a/packages/world-vercel/src/ws-streamer.test.ts
+++ b/packages/world-vercel/src/ws-streamer.test.ts
@@ -1,0 +1,304 @@
+import { decode } from 'cbor-x';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { encodeFrame } from './frames.js';
+import {
+  closeStreamOverWs,
+  resetWsStreamWritersForTest,
+  writeMultiStreamOverWs,
+  writeStreamOverWs,
+} from './ws-streamer.js';
+
+const { sockets, socketBehavior, FakeSocket } = vi.hoisted(() => {
+  class FakeSocket {
+    static OPEN = 1;
+    readyState = FakeSocket.OPEN;
+    sent: Uint8Array[] = [];
+    url: string;
+    private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+    constructor(url: string) {
+      this.url = url;
+      sockets.push(this);
+      if (socketBehavior.autoOpen) queueMicrotask(() => this.emit('open'));
+    }
+
+    on(event: string, callback: (...args: never[]) => void) {
+      this.listeners.set(event, [
+        ...(this.listeners.get(event) ?? []),
+        callback as (...args: unknown[]) => void,
+      ]);
+      return this;
+    }
+
+    once(event: string, callback: (...args: never[]) => void) {
+      const once = (...args: unknown[]) => {
+        this.listeners.set(
+          event,
+          (this.listeners.get(event) ?? []).filter((item) => item !== once)
+        );
+        callback(...(args as never[]));
+      };
+      return this.on(event, once as (...args: never[]) => void);
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      for (const callback of this.listeners.get(event) ?? []) callback(...args);
+    }
+
+    send(frame: Uint8Array, callback: (error?: Error) => void) {
+      this.sent.push(frame);
+      callback();
+    }
+
+    close() {
+      this.readyState = 3;
+    }
+
+    failUpgrade(error = new Error('upgrade declined')) {
+      this.emit('error', error);
+      this.emit('close');
+    }
+  }
+
+  const sockets: FakeSocket[] = [];
+  const socketBehavior = { autoOpen: true };
+  return { sockets, socketBehavior, FakeSocket };
+});
+
+vi.mock('ws', () => ({ WebSocket: FakeSocket }));
+vi.mock('./utils.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./utils.js')>()),
+  getHttpUrl: () => ({
+    baseUrl: 'https://example.test/api',
+    usingProxy: false,
+  }),
+  getHttpConfig: async () => ({
+    baseUrl: 'https://example.test/api',
+    headers: new Headers({ authorization: 'Bearer test' }),
+  }),
+}));
+
+function metaOf(raw: Uint8Array): Record<string, unknown> {
+  const metaLength = new DataView(
+    raw.buffer,
+    raw.byteOffset,
+    raw.byteLength
+  ).getUint32(0, false);
+  return decode(raw.subarray(4, 4 + metaLength)) as Record<string, unknown>;
+}
+
+function bodyOf(raw: Uint8Array): Uint8Array {
+  const view = new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
+  const metaLength = view.getUint32(0, false);
+  const bodyOffset = 4 + metaLength;
+  const bodyLength = view.getUint32(bodyOffset, false);
+  return raw.slice(bodyOffset + 4, bodyOffset + 4 + bodyLength);
+}
+
+function ack(socket: InstanceType<typeof FakeSocket>, index = 1): void {
+  const sent = socket.sent.at(-1);
+  if (!sent) throw new Error('socket has no sent frame to acknowledge');
+  const reqId = metaOf(sent).reqId;
+  socket.emit(
+    'message',
+    Buffer.from(
+      encodeFrame(
+        { reqId, type: 'stream_ack', status: 200, nextIndex: index },
+        new Uint8Array(0)
+      )
+    )
+  );
+}
+
+async function waitForSocket(): Promise<FakeSocket> {
+  await vi.waitFor(() => expect(sockets).toHaveLength(1));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return sockets[0];
+}
+
+beforeEach(() => {
+  resetWsStreamWritersForTest();
+  sockets.length = 0;
+  socketBehavior.autoOpen = true;
+  delete process.env.WORKFLOW_MAX_CHUNKS_PER_REQUEST;
+});
+
+describe('per-stream WebSocket writer', () => {
+  it('uses HTTP for the first write while opening the stream-scoped socket', async () => {
+    const http = vi.fn(async () => {});
+    await writeStreamOverWs('run/a', 'output/b', 'first', undefined, http);
+    const socket = await waitForSocket();
+
+    expect(http).toHaveBeenCalledOnce();
+    expect(socket.url).toBe(
+      'wss://example.test/api/websockets/v1/runs/run%2Fa/streams/output%2Fb'
+    );
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  it('attempts a declined upgrade only once until close removes the tombstone', async () => {
+    socketBehavior.autoOpen = false;
+    const firstHttp = vi.fn(async () => {});
+    await writeStreamOverWs('run-1', 'declined', 'first', undefined, firstHttp);
+    const socket = await waitForSocket();
+    socket.failUpgrade();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const secondHttp = vi.fn(async () => {});
+    const multiHttp = vi.fn(async () => {});
+    await writeStreamOverWs(
+      'run-1',
+      'declined',
+      'second',
+      undefined,
+      secondHttp
+    );
+    await writeMultiStreamOverWs(
+      'run-1',
+      'declined',
+      ['third', 'fourth'],
+      undefined,
+      multiHttp
+    );
+
+    expect(sockets).toHaveLength(1);
+    expect(firstHttp).toHaveBeenCalledOnce();
+    expect(secondHttp).toHaveBeenCalledOnce();
+    expect(multiHttp).toHaveBeenCalledOnce();
+
+    const closeHttp = vi.fn(async () => {});
+    await closeStreamOverWs('run-1', 'declined', undefined, closeHttp);
+    expect(closeHttp).toHaveBeenCalledOnce();
+
+    await writeStreamOverWs(
+      'run-1',
+      'declined',
+      'new lifecycle',
+      undefined,
+      async () => {}
+    );
+    await vi.waitFor(() => expect(sockets).toHaveLength(2));
+  });
+
+  it('writes without a redundant stream name after the HTTP barrier', async () => {
+    await writeStreamOverWs(
+      'run-1',
+      'output',
+      'first',
+      undefined,
+      async () => {}
+    );
+    const socket = await waitForSocket();
+
+    const second = writeStreamOverWs(
+      'run-1',
+      'output',
+      'second',
+      undefined,
+      async () => {
+        throw new Error('unexpected HTTP fallback');
+      }
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+    expect(metaOf(socket.sent[0])).toEqual({
+      reqId: 1,
+      type: 'stream_write',
+      count: 1,
+    });
+    expect(new TextDecoder().decode(bodyOf(socket.sent[0]))).toBe('second');
+    ack(socket);
+    await second;
+  });
+
+  it('keeps at most five batches in flight and sends the next page after ACKs', async () => {
+    process.env.WORKFLOW_MAX_CHUNKS_PER_REQUEST = '1';
+    await writeStreamOverWs(
+      'run-1',
+      'output',
+      'first',
+      undefined,
+      async () => {}
+    );
+    const socket = await waitForSocket();
+
+    const write = writeMultiStreamOverWs(
+      'run-1',
+      'output',
+      ['a', 'b', 'c', 'd', 'e', 'f'],
+      undefined,
+      async () => {
+        throw new Error('unexpected HTTP fallback');
+      }
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(5));
+    expect(socket.sent.map(metaOf)).toEqual(
+      [1, 2, 3, 4, 5].map((reqId) => ({
+        reqId,
+        type: 'stream_write',
+        count: 1,
+      }))
+    );
+
+    for (let i = 0; i < 5; i++) {
+      const reqId = i + 1;
+      socket.emit(
+        'message',
+        Buffer.from(
+          encodeFrame(
+            { reqId, type: 'stream_ack', status: 200, nextIndex: reqId },
+            new Uint8Array(0)
+          )
+        )
+      );
+    }
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(6));
+    ack(socket, 6);
+    await write;
+  });
+
+  it('keeps close on HTTP while the upgrade or HTTP barrier is pending', async () => {
+    let releaseHttp!: () => void;
+    const pendingHttp = new Promise<void>((resolve) => {
+      releaseHttp = resolve;
+    });
+    const first = writeStreamOverWs(
+      'run-1',
+      'output',
+      'first',
+      undefined,
+      () => pendingHttp
+    );
+    const socket = await waitForSocket();
+    const closeHttp = vi.fn(async () => {});
+    const close = closeStreamOverWs('run-1', 'output', undefined, closeHttp);
+
+    expect(socket.readyState).toBe(3);
+    expect(closeHttp).not.toHaveBeenCalled();
+    releaseHttp();
+    await Promise.all([first, close]);
+    expect(closeHttp).toHaveBeenCalledOnce();
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  it('closes over the socket after a stream_close ACK', async () => {
+    await writeStreamOverWs(
+      'run-1',
+      'output',
+      'first',
+      undefined,
+      async () => {}
+    );
+    const socket = await waitForSocket();
+    const close = closeStreamOverWs('run-1', 'output', undefined, async () => {
+      throw new Error('unexpected HTTP close');
+    });
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+    expect(metaOf(socket.sent[0])).toEqual({
+      reqId: 1,
+      type: 'stream_close',
+    });
+    ack(socket);
+    await close;
+    expect(socket.readyState).toBe(3);
+  });
+});

--- a/packages/world-vercel/src/ws-streamer.ts
+++ b/packages/world-vercel/src/ws-streamer.ts
@@ -1,0 +1,427 @@
+import { globalSingleton } from '@workflow/utils';
+import { WebSocket } from 'ws';
+import { decodeFrames, encodeFrame } from './frames.js';
+import { getRequestTimeoutMs, headersToRecord } from './http-core.js';
+import { encodeMultiChunks, getMaxChunksPerRequest } from './streamer.js';
+import { injectTraceContextIntoHeaders } from './telemetry.js';
+import type { APIConfig } from './utils.js';
+import { getHttpConfig, getHttpUrl } from './utils.js';
+import { version } from './version.js';
+
+const EMPTY = new Uint8Array(0);
+const MAX_IN_FLIGHT_BATCHES = 5;
+const IDLE_TIMEOUT_MS = 30_000;
+
+type Reply = { meta: Record<string, unknown>; body: Uint8Array };
+type Pending = {
+  resolve: (reply: Reply) => void;
+  reject: (error: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function asBytes(chunk: string | Uint8Array): Uint8Array {
+  return typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk;
+}
+
+function streamWsUrl(baseUrl: string, runId: string, name: string): string {
+  const url = new URL(baseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/websockets/v1/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}`;
+  return url.toString();
+}
+
+class StreamWriterSocket {
+  private ws: WebSocket | undefined;
+  private nextReqId = 1;
+  private pending = new Map<number, Pending>();
+  private idleTimer: ReturnType<typeof setTimeout> | undefined;
+  private closed = false;
+
+  constructor(
+    readonly url: string,
+    private readonly onClose: () => void
+  ) {}
+
+  async connect(config?: APIConfig): Promise<void> {
+    const { headers } = await getHttpConfig(config);
+    await injectTraceContextIntoHeaders(headers);
+    const ws = new WebSocket(this.url, { headers: headersToRecord(headers) });
+    this.ws = ws;
+    ws.binaryType = 'nodebuffer';
+
+    await new Promise<void>((resolve, reject) => {
+      let opened = false;
+      ws.once('open', () => {
+        opened = true;
+        this.armIdleTimer();
+        resolve();
+      });
+      ws.once('error', (error) => {
+        if (!opened) reject(error);
+        else this.fail(error);
+      });
+      ws.once('close', () => {
+        if (!opened)
+          reject(
+            new Error(
+              `stream WebSocket upgrade closed before opening (${this.url})`
+            )
+          );
+        this.fail(new Error(`stream WebSocket closed (${this.url})`));
+      });
+      ws.on('message', (raw: Buffer) => {
+        void this.handleMessage(new Uint8Array(raw));
+      });
+    });
+  }
+
+  async request(buildFrame: (reqId: number) => Uint8Array): Promise<Reply> {
+    const ws = this.ws;
+    if (this.closed || !ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error(`stream WebSocket is not open (${this.url})`);
+    }
+    this.cancelIdleTimer();
+    const reqId = this.nextReqId++;
+    const timeoutMs = getRequestTimeoutMs();
+    return new Promise<Reply>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (!this.pending.delete(reqId)) return;
+        const error = new Error(
+          `stream WebSocket request ${reqId} timed out after ${timeoutMs}ms`
+        );
+        reject(error);
+        this.fail(error);
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(reqId, { resolve, reject, timer });
+      ws.send(buildFrame(reqId), (error) => {
+        if (!error) return;
+        const pending = this.pending.get(reqId);
+        if (!pending) return;
+        this.pending.delete(reqId);
+        clearTimeout(pending.timer);
+        reject(error);
+        this.fail(error);
+      });
+    }).finally(() => this.armIdleTimer());
+  }
+
+  close(reason: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.cancelIdleTimer();
+    this.onClose();
+    this.ws?.close(1000, reason);
+    this.rejectPending(new Error(`stream WebSocket closed: ${reason}`));
+  }
+
+  private async handleMessage(raw: Uint8Array): Promise<void> {
+    const frames = [];
+    try {
+      for await (const frame of decodeFrames(
+        (async function* () {
+          yield raw;
+        })()
+      )) {
+        frames.push(frame);
+      }
+    } catch (error) {
+      this.fail(error);
+      return;
+    }
+    if (frames.length !== 1) {
+      this.fail(
+        new Error(`stream WebSocket message contained ${frames.length} frames`)
+      );
+      return;
+    }
+    const frame = frames[0];
+    const reqId = frame.meta.reqId;
+    if (typeof reqId !== 'number') {
+      this.fail(new Error('stream WebSocket reply carried no numeric reqId'));
+      return;
+    }
+    const pending = this.pending.get(reqId);
+    if (!pending) return;
+    this.pending.delete(reqId);
+    clearTimeout(pending.timer);
+    pending.resolve({ meta: frame.meta, body: frame.body });
+  }
+
+  private fail(error: unknown): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.cancelIdleTimer();
+    this.onClose();
+    this.rejectPending(error);
+    this.ws?.close();
+  }
+
+  private rejectPending(error: unknown): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private armIdleTimer(): void {
+    if (this.closed || this.pending.size > 0 || this.idleTimer) return;
+    this.idleTimer = setTimeout(
+      () => this.close('idle timeout'),
+      IDLE_TIMEOUT_MS
+    );
+    this.idleTimer.unref?.();
+  }
+
+  private cancelIdleTimer(): void {
+    if (!this.idleTimer) return;
+    clearTimeout(this.idleTimer);
+    this.idleTimer = undefined;
+  }
+}
+
+type WriterState = {
+  socket?: StreamWriterSocket;
+  connect: Promise<void>;
+  status: 'connecting' | 'open' | 'http' | 'closed';
+  httpBarrier: Promise<void>;
+  httpPending: number;
+  httpFailure?: unknown;
+  inFlight: number;
+  slotWaiters: Array<() => void>;
+  drainWaiters: Array<() => void>;
+};
+
+const state = globalSingleton(
+  `@workflow/world-vercel//wsStreamWriters@${version}`,
+  1,
+  () => new Map<string, WriterState>()
+);
+
+function writerKey(
+  runId: string,
+  name: string,
+  config?: APIConfig
+): string | null {
+  const { baseUrl, usingProxy } = getHttpUrl(config);
+  if (usingProxy) return null;
+  return streamWsUrl(baseUrl, runId, name);
+}
+
+function getWriter(
+  runId: string,
+  name: string,
+  config?: APIConfig
+): WriterState | null {
+  const key = writerKey(runId, name, config);
+  if (!key) return null;
+  const existing = state.get(key);
+  if (existing && existing.status !== 'closed') return existing;
+
+  const writer: WriterState = {
+    status: 'connecting',
+    httpBarrier: Promise.resolve(),
+    httpPending: 0,
+    inFlight: 0,
+    slotWaiters: [],
+    drainWaiters: [],
+    connect: Promise.resolve(),
+  };
+  const socket = new StreamWriterSocket(key, () => {
+    if (state.get(key) === writer && writer.status !== 'http') {
+      state.delete(key);
+    }
+    if (writer.status !== 'closed') writer.status = 'http';
+  });
+  writer.socket = socket;
+  writer.connect = socket
+    .connect(config)
+    .then(() => {
+      if (writer.status === 'connecting') writer.status = 'open';
+      else socket.close('upgrade no longer needed');
+    })
+    .catch((error) => {
+      console.warn(
+        `world-vercel: stream WebSocket upgrade failed; using HTTP (${describeError(error)}).`
+      );
+      writer.status = 'http';
+      // Keep a per-stream HTTP tombstone after a declined upgrade. Removing it
+      // here makes the next append construct another socket, turning an
+      // unsupported endpoint into one upgrade attempt per batch. `close()`
+      // removes the tombstone so a later lifecycle can negotiate afresh.
+      state.set(key, writer);
+    });
+  state.set(key, writer);
+  return writer;
+}
+
+function sendHttp(
+  state: WriterState,
+  fallback: () => Promise<void>
+): Promise<void> {
+  state.httpPending++;
+  const operation = state.httpBarrier.then(fallback);
+  state.httpBarrier = operation
+    .catch((error) => {
+      state.httpFailure = error;
+      state.status = 'http';
+      state.socket?.close('HTTP barrier failed');
+    })
+    .finally(() => {
+      state.httpPending--;
+    });
+  return operation;
+}
+
+function successfulReply(operation: 'write' | 'close', reply: Reply): void {
+  const { status, type } = reply.meta;
+  if (
+    type !== 'stream_ack' ||
+    typeof status !== 'number' ||
+    status < 200 ||
+    status >= 300
+  ) {
+    const detail = new TextDecoder().decode(reply.body);
+    throw new Error(
+      `Stream ${operation} failed over WS: status ${String(status ?? 'unknown')}` +
+        (detail ? `: ${detail}` : '')
+    );
+  }
+}
+
+async function acquireBatchSlot(writer: WriterState): Promise<() => void> {
+  if (writer.inFlight >= MAX_IN_FLIGHT_BATCHES) {
+    await new Promise<void>((resolve) => writer.slotWaiters.push(resolve));
+  } else {
+    writer.inFlight++;
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const next = writer.slotWaiters.shift();
+    if (next) {
+      next();
+      return;
+    }
+    writer.inFlight--;
+    if (writer.inFlight === 0) {
+      for (const resolve of writer.drainWaiters.splice(0)) resolve();
+    }
+  };
+}
+
+async function waitForBatches(writer: WriterState): Promise<void> {
+  if (writer.inFlight === 0) return;
+  await new Promise<void>((resolve) => writer.drainWaiters.push(resolve));
+}
+
+async function sendBatch(
+  writer: WriterState,
+  count: number,
+  body: Uint8Array
+): Promise<void> {
+  await writer.httpBarrier;
+  const release = await acquireBatchSlot(writer);
+  try {
+    if (writer.status !== 'open' || !writer.socket) {
+      throw new Error('stream WebSocket became unavailable after upgrade');
+    }
+    const reply = await writer.socket.request((reqId) =>
+      encodeFrame({ reqId, type: 'stream_write', count }, body)
+    );
+    successfulReply('write', reply);
+  } finally {
+    release();
+  }
+}
+
+export async function writeStreamOverWs(
+  runId: string,
+  name: string,
+  chunk: string | Uint8Array,
+  config: APIConfig | undefined,
+  httpFallback: () => Promise<void>
+): Promise<void> {
+  const writer = getWriter(runId, name, config);
+  if (!writer || writer.status !== 'open' || writer.httpPending > 0) {
+    if (writer) void writer.connect;
+    return writer ? sendHttp(writer, httpFallback) : httpFallback();
+  }
+  return sendBatch(writer, 1, asBytes(chunk));
+}
+
+export async function writeMultiStreamOverWs(
+  runId: string,
+  name: string,
+  chunks: (string | Uint8Array)[],
+  config: APIConfig | undefined,
+  httpFallback: () => Promise<void>
+): Promise<void> {
+  const writer = getWriter(runId, name, config);
+  if (!writer || writer.status !== 'open' || writer.httpPending > 0) {
+    if (writer) void writer.connect;
+    return writer ? sendHttp(writer, httpFallback) : httpFallback();
+  }
+
+  const batches: Array<{ count: number; body: Uint8Array }> = [];
+  const limit = getMaxChunksPerRequest();
+  for (let i = 0; i < chunks.length; i += limit) {
+    const batch = chunks.slice(i, i + limit);
+    batches.push({
+      count: batch.length,
+      body: batch.length === 1 ? asBytes(batch[0]) : encodeMultiChunks(batch),
+    });
+  }
+
+  for (let i = 0; i < batches.length; i += MAX_IN_FLIGHT_BATCHES) {
+    await Promise.all(
+      batches
+        .slice(i, i + MAX_IN_FLIGHT_BATCHES)
+        .map((batch) => sendBatch(writer, batch.count, batch.body))
+    );
+  }
+}
+
+export async function closeStreamOverWs(
+  runId: string,
+  name: string,
+  config: APIConfig | undefined,
+  httpFallback: () => Promise<void>
+): Promise<void> {
+  const key = writerKey(runId, name, config);
+  const writer = key ? state.get(key) : undefined;
+  if (!writer || writer.status !== 'open' || writer.httpPending > 0) {
+    if (writer && key) {
+      writer.status = 'closed';
+      writer.socket?.close('close stayed on HTTP');
+      state.delete(key);
+      await writer.httpBarrier;
+      if (writer.httpFailure !== undefined) throw writer.httpFailure;
+    }
+    return httpFallback();
+  }
+
+  const socket = writer.socket;
+  if (!socket || !key) return httpFallback();
+  await writer.httpBarrier;
+  await waitForBatches(writer);
+  const reply = await socket.request((reqId: number) =>
+    encodeFrame({ reqId, type: 'stream_close' }, EMPTY)
+  );
+  successfulReply('close', reply);
+  writer.status = 'closed';
+  socket.close('stream closed');
+  state.delete(key);
+}
+
+export function resetWsStreamWritersForTest(): void {
+  for (const writer of state.values()) writer.socket?.close('test reset');
+  state.clear();
+}

--- a/packages/world-vercel/src/ws-transport-enabled.ts
+++ b/packages/world-vercel/src/ws-transport-enabled.ts
@@ -53,3 +53,9 @@ export function isWsEventsTransportStrict(): boolean {
   const raw = process.env.WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT;
   return raw === '1' || raw === 'true';
 }
+
+/** HTTP unless the streams prototype is explicitly enabled. Kept separate
+ * from the events gate so each capability can be benchmarked independently. */
+export function isWsStreamsTransportEnabled(): boolean {
+  return process.env.WORKFLOW_STREAMS_TRANSPORT === 'ws';
+}


### PR DESCRIPTION
### Description

This exploratory client extends the generic WebSocket transport from #3084 and pairs with workflow-server PR #710. The opt-in `WORKFLOW_STREAMS_TRANSPORT=ws` mode covers stream writes, batched writes, close, live reads, explicit resume/end reasons, and wire-level cancellation while keeping event writes on the existing one-shot request path.

The explicit `stream_end.reason` improves resume correctness without adding a second path to `createReconnectingFramedStream`: the WS adapter presents one stable framed stream and removes HTTP abort-vs-EOF interpretation, partial-frame discard/counting, and client resume arithmetic from core. The cost moves into `world-vercel`, which now owns subscription routing, reconnect budgets, cancellation acknowledgement, and socket lifecycle. Append retries remain limited to failures known not to have been sent plus 429; idempotent close/cancel may also retry ambiguous transport failures and 5xx.

### How did you test your changes?

Cross-repo E2E used WS client deployment `dpl_ESkNDLV3Ft2k1ZEQQJeWFk9C5RkB` against server PR #710 deployment `dpl_57VtZSaMF8M43dPYQH9td5ZNfCbG`. Both full 30-sample benchmark runs completed: [WS](https://github.com/vercel/workflow/actions/runs/31034317860) and [HTTP](https://github.com/vercel/workflow/actions/runs/31034588528).

| Scenario | HTTP | WS | Change |
| --- | ---: | ---: | ---: |
| First chunk, average | 165.9 ms | 109.4 ms | -34.1% |
| First chunk, p75 / p90 / p99 | 177 / 211 / 316 ms | 111 / 128 / 337 ms | p99 includes one WS outlier |
| 300 text chunks, average excess overhead | 166.2 ms | 145.4 ms | -12.5% |
| 300 structured chunks, average excess overhead | 170.2 ms | 133.3 ms | -21.7% |
| Effective text / structured throughput | 94.75 / 94.63 chunks/s | 95.38 / 95.75 chunks/s | producer paced at 100/s |

A representative 300-chunk HTTP run emitted 50 physical stream HTTP requests (2 reads, 46 writes, 2 closes). The WS shape emitted no per-operation HTTP requests after at most two reader/writer-process socket upgrades; the stream operations were multiplexed as frames.

- `@workflow/world-vercel`: 25 test files, 449 tests passed; the post-wire-fix focused suite passed 83 tests.
- Package build, changed-file Biome, and `git diff --check` passed. CI Biome, Ubuntu unit tests, docs checks, and tarball checks passed.
- The canonical fixture matches the server copy byte-for-byte (`ee59799126b9720a226c62609b9fa79c13a00fdd63f3fcdca0b86480191f4a04`).
- Full workspace typecheck/test were attempted but stopped at the SWC plugin because Cargo is unavailable locally. Full lint reached one unrelated baseline error plus existing warnings.

### Docs Preview

- [Vercel World](https://workflow-docs-5o3gjrieg.vercel.sh/v5/worlds/vercel)
- [World configuration](https://workflow-docs-5o3gjrieg.vercel.sh/v5/docs/configuration/worlds)

### PR Checklist - Required to merge

- [ ] 📦 `pnpm changeset` was run to create a changelog for this PR
  - Use the correct semver bump type: `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
