### PR TITLE
Backport #3370: [world-vercel] Recover from wedged HTTP/2 events connections

### DIFF
--- a/.changeset/loud-pugs-recycle.md
+++ b/.changeset/loud-pugs-recycle.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Recover from HTTP/2 connections that stop delivering event requests, and make `WORKFLOW_H2_MULTIPLEX=0` disable HTTP/2 on the events path entirely

--- a/docs/content/docs/deploying/world/vercel-world.mdx
+++ b/docs/content/docs/deploying/world/vercel-world.mdx
@@ -115,7 +115,7 @@ Custom base URL for the Vercel workflow API. Automatically detected.
 
 ### `WORKFLOW_H2_MULTIPLEX`
 
-Enabled by default. Lets concurrent event-log requests share one HTTP/2 connection instead of opening one connection per in-flight request. Set to `0` to send one event request per connection.
+Enabled by default. Lets concurrent event-log requests share one HTTP/2 connection instead of opening one connection per in-flight request. Set to `0` to take the event-log requests off HTTP/2 entirely, back to one request per HTTP/1.1 connection. Use this as the kill switch if HTTP/2 turns out to be at fault for event delivery problems.
 
 ### Programmatic configuration
 

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@workflow/errors';
 import { decode, encode } from 'cbor-x';
 import { MockAgent } from 'undici';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createWorkflowRunEventV4,
   getEventV4,
@@ -15,6 +15,11 @@ import {
   throwForErrorResponse,
 } from './events-v4.js';
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
+import {
+  EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES,
+  getEventsDispatcher,
+} from './http-client.js';
+import { WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
 
 /**
  * The v4 client must preserve the typed-error contract of the v3
@@ -377,5 +382,47 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
     expect(capturedMeta?.eventType).toBe('wait_created');
     expect('stateUpdatedAt' in (capturedMeta ?? {})).toBe(false);
     agent.assertNoPendingInterceptors();
+  });
+});
+
+/**
+ * The recycler in http-client only sees transport failures the v4 client
+ * reports to it. This covers that wiring end to end: a `fetch()` that rejects
+ * the way a wedged HTTP/2 session does must retire the shared events pool once
+ * the failures reach the threshold. Without the `onTransportOutcome` hook in
+ * `fetchV4` the recycler is never told anything and the pool lives forever.
+ */
+describe('v4 transport reports failures to the events recycler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Shape of a wedged-session rejection: `fetch` wraps undici's
+  // InformationalError, so the code the recycler matches on is one `cause` down.
+  const wedgedSessionError = () =>
+    new TypeError('fetch failed', {
+      cause: Object.assign(new Error('HTTP/2: "stream timeout after 300"'), {
+        code: 'UND_ERR_INFO',
+      }),
+    });
+
+  it('rebuilds the shared pool after repeated stream timeouts', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(wedgedSessionError());
+
+    // No `dispatcher` in the config: the request must resolve the shared one,
+    // which is what the recycler owns.
+    const before = getEventsDispatcher({ token: 'test-token' });
+
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
+      await expect(
+        getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
+      ).rejects.toThrow();
+      // Still the same pool until the threshold is reached.
+      if (i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1) {
+        expect(getEventsDispatcher({ token: 'test-token' })).toBe(before);
+      }
+    }
+
+    expect(getEventsDispatcher({ token: 'test-token' })).not.toBe(before);
   });
 });

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -23,7 +23,10 @@
 
 import { decode } from 'cbor-x';
 import { decodeFrames, encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
-import { getEventsDispatcher } from './http-client.js';
+import {
+  getEventsDispatcher,
+  noteEventsTransportOutcome,
+} from './http-client.js';
 import {
   errorForResponse,
   instrumentedFetch,
@@ -60,12 +63,19 @@ async function fetchV4(
   config: APIConfig | undefined,
   opName: string
 ): Promise<Response> {
+  const dispatcher = getEventsDispatcher(config);
   return instrumentedFetch({
     method: init.method,
     url,
     headers: init.headers,
     body: init.body,
-    dispatcher: getEventsDispatcher(config),
+    dispatcher,
+    // Repeated transport failures retire the shared events pool and the next
+    // request builds a fresh one. undici keeps a black-holed HTTP/2 session in
+    // service indefinitely, so without this every request routed onto it fails
+    // until the compute instance is recycled — see noteEventsTransportOutcome.
+    onTransportOutcome: (error) =>
+      noteEventsTransportOutcome(dispatcher, error),
     timeoutMs: null,
     logLabel: opName,
     buildError: async (response) =>

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -1,21 +1,39 @@
 import { createServer, type Server } from 'node:http';
 import { createSecureServer, type Http2SecureServer } from 'node:http2';
-import type { AddressInfo } from 'node:net';
-import type { TLSSocket } from 'node:tls';
-import { Agent } from 'undici';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
+  type AddressInfo,
+  connect,
+  createServer as createNetServer,
+  type Server as NetServer,
+} from 'node:net';
+import type { TLSSocket } from 'node:tls';
+import { Agent, type RetryAgent } from 'undici';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createDispatcherRecycler,
   createEventsDispatcher,
   createStreamDispatcher,
   DEFAULT_BODY_TIMEOUT_MS,
   DEFAULT_HEADERS_TIMEOUT_MS,
+  type DispatcherRecycler,
+  EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES,
   getAgentOptions,
   getDispatcher,
   getEventsAgentOptions,
+  getEventsAgentOptionsNoH2,
   getEventsDispatcher,
   getStreamAgentOptions,
   getStreamCloseDispatcher,
   getStreamDispatcher,
+  isRecyclableTransportError,
   MAX_RETRIES,
   RETRY_ERROR_CODES,
   STREAM_CLOSE_RETRY_OPTIONS,
@@ -112,6 +130,15 @@ describe('agent transport', () => {
     expect(getEventsAgentOptions().allowH2).toBe(true);
     expect(getStreamAgentOptions().allowH2).toBe(true);
     expect(getAgentOptions().allowH2).toBe(false);
+  });
+
+  // WORKFLOW_H2_MULTIPLEX=0 is the operational escape hatch for an H2 transport
+  // fault, so it has to leave nothing of H2 behind: `allowH2: true` with the
+  // interceptor skipped still keeps a wedged session (see
+  // getEventsAgentOptionsNoH2).
+  it('gives the kill switch an events agent with no HTTP/2 at all', () => {
+    expect(getEventsAgentOptionsNoH2().allowH2).toBe(false);
+    expect(getEventsAgentOptionsNoH2().pipelining).toBe(1);
   });
 
   // `allowH2` alone buys nothing: undici gates in-flight requests per
@@ -634,16 +661,198 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
       }
     }
   });
