### PR TITLE
[core] Publish the wake on a live-run hook_received conflict instead of throwing HookNotFoundError

### DIFF
--- a/.changeset/hook-resume-conflict-converge.md
+++ b/.changeset/hook-resume-conflict-converge.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Sequential hook resume no longer treats a conflict (409) on the `hook_received` write as "hook gone": when the run is still live it publishes the wake and reports success, so a durably-committed resume can no longer be lost behind a spurious `HookNotFoundError`.

--- a/packages/core/src/runtime/resume-hook.fast-path.test.ts
+++ b/packages/core/src/runtime/resume-hook.fast-path.test.ts
@@ -14,10 +14,26 @@ import { resumeHook, resumeWebhook } from './resume-hook.js';
 import { setWorld } from './world.js';
 
 vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }));
+// A recording span so tests can assert which attributes were (not) emitted —
+// notably that convergence telemetry is withheld when the wake publish fails.
+const { mockSpan } = vi.hoisted(() => ({
+  mockSpan: {
+    setAttributes: vi.fn(),
+    addLink: vi.fn(),
+    addEvent: vi.fn(),
+    recordException: vi.fn(),
+  },
+}));
 vi.mock('../telemetry.js', () => ({
   linkToTraceCarrier: vi.fn(),
-  trace: vi.fn((_name, fn) => fn(undefined)),
+  trace: vi.fn((_name, fn) => fn(mockSpan)),
 }));
+
+/** Flattened keys of every setAttributes call recorded on the mock span. */
+const recordedAttributeKeys = () =>
+  mockSpan.setAttributes.mock.calls.flatMap((call) =>
+    Object.keys(call[0] ?? {})
+  );
 // Stub payload (de)serialization so these control-flow tests don't depend on
 // devalue/encryption/Request framing — SerializationFormat is kept real for
 // the capability checks. Byte-level sealing is covered by the sibling
@@ -32,7 +48,10 @@ vi.mock('../serialization.js', async (importActual) => {
 });
 
 describe('resumeHook (resumeContext fast path)', () => {
-  afterEach(() => setWorld(undefined));
+  afterEach(() => {
+    setWorld(undefined);
+    mockSpan.setAttributes.mockClear();
+  });
 
   const baseHook = {
     runId: 'wrun_ctx',
@@ -193,6 +212,35 @@ describe('resumeHook (resumeContext fast path)', () => {
         hookResumeTiming: expect.objectContaining({ strategy: 'sequential' }),
       }),
       expect.objectContaining({ deploymentId: resumeContext.deploymentId })
+    );
+    // The convergence marker is recorded — and only because the publish
+    // succeeded (see the publish-failure test below).
+    expect(recordedAttributeKeys()).toContain(
+      'workflow.hook.resume_conflict_converged'
+    );
+  });
+
+  it('does not record convergence telemetry when the wake publish fails', async () => {
+    // The converged-conflict span attribute claims "the run was re-triggered".
+    // If the queue publish rejects, no wake went out: the publish error must
+    // propagate to the caller (unchanged behavior) and the span must NOT carry
+    // the convergence marker for a re-trigger that never happened.
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new EntityConflictError('duplicate hook_received'));
+    const runsGet = vi.fn().mockResolvedValue({
+      runId: hook.runId,
+      status: 'running',
+    } as unknown as WorkflowRun);
+    const queue = vi.fn().mockRejectedValue(new Error('queue unavailable'));
+    makeWorld(hook, { createEvent, runsGet, queue });
+
+    await expect(resumeHook(hook.token, { foo: 'bar' })).rejects.toThrow(
+      'queue unavailable'
+    );
+    expect(recordedAttributeKeys()).not.toContain(
+      'workflow.hook.resume_conflict_converged'
     );
   });
 

--- a/packages/core/src/runtime/resume-hook.fast-path.test.ts
+++ b/packages/core/src/runtime/resume-hook.fast-path.test.ts
@@ -163,26 +163,77 @@ describe('resumeHook (resumeContext fast path)', () => {
     expect(queue).not.toHaveBeenCalled();
   });
 
