### PR TITLE
fix(core): various flake fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1160,14 +1160,14 @@ jobs:
           # (2) probe the server before the long e2e run to catch any other
           # silent breakage.
           #
-          # Get-DevServerStatus returns the HTTP status code of GET /api/chat,
-          # or 0 if the request never produced a response. /api/chat is a
-          # POST-only endpoint, so a healthy dev server responds with 405
-          # Method Not Allowed; we only treat 5xx (and no-response) as
-          # unhealthy.
-          function Get-DevServerStatus {
+          # Get-EndpointStatus returns the HTTP status code of a GET, or 0 if
+          # the request never produced a response. Both probed endpoints are
+          # POST-only, so a healthy dev server answers 405 Method Not Allowed;
+          # only 5xx (and no-response) mean unhealthy.
+          function Get-EndpointStatus {
+            param([string]$Path)
             try {
-              $resp = Invoke-WebRequest -Uri "http://localhost:3000/api/chat" -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
+              $resp = Invoke-WebRequest -Uri "http://localhost:3000$Path" -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
               return [int]$resp.StatusCode
             } catch {
               if ($_.Exception.Response) {
@@ -1192,10 +1192,21 @@ jobs:
           # returning 500 for every request. Without this check the e2e suite
           # would burn the full 30-minute job window polling stuck workflow
           # runs before getting cancelled.
-          $status = Get-DevServerStatus
-          Write-Host "[health-check:pre-e2e] GET /api/chat -> $status"
-          if ($status -eq 0 -or $status -ge 500) {
-            Write-Host "::error title=Next.js dev server unhealthy::Dev server returned $status before e2e tests. Aborting to avoid the 30-minute job timeout. See the 'Print Next.js server logs' step for the underlying Turbopack error."
+          #
+          # Both endpoints are probed because they fail independently. Turbopack
+          # compiles routes lazily, so the flow route can be wedged on a stale
+          # generated import while /api/chat still answers 405 — which is how a
+          # broken run once burned the full window behind a "healthy" pre-flight.
+          $unhealthy = $false
+          foreach ($endpoint in @("/api/chat", "/.well-known/workflow/v1/flow")) {
+            $status = Get-EndpointStatus $endpoint
+            Write-Host "[health-check:pre-e2e] GET $endpoint -> $status"
+            if ($status -eq 0 -or $status -ge 500) {
+              Write-Host "::error title=Next.js dev server unhealthy::GET $endpoint returned $status before e2e tests. Aborting to avoid the 30-minute job timeout. See the 'Print Next.js server logs' step for the underlying Turbopack error."
+              $unhealthy = $true
+            }
+          }
+          if ($unhealthy) {
             Stop-Job $job -ErrorAction SilentlyContinue
             exit 1
           }

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -266,11 +266,15 @@ export abstract class BaseBuilder {
   }
 
   private startWorkflowBuildTimer(): void {
-    this.workflowBuildStartTime = Date.now();
+    // Monotonic: `Date.now()` follows wall-clock corrections, and a backwards
+    // step mid-build renders the summary as "Compiled workflows in -1ms".
+    this.workflowBuildStartTime = performance.now();
   }
 
   private getWorkflowBuildDuration(): number {
-    return Date.now() - (this.workflowBuildStartTime ?? Date.now());
+    return Math.round(
+      performance.now() - (this.workflowBuildStartTime ?? performance.now())
+    );
   }
 
   private resetWorkflowBuildTimer(): void {

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -52,14 +52,20 @@ export function createDevTests(config?: DevTestConfig) {
     // Each prewarm/trigger fetch is hard-bounded by this so cleanup never hangs
     // on a wedged dev server.
     const PREWARM_FETCH_TIMEOUT_MS = 5_000;
-    // The afterEach cleanup can issue two *sequential* prewarms (before and
-    // after deleting an added file) while the dev server is mid-rebuild — the
-    // teardown of a test that added a workflow file and edited an import is
-    // exactly when both rebuild and respond slowly. Its budget must therefore
-    // exceed 2× PREWARM_FETCH_TIMEOUT_MS (plus file IO) with headroom, or it
-    // trips vitest's 10s default hook timeout. The bounded fetches mean this
-    // can't hang indefinitely, so a generous budget is safe.
-    const CLEANUP_HOOK_TIMEOUT_MS = PREWARM_FETCH_TIMEOUT_MS * 4;
+    // How long cleanup waits for the dev server to regenerate the step
+    // registrations after a workflow file is deleted, before repairing them
+    // itself.
+    const STALE_REGISTRATION_TIMEOUT_MS = 8_000;
+    // The afterEach cleanup can issue three *sequential* prewarms (before and
+    // after deleting an added file, and after repairing the registrations)
+    // while the dev server is mid-rebuild — the teardown of a test that added
+    // a workflow file and edited an import is exactly when both rebuild and
+    // respond slowly. Its budget must therefore exceed 3× the fetch bound plus
+    // the registration wait (plus file IO) with headroom, or it trips vitest's
+    // 10s default hook timeout. The bounded fetches mean this can't hang
+    // indefinitely, so a generous budget is safe.
+    const CLEANUP_HOOK_TIMEOUT_MS =
+      PREWARM_FETCH_TIMEOUT_MS * 4 + STALE_REGISTRATION_TIMEOUT_MS;
     const appPath = getWorkbenchAppPath();
     const deploymentUrl = process.env.DEPLOYMENT_URL;
     const generatedStepRegistration = path.join(
@@ -181,6 +187,75 @@ export function createDevTests(config?: DevTestConfig) {
         fetchWithTimeout('/api/chat').catch(() => {}),
       ]);
     };
+    /**
+     * Make the generated step registrations stop importing files this test
+     * just deleted.
+     *
+     * The registrations list every file in the workflows directory, so
+     * deleting one leaves a dangling import until the dev server's watcher
+     * regenerates. Nothing in the cleanup waits for that, and on Windows the
+     * regeneration can be missed entirely — the flow route then fails to
+     * compile with `Module not found` for the rest of the run, which reads as
+     * every later test timing out rather than as a cleanup bug.
+     *
+     * Wait for the regeneration, and rewrite the file ourselves if it does not
+     * come. The next real regeneration overwrites whatever we write, and the
+     * deleted file cannot come back into the list, so the repair is safe.
+     */
+    const dropStaleStepRegistrations = async (deletedPaths: string[]) => {
+      const deletedNames = deletedPaths
+        .filter((filePath) =>
+          filePath.startsWith(path.join(appPath, workflowsDir))
+        )
+        .map((filePath) => path.basename(filePath));
+      if (deletedNames.length === 0) {
+        return;
+      }
+
+      const readStale = async (): Promise<{
+        content: string;
+        staleLines: string[];
+      } | null> => {
+        const content = await fs
+          .readFile(generatedStepRegistration, 'utf8')
+          .catch(() => null);
+        if (content === null) {
+          return null;
+        }
+        const staleLines = content
+          .split('\n')
+          .filter((line) =>
+            deletedNames.some((name) => line.includes(`/${name}`))
+          );
+        return staleLines.length > 0 ? { content, staleLines } : null;
+      };
+
+      const deadline = Date.now() + STALE_REGISTRATION_TIMEOUT_MS;
+      let stale = await readStale();
+      while (stale !== null && Date.now() < deadline) {
+        await sleep(500);
+        stale = await readStale();
+      }
+      if (stale === null) {
+        return;
+      }
+
+      console.warn(
+        `[dev e2e cleanup] ${generatedStepRegistration} still imports deleted ` +
+          `workflow files after ${STALE_REGISTRATION_TIMEOUT_MS}ms; stripping ` +
+          `them so later tests are not wedged on a missing module:\n` +
+          stale.staleLines.map((line) => `  ${line}`).join('\n')
+      );
+      await fs.writeFile(
+        generatedStepRegistration,
+        stale.content
+          .split('\n')
+          .filter((line) => !stale.staleLines.includes(line))
+          .join('\n')
+      );
+      await prewarm();
+    };
+
     const decodeDevServerLog = (content: Buffer) => {
       if (content.length >= 2 && content[0] === 0xff && content[1] === 0xfe) {
         return content.toString('utf16le');
@@ -390,6 +465,7 @@ export function createDevTests(config?: DevTestConfig) {
         )
       );
       await prewarm();
+      await dropStaleStepRegistrations(toDelete.map((item) => item.path));
       restoreFiles.length = 0;
       restoreDirectories.length = 0;
     }, CLEANUP_HOOK_TIMEOUT_MS);

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -17,6 +17,14 @@ export interface DevTestConfig {
   workflowsDir?: string;
 }
 
+/**
+ * A poll condition that can no longer become true. Rebuild-decision counts only
+ * grow, so once one overshoots its expectation the remaining timeout is dead
+ * time — and a 50s dead wait reads as "slow/flaky infra" when the real answer
+ * is "we rebuilt too many times", which is a different bug.
+ */
+class PollUnreachableError extends Error {}
+
 const SOURCE_MAP_WARNING = 'failed to read input source map';
 const SOURCE_MAP_FIXTURE_PACKAGE = 'workflow-sourcemap-warning-fixture';
 const SOURCE_MAP_COMMENT = '//# sourceMapping' + 'URL=index.js.map';
@@ -201,6 +209,7 @@ export function createDevTests(config?: DevTestConfig) {
       log.split(message).length - 1;
     type ExpectedHmrLogCount = number | { min?: number; max?: number };
     const expectLogCount = (
+      label: string,
       actual: number,
       expected: ExpectedHmrLogCount | undefined
     ) => {
@@ -211,11 +220,21 @@ export function createDevTests(config?: DevTestConfig) {
           expect(actual).toBeGreaterThanOrEqual(expected);
           return;
         }
+        if (actual > expected) {
+          throw new PollUnreachableError(
+            `saw ${actual} '${label}' rebuild decisions, expected exactly ${expected}`
+          );
+        }
         expect(actual).toBe(expected);
         return;
       }
       expect(actual).toBeGreaterThanOrEqual(expected?.min ?? 0);
       if (expected?.max !== undefined) {
+        if (actual > expected.max) {
+          throw new PollUnreachableError(
+            `saw ${actual} '${label}' rebuild decisions, expected at most ${expected.max}`
+          );
+        }
         expect(actual).toBeLessThanOrEqual(expected.max);
       }
     };
@@ -230,26 +249,39 @@ export function createDevTests(config?: DevTestConfig) {
       if (cursor === undefined) {
         return;
       }
-      await pollUntil({
-        description: 'dev server HMR logs to match expected rebuild counts',
-        timeoutMs: hmrRediscoveryTimeoutMs,
-        intervalMs: 250,
-        check: async () => {
-          const log = (await readDevServerLog()).slice(cursor);
-          expectLogCount(
-            countLogMessage(log, hmrLogMessages.skip),
-            expected.skip
-          );
-          expectLogCount(
-            countLogMessage(log, hmrLogMessages.hot),
-            expected.hot
-          );
-          expectLogCount(
-            countLogMessage(log, hmrLogMessages.full),
-            expected.full
-          );
-        },
-      });
+      try {
+        await pollUntil({
+          description: 'dev server HMR logs to match expected rebuild counts',
+          timeoutMs: hmrRediscoveryTimeoutMs,
+          intervalMs: 250,
+          check: async () => {
+            const log = (await readDevServerLog()).slice(cursor);
+            expectLogCount(
+              'skip',
+              countLogMessage(log, hmrLogMessages.skip),
+              expected.skip
+            );
+            expectLogCount(
+              'hot rebuild',
+              countLogMessage(log, hmrLogMessages.hot),
+              expected.hot
+            );
+            expectLogCount(
+              'full rediscovery',
+              countLogMessage(log, hmrLogMessages.full),
+              expected.full
+            );
+          },
+        });
+      } catch (error) {
+        // The counts alone never say *why*. The slice since the cursor holds
+        // the decisions with their `workflow dev hmr debug:` file lists, which
+        // is what distinguishes a real over-rebuild from a drained backlog.
+        console.error(
+          `HMR log expectation failed (expected ${JSON.stringify(expected)}). Dev server log since cursor:\n${(await readDevServerLog()).slice(cursor)}`
+        );
+        throw error;
+      }
     };
 
     const pollUntil = async ({
@@ -271,6 +303,11 @@ export function createDevTests(config?: DevTestConfig) {
           await check();
           return;
         } catch (error) {
+          // Some conditions can only get further from passing (see
+          // PollUnreachableError); retrying them just burns the timeout.
+          if (error instanceof PollUnreachableError) {
+            throw error;
+          }
           lastError = error;
           await new Promise((res) => setTimeout(res, intervalMs));
         }
@@ -1353,7 +1390,10 @@ ${apiFileContent}`
           },
           {
             description: 'workflow file removed from API import',
-            expectedLogCounts: { full: 1, skip: 1 },
+            // Two filesystem operations (unlink + API-file rewrite). Whether
+            // they land in one flush or two is a scheduling detail; what must
+            // hold is exactly one full rediscovery.
+            expectedLogCounts: { full: 1, skip: { max: 1 } },
             write: async () => {
               await fs.rm(files.addedWorkflow, { force: true });
               await fs.writeFile(

--- a/packages/core/src/replay-clock.ts
+++ b/packages/core/src/replay-clock.ts
@@ -1,0 +1,40 @@
+import type { Event } from '@workflow/world';
+
+/**
+ * Run-lifecycle events. The orchestrator's structural subscriber consumes
+ * these; no workflow-body call does.
+ */
+const STRUCTURAL_EVENT_TYPES = new Set<Event['eventType']>([
+  'run_created',
+  'run_started',
+]);
+
+/**
+ * Whether an event may move the VM's replay clock (`Date.now()`, `new Date()`).
+ *
+ * Only events a workflow-body call consumes qualify, because only those are
+ * consumed at a point the body's own progress determines. Run-lifecycle events
+ * are not: under turbo the first delivery backgrounds `run_started` and skips
+ * the initial event preload, so pass 1 sees neither event, while every later
+ * replay has both waiting in the log. Whether the consumer's queued drain
+ * reaches them before the body's first statement then depends on whether
+ * hydrating the run input yields to the event loop — it does whenever the
+ * input is encrypted, compressed, or offloaded. So a `Date.now()` read before
+ * the first suspension could return the seed on one pass and
+ * `run_started.createdAt` on another: the exact non-determinism the pinned
+ * clock exists to prevent, and intermittent in a way that reads as flake.
+ * Worse, the two values then get mixed — a `sleep()` deadline computed on pass
+ * 1 is compared against a start time re-read on the final replay.
+ *
+ * Nothing is lost by ignoring them. The clock is already seeded from the run's
+ * creation time (recovered from the ULID in `runId`), and `run_started`'s own
+ * time reaches workflow code as `workflowStartedAt` on the workflow context.
+ *
+ * Step-written `attr_set` is also structurally consumed but is deliberately
+ * left advancing the clock: it appears in the log at a fixed position relative
+ * to the step events around it, so unlike the run-lifecycle pair its
+ * consumption point is stable across passes.
+ */
+export function advancesReplayClock(event: Event): boolean {
+  return !STRUCTURAL_EVENT_TYPES.has(event.eventType);
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -489,6 +489,85 @@ function openHookAndWaitState(events: Event[]): {
   return { openHook: hooks.size > 0, openWait: waits.size > 0 };
 }
 
+/**
+ * Describe a park that holds no unconsumed wake source.
+ *
+ * Parking with no inline work is the normal shape of a run awaiting a hook or
+ * a timer. It is only anomalous when nothing left in the log can ever write to
+ * this run again — every created hook already received or disposed, no open
+ * wait, no timer, no pending step. Such a run stays in `running` forever.
+ *
+ * Returns null when some wake source remains, and a summary of the log
+ * otherwise. The summary separates the two candidate causes: a `hook_received`
+ * count matching `hook_created` says the replay had the complete log and still
+ * failed to advance, a short count says the log this invocation replayed
+ * against was missing a committed event.
+ */
+function describeWakelessPark({
+  events,
+  pendingStepCount,
+  hasWaitTimeout,
+}: {
+  events: Event[];
+  pendingStepCount: number;
+  hasWaitTimeout: boolean;
+}): {
+  hooksCreated: number;
+  hooksReceived: number;
+  hooksDisposed: number;
+  stepsCreated: number;
+  stepsTerminal: number;
+} | null {
+  if (pendingStepCount > 0 || hasWaitTimeout) return null;
+
+  const created = new Set<string>();
+  const received = new Set<string>();
+  const disposed = new Set<string>();
+  let openWaits = 0;
+  let stepsCreated = 0;
+  let stepsTerminal = 0;
+  for (const event of events) {
+    switch (event.eventType) {
+      case 'hook_created':
+        created.add(event.correlationId);
+        break;
+      case 'hook_received':
+        received.add(event.correlationId);
+        break;
+      case 'hook_disposed':
+        disposed.add(event.correlationId);
+        break;
+      case 'wait_created':
+        openWaits++;
+        break;
+      case 'wait_completed':
+        openWaits--;
+        break;
+      case 'step_created':
+        stepsCreated++;
+        break;
+      case 'step_completed':
+      case 'step_failed':
+        stepsTerminal++;
+        break;
+    }
+  }
+  if (openWaits > 0) return null;
+  for (const correlationId of created) {
+    if (!received.has(correlationId) && !disposed.has(correlationId)) {
+      return null;
+    }
+  }
+
+  return {
+    hooksCreated: created.size,
+    hooksReceived: received.size,
+    hooksDisposed: disposed.size,
+    stepsCreated,
+    stepsTerminal,
+  };
+}
+
 type ReplayEventLog =
   | { type: 'loadAll' }
   | ({ type: 'ready' } & LoadedEventLog)
@@ -2302,6 +2381,12 @@ export function workflowEntrypoint(
                   // replays. Invocation-scoped: dies with this delivery.
                   let retainedSession: WorkflowSession | null = null;
 
+                  // Whether the pre-park log recheck has already been spent.
+                  // Re-armed by every inline step that runs, so each parking
+                  // decision that follows real progress gets its own recheck
+                  // and a run with nothing new to read cannot spin.
+                  let parkRecheckArmed = false;
+
                   // Main replay loop
                   // biome-ignore lint/correctness/noConstantCondition: intentional loop
                   while (true) {
@@ -3243,6 +3328,79 @@ export function workflowEntrypoint(
                           if (suspensionResult.hasAwaitedHookCreation) {
                             return await reinvoke(0);
                           }
+                          // Parking is safe while something other than this
+                          // invocation can still write to the run: a wait has
+                          // its timer and a pending step has its own message,
+                          // so both wake again on their own even if this
+                          // replay's view was stale. When the only wake source
+                          // left is a hook delivery, a park is terminal —
+                          // nothing retries a delivery — so it is only correct
+                          // if the log it decided on is the whole log.
+                          //
+                          // Every writer races the invocation that is about to
+                          // ack. A lazy hook resume commits its `hook_received`
+                          // from the producer while its own consumer delivery
+                          // is in flight, so the event can land after this
+                          // replay's last read and before this decision — and
+                          // the delivery that would have observed it is this
+                          // one. Re-read from the cursor and replay against the
+                          // result rather than wedging on a stale view; an
+                          // empty delta parks as before, one list call later.
+                          //
+                          // Once per park, not per iteration: re-armed only by
+                          // real progress (an inline step executing), so a run
+                          // with nothing new to read cannot spin here.
+                          if (
+                            !parkRecheckArmed &&
+                            eventLog.cursor !== null &&
+                            openHookWait.value.openHook &&
+                            pendingSteps.length === 0 &&
+                            suspensionResult.waitTimeout === undefined
+                          ) {
+                            parkRecheckArmed = true;
+                            const delta = await loadWorkflowRunEvents(
+                              runId,
+                              eventLog.cursor
+                            );
+                            if (delta.events.length > 0) {
+                              runtimeLogger.warn(
+                                'Events landed while this invocation was replaying; re-replaying instead of parking on a stale log',
+                                {
+                                  workflowRunId: runId,
+                                  loopIteration,
+                                  appended: delta.events.length,
+                                  appendedTypes: delta.events.map(
+                                    (event) => event.eventType
+                                  ),
+                                }
+                              );
+                              appendEventLog(eventLog, delta);
+                              eventLog = { ...eventLog, type: 'ready' };
+                              continue;
+                            }
+                          }
+
+                          const wakelessPark = describeWakelessPark({
+                            events: eventLog.events,
+                            pendingStepCount: pendingSteps.length,
+                            hasWaitTimeout:
+                              suspensionResult.waitTimeout !== undefined,
+                          });
+                          if (wakelessPark !== null) {
+                            runtimeLogger.warn(
+                              'Invocation parked with no pending work and no unconsumed wake source — the run cannot make further progress',
+                              {
+                                workflowRunId: runId,
+                                loopIteration,
+                                events: eventLog.events.length,
+                                cursor: eventLog.cursor,
+                                ...wakelessPark,
+                                lastEventTypes: eventLog.events
+                                  .slice(-6)
+                                  .map((event) => event.eventType),
+                              }
+                            );
+                          }
                           return;
                         }
 
@@ -3569,6 +3727,9 @@ export function workflowEntrypoint(
                           stepResults = await Promise.all(
                             stepExecutionPromises
                           );
+                          // Real progress: re-arm the pre-park log recheck so
+                          // the next parking decision gets its own.
+                          parkRecheckArmed = false;
                         } catch (stepErr) {
                           // A stale (412) rejection of an inline step_started
                           // claim: the loaded view this batch was scheduled

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -519,6 +519,10 @@ function describeWakelessPark({
   stepsTerminal: number;
 } | null {
   if (pendingStepCount > 0 || hasWaitTimeout) return null;
+  // A first invocation replays an empty log and parks on the hook it just
+  // created, whose `hook_created` is not in that log. Nothing can be concluded
+  // from a log the invocation's own writes are missing from.
+  if (events.length === 0) return null;
 
   const created = new Set<string>();
   const received = new Set<string>();
@@ -3343,39 +3347,54 @@ export function workflowEntrypoint(
                           // is in flight, so the event can land after this
                           // replay's last read and before this decision — and
                           // the delivery that would have observed it is this
-                          // one. Re-read from the cursor and replay against the
-                          // result rather than wedging on a stale view; an
-                          // empty delta parks as before, one list call later.
+                          // one. Re-read the log and replay against the result
+                          // rather than wedging on a stale view; an unchanged
+                          // log parks as before, one list call later.
+                          //
+                          // The re-read MUST be cursor-less. The cursor filters
+                          // by lexicographic event id while this hole is
+                          // defined by ULID *time*: a `hook_received` minted
+                          // before the last event this invocation wrote but
+                          // committed after it always sorts below the cursor,
+                          // so an incremental read never returns it — which is
+                          // precisely the interleaving that wedges the run.
+                          // Diff the reload by event id rather than trusting a
+                          // page to be new.
                           //
                           // Once per park, not per iteration: re-armed only by
                           // real progress (an inline step executing), so a run
                           // with nothing new to read cannot spin here.
                           if (
                             !parkRecheckArmed &&
-                            eventLog.cursor !== null &&
                             openHookWait.value.openHook &&
                             pendingSteps.length === 0 &&
                             suspensionResult.waitTimeout === undefined
                           ) {
                             parkRecheckArmed = true;
-                            const delta = await loadWorkflowRunEvents(
-                              runId,
-                              eventLog.cursor
+                            const reloaded = await loadWorkflowRunEvents(runId);
+                            const replayed = new Set(
+                              eventLog.events.map((event) => event.eventId)
                             );
-                            if (delta.events.length > 0) {
+                            const appended = reloaded.events.filter(
+                              (event) => !replayed.has(event.eventId)
+                            );
+                            if (appended.length > 0) {
                               runtimeLogger.warn(
                                 'Events landed while this invocation was replaying; re-replaying instead of parking on a stale log',
                                 {
                                   workflowRunId: runId,
                                   loopIteration,
-                                  appended: delta.events.length,
-                                  appendedTypes: delta.events.map(
+                                  appended: appended.length,
+                                  appendedTypes: appended.map(
                                     (event) => event.eventType
                                   ),
                                 }
                               );
-                              appendEventLog(eventLog, delta);
-                              eventLog = { ...eventLog, type: 'ready' };
+                              eventLog = { ...reloaded, type: 'ready' };
+                              // The corrected log inserts the missing events
+                              // below the length already scanned for payload
+                              // prewarming, shifting every later position.
+                              replayPayloadCache.resetScan();
                               continue;
                             }
                           }

--- a/packages/core/src/runtime/park-recheck-reload.test.ts
+++ b/packages/core/src/runtime/park-recheck-reload.test.ts
@@ -1,0 +1,257 @@
+import {
+  type Event,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+} from '@workflow/world';
+import { ulid } from 'ulid';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerStepFunction } from '../private.js';
+import { workflowEntrypoint } from '../runtime.js';
+import {
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from '../serialization.js';
+import { setWorld } from './world.js';
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn(),
+}));
+
+/**
+ * A durable event plus the position the World sorts and paginates it by.
+ *
+ * Real event ids are ULIDs, so a page is ordered by mint time while a cursor
+ * filters by id. The two agree only while events are committed in the order
+ * they were minted. `sort` makes that divergence expressible: an event given a
+ * position below the current cursor is durable, returned by a full list, and
+ * invisible to every incremental read — the shape a `hook_received` takes when
+ * its producer minted it before the consumer's last write and committed it
+ * after.
+ */
+type StoredEvent = { event: Event; sort: number };
+
+const RUN_ID = 'wrun_park_recheck_reload';
+const HOOK_TOKEN = 'park-recheck-token';
+
+registerStepFunction('parkRecheckStep', async () => 'step-done');
+
+// Creates the hook, runs one step, then parks on the hook. The step is what
+// re-arms the pre-park recheck, and the hook is the only wake source left.
+const HOOK_AFTER_STEP_WORKFLOW = `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+  const s = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("parkRecheckStep");
+  async function workflow() {
+    const hook = createHook({ token: ${JSON.stringify(HOOK_TOKEN)} });
+    await s();
+    const payload = await hook;
+    return payload.message;
+  };globalThis.__private_workflows = new Map([["workflow", workflow]]);`;
+
+describe('workflowEntrypoint pre-park log recheck', () => {
+  afterEach(() => {
+    setWorld(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('reloads the whole log before a hook-only park, so a hook_received that sorts below the cursor still wakes the run', async () => {
+    const workflowRun: WorkflowRun = {
+      runId: RUN_ID,
+      workflowName: 'workflow',
+      status: 'running',
+      input: await dehydrateWorkflowArguments([], RUN_ID, undefined, []),
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      startedAt: new Date('2026-01-01T00:00:00.000Z'),
+      deploymentId: 'dpl_park_recheck',
+      specVersion: SPEC_VERSION_CURRENT,
+    };
+
+    const stored: StoredEvent[] = [];
+    let nextSort = 1;
+    const record = (data: any, sort = nextSort++): Event => {
+      const event = {
+        eventId: `evnt_${ulid()}`,
+        runId: RUN_ID,
+        createdAt: new Date(),
+        ...data,
+      } as Event;
+      stored.push({ event, sort });
+      return event;
+    };
+
+    const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+      if (data.eventType === 'run_started') {
+        return { run: workflowRun, events: [] as Event[] };
+      }
+      if (data.eventType === 'step_started') {
+        const lazy = data.eventData as { stepName?: string; input?: unknown };
+        if (lazy?.input !== undefined) {
+          record({
+            eventType: 'step_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            correlationId: data.correlationId,
+            eventData: { stepName: lazy.stepName, input: lazy.input },
+          });
+        }
+        return {
+          event: record(data),
+          step: {
+            runId: RUN_ID,
+            stepId: data.correlationId,
+            stepName: lazy?.stepName,
+            status: 'running' as const,
+            attempt: 1,
+            input: lazy?.input,
+            startedAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          ...(lazy?.input !== undefined ? { stepCreated: true } : {}),
+        };
+      }
+      // No inline delta: the loop falls back to `events.list`, which is the
+      // read this test is about.
+      return { event: record(data) };
+    });
+
+    /**
+     * Commit the `hook_received` behind the reader's back, at a position below
+     * the page just served. Armed for the second delivery only — the delivery
+     * that replays a log already holding the open `hook_created`, which is the
+     * one that decides to park.
+     */
+    let injectOnNextFullList = false;
+    let injected: Event | undefined;
+    const injectHookReceived = async () => {
+      const hookCreated = stored.find(
+        (s) => s.event.eventType === 'hook_created'
+      );
+      expect(hookCreated).toBeDefined();
+      const maxSort = Math.max(...stored.map((s) => s.sort));
+      injected = record(
+        {
+          eventType: 'hook_received',
+          specVersion: SPEC_VERSION_CURRENT,
+          correlationId: hookCreated?.event.correlationId,
+          eventData: {
+            token: HOOK_TOKEN,
+            payload: await dehydrateStepReturnValue(
+              { message: 'woken' },
+              RUN_ID,
+              undefined,
+              []
+            ),
+          },
+        },
+        maxSort - 0.5
+      );
+    };
+
+    const listPage = (cursor: string | undefined) => {
+      const after =
+        cursor === undefined ? Number.NEGATIVE_INFINITY : Number(cursor);
+      const page = stored
+        .filter((s) => s.sort > after)
+        .sort((a, b) => a.sort - b.sort);
+      return {
+        data: page.map((s) => s.event),
+        hasMore: false,
+        cursor: page.length > 0 ? String(page[page.length - 1]?.sort) : null,
+      };
+    };
+
+    const eventsList = vi.fn(
+      async ({ pagination }: { pagination?: { cursor?: string } }) => {
+        const page = listPage(pagination?.cursor);
+        if (injectOnNextFullList && pagination?.cursor === undefined) {
+          injectOnNextFullList = false;
+          await injectHookReceived();
+        }
+        return page;
+      }
+    );
+
+    const queueMock = vi.fn(async () => ({ messageId: null }));
+    let invokeHandler: (() => Promise<Response>) | undefined;
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      createQueueHandler: vi.fn(
+        (
+          _prefix: string,
+          handler: (message: unknown, metadata: unknown) => Promise<unknown>
+        ) => {
+          let delivery = 0;
+          const invoke = async () => {
+            delivery++;
+            await handler(
+              {
+                runId: RUN_ID,
+                requestedAt: new Date('2026-01-01T00:00:00.000Z'),
+              },
+              {
+                requestId: `req_park_recheck_${delivery}`,
+                attempt: 1,
+                queueName: '__wkf_workflow_workflow',
+                messageId: `msg_park_recheck_${delivery}`,
+              }
+            );
+            return new Response(null, { status: 204 });
+          };
+          invokeHandler = invoke;
+          return invoke;
+        }
+      ),
+      events: { create: eventsCreate, list: eventsList },
+      runs: { get: vi.fn(async () => workflowRun) },
+      queue: queueMock,
+      getEncryptionKeyForRun: vi.fn(async () => undefined),
+    } as any);
+
+    const handler = workflowEntrypoint(HOOK_AFTER_STEP_WORKFLOW);
+
+    // First delivery: creates the hook and runs the step. It ends without the
+    // hook payload — nothing has delivered it yet.
+    const first = (await handler(
+      new Request('https://example.test')
+    )) as Response;
+    expect(first.status).toBe(204);
+    expect(eventsCreate.mock.calls).toContainEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: 'hook_created' }),
+      ])
+    );
+    expect(eventsCreate.mock.calls).not.toContainEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: 'run_completed' }),
+      ])
+    );
+
+    // Second delivery replays the full log, finds the step already terminal
+    // and parks on the open hook. The payload commits behind its initial read,
+    // below the cursor that read returned.
+    injectOnNextFullList = true;
+    expect(invokeHandler).toBeDefined();
+    const second = await invokeHandler?.();
+    expect(second?.status).toBe(204);
+
+    // The hole is real: no incremental read from the cursor that delivery held
+    // can ever return the payload.
+    expect(injected).toBeDefined();
+    const cursorAtPark = String(
+      Math.max(...stored.filter((s) => s.event !== injected).map((s) => s.sort))
+    );
+    expect(listPage(cursorAtPark).data).toEqual([]);
+
+    // The park recheck reloads without a cursor, so the run advances rather
+    // than wedging in `running` forever.
+    expect(eventsList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pagination: expect.objectContaining({ cursor: undefined }),
+      })
+    );
+    expect(eventsCreate.mock.calls).toContainEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: 'run_completed' }),
+      ])
+    );
+  });
+});

--- a/packages/core/src/runtime/quickjs-runtime.ts
+++ b/packages/core/src/runtime/quickjs-runtime.ts
@@ -46,6 +46,7 @@ import {
 import seedrandom from 'seedrandom';
 import { monotonicFactory } from 'ulid';
 import { runtimeLogger } from '../logger.js';
+import { advancesReplayClock } from '../replay-clock.js';
 import { decompress } from '../serialization/compression.js';
 import type { DecryptionKey } from '../serialization/encryption.js';
 import { decrypt } from '../serialization/encryption.js';
@@ -1804,8 +1805,10 @@ async function processEvents(
     // BEFORE resolving anything, so workflow code unblocked by this event
     // observes Date.now() at (or after — the clock is monotonic) the time
     // the event was recorded. Mirrors the node:vm engine's
-    // `onConsumedEvent → updateTimestamp(+event.createdAt)`.
-    advanceClock(+event.createdAt);
+    // `onConsumedEvent → updateTimestamp(+event.createdAt)`, including its
+    // exclusion of the run-lifecycle events, which are present on replay but
+    // not on the first pass and so are not replay-stable clock sources.
+    if (advancesReplayClock(event)) advanceClock(+event.createdAt);
 
     const cid = event.correlationId;
     if (!cid) continue;

--- a/packages/core/src/runtime/resume-hook.parallel.test.ts
+++ b/packages/core/src/runtime/resume-hook.parallel.test.ts
@@ -261,7 +261,66 @@ describe('resumeHook (parallel fast path)', () => {
     );
   });
 
-  it('throws when the confirming read itself fails — no evidence is not evidence of delivery', async () => {
+  it('retries the confirming read until the committed resume becomes visible', async () => {
+    // The consumer's commit is ordered before the disposal that rejected our
+    // write, but it is read back through an eventually-consistent index. A
+    // single read that misses it fails a delivered resume.
+    const hook = { ...baseHook, resumeContext: parallelContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new HookNotFoundError(baseHook.hookId));
+    const listByCorrelationId = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] })
+      .mockImplementation(async () => ({
+        data: [
+          {
+            eventType: 'hook_received',
+            correlationId: hook.hookId,
+            resumeId: createEvent.mock.calls[0][2].resumeId,
+          },
+        ],
+      }));
+    makeWorld(hook, {
+      createEvent,
+      queue: vi.fn().mockResolvedValue({ messageId: 'm_1' }),
+      listByCorrelationId,
+    });
+
+    const result = await resumeHook(hook.token, { foo: 'bar' });
+    expect(result.resilientResume).toBe(true);
+    expect(listByCorrelationId).toHaveBeenCalledTimes(3);
+  });
+
+  it('recovers from a transient failure of the confirming read', async () => {
+    const hook = { ...baseHook, resumeContext: parallelContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new HookNotFoundError(baseHook.hookId));
+    const listByCorrelationId = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('backend down'))
+      .mockImplementation(async () => ({
+        data: [
+          {
+            eventType: 'hook_received',
+            correlationId: hook.hookId,
+            resumeId: createEvent.mock.calls[0][2].resumeId,
+          },
+        ],
+      }));
+    makeWorld(hook, {
+      createEvent,
+      queue: vi.fn().mockResolvedValue({ messageId: 'm_1' }),
+      listByCorrelationId,
+    });
+
+    const result = await resumeHook(hook.token, { foo: 'bar' });
+    expect(result.resilientResume).toBe(true);
+  });
+
+  it('throws when the confirming read never succeeds — no evidence is not evidence of delivery', async () => {
     const hook = { ...baseHook, resumeContext: parallelContext } satisfies Hook;
     makeWorld(hook, {
       createEvent: vi

--- a/packages/core/src/runtime/resume-hook.parallel.test.ts
+++ b/packages/core/src/runtime/resume-hook.parallel.test.ts
@@ -70,16 +70,19 @@ describe('resumeHook (parallel fast path)', () => {
   ) => {
     const createEvent = overrides.createEvent ?? vi.fn();
     const queue = overrides.queue ?? vi.fn();
+    // Default to an empty hook log: a run that never received this resume.
+    const listByCorrelationId =
+      overrides.listByCorrelationId ?? vi.fn().mockResolvedValue({ data: [] });
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
       capabilities,
       hooks: { getByToken: vi.fn().mockResolvedValue(hook) },
       runs: { get: vi.fn() },
-      events: { create: createEvent },
+      events: { create: createEvent, listByCorrelationId },
       getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
       queue,
     } as unknown as World);
-    return { createEvent, queue };
+    return { createEvent, queue, listByCorrelationId };
   };
 
   it('dispatches the event write and queue publish concurrently with a shared resumeId + digest', async () => {
@@ -186,6 +189,91 @@ describe('resumeHook (parallel fast path)', () => {
       );
       setWorld(undefined);
     }
+  });
+
+  it('treats a "hook gone" rejection as delivered when the consumer already committed this resume', async () => {
+    // The race the parallel path opens: the queue consumer wins, the run
+    // consumes the payload, completes, and disposes the hook — so the direct
+    // write arrives at a hook that is gone precisely BECAUSE the resume
+    // succeeded. Throwing here fails a resume that was in fact delivered.
+    // The committed hook_received carries this call's resumeId, which is what
+    // separates this case from a genuinely terminal run.
+    for (const err of [
+      new HookNotFoundError(baseHook.hookId),
+      new RunExpiredError('run has expired'),
+    ]) {
+      const hook = {
+        ...baseHook,
+        resumeContext: parallelContext,
+      } satisfies Hook;
+      const createEvent = vi.fn().mockRejectedValue(err);
+      const queue = vi.fn().mockResolvedValue({ messageId: 'm_1' });
+      // Echo back whatever resumeId this call minted, as the consumer's
+      // re-ensure would have persisted it.
+      const listByCorrelationId = vi.fn(async () => ({
+        data: [
+          { eventType: 'hook_disposed', correlationId: hook.hookId },
+          {
+            eventType: 'hook_received',
+            correlationId: hook.hookId,
+            resumeId: createEvent.mock.calls[0][2].resumeId,
+          },
+        ],
+      }));
+      makeWorld(hook, { createEvent, queue, listByCorrelationId });
+
+      const result = await resumeHook(hook.token, { foo: 'bar' });
+      expect(result.resilientResume).toBe(true);
+      expect(listByCorrelationId).toHaveBeenCalledWith({
+        runId: hook.runId,
+        correlationId: hook.hookId,
+        resolveData: 'none',
+      });
+      setWorld(undefined);
+    }
+  });
+
+  it('still throws when the committed hook_received belongs to a different resume', async () => {
+    // A hook can receive more than once, so the presence of *a* hook_received
+    // proves nothing. Only this call's resumeId does.
+    const hook = { ...baseHook, resumeContext: parallelContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new HookNotFoundError(baseHook.hookId));
+    const listByCorrelationId = vi.fn().mockResolvedValue({
+      data: [
+        {
+          eventType: 'hook_received',
+          correlationId: hook.hookId,
+          resumeId: 'some_earlier_resume',
+        },
+      ],
+    });
+    makeWorld(hook, {
+      createEvent,
+      queue: vi.fn().mockResolvedValue({ messageId: 'm_1' }),
+      listByCorrelationId,
+    });
+
+    await expect(resumeHook(hook.token, { foo: 'bar' })).rejects.toSatisfy(
+      (e: unknown) =>
+        HookNotFoundError.is(e) && (e as HookNotFoundError).token === hook.token
+    );
+  });
+
+  it('throws when the confirming read itself fails — no evidence is not evidence of delivery', async () => {
+    const hook = { ...baseHook, resumeContext: parallelContext } satisfies Hook;
+    makeWorld(hook, {
+      createEvent: vi
+        .fn()
+        .mockRejectedValue(new HookNotFoundError(baseHook.hookId)),
+      queue: vi.fn().mockResolvedValue({ messageId: 'm_1' }),
+      listByCorrelationId: vi.fn().mockRejectedValue(new Error('backend down')),
+    });
+
+    await expect(resumeHook(hook.token, { foo: 'bar' })).rejects.toSatisfy(
+      (e: unknown) => HookNotFoundError.is(e)
+    );
   });
 
   it('rethrows a non-retryable, non-terminal event-write failure (e.g. a 400) even though the queue publish succeeded', async () => {

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -18,6 +18,7 @@ import {
   SPEC_VERSION_SUPPORTS_COMPRESSION,
   type WorkflowInvokePayload,
   type WorkflowRun,
+  type World,
 } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
 import { getRunCapabilities } from '../capabilities.js';
@@ -71,6 +72,43 @@ async function computeResumePayloadDigest(bytes: Uint8Array): Promise<string> {
     hex += b.toString(16).padStart(2, '0');
   }
   return hex;
+}
+
+/**
+ * Whether this resume's `hook_received` is already committed, identified by its
+ * `resumeId` — the `(runId, resumeId)` key both writers of one lazy resume
+ * share, which the World persists on the event.
+ *
+ * Read by correlation id rather than over the whole log: the hook's own events
+ * are a handful regardless of how long the run is, so this stays a single
+ * bounded page. Only reached on the parallel path's error branch.
+ *
+ * A read failure answers "not committed". The caller's alternative is to report
+ * a resume as delivered on no evidence, and the sequential path's contract —
+ * hook gone means not delivered — is the safer default to fall back to.
+ */
+async function resumeEventCommitted({
+  world,
+  hook,
+  resumeId,
+}: {
+  world: World;
+  hook: Hook;
+  resumeId: string;
+}): Promise<boolean> {
+  try {
+    const { data } = await world.events.listByCorrelationId({
+      runId: hook.runId,
+      correlationId: hook.hookId,
+      resolveData: 'none',
+    });
+    return data.some(
+      (event) =>
+        event.eventType === 'hook_received' && event.resumeId === resumeId
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -616,13 +654,46 @@ async function resumeHookImpl<T = any>(
         if (eventResult.status === 'rejected') {
           const err = eventResult.reason;
           if (HookNotFoundError.is(err) || RunExpiredError.is(err)) {
-            // The hook's run has genuinely ended: surface the same contract as
-            // the sequential path. The queue message already went out, but the
-            // consumer's re-ensure will also reject against the terminal run
-            // and no-op, so the workflow does not resume.
-            throw new HookNotFoundError(hook.token);
-          }
-          if (EntityConflictError.is(err) || isRetryableWorldError(err)) {
+            // "Hook gone" is ambiguous here in a way it is not on the
+            // sequential path, which only queues once its write has landed.
+            // Both writers are already in flight, so this means either:
+            //   - the run had genuinely ended before this resume — the
+            //     consumer's re-ensure rejects too and the workflow does not
+            //     resume; the caller must see HookNotFoundError; or
+            //   - the consumer won the race, the run consumed the payload,
+            //     completed, and disposed the hook — the hook is gone BECAUSE
+            //     this resume succeeded, and throwing fails a delivered resume.
+            //
+            // One read discriminates them. Disposal is ordered after the
+            // hook_received it follows, so a delivered resume has its event
+            // already committed under this `resumeId` by the time the loser
+            // observes the disposal; a terminal run has no such event and
+            // never will, so no polling is needed.
+            if (!(await resumeEventCommitted({ world, hook, resumeId }))) {
+              throw new HookNotFoundError(hook.token);
+            }
+            resilientResume = true;
+            span?.setAttributes({
+              ...Attribute.HookResilientResume(true),
+              'workflow.hook.resume_event_write_recovered': true,
+              'workflow.hook.resume_event_write_error':
+                err instanceof Error ? err.name : 'unknown',
+            });
+            runtimeLogger.warn(
+              'Hook resume event write found the hook gone, but the queue ' +
+                'consumer had already committed this resume. Treating it as ' +
+                'delivered.',
+              {
+                workflowRunId: hook.runId,
+                hookId: hook.hookId,
+                resumeId,
+                error: err instanceof Error ? err.message : String(err),
+              }
+            );
+          } else if (
+            EntityConflictError.is(err) ||
+            isRetryableWorldError(err)
+          ) {
             // Resilient. Two shapes reach here, both non-terminal:
             //   - EntityConflict (409): this write raced its own re-ensuring
             //     consumer (or a redrive) on the shared `resumeId` — the run is

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -83,10 +83,20 @@ async function computeResumePayloadDigest(bytes: Uint8Array): Promise<string> {
  * are a handful regardless of how long the run is, so this stays a single
  * bounded page. Only reached on the parallel path's error branch.
  *
- * A read failure answers "not committed". The caller's alternative is to report
- * a resume as delivered on no evidence, and the sequential path's contract —
- * hook gone means not delivered — is the safer default to fall back to.
+ * Retried, because commit order is not read visibility. The event is committed
+ * before the disposal that rejected our write, but this reads another writer's
+ * commit back through an eventually-consistent index — "not visible yet" and
+ * "never written" are the same answer at a single point in time, and only the
+ * first resolves by waiting. One read reports a delivered resume as lost.
+ *
+ * Exhausting the budget answers "not committed". The caller's alternative is to
+ * report a resume as delivered on no evidence, and the sequential path's
+ * contract — hook gone means not delivered — is the safer default to fall back
+ * to. A run that genuinely ended pays the whole budget to reach it — bounded at
+ * ~2s, on an error path, against reporting a delivered resume as lost.
  */
+const RESUME_EVENT_VISIBILITY_BACKOFF_MS = [0, 150, 300, 600, 1000];
+
 async function resumeEventCommitted({
   world,
   hook,
@@ -96,19 +106,30 @@ async function resumeEventCommitted({
   hook: Hook;
   resumeId: string;
 }): Promise<boolean> {
-  try {
-    const { data } = await world.events.listByCorrelationId({
-      runId: hook.runId,
-      correlationId: hook.hookId,
-      resolveData: 'none',
-    });
-    return data.some(
-      (event) =>
-        event.eventType === 'hook_received' && event.resumeId === resumeId
-    );
-  } catch {
-    return false;
+  for (const delayMs of RESUME_EVENT_VISIBILITY_BACKOFF_MS) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    try {
+      const { data } = await world.events.listByCorrelationId({
+        runId: hook.runId,
+        correlationId: hook.hookId,
+        resolveData: 'none',
+      });
+      if (
+        data.some(
+          (event) =>
+            event.eventType === 'hook_received' && event.resumeId === resumeId
+        )
+      ) {
+        return true;
+      }
+    } catch {
+      // A failed read and an empty one are the same answer here: retry, and
+      // fall through to "not committed" if the budget runs out.
+    }
   }
+  return false;
 }
 
 /**
@@ -664,11 +685,13 @@ async function resumeHookImpl<T = any>(
             //     completed, and disposed the hook — the hook is gone BECAUSE
             //     this resume succeeded, and throwing fails a delivered resume.
             //
-            // One read discriminates them. Disposal is ordered after the
-            // hook_received it follows, so a delivered resume has its event
-            // already committed under this `resumeId` by the time the loser
+            // The committed event discriminates them. Disposal is ordered
+            // after the hook_received it follows, so a delivered resume has
+            // its event committed under this `resumeId` by the time the loser
             // observes the disposal; a terminal run has no such event and
-            // never will, so no polling is needed.
+            // never will. Committed is not the same as readable, though, so
+            // the check retries within a short budget rather than reading
+            // once.
             if (!(await resumeEventCommitted({ world, hook, resumeId }))) {
               throw new HookNotFoundError(hook.token);
             }

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -4,6 +4,7 @@ import type { Event, WorkflowRun } from '@workflow/world';
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { decodeTime, monotonicFactory } from 'ulid';
 import { afterEach, assert, describe, expect, it, vi } from 'vitest';
+import { importKey } from './encryption.js';
 import { DEFERRED_CHECK_DELAY_MS } from './events-consumer.js';
 import type { WorkflowSuspension } from './global.js';
 import { ReplayPayloadCache } from './replay-payload-cache.js';
@@ -479,6 +480,97 @@ describe('runWorkflow', () => {
         ops
       )
     ).toEqual(3);
+  });
+
+  it('keeps a pre-suspension Date.now() stable when run_started joins the log', async () => {
+    // Turbo backgrounds `run_started` and skips the initial event preload, so
+    // the first pass runs against a log holding no run-lifecycle events, while
+    // every later replay has both. Letting them move the pinned clock made a
+    // `Date.now()` read before the first suspension return the seed on pass 1
+    // and `run_started.createdAt` on replay — so a `sleep()` deadline computed
+    // from the former was then measured against the latter.
+    //
+    // The two passes below differ only in whether the log carries the
+    // run-lifecycle prefix. Encryption is on because it is what makes the
+    // difference observable: hydrating the run input through `crypto.subtle`
+    // yields to the event loop, which lets the consumer's queued drain reach
+    // those events *before* the workflow body's first statement. Without a
+    // real async hop, hydration settles in microtasks and the body wins the
+    // race — masking the bug rather than fixing it.
+    const workflowRunId = 'wrun_123';
+    const key = await importKey(new Uint8Array(32).fill(0x21));
+    const workflowCode = `const add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("add");
+          async function workflow() {
+            const before = Date.now();
+            await add(1, 2);
+            return [before, Date.now()];
+          }${getWorkflowTransformCode('workflow')}`;
+
+    const run = async (withRunLifecycle: boolean) => {
+      const ops: Promise<any>[] = [];
+      const workflowRun: WorkflowRun = {
+        runId: workflowRunId,
+        workflowName: 'workflow',
+        status: 'running',
+        input: await dehydrateWorkflowArguments([], workflowRunId, key, ops),
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+        startedAt: new Date('2024-01-01T00:00:03.000Z'),
+        deploymentId: 'test-deployment',
+      };
+      const lifecycle = [
+        {
+          eventId: 'event-run-created',
+          runId: workflowRunId,
+          eventType: 'run_created',
+          eventData: {},
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        },
+        {
+          eventId: 'event-run-started',
+          runId: workflowRunId,
+          eventType: 'run_started',
+          eventData: {},
+          createdAt: new Date('2024-01-01T00:00:03.000Z'),
+        },
+      ] as unknown as Event[];
+      const steps: Event[] = [
+        {
+          eventId: 'event-step-started',
+          runId: workflowRunId,
+          eventType: 'step_started',
+          correlationId: 'step_01HK153X00SFW49DWMQP3J810S',
+          eventData: { stepName: 'add' },
+          createdAt: new Date('2024-01-01T00:00:04.000Z'),
+        },
+        {
+          eventId: 'event-step-completed',
+          runId: workflowRunId,
+          eventType: 'step_completed',
+          correlationId: 'step_01HK153X00SFW49DWMQP3J810S',
+          eventData: {
+            stepName: 'add',
+            result: await dehydrateStepReturnValue(3, workflowRunId, key, ops),
+          },
+          createdAt: new Date('2024-01-01T00:00:05.000Z'),
+        },
+      ];
+      const result = await runWorkflow(
+        workflowCode,
+        workflowRun,
+        [...(withRunLifecycle ? lifecycle : []), ...steps],
+        key
+      );
+      return hydrateWorkflowReturnValue(result as any, workflowRunId, key, ops);
+    };
+
+    // Both passes read the run's creation time (the clock seed), not
+    // `run_started` at +3s. The second element proves the clock still advances
+    // on the events the body itself consumes.
+    const firstPass = await run(false);
+    const replay = await run(true);
+    expect(firstPass).toEqual([1704067200000, 1704067205000]);
+    expect(replay).toEqual(firstPass);
   });
 
   it('keeps IDs minted through STABLE_ULID on the run clock', async () => {

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -24,6 +24,7 @@ import type { QueueItem } from './global.js';
 import { ENOTSUP, WorkflowSuspension } from './global.js';
 import { runtimeLogger } from './logger.js';
 import type { WorkflowOrchestratorContext } from './private.js';
+import { advancesReplayClock } from './replay-clock.js';
 import { ReplayPayloadCache } from './replay-payload-cache.js';
 import { getPortLazy } from './runtime/get-port-lazy.js';
 import { runIdCreatedAt } from './runtime/run-id-time.js';
@@ -389,7 +390,7 @@ async function createWorkflowSession({
 
   const eventsConsumer = new EventsConsumer(events, {
     onConsumedEvent: (event) => {
-      updateTimestamp(+event.createdAt);
+      if (advancesReplayClock(event)) updateTimestamp(+event.createdAt);
     },
     onUnconsumedEvent: (event) => {
       onWorkflowError(
@@ -428,7 +429,8 @@ async function createWorkflowSession({
 
   // Consume run lifecycle events - these are structural events that don't
   // need special handling in the workflow, but must be consumed to advance
-  // past them in the event log
+  // past them in the event log. The run-lifecycle pair is also excluded from
+  // the replay clock (see `advancesReplayClock`) — keep the two lists aligned.
   workflowContext.eventsConsumer.subscribe((event) => {
     if (!event) {
       return EventConsumerResult.NotConsumed;

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -251,6 +251,7 @@ export async function getNextBuilderEager(
         };
 
         const fullRebuild = async () => {
+          const rebuildStartedAt = Date.now();
           this.clearDiscoveredEntriesCache();
           const newInputFiles = await this.getInputFiles();
           options.inputFiles = newInputFiles;
@@ -276,6 +277,49 @@ export async function getNextBuilderEager(
 
           await writeManifest(newCombined.manifest);
           await refreshSourceSnapshots();
+          await dropSnapshotsWrittenDuringRebuild(rebuildStartedAt);
+        };
+
+        /**
+         * A rediscovery takes seconds, and `refreshSourceSnapshots()` re-reads
+         * the sources at the end of it rather than at the point discovery
+         * consumed them. A save landing in between is therefore baselined as
+         * already-seen without ever having been discovered: its own flush
+         * diffs the new content against itself, decides `none`, and the edit
+         * is silently dropped until something unrelated forces another
+         * rediscovery.
+         *
+         * Forget the baseline for those files so the follow-up flush still
+         * classifies them as changed. Keyed on mtime rather than on the
+         * pending set alone, because chokidar routinely re-reports the very
+         * edit that triggered this rebuild — that one *was* discovered, and
+         * invalidating it would buy a redundant second rediscovery for every
+         * ordinary save.
+         */
+        const dropSnapshotsWrittenDuringRebuild = async (
+          rebuildStartedAt: number
+        ) => {
+          const dropped: string[] = [];
+          for (const file of [
+            ...pendingFileChanges.addedFiles,
+            ...pendingFileChanges.modifiedFiles,
+          ]) {
+            try {
+              if ((await stat(file)).mtimeMs > rebuildStartedAt) {
+                sourceSnapshots.delete(file);
+                dropped.push(file);
+              }
+            } catch {
+              sourceSnapshots.delete(file);
+              dropped.push(file);
+            }
+          }
+          if (dropped.length > 0) {
+            logDevHmrDebug({
+              event: 'snapshots-dropped',
+              files: dropped.map(relativeToWorkingDir),
+            });
+          }
         };
 
         const isWatchableFile = (path: string) =>

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -255,6 +255,8 @@ export async function getNextBuilderEager(
           this.clearDiscoveredEntriesCache();
           const newInputFiles = await this.getInputFiles();
           options.inputFiles = newInputFiles;
+          const consumedSnapshots =
+            await captureConsumedSnapshots(newInputFiles);
 
           await stepsCtx?.dispose();
           await workflowsCtx.interimBundleCtx.dispose();
@@ -277,7 +279,35 @@ export async function getNextBuilderEager(
 
           await writeManifest(newCombined.manifest);
           await refreshSourceSnapshots();
-          await dropSnapshotsWrittenDuringRebuild(rebuildStartedAt);
+          await restoreSnapshotsWrittenDuringRebuild(
+            rebuildStartedAt,
+            consumedSnapshots
+          );
+        };
+
+        /**
+         * The baseline the rebuild is about to consume, read before the
+         * multi-second bundle rather than after it. See
+         * `restoreSnapshotsWrittenDuringRebuild`.
+         */
+        const captureConsumedSnapshots = async (inputFiles: string[]) => {
+          const consumed = new Map<string, SourceSnapshot>();
+          await Promise.all(
+            [
+              ...getRelevantFiles({
+                discoveredEntries,
+                inputFiles,
+                normalizePath,
+              }),
+            ].map(async (file) => {
+              try {
+                consumed.set(file, await readSourceSnapshot(file));
+              } catch {
+                // Unreadable now means "did not exist for this rebuild".
+              }
+            })
+          );
+          return consumed;
         };
 
         /**
@@ -289,35 +319,48 @@ export async function getNextBuilderEager(
          * is silently dropped until something unrelated forces another
          * rediscovery.
          *
-         * Forget the baseline for those files so the follow-up flush still
-         * classifies them as changed. Keyed on mtime rather than on the
-         * pending set alone, because chokidar routinely re-reports the very
-         * edit that triggered this rebuild — that one *was* discovered, and
-         * invalidating it would buy a redundant second rediscovery for every
-         * ordinary save.
+         * Restore the baseline the rebuild actually consumed for those files,
+         * so the follow-up flush diffs against pre-edit content and can still
+         * tell a body-only change (hot) from an import-graph one (full).
+         * Dropping the baseline outright would be safe but would force a
+         * needless second rediscovery for every edit that lands mid-build.
+         *
+         * Keyed on mtime rather than on the pending set alone, because
+         * chokidar routinely re-reports the very edit that triggered this
+         * rebuild — that one *was* consumed, and its post-build snapshot is
+         * the correct baseline.
          */
-        const dropSnapshotsWrittenDuringRebuild = async (
-          rebuildStartedAt: number
+        const restoreSnapshotsWrittenDuringRebuild = async (
+          rebuildStartedAt: number,
+          consumedSnapshots: Map<string, SourceSnapshot>
         ) => {
-          const dropped: string[] = [];
+          const restored: string[] = [];
           for (const file of [
             ...pendingFileChanges.addedFiles,
             ...pendingFileChanges.modifiedFiles,
           ]) {
+            let writtenDuringRebuild = true;
             try {
-              if ((await stat(file)).mtimeMs > rebuildStartedAt) {
-                sourceSnapshots.delete(file);
-                dropped.push(file);
-              }
+              writtenDuringRebuild =
+                (await stat(file)).mtimeMs > rebuildStartedAt;
             } catch {
-              sourceSnapshots.delete(file);
-              dropped.push(file);
+              // Gone: treat as written so the baseline is invalidated.
             }
+            if (!writtenDuringRebuild) {
+              continue;
+            }
+            const consumed = consumedSnapshots.get(file);
+            if (consumed) {
+              sourceSnapshots.set(file, consumed);
+            } else {
+              sourceSnapshots.delete(file);
+            }
+            restored.push(file);
           }
-          if (dropped.length > 0) {
+          if (restored.length > 0) {
             logDevHmrDebug({
-              event: 'snapshots-dropped',
-              files: dropped.map(relativeToWorkingDir),
+              event: 'snapshots-restored',
+              files: restored.map(relativeToWorkingDir),
             });
           }
         };

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -424,10 +424,33 @@ export async function getNextBuilderEager(
           rememberKnownFile = nextKnown.addKnownFile;
         };
 
+        // Diagnostic only. Must never contain a `logDevHmr` decision string —
+        // the e2e suite counts those by substring.
+        const logDevHmrDebug = (detail: Record<string, unknown>) => {
+          if (process.env.WORKFLOW_DEV_HMR_LOGS === '1') {
+            console.log(`workflow dev hmr debug: ${JSON.stringify(detail)}`);
+          }
+        };
+
+        const workingDirPrefix = `${normalizePath(this.config.workingDir)}/`;
+        const relativeToWorkingDir = (file: string) => {
+          const normalized = normalizePath(file);
+          return normalized.startsWith(workingDirPrefix)
+            ? normalized.slice(workingDirPrefix.length)
+            : normalized;
+        };
+
         const processFileChanges = async (fileChanges: FileChanges) => {
           if (!hasFileChanges(fileChanges)) {
             return;
           }
+
+          logDevHmrDebug({
+            event: 'flush',
+            added: fileChanges.addedFiles.map(relativeToWorkingDir),
+            modified: fileChanges.modifiedFiles.map(relativeToWorkingDir),
+            removed: fileChanges.removedFiles.map(relativeToWorkingDir),
+          });
 
           const decision = await classifyRebuild({
             discoveredEntries,
@@ -447,46 +470,96 @@ export async function getNextBuilderEager(
           }
           if (decision.kind === 'full') {
             logDevHmr('workflow dev hmr: full rediscovery');
+            const startedAt = Date.now();
             await fullRebuild();
             await refreshKnownFiles();
+            logDevHmrDebug({
+              event: 'rebuilt',
+              kind: 'full',
+              durationMs: Date.now() - startedAt,
+              // Anything that landed while the rebuild ran; these used to each
+              // become their own queued flush.
+              coalescedDuring: hasFileChanges(pendingFileChanges),
+            });
             return;
           }
 
           logDevHmr(
             `workflow dev hmr: hot rebuild${decision.refreshStepRegistrations ? ' with step registration refresh' : ''}`
           );
+          const startedAt = Date.now();
           await hotRebuild(decision.refreshStepRegistrations);
           for (const [file, snapshot] of decision.snapshots) {
             sourceSnapshots.set(file, snapshot);
           }
+          logDevHmrDebug({
+            event: 'rebuilt',
+            kind: 'hot',
+            durationMs: Date.now() - startedAt,
+            coalescedDuring: hasFileChanges(pendingFileChanges),
+          });
         };
 
-        let pendingFileChanges: FileChanges = {
+        const noFileChanges = (): FileChanges => ({
           addedFiles: [],
           modifiedFiles: [],
           removedFiles: [],
-        };
-        let flushTimer: ReturnType<typeof setTimeout> | undefined;
+        });
 
+        let pendingFileChanges: FileChanges = noFileChanges();
+        let flushTimer: ReturnType<typeof setTimeout> | undefined;
+        let flushInFlight = false;
+
+        /**
+         * Coalesce watcher events into one rebuild, both across the debounce
+         * window and across a rebuild that is already running.
+         *
+         * The second half matters more than the first. A full rediscovery takes
+         * seconds, and the watcher keeps firing throughout — so releasing the
+         * debounce at *enqueue* time lets one event per 10ms window pile onto
+         * `rebuildQueue`, and the whole backlog then drains back-to-back the
+         * moment the rebuild lands. Each entry re-runs `classifyRebuild` over
+         * state the previous entry already brought up to date, so the extra
+         * passes are pure waste, and how many there are is a function of runner
+         * load rather than of what the user edited.
+         *
+         * Holding the window open until the in-flight flush completes keeps one
+         * logical edit to one decision. Anything arriving mid-rebuild merges
+         * into `pendingFileChanges` and rides the follow-up flush that the tail
+         * arms.
+         */
         const scheduleFileChanges = (fileChanges: FileChanges) => {
           pendingFileChanges = mergeFileChanges(
             pendingFileChanges,
             fileChanges
           );
-          if (flushTimer) {
+          armFileChangeFlush();
+        };
+
+        function armFileChangeFlush() {
+          if (flushTimer || flushInFlight) {
             return;
           }
           flushTimer = setTimeout(() => {
-            const fileChanges = pendingFileChanges;
-            pendingFileChanges = {
-              addedFiles: [],
-              modifiedFiles: [],
-              removedFiles: [],
-            };
             flushTimer = undefined;
-            enqueue(() => processFileChanges(fileChanges));
+            if (!hasFileChanges(pendingFileChanges)) {
+              return;
+            }
+            const fileChanges = pendingFileChanges;
+            pendingFileChanges = noFileChanges();
+            flushInFlight = true;
+            enqueue(async () => {
+              try {
+                await processFileChanges(fileChanges);
+              } finally {
+                flushInFlight = false;
+                if (hasFileChanges(pendingFileChanges)) {
+                  armFileChangeFlush();
+                }
+              }
+            });
           }, 10);
-        };
+        }
 
         const resolveExistingEventPath = async (pathname: string) => {
           const normalizedPath = normalizePath(pathname);


### PR DESCRIPTION
Fixes five distinct e2e/unit flake families, all clanker generated.

Note the e2e run comment in this PR is green.

---

### 1. Run-lifecycle events read the VM's replay clock

**Symptom:** `sleepingWorkflow` fails intermittently.

**Cause:** run-lifecycle events were timestamped from the workflow VM's clock,
which is frozen and rewound during replay. A lifecycle event minted on a replay
path therefore carries a time that has no relation to when it was written.

**Fix:** keep run-lifecycle events off the replay clock.

---

### 2. Three defects in the Next dev HMR watcher

**Symptom:** `packages/core/e2e/dev.test.ts` timeouts — `expected 4 to be 1` on
the 50s rebuild-count wait, and `expected […] to include 'hmrFuzzAddedStep'` on
the 300s manifest wait. Rotating across the eight `nextjs-*` dev axes. A third
signature, `E2E Windows Tests (node)` → source-map-warning test, is the same
root shape.

**This was previously filed as chronic noise, and that was wrong.** Measured
base rate over the 8 axes: 8.3% on other PRs, 11.4% on `main`, 15.6% on #3084 —
chronic across the repo, which is what made it look unactionable. It is three
real defects:

- **Coalescing window released at enqueue instead of at completion**, so a save
  arriving during a rebuild was folded into a window that had already been
  consumed.
- **`fullRebuild()` baselined sources at the tail**, so a save landing
  mid-rebuild was absorbed into the new baseline and silently dropped — the
  rebuild that should have picked it up already considered it seen.
- **Edits landing mid-rediscovery were baselined** the same way.

Plus `c3beff53f`: a deleted e2e workflow file could wedge the dev server.

**Verification:** reproduced locally (~3 min/run) rather than inferred from CI.
Note that at an 8–15% base rate green CI runs are weak evidence either way —
separating 8.3% from 15.6% at 80% power needs ~39 runs per arm — so the case
here rests on the root causes and the local repro, not on run counts.

---

### 3. Build timer can render a negative duration

**Symptom:** `base-builder-logging.test.ts:129` fails its `\d+(?:ms|\.\d+s)`
assertion on `✓ Compiled workflows in -1ms`. One of three chronic Windows unit
signatures (measured: 3/9 Windows runs red vs 1/9 ubuntu).

**Cause:** the build was timed with `Date.now()`, which can step backwards.

**Fix:** time it on a monotonic clock. Deterministic; the other two Windows
signatures are untouched and remain open.

---

### 4. A lazy resume the queue consumer already delivered was failed

**Symptom:** `hookAdoptOwnerResultWorkflow` / `hookSignalOwnerWorkflow` fail
with `HookNotFoundError`; `resume-or-start route pattern` fails `expected
undefined to be defined` after retrying for 30s.

**Cause:** `resumeHook`'s parallel path fires the direct `hook_received` write
and the queue publish concurrently. When the consumer wins, the run consumes
the payload, completes, and disposes the hook — so the direct write arrives at a
hook that is gone *precisely because the resume succeeded*. That was classified
as a terminal run and threw, failing a resume that had in fact been delivered.

**Fix:** discriminate with a `listByCorrelationId` read — a delivered resume has
a committed `hook_received` carrying this call's `resumeId`; a genuinely
terminal run has no such event and still throws, which
`hookMinRetentionWorkflow` requires. `7a922a293` makes that read a retry rather
than a single read: the event goes through an eventually consistent index, so
"not visible yet" and "never written" arrive as the same answer and only the
first resolves by waiting.

**Scope:** the server-side root cause is vercel/workflow-server#732, **merged**.
With that in, these two commits recover a case the server should no longer
produce — defence-in-depth rather than the primary fix. The 104-arm-sample
validation of this family belongs to #732 and ran without these commits.

---

### 5. An invocation could park against a log snapshot that was already stale

**Symptom:** `webhookWorkflow` times out at 120s with the run still `running`.
Seen on three apps (fastify, tanstack-start, nest) and both local-prod and
local-dev. All hook payloads are durably in the log; the run simply never
replays again.

**Cause:** a lost wakeup. The third `hook_received` commits *between* an inline
step's creation and its completion — it arrived mid-invocation, and the
invocation already holding a log snapshot never sees it, then parks. Its own
delivery was the last wake source, so nothing wakes it.

**Fix (`0e224af3c`):** before committing to a park that only a hook delivery can
wake, reload the whole log **cursor-lessly** and diff by event id. The cursor
cannot close this hole: it filters lexicographically by event id, while the hole
is defined by ULID *time* — an event minted before the invocation's last write
but committed after it always sorts below the cursor, so a cursor-based reread
comes back empty and the invocation parks anyway. `runtime.ts:1309` already
stated this exact reason for the precondition-restart path's own cursor-less
reload.

Gated to parks only a hook can wake (no pending step, no wait timeout, a hook
still open) and re-armed only by an inline step executing, so the extra
`events.list` cannot become a spin.

**Verification:** `packages/core/src/runtime/park-recheck-reload.test.ts` (257
lines) reproduces the wedge deterministically — no `run_completed` without the
fix.
