### PR TITLE
feat(world-vercel): enrich STSO event spans

### DIFF
--- a/.changeset/event-write-stso-spans.md
+++ b/.changeset/event-write-stso-spans.md
@@ -2,4 +2,4 @@
 '@workflow/world-vercel': patch
 ---
 
-Add the Workflow client version and step-to-step overhead to terminal event-write client spans for service and version latency analysis.
+Add the Workflow client version, step-to-step overhead, and active latency optimizations to terminal event-write client spans for service and version latency analysis.

--- a/.changeset/event-write-stso-spans.md
+++ b/.changeset/event-write-stso-spans.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Add the Workflow client version and step-to-step overhead to terminal event-write client spans for service and version latency analysis.

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -62,12 +62,15 @@ import { deserializeStep, StepWireSchema } from './steps.js';
 import {
   ErrorType,
   NetworkProtocolName,
+  StepStsoMs,
+  WorkflowClientVersion,
   WorkflowEventsTransport,
   WorkflowEventType,
   WorkflowWsRequestId,
   WorkflowWsUrl,
 } from './telemetry.js';
 import { type APIConfig, getHttpConfig, getHttpUrl } from './utils.js';
+import { version } from './version.js';
 import type { WsFrameReply } from './ws-transport.js';
 import { isWsEventsTransportEnabled } from './ws-transport-enabled.js';
 
@@ -709,6 +712,8 @@ async function postWorkflowRunEventV4(
     {
       ...WorkflowEventsTransport('http'),
       ...WorkflowEventType(input.eventType),
+      ...WorkflowClientVersion(`@workflow/world-vercel/${version}`),
+      ...(input.stso !== undefined ? StepStsoMs(input.stso) : {}),
     }
   );
 }
