### PR TITLE
[world-vercel] Bound the inline structured error in v4 event metadata

### DIFF
--- a/.changeset/lucky-owls-listen.md
+++ b/.changeset/lucky-owls-listen.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Bound the inline structured error carried in v4 event metadata so a multi-megabyte error message or stack no longer makes the server reject `step_retrying` / `step_failed` / `run_failed` writes

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -284,6 +284,226 @@ describe('splitEventDataForV4 structured errors', () => {
   });
 });
 
+/**
+ * The server's caps, mirrored so the assertions below state what they are
+ * protecting: an error past either one is not merely fat on the wire, the
+ * whole terminal event is refused and the run keeps no record of failing.
+ */
+const SERVER_MAX_META_BYTES = 64 * 1024;
+const SERVER_MAX_STRUCTURED_ERROR_BYTES = 32 * 1024;
+
+const byteLength = (value: string) =>
+  new TextEncoder().encode(value).byteLength;
+
+describe('splitEventDataForV4 oversized structured errors', () => {
+  it('bounds a multi-MiB step_failed error message and stack', () => {
+    const error = `boom: ${'x'.repeat(5 * 1024 * 1024)}`;
+    const stack = `Error: boom\n${'    at fn (/app/step.js:10:5)\n'.repeat(50_000)}`;
+
+    const { payload, meta } = splitEventDataForV4({
+      eventType: 'step_failed',
+      correlationId: 'step_1',
+      specVersion: 2,
+      eventData: { stepName: 'a-step', error, stack },
+    } as AnyEventRequest);
+
+    // Still the meta path (nothing to stream — the error is not dehydrated).
+    expect(payload).toBeUndefined();
+    expect(byteLength(meta.error as string)).toBeLessThan(
+      SERVER_MAX_STRUCTURED_ERROR_BYTES
+    );
+    expect(byteLength(meta.stack as string)).toBeLessThan(
+      SERVER_MAX_STRUCTURED_ERROR_BYTES
+    );
+    // The whole meta block, which is what the server actually rejected.
+    expect(encode(meta).byteLength).toBeLessThan(SERVER_MAX_META_BYTES);
+    // Diagnostic value survives: the head, plus a marker naming what was lost.
+    expect(meta.error as string).toMatch(/^boom: x+/);
+    expect(meta.error as string).toMatch(
+      new RegExp(`truncated: ${byteLength(error)} bytes`)
+    );
+    expect(meta.stack as string).toMatch(/^Error: boom\n {4}at fn/);
+    expect(meta.stack as string).toMatch(/truncated: \d+ bytes/);
+  });
+
+  it('bounds a multi-MiB step_retrying error while keeping retryAfter', () => {
+    const retryAfter = new Date('2026-06-10T12:00:00.000Z');
+    const { meta } = splitEventDataForV4({
+      eventType: 'step_retrying',
+      correlationId: 'step_1',
+      specVersion: 2,
+      eventData: {
+        stepName: 'a-step',
+        error: 'flake: '.repeat(1024 * 1024),
+        stack: 'Error: flake\n    at fn'.repeat(100_000),
+        retryAfter,
+      },
+    } as AnyEventRequest);
+
+    expect(encode(meta).byteLength).toBeLessThan(SERVER_MAX_META_BYTES);
+    expect(meta.retryAfter).toEqual(retryAfter);
+  });
+
+  it('bounds a multi-MiB run_failed error object, preserving its shape', () => {
+    const { meta } = splitEventDataForV4({
+      eventType: 'run_failed',
+      specVersion: 2,
+      eventData: {
+        error: {
+          message: 'kaboom: '.repeat(1024 * 1024),
+          stack: 'Error: kaboom\n    at main'.repeat(200_000),
+        },
+        errorCode: 'RUNTIME_ERROR',
+      },
+    } as AnyEventRequest);
+
+    // run_failed's consumers (deserializeError, the observability UI, the
+    // server's structuredError materialization) read `message` / `stack` off
+    // an object — truncation must not flatten it to a string.
+    const error = meta.error as { message: string; stack: string };
+    expect(error.message).toMatch(/^kaboom: /);
+    expect(error.stack).toMatch(/^Error: kaboom\n {4}at main/);
+    expect(encode(meta.error).byteLength).toBeLessThan(
+      SERVER_MAX_STRUCTURED_ERROR_BYTES
+    );
+    expect(encode(meta).byteLength).toBeLessThan(SERVER_MAX_META_BYTES);
+    expect(meta.errorCode).toBe('RUNTIME_ERROR');
+  });
+
+  it('keeps small sibling fields on a truncated run_failed error object', () => {
+    const { meta } = splitEventDataForV4({
+      eventType: 'run_failed',
+      specVersion: 2,
+      eventData: {
+        error: {
+          message: 'kaboom: '.repeat(1024 * 1024),
+          stack: 'Error: kaboom',
+          code: 'ERR_CUSTOM',
+        },
+      },
+    } as AnyEventRequest);
+
+    const error = meta.error as Record<string, unknown>;
+    expect(error.code).toBe('ERR_CUSTOM');
+    expect(error.stack).toBe('Error: kaboom');
+    expect(encode(meta.error).byteLength).toBeLessThan(
+      SERVER_MAX_STRUCTURED_ERROR_BYTES
+    );
+  });
+
+  it('drops an oversized sibling field rather than blowing the budget', () => {
+    // Truncating message/stack is not enough when the bulk is somewhere
+    // else on the object; the bound still has to hold.
+    const { meta } = splitEventDataForV4({
+      eventType: 'run_failed',
+      specVersion: 2,
+      eventData: {
+        error: {
+          message: 'kaboom',
+          stack: 'Error: kaboom',
+          responseBody: 'y'.repeat(3 * 1024 * 1024),
+        },
+      },
+    } as AnyEventRequest);
+
+    const error = meta.error as Record<string, unknown>;
+    expect(error).toEqual({ message: 'kaboom', stack: 'Error: kaboom' });
+    expect(encode(meta.error).byteLength).toBeLessThan(
+      SERVER_MAX_STRUCTURED_ERROR_BYTES
+    );
+  });
+
+  it('leaves an in-budget error byte-identical', () => {
+    // The overwhelmingly common case must be untouched: same value, same
+    // wire bytes as before the bound existed.
+    const error = 'x'.repeat(8 * 1024);
+    const stack = `Error: boom\n${'    at fn (/app/step.js:10:5)\n'.repeat(20)}`;
+    const { meta } = splitEventDataForV4({
+      eventType: 'step_failed',
+      correlationId: 'step_1',
+      specVersion: 2,
+      eventData: { stepName: 'a-step', error, stack },
+    } as AnyEventRequest);
+
+    expect(meta.error).toBe(error);
+    expect(meta.stack).toBe(stack);
+  });
+
+  it('truncates on a code-point boundary', () => {
+    // A byte-wise slice through a 4-byte emoji would leave a mojibake tail
+    // (or a lone surrogate) in the message the user reads.
+    const { meta } = splitEventDataForV4({
+      eventType: 'step_failed',
+      correlationId: 'step_1',
+      specVersion: 2,
+      eventData: { stepName: 'a-step', error: '😀'.repeat(1024 * 1024) },
+    } as AnyEventRequest);
+
+    const error = meta.error as string;
+    expect(error).not.toContain('�');
+    expect(error).toMatch(/^😀+/);
+    expect(byteLength(error)).toBeLessThan(SERVER_MAX_STRUCTURED_ERROR_BYTES);
+  });
+});
+
+describe('createWorkflowRunEvent oversized error frame', () => {
+  it('posts a step_failed frame whose meta block stays under the server cap', async () => {
+    const agent = mockAgent();
+    let capturedMeta: Record<string, unknown> | undefined;
+    let capturedMetaBytes = 0;
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/step_failed',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        (opts: { body?: unknown }) => {
+          capturedMeta = decodePostedMeta(opts.body);
+          capturedMetaBytes = encode(capturedMeta).byteLength;
+          return encode({});
+        },
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': '2026-06-10T00:00:04.000Z',
+          },
+        }
+      );
+
+    await createWorkflowRunEvent(
+      'wrun_1',
+      {
+        eventType: 'step_failed',
+        correlationId: 'step_1',
+        specVersion: 2,
+        eventData: {
+          stepName: 'a-step',
+          error: 'boom: '.repeat(1024 * 1024),
+          stack: 'Error: boom\n    at fn'.repeat(200_000),
+          deploymentId: 'dpl_1',
+          workflowName: 'a-workflow',
+        },
+      } as AnyEventRequest,
+      undefined,
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(capturedMetaBytes).toBeGreaterThan(0);
+    expect(capturedMetaBytes).toBeLessThan(SERVER_MAX_META_BYTES);
+    expect(byteLength(capturedMeta?.error as string)).toBeLessThan(
+      SERVER_MAX_STRUCTURED_ERROR_BYTES
+    );
+    expect(byteLength(capturedMeta?.stack as string)).toBeLessThan(
+      SERVER_MAX_STRUCTURED_ERROR_BYTES
+    );
+    agent.assertNoPendingInterceptors();
+  });
+});
+
 describe('splitEventDataForV4 hook fields', () => {
   it('routes hook_created token + isWebhook into the frame meta', () => {
     // The runtime marks webhook hooks via eventData.isWebhook; the backend

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -47,7 +47,7 @@ import {
   validateUlidTimestamp,
   type WorkflowRun,
 } from '@workflow/world';
-import { decode } from 'cbor-x';
+import { decode, encode } from 'cbor-x';
 import { withEventPostRetry } from './event-retry.js';
 import {
   createWorkflowRunEventV4,
@@ -164,6 +164,114 @@ const structuredErrorEventTypes = new Set<string>([
 ]);
 
 // =============================================================================
+// Inline structured-error bounds
+// =============================================================================
+
+/**
+ * Byte budgets for the inline structured error this line carries in the v4
+ * frame meta (`meta.error` / `meta.stack` — see `SplitEventData`).
+ *
+ * The meta block is the one part of a v4 frame with no streaming escape
+ * hatch, and the server caps it: 64 KiB for the whole block, 32 KiB each
+ * for `meta.error` (CBOR-encoded) and `meta.stack` (UTF-8). Past that the
+ * write is refused outright, so the terminal event never lands and the run
+ * is left in `running` with no failure recorded. These budgets sum to
+ * 24 KiB, leaving ~40 KiB for the rest of the block — every other meta
+ * field is itself server-capped, the largest (executionContext) at 2 KiB.
+ *
+ * Raising these is the wrong fix if they ever bind: data that big belongs
+ * in the frame body, where the server streams it into a ref.
+ */
+const META_ERROR_MAX_BYTES = 16 * 1024;
+const META_STACK_MAX_BYTES = 8 * 1024;
+
+/** Headroom for CBOR framing when a budget covers an encoded value rather
+ *  than a raw string: ≤5 bytes for a string head, a few dozen for a small
+ *  map's keys and headers. */
+const CBOR_OVERHEAD_RESERVE = 64;
+
+const utf8Encoder = new TextEncoder();
+
+/** Trailing U+FFFD left behind when a non-fatal decode hits a multi-byte
+ *  sequence the byte slice cut in half. */
+const TRAILING_REPLACEMENT_CHAR = /�$/;
+
+/**
+ * Truncate to `maxBytes` of UTF-8 on a code-point boundary, appending a
+ * marker that names the original size so the loss is visible rather than
+ * looking like a message that simply ended.
+ */
+function truncateUtf8(value: string, maxBytes: number): string {
+  const bytes = utf8Encoder.encode(value);
+  if (bytes.byteLength <= maxBytes) return value;
+  const marker = `… [truncated: ${bytes.byteLength} bytes exceeds the ${maxBytes}-byte v4 event metadata budget]`;
+  const markerBytes = utf8Encoder.encode(marker).byteLength;
+  const keep = Math.max(0, maxBytes - markerBytes);
+  const head = new TextDecoder()
+    .decode(bytes.subarray(0, keep))
+    .replace(TRAILING_REPLACEMENT_CHAR, '');
+  return head + marker;
+}
+
+/**
+ * Bound the inline `meta.error` value to `META_ERROR_MAX_BYTES` encoded.
+ *
+ * An in-budget error passes through untouched, so the common case stays
+ * byte-identical to what this line has always sent. A rewritten one keeps
+ * the shape its consumers read `message` / `stack` / `code` off of
+ * (`deserializeStep`, `deserializeError`, and the server's StructuredError
+ * materialization).
+ */
+function boundMetaError(value: unknown): unknown {
+  if (encode(value).byteLength <= META_ERROR_MAX_BYTES) return value;
+
+  // step_failed / step_retrying: a bare message string.
+  if (typeof value === 'string') {
+    return truncateUtf8(value, META_ERROR_MAX_BYTES - CBOR_OVERHEAD_RESERVE);
+  }
+
+  // run_failed: a `{ message, stack? }` object. Truncate both strings and
+  // keep the other fields, then fall back to message+stack alone if some
+  // unexpected sibling field is what blew the budget.
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const source = value as Record<string, unknown>;
+    const half = Math.floor((META_ERROR_MAX_BYTES - CBOR_OVERHEAD_RESERVE) / 2);
+    const message = truncateUtf8(stringifyErrorField(source.message), half);
+    const stack =
+      source.stack === undefined
+        ? undefined
+        : truncateUtf8(stringifyErrorField(source.stack), half);
+    const withSiblings = {
+      ...source,
+      message,
+      ...(stack === undefined ? {} : { stack }),
+    };
+    if (encode(withSiblings).byteLength <= META_ERROR_MAX_BYTES) {
+      return withSiblings;
+    }
+    return { message, ...(stack === undefined ? {} : { stack }) };
+  }
+
+  // Not a shape this runtime emits, and not one we can bound while
+  // preserving it. Keep the event writable rather than lose the failure.
+  return {
+    message: `[error omitted: ${encode(value).byteLength} encoded bytes exceeds the ${META_ERROR_MAX_BYTES}-byte v4 event metadata budget]`,
+  };
+}
+
+/** Coerce an error `message` / `stack` field to the string the wire wants,
+ *  tolerating the non-string values `eventData` is loosely typed to allow. */
+function stringifyErrorField(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === undefined || value === null) return 'Unknown error';
+  try {
+    return String(value);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+// =============================================================================
 // Helpers
 // =============================================================================
 
@@ -189,14 +297,14 @@ interface SplitEventData {
      * as an opaque body — the backend rebuilds the same StructuredError it
      * did on the pre-v4 wire from this meta. (A runtime that dehydrates
      * errors into a Uint8Array instead routes them through the frame body
-     * via `payload`.)
+     * via `payload`.) Bounded to `META_ERROR_MAX_BYTES`.
      */
     error?: unknown;
     /**
      * Companion stack string for step_failed / step_retrying, whose `error`
      * is a bare message. The backend folds it into the step's
      * structuredError. run_failed carries its stack inside the `error`
-     * object instead.
+     * object instead. Bounded to `META_STACK_MAX_BYTES`.
      */
     stack?: string;
     /** Structured executionContext, included verbatim in frame meta. */
@@ -323,7 +431,7 @@ export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
   // into the step's structuredError. run_failed keeps its stack inside the
   // error object, so there is no top-level `stack` to lift there.
   if (typeof eventData.stack === 'string') {
-    meta.stack = eventData.stack;
+    meta.stack = truncateUtf8(eventData.stack, META_STACK_MAX_BYTES);
   }
   if (
     eventData.executionContext !== undefined &&
@@ -365,7 +473,7 @@ export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
         // StructuredError the pre-v4 wire produced, instead of wrapping it
         // as an opaque body the backend would store verbatim. The matching
         // read path (buildEventFromV4) decodes it back.
-        meta.error = value;
+        meta.error = boundMetaError(value);
       } else {
         // Any other payload field arriving as a non-Uint8Array is a real
         // contract violation (those fields are always dehydrated bytes) —


### PR DESCRIPTION
## Summary & Motivation

The meta block is the one part of a v4 frame with no streaming escape hatch, so on this line — where run/step errors aren't dehydrated into the body — a multi-megabyte thrown message made the server reject the write and the run sat in `running` with no failure recorded. Truncation keeps the `{ message, stack }` shape consumers read, since `deserializeError` and `deserializeStep` resolve these to structured objects rather than refs.

## Test Plan

Unit tests added; full `@workflow/world-vercel` suite and typecheck pass, and the budgets were cross-checked against the server's caps.
