### PR TITLE
[builders] Fix the onAfterTransform README sample

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the `onAfterTransform` sample in the builders README so it type-checks on its own.

--- a/packages/builders/README.md
+++ b/packages/builders/README.md
@@ -36,19 +36,19 @@ Builder configurations can provide an optional `onAfterTransform` observer for
 tooling that derives metadata from the exact SWC output used by a build:
 
 ```typescript
-const builder = new MyBuilder({
-  // Other builder configuration...
-  onAfterTransform: async ({
-    mode,
-    filename,
-    absolutePath,
-    source,
-    code,
-    workflowManifest,
-  }) => {
-    // Observe the accepted transform result.
-  },
-});
+import type { WorkflowAfterTransformHook } from '@workflow/builders';
+
+// Pass as `onAfterTransform` in the builder configuration.
+const onAfterTransform: WorkflowAfterTransformHook = async ({
+  mode,
+  filename,
+  absolutePath,
+  source,
+  code,
+  workflowManifest,
+}) => {
+  // Observe the accepted transform result.
+};
 ```
 
 The observer is awaited after the transform's manifest entries have been


### PR DESCRIPTION
`Docs Code Samples` is red on `main` as of 4ec7acaa71 (#3163). The harness type-checks each fenced block independently, and the new `onAfterTransform` example calls `new MyBuilder(...)` where `MyBuilder` is declared in an earlier block:

```
FAIL packages/builders/README.md line 39
  Line 1: Cannot find name 'MyBuilder'. Did you mean 'builder'? (TS2552)
```

Typed the hook directly instead of constructing a builder, so the block stands alone.

Verified locally: `DOCS_FILE="builders/README.md" pnpm vitest run src` in `packages/docs-typecheck` fails on `main`'s README and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)