### PR TITLE
fix(core): preserve `new.target` in the deterministic `Date` override so `Date` subclasses work

### DIFF
--- a/.changeset/date-subclass-vm.md
+++ b/.changeset/date-subclass-vm.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Fix `Date` subclassing inside workflow functions. The deterministic `Date` override in the workflow VM is now a class that preserves `new.target`, so subclasses like `TZDate` from `@date-fns/tz` keep their identity, methods, and fields.
+Fix `Date` subclassing inside workflow functions. The deterministic `Date` override in the workflow VM now forwards `new.target` via `Reflect.construct`, so subclasses like `TZDate` from `@date-fns/tz` keep their identity, methods, and fields. Calling `Date()` without `new` now returns the (fixed) time string per spec, instead of a `Date` object.

--- a/.changeset/date-subclass-vm.md
+++ b/.changeset/date-subclass-vm.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix `Date` subclassing inside workflow functions. The deterministic `Date` override in the workflow VM is now a class that preserves `new.target`, so subclasses like `TZDate` from `@date-fns/tz` keep their identity, methods, and fields.

--- a/packages/core/src/vm/index.test.ts
+++ b/packages/core/src/vm/index.test.ts
@@ -49,6 +49,53 @@ describe('createContext', () => {
     expect(result).toEqual(specificTime);
   });
 
