### PR TITLE
feat(world): batch analytics event lookups

### DIFF
--- a/.changeset/batch-analytics-event-lookup.md
+++ b/.changeset/batch-analytics-event-lookup.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world': minor
+'@workflow/world-vercel': minor
+---
+
+Add a bounded batch analytics event lookup for enriching canonical event pages.

--- a/packages/world-vercel/src/analytics.test.ts
+++ b/packages/world-vercel/src/analytics.test.ts
@@ -10,6 +10,62 @@ vi.mock('./utils.js', () => ({
 
 const { createAnalytics } = await import('./analytics.js');
 
+const eventRow = {
+  runId: 'wrun_1',
+  eventId: 'evnt_1',
+  eventType: 'run_started',
+  workflowName: 'test-workflow',
+  deploymentId: 'dpl_1',
+  runCreatedAt: '2026-07-13 17:09:11.000',
+  createdAt: '2026-07-13 17:09:11.593',
+  vercelId: 'request-grain-id',
+  requestId: 'sibling-request-column',
+  computeInstanceId: 'compute-instance-id',
+};
+
+describe('createAnalytics events.getMany', () => {
+  beforeEach(() => {
+    state.makeRequest.mockReset();
+    state.makeRequest.mockResolvedValue([eventRow]);
+  });
+
+  it('posts one deduplicated batch and parses analytics provenance', async () => {
+    const analytics = createAnalytics();
+    await expect(
+      analytics.events.getMany('wrun/1', ['evnt_1', 'evnt_1', 'evnt_2'])
+    ).resolves.toEqual([eventRow]);
+
+    const request = state.makeRequest.mock.calls[0][0];
+    expect(request.endpoint).toBe(
+      '/v2/analytics/runs/wrun%2F1/events/get-many'
+    );
+    expect(request.options).toEqual({ method: 'POST' });
+    expect(request.data).toEqual({ eventIds: ['evnt_1', 'evnt_2'] });
+    expect(request.schema.parse([eventRow])).toMatchObject([
+      {
+        vercelId: 'request-grain-id',
+        requestId: 'sibling-request-column',
+        computeInstanceId: 'compute-instance-id',
+      },
+    ]);
+    expect(state.makeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects empty and over-limit batches without a request', () => {
+    const analytics = createAnalytics();
+    expect(() => analytics.events.getMany('wrun_1', [])).toThrow(
+      'at least one'
+    );
+    expect(() =>
+      analytics.events.getMany(
+        'wrun_1',
+        Array.from({ length: 101 }, (_, index) => `evnt_${index}`)
+      )
+    ).toThrow('at most 100');
+    expect(state.makeRequest).not.toHaveBeenCalled();
+  });
+});
+
 describe('createAnalytics attributes', () => {
   beforeEach(() => {
     state.makeRequest.mockReset();

--- a/packages/world-vercel/src/analytics.ts
+++ b/packages/world-vercel/src/analytics.ts
@@ -1,4 +1,5 @@
 import {
+  ANALYTICS_EVENTS_GET_MANY_LIMIT,
   type Analytics,
   AnalyticsAttributeKeySchema,
   AnalyticsEventSchema,
@@ -25,6 +26,19 @@ function appendPagination(
 function createQueryString(params: URLSearchParams): string {
   const query = params.toString();
   return query ? `?${query}` : '';
+}
+
+function normalizeEventIds(eventIds: readonly string[]): string[] {
+  const uniqueEventIds = [...new Set(eventIds)];
+  if (uniqueEventIds.length === 0) {
+    throw new RangeError('eventIds must contain at least one event ID');
+  }
+  if (uniqueEventIds.length > ANALYTICS_EVENTS_GET_MANY_LIMIT) {
+    throw new RangeError(
+      `eventIds must contain at most ${ANALYTICS_EVENTS_GET_MANY_LIMIT} unique event IDs`
+    );
+  }
+  return uniqueEventIds;
 }
 
 function appendAttributeListParams(
@@ -115,6 +129,15 @@ export function createAnalytics(config?: APIConfig): Analytics {
           endpoint: `/v2/analytics/runs/${encodeURIComponent(runId)}/events/${encodeURIComponent(eventId)}`,
           config,
           schema: AnalyticsEventSchema,
+        });
+      },
+      getMany(runId, eventIds) {
+        return makeRequest({
+          endpoint: `/v2/analytics/runs/${encodeURIComponent(runId)}/events/get-many`,
+          options: { method: 'POST' },
+          data: { eventIds: normalizeEventIds(eventIds) },
+          config,
+          schema: AnalyticsEventSchema.array(),
         });
       },
       list(params) {

--- a/packages/world/src/analytics.test.ts
+++ b/packages/world/src/analytics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AnalyticsRunSchema } from './analytics.js';
+import { AnalyticsEventSchema, AnalyticsRunSchema } from './analytics.js';
 
 const base = {
   runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ',
@@ -8,6 +8,27 @@ const base = {
   workflowName: 'workflow//./src/w//myWorkflow',
   updatedAt: '2026-07-13 17:09:11.593',
 };
+
+describe('AnalyticsEventSchema', () => {
+  it('preserves vercelId and computeInstanceId as distinct provenance fields', () => {
+    const event = AnalyticsEventSchema.parse({
+      runId: 'wrun_01KX2M5N3RBNC12RYWYYH4WWQJ',
+      eventId: 'evnt_01KX2M5N3RBNC12RYWYYH4WWQJ',
+      eventType: 'run_started',
+      workflowName: 'test-workflow',
+      deploymentId: 'dpl_1',
+      runCreatedAt: '2026-07-13 17:09:11.000',
+      createdAt: '2026-07-13 17:09:11.593',
+      vercelId: 'request-grain-id',
+      requestId: 'sibling-request-column',
+      computeInstanceId: 'compute-instance-id',
+    });
+
+    expect(event.vercelId).toBe('request-grain-id');
+    expect(event.requestId).toBe('sibling-request-column');
+    expect(event.computeInstanceId).toBe('compute-instance-id');
+  });
+});
 
 describe('analytics date coercion', () => {
   it('parses timezone-naive datetime strings as UTC regardless of process TZ', () => {

--- a/packages/world/src/analytics.ts
+++ b/packages/world/src/analytics.ts
@@ -194,6 +194,9 @@ export interface AnalyticsListEventsByCorrelationIdParams {
   pagination?: PaginationOptions;
 }
 
+/** Maximum number of event IDs accepted by one analytics batch lookup. */
+export const ANALYTICS_EVENTS_GET_MANY_LIMIT = 100;
+
 export interface AnalyticsListHooksParams {
   runId: string;
   pagination?: PaginationOptions;
@@ -228,6 +231,16 @@ export interface Analytics {
   };
   events: {
     get(runId: string, eventId: string): Promise<AnalyticsEvent>;
+    /**
+     * Retrieves the analytics rows present for a bounded set of event IDs in
+     * one run. Missing rows are omitted because analytics ingestion may lag
+     * canonical storage. Duplicate IDs are looked up once; result ordering is
+     * not guaranteed.
+     */
+    getMany(
+      runId: string,
+      eventIds: readonly string[]
+    ): Promise<AnalyticsEvent[]>;
     list(
       params: AnalyticsListEventsParams
     ): Promise<PaginatedResponse<AnalyticsEvent>>;

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -1,5 +1,6 @@
 export type * from './analytics.js';
 export {
+  ANALYTICS_EVENTS_GET_MANY_LIMIT,
   AnalyticsAttributeKeySchema,
   AnalyticsEventSchema,
   AnalyticsHookSchema,


### PR DESCRIPTION
## Summary & Motivation

Adds `events.getMany` to the analytics API, letting dashboard consumers enrich canonical event pages with ClickHouse provenance in one bounded, deduplicated batch request instead of N point lookups. Coordinated with a workflow-server batch endpoint.

## Test Plan

Added unit tests for the client and schema; also ran Biome checks, `git diff --check`, and world-vercel typecheck.
