### PR TITLE
[deps] Dedupe zod and undici by publishing caret ranges

### DIFF
--- a/.changeset/dedupe-zod-undici-ranges.md
+++ b/.changeset/dedupe-zod-undici-ranges.md
@@ -1,0 +1,13 @@
+---
+'@workflow/world-vercel': patch
+'@workflow/world-postgres': patch
+'@workflow/world-testing': patch
+'@workflow/world-local': patch
+'@workflow/core': patch
+'@workflow/world': patch
+'@workflow/cli': patch
+'@workflow/ai': patch
+'workflow': patch
+---
+
+Widen the published `zod` and `undici` ranges to carets so they deduplicate with other packages in an app instead of installing a second copy.

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -309,10 +309,13 @@ const CreateEventV4PageSchema = z.union([
     cursor: z.string().nullable(),
     hasMore: z.boolean(),
   }),
+  // No page at all. The keys have to be spelled `.optional()` and not just
+  // `z.undefined()`: since zod 4.4 a key is only allowed to be missing when its
+  // schema is optional, and a response without a page omits these outright.
   z.object({
-    events: z.undefined(),
-    cursor: z.undefined(),
-    hasMore: z.undefined(),
+    events: z.undefined().optional(),
+    cursor: z.undefined().optional(),
+    hasMore: z.undefined().optional(),
   }),
 ]);
 

--- a/packages/world/src/serialization.ts
+++ b/packages/world/src/serialization.ts
@@ -25,8 +25,15 @@ export const LegacySerializedDataSchemaV1: z.ZodType<unknown> = z.any();
 /**
  * Union schema that accepts both v2+ (Uint8Array) and legacy (any) serialized data.
  * Use this for validation when data may come from either specVersion.
+ *
+ * Serialized payloads are frequently absent: they travel in a frame body rather
+ * than the metadata object, or the event simply carries none. The `.optional()`
+ * is what allows the key to be missing at parse time. Up to zod 4.3 the
+ * `z.any()` branch did that implicitly, while the inferred type stayed
+ * required; zod 4.4 made `any`/`unknown` keys required at parse time too. The
+ * cast keeps the inferred type as it has always been, so consumers still see
+ * these keys as present, and only the parse-time tolerance is restored.
  */
-export const SerializedDataSchema = z.union([
-  BinarySerializedDataSchema,
-  LegacySerializedDataSchemaV1,
-]);
+export const SerializedDataSchema = z
+  .union([BinarySerializedDataSchema, LegacySerializedDataSchemaV1])
+  .optional() as unknown as z.ZodType<SerializedData>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,14 +49,14 @@ catalogs:
       specifier: ~3.0.1
       version: 3.0.1
     undici:
-      specifier: 7.29.0
+      specifier: ^7.29.0
       version: 7.29.0
     vitest:
       specifier: ^4.1.10
       version: 4.1.10
     zod:
-      specifier: ~4.3.6
-      version: 4.3.6
+      specifier: ^4.3.6
+      version: 4.4.3
 
 overrides:
   '@opentelemetry/api': 1.9.1
@@ -254,7 +254,7 @@ importers:
         version: link:../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       bun:
         specifier: ^1.3.0
@@ -288,14 +288,14 @@ importers:
         version: link:../serde
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@workflow/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -305,19 +305,19 @@ importers:
     optionalDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.0
-        version: 3.0.58(zod@4.3.6)
+        version: 3.0.58(zod@4.4.3)
       '@ai-sdk/gateway':
         specifier: ^3.0.0
