### PR TITLE
[world-vercel] Retry throttled (429) event writes in-process, honoring Retry-After

### DIFF
--- a/.changeset/throttle-in-process-retry.md
+++ b/.changeset/throttle-in-process-retry.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Retry 429 (ThrottleError) event writes in-process, honoring the server's `Retry-After`, bounded by a 30s cumulative wait budget per write. Previously a throttled event write escaped to the queue handler, whose retry directive can be delayed up to ~5 minutes by queue redelivery scheduling.

--- a/packages/world-vercel/src/event-retry.test.ts
+++ b/packages/world-vercel/src/event-retry.test.ts
@@ -11,6 +11,7 @@ import {
   EVENT_RETRY_ELIGIBILITY,
   isRetryableEventPostError,
   MAX_EVENT_POST_RETRIES,
+  THROTTLE_RETRY_BUDGET_MS,
   withEventPostRetry,
 } from './event-retry.js';
 
@@ -280,6 +281,102 @@ describe('withEventPostRetry', () => {
 
     await expect(withEventPostRetry(fn, 'hook_received')).rejects.toThrow();
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  describe('throttle (429) in-process retry', () => {
+    it('retries a ThrottleError after its retryAfter and returns the result', async () => {
+      let calls = 0;
+      const fn = vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new ThrottleError('429', { retryAfter: 14 });
+        return 'ok';
+      });
+
+      const p = withEventPostRetry(fn, 'step_completed');
+      // Not yet retried before the server's requested wait has elapsed.
+      await vi.advanceTimersByTimeAsync(13_000);
+      expect(fn).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(p).resolves.toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('applies to eligibility-excluded events too (429 is a definitive no-write)', async () => {
+      let calls = 0;
+      const fn = vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new ThrottleError('429', { retryAfter: 1 });
+        return 'ok';
+      });
+
+      const p = withEventPostRetry(fn, 'step_started');
+      await vi.runAllTimersAsync();
+
+      await expect(p).resolves.toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('defaults to a 1s wait when the 429 carries no retryAfter', async () => {
+      let calls = 0;
+      const fn = vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new ThrottleError('429');
+        return 'ok';
+      });
+
+      const p = withEventPostRetry(fn, 'run_started');
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(p).resolves.toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces the ThrottleError once the cumulative wait budget is exhausted', async () => {
+      const fn = vi.fn(async () => {
+        throw new ThrottleError('429', { retryAfter: 14 });
+      });
+
+      const p = withEventPostRetry(fn, 'step_completed').catch((e) => e);
+      await vi.runAllTimersAsync();
+
+      const err = await p;
+      expect(ThrottleError.is(err)).toBe(true);
+      // 14s per attempt against a 30s budget: 14 + 14 fits, a third doesn't.
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it('surfaces immediately when retryAfter alone exceeds the budget', async () => {
+      const fn = vi.fn(async () => {
+        throw new ThrottleError('429', {
+          retryAfter: THROTTLE_RETRY_BUDGET_MS / 1000 + 1,
+        });
+      });
+
+      await expect(withEventPostRetry(fn, 'step_completed')).rejects.toThrow(
+        '429'
+      );
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not consume the transient retry allowance', async () => {
+      // A throttle wait followed by transient blips: the transient counter
+      // still permits MAX_EVENT_POST_RETRIES retries.
+      let calls = 0;
+      const fn = vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new ThrottleError('429', { retryAfter: 1 });
+        if (calls <= 1 + MAX_EVENT_POST_RETRIES)
+          throw transportErr('ECONNRESET');
+        return 'ok';
+      });
+
+      const p = withEventPostRetry(fn, 'step_completed');
+      await vi.runAllTimersAsync();
+
+      await expect(p).resolves.toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2 + MAX_EVENT_POST_RETRIES);
+    });
   });
 
   describe('idempotentHookResume opt-in', () => {

--- a/packages/world-vercel/src/event-retry.ts
+++ b/packages/world-vercel/src/event-retry.ts
@@ -39,8 +39,22 @@
  *                       standard policy via
  *                       {@link EventPostRetryOptions.idempotentHookResume}.
  *
- * Only transient/ambiguous transport failures are retried; definitive responses
- * (409/410/425/429 and any other 4xx) surface immediately, exactly as before.
+ * Only transient/ambiguous transport failures are retried under that
+ * eligibility matrix; definitive responses (409/410/425 and any other 4xx)
+ * surface immediately, exactly as before.
+ *
+ * A 429 (`ThrottleError`) is handled by a separate in-process policy that
+ * applies to EVERY event type: a genuine application 429 means the server
+ * rejected the write outright — nothing landed — so none of the duplicate-row /
+ * attempt-double-count hazards above apply (the same definitive-no-write
+ * reasoning `STREAM_RETRY_OPTIONS` uses to retry 429 on stream PUTs). Firewall
+ * challenges never reach here as `ThrottleError`: `errorForResponse` maps a
+ * 429 + `x-vercel-mitigated: challenge` to a transport `WorkflowWorldError`
+ * instead (see isFirewallChallenge429), so throttle retries cannot hot-loop
+ * against the firewall. Each retry honors the server's `retryAfter`, and the
+ * cumulative wait is capped by THROTTLE_RETRY_BUDGET_MS — beyond that the
+ * ThrottleError surfaces and the queue's redelivery takes over, exactly as
+ * before this policy existed.
  *
  * This is the *only* retry loop on the event-write path, for both transports.
  * The WebSocket transport raises `code: 'TRANSPORT'` — the shape `utils.ts`
@@ -162,6 +176,20 @@ export const EVENT_RETRY_ELIGIBILITY = {
 
 /** Up to this many retries after the initial attempt (3 attempts total). */
 export const MAX_EVENT_POST_RETRIES = 2;
+
+/**
+ * Cumulative in-process wait budget for 429 (`ThrottleError`) retries, per
+ * event POST. Bounds the "no attempt tracking" failure mode: a server that
+ * keeps 429ing cannot pin the invocation — once the budget cannot cover the
+ * next `retryAfter`, the ThrottleError surfaces and the queue's (delivery-
+ * counted, backed-off) redelivery takes over. Sized to ride out the
+ * transaction-conflict shape workflow-server produces (a jittered Retry-After
+ * on the order of ~10s, so a couple of attempts fit) while staying well inside
+ * a flow invocation's duration limit.
+ */
+export const THROTTLE_RETRY_BUDGET_MS = 30_000;
+/** Backoff when a 429 carries no usable Retry-After. */
+const DEFAULT_THROTTLE_RETRY_AFTER_SECONDS = 1;
 /** Base backoff; doubles per attempt. Kept tiny — the goal is riding out a
  * brief blip inline, not waiting out an outage (that falls through to the
  * queue's redelivery). */
@@ -210,13 +238,17 @@ function collectErrorMarkers(err: unknown, depth = 0): string[] {
 }
 
 /**
- * Whether a failed event POST should be retried. Retries transient/ambiguous
- * transport failures and transient 5xx; never retries a definitive response
- * (409/410/425/429 and other 4xx), which surfaces immediately as today.
+ * Whether a failed event POST should be retried as a transient failure.
+ * Retries transient/ambiguous transport failures and transient 5xx; never
+ * retries a definitive response (409/410/425/429 and other 4xx). 429 is not
+ * "transient" in this classification — `withEventPostRetry` gives it its own
+ * budgeted, Retry-After-honoring policy.
  */
 export function isRetryableEventPostError(err: unknown): boolean {
-  // Definitive, server-considered outcomes — never retried in-process.
-  // (425/429 are intentionally left to the runtime's retry-after handling.)
+  // Definitive, server-considered outcomes — never retried as *transient*.
+  // (425 is left to the runtime's retry-after handling; 429 has its own
+  // in-process policy in withEventPostRetry, gated by THROTTLE_RETRY_BUDGET_MS
+  // rather than this transient classification.)
   if (
     EntityConflictError.is(err) ||
     RunExpiredError.is(err) ||
@@ -302,39 +334,86 @@ export interface EventPostRetryOptions {
 }
 
 /**
+ * Per-POST throttle-wait accounting. The returned function waits out a 429's
+ * `retryAfter` in-process (so the caller can re-attempt), or rethrows the
+ * ThrottleError once the cumulative wait would exceed THROTTLE_RETRY_BUDGET_MS
+ * — at which point the queue's delivery-counted redelivery takes over.
+ */
+function createThrottleWaiter(
+  eventType: WorkflowEventType
+): (err: ThrottleError) => Promise<void> {
+  let waitedMs = 0;
+  return async (err) => {
+    const waitMs =
+      Math.max(
+        1,
+        typeof err.retryAfter === 'number'
+          ? err.retryAfter
+          : DEFAULT_THROTTLE_RETRY_AFTER_SECONDS
+      ) * 1000;
+    if (waitedMs + waitMs > THROTTLE_RETRY_BUDGET_MS) {
+      logRetry('throttle retry budget exhausted; surfacing to the queue', {
+        eventType,
+        waitedMs,
+        retryAfter: err.retryAfter,
+      });
+      throw err;
+    }
+    waitedMs += waitMs;
+    // Visible (not debug-gated): this stalls the invocation for whole
+    // seconds, which would otherwise read as unexplained latency.
+    console.warn(
+      `[workflow] Throttled (429) writing ${eventType} event; retrying in-process in ${waitMs / 1000}s`
+    );
+    await sleep(waitMs);
+  };
+}
+
+/** Whether this event type may retry transient failures in-process, including
+ * the narrow `hook_received` lazy-resume opt-in (see EventPostRetryOptions). */
+function isEligibleForTransientRetry(
+  eventType: WorkflowEventType,
+  options?: EventPostRetryOptions
+): boolean {
+  return (
+    (eventType === 'hook_received' && options?.idempotentHookResume === true) ||
+    (EVENT_RETRY_ELIGIBILITY[eventType]?.retryable ?? false)
+  );
+}
+
+/**
  * Run an event POST, retrying transient transport failures in-process when the
- * event type is idempotent-on-retry. Non-retryable event types and definitive
- * responses run/throw on the first attempt, preserving existing behavior.
+ * event type is idempotent-on-retry, and 429 throttles in-process for every
+ * event type (a 429 is a definitive no-write — see the module comment) while
+ * the cumulative `retryAfter` wait fits THROTTLE_RETRY_BUDGET_MS. Other
+ * definitive responses run/throw on the first attempt, preserving existing
+ * behavior.
  */
 export async function withEventPostRetry<T>(
   fn: () => Promise<T>,
   eventType: WorkflowEventType,
   options?: EventPostRetryOptions
 ): Promise<T> {
-  const retryable =
-    (eventType === 'hook_received' && options?.idempotentHookResume === true) ||
-    (EVENT_RETRY_ELIGIBILITY[eventType]?.retryable ?? false);
-  for (let attempt = 0; ; attempt++) {
+  const retryable = isEligibleForTransientRetry(eventType, options);
+  // Throttle waits draw on a shared per-POST budget instead of the transient
+  // attempt counter, so a throttled write keeps its full transient-blip
+  // allowance (and vice versa).
+  const waitOutThrottle = createThrottleWaiter(eventType);
+  for (let attempt = 0; ; ) {
     try {
       return await fn();
     } catch (err) {
-      const transient = retryable && isRetryableEventPostError(err);
-      if (transient && attempt < MAX_EVENT_POST_RETRIES) {
-        const backoff =
-          EVENT_POST_RETRY_BASE_MS * 2 ** attempt +
-          Math.floor(Math.random() * EVENT_POST_RETRY_JITTER_MS);
-        logRetry('retrying event POST after transient failure', {
-          eventType,
-          attempt: attempt + 1,
-          backoffMs: backoff,
-          error: errorMarker(err),
-        });
-        await sleep(backoff);
+      if (ThrottleError.is(err)) {
+        await waitOutThrottle(err);
         continue;
       }
-      // Out of retries on a still-transient failure: surface it so the queue
-      // redelivers (the worst-case fallthrough the in-process retry rode against).
-      if (transient) {
+      if (!retryable || !isRetryableEventPostError(err)) {
+        throw err;
+      }
+      if (attempt >= MAX_EVENT_POST_RETRIES) {
+        // Out of retries on a still-transient failure: surface it so the queue
+        // redelivers (the worst-case fallthrough the in-process retry rode
+        // against).
         logRetry(
           'exhausted in-process retries; surfacing for queue redelivery',
           {
@@ -343,8 +422,19 @@ export async function withEventPostRetry<T>(
             error: errorMarker(err),
           }
         );
+        throw err;
       }
-      throw err;
+      const backoff =
+        EVENT_POST_RETRY_BASE_MS * 2 ** attempt +
+        Math.floor(Math.random() * EVENT_POST_RETRY_JITTER_MS);
+      attempt++;
+      logRetry('retrying event POST after transient failure', {
+        eventType,
+        attempt,
+        backoffMs: backoff,
+        error: errorMarker(err),
+      });
+      await sleep(backoff);
     }
   }
 }

--- a/packages/world-vercel/src/event-retry.ts
+++ b/packages/world-vercel/src/event-retry.ts
@@ -182,10 +182,10 @@ export const MAX_EVENT_POST_RETRIES = 2;
  * event POST. Bounds the "no attempt tracking" failure mode: a server that
  * keeps 429ing cannot pin the invocation — once the budget cannot cover the
  * next `retryAfter`, the ThrottleError surfaces and the queue's (delivery-
- * counted, backed-off) redelivery takes over. Sized to ride out the
- * transaction-conflict shape workflow-server produces (a jittered Retry-After
- * on the order of ~10s, so a couple of attempts fit) while staying well inside
- * a flow invocation's duration limit.
+ * counted, backed-off) redelivery takes over. Sized so a couple of attempts
+ * fit at the Retry-After magnitudes the backend sends under write contention
+ * (on the order of ~10s) while staying well inside a flow invocation's
+ * duration limit.
  */
 export const THROTTLE_RETRY_BUDGET_MS = 30_000;
 /** Backoff when a 429 carries no usable Retry-After. */


### PR DESCRIPTION
## Context

The backend can reject an event write with a 429 and a `Retry-After` of a few seconds (e.g. under write contention). The SDK mapped these to `ThrottleError` but never retried them in-process: the error escaped to the queue handler, and queue redelivery scheduling can delay the retry far beyond the requested `Retry-After` — observed in practice as a `retryAfter: 14` throttle followed by a ~5-minute stall before the next delivery attempt.

The intended behavior for `ThrottleError` is in-process retry.

## Change

`withEventPostRetry` now retries 429s in-process:

- **Applies to every event type**, including the `EVENT_RETRY_ELIGIBILITY`-excluded ones (`step_started`, `step_retrying`, `hook_received`): a genuine application 429 is a definitive no-write — the server rejected the request outright — so the duplicate-row / attempt-double-count hazards that matrix protects against don't apply. This is the same reasoning `STREAM_RETRY_OPTIONS` already uses to retry 429 on stream PUTs.
- **Honors the server's `retryAfter`** (default 1s when absent).
- **Bounded**: cumulative throttle wait is capped at 30s per POST (`THROTTLE_RETRY_BUDGET_MS`), addressing the "no attempt tracking → could spin until the flow route dies" concern. Once the budget can't cover the next `retryAfter`, the `ThrottleError` surfaces and queue redelivery takes over exactly as before.
- Throttle waits draw on their own budget, not the transient-retry attempt counter.
- Firewall-challenge 429s cannot reach this path: `errorForResponse` maps `x-vercel-mitigated: challenge` to a transport `WorkflowWorldError`, not `ThrottleError`, so the original "let 429s pass through" rationale (never hot-loop against the firewall) is preserved.

Each in-process throttle retry logs a visible `console.warn` (it stalls the invocation for whole seconds, which would otherwise read as unexplained latency).

## Notes

- The queue-redelivery scheduling delay is being addressed separately on the queue side; this PR shrinks how often the SDK lands in it, but exhausted budgets / 5xx / transport failures still fall through to queue redelivery.
- Server-side `Retry-After` sizing may be worth revisiting now that the client waits it out in-process.

## Testing

- New unit tests in `event-retry.test.ts` cover: honoring `retryAfter`, applying to eligibility-excluded types, the no-`retryAfter` default, budget exhaustion (cumulative and single-wait-exceeds-budget), and budget independence from the transient allowance.
- `pnpm vitest run src/event-retry.test.ts src/events-retry.test.ts src/events-v4-ws.test.ts` — 53 passed.