### PR TITLE
chore(deps): update undici to v8

### DIFF
--- a/.changeset/eighty-cases-judge.md
+++ b/.changeset/eighty-cases-judge.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-vercel': minor
+'@workflow/world-local': minor
+---
+
+Update undici to v8, which requires Node.js 22.19 or newer.

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -140,7 +140,12 @@ export function createQueue(config: Partial<Config>): LocalQueue {
   // handler wrappers, so an unwrapped Agent fails every delivery with
   // `TypeError: fetch failed` / `invalid onRequestStart method`.
   // `Dispatcher1Wrapper` is undici's bridge for this, and forwards
-  // `close()` to the Agent it wraps.
+  // `close()` to the Agent it wraps. It is usable here because this agent is
+  // HTTP/1.1 only: the wrapper reads `controller.rawHeaders`, which the H1
+  // parser fills with the `Buffer[]` pair list a v1 handler expects but
+  // `client-h2.js` fills with a parsed object that the same handler reads no
+  // headers out of. The wrapper hides that by forcing `allowH2: false` on every
+  // dispatch, which costs nothing when the agent never wanted H2.
   const httpAgent = new Dispatcher1Wrapper(new Agent(getQueueAgentOptions()));
   const transport = new TypedJsonTransport();
   const generateId = monotonicFactory();

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -10,7 +10,7 @@ import {
 } from '@workflow/world';
 import { Sema } from 'async-sema';
 import { monotonicFactory } from 'ulid';
-import { Agent } from 'undici';
+import { Agent, Dispatcher1Wrapper } from 'undici';
 import { z } from 'zod/v4';
 import type { Config } from './config.js';
 import { resolveBaseUrl, resolveDirectBaseUrl } from './config.js';
@@ -81,6 +81,12 @@ function envTimeoutMs(name: string, fallback: number): number {
  */
 export function getQueueAgentOptions() {
   return {
+    // undici 8 negotiates HTTP/2 by default whenever the origin offers it over
+    // ALPN. Local deliveries carry the same duplex-streaming and
+    // webhook-respondWith shapes that keep world-vercel's default agent on
+    // HTTP/1.1, so this pins the pre-undici-8 transport rather than letting an
+    // https:// dev origin quietly switch protocols.
+    allowH2: false,
     bodyTimeout: envTimeoutMs(
       'WORKFLOW_LOCAL_BODY_TIMEOUT_MS',
       DEFAULT_BODY_TIMEOUT_MS
@@ -128,7 +134,14 @@ function isDetachedArrayBufferQueueError(error: unknown): boolean {
 }
 
 export function createQueue(config: Partial<Config>): LocalQueue {
-  const httpAgent = new Agent(getQueueAgentOptions());
+  // Wrapped for the global `fetch` below: that fetch belongs to the undici
+  // bundled into Node, which drives a custom dispatcher with a v1 handler
+  // (`onConnect`/`onHeaders`/`onData`/`onComplete`). undici 8 dropped the legacy
+  // handler wrappers, so an unwrapped Agent fails every delivery with
+  // `TypeError: fetch failed` / `invalid onRequestStart method`.
+  // `Dispatcher1Wrapper` is undici's bridge for this, and forwards
+  // `close()` to the Agent it wraps.
+  const httpAgent = new Dispatcher1Wrapper(new Agent(getQueueAgentOptions()));
   const transport = new TypedJsonTransport();
   const generateId = monotonicFactory();
   const semaphore = new Sema(WORKFLOW_LOCAL_QUEUE_CONCURRENCY);
@@ -231,7 +244,7 @@ export function createQueue(config: Partial<Config>): LocalQueue {
               response = await directHandler(req);
             } else {
               const baseUrl = await resolveBaseUrl(config);
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici v7 dispatcher types don't match @types/node's RequestInit
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher types don't match @types/node's RequestInit
               response = await fetch(
                 createWorkflowUrl(baseUrl, { type: 'flow' }),
                 {

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -60,6 +60,31 @@ const runningRun = {
  * (`RunExpiredError.is`, `TooEarlyError.is`, the 404 → HookNotFoundError
  * translation in events.ts) for core retry/terminal-state control flow.
  */
+/**
+ * Reads a request body as the mock hands it to a reply callback.
+ *
+ * undici 8's MockAgent consumes the outgoing body to drive the handler's
+ * body-sent hooks, then substitutes a replayable async iterable for it; undici 7
+ * passed whatever `fetch` dispatched (a `Uint8Array`) straight through. Reply
+ * callbacks therefore have to drain it, which makes them async.
+ */
+async function mockBodyBytes(rawBody: unknown): Promise<Uint8Array> {
+  if (rawBody == null) return new Uint8Array();
+  if (typeof rawBody === 'string') return new TextEncoder().encode(rawBody);
+  if (rawBody instanceof Uint8Array) return rawBody;
+  if (
+    typeof (rawBody as AsyncIterable<Uint8Array>)[Symbol.asyncIterator] ===
+    'function'
+  ) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of rawBody as AsyncIterable<Uint8Array>) {
+      chunks.push(Buffer.from(chunk));
+    }
+    return new Uint8Array(Buffer.concat(chunks));
+  }
+  return new Uint8Array(rawBody as ArrayBufferLike);
+}
+
 describe('throwForErrorResponse', () => {
   const call = (
     status: number,
@@ -832,8 +857,8 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          const bytes = new Uint8Array(opts.body as ArrayBufferLike);
+        async (opts: { body?: unknown }) => {
+          const bytes = await mockBodyBytes(opts.body);
           const metaLen = new DataView(
             bytes.buffer,
             bytes.byteOffset,
@@ -1127,8 +1152,8 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          const bytes = new Uint8Array(opts.body as ArrayBufferLike);
+        async (opts: { body?: unknown }) => {
+          const bytes = await mockBodyBytes(opts.body);
           const metaLen = new DataView(
             bytes.buffer,
             bytes.byteOffset,
@@ -1185,8 +1210,8 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          const bytes = new Uint8Array(opts.body as ArrayBufferLike);
+        async (opts: { body?: unknown }) => {
+          const bytes = await mockBodyBytes(opts.body);
           const metaLen = new DataView(
             bytes.buffer,
             bytes.byteOffset,
@@ -1245,8 +1270,8 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          const bytes = new Uint8Array(opts.body as ArrayBufferLike);
+        async (opts: { body?: unknown }) => {
+          const bytes = await mockBodyBytes(opts.body);
           const metaLen = new DataView(
             bytes.buffer,
             bytes.byteOffset,
@@ -1303,8 +1328,8 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          const bytes = new Uint8Array(opts.body as ArrayBufferLike);
+        async (opts: { body?: unknown }) => {
+          const bytes = await mockBodyBytes(opts.body);
           const metaLen = new DataView(
             bytes.buffer,
             bytes.byteOffset,
@@ -1362,11 +1387,10 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
  */
 describe('v4 POST frame meta forwards every field the splitter produces', () => {
   /** Decode `[u32_be meta_len][cbor_meta][u32_be body_len][body]`. */
-  function decodeFrameMeta(body: unknown): Record<string, unknown> {
-    const bytes =
-      body instanceof Uint8Array
-        ? body
-        : new Uint8Array(body as ArrayBufferLike);
+  async function decodeFrameMeta(
+    body: unknown
+  ): Promise<Record<string, unknown>> {
+    const bytes = await mockBodyBytes(body);
     const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     const metaLen = view.getUint32(0, false);
     return decode(bytes.subarray(4, 4 + metaLen)) as Record<string, unknown>;
@@ -1389,8 +1413,8 @@ describe('v4 POST frame meta forwards every field the splitter produces', () => 
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          captured = decodeFrameMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          captured = await decodeFrameMeta(opts.body);
           if (data.eventType !== 'run_started') {
             return createEventBody(data, { run: runningRun });
           }

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -48,11 +48,35 @@ function mockAgent() {
   return agent;
 }
 
-function decodePostedMeta(rawBody: unknown): Record<string, unknown> {
-  const bytes =
-    typeof rawBody === 'string'
-      ? new TextEncoder().encode(rawBody)
-      : new Uint8Array(rawBody as ArrayBufferLike);
+/**
+ * Reads a request body as the mock hands it to a reply callback.
+ *
+ * undici 8's MockAgent consumes the outgoing body to drive the handler's
+ * body-sent hooks, then substitutes a replayable async iterable for it; undici 7
+ * passed whatever `fetch` dispatched (a `Uint8Array`) straight through. Reply
+ * callbacks therefore have to drain it, which makes them async.
+ */
+async function mockBodyBytes(rawBody: unknown): Promise<Uint8Array> {
+  if (rawBody == null) return new Uint8Array();
+  if (typeof rawBody === 'string') return new TextEncoder().encode(rawBody);
+  if (rawBody instanceof Uint8Array) return rawBody;
+  if (
+    typeof (rawBody as AsyncIterable<Uint8Array>)[Symbol.asyncIterator] ===
+    'function'
+  ) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of rawBody as AsyncIterable<Uint8Array>) {
+      chunks.push(Buffer.from(chunk));
+    }
+    return new Uint8Array(Buffer.concat(chunks));
+  }
+  return new Uint8Array(rawBody as ArrayBufferLike);
+}
+
+async function decodePostedMeta(
+  rawBody: unknown
+): Promise<Record<string, unknown>> {
+  const bytes = await mockBodyBytes(rawBody);
   const metaLen = new DataView(
     bytes.buffer,
     bytes.byteOffset,
@@ -200,8 +224,8 @@ describe('createWorkflowRunEvent precondition snapshot wire fields', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          capturedMeta = await decodePostedMeta(opts.body);
           return runStartedResponse();
         },
         {
@@ -238,8 +262,8 @@ describe('createWorkflowRunEvent precondition snapshot wire fields', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          capturedMeta = await decodePostedMeta(opts.body);
           return runStartedResponse();
         },
         {
@@ -276,8 +300,8 @@ describe('createWorkflowRunEvent precondition snapshot wire fields', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          capturedMeta = await decodePostedMeta(opts.body);
           return runStartedResponse();
         },
         {
@@ -319,8 +343,8 @@ describe('createWorkflowRunEvent precondition snapshot wire fields', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          capturedMeta = await decodePostedMeta(opts.body);
           return runStartedResponse();
         },
         {
@@ -357,11 +381,10 @@ describe('createWorkflowRunEvent precondition snapshot wire fields', () => {
       .intercept({ path: '/api/v1/runs/wrun_legacy/events', method: 'POST' })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedBody =
-            typeof opts.body === 'string'
-              ? opts.body
-              : new TextDecoder().decode(opts.body as ArrayBufferLike);
+        async (opts: { body?: unknown }) => {
+          capturedBody = new TextDecoder().decode(
+            await mockBodyBytes(opts.body)
+          );
           return {
             eventId: 'evnt_legacy',
             runId: 'wrun_legacy',
@@ -475,8 +498,8 @@ async function postStepStartedMeta(
     })
     .reply(
       200,
-      (opts: { body?: unknown }) => {
-        capturedMeta = decodePostedMeta(opts.body);
+      async (opts: { body?: unknown }) => {
+        capturedMeta = await decodePostedMeta(opts.body);
         return createEventBody(
           {
             eventType: 'step_started',
@@ -559,8 +582,8 @@ describe('createWorkflowRunEvent replayDivergenceCount wire field', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          capturedMeta = await decodePostedMeta(opts.body);
           return createEventBody(
             {
               eventType: 'run_completed',
@@ -937,8 +960,8 @@ describe('createWorkflowRunEvent response coercion', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          capturedMeta = await decodePostedMeta(opts.body);
           return runStartedResponse();
         },
         {
@@ -1716,8 +1739,8 @@ describe('createWorkflowRunEvent hook_received replay preload', () => {
       })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
-          capturedMeta = decodePostedMeta(opts.body);
+        async (opts: { body?: unknown }) => {
+          capturedMeta = await decodePostedMeta(opts.body);
           return hookReplayStreamResponse();
         },
         {

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -77,6 +77,75 @@ describe('getDispatcher', () => {
     );
   });
 
+  // Headers and trailers reach a v1 handler by two different routes: the H1
+  // parser puts the raw `Buffer[]` on the controller, H2 has only the parsed
+  // object passed to the callback. The controller carries a separate list for
+  // each, and the response headers are still on it once the body ends, so
+  // reading the wrong one delivers headers where trailers belong.
+  it('keeps headers and trailers distinct in both dispatcher shapes', () => {
+    const drive = (
+      controller: Record<string, unknown>,
+      parsedHeaders: unknown,
+      parsedTrailers: unknown
+    ) => {
+      const seen: Record<string, unknown> = {};
+      const inner = {
+        dispatch(_opts: unknown, handler: Record<string, unknown>) {
+          (handler.onResponseStart as (...a: unknown[]) => void)(
+            controller,
+            200,
+            parsedHeaders,
+            'OK'
+          );
+          (handler.onResponseEnd as (...a: unknown[]) => void)(
+            controller,
+            parsedTrailers
+          );
+          return true;
+        },
+        close: async () => undefined,
+        destroy: async () => undefined,
+      };
+      const bridged = getDispatcher({ dispatcher: inner }) as {
+        dispatch: (o: unknown, h: unknown) => void;
+      };
+      bridged.dispatch(
+        { origin: 'https://example.test', path: '/', method: 'GET' },
+        {
+          onConnect() {},
+          onHeaders: (_s: number, raw: Buffer[]) => {
+            seen.headers = raw.map(String);
+          },
+          onData() {},
+          onComplete: (raw: Buffer[]) => {
+            seen.trailers = raw.map(String);
+          },
+          onError() {},
+        }
+      );
+      return seen;
+    };
+
+    // H1: both lists arrive on the controller.
+    expect(
+      drive(
+        {
+          rawHeaders: [Buffer.from('x-h'), Buffer.from('1')],
+          rawTrailers: [Buffer.from('x-t'), Buffer.from('2')],
+        },
+        undefined,
+        undefined
+      )
+    ).toEqual({ headers: ['x-h', '1'], trailers: ['x-t', '2'] });
+
+    // H2: neither list is on the controller, so both come from the parsed
+    // objects and have to be converted to the pair list a v1 handler reads.
+    expect(drive({}, { 'x-h': '1' }, { 'x-t': '2' })).toEqual({
+      headers: ['x-h', '1'],
+      trailers: ['x-t', '2'],
+    });
+  });
+
   // `APIConfig.dispatcher` takes an instance from any undici version, and undici
   // 6 speaks the v1 handler ABI only: it validates the handler on dispatch and
   // rejects a pure v2 one with `invalid onError method`. So the bridge emits a

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -42,8 +42,11 @@ function fakeDispatcher() {
 /**
  * A caller's dispatcher is handed to the global `fetch`, which drives it with a
  * v1 handler that undici 8 rejects, so it is bridged rather than passed through.
- * The bridge must forward to the caller's own `dispatch`, and must not leak the
- * `allowH2: false` the bridge injects (see `bridgeCallerDispatcher`).
+ * The bridge must forward to the caller's own `dispatch`, and must pass the
+ * dispatch options through untouched: nothing may rewrite the caller's protocol
+ * choice on the way down (see `bridgeCallerDispatcher`). An injected
+ * `allowH2: false` would both downgrade the caller and, under a `MockAgent`,
+ * reroute the request to a pool holding no interceptors.
  */
 function expectBridgedTo(
   resolved: unknown,
@@ -72,6 +75,51 @@ describe('getDispatcher', () => {
     expect(getDispatcher({ dispatcher: custom })).toBe(
       getDispatcher({ dispatcher: custom })
     );
+  });
+
+  // `APIConfig.dispatcher` takes an instance from any undici version, and undici
+  // 6 speaks the v1 handler ABI only: it validates the handler on dispatch and
+  // rejects a pure v2 one with `invalid onError method`. So the bridge emits a
+  // handler carrying both. Measured across undici 6, 7 and 8, exactly one ABI is
+  // driven per request and never both.
+  it('gives the caller a handler that still speaks the v1 ABI', () => {
+    const seen: unknown[] = [];
+    const v1Only = {
+      dispatch(_opts: unknown, handler: Record<string, unknown>) {
+        // undici 6's own validation, then its own callback sequence.
+        for (const name of ['onConnect', 'onHeaders', 'onData', 'onComplete']) {
+          expect(typeof handler[name]).toBe('function');
+        }
+        const raw = [Buffer.from('x-probe'), Buffer.from('yes')];
+        (handler.onConnect as () => void)();
+        (handler.onHeaders as (s: number, r: unknown) => void)(200, raw);
+        (handler.onData as (c: Buffer) => void)(Buffer.from('ok'));
+        (handler.onComplete as (t: unknown) => void)(null);
+        return true;
+      },
+      close: async () => undefined,
+      destroy: async () => undefined,
+    };
+    const bridged = getDispatcher({ dispatcher: v1Only }) as {
+      dispatch: (o: unknown, h: unknown) => void;
+    };
+    bridged.dispatch(
+      { origin: 'https://example.test', path: '/', method: 'GET' },
+      {
+        onConnect: () => seen.push('onConnect'),
+        onHeaders: (status: number, raw: Buffer[]) =>
+          seen.push(`onHeaders ${status} ${raw[0]}=${raw[1]}`),
+        onData: (chunk: Buffer) => seen.push(`onData ${chunk}`),
+        onComplete: () => seen.push('onComplete'),
+        onError: () => seen.push('onError'),
+      }
+    );
+    expect(seen).toEqual([
+      'onConnect',
+      'onHeaders 200 x-probe=yes',
+      'onData ok',
+      'onComplete',
+    ]);
   });
 });
 
@@ -260,10 +308,10 @@ TTVKDw9WMB6CyIX5kV0cOG/S8OO+1l3ZPaogkzj0P5OnJaYPvpp2kpGrlQ==
 // connect instead of silently passing.
 //
 // It has to be the production factory, not a bare Agent: the global `fetch`
-// drives its dispatcher with a v1 handler, which undici 8 only accepts through
-// `Dispatcher1Wrapper` — and that wrapper forces `allowH2: false` onto every
-// request unless the wiring in `forGlobalFetch` undoes it. A bare Agent here
-// would fail on the handler ABI long before it could catch that downgrade.
+// drives its dispatcher with a v1 handler, and an undici 8 Agent rejects that
+// handler outright. Only the bridge `forGlobalFetch` applies makes the request
+// possible at all, so a bare Agent here would fail on the handler ABI long
+// before it could say anything about the protocol.
 describe('HTTP/2 over global fetch with an undici dispatcher', () => {
   let server: Http2SecureServer;
   let port: number;
@@ -278,7 +326,11 @@ describe('HTTP/2 over global fetch with an undici dispatcher', () => {
     server.on('stream', (stream) => {
       negotiatedAlpn = (stream.session?.socket as TLSSocket | undefined)
         ?.alpnProtocol;
-      stream.respond({ ':status': 200 });
+      stream.respond({
+        ':status': 200,
+        'content-type': 'application/vnd.workflow.v4-frames',
+        'x-multi': ['a', 'b'],
+      });
       stream.end('ok');
     });
     await new Promise<void>((resolve) => {
@@ -304,11 +356,30 @@ describe('HTTP/2 over global fetch with an undici dispatcher', () => {
     expect(negotiatedAlpn).toBe('h2');
   });
 
+  // Status and body survive a broken header bridge; the headers do not. undici's
+  // own `Dispatcher1Wrapper` forwards `controller.rawHeaders` to the v1 handler,
+  // and on an H2 path that field is a plain `{ name: value }` object rather than
+  // the `Buffer[]` pair list H1 supplies, so the handler's pair-wise loop reads
+  // nothing and every response header disappears. `fetchV4` then rejects the
+  // reply for a missing `content-type`, which is what this asserts against.
+  it('preserves response headers over h2', async () => {
+    const res = await fetch(`https://127.0.0.1:${port}/`, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+      dispatcher: agent,
+    } as any);
+    await res.text();
+    expect(negotiatedAlpn).toBe('h2');
+    expect(res.headers.get('content-type')).toBe(
+      'application/vnd.workflow.v4-frames'
+    );
+    // A repeated header must stay repeated, not collapse to its first value.
+    expect(res.headers.get('x-multi')).toBe('a, b');
+  });
+
   // The same hazard from the other side: `APIConfig.dispatcher` takes an
   // undici instance the caller constructed, and a caller who installs undici
   // today gets 8, whose dispatchers reject the v1 handler global `fetch` drives
-  // them with. Unbridged, this request never settles. Stripping `allowH2` in
-  // the bridge is what keeps the caller's own H2 preference intact.
+  // them with. Unbridged, this request never settles.
   it('lets a caller-supplied undici 8 dispatcher complete a request', async () => {
     const callerAgent = new Agent({ connect: { rejectUnauthorized: false } });
     negotiatedAlpn = undefined;
@@ -320,6 +391,9 @@ describe('HTTP/2 over global fetch with an undici dispatcher', () => {
       expect(res.status).toBe(200);
       expect(await res.text()).toBe('ok');
       expect(negotiatedAlpn).toBe('h2');
+      expect(res.headers.get('content-type')).toBe(
+        'application/vnd.workflow.v4-frames'
+      );
     } finally {
       await callerAgent.close();
     }

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -22,15 +22,56 @@ import {
   STREAM_RETRY_OPTIONS,
 } from './http-client.js';
 
+/**
+ * A caller-supplied dispatcher, of the shape `APIConfig.dispatcher` documents:
+ * any object implementing the dispatcher contract, from any undici version.
+ */
+function fakeDispatcher() {
+  const seen: Array<Record<string, unknown>> = [];
+  return {
+    seen,
+    dispatch(opts: Record<string, unknown>) {
+      seen.push(opts);
+      return true;
+    },
+    close: async () => undefined,
+    destroy: async () => undefined,
+  };
+}
+
+/**
+ * A caller's dispatcher is handed to the global `fetch`, which drives it with a
+ * v1 handler that undici 8 rejects, so it is bridged rather than passed through.
+ * The bridge must forward to the caller's own `dispatch`, and must not leak the
+ * `allowH2: false` the bridge injects (see `bridgeCallerDispatcher`).
+ */
+function expectBridgedTo(
+  resolved: unknown,
+  custom: ReturnType<typeof fakeDispatcher>
+) {
+  expect(resolved).not.toBe(custom);
+  (resolved as { dispatch: (o: unknown, h: unknown) => void }).dispatch(
+    { origin: 'https://example.test', path: '/', method: 'GET' },
+    { onConnect() {}, onHeaders() {}, onData() {}, onComplete() {} }
+  );
+  expect(custom.seen).toHaveLength(1);
+  expect('allowH2' in custom.seen[0]).toBe(false);
+}
+
 describe('getDispatcher', () => {
   it('returns the shared default dispatcher when none is provided', () => {
     expect(getDispatcher()).toBe(getDispatcher());
     expect(getDispatcher({})).toBe(getDispatcher());
   });
 
-  it('returns the caller-supplied dispatcher when provided', () => {
-    const custom = {};
-    expect(getDispatcher({ dispatcher: custom })).toBe(custom);
+  it('bridges the caller-supplied dispatcher for global fetch', () => {
+    const custom = fakeDispatcher();
+    expectBridgedTo(getDispatcher({ dispatcher: custom }), custom);
+    // Stable per input: the recycler and the retry bookkeeping compare
+    // dispatchers by reference.
+    expect(getDispatcher({ dispatcher: custom })).toBe(
+      getDispatcher({ dispatcher: custom })
+    );
   });
 });
 
@@ -40,9 +81,9 @@ describe('getEventsDispatcher', () => {
     expect(getEventsDispatcher()).not.toBe(getDispatcher());
   });
 
-  it('returns the caller-supplied dispatcher when provided', () => {
-    const custom = {};
-    expect(getEventsDispatcher({ dispatcher: custom })).toBe(custom);
+  it('bridges the caller-supplied dispatcher for global fetch', () => {
+    const custom = fakeDispatcher();
+    expectBridgedTo(getEventsDispatcher({ dispatcher: custom }), custom);
   });
 });
 
@@ -53,9 +94,9 @@ describe('getStreamDispatcher', () => {
     expect(getStreamDispatcher()).not.toBe(getEventsDispatcher());
   });
 
-  it('returns the caller-supplied dispatcher when provided', () => {
-    const custom = {};
-    expect(getStreamDispatcher({ dispatcher: custom })).toBe(custom);
+  it('bridges the caller-supplied dispatcher for global fetch', () => {
+    const custom = fakeDispatcher();
+    expectBridgedTo(getStreamDispatcher({ dispatcher: custom }), custom);
   });
 
   // Stream writes (PUT) append chunks and are NOT idempotent. Retrying a write
@@ -89,8 +130,8 @@ describe('getStreamDispatcher', () => {
   it('close uses its own shared dispatcher, distinct from the write dispatcher', () => {
     expect(getStreamCloseDispatcher()).toBe(getStreamCloseDispatcher());
     expect(getStreamCloseDispatcher()).not.toBe(getStreamDispatcher());
-    const custom = {};
-    expect(getStreamCloseDispatcher({ dispatcher: custom })).toBe(custom);
+    const custom = fakeDispatcher();
+    expectBridgedTo(getStreamCloseDispatcher({ dispatcher: custom }), custom);
   });
 });
 
@@ -102,7 +143,7 @@ describe('agent transport', () => {
   // Flipping either silently would regress one side or the other.
   it('enables HTTP/2 for the events API only', () => {
     expect(EVENTS_AGENT_OPTIONS.allowH2).toBe(true);
-    expect(STREAM_AGENT_OPTIONS.allowH2).toBe(true);
+    expect(STREAM_AGENT_OPTIONS.allowH2).toBe(false);
     expect(DEFAULT_AGENT_OPTIONS.allowH2).toBe(false);
   });
 
@@ -115,12 +156,14 @@ describe('agent transport', () => {
     expect(EVENTS_AGENT_OPTIONS_NO_H2.pipelining).toBe(1);
   });
 
-  // `allowH2` alone buys nothing: undici gates in-flight requests per
-  // connection on `pipelining`, so `pipelining: 1` reduces an H2 agent to H1
-  // behavior (one stream per connection). These two constants are the
-  // difference between multiplexing and not — see EVENTS_AGENT_OPTIONS.
-  it('gives the events agent a pipelining depth that permits multiplexing', () => {
-    expect(EVENTS_AGENT_OPTIONS.pipelining).toBeGreaterThan(1);
+  // undici decides the H2 in-flight ceiling from the peer's
+  // SETTINGS_MAX_CONCURRENT_STREAMS, and `pipelining` only applies before a
+  // protocol is negotiated — where the H1 default of 1 is the value we want. A
+  // `pipelining` here would also raise H1 pipelining depth on an H2 fallback,
+  // which is exactly what DEFAULT_AGENT_OPTIONS avoids. See
+  // EVENTS_AGENT_OPTIONS; the multiplexing itself is covered end to end below.
+  it('leaves pipelining unset on the events agent', () => {
+    expect('pipelining' in EVENTS_AGENT_OPTIONS).toBe(false);
   });
 
   // Inverse guard: stream appends are not idempotent, so they must NOT
@@ -209,18 +252,23 @@ TTVKDw9WMB6CyIX5kV0cOG/S8OO+1l3ZPaogkzj0P5OnJaYPvpp2kpGrlQ==
 -----END CERTIFICATE-----`;
 
 // Proves the exact mechanism the v4 events path relies on: a request issued
-// through the *global* `fetch` with an `allowH2` undici dispatcher actually
+// through the *global* `fetch` with the real events dispatcher actually
 // negotiates HTTP/2 over ALPN. `fetchV4` (events-v4.ts) routes through global
 // `fetch` for observability instrumentation rather than `undici.request`, so we
 // verify h2 survives that route. The server only speaks h2 (allowHTTP1 left at
 // its default of false), so a client that fell back to HTTP/1.1 would fail to
 // connect instead of silently passing.
+//
+// It has to be the production factory, not a bare Agent: the global `fetch`
+// drives its dispatcher with a v1 handler, which undici 8 only accepts through
+// `Dispatcher1Wrapper` — and that wrapper forces `allowH2: false` onto every
+// request unless the wiring in `forGlobalFetch` undoes it. A bare Agent here
+// would fail on the handler ABI long before it could catch that downgrade.
 describe('HTTP/2 over global fetch with an undici dispatcher', () => {
   let server: Http2SecureServer;
   let port: number;
   let negotiatedAlpn: string | false | null | undefined;
-  const agent = new Agent({
-    allowH2: true,
+  const agent = createEventsDispatcher({
     connect: { rejectUnauthorized: false },
   });
 
@@ -255,14 +303,35 @@ describe('HTTP/2 over global fetch with an undici dispatcher', () => {
     expect(await res.text()).toBe('ok');
     expect(negotiatedAlpn).toBe('h2');
   });
+
+  // The same hazard from the other side: `APIConfig.dispatcher` takes an
+  // undici instance the caller constructed, and a caller who installs undici
+  // today gets 8, whose dispatchers reject the v1 handler global `fetch` drives
+  // them with. Unbridged, this request never settles. Stripping `allowH2` in
+  // the bridge is what keeps the caller's own H2 preference intact.
+  it('lets a caller-supplied undici 8 dispatcher complete a request', async () => {
+    const callerAgent = new Agent({ connect: { rejectUnauthorized: false } });
+    negotiatedAlpn = undefined;
+    try {
+      const res = await fetch(`https://127.0.0.1:${port}/`, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
+        dispatcher: getDispatcher({ dispatcher: callerAgent }),
+      } as any);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('ok');
+      expect(negotiatedAlpn).toBe('h2');
+    } finally {
+      await callerAgent.close();
+    }
+  });
 });
 
 // Negotiating h2 is not the same as using it. This measures the property the
 // events agent actually exists for: concurrent POSTs sharing ONE connection as
-// parallel H2 streams. It is the regression test the config-only assertions
-// above cannot be — before the pipelining + interceptor fix, `allowH2` was true
-// and ALPN was h2, yet 16 concurrent requests still produced 8 serialized
-// requests over 8 TCP connections, exactly like the H1 agent.
+// parallel H2 streams, and the inverse property for stream appends. It is the
+// regression test the config-only assertions above cannot be — a dispatcher can
+// be configured for H2, negotiate h2 over ALPN, and still serialize every
+// request behind the last one.
 describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
   const CONCURRENCY = 16;
 
@@ -297,7 +366,13 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
   }
 
   beforeAll(async () => {
-    server = createSecureServer({ key: TEST_KEY, cert: TEST_CERT });
+    // `allowHTTP1` so the same origin serves both agents: the events agent
+    // negotiates h2, the stream agent (`allowH2: false`) speaks HTTP/1.1.
+    server = createSecureServer({
+      key: TEST_KEY,
+      cert: TEST_CERT,
+      allowHTTP1: true,
+    });
     server.on('session', (session) => {
       sessions++;
       // Agents are closed while the pool still holds idle sessions; the
@@ -324,6 +399,32 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
           }
           stream.respond({ ':status': 200 });
           stream.end(path);
+        })();
+      });
+    });
+    // HTTP/1.1 requests do not surface as `stream` events. The stream-write
+    // agent lands here, and it has to observe the same barrier as the h2 path
+    // or the two branches would not be measuring the same thing.
+    server.on('request', (req, res) => {
+      // node's http2 compat layer raises `request` for h2 streams as well, which
+      // the `stream` handler above has already answered.
+      if (req.httpVersionMajor !== 1) return;
+      req.on('error', () => undefined);
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        void (async () => {
+          const path = String(req.url);
+          receivedBodies.push(Buffer.concat(chunks).toString());
+          await onArrival(path);
+          if (path.startsWith('/req-')) inFlight--;
+          if (path === '/flaky' && ++flakyAttempts === 1) {
+            res.writeHead(503);
+            res.end('retry me');
+            return;
+          }
+          res.writeHead(200);
+          res.end(path);
         })();
       });
     });
@@ -407,7 +508,10 @@ describe('HTTP/2 multiplexing (events vs stream-write agents)', () => {
     try {
       await burst(agent);
       // Bounded by the pool size, not by CONCURRENCY: each connection carries
-      // at most one append, so a reset can only ever fail one write.
+      // at most one append, so a reset can only ever fail one write. On HTTP/1.1
+      // that ceiling is `pipelining: 1` per connection; the same assertion held
+      // on H2 until undici 8 stopped gating non-idempotent requests, which is
+      // why the agent no longer offers h2 at all.
       expect(maxConcurrentStreams).toBeLessThanOrEqual(
         STREAM_AGENT_OPTIONS.connections
       );

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -679,11 +679,19 @@ function toRawHeaders(headers: Record<string, string | string[]>): Buffer[] {
 
 /**
  * Header list for a v1 handler, whichever shape the dispatcher produced: the H1
- * parser hands the raw `Buffer[]` through the controller, H2 hands a parsed
- * object as the `onResponseStart` argument.
+ * parser exposes the raw `Buffer[]` on the controller, while H2 has only the
+ * parsed object passed as the callback argument. `field` selects which of the
+ * controller's two lists applies, since headers and trailers each have their own
+ * and the response headers stay on the controller after the body ends.
  */
-function rawHeadersFor(controller: unknown, parsed: unknown): unknown {
-  const fromController = (controller as { rawHeaders?: unknown })?.rawHeaders;
+function rawHeadersFor(
+  controller: unknown,
+  parsed: unknown,
+  field: 'rawHeaders' | 'rawTrailers' = 'rawHeaders'
+): unknown {
+  const fromController = (controller as Record<string, unknown> | undefined)?.[
+    field
+  ];
   if (Array.isArray(fromController)) return fromController;
   return toRawHeaders((parsed ?? {}) as Record<string, string | string[]>);
 }
@@ -749,7 +757,7 @@ function wrapV1Handler(handler: V1Handler): Dispatcher.DispatchHandler {
       if (handler.onData?.(chunk) === false) controller.pause();
     },
     onResponseEnd(controller, trailers) {
-      handler.onComplete?.(rawHeadersFor(controller, trailers));
+      handler.onComplete?.(rawHeadersFor(controller, trailers, 'rawTrailers'));
     },
     onResponseError(_controller, error) {
       if (!handler.onError) throw error;

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -343,11 +343,11 @@ export function bufferStreamedBodyInterceptor(
         // error, so the awaiting fetch() rejects instead of hanging.
         //
         // `onResponseError` is the v2 handler callback. undici 8 removed the
-        // legacy handler wrappers, and because the composed dispatcher is
-        // wrapped in `Dispatcher1Wrapper` (see forGlobalFetch) that bridge sits
-        // *outside* this interceptor — so the handler arriving here is always v2
-        // and the v7-era `onError` no longer exists on it. Calling the old name
-        // would be a silent no-op and hang the awaiting fetch() forever.
+        // legacy handler wrappers, and the v1 bridge sits *outside* this
+        // interceptor (see forGlobalFetch), so the handler arriving here is
+        // always v2 and the v7-era `onError` no longer exists on it. Calling the
+        // old name would be a silent no-op and hang the awaiting fetch()
+        // forever.
         //
         // The failure happened before anything was dispatched, so there is no
         // real controller to hand over; a never-aborted stub satisfies the
@@ -824,8 +824,9 @@ function bridgeV1Handler<T>(dispatcher: T): T {
  * A v8 one handed straight to global `fetch` hangs forever (see
  * `forGlobalFetch`), and undici 8 is now what a caller who installs `undici`
  * alongside this package gets, so the bridge has to be applied here too. It is
- * safe for older dispatchers as well: undici 6/7 dispatchers accept the v2
- * handler the bridge produces.
+ * safe for older dispatchers as well, which is why the handler it produces
+ * carries the v1 callbacks alongside the v2 ones: undici 7 takes the v2 ones,
+ * and undici 6, which knows only v1, takes the v1 ones (see `wrapV1Handler`).
  *
  * Memoized because the recycler and the retry bookkeeping compare dispatchers by
  * reference, and a caller may pass the same instance to many calls.

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -1,4 +1,10 @@
-import { Agent, type Dispatcher, RetryAgent, type RetryHandler } from 'undici';
+import {
+  Agent,
+  type Dispatcher,
+  Dispatcher1Wrapper,
+  RetryAgent,
+  type RetryHandler,
+} from 'undici';
 import type { APIConfig } from './utils.js';
 
 let _dispatcher: RetryAgent | undefined;
@@ -15,21 +21,6 @@ const BASE_AGENT_OPTIONS = {
   connections: 8,
   keepAliveTimeout: 10_000,
 };
-
-/**
- * In-flight H2 streams allowed per connection. Matches undici's
- * `maxConcurrentStreams` default (100), which is the real ceiling once the
- * server's SETTINGS_MAX_CONCURRENT_STREAMS is known — so this only has to be
- * large enough not to be the binding constraint. The Vercel edge advertises
- * SETTINGS_MAX_CONCURRENT_STREAMS 160, so it isn't.
- *
- * Note that undici's `maxConcurrentStreams` *option* is not this gate: it only
- * seeds `peerMaxConcurrentStreams` at connect time and is then overwritten by
- * the server's SETTINGS. Raising it is inert — measured at ±1.6% (inside a 6.1%
- * noise floor) across every workload shape. `pipelining` is the only knob that
- * actually gates in-flight streams; see EVENTS_AGENT_OPTIONS.
- */
-const H2_MAX_IN_FLIGHT_STREAMS = 100;
 
 /**
  * H2 *receive* flow-control windows for the events agent, in bytes.
@@ -51,6 +42,15 @@ const H2_MAX_IN_FLIGHT_STREAMS = 100;
  * Measured against a loopback H2 origin mirroring the edge's SETTINGS at 10 ms
  * RTT, these cut read wall time by 76–86% versus undici's defaults across 1, 4
  * and 32 concurrent reads, against noise floors of 0.3–3.9%.
+ *
+ * These are set through the flat `initialWindowSize`/`connectionWindowSize`
+ * options even though undici 8.10 marks them `@deprecated` in favour of
+ * `h2Options`. The replacement the deprecation names does not work: undici reads
+ * `h2Options.initialWindowSize`, while it *validates* — and its types document —
+ * `h2Options.settings.initialWindowSize`, so the documented spelling is accepted
+ * and then silently ignored. Measured against a loopback H2 origin, the flat
+ * option puts 4 MiB on the wire and `h2Options.settings.initialWindowSize` leaves
+ * the server seeing undici's 256 KiB default. Revisit once upstream aligns them.
  *
  * Sizing: the stream window is what binds a single read, and 4 MiB captures that
  * win in full (a 4 MiB page goes from 216 ms to 17 ms; 2 MiB only reaches 29 ms).
@@ -104,29 +104,26 @@ export const DEFAULT_AGENT_OPTIONS = {
  * Re-enabling H2 more broadly is gated on resolving those issues (notably the
  * earlier SvelteKit-on-Vercel-prod hang).
  *
- * `pipelining` must be set for H2 to multiplex at all. undici gates in-flight
- * requests per connection on `getPipelining(client)`, which reads
- * `client[kPipelining] ?? httpContext.defaultPipelining ?? 1`. `client-h2.js`
- * sets `defaultPipelining: Infinity`, but the Client constructor coerces
- * `pipelining` to a number (`pipelining != null ? pipelining : 1`), so
- * `kPipelining` is never nullish and H2's Infinity is unreachable — leaving one
- * in-flight stream per connection. Before this was set, the H2 agent behaved
- * byte-for-byte like the H1 agent: 16 concurrent requests produced 8 in-flight
- * requests over 8 TCP connections. See nodejs/undici#4143.
+ * `pipelining` is deliberately not set. undici picks the per-connection
+ * in-flight ceiling protocol-aware (`getMaxConcurrent` in `client.js`): on H2 it
+ * is the peer's SETTINGS_MAX_CONCURRENT_STREAMS, and `pipelining` only applies
+ * before a protocol has been negotiated, where the H1 default of 1 is the safe
+ * value. The Vercel edge advertises SETTINGS_MAX_CONCURRENT_STREAMS 160, so the
+ * ceiling is not the binding constraint. Measured against a loopback H2 origin,
+ * 16 concurrent requests run as 16 parallel streams on one connection with no
+ * `pipelining` set at all.
  *
  * Multiplexing interacts with flow control, which is why the receive windows are
- * raised here too. Concentrating N streams onto one connection makes them share
- * that connection's single receive window, so the download side gets *worse* as
+ * raised here. Concentrating N streams onto one connection makes them share that
+ * connection's single receive window, so the download side gets *worse* as
  * multiplexing improves unless the window grows with it: at 32 concurrent reads,
- * `pipelining: 1` measured 70% faster than `pipelining: 100` on downloads purely
- * because spreading streams over 8 connections gave them 8 separate windows.
- * Raising the windows removes that trade-off — the multiplexed agent then beats
- * both.
+ * one-stream-per-connection measured 70% faster than multiplexing purely because
+ * spreading streams over 8 connections gave them 8 separate windows. Raising the
+ * windows removes that trade-off — the multiplexed agent then beats both.
  */
 export const EVENTS_AGENT_OPTIONS = {
   ...BASE_AGENT_OPTIONS,
   allowH2: true,
-  pipelining: H2_MAX_IN_FLIGHT_STREAMS,
   initialWindowSize: H2_STREAM_WINDOW_BYTES,
   connectionWindowSize: H2_CONNECTION_WINDOW_BYTES,
 } as const;
@@ -154,28 +151,35 @@ export const EVENTS_AGENT_OPTIONS_NO_H2 = {
 } as const;
 
 /**
- * Options for the stream write/close Agents. H2 is enabled (these send a
- * fully-buffered body, or none, so they avoid the duplex-streaming issues that
- * keep the long-lived live-read on plain `fetch`), but multiplexing is
- * deliberately left OFF — `pipelining: 1`, one in-flight request per
- * connection.
+ * Options for the stream write/close Agents. Multiplexing is deliberately OFF:
+ * one in-flight request per connection, so at most `connections` appends are
+ * ever exposed to a single transport failure.
  *
  * Stream appends are not idempotent. Multiplexing N appends onto one connection
- * makes a single RST_STREAM / GOAWAY / socket reset fail all N at once, and
+ * makes a single GOAWAY / socket reset fail all N at once, and
  * STREAM_RETRY_OPTIONS retries PUT on exactly those transient `errorCodes` — so
  * a connection-level blip would resend chunks the server may already have
- * applied and duplicate them. Serializing keeps the existing
- * one-request-per-connection failure isolation that policy was written against.
+ * applied and duplicate them. One request per connection keeps the failure
+ * isolation that policy was written against.
  *
- * Note this is currently belt-and-braces: undici's H2 `busy()` check already
- * serializes non-idempotent requests (`client-h2.js`: `if
- * (request.idempotent === false) return true`), so PUTs would not multiplex even
- * at a higher pipelining value. Setting it explicitly means the safety property
- * does not silently depend on that upstream detail.
+ * `pipelining: 1` alone no longer buys that on H2. It used to: undici's H2
+ * `busy()` check reported the connection busy for any non-idempotent request, so
+ * PUTs serialized regardless. undici 8 dropped that gate on purpose ("HTTP/2
+ * multiplexes requests on independent streams, so non-idempotent requests can be
+ * dispatched concurrently") and made the H2 in-flight ceiling the peer's
+ * SETTINGS_MAX_CONCURRENT_STREAMS rather than `pipelining`. Measured against a
+ * loopback H2 origin, 16 concurrent appends went from 1 to 16 in flight on one
+ * connection. There is no client-side option that caps it back: the
+ * `maxConcurrentStreams` option only seeds `peerMaxConcurrentStreams` and is
+ * overwritten by the server's SETTINGS.
+ *
+ * So H2 is off here. These requests send a fully-buffered body or none, so H2 was
+ * safe for them, but with multiplexing suppressed it was never doing anything the
+ * H1 agent does not — the events agent is where H2 earns its place.
  */
 export const STREAM_AGENT_OPTIONS = {
   ...BASE_AGENT_OPTIONS,
-  allowH2: true,
+  allowH2: false,
   pipelining: 1,
 } as const;
 
@@ -270,39 +274,49 @@ function contentLength(headers: unknown): number {
 }
 
 /**
- * Undici interceptor that lets the events API actually multiplex over H2.
- *
- * `pipelining` (see EVENTS_AGENT_OPTIONS) is necessary but not sufficient:
- * undici's H2 `busy()` check reports the connection busy — serializing the
- * request behind whatever is in flight — for two more reasons, both of which
- * every events request trips.
- *
- * 1. Non-idempotent method. `client-h2.js` returns busy when
- *    `request.idempotent === false`, and undici only treats GET/HEAD as
- *    idempotent by default (`core/request.js`), so every event-write POST
- *    serializes. We mark them idempotent for *concurrency* purposes only: in
- *    undici 7 the flag feeds nothing but the H1/H2 `busy()` gates — it does not
- *    cause resends. Retries are governed solely by RetryAgent, whose
- *    `methods` default (`['GET','HEAD','OPTIONS','PUT','DELETE','TRACE']`)
- *    excludes POST, so an event write is still never replayed. See
- *    nodejs/undici#5390.
- *
- * 2. Streamed request body. `client-h2.js` also returns busy for a body that is
- *    a stream / async iterable, because such a body can error mid-flight and
- *    take unrelated in-flight requests down with it. events-v4 hands us a fully
- *    materialized `Uint8Array`, but it dispatches through the global `fetch`
- *    (deliberately — that is what keeps v4 traffic visible in Vercel's outgoing
- *    -requests view, see events-v4.ts), and `fetch` converts every body into an
- *    async iterable on the way down. Draining it back into a Buffer restores the
- *    buffered-body shape undici needs, at the cost of one copy of an
- *    already-in-memory payload. Bodies without a usable `content-length`, or
- *    above H2_REBUFFER_MAX_BYTES, are passed through untouched (and stay
- *    serialized) rather than buffered blind.
- *
- * Without both of these, `pipelining` alone leaves the events agent at one
- * in-flight request per connection.
+ * Stand-in `DispatchController` for reporting an error that occurred before the
+ * request was dispatched, so there is no controller undici created for it. Only
+ * the error itself is consumed in that path (the v1 bridge rejects the awaiting
+ * `fetch()` with it); the accessors exist to satisfy the interface.
  */
-export function h2MultiplexInterceptor(
+const NULL_DISPATCH_CONTROLLER: Dispatcher.DispatchController = {
+  get aborted() {
+    return false;
+  },
+  get paused() {
+    return false;
+  },
+  get reason() {
+    return null;
+  },
+  abort: () => undefined,
+  pause: () => undefined,
+  resume: () => undefined,
+};
+
+/**
+ * Undici interceptor that turns a streamed events-API request body back into a
+ * Buffer before it is dispatched, so a retry can resend it.
+ *
+ * events-v4 hands us a fully materialized `Uint8Array`, but it dispatches
+ * through the global `fetch` (deliberately — that is what keeps v4 traffic
+ * visible in Vercel's outgoing-requests view, see events-v4.ts), and `fetch`
+ * converts every body into an async iterable on the way down. An async iterable
+ * can only be consumed once, so when RetryAgent re-dispatches on a 5xx the body
+ * is already exhausted: measured against a loopback H2 origin, the retry aborts
+ * the request with `NGHTTP2_PROTOCOL_ERROR` instead of resending. Draining the
+ * body into a Buffer first costs one copy of an already-in-memory payload and
+ * makes the retry byte-identical. Bodies without a usable `content-length`, or
+ * above H2_REBUFFER_MAX_BYTES, are passed through untouched rather than buffered
+ * blind.
+ *
+ * This used to also be what made the events path multiplex, by marking requests
+ * `idempotent` so undici's H2 `busy()` gate would not serialize them behind each
+ * other. undici 8 dispatches non-idempotent requests (nodejs/undici#5391) and
+ * stream-bodied requests (nodejs/undici#5538) concurrently on its own, so that
+ * part is gone and requests are no longer relabelled.
+ */
+export function bufferStreamedBodyInterceptor(
   dispatch: Dispatcher['dispatch']
 ): Dispatcher['dispatch'] {
   return (opts, handler) => {
@@ -317,26 +331,34 @@ export function h2MultiplexInterceptor(
     const length = contentLength(opts.headers);
 
     if (!isAsyncIterable || !(length >= 0) || length > H2_REBUFFER_MAX_BYTES) {
-      return dispatch({ ...opts, idempotent: true }, handler);
+      return dispatch(opts, handler);
     }
 
     // Drain asynchronously, then dispatch. Returning `true` reports "no
-    // backpressure", which is accurate: the request is accepted, and the pool
-    // gate we are lifting is exactly the one that would have reported drain.
+    // backpressure", which is accurate: the request is accepted, and the drain
+    // is bounded by H2_REBUFFER_MAX_BYTES.
     void (async () => {
       try {
         const chunks: Buffer[] = [];
         for await (const chunk of body as AsyncIterable<Uint8Array>) {
           chunks.push(Buffer.from(chunk));
         }
-        dispatch(
-          { ...opts, body: Buffer.concat(chunks), idempotent: true },
-          handler
-        );
+        dispatch({ ...opts, body: Buffer.concat(chunks) }, handler);
       } catch (error) {
         // Surface a drain failure the way undici would have surfaced a body
         // error, so the awaiting fetch() rejects instead of hanging.
-        handler.onError?.(error as Error);
+        //
+        // `onResponseError` is the v2 handler callback. undici 8 removed the
+        // legacy handler wrappers, and because the composed dispatcher is
+        // wrapped in `Dispatcher1Wrapper` (see forGlobalFetch) that bridge sits
+        // *outside* this interceptor — so the handler arriving here is always v2
+        // and the v7-era `onError` no longer exists on it. Calling the old name
+        // would be a silent no-op and hang the awaiting fetch() forever.
+        //
+        // The failure happened before anything was dispatched, so there is no
+        // real controller to hand over; a never-aborted stub satisfies the
+        // signature without pretending the request reached the wire.
+        handler.onResponseError?.(NULL_DISPATCH_CONTROLLER, error as Error);
       }
     })();
     return true;
@@ -523,7 +545,9 @@ export function noteEventsTransportOutcome(
  * shared default agent (HTTP/1.1).
  */
 export function getDispatcher(config?: APIConfig): unknown {
-  return config?.dispatcher ?? getDefaultDispatcher();
+  if (config?.dispatcher != null)
+    return bridgeCallerDispatcher(config.dispatcher);
+  return getDefaultDispatcher();
 }
 
 /**
@@ -537,7 +561,9 @@ export function getDispatcher(config?: APIConfig): unknown {
  * returned value.
  */
 export function getEventsDispatcher(config?: APIConfig): unknown {
-  return config?.dispatcher ?? eventsRecycler.get();
+  if (config?.dispatcher != null)
+    return bridgeCallerDispatcher(config.dispatcher);
+  return eventsRecycler.get();
 }
 
 /**
@@ -548,7 +574,9 @@ export function getEventsDispatcher(config?: APIConfig): unknown {
  * 5xx — chosen because stream appends are not idempotent.
  */
 export function getStreamDispatcher(config?: APIConfig): unknown {
-  return config?.dispatcher ?? getDefaultStreamDispatcher();
+  if (config?.dispatcher != null)
+    return bridgeCallerDispatcher(config.dispatcher);
+  return getDefaultStreamDispatcher();
 }
 
 /**
@@ -557,7 +585,138 @@ export function getStreamDispatcher(config?: APIConfig): unknown {
  * (see STREAM_CLOSE_RETRY_OPTIONS), unlike chunk appends.
  */
 export function getStreamCloseDispatcher(config?: APIConfig): unknown {
-  return config?.dispatcher ?? getDefaultStreamCloseDispatcher();
+  if (config?.dispatcher != null)
+    return bridgeCallerDispatcher(config.dispatcher);
+  return getDefaultStreamCloseDispatcher();
+}
+
+/**
+ * Makes a dispatcher usable as the `dispatcher` option of the *global* `fetch`.
+ *
+ * Every request in this package goes through global `fetch` (see `makeRequest`
+ * in http-core.ts, and `fetchV4` in events-v4.ts — v4 does so deliberately, to
+ * stay visible in Vercel's outgoing-requests view). That `fetch` belongs to the
+ * undici bundled into Node, not to the undici in our dependencies, and it drives
+ * a custom dispatcher with a *v1* handler (`onConnect`/`onHeaders`/`onData`/
+ * `onComplete`/`onError`).
+ *
+ * undici 8 removed the legacy handler wrappers that used to accept such a
+ * handler, and the two failure modes are both silent-to-severe:
+ *  - a bare `Agent` rejects the request with `TypeError: fetch failed`, cause
+ *    `invalid onRequestStart method`;
+ *  - a `RetryAgent` (or a composed dispatcher) never calls any callback the v1
+ *    handler implements, so `fetch()` simply *never settles* — every request
+ *    hangs until the caller's own timeout.
+ *
+ * `Dispatcher1Wrapper` is undici's supported bridge for exactly this: it accepts
+ * the v1 handler and translates to the v2 callbacks the v8 dispatcher emits. It
+ * must be the outermost layer, which is why it is applied here rather than
+ * inside `compose()`.
+ *
+ * It also forces `allowH2: false` onto every request it forwards, because a v1
+ * handler cannot carry a WebSocket upgrade over H2 (nodejs/undici#4989), and the
+ * Agent honours that per-request: `opts.allowH2 === false` routes to a separate
+ * `${origin}#http1-only` pool. Left in place that would silently downgrade the
+ * events path to HTTP/1.1 and undo the multiplexing and flow-control work these
+ * agents exist for — ALPN would negotiate `http/1.1` while every option here
+ * still said H2. `restoreH2` deletes the injected flag again on the way down.
+ * That is safe for these dispatchers specifically: they only ever carry plain
+ * request/response traffic, and the WebSocket transport (events-v4-ws.ts) does
+ * not run through them.
+ *
+ * Wrapping is done once per dispatcher, at construction, because
+ * `DispatcherRecycler.note()` identifies the dispatcher a request used by
+ * reference — a wrapper minted per request would never match.
+ *
+ * `interceptors` are composed underneath the bridge, so they observe the v2
+ * handler the bridge produces. The composed dispatcher goes through
+ * `withBoundLifecycle` because `compose()` returns a Proxy whose `close()` is
+ * broken, and `Dispatcher1Wrapper` forwards `close()`/`destroy()` straight
+ * through to whatever it wraps.
+ */
+function forGlobalFetch(
+  dispatcher: RetryAgent,
+  ...interceptors: Array<Dispatcher.DispatcherComposeInterceptor>
+): RetryAgent {
+  // `compose` applies left to right, so `restoreH2` last makes it outermost.
+  const composed = dispatcher.compose(
+    ...interceptors,
+    restoreH2
+  ) as unknown as RetryAgent;
+  return new Dispatcher1Wrapper(
+    withBoundLifecycle(dispatcher, composed)
+  ) as unknown as RetryAgent;
+}
+
+/**
+ * Drops the `allowH2: false` that `Dispatcher1Wrapper` injects, so the agent's
+ * own `allowH2` decides the protocol. Deleting the key rather than setting it to
+ * `true` keeps `DEFAULT_AGENT_OPTIONS`/`EVENTS_AGENT_OPTIONS_NO_H2` on HTTP/1.1.
+ */
+function restoreH2(dispatch: Dispatcher['dispatch']): Dispatcher['dispatch'] {
+  return (opts, handler) => {
+    const { allowH2: _injected, ...rest } =
+      opts as Dispatcher.DispatchOptions & {
+        allowH2?: boolean;
+      };
+    return dispatch(rest, handler);
+  };
+}
+
+/**
+ * Same bridge as `forGlobalFetch`, for a dispatcher supplied by the caller
+ * through `APIConfig.dispatcher`.
+ *
+ * That option is documented as accepting a dispatcher from any undici version.
+ * A v8 one handed straight to global `fetch` hangs forever (see
+ * `forGlobalFetch`), and undici 8 is now what a caller who installs `undici`
+ * alongside this package gets, so the bridge has to be applied here too. It is
+ * safe for older dispatchers as well: undici 6/7 dispatchers accept the v2
+ * handler the bridge produces.
+ *
+ * `allowH2` is stripped for the same reason as in `restoreH2`, and it matters
+ * more here: an undici `MockAgent` keys its interceptors off the pool the inner
+ * Agent selects, and the injected flag sends the request to a separate
+ * `${origin}#http1-only` pool that holds no interceptors, so mocked requests
+ * escape to the network instead of being intercepted.
+ *
+ * Memoized because the recycler and the retry bookkeeping compare dispatchers by
+ * reference, and a caller may pass the same instance to many calls.
+ */
+const bridgedCallerDispatchers = new WeakMap<object, unknown>();
+
+function bridgeCallerDispatcher(dispatcher: unknown): unknown {
+  if (
+    dispatcher == null ||
+    typeof dispatcher !== 'object' ||
+    dispatcher instanceof Dispatcher1Wrapper
+  ) {
+    return dispatcher;
+  }
+  const cached = bridgedCallerDispatchers.get(dispatcher);
+  if (cached !== undefined) return cached;
+
+  const inner = dispatcher as Dispatcher;
+  const bridged = new Dispatcher1Wrapper({
+    dispatch(opts: Dispatcher.DispatchOptions, handler: unknown) {
+      const { allowH2: _injected, ...rest } =
+        opts as Dispatcher.DispatchOptions & {
+          allowH2?: boolean;
+        };
+      return (
+        inner.dispatch as unknown as (
+          o: Dispatcher.DispatchOptions,
+          h: unknown
+        ) => boolean
+      ).call(inner, rest, handler);
+    },
+    close: (...args: unknown[]) =>
+      (inner.close as (...a: unknown[]) => unknown).apply(inner, args),
+    destroy: (...args: unknown[]) =>
+      (inner.destroy as (...a: unknown[]) => unknown).apply(inner, args),
+  } as unknown as Dispatcher);
+  bridgedCallerDispatchers.set(dispatcher, bridged);
+  return bridged;
 }
 
 /** Build a shared undici RetryAgent wrapping an Agent with the given options. */
@@ -565,7 +724,7 @@ function makeRetryDispatcher(
   agentOptions: typeof DEFAULT_AGENT_OPTIONS,
   retryOptions: RetryHandler.RetryOptions
 ): RetryAgent {
-  return new RetryAgent(new Agent(agentOptions), retryOptions);
+  return forGlobalFetch(new RetryAgent(new Agent(agentOptions), retryOptions));
 }
 
 /**
@@ -587,7 +746,7 @@ export function createEventsDispatcher(
     RETRY_AGENT_OPTIONS
   );
   if (!h2) {
-    return agent;
+    return forGlobalFetch(agent);
   }
   // The interceptor wraps the RetryAgent (rather than the Agent inside it) so
   // that retries re-send the *drained* body. RetryHandler captures its own copy
@@ -596,10 +755,7 @@ export function createEventsDispatcher(
   // copy would wrap the stream the interceptor is about to consume, so a retry
   // would re-iterate an exhausted stream and send an empty body. Composed
   // outside, RetryHandler captures the Buffer and replays it verbatim.
-  return withBoundLifecycle(
-    agent,
-    agent.compose(h2MultiplexInterceptor) as unknown as RetryAgent
-  );
+  return forGlobalFetch(agent, bufferStreamedBodyInterceptor);
 }
 
 /**
@@ -633,9 +789,11 @@ export function createStreamDispatcher(
   retryOptions: RetryHandler.RetryOptions,
   agentOverrides?: Partial<Agent.Options>
 ): RetryAgent {
-  return new RetryAgent(
-    new Agent({ ...STREAM_AGENT_OPTIONS, ...agentOverrides }),
-    retryOptions
+  return forGlobalFetch(
+    new RetryAgent(
+      new Agent({ ...STREAM_AGENT_OPTIONS, ...agentOverrides }),
+      retryOptions
+    )
   );
 }
 

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -1,10 +1,4 @@
-import {
-  Agent,
-  type Dispatcher,
-  Dispatcher1Wrapper,
-  RetryAgent,
-  type RetryHandler,
-} from 'undici';
+import { Agent, Dispatcher, RetryAgent, type RetryHandler } from 'undici';
 import type { APIConfig } from './utils.js';
 
 let _dispatcher: RetryAgent | undefined;
@@ -608,21 +602,27 @@ export function getStreamCloseDispatcher(config?: APIConfig): unknown {
  *    handler implements, so `fetch()` simply *never settles* — every request
  *    hangs until the caller's own timeout.
  *
- * `Dispatcher1Wrapper` is undici's supported bridge for exactly this: it accepts
- * the v1 handler and translates to the v2 callbacks the v8 dispatcher emits. It
- * must be the outermost layer, which is why it is applied here rather than
- * inside `compose()`.
+ * `bridgeV1Handler` translates the v1 handler into the v2 callbacks the v8
+ * dispatcher emits. It must be the outermost layer, which is why it is applied
+ * here rather than inside `compose()`.
  *
- * It also forces `allowH2: false` onto every request it forwards, because a v1
- * handler cannot carry a WebSocket upgrade over H2 (nodejs/undici#4989), and the
- * Agent honours that per-request: `opts.allowH2 === false` routes to a separate
- * `${origin}#http1-only` pool. Left in place that would silently downgrade the
- * events path to HTTP/1.1 and undo the multiplexing and flow-control work these
- * agents exist for — ALPN would negotiate `http/1.1` while every option here
- * still said H2. `restoreH2` deletes the injected flag again on the way down.
- * That is safe for these dispatchers specifically: they only ever carry plain
- * request/response traffic, and the WebSocket transport (events-v4-ws.ts) does
- * not run through them.
+ * undici ships its own bridge for this, `Dispatcher1Wrapper`, and it cannot be
+ * used on an H2 path. It forwards `controller.rawHeaders` to `onHeaders`, which
+ * the H1 parser sets to the raw `Buffer[]` a v1 handler expects, but which
+ * `client-h2.js` sets to a plain `{ name: value }` object. That object has no
+ * `.length`, so the pair-wise loop in `fetch`'s v1 handler reads zero headers and
+ * the response arrives with an empty `Headers` and the right status and body.
+ * Measured against a loopback H2 origin: `content-type` and every other response
+ * header disappear. undici's wrapper compensates by forcing `allowH2: false` onto
+ * every request (a v1 handler also cannot carry a WebSocket upgrade over H2,
+ * nodejs/undici#4989), and the Agent honours that per request by routing to a
+ * separate `${origin}#http1-only` pool. Accepting that would downgrade the events
+ * path to HTTP/1.1 and undo the multiplexing and flow-control work these agents
+ * exist for, with ALPN negotiating `http/1.1` while every option here still said
+ * H2. The bridge below instead normalizes the header shape and leaves `allowH2`
+ * alone. That is safe for these dispatchers specifically: they only ever carry
+ * plain request/response traffic, and the WebSocket transport (events-v4-ws.ts)
+ * does not run through them.
  *
  * Wrapping is done once per dispatcher, at construction, because
  * `DispatcherRecycler.note()` identifies the dispatcher a request used by
@@ -631,36 +631,181 @@ export function getStreamCloseDispatcher(config?: APIConfig): unknown {
  * `interceptors` are composed underneath the bridge, so they observe the v2
  * handler the bridge produces. The composed dispatcher goes through
  * `withBoundLifecycle` because `compose()` returns a Proxy whose `close()` is
- * broken, and `Dispatcher1Wrapper` forwards `close()`/`destroy()` straight
- * through to whatever it wraps.
+ * broken, and the bridge forwards `close()`/`destroy()` straight through to
+ * whatever it wraps.
  */
 function forGlobalFetch(
   dispatcher: RetryAgent,
   ...interceptors: Array<Dispatcher.DispatcherComposeInterceptor>
 ): RetryAgent {
-  // `compose` applies left to right, so `restoreH2` last makes it outermost.
-  const composed = dispatcher.compose(
-    ...interceptors,
-    restoreH2
-  ) as unknown as RetryAgent;
-  return new Dispatcher1Wrapper(
-    withBoundLifecycle(dispatcher, composed)
-  ) as unknown as RetryAgent;
+  const composed = dispatcher.compose(...interceptors) as unknown as RetryAgent;
+  return bridgeV1Handler(withBoundLifecycle(dispatcher, composed));
+}
+
+interface V1Handler {
+  onConnect?: (abort: (reason?: Error) => void, context?: unknown) => void;
+  onHeaders?: (
+    statusCode: number,
+    rawHeaders: unknown,
+    resume: () => void,
+    statusText?: string
+  ) => boolean | void;
+  onData?: (chunk: Buffer) => boolean | void;
+  onComplete?: (rawTrailers: unknown) => void;
+  onError?: (error: Error) => void;
+  onUpgrade?: (
+    statusCode: number,
+    rawHeaders: unknown,
+    socket: unknown
+  ) => void;
+  onBodySent?: (chunk: unknown) => void;
+  onRequestSent?: () => void;
+  onResponseStarted?: () => void;
 }
 
 /**
- * Drops the `allowH2: false` that `Dispatcher1Wrapper` injects, so the agent's
- * own `allowH2` decides the protocol. Deleting the key rather than setting it to
- * `true` keeps `DEFAULT_AGENT_OPTIONS`/`EVENTS_AGENT_OPTIONS_NO_H2` on HTTP/1.1.
+ * The `Buffer[]` pair list a v1 handler parses headers out of. Mirrors undici's
+ * internal `toRawHeaders`, which is not exported.
  */
-function restoreH2(dispatch: Dispatcher['dispatch']): Dispatcher['dispatch'] {
-  return (opts, handler) => {
-    const { allowH2: _injected, ...rest } =
-      opts as Dispatcher.DispatchOptions & {
-        allowH2?: boolean;
-      };
-    return dispatch(rest, handler);
-  };
+function toRawHeaders(headers: Record<string, string | string[]>): Buffer[] {
+  const raw: Buffer[] = [];
+  for (const [name, value] of Object.entries(headers)) {
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      raw.push(Buffer.from(name, 'latin1'), Buffer.from(`${entry}`, 'latin1'));
+    }
+  }
+  return raw;
+}
+
+/**
+ * Header list for a v1 handler, whichever shape the dispatcher produced: the H1
+ * parser hands the raw `Buffer[]` through the controller, H2 hands a parsed
+ * object as the `onResponseStart` argument.
+ */
+function rawHeadersFor(controller: unknown, parsed: unknown): unknown {
+  const fromController = (controller as { rawHeaders?: unknown })?.rawHeaders;
+  if (Array.isArray(fromController)) return fromController;
+  return toRawHeaders((parsed ?? {}) as Record<string, string | string[]>);
+}
+
+const V1_CALLBACKS = [
+  'onConnect',
+  'onHeaders',
+  'onData',
+  'onComplete',
+  'onError',
+  'onUpgrade',
+] as const;
+
+/**
+ * Adapts a v1 handler to the v2 callbacks an undici 8 dispatcher emits, while
+ * keeping the v1 callbacks on the same object.
+ *
+ * `APIConfig.dispatcher` accepts an instance from any undici version, and undici
+ * 6 knows only the v1 ABI: it validates the handler on dispatch and rejects a
+ * pure v2 one with `invalid onError method`. Measured across 6, 7 and 8, a
+ * handler carrying both ABIs is driven through exactly one of them and never
+ * both: 6 calls only the v1 callbacks, 7 and 8 only the v2 ones.
+ *
+ * The v1 callbacks are copied rather than defined unconditionally so that undici
+ * 6 still sees a handler missing a required callback as missing it.
+ */
+function wrapV1Handler(handler: V1Handler): Dispatcher.DispatchHandler {
+  const passthrough: Record<string, unknown> = {};
+  for (const name of V1_CALLBACKS) {
+    const callback = handler[name];
+    if (typeof callback === 'function') {
+      passthrough[name] = callback.bind(handler);
+    }
+  }
+  return {
+    ...passthrough,
+    onRequestStart(controller, context) {
+      // `abort()` types its reason as required, but undici defaults an
+      // undefined one to RequestAbortedError. Passing it through keeps the
+      // error identity a v1 caller expects.
+      handler.onConnect?.(
+        (reason?: Error) => controller.abort(reason as Error),
+        context
+      );
+    },
+    onRequestUpgrade(controller, statusCode, headers, socket) {
+      handler.onUpgrade?.(
+        statusCode,
+        rawHeadersFor(controller, headers),
+        socket
+      );
+    },
+    onResponseStart(controller, statusCode, headers, statusMessage) {
+      const proceed = handler.onHeaders?.(
+        statusCode,
+        rawHeadersFor(controller, headers),
+        () => controller.resume(),
+        statusMessage
+      );
+      if (proceed === false) controller.pause();
+    },
+    onResponseData(controller, chunk) {
+      if (handler.onData?.(chunk) === false) controller.pause();
+    },
+    onResponseEnd(controller, trailers) {
+      handler.onComplete?.(rawHeadersFor(controller, trailers));
+    },
+    onResponseError(_controller, error) {
+      if (!handler.onError) throw error;
+      handler.onError(error);
+    },
+    onBodySent(chunk) {
+      handler.onBodySent?.(chunk);
+    },
+    onRequestSent() {
+      handler.onRequestSent?.();
+    },
+    onResponseStarted() {
+      handler.onResponseStarted?.();
+    },
+  } as Dispatcher.DispatchHandler;
+}
+
+/**
+ * A dispatcher that accepts a v1 handler, passing a v2 one straight through (a
+ * future Node whose bundled `fetch` drives v2 handlers needs no bridging).
+ */
+class V1BridgeDispatcher extends Dispatcher {
+  readonly #inner: Dispatcher;
+
+  constructor(inner: Dispatcher) {
+    super();
+    this.#inner = inner;
+  }
+
+  dispatch(opts: Dispatcher.DispatchOptions, handler: V1Handler): boolean {
+    return this.#inner.dispatch(
+      opts,
+      typeof (handler as Dispatcher.DispatchHandler).onRequestStart ===
+        'function'
+        ? (handler as Dispatcher.DispatchHandler)
+        : wrapV1Handler(handler)
+    );
+  }
+
+  close(...args: unknown[]): Promise<void> {
+    return (this.#inner.close as (...a: unknown[]) => Promise<void>).apply(
+      this.#inner,
+      args
+    );
+  }
+
+  destroy(...args: unknown[]): Promise<void> {
+    return (this.#inner.destroy as (...a: unknown[]) => Promise<void>).apply(
+      this.#inner,
+      args
+    );
+  }
+}
+
+function bridgeV1Handler<T>(dispatcher: T): T {
+  return new V1BridgeDispatcher(dispatcher as Dispatcher) as unknown as T;
 }
 
 /**
@@ -674,12 +819,6 @@ function restoreH2(dispatch: Dispatcher['dispatch']): Dispatcher['dispatch'] {
  * safe for older dispatchers as well: undici 6/7 dispatchers accept the v2
  * handler the bridge produces.
  *
- * `allowH2` is stripped for the same reason as in `restoreH2`, and it matters
- * more here: an undici `MockAgent` keys its interceptors off the pool the inner
- * Agent selects, and the injected flag sends the request to a separate
- * `${origin}#http1-only` pool that holds no interceptors, so mocked requests
- * escape to the network instead of being intercepted.
- *
  * Memoized because the recycler and the retry bookkeeping compare dispatchers by
  * reference, and a caller may pass the same instance to many calls.
  */
@@ -689,32 +828,14 @@ function bridgeCallerDispatcher(dispatcher: unknown): unknown {
   if (
     dispatcher == null ||
     typeof dispatcher !== 'object' ||
-    dispatcher instanceof Dispatcher1Wrapper
+    dispatcher instanceof V1BridgeDispatcher
   ) {
     return dispatcher;
   }
   const cached = bridgedCallerDispatchers.get(dispatcher);
   if (cached !== undefined) return cached;
 
-  const inner = dispatcher as Dispatcher;
-  const bridged = new Dispatcher1Wrapper({
-    dispatch(opts: Dispatcher.DispatchOptions, handler: unknown) {
-      const { allowH2: _injected, ...rest } =
-        opts as Dispatcher.DispatchOptions & {
-          allowH2?: boolean;
-        };
-      return (
-        inner.dispatch as unknown as (
-          o: Dispatcher.DispatchOptions,
-          h: unknown
-        ) => boolean
-      ).call(inner, rest, handler);
-    },
-    close: (...args: unknown[]) =>
-      (inner.close as (...a: unknown[]) => unknown).apply(inner, args),
-    destroy: (...args: unknown[]) =>
-      (inner.destroy as (...a: unknown[]) => unknown).apply(inner, args),
-  } as unknown as Dispatcher);
+  const bridged = bridgeV1Handler(dispatcher as Dispatcher);
   bridgedCallerDispatchers.set(dispatcher, bridged);
   return bridged;
 }

--- a/packages/world-vercel/src/runs.test.ts
+++ b/packages/world-vercel/src/runs.test.ts
@@ -6,6 +6,31 @@ import { WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
 
 const ORIGIN = WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
 
+/**
+ * Reads a request body as the mock hands it to a reply callback.
+ *
+ * undici 8's MockAgent consumes the outgoing body to drive the handler's
+ * body-sent hooks, then substitutes a replayable async iterable for it; undici 7
+ * passed whatever `fetch` dispatched (a `Uint8Array`) straight through. Reply
+ * callbacks therefore have to drain it, which makes them async.
+ */
+async function mockBodyBytes(rawBody: unknown): Promise<Uint8Array> {
+  if (rawBody == null) return new Uint8Array();
+  if (typeof rawBody === 'string') return new TextEncoder().encode(rawBody);
+  if (rawBody instanceof Uint8Array) return rawBody;
+  if (
+    typeof (rawBody as AsyncIterable<Uint8Array>)[Symbol.asyncIterator] ===
+    'function'
+  ) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of rawBody as AsyncIterable<Uint8Array>) {
+      chunks.push(Buffer.from(chunk));
+    }
+    return new Uint8Array(Buffer.concat(chunks));
+  }
+  return new Uint8Array(rawBody as ArrayBufferLike);
+}
+
 describe('getWorkflowRuns', () => {
   it('delegates to getWorkflowRun for unique IDs, preserves input order, and returns null for missing runs', async () => {
     const agent = new MockAgent();
@@ -62,9 +87,9 @@ describe('cancelWorkflowRuns', () => {
       .intercept({ path: '/api/v4/runs/cancel', method: 'POST' })
       .reply(
         200,
-        (opts: { body?: unknown }) => {
+        async (opts: { body?: unknown }) => {
           requestCount++;
-          capturedBody = decode(new Uint8Array(opts.body as ArrayBufferLike));
+          capturedBody = decode(await mockBodyBytes(opts.body));
           return encode({
             summary: {
               requested: 2,

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -457,7 +457,7 @@ export async function makeRequest<T>({
         const fetchStart = Date.now();
         let response: Response;
         try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici v7 dispatcher types don't match @types/node's RequestInit
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher types don't match @types/node's RequestInit
           response = await fetch(request, {
             dispatcher: getDispatcher(config),
           } as any);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ~3.0.1
       version: 3.0.1
     undici:
-      specifier: 7.29.0
-      version: 7.29.0
+      specifier: 8.10.0
+      version: 8.10.0
     vitest:
       specifier: ^4.1.10
       version: 4.1.10
@@ -1382,7 +1382,7 @@ importers:
         version: 3.0.1
       undici:
         specifier: 'catalog:'
-        version: 7.29.0
+        version: 8.10.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1547,7 +1547,7 @@ importers:
         version: 3.0.1
       undici:
         specifier: 'catalog:'
-        version: 7.29.0
+        version: 8.10.0
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -16512,13 +16512,13 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -35009,7 +35009,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.1
       tmp: 0.2.5
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -35297,9 +35297,9 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@7.28.0: {}
-
   undici@7.29.0: {}
+
+  undici@8.10.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   semver: 7.7.4
   typescript: ^6.0.3
   ulid: ~3.0.1
-  undici: 7.29.0
+  undici: 8.10.0
   vitest: ^4.1.10
   zod: ~4.3.6
 


### PR DESCRIPTION
Bumps the workspace catalog from `undici@7.29.0` to `undici@8.10.0` and adapts the two packages that depend on it, `@workflow/world-vercel` and `@workflow/world-local`.

undici 8 is a breaking release for anyone who constructs a dispatcher and hands it to the global `fetch`, which is exactly what both packages do. Most of the diff is that adaptation. A secondary chunk removes workarounds that v8 made unnecessary, and one change gives up a property v8 removed.

## Relevant changes between undici 7 and 8

### 1. Node.js floor moved to 22.19

`undici@8` declares `engines: {"node": ">=22.19.0"}`; `undici@7.29.0` declared `>=20.18.1`.

Nothing under `packages/` declares `engines`, so this PR does not change what npm/pnpm will let a consumer install. It does mean `@workflow/world-vercel` and `@workflow/world-local` no longer support Node 18 or 20 in practice. The root `package.json` still says `^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0`. Whether to narrow that, and whether to start declaring `engines` on the published packages, is a policy call I left for review rather than making here. CI runs `node-version: 22.x`, which resolves above the floor.

### 2. The dispatcher handler ABI is v2 only ([#4786](https://github.com/nodejs/undici/pull/4786))

v8 removed the legacy handler wrappers. A dispatcher is now driven with the v2 callbacks:

| v1 | v2 |
| --- | --- |
| `onConnect` | `onRequestStart` |
| `onHeaders` | `onResponseStart` |
| `onData` | `onResponseData` |
| `onComplete` | `onResponseEnd` |
| `onError` | `onResponseError` |
| `onUpgrade` | `onRequestUpgrade` |

Pause, resume and abort moved onto a `DispatchController` handed to the callbacks.

This matters because every request in `world-vercel` goes through the *global* `fetch` (`makeRequest` in `http-core.ts`, and `fetchV4` in `events-v4.ts`, which does so deliberately to stay visible in Vercel's outgoing-requests view). That `fetch` belongs to the undici bundled into Node, not to the undici in our dependencies, and it drives a custom `dispatcher` with a **v1** handler. Two failure modes, both observed:

- a bare `Agent`: `TypeError: fetch failed`, cause `InvalidArgumentError: invalid onRequestStart method`;
- a `RetryAgent` or a composed dispatcher: no callback the v1 handler implements is ever called, so `fetch()` **never settles**. The request hangs until the caller's own timeout.

The fix is a v1-to-v2 bridge applied as the outermost layer of every dispatcher this package hands to `fetch` (`forGlobalFetch`). It is applied once at construction, not per request, because `DispatcherRecycler.note()` identifies the dispatcher a request used by reference.

### 3. undici's own bridge drops every response header over HTTP/2

undici ships `Dispatcher1Wrapper` for exactly this, and it cannot be used on an H2 path. It forwards `controller.rawHeaders` to the v1 `onHeaders`. `lib/core/request.js` sets that field unconditionally, but the two protocols fill it with different shapes: the H1 parser supplies the raw `Buffer[]` name/value pair list a v1 handler expects, while `client-h2.js` supplies a parsed `{ name: value }` object. That object has no `.length`, so the pair-wise loop in `fetch`'s v1 handler reads **zero** headers. Status and body arrive intact, and `Headers` is empty.

undici masks this by forcing `allowH2: false` into every dispatch:

```js
// lib/dispatcher/dispatcher1-wrapper.js
dispatch (opts, handler) {
  // Legacy (v1) consumers do not support HTTP/2, so force HTTP/1.1.
  if (opts.allowH2 !== false) {
    opts = { ...opts, allowH2: false }
```

The stated reason is that a v1 handler cannot carry a WebSocket upgrade over H2 ([nodejs/undici#4989](https://github.com/nodejs/undici/issues/4989)). `Agent` honours the flag per request by selecting a *different pool*:

```js
// lib/dispatcher/agent.js
const allowH2 = opts.allowH2 ?? this[kOptions].allowH2
const key = allowH2 === false ? `${origin}#http1-only` : origin
```

So using undici's wrapper silently downgrades the events agent to HTTP/1.1: every option would still say H2 while ALPN negotiated `http/1.1`, undoing the multiplexing and flow-control work those agents exist for. It also breaks `MockAgent`, which registers its interceptors on the un-suffixed key, so the injected flag sends mocked requests to a pool holding no interceptors and they escape to the network.

An earlier revision of this PR used the wrapper and composed an interceptor under it to delete the injected flag. That produced the header bug above in production: every E2E Vercel Prod lane failed with `v4 listEvents: expected application/vnd.workflow.v4-frames, got (none)`, because `fetchV4` checks the response `content-type` and there were no response headers at all.

This PR therefore carries its own bridge (`V1BridgeDispatcher` in `http-client.ts`), which normalizes the header shape to the `Buffer[]` pair list a v1 handler parses, and leaves `allowH2` untouched. That is safe for these dispatchers specifically: they carry plain request/response traffic only, and the WebSocket transport (`events-v4-ws.ts`) does not go through them. `http-client.test.ts` now asserts that response headers survive over h2, including a repeated header; the h2 harness previously replied with no headers at all, which is why nothing caught this.

### 4. Caller-supplied dispatchers now need bridging too, across three undici majors

`APIConfig.dispatcher` is documented as accepting a dispatcher from any undici version, and the four accessors used to return it untouched. A caller who installs `undici` today gets 8, and that dispatcher hangs under global `fetch` for the reason in (2). `bridgeCallerDispatcher` applies the same bridge, memoized in a `WeakMap` so the recycler's and the retry bookkeeping's by-reference comparisons still hold.

undici 6 complicates this: it speaks the v1 ABI only, validates the handler on dispatch, and rejects a pure v2 one with `invalid onError method`. Since a v6 dispatcher works fine unbridged today, bridging it naively would be a regression. The bridge therefore emits a handler carrying **both** ABIs. Measured against undici 6.28, 7.29 and 8.10 with a handler exposing both: 6 drives only the v1 callbacks, 7 and 8 drive only the v2 ones, and none of them drives both. All three complete a real h2 request and a `MockAgent` request through the bridge.

### 5. HTTP/2 is on by default ([#4828](https://github.com/nodejs/undici/pull/4828))

v8 negotiates H2 whenever the origin offers it over ALPN. Any path that must stay on HTTP/1.1 has to say so. `DEFAULT_AGENT_OPTIONS` already did; `world-local`'s queue agent now sets `allowH2: false` explicitly rather than inheriting the old default.

### 6. The H2 in-flight ceiling is protocol-aware, so `pipelining` is no longer a multiplexing knob ([#5362](https://github.com/nodejs/undici/pull/5362), fixing [#4143](https://github.com/nodejs/undici/issues/4143))

In v7, `pipelining` had to be set for H2 to multiplex at all: undici gated in-flight requests on `getPipelining(client)`, and the Client constructor coerced `pipelining` to a number, so `client-h2.js`'s `defaultPipelining: Infinity` was unreachable. Our events agent carried `pipelining: 100` purely for that.

v8 picks the ceiling by protocol: on H2 it is the peer's `SETTINGS_MAX_CONCURRENT_STREAMS`, and `pipelining` only applies before a protocol is negotiated. `pipelining` is now removed from `EVENTS_AGENT_OPTIONS`. Measured against a loopback H2 origin, 16 concurrent requests run as 16 parallel streams on one connection with no `pipelining` set. Leaving it in would have raised H1 pipelining depth on an H2 fallback, which is what `DEFAULT_AGENT_OPTIONS` deliberately avoids.

### 7. `busy()` no longer serializes non-idempotent or stream-bodied requests ([#5391](https://github.com/nodejs/undici/pull/5391), [#5538](https://github.com/nodejs/undici/pull/5538))

v7's H2 `busy()` returned true for `request.idempotent === false` and for a stream/async-iterable body. v8 dispatches both concurrently, on the reasoning that H2 streams are independent.

This cuts both ways:

- **Events path (win).** `h2MultiplexInterceptor` existed largely to relabel POSTs `idempotent: true` so they would not serialize. That relabelling is gone. What remains is the body re-buffering, so the interceptor is renamed `bufferStreamedBodyInterceptor`. That part is still needed for a different reason: `fetch` converts every body into an async iterable, an async iterable can be consumed once, and on a RetryAgent re-dispatch the exhausted body aborts the request with `NGHTTP2_PROTOCOL_ERROR` instead of resending.
- **Stream write/close agents (loss).** Their append-isolation property depended on that `busy()` gate. Stream appends are not idempotent, and `STREAM_RETRY_OPTIONS` retries PUT on transient `errorCodes`, so multiplexing N appends onto one connection would let a single GOAWAY or socket reset fail all N and resend chunks the server may already have applied. Measured on v8: 16 concurrent appends went from 1 to 16 in flight on one connection. There is no client-side option that caps it back (see 8), so `STREAM_AGENT_OPTIONS` now sets `allowH2: false`. Those requests send a fully buffered body or none, so H2 was safe for them, but with multiplexing suppressed it was doing nothing the H1 agent does not.

### 8. h2 options were namespaced, and the replacement has two bugs ([#5498](https://github.com/nodejs/undici/pull/5498), 8.10.0)

The flat `maxConcurrentStreams`, `initialWindowSize` and `connectionWindowSize` are marked `@deprecated` in favour of `h2Options.*`. The events agent keeps the flat spelling, because the documented replacement does not work:

- `h2Options.maxConcurrentStreams` throws `InvalidArgumentError`. While validating `maxConcurrentStreams`, undici validates `h2Options.connectionWindowSize` (`lib/dispatcher/client.js`), so the option is unusable on its own.
- `h2Options.settings.initialWindowSize` is validated and typed, and then ignored: undici reads `h2Options.initialWindowSize`. Measured against a loopback H2 origin, the flat option puts 4 MiB on the wire, while the documented spelling leaves the server seeing undici's 256 KiB default.

Separately confirmed (unchanged from v7, worth stating because it is easy to reach for): the `maxConcurrentStreams` *option* only seeds `peerMaxConcurrentStreams` at connect time and is overwritten by the server's SETTINGS, so it cannot be used to cap in-flight streams. That is why (7) is solved with `allowH2: false` rather than a stream cap.

### 9. `MockAgent` changes the shape of `opts.body` seen by reply callbacks

Test-only, but it accounts for a chunk of the diff. When the handler exposes body-sent hooks, and `Dispatcher1Wrapper`'s `LegacyHandlerWrapper` always defines them, v8's `mockDispatch` defers the reply callback, drains the outgoing body, and substitutes a replayable async iterable. v7 passed whatever `fetch` dispatched (a `Uint8Array`) straight through. Reply callbacks that inspect the request body therefore have to drain it, which makes them async. v8 also accepts promise-returning reply callbacks, which is what makes that possible.

### 10. Unchanged, checked because a break here would be silent

- **`Dispatcher.compose()` still returns a Proxy that loses `this`.** `close()` on a composed `RetryAgent` throws `TypeError: Cannot read private member #agent`. The existing `withBoundLifecycle` workaround stays.
- **undici still lazily calls `require('node:http2')`** (`lib/dispatcher/client-h2.js`). The `createRequire` banner shims in `packages/nitro`, `packages/sveltekit` and `packages/web` are still load-bearing and are unchanged.

## Testing

- `@workflow/world-vercel`: 479 tests across 23 files pass.
- `@workflow/world-local`: 524 tests across 14 files pass.
- Typecheck and lint clean for both.

New coverage in `http-client.test.ts`:

- Every accessor bridges a caller-supplied dispatcher instead of returning it by identity, forwards to the caller's own `dispatch`, passes the dispatch options through untouched, and is stable per input.
- Response headers survive over h2, including a repeated header. This is the regression from (3), and it fails with an empty `Headers` if the bridge forwards the H2 header object through unnormalized.
- The bridged handler still answers the v1 ABI, driven the way undici 6 drives it.
- Headers and trailers stay distinct in both dispatcher shapes: the H1 shape, where both raw lists are on the controller, and the H2 shape, where neither is and both come from the parsed callback argument.
- A caller-supplied `undici@8` `Agent` completes a real request through global `fetch`, still negotiates h2, and sees its response headers. Unbridged, that request fails with `invalid onRequestStart method`.
- The multiplexing harness now serves HTTP/1.1 and h2 from one origin, so the events agent (h2, expected to multiplex) and the stream agent (`allowH2: false`, expected not to) are measured against the same concurrency barrier.

Measurements referenced above were taken with throwaway probe scripts against a loopback `node:http2` origin, not checked in.

## Risk

The behavior change most likely to be felt in production is (7): stream write and close now speak HTTP/1.1 rather than h2-without-multiplexing. Wire-level shape per request is the same, one request per connection either way.

The bridge in (2), (3) and (4) sits on every outgoing request in `world-vercel`, so it is the highest-blast-radius part of the diff. It is also the part that already failed once in production shape, on the header path in (3), which the E2E Vercel Prod lanes caught and unit tests did not.