+  it('should support subclassing `Date`', () => {
+    const { context } = createContext({ seed, fixedTimestamp });
+
+    const result = vm.runInContext(
+      `
+      class Sub extends Date {
+        constructor(...args) {
+          super(...args);
+          this.tag = 'sub';
+        }
+        label() {
+          return 'sub';
+        }
+      }
+      const sub = new Sub(2026, 6, 29);
+      const defaulted = new Sub();
+      ({
+        isSub: sub instanceof Sub,
+        isDate: sub instanceof Date,
+        keepsMethods: sub.label(),
+        keepsFields: sub.tag,
+        argsForwarded: sub.getTime() === new Date(2026, 6, 29).getTime(),
+        defaultedIsFixed: defaulted.getTime(),
+      })
+      `,
+      context
+    );
+
+    expect(result.isSub).toBe(true);
+    expect(result.isDate).toBe(true);
+    expect(result.keepsMethods).toBe('sub');
+    expect(result.keepsFields).toBe('sub');
+    expect(result.argsForwarded).toBe(true);
+    expect(result.defaultedIsFixed).toEqual(fixedTimestamp);
+  });
+
+  it('should preserve `Date` static methods', () => {
+    const { context } = createContext({ seed, fixedTimestamp });
+
+    expect(
+      vm.runInContext("Date.parse('2000-01-01T00:00:00.000Z')", context)
+    ).toEqual(946684800000);
+    expect(vm.runInContext('Date.UTC(2000, 0, 1)', context)).toEqual(
+      946684800000
+    );
+  });
+
   it('should have deterministic `crypto.getRandomValues()`', () => {
     const { context } = createContext({ seed, fixedTimestamp });
 

--- a/packages/core/src/vm/index.test.ts
+++ b/packages/core/src/vm/index.test.ts
@@ -85,6 +85,17 @@ describe('createContext', () => {
     expect(result.defaultedIsFixed).toEqual(fixedTimestamp);
   });
 
+  it('should keep `Date()` callable without `new`, returning the fixed time string', () => {
+    const { context } = createContext({ seed, fixedTimestamp });
+
+    const result = vm.runInContext('Date()', context);
+
+    expect(result).toBeTypeOf('string');
+    expect(result).toEqual(vm.runInContext('new Date().toString()', context));
+    // Per spec, `Date()` as a function ignores its arguments
+    expect(vm.runInContext('Date(2000, 0, 1)', context)).toEqual(result);
+  });
+
   it('should preserve `Date` static methods', () => {
     const { context } = createContext({ seed, fixedTimestamp });
 

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -60,21 +60,22 @@ export function createContext(options: CreateContextOptions) {
   // Deterministic `Math.random()`
   g.Math.random = rng;
 
-  // Override `Date` constructor to return fixed time when called without arguments
+  // Override `Date` constructor to return fixed time when called without
+  // arguments. A `class` (rather than a plain function) keeps `new.target`
+  // intact so user code can still subclass `Date` (e.g. `TZDate` from
+  // `@date-fns/tz`), and `extends` preserves the prototype chain and statics.
   const Date_ = g.Date;
   // biome-ignore lint/suspicious/noShadowRestrictedNames: We're shadowing the global `Date` property to make it deterministic.
-  (g as any).Date = function Date(
-    ...args: Parameters<(typeof globalThis)['Date']>[]
-  ) {
-    if (args.length === 0) {
-      return new Date_(fixedTimestamp);
+  (g as any).Date = class Date extends Date_ {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        super(fixedTimestamp);
+      } else {
+        // @ts-expect-error - Args is `Date` constructor arguments
+        super(...args);
+      }
     }
-    // @ts-expect-error - Args is `Date` constructor arguments
-    return new Date_(...args);
   };
-  (g as any).Date.prototype = Date_.prototype;
-  // Preserve static methods
-  Object.setPrototypeOf(g.Date, Date_);
   g.Date.now = () => fixedTimestamp;
 
   // Deterministic `crypto` using Proxy to avoid mutating global objects

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -61,21 +61,25 @@ export function createContext(options: CreateContextOptions) {
   g.Math.random = rng;
 
   // Override `Date` constructor to return fixed time when called without
-  // arguments. A `class` (rather than a plain function) keeps `new.target`
-  // intact so user code can still subclass `Date` (e.g. `TZDate` from
-  // `@date-fns/tz`), and `extends` preserves the prototype chain and statics.
+  // arguments. Constructing through `Reflect.construct` with `new.target`
+  // keeps subclassing intact (e.g. `TZDate` from `@date-fns/tz`), while a
+  // plain function (rather than a `class`) keeps `Date()` callable without
+  // `new`, which per spec ignores its arguments and returns the time string.
   const Date_ = g.Date;
   // biome-ignore lint/suspicious/noShadowRestrictedNames: We're shadowing the global `Date` property to make it deterministic.
-  (g as any).Date = class Date extends Date_ {
-    constructor(...args: any[]) {
-      if (args.length === 0) {
-        super(fixedTimestamp);
-      } else {
-        // @ts-expect-error - Args is `Date` constructor arguments
-        super(...args);
-      }
+  (g as any).Date = function Date(...args: any[]) {
+    if (new.target === undefined) {
+      return new Date_(fixedTimestamp).toString();
     }
+    return Reflect.construct(
+      Date_,
+      args.length === 0 ? [fixedTimestamp] : args,
+      new.target
+    );
   };
+  (g as any).Date.prototype = Date_.prototype;
+  // Preserve static methods
+  Object.setPrototypeOf(g.Date, Date_);
   g.Date.now = () => fixedTimestamp;
 
   // Deterministic `crypto` using Proxy to avoid mutating global objects


### PR DESCRIPTION
Fixes #3371

## Problem

`createContext()` replaces the VM's global `Date` with a plain function. A plain function has no `[[Construct]]` behavior that forwards `new.target`, so when user code does `class X extends Date`, `super()` returns a fresh plain `Date` object which becomes `this` — the subclass instance loses its identity, methods, and fields.

This silently breaks every library that models a date by subclassing `Date`, e.g. `TZDate` from `@date-fns/tz` (the officially recommended way to do time-zone-aware math with date-fns v4). Inside a workflow body, a `TZDate` degrades to a plain `Date`, so every zone-aware getter falls back to the container's time zone. Since the epoch value stays correct, this presents as a silent, production-only off-by-one-day bug. Full analysis in #3371.

## Fix

Replace the plain-function override with a class so `new.target` is preserved:

```ts
(g as any).Date = class Date extends Date_ {
  constructor(...args: any[]) {
    if (args.length === 0) {
      super(fixedTimestamp);
    } else {
      // @ts-expect-error - Args is `Date` constructor arguments
      super(...args);
    }
  }
};
g.Date.now = () => fixedTimestamp;
```

Both of the previous fix-ups become unnecessary, because `extends` already sets up the whole prototype chain:

- `(g as any).Date.prototype = Date_.prototype` — with `extends` the real chain is in place (and the assignment would be illegal on a class, whose `prototype` is non-writable).
- `Object.setPrototypeOf(g.Date, Date_)` — `extends` already makes the statics (`Date.parse`, `Date.UTC`) inherited; only the `Date.now` override stays as an own property.

Determinism is unchanged: zero-arg construction still returns the fixed timestamp, and `Date.now()` is still overridden. Covered by the existing determinism tests plus two new ones (subclassing, statics).

One behavioral note: calling `Date()` without `new` now throws (classes are not callable), where the old override returned a `Date` *object* — itself already a deviation from the spec, which returns a string. If callable `Date()` needs to keep working, the alternative is a plain function that branches on `new.target` and uses `Reflect.construct(Date_, args, new.target)`; happy to switch to that if preferred.

## Tests

- `should support subclassing \`Date\`` — subclass keeps identity (`instanceof`), methods, fields; constructor args are forwarded; zero-arg subclass construction still gets the fixed timestamp
- `should preserve \`Date\` static methods` — `Date.parse` / `Date.UTC` still inherited

All 36 tests in `packages/core/src/vm/index.test.ts` pass, `pnpm typecheck` is clean. (The `runtime.test.ts` failure `re-routes a misrouted lazy hook resume` also fails on an unmodified checkout of `main`, so it is unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
