### PR TITLE
[ci] Run CI for #3372 (Date subclassing fix)

### DIFF
--- a/.changeset/date-subclass-vm.md
+++ b/.changeset/date-subclass-vm.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Fix `Date` subclassing inside workflow functions. The deterministic `Date` override in the workflow VM is now a class that preserves `new.target`, so subclasses like `TZDate` from `@date-fns/tz` keep their identity, methods, and fields.
+Fix `Date` subclassing inside workflow functions. The deterministic `Date` override in the workflow VM now forwards `new.target` via `Reflect.construct`, so subclasses like `TZDate` from `@date-fns/tz` keep their identity, methods, and fields. Calling `Date()` without `new` now returns the (fixed) time string per spec, instead of a `Date` object.

--- a/.changeset/date-subclass-vm.md
+++ b/.changeset/date-subclass-vm.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix `Date` subclassing inside workflow functions. The deterministic `Date` override in the workflow VM is now a class that preserves `new.target`, so subclasses like `TZDate` from `@date-fns/tz` keep their identity, methods, and fields.

--- a/packages/core/src/vm/index.test.ts
+++ b/packages/core/src/vm/index.test.ts
@@ -49,6 +49,53 @@ describe('createContext', () => {
     expect(result).toEqual(specificTime);
   });
 
+  it('should support subclassing `Date`', () => {
+    const { context } = createContext({ seed, fixedTimestamp });
+
+    const result = vm.runInContext(
+      `
+      class Sub extends Date {
+        constructor(...args) {
+          super(...args);
+          this.tag = 'sub';
+        }
+        label() {
+          return 'sub';
+        }
+      }
+      const sub = new Sub(2026, 6, 29);
+      const defaulted = new Sub();
+      ({
+        isSub: sub instanceof Sub,
+        isDate: sub instanceof Date,
+        keepsMethods: sub.label(),
+        keepsFields: sub.tag,
+        argsForwarded: sub.getTime() === new Date(2026, 6, 29).getTime(),
+        defaultedIsFixed: defaulted.getTime(),
+      })
+      `,
+      context
+    );
+
+    expect(result.isSub).toBe(true);
+    expect(result.isDate).toBe(true);
+    expect(result.keepsMethods).toBe('sub');
+    expect(result.keepsFields).toBe('sub');
+    expect(result.argsForwarded).toBe(true);
+    expect(result.defaultedIsFixed).toEqual(fixedTimestamp);
+  });
+
+  it('should preserve `Date` static methods', () => {
+    const { context } = createContext({ seed, fixedTimestamp });
+
+    expect(
+      vm.runInContext("Date.parse('2000-01-01T00:00:00.000Z')", context)
+    ).toEqual(946684800000);
+    expect(vm.runInContext('Date.UTC(2000, 0, 1)', context)).toEqual(
+      946684800000
+    );
+  });
+
   it('should have deterministic `crypto.getRandomValues()`', () => {
     const { context } = createContext({ seed, fixedTimestamp });
 

--- a/packages/core/src/vm/index.test.ts
+++ b/packages/core/src/vm/index.test.ts
@@ -85,6 +85,17 @@ describe('createContext', () => {
     expect(result.defaultedIsFixed).toEqual(fixedTimestamp);
   });
 
+  it('should keep `Date()` callable without `new`, returning the fixed time string', () => {
+    const { context } = createContext({ seed, fixedTimestamp });
+
+    const result = vm.runInContext('Date()', context);
+
+    expect(result).toBeTypeOf('string');
+    expect(result).toEqual(vm.runInContext('new Date().toString()', context));
+    // Per spec, `Date()` as a function ignores its arguments
+    expect(vm.runInContext('Date(2000, 0, 1)', context)).toEqual(result);
+  });
+
   it('should preserve `Date` static methods', () => {
     const { context } = createContext({ seed, fixedTimestamp });
 

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -60,21 +60,22 @@ export function createContext(options: CreateContextOptions) {
   // Deterministic `Math.random()`
   g.Math.random = rng;
 
-  // Override `Date` constructor to return fixed time when called without arguments
+  // Override `Date` constructor to return fixed time when called without
+  // arguments. A `class` (rather than a plain function) keeps `new.target`
+  // intact so user code can still subclass `Date` (e.g. `TZDate` from
+  // `@date-fns/tz`), and `extends` preserves the prototype chain and statics.
   const Date_ = g.Date;
   // biome-ignore lint/suspicious/noShadowRestrictedNames: We're shadowing the global `Date` property to make it deterministic.
-  (g as any).Date = function Date(
-    ...args: Parameters<(typeof globalThis)['Date']>[]
-  ) {
-    if (args.length === 0) {
-      return new Date_(fixedTimestamp);
+  (g as any).Date = class Date extends Date_ {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        super(fixedTimestamp);
+      } else {
+        // @ts-expect-error - Args is `Date` constructor arguments
+        super(...args);
+      }
     }
-    // @ts-expect-error - Args is `Date` constructor arguments
-    return new Date_(...args);
   };
-  (g as any).Date.prototype = Date_.prototype;
-  // Preserve static methods
-  Object.setPrototypeOf(g.Date, Date_);
   g.Date.now = () => fixedTimestamp;
 
   // Deterministic `crypto` using Proxy to avoid mutating global objects

--- a/packages/core/src/vm/index.ts
+++ b/packages/core/src/vm/index.ts
@@ -61,21 +61,25 @@ export function createContext(options: CreateContextOptions) {
   g.Math.random = rng;
 
   // Override `Date` constructor to return fixed time when called without
-  // arguments. A `class` (rather than a plain function) keeps `new.target`
-  // intact so user code can still subclass `Date` (e.g. `TZDate` from
-  // `@date-fns/tz`), and `extends` preserves the prototype chain and statics.
+  // arguments. Constructing through `Reflect.construct` with `new.target`
+  // keeps subclassing intact (e.g. `TZDate` from `@date-fns/tz`), while a
+  // plain function (rather than a `class`) keeps `Date()` callable without
+  // `new`, which per spec ignores its arguments and returns the time string.
   const Date_ = g.Date;
   // biome-ignore lint/suspicious/noShadowRestrictedNames: We're shadowing the global `Date` property to make it deterministic.
-  (g as any).Date = class Date extends Date_ {
-    constructor(...args: any[]) {
-      if (args.length === 0) {
-        super(fixedTimestamp);
-      } else {
-        // @ts-expect-error - Args is `Date` constructor arguments
-        super(...args);
-      }
+  (g as any).Date = function Date(...args: any[]) {
+    if (new.target === undefined) {
+      return new Date_(fixedTimestamp).toString();
     }
+    return Reflect.construct(
+      Date_,
+      args.length === 0 ? [fixedTimestamp] : args,
+      new.target
+    );
   };
+  (g as any).Date.prototype = Date_.prototype;
+  // Preserve static methods
+  Object.setPrototypeOf(g.Date, Date_);
   g.Date.now = () => fixedTimestamp;
 
   // Deterministic `crypto` using Proxy to avoid mutating global objects


### PR DESCRIPTION
CI-run PR for #3372 (`fix(core): preserve new.target in the deterministic Date override`), authored by @ar-tama.

Third-party fork PRs don't get full CI here, so this branch points at the **exact head commit of the contributor's branch** (4c7cd3c20bc81c1edcb1588da9c22af5c5fcddfd — no modifications) to run the suite against it.

- Do not merge this PR — it exists only to produce CI results for #3372.
- Review discussion happens on #3372.
- If #3372 is updated, delete this branch and recreate it at the new head.