### PR TITLE
[world-local] [test-only] Extend test budget on Windows runner for local storage test

### DIFF
--- a/.changeset/windows-preload-timeout.md
+++ b/.changeset/windows-preload-timeout.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Raise the timeout on the world-local complete-preload test so it stops failing on the Windows CI runner.

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -9,6 +9,7 @@ import { monotonicFactory } from 'ulid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fsModule from './fs.js';
 import { promoteExclusive, writeExclusive, writeJSON } from './fs.js';
+import { MAX_CACHED_EVENT_ENTRIES } from './storage/events-storage.js';
 import * as helpers from './storage/helpers.js';
 import {
   hashToken,
@@ -1281,13 +1282,30 @@ describe('Storage', () => {
         expect(fileExists).toBe(true);
       });
 
+      // Sized one event past the event cache so the preload cannot be served
+      // from cached entries alone and has to go back to the JSON files for at
+      // least one of them. Below the ceiling this still passes, and would stop
+      // covering that fallback, so the count tracks the ceiling rather than
+      // restating it.
+      //
+      // Those writes are sequential and each one is a file write, which is the
+      // whole cost of the test: ~1s on a developer machine, but two minutes on
+      // the Windows CI runner, where per-write latency is orders of magnitude
+      // worse. Batching them with `Promise.all` is slower, not faster: writers
+      // then contend for the same event slot and re-probe. Hence the timeout
+      // well past any other test in this file.
       it('returns the complete preload when run_started is retried', async () => {
+        const total = MAX_CACHED_EVENT_ENTRIES + 1;
+
         await storage.events.create(testRunId, {
           eventType: 'run_started',
           specVersion: SPEC_VERSION_CURRENT,
         });
 
-        for (let index = 0; index < 999; index++) {
+        // `run_created` from the fixture and the first `run_started` are
+        // already on the log, and the retry below is idempotent and appends
+        // nothing, so the fill is two short of `total`.
+        for (let index = 0; index < total - 2; index++) {
           await storage.events.create(testRunId, {
             eventType: 'attr_set',
             specVersion: SPEC_VERSION_CURRENT,
@@ -1304,16 +1322,16 @@ describe('Storage', () => {
         });
         assert(preloaded.events);
         assert(preloaded.cursor);
-        expect(preloaded.events).toHaveLength(1001);
+        expect(preloaded.events).toHaveLength(total);
         expect(preloaded.hasMore).toBe(false);
 
         const all = await storage.events.list({
           runId: testRunId,
-          pagination: { sortOrder: 'asc', limit: 2000 },
+          pagination: { sortOrder: 'asc', limit: total * 2 },
         });
 
         expect(preloaded.events).toEqual(all.data);
-      }, 120_000);
+      }, 300_000);
 
       it('returns a resumable partial preload at the event ceiling', async () => {
         await storage.events.create(testRunId, {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -108,6 +108,14 @@ import { withRunFileLock } from './runs-storage.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Entry ceiling for the in-process event cache. A run whose log exceeds this
+ * cannot be served from the cache alone, so reads past it go back to the JSON
+ * files. Exported so a test that means to cross that boundary can size itself
+ * from the ceiling rather than restate it.
+ */
+export const MAX_CACHED_EVENT_ENTRIES = 1000;
+
 function getHookRetentionLimitMs(): number {
   const days = Number(
     process.env.WORKFLOW_LOCAL_HOOK_RETENTION_LIMIT_DAYS ?? 30
@@ -575,7 +583,7 @@ export function createEventsStorage(
   // and entry count are both bounded so active/waiting runs cannot retain
   // unbounded histories in a long-lived development server.
   const maxCachedEventBytes = 4 * 1024 * 1024;
-  const maxCachedEventEntries = 1000;
+  const maxCachedEventEntries = MAX_CACHED_EVENT_ENTRIES;
   const eventCache = new Map<string, Event>();
   const cachedEventBytes = new Map<string, number>();
   const cachedPathsByRunId = new Map<string, Set<string>>();


### PR DESCRIPTION
`Unit Tests (windows-latest)` has been red on `main`. One of its two independent
failures is `packages/world-local/src/storage.test.ts`, reported at lines 1284
and 1353 across main runs 31604115603, 31533009514 and 31616799260.

`returns the complete preload when run_started is retried` writes 999 events
sequentially, then asserts the preload. On the Windows runner each write costs
orders of magnitude more than locally, and the whole file drifted past its
budget: a green run took 143491ms and a failing run 154816ms with the same 245
tests, 8% apart. `events.create` is linear locally at ~0.95ms across n = 250,
500, 1000, 2000, so nothing got slower per event. It is a marginal budget, not
a step regression.

Two things that look like fixes and are not:

- **Batch the writes.** At width 32 it is *slower* (1368ms vs 988ms sequential):
  the writers contend for the same event slot and re-probe.
- **Shrink the event count.** At 501 the test still passes, which is the trap.
  The 1000 is load-bearing: it is the event cache's entry ceiling, so the test
  is the only thing covering the read-past-cache fallback. Below the ceiling it
  goes on passing while silently covering nothing.

So: export `MAX_CACHED_EVENT_ENTRIES` and size the test from it (ceiling + 1)
rather than restating the number, and raise the timeout. The comment records
why the count is what it is and why batching is not the cheaper option.

Windows CI on this branch confirms world-local now passes entirely,
`Test Files 15 passed (15)`.

The other failure family, `packages/core/src/events-consumer.test.ts` at lines
1005 and 1123, is not addressed here. It has its own fix in a follow-up PR.