-  it('re-keys an EntityConflictError (compat / conflict-shaped rejection) from events.create to HookNotFoundError(token)', async () => {
-    // Current Vercel behavior returns 404 for a terminal run (mapped to
-    // HookNotFoundError, covered above). EntityConflictError is kept for
-    // compatibility with older / conflict-shaped (HTTP 409) rejection
-    // behavior. On the fast path it surfaces from events.create and must be
-    // re-keyed to HookNotFoundError(token), matching the pre-fast-path
-    // contract where resumeHook threw HookNotFoundError.
+  it('converges an EntityConflictError from events.create when the run is live: publishes the wake and succeeds', async () => {
+    // A conflict-shaped (HTTP 409) rejection means a hook_received for this
+    // hook already COMMITTED — it is not proof the hook is gone. On a live
+    // run, throwing HookNotFoundError without publishing would be a lost
+    // resume (durable payload, no wake in flight, caller told the token is
+    // invalid). The sequential path must instead publish the wake and report
+    // success, exactly as if its own write had won — mirroring how the
+    // parallel path converges a 409 via its already-published queue message.
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new EntityConflictError('duplicate hook_received'));
+    const runsGet = vi.fn().mockResolvedValue({
+      runId: hook.runId,
+      status: 'running',
+    } as unknown as WorkflowRun);
+    const { queue } = makeWorld(hook, { createEvent, runsGet });
+
+    const resumed = await resumeHook(hook.token, { foo: 'bar' });
+
+    expect(resumed.token).toBe(hook.token);
+    expect(runsGet).toHaveBeenCalledWith(hook.runId, { resolveData: 'none' });
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect(queue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        runId: hook.runId,
+        hookResumeTiming: expect.objectContaining({ strategy: 'sequential' }),
+      }),
+      expect.objectContaining({ deploymentId: resumeContext.deploymentId })
+    );
+  });
+
+  it('re-keys an EntityConflictError to HookNotFoundError(token) when the run is terminal (no re-trigger)', async () => {
+    // The historical contract survives where it is correct: a conflict against
+    // a run that has ended means there is nothing left to wake, so the caller
+    // still gets HookNotFoundError and no queue message is published.
     const hook = { ...baseHook, resumeContext } satisfies Hook;
     const createEvent = vi
       .fn()
       .mockRejectedValue(new EntityConflictError('run has already ended'));
-    const { runsGet, queue } = makeWorld(hook, { createEvent });
+    const runsGet = vi.fn().mockResolvedValue({
+      runId: hook.runId,
+      status: 'completed',
+    } as unknown as WorkflowRun);
+    const { queue } = makeWorld(hook, { createEvent, runsGet });
 
     await expect(resumeHook(hook.token, { foo: 'bar' })).rejects.toSatisfy(
       (err: unknown) =>
         HookNotFoundError.is(err) &&
         (err as HookNotFoundError).token === hook.token
     );
-    expect(runsGet).not.toHaveBeenCalled();
+    expect(runsGet).toHaveBeenCalledWith(hook.runId, { resolveData: 'none' });
     expect(queue).not.toHaveBeenCalled();
+  });
+
+  it('fails open to publishing the wake when the conflict status check itself fails', async () => {
+    // If the run's status cannot be read, publishing is the safe direction: a
+    // spurious wake no-ops on a terminal run, while throwing HookNotFoundError
+    // on a live run loses a durably-committed resume.
+    const hook = { ...baseHook, resumeContext } satisfies Hook;
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(new EntityConflictError('duplicate hook_received'));
+    const runsGet = vi.fn().mockRejectedValue(new Error('status read failed'));
+    const { queue } = makeWorld(hook, { createEvent, runsGet });
+
+    const resumed = await resumeHook(hook.token, { foo: 'bar' });
+
+    expect(resumed.token).toBe(hook.token);
+    expect(queue).toHaveBeenCalledTimes(1);
   });
 
   it('re-keys a RunExpiredError (world-local / world-postgres terminal run) from events.create to HookNotFoundError(token)', async () => {

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -536,16 +536,14 @@ async function resumeHookImpl<T = any>(
         //   - a terminal run on world-local / world-postgres rejects with
         //     RunExpiredError.
         //
-        // On the SEQUENTIAL path an EntityConflictError (HTTP 409) is also
-        // treated as "hook gone" for historical / conflict-shaped-rejection
-        // compatibility: there is no queue message in flight, so a conflict has
-        // no re-ensuring consumer to converge on. The PARALLEL path handles 409
-        // differently (see below) — it published the queue message before the
-        // conflict, so the consumer will converge the event.
+        // An EntityConflictError (HTTP 409) is deliberately NOT in this set: a
+        // conflict-shaped rejection means a `hook_received` for this hook
+        // already COMMITTED durably, which is not proof the hook is gone. The
+        // sequential path disambiguates it via the run's status below; the
+        // PARALLEL path published the queue message before the conflict, so
+        // its re-ensuring consumer converges the event (see below).
         const isHookGoneError = (err: unknown): boolean =>
-          HookNotFoundError.is(err) ||
-          EntityConflictError.is(err) ||
-          RunExpiredError.is(err);
+          HookNotFoundError.is(err) || RunExpiredError.is(err);
 
         if (!useParallelResume) {
           // Sequential path: create a hook_received event, then re-trigger.
@@ -564,7 +562,62 @@ async function resumeHookImpl<T = any>(
             if (isHookGoneError(err)) {
               throw new HookNotFoundError(hook.token);
             }
-            throw err;
+            if (!EntityConflictError.is(err)) {
+              throw err;
+            }
+            // Conflict-shaped (HTTP 409) rejection. Historically this was
+            // treated as "hook gone", but a conflict means the World REFUSED a
+            // duplicate — i.e. some `hook_received` for this hook is already
+            // committed. Throwing HookNotFoundError here would be a lost
+            // resume: the payload is durable, no queue message is in flight to
+            // wake the run (unlike the parallel path), and the caller is told
+            // the token is invalid so it stops retrying. Disambiguate via the
+            // run's live status:
+            //   - terminal run → preserve the historical contract and throw
+            //     HookNotFoundError (nothing left to wake);
+            //   - live run → converge on the committed event: publish the wake
+            //     below and report success, exactly as if this write had won.
+            //   - status unknown (the read itself failed) → still publish. The
+            //     wake is idempotent and a consumer no-ops on a terminal run,
+            //     so a spurious publish is harmless, while throwing
+            //     HookNotFoundError on a live run loses the resume — fail open
+            //     toward waking.
+            let runIsTerminal = false;
+            try {
+              const run = await world.runs.get(hook.runId, {
+                resolveData: 'none',
+              });
+              runIsTerminal = isTerminalWorkflowRunStatus(run.status);
+            } catch (statusErr) {
+              runtimeLogger.warn(
+                'Hook resume conflict: run status check failed; publishing the wake anyway',
+                {
+                  workflowRunId: hook.runId,
+                  hookId: hook.hookId,
+                  error:
+                    statusErr instanceof Error
+                      ? statusErr.message
+                      : String(statusErr),
+                }
+              );
+            }
+            if (runIsTerminal) {
+              throw new HookNotFoundError(hook.token);
+            }
+            span?.setAttributes({
+              ...Attribute.HookResumeConflictConverged(true),
+            });
+            runtimeLogger.warn(
+              'Hook resume event write was rejected as a duplicate while the ' +
+                'run is still live; converging on the committed hook_received ' +
+                'and re-triggering the run.',
+              {
+                workflowRunId: hook.runId,
+                hookId: hook.hookId,
+                error: err instanceof Error ? err.message : String(err),
+              }
+            );
+            // Fall through to the queue publish below.
           }
 
           // T1 of the TTR window. Stamped immediately before the publish so

--- a/packages/core/src/runtime/resume-hook.ts
+++ b/packages/core/src/runtime/resume-hook.ts
@@ -546,6 +546,10 @@ async function resumeHookImpl<T = any>(
           HookNotFoundError.is(err) || RunExpiredError.is(err);
 
         if (!useParallelResume) {
+          // Set when a live-run duplicate conflict is being converged (see the
+          // catch below); telemetry for it is emitted only after the wake
+          // publish succeeds.
+          let convergedConflict: unknown;
           // Sequential path: create a hook_received event, then re-trigger.
           try {
             await world.events.create(
@@ -604,19 +608,12 @@ async function resumeHookImpl<T = any>(
             if (runIsTerminal) {
               throw new HookNotFoundError(hook.token);
             }
-            span?.setAttributes({
-              ...Attribute.HookResumeConflictConverged(true),
-            });
-            runtimeLogger.warn(
-              'Hook resume event write was rejected as a duplicate while the ' +
-                'run is still live; converging on the committed hook_received ' +
-                'and re-triggering the run.',
-              {
-                workflowRunId: hook.runId,
-                hookId: hook.hookId,
-                error: err instanceof Error ? err.message : String(err),
-              }
-            );
+            // Convergence is only REAL once the wake publish below succeeds —
+            // record the conflict here and emit the telemetry after the
+            // publish, so a failed publish (which propagates to the caller and
+            // means no wake went out) never leaves a span claiming the run was
+            // re-triggered.
+            convergedConflict = err;
             // Fall through to the queue publish below.
           }
 
@@ -638,6 +635,27 @@ async function resumeHookImpl<T = any>(
             } satisfies WorkflowInvokePayload,
             queueOptions
           );
+
+          if (convergedConflict !== undefined) {
+            // The wake is durably published, so the convergence actually
+            // happened — safe to record it now.
+            span?.setAttributes({
+              ...Attribute.HookResumeConflictConverged(true),
+            });
+            runtimeLogger.warn(
+              'Hook resume event write was rejected as a duplicate while the ' +
+                'run is still live; converged on the committed hook_received ' +
+                'and re-triggered the run.',
+              {
+                workflowRunId: hook.runId,
+                hookId: hook.hookId,
+                error:
+                  convergedConflict instanceof Error
+                    ? convergedConflict.message
+                    : String(convergedConflict),
+              }
+            );
+          }
 
           return hook;
         }

--- a/packages/core/src/telemetry/semantic-conventions.ts
+++ b/packages/core/src/telemetry/semantic-conventions.ts
@@ -446,6 +446,17 @@ export const HookResilientResumeMaterialized = SemanticConvention<boolean>(
 );
 
 /**
+ * Producer-side signal (on the `hook.resume` span) that the SEQUENTIAL path's
+ * `hook_received` write was rejected as a conflict (HTTP 409) while the run
+ * was still live — some receive for this hook had already committed — so the
+ * resume converged on the committed event: the wake message was published and
+ * the caller's resume reported success instead of HookNotFoundError.
+ */
+export const HookResumeConflictConverged = SemanticConvention<boolean>(
+  'workflow.hook.resume_conflict_converged'
+);
+
+/**
  * Consumer-side signal (on the workflow execution span) of how a lazy hook
  * resume initialized its replay state:
  *


### PR DESCRIPTION
## Problem

The **sequential** `resumeHook()` path treated an `EntityConflictError` (HTTP 409) from the `hook_received` write as "hook gone": it threw `HookNotFoundError(token)` **before the queue publish ever happened** (`isHookGoneError` included `EntityConflictError.is`).

A conflict-shaped rejection means the World *refused a duplicate* — i.e. some `hook_received` for this hook is already durably committed. Throwing at that point is a lost resume:

- the payload exists in the event log,
- **no wake message is in flight** to re-trigger the run (unlike the parallel path, whose queue publish fires alongside the write and whose consumer converges the 409), and
- the caller is told the token is invalid, so it stops retrying.

The canonical trigger is a landed-write-lost-response: the write commits server-side, the response is lost (ECONNRESET / 5xx-after-commit), the caller retries `resumeHook()`, and the retry's 409 turns into a permanent `HookNotFoundError` while the run sits suspended forever.

On today's Vercel backend this is latent for running runs (ordinary `hook_received` has no conflict guard; terminal runs reject with 404 → `HookNotFoundError`, and world-local/world-postgres use `RunExpiredError`) — but this was the one place the SDK translated a 409 into "give up with no continuation scheduled", and any conflict-shaped World rejection would trip it.

## Fix

Split `EntityConflictError` out of `isHookGoneError` and disambiguate it by the run's live status (one `runs.get` on this rare path):

- **terminal run** → preserve the historical contract: `HookNotFoundError(token)`, no publish;
- **live run** → converge on the committed event: publish the sequential wake (same payload incl. `hookResumeTiming`) and report success, exactly as if this write had won — mirroring the parallel path's 409 handling. Emits a `workflow.hook.resume_conflict_converged` span attribute and a warn log;
- **status unreadable** → fail open toward publishing: a spurious wake no-ops on a terminal run, while throwing on a live run loses a durably-committed resume.

`HookNotFoundError` / `RunExpiredError` behavior is unchanged, and the parallel path and fast-path consumer logic are untouched.

## Tests

- 409 + running run → wake published once (sequential timing payload), resume succeeds
- 409 + terminal run → `HookNotFoundError(token)`, no publish
- 409 + `runs.get` failure → wake published, resume succeeds
- Existing `HookNotFoundError` / `RunExpiredError` re-keying tests unchanged and green

`packages/core`: 95 files, 2119 passed (+3 expected-fail) — full suite green. Pre-existing `noExcessiveCognitiveComplexity` warning on `resumeHookImpl` (107 on main) remains advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)