-        version: 3.0.66(zod@4.3.6)
+        version: 3.0.66(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^3.0.0
-        version: 3.0.43(zod@4.3.6)
+        version: 3.0.43(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.0
-        version: 3.0.41(zod@4.3.6)
+        version: 3.0.41(zod@4.4.3)
       '@ai-sdk/xai':
         specifier: ^3.0.0
-        version: 3.0.67(zod@4.3.6)
+        version: 3.0.67(zod@4.4.3)
 
   packages/astro:
     dependencies:
@@ -496,7 +496,7 @@ importers:
         version: 5.1.0
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -569,7 +569,7 @@ importers:
         version: 3.0.1
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@opentelemetry/api':
         specifier: 1.9.1
@@ -624,13 +624,13 @@ importers:
         version: link:../next
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       workflow:
         specifier: workspace:*
         version: link:../workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1345,7 +1345,7 @@ importers:
         version: 3.0.1
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1385,7 +1385,7 @@ importers:
         version: 7.29.0
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@opentelemetry/api':
         specifier: 1.9.1
@@ -1449,7 +1449,7 @@ importers:
         version: 3.0.1
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@testcontainers/postgresql':
         specifier: 11.12.0
@@ -1535,7 +1535,7 @@ importers:
         version: link:../workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/jsonlines':
         specifier: 0.1.5
@@ -1584,7 +1584,7 @@ importers:
         version: 8.20.0
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@opentelemetry/api':
         specifier: 1.9.1
@@ -1730,7 +1730,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       astro:
         specifier: ^7.0.6
         version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@netlify/blobs@9.1.2)(@types/node@24.6.2)(@vercel/blob@2.0.0)(@vercel/functions@3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0))(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(ioredis@5.10.1)(jiti@2.7.0)(rollup@4.62.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
@@ -1739,13 +1739,13 @@ importers:
         version: 4.2.0
       openai:
         specifier: 6.9.0
-        version: 6.9.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.9.0(ws@8.20.0)(zod@4.4.3)
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/example:
     dependencies:
@@ -1763,7 +1763,7 @@ importers:
         version: link:../../packages/ai
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1772,13 +1772,13 @@ importers:
         version: 0.0.4
       openai:
         specifier: ^6
-        version: 6.1.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.1.0(ws@8.20.0)(zod@4.4.3)
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/lodash.chunk':
         specifier: ^4.2.9
@@ -1816,19 +1816,19 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
       openai:
         specifier: ^6.1.0
-        version: 6.6.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.6.0(ws@8.20.0)(zod@4.4.3)
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/fastify:
     dependencies:
@@ -1850,13 +1850,13 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
       openai:
         specifier: ^6.6.0
-        version: 6.9.1(ws@8.20.0)(zod@4.3.6)
+        version: 6.9.1(ws@8.20.0)(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1865,7 +1865,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/hono:
     devDependencies:
@@ -1877,7 +1877,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       hono:
         specifier: ^4.12.27
         version: 4.12.28
@@ -1889,13 +1889,13 @@ importers:
         version: 3.0.260610-beta(@netlify/blobs@9.1.2)(@vercel/blob@2.0.0)(@vercel/functions@3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0))(@vercel/queue@0.3.1)(better-sqlite3@11.10.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.2)(vite@8.1.3(@types/node@24.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       openai:
         specifier: ^6.6.0
-        version: 6.6.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.6.0(ws@8.20.0)(zod@4.4.3)
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/nest:
     dependencies:
@@ -1919,7 +1919,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -1928,7 +1928,7 @@ importers:
         version: 4.2.0
       openai:
         specifier: ^6.1.0
-        version: 6.9.1(ws@8.20.0)(zod@4.3.6)
+        version: 6.9.1(ws@8.20.0)(zod@4.4.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1959,13 +1959,13 @@ importers:
         version: 6.0.3
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/nextjs-turbopack:
     dependencies:
       '@ai-sdk/react':
         specifier: 2.0.76
-        version: 2.0.76(react@19.2.7)(zod@4.3.6)
+        version: 2.0.76(react@19.2.7)(zod@4.4.3)
       '@node-rs/xxhash':
         specifier: 1.7.6
         version: 1.7.6
@@ -1998,7 +1998,7 @@ importers:
         version: link:../../packages/ai
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -2028,7 +2028,7 @@ importers:
         version: 16.2.11(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       openai:
         specifier: 6.9.1
-        version: 6.9.1(ws@8.20.0)(zod@4.3.6)
+        version: 6.9.1(ws@8.20.0)(zod@4.4.3)
       radix-ui:
         specifier: 1.4.3
         version: 1.4.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2055,7 +2055,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -2089,7 +2089,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: 2.0.76
-        version: 2.0.76(react@19.2.7)(zod@4.3.6)
+        version: 2.0.76(react@19.2.7)(zod@4.4.3)
       '@node-rs/xxhash':
         specifier: 1.7.6
         version: 1.7.6
@@ -2122,7 +2122,7 @@ importers:
         version: link:../../packages/ai
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -2152,7 +2152,7 @@ importers:
         version: 16.2.11(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       openai:
         specifier: 6.9.1
-        version: 6.9.1(ws@8.20.0)(zod@4.3.6)
+        version: 6.9.1(ws@8.20.0)(zod@4.4.3)
       radix-ui:
         specifier: 1.4.3
         version: 1.4.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2179,7 +2179,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -2219,7 +2219,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       h3:
         specifier: ^1.15.5
         version: 1.15.11
@@ -2231,13 +2231,13 @@ importers:
         version: 2.13.4(@netlify/blobs@9.1.2)(@vercel/blob@2.0.0)(@vercel/functions@3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0))(better-sqlite3@11.10.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(oxc-parser@0.133.0)(rolldown@1.1.4)(srvx@0.11.21)
       openai:
         specifier: ^6.6.0
-        version: 6.6.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.6.0(ws@8.20.0)(zod@4.4.3)
       workflow:
         specifier: workspace:*
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/nitro-v3:
     dependencies:
@@ -2253,7 +2253,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2262,7 +2262,7 @@ importers:
         version: 3.0.260610-beta(@netlify/blobs@9.1.2)(@vercel/blob@2.0.0)(@vercel/functions@3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0))(@vercel/queue@0.3.1)(better-sqlite3@11.10.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.2)(vite@8.1.3(@types/node@24.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       openai:
         specifier: ^6.1.0
-        version: 6.6.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.6.0(ws@8.20.0)(zod@4.4.3)
       rollup:
         specifier: ^4.62.2
         version: 4.62.2
@@ -2271,7 +2271,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/nuxt:
     dependencies:
@@ -2290,7 +2290,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       h3:
         specifier: ^1.15.5
         version: 1.15.11
@@ -2302,7 +2302,7 @@ importers:
         version: 4.4.8(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.4.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vercel/blob@2.0.0)(@vercel/functions@3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0))(@vue/compiler-sfc@3.5.35)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.62.2))(rollup@4.62.2)(terser@5.44.0)(tsx@4.20.6)(typescript@6.0.3)(vite@7.3.6(@types/node@22.19.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(yaml@2.9.0)
       openai:
         specifier: ^6.6.0
-        version: 6.6.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.6.0(ws@8.20.0)(zod@4.4.3)
       vite:
         specifier: 7.3.6
         version: 7.3.6(@types/node@22.19.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
@@ -2311,7 +2311,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/sim-world:
     devDependencies:
@@ -2335,7 +2335,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: 2.0.76
-        version: 2.0.76(react@19.2.7)(zod@4.3.6)
+        version: 2.0.76(react@19.2.7)(zod@4.4.3)
       '@node-rs/xxhash':
         specifier: 1.7.6
         version: 1.7.6
@@ -2359,7 +2359,7 @@ importers:
         version: link:../../packages/ai
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       exsolve:
         specifier: ^1.0.7
         version: 1.0.7
@@ -2371,7 +2371,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@sveltejs/kit':
         specifier: ^2.69.1
@@ -2521,7 +2521,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2530,7 +2530,7 @@ importers:
         version: 3.0.260610-beta(@netlify/blobs@9.1.2)(@vercel/blob@2.0.0)(@vercel/functions@3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0))(@vercel/queue@0.3.1)(better-sqlite3@11.10.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.2)(vite@7.3.6(@types/node@24.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       openai:
         specifier: ^6.1.0
-        version: 6.9.1(ws@8.20.0)(zod@4.3.6)
+        version: 6.9.1(ws@8.20.0)(zod@4.4.3)
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@24.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
@@ -2539,7 +2539,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/vite:
     dependencies:
@@ -2555,7 +2555,7 @@ importers:
         version: link:../../packages/world-postgres
       ai:
         specifier: 'catalog:'
-        version: 6.0.116(zod@4.3.6)
+        version: 6.0.116(zod@4.4.3)
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2564,7 +2564,7 @@ importers:
         version: 3.0.260610-beta(@netlify/blobs@9.1.2)(@vercel/blob@2.0.0)(@vercel/functions@3.8.0(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0))(@vercel/queue@0.3.1)(better-sqlite3@11.10.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.2)(vite@7.3.6(@types/node@24.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       openai:
         specifier: ^6.6.0
-        version: 6.6.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.6.0(ws@8.20.0)(zod@4.4.3)
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@24.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
@@ -2573,7 +2573,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   workbench/vitest:
     devDependencies:
@@ -2594,7 +2594,7 @@ importers:
         version: link:../../packages/workflow
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
 packages:
 
@@ -16561,10 +16561,6 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -17551,9 +17547,6 @@ packages:
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -17577,19 +17570,19 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@3.0.58(zod@4.3.6)':
+  '@ai-sdk/anthropic@3.0.58(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.4.3)
+      zod: 4.4.3
     optional: true
 
-  '@ai-sdk/gateway@2.0.0(zod@4.3.6)':
+  '@ai-sdk/gateway@2.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.3.6)
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.4.3)
       '@vercel/oidc': 3.0.3
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.143(zod@4.4.3)':
     dependencies:
@@ -17598,13 +17591,6 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
-      zod: 4.3.6
-
   '@ai-sdk/gateway@3.0.66(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -17612,40 +17598,33 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/google@3.0.43(zod@4.3.6)':
+  '@ai-sdk/google@3.0.43(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.4.3)
+      zod: 4.4.3
     optional: true
 
-  '@ai-sdk/openai-compatible@2.0.35(zod@4.3.6)':
+  '@ai-sdk/openai-compatible@2.0.35(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.4.3)
+      zod: 4.4.3
     optional: true
 
-  '@ai-sdk/openai@3.0.41(zod@4.3.6)':
+  '@ai-sdk/openai@3.0.41(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.4.3)
+      zod: 4.4.3
     optional: true
 
-  '@ai-sdk/provider-utils@3.0.12(zod@4.3.6)':
+  '@ai-sdk/provider-utils@3.0.12(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
-
-  '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.19(zod@4.4.3)':
     dependencies:
@@ -17673,15 +17652,15 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@2.0.76(react@19.2.7)(zod@4.3.6)':
+  '@ai-sdk/react@2.0.76(react@19.2.7)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.3.6)
-      ai: 5.0.76(zod@4.3.6)
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.4.3)
+      ai: 5.0.76(zod@4.4.3)
       react: 19.2.7
       swr: 2.3.6(react@19.2.7)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@ai-sdk/react@3.0.221(react@19.2.4)(zod@4.4.3)':
     dependencies:
@@ -17693,12 +17672,12 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/xai@3.0.67(zod@4.3.6)':
+  '@ai-sdk/xai@3.0.67(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.35(zod@4.3.6)
+      '@ai-sdk/openai-compatible': 2.0.35(zod@4.4.3)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.4.3)
+      zod: 4.4.3
     optional: true
 
   '@alloc/quick-lru@5.2.0': {}
@@ -27013,21 +26992,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.76(zod@4.3.6):
+  ai@5.0.76(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 2.0.0(zod@4.3.6)
+      '@ai-sdk/gateway': 2.0.0(zod@4.4.3)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.3.6)
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
-      zod: 4.3.6
-
-  ai@6.0.116(zod@4.3.6):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
-      '@opentelemetry/api': 1.9.1
-      zod: 4.3.6
+      zod: 4.4.3
 
   ai@6.0.116(zod@4.4.3):
     dependencies:
@@ -27254,7 +27225,7 @@ snapshots:
       vitefu: 1.1.3(vite@8.1.3(@types/node@22.19.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -27346,7 +27317,7 @@ snapshots:
       vitefu: 1.1.3(vite@8.1.3(@types/node@24.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -29414,7 +29385,7 @@ snapshots:
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       next: 16.2.11(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -32482,25 +32453,25 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.1.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.1.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  openai@6.6.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.6.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  openai@6.9.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.9.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  openai@6.9.1(ws@8.20.0)(zod@4.3.6):
+  openai@6.9.1(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   optionator@0.9.4:
     dependencies:
@@ -35058,7 +35029,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.1
       tmp: 0.2.5
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -35345,8 +35316,6 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
-
-  undici@7.28.0: {}
 
   undici@7.29.0: {}
 
@@ -36583,8 +36552,6 @@ snapshots:
       readable-stream: 4.7.0
 
   zod@4.1.11: {}
-
-  zod@4.3.6: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,9 +21,9 @@ catalog:
   semver: 7.7.4
   typescript: ^6.0.3
   ulid: ~3.0.1
-  undici: 7.29.0
+  undici: ^7.29.0
   vitest: ^4.1.10
-  zod: ~4.3.6
+  zod: ^4.3.6
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## What

Catalog change: `undici: 7.29.0` → `^7.29.0`, `zod: ~4.3.6` → `^4.3.6`.

Those catalog entries become the literal ranges in the published manifests of `@workflow/core`, `@workflow/world`, `@workflow/world-local`, `@workflow/world-vercel`, `@workflow/world-postgres`, `@workflow/world-testing`, `@workflow/cli` and `@workflow/ai`. An exact pin or a tilde can only ever match one version, so any other dependency in the app asking for a compatible-but-different version gets its own copy.

The exact `undici` pin dedupes with `@ai-sdk/provider-utils`' `^7.28.0` today only because 7.29.0 happens to be the newest 7.x. It splits the moment 7.30.0 ships.

## zod 4.4

`^4.3.6` resolves to 4.4.3 in this repo. zod 4.4 stopped treating `any`, `unknown` and `undefined` object keys as implicitly optional, which broke 43 tests across `@workflow/world-vercel` and `@workflow/world-local`. Two places relied on that looseness:

- `SerializedDataSchema` (`packages/world/src/serialization.ts`). Serialized payloads are routinely absent, since they travel in a frame body rather than the metadata object. The `z.any()` branch used to make every key holding this schema optional at parse time while the inferred type stayed required. The `.optional()` plus cast restores exactly that split.
- `CreateEventV4PageSchema`'s no-page branch (`packages/world-vercel/src/events-v4.ts`), where the three page keys are omitted outright.

Verified against both zod 4.3.6 (via a temporary override) and 4.4.3, so the `^4.3.6` floor is accurate.

## What this does not fix

Neither remaining duplicate in a `workflow` + `ai` install is ours:

- **zod 4.1.11** comes from `@vercel/cli-auth@0.0.1` and `@vercel/cli-config@0.2.3`, both of which pin zod exactly. Needs an upstream unpin.
- **undici 5.29.0** comes from `@ai-sdk/provider-utils@4`, which wants `^5.29.0`. Different major, no range on our side bridges it.

## Test plan

- `pnpm build`, `pnpm typecheck`, `pnpm test` green on zod 4.4.3
- `pnpm test` green again with a temporary `zod: 4.3.6` override, confirming the floor
- Packed tarballs carry `zod: ^4.3.6` / `undici: ^7.29.0`