### PR TITLE
feat(core): measure hook-triggered time to resume

### DIFF
--- a/.changeset/hook-resume-ttr-telemetry.md
+++ b/.changeset/hook-resume-ttr-telemetry.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+---
+
+Add OTEL telemetry for hook-triggered time-to-resume: `workflow.resume.total_ms` plus a non-overlapping phase breakdown, on the first durable step after a resume.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -92,6 +92,10 @@ import {
   ReplayBudget,
 } from './runtime/replay-budget.js';
 import { ReplayRecoveryReporter } from './runtime/replay-recovery-reporter.js';
+import {
+  resumeTimingForMessage,
+  resumeTrackingFromMessage,
+} from './runtime/resume-latency.js';
 import { runIdCreatedAt } from './runtime/run-id-time.js';
 import {
   DEFAULT_STEP_MAX_RETRIES,
@@ -643,6 +647,11 @@ export function workflowEntrypoint(
     worldHandlers.createQueueHandler(
       workflowPrefix,
       async (message_, metadata) => {
+        // T2 of the hook-resume TTR window (see runtime/resume-latency.ts):
+        // the instant this consumer began, before message parsing. Only used
+        // when the message turns out to carry resume timing; taking it
+        // unconditionally keeps it honest for the deliveries that do.
+        const handlerEnteredAtMs = Date.now();
         // Check if this is a health check message
         // NOTE: Health check messages are intentionally unauthenticated for monitoring purposes.
         // They only write a simple status response to a stream and do not expose sensitive data.
@@ -668,7 +677,35 @@ export function workflowEntrypoint(
           runInput,
           hookInput,
           stepInput,
+          hookResumeTiming,
         } = WorkflowInvokePayloadSchema.parse(message_);
+
+        // --- Hook-resume TTR telemetry (runtime/resume-latency.ts) ---
+        // Threaded through this invocation and CONSUMED by the first durable
+        // step that follows the resumption — cleared at that point so a later
+        // step, a retry, or a redelivery never re-reports the same resume.
+        //
+        // Two delivery shapes carry timing:
+        //  - the resume's own invocation (no `stepId`): the producer's T0/T1
+        //    ride the message and this handler's entry is T2.
+        //  - a step this invocation handed to another invocation (`stepId`
+        //    present): the resuming invocation already stamped T2..T4 onto
+        //    the message, so they are read back verbatim.
+        let resumeTracking = resumeTrackingFromMessage(
+          hookResumeTiming,
+          incomingStepId !== undefined ? 'dispatched' : 'inline'
+        );
+        if (resumeTracking && incomingStepId === undefined) {
+          resumeTracking.consumerStartedAtMs = handlerEnteredAtMs;
+        }
+        if (
+          resumeTracking &&
+          !Number.isFinite(resumeTracking.consumerStartedAtMs)
+        ) {
+          // A step message from a producer that forwarded timing without the
+          // consumer boundaries. Nothing additive can be reported.
+          resumeTracking = undefined;
+        }
         // `start()` always attaches a trace carrier, but
         // serializeTraceCarrier() returns `{}` when no OTEL SDK is registered
         // or no span is active — treat an empty carrier the same as an
@@ -1524,6 +1561,10 @@ export function workflowEntrypoint(
                           ...(await replayMessage()),
                           stepId: incomingStepId,
                           stepName: incomingStepName,
+                          // Carry the resume timing verbatim so the re-routed
+                          // hop stays inside `step_dispatch` rather than
+                          // vanishing from the TTR decomposition.
+                          ...(hookResumeTiming ? { hookResumeTiming } : {}),
                         }))) !== 'continue'
                       ) {
                         return;
@@ -1569,6 +1610,13 @@ export function workflowEntrypoint(
                           ) + 1;
                       }
 
+                      // TTR: this delivery IS the dispatched next step of a
+                      // resumption. Consume the tracking here so the inline
+                      // replay this handler may fall through to cannot
+                      // report it again.
+                      const bgResumeTracking = resumeTracking;
+                      resumeTracking = undefined;
+
                       // Pause the replay budget while the step body runs —
                       // step duration is bounded by the platform's function
                       // maxDuration, not by the replay timeout. See the
@@ -1601,6 +1649,9 @@ export function workflowEntrypoint(
                             // gate, verified against the recorded step_started
                             // count once it crosses the ceiling (see above).
                             authoritativeAttempt: bgAuthoritativeAttempt,
+                            ...(bgResumeTracking
+                              ? { resumeTracking: bgResumeTracking }
+                              : {}),
                           });
                         stepResult = await runStepSingleFlight(
                           runId,
@@ -1828,6 +1879,11 @@ export function workflowEntrypoint(
                           async () => ({
                             ...(await replayMessage()),
                             hookInput,
+                            // Forwarded UNMODIFIED — in particular without
+                            // this delivery's entry time — so the misrouted
+                            // hop is attributed to `queue_delivery` and T2
+                            // ends up being the final consumer's entry.
+                            ...(hookResumeTiming ? { hookResumeTiming } : {}),
                           }),
                           awaitRunReady
                         )) !== 'continue'
