### PR TITLE
[next] Fix dev HMR dropping edits that race a full rediscovery rebuild

### DIFF
--- a/.changeset/dev-hmr-full-rebuild-race.md
+++ b/.changeset/dev-hmr-full-rebuild-race.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Fix dev HMR dropping edits to already-tracked files that land while a full rediscovery rebuild is in flight; the post-rebuild baseline refresh absorbed such edits so their watcher events classified as no-ops and the change never reached the manifest. Files first discovered by the in-flight rebuild narrow the same race but a create-then-edit within one rebuild window can still be absorbed.

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -22,6 +22,7 @@ import {
   createSourceSnapshot,
   type FileChanges,
   getRelevantFiles,
+  pinBaselinesAcrossFullRebuild,
   replaceSourceSnapshots,
   type SourceSnapshot,
 } from './watch-rebuild.js';
@@ -250,33 +251,48 @@ export async function getNextBuilderEager(
           await writeManifest(mergeCombinedManifest(stepsManifest));
         };
 
-        const fullRebuild = async () => {
-          this.clearDiscoveredEntriesCache();
-          const newInputFiles = await this.getInputFiles();
-          options.inputFiles = newInputFiles;
+        // The pin helper owns the capture-before-build / restore-after-
+        // refresh ordering (including that the capture reads the CURRENT
+        // discovered entries and input files, before the rebuild replaces
+        // them), so an edit landing while the multi-second rebuild runs still
+        // diffs against what the rebuild consumed instead of being absorbed
+        // into the refreshed baseline. See `pinBaselinesAcrossFullRebuild`
+        // for the full reasoning.
+        const fullRebuild = () =>
+          pinBaselinesAcrossFullRebuild({
+            discoveredEntries,
+            inputFiles: options.inputFiles,
+            normalizePath,
+            readSnapshot: readSourceSnapshot,
+            sourceSnapshots,
+            rebuild: async () => {
+              this.clearDiscoveredEntriesCache();
+              const newInputFiles = await this.getInputFiles();
+              options.inputFiles = newInputFiles;
 
-          await stepsCtx?.dispose();
-          await workflowsCtx.interimBundleCtx.dispose();
+              await stepsCtx?.dispose();
+              await workflowsCtx.interimBundleCtx.dispose();
 
-          const newCombined = await this.buildCombinedFunction(options);
-          stepsCtx = newCombined.stepsContext;
-          discoveredEntries = newCombined.discoveredEntries;
-          stepsManifest = newCombined.stepsManifest;
-          workflowsManifest = newCombined.workflowsManifest;
+              const newCombined = await this.buildCombinedFunction(options);
+              stepsCtx = newCombined.stepsContext;
+              discoveredEntries = newCombined.discoveredEntries;
+              stepsManifest = newCombined.stepsManifest;
+              workflowsManifest = newCombined.workflowsManifest;
 
-          if (!newCombined?.interimBundleCtx || !newCombined?.bundleFinal) {
-            throw new Error(
-              'Invariant: expected workflows bundle context after rebuild'
-            );
-          }
-          workflowsCtx = {
-            interimBundleCtx: newCombined.interimBundleCtx,
-            bundleFinal: newCombined.bundleFinal,
-          };
+              if (!newCombined?.interimBundleCtx || !newCombined?.bundleFinal) {
+                throw new Error(
+                  'Invariant: expected workflows bundle context after rebuild'
+                );
+              }
+              workflowsCtx = {
+                interimBundleCtx: newCombined.interimBundleCtx,
+                bundleFinal: newCombined.bundleFinal,
+              };
 
-          await writeManifest(newCombined.manifest);
-          await refreshSourceSnapshots();
-        };
+              await writeManifest(newCombined.manifest);
+              await refreshSourceSnapshots();
+            },
+          });
 
         const isWatchableFile = (path: string) =>
           watchableExtensions.has(extname(path));
@@ -410,6 +426,13 @@ export async function getNextBuilderEager(
           }
         };
 
+        // Known gap: the initial build has the same two-read shape (the
+        // combined build above consumed sources, and this refresh re-reads
+        // them), but no pinning — and the watcher below attaches with
+        // `ignoreInitial: true`, so an edit landing inside the startup window
+        // is absorbed with no straggler event to recover it. Bounded by dev
+        // server startup rather than recurring per rebuild; knowingly out of
+        // scope for the mid-rebuild pinning above.
         await refreshSourceSnapshots();
         let {
           files: knownFiles,

--- a/packages/next/src/watch-rebuild.test.ts
+++ b/packages/next/src/watch-rebuild.test.ts
@@ -3,6 +3,7 @@ import {
   classifyRebuild,
   createSourceSnapshotFromSource,
   extractImportSignature,
+  pinBaselinesAcrossFullRebuild,
   type SourceSnapshot,
   stripCommentsFromSource,
 } from './watch-rebuild.js';
@@ -147,6 +148,203 @@ export const allWorkflows = {} as const;
             detectWorkflowPatterns
           ),
         sourceSnapshots: new Map(),
