### PR TITLE
feat(runtime): publish diagnostics_channel tracing events around step execution

### DIFF
--- a/.changeset/chilly-pandas-tell.md
+++ b/.changeset/chilly-pandas-tell.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': minor
+'workflow': minor
+---
+
+Publish `diagnostics_channel` tracing events around step execution: a `TracingChannel` named `workflow.step` fires start/end/asyncStart/asyncEnd/error per step attempt with metadata-only payload (run id, step id, step name, workflow name, attempt, fatal-vs-retryable classification). Zero overhead with no subscribers; no OpenTelemetry dependency required to consume.

--- a/docs/content/docs/v5/observability/diagnostics-channel.mdx
+++ b/docs/content/docs/v5/observability/diagnostics-channel.mdx
@@ -1,0 +1,149 @@
+---
+title: Diagnostics Channel
+description: Subscribe to step execution events through Node.js diagnostics_channel — no OpenTelemetry required.
+type: reference
+summary: The workflow.step tracing channel and its payload schema.
+prerequisites:
+  - /docs/foundations/workflows-and-steps
+related:
+  - /docs/observability/tracing
+  - /docs/how-it-works/event-sourcing
+---
+
+The runtime publishes a [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel)
+named `workflow.step` around every step attempt. This is a plain
+`node:diagnostics_channel` convention — the same primitive Node.js core and
+undici use — so any APM or observability library that consumes tracing
+channels can observe step execution with **zero dependencies on this SDK's
+internals and no OpenTelemetry requirement**. When nothing subscribes, the
+channel adds no meaningful overhead to step execution.
+
+Steps are the only emission point. Workflow function bodies replay
+deterministically, so they deliberately have no channel: emission there would
+produce duplicate events for work that already happened.
+
+## Channel and events
+
+`diagnostics_channel.tracingChannel('workflow.step')` exposes the five
+standard events, published as
+`tracing:workflow.step:{start,end,asyncStart,asyncEnd,error}`:
+
+| Event | When |
+| --- | --- |
+| `start` | synchronously, immediately before the step function is invoked |
+| `end` | synchronously, when the invocation returns (the promise is still pending) |
+| `error` | once, if the step function's promise rejects |
+| `asyncStart` / `asyncEnd` | when the step function's promise settles |
+
+## Payload
+
+All events share one context object per attempt:
+
+```typescript
+interface StepTracingContext {
+  runId: string        // wrun_...
+  stepId: string       // step correlation id within the run
+  stepName: string     // full machine step name (including source module)
+  workflowName: string
+  attempt: number      // 1-based
+  // on error events only:
+  classification?: "fatal" | "retryable"
+  error?: unknown      // the thrown value
+}
+```
+
+Step **arguments and return values are never on the payload**. Step payloads
+can be encrypted end to end, so the channel carries metadata only.
+
+`classification` is `"fatal"` when the thrown error is a
+[`FatalError`](/docs/api-reference/workflow-errors/fatal-error) (including
+aborts promoted to fatal), `"retryable"` otherwise. Whether a retry actually
+happens is decided afterwards against the step's retry budget — a subscriber
+that needs "did it retry" should watch for the next attempt's `start`.
+
+## Subscribing
+
+```typescript title="instrumentation.ts" lineNumbers
+import { tracingChannel } from "node:diagnostics_channel"
+
+interface StepTracingContext {
+  runId: string
+  stepId: string
+  stepName: string
+  workflowName: string
+  attempt: number
+  classification?: "fatal" | "retryable"
+  error?: unknown
+}
+
+const channel = tracingChannel<unknown, StepTracingContext>("workflow.step")
+
+channel.start.subscribe((ctx) => {
+  const step = ctx as StepTracingContext
+  console.log(`step ${step.stepName} attempt ${step.attempt} starting`)
+})
+
+channel.error.subscribe((ctx) => {
+  const step = ctx as StepTracingContext
+  console.error(`step ${step.stepName} failed (${step.classification})`, step.error)
+})
+```
+
+## Binding spans with async context
+
+The channel's `start` event supports
+[`bindStore`](https://nodejs.org/api/diagnostics_channel.html#tracingchannelstart),
+which makes a store value active for the entire step body — across every
+`await`. This is how a subscriber opens a span per attempt and has all
+auto-instrumented work inside the step (fetch/undici, database clients, AI
+SDK calls) parent under it, without touching user code:
+
+```typescript title="instrumentation.ts" lineNumbers
+import { AsyncLocalStorage } from "node:async_hooks"
+import { tracingChannel } from "node:diagnostics_channel"
+import { context, trace, type Context, type Span } from "@opentelemetry/api"
+
+interface StepTracingContext {
+  runId: string
+  stepId: string
+  stepName: string
+  workflowName: string
+  attempt: number
+}
+
+// The AsyncLocalStorage your OpenTelemetry context manager reads from
+// (e.g. AsyncLocalStorageContextManager's storage).
+declare const store: AsyncLocalStorage<Context>
+
+const channel = tracingChannel<Context, StepTracingContext>("workflow.step")
+const tracer = trace.getTracer("workflow-steps")
+const spans = new Map<string, Span>()
+
+channel.start.bindStore(store, (ctx) => {
+  const span = tracer.startSpan(`workflow.step.attempt ${ctx.stepName}`, {
+    attributes: {
+      "workflow.run_id": ctx.runId,
+      "workflow.step_id": ctx.stepId,
+      "workflow.attempt": ctx.attempt,
+    },
+  })
+  spans.set(ctx.stepId, span)
+  return trace.setSpan(context.active(), span)
+})
+
+const endSpan = (ctx: unknown) =>
+  spans.get((ctx as StepTracingContext).stepId)?.end()
+channel.asyncEnd.subscribe(endSpan)
+channel.error.subscribe(endSpan)
+```
+
+When the SDK's [built-in OpenTelemetry tracing](/docs/observability/tracing)
+is also active, its `step.execute` span becomes a child of the span you set
+here, and auto-instrumented spans nest beneath it — the two mechanisms
+compose.
+
+## Stability
+
+The channel name and the payload fields documented above are a public
+convention: fields may be added over time, but existing fields will not be
+renamed or removed within a major version.

--- a/docs/content/docs/v5/observability/meta.json
+++ b/docs/content/docs/v5/observability/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Observability",
-  "pages": ["tracing", "attributes"]
+  "pages": ["tracing", "diagnostics-channel", "attributes"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -115,6 +115,7 @@
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/context-async-hooks": "1.30.1",
     "@opentelemetry/core": "1.30.1",
+    "@opentelemetry/instrumentation-undici": "^0.31.0",
     "@opentelemetry/sdk-trace-base": "1.30.1",
     "@types/debug": "4.1.12",
     "@types/node": "catalog:",

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -108,6 +108,19 @@ const stepTracingChannel = tracingChannel<unknown, StepTracingContext>(
   'workflow.step'
 );
 
+function hasStepTracingSubscribers(): boolean {
+  // Check the constituent channels instead of TracingChannel.hasSubscribers,
+  // which is not available across the full Node.js version range we support.
+  // This also detects stores registered with bindStore().
+  return (
+    stepTracingChannel.start.hasSubscribers ||
+    stepTracingChannel.end.hasSubscribers ||
+    stepTracingChannel.asyncStart.hasSubscribers ||
+    stepTracingChannel.asyncEnd.hasSubscribers ||
+    stepTracingChannel.error.hasSubscribers
+  );
+}
+
 /**
  * Extract the inline delta from a step-terminal `events.create` result,
  * if the World populated one. A delta is only meaningful when the caller
@@ -915,31 +928,37 @@ export async function executeStep(
         });
       }
       const stepBody = stepFn;
-      const tracingContext: StepTracingContext = {
-        runId: workflowRunId,
-        stepId,
-        stepName,
-        workflowName,
-        attempt,
-      };
       try {
-        // The traced fn resolves `undefined` on purpose: TracingChannel
-        // copies a promise's resolved value onto `context.result`, and step
-        // return values must never reach subscribers (see
-        // StepTracingContext). The real result is captured into `result`
-        // directly.
-        await stepTracingChannel.tracePromise(async () => {
-          try {
-            result = await runStepUserCode();
-          } catch (err) {
-            tracingContext.classification = FatalError.is(
-              promoteAbortErrorToFatal(err)
-            )
-              ? 'fatal'
-              : 'retryable';
-            throw err;
-          }
-        }, tracingContext);
+        if (!hasStepTracingSubscribers()) {
+          // Match Undici's diagnostics-channel fast path: do not allocate a
+          // context or enter the tracing wrapper when no channel is observed.
+          result = await runStepUserCode();
+        } else {
+          const tracingContext: StepTracingContext = {
+            runId: workflowRunId,
+            stepId,
+            stepName,
+            workflowName,
+            attempt,
+          };
+          // The traced fn resolves `undefined` on purpose: TracingChannel
+          // copies a promise's resolved value onto `context.result`, and step
+          // return values must never reach subscribers (see
+          // StepTracingContext). The real result is captured into `result`
+          // directly.
+          await stepTracingChannel.tracePromise(async () => {
+            try {
+              result = await runStepUserCode();
+            } catch (err) {
+              tracingContext.classification = FatalError.is(
+                promoteAbortErrorToFatal(err)
+              )
+                ? 'fatal'
+                : 'retryable';
+              throw err;
+            }
+          }, tracingContext);
+        }
       } catch (err) {
         userCodeError = err;
         userCodeFailed = true;

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -1,3 +1,4 @@
+import { tracingChannel } from 'node:diagnostics_channel';
 import { types } from 'node:util';
 import {
   EntityConflictError,
@@ -64,6 +65,48 @@ import {
 import { safeWaitUntil } from './wait-until.js';
 
 export const DEFAULT_STEP_MAX_RETRIES = 3;
+
+/**
+ * Context published on the `workflow.step` tracing channel around every step
+ * attempt (channel names `tracing:workflow.step:{start,end,asyncStart,
+ * asyncEnd,error}`). The payload is metadata only — step arguments and return
+ * values never appear on it, because step payloads may be encrypted
+ * end-to-end. The channel has zero meaningful overhead when nothing
+ * subscribes, and subscribing requires no OpenTelemetry (or any other)
+ * dependency: it is a plain `node:diagnostics_channel` convention, so any
+ * consumer of `tracingChannel` (OTel instrumentations, dd-trace, custom
+ * subscribers) can observe step execution.
+ *
+ * The workflow-body execution path deliberately has NO channel: workflow
+ * scope replays, and emission there would produce duplicate and fictional
+ * events. Steps execute exactly once per attempt, so this is the only sound
+ * emission point.
+ */
+export interface StepTracingContext {
+  /** Workflow run id (`wrun_...`). */
+  runId: string;
+  /** Compiler-assigned step correlation id within the run. */
+  stepId: string;
+  /** Full machine step name (including source module). */
+  stepName: string;
+  /** Workflow function name. */
+  workflowName: string;
+  /** 1-based attempt number for this execution. */
+  attempt: number;
+  /**
+   * Set before the channel's `error` event fires: `fatal` when the thrown
+   * error is a `FatalError` (including promoted abort errors), `retryable`
+   * otherwise. Whether a retry actually happens is decided later against the
+   * step's retry budget — subscribers wanting "will retry" must also watch
+   * the next attempt's `start`.
+   */
+  classification?: 'fatal' | 'retryable';
+  /** The thrown error, populated by TracingChannel on the error event. */
+  error?: unknown;
+}
+const stepTracingChannel = tracingChannel<unknown, StepTracingContext>(
+  'workflow.step'
+);
 
 /**
  * Extract the inline delta from a step-terminal `events.create` result,
@@ -871,8 +914,38 @@ export async function executeStep(
           ),
         });
       }
+      const stepBody = stepFn;
+      const tracingContext: StepTracingContext = {
+        runId: workflowRunId,
+        stepId,
+        stepName,
+        workflowName,
+        attempt,
+      };
       try {
-        result = await trace('step.execute', {}, async () => {
+        // The traced fn resolves `undefined` on purpose: TracingChannel
+        // copies a promise's resolved value onto `context.result`, and step
+        // return values must never reach subscribers (see
+        // StepTracingContext). The real result is captured into `result`
+        // directly.
+        await stepTracingChannel.tracePromise(async () => {
+          try {
+            result = await runStepUserCode();
+          } catch (err) {
+            tracingContext.classification = FatalError.is(
+              promoteAbortErrorToFatal(err)
+            )
+              ? 'fatal'
+              : 'retryable';
+            throw err;
+          }
+        }, tracingContext);
+      } catch (err) {
+        userCodeError = err;
+        userCodeFailed = true;
+      }
+      async function runStepUserCode(): Promise<unknown> {
+        return await trace('step.execute', {}, async () => {
           return await contextStorage.run(
             {
               stepMetadata: {
@@ -902,12 +975,9 @@ export async function executeStep(
                 ? params.runReadyBarrier
                 : undefined,
             },
-            () => stepFn.apply(thisVal, args)
+            () => stepBody.apply(thisVal, args)
           );
         });
-      } catch (err) {
-        userCodeError = err;
-        userCodeFailed = true;
       }
       const executionTimeMs = Date.now() - executionStartTime;
 

--- a/packages/core/src/runtime/step-tracing-channel.test.ts
+++ b/packages/core/src/runtime/step-tracing-channel.test.ts
@@ -19,10 +19,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   type Context,
+  type ContextManager,
   context as otelContext,
   trace as otelTrace,
+  ROOT_CONTEXT,
 } from '@opentelemetry/api';
-import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 import {
   BasicTracerProvider,
@@ -40,6 +41,43 @@ import { dehydrateStepArguments } from '../serialization.js';
 import { executeStep, type StepTracingContext } from './step-executor.js';
 
 const channel = tracingChannel<unknown, StepTracingContext>('workflow.step');
+
+class TestContextManager implements ContextManager {
+  constructor(private readonly storage: AsyncLocalStorage<Context>) {}
+
+  active(): Context {
+    return this.storage.getStore() ?? ROOT_CONTEXT;
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    context: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    const callback = thisArg == null ? fn : fn.bind(thisArg);
+    return this.storage.run(context, callback, ...args);
+  }
+
+  bind<T>(context: Context, target: T): T {
+    if (typeof target !== 'function') return target;
+
+    const manager = this;
+    const fn = target as (...args: unknown[]) => unknown;
+    return function (this: unknown, ...args: unknown[]) {
+      return manager.with(context, fn, this, ...args);
+    } as T;
+  }
+
+  enable(): this {
+    return this;
+  }
+
+  disable(): this {
+    this.storage.disable();
+    return this;
+  }
+}
 
 let counter = 0;
 function uniqueStepName(): string {
@@ -139,6 +177,27 @@ afterEach(() => {
 });
 
 describe('workflow.step channel — payload and sequencing', () => {
+  it('executes normally when none of the constituent channels are observed', async () => {
+    expect([
+      channel.start.hasSubscribers,
+      channel.end.hasSubscribers,
+      channel.asyncStart.hasSubscribers,
+      channel.asyncEnd.hasSubscribers,
+      channel.error.hasSubscribers,
+    ]).toEqual([false, false, false, false, false]);
+
+    const world = makeWorld();
+    const stepName = uniqueStepName();
+    const { runId, stepId } = await setupRunningStep({
+      world,
+      stepName,
+      body: async () => 'fast-path-result',
+    });
+
+    const result = await runStep(world, runId, stepId, stepName);
+    expect(result.type).toBe('completed');
+  });
+
   it('publishes start/end/asyncStart/asyncEnd with full metadata payload on success', async () => {
     const { events, cleanup } = recordEvents();
     cleanups.push(cleanup);
@@ -327,7 +386,8 @@ describe('workflow.step channel — OTel subscriber end to end', () => {
     const exporter = new InMemorySpanExporter();
     const provider = new BasicTracerProvider();
     provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
-    const contextManager = new AsyncLocalStorageContextManager();
+    const otelAls = new AsyncLocalStorage<Context>();
+    const contextManager = new TestContextManager(otelAls);
     contextManager.enable();
     otelContext.setGlobalContextManager(contextManager);
     otelTrace.setGlobalTracerProvider(provider);
@@ -342,14 +402,9 @@ describe('workflow.step channel — OTel subscriber end to end', () => {
     });
 
     const tracer = provider.getTracer('workflow-step-subscriber');
-    // Bind the context manager's underlying storage to the channel's start
-    // event: the attempt span becomes the active context for the entire step
-    // body, so any auto-instrumentation parents under it.
-    const otelAls = (
-      contextManager as unknown as {
-        _asyncLocalStorage: AsyncLocalStorage<Context>;
-      }
-    )._asyncLocalStorage;
+    // Bind the test context manager's storage to the channel's start event: the
+    // attempt span becomes the active context for the entire step body, so any
+    // auto-instrumentation parents under it.
     const spansByStepId = new Map<
       string,
       ReturnType<typeof tracer.startSpan>

--- a/packages/core/src/runtime/step-tracing-channel.test.ts
+++ b/packages/core/src/runtime/step-tracing-channel.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for the `workflow.step` diagnostics tracing channel published around
+ * step execution (see StepTracingContext in step-executor.ts).
+ *
+ * Covers:
+ *  - event payload and start/end/asyncStart/asyncEnd/error sequencing,
+ *    including retries and fatal-vs-retryable classification
+ *  - async context flow: AsyncLocalStorage bound via `channel.start.bindStore`
+ *    survives nested awaits inside the step body, so auto-instrumentation
+ *    (undici et al.) parents under a subscriber-opened span with no user code
+ *  - no context bleed across concurrently executing steps
+ *  - step return values never reach subscribers
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { tracingChannel } from 'node:diagnostics_channel';
+import { mkdtempSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type Context,
+  context as otelContext,
+  trace as otelTrace,
+} from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { FatalError } from '@workflow/errors';
+import type { World } from '@workflow/world';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
+import { createWorld } from '@workflow/world-local';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerStepFunction } from '../private.js';
+import { dehydrateStepArguments } from '../serialization.js';
+import { executeStep, type StepTracingContext } from './step-executor.js';
+
+const channel = tracingChannel<unknown, StepTracingContext>('workflow.step');
+
+let counter = 0;
+function uniqueStepName(): string {
+  counter += 1;
+  return `step//./step-tracing-channel-test//step${counter}`;
+}
+
+function makeWorld(): World {
+  const dataDir = mkdtempSync(join(tmpdir(), 'wf-step-tracing-'));
+  return createWorld({ dataDir, tag: `tc${counter}` });
+}
+
+async function setupRunningStep(opts: {
+  world: World;
+  stepName: string;
+  body: (...args: unknown[]) => Promise<unknown>;
+  maxRetries?: number;
+}): Promise<{ runId: string; stepId: string }> {
+  const { world, stepName, body } = opts;
+  const runInput = await dehydrateStepArguments([], 'run', undefined);
+  const created = await world.events.create(null, {
+    eventType: 'run_created',
+    specVersion: SPEC_VERSION_CURRENT,
+    eventData: {
+      deploymentId: 'dpl_test',
+      workflowName: 'wf',
+      input: runInput,
+    },
+  });
+  const runId = created.run!.runId;
+  await world.events.create(runId, {
+    eventType: 'run_started',
+    specVersion: SPEC_VERSION_CURRENT,
+    eventData: {},
+  } as never);
+
+  const stepId = `step_tc_${counter}`;
+  // Step inputs are serialized as { args, closureVars, thisVal } — the shape
+  // the suspension handler enqueues (see suspension-handler.ts).
+  const stepInput = await dehydrateStepArguments(
+    { args: [], closureVars: undefined, thisVal: null },
+    runId,
+    undefined
+  );
+  await world.events.create(runId, {
+    eventType: 'step_created',
+    specVersion: SPEC_VERSION_CURRENT,
+    correlationId: stepId,
+    eventData: { stepName, input: stepInput },
+  });
+
+  registerStepFunction(
+    stepName,
+    Object.assign(body, { maxRetries: opts.maxRetries ?? 3 })
+  );
+  return { runId, stepId };
+}
+
+function runStep(
+  world: World,
+  runId: string,
+  stepId: string,
+  stepName: string
+) {
+  return executeStep({
+    world,
+    workflowRunId: runId,
+    workflowName: 'wf',
+    workflowStartedAt: Date.now(),
+    stepId,
+    stepName,
+  });
+}
+
+type RecordedEvent = { name: string; ctx: StepTracingContext };
+
+function recordEvents(): { events: RecordedEvent[]; cleanup: () => void } {
+  const events: RecordedEvent[] = [];
+  const rec = (name: string) => (ctx: StepTracingContext) => {
+    events.push({ name, ctx: { ...ctx } });
+  };
+  const handlers = {
+    start: rec('start'),
+    end: rec('end'),
+    asyncStart: rec('asyncStart'),
+    asyncEnd: rec('asyncEnd'),
+    error: rec('error'),
+  };
+  channel.subscribe(handlers);
+  return { events, cleanup: () => channel.unsubscribe(handlers) };
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  counter += 1;
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+describe('workflow.step channel — payload and sequencing', () => {
+  it('publishes start/end/asyncStart/asyncEnd with full metadata payload on success', async () => {
+    const { events, cleanup } = recordEvents();
+    cleanups.push(cleanup);
+
+    const world = makeWorld();
+    const stepName = uniqueStepName();
+    const { runId, stepId } = await setupRunningStep({
+      world,
+      stepName,
+      body: async () => 'a-return-value-subscribers-must-not-see',
+    });
+
+    const result = await runStep(world, runId, stepId, stepName);
+    expect(result.type).toBe('completed');
+
+    expect(events.map((e) => e.name)).toEqual([
+      'start',
+      'end',
+      'asyncStart',
+      'asyncEnd',
+    ]);
+    for (const e of events) {
+      expect(e.ctx.runId).toBe(runId);
+      expect(e.ctx.stepId).toBe(stepId);
+      expect(e.ctx.stepName).toBe(stepName);
+      expect(e.ctx.workflowName).toBe('wf');
+      expect(e.ctx.attempt).toBe(1);
+      // Step return values must never reach subscribers: the traced fn
+      // resolves undefined, so TracingChannel's context.result carries
+      // nothing.
+      expect(
+        (e.ctx as Record<string, unknown>).result,
+        `event ${e.name} leaked a result`
+      ).toBeUndefined();
+    }
+  });
+
+  it('fires error exactly once per retryable attempt, classified retryable, then a clean attempt 2', async () => {
+    const { events, cleanup } = recordEvents();
+    cleanups.push(cleanup);
+
+    const world = makeWorld();
+    const stepName = uniqueStepName();
+    let calls = 0;
+    const { runId, stepId } = await setupRunningStep({
+      world,
+      stepName,
+      body: async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('transient boom');
+        return 'ok';
+      },
+    });
+
+    const first = await runStep(world, runId, stepId, stepName);
+    expect(first.type).toBe('retry');
+
+    const errors = events.filter((e) => e.name === 'error');
+    expect(errors).toHaveLength(1);
+    expect((errors[0].ctx.error as Error).message).toBe('transient boom');
+    expect(errors[0].ctx.classification).toBe('retryable');
+    expect(errors[0].ctx.attempt).toBe(1);
+    // TracingChannel ordering for a rejected promise: `end` fires at
+    // synchronous return, `error` when the promise rejects.
+    expect(events.map((e) => e.name)).toEqual([
+      'start',
+      'end',
+      'error',
+      'asyncStart',
+      'asyncEnd',
+    ]);
+
+    events.length = 0;
+    const second = await runStep(world, runId, stepId, stepName);
+    expect(second.type).toBe('completed');
+    expect(events.filter((e) => e.name === 'error')).toHaveLength(0);
+    expect(events.find((e) => e.name === 'start')?.ctx.attempt).toBe(2);
+  });
+
+  it('classifies a FatalError throw as fatal', async () => {
+    const { events, cleanup } = recordEvents();
+    cleanups.push(cleanup);
+
+    const world = makeWorld();
+    const stepName = uniqueStepName();
+    const { runId, stepId } = await setupRunningStep({
+      world,
+      stepName,
+      body: async () => {
+        throw new FatalError('unrecoverable');
+      },
+    });
+
+    const result = await runStep(world, runId, stepId, stepName);
+    expect(result.type).toBe('failed');
+    const errors = events.filter((e) => e.name === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].ctx.classification).toBe('fatal');
+  });
+});
+
+describe('workflow.step channel — async context flow', () => {
+  it('ALS store bound on start survives nested awaits inside the step body', async () => {
+    const als = new AsyncLocalStorage<StepTracingContext>();
+    channel.start.bindStore(als, (ctx) => ctx);
+    cleanups.push(() => channel.start.unbindStore(als));
+
+    const world = makeWorld();
+    const stepName = uniqueStepName();
+    const seen: Array<string | undefined> = [];
+    const { runId, stepId } = await setupRunningStep({
+      world,
+      stepName,
+      body: async () => {
+        seen.push(als.getStore()?.stepId);
+        await new Promise((r) => setTimeout(r, 5));
+        seen.push(als.getStore()?.stepId);
+        await (async () => {
+          await Promise.resolve();
+          await new Promise((r) => setImmediate(r));
+          seen.push(als.getStore()?.stepId);
+        })();
+        seen.push(als.getStore()?.stepId);
+        return 'ok';
+      },
+    });
+
+    const result = await runStep(world, runId, stepId, stepName);
+    expect(result.type).toBe('completed');
+    expect(seen).toEqual([stepId, stepId, stepId, stepId]);
+  });
+
+  it('does not bleed context across concurrently executing steps', async () => {
+    const als = new AsyncLocalStorage<StepTracingContext>();
+    channel.start.bindStore(als, (ctx) => ctx);
+    cleanups.push(() => channel.start.unbindStore(als));
+
+    const mismatches: string[] = [];
+    const makeBody = (expectedStepId: () => string) => {
+      return async () => {
+        for (let i = 0; i < 20; i++) {
+          await new Promise((r) => setTimeout(r, Math.random() * 3));
+          const got = als.getStore()?.stepId;
+          if (got !== expectedStepId()) {
+            mismatches.push(`expected ${expectedStepId()}, saw ${got}`);
+          }
+        }
+        return 'ok';
+      };
+    };
+
+    const worldA = makeWorld();
+    const stepNameA = uniqueStepName();
+    let stepIdA = '';
+    const a = await setupRunningStep({
+      world: worldA,
+      stepName: stepNameA,
+      body: makeBody(() => stepIdA),
+    });
+    stepIdA = a.stepId;
+
+    counter += 1;
+    const worldB = makeWorld();
+    const stepNameB = uniqueStepName();
+    let stepIdB = '';
+    const b = await setupRunningStep({
+      world: worldB,
+      stepName: stepNameB,
+      body: makeBody(() => stepIdB),
+    });
+    stepIdB = b.stepId;
+
+    const [ra, rb] = await Promise.all([
+      runStep(worldA, a.runId, a.stepId, stepNameA),
+      runStep(worldB, b.runId, b.stepId, stepNameB),
+    ]);
+    expect(ra.type).toBe('completed');
+    expect(rb.type).toBe('completed');
+    expect(mismatches).toEqual([]);
+  });
+});
+
+describe('workflow.step channel — OTel subscriber end to end', () => {
+  it('a fetch inside the step body parents (transitively) under a subscriber-opened attempt span', async () => {
+    // OTel pipeline as a runtime binding would construct it.
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    const contextManager = new AsyncLocalStorageContextManager();
+    contextManager.enable();
+    otelContext.setGlobalContextManager(contextManager);
+    otelTrace.setGlobalTracerProvider(provider);
+    const undiciInstr = new UndiciInstrumentation();
+    undiciInstr.setTracerProvider(provider);
+    undiciInstr.enable();
+    cleanups.push(() => {
+      undiciInstr.disable();
+      otelTrace.disable();
+      otelContext.disable();
+      contextManager.disable();
+    });
+
+    const tracer = provider.getTracer('workflow-step-subscriber');
+    // Bind the context manager's underlying storage to the channel's start
+    // event: the attempt span becomes the active context for the entire step
+    // body, so any auto-instrumentation parents under it.
+    const otelAls = (
+      contextManager as unknown as {
+        _asyncLocalStorage: AsyncLocalStorage<Context>;
+      }
+    )._asyncLocalStorage;
+    const spansByStepId = new Map<
+      string,
+      ReturnType<typeof tracer.startSpan>
+    >();
+    channel.start.bindStore(otelAls, (ctx: StepTracingContext) => {
+      const span = tracer.startSpan(`workflow.step.attempt ${ctx.stepName}`, {
+        attributes: {
+          'workflow.run_id': ctx.runId,
+          'workflow.step_id': ctx.stepId,
+          'workflow.attempt': ctx.attempt,
+        },
+      });
+      spansByStepId.set(ctx.stepId, span);
+      return otelTrace.setSpan(otelContext.active(), span);
+    });
+    const endHandlers = {
+      asyncEnd: (ctx: StepTracingContext) => {
+        spansByStepId.get(ctx.stepId)?.end();
+      },
+      error: (ctx: StepTracingContext) => {
+        spansByStepId.get(ctx.stepId)?.end();
+      },
+    };
+    channel.subscribe(endHandlers);
+    cleanups.push(() => {
+      channel.start.unbindStore(otelAls);
+      channel.unsubscribe(endHandlers);
+    });
+
+    const server: Server = createServer((_req, res) => res.end('hello'));
+    await new Promise<void>((r) => server.listen(0, r));
+    const port = (server.address() as { port: number }).port;
+    cleanups.push(() => server.close());
+
+    const world = makeWorld();
+    const stepName = uniqueStepName();
+    const { runId, stepId } = await setupRunningStep({
+      world,
+      stepName,
+      body: async () => {
+        const res = await fetch(`http://127.0.0.1:${port}/hello`);
+        return await res.text();
+      },
+    });
+
+    const result = await runStep(world, runId, stepId, stepName);
+    expect(result.type).toBe('completed');
+
+    await provider.forceFlush();
+    const spans = exporter.getFinishedSpans();
+    const attemptSpan = spans.find((s) =>
+      s.name.startsWith('workflow.step.attempt')
+    );
+    expect(attemptSpan).toBeDefined();
+    const undiciSpan = spans.find((s) =>
+      s.attributes['url.full']?.toString().includes(`127.0.0.1:${port}`)
+    );
+    expect(undiciSpan).toBeDefined();
+
+    // Walk ancestry: the undici span must reach the attempt span through its
+    // parent chain. Intermediate spans (the runtime's own step.execute) are
+    // expected — the channel composes with the SDK's built-in OTel tracing.
+    const byId = new Map(spans.map((s) => [s.spanContext().spanId, s]));
+    const chain: string[] = [];
+    let cur: ReadableSpan | undefined = undiciSpan;
+    let reachedAttempt = false;
+    for (let hops = 0; cur && hops < 10; hops++) {
+      const parentId = (cur as unknown as { parentSpanId?: string })
+        .parentSpanId;
+      if (!parentId) break;
+      cur = byId.get(parentId);
+      if (cur) chain.push(cur.name);
+      if (cur === attemptSpan) {
+        reachedAttempt = true;
+        break;
+      }
+    }
+    expect(reachedAttempt, `ancestry chain: ${chain.join(' -> ')}`).toBe(true);
+    expect(undiciSpan!.spanContext().traceId).toBe(
+      attemptSpan!.spanContext().traceId
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,6 +580,9 @@ importers:
       '@opentelemetry/core':
         specifier: 1.30.1
         version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici':
+        specifier: ^0.31.0
+        version: 0.31.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
         specifier: 1.30.1
         version: 1.30.1(@opentelemetry/api@1.9.1)
@@ -1757,7 +1760,7 @@ importers:
         version: 3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0)
       '@vercel/otel':
         specifier: ^1.13.0
-        version: 1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
+        version: 1.13.0(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
       '@workflow/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -1992,7 +1995,7 @@ importers:
         version: 1.0.2(react@19.2.7)
       '@vercel/otel':
         specifier: ^1.13.0
-        version: 1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
+        version: 1.13.0(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
       '@workflow/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -2116,7 +2119,7 @@ importers:
         version: 1.0.2(react@19.2.7)
       '@vercel/otel':
         specifier: ^1.13.0
-        version: 1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
+        version: 1.13.0(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
       '@workflow/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -2353,7 +2356,7 @@ importers:
         version: 1.15.3
       '@vercel/otel':
         specifier: ^1.13.0
-        version: 1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
+        version: 1.13.0(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))
       '@workflow/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -5008,6 +5011,10 @@ packages:
     resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
     engines: {node: '>=20.0'}
 
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
@@ -5028,9 +5035,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/instrumentation@0.57.2':
-    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
-    engines: {node: '>=14'}
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/instrumentation-undici@0.31.0':
+    resolution: {integrity: sha512-qunCfgSFV+bjRdAYkWIjVX38jIN/Xj80CiERXXdzYAmdigCFvJPB3AY3j43bjJlkhgbJJSCGdbvQUSut8QIiyQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/instrumentation@0.221.0':
+    resolution: {integrity: sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': 1.9.1
 
@@ -5060,6 +5079,10 @@ packages:
 
   '@opentelemetry/semantic-conventions@1.28.0':
     resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
   '@orama/orama@3.1.16':
@@ -9617,9 +9640,6 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
-  '@types/shimmer@1.2.0':
-    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
-
   '@types/ssh2-streams@0.1.12':
     resolution: {integrity: sha512-Sy8tpEmCce4Tq0oSOYdfqaBpA3hDM8SoxoFh5vzFsu2oL+znzGz8oVWW7xb4K920yYMUY+PIG31qZnFMfPWNCg==}
 
@@ -10825,8 +10845,8 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
-  cjs-module-lexer@1.4.3:
-    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -11816,6 +11836,9 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -12732,8 +12755,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  import-in-the-middle@1.15.0:
-    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
 
   impound@1.1.5:
     resolution: {integrity: sha512-5AUn+QE0UofqNHu5f2Skf6Svukdg4ehOIq8O0EtqIx4jta0CDZYBPqpIHt0zrlUTiFVYlLpeH39DoikXBjPKpA==}
@@ -15498,9 +15522,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  require-in-the-middle@7.5.2:
-    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
-    engines: {node: '>=8.6.0'}
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -15786,9 +15810,6 @@ packages:
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
-
-  shimmer@1.2.1:
-    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -20403,6 +20424,10 @@ snapshots:
 
   '@oozcitak/util@10.0.0': {}
 
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -20418,15 +20443,26 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.57.2
-      '@types/shimmer': 1.2.0
-      import-in-the-middle: 1.15.0
-      require-in-the-middle: 7.5.2
-      semver: 7.8.2
-      shimmer: 1.2.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation-undici@0.31.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -20457,6 +20493,8 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@orama/orama@3.1.16': {}
 
@@ -26052,8 +26090,6 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.0
 
-  '@types/shimmer@1.2.0': {}
-
   '@types/ssh2-streams@0.1.12':
     dependencies:
       '@types/node': 22.19.0
@@ -26270,11 +26306,11 @@ snapshots:
       '@vercel/cli-exec': 1.0.1
       jose: 5.10.0
 
-  '@vercel/otel@1.13.0(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))':
+  '@vercel/otel@1.13.0(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.57.2
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
@@ -27830,7 +27866,7 @@ snapshots:
 
   citty@0.2.2: {}
 
-  cjs-module-lexer@1.4.3: {}
+  cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -28721,6 +28757,8 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -29980,11 +30018,10 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-in-the-middle@1.15.0:
+  import-in-the-middle@3.3.3:
     dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      cjs-module-lexer: 1.4.3
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
       module-details-from-path: 1.0.4
 
   impound@1.1.5:
@@ -34046,11 +34083,10 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2:
+  require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
-      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
@@ -34467,8 +34503,6 @@ snapshots:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
-
-  shimmer@1.2.1: {}
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
## What

Publishes a Node.js [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel)
named **`workflow.step`** around every step attempt in the runtime's step
executor. Five standard events (`tracing:workflow.step:{start,end,asyncStart,asyncEnd,error}`),
one shared context object per attempt:

```ts
{ runId, stepId, stepName, workflowName, attempt,
  classification?: 'fatal' | 'retryable',  // error events
  error?: unknown }                        // error events
```

Metadata only — **step arguments and return values never reach subscribers**
(step payloads may be encrypted end to end; the traced fn deliberately
resolves `undefined` so TracingChannel's `context.result` stays empty).

Steps are the only emission point. The workflow-body path replays and gets no
channel — emission there would produce duplicate and fictional events.

## Why diagnostics_channel

- Same primitive Node core and undici use for exactly this purpose; composes
  with the SDK's existing optional-OTel tracing (`telemetry.ts`) rather than
  duplicating it. The built-in `step.execute` span becomes a child of
  whatever context a subscriber binds — verified in the test suite.
- dd-trace and OpenTelemetry instrumentation libraries already consume
  `tracingChannel`, so third-party APM support for step execution comes free.
- Zero new API surface beyond a documented channel name; zero dependencies
  for subscribers; the runtime keeps zero OTel version surface here.

## Overhead

`+21 ns` per step invocation with no subscribers (Node v25.8.2, 2M
iterations: direct await 29.5 ns/op vs `tracePromise` 50.6 ns/op). Against
the ~24 ms mean of a world-local `executeStep` this is ~0.0001%; against even
a hypothetical 1 ms step, 0.002%. With a no-op subscriber attached: +73 ns.

## Contents

- `packages/core/src/runtime/step-executor.ts`: channel creation at module
  load + `tracePromise` wrap of the user step invocation (~40 lines with
  docs). Error path classifies fatal-vs-retryable (FatalError semantics,
  incl. promoted abort errors) onto the context before the error event.
- `packages/core/src/runtime/step-tracing-channel.test.ts`: payload +
  sequencing (incl. retry and fatal classification), async context flow via
  `channel.start.bindStore` through nested awaits, concurrency isolation,
  return-value non-leakage, and an end-to-end OTel test proving a `fetch`
  inside a step parents under a subscriber-opened attempt span via undici
  auto-instrumentation (new devDep: `@opentelemetry/instrumentation-undici`).
- `docs/content/docs/v5/observability/diagnostics-channel.mdx`: channel name
  + payload schema as a public convention, plain subscriber example, and the
  `bindStore` span-binding pattern.
- Changeset: minor for `workflow` / `@workflow/core`.

## Deliberately out of scope

- Workflow-lifecycle channel (workflow scope replays; must never emit).
- Config surface, OTel imports, exporters.
- `workflowVersion` / `sourceFile` payload fields (not in scope at the
  invocation site today; additive later via `StepExecutorParams`).

## Notes for reviewers

- The wrapper sits OUTSIDE the existing `trace('step.execute')` call so a
  subscriber-bound async context also parents the SDK's own span — the two
  mechanisms compose (asserted in the e2e test).
- `classification: 'retryable'` means "not a FatalError"; whether a retry
  happens is decided later against `maxRetries`. Documented as such.
- Independent of PR #3163 (`onAfterTransform`) and the planned
  `onAfterBundle` PR; any landing order works.