@@ -1988,6 +2044,9 @@ export function workflowEntrypoint(
                         // Anchors RSFS — see the declaration above. This
                         // response plays run_started's role on this path.
                         runStartedReceivedAtMs = Date.now();
+                        if (resumeTracking) {
+                          resumeTracking.setupSource = 'hook_preload';
+                        }
                         eventLog = {
                           type: 'ready',
                           events: result.events,
@@ -2170,6 +2229,13 @@ export function workflowEntrypoint(
                         maxEventsLimit = clampMaxEvents(result.maxEvents);
                         // Anchors RSFS — see the declaration above.
                         runStartedReceivedAtMs = Date.now();
+                        // Covers both the plain sequential resume and the
+                        // lazy fast path's fallback (whose hoisted write
+                        // returned no usable preload and left workflowRun
+                        // unset, so it lands here).
+                        if (resumeTracking) {
+                          resumeTracking.setupSource = 'run_started';
+                        }
 
                         if (result.events?.length) {
                           const loaded = {
@@ -2242,6 +2308,18 @@ export function workflowEntrypoint(
                     workflowRun,
                     'Workflow run must be loaded before replay'
                   );
+                  // Neither setup branch ran, so the run arrived already
+                  // loaded and setup was a plain event load. Only the
+                  // background-step fall-through reaches here with a run
+                  // preloaded today, and it consumes the tracking before this
+                  // point — so this is the honest default rather than a live
+                  // path, and keeps the dimension total if one is ever added.
+                  if (
+                    resumeTracking &&
+                    resumeTracking.setupSource === undefined
+                  ) {
+                    resumeTracking.setupSource = 'event_load';
+                  }
 
                   // Covers every flow replay — initial start, step completions,
                   // hook resumptions, wait completions — and stops before any
@@ -2269,6 +2347,9 @@ export function workflowEntrypoint(
                       async () => ({
                         ...(await replayMessage()),
                         ...(hookInput ? { hookInput } : {}),
+                        // See the pre-check re-route above: forwarded as
+                        // received, so the extra hop is queue delivery.
+                        ...(hookResumeTiming ? { hookResumeTiming } : {}),
                       }),
                       awaitRunReady
                     )) !== 'continue'
@@ -2832,6 +2913,14 @@ export function workflowEntrypoint(
                         executionMode: retainedSession ? 'retained' : 'replay',
                       });
                       replayStart = Date.now();
+                      // TTR T3. `??=` so it marks the FIRST replay pass of
+                      // this invocation: a resume that needs more than one
+                      // pass to reach its step (e.g. a pre-step
+                      // `setAttributes` detour) reports the extra passes
+                      // inside `replay`, keeping the phases additive.
+                      if (resumeTracking) {
+                        resumeTracking.replayStartedAtMs ??= replayStart;
+                      }
                       // Start every missing decrypt/decompress operation up
                       // front (already-prepared payloads are skipped). Web
                       // Crypto work overlaps VM setup on the replay path and
@@ -2953,7 +3042,18 @@ export function workflowEntrypoint(
                         // resume this measures the resume (typically ~0ms),
                         // not a replay, so the field's distribution is
                         // bimodal once retention is active.
-                        const replayDurationMs = Date.now() - replayStart;
+                        const suspendedAtMs = Date.now();
+                        const replayDurationMs = suspendedAtMs - replayStart;
+                        // TTR T4 — the next durable step has been encountered.
+                        // Gated on the suspension actually scheduling steps:
+                        // a suspension that only creates hooks/waits has not
+                        // reached a step, and a later pass may. Taken from
+                        // the same instant as `replayDurationMs` so T4 can
+                        // never precede T3.
+                        if (resumeTracking && err.stepCount > 0) {
+                          resumeTracking.nextStepEncounteredAtMs ??=
+                            suspendedAtMs;
+                        }
                         runtimeLogger.debug('Workflow suspended', {
                           workflowRunId: runId,
                           loopIteration,
@@ -3305,6 +3405,47 @@ export function workflowEntrypoint(
                         const ownedRecoverySteps: StepInvocationQueueItem[] =
                           [];
                         let backstopWakesArmed = 0;
+                        // TTR hand-off. The measurement may only go to an
+                        // execution that will actually ATTEMPT the next
+                        // durable step, and the loop below is what decides
+                        // which those are — so the decision is made against
+                        // its classification, never ahead of it.
+                        //
+                        // This invocation keeps the tracking whenever it will
+                        // run something itself: a deferred lazy-inline step,
+                        // or an owned-recovery step (a redelivery of the
+                        // owning message re-executing the step it crashed
+                        // on). Both land in `inlineExecutions` below and
+                        // consume it there. Only when neither exists is it
+                        // handed to the FIRST step this invocation actually
+                        // enqueues as a step message.
+                        //
+                        // A step converted into a delayed backstop wake is
+                        // NOT an attempt — the wake is a plain run
+                        // continuation, and whichever invocation eventually
+                        // runs the step is a different delivery — so it must
+                        // not take the sample. If every pending step becomes
+                        // a backstop, nothing here attempts the step and the
+                        // resumption goes unreported, which is the honest
+                        // outcome rather than a total attributed to work this
+                        // delivery never did.
+                        //
+                        // Gated on there being a measurement to place at all:
+                        // `&&` short-circuits, so a delivery carrying no
+                        // tracking — every non-resume delivery, and every
+                        // resume past the step that consumed it — never pays
+                        // for the pending-step scan. That matters on wide
+                        // fan-outs, where `pendingSteps` runs to hundreds.
+                        let handOffResumeTiming =
+                          resumeTracking !== undefined &&
+                          lazyInlineSteps.length === 0 &&
+                          !pendingSteps.some(
+                            (step) =>
+                              !inlineCorrelationIds.has(step.correlationId) &&
+                              inlineOwnership &&
+                              isStepOwnershipActive(step) &&
+                              step.ownerMessageId === metadata.messageId
+                          );
                         for (const step of pendingSteps) {
                           if (inlineCorrelationIds.has(step.correlationId)) {
                             continue;
@@ -3372,6 +3513,16 @@ export function workflowEntrypoint(
                             );
                             continue;
                           }
+                          // This step IS being attempted, by the invocation
+                          // that picks the message up. Consume the tracking
+                          // here — the first such step and no other.
+                          const stepResumeTiming = handOffResumeTiming
+                            ? resumeTimingForMessage(resumeTracking)
+                            : undefined;
+                          if (stepResumeTiming) {
+                            handOffResumeTiming = false;
+                            resumeTracking = undefined;
+                          }
                           dispatches.push(
                             queueMessage(
                               world,
@@ -3382,6 +3533,9 @@ export function workflowEntrypoint(
                                 stepName: step.stepName,
                                 traceCarrier,
                                 requestedAt: new Date(),
+                                ...(stepResumeTiming
+                                  ? { hookResumeTiming: stepResumeTiming }
+                                  : {}),
                               },
                               {
                                 // Step-identity-scoped: dedupes against every
@@ -3698,6 +3852,19 @@ export function workflowEntrypoint(
                           eventLog.cursor
                         );
 
+                        // TTR: consumed by this batch. Every step is handed
+                        // the SAME tracking object and its one-shot
+                        // `reported` latch picks the single step that
+                        // actually reaches user code — so the sample
+                        // survives the batch's first step losing its atomic
+                        // create-claim to a concurrent invocation while a
+                        // sibling runs, without a parallel batch reporting
+                        // once per sibling. Cleared here so a later loop
+                        // iteration's steps — and any in-process replay
+                        // restart — cannot report the same resumption again.
+                        const batchResumeTracking = resumeTracking;
+                        resumeTracking = undefined;
+
                         replayBudget.pause();
                         let stepResults: Awaited<
                           ReturnType<typeof executeStep>
@@ -3781,6 +3948,9 @@ export function workflowEntrypoint(
                                 s.lazyStepInput !== undefined &&
                                 latencyTracking
                                   ? { latencyTracking }
+                                  : {}),
+                                ...(batchResumeTracking
+                                  ? { resumeTracking: batchResumeTracking }
                                   : {}),
                                 ...(requestInlineDelta && eventLog.cursor
                                   ? {

--- a/packages/core/src/runtime/resume-hook.parallel.test.ts
+++ b/packages/core/src/runtime/resume-hook.parallel.test.ts
@@ -70,16 +70,17 @@ describe('resumeHook (parallel fast path)', () => {
   ) => {
     const createEvent = overrides.createEvent ?? vi.fn();
     const queue = overrides.queue ?? vi.fn();
+    const getByToken = overrides.getByToken ?? vi.fn().mockResolvedValue(hook);
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
       capabilities,
-      hooks: { getByToken: vi.fn().mockResolvedValue(hook) },
+      hooks: { getByToken },
       runs: { get: vi.fn() },
       events: { create: createEvent },
       getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
       queue,
     } as unknown as World);
-    return { createEvent, queue };
+    return { createEvent, queue, getByToken };
   };
 
   it('dispatches the event write and queue publish concurrently with a shared resumeId + digest', async () => {
@@ -120,6 +121,29 @@ describe('resumeHook (parallel fast path)', () => {
       // consumer's cheap pre-write affinity check.
       deploymentId: 'deployment_par',
     });
+  });
+
+  it('stamps the resume TTR window on the queue message', async () => {
+    const hook = { ...baseHook, resumeContext: parallelContext } satisfies Hook;
+    const { queue } = makeWorld(hook);
+
+    const before = Date.now();
+    await resumeHook(hook.token, { foo: 'bar' });
+    const after = Date.now();
+
+    const [, payloadArg] = queue.mock.calls[0];
+    const timing = payloadArg.hookResumeTiming;
+    expect(timing.strategy).toBe('parallel');
+    // T0 is entry into resumeHook and T1 the publish request, so both fall
+    // inside this call and in that order.
+    expect(timing.resumeRequestedAtMs).toBeGreaterThanOrEqual(before);
+    expect(timing.queuePublishRequestedAtMs).toBeGreaterThanOrEqual(
+      timing.resumeRequestedAtMs
+    );
+    expect(timing.queuePublishRequestedAtMs).toBeLessThanOrEqual(after);
+    // The consumer boundaries belong to the consuming invocation.
+    expect(timing.consumerStartedAtMs).toBeUndefined();
+    expect(timing.setupSource).toBeUndefined();
   });
 
   it('always throws when the queue publish fails', async () => {
@@ -331,6 +355,13 @@ describe('resumeHook (parallel fast path)', () => {
     expect(queue).toHaveBeenCalledTimes(1);
     const [, payloadArg] = queue.mock.calls[0];
     expect(payloadArg.hookInput).toBeUndefined();
+    // TTR is measured on both dispatch paths — the sequential message carries
+    // no hookInput but still reports its own strategy.
+    expect(payloadArg.hookResumeTiming).toMatchObject({
+      strategy: 'sequential',
+      resumeRequestedAtMs: expect.any(Number),
+      queuePublishRequestedAtMs: expect.any(Number),
+    });
   });
 
   it('falls back to the sequential path when the run lacks the hookResumeInput marker', async () => {
@@ -509,6 +540,42 @@ describe('resumeHook (parallel fast path)', () => {
     expect(optsArg.resumePayloadDigest).toMatch(/^[0-9a-f]{64}$/);
     const [, payloadArg] = queue.mock.calls[0];
     expect(payloadArg.hookInput).toBeDefined();
+  });
+
+  it('opens the resumeWebhook TTR window before its own hook lookup', async () => {
+    // `resumeWebhook` does real producer-side work before it reaches the
+    // shared implementation: the by-token lookup and the run-key resolution
+    // it can trigger. Stamping T0 inside the implementation would silently
+    // exclude that, so webhook resumes would report a systematically shorter
+    // total than `resumeHook` ones into the same distribution. The clock is
+    // pinned and advanced only by the lookup, so the assertion is exact.
+    let clock = 1_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    try {
+      const hook = {
+        ...baseHook,
+        isWebhook: true,
+        resumeContext: parallelContext,
+      } satisfies Hook;
+      const { queue } = makeWorld(hook, {
+        // The lookup takes 500ms of wall clock.
+        getByToken: vi.fn(async () => {
+          clock += 500;
+          return hook;
+        }),
+      });
+
+      await resumeWebhook(hook.token, new Request('http://x'));
+
+      const [, payloadArg] = queue.mock.calls[0];
+      const timing = payloadArg.hookResumeTiming;
+      expect(timing.resumeRequestedAtMs).toBe(1_000);
+      expect(
+        timing.queuePublishRequestedAtMs - timing.resumeRequestedAtMs
+      ).toBeGreaterThanOrEqual(500);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('ignores a stale resumeCapabilities below the required dedup version', async () => {

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -260,7 +260,16 @@ export async function resumeHook<T = any>(
   // implementation with the fresh attestation set. Keeping the freshness flag
   // off the exported signature prevents a caller from passing a stale Hook plus
   // `true` and reactivating dynamic dedup against a rolled-back backend.
-  return resumeHookImpl(tokenOrHook, payload, encryptionKeyOverride, false);
+  //
+  // T0 of the hook-resume TTR window is taken HERE, at the public entry point,
+  // rather than inside the implementation — see the parameter's doc comment.
+  return resumeHookImpl(
+    tokenOrHook,
+    payload,
+    encryptionKeyOverride,
+    false,
+    Date.now()
+  );
 }
 
 /**
@@ -272,12 +281,20 @@ export async function resumeHook<T = any>(
  *   by token during THIS resume, so its response-only `resumeCapabilities`
  *   reflects the live backend and may be trusted for the dynamic-dedup gate.
  *   A token string is always fetched fresh here, so it is implicitly fresh.
+ * @param resumeRequestedAtMs - T0 of the hook-resume TTR window (see
+ *   runtime/resume-latency.ts), stamped by the PUBLIC entry point the caller
+ *   used. It is a parameter rather than a local because `resumeWebhook` does
+ *   real work before it gets here — the by-token lookup, the run-key
+ *   resolution that hydrates hook metadata, and the `respondWith` setup — and
+ *   stamping locally would silently exclude all of it, so the two entry points
+ *   would report the same metric over different windows.
  */
 async function resumeHookImpl<T = any>(
   tokenOrHook: string | Hook,
   payload: T,
   encryptionKeyOverride: PayloadKey | undefined,
-  hookFreshlyLookedUp: boolean
+  hookFreshlyLookedUp: boolean,
+  resumeRequestedAtMs: number
 ): Promise<ResumedHook> {
   return await waitedUntil(() => {
     return trace('hook.resume', async (span) => {
@@ -550,11 +567,21 @@ async function resumeHookImpl<T = any>(
             throw err;
           }
 
+          // T1 of the TTR window. Stamped immediately before the publish so
+          // `producer_prep` covers exactly the work above it (hook lookup,
+          // key resolution, serialization, and — on this path — the awaited
+          // `hook_received` write, which is genuinely serial here).
+          const queuePublishRequestedAtMs = Date.now();
           await world.queue(
             queueName,
             {
               runId: hook.runId,
               traceCarrier: resumeContext.traceCarrier ?? undefined,
+              hookResumeTiming: {
+                resumeRequestedAtMs,
+                queuePublishRequestedAtMs,
+                strategy: 'sequential',
+              },
             } satisfies WorkflowInvokePayload,
             queueOptions
           );
@@ -571,18 +598,14 @@ async function resumeHookImpl<T = any>(
         );
         span?.setAttributes({ 'workflow.hook.resume_id': resumeId });
 
-        const [eventResult, queueResult] = await Promise.allSettled([
-          world.events.create(
-            hook.runId,
-            {
-              eventType: 'hook_received',
-              specVersion: SPEC_VERSION_CURRENT,
-              correlationId: hook.hookId,
-              eventData,
-            },
-            { v1Compat, resumeId, resumePayloadDigest: payloadDigest }
-          ),
-          world.queue(
+        // Wrapped in a thunk purely so T1 of the TTR window is stamped at the
+        // exact instant the publish is requested — after the racing
+        // `hook_received` write has been kicked off, which is where the
+        // additive `producer_prep` phase must end. The two calls still start
+        // in the same turn and race exactly as before.
+        const publishInvocation = () => {
+          const queuePublishRequestedAtMs = Date.now();
+          return world.queue(
             queueName,
             {
               runId: hook.runId,
@@ -598,9 +621,27 @@ async function resumeHookImpl<T = any>(
                 // hoisted hook_received write instead of after.
                 deploymentId: resumeContext.deploymentId,
               },
+              hookResumeTiming: {
+                resumeRequestedAtMs,
+                queuePublishRequestedAtMs,
+                strategy: 'parallel',
+              },
             } satisfies WorkflowInvokePayload,
             queueOptions
+          );
+        };
+        const [eventResult, queueResult] = await Promise.allSettled([
+          world.events.create(
+            hook.runId,
+            {
+              eventType: 'hook_received',
+              specVersion: SPEC_VERSION_CURRENT,
+              correlationId: hook.hookId,
+              eventData,
+            },
+            { v1Compat, resumeId, resumePayloadDigest: payloadDigest }
           ),
+          publishInvocation(),
         ]);
 
         // Queue failure is always fatal — the run was not re-triggered, so no
@@ -718,6 +759,12 @@ export async function resumeWebhook(
   token: string,
   request: Request
 ): Promise<Response> {
+  // T0 of the hook-resume TTR window. Everything below — the by-token lookup,
+  // the run-key resolution it may trigger, and the `respondWith` setup — is
+  // real producer-side latency on this path, so the window has to open here
+  // and not inside `resumeHookImpl`; otherwise webhook resumes would report a
+  // systematically shorter total than `resumeHook` ones into the same metric.
+  const resumeRequestedAtMs = Date.now();
   const { hook, encryptionKey } = await getHookByTokenWithKey(token);
 
   // Only webhooks can be resumed via the public endpoint.
@@ -760,7 +807,7 @@ export async function resumeWebhook(
   // backend — call the internal implementation with the fresh attestation so
   // the parallel fast path stays available without a second GET. (The public
   // `resumeHook` never sets this, so a caller cannot forge it.)
-  await resumeHookImpl(hook, request, encryptionKey, true);
+  await resumeHookImpl(hook, request, encryptionKey, true, resumeRequestedAtMs);
 
   if (responseReadable) {
     // Wait for the readable stream to emit one chunk,

--- a/packages/core/src/runtime/resume-latency.runtime.test.ts
+++ b/packages/core/src/runtime/resume-latency.runtime.test.ts
@@ -1,0 +1,1234 @@
+/**
+ * End-to-end coverage for hook-resume TTR telemetry through the real
+ * `workflowEntrypoint` replay loop: a resume delivery carrying producer
+ * timing must close the measurement on the first durable step that follows
+ * it — exactly once, with phases that add up to the total — and a resume
+ * whose next step is queued instead of run inline must hand the boundaries to
+ * that step's message so the receiving invocation finishes the measurement.
+ *
+ * Modeled on resume-hook.consumer-preload.test.ts (same fake World, seeded VM
+ * and real ULID event IDs), with a workflow that runs steps after the hook
+ * resolves.
+ *
+ * `Date.now()` is replaced by a counter that advances one millisecond per
+ * call, which makes every boundary distinct and strictly increasing without
+ * pinning the assertions to a brittle exact schedule. The properties asserted
+ * — presence, additivity, dimensions, and which step reports — hold for any
+ * such clock.
+ */
+import { trace as otelTrace } from '@opentelemetry/api';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { EntityConflictError } from '@workflow/errors';
+import {
+  type CreateEventParams,
+  type CreateEventRequest,
+  type Event,
+  type HookResumeTiming,
+  SPEC_VERSION_CURRENT,
+  type WorkflowInvokePayload,
+  type WorkflowRun,
+  type World,
+} from '@workflow/world';
+import { monotonicFactory } from 'ulid';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { registerStepFunction } from '../private.js';
+import { workflowEntrypoint } from '../runtime.js';
+import {
+  dehydrateStepArguments,
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from '../serialization.js';
+import { createContext } from '../vm/index.js';
+import { setWorld } from './world.js';
+
+vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }));
+vi.mock('@workflow/utils/get-port', () => ({
+  getPort: vi.fn().mockResolvedValue(3000),
+}));
+
+const spanExporter = new InMemorySpanExporter();
+const tracerProvider = new BasicTracerProvider();
+
+beforeAll(() => {
+  tracerProvider.addSpanProcessor(new SimpleSpanProcessor(spanExporter));
+  otelTrace.setGlobalTracerProvider(tracerProvider);
+});
+
+afterAll(async () => {
+  await tracerProvider.shutdown();
+  otelTrace.disable();
+});
+
+const TOTAL_KEY = 'workflow.resume.total_ms';
+const PHASE_KEYS = [
+  'workflow.resume.phase.producer_prep_ms',
+  'workflow.resume.phase.queue_delivery_ms',
+  'workflow.resume.phase.resume_setup_ms',
+  'workflow.resume.phase.replay_ms',
+  'workflow.resume.phase.step_dispatch_ms',
+  'workflow.resume.phase.step_claim_ms',
+  'workflow.resume.phase.step_prepare_ms',
+] as const;
+
+/**
+ * The fake clock's first reading. Producer boundaries sit below it so the
+ * whole sequence stays ordered across the (notionally separate) machines.
+ */
+const CLOCK_BASE_MS = 1_800_000_000_000;
+const PRODUCER_TIMING: HookResumeTiming = {
+  resumeRequestedAtMs: CLOCK_BASE_MS - 120,
+  queuePublishRequestedAtMs: CLOCK_BASE_MS - 80,
+  strategy: 'parallel',
+};
+
+function stepSpans(): ReadableSpan[] {
+  return spanExporter
+    .getFinishedSpans()
+    .filter((s) => s.name.startsWith('step.execute '));
+}
+
+function stepSpan(stepName: string): ReadableSpan | undefined {
+  return stepSpans().find((s) => s.attributes['step.name'] === stepName);
+}
+
+/** The named step's span attributes, failing the test if it never ran. */
+function stepAttributes(stepName: string): ReadableSpan['attributes'] {
+  const span = stepSpan(stepName);
+  if (!span) throw new Error(`no step.execute span for "${stepName}"`);
+  return span.attributes;
+}
+
+/**
+ * The resume timing forwarded onto a dispatched step message, failing the
+ * test if the runtime did not hand one off.
+ */
+function forwardedTiming(
+  message: WorkflowInvokePayload | undefined
+): HookResumeTiming {
+  const timing = message?.hookResumeTiming;
+  if (!timing) throw new Error('expected the step message to carry timing');
+  return timing;
+}
+
+function sumPhases(attrs: ReadableSpan['attributes']): number {
+  return PHASE_KEYS.reduce(
+    (total, key) => total + ((attrs[key] as number | undefined) ?? 0),
+    0
+  );
+}
+
+function getWorkflowTransformCode(workflowName: string) {
+  return `;globalThis.__private_workflows = new Map([[${JSON.stringify(workflowName)}, ${workflowName}]]);`;
+}
+
+/**
+ * Two sequential steps after the hook resolves, so a scenario can assert that
+ * only the first one reports the resumption.
+ */
+const SEQUENTIAL_WORKFLOW = `
+  const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
+  const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+  const firstStep = useStep("firstStep");
+  const secondStep = useStep("secondStep");
+
+  async function workflow(token) {
+    const hook = createHook({ token });
+    const payload = await hook;
+    const a = await firstStep({ value: payload.value });
+    return await secondStep({ value: a });
+  }
+  ${getWorkflowTransformCode('workflow')}
+`;
+
+/**
+ * A step kicked off BEFORE the hook resolves, so on the resume delivery it is
+ * already `step_created` and pending. Nothing then needs lazy creation, the
+ * inline batch is empty, and the runtime dispatches it as a step message —
+ * the hand-off path.
+ */
+const PENDING_STEP_WORKFLOW = `
+  const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
+  const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+  const pendingStep = useStep("pendingStep");
+
+  async function workflow(token) {
+    const hook = createHook({ token });
+    const inFlight = pendingStep({ started: true });
+    const payload = await hook;
+    return (await inFlight) + ":" + payload.value;
+  }
+  ${getWorkflowTransformCode('workflow')}
+`;
+
+/**
+ * Two steps kicked off before the hook resolves. Neither needs creation on the
+ * resume delivery, so the dispatch loop classifies both — which is what lets a
+ * scenario make the FIRST one owned-recovery or backstopped and check where
+ * the measurement ends up.
+ */
+const TWO_PENDING_STEPS_WORKFLOW = `
+  const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
+  const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+  const pendingStep = useStep("pendingStep");
+  const otherStep = useStep("otherStep");
+
+  async function workflow(token) {
+    const hook = createHook({ token });
+    const a = pendingStep({ started: true });
+    const b = otherStep({ started: true });
+    const payload = await hook;
+    return (await a) + ":" + (await b) + ":" + payload.value;
+  }
+  ${getWorkflowTransformCode('workflow')}
+`;
+
+/**
+ * Two steps started in parallel AFTER the hook resolves, so both are lazy
+ * inline in one batch — the shape where the batch's first step can lose its
+ * atomic create-claim while its sibling proceeds.
+ */
+const PARALLEL_INLINE_WORKFLOW = `
+  const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
+  const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+  const firstStep = useStep("firstStep");
+  const secondStep = useStep("secondStep");
+
+  async function workflow(token) {
+    const hook = createHook({ token });
+    const payload = await hook;
+    const [a, b] = await Promise.all([
+      firstStep({ value: payload.value }),
+      secondStep({ value: payload.value }),
+    ]);
+    return a + ":" + b;
+  }
+  ${getWorkflowTransformCode('workflow')}
+`;
+
+/**
+ * `Date.now()` as read by the first line of a step body. With the counter
+ * clock this is exactly one tick past the runtime's last reading, which is how
+ * the T7 boundary is pinned to the instant before user code.
+ */
+let bodyEntryClock: number | undefined;
+
+registerStepFunction('firstStep', async (arg: { value: string }) => {
+  bodyEntryClock ??= Date.now();
+  return arg.value;
+});
+registerStepFunction('secondStep', async (arg: { value: string }) => {
+  bodyEntryClock ??= Date.now();
+  return arg.value;
+});
+registerStepFunction('pendingStep', async () => 'pending-done');
+registerStepFunction('otherStep', async () => 'other-done');
+
+/** The queue message id every scenario's delivery arrives under. */
+const MESSAGE_ID = 'msg_workflow';
+
+interface ScenarioOptions {
+  /** Which workflow (and therefore which dispatch shape) to drive. */
+  workflow?:
+    | 'sequential'
+    | 'pendingStep'
+    | 'twoPendingSteps'
+    | 'parallelInline';
+  /** Producer timing on the delivery; omit to model an older producer. */
+  timing?: HookResumeTiming | undefined;
+  /**
+   * Deliver as a queued step message (`stepId`) rather than a resume, using
+   * this timing — the receiving half of the dispatch hand-off.
+   */
+  stepDelivery?: { stepId: string; stepName: string };
+  /** Queue delivery count, so a redelivery/retry can be modeled. */
+  attempt?: number;
+  /**
+   * Where this invocation's fake clock starts. A second invocation in the
+   * same test must continue past the first one's boundaries — it models a
+   * different machine later in wall-clock time, not a clock rewind.
+   */
+  clockStart?: number;
+  /**
+   * Seed a `step_started` for the pending step, so the world reports the next
+   * execution as attempt 2 — the shape a redelivery of a step message whose
+   * previous delivery already claimed the step actually sees.
+   */
+  priorStepStarted?: boolean;
+  /**
+   * The consuming deployment's own id. Setting it to anything but the run's
+   * pinned deployment models a misrouted delivery, which the affinity guard
+   * re-routes to the pinned deployment instead of replaying.
+   */
+  ambientDeploymentId?: string;
+  /**
+   * Stamp a live inline-ownership lease on the FIRST pending step by seeding
+   * a recent `step_started` carrying this owner. `MESSAGE_ID` makes this
+   * delivery the owner (owned recovery — the step re-executes inline here);
+   * any other id makes it someone else's live lease (a delayed backstop wake
+   * instead of a step dispatch).
+   */
+  pendingStepOwner?: string;
+  /**
+   * Reject the first lazy `step_started` claim with `EntityConflictError`,
+   * modelling a concurrent invocation winning the atomic create-claim for the
+   * batch's first step while its sibling proceeds.
+   */
+  failFirstLazyClaim?: boolean;
+}
+
+const WORKFLOW_SOURCES = {
+  sequential: SEQUENTIAL_WORKFLOW,
+  pendingStep: PENDING_STEP_WORKFLOW,
+  twoPendingSteps: TWO_PENDING_STEPS_WORKFLOW,
+  parallelInline: PARALLEL_INLINE_WORKFLOW,
+} as const;
+
+async function runScenario(options: ScenarioOptions = {}) {
+  // Monotonic fake clock: every reading is distinct and increasing, so the
+  // TTR boundary set is always well-ordered but never a fixed schedule.
+  const clockStart = options.clockStart ?? CLOCK_BASE_MS;
+  let clock = clockStart;
+  vi.spyOn(Date, 'now').mockImplementation(() => clock++);
+
+  const workflowSource = WORKFLOW_SOURCES[options.workflow ?? 'sequential'];
+  const runId = 'wrun_resume_ttr';
+  const workflowName = 'workflow';
+  const deploymentId = 'dpl_resume_ttr';
+  const hookToken = 'resume-ttr-token';
+  const resumeId = 'resume-ttr-1';
+  const payloadDigest = 'd'.repeat(64);
+  const startedAt = new Date('2026-05-19T12:00:00.000Z');
+
+  const workflowArgs = await dehydrateWorkflowArguments(
+    [hookToken],
+    runId,
+    undefined
+  );
+
+  // Correlation ids the seeded VM derives during replay, in the order the
+  // workflow mints them.
+  const { globalThis: vmGlobalThis } = createContext({
+    seed: `${runId}:${workflowName}:${deploymentId}`,
+    fixedTimestamp: +startedAt,
+  });
+  const vmUlid = monotonicFactory(() => vmGlobalThis.Math.random());
+  const hookCorrelationId = `hook_${vmUlid(+startedAt)}`;
+  const pendingStepCorrelationId = `step_${vmUlid(+startedAt)}`;
+  const otherStepCorrelationId = `step_${vmUlid(+startedAt)}`;
+
+  const workflowRun: WorkflowRun = {
+    runId,
+    workflowName,
+    status: 'running',
+    input: workflowArgs,
+    deploymentId,
+    specVersion: SPEC_VERSION_CURRENT,
+    startedAt,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  };
+
+  const hostUlid = monotonicFactory();
+  let eventIndex = 0;
+  const event = (data: CreateEventRequest): Event => {
+    const t = +startedAt + ++eventIndex * 100;
+    return {
+      ...data,
+      specVersion: data.specVersion ?? SPEC_VERSION_CURRENT,
+      runId,
+      eventId: `evnt_${hostUlid(t)}`,
+      createdAt: new Date(t),
+    } as Event;
+  };
+
+  const payloadBytes = await dehydrateStepReturnValue(
+    { value: 'resumed' },
+    runId,
+    undefined
+  );
+
+  const durableEvents: Event[] = [
+    event({
+      eventType: 'run_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      eventData: { deploymentId, workflowName, input: workflowArgs },
+    }),
+    event({ eventType: 'run_started', specVersion: SPEC_VERSION_CURRENT }),
+    event({
+      eventType: 'hook_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: hookCorrelationId,
+      eventData: { token: hookToken },
+    }),
+  ];
+  const preCreatedSteps: Array<{ correlationId: string; stepName: string }> =
+    options.workflow === 'pendingStep'
+      ? [{ correlationId: pendingStepCorrelationId, stepName: 'pendingStep' }]
+      : options.workflow === 'twoPendingSteps'
+        ? [
+            {
+              correlationId: pendingStepCorrelationId,
+              stepName: 'pendingStep',
+            },
+            { correlationId: otherStepCorrelationId, stepName: 'otherStep' },
+          ]
+        : [];
+  for (const preCreated of preCreatedSteps) {
+    durableEvents.push(
+      event({
+        eventType: 'step_created',
+        specVersion: SPEC_VERSION_CURRENT,
+        correlationId: preCreated.correlationId,
+        eventData: {
+          stepName: preCreated.stepName,
+          workflowName,
+          input: await dehydrateStepArguments(
+            {
+              args: [{ started: true }],
+              closureVars: undefined,
+              thisVal: undefined,
+            },
+            runId,
+            undefined
+          ),
+        },
+      })
+    );
+  }
+  if (options.priorStepStarted) {
+    durableEvents.push(
+      event({
+        eventType: 'step_started',
+        specVersion: SPEC_VERSION_CURRENT,
+        correlationId: pendingStepCorrelationId,
+        eventData: { stepName: 'pendingStep' },
+      } as CreateEventRequest)
+    );
+  }
+  if (options.pendingStepOwner !== undefined) {
+    // Dated at the fake clock's start so the ownership lease is still live
+    // when the dispatch loop evaluates it. `event()`'s own timestamps sit
+    // months earlier, which would read as an expired lease.
+    durableEvents.push({
+      ...event({
+        eventType: 'step_started',
+        specVersion: SPEC_VERSION_CURRENT,
+        correlationId: pendingStepCorrelationId,
+        eventData: {
+          stepName: 'pendingStep',
+          ownerMessageId: options.pendingStepOwner,
+        },
+      } as CreateEventRequest),
+      createdAt: new Date(clockStart),
+    } as Event);
+  }
+  // The producer's direct write already landed, so the consumer's hoisted
+  // write converges on it — the common parallel-path shape.
+  durableEvents.push({
+    ...event({
+      eventType: 'hook_received',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: hookCorrelationId,
+      eventData: { token: hookToken, payload: payloadBytes },
+    }),
+    resumeId,
+  } as Event);
+
+  const createdEvents: CreateEventRequest[] = [];
+  let lazyClaimRejected = false;
+
+  const listEvents = vi.fn(async () => ({
+    data: [...durableEvents],
+    hasMore: false,
+    cursor: durableEvents.at(-1)?.eventId ?? null,
+  }));
+
+  const buildStepEntity = (correlationId: string | undefined) => {
+    const created = durableEvents.find(
+      (e) => e.eventType === 'step_created' && e.correlationId === correlationId
+    );
+    const data = created?.eventData as
+      | { stepName?: string; input?: unknown }
+      | undefined;
+    const starts = durableEvents.filter(
+      (e) => e.eventType === 'step_started' && e.correlationId === correlationId
+    ).length;
+    return {
+      runId,
+      stepId: correlationId,
+      stepName: data?.stepName,
+      status: 'running',
+      attempt: starts,
+      input: data?.input,
+      startedAt: new Date(+startedAt),
+      createdAt: new Date(+startedAt),
+      updatedAt: new Date(+startedAt),
+    };
+  };
+
+  const createEvent = vi.fn(
+    async (
+      _runId: string,
+      request: CreateEventRequest,
+      params?: CreateEventParams
+    ) => {
+      createdEvents.push(request);
+
+      if (request.eventType === 'run_started') {
+        return {
+          run: workflowRun,
+          events: [...durableEvents],
+          cursor: durableEvents.at(-1)?.eventId ?? null,
+          hasMore: false,
+          maxEvents: 25_000,
+        };
+      }
+
+      if (request.eventType === 'hook_received') {
+        const canonical = durableEvents.find(
+          (e) => e.eventType === 'hook_received' && e.resumeId === resumeId
+        );
+        if (params?.preloadEvents !== true) {
+          return { event: canonical };
+        }
+        return {
+          event: canonical,
+          run: workflowRun,
+          events: [...durableEvents],
+          cursor: durableEvents.at(-1)?.eventId ?? null,
+          hasMore: false,
+          maxEvents: 25_000,
+        };
+      }
+
+      // Lazy step start: synthesize the step_created the world would create.
+      const lazyStepStart =
+        request.eventType === 'step_started' &&
+        !!request.eventData &&
+        (request.eventData as { input?: unknown }).input !== undefined;
+      if (lazyStepStart && options.failFirstLazyClaim && !lazyClaimRejected) {
+        // A concurrent invocation won the atomic create-claim for this step.
+        // The real server answers the loser with a 409.
+        lazyClaimRejected = true;
+        throw new EntityConflictError('step already created');
+      }
+      let effective = request;
+      if (lazyStepStart) {
+        const lazy = request.eventData as {
+          stepName?: string;
+          input?: unknown;
+        };
+        durableEvents.push(
+          event({
+            eventType: 'step_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            correlationId: request.correlationId,
+            eventData: {
+              stepName: lazy.stepName,
+              workflowName,
+              input: lazy.input,
+            },
+          } as CreateEventRequest)
+        );
+        const { input: _input, ...startData } = lazy;
+        effective = {
+          ...request,
+          eventData: startData,
+        } as CreateEventRequest;
+      }
+
+      const created = event(effective);
+      durableEvents.push(created);
+
+      if (effective.eventType === 'step_started') {
+        return {
+          event: created,
+          step: buildStepEntity(effective.correlationId),
+          ...(lazyStepStart ? { stepCreated: true } : {}),
+        };
+      }
+      return { event: created };
+    }
+  );
+
+  let capturedHandler:
+    | ((
+        message: unknown,
+        metadata: { queueName: string; messageId: string; attempt: number }
+      ) => Promise<unknown>)
+    | undefined;
+  const queue = vi.fn().mockResolvedValue({ messageId: 'msg_resume_ttr' });
+
+  setWorld({
+    specVersion: SPEC_VERSION_CURRENT,
+    capabilities: { deploymentAffinity: true },
+    getDeploymentId: vi.fn(
+      async () => options.ambientDeploymentId ?? deploymentId
+    ),
+    createQueueHandler: vi.fn((_prefix, handler) => {
+      capturedHandler = handler;
+      return vi.fn();
+    }),
+    events: { list: listEvents, create: createEvent },
+    runs: { get: vi.fn(async () => workflowRun) },
+    queue,
+    getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
+  } as unknown as World);
+
+  const handler = workflowEntrypoint(workflowSource);
+  await handler(new Request('http://localhost', { method: 'POST' }));
+  expect(capturedHandler).toBeDefined();
+
+  const message: Record<string, unknown> = options.stepDelivery
+    ? {
+        runId,
+        stepId: options.stepDelivery.stepId,
+        stepName: options.stepDelivery.stepName,
+      }
+    : {
+        runId,
+        hookInput: {
+          hookId: hookCorrelationId,
+          resumeId,
+          token: hookToken,
+          payload: payloadBytes,
+          payloadDigest,
+          deploymentId,
+        },
+      };
+  if (options.timing !== undefined) {
+    message.hookResumeTiming = options.timing;
+  }
+
+  await capturedHandler?.(message, {
+    queueName: `__wkf_workflow_${workflowName}`,
+    messageId: MESSAGE_ID,
+    attempt: options.attempt ?? 1,
+  });
+
+  const queuedMessages = queue.mock.calls.map(
+    ([, payload]) => payload as WorkflowInvokePayload
+  );
+  /** Step messages this invocation enqueued, in order. */
+  const dispatchedStepMessages = queuedMessages.filter(
+    (payload) => payload?.stepId !== undefined
+  );
+
+  return {
+    runId,
+    pendingStepCorrelationId,
+    otherStepCorrelationId,
+    queuedMessages,
+    dispatchedStepMessages,
+    createdEvents,
+    queue,
+  };
+}
+
+describe('hook-resume TTR telemetry (runtime)', () => {
+  beforeEach(() => {
+    spanExporter.reset();
+    bodyEntryClock = undefined;
+  });
+
+  afterEach(() => {
+    setWorld(undefined);
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    spanExporter.reset();
+  });
+
+  it('reports total TTR and every phase on the first step after the resume', async () => {
+    await runScenario({ timing: PRODUCER_TIMING });
+
+    const attrs = stepAttributes('firstStep');
+    expect(attrs[TOTAL_KEY]).toBeTypeOf('number');
+    for (const key of PHASE_KEYS) {
+      expect(attrs[key], `missing phase ${key}`).toBeTypeOf('number');
+    }
+    expect(attrs['workflow.resume.trigger']).toBe('hook');
+    expect(attrs['workflow.resume.strategy']).toBe('parallel');
+    expect(attrs['workflow.resume.step_execution']).toBe('inline');
+    // The hoisted hook_received write returned a usable preload, so neither
+    // run_started nor the initial events.list ran.
+    expect(attrs['workflow.resume.setup_source']).toBe('hook_preload');
+  });
+
+  it('reports phases that sum to the total', async () => {
+    await runScenario({ timing: PRODUCER_TIMING });
+
+    const attrs = stepAttributes('firstStep');
+    expect(sumPhases(attrs)).toBe(attrs[TOTAL_KEY]);
+  });
+
+  it('reports the resumption on exactly one step', async () => {
+    await runScenario({ timing: PRODUCER_TIMING });
+
+    // Both steps ran (the workflow chains them) but only the first — the one
+    // that immediately followed the resume — carries the measurement.
+    expect(stepSpan('secondStep')).toBeDefined();
+    expect(stepSpan('secondStep')?.attributes[TOTAL_KEY]).toBeUndefined();
+    expect(
+      stepSpans().filter((s) => s.attributes[TOTAL_KEY] !== undefined)
+    ).toHaveLength(1);
+  });
+
+  it('emits nothing for a queue message with no timing (an older producer)', async () => {
+    await runScenario({ timing: undefined });
+
+    expect(stepSpans().length).toBeGreaterThan(0);
+    for (const span of stepSpans()) {
+      expect(span.attributes[TOTAL_KEY]).toBeUndefined();
+      for (const key of PHASE_KEYS) {
+        expect(span.attributes[key]).toBeUndefined();
+      }
+    }
+  });
+
+  it('runs the resume normally when the timing itself is malformed', async () => {
+    // A telemetry field must never be able to fail the delivery: an
+    // unparseable value is dropped and the run proceeds without a
+    // measurement, rather than throwing on every redelivery.
+    const { createdEvents } = await runScenario({
+      timing: {
+        resumeRequestedAtMs: Number.NaN,
+        queuePublishRequestedAtMs: CLOCK_BASE_MS - 80,
+        strategy: 'parallel',
+      },
+    });
+
+    expect(createdEvents.some((e) => e.eventType === 'run_completed')).toBe(
+      true
+    );
+    expect(stepSpans().length).toBeGreaterThan(0);
+    for (const span of stepSpans()) {
+      expect(span.attributes[TOTAL_KEY]).toBeUndefined();
+    }
+  });
+
+  it('emits nothing when the producer clock runs ahead of the consumer', async () => {
+    // A producer whose clock is far ahead makes T1 land after T2; a negative
+    // phase is never reported, so the whole sample is dropped.
+    await runScenario({
+      timing: {
+        resumeRequestedAtMs: CLOCK_BASE_MS + 60_000,
+        queuePublishRequestedAtMs: CLOCK_BASE_MS + 60_100,
+        strategy: 'parallel',
+      },
+    });
+
+    for (const span of stepSpans()) {
+      expect(span.attributes[TOTAL_KEY]).toBeUndefined();
+    }
+  });
+
+  it('carries the boundaries onto a dispatched step message', async () => {
+    const { dispatchedStepMessages, pendingStepCorrelationId } =
+      await runScenario({
+        workflow: 'pendingStep',
+        timing: PRODUCER_TIMING,
+      });
+
+    expect(dispatchedStepMessages).toHaveLength(1);
+    const dispatched = dispatchedStepMessages[0];
+    expect(dispatched.stepId).toBe(pendingStepCorrelationId);
+    const forwarded = forwardedTiming(dispatched);
+    // Producer boundaries survive verbatim...
+    expect(forwarded.resumeRequestedAtMs).toBe(
+      PRODUCER_TIMING.resumeRequestedAtMs
+    );
+    expect(forwarded.queuePublishRequestedAtMs).toBe(
+      PRODUCER_TIMING.queuePublishRequestedAtMs
+    );
+    expect(forwarded.strategy).toBe('parallel');
+    // ...and this invocation's own boundaries ride along so the receiving
+    // invocation can finish the measurement.
+    expect(forwarded.consumerStartedAtMs).toBeTypeOf('number');
+    expect(forwarded.replayStartedAtMs).toBeGreaterThanOrEqual(
+      Number(forwarded.consumerStartedAtMs)
+    );
+    expect(forwarded.nextStepEncounteredAtMs).toBeGreaterThanOrEqual(
+      Number(forwarded.replayStartedAtMs)
+    );
+    expect(forwarded.setupSource).toBe('hook_preload');
+    // The invocation that handed the step off does not also report it.
+    expect(
+      stepSpans().filter((s) => s.attributes[TOTAL_KEY] !== undefined)
+    ).toHaveLength(0);
+  });
+
+  it('completes the measurement in the invocation that receives the step', async () => {
+    // Round 1: the resuming invocation dispatches the step with its timing.
+    const first = await runScenario({
+      workflow: 'pendingStep',
+      timing: PRODUCER_TIMING,
+    });
+    const forwarded = forwardedTiming(first.dispatchedStepMessages[0]);
+    spanExporter.reset();
+    setWorld(undefined);
+    vi.restoreAllMocks();
+
+    // Round 2: that step message is delivered to a fresh invocation, whose
+    // clock picks up where the dispatching one left off.
+    const arrivalMs = Number(forwarded.nextStepEncounteredAtMs) + 25;
+    await runScenario({
+      workflow: 'pendingStep',
+      timing: forwarded,
+      clockStart: arrivalMs,
+      stepDelivery: {
+        stepId: first.pendingStepCorrelationId,
+        stepName: 'pendingStep',
+      },
+    });
+
+    const attrs = stepAttributes('pendingStep');
+    expect(attrs[TOTAL_KEY]).toBeTypeOf('number');
+    expect(sumPhases(attrs)).toBe(attrs[TOTAL_KEY]);
+    expect(attrs['workflow.resume.step_execution']).toBe('dispatched');
+    expect(attrs['workflow.resume.strategy']).toBe('parallel');
+    expect(attrs['workflow.resume.setup_source']).toBe('hook_preload');
+    // The queue hop from the resuming invocation to this one falls inside the
+    // dispatch phase, so it covers at least that gap.
+    expect(
+      attrs['workflow.resume.phase.step_dispatch_ms']
+    ).toBeGreaterThanOrEqual(
+      arrivalMs - Number(forwarded.nextStepEncounteredAtMs)
+    );
+  });
+
+  it('does not re-report on a redelivery of the same step message', async () => {
+    const first = await runScenario({
+      workflow: 'pendingStep',
+      timing: PRODUCER_TIMING,
+    });
+    const forwarded = forwardedTiming(first.dispatchedStepMessages[0]);
+    spanExporter.reset();
+    setWorld(undefined);
+    vi.restoreAllMocks();
+
+    // Same message, second delivery, and the previous delivery already
+    // claimed the step — so this is attempt 2: a re-execution, not the
+    // resumption.
+    await runScenario({
+      workflow: 'pendingStep',
+      timing: forwarded,
+      clockStart: Number(forwarded.nextStepEncounteredAtMs) + 25,
+      stepDelivery: {
+        stepId: first.pendingStepCorrelationId,
+        stepName: 'pendingStep',
+      },
+      attempt: 2,
+      priorStepStarted: true,
+    });
+
+    for (const span of stepSpans()) {
+      expect(span.attributes[TOTAL_KEY]).toBeUndefined();
+    }
+  });
+
+  it('reports run_started as the setup source when the preload is unusable', async () => {
+    // Force the fallback by making the hoisted hook_received write return no
+    // preload, so the generic run_started setup runs.
+    await runScenarioWithoutPreload();
+
+    const attrs = stepAttributes('firstStep');
+    expect(attrs[TOTAL_KEY]).toBeTypeOf('number');
+    expect(attrs['workflow.resume.setup_source']).toBe('run_started');
+    expect(sumPhases(attrs)).toBe(attrs[TOTAL_KEY]);
+  });
+
+  it('leaves a re-routed delivery inside queue_delivery', async () => {
+    // Round 1: the message lands on the wrong deployment. The affinity guard
+    // re-routes it, and the timing must ride along UNCHANGED — in particular
+    // without this deployment's entry time — so the wasted hop is charged to
+    // queue delivery rather than disappearing.
+    const misrouted = await runScenario({
+      timing: PRODUCER_TIMING,
+      ambientDeploymentId: 'dpl_somewhere_else',
+    });
+
+    const rerouted = misrouted.queue.mock.calls
+      .map(([, payload]) => payload as WorkflowInvokePayload)
+      .find((payload) => payload?.hookInput !== undefined);
+    const reroutedTiming = forwardedTiming(rerouted);
+    // Unchanged: no consumer boundaries were stamped by the wrong deployment.
+    expect(reroutedTiming).toEqual(PRODUCER_TIMING);
+    // Nothing ran here, so nothing reported.
+    expect(stepSpans()).toHaveLength(0);
+
+    spanExporter.reset();
+    setWorld(undefined);
+    vi.restoreAllMocks();
+
+    // Round 2: the pinned deployment receives the re-routed message later.
+    const rerouteArrivalMs = CLOCK_BASE_MS + 500;
+    await runScenario({
+      timing: reroutedTiming,
+      clockStart: rerouteArrivalMs,
+    });
+
+    const attrs = stepAttributes('firstStep');
+    expect(attrs[TOTAL_KEY]).toBeTypeOf('number');
+    expect(sumPhases(attrs)).toBe(attrs[TOTAL_KEY]);
+    // T2 is this (final) consumer's entry, so the misrouted hop is inside
+    // queue_delivery — which therefore covers the whole detour.
+    expect(
+      attrs['workflow.resume.phase.queue_delivery_ms']
+    ).toBeGreaterThanOrEqual(
+      rerouteArrivalMs - PRODUCER_TIMING.queuePublishRequestedAtMs
+    );
+  });
+
+  it('closes the window at the last instant before user code', async () => {
+    // The counter clock advances one tick per reading, so if T7 is taken
+    // immediately before `stepFn.apply()` then the body's own first reading
+    // is exactly one tick later. This pins the boundary past the inner span
+    // and the step-context setup that `step_prepare_ms` is defined to cover —
+    // anchoring it at `executionStartTime` (before both) would leave a gap.
+    await runScenario({ timing: PRODUCER_TIMING });
+
+    const attrs = stepAttributes('firstStep');
+    expect(bodyEntryClock).toBeTypeOf('number');
+    const t7 = Number(bodyEntryClock) - 1;
+    expect(attrs[TOTAL_KEY]).toBe(t7 - PRODUCER_TIMING.resumeRequestedAtMs);
+  });
+
+  it('keeps the measurement here when the first pending step is owned recovery', async () => {
+    // The first pending step is inline-owned by THIS message, so it
+    // re-executes in this invocation; the sibling is dispatched. The
+    // measurement must stay with the inline execution rather than being
+    // shipped off on the sibling's message.
+    const { dispatchedStepMessages, otherStepCorrelationId } =
+      await runScenario({
+        workflow: 'twoPendingSteps',
+        timing: PRODUCER_TIMING,
+        pendingStepOwner: MESSAGE_ID,
+        attempt: 2,
+      });
+
+    expect(dispatchedStepMessages.map((message) => message.stepId)).toContain(
+      otherStepCorrelationId
+    );
+    for (const message of dispatchedStepMessages) {
+      expect(message.hookResumeTiming).toBeUndefined();
+    }
+    // The recovered step is by definition a re-execution (its first attempt
+    // already started), so the attempt guard suppresses the sample. What
+    // matters here is that it was not misattributed to the sibling.
+    for (const span of stepSpans()) {
+      expect(span.attributes[TOTAL_KEY]).toBeUndefined();
+    }
+  });
+
+  it('does not hand the measurement to a delayed backstop wake', async () => {
+    // The first pending step is owned by ANOTHER live invocation, so this
+    // delivery only arms a backstop for it — not an attempt. The sibling it
+    // does dispatch is the first step this delivery actually causes to run,
+    // so the measurement goes there.
+    const { queuedMessages, dispatchedStepMessages, otherStepCorrelationId } =
+      await runScenario({
+        workflow: 'twoPendingSteps',
+        timing: PRODUCER_TIMING,
+        pendingStepOwner: 'msg_some_other_invocation',
+      });
+
+    const backstopWakes = queuedMessages.filter(
+      (payload) => payload?.stepId === undefined
+    );
+    expect(backstopWakes.length).toBeGreaterThan(0);
+    for (const wake of backstopWakes) {
+      expect(wake.hookResumeTiming).toBeUndefined();
+    }
+
+    expect(dispatchedStepMessages).toHaveLength(1);
+    expect(dispatchedStepMessages[0].stepId).toBe(otherStepCorrelationId);
+    expect(dispatchedStepMessages[0].hookResumeTiming).toBeDefined();
+  });
+
+  it('drops the sample when every pending step becomes a backstop', async () => {
+    // Nothing is attempted by this delivery, so there is no step to attribute
+    // the resumption to. Reporting it against a wake would credit work this
+    // invocation never did.
+    const { queuedMessages, dispatchedStepMessages } = await runScenario({
+      workflow: 'pendingStep',
+      timing: PRODUCER_TIMING,
+      pendingStepOwner: 'msg_some_other_invocation',
+    });
+
+    expect(dispatchedStepMessages).toHaveLength(0);
+    for (const message of queuedMessages) {
+      expect(message.hookResumeTiming).toBeUndefined();
+    }
+    expect(stepSpans()).toHaveLength(0);
+  });
+
+  it('still reports when the batch’s first step loses its create-claim', async () => {
+    // A concurrent invocation wins the first inline step's atomic
+    // create-claim; that step never reaches user code. Its sibling does, and
+    // the shared one-shot latch lets it take the measurement instead of the
+    // sample being pinned to — and lost with — the first step.
+    await runScenario({
+      workflow: 'parallelInline',
+      timing: PRODUCER_TIMING,
+      failFirstLazyClaim: true,
+    });
+
+    const reporting = stepSpans().filter(
+      (s) => s.attributes[TOTAL_KEY] !== undefined
+    );
+    expect(reporting).toHaveLength(1);
+    const attrs = reporting[0].attributes;
+    expect(sumPhases(attrs)).toBe(attrs[TOTAL_KEY]);
+    expect(attrs['workflow.resume.step_execution']).toBe('inline');
+  });
+
+  it('reports once for a parallel batch where every step runs', async () => {
+    await runScenario({
+      workflow: 'parallelInline',
+      timing: PRODUCER_TIMING,
+    });
+
+    expect(stepSpans().length).toBeGreaterThan(1);
+    expect(
+      stepSpans().filter((s) => s.attributes[TOTAL_KEY] !== undefined)
+    ).toHaveLength(1);
+  });
+
+  it('reports the sequential dispatch strategy', async () => {
+    await runScenario({
+      timing: { ...PRODUCER_TIMING, strategy: 'sequential' },
+    });
+
+    expect(stepAttributes('firstStep')['workflow.resume.strategy']).toBe(
+      'sequential'
+    );
+  });
+});
+
+/**
+ * The lazy fast path's fallback: the hoisted `hook_received` write succeeds
+ * but returns no usable preload, so the invocation initializes through
+ * `run_started` instead. Same fake World as {@link runScenario} with the
+ * preload response suppressed.
+ */
+async function runScenarioWithoutPreload() {
+  let clock = CLOCK_BASE_MS;
+  vi.spyOn(Date, 'now').mockImplementation(() => clock++);
+
+  const runId = 'wrun_resume_ttr_fallback';
+  const workflowName = 'workflow';
+  const deploymentId = 'dpl_resume_ttr';
+  const hookToken = 'resume-ttr-token';
+  const resumeId = 'resume-ttr-fallback';
+  const startedAt = new Date('2026-05-19T12:00:00.000Z');
+
+  const workflowArgs = await dehydrateWorkflowArguments(
+    [hookToken],
+    runId,
+    undefined
+  );
+  const { globalThis: vmGlobalThis } = createContext({
+    seed: `${runId}:${workflowName}:${deploymentId}`,
+    fixedTimestamp: +startedAt,
+  });
+  const vmUlid = monotonicFactory(() => vmGlobalThis.Math.random());
+  const hookCorrelationId = `hook_${vmUlid(+startedAt)}`;
+
+  const workflowRun: WorkflowRun = {
+    runId,
+    workflowName,
+    status: 'running',
+    input: workflowArgs,
+    deploymentId,
+    specVersion: SPEC_VERSION_CURRENT,
+    startedAt,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  };
+
+  const hostUlid = monotonicFactory();
+  let eventIndex = 0;
+  const event = (data: CreateEventRequest): Event => {
+    const t = +startedAt + ++eventIndex * 100;
+    return {
+      ...data,
+      specVersion: data.specVersion ?? SPEC_VERSION_CURRENT,
+      runId,
+      eventId: `evnt_${hostUlid(t)}`,
+      createdAt: new Date(t),
+    } as Event;
+  };
+
+  const payloadBytes = await dehydrateStepReturnValue(
+    { value: 'resumed' },
+    runId,
+    undefined
+  );
+  const durableEvents: Event[] = [
+    event({
+      eventType: 'run_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      eventData: { deploymentId, workflowName, input: workflowArgs },
+    }),
+    event({ eventType: 'run_started', specVersion: SPEC_VERSION_CURRENT }),
+    event({
+      eventType: 'hook_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: hookCorrelationId,
+      eventData: { token: hookToken },
+    }),
+    {
+      ...event({
+        eventType: 'hook_received',
+        specVersion: SPEC_VERSION_CURRENT,
+        correlationId: hookCorrelationId,
+        eventData: { token: hookToken, payload: payloadBytes },
+      }),
+      resumeId,
+    } as Event,
+  ];
+
+  const buildStepEntity = (correlationId: string | undefined) => {
+    const created = durableEvents.find(
+      (e) => e.eventType === 'step_created' && e.correlationId === correlationId
+    );
+    const data = created?.eventData as
+      | { stepName?: string; input?: unknown }
+      | undefined;
+    return {
+      runId,
+      stepId: correlationId,
+      stepName: data?.stepName,
+      status: 'running',
+      attempt: 1,
+      input: data?.input,
+      startedAt: new Date(+startedAt),
+      createdAt: new Date(+startedAt),
+      updatedAt: new Date(+startedAt),
+    };
+  };
+
+  const createEvent = vi.fn(
+    async (_runId: string, request: CreateEventRequest) => {
+      if (request.eventType === 'run_started') {
+        return {
+          run: workflowRun,
+          events: [...durableEvents],
+          cursor: durableEvents.at(-1)?.eventId ?? null,
+          hasMore: false,
+          maxEvents: 25_000,
+        };
+      }
+      if (request.eventType === 'hook_received') {
+        // No preload in the response — an older server, or a World that
+        // ignored `preloadEvents`.
+        return {
+          event: durableEvents.find(
+            (e) => e.eventType === 'hook_received' && e.resumeId === resumeId
+          ),
+        };
+      }
+      const lazyStepStart =
+        request.eventType === 'step_started' &&
+        !!request.eventData &&
+        (request.eventData as { input?: unknown }).input !== undefined;
+      let effective = request;
+      if (lazyStepStart) {
+        const lazy = request.eventData as {
+          stepName?: string;
+          input?: unknown;
+        };
+        durableEvents.push(
+          event({
+            eventType: 'step_created',
+            specVersion: SPEC_VERSION_CURRENT,
+            correlationId: request.correlationId,
+            eventData: {
+              stepName: lazy.stepName,
+              workflowName,
+              input: lazy.input,
+            },
+          } as CreateEventRequest)
+        );
+        const { input: _input, ...startData } = lazy;
+        effective = {
+          ...request,
+          eventData: startData,
+        } as CreateEventRequest;
+      }
+      const created = event(effective);
+      durableEvents.push(created);
+      if (effective.eventType === 'step_started') {
+        return {
+          event: created,
+          step: buildStepEntity(effective.correlationId),
+          ...(lazyStepStart ? { stepCreated: true } : {}),
+        };
+      }
+      return { event: created };
+    }
+  );
+
+  let capturedHandler:
+    | ((
+        message: unknown,
+        metadata: { queueName: string; messageId: string; attempt: number }
+      ) => Promise<unknown>)
+    | undefined;
+  setWorld({
+    specVersion: SPEC_VERSION_CURRENT,
+    capabilities: { deploymentAffinity: true },
+    getDeploymentId: vi.fn(async () => deploymentId),
+    createQueueHandler: vi.fn((_prefix, handler) => {
+      capturedHandler = handler;
+      return vi.fn();
+    }),
+    events: {
+      list: vi.fn(async () => ({
+        data: [...durableEvents],
+        hasMore: false,
+        cursor: durableEvents.at(-1)?.eventId ?? null,
+      })),
+      create: createEvent,
+    },
+    runs: { get: vi.fn(async () => workflowRun) },
+    queue: vi.fn().mockResolvedValue({ messageId: 'msg_fallback' }),
+    getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
+  } as unknown as World);
+
+  const handler = workflowEntrypoint(SEQUENTIAL_WORKFLOW);
+  await handler(new Request('http://localhost', { method: 'POST' }));
+  await capturedHandler?.(
+    {
+      runId,
+      hookInput: {
+        hookId: hookCorrelationId,
+        resumeId,
+        token: hookToken,
+        payload: payloadBytes,
+        payloadDigest: 'e'.repeat(64),
+        deploymentId,
+      },
+      hookResumeTiming: PRODUCER_TIMING,
+    },
+    {
+      queueName: `__wkf_workflow_${workflowName}`,
+      messageId: 'msg_workflow_fallback',
+      attempt: 1,
+    }
+  );
+}

--- a/packages/core/src/runtime/resume-latency.test.ts
+++ b/packages/core/src/runtime/resume-latency.test.ts
@@ -1,0 +1,326 @@
+import type { HookResumeTiming } from '@workflow/world';
+import { describe, expect, it } from 'vitest';
+import {
+  computeResumeTtrAttributes,
+  type ResumeTtrTracking,
+  resumeTimingForMessage,
+  resumeTrackingFromMessage,
+} from './resume-latency.js';
+
+/**
+ * A complete, well-ordered boundary set. Phase durations are all distinct so a
+ * mis-wired boundary shows up as a wrong number rather than a coincidence:
+ *
+ *   T0 1_000  producer_prep   =  10
+ *   T1 1_010  queue_delivery  =  40
+ *   T2 1_050  resume_setup    =  20
+ *   T3 1_070  replay          =  30
+ *   T4 1_100  step_dispatch   =   5
+ *   T5 1_105  step_claim      =  15
+ *   T6 1_120  step_prepare    =   7
+ *   T7 1_127  total           = 127
+ */
+const TRACKING: ResumeTtrTracking = {
+  trigger: 'hook',
+  strategy: 'parallel',
+  resumeRequestedAtMs: 1_000,
+  queuePublishRequestedAtMs: 1_010,
+  consumerStartedAtMs: 1_050,
+  replayStartedAtMs: 1_070,
+  nextStepEncounteredAtMs: 1_100,
+  setupSource: 'hook_preload',
+  stepExecution: 'inline',
+};
+
+const CLAIM = {
+  attempt: 1,
+  stepClaimStartedAtMs: 1_105,
+  stepClaimCompletedAtMs: 1_120 as number | undefined,
+  stepCodeStartedAtMs: 1_127,
+};
+
+const PHASE_KEYS = [
+  'workflow.resume.phase.producer_prep_ms',
+  'workflow.resume.phase.queue_delivery_ms',
+  'workflow.resume.phase.resume_setup_ms',
+  'workflow.resume.phase.replay_ms',
+  'workflow.resume.phase.step_dispatch_ms',
+  'workflow.resume.phase.step_claim_ms',
+  'workflow.resume.phase.step_prepare_ms',
+] as const;
+
+/** Sum of whichever phases were emitted. */
+function sumPhases(attrs: Record<string, string | number>): number {
+  return PHASE_KEYS.reduce(
+    (total, key) => total + ((attrs[key] as number | undefined) ?? 0),
+    0
+  );
+}
+
+/** The emitted attributes, failing the test if the sample was suppressed. */
+function emitted(
+  params: Parameters<typeof computeResumeTtrAttributes>[0]
+): Record<string, string | number> {
+  const attrs = computeResumeTtrAttributes(params);
+  if (!attrs) throw new Error('expected TTR attributes to be emitted');
+  return attrs;
+}
+
+describe('computeResumeTtrAttributes', () => {
+  it('emits total TTR and every phase for a lazy inline execution', () => {
+    const attrs = computeResumeTtrAttributes({ tracking: TRACKING, ...CLAIM });
+    expect(attrs).toEqual({
+      'workflow.resume.total_ms': 127,
+      'workflow.resume.phase.producer_prep_ms': 10,
+      'workflow.resume.phase.queue_delivery_ms': 40,
+      'workflow.resume.phase.resume_setup_ms': 20,
+      'workflow.resume.phase.replay_ms': 30,
+      'workflow.resume.phase.step_dispatch_ms': 5,
+      'workflow.resume.phase.step_claim_ms': 15,
+      'workflow.resume.phase.step_prepare_ms': 7,
+      'workflow.resume.trigger': 'hook',
+      'workflow.resume.strategy': 'parallel',
+      'workflow.resume.setup_source': 'hook_preload',
+      'workflow.resume.step_execution': 'inline',
+    });
+  });
+
+  it('reports phases that sum exactly to the total', () => {
+    const attrs = emitted({ tracking: TRACKING, ...CLAIM });
+    // Every phase is derived from the same boundary set, so the identity is
+    // exact — the tolerance is only here to document that a dashboard should
+    // not assume better than millisecond rounding.
+    expect(sumPhases(attrs)).toBeCloseTo(
+      attrs['workflow.resume.total_ms'] as number,
+      5
+    );
+  });
+
+  it('omits only step_claim when the claim was not awaited (optimistic start)', () => {
+    const attrs = emitted({
+      tracking: TRACKING,
+      ...CLAIM,
+      stepClaimCompletedAtMs: undefined,
+    });
+    expect(attrs).not.toHaveProperty('workflow.resume.phase.step_claim_ms');
+    // step_prepare absorbs the claim window (T5 → T7), so the sum still holds.
+    expect(attrs['workflow.resume.phase.step_prepare_ms']).toBe(22);
+    expect(sumPhases(attrs)).toBe(attrs['workflow.resume.total_ms']);
+  });
+
+  it('reports a dispatched next step with its own step_execution dimension', () => {
+    const attrs = computeResumeTtrAttributes({
+      tracking: { ...TRACKING, stepExecution: 'dispatched' },
+      ...CLAIM,
+    });
+    expect(attrs?.['workflow.resume.step_execution']).toBe('dispatched');
+    expect(attrs?.['workflow.resume.total_ms']).toBe(127);
+  });
+
+  it('emits nothing without tracking (an old queue message)', () => {
+    expect(
+      computeResumeTtrAttributes({ tracking: undefined, ...CLAIM })
+    ).toBeUndefined();
+  });
+
+  it('emits nothing on a retry attempt', () => {
+    expect(
+      computeResumeTtrAttributes({ tracking: TRACKING, ...CLAIM, attempt: 2 })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['replayStartedAtMs', { replayStartedAtMs: undefined }],
+    ['nextStepEncounteredAtMs', { nextStepEncounteredAtMs: undefined }],
+  ] as const)('emits nothing when %s is missing', (_label, override) => {
+    expect(
+      computeResumeTtrAttributes({
+        tracking: { ...TRACKING, ...override },
+        ...CLAIM,
+      })
+    ).toBeUndefined();
+  });
+
+  it('emits nothing when the claim start is missing', () => {
+    expect(
+      computeResumeTtrAttributes({
+        tracking: TRACKING,
+        ...CLAIM,
+        stepClaimStartedAtMs: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    // Producer/consumer clock skew: T2 lands before T1.
+    ['queue_delivery inverted', { consumerStartedAtMs: 1_005 }],
+    ['resume_setup inverted', { replayStartedAtMs: 1_040 }],
+    ['replay inverted', { nextStepEncounteredAtMs: 1_060 }],
+    ['producer_prep inverted', { queuePublishRequestedAtMs: 990 }],
+  ] as const)('omits the whole sample rather than a negative phase (%s)', (_label, override) => {
+    expect(
+      computeResumeTtrAttributes({
+        tracking: { ...TRACKING, ...override },
+        ...CLAIM,
+      })
+    ).toBeUndefined();
+  });
+
+  it('omits the sample when the claim boundaries invert', () => {
+    expect(
+      computeResumeTtrAttributes({
+        tracking: TRACKING,
+        ...CLAIM,
+        stepClaimCompletedAtMs: 1_100,
+      })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ] as const)('omits the sample for a non-finite boundary (%s)', (value) => {
+    expect(
+      computeResumeTtrAttributes({
+        tracking: { ...TRACKING, consumerStartedAtMs: value },
+        ...CLAIM,
+      })
+    ).toBeUndefined();
+  });
+
+  it('accepts a zero-length phase (boundaries within the same millisecond)', () => {
+    const attrs = computeResumeTtrAttributes({
+      tracking: { ...TRACKING, replayStartedAtMs: 1_050 },
+      ...CLAIM,
+    });
+    expect(attrs?.['workflow.resume.phase.resume_setup_ms']).toBe(0);
+    expect(attrs?.['workflow.resume.phase.replay_ms']).toBe(50);
+  });
+
+  it('omits the strategy and setup_source dimensions when unknown', () => {
+    const attrs = emitted({
+      tracking: {
+        ...TRACKING,
+        strategy: undefined,
+        setupSource: undefined,
+      },
+      ...CLAIM,
+    });
+    expect(attrs).not.toHaveProperty('workflow.resume.strategy');
+    expect(attrs).not.toHaveProperty('workflow.resume.setup_source');
+    expect(attrs['workflow.resume.trigger']).toBe('hook');
+  });
+});
+
+describe('resumeTrackingFromMessage', () => {
+  const timing: HookResumeTiming = {
+    resumeRequestedAtMs: 1_000,
+    queuePublishRequestedAtMs: 1_010,
+    strategy: 'sequential',
+    consumerStartedAtMs: 1_050,
+    replayStartedAtMs: 1_070,
+    nextStepEncounteredAtMs: 1_100,
+    setupSource: 'run_started',
+  };
+
+  it('rebuilds a dispatched step message verbatim', () => {
+    expect(resumeTrackingFromMessage(timing, 'dispatched')).toEqual({
+      trigger: 'hook',
+      strategy: 'sequential',
+      resumeRequestedAtMs: 1_000,
+      queuePublishRequestedAtMs: 1_010,
+      consumerStartedAtMs: 1_050,
+      replayStartedAtMs: 1_070,
+      nextStepEncounteredAtMs: 1_100,
+      setupSource: 'run_started',
+      stepExecution: 'dispatched',
+    });
+  });
+
+  it('returns undefined for a message with no timing (an old producer)', () => {
+    expect(resumeTrackingFromMessage(undefined, 'inline')).toBeUndefined();
+  });
+
+  it('returns undefined when the producer boundaries are not finite', () => {
+    expect(
+      resumeTrackingFromMessage(
+        { resumeRequestedAtMs: Number.NaN, queuePublishRequestedAtMs: 1_010 },
+        'inline'
+      )
+    ).toBeUndefined();
+  });
+
+  it('leaves the consumer start unusable on a producer-only message', () => {
+    // The runtime overwrites this with its own handler-entry time for an
+    // inline resume, and drops the tracking entirely if it does not.
+    const tracking = resumeTrackingFromMessage(
+      {
+        resumeRequestedAtMs: 1_000,
+        queuePublishRequestedAtMs: 1_010,
+        strategy: 'parallel',
+      },
+      'inline'
+    );
+    expect(Number.isFinite(tracking?.consumerStartedAtMs)).toBe(false);
+    expect(tracking?.replayStartedAtMs).toBeUndefined();
+  });
+
+  it.each([
+    'bogus',
+    '',
+  ] as const)('ignores an unrecognized strategy (%s) rather than failing', (strategy) => {
+    const tracking = resumeTrackingFromMessage(
+      { ...timing, strategy },
+      'inline'
+    );
+    expect(tracking).toBeDefined();
+    expect(tracking?.strategy).toBeUndefined();
+  });
+
+  it('ignores an unrecognized setup source', () => {
+    const tracking = resumeTrackingFromMessage(
+      { ...timing, setupSource: 'from_the_future' },
+      'inline'
+    );
+    expect(tracking).toBeDefined();
+    expect(tracking?.setupSource).toBeUndefined();
+  });
+});
+
+describe('resumeTimingForMessage', () => {
+  it('round-trips through a dispatched step message', () => {
+    const forwarded = resumeTimingForMessage(TRACKING);
+    expect(forwarded).toEqual({
+      resumeRequestedAtMs: 1_000,
+      queuePublishRequestedAtMs: 1_010,
+      strategy: 'parallel',
+      consumerStartedAtMs: 1_050,
+      replayStartedAtMs: 1_070,
+      nextStepEncounteredAtMs: 1_100,
+      setupSource: 'hook_preload',
+    });
+    // The receiving invocation reconstructs the same measurement, differing
+    // only in how the step got there.
+    const rebuilt = resumeTrackingFromMessage(forwarded, 'dispatched');
+    expect(rebuilt).toEqual({ ...TRACKING, stepExecution: 'dispatched' });
+    expect(computeResumeTtrAttributes({ tracking: rebuilt, ...CLAIM })).toEqual(
+      computeResumeTtrAttributes({
+        tracking: { ...TRACKING, stepExecution: 'dispatched' },
+        ...CLAIM,
+      })
+    );
+  });
+
+  it('returns undefined without tracking', () => {
+    expect(resumeTimingForMessage(undefined)).toBeUndefined();
+  });
+
+  it('refuses to forward tracking with no usable consumer start', () => {
+    expect(
+      resumeTimingForMessage({
+        ...TRACKING,
+        consumerStartedAtMs: Number.NaN,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/runtime/resume-latency.ts
+++ b/packages/core/src/runtime/resume-latency.ts
@@ -1,0 +1,302 @@
+import type { HookResumeTiming } from '@workflow/world';
+import * as Attribute from '../telemetry/semantic-conventions.js';
+
+/**
+ * Hook-triggered time-to-resume (TTR): wall-clock from entry into
+ * `resumeHook()` (T0) to the first line of the next durable step (T7), plus a
+ * decomposition into non-overlapping phases that sum exactly to it.
+ *
+ * ```text
+ * T0 resumeHook() entered
+ *      producer_prep   — hook lookup, serialization, encryption
+ * T1 queue publish requested
+ *      queue_delivery  — network + VQS delivery (incl. any affinity re-route)
+ * T2 final consumer's queue handler entered
+ *      resume_setup    — affinity check, hook_received re-ensure, replay preload
+ * T3 replay begins
+ *      replay          — VM/session creation and workflow replay
+ * T4 next durable step encountered
+ *      step_dispatch   — suspension handling, inline batch or queue dispatch
+ * T5 step_started request begins
+ *      step_claim      — the claim round trip
+ * T6 step_started response returned
+ *      step_prepare    — key resolution, argument hydration, context setup
+ * T7 immediately before stepFn.apply()
+ * ```
+ *
+ * The producer's direct `hook_received` POST races the queue publish on the
+ * parallel fast path, so it deliberately has no phase of its own — the two
+ * overlap, and representing both as additive phases would double-count. It
+ * remains visible as a contextual span (`hook.resume`).
+ *
+ * T0/T1 are stamped on the producer's machine and T2..T7 on the consumer's, so
+ * the measurement is subject to cross-machine clock skew. Rather than clamp
+ * (which would break the sum-equals-total property this decomposition exists
+ * for), a non-monotonic boundary set drops the whole sample — see
+ * {@link computeResumeTtrAttributes}.
+ */
+
+/** What caused the resumption being measured. Only hooks are measured today. */
+export type ResumeTrigger = 'hook';
+
+/** Which `resumeHook()` dispatch path produced this resume. */
+export type ResumeStrategy = 'parallel' | 'sequential';
+
+/**
+ * How the consuming invocation initialized its replay state:
+ *
+ * - `hook_preload` — the hoisted `hook_received` write returned a usable
+ *   replay preload, so neither `run_started` nor the initial `events.list` ran.
+ * - `run_started` — the generic `run_started` setup ran (including the fast
+ *   path's fallback, where the hoisted write succeeded but returned no usable
+ *   preload).
+ * - `event_load` — neither setup ran because the run arrived already loaded,
+ *   so setup was a plain event load. No current path produces it (the one
+ *   preloaded-run path, the background-step fall-through, consumes the
+ *   tracking on its own step first); it is the honest default rather than a
+ *   live value, and keeps the dimension total if such a path is added.
+ */
+export type ResumeSetupSource = 'hook_preload' | 'run_started' | 'event_load';
+
+/** Whether the measured step ran in the resuming invocation or a queued one. */
+export type ResumeStepExecution = 'inline' | 'dispatched';
+
+/**
+ * The resume boundaries observed so far, threaded from the queue handler into
+ * `executeStep`. Producer fields arrive on the queue message
+ * ({@link HookResumeTiming}); consumer fields are stamped by the invocation
+ * that replays the resume.
+ *
+ * The runtime holds at most one of these per invocation and CONSUMES it when
+ * it hands it to the execution that will attempt the next durable step, so a
+ * later step in the same invocation — or a retry of the same step — never
+ * re-reports the same resumption. Within one inline batch the object is
+ * shared by every step and the {@link ResumeTtrTracking.reported} latch picks
+ * the single reporter.
+ */
+export interface ResumeTtrTracking {
+  trigger: ResumeTrigger;
+  /** Absent only if an older producer omitted it from the queue message. */
+  strategy?: ResumeStrategy;
+  /** T0 — entry into `resumeHook()`. */
+  resumeRequestedAtMs: number;
+  /** T1 — immediately before the queue publish was requested. */
+  queuePublishRequestedAtMs: number;
+  /**
+   * T2 — entry into the FINAL consumer's queue handler. A delivery that
+   * re-routes for deployment affinity never stamps this, so the re-routed hop
+   * stays inside `queue_delivery` where it belongs.
+   */
+  consumerStartedAtMs: number;
+  /** T3 — this invocation's first replay pass. */
+  replayStartedAtMs?: number;
+  /** T4 — replay first encountered a durable step after the resume. */
+  nextStepEncounteredAtMs?: number;
+  setupSource?: ResumeSetupSource;
+  stepExecution: ResumeStepExecution;
+  /**
+   * One-shot latch, set by the step executor once this resumption has been
+   * reported. Every step of an inline batch is handed the SAME tracking
+   * object, so the first one to reach user code takes the measurement and the
+   * rest see this and skip — one resumption, one sample, without pinning the
+   * sample to a step that may lose its create-claim and never run.
+   *
+   * Deliberately not part of {@link HookResumeTiming}: it is invocation-local
+   * state, and a queue message carries the boundaries, not the claim.
+   */
+  reported?: boolean;
+}
+
+/**
+ * Rebuild tracking from a queue message's timing object. Returns undefined for
+ * a message that carries none (an older producer, or any non-hook delivery) —
+ * the caller then simply reports no TTR.
+ */
+export function resumeTrackingFromMessage(
+  timing: HookResumeTiming | undefined,
+  stepExecution: ResumeStepExecution
+): ResumeTtrTracking | undefined {
+  if (!timing) return undefined;
+  if (
+    !Number.isFinite(timing.resumeRequestedAtMs) ||
+    !Number.isFinite(timing.queuePublishRequestedAtMs)
+  ) {
+    return undefined;
+  }
+  return {
+    trigger: 'hook',
+    ...(timing.strategy === 'parallel' || timing.strategy === 'sequential'
+      ? { strategy: timing.strategy }
+      : {}),
+    resumeRequestedAtMs: timing.resumeRequestedAtMs,
+    queuePublishRequestedAtMs: timing.queuePublishRequestedAtMs,
+    // A dispatched step reads the resuming invocation's boundaries off the
+    // message; an inline one has them stamped locally by the caller, which
+    // overwrites this placeholder immediately after construction.
+    consumerStartedAtMs: timing.consumerStartedAtMs ?? Number.NaN,
+    ...(timing.replayStartedAtMs !== undefined
+      ? { replayStartedAtMs: timing.replayStartedAtMs }
+      : {}),
+    ...(timing.nextStepEncounteredAtMs !== undefined
+      ? { nextStepEncounteredAtMs: timing.nextStepEncounteredAtMs }
+      : {}),
+    ...(timing.setupSource === 'hook_preload' ||
+    timing.setupSource === 'run_started' ||
+    timing.setupSource === 'event_load'
+      ? { setupSource: timing.setupSource }
+      : {}),
+    stepExecution,
+  };
+}
+
+/**
+ * Serialize tracking back onto a queue message, for the case where the
+ * resuming invocation dispatches the next durable step to another invocation
+ * instead of running it inline. Returns undefined when the tracking is not
+ * complete enough to be worth forwarding.
+ */
+export function resumeTimingForMessage(
+  tracking: ResumeTtrTracking | undefined
+): HookResumeTiming | undefined {
+  if (!tracking) return undefined;
+  if (!Number.isFinite(tracking.consumerStartedAtMs)) return undefined;
+  return {
+    resumeRequestedAtMs: tracking.resumeRequestedAtMs,
+    queuePublishRequestedAtMs: tracking.queuePublishRequestedAtMs,
+    ...(tracking.strategy !== undefined ? { strategy: tracking.strategy } : {}),
+    consumerStartedAtMs: tracking.consumerStartedAtMs,
+    ...(tracking.replayStartedAtMs !== undefined
+      ? { replayStartedAtMs: tracking.replayStartedAtMs }
+      : {}),
+    ...(tracking.nextStepEncounteredAtMs !== undefined
+      ? { nextStepEncounteredAtMs: tracking.nextStepEncounteredAtMs }
+      : {}),
+    ...(tracking.setupSource !== undefined
+      ? { setupSource: tracking.setupSource }
+      : {}),
+  };
+}
+
+/** Every boundary the emission gate requires, plus the optional claim end. */
+interface ResumeBoundaries {
+  /** T0 */ resumeRequestedAtMs: number;
+  /** T1 */ queuePublishRequestedAtMs: number;
+  /** T2 */ consumerStartedAtMs: number;
+  /** T3 */ replayStartedAtMs: number;
+  /** T4 */ nextStepEncounteredAtMs: number;
+  /** T5 */ stepClaimStartedAtMs: number;
+  /** T6 — absent on the optimistic-start path; see below. */
+  stepClaimCompletedAtMs: number | undefined;
+  /** T7 */ stepCodeStartedAtMs: number;
+}
+
+/**
+ * Validate that every required boundary is a finite epoch-ms value and that
+ * the whole sequence is non-decreasing. Returns undefined otherwise, which
+ * suppresses the metric entirely rather than reporting a phase that never
+ * happened or a negative duration.
+ */
+function validateBoundaries(
+  b: ResumeBoundaries
+): readonly number[] | undefined {
+  const ordered = [
+    b.resumeRequestedAtMs,
+    b.queuePublishRequestedAtMs,
+    b.consumerStartedAtMs,
+    b.replayStartedAtMs,
+    b.nextStepEncounteredAtMs,
+    b.stepClaimStartedAtMs,
+    ...(b.stepClaimCompletedAtMs !== undefined
+      ? [b.stepClaimCompletedAtMs]
+      : []),
+    b.stepCodeStartedAtMs,
+  ];
+  for (const value of ordered) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  }
+  for (let i = 1; i < ordered.length; i++) {
+    if (ordered[i] < ordered[i - 1]) return undefined;
+  }
+  return ordered;
+}
+
+/**
+ * Compute the TTR span attributes for a step that is the first durable step
+ * following a hook resume. Returns undefined — emitting nothing at all — when
+ * any of these hold:
+ *
+ * - the invocation carries no resume tracking (not a hook resume, or an older
+ *   queue message with no timing);
+ * - this is a retry (`attempt !== 1`), which measures a re-execution rather
+ *   than the resumption;
+ * - a required boundary is missing, non-finite, or out of order.
+ *
+ * `step_claim_ms` is the one phase that may be individually omitted. Under
+ * optimistic inline start the `step_started` claim is deliberately NOT awaited
+ * before the body runs, so its completion instant does not exist yet at T7;
+ * rather than invent one, the claim phase is dropped and `step_prepare_ms`
+ * spans T5→T7. The sum-equals-total property holds either way.
+ */
+export function computeResumeTtrAttributes(params: {
+  tracking: ResumeTtrTracking | undefined;
+  /** The attempt number of the execution about to run. */
+  attempt: number;
+  /** T5 — `Date.now()` immediately before the `step_started` request. */
+  stepClaimStartedAtMs: number | undefined;
+  /** T6 — `Date.now()` once the `step_started` response returned. */
+  stepClaimCompletedAtMs: number | undefined;
+  /** T7 — `Date.now()` immediately before `stepFn.apply()`. */
+  stepCodeStartedAtMs: number;
+}): Record<string, string | number> | undefined {
+  const { tracking } = params;
+  if (!tracking || params.attempt !== 1) return undefined;
+  if (
+    tracking.replayStartedAtMs === undefined ||
+    tracking.nextStepEncounteredAtMs === undefined ||
+    params.stepClaimStartedAtMs === undefined
+  ) {
+    return undefined;
+  }
+
+  const boundaries: ResumeBoundaries = {
+    resumeRequestedAtMs: tracking.resumeRequestedAtMs,
+    queuePublishRequestedAtMs: tracking.queuePublishRequestedAtMs,
+    consumerStartedAtMs: tracking.consumerStartedAtMs,
+    replayStartedAtMs: tracking.replayStartedAtMs,
+    nextStepEncounteredAtMs: tracking.nextStepEncounteredAtMs,
+    stepClaimStartedAtMs: params.stepClaimStartedAtMs,
+    stepClaimCompletedAtMs: params.stepClaimCompletedAtMs,
+    stepCodeStartedAtMs: params.stepCodeStartedAtMs,
+  };
+  if (!validateBoundaries(boundaries)) return undefined;
+
+  const {
+    resumeRequestedAtMs: t0,
+    queuePublishRequestedAtMs: t1,
+    consumerStartedAtMs: t2,
+    replayStartedAtMs: t3,
+    nextStepEncounteredAtMs: t4,
+    stepClaimStartedAtMs: t5,
+    stepClaimCompletedAtMs: t6,
+    stepCodeStartedAtMs: t7,
+  } = boundaries;
+
+  return {
+    ...Attribute.ResumeTotalMs(t7 - t0),
+    ...Attribute.ResumeProducerPrepMs(t1 - t0),
+    ...Attribute.ResumeQueueDeliveryMs(t2 - t1),
+    ...Attribute.ResumeSetupMs(t3 - t2),
+    ...Attribute.ResumeReplayMs(t4 - t3),
+    ...Attribute.ResumeStepDispatchMs(t5 - t4),
+    ...(t6 !== undefined ? Attribute.ResumeStepClaimMs(t6 - t5) : {}),
+    ...Attribute.ResumeStepPrepareMs(t7 - (t6 ?? t5)),
+    ...Attribute.ResumeTrigger(tracking.trigger),
+    ...(tracking.strategy !== undefined
+      ? Attribute.ResumeStrategy(tracking.strategy)
+      : {}),
+    ...(tracking.setupSource !== undefined
+      ? Attribute.ResumeSetupSource(tracking.setupSource)
+      : {}),
+    ...Attribute.ResumeStepExecution(tracking.stepExecution),
+  };
+}

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -57,6 +57,10 @@ import {
 } from './helpers.js';
 import { ReplayRecoveryReporter } from './replay-recovery-reporter.js';
 import {
+  computeResumeTtrAttributes,
+  type ResumeTtrTracking,
+} from './resume-latency.js';
+import {
   computeStepLatencyEventData,
   type StepLatencyEventData,
   type StepLatencyTracking,
@@ -193,6 +197,15 @@ export interface StepExecutorParams {
    * runtime/step-latency.ts.
    */
   latencyTracking?: StepLatencyTracking;
+  /**
+   * Hook-resume TTR telemetry: the boundaries of a hook resumption whose next
+   * durable step is the one this call is about to execute. When set, the
+   * executor closes the measurement against the `step_started` claim and the
+   * wall clock taken immediately before user code, and attaches the total plus
+   * its phase breakdown to this step's `step.execute` span. Set by the runtime
+   * for exactly one step per resumption — see runtime/resume-latency.ts.
+   */
+  resumeTracking?: ResumeTtrTracking;
   /**
    * Authoritative attempt number for this execution, used to bound retries
    * against `maxRetries` BEFORE the body runs. In order to also catch
@@ -543,6 +556,13 @@ export async function executeStep(
     // issued (either path below) — anchors RSFS's end point. See
     // StepLatencyEventData.rsfs and the call sites below.
     let stepStartPostSentAtMs: number | undefined;
+    // `Date.now()` taken once the `step_started` response has returned and the
+    // claim succeeded — T6 of the hook-resume TTR window. Only the await path
+    // can set it: optimistic inline start deliberately does not wait for the
+    // claim before running the body, so at T7 it has no completion instant and
+    // the TTR breakdown reports no `step_claim_ms` (see
+    // runtime/resume-latency.ts).
+    let stepClaimCompletedAtMs: number | undefined;
     // Settled outcome of the in-flight optimistic `step_started`. Handlers are
     // attached synchronously (`.then(ok, err)`) so a fast rejection never
     // surfaces as an unhandledRejection while the body runs.
@@ -659,6 +679,7 @@ export async function executeStep(
           // fresh replay.
           startEventParams
         );
+        stepClaimCompletedAtMs = Date.now();
 
         step = startResult.step;
       } catch (err) {
@@ -871,6 +892,41 @@ export async function executeStep(
           ),
         });
       }
+      /**
+       * Close the hook-resume TTR measurement (see runtime/resume-latency.ts).
+       *
+       * Called from INSIDE `contextStorage.run`, immediately before
+       * `stepFn.apply()` — deliberately not alongside the step-latency
+       * telemetry above. `executionStartTime` is taken before the inner
+       * `step.execute` span and the step context are established, and
+       * `step_prepare_ms` is documented to include exactly that setup, so
+       * anchoring T7 there would under-report both the phase and the total.
+       * TTFS/STSO keep their own anchor so this changes nothing about them.
+       *
+       * The `reported` latch makes one resumption yield one sample even
+       * though every step of an inline batch is handed the same tracking
+       * object: whichever step first reaches user code takes the
+       * measurement. Sharing it (rather than pinning the batch's first step)
+       * is what keeps the sample alive when that first step loses its atomic
+       * create-claim to a concurrent invocation while a sibling proceeds.
+       * The check-and-set is synchronous, so concurrent siblings cannot both
+       * pass it.
+       */
+      const reportResumeTtr = (): void => {
+        const tracking = params.resumeTracking;
+        if (!tracking || tracking.reported) return;
+        const attributes = computeResumeTtrAttributes({
+          tracking,
+          attempt,
+          stepClaimStartedAtMs: stepStartPostSentAtMs,
+          stepClaimCompletedAtMs,
+          stepCodeStartedAtMs: Date.now(),
+        });
+        if (!attributes) return;
+        tracking.reported = true;
+        span?.setAttributes(attributes);
+      };
+
       try {
         result = await trace('step.execute', {}, async () => {
           return await contextStorage.run(
@@ -902,7 +958,11 @@ export async function executeStep(
                 ? params.runReadyBarrier
                 : undefined,
             },
-            () => stepFn.apply(thisVal, args)
+            () => {
+              // The last instant before user code — T7 of the resume window.
+              reportResumeTtr();
+              return stepFn.apply(thisVal, args);
+            }
           );
         });
       } catch (err) {

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -491,6 +491,95 @@ export const StepResilientDispatchMaterialized = SemanticConvention<boolean>(
   'workflow.step.resilient_dispatch_materialized'
 );
 
+// Hook-triggered time-to-resume (TTR) attributes
+//
+// Set on the `step.execute <name>` span of the FIRST durable step following a
+// hook resume, and only there: one resumption produces exactly one sample, so
+// a later step in the same invocation, a retry, or a redelivery never
+// re-reports it. The phases are non-overlapping and sum exactly to
+// {@link ResumeTotalMs} — see runtime/resume-latency.ts for the boundary
+// definitions and the emission gate.
+//
+// Deliberately carries no `resumeId`, run ID, or token: the metric is meant to
+// be aggregated across every resume, and high-cardinality keys would make that
+// prohibitive. Existing trace-correlation fields on the same span are
+// unchanged and still identify the individual run.
+
+/** Total TTR: entry into `resumeHook()` → immediately before `stepFn.apply()`. */
+export const ResumeTotalMs = SemanticConvention<number>(
+  'workflow.resume.total_ms'
+);
+
+/** Phase: `resumeHook()` entry → the queue publish being requested. */
+export const ResumeProducerPrepMs = SemanticConvention<number>(
+  'workflow.resume.phase.producer_prep_ms'
+);
+
+/** Phase: queue publish requested → the final consumer's handler being entered. */
+export const ResumeQueueDeliveryMs = SemanticConvention<number>(
+  'workflow.resume.phase.queue_delivery_ms'
+);
+
+/** Phase: consumer entry → replay beginning. */
+export const ResumeSetupMs = SemanticConvention<number>(
+  'workflow.resume.phase.resume_setup_ms'
+);
+
+/** Phase: replay beginning → the next durable step being encountered. */
+export const ResumeReplayMs = SemanticConvention<number>(
+  'workflow.resume.phase.replay_ms'
+);
+
+/** Phase: step encountered → the `step_started` request beginning. */
+export const ResumeStepDispatchMs = SemanticConvention<number>(
+  'workflow.resume.phase.step_dispatch_ms'
+);
+
+/**
+ * Phase: `step_started` request beginning → its response returning. Omitted
+ * under optimistic inline start, where the claim is not awaited before the
+ * body runs and therefore has no completion instant at that point; the time
+ * is then reported entirely as {@link ResumeStepPrepareMs}.
+ */
+export const ResumeStepClaimMs = SemanticConvention<number>(
+  'workflow.resume.phase.step_claim_ms'
+);
+
+/**
+ * Phase: claim returning → immediately before `stepFn.apply()`. Deliberately
+ * includes encryption-key resolution, argument hydration, and step-context
+ * setup; `workflow.queue.deserialize_time_ms` still isolates hydration.
+ */
+export const ResumeStepPrepareMs = SemanticConvention<number>(
+  'workflow.resume.phase.step_prepare_ms'
+);
+
+/** What triggered the measured resumption. */
+export const ResumeTrigger = SemanticConvention<'hook'>(
+  'workflow.resume.trigger'
+);
+
+/** Which `resumeHook()` dispatch path produced this resume. */
+export const ResumeStrategy = SemanticConvention<'parallel' | 'sequential'>(
+  'workflow.resume.strategy'
+);
+
+/**
+ * How the consuming invocation initialized replay state. Distinct from the
+ * pre-existing {@link HookResumeSetupSource} (`workflow.resume_setup_source`,
+ * on the workflow execution span), which reports the finer-grained
+ * hoisted-write outcome; this one is the TTR dimension and shares the metric's
+ * three-value vocabulary.
+ */
+export const ResumeSetupSource = SemanticConvention<
+  'hook_preload' | 'run_started' | 'event_load'
+>('workflow.resume.setup_source');
+
+/** Whether the measured step ran in the resuming invocation or a queued one. */
+export const ResumeStepExecution = SemanticConvention<'inline' | 'dispatched'>(
+  'workflow.resume.step_execution'
+);
+
 // Webhook attributes
 
 /** Number of webhook handlers triggered */

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -216,6 +216,53 @@ export const HookResumeInputSchema = z.object({
 });
 export type HookResumeInput = z.infer<typeof HookResumeInputSchema>;
 
+/**
+ * Wall-clock boundaries of a hook-triggered resume, carried on the queue
+ * message so the SDK can report end-to-end time-to-resume (TTR) — entry into
+ * `resumeHook()` through to the first line of the next durable step — and its
+ * non-overlapping phase breakdown, as span attributes on that step's
+ * `step.execute` span. See `runtime/resume-latency.ts` in `@workflow/core`.
+ *
+ * Two groups of fields:
+ *
+ * - Producer fields (`resumeRequestedAtMs`, `queuePublishRequestedAtMs`,
+ *   `strategy`) are stamped by `resumeHook()` on the invocation message. They
+ *   ride along on a deployment-affinity re-route unchanged, so a misrouted
+ *   delivery's extra hop stays inside `queue_delivery`.
+ * - Consumer fields (`consumerStartedAtMs`, `replayStartedAtMs`,
+ *   `nextStepEncounteredAtMs`, `setupSource`) are filled in by the invocation
+ *   that replayed the resume, and ONLY when it dispatches the next durable
+ *   step to a separate queue invocation instead of running it inline. They let
+ *   that invocation report the same single TTR measurement.
+ *
+ * Every field is advisory and the whole object is optional, in all three
+ * directions that matter for a rolling deploy: a new producer's timing is
+ * ignored by an old consumer, a new consumer simply reports no TTR for an old
+ * message, and workflow-server never reads it at all.
+ *
+ * `strategy` and `setupSource` are deliberately typed as plain strings rather
+ * than enums: an unrecognized value from a newer producer must not fail the
+ * parse of the whole invocation payload (which would wedge the run) — it is
+ * only ever forwarded to a span attribute.
+ */
+export const HookResumeTimingSchema = z.object({
+  /** Epoch ms at entry into `resumeHook()` — the start of the TTR window. */
+  resumeRequestedAtMs: z.number(),
+  /** Epoch ms immediately before the queue publish was requested. */
+  queuePublishRequestedAtMs: z.number(),
+  /** Which `resumeHook()` dispatch path ran: `parallel` or `sequential`. */
+  strategy: z.string().optional(),
+  /** Epoch ms the final consumer's queue handler was entered. */
+  consumerStartedAtMs: z.number().optional(),
+  /** Epoch ms this invocation's first replay pass began. */
+  replayStartedAtMs: z.number().optional(),
+  /** Epoch ms replay first encountered a durable step after the resume. */
+  nextStepEncounteredAtMs: z.number().optional(),
+  /** How the consumer initialized replay state: see `ResumeSetupSource`. */
+  setupSource: z.string().optional(),
+});
+export type HookResumeTiming = z.infer<typeof HookResumeTimingSchema>;
+
 export const WorkflowInvokePayloadSchema = z.object({
   runId: z.string(),
   traceCarrier: TraceCarrierSchema.optional(),
@@ -259,6 +306,20 @@ export const WorkflowInvokePayloadSchema = z.object({
    * `step_created` event exists (keyed by `stepId`) before executing the step.
    */
   stepInput: StepDispatchInputSchema.optional(),
+  /**
+   * Hook-resume TTR timing. Present on both `resumeHook()` dispatch paths
+   * (unlike `hookInput`, which only rides the parallel fast path), and
+   * forwarded onto a dispatched step message when the resuming invocation
+   * hands the next durable step to another invocation. Purely observational —
+   * see {@link HookResumeTimingSchema}.
+   *
+   * `.catch(undefined)` because this field must never be able to fail the
+   * parse of the invocation payload: a malformed value (a NaN boundary, a
+   * shape change from a future producer) would otherwise throw on every
+   * delivery of that message and burn the run's delivery budget over a
+   * telemetry field. Anything unparseable degrades to "no measurement".
+   */
+  hookResumeTiming: HookResumeTimingSchema.optional().catch(undefined),
 });
 
 export type WorkflowInvokePayload = z.infer<typeof WorkflowInvokePayloadSchema>;


### PR DESCRIPTION
Adds SDK-side OTEL telemetry for hook-triggered time-to-resume, so we can see where the latency between `resumeHook()` and the next step actually goes.

`workflow.resume.total_ms` — entry into the public resume API → the first line of the next durable step — plus a non-overlapping phase breakdown that sums exactly to it:

`producer_prep` · `queue_delivery` · `resume_setup` · `replay` · `step_dispatch` · `step_claim` · `step_prepare`

Dimensioned by `trigger`, `strategy` (parallel/sequential), `setup_source`, and `step_execution` (inline/dispatched). All on the first step's `step.execute` span — one resumption, one sample.

The boundaries travel on a new optional `hookResumeTiming` field on the queue message. No workflow-server change; the field is optional in both directions and parses with `.catch(undefined)` so a malformed value can't fail a delivery. A sample is emitted only when every boundary is present, finite, and monotonic — a clock-skewed set is dropped rather than reported as a negative phase.
