### PR TITLE
[bench] Add a Promise.all fan-out scenario with Fan-out TTFS/TTLS rows

### DIFF
--- a/.changeset/bench-fanout-scenario.md
+++ b/.changeset/bench-fanout-scenario.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a `Promise.all(100 no-op steps)` scenario to the CI benchmark, reported as separate Fan-out TTFS (first step of the fan-out to complete) and Fan-out TTLS (last one) rows so a change that speeds up the first branch while stretching the tail stays visible.

--- a/.github/scripts/render-benchmark-comment.mjs
+++ b/.github/scripts/render-benchmark-comment.mjs
@@ -33,6 +33,16 @@ const METRIC_LABELS = {
     description:
       'time to first step body (in-deployment start() → first step body, deployment clocks)',
   },
+  'fanout-ttfs': {
+    name: 'Fan-out TTFS',
+    description:
+      'fan-out time to first step (in-deployment start() → first of the parallel step bodies to complete)',
+  },
+  'fanout-ttls': {
+    name: 'Fan-out TTLS',
+    description:
+      'fan-out time to last step (in-deployment start() → last of the parallel step bodies to complete, i.e. when the Promise.all resolves)',
+  },
   stso: {
     name: 'STSO',
     description: 'step-to-step overhead (gap between consecutive step bodies)',
@@ -53,7 +63,15 @@ const METRIC_LABELS = {
       'stream overhead (end-to-end write+consume time beyond the modelled generation window)',
   },
 };
-const METRIC_ORDER = ['ttfs', 'stso', 'wo', 'sl', 'so'];
+const METRIC_ORDER = [
+  'ttfs',
+  'fanout-ttfs',
+  'fanout-ttls',
+  'stso',
+  'wo',
+  'sl',
+  'so',
+];
 
 export function parseArgs(argv) {
   const args = {
@@ -655,7 +673,7 @@ function renderFooter(entries) {
         ]
       : []),
     '',
-    '<sub>All metrics are measured from deployment-side timestamps only. Runs are triggered by an in-deployment route that stamps the anchor (`clientStart`) right before `start()`, so the CI runner’s request and its path through api.vercel.com sit outside every measured window. TTFS = in-deployment `start()` → first step body (turbo uses the in-process fast path, non-turbo the dispatch path), and includes the VQS dispatch hop plus any `/flow` cold start. STSO/WO are measured between step bodies on the deployment. SL is measured inside the workflow (parallel reader/writer steps), so it no longer includes the api.vercel.com read path.</sub>',
+    '<sub>All metrics are measured from deployment-side timestamps only. Runs are triggered by an in-deployment route that stamps the anchor (`clientStart`) right before `start()`, so the CI runner’s request and its path through api.vercel.com sit outside every measured window. TTFS = in-deployment `start()` → first step body (turbo uses the in-process fast path, non-turbo the dispatch path), and includes the VQS dispatch hop plus any `/flow` cold start. Fan-out TTFS/TTLS are the first and last step completions of a single `Promise.all` over trivial steps, from the same anchor, so the gap between the two rows is the spread the runtime adds across the fan-out. STSO/WO are measured between step bodies on the deployment. SL is measured inside the workflow (parallel reader/writer steps), so it no longer includes the api.vercel.com read path.</sub>',
     '',
     '<sub>Cold starts are kept in the numbers on purpose — they are part of real bursty-workload latency. The workbench deployment cold-starts the `/flow` invocation for a large fraction of runs, inflating P75+; the **Best** column shows the fastest (warm-start) sample for comparison.</sub>',
   ];

--- a/.github/scripts/render-benchmark-comment.test.js
+++ b/.github/scripts/render-benchmark-comment.test.js
@@ -197,6 +197,101 @@ test('renders both SO payload-shape rows under one metric', async () => {
   assert.match(body, /Targets \(p75\/p90\/p99, ms\) — SO 250\/500\/1000/);
 });
 
