### PR TITLE
[world] Expose capabilities in deployment health checks

### DIFF
--- a/.changeset/capabilities-health-schema.md
+++ b/.changeset/capabilities-health-schema.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'@workflow/world': minor
+'workflow': minor
+---
+
+Export a Zod-backed World capabilities schema and include World capabilities in health-check responses.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2983,6 +2983,7 @@ describe.concurrent('e2e', () => {
         timeout: 30000,
       });
       expect(workflowResult.healthy).toBe(true);
+      if (!workflowResult.healthy) throw new Error(workflowResult.error);
       // The deployed app advertises its `@workflow/core` version so
       // callers can derive capability metadata (see `getRunCapabilities`
       // in `capabilities.ts`).

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -236,6 +236,38 @@ describe('healthCheck response parsing', () => {
     expect(result.workflowCoreVersion).toBe('5.0.0-beta.7');
   });
 
+  it('surfaces valid World capabilities', async () => {
+    const world = makeWorldWithResponse(
+      JSON.stringify({
+        healthy: true,
+        capabilities: {
+          hookRetention: { active: true },
+          futureCapability: true,
+        },
+      })
+    );
+
+    await expect(healthCheck(world, { timeout: 1000 })).resolves.toMatchObject({
+      healthy: true,
+      capabilities: { hookRetention: { active: true } },
+    });
+  });
+
+  it('rejects invalid World capabilities', async () => {
+    const world = makeWorldWithResponse(
+      JSON.stringify({
+        healthy: true,
+        capabilities: { hookRetention: { active: 'yes' } },
+      })
+    );
+
+    const result = await healthCheck(world, { timeout: 1000 });
+
+    expect(result.healthy).toBe(false);
+    expect(result.error).toMatch(/Invalid health check response/);
+    expect(world.streams.get).toHaveBeenCalledOnce();
+  });
+
   it('omits workflowCoreVersion when the response does not include the field', async () => {
     // Independent of specVersion — the field is omitted by any responder
     // running an older `@workflow/core` that predates the addition of
@@ -257,9 +289,7 @@ describe('healthCheck response parsing', () => {
     expect(result.workflowCoreVersion).toBeUndefined();
   });
 
-  it('omits workflowCoreVersion when the field is the wrong type', async () => {
-    // Defensive: the parser only accepts strings. Anything else is dropped
-    // rather than surfaced as garbage.
+  it('rejects workflowCoreVersion with the wrong type', async () => {
     const world = makeWorldWithResponse(
       JSON.stringify({
         healthy: true,
@@ -272,8 +302,8 @@ describe('healthCheck response parsing', () => {
 
     const result = await healthCheck(world, { timeout: 1000 });
 
-    expect(result.healthy).toBe(true);
-    expect(result.workflowCoreVersion).toBeUndefined();
+    expect(result.healthy).toBe(false);
+    expect(result.error).toMatch(/Invalid health check response/);
   });
 
   it('surfaces hookResumeInputVersion from the target so the caller stamps the consumer value', async () => {
@@ -317,9 +347,7 @@ describe('healthCheck response parsing', () => {
     expect(result.hookResumeInputVersion).toBeUndefined();
   });
 
-  it('omits hookResumeInputVersion when the field is the wrong type', async () => {
-    // Defensive: only a number is accepted; anything else is dropped rather
-    // than surfaced as a bogus capability.
+  it('rejects hookResumeInputVersion with the wrong type', async () => {
     const world = makeWorldWithResponse(
       JSON.stringify({
         healthy: true,
@@ -332,8 +360,8 @@ describe('healthCheck response parsing', () => {
 
     const result = await healthCheck(world, { timeout: 1000 });
 
-    expect(result.healthy).toBe(true);
-    expect(result.hookResumeInputVersion).toBeUndefined();
+    expect(result.healthy).toBe(false);
+    expect(result.error).toMatch(/Invalid health check response/);
   });
 
   it('returns healthy with no fields for non-JSON plain-text responses', async () => {
@@ -349,6 +377,38 @@ describe('healthCheck response parsing', () => {
     expect(result.healthy).toBe(true);
     expect(result.specVersion).toBeUndefined();
     expect(result.workflowCoreVersion).toBeUndefined();
+  });
+
+  it('returns an unhealthy response error', async () => {
+    const world = makeWorldWithResponse(
+      JSON.stringify({ healthy: false, error: 'maintenance' })
+    );
+
+    await expect(healthCheck(world, { timeout: 1000 })).resolves.toEqual({
+      healthy: false,
+      error: 'maintenance',
+    });
+  });
+
+  it('polls again after an empty completed stream', async () => {
+    const world = makeWorldWithResponse(JSON.stringify({ healthy: true }));
+    vi.mocked(world.streams.get)
+      .mockResolvedValueOnce(new ReadableStream<Uint8Array>())
+      .mockResolvedValueOnce(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(JSON.stringify({ healthy: true }))
+            );
+            controller.close();
+          },
+        })
+      );
+
+    const result = await healthCheck(world, { timeout: 1000 });
+
+    expect(result.healthy).toBe(true);
+    expect(world.streams.get).toHaveBeenCalledTimes(2);
   });
 
   it('publishes to the default health-check topic when no namespace is given', async () => {
@@ -398,6 +458,20 @@ describe('healthCheck response parsing', () => {
 
     expect(result.healthy).toBe(false);
     expect(result.error).toMatch(/timed out/);
+  });
+
+  it('bounds reads from an open stream by the overall timeout', async () => {
+    const world = {
+      queue: vi.fn().mockResolvedValue(undefined),
+      streams: {
+        get: vi.fn(async () => new ReadableStream<Uint8Array>()),
+      },
+    } as unknown as World;
+
+    const result = await healthCheck(world, { timeout: 20 });
+
+    expect(result.healthy).toBe(false);
+    expect(result.error).toMatch(/timed out after 20ms/);
   });
 });
 
@@ -1031,6 +1105,20 @@ describe('health check run public key', () => {
     expect(getEncryptionKeyForRun).not.toHaveBeenCalled();
     expect(writtenResponse(write).encryptionPublicKey).toBeUndefined();
     expect(writtenResponse(write).healthy).toBe(true);
+  });
+
+  it('returns the target World capabilities', async () => {
+    const { getWorldLazy } = await import('./get-world-lazy.js');
+    const { world, write } = responderWorld(undefined);
+    world.capabilities = { hookRetention: { active: true } };
+    vi.mocked(getWorldLazy).mockReturnValue(world as any);
+
+    await handleHealthCheckMessage({
+      __healthCheck: true,
+      correlationId: 'corr_capabilities',
+    });
+
+    expect(writtenResponse(write).capabilities).toEqual(world.capabilities);
   });
 
   it('omits the key when encryption is not configured', async () => {

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -22,8 +22,10 @@ import {
   resolveQueueNamespace,
   SPEC_VERSION_CURRENT,
   SPEC_VERSION_LEGACY,
+  WorldCapabilitiesSchema,
 } from '@workflow/world';
 import { monotonicFactory } from 'ulid';
+import { z } from 'zod';
 import { runtimeLogger } from '../logger.js';
 import { bytesToBase64, deriveRunKeyPair } from '../sealed-box.js';
 import {
@@ -75,47 +77,39 @@ function getHealthCheckStreamName(correlationId: string): string {
   return `__health_check__${correlationId}`;
 }
 
-/**
- * Result of a health check operation.
- */
-export interface HealthCheckResult {
-  healthy: boolean;
-  /** Error message if health check failed */
-  error?: string;
-  /** Latency if the health check was successful */
-  latencyMs?: number;
-  /** Spec version of the responding deployment */
-  specVersion?: number;
-  /**
-   * `@workflow/core` version of the responding deployment, used for
-   * capability detection (see `getRunCapabilities`). Omitted when the
-   * responding deployment did not provide the field as a string:
-   * for example, an older `@workflow/core` that predates this field,
-   * or a non-JSON plain-text health response.
-   */
-  workflowCoreVersion?: string;
-  /**
-   * The target run's X25519 public key (base64), returned only when the probe
-   * carried a `runId` and the responding deployment has encryption enabled.
-   *
-   * Lets a cross-deployment `start()` seal the workflow arguments using a
-   * response it was already waiting on, instead of making a separate
-   * key-lookup request.
-   */
-  encryptionPublicKey?: string;
-  /**
-   * The responding deployment's `HOOK_RESUME_INPUT_VERSION`: the protocol
-   * version at which the *consumer* (queue-message target) materializes the
-   * `hook_received` event from `hookInput` on replay. A cross-deployment
-   * `start()` stamps the *target's* value (not the caller's) into the new
-   * run's `executionContext.hookResumeInputVersion`. Current producers write
-   * the event durably before publishing the wake and do not read the marker;
-   * OLDER producers still gate their lazy path on it, so it keeps being
-   * stamped. Omitted when the responding deployment predates this field,
-   * which fails that gate closed.
-   */
-  hookResumeInputVersion?: number;
-}
+const HealthyHealthCheckResponseSchema = z.object({
+  healthy: z.literal(true),
+  /** Spec version of the responding deployment. */
+  specVersion: z.number().optional(),
+  /** `@workflow/core` version of the responding deployment. */
+  workflowCoreVersion: z.string().optional(),
+  /** The target run's X25519 public key, encoded as base64. */
+  encryptionPublicKey: z.string().optional(),
+  /** The responding deployment's hook-resume input protocol version. */
+  hookResumeInputVersion: z.number().optional(),
+  /** Optional features supported by the responding deployment's World. */
+  capabilities: WorldCapabilitiesSchema.optional(),
+});
+
+const UnhealthyHealthCheckResponseSchema = z.object({
+  healthy: z.literal(false),
+  error: z.string(),
+});
+
+export const HealthCheckResponseSchema = z.discriminatedUnion('healthy', [
+  HealthyHealthCheckResponseSchema,
+  UnhealthyHealthCheckResponseSchema,
+]);
+
+type HealthyHealthCheckResponse = z.infer<
+  typeof HealthyHealthCheckResponseSchema
+>;
+type HealthCheckResponse = z.infer<typeof HealthCheckResponseSchema>;
+
+/** Result of a health check operation. */
+export type HealthCheckResult =
+  | (HealthyHealthCheckResponse & { latencyMs: number })
+  | z.infer<typeof UnhealthyHealthCheckResponseSchema>;
 
 /**
  * Checks if the given message is a health check payload.
@@ -186,15 +180,14 @@ export async function handleHealthCheckMessage(
 
   const response = JSON.stringify({
     healthy: true,
-    correlationId: healthCheck.correlationId,
     specVersion: worldSpecVersion ?? SPEC_VERSION_CURRENT,
     workflowCoreVersion,
     // We are executing inside the target deployment, so this constant reflects
     // the *consumer's* hook-resume protocol version, exactly what a
     // cross-deployment caller needs to gate its parallel resume path on.
     hookResumeInputVersion: HOOK_RESUME_INPUT_VERSION,
+    capabilities: world.capabilities,
     ...(encryptionPublicKey ? { encryptionPublicKey } : {}),
-    timestamp: Date.now(),
   });
   // Use a deterministic fake runId derived from the correlationId so that
   // the reader side produces the same value.
@@ -245,10 +238,6 @@ const HEALTH_CHECK_POLL_INTERVAL = 100;
 const HEALTH_CHECK_READ_TIMEOUT = 500;
 
 /**
- * Read chunks from a stream with a timeout per read operation.
- * Returns { chunks, timedOut } where timedOut indicates if a read timed out.
- */
-/**
  * Race a promise against a deadline. Rejects with a timeout error when the
  * deadline elapses first. Used to bound `world.streams.get()` inside the
  * health-check poll loop: some worlds hold that request open until the
@@ -280,15 +269,17 @@ async function readStreamWithTimeout(
 
   while (!done && !timedOut) {
     const readPromise = reader.read();
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<{ done: true; value: undefined }>(
       (resolve) =>
-        setTimeout(() => {
+        (timer = setTimeout(() => {
           timedOut = true;
           resolve({ done: true, value: undefined });
-        }, readTimeout)
+        }, readTimeout))
     );
 
     const result = await Promise.race([readPromise, timeoutPromise]);
+    clearTimeout(timer);
     done = result.done;
     if (result.value) chunks.push(result.value);
   }
@@ -298,15 +289,17 @@ async function readStreamWithTimeout(
 
 /**
  * Parse and validate a health check response from stream chunks.
- * Returns the parsed response or null if invalid.
+ * Returns the parsed response or an immediate validation failure.
  */
-function parseHealthCheckResponse(chunks: Uint8Array[]): {
-  healthy: boolean;
-  specVersion?: number;
-  workflowCoreVersion?: string;
-  encryptionPublicKey?: string;
-} | null {
-  if (chunks.length === 0) return null;
+type ParsedHealthCheckResponse =
+  | { status: 'empty' }
+  | { status: 'valid'; response: HealthCheckResponse }
+  | { status: 'invalid'; error: string };
+
+function parseHealthCheckResponse(
+  chunks: Uint8Array[]
+): ParsedHealthCheckResponse {
+  if (chunks.length === 0) return { status: 'empty' };
 
   const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
   const combined = new Uint8Array(totalLength);
@@ -324,44 +317,57 @@ function parseHealthCheckResponse(chunks: Uint8Array[]): {
     // Old deployments (specVersion < 3) return plain text like
     // 'Workflow SDK "..." endpoint is healthy'. Treat any non-empty
     // text response as a healthy deployment with unknown specVersion.
-    if (responseText.length > 0) {
-      return { healthy: true };
-    }
-    return null;
+    return { status: 'valid', response: { healthy: true } };
   }
 
-  if (
-    typeof response !== 'object' ||
-    response === null ||
-    !('healthy' in response) ||
-    typeof (response as { healthy: unknown }).healthy !== 'boolean'
-  ) {
-    return null;
-  }
+  const result = HealthCheckResponseSchema.safeParse(response);
+  if (result.success) return { status: 'valid', response: result.data };
 
-  const r = response as Record<string, unknown>;
-  const parsed: {
-    healthy: boolean;
-    specVersion?: number;
-    workflowCoreVersion?: string;
-    encryptionPublicKey?: string;
-    hookResumeInputVersion?: number;
-  } = {
-    healthy: r.healthy as boolean,
+  return {
+    status: 'invalid',
+    error: `Invalid health check response: ${result.error.issues.map((issue) => issue.message).join(', ')}`,
   };
-  if (typeof r.specVersion === 'number') {
-    parsed.specVersion = r.specVersion;
+}
+
+async function readHealthCheckResponse(
+  world: World,
+  runId: string,
+  streamName: string,
+  deadline: number
+): Promise<ParsedHealthCheckResponse> {
+  const stream = await withDeadline(
+    world.streams.get(runId, streamName),
+    deadline - Date.now()
+  );
+  const reader = stream.getReader();
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) return { status: 'empty' };
+
+  const result = await readStreamWithTimeout(
+    reader,
+    Math.min(HEALTH_CHECK_READ_TIMEOUT, remainingMs)
+  );
+  if (result.timedOut) {
+    void reader.cancel().catch(() => {});
+    return { status: 'empty' };
   }
-  if (typeof r.workflowCoreVersion === 'string') {
-    parsed.workflowCoreVersion = r.workflowCoreVersion;
+  return parseHealthCheckResponse(result.chunks);
+}
+
+function finishHealthCheck(
+  response: ParsedHealthCheckResponse,
+  startTime: number
+): HealthCheckResult | undefined {
+  switch (response.status) {
+    case 'empty':
+      return undefined;
+    case 'invalid':
+      return { healthy: false, error: response.error };
+    case 'valid':
+      return response.response.healthy
+        ? { ...response.response, latencyMs: Date.now() - startTime }
+        : response.response;
   }
-  if (typeof r.encryptionPublicKey === 'string') {
-    parsed.encryptionPublicKey = r.encryptionPublicKey;
-  }
-  if (typeof r.hookResumeInputVersion === 'number') {
-    parsed.hookResumeInputVersion = r.hookResumeInputVersion;
-  }
-  return parsed;
 }
 
 export async function healthCheck(
@@ -379,11 +385,13 @@ export async function healthCheck(
   // region on both sides.
   const correlationId = world.createRunId?.() ?? generateId();
   const streamName = getHealthCheckStreamName(correlationId);
+  const healthCheckRunId = generateHealthCheckRunId(correlationId);
 
   const queueName =
     `${getQueueTopicPrefix('workflow', resolveQueueNamespace(options?.namespace))}health_check` as ValidQueueName;
 
   const startTime = Date.now();
+  const deadline = startTime + timeout;
 
   try {
     await world.queue(
@@ -401,50 +409,26 @@ export async function healthCheck(
       }
     );
 
-    while (Date.now() - startTime < timeout) {
+    while (Date.now() < deadline) {
+      let response: ParsedHealthCheckResponse = { status: 'empty' };
       try {
-        const remainingMs = timeout - (Date.now() - startTime);
-        const stream = await withDeadline(
-          world.streams.get(
-            generateHealthCheckRunId(correlationId),
-            streamName
-          ),
-          remainingMs
-        );
-        const reader = stream.getReader();
-        const { chunks, timedOut } = await readStreamWithTimeout(
-          reader,
-          HEALTH_CHECK_READ_TIMEOUT
-        );
-
-        if (timedOut) {
-          try {
-            reader.cancel();
-          } catch {
-            // Ignore cancel errors
-          }
-          await new Promise((resolve) =>
-            setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-          );
-          continue;
-        }
-
-        const response = parseHealthCheckResponse(chunks);
-        if (response) {
-          return {
-            ...response,
-            latencyMs: Date.now() - startTime,
-          };
-        }
-
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
+        response = await readHealthCheckResponse(
+          world,
+          healthCheckRunId,
+          streamName,
+          deadline
         );
       } catch {
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL)
-        );
+        // Retry transient stream errors until the overall deadline.
       }
+      const result = finishHealthCheck(response, startTime);
+      if (result) return result;
+
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(HEALTH_CHECK_POLL_INTERVAL, remainingMs))
+      );
     }
     return {
       healthy: false,

--- a/packages/core/src/runtime/start.ts
+++ b/packages/core/src/runtime/start.ts
@@ -384,8 +384,11 @@ export async function start<TArgs extends unknown[], TResult>(
           timeout: CROSS_DEPLOYMENT_CAPABILITY_PROBE_TIMEOUT_MS,
           namespace: opts.namespace,
         }).catch(() => undefined);
-        probedRunPublicKey = probe?.encryptionPublicKey;
-        const capabilities = getRunCapabilities(probe?.workflowCoreVersion);
+        const healthyProbe = probe?.healthy ? probe : undefined;
+        probedRunPublicKey = healthyProbe?.encryptionPublicKey;
+        const capabilities = getRunCapabilities(
+          healthyProbe?.workflowCoreVersion
+        );
         framedByteStreams = capabilities.framedByteStreams;
         targetSupportsCompression = capabilities.supportedFormats.has(
           SerializationFormat.GZIP
@@ -393,7 +396,7 @@ export async function start<TArgs extends unknown[], TResult>(
         // The responder runs inside the target deployment, so its
         // `hookResumeInputVersion` reflects the consumer. Undefined on an
         // older target or a probe timeout, leaving the marker off.
-        targetHookResumeInputVersion = probe?.hookResumeInputVersion;
+        targetHookResumeInputVersion = healthyProbe?.hookResumeInputVersion;
       }
 
       const ops: Promise<void>[] = [];

--- a/packages/web/app/server/workflow-server-actions.server.ts
+++ b/packages/web/app/server/workflow-server-actions.server.ts
@@ -1460,7 +1460,6 @@ export async function runHealthCheck(
     return createResponse({
       healthy: false,
       error: errorMessage,
-      latencyMs: undefined,
     });
   }
 }

--- a/packages/world/src/capabilities.ts
+++ b/packages/world/src/capabilities.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+/**
+ * Optional features a World implementation supports. Missing capabilities are
+ * unsupported so runtime behavior always fails closed.
+ */
+export const WorldCapabilitiesSchema = z.object({
+  /**
+   * Supports `experimental_minRetention` for Hooks. Missing or inactive means
+   * the runtime rejects retained Hooks before registration.
+   */
+  hookRetention: z.object({ active: z.boolean() }).optional(),
+
+  /**
+   * The World's queue supports `maxConcurrency`-limited consumption. This
+   * declares queue support, not deployed configuration, so the runtime cannot
+   * enable a fast path from this capability alone.
+   */
+  maxConcurrency: z.boolean().optional(),
+
+  /**
+   * `events.create` deduplicates concurrent `hook_received` writes sharing a
+   * `(runId, resumeId)`, and `events.list` returns the persisted `resumeId`.
+   * Worlds that accept but do not enforce or round-trip it must leave this
+   * unset.
+   */
+  hookResumeDedup: z.boolean().optional(),
+
+  /**
+   * Deployments are atomic and immutable, so a deployment id always names one
+   * fixed build. Worlds with synthetic or version-tagged deployment ids must
+   * leave this unset.
+   */
+  deploymentAffinity: z.boolean().optional(),
+});
+
+export type WorldCapabilities = z.infer<typeof WorldCapabilitiesSchema>;

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -24,6 +24,8 @@ export {
   ROOT_RUN_ID_ATTRIBUTE,
   validateAttributeChanges,
 } from './attributes.js';
+export type * from './capabilities.js';
+export { WorldCapabilitiesSchema } from './capabilities.js';
 export {
   _resetEnvWarnCacheForTests,
   type EnvNumberOptions,

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -3,6 +3,7 @@ import type {
   AttributeChange,
   ExperimentalSetAttributesResult,
 } from './attributes.js';
+import type { WorldCapabilities } from './capabilities.js';
 import type {
   BatchEventRequest,
   CreateEventBatchParams,
@@ -455,90 +456,6 @@ export interface Storage {
      */
     list(params: ListHooksParams): Promise<PaginatedResponse<Hook>>;
   };
-}
-
-/**
- * Optional feature capabilities a World implementation declares so the core
- * runtime can enable optimizations that depend on backend behavior, instead
- * of inferring support from environment variables alone. Every capability
- * defaults to "unsupported" when absent: runtime fast paths that rely on
- * one must fail closed (keep their conservative behavior) unless the World
- * explicitly declares it.
- */
-export interface WorldCapabilities {
-  /**
-   * Supports `experimental_minRetention` for Hooks. Missing or inactive means
-   * the runtime rejects retained Hooks before registration.
-   */
-  hookRetention?: {
-    active: boolean;
-  };
-
-  /**
-   * The World's queue supports `maxConcurrency`-limited consumption, in
-   * particular the per-run flow topics consumed with `maxConcurrency: 1`
-   * that `WORKFLOW_SEQUENTIAL_REPLAYS=1` uses to serialize a run's
-   * orchestrator invocations. Worlds whose queue has no concurrency-limit
-   * concept must leave this unset.
-   *
-   * Note this declares queue *support*, not deployed configuration: the
-   * serialization also requires the build-time half (a flow trigger emitted
-   * with `maxConcurrency: 1`), which a runtime process cannot verify today.
-   * The core runtime therefore does not yet take any fast path from this
-   * capability alone: it exists so a future build-verified signal can be
-   * combined with it (and so Worlds document the contract explicitly).
-   */
-  maxConcurrency?: boolean;
-
-  /**
-   * The World's `events.create` deduplicates concurrent `hook_received` writes
-   * that carry the same `(runId, resumeId)`, collapsing them onto a single
-   * committed event and returning the canonical one to every caller. Two
-   * writers rely on it: `resumeHook()`'s durable write attaches a `resumeId` +
-   * payload digest so transport-level retries of one write converge on exactly
-   * one event, and legacy `hookInput` queue redeliveries (from older
-   * producers) converge through the same constraint.
-   *
-   * The core runtime fails closed on this: a `resumeId` is attached ONLY when
-   * the World declares `hookResumeDedup === true` (or the live backend attests
-   * it per-lookup, below). A World that accepts a `resumeId` but does not
-   * enforce the `(runId, resumeId)` constraint must leave this unset so the
-   * runtime keeps the plain single-shot write.
-   *
-   * Declaring this also commits the World to ROUND-TRIPPING the key:
-   * `events.list` must return `resumeId` on `hook_received` events it
-   * persisted with one, because the legacy `hookInput` consumer path detects
-   * an already-materialized resume by matching `resumeId` in the loaded log.
-   *
-   * Enabled statically for `world-local` (filesystem sidecar claim keyed on
-   * `(runId, resumeId)`; the adapter and its backend ship together, so a static
-   * capability can never drift from the backend). `world-vercel` deliberately
-   * leaves this UNSET and instead attests support per-lookup via the
-   * server-computed, response-only `Hook.resumeCapabilities.hookResumeDedupVersion`
-   * (see `HookResumeCapabilitiesSchema`), so a server rollback or kill switch
-   * degrades new resumes to plain writes immediately without redeploying
-   * the adapter. `world-postgres` leaves it unset for now.
-   *
-   * The resume gate treats EITHER signal as backend support (see
-   * `resume-hook.ts`): this static capability OR a current
-   * `resumeCapabilities.hookResumeDedupVersion` on the by-token hook.
-   */
-  hookResumeDedup?: boolean;
-
-  /**
-   * Deployments are atomic and immutable: a deployment id names one fixed
-   * build for its whole lifetime, so a run pinned to one may only execute
-   * there. Worlds that declare this get the runtime's deployment-affinity
-   * guard, which re-routes a misrouted delivery to the run's own deployment
-   * and ultimately fails the run with `DEPLOYMENT_MISMATCH`.
-   *
-   * Worlds whose deployment id is synthetic or version-tagged (e.g.
-   * `dpl_local@<sdk-version>`, which legitimately differs across SDK versions
-   * within one logical environment) must leave this unset: there a
-   * "mismatch" is not a real cross-deployment delivery, and guarding would
-   * fail ordinary runs after a version bump.
-   */
-  deploymentAffinity?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- define WorldCapabilitiesSchema with Zod and infer WorldCapabilities from it
- return a World's capabilities from queue-based health checks
- keep the direct HTTP health probe lightweight and independent of World initialization
- preserve compatibility with older and malformed health responses by treating missing or invalid capabilities as unsupported

This gives start() one capability shape for both the current World and a target deployment's World.

## Stack

1. **#3425 — World capabilities in health checks**
2. #3426 — Atomic start Hook admission

## Testing

- pnpm --filter @workflow/world build
- pnpm --filter @workflow/core build
- pnpm --filter @workflow/core exec vitest run src/runtime/helpers.test.ts
- targeted local E2E for the direct HTTP health endpoint