### PR TITLE
feat(runtime): report replay cost per step batch, flagged by retained-VM mode

### DIFF
--- a/.changeset/replay-cost-telemetry.md
+++ b/.changeset/replay-cost-telemetry.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Report replay cost for every step-to-step transition, not just a run's first step, and flag whether a retained VM served the batch

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -3015,14 +3015,21 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     expect(second.eventData.stso).toBeLessThanOrEqual(elapsed);
     expect(second.eventData.stepCount).toBe(1);
     expect(second.eventData.eventCount).toBeGreaterThan(0);
+    // `retained` is per-pass, not per-invocation: the first step's pass built
+    // the VM (a full replay, so no flag above), the second step's pass
+    // resumed the session this same invocation retained.
     expect(second.eventData.optimizations).toEqual([
       'turbo',
       'lazyStepStart',
       'optimisticStart',
+      'retained',
     ]);
-    // STSO-only steps never qualify for RSFS (it shares TTFS eligibility).
+    // STSO-only steps never qualify for RSFS (it shares TTFS eligibility),
+    // but finalSchedulingReplay is ungated — reported for any batch STSO is,
+    // not just the run's first step.
     expect(second.eventData.rsfs).toBeUndefined();
-    expect(second.eventData.finalSchedulingReplay).toBeUndefined();
+    expect(second.eventData.finalSchedulingReplay).toBeGreaterThanOrEqual(0);
+    expect(second.eventData.finalSchedulingReplay).toBeLessThanOrEqual(elapsed);
   });
 
   it('anchors ttfs correctly for a region-tagged run ID (tag bit cleared, not a future timestamp)', async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -2624,6 +2624,10 @@ export function workflowEntrypoint(
                     }
 
                     let replayStart = 0;
+                    // Whether this pass was served by a retained VM session.
+                    // Set at the resume/replay decision below, before
+                    // `retainedSession` is reassigned for the next iteration.
+                    let servedByRetainedSession = false;
                     try {
                       // --- QuickJS VM engine dispatch ---
                       // The QuickJS engine (opt-in via WORKFLOW_VM=quickjs
@@ -2980,6 +2984,15 @@ export function workflowEntrypoint(
                       let workflowResult: WorkflowResumeResult = retainedSession
                         ? await resumeWorkflow(retainedSession, eventLog.events)
                         : { type: 'replay' };
+                      // A retained resume can still report back `{ type:
+                      // 'replay' }` (internal cache miss), in which case this
+                      // pass falls through to a full replay below and is not
+                      // a retained pass. The `workflow.run` span cannot say
+                      // this: it is tagged `retained` when it opens, before
+                      // the resume result is known.
+                      servedByRetainedSession =
+                        retainedSession !== null &&
+                        workflowResult.type !== 'replay';
 
                       if (workflowResult.type === 'replay') {
                         retainedSession = null;
@@ -3981,6 +3994,7 @@ export function workflowEntrypoint(
                           suspensionCreatedHooks:
                             err.hookCount > 0 || suspensionResult.hasHookEvents,
                           turbo,
+                          retained: servedByRetainedSession,
                         });
 
                         // Slot snapshot for the inline step_started claims: the

--- a/packages/core/src/runtime/step-latency.test.ts
+++ b/packages/core/src/runtime/step-latency.test.ts
@@ -36,6 +36,7 @@ const BASE = {
   suspensionHasWaits: false,
   suspensionCreatedHooks: false,
   turbo: false,
+  retained: false,
 };
 
 describe('computeStepLatencyTracking', () => {
@@ -47,6 +48,8 @@ describe('computeStepLatencyTracking', () => {
     expect(tracking).toEqual({
       ttfsAnchorMs: 1_000,
       preStepBlockingMs: 0,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -60,6 +63,8 @@ describe('computeStepLatencyTracking', () => {
     expect(tracking).toEqual({
       ttfsAnchorMs: 1_000,
       preStepBlockingMs: 0,
+      replayMs: 0,
+      retained: false,
       turbo: true,
     });
   });
@@ -88,6 +93,8 @@ describe('computeStepLatencyTracking', () => {
     expect(tracking).toEqual({
       ttfsAnchorMs: 1_000,
       preStepBlockingMs: 42,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -112,6 +119,8 @@ describe('computeStepLatencyTracking', () => {
       preStepBlockingMs: 0,
       // Earliest attr write wins; occurredAt preferred over createdAt.
       preStepAttrStartMs: 3_000,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -133,6 +142,8 @@ describe('computeStepLatencyTracking', () => {
       ttfsAnchorMs: 1_000,
       preStepBlockingMs: 40,
       preStepAttrStartMs: 3_000,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -151,6 +162,8 @@ describe('computeStepLatencyTracking', () => {
       ttfsAnchorMs: 1_000,
       preStepBlockingMs: 0,
       preStepAttrStartMs: 3_000,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -194,6 +207,7 @@ describe('computeStepLatencyTracking', () => {
       preStepBlockingMs: 0,
       rsfsAnchorMs: 1_100,
       replayMs: 25,
+      retained: false,
       turbo: false,
     });
   });
@@ -205,11 +219,33 @@ describe('computeStepLatencyTracking', () => {
       runStartedReceivedAtMs: undefined,
       replayMs: 25,
     });
+    // replayMs is ungated: it is reported for any batch this function tracks,
+    // even one with no RSFS window of its own.
     expect(tracking).toEqual({
       ttfsAnchorMs: 1_000,
       preStepBlockingMs: 0,
+      replayMs: 25,
+      retained: false,
       turbo: false,
     });
+  });
+
+  it('reports replayMs and retained for an STSO-only (non-first-step) batch', () => {
+    const tracking = computeStepLatencyTracking({
+      ...BASE,
+      events: [
+        makeEvent('run_created'),
+        makeEvent('run_started'),
+        makeEvent('step_completed', { createdAt: new Date(4_500) }),
+      ],
+      invocationStartedClean: false,
+      replayMs: 33,
+      retained: true,
+    });
+    expect(tracking?.ttfsAnchorMs).toBeUndefined();
+    expect(tracking?.rsfsAnchorMs).toBeUndefined();
+    expect(tracking?.replayMs).toBe(33);
+    expect(tracking?.retained).toBe(true);
   });
 
   it('does not mark RSFS when TTFS is disqualified, even though runStartedReceivedAtMs is recoverable', () => {
@@ -240,6 +276,8 @@ describe('computeStepLatencyTracking', () => {
       prevStepEndMs: 4_500,
       stepCount: 1,
       eventCount: 3,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -253,6 +291,8 @@ describe('computeStepLatencyTracking', () => {
       prevStepEndMs: 5_000,
       stepCount: 1,
       eventCount: 1,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -271,6 +311,8 @@ describe('computeStepLatencyTracking', () => {
       prevStepEndMs: new Date('2024-01-01T00:00:00.000Z').getTime(),
       stepCount: 2,
       eventCount: 3,
+      replayMs: 0,
+      retained: false,
       turbo: false,
     });
   });
@@ -324,6 +366,7 @@ describe('computeStepLatencyEventData', () => {
         preStepBlockingMs: 40,
         preStepAttrStartMs: 3_000,
         turbo: false,
+        retained: false,
       },
       // Includes the setAttributes detour — must be excluded.
       stepCodeStartedAtMs: 60_000,
@@ -345,6 +388,7 @@ describe('computeStepLatencyEventData', () => {
         stepCount: 7,
         eventCount: 42,
         turbo: false,
+        retained: false,
       },
       stepCodeStartedAtMs: 2_000,
       stepStartPostSentAtMs: undefined,
@@ -360,6 +404,49 @@ describe('computeStepLatencyEventData', () => {
     });
   });
 
+  it('reports finalSchedulingReplay for an STSO (non-first-step) batch, not just RSFS', () => {
+    const data = computeStepLatencyEventData({
+      tracking: {
+        prevStepEndMs: 1_500,
+        stepCount: 7,
+        eventCount: 42,
+        replayMs: 33,
+        turbo: false,
+        retained: true,
+      },
+      stepCodeStartedAtMs: 2_000,
+      stepStartPostSentAtMs: undefined,
+      attempt: 1,
+      lazyStepStart: true,
+      optimisticStart: false,
+    });
+    expect(data).toEqual({
+      stso: 500,
+      stepCount: 7,
+      eventCount: 42,
+      finalSchedulingReplay: 33,
+      optimizations: ['lazyStepStart', 'retained'],
+    });
+  });
+
+  it('omits the retained optimization when a full replay served the batch', () => {
+    const data = computeStepLatencyEventData({
+      tracking: {
+        prevStepEndMs: 1_500,
+        replayMs: 900,
+        turbo: true,
+        retained: false,
+      },
+      stepCodeStartedAtMs: 2_000,
+      stepStartPostSentAtMs: undefined,
+      attempt: 1,
+      lazyStepStart: false,
+      optimisticStart: false,
+    });
+    expect(data?.finalSchedulingReplay).toBe(900);
+    expect(data?.optimizations).toEqual(['turbo']);
+  });
+
   it('clamps negative durations (cross-machine clock skew) to zero', () => {
     const data = computeStepLatencyEventData({
       tracking: {
@@ -369,6 +456,7 @@ describe('computeStepLatencyEventData', () => {
         stepCount: 3,
         eventCount: 9,
         turbo: false,
+        retained: false,
       },
       stepCodeStartedAtMs: 4_000,
       stepStartPostSentAtMs: undefined,
@@ -394,6 +482,7 @@ describe('computeStepLatencyEventData', () => {
         ttfsAnchorMs: 2_000 + 2 ** 47,
         preStepBlockingMs: 0,
         turbo: true,
+        retained: false,
       },
       stepCodeStartedAtMs: 2_000,
       attempt: 1,
@@ -414,6 +503,7 @@ describe('computeStepLatencyEventData', () => {
         stepCount: 2,
         eventCount: 5,
         turbo: false,
+        retained: false,
       },
       stepCodeStartedAtMs: 2_000,
       attempt: 1,
@@ -460,6 +550,7 @@ describe('computeStepLatencyEventData', () => {
         rsfsAnchorMs: 1_200,
         replayMs: 15,
         turbo: false,
+        retained: false,
       },
       stepCodeStartedAtMs: 2_000,
       stepStartPostSentAtMs: 1_950,
@@ -483,6 +574,7 @@ describe('computeStepLatencyEventData', () => {
         rsfsAnchorMs: 1_200,
         replayMs: 15,
         turbo: false,
+        retained: false,
       },
       stepCodeStartedAtMs: 2_000,
       stepStartPostSentAtMs: undefined,
@@ -505,6 +597,7 @@ describe('computeStepLatencyEventData', () => {
         rsfsAnchorMs: 5_000,
         replayMs: 10,
         turbo: false,
+        retained: false,
       },
       stepCodeStartedAtMs: 2_000,
       stepStartPostSentAtMs: 4_000,

--- a/packages/core/src/runtime/step-latency.ts
+++ b/packages/core/src/runtime/step-latency.ts
@@ -75,21 +75,30 @@ export interface StepLatencyTracking {
    * Wall-clock ms this invocation's synchronous workflow-function replay
    * took: from calling `runWorkflow` to it throwing the suspension that
    * scheduled this batch. Excludes awaited network I/O (the suspension's
-   * event commits, the step's own start POST). Present only alongside
-   * `rsfsAnchorMs`.
+   * event commits, the step's own start POST). Reported for every batch that
+   * qualifies for TTFS or STSO, not just the first step.
    *
-   * This is the FINAL replay pass only: the invocation that reached and
-   * scheduled the first step. Valid RSFS paths can replay more than once
-   * before the first step (e.g. a workflow-body `setAttributes()` detour
-   * replays twice), and a redelivery omits earlier invocations' replay work
-   * entirely; this value is not accumulated across those earlier passes.
-   * Do not read it as "the replay portion of RSFS": RSFS
-   * ({@link rsfsAnchorMs}) covers the whole run_started-to-first-step
-   * window, this covers only the last pass.
+   * This is the FINAL pass only: the one that reached and scheduled this
+   * batch. Valid RSFS paths can replay more than once before the first step
+   * (e.g. a workflow-body `setAttributes()` detour replays twice), and a
+   * redelivery omits earlier invocations' replay work entirely; this value is
+   * not accumulated across those earlier passes. Do not read it as "the
+   * replay portion of RSFS": RSFS ({@link rsfsAnchorMs}) covers the whole
+   * run_started-to-first-step window, this covers only the last pass.
+   *
+   * On a retained resume this measures the resume, not a replay, which is
+   * why the distribution is bimodal and why {@link retained} is reported
+   * alongside it as the dimension that separates the two modes.
    */
   replayMs?: number;
   /** Whether turbo mode is active for this invocation. */
   turbo: boolean;
+  /**
+   * Whether a retained VM session served this batch, as opposed to a full
+   * replay from the event log. Reported as a `retained` entry in
+   * {@link StepLatencyEventData.optimizations}, alongside `turbo`.
+   */
+  retained: boolean;
 }
 
 /**
@@ -111,12 +120,18 @@ export interface StepLatencyEventData {
   /** Client-measured run_started → first step's start POST, ms. */
   rsfs?: number;
   /**
-   * Client-measured wall-clock ms of the FINAL replay pass that scheduled
-   * the first step (see {@link StepLatencyTracking.replayMs}); not
-   * accumulated across earlier pre-first-step passes, so it must not be
-   * read as "the replay portion of `rsfs`".
+   * Client-measured wall-clock ms of the FINAL pass that scheduled this
+   * batch (see {@link StepLatencyTracking.replayMs}); not accumulated
+   * across earlier passes, so it must not be read as "the replay portion of
+   * `rsfs`". Present whenever `ttfs` or `stso` is.
    */
   finalSchedulingReplay?: number;
+  /**
+   * Active runtime modes for this measurement: `turbo`, `lazyStepStart`,
+   * `optimisticStart`, and `retained` (a retained VM served the batch; its
+   * absence means a full replay). The server turns each known entry into a
+   * bounded boolean tag on every latency metric.
+   */
   optimizations?: string[];
 }
 
@@ -215,6 +230,8 @@ export function computeStepLatencyTracking(params: {
   suspensionCreatedHooks: boolean;
   /** Whether turbo mode is active for this invocation. */
   turbo: boolean;
+  /** See {@link StepLatencyTracking.retained}. */
+  retained: boolean;
 }): StepLatencyTracking | undefined {
   const { events } = params;
 
@@ -291,16 +308,17 @@ export function computeStepLatencyTracking(params: {
           ...(preStepAttrStartMs !== undefined ? { preStepAttrStartMs } : {}),
         }
       : {}),
-    ...(rsfsEligible
-      ? {
-          rsfsAnchorMs: params.runStartedReceivedAtMs,
-          replayMs: params.replayMs,
-        }
-      : {}),
+    ...(rsfsEligible ? { rsfsAnchorMs: params.runStartedReceivedAtMs } : {}),
     ...(prevStepEndMs !== undefined
       ? { prevStepEndMs, stepCount, eventCount }
       : {}),
+    // Not gated on rsfsEligible: replay cost is meaningful for every batch
+    // this function returns tracking for. Gating it on RSFS left the STSO
+    // population — ordinary step-to-step transitions, the bulk of step
+    // scheduling — with no replay-cost telemetry at all.
+    replayMs: params.replayMs,
     turbo: params.turbo,
+    retained: params.retained,
   };
 }
 
@@ -378,12 +396,11 @@ export function computeStepLatencyEventData(params: {
   // passes (e.g. a setAttributes detour) and must not be read as "the
   // replay portion of rsfs"; rsfs covers the whole window.
   //
-  // finalSchedulingReplay duplicates what OTEL already captures on the run/invocation
-  // span, but is deliberately collected as client telemetry so the server
-  // can emit it as an UNSAMPLED, full-population metric: workflow-server's
-  // server spans are heavily sampled in production (~7%), and client spans
-  // can't be filtered by SDK version, so neither can serve as the
-  // dashboard's exact TTFS decomposition.
+  // finalSchedulingReplay duplicates what OTEL already captures on the
+  // run/invocation span, but is deliberately collected as client telemetry
+  // so the server can emit it as an UNSAMPLED, full-population metric:
+  // workflow-server's server spans are heavily sampled in production (~7%),
+  // so they cannot serve as the dashboard's exact TTFS decomposition.
   const rsfs =
     tracking.rsfsAnchorMs !== undefined &&
     params.stepStartPostSentAtMs !== undefined
@@ -403,6 +420,11 @@ export function computeStepLatencyEventData(params: {
   if (params.lazyStepStart) optimizations.push('lazyStepStart');
   if (params.optimisticStart) optimizations.push('optimisticStart');
   if (params.preclaimedStart) optimizations.push('preclaimedStart');
+  // Rides the existing optimizations list rather than a dedicated wire
+  // field: the server already parses this array and turns each known entry
+  // into a bounded boolean tag on every latency metric, so `retained`
+  // dimensions ttfs/stso/rsfs/finalSchedulingReplay for free.
+  if (tracking.retained) optimizations.push('retained');
 
   return {
     ...(ttfs !== undefined ? { ttfs } : {}),


### PR DESCRIPTION
This changes metrics and spans only:

1. More spans get `replayCost`
2. Added `retained` as an optimization tag so it is reported by the backend spans.

<details>
## Summary

Two changes, both in `@workflow/core`:

1. **Replay cost is now reported for every batch that qualifies for TTFS *or* STSO**, not just the run's first step. `replayMs` was gated on RSFS eligibility, so every ordinary step-to-step transition — the STSO population, which is the bulk of step scheduling — had no replay-cost telemetry at all. The value was already measured at every suspension (`replayDurationMs` in `runtime.ts`) and then discarded.

3. **Whether a retained VM served the batch is reported as a `retained` entry in the existing `optimizations` list**, alongside `turbo`/`lazyStepStart`/`optimisticStart`. `finalSchedulingReplay` measures a resume on the retained path and a full replay otherwise, so without this dimension the metric is knowingly bimodal — the existing doc comment says so.

## Why `optimizations` instead of a dedicated field

An earlier version of this PR added a `replayMode: 'replay' | 'retained'` wire field, which cost two extra packages here (`world-vercel`, `world`) plus a parse/sanitize path and a metric tag in workflow-server.

Riding the existing `optimizations` array instead means the SDK change is one line and the server needs no new parsing at all: `reportClientStepLatency` already turns each known entry into a bounded boolean tag applied to *every* latency metric. So the companion backend change — **vercel/workflow-server#767** — collapses to adding one entry to `OPTIMIZATION_TAGS`, and `retained` dimensions `ttfs_ms`, `stso_ms`, `rsfs_ms` and `final_scheduling_replay_ms` rather than only the last of those. Unknown entries are already ignored server-side, so old and new SDKs interoperate; `client_version` is already a tag on these metrics, so "no flag because full replay" stays distinguishable from "no flag because old SDK".

## Why the retained flag is computed here rather than read off a span

`traceExecution` tags the `workflow.run` span `retained` when the span opens, before `session.resume()` can come back with `{ type: 'replay' }` on an internal cache miss and fall through to a real replay. The flag in this PR is computed after the resume result is known, so it does not inherit that mislabeling.

## Motivation

Production analysis of the `v0chat` STSO tail: retained batches were 88.5% of sampled steps with a 2.0 s STSO p75, full replays 11.4% with a 58.7 s p75, and full replay accounted for 66% of everything above p90. Mode is the strongest tail discriminator found, and it was only reachable via a cross-span temporal join over ~7% sampled spans.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/runtime/step-latency.test.ts` — 38 passed, including the STSO broadening and both `retained` states
- [x] `pnpm exec vitest run packages/core/src/runtime.test.ts` — 44 passed; the turbo latency test now pins that the first step's pass (a full replay that built the VM) has no `retained` flag while the second step's pass, resumed from the session the same invocation retained, does
- [x] `pnpm exec vitest run packages/core/src/workflow.test.ts` — 89 passed, 1 expected fail
- [x] `pnpm --filter @workflow/core typecheck`
- [ ] Confirm in staging that `step_completed`/`step_failed` events for ordinary (non-first-step) suspensions carry `finalSchedulingReplay`, and that `retained` appears in `optimizations`
</details>