+test('renders the fan-out scenario as one Fan-out TTFS row and one Fan-out TTLS row', async () => {
+  const { renderComment } = await loadModule();
+  const fanOutRow = (metric, overrides) => ({
+    metric,
+    scenario: 'Promise.all(100 steps)',
+    unit: 'ms',
+    best: 300,
+    avg: 420,
+    p75: 450,
+    p90: 520,
+    p99: 700,
+    samples: 10,
+    ...overrides,
+  });
+  const result = sampleResult({
+    scenarios: [
+      {
+        name: 'Promise.all(100 steps)',
+        description: '100 trivial no-op steps started together',
+      },
+    ],
+    metrics: [
+      // Deliberately out of display order: the table sorts by METRIC_ORDER.
+      fanOutRow('fanout-ttls', { best: 900, p75: 1400, p90: 1800, p99: 2600 }),
+      fanOutRow('fanout-ttfs'),
+      sampleResult().metrics[0],
+    ],
+  });
+  const body = renderComment({
+    status: 'completed',
+    results: [result],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+
+  assert.match(
+    body,
+    /\| \*\*Fan-out TTFS\*\* \| Promise\.all\(100 steps\) \| 300 \|/
+  );
+  assert.match(
+    body,
+    /\| \*\*Fan-out TTLS\*\* \| Promise\.all\(100 steps\) \| 900 \|/
+  );
+  // Neither row falls back to the raw metric id.
+  assert.doesNotMatch(body, /\| fanout-ttfs \|/);
+  assert.doesNotMatch(body, /\| fanout-ttls \|/);
+  // Display order: single-step TTFS, then the fan-out pair with first before last.
+  const order = ['**TTFS**', '**Fan-out TTFS**', '**Fan-out TTLS**'].map(
+    (name) => body.indexOf(name)
+  );
+  assert.ok(
+    order.every((index, i) => index > -1 && (i === 0 || index > order[i - 1])),
+    `unexpected row order: ${JSON.stringify(order)}`
+  );
+  // Both metrics are defined in the collapsed footer.
+  assert.match(body, /\*\*Fan-out TTFS\*\*: fan-out time to first step/);
+  assert.match(body, /\*\*Fan-out TTLS\*\*: fan-out time to last step/);
+  // No targets on the fan-out rows, so they contribute nothing to the targets
+  // legend and carry no 🔴 marks.
+  assert.doesNotMatch(body, /Targets \(p75\/p90\/p99, ms\) —[^<]*Fan-out/);
+  assert.doesNotMatch(body, /\| \*\*Fan-out TT[FL]S\*\* \|[^\n]*🔴/);
+});
+
+test('diffs fan-out rows against a baseline keyed on their own metric ids', async () => {
+  const { renderComment } = await loadModule();
+  const fanOutRow = (metric, best) => ({
+    metric,
+    scenario: 'Promise.all(100 steps)',
+    unit: 'ms',
+    best,
+    avg: best,
+    p75: best,
+    p90: best,
+    p99: best,
+    samples: 10,
+  });
+  const metricsFor = (ttfsBest, ttlsBest) => [
+    fanOutRow('fanout-ttfs', ttfsBest),
+    fanOutRow('fanout-ttls', ttlsBest),
+  ];
+  const body = renderComment({
+    status: 'completed',
+    // First branch lands as fast as on main; the tail is 50% slower.
+    results: [sampleResult({ metrics: metricsFor(300, 1500) })],
+    baseline: [sampleResult({ metrics: metricsFor(300, 1000) })],
+    history: [],
+    commit: 'abcdef1234567890',
+  });
+
+  // TTFS unchanged, TTLS regressed — the two rows carry independent deltas,
+  // which is the point of splitting them.
+  assert.match(body, /\| \*\*Fan-out TTFS\*\* \|[^\n]*300 \(±0%\)/);
+  assert.match(body, /\| \*\*Fan-out TTLS\*\* \|[^\n]*1500 \(\+50%\) 🔻/);
+});
+
 test('renders best/p75/p90/p99 deltas with 🔻/💚 threshold marks and embeds them', async () => {
   const { renderComment, extractHistory } = await loadModule();
   const baseline = sampleResult({

--- a/packages/core/e2e/benchmark.test.ts
+++ b/packages/core/e2e/benchmark.test.ts
@@ -38,6 +38,15 @@
  *          the two have very different cost profiles and averaging them
  *          together hides that. The workflow itself tags each step's kind
  *          (see workflows/97_bench.ts's `stepKind`).
+ * - Fan-out TTFS/TTLS: the two ends of a single `Promise.all` over many trivial
+ *          steps, both anchored on the same in-deployment `clientStart`. TTFS is
+ *          the earliest step body to *finish* (`min(step.end) - clientStart`) —
+ *          the first branch a caller could observe — and TTLS the latest
+ *          (`max(step.end) - clientStart`), when the whole fan-out is joinable.
+ *          The step bodies are no-ops, so TTLS - TTFS is the spread the runtime
+ *          adds across the fan-out (dispatch + concurrency), not body work.
+ *          Reported as separate rows so a change that speeds up the first
+ *          branch while stretching the tail is visible instead of averaged out.
  * - WO    (workflow overhead): total time the run spends outside of step
  *          bodies over the whole sequential run, from the in-deployment
  *          `clientStart` to the end of the last step body:
@@ -69,8 +78,10 @@
  * 2. benchStreamWorkflow          — 1 streaming step, turbo mode → TTFS (turbo)
  * 3. benchHookStreamWorkflow      — hook + 1 step, non-turbo → TTFS (non-turbo)
  * 4. benchSequentialStepsWorkflow — 1020 trivial sequential steps → STSO + WO
- * 5. benchSlWorkflow              — parallel reader/writer steps → SL
- * 6. benchSoWorkflow              — paced LLM-shaped stream, drained → SO
+ * 5. benchFanOutStepsWorkflow     — Promise.all over 100 trivial steps
+ *                                   → Fan-out TTFS + Fan-out TTLS
+ * 6. benchSlWorkflow              — parallel reader/writer steps → SL
+ * 7. benchSoWorkflow              — paced LLM-shaped stream, drained → SO
  *                                   (run in text and structured payload modes)
  *
  * Each scenario runs many iterations (env-tunable, see BENCH_* below) so the
@@ -120,6 +131,12 @@ const SL_ITERATIONS = envInt('BENCH_SL_ITERATIONS', STREAM_ITERATIONS);
 const SO_ITERATIONS = envInt('BENCH_SO_ITERATIONS', STREAM_ITERATIONS);
 const SEQUENTIAL_ITERATIONS = envInt('BENCH_SEQUENTIAL_ITERATIONS', 1);
 const SEQUENTIAL_STEP_COUNT = envInt('BENCH_SEQUENTIAL_STEP_COUNT', 1020);
+// The fan-out scenario yields exactly one TTFS and one TTLS sample per
+// iteration (they are whole-run properties), so it needs several iterations for
+// percentiles — but each iteration executes FANOUT_STEP_COUNT steps, so it gets
+// fewer than the single-step scenarios to keep the job's wall time bounded.
+const FANOUT_ITERATIONS = envInt('BENCH_FANOUT_ITERATIONS', 10);
+const FANOUT_STEP_COUNT = envInt('BENCH_FANOUT_STEP_COUNT', 100);
 const WARMUP_ITERATIONS = envInt('BENCH_WARMUP_ITERATIONS', 2, 0);
 
 // Methodology version — bump whenever the measurement window changes in a way
@@ -152,6 +169,10 @@ const SO_TARGETS = { p75: 250, p90: 500, p99: 1000 };
 
 // Guard timeouts so a single stuck run fails fast instead of eating the job.
 const RUN_TIMEOUT_MS = envInt('BENCH_RUN_TIMEOUT_MS', 120_000);
+// Extra guard time granted per step for the multi-step scenarios (sequential and
+// fan-out), on top of RUN_TIMEOUT_MS. Deliberately loose: it exists to kill a
+// stuck run, not to assert a per-step budget.
+const PER_STEP_TIMEOUT_ALLOWANCE_MS = 2_000;
 // Preflight guard: a trivial 1-step run must complete within this window
 // before any scenario spends its attempt budget (see beforeAll below).
 const PREFLIGHT_TIMEOUT_MS = envInt('BENCH_PREFLIGHT_TIMEOUT_MS', 180_000);
@@ -205,6 +226,18 @@ interface SequentialIterationResult {
   stsoQueueHopMs: number[];
   /** Whole-run workflow overhead, anchored on the in-deployment clientStart. */
   woMs: number;
+}
+
+interface FanOutIterationResult {
+  runId: string;
+  /** Datadog trace id for the `/api/bench` request that started this run, when
+   * the deployment's route reports one. */
+  traceId?: string;
+  /** `min(step.end) - clientStart`: the first of the parallel steps to finish. */
+  fanOutTtfsMs: number;
+  /** `max(step.end) - clientStart`: the last of them, i.e. when the whole
+   * `Promise.all` is joinable. */
+  fanOutTtlsMs: number;
 }
 
 interface SlIterationResult {
@@ -358,7 +391,7 @@ async function runSequentialIteration(
   try {
     const returnValue = await withTimeout(
       getReturnValue(runId),
-      RUN_TIMEOUT_MS + stepCount * 2_000,
+      RUN_TIMEOUT_MS + stepCount * PER_STEP_TIMEOUT_ALLOWANCE_MS,
       `benchSequentialStepsWorkflow returnValue (run ${runId})`
     );
     const steps = timingsFromReturnValue(returnValue, runId);
@@ -381,6 +414,49 @@ async function runSequentialIteration(
       stsoInlineMs,
       stsoQueueHopMs,
       woMs: workflowOverheadMs(clientStart, steps),
+    };
+  } catch (error) {
+    (error as Error).message += ` (run ${runId})`;
+    throw error;
+  }
+}
+
+async function runFanOutIteration(
+  stepCount: number
+): Promise<FanOutIterationResult> {
+  const { runId, clientStart, traceId } = await triggerBenchRun(
+    'benchFanOutStepsWorkflow',
+    [stepCount]
+  );
+  try {
+    const returnValue = await withTimeout(
+      getReturnValue(runId),
+      RUN_TIMEOUT_MS + stepCount * PER_STEP_TIMEOUT_ALLOWANCE_MS,
+      `benchFanOutStepsWorkflow returnValue (run ${runId})`
+    );
+    const steps = timingsFromReturnValue(returnValue, runId);
+    if (steps.length !== stepCount) {
+      throw new Error(
+        `Run ${runId} returned ${steps.length} step timings, expected ${stepCount}`
+      );
+    }
+    // Both ends of the fan-out come off step-body exit timestamps, so a run
+    // whose first branch lands early but whose tail drags reports two different
+    // numbers rather than one blended average. Reduced rather than spread into
+    // Math.min/max: the step count is env-tunable, and a large fan-out would
+    // overflow the argument limit.
+    let firstEnd = Number.POSITIVE_INFINITY;
+    let lastEnd = Number.NEGATIVE_INFINITY;
+    for (const { end } of steps) {
+      if (end < firstEnd) firstEnd = end;
+      if (end > lastEnd) lastEnd = end;
+    }
+    return {
+      runId,
+      traceId,
+      // Deployment-side clocks on both sides; clamp to absorb tiny skew.
+      fanOutTtfsMs: Math.max(0, firstEnd - clientStart),
+      fanOutTtlsMs: Math.max(0, lastEnd - clientStart),
     };
   } catch (error) {
     (error as Error).message += ` (run ${runId})`;
@@ -562,7 +638,7 @@ function computeStats(samples: number[]): MetricStats {
 }
 
 interface MetricRow extends MetricStats {
-  /** Short metric id: ttfs | stso | wo | sl */
+  /** Short metric id: ttfs | fanout-ttfs | fanout-ttls | stso | wo | sl | so */
   metric: string;
   /** Short scenario label; explained via scenario descriptions in the output */
   scenario: string;
@@ -606,6 +682,7 @@ const SCENARIO_STEP = 'step';
 const SCENARIO_TURBO_STREAM = 'stream';
 const SCENARIO_HOOK_STREAM = 'hook + stream';
 const SCENARIO_SEQUENTIAL = `${SEQUENTIAL_STEP_COUNT} steps`;
+const SCENARIO_FANOUT = `Promise.all(${FANOUT_STEP_COUNT} steps)`;
 const SCENARIO_STREAM_LATENCY = 'stream latency';
 // Two SO scenarios differing only in payload shape. The labels are distinct
 // from the pre-existing 'stream overhead' baseline key, so the payload change
@@ -632,6 +709,10 @@ const SCENARIO_DESCRIPTIONS = [
   {
     name: SCENARIO_SEQUENTIAL,
     description: `${SEQUENTIAL_STEP_COUNT} trivial sequential steps; STSO is measured between consecutive steps in the given step ranges, and WO is the whole-run overhead outside step bodies`,
+  },
+  {
+    name: SCENARIO_FANOUT,
+    description: `${FANOUT_STEP_COUNT} trivial no-op steps started together in a single Promise.all; Fan-out TTFS is the first of them to complete and Fan-out TTLS the last, both from the in-deployment clientStart, so their gap is the spread the runtime adds across the fan-out`,
   },
   {
     name: SCENARIO_STREAM_LATENCY,
@@ -796,6 +877,42 @@ describe('workflow benchmarks', () => {
     }
   );
 
+  test('scenario: fan-out steps', { timeout: 60 * 60_000 }, async () => {
+    const results = await runScenario(
+      SCENARIO_FANOUT,
+      FANOUT_ITERATIONS,
+      () => runFanOutIteration(FANOUT_STEP_COUNT),
+      {
+        // No warmup: a warmup iteration costs a whole fan-out run, the earlier
+        // scenarios already warmed the client and the world, and cold starts
+        // are kept in these numbers on purpose (see the file header).
+        warmupIterations: 0,
+      }
+    );
+    // Same reason the sequential scenario logs its runs: when a percentile
+    // moves, the investigation starts in APM, and the run ids behind these
+    // samples are only available here.
+    for (const { runId, traceId } of results) {
+      console.log(
+        `[bench] ${SCENARIO_FANOUT} run ${runId}` +
+          (traceId ? ` — trace ${DATADOG_TRACE_URL}${traceId}` : '') +
+          ` — spans ${datadogRunSearchUrl(runId)}`
+      );
+    }
+    // No targets: fan-out latency under contention is a new population, and the
+    // single-step TTFS targets describe a different shape of run.
+    recordMetric(
+      'fanout-ttfs',
+      SCENARIO_FANOUT,
+      results.map((r) => r.fanOutTtfsMs)
+    );
+    recordMetric(
+      'fanout-ttls',
+      SCENARIO_FANOUT,
+      results.map((r) => r.fanOutTtlsMs)
+    );
+  });
+
   test('scenario: sequential steps', { timeout: 60 * 60_000 }, async () => {
     const results = await runScenario(
       SCENARIO_SEQUENTIAL,
@@ -882,6 +999,8 @@ describe('workflow benchmarks', () => {
         soDurationSeconds: SO_DURATION_SECONDS,
         sequentialIterations: SEQUENTIAL_ITERATIONS,
         sequentialStepCount: SEQUENTIAL_STEP_COUNT,
+        fanoutIterations: FANOUT_ITERATIONS,
+        fanoutStepCount: FANOUT_STEP_COUNT,
         warmupIterations: WARMUP_ITERATIONS,
       },
       scenarios: SCENARIO_DESCRIPTIONS,

--- a/workbench/example/workflows/97_bench.ts
+++ b/workbench/example/workflows/97_bench.ts
@@ -10,7 +10,9 @@
 // - Every step records `start`/`end` (`Date.now()` at body entry/exit) and the
 //   workflow returns the collected timings. The runner combines them with the
 //   in-deployment `clientStart` to compute time-to-first-step (TTFS),
-//   step-to-step overhead (STSO), and workflow overhead (WO).
+//   step-to-step overhead (STSO), workflow overhead (WO), and — on the fan-out
+//   scenario — the first/last step completion of a `Promise.all` (Fan-out
+//   TTFS/TTLS).
 // - `benchSlWorkflow` measures stream latency (SL) entirely on the deployment:
 //   a reader step and a writer step run in parallel on a dedicated namespaced
 //   stream, and the workflow returns both the writer's `writtenAt` and the
@@ -202,6 +204,28 @@ export async function benchSequentialStepsWorkflow(count: number): Promise<{
     steps.push(await timedNoopStep(i));
   }
   return { steps };
+}
+
+/**
+ * Fan-out scenario: `count` trivial steps started together in one
+ * `Promise.all`.
+ *
+ * Every step is dispatched from the same suspension, so the run's step
+ * timings describe how the runtime spreads a fan-out: the earliest step body
+ * to finish is the first branch a caller could observe, the latest is when
+ * the whole fan-out is joinable. The runner turns those into Fan-out
+ * TTFS/TTLS. Steps are the same no-op bodies the sequential scenario uses, so
+ * the spread is dispatch and concurrency cost, not body work.
+ */
+export async function benchFanOutStepsWorkflow(count: number): Promise<{
+  steps: BenchStepTiming[];
+}> {
+  'use workflow';
+  const pending: Promise<BenchStepTiming>[] = [];
+  for (let i = 0; i < count; i++) {
+    pending.push(timedNoopStep(i));
+  }
+  return { steps: await Promise.all(pending) };
 }
 
 /**


### PR DESCRIPTION
The CI benchmark measured sequential step latency (TTFS on a single step, STSO between consecutive ones) but nothing about a fan-out, where the runtime dispatches many steps from one suspension and the interesting question is how wide the spread between the first and the last of them is.

`benchFanOutStepsWorkflow` starts `count` trivial no-op steps in a single `Promise.all`. The runner derives two samples per run off the same in-deployment `clientStart` anchor every other metric uses:

- **Fan-out TTFS** = `min(step.end) - clientStart` — the earliest step body to finish, i.e. the first branch a caller could observe.
- **Fan-out TTLS** = `max(step.end) - clientStart` — the latest, i.e. when the whole `Promise.all` is joinable.

They render as two rows rather than one, so a change that speeds up the first branch while stretching the tail shows up instead of being averaged away. Since the bodies are no-ops, the gap between the rows is dispatch and concurrency cost, not body work.

Defaults: 100 steps, 10 iterations (`BENCH_FANOUT_STEP_COUNT` / `BENCH_FANOUT_ITERATIONS`), no warmup — each warmup would cost a full fan-out run, and cold starts are kept in these numbers on purpose. No targets on either row yet: fan-out latency under contention is a new population, and the single-step TTFS targets describe a different shape of run. Also extracted the sequential scenario's inline per-step timeout allowance into a constant now that two scenarios share it.

## Verification

Ran the scenario against a local `nextjs-turbopack` dev server on world-local (not CI, so the absolute numbers are not representative — one Node process serializes the fan-out that Fluid would spread):

| Fan-out | TTFS | TTLS |
|---|---|---|
| 20 steps x2 | 223, 224 ms | 450, 482 ms |
| 100 steps x2 | 680, 1460 ms | 6498, 7159 ms |

The rendered PR comment was checked against that result JSON, and the renderer has two new unit tests: the row labels/ordering/absence of targets, and that the two rows carry independent baseline deltas (TTFS flat, TTLS +50% flagged). This PR's own benchmark comment is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)