@@ -930,6 +935,8 @@ async function postEventFrameOverWs(
       attributes: {
         ...WorkflowEventsTransport('ws'),
         ...WorkflowEventType(input.eventType),
+        ...WorkflowClientVersion(`@workflow/world-vercel/${version}`),
+        ...(input.stso !== undefined ? StepStsoMs(input.stso) : {}),
         ...NetworkProtocolName('websocket'),
         ...WorkflowWsUrl(wsUrl),
       },

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -62,6 +62,7 @@ import { deserializeStep, StepWireSchema } from './steps.js';
 import {
   ErrorType,
   NetworkProtocolName,
+  StepLatencyOptimizations,
   StepStsoMs,
   WorkflowClientVersion,
   WorkflowEventsTransport,
@@ -102,7 +103,7 @@ async function fetchV4(
   init: { method: string; headers: Headers; body?: Uint8Array },
   config: APIConfig | undefined,
   opName: string,
-  attributes?: Record<string, string | number>
+  attributes?: Record<string, string | number | string[]>
 ): Promise<Response> {
   const dispatcher = getEventsDispatcher(config);
   return instrumentedFetch({
@@ -714,6 +715,9 @@ async function postWorkflowRunEventV4(
       ...WorkflowEventType(input.eventType),
       ...WorkflowClientVersion(`@workflow/world-vercel/${version}`),
       ...(input.stso !== undefined ? StepStsoMs(input.stso) : {}),
+      ...(input.optimizations !== undefined
+        ? StepLatencyOptimizations(input.optimizations)
+        : {}),
     }
   );
 }
@@ -937,6 +941,9 @@ async function postEventFrameOverWs(
         ...WorkflowEventType(input.eventType),
         ...WorkflowClientVersion(`@workflow/world-vercel/${version}`),
         ...(input.stso !== undefined ? StepStsoMs(input.stso) : {}),
+        ...(input.optimizations !== undefined
+          ? StepLatencyOptimizations(input.optimizations)
+          : {}),
         ...NetworkProtocolName('websocket'),
         ...WorkflowWsUrl(wsUrl),
       },

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -364,7 +364,7 @@ export interface HttpClientSpanOptions {
    */
   spanName?: string;
   /** Extra attributes merged on top of the standard HTTP attributes. */
-  attributes?: Record<string, string | number>;
+  attributes?: Record<string, string | number | string[]>;
 }
 
 /**

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -282,6 +282,14 @@ export const WorkflowEventType = SemanticConvention<string>(
   'workflow.event.type'
 );
 
+/** Version of the Workflow client package issuing the request. */
+export const WorkflowClientVersion = SemanticConvention<string>(
+  'workflow.client.version'
+);
+
+/** Client-measured step-to-step overhead in milliseconds. */
+export const StepStsoMs = SemanticConvention<number>('step.stso_ms');
+
 /**
  * The socket a WS event write actually travelled over
  * (workflow.events.ws.url). `url.full` names the v4 REST endpoint the frame is

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -290,6 +290,11 @@ export const WorkflowClientVersion = SemanticConvention<string>(
 /** Client-measured step-to-step overhead in milliseconds. */
 export const StepStsoMs = SemanticConvention<number>('step.stso_ms');
 
+/** Runtime optimizations active for the step latency measurement. */
+export const StepLatencyOptimizations = SemanticConvention<string[]>(
+  'step.latency_optimizations'
+);
+
 /**
  * The socket a WS event write actually travelled over
  * (workflow.events.ws.url). `url.full` names the v4 REST endpoint the frame is

--- a/packages/world-vercel/src/ws-transport-spans.test.ts
+++ b/packages/world-vercel/src/ws-transport-spans.test.ts
@@ -46,6 +46,7 @@ import {
   V4_FRAME_CONTENT_TYPE,
 } from './frames.js';
 import { WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
+import { version } from './version.js';
 
 vi.mock('@vercel/oidc', () => ({
   getVercelOidcToken: vi.fn().mockRejectedValue(new Error('no OIDC')),
@@ -148,6 +149,7 @@ const input = {
   eventType: 'step_completed',
   specVersion: 2,
   correlationId: 'step_1',
+  stso: 468,
 } as const;
 
 /** The materialized CBOR body a `step_completed` write answers with. */
@@ -284,6 +286,10 @@ describe('per-write client span', () => {
     expect(span.attributes['network.protocol.name']).toBe('websocket');
     expect(span.attributes['workflow.events.ws.url']).toBe(WS_URL);
     expect(span.attributes['workflow.event.type']).toBe('step_completed');
+    expect(span.attributes['workflow.client.version']).toBe(
+      `@workflow/world-vercel/${version}`
+    );
+    expect(span.attributes['step.stso_ms']).toBe(468);
   });
 
   it('carries the reqId that joins it to the server log line for the same frame', async () => {
@@ -521,6 +527,10 @@ describe('transport parity', () => {
     expect(span.attributes['http.request.method']).toBe('POST');
     expect(span.attributes['workflow.event.type']).toBe('step_completed');
     expect(span.attributes['workflow.events.transport']).toBe('http');
+    expect(span.attributes['workflow.client.version']).toBe(
+      `@workflow/world-vercel/${version}`
+    );
+    expect(span.attributes['step.stso_ms']).toBe(468);
     expect(span.attributes['network.protocol.name']).toBeUndefined();
     agent.assertNoPendingInterceptors();
   });

--- a/packages/world-vercel/src/ws-transport-spans.test.ts
+++ b/packages/world-vercel/src/ws-transport-spans.test.ts
@@ -150,6 +150,7 @@ const input = {
   specVersion: 2,
   correlationId: 'step_1',
   stso: 468,
+  optimizations: ['lazyStepStart'],
 } as const;
 
 /** The materialized CBOR body a `step_completed` write answers with. */
@@ -290,6 +291,9 @@ describe('per-write client span', () => {
       `@workflow/world-vercel/${version}`
     );
     expect(span.attributes['step.stso_ms']).toBe(468);
+    expect(span.attributes['step.latency_optimizations']).toEqual([
+      'lazyStepStart',
+    ]);
   });
 
   it('carries the reqId that joins it to the server log line for the same frame', async () => {
@@ -531,6 +535,9 @@ describe('transport parity', () => {
       `@workflow/world-vercel/${version}`
     );
     expect(span.attributes['step.stso_ms']).toBe(468);
+    expect(span.attributes['step.latency_optimizations']).toEqual([
+      'lazyStepStart',
+    ]);
     expect(span.attributes['network.protocol.name']).toBeUndefined();
     agent.assertNoPendingInterceptors();
   });


### PR DESCRIPTION
Enrich the existing v4 event-write `http POST` **CLIENT** span. No new span is created.

The modified span is emitted by HTTP event writes through `fetchV4` / `instrumentedFetch` and WebSocket event writes through the existing synthetic parity span in `postEventFrameOverWs` / `withHttpClientSpan`.

## Added attributes

- `workflow.client.version` on every v4 event write, formatted as `@workflow/world-vercel/<version>`
- `step.stso_ms` when the event input carries step-to-step overhead telemetry
- `step.latency_optimizations` when the event input carries the active runtime optimization list, such as `lazyStepStart`, `turbo`, and `optimisticStart`

The span already inherits the client application OTEL `service.name` and carries the event type, transport, URL, and status. The added fields allow sampled STSO analysis by client service, Workflow SDK version, and runtime mode on one span.

## Validation

- Dependency-aware `@workflow/world-vercel` build
- `ws-transport-spans.test.ts`: 13 tests passed
- `@workflow/world-vercel` typecheck
- Biome and `git diff --check`