### PR TITLE
[core] Record step execution duration metric

### DIFF
--- a/.changeset/step-execute-duration-metric.md
+++ b/.changeset/step-execute-duration-metric.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Record a `workflow.step.execute.duration` OpenTelemetry histogram around user step execution

--- a/packages/core/src/runtime/step-executor.ts
+++ b/packages/core/src/runtime/step-executor.ts
@@ -39,7 +39,7 @@ import {
 } from '../serialization.js';
 import { contextStorage } from '../step/context-storage.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
-import { trace } from '../telemetry.js';
+import { recordStepExecutionDuration, trace } from '../telemetry.js';
 import {
   getErrorName,
   getErrorStack,
@@ -978,6 +978,8 @@ export async function executeStep(
         span?.setAttributes(attributes);
       };
 
+      let stepExecutionStatus: 'ok' | 'error' = 'ok';
+      const stepExecutionStartTime = performance.now();
       try {
         result = await trace('step.execute', {}, async () => {
           return await contextStorage.run(
@@ -1017,8 +1019,14 @@ export async function executeStep(
           );
         });
       } catch (err) {
+        stepExecutionStatus = 'error';
         userCodeError = err;
         userCodeFailed = true;
+      } finally {
+        void recordStepExecutionDuration(
+          performance.now() - stepExecutionStartTime,
+          stepExecutionStatus
+        );
       }
       const executionTimeMs = Date.now() - executionStartTime;
 

--- a/packages/core/src/telemetry-metrics.test.ts
+++ b/packages/core/src/telemetry-metrics.test.ts
@@ -1,0 +1,30 @@
+import { metrics as otelMetrics } from '@opentelemetry/api';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { recordStepExecutionDuration } from './telemetry.js';
+
+const histogram = { record: vi.fn() };
+const meter = { createHistogram: vi.fn(() => histogram) };
+const provider = { getMeter: vi.fn(() => meter) };
+
+otelMetrics.setGlobalMeterProvider(provider as any);
+
+afterAll(() => {
+  otelMetrics.disable();
+});
+
+describe('recordStepExecutionDuration', () => {
+  it('records a millisecond histogram with only a bounded status dimension', async () => {
+    await recordStepExecutionDuration(125, 'ok');
+
+    expect(meter.createHistogram).toHaveBeenCalledWith(
+      'workflow.step.execute.duration',
+      {
+        description: 'Duration of user step execution',
+        unit: 'ms',
+      }
+    );
+    expect(histogram.record).toHaveBeenCalledWith(125, {
+      'workflow.step.status': 'ok',
+    });
+  });
+});

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -180,6 +180,18 @@ const Tracer = once(async () => {
   return tracer;
 });
 
+const StepExecutionDurationHistogram = once(async () => {
+  const otel = await OtelApi.value;
+  if (!otel) return null;
+  // service.name is a resource attribute, applied by the configured provider.
+  return otel.metrics
+    .getMeter('workflow')
+    .createHistogram('workflow.step.execute.duration', {
+      description: 'Duration of user step execution',
+      unit: 'ms',
+    });
+});
+
 /**
  * One-shot runtime diagnostic (DEBUG=workflow:* only), same shape as the one
  * world-vercel emits tagged `world-vercel`: prints how this module instance
@@ -276,6 +288,19 @@ export async function recordElapsedSpan(
   const tracer = await Tracer.value;
   if (!tracer) return;
   tracer.startSpan(spanName, { ...opts, startTime: startEpochMs }).end();
+}
+
+/**
+ * Records the same user-code interval as the inner `step.execute` span. The
+ * configured OpenTelemetry meter provider attaches resource dimensions such as
+ * service.name, so this avoids accepting a caller-controlled service tag.
+ */
+export async function recordStepExecutionDuration(
+  durationMs: number,
+  status: 'ok' | 'error'
+): Promise<void> {
+  const histogram = await StepExecutionDurationHistogram.value;
+  histogram?.record(durationMs, { 'workflow.step.status': status });
 }
 
 /**


### PR DESCRIPTION
## Summary
- record `workflow.step.execute.duration` as an OpenTelemetry histogram around the inner user-code step span
- rely on resource `service.name` for the service dimension and add only a bounded status attribute
- cover the histogram name, unit, and attributes with a focused unit test

## Validation
- `pnpm exec vitest run packages/core/src/telemetry-metrics.test.ts`
- `pnpm --filter @workflow/core typecheck`