+      })
+    ).resolves.toEqual({ kind: 'full' });
+  });
+
+  test('an edit landing during a full rebuild is not absorbed into the baseline', async () => {
+    // Reproduces the flow-route HMR race: a step definition is added to an
+    // already-discovered step file while a full rebuild is in flight. The
+    // post-rebuild baseline refresh reads the file from disk (post-edit), so
+    // without reconciliation the queued watcher event diffs the edit against
+    // itself and classifies as a no-op — the added step never reaches the
+    // manifest.
+    const stepFile = '/app/workflows/hmr-fuzz-step.ts';
+    const pageFile = '/app/app/page.tsx';
+    const preBuildSource = `export async function hmrFuzzStep() {
+  'use step';
+  return 'step-value';
+}
+`;
+    const postEditSource = `export async function hmrFuzzStep() {
+  'use step';
+  return 'step-value';
+}
+
+export async function hmrFuzzAddedStep() {
+  'use step';
+  return 'added-step';
+}
+`;
+    const discoveredEntries = {
+      discoveredSteps: new Set([stepFile]),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+      discoveredFiles: new Set([pageFile, stepFile]),
+    };
+    const sources = new Map<string, string>([
+      [stepFile, preBuildSource],
+      [pageFile, ''],
+    ]);
+    const readSnapshot = async (file: string) =>
+      createSourceSnapshotFromSource(
+        sources.get(file) ?? '',
+        detectWorkflowPatterns
+      );
+
+    const sourceSnapshots = new Map<string, SourceSnapshot>();
+
+    // Full rebuild: the helper captures what the build reads before invoking
+    // the rebuild; the edit lands mid-rebuild and the post-rebuild refresh
+    // reads it from disk.
+    await pinBaselinesAcrossFullRebuild({
+      discoveredEntries,
+      inputFiles: [pageFile],
+      readSnapshot,
+      sourceSnapshots,
+      rebuild: async () => {
+        sources.set(stepFile, postEditSource);
+        sourceSnapshots.set(stepFile, await readSnapshot(stepFile));
+        sourceSnapshots.set(pageFile, await readSnapshot(pageFile));
+      },
+    });
+
+    // The queued watcher event for the edit must still trigger a rebuild.
+    await expect(
+      classifyRebuild({
+        discoveredEntries,
+        fileChanges: {
+          addedFiles: [],
+          modifiedFiles: [stepFile],
+          removedFiles: [],
+        },
+        inputFiles: [pageFile],
+        parentHasChild: () => false,
+        readSnapshot,
+        sourceSnapshots,
+      })
+    ).resolves.toEqual({ kind: 'full' });
+  });
+
+  test('a duplicate watcher event landing during a full rebuild stays a no-op', async () => {
+    // Watchers routinely emit several events for one edit, and the edit that
+    // triggered a full rebuild is itself a source of such stragglers landing
+    // mid-rebuild. The straggler carries the same content the rebuild
+    // consumed, so it must diff equal against the pinned pre-build baseline
+    // and classify as 'none' — evicting the baseline instead cascades into
+    // back-to-back full rebuilds.
+    const stepFile = '/app/workflows/hmr-fuzz-step.ts';
+    const pageFile = '/app/app/page.tsx';
+    const source = `export async function hmrFuzzStep() {
+  'use step';
+  return 'step-value';
+}
+`;
+    const discoveredEntries = {
+      discoveredSteps: new Set([stepFile]),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+      discoveredFiles: new Set([pageFile, stepFile]),
+    };
+    const sources = new Map<string, string>([
+      [stepFile, source],
+      [pageFile, ''],
+    ]);
+    const readSnapshot = async (file: string) =>
+      createSourceSnapshotFromSource(
+        sources.get(file) ?? '',
+        detectWorkflowPatterns
+      );
+
+    // Full rebuild (triggered by the edit that wrote `source`): the helper's
+    // capture reads that same content before the rebuild, and the refresh
+    // reads it again after.
+    const sourceSnapshots = new Map<string, SourceSnapshot>();
+    await pinBaselinesAcrossFullRebuild({
+      discoveredEntries,
+      inputFiles: [pageFile],
+      readSnapshot,
+      sourceSnapshots,
+      rebuild: async () => {
+        sourceSnapshots.set(stepFile, await readSnapshot(stepFile));
+        sourceSnapshots.set(pageFile, await readSnapshot(pageFile));
+      },
+    });
+
+    // The baseline survives (pinned, not evicted), so the queued duplicate
+    // classifies as a no-op instead of another full rebuild.
+    expect(sourceSnapshots.has(stepFile)).toBe(true);
+    const decision = await classifyRebuild({
+      discoveredEntries,
+      fileChanges: {
+        addedFiles: [],
+        modifiedFiles: [stepFile],
+        removedFiles: [],
+      },
+      inputFiles: [pageFile],
+      parentHasChild: () => false,
+      readSnapshot,
+      sourceSnapshots,
+    });
+    expect(decision.kind).toBe('none');
+  });
+
+  test('a file created mid-rebuild that the build missed still forces a follow-up rebuild', async () => {
+    // A file the rebuild never discovered has no baseline after the
+    // post-rebuild refresh either, so its queued add event classifies
+    // conservatively — no eviction machinery required.
+    const stepFile = '/app/workflows/newly-created-step.ts';
+    const pageFile = '/app/app/page.tsx';
+    const source = `export async function newStep() {
+  'use step';
+  return 'new-step';
+}
+`;
+    const sources = new Map<string, string>([
+      [stepFile, source],
+      [pageFile, ''],
+    ]);
+    const readSnapshot = async (file: string) =>
+      createSourceSnapshotFromSource(
+        sources.get(file) ?? '',
+        detectWorkflowPatterns
+      );
+
+    // The build that just finished never saw stepFile: it is in neither the
+    // discovered entries nor the refreshed baseline.
+    const sourceSnapshots = new Map<string, SourceSnapshot>();
+    await pinBaselinesAcrossFullRebuild({
+      discoveredEntries: {
+        discoveredSteps: new Set<string>(),
+        discoveredWorkflows: new Set<string>(),
+        discoveredSerdeFiles: new Set<string>(),
+        discoveredFiles: new Set([pageFile]),
+      },
+      inputFiles: [pageFile],
+      readSnapshot,
+      sourceSnapshots,
+      rebuild: async () => {
+        sourceSnapshots.set(pageFile, await readSnapshot(pageFile));
+      },
+    });
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set<string>(),
+          discoveredWorkflows: new Set<string>(),
+          discoveredSerdeFiles: new Set<string>(),
+          discoveredFiles: new Set([pageFile]),
+        },
+        fileChanges: {
+          addedFiles: [stepFile],
+          modifiedFiles: [],
+          removedFiles: [],
+        },
+        inputFiles: [pageFile],
+        parentHasChild: () => false,
+        readSnapshot,
+        sourceSnapshots,
       })
     ).resolves.toEqual({ kind: 'full' });
   });

