### PR TITLE
fix(streams): surface typed retention expiry errors

### DIFF
--- a/.changeset/stream-expired-errors.md
+++ b/.changeset/stream-expired-errors.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/errors': patch
+'@workflow/world-vercel': patch
+---
+
+Surface typed terminal errors when stream retention expires.

--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -1,3 +1,4 @@
+import { StreamExpiredError } from '@workflow/errors';
 import { SPEC_VERSION_CURRENT, type World } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -222,6 +223,37 @@ describe('createReconnectingFramedStream', () => {
     // index 0 once, then index 2 twice — the failed reopen and the retry both
     // resume from the same position.
     expect(calls).toEqual([0, 2, 2]);
+  });
+
+  it('surfaces retention expiry from a reconnect without retrying it', async () => {
+    const expired = new StreamExpiredError(
+      'stream expired',
+      RUN_ID,
+      's',
+      new Date('2026-08-10T14:40:00.000Z')
+    );
+    let calls = 0;
+    const world = {
+      specVersion: SPEC_VERSION_CURRENT,
+      streams: {
+        get: vi.fn(async () => {
+          calls++;
+          if (calls === 1) {
+            return scriptedStream([
+              { kind: 'value', value: payloadFrame(1) },
+              { kind: 'error', err: new Error('connection dropped') },
+            ]);
+          }
+          throw expired;
+        }),
+      },
+    } as unknown as World;
+    setWorld(world);
+
+    const reader = createReconnectingFramedStream(RUN_ID, 's', 0).getReader();
+    expect((await reader.read()).value).toEqual(payloadFrame(1));
+    await expect(reader.read()).rejects.toBe(expired);
+    expect(calls).toBe(2);
   });
 
   it('respects an initial non-zero startIndex on reconnect', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1,6 +1,7 @@
 import {
   RuntimeDecryptionError,
   SerializationError,
+  StreamExpiredError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
 import { once } from '@workflow/utils';
@@ -945,7 +946,11 @@ export function createReconnectingFramedStream(
       try {
         await connect();
         return;
-      } catch {
+      } catch (error) {
+        // Retention expiry is terminal and retrying cannot restore the stream.
+        // Preserve the typed error immediately instead of turning one 410 into
+        // 50 reconnect attempts and a generic budget-exhaustion error.
+        if (StreamExpiredError.is(error)) throw error;
         // Reopen failed transiently; loop to retry, counting against the
         // budget so a server that never recovers still terminates the stream.
       }

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -790,6 +790,29 @@ export class RunExpiredError extends WorkflowWorldError {
 }
 
 /**
+ * Thrown when a stream is no longer readable because its owning run passed its
+ * storage-retention boundary. This is terminal: retrying cannot restore data.
+ *
+ * Unlike {@link RunExpiredError}, this identifies the failed stream read and
+ * exposes the server's authoritative expiry timestamp for user-facing errors.
+ */
+export class StreamExpiredError extends WorkflowWorldError {
+  constructor(
+    message: string,
+    readonly runId?: string,
+    readonly streamId?: string,
+    readonly expiredAt?: Date
+  ) {
+    super(message, { status: 410, code: 'stream-expired' });
+    this.name = 'StreamExpiredError';
+  }
+
+  static is(value: unknown): value is StreamExpiredError {
+    return isError(value) && value.name === 'StreamExpiredError';
+  }
+}
+
+/**
  * Thrown when an operation cannot proceed because a required timestamp
  * (e.g. retryAfter) has not been reached yet.
  *

--- a/packages/world-vercel/src/http-core.test.ts
+++ b/packages/world-vercel/src/http-core.test.ts
@@ -1,6 +1,7 @@
 import {
   EntityConflictError,
   RunExpiredError,
+  StreamExpiredError,
   ThrottleError,
   TooEarlyError,
   WorkflowWorldError,
@@ -26,8 +27,27 @@ describe('errorForResponse', () => {
     expect(errorForResponse(409, 'boom')).toBeInstanceOf(EntityConflictError);
   });
 
-  it('maps 410 to RunExpiredError', () => {
+  it('maps an unstructured 410 to RunExpiredError', () => {
     expect(errorForResponse(410, 'boom')).toBeInstanceOf(RunExpiredError);
+  });
+
+  it('maps a stream-expired 410 to StreamExpiredError with its details', () => {
+    const err = errorForResponse(410, 'stream expired', {
+      code: 'stream-expired',
+      details: {
+        runId: 'wrun_test',
+        streamId: 'stream-test',
+        expiredAt: '2026-08-10T14:40:00.000Z',
+      },
+    });
+
+    expect(err).toMatchObject({
+      name: 'StreamExpiredError',
+      runId: 'wrun_test',
+      streamId: 'stream-test',
+      expiredAt: new Date('2026-08-10T14:40:00.000Z'),
+    });
+    expect(err).toBeInstanceOf(StreamExpiredError);
   });
 
   it('maps 425 to TooEarlyError carrying retryAfter', () => {

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -21,6 +21,7 @@ import {
   EntityConflictError,
   PreconditionFailedError,
   RunExpiredError,
+  StreamExpiredError,
   ThrottleError,
   TooEarlyError,
   WorkflowWorldError,
@@ -172,7 +173,8 @@ export function headersToRecord(headers: Headers): Record<string, string> {
  * truth for the status → error-type contract the runtime branches on:
  *
  *   - 409 → EntityConflictError (start() dedupe, terminal-state transitions)
- *   - 410 → RunExpiredError (runtime exits without retrying)
+ *   - 410 → StreamExpiredError when the response code is `stream-expired`,
+ *     otherwise RunExpiredError (both terminal)
  *   - 412 → PreconditionFailedError + retryAfter + details (stale precondition
  *     snapshot — the optimistic-concurrency guard on event creation; `details`
  *     carries the events the backend returned inline, when it did)
@@ -195,15 +197,41 @@ export function errorForResponse(
     code?: string;
     url?: string;
     mitigated?: string | null;
-    /** Rejection detail for a 412 — the events the backend says the client's
-     *  snapshot was missing, when it returned them inline. Ignored for every
-     *  other status. */
+    /** Rejection detail returned by the backend. A stream-expired 410 carries
+     * its run, stream, and authoritative retention timestamp here; 412 carries
+     * events the backend says the client's snapshot was missing. */
     details?: unknown;
   } = {}
 ): Error {
   const { retryAfter, code, url, mitigated, details } = opts;
   if (status === 409) return new EntityConflictError(message);
-  if (status === 410) return new RunExpiredError(message);
+  if (status === 410) {
+    if (code === 'stream-expired') {
+      const streamDetails =
+        details && typeof details === 'object'
+          ? (details as {
+              runId?: unknown;
+              streamId?: unknown;
+              expiredAt?: unknown;
+            })
+          : undefined;
+      const expiredAt =
+        typeof streamDetails?.expiredAt === 'string'
+          ? new Date(streamDetails.expiredAt)
+          : undefined;
+      return new StreamExpiredError(
+        message,
+        typeof streamDetails?.runId === 'string'
+          ? streamDetails.runId
+          : undefined,
+        typeof streamDetails?.streamId === 'string'
+          ? streamDetails.streamId
+          : undefined,
+        expiredAt && !Number.isNaN(expiredAt.getTime()) ? expiredAt : undefined
+      );
+    }
+    return new RunExpiredError(message);
+  }
   if (status === 412)
     return new PreconditionFailedError(message, { retryAfter, details });
   if (status === 425) return new TooEarlyError(message, { retryAfter });

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -1,3 +1,4 @@
+import { StreamExpiredError } from '@workflow/errors';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { encodeMultiChunks, MAX_CHUNKS_PER_REQUEST } from './streamer.js';
 
@@ -205,6 +206,60 @@ describe('streams.get', () => {
     // v3, not v2: the reconnecting reader relies on the server erroring the
     // body on a max-duration timeout rather than closing it cleanly.
     expect(url.pathname).toBe('/v3/runs/run-123/stream/my-stream');
+  });
+
+  it('throws a typed terminal error with the retention details on 410', async () => {
+    const expiredAt = '2026-08-10T14:40:00.000Z';
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      Response.json(
+        {
+          success: false,
+          error: 'stream-expired',
+          message: 'The stream reached its storage retention limit',
+          details: {
+            runId: 'wrun_test',
+            streamId: 'stream-test',
+            expiredAt,
+          },
+        },
+        { status: 410 }
+      )
+    );
+
+    const streamer = await getStreamer();
+    const error = await streamer.streams
+      .get('wrun_test', 'stream-test')
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(StreamExpiredError);
+    expect(error).toMatchObject({
+      message: 'The stream reached its storage retention limit',
+      runId: 'wrun_test',
+      streamId: 'stream-test',
+      expiredAt: new Date(expiredAt),
+      status: 410,
+      code: 'stream-expired',
+    });
+    const request = vi.mocked(globalThis.fetch).mock.calls[0];
+    const headers = (request[1] as RequestInit).headers as Headers;
+    expect(headers.get('Accept')).toBe('application/json');
+  });
+
+  it('falls back safely for non-stream-expired errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      Response.json(
+        { error: 'run-expired', message: 'Run is unavailable' },
+        { status: 410 }
+      )
+    );
+
+    const streamer = await getStreamer();
+    await expect(
+      streamer.streams.get('wrun_test', 'stream-test')
+    ).rejects.toThrow('Run is unavailable');
+    await expect(
+      streamer.streams.get('wrun_test', 'stream-test')
+    ).rejects.not.toBeInstanceOf(StreamExpiredError);
   });
 
   it('passes startIndex as a query parameter on the v3 read', async () => {

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -10,7 +10,11 @@ import {
   getStreamCloseDispatcher,
   getStreamDispatcher,
 } from './http-client.js';
-import { getVercelDiagnostics, instrumentedFetch } from './http-core.js';
+import {
+  errorForResponse,
+  getVercelDiagnostics,
+  instrumentedFetch,
+} from './http-core.js';
 import {
   WorkflowRunId,
   WorkflowStreamName,
@@ -99,6 +103,26 @@ function streamSpanAttributes(args: {
       ? WorkflowStreamStartIndex(args.startIndex)
       : {}),
   };
+}
+
+async function createStreamReadError(response: Response): Promise<Error> {
+  const fallback = `Failed to fetch stream: ${response.status}`;
+  if (response.status !== 410) return new Error(fallback);
+
+  try {
+    const body = (await response.json()) as {
+      error?: string;
+      message?: string;
+      details?: unknown;
+    };
+    return errorForResponse(
+      response.status,
+      typeof body.message === 'string' ? body.message : fallback,
+      { code: body.error, details: body.details }
+    );
+  } catch {
+    return new Error(fallback);
+  }
 }
 
 function createStreamRequestError(
@@ -297,6 +321,11 @@ export function createStreamer(config?: APIConfig): Streamer {
 
       async get(runId: string, name: string, startIndex?: number) {
         const httpConfig = await getHttpConfig(config);
+        // Stream bytes themselves are untyped binary, but any pre-header error
+        // is a JSON envelope. Asking explicitly avoids a CBOR 410 that this
+        // binary response path cannot decode while leaving successful stream
+        // bodies unchanged.
+        httpConfig.headers.set('Accept', 'application/json');
         const url = getStreamReadUrl(name, runId, httpConfig);
         if (typeof startIndex === 'number') {
           url.searchParams.set('startIndex', String(startIndex));
@@ -322,8 +351,7 @@ export function createStreamer(config?: APIConfig): Streamer {
             operation: 'read',
             startIndex,
           }),
-          buildError: (res) =>
-            new Error(`Failed to fetch stream: ${res.status}`),
+          buildError: createStreamReadError,
         });
         if (!response.body) {
           throw new Error('No response body for stream');

--- a/packages/world-vercel/src/utils.test.ts
+++ b/packages/world-vercel/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { PreconditionFailedError } from '@workflow/errors';
+import { PreconditionFailedError, StreamExpiredError } from '@workflow/errors';
 import { encode } from 'cbor-x';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -286,6 +286,40 @@ describe('getHttpConfig (proxied path)', () => {
     // The trusted-sources bypass header is meaningless on the proxied
     // path (api.vercel.com is public) and must NOT be attached.
     expect(headers.get('x-vercel-trusted-oidc-idp-token')).toBeNull();
+  });
+});
+
+describe('makeRequest stream expiry errors', () => {
+  it.each([
+    ['/v2/runs/wrun_test/streams/stream-test/chunks'],
+    ['/v2/runs/wrun_test/streams/stream-test/info'],
+  ])('preserves stream-expired details from %s', async (endpoint) => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      Response.json(
+        {
+          error: 'stream-expired',
+          message: 'The stream reached its storage retention limit',
+          details: {
+            runId: 'wrun_test',
+            streamId: 'stream-test',
+            expiredAt: '2026-08-10T14:40:00.000Z',
+          },
+        },
+        { status: 410 }
+      )
+    );
+
+    const error = await makeRequest({
+      endpoint,
+      schema: z.never(),
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(StreamExpiredError);
+    expect(error).toMatchObject({
+      runId: 'wrun_test',
+      streamId: 'stream-test',
+      expiredAt: new Date('2026-08-10T14:40:00.000Z'),
+    });
   });
 });
 

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -515,13 +515,22 @@ export async function makeRequest<T>({
         });
 
         if (!response.ok) {
-          const errorData: { message?: string; code?: string; error?: string } =
-            await parseResponseBody(response)
-              .then(
-                (r) =>
-                  r.data as { message?: string; code?: string; error?: string }
-              )
-              .catch(() => ({}));
+          const errorData: {
+            message?: string;
+            code?: string;
+            error?: string;
+            details?: unknown;
+          } = await parseResponseBody(response)
+            .then(
+              (r) =>
+                r.data as {
+                  message?: string;
+                  code?: string;
+                  error?: string;
+                  details?: unknown;
+                }
+            )
+            .catch(() => ({}));
           const errorCode = errorData.code ?? errorData.error;
           logCurlRepro(request.method, url, headers);
 
@@ -544,6 +553,7 @@ export async function makeRequest<T>({
             code: errorCode,
             retryAfter,
             mitigated: response.headers.get('x-vercel-mitigated'),
+            details: errorData.details,
           });
           span?.setAttributes({
             ...ErrorType(errorCode || `HTTP ${response.status}`),


### PR DESCRIPTION
## Summary & Motivation

Adds `StreamExpiredError` to `@workflow/errors`, carrying the run, stream, and server-reported expiry timestamp from workflow-server's 410 `stream-expired` envelope. The reconnect loop rethrows it instead of retrying, since retention expiry is terminal and a retry budget would only convert it into a generic exhaustion error.

## Test Plan

Unit tests added for the 410 decoding path and the reconnect rethrow; typechecks pass across the touched packages.