+});
 
-  it('WORKFLOW_H2_MULTIPLEX=0 falls back to one request per connection', async () => {
+// The transport fault this whole mechanism exists for: an HTTP/2 session whose
+// TCP connection stays established while no bytes cross it. undici keeps such a
+// session in service — on a stream timeout it deliberately does not destroy the
+// socket, and `keepAliveTimeout` is never read on the H2 path — so every request
+// the pool routes onto it times out, indefinitely.
+//
+// The origin here is a real h2 server behind a TCP proxy that stops forwarding
+// bytes for one chosen flow, which is the closest reproduction of the production
+// shape (a middlebox dropping an established mapping) that a test can be.
+describe('wedged HTTP/2 session', () => {
+  // Any value above the pool's connection count, so the loop cannot pass merely
+  // by exhausting the poisoned connection.
+  const REQUESTS_AFTER_BLACKHOLE = 12;
+  // Long enough that a healthy loopback request never hits it, short enough that
+  // a wedged one gives up quickly. This is the timeout that turns a black hole
+  // into the UND_ERR_INFO stream timeout seen in production.
+  const STREAM_TIMEOUT_MS = 300;
+
+  let server: Http2SecureServer;
+  let proxy: NetServer;
+  let origin: string;
+  let flows: number;
+  let holed: Set<number>;
+  let httpVersions: string[];
+
+  /** Options that point an events agent at the loopback proxy. */
+  const AGENT_OVERRIDES = {
+    connect: { rejectUnauthorized: false },
+    bodyTimeout: STREAM_TIMEOUT_MS,
+    headersTimeout: STREAM_TIMEOUT_MS,
+  };
+
+  beforeAll(async () => {
+    // allowHTTP1 so the same origin can serve the kill-switch case, which takes
+    // the agent off h2 entirely.
+    server = createSecureServer({
+      key: TEST_KEY,
+      cert: TEST_CERT,
+      allowHTTP1: true,
+    });
+    server.on('sessionError', () => undefined);
+    server.on('clientError', () => undefined);
+    server.on('request', (req, res) => {
+      httpVersions.push(req.httpVersion);
+      res.writeHead(200);
+      res.end('ok');
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const originPort = (server.address() as AddressInfo).port;
+
+    // Byte-forwarding proxy. A flow in `holed` keeps both sockets open and
+    // simply drops everything in both directions.
+    proxy = createNetServer((client) => {
+      const id = ++flows;
+      const upstream = connect(originPort, '127.0.0.1');
+      client.on('data', (b) => {
+        if (!holed.has(id)) upstream.write(b);
+      });
+      upstream.on('data', (b) => {
+        if (!holed.has(id)) client.write(b);
+      });
+      const kill = () => {
+        client.destroy();
+        upstream.destroy();
+      };
+      for (const socket of [client, upstream]) {
+        socket.on('error', kill);
+        socket.on('close', kill);
+      }
+    });
+    await new Promise<void>((resolve) => {
+      proxy.listen(0, '127.0.0.1', resolve);
+    });
+    origin = `https://127.0.0.1:${(proxy.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      proxy.close(() => resolve());
+    });
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  beforeEach(() => {
+    flows = 0;
+    holed = new Set();
+    httpVersions = [];
+  });
+
+  /** One request through `dispatcher`; resolves to the error, or undefined. */
+  async function attempt(dispatcher: unknown): Promise<unknown> {
+    try {
+      const response = await fetch(`${origin}/`, {
+        method: 'POST',
+        body: 'x',
+        dispatcher,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+      } as any);
+      await response.text();
+      return undefined;
+    } catch (error) {
+      return error;
+    }
+  }
+
+  // Establishes the premise. Without the failure accounting, an events agent
+  // whose session has been black-holed never recovers on its own — which is why
+  // one bad flow produced a 25-minute outage rather than a blip.
+  it('never recovers on its own (the failure this fixes)', async () => {
+    const agent = createEventsDispatcher(AGENT_OVERRIDES);
+    try {
+      expect(await attempt(agent)).toBeUndefined();
+      holed.add(1);
+
+      const errors: unknown[] = [];
+      for (let i = 0; i < REQUESTS_AFTER_BLACKHOLE; i++) {
+        const error = await attempt(agent);
+        if (error) errors.push(error);
+      }
+      // Every single one, and every one for the reason we key the rebuild off.
+      expect(errors).toHaveLength(REQUESTS_AFTER_BLACKHOLE);
+      expect(errors.every(isRecyclableTransportError)).toBe(true);
+      // The pool never opened a replacement connection.
+      expect(flows).toBe(1);
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it('recovers after the failure threshold, and stays recovered', async () => {
+    const recycler = createDispatcherRecycler(
+      () => createEventsDispatcher(AGENT_OVERRIDES),
+      'test transport'
+    );
+    const first = recycler.get();
+    try {
+      recycler.note(first, await attempt(first));
+      holed.add(1);
+
+      const failures: number[] = [];
+      const successes: number[] = [];
+      for (let i = 0; i < REQUESTS_AFTER_BLACKHOLE; i++) {
+        // Re-resolved per request, exactly as fetchV4 does — caching the
+        // dispatcher across requests would pin the caller to the retired pool.
+        const dispatcher = recycler.get();
+        const error = await attempt(dispatcher);
+        recycler.note(dispatcher, error);
+        (error ? failures : successes).push(i);
+      }
+
+      // Bounded, not merely eventually-fine: the threshold is the entire cost of
+      // the fault, and everything after it succeeds on the rebuilt pool.
+      expect(failures).toHaveLength(EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES);
+      expect(successes[0]).toBe(EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES);
+      expect(recycler.get()).not.toBe(first);
+      expect(flows).toBeGreaterThan(1);
+    } finally {
+      await recycler.get().close();
+      await first.close();
+    }
+  });
+
+  // The kill switch has to reach `allowH2`, not just the multiplexing
+  // interceptor: with H2 still enabled the pool keeps the wedged session and the
+  // switch mitigates nothing. On H1, undici destroys the socket when the request
+  // times out, so the next request opens a fresh connection by itself.
+  it('WORKFLOW_H2_MULTIPLEX=0 takes the events agent off h2, restoring self-healing', async () => {
     const previous = process.env.WORKFLOW_H2_MULTIPLEX;
     process.env.WORKFLOW_H2_MULTIPLEX = '0';
-    // Read when the dispatcher is built, so the kill switch only takes effect
-    // for agents created after it is set.
-    const agent = createEventsDispatcher(LOOPBACK);
+    // Read when the dispatcher is built, so the switch only affects agents
+    // created after it is set.
+    const agent = createEventsDispatcher(AGENT_OVERRIDES);
     try {
-      await burst(agent);
-      expect(maxConcurrentStreams).toBeLessThan(CONCURRENCY);
+      expect(await attempt(agent)).toBeUndefined();
+      expect(httpVersions).toEqual(['1.1']);
+      holed.add(1);
+
+      const errors: unknown[] = [];
+      for (let i = 0; i < REQUESTS_AFTER_BLACKHOLE; i++) {
+        const error = await attempt(agent);
+        if (error) errors.push(error);
+      }
+      // A handful of connections are lost to the black hole; the point is that
+      // the agent keeps making progress instead of wedging forever.
+      expect(errors.length).toBeLessThan(REQUESTS_AFTER_BLACKHOLE);
+      expect(flows).toBeGreaterThan(1);
     } finally {
       await agent.close();
       if (previous === undefined) {
@@ -652,5 +861,104 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
         process.env.WORKFLOW_H2_MULTIPLEX = previous;
       }
     }
+  });
+});
+
+describe('dispatcher recycling accounting', () => {
+  const stub = () =>
+    ({ close: async () => undefined }) as unknown as RetryAgent;
+  const h2StreamTimeout = () =>
+    // The shape production sees: `fetch` rejects with its own TypeError and the
+    // undici error is only reachable through `cause`.
+    new TypeError('fetch failed', {
+      cause: Object.assign(new Error('HTTP/2: "stream timeout after 300"'), {
+        code: 'UND_ERR_INFO',
+      }),
+    });
+
+  function fail(recycler: DispatcherRecycler, times: number): void {
+    for (let i = 0; i < times; i++) {
+      recycler.note(recycler.get(), h2StreamTimeout());
+    }
+  }
+
+  it('rebuilds only once the failures are consecutive', () => {
+    const recycler = createDispatcherRecycler(stub, 'test');
+    const first = recycler.get();
+
+    fail(recycler, EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1);
+    expect(recycler.get()).toBe(first);
+    // A delivered response means the pool works; the count starts over.
+    recycler.note(recycler.get());
+    fail(recycler, EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1);
+    expect(recycler.get()).toBe(first);
+
+    recycler.note(recycler.get(), h2StreamTimeout());
+    expect(recycler.get()).not.toBe(first);
+  });
+
+  // The tail of the batch that provoked a rebuild reports its failures late, on
+  // the already-retired dispatcher. Counting those would recycle the replacement
+  // immediately and, under sustained concurrency, every pool after it.
+  it('ignores outcomes from a dispatcher it no longer owns', () => {
+    const recycler = createDispatcherRecycler(stub, 'test');
+    const first = recycler.get();
+    fail(recycler, EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES);
+    const second = recycler.get();
+    expect(second).not.toBe(first);
+
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
+      recycler.note(first, h2StreamTimeout());
+    }
+    expect(recycler.get()).toBe(second);
+
+    // Same guard covers a caller-supplied dispatcher (APIConfig.dispatcher):
+    // its failures say nothing about the shared pool.
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
+      recycler.note({}, h2StreamTimeout());
+    }
+    expect(recycler.get()).toBe(second);
+  });
+
+  // A rebuild only helps for failures that happened on an established
+  // connection. Connect/DNS/TLS errors would hit the same wall from a new pool,
+  // and an abort is the caller's own doing.
+  it('counts only transport failures a rebuild can fix', () => {
+    expect(isRecyclableTransportError(h2StreamTimeout())).toBe(true);
+    for (const code of ['UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT']) {
+      expect(
+        isRecyclableTransportError(Object.assign(new Error(code), { code }))
+      ).toBe(true);
+    }
+    for (const code of [
+      'UND_ERR_CONNECT_TIMEOUT',
+      'UND_ERR_ABORTED',
+      'ENOTFOUND',
+      'ECONNREFUSED',
+      'CERT_HAS_EXPIRED',
+    ]) {
+      expect(
+        isRecyclableTransportError(Object.assign(new Error(code), { code }))
+      ).toBe(false);
+    }
+    expect(isRecyclableTransportError(new Error('nope'))).toBe(false);
+    expect(isRecyclableTransportError(undefined)).toBe(false);
+
+    const recycler = createDispatcherRecycler(stub, 'test');
+    const first = recycler.get();
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES * 2; i++) {
+      recycler.note(
+        recycler.get(),
+        Object.assign(new Error('aborted'), { code: 'UND_ERR_ABORTED' })
+      );
+    }
+    expect(recycler.get()).toBe(first);
+  });
+
+  // Cycles are self-limiting: a `cause` chain that loops must not hang the walk.
+  it('survives a self-referential cause chain', () => {
+    const error = new Error('loop') as Error & { cause?: unknown };
+    error.cause = error;
+    expect(isRecyclableTransportError(error)).toBe(false);
   });
 });

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -2,7 +2,6 @@ import { Agent, type Dispatcher, RetryAgent, type RetryHandler } from 'undici';
 import type { APIConfig } from './utils.js';
 
 let _dispatcher: RetryAgent | undefined;
-let _eventsDispatcher: RetryAgent | undefined;
 let _streamDispatcher: RetryAgent | undefined;
 let _streamCloseDispatcher: RetryAgent | undefined;
 
@@ -238,6 +237,30 @@ export function getEventsAgentOptions() {
 }
 
 /**
+ * Events-agent options with HTTP/2 off entirely — what `WORKFLOW_H2_MULTIPLEX=0`
+ * selects. Identical to the H1 default agent, so the kill switch puts the events
+ * path back on the transport it used before H2 was enabled there.
+ *
+ * Leaving `allowH2: true` and only skipping the multiplexing interceptor is not a
+ * mitigation for an H2 transport fault: undici never evicts an HTTP/2 session
+ * when a stream times out (`client-h2.js`: "We do not destroy the socket as we
+ * can continue using the session"), and `keepAliveTimeout` is not consulted on
+ * the H2 path at all, so a session whose flow has been black-holed while the TCP
+ * connection stays established is never retired. Measured against a loopback h2
+ * origin behind a TCP proxy that black-holes one flow: with `allowH2: true` one
+ * request in eight kept failing indefinitely, while `allowH2: false` evicted the
+ * socket on the first timeout and recovered on the next request. The kill switch
+ * has to reach `allowH2` to get that behavior back.
+ */
+export function getEventsAgentOptionsNoH2() {
+  return {
+    ...getBaseAgentOptions(),
+    allowH2: false,
+    pipelining: 1,
+  } as const;
+}
+
+/**
  * Options for the stream write/close Agents. H2 is enabled (these send a
  * fully-buffered body, or none, so they avoid the duplex-streaming issues that
  * keep the long-lived live-read on plain `fetch`), but multiplexing is
@@ -344,8 +367,14 @@ export const STREAM_CLOSE_RETRY_OPTIONS: RetryHandler.RetryOptions = {
  */
 const H2_REBUFFER_MAX_BYTES = 1 << 20; // 1 MiB
 
-/** Set `WORKFLOW_H2_MULTIPLEX=0` to fall back to one request per connection. */
-function h2MultiplexEnabled(): boolean {
+/**
+ * Set `WORKFLOW_H2_MULTIPLEX=0` to take the events API off HTTP/2 entirely: no
+ * multiplexing interceptor *and* `allowH2: false` (see
+ * EVENTS_AGENT_OPTIONS_NO_H2 for why both are needed for this to be a usable
+ * kill switch). Read when a dispatcher is built, so it applies to agents created
+ * after it is set.
+ */
+function h2EventsEnabled(): boolean {
   return process.env.WORKFLOW_H2_MULTIPLEX !== '0';
 }
 
@@ -434,6 +463,181 @@ export function h2MultiplexInterceptor(
 }
 
 /**
+ * Consecutive transport failures on the *same* shared dispatcher before it is
+ * retired and rebuilt.
+ *
+ * The count is what separates a fault undici recovers from on its own from one it
+ * does not. On HTTP/1.1, and on H2 for connection-level events (GOAWAY, socket
+ * reset), undici destroys the connection as part of failing the request, so the
+ * next request opens a fresh one and a single failure is the whole story. The
+ * case this exists for is the one where it doesn't: an H2 stream timeout leaves
+ * the session in place by design, so if the flow underneath it has been
+ * black-holed while TCP stays established, every later request routed onto that
+ * session times out too — indefinitely. Requiring several failures in a row means
+ * the self-healing paths never trigger a rebuild, and the wedged-session path
+ * always does.
+ */
+export const EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES = 3;
+
+/**
+ * Floor on how often a recycler will rebuild, so a persistently unreachable
+ * origin can't turn every few requests into a fresh TLS handshake.
+ */
+const RECYCLE_MIN_INTERVAL_MS = 5_000;
+
+/**
+ * How long a retired dispatcher is left dispatchable before it is closed.
+ *
+ * A request that resolved the dispatcher just before the swap has not dispatched
+ * yet, and `close()` would reject it with ClientClosedError — turning a healthy
+ * event write into a step retry. The delay makes that race impossible in
+ * practice; the retired agent serves those few requests and then closes.
+ */
+const RETIRED_CLOSE_DELAY_MS = 5_000;
+
+/**
+ * Backstop for `close()` never settling. Closing is graceful: it waits for
+ * in-flight requests, which on a black-holed session means waiting for each
+ * stream's own timeout. Anything still in flight this long after retirement is
+ * wedged by definition, so the sockets get freed the hard way.
+ */
+const RETIRED_DESTROY_DELAY_MS = 60_000;
+
+/**
+ * undici error codes that mean "no response arrived over a connection that was
+ * already established". These are the failures a rebuild can fix; DNS, connect
+ * and TLS errors are excluded because a new agent would hit the same wall, and an
+ * abort is excluded because it is the caller's own doing.
+ */
+const RECYCLABLE_ERROR_CODES = new Set([
+  // Covers H2 stream timeout, frameError and GOAWAY (undici InformationalError).
+  'UND_ERR_INFO',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+]);
+
+/** Guard against a self-referential `cause` chain. */
+const MAX_CAUSE_DEPTH = 8;
+
+/**
+ * True when `error` (or anything in its `cause` chain) is a transport failure a
+ * dispatcher rebuild can fix. The chain walk is required, not defensive: `fetch`
+ * rejects with `TypeError: fetch failed` and hangs the undici error off `cause`,
+ * so the code is never on the error the caller sees. Exported for tests.
+ */
+export function isRecyclableTransportError(error: unknown): boolean {
+  let current = error;
+  for (let depth = 0; current && depth < MAX_CAUSE_DEPTH; depth++) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === 'string' && RECYCLABLE_ERROR_CODES.has(code)) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+export interface DispatcherRecycler {
+  /** The current shared dispatcher, built on first use. */
+  get(): RetryAgent;
+  /**
+   * Record the transport-level outcome of one request: `error` when the
+   * `fetch()`/dispatch itself failed, nothing when a response arrived (whatever
+   * its status — an HTTP error is the origin answering, so the transport worked).
+   *
+   * `dispatcher` is the dispatcher the request actually used. Outcomes from any
+   * other dispatcher are ignored, which covers both a caller-supplied override
+   * and the tail of the batch that provoked a rebuild: those requests were issued
+   * on the now-retired agent, and counting them would immediately recycle its
+   * replacement too.
+   */
+  note(dispatcher: unknown, error?: unknown): void;
+}
+
+/**
+ * Wraps a dispatcher factory with the failure accounting that retires a wedged
+ * connection pool. Exported so a test can drive the whole loop against a
+ * loopback origin; production uses the events recycler below.
+ */
+export function createDispatcherRecycler(
+  factory: () => RetryAgent,
+  label: string
+): DispatcherRecycler {
+  let current: RetryAgent | undefined;
+  let consecutiveFailures = 0;
+  let lastRecycledAt = 0;
+
+  function retire(stale: RetryAgent): void {
+    const closeTimer = setTimeout(() => {
+      void Promise.resolve(stale.close?.()).catch(() => undefined);
+    }, RETIRED_CLOSE_DELAY_MS);
+    const destroyTimer = setTimeout(() => {
+      void Promise.resolve(stale.destroy?.()).catch(() => undefined);
+    }, RETIRED_DESTROY_DELAY_MS);
+    // Never hold the process open for a pool we have already given up on.
+    closeTimer.unref?.();
+    destroyTimer.unref?.();
+  }
+
+  return {
+    get(): RetryAgent {
+      current ??= factory();
+      return current;
+    },
+
+    note(dispatcher: unknown, error?: unknown): void {
+      if (!current || dispatcher !== current) return;
+      if (error === undefined) {
+        consecutiveFailures = 0;
+        return;
+      }
+      if (!isRecyclableTransportError(error)) return;
+      consecutiveFailures++;
+      if (consecutiveFailures < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES) {
+        return;
+      }
+      const now = Date.now();
+      if (now - lastRecycledAt < RECYCLE_MIN_INTERVAL_MS) return;
+      lastRecycledAt = now;
+      consecutiveFailures = 0;
+      const stale = current;
+      // Swap first: subsequent requests build and use a fresh pool, and the
+      // stale agent stops receiving `note` calls.
+      current = undefined;
+      // Breadcrumb on stderr (stdout is a machine-parsed contract in the CLI):
+      // a rebuild means the transport was stuck, which is worth seeing in
+      // function logs even though the SDK recovered on its own.
+      console.warn(
+        `[workflow] ${label}: rebuilding connection pool after ${EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES} consecutive transport failures`
+      );
+      retire(stale);
+    },
+  };
+}
+
+/**
+ * The shared events dispatcher, with the failure accounting that makes a
+ * black-holed HTTP/2 session self-healing. See createDispatcherRecycler and
+ * EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES.
+ */
+const eventsRecycler = createDispatcherRecycler(
+  () => createEventsDispatcher(),
+  'events transport'
+);
+
+/**
+ * Record the transport-level outcome of a v4 events request so a wedged
+ * connection pool gets retired. No-ops for a caller-supplied dispatcher. Called
+ * by `fetchV4`; see DispatcherRecycler.note.
+ */
+export function noteEventsTransportOutcome(
+  dispatcher: unknown,
+  error?: unknown
+): void {
+  eventsRecycler.note(dispatcher, error);
+}
+
+/**
  * Resolves the undici dispatcher for a request: the caller's override, or the
  * shared default agent (HTTP/1.1).
  */
@@ -445,9 +649,14 @@ export function getDispatcher(config?: APIConfig): unknown {
  * Resolves the dispatcher for the v4 events API: the caller's override, or the
  * shared HTTP/2 events agent. See getEventsAgentOptions for why the events API
  * uses H2 while the default path stays on H1.
+ *
+ * The shared agent is not a fixed instance for the life of the process: repeated
+ * transport failures retire it and the next call here builds a replacement (see
+ * noteEventsTransportOutcome). Resolve it per request rather than caching the
+ * returned value.
  */
 export function getEventsDispatcher(config?: APIConfig): unknown {
-  return config?.dispatcher ?? getDefaultEventsDispatcher();
+  return config?.dispatcher ?? eventsRecycler.get();
 }
 
 /**
@@ -480,11 +689,15 @@ export function getStreamCloseDispatcher(config?: APIConfig): unknown {
 export function createEventsDispatcher(
   agentOverrides?: Partial<Agent.Options>
 ): RetryAgent {
+  const h2 = h2EventsEnabled();
   const agent = new RetryAgent(
-    new Agent({ ...getEventsAgentOptions(), ...agentOverrides }),
+    new Agent({
+      ...(h2 ? getEventsAgentOptions() : getEventsAgentOptionsNoH2()),
+      ...agentOverrides,
+    }),
     getRetryAgentOptions()
   );
-  if (!h2MultiplexEnabled()) {
+  if (!h2) {
     return agent;
   }
   // The interceptor wraps the RetryAgent (rather than the Agent inside it) so
@@ -554,18 +767,6 @@ function getDefaultDispatcher(): RetryAgent {
     getRetryAgentOptions()
   );
   return _dispatcher;
-}
-
-/**
- * Returns the shared HTTP/2 RetryAgent used by the v4 events API. Same retry /
- * pooling / timeout behavior as the default dispatcher, but with `allowH2`
- * enabled, a pipelining depth that lets H2 actually multiplex
- * (getEventsAgentOptions), and the interceptor that lifts undici's remaining
- * two per-request H2 busy gates (h2MultiplexInterceptor).
- */
-function getDefaultEventsDispatcher(): RetryAgent {
-  _eventsDispatcher ??= createEventsDispatcher();
-  return _eventsDispatcher;
 }
 
 /**

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -320,6 +320,14 @@ export interface InstrumentedFetchOptions {
    * `errorForResponse`.
    */
   buildError?: (response: Response) => Error | Promise<Error>;
+  /**
+   * Notified about the transport-level outcome of the `fetch()` call: the thrown
+   * error when no response arrived, `undefined` when one did. An HTTP error
+   * status is *not* reported as a failure — the origin answered, so the transport
+   * worked. Lets a caller that owns a shared dispatcher retire it when its
+   * connections stop delivering (see noteEventsTransportOutcome).
+   */
+  onTransportOutcome?: (error?: unknown) => void;
 }
 
 /**
@@ -349,6 +357,7 @@ export async function instrumentedFetch(
     cacheBust = true,
     logLabel,
     buildError,
+    onTransportOutcome,
   } = opts;
   const label = logLabel ?? url;
 
@@ -390,6 +399,9 @@ export async function instrumentedFetch(
         } as any);
       } catch (error) {
         const elapsed = Date.now() - start;
+        // Report the raw error, before the timeout mapping below rewraps it: the
+        // undici error code the caller matches on lives in this chain.
+        onTransportOutcome?.(error);
         // AbortSignal.timeout() surfaces as a DOMException named 'TimeoutError'.
         // Map to WorkflowWorldError so existing catch sites treat it like any
         // other world transport failure.
@@ -408,6 +420,7 @@ export async function instrumentedFetch(
         throw error;
       }
       const ms = Date.now() - start;
+      onTransportOutcome?.();
 
       httpLog(method, label, response, ms);
       span?.setAttributes({ ...HttpResponseStatusCode(response.status) });

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -33,7 +33,7 @@ import { version } from './version.js';
  *
  * Example: 'https://workflow-server-git-branch-name.vercel.sh'
  */
-const WORKFLOW_SERVER_URL_OVERRIDE = '';
+export const WORKFLOW_SERVER_URL_OVERRIDE = '';
 
 /**
  * HTTP methods that are safe to transparently re-issue inside the adapter.


### PR DESCRIPTION
Manual backport of #3370 (cherry-pick `bf4dda64`) to `stable`.

The automated **Backport to stable** job never ran for #3370: it merged at 18:45Z on 2026-08-06, during the GitHub Actions major outage that began at 15:22Z. The push to `main` created zero workflow runs for `bf4dda64` (Tests, Lint, Release and Docs Checks are all missing too, not just the backport). The `push` path keys on `github.event.after`, so a later merge to `main` will not pick this commit up.

`stable` is exposed to the same fault: its events agent already runs `allowH2: true` with a multiplexing `pipelining` depth, so a black-holed HTTP/2 session wedges it identically.

## Deviations from the commit on `main`

The cherry-pick conflicted. All differences below are adaptations to `stable`, no behavior changes.

- **Options are functions, not module constants.** `stable` uses `getEventsAgentOptions()` / `getRetryAgentOptions()` / `getBaseAgentOptions()` where `main` uses `EVENTS_AGENT_OPTIONS` / `RETRY_AGENT_OPTIONS` / `BASE_AGENT_OPTIONS`. The new `EVENTS_AGENT_OPTIONS_NO_H2` constant is therefore ported as `getEventsAgentOptionsNoH2()`.
- **Docs page differs.** The wording change landed on `docs/content/docs/v5/configuration/runtime-tuning.mdx`, which does not exist on `stable`. Ported to `docs/content/docs/deploying/world/vercel-world.mdx`, where `stable` documents `WORKFLOW_H2_MULTIPLEX`.
- **`WORKFLOW_SERVER_URL_OVERRIDE` is now exported** from `utils.ts`, matching `main`. The new `events-v4` test imports it. The value stays `''`, so the lint guard (which greps for `const WORKFLOW_SERVER_URL_OVERRIDE = '';`) still matches.
- **Test import aliasing.** `stable`'s `http-client.test.ts` imports `createServer`/`Server` from `node:http`, which collides with the `node:net` imports the black-hole harness needs. Imported as `createNetServer` / `NetServer`.
- **One main-only test block excluded.** The conflict region swallowed `describe('v4 POST frame meta forwards every field the splitter produces')`, which is not on `stable`. Only #3370's own additions were taken.

## Verification

Run locally, since CI is degraded by the outage:

- `packages/world-vercel` typecheck: passes.
- `packages/world-vercel` tests: 250 passed / 16 files.
- Biome check on the changed files: clean.

The ported tests all execute, including the premise test (12/12 requests fail on a single TCP flow with no recovery) and the recovery test (exactly 3 failures, then success on a rebuilt pool).