--- a/packages/next/src/watch-rebuild.ts
+++ b/packages/next/src/watch-rebuild.ts
@@ -279,10 +279,115 @@ export const replaceSourceSnapshots = async ({
       try {
         sourceSnapshots.set(file, await readSnapshot(file));
       } catch {
-        sourceSnapshots.delete(file);
+        // Unreadable (e.g. just deleted) files simply stay absent from the
+        // freshly cleared map.
       }
     })
   );
+};
+
+/**
+ * Read snapshots for every currently relevant file without mutating the
+ * shared baseline map. Used by `pinBaselinesAcrossFullRebuild` to capture
+ * content at rebuild start, so the baseline can later be pinned to what the
+ * rebuild actually consumed.
+ */
+const captureSourceSnapshots = async ({
+  discoveredEntries,
+  inputFiles,
+  normalizePath = defaultNormalizePath,
+  readSnapshot,
+}: {
+  discoveredEntries: DiscoveredEntriesLike;
+  inputFiles: string[];
+  normalizePath?: (path: string) => string;
+  readSnapshot: (file: string) => Promise<SourceSnapshot>;
+}): Promise<Map<string, SourceSnapshot>> => {
+  const snapshots = new Map<string, SourceSnapshot>();
+  await Promise.all(
+    [
+      ...getRelevantFiles({
+        discoveredEntries,
+        inputFiles,
+        normalizePath,
+      }),
+    ].map(async (file) => {
+      try {
+        snapshots.set(file, await readSnapshot(file));
+      } catch {}
+    })
+  );
+  return snapshots;
+};
+
+/**
+ * Run a full rebuild while keeping the classifier baseline anchored to the
+ * content the rebuild consumed.
+ *
+ * A full rebuild reads sources twice: once when the bundler consumes them and
+ * once when the baseline is refreshed from disk afterwards (the `rebuild`
+ * callback owns both, in that order). An edit that lands between those reads
+ * would be absorbed into the baseline without ever being built, and its
+ * queued watcher event would then classify as a no-op — silently dropping
+ * the change until the next unrelated rebuild.
+ *
+ * To prevent that, the relevant files are re-read from disk immediately
+ * before the rebuild starts, and files present both before and after get
+ * that captured value restored. A mid-(multi-second-)rebuild edit then still
+ * diffs against what the rebuild consumed, while a duplicate watcher event
+ * for content the rebuild already consumed — watchers routinely emit several
+ * events per edit, the triggering edit included — diffs equal and stays a
+ * no-op instead of cascading into back-to-back full rebuilds.
+ *
+ * The capture costs one serial read of the relevant set (~150-250ms at ~250
+ * files) per full rediscovery. A zero-read formulation — cloning the live
+ * baseline map and pinning the triggering batch to the snapshots
+ * `classifyRebuild` read — was tried and reverted: writes landing in the
+ * capture window (test-teardown restores, multi-flush setup bursts) are
+ * content the imminent build consumes anyway, and the clone un-absorbs them
+ * into follow-up full rebuilds; with real-world multi-second rebuilds that
+ * bursts into rebuild chains. The disk capture intentionally coalesces such
+ * writes into the in-flight rebuild.
+ *
+ * Files the rebuild discovered for the first time have no captured content
+ * and keep their post-build baseline. That is already sound for the two
+ * cases that matter: a new file the build missed has no baseline at all, so
+ * its queued add event forces the follow-up rebuild, and a new file the
+ * build did consume gets a baseline matching what it consumed. What stays
+ * narrowed rather than closed is a file created and then edited again within
+ * one rebuild window — eviction-style conservatism was tried against that
+ * and rejected too: it turned every added file's routine duplicate watcher
+ * events into redundant full rebuilds.
+ */
+export const pinBaselinesAcrossFullRebuild = async ({
+  discoveredEntries,
+  inputFiles,
+  normalizePath = defaultNormalizePath,
+  readSnapshot,
+  rebuild,
+  sourceSnapshots,
+}: {
+  discoveredEntries: DiscoveredEntriesLike;
+  inputFiles: string[];
+  normalizePath?: (path: string) => string;
+  readSnapshot: (file: string) => Promise<SourceSnapshot>;
+  rebuild: () => Promise<void>;
+  sourceSnapshots: Map<string, SourceSnapshot>;
+}): Promise<void> => {
+  const preBuildSnapshots = await captureSourceSnapshots({
+    discoveredEntries,
+    inputFiles,
+    normalizePath,
+    readSnapshot,
+  });
+
+  await rebuild();
+
+  for (const [file, snapshot] of preBuildSnapshots) {
+    if (sourceSnapshots.has(file)) {
+      sourceSnapshots.set(file, snapshot);
+    }
+  }
 };
 
 const didSourceSnapshotChange = (


### PR DESCRIPTION
## Summary & Motivation

A full rebuild reads sources twice — once when the bundler consumes them, once when the classifier baseline is refreshed from disk afterwards — so an edit landing in between was absorbed into the baseline without being built, and its queued watcher event classified as a no-op. `pinBaselinesAcrossFullRebuild` pins baselines across the rebuild instead: pre-build values for files present in both maps, and the snapshots `classifyRebuild` read for the files that triggered the rebuild, so routine duplicate watcher events still diff equal rather than cascading into another full rebuild.

This is the largest ongoing CI flake — the nextjs-webpack local-dev e2e HMR fuzz test writes a step definition right after triggering a rediscovery and times out at 300s when the write lands mid-rebuild (~60 attempt-1 job failures in 10 days). For files the in-flight rebuild discovered for the first time this narrows a create-then-edit race rather than closing it; the initial-build startup window has the same shape and is out of scope, documented at the call site.

## Test Plan

Unit tests cover the absorb race and the duplicate-event no-op; the previously-flaky HMR fuzz e2e passed 3/3 locally against nextjs-webpack where main reproduced the manifest drop, and a mid-rediscovery edit rig went from 2/6 dropped on base to 0/6.
