### PR TITLE
Let the workflow-server test generator opt into benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,10 +44,18 @@ jobs:
     name: Create PR Comment
     runs-on: ubuntu-latest
     needs: ci-scope
+    # `workflow-server-test` PRs are generated (one per open workflow-server
+    # PR, refreshed on every push) and carry workflow's own `main` plus a
+    # server-URL override, so benchmarking them measures main against itself
+    # and is normally waste. `stress-test` is the generator's explicit opt-in
+    # for the case where it isn't: the branch also patches the events
+    # transport, so the run measures something no other job in this repo does.
+    # Repeated on all three jobs below — Actions has no anchors.
     if: >-
       github.event_name == 'pull_request' &&
       !startsWith(github.head_ref, 'changeset-release/') &&
-      !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') &&
+      (!contains(github.event.pull_request.labels.*.name, 'workflow-server-test') ||
+      contains(github.event.pull_request.labels.*.name, 'stress-test')) &&
       needs.ci-scope.outputs.fast-path != 'true'
     timeout-minutes: 5
 
@@ -112,7 +120,8 @@ jobs:
     # main's, so it would only compare main's baseline against itself.
     if: >-
       !startsWith(github.head_ref, 'changeset-release/') &&
-      !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') &&
+      (!contains(github.event.pull_request.labels.*.name, 'workflow-server-test') ||
+      contains(github.event.pull_request.labels.*.name, 'stress-test')) &&
       (needs.ci-scope.outputs.fast-path != 'true' ||
       github.event_name == 'workflow_dispatch')
     timeout-minutes: 60
@@ -195,7 +204,8 @@ jobs:
       always() && !cancelled() &&
       github.event_name == 'pull_request' &&
       !startsWith(github.head_ref, 'changeset-release/') &&
-      !contains(github.event.pull_request.labels.*.name, 'workflow-server-test') &&
+      (!contains(github.event.pull_request.labels.*.name, 'workflow-server-test') ||
+      contains(github.event.pull_request.labels.*.name, 'stress-test')) &&
       needs.ci-scope.outputs.fast-path != 'true'
     timeout-minutes: 10
 


### PR DESCRIPTION
The three benchmark jobs skip `workflow-server-test` PRs outright. That is right by default: those PRs are generated one per open workflow-server PR and carry this repo's own `main` plus a server-URL override, so benchmarking them compares main against itself.

It stops being right when the generated branch also patches the events transport. [vercel/workflow-server#746](https://github.com/vercel/workflow-server/pull/746) makes the generator do exactly that — it now patches `ws-transport-enabled.ts` alongside the URL override, so every lane on the generated branch reaches the preview server over WebSockets. A benchmark run on such a branch measures the WS write path end to end, which nothing else in this repo does: every other job here exercises the HTTP transport.

So keep the exclusion and give `stress-test` the meaning its label description already claims — an explicit opt-in that overrides it. Only the generator sets it, and only on branches where the extra deploys buy a measurement.

Repeated on all three jobs (`pr-comment-start`, `benchmark`, `comment`) because Actions has no YAML anchors. On `push` to main the label expression evaluates over an empty array, so main's behaviour is unchanged.