### PR TITLE
[world-sim] Remove mint-ordered log

### DIFF
--- a/.github/workflows/world-sim.yml
+++ b/.github/workflows/world-sim.yml
@@ -1,22 +1,11 @@
 name: World Sim
 
 # Plays the deterministic scenario book (`workbench/sim-world`) against the
-# runtime in this commit, once per log world, and publishes the two summaries.
+# runtime in this commit and publishes its summary.
 #
-# This lane never blocks a merge, by design. Three scenarios in the book fail on
-# purpose: each one is a reproduction of a corruption the runtime can still
-# produce, stating the outcome its own durable log implies, and staying red
-# until the runtime gets there. A gate that goes red on every PR is a gate
-# everyone learns to ignore, so the job publishes numbers instead of verdicts —
-# and the number to watch is in the comment, not the check mark.
-#
-#   mint-ordered (production):  38 passed, 3 failed, 3 violations
-#   append-only:                41 passed, 0 failed, 0 violations
-#
-# A fourth red is a regression. Two means something got fixed and a scenario
-# is ready to retire. The append-only column is the measurement the pair exists
-# for: it says which of the three would close if event positions were assigned
-# at commit instead of at the handler's mint.
+# This lane never blocks a merge, by design. The job publishes its numbers
+# instead of a verdict, so the comment is the result to watch, not the check
+# mark.
 
 on:
   push:
@@ -49,8 +38,8 @@ jobs:
     # on a PR it has nothing to say about. The step summary and the artifact
     # still carry whatever did happen.
     continue-on-error: true
-    # The book itself is ~11s per world on a laptop. Everything else here is
-    # install and build.
+    # The book itself is ~11s on a laptop. Everything else here is install and
+    # build.
     timeout-minutes: 15
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -72,35 +61,17 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-workflow-dev
 
-      # Both worlds run with their real exit codes: `continue-on-error` records
-      # the non-zero without ending the job, so the step's own status still
-      # says whether the book was clean. Paths are absolute because pnpm runs
-      # the script from the package directory, not the workspace root.
-      - name: Play the book (mint-ordered log)
-        id: mint
+      - name: Play the book
+        id: world-sim
         continue-on-error: true
         run: |
           pnpm --filter @workflow/sim-world-workbench sim \
             --no-color \
-            --title 'Mint-ordered log' \
-            --summary-file "${{ github.workspace }}/world-sim-mint.md" \
-            --detail-file "${{ github.workspace }}/world-sim-mint.txt"
+            --summary-file "${{ github.workspace }}/world-sim.md" \
+            --detail-file "${{ github.workspace }}/world-sim.txt"
 
-      - name: Play the book (append-only log)
-        id: append-only
-        continue-on-error: true
-        run: |
-          pnpm --filter @workflow/sim-world-workbench sim \
-            --no-color \
-            --append-only \
-            --title 'Append-only log' \
-            --summary-file "${{ github.workspace }}/world-sim-append-only.md" \
-            --detail-file "${{ github.workspace }}/world-sim-append-only.txt"
-
-      # Four visible lines when collapsed: the heading, one line saying what
-      # this is, and one per world. Everything else is behind a fold. The
-      # comment is reposted on every push to the PR, so what it costs when it
-      # has nothing new to say is the thing to keep small.
+      # The comment is reposted on every push to the PR, so what it costs when
+      # it has nothing new to say is the thing to keep small.
       - name: Render summary
         if: always()
         run: |
@@ -110,22 +81,17 @@ jobs:
             echo
             echo "Simulated world deterministic testing for races. [Traces]($run_url)"
             echo
-            for world in mint append-only; do
-              if [ -f "world-sim-$world.md" ]; then
+            if [ -f world-sim.md ]; then
                 # The summary names its detail file by the path it was given,
                 # which is absolute so that pnpm's package-directory cwd cannot
                 # scatter them. Strip the workspace prefix back off, leaving
                 # the bare name the artifact below actually contains.
-                sed "s|${{ github.workspace }}/||g" "world-sim-$world.md"
-                # Blank line between the two folds. Adjacent HTML blocks with
-                # nothing between them get parsed as one, and the second world
-                # disappears into the first one's fold.
+                sed "s|${{ github.workspace }}/||g" world-sim.md
                 echo
-              else
-                echo "🟠 _The $world run produced no summary — see the job log._"
+            else
+                echo "🟠 _The run produced no summary — see the job log._"
                 echo
-              fi
-            done
+            fi
           } | tee world-sim-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       # Skipped on forks, where `pull_request` grants read-only permissions and
@@ -147,9 +113,7 @@ jobs:
           name: world-sim-traces
           path: |
             world-sim-summary.md
-            world-sim-mint.md
-            world-sim-mint.txt
-            world-sim-append-only.md
-            world-sim-append-only.txt
+            world-sim.md
+            world-sim.txt
           retention-days: 7
           if-no-files-found: ignore

--- a/packages/world-sim/README.md
+++ b/packages/world-sim/README.md
@@ -121,18 +121,7 @@ every *validation* is kept, because rejections are the observable contract.
 
 ## World behaviors
 
-A scenario picks the world it plays in, and each behavior below changes a rule
-the runtime is written against.
-
-**Mint-ordered log** — the default. A position is assigned when the event's
-handler mints its id, and the event is committed to storage separately. The id
-*is* the log's sort key, so a write held between the two lands *behind* events
-minted later and committed sooner: an event can arrive in the past, and a read
-taken in between saw a log the log itself went on to contradict.
-
-**Append-only log** (`appendOnlyLog: true`) — a position is assigned at commit.
-A write overtaken while it was held gives up its position and re-takes the tail.
-Two things follow:
+**Event log** — positions are assigned at commit. Two things follow:
 
 - Log order is commit order. Nothing is inserted behind a row a reader has
   already seen, so no two reads can disagree about the past.
@@ -141,12 +130,8 @@ Two things follow:
   into lag, and lag is what an optimistic-concurrency fence can see; a hole is
   what it cannot.
 
-Uncontended writes are untouched either way: a position that is still the newest
-when it commits keeps its id, so a scenario that never holds a write mid-flight
-produces a byte-identical log in both. `withholdNextEvent` follows the same
-rule — a hole in the mint-ordered log, a truncated tail under append-only —
-which is why `StaleRead` reports `{ eventId, hidden, truncated }` and the trace
-distinguishes a lagging read from a stale one.
+`withholdNextEvent` models a lagging replica by truncating the visible tail;
+`StaleRead` reports `{ eventId, hidden, truncated }` for that read.
 
 **Precondition fence** (`preconditionGuard: true`) — rejects a write whose
 snapshot is strictly older than the newest externally originated event. It is a
@@ -166,11 +151,8 @@ client's own — newest loaded position, and how many loaded events sit at or
 below it. A write the facade attached no snapshot to did not come from a replay
 context and is never fenced.
 
-Each is a spec field, and `RunScenarioOptions` carries a run-wide override —
-`pnpm sim --append-only`, `--fence` / `--no-fence` — where `undefined` leaves
-each scenario's own choice alone. Playing one book under two behaviors and
-diffing the results is what the pair is for; [DESIGN.md
-§5](./DESIGN.md#the-two-guards) has the guards in full.
+Each is a spec field, and `RunScenarioOptions` carries a run-wide override for
+the fence. [DESIGN.md §5](./DESIGN.md#the-two-guards) has the guards in full.
 
 ## Usage
 
@@ -377,12 +359,8 @@ const script: ScenarioScript = async (sim) => {
 `{stepName, token, correlationId, where, label, timeoutMs}`.
 
 Both advances hold a writer whose event has no position yet, so a write that
-commits during the hold sorts *ahead* of it. For the other order — an event that
-already owns an earlier slot and has not appeared — hold the write itself with
-[`sim.beginHookDelivery`](#withholdings), which reserves the position and hands
-back a `commit()`. Under `appendOnlyLog` that reservation is provisional: an
-overtaken write gives it up and re-takes the tail, which is exactly how the world
-closes the gap. See [World behaviors](#world-behaviors).
+commits during the hold sorts ahead of it. `sim.beginHookDelivery` can defer an
+external hook write until its `commit()` call.
 
 `runTo` is **level-triggered**: it consults recorded history, so a point this
 writer already passed is an `AlreadyPassedError` naming the point rather than a
@@ -435,7 +413,7 @@ and changes what storage answers.
 | method | writer | description |
 | --- | --- | --- |
 | `sim.withholdNextEvent(reads?)` | whichever commits next | Hide the next event committed to storage from the next `reads` event-log reads (default 1). Call it immediately before the write to hide. |
-| `sim.beginHookDelivery(token, payload)` | `external` | Deliver a hook, withheld between its two halves: assigned a position in the event log, not committed to storage. Returns `{eventId, commit()}`. |
+| `sim.beginHookDelivery(token, payload)` | `external` | Begin an external hook delivery and return `commit()`, which writes it at the log tail. |
 
 `beginHookDelivery` is the one place inside an `external` writer a script can
 reach, and it is a withholding rather than an advance because holding that
@@ -443,9 +421,8 @@ writer would be the wrong model: an out-of-band receiver is a separate process,
 so nothing of the run's is blocked while its write is in flight. Holding an
 inline write would stall the delivery that made it, and the reader with it.
 
-Both change shape with the log. Under `appendOnlyLog` a withheld read is cut
-short at the withheld event instead of missing it from the middle — the log can
-be behind, never wrong — and an overtaken hook re-takes the tail on `commit()`.
+A withheld read is cut short at the withheld event: the log can be behind, never
+wrong.
 
 ### Everything else a script can do
 
@@ -457,7 +434,6 @@ be behind, never wrong — and an overtaken hook re-takes the tail on `commit()`
 | `deliverQueued(select?)` | Deliver one queued message now, concurrently with a held writer |
 | `note(msg)` / `check(name, cond)` | Record a marker / an assertion in the trace; a false check fails the scenario |
 | `world` | Read-only snapshot: runs, events, steps, hooks, waits, pending messages, rejected calls |
-| `appendOnlyLog` | Which log this run is playing against — for *phrasing* a check, never for branching the tempo |
 
 A scenario with no script at all is a control: the run plays out on the default
 schedule, and the only question is whether the log it leaves reproduces it.
@@ -530,22 +506,14 @@ so adding an option to one of them is not a change to the package's public
 signature. Promote a name to the entry when something outside the package needs
 it, not before.
 
-**A new world flag is tri-state at the runner.** `ScenarioSpec` carries the
-scenario's own choice, `RunScenarioOptions` the run-wide override, and
-`undefined` means "leave it to the spec" — not the same as `false`, because a
-scenario that asked for the flag must keep it. `run.ts` maps `--x` / `--no-x`
-onto that, and the resolved value reaches `createSimWorld` and the chips line.
-
 **Anything a scenario can observe has to survive replay.** `verifyReplay`
-re-plays the log in a fresh world built from the same options, so a store rule
-that is not applied there turns every scenario using it red for the wrong
-reason.
+re-plays the log in a fresh world, so a store rule that is not applied there
+turns every scenario using it red for the wrong reason.
 
 **Tests come in two shapes.** `src/*.test.ts` are vitest units against the
-pieces in isolation — copy `store.test.ts` for anything that changes what the
-log looks like, where the append-only block is written as pairs asserting
-*opposite* outcomes in the two worlds. The scenario book is the integration
-test; run it before and after and diff the counts.
+ pieces in isolation — copy `store.test.ts` for anything that changes what the
+ log looks like. The scenario book is the integration test; run it before and
+ after and diff the counts.
 
 ## What this does *not* give you
 

--- a/packages/world-sim/src/invariants.test.ts
+++ b/packages/world-sim/src/invariants.test.ts
@@ -133,29 +133,6 @@ describe('invariants', () => {
     ).toContain('log.monotonic-order');
   });
 
-  it('skips the order rule when the world makes no such promise', () => {
-    const a = event({
-      eventType: 'run_created',
-      eventData: {
-        deploymentId: 'd',
-        workflowName: 'w',
-        input: new Uint8Array(),
-      },
-    });
-    const b = event({ eventType: 'run_started' });
-    expect(
-      rules(
-        checkInvariants({
-          runId: RUN,
-          events: [a, b],
-          runs: [run('running')],
-          steps: [],
-          waits: [],
-        })
-      )
-    ).not.toContain('log.monotonic-order');
-  });
-
   it('catches an out-of-order log', () => {
     const a = event({
       eventType: 'run_created',

--- a/packages/world-sim/src/invariants.ts
+++ b/packages/world-sim/src/invariants.ts
@@ -28,20 +28,8 @@ export interface InvariantInput {
   runId: string;
   /** The run's events in log order — the order every reader sees them in. */
   events: Event[];
-  /**
-   * The same events in the order they were *committed*, supplied only by a
-   * world that promises the two orders agree — i.e. an append-only log.
-   *
-   * Only `log.monotonic-order` reads it, and it has to: comparing the sorted
-   * array against sort order can only ever pass, which is why that rule was
-   * unfirable before. Under a mint-ordered log the field is omitted and the
-   * rule is skipped, because there an out-of-order commit is the premise the
-   * scenario deliberately injected — production mints ids at the handler
-   * boundary, so its log gains rows in the past by design. Asserting otherwise
-   * would fail every scenario that holds a write across a peer's commit, which
-   * is the setup, not the fault.
-   */
-  eventsInCommitOrder?: Event[];
+  /** The same events in the order they were committed. */
+  eventsInCommitOrder: Event[];
   runs: WorkflowRun[];
   steps: Step[];
   waits: Wait[];
@@ -78,13 +66,13 @@ export function checkInvariants(input: InvariantInput): InvariantViolation[] {
   }
 
   // `events.list` sorts by (createdAt, eventId), and replay consumes events in
-  // that order. An append-only log promises commit order *is* that order; if it
+  // that order. Commit order must be that order; if it
   // is not, the log gained a row behind a position readers had already passed,
   // so a read taken in between saw a sequence the finished log contradicts.
   // Walking the sorted array could never notice — it is sorted, so it is
   // monotonic by construction. This is the check that the promise was kept.
   let previousKey = '';
-  for (const event of input.eventsInCommitOrder ?? []) {
+  for (const event of input.eventsInCommitOrder) {
     const key = `${event.createdAt.toISOString()}|${event.eventId}`;
     if (previousKey && key <= previousKey) {
       add(

--- a/packages/world-sim/src/replay.ts
+++ b/packages/world-sim/src/replay.ts
@@ -43,14 +43,6 @@ export interface ReplayCheckInput {
   events: readonly Event[];
   handler: (req: Request) => Promise<Response>;
   limits: Required<ScenarioLimits>;
-  /**
-   * Replay under the same log rules as the run being checked. It cannot change
-   * the outcome — the replay seeds a finished log and writes only at a clock
-   * past its tail, so nothing it appends can be overtaken — but a replay
-   * playing by different rules than the run it verifies is a trap worth not
-   * setting.
-   */
-  appendOnlyLog?: boolean;
 }
 
 export interface ReplayCheckResult {
@@ -133,10 +125,7 @@ export async function verifyReplay(
   const replayClock = createVirtualClock(terminal.createdAt.getTime() + 1);
   const uninstallClock = replayClock.install();
 
-  const replayWorld = createSimWorld({
-    clock: replayClock,
-    appendOnlyLog: input.appendOnlyLog,
-  });
+  const replayWorld = createSimWorld({ clock: replayClock });
   replayWorld.store.seedFromLog(seeded);
   replayWorld.registerHandler(WORKFLOW_QUEUE_PREFIX, handler);
   replayWorld.setScenarioApi(() => {

--- a/packages/world-sim/src/report.ts
+++ b/packages/world-sim/src/report.ts
@@ -414,10 +414,7 @@ export function renderScenario(
       `      run=${result.runId || '(none)'} outcome=${result.outcome} ` +
         `events=${result.events.length} deliveries=${result.deliveries} ` +
         `worldCalls=${result.worldCalls} virtual=${formatDuration(result.virtualElapsedMs)} ` +
-        `wall=${result.wallMs.toFixed(0)}ms replay=${describeReplay(result)}` +
-        // Only when it is on. The default is production, and a line that
-        // repeats "this is the ordinary world" on every scenario says nothing.
-        (result.appendOnlyLog ? ' log=append-only' : ''),
+        `wall=${result.wallMs.toFixed(0)}ms replay=${describeReplay(result)}`,
       'dim'
     )
   );

--- a/packages/world-sim/src/scenario.ts
+++ b/packages/world-sim/src/scenario.ts
@@ -138,17 +138,6 @@ export interface ScenarioSpec {
    * `preconditionGuard: true` to model the watermark alone.
    */
   countGuard?: boolean;
-  /**
-   * Run this scenario against an append-only log, where an event takes its
-   * position at commit and a read can therefore be behind but never
-   * self-contradictory. See `SimStoreOptions.appendOnlyLog`.
-   *
-   * Off by default, and no scenario in the book sets it: the interesting use is
-   * as a global override (`RunScenarioOptions.appendOnlyLog`), where the whole
-   * book runs twice and the diff is the answer to "which of these failures are
-   * about the mint-before-commit window, and which are about something else?".
-   */
-  appendOnlyLog?: boolean;
 }
 
 export interface ScenarioExpectation {
@@ -171,12 +160,6 @@ export interface ScenarioResult {
   runId: string;
   outcome: ScenarioOutcome;
   ok: boolean;
-  /**
-   * Which log the run played against — resolved from the spec and the run
-   * option, so a stored result says which world produced it rather than
-   * leaving the reader to remember.
-   */
-  appendOnlyLog: boolean;
   /** Scenario-level failures: unmet expectations, failed checks, script errors. */
   problems: string[];
   /** World-contract violations found by re-deriving state from the log. */
@@ -208,16 +191,6 @@ export interface RunScenarioOptions {
   /** Workflow function name → machine workflow id, from `buildSimBundle`. */
   workflowIds?: Record<string, string>;
   /**
-   * Force `SimStoreOptions.appendOnlyLog` on or off for this run, overriding
-   * whatever the spec asked for.
-   *
-   * This is the knob a caller flips to play the same book under both worlds —
-   * the CLI's `--append-only`, the page's toggle. `undefined` leaves the
-   * decision to the spec, which is how a book of scenarios written against
-   * production keeps behaving like one.
-   */
-  appendOnlyLog?: boolean;
-  /**
    * Force `SimStoreOptions.preconditionGuard` on or off for this run,
    * overriding whatever the spec asked for.
    *
@@ -241,7 +214,6 @@ export async function runScenario(
 ): Promise<ScenarioResult> {
   const limits = { ...DEFAULT_LIMITS, ...spec.limits };
   const clock = createVirtualClock();
-  const appendOnlyLog = options.appendOnlyLog ?? spec.appendOnlyLog ?? false;
   // One expectation, whichever world this is. Aliased rather than read inline
   // so the outcome check and the output check below cannot drift apart.
   const expected = spec.expect;
@@ -254,7 +226,6 @@ export async function runScenario(
     clock,
     preconditionGuard,
     countGuard: spec.countGuard ?? preconditionGuard,
-    appendOnlyLog,
   });
 
   const workflowId =
@@ -270,8 +241,7 @@ export async function runScenario(
       )
         .filter((k) => !k.includes('#'))
         .sort()
-        .join(', ')}`,
-      appendOnlyLog
+        .join(', ')}`
     );
   }
 
@@ -298,7 +268,6 @@ export async function runScenario(
 
   const api: ScenarioApi = {
     world: world.snapshot,
-    appendOnlyLog,
     get runId() {
       return runId;
     },
@@ -315,24 +284,9 @@ export async function runScenario(
       await world.asExternal(() => resumeHook(token, payload));
     },
     async beginHookDelivery(token, payload) {
-      // Take the position now and commit later. This is the handler boundary
-      // split made visible to a script: the receiver has entered `resumeHook`,
-      // its event id is minted and its slot in the log is spoken for, but the
-      // storage write has not happened — so every other writer that commits in
-      // the meantime lands *behind* a position nobody can see yet.
-      //
-      // It has to be an out-of-band writer. An inline step's `step_completed`
-      // held the same way would stall the orchestrator that should misread the
-      // log, because the runtime awaits its promise before deciding anything.
-      const position = world.reservePosition(runId);
       return {
-        eventId: position.eventId,
         async commit() {
-          await world.asExternal(() =>
-            world.withReservedPosition(position, () =>
-              resumeHook(token, payload)
-            )
-          );
+          await world.asExternal(() => resumeHook(token, payload));
         },
       };
     },
@@ -471,7 +425,6 @@ export async function runScenario(
           events: world.store.allEvents(runId),
           handler: options.handler,
           limits,
-          appendOnlyLog,
         });
       } finally {
         uninstallClock = clock.install();
@@ -560,10 +513,7 @@ export async function runScenario(
     ? checkInvariants({
         runId,
         events,
-        // Only meaningful when the world promises commit order is log order.
-        ...(appendOnlyLog
-          ? { eventsInCommitOrder: world.store.allEventsInCommitOrder(runId) }
-          : {}),
+        eventsInCommitOrder: world.store.allEventsInCommitOrder(runId),
         runs: world.store.allRuns(),
         steps: world.store.allSteps(runId),
         waits: world.store.allWaits(runId),
@@ -595,7 +545,6 @@ export async function runScenario(
     runId,
     outcome,
     ok: problems.length === 0 && violations.length === 0 && outcome !== 'error',
-    appendOnlyLog,
     problems,
     violations,
     events,
@@ -678,8 +627,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
 
 function failedBeforeStart(
   spec: ScenarioSpec,
-  problem: string,
-  appendOnlyLog: boolean
+  problem: string
 ): ScenarioResult {
   return {
     id: spec.id,
@@ -688,7 +636,6 @@ function failedBeforeStart(
     runId: '',
     outcome: 'error',
     ok: false,
-    appendOnlyLog,
     problems: [problem],
     violations: [],
     events: [],

--- a/packages/world-sim/src/store.test.ts
+++ b/packages/world-sim/src/store.test.ts
@@ -412,7 +412,7 @@ describe('sim store', () => {
 
       guarded.tick(10);
       const snapshot = {
-        updatedAt: guarded.nowMs(),
+        maxSlot: guarded.store.allEvents(RUN).length,
         count: guarded.store.allEvents(RUN).length,
       };
       guarded.tick(10);
@@ -437,7 +437,7 @@ describe('sim store', () => {
         )
       ).rejects.toThrow(/out of band/);
 
-      // An up-to-date snapshot passes — an equal timestamp must not livelock.
+      // An up-to-date snapshot passes — an equal slot must not livelock.
       await expect(
         guarded.store.events.create(
           RUN,
@@ -449,7 +449,7 @@ describe('sim store', () => {
           },
           {
             snapshot: {
-              updatedAt: guarded.nowMs(),
+              maxSlot: guarded.store.allEvents(RUN).length,
               count: guarded.store.allEvents(RUN).length,
             },
           }

--- a/packages/world-sim/src/store.test.ts
+++ b/packages/world-sim/src/store.test.ts
@@ -3,31 +3,17 @@ import {
   HookNotFoundError,
   RunExpiredError,
 } from '@workflow/errors';
-import { requireEventSlot, SPEC_VERSION_CURRENT } from '@workflow/world';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createIdFactory } from './ids.js';
 import {
   createSimStore,
-  type LoadedSnapshot,
-  type MintedEvent,
   type SimStore,
   type SimStoreOptions,
   type StaleRead,
 } from './store.js';
 
 const SPEC = SPEC_VERSION_CURRENT;
-
-/**
- * The snapshot of a caller that loaded the run's whole log. The store is driven
- * directly here, so there is no facade tracking reads to derive one from.
- */
-function loadedAll(store: SimStore): LoadedSnapshot {
-  const events = store.allEvents(RUN);
-  return {
-    maxSlot: Math.max(...events.map((e) => requireEventSlot(e.eventId))),
-    count: events.length,
-  };
-}
 
 function setup(options?: Omit<SimStoreOptions, 'now' | 'ids'>) {
   let now = 1_704_067_200_000;
@@ -53,18 +39,6 @@ async function createRun(store: SimStore, runId: string) {
     eventType: 'run_started',
     specVersion: SPEC,
   });
-}
-
-type CreateParams = Parameters<SimStore['events']['create']>[2];
-
-/**
- * Commit at a position minted earlier — the hold the world facade opens
- * between the handler boundary and the storage write. `minted` rides on the
- * store's internal create params, which are deliberately not public, so a test
- * driving the store directly has to say so out loud.
- */
-function heldAt(minted: MintedEvent): CreateParams {
-  return { minted } as unknown as CreateParams;
 }
 
 const RUN = 'wrun_01HK153X00000000000105JM0S';
@@ -437,7 +411,10 @@ describe('sim store', () => {
       });
 
       guarded.tick(10);
-      const snapshot = loadedAll(guarded.store);
+      const snapshot = {
+        updatedAt: guarded.nowMs(),
+        count: guarded.store.allEvents(RUN).length,
+      };
       guarded.tick(10);
       // An out-of-band resume: no snapshot, so it advances the marker.
       await guarded.store.events.create(RUN, {
@@ -460,7 +437,7 @@ describe('sim store', () => {
         )
       ).rejects.toThrow(/out of band/);
 
-      // An up-to-date snapshot passes — an equal watermark must not livelock.
+      // An up-to-date snapshot passes — an equal timestamp must not livelock.
       await expect(
         guarded.store.events.create(
           RUN,
@@ -470,13 +447,18 @@ describe('sim store', () => {
             correlationId: 'step_1',
             eventData: { stepName: 'step//./w//s', input: new Uint8Array() },
           },
-          { snapshot: loadedAll(guarded.store) }
+          {
+            snapshot: {
+              updatedAt: guarded.nowMs(),
+              count: guarded.store.allEvents(RUN).length,
+            },
+          }
         )
       ).resolves.toBeTruthy();
     });
   });
 
-  describe('append-only log', () => {
+  describe('event log ordering', () => {
     const hook = {
       eventType: 'hook_created',
       specVersion: SPEC,
@@ -490,88 +472,21 @@ describe('sim store', () => {
       eventData: { stepName: 'step//./w//s', input: new Uint8Array() },
     } as const;
 
-    it('is off by default: a held write lands behind one committed sooner', async () => {
+    it('assigns positions in commit order', async () => {
       await createRun(store, RUN);
-      // The handler boundary takes a position; the write is then held.
-      const minted = store.mintEvent(RUN);
+      const first = await store.events.create(RUN, hook);
       tick(10);
-      const overtook = await store.events.create(RUN, hook);
-      const held = await store.events.create(RUN, step, heldAt(minted));
+      const second = await store.events.create(RUN, step);
 
-      expect(held.event?.eventId).toBe(minted.eventId);
-      // The log gained a row in the past: the later commit sorts first, so a
-      // reader that already saw `overtook` has been passed by something older.
       const ids = store.allEvents(RUN).map((e) => e.eventId);
-      expect(ids.indexOf(minted.eventId)).toBeLessThan(
-        ids.indexOf(overtook.event?.eventId ?? '')
-      );
-    });
-
-    it('re-mints a write that was overtaken while it was held', async () => {
-      const world = setup({ appendOnlyLog: true });
-      await createRun(world.store, RUN);
-      const minted = world.store.mintEvent(RUN);
-      world.tick(10);
-      const overtook = await world.store.events.create(RUN, hook);
-      const held = await world.store.events.create(RUN, step, heldAt(minted));
-
-      // The reserved position is abandoned. Nothing is ever inserted behind a
-      // row a reader could already have seen, so log order is commit order.
-      const heldId = held.event?.eventId ?? '';
-      expect(heldId).not.toBe(minted.eventId);
-      expect(heldId > (overtook.event?.eventId ?? '')).toBe(true);
-      const ids = world.store.allEvents(RUN).map((e) => e.eventId);
       expect(ids).toEqual([...ids].sort());
-      expect(ids.at(-1)).toBe(heldId);
-    });
-
-    it('leaves an uncontended write at the position it minted', async () => {
-      const world = setup({ appendOnlyLog: true });
-      await createRun(world.store, RUN);
-      const minted = world.store.mintEvent(RUN);
-      world.tick(10);
-      const uncontended = await world.store.events.create(
-        RUN,
-        step,
-        heldAt(minted)
-      );
-
-      // Still the newest position when it arrived, so it keeps both halves of
-      // the mint — including a `createdAt` from before the tick. A scenario
-      // that never holds a write mid-flight logs the same bytes either way.
-      expect(uncontended.event?.eventId).toBe(minted.eventId);
-      expect(uncontended.event?.createdAt).toEqual(minted.createdAt);
-    });
-
-    it('punches a hole in a withheld read by default', async () => {
-      const seen: StaleRead[] = [];
-      const world = setup({ onStaleRead: (read) => seen.push(read) });
-      await createRun(world.store, RUN);
-      world.store.withholdNextEvent(1);
-      const withheld = await world.store.events.create(RUN, hook);
-      world.tick(1);
-      const after = await world.store.events.create(RUN, step);
-
-      const page = await world.store.events.list({
-        runId: RUN,
-        pagination: { limit: 50, sortOrder: 'asc' },
-      });
-      const ids = page.data.map((e) => e.eventId);
-      // The withheld event vanishes and its successor stays: the reader holds
-      // proof that something newer exists, which is what no watermark can see.
-      expect(ids).not.toContain(withheld.event?.eventId);
-      expect(ids).toContain(after.event?.eventId);
-      expect(seen).toEqual([
-        { eventId: withheld.event?.eventId, hidden: 1, truncated: false },
-      ]);
+      expect(ids.at(-2)).toBe(first.event?.eventId);
+      expect(ids.at(-1)).toBe(second.event?.eventId);
     });
 
     it('truncates a withheld read rather than punching a hole', async () => {
       const seen: StaleRead[] = [];
-      const world = setup({
-        appendOnlyLog: true,
-        onStaleRead: (read) => seen.push(read),
-      });
+      const world = setup({ onStaleRead: (read) => seen.push(read) });
       await createRun(world.store, RUN);
       world.store.withholdNextEvent(1);
       const withheld = await world.store.events.create(RUN, hook);
@@ -599,7 +514,7 @@ describe('sim store', () => {
     });
 
     it('serves the real log once the withhold window closes', async () => {
-      const world = setup({ appendOnlyLog: true });
+      const world = setup();
       await createRun(world.store, RUN);
       world.store.withholdNextEvent(1);
       await world.store.events.create(RUN, hook);

--- a/packages/world-sim/src/store.ts
+++ b/packages/world-sim/src/store.ts
@@ -43,16 +43,14 @@ import {
   type PaginatedResponse,
   type PaginationOptions,
   type ResolveData,
-  requireEventSlot,
   SPEC_VERSION_CURRENT,
   type Step,
   type Storage,
-  slotToEventId,
   stripEventDataRefs,
   type Wait,
   type WorkflowRun,
 } from '@workflow/world';
-import type { IdFactory } from './ids.js';
+import { type IdFactory, ulidTimeOf } from './ids.js';
 
 /** Per-run event ceiling reported on run responses, mirroring the other worlds. */
 const MAX_EVENTS_PER_RUN = 25_000;
@@ -69,51 +67,22 @@ const DEFAULT_PAGE_LIMIT = 20;
 const RUN_EVENT_INDEX_WINDOW = 16;
 
 /**
- * A log position, taken before the write that will occupy it commits.
- *
- * The event id *is* the position: `evnt_` followed by the event's 1-based slot
- * in its run's log. This store hands the slot out in the request handler rather
- * than at the append, which is the shape a World has whenever it cannot ask
- * storage to allocate — and everything downstream follows from that one fact. A
- * write that takes a slot and then takes a while to commit keeps the earlier
- * slot it was given, so the log can gain an event *behind* a position a reader
- * has already seen. That is the hole no high-water mark can detect, and
- * reproducing it is the reason taking a position is separable from appending.
- *
- * `createdAt` is the mint instant, not the commit instant, matching a World
- * that derives the row's timestamp at the handler boundary. Entity rows
- * (step/run/hook timestamps) still use the commit instant, because those are
- * written by the transaction rather than carried with the position.
- */
-export interface MintedEvent {
-  eventId: string;
-  createdAt: Date;
-}
-
-/**
  * Sim-internal `events.create` params, supplied by the world facade rather than
  * by the runtime under test.
  */
 interface SimCreateParams {
   /**
-   * The position minted for this write at the handler boundary. Absent when the
-   * store is driven directly (unit tests), in which case `create` mints on
-   * entry — the same instant, just without a hold point in between.
-   */
-  minted?: MintedEvent;
-  /**
    * The log this write was decided against, or absent when the write did not
    * come from a replay context at all (an out-of-band writer, or a store driven
    * directly by a unit test).
    *
-   * Reconstructed by the world facade from the pages the writer read rather
-   * than taken off the wire, because the wire carries only half of it: the
-   * runtime states the highest slot it holds, and the fence also wants how many
-   * events it loaded at or below that slot. The reconstruction is the same
-   * derivation the client made — the newest loaded position, and how many
-   * events sit at or below it — which is what lets the fence spot a hole
-   * *behind* the watermark that no comparison against the watermark alone can
-   * see.
+   * Reconstructed by the world facade from the pages the writer read, because
+   * the runtime no longer states it: `@workflow/core` describes its snapshot as
+   * a slot count, and the sim mints ULIDs, so there is nothing on the wire for
+   * the fence to read. The reconstruction is the same derivation the client
+   * used to make — the newest loaded position, and how many events sit at or
+   * below it — which is what lets the fence spot a hole *behind* the watermark
+   * that no comparison against the watermark alone can see.
    *
    * See `SimStoreOptions.preconditionGuard` and `SimWorldOptions.countGuard`.
    */
@@ -122,9 +91,9 @@ interface SimCreateParams {
 
 /** What a replay-context writer had loaded when it decided to write. */
 export interface LoadedSnapshot {
-  /** Slot of the newest loaded event. */
-  maxSlot: number;
-  /** How many loaded events sit at or below {@link maxSlot}. */
+  /** ULID time of the newest loaded event. */
+  updatedAt: number;
+  /** How many loaded events sit at or below {@link updatedAt}. */
   count: number;
 }
 
@@ -146,10 +115,10 @@ interface RunEventIndex {
  */
 function countRecordedAtOrBelow(
   index: RunEventIndex,
-  maxSlot: number
+  updatedAt: number
 ): number | null {
   const above = index.recentEventIds.filter(
-    (id) => requireEventSlot(id) > maxSlot
+    (id) => ulidTimeOf(id) > updatedAt
   ).length;
   const pruned = index.total > index.recentEventIds.length;
   if (pruned && above === index.recentEventIds.length) return null;
@@ -160,16 +129,13 @@ export interface SimStoreOptions {
   now(): number;
   ids: IdFactory;
   /**
-   * Reject a replay-context write whose snapshot predates the newest
-   * externally-originated event, with a `PreconditionFailedError` (412).
+   * Enforce the optimistic-concurrency precondition guard described in
+   * `WorldCapabilities.preconditionGuard`: reject a replay-context write whose
+   * snapshot predates the newest externally-originated event.
    *
-   * No shipped World does this — the runtime does not need it, since a
-   * reader's log is a prefix and its next write reports what it was pushed
-   * past. The option stays because the sim is where the *reception* path is
-   * exercised: the runtime still handles a 412 (restart in place, then
-   * re-invoke), and a World that allocates positions away from the commit may
-   * still want to refuse rather than report. Off by default, and never
-   * implicit, because arming it changes which runtime fast paths engage.
+   * Off by default. Turning it on is the point of a simulation — it lets a
+   * scenario check that the runtime recovers from a 412 fence — but it also
+   * changes which runtime fast paths engage, so it is never implicit.
    */
   preconditionGuard?: boolean;
   /**
@@ -187,40 +153,6 @@ export interface SimStoreOptions {
    * reconstructs; see `SimWorldOptions.countGuard`.
    */
   countGuard?: boolean;
-  /**
-   * Make the log append-only in the strong sense: an event takes its position
-   * when it *commits*, not when its handler minted one.
-   *
-   * Production does the opposite, and for a reason — DynamoDB does not
-   * generate ids, so workflow-server mints the event id at the handler
-   * boundary and that id *is* the log's sort key. A write held between its
-   * mint and its commit therefore lands *behind* events that were minted later
-   * and committed sooner, and the log gains a row in the past. Every read that
-   * happened in between saw a log the log itself went on to contradict. That
-   * one fact is what the six red scenarios in the book are about.
-   *
-   * With this on, a write that was overtaken while it was held gives up its
-   * reserved position and re-mints at the tail. Two consequences follow, and
-   * they are the whole point:
-   *
-   * - Log order is commit order. Nothing is ever inserted behind a row a
-   *   reader has already seen, so no two reads can disagree about the past.
-   * - Every read is a prefix of the final log. A read can be *short* — it may
-   *   miss a write that has not committed yet, or one a lagging replica has
-   *   not caught up to (see `withholdNextEvent`) — but never self-inconsistent.
-   *   Staleness collapses into lag, and lag is what the optimistic-concurrency
-   *   fence can see; a hole is what it cannot.
-   *
-   * What it costs is the property the boundary mint was buying: a write no
-   * longer knows where it will land until it lands. Off by default, because
-   * the simulation's job is to model the world that exists. Turning it on
-   * answers the other question — which of these failures survive if it didn't?
-   *
-   * Uncontended writes are untouched. A mint that is still the newest position
-   * when it commits keeps its id, so a scenario that never holds a write
-   * mid-flight produces a byte-identical log either way.
-   */
-  appendOnlyLog?: boolean;
   /** Invoked after every successful append, before the create call returns. */
   onEvent?(event: Event): void;
   /** Invoked when a read was served an incomplete log. */
@@ -235,8 +167,7 @@ export interface StaleRead {
   hidden: number;
   /**
    * The read was cut short at `eventId` rather than served around it: a
-   * replica that is behind, not one that is wrong. Only `appendOnlyLog`
-   * produces this shape — see there.
+   * replica that is behind, not one that is wrong.
    */
   truncated: boolean;
 }
@@ -253,41 +184,11 @@ export interface SimStore extends Storage {
    */
   seedFromLog(log: readonly Event[]): void;
   /**
-   * Take the run's next log position, without writing anything.
-   *
-   * The world facade calls this at the handler boundary — before any hold can
-   * fire — so a write held mid-flight already owns the position it will
-   * eventually occupy. See {@link MintedEvent}.
-   */
-  mintEvent(runId: string): MintedEvent;
-  /**
    * Hide the *next* event appended from the following `reads` event-log reads.
    *
    * This models one concurrent writer precisely. Under real concurrency two
-   * writers take positions 7 and 8, and a reader can observe 8 while 7 is still
-   * in flight — a *hole*, not a truncated tail. Withholding a suffix instead
-   * would hide the reader's own write too, which is a different (and less
-   * interesting) fault.
-   *
-   * It is the second of the three preconditions for a corrupted event log — a
-   * write derived from an incomplete event load. A strictly serial scheduler
-   * cannot reach it by accident, so a scenario has to ask for it.
-   *
-   * Note which world this models. Hiding an event that is already *committed*
-   * is a stale read, and workflow-server has eliminated those: it pays 2× the
-   * RCU for strongly-consistent reads on every page, so every event committed
-   * before a read started is visible to it. This primitive therefore models an
-   * eventually-consistent backend (or the older split-query world-vercel read
-   * path), and it is the *weaker* fault of the two. The stronger one needs no
-   * withholding at all: hold a write between its mint and its commit and the
-   * reader genuinely cannot see it, because it is not there yet — while its
-   * position, already assigned, sits behind whatever the reader did see. Prefer
-   * a hold when the scenario's point is production behaviour.
-   *
-   * Under `appendOnlyLog` the hole is not expressible, so this degrades to the
-   * honest version of the same lag: the read stops *at* the withheld event
-   * instead of stepping over it. The reader still misses the write; what it no
-   * longer does is miss it while holding proof that something newer exists.
+   * read stops at the withheld event, modeling a lagging replica that has not
+   * caught up yet.
    */
   withholdNextEvent(reads?: number): void;
   /** Every event ever appended, in log order. */
@@ -407,7 +308,6 @@ interface AppliedEntities {
 
 export function createSimStore(options: SimStoreOptions): SimStore {
   const { ids, now: nowMs } = options;
-  const appendOnlyLog = options.appendOnlyLog === true;
 
   const events: Event[] = [];
   const runs = new Map<string, WorkflowRun>();
@@ -421,28 +321,10 @@ export function createSimStore(options: SimStoreOptions): SimStore {
   /** hookIds that have been explicitly disposed; disposal is permanent. */
   const disposedHooks = new Set<string>();
   /**
-   * Per run: slot of the newest externally-originated event. Only read when
-   * `preconditionGuard` is on. See `SimCreateParams.snapshot`.
+   * Per run: ULID time of the newest externally-originated event. Only read
+   * when `preconditionGuard` is on. See `SimCreateParams.snapshot`.
    */
   const externalWriteMarker = new Map<string, number>();
-  /**
-   * Per run: the highest slot handed out, committed or merely spoken for.
-   *
-   * Separate from the committed log because a position is taken at the handler
-   * boundary: between `mintEvent` and the append, the slot exists and belongs
-   * to nobody. A write that never commits gives its slot back (see
-   * `releaseSlot`); a position reserved and then abandoned out of band leaves
-   * it empty for good.
-   */
-  const highestSlot = new Map<string, number>();
-  /**
-   * Per run: positions handed out and given back, still unoccupied.
-   *
-   * Reused before the range grows, so the log stays dense. What makes that
-   * safe is that a slot only lands here once its create has returned: nothing
-   * is still holding it, and nothing ever will.
-   */
-  const freeSlots = new Map<string, number[]>();
   /**
    * Per run: the tail of the log, for the count guard. Records *every* event,
    * replay-origin included — the corruption it guards against is one replay
@@ -459,24 +341,18 @@ export function createSimStore(options: SimStoreOptions): SimStore {
    * Serve a read, minus any event currently being withheld. Reads outside a
    * withhold window get the real log.
    *
-   * Both modes hide the same event and differ only in what they do with the
-   * ones behind it. The default punches a hole — the withheld event vanishes
-   * and its successors stay — which is what an eventually-consistent replica
-   * does and what no watermark can detect. Under `appendOnlyLog` the read is
-   * cut short there instead, leaving a prefix: still short, but no longer
-   * carrying evidence that contradicts itself.
+   * A withheld event cuts the read short there, leaving a prefix of the real
+   * log: short, but never self-contradictory.
    */
   function applyWithhold(source: readonly Event[]): readonly Event[] {
     if (!withheld || withheld.remaining <= 0) return source;
     const { eventId } = withheld;
     withheld.remaining--;
     if (withheld.remaining <= 0) withheld = undefined;
-    const visible = appendOnlyLog
-      ? source.filter((e) => e.eventId < eventId)
-      : source.filter((e) => e.eventId !== eventId);
+    const visible = source.filter((e) => e.eventId < eventId);
     const hidden = source.length - visible.length;
     if (hidden > 0) {
-      options.onStaleRead?.({ eventId, hidden, truncated: appendOnlyLog });
+      options.onStaleRead?.({ eventId, hidden, truncated: true });
     }
     return visible;
   }
@@ -485,69 +361,8 @@ export function createSimStore(options: SimStoreOptions): SimStore {
   const waitKey = (runId: string, correlationId: string) =>
     `${runId}:${correlationId}`;
 
-  /** Highest slot committed to a run's log, or 0 for a log with no events. */
-  function committedSlot(runId: string): number {
-    let max = 0;
-    for (const event of events) {
-      if (event.runId !== runId) continue;
-      const slot = requireEventSlot(event.eventId);
-      if (slot > max) max = slot;
-    }
-    return max;
-  }
-
-  function mintEvent(runId: string): MintedEvent {
-    let slot: number;
-    const free = appendOnlyLog ? undefined : freeSlots.get(runId);
-    if (free?.length) {
-      free.sort((a, b) => a - b);
-      slot = free.shift() as number;
-    } else {
-      slot = (highestSlot.get(runId) ?? 0) + 1;
-      highestSlot.set(runId, slot);
-    }
-    return { eventId: slotToEventId(slot), createdAt: new Date(nowMs()) };
-  }
-
-  /**
-   * Give a slot back when nothing committed at it.
-   *
-   * A hole in the log is corruption as far as the runtime is concerned, so a
-   * create that appends nothing must not consume a position. Two kinds do: one
-   * the store rejects outright, and one it accepts as a no-op (a second
-   * `run_started` for a run already started, say). Production reaches the same
-   * place from the other side, by allocating inside the transaction, after the
-   * validation, so a write it refuses never had a slot to lose. Reproducing
-   * *that* difference is not what this store is for: the fault it stages is
-   * two writes taking positions in one order and committing in another, and a
-   * rejection leaving a permanent hole would sit on top of every one of those
-   * scenarios as a second, unrelated corruption.
-   *
-   * A slot at the top of the range is dropped rather than recycled, because a
-   * range that never grew is not a hole to fill. Anything below it goes on the
-   * free list, since concurrent writers mean the rejected position is not
-   * always the newest one.
-   */
-  function releaseSlot(runId: string, position: MintedEvent): void {
-    // Under `appendOnlyLog` the position is decided at the append, which keeps
-    // the mark on the committed tail; a reservation nothing used was never
-    // counted in the first place.
-    if (appendOnlyLog) return;
-    const occupied = events.some(
-      (e) => e.runId === runId && e.eventId === position.eventId
-    );
-    if (occupied) return;
-    const free = freeSlots.get(runId) ?? [];
-    free.push(requireEventSlot(position.eventId));
-    let highest = highestSlot.get(runId) ?? 0;
-    let index = free.indexOf(highest);
-    while (index !== -1) {
-      free.splice(index, 1);
-      highest--;
-      index = free.indexOf(highest);
-    }
-    highestSlot.set(runId, highest);
-    freeSlots.set(runId, free);
+  function eventPosition(): Pick<Event, 'eventId' | 'createdAt'> {
+    return { eventId: ids.eventId(), createdAt: new Date(nowMs()) };
   }
 
   function recordInIndex(event: Event): void {
@@ -566,41 +381,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     runEventIndex.set(event.runId, index);
   }
 
-  /**
-   * The position an event actually commits at.
-   *
-   * Only `appendOnlyLog` can move one, and there it moves every write that is
-   * not already landing on the run's next free slot: the position is whatever
-   * follows the newest *committed* event, decided here rather than at the
-   * boundary. A write that was never overtaken is already there, so uncontended
-   * history is unchanged; one that was overtaken while it was held gives up the
-   * slot it reserved and takes the tail.
-   *
-   * Recomputing rather than comparing also keeps the log dense. A slot the
-   * boundary handed out and nothing committed at is a permanent hole in the
-   * default mode; under `appendOnlyLog` nothing consumes a slot until it
-   * commits, so no reservation can leave one behind.
-   */
-  function positionAtCommit(event: Event): Event {
-    if (!appendOnlyLog) return event;
-    const next = committedSlot(event.runId) + 1;
-    if (requireEventSlot(event.eventId) === next) return event;
-    return {
-      ...event,
-      eventId: slotToEventId(next),
-      createdAt: new Date(nowMs()),
-    };
-  }
-
-  function append(incoming: Event): Event {
-    const event = positionAtCommit(incoming);
-    if (appendOnlyLog) {
-      // The commit decided the position, so the allocator follows the log
-      // rather than the other way round. A write that reserved a slot and
-      // then committed *below* it would otherwise leave the mark above the
-      // tail, and the next mint would skip the difference.
-      highestSlot.set(event.runId, requireEventSlot(event.eventId));
-    }
+  function append(event: Event): Event {
     events.push(event);
     recordInIndex(event);
     if (armedWithhold !== undefined) {
@@ -896,25 +677,17 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     }
   }
 
-  /**
-   * Append one event, or refuse to.
-   *
-   * `held` carries the position this call is holding out to the wrapper below,
-   * which hands it back when the call throws. It is a parameter rather than a
-   * closure variable because two creates can be in flight at once.
-   */
-  async function commitEvent(
+  async function create(
     runIdArg: string | null,
     data: AnyEventRequest,
-    params: CreateEventParams | undefined,
-    held: { runId?: string; position?: MintedEvent }
+    params?: CreateEventParams
   ): Promise<EventResult> {
-    // Commit time, for the entity rows the transaction writes. The *event's*
-    // timestamp comes from its minted position instead — see `MintedEvent`.
+    // Event and entity timestamps are both assigned at commit.
     const now = new Date(nowMs());
     const internal = params as
       | (CreateEventParams & SimCreateParams)
       | undefined;
+    let position = eventPosition();
     const resolveData: ResolveData = params?.resolveData ?? 'all';
     const specVersion = data.specVersion ?? SPEC_VERSION_CURRENT;
 
@@ -926,14 +699,6 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     } else {
       runId = runIdArg;
     }
-
-    // Reassigned only by the two paths that write a *synthetic* event ahead of
-    // the requested one: the synthetic takes the position taken at the
-    // boundary (which is the earlier one, for exactly this ordering) and the
-    // requested event takes a fresh one so it still sorts after.
-    let position = internal?.minted ?? mintEvent(runId);
-    held.runId = runId;
-    held.position = position;
 
     let currentRun = runs.get(runId);
 
@@ -962,10 +727,9 @@ export function createSimStore(options: SimStoreOptions): SimStore {
         } as Event;
         currentRun = applyEvent(synthetic, now).run;
         append(synthetic);
-        // The synthetic took the boundary-minted position, so the `run_started`
-        // row built below needs a fresh one to sort after it.
-        position = mintEvent(runId);
-        held.position = position;
+        // The synthetic is committed first, so the requested row takes the next
+        // position and sorts after it.
+        position = eventPosition();
       }
     }
 
@@ -985,7 +749,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     const snapshot = internal?.snapshot;
     if (options.preconditionGuard && snapshot) {
       const marker = externalWriteMarker.get(runId);
-      if (marker !== undefined && snapshot.maxSlot < marker) {
+      if (marker !== undefined && snapshot.updatedAt < marker) {
         throw new PreconditionFailedError(
           `Run "${runId}" changed out of band since the caller's snapshot`
         );
@@ -1001,7 +765,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       if (options.countGuard) {
         const index = runEventIndex.get(runId);
         const recorded = index
-          ? countRecordedAtOrBelow(index, snapshot.maxSlot)
+          ? countRecordedAtOrBelow(index, snapshot.updatedAt)
           : null;
         if (recorded !== null && recorded > snapshot.count) {
           throw new PreconditionFailedError(
@@ -1261,27 +1025,16 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       stepCreatedLazily = true;
 
       // The input now lives on the synthetic `step_created`; keep only the
-      // metadata on the `step_started` row. The synthetic took the position
-      // minted at the boundary — production mints it first for this very
-      // reason — so re-mint the `step_started` to sort after it.
-      //
-      // Consequence worth knowing: a lazy `step_started` held mid-flight does
-      // *not* keep an early position, because the pair's positions are settled
-      // here, at commit. Production mints both in the handler, so it can hold
-      // an early position for either. No scenario needs that yet; the writes
-      // that race for position in practice are the completions.
+      // metadata on the `step_started` row. The synthetic is committed first,
+      // so `step_started` takes the next position.
       const { input: _dropped, ...rest } = data.eventData;
-      position = mintEvent(runId);
-      held.position = position;
+      position = eventPosition();
       event = { ...event, ...position, eventData: rest } as Event;
     }
 
     // ---- The fold ----------------------------------------------------------
     const { run, step, hook, wait } = applyEvent(event, now);
 
-    // Reassigned, not just appended: under `appendOnlyLog` the commit is where
-    // the position is decided, and everything below — the fence's marker, the
-    // returned row — has to speak about the event as it actually landed.
     event = append(event);
 
     // Track externally-originated writes for the precondition fence. A write
@@ -1292,10 +1045,10 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     // Two details are load-bearing, both copied from workflow-server's
     // `recordOutsideEvent`:
     //
-    // - The mark is the event's *own* slot, not the commit instant. It has to
-    //   be the same derivation as a caller's watermark (the slot of its newest
-    //   loaded event) or a caller holding exactly this event would compare as
-    //   older and 412 forever.
+    // - The mark is the event's *own* position time, not the commit instant. It
+    //   has to be the same derivation as a caller's watermark (the position
+    //   time of its newest loaded event) or a caller holding exactly this event
+    //   would compare as older and 412 forever.
     // - The write is forward-only. Concurrent out-of-band events can commit out
     //   of position order — the whole subject of these scenarios — and letting a
     //   late-committing older event drag the mark backwards would silently
@@ -1310,7 +1063,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       const previous = externalWriteMarker.get(runId) ?? 0;
       externalWriteMarker.set(
         runId,
-        Math.max(previous, requireEventSlot(event.eventId))
+        Math.max(previous, event.createdAt.getTime())
       );
     }
 
@@ -1364,19 +1117,6 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     // optional spread: the latter widens the three fields to `T | undefined`,
     // which is neither arm of the union.
     return deltaPage ? { ...result, ...deltaPage } : result;
-  }
-
-  async function create(
-    runIdArg: string | null,
-    data: AnyEventRequest,
-    params?: CreateEventParams
-  ): Promise<EventResult> {
-    const held: { runId?: string; position?: MintedEvent } = {};
-    try {
-      return await commitEvent(runIdArg, data, params, held);
-    } finally {
-      if (held.runId && held.position) releaseSlot(held.runId, held.position);
-    }
   }
 
   const storage: SimStore = {
@@ -1542,34 +1282,18 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       armedWithhold = reads;
     },
 
-    mintEvent,
-
     seedFromLog(log) {
       for (const event of log) {
         const seeded = clone(event) as Event;
         events.push(seeded);
         recordInIndex(seeded);
-        // A cold start inherits the log's positions, so the next write has to
-        // continue them. Taking the maximum rather than counting: the log a
-        // scenario seeds is whatever the previous process committed, holes
-        // included, and re-issuing a slot it already used would be worse than
-        // leaving the hole.
-        const slot = requireEventSlot(seeded.eventId);
-        const highest = highestSlot.get(seeded.runId) ?? 0;
-        if (slot > highest) highestSlot.set(seeded.runId, slot);
         // The event's own position time is the only clock a seeded row can
         // have: the live one belongs to whenever this world was built.
         applyEvent(seeded, seeded.createdAt);
       }
     },
 
-    // Log order, which is position order — not the order the appends happened.
-    // The two differ exactly when a write was minted before another and
-    // committed after it, which is the fault these scenarios are about. The
-    // trace keeps commit order; this is what a reader sees.
-    //
-    // Under `appendOnlyLog` the two orders are the same by construction, and
-    // this sort is a no-op that stays for the invariant it documents.
+    // Log order and commit order are the same: positions are assigned at commit.
     allEvents: (runId) =>
       (runId ? eventsForRun(runId) : events)
         .map(clone)

--- a/packages/world-sim/src/store.ts
+++ b/packages/world-sim/src/store.ts
@@ -45,14 +45,14 @@ import {
   type ResolveData,
   requireEventSlot,
   SPEC_VERSION_CURRENT,
-  slotToEventId,
   type Step,
   type Storage,
+  slotToEventId,
   stripEventDataRefs,
   type Wait,
   type WorkflowRun,
 } from '@workflow/world';
-import { type IdFactory } from './ids.js';
+import type { IdFactory } from './ids.js';
 
 /** Per-run event ceiling reported on run responses, mirroring the other worlds. */
 const MAX_EVENTS_PER_RUN = 25_000;
@@ -373,7 +373,10 @@ export function createSimStore(options: SimStoreOptions): SimStore {
   function committedSlot(runId: string): number {
     return events
       .filter((event) => event.runId === runId)
-      .reduce((max, event) => Math.max(max, requireEventSlot(event.eventId)), 0);
+      .reduce(
+        (max, event) => Math.max(max, requireEventSlot(event.eventId)),
+        0
+      );
   }
 
   function recordInIndex(event: Event): void {
@@ -776,7 +779,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       if (options.countGuard) {
         const index = runEventIndex.get(runId);
         const recorded = index
-            ? countRecordedAtOrBelow(index, snapshot.maxSlot)
+          ? countRecordedAtOrBelow(index, snapshot.maxSlot)
           : null;
         if (recorded !== null && recorded > snapshot.count) {
           throw new PreconditionFailedError(

--- a/packages/world-sim/src/store.ts
+++ b/packages/world-sim/src/store.ts
@@ -1056,10 +1056,9 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     // Two details are load-bearing, both copied from workflow-server's
     // `recordOutsideEvent`:
     //
-    // - The mark is the event's *own* position time, not the commit instant. It
-    //   has to be the same derivation as a caller's watermark (the position
-    //   time of its newest loaded event) or a caller holding exactly this event
-    //   would compare as older and 412 forever.
+    // - The mark is the event's own slot, not the commit instant. It has to use
+    //   the same unit as a caller's newest loaded position or a caller holding
+    //   exactly this event would compare as older and 412 forever.
     // - The write is forward-only. Concurrent out-of-band events can commit out
     //   of position order — the whole subject of these scenarios — and letting a
     //   late-committing older event drag the mark backwards would silently
@@ -1074,7 +1073,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       const previous = externalWriteMarker.get(runId) ?? 0;
       externalWriteMarker.set(
         runId,
-        Math.max(previous, event.createdAt.getTime())
+        Math.max(previous, requireEventSlot(event.eventId))
       );
     }
 

--- a/packages/world-sim/src/store.ts
+++ b/packages/world-sim/src/store.ts
@@ -43,14 +43,16 @@ import {
   type PaginatedResponse,
   type PaginationOptions,
   type ResolveData,
+  requireEventSlot,
   SPEC_VERSION_CURRENT,
+  slotToEventId,
   type Step,
   type Storage,
   stripEventDataRefs,
   type Wait,
   type WorkflowRun,
 } from '@workflow/world';
-import { type IdFactory, ulidTimeOf } from './ids.js';
+import { type IdFactory } from './ids.js';
 
 /** Per-run event ceiling reported on run responses, mirroring the other worlds. */
 const MAX_EVENTS_PER_RUN = 25_000;
@@ -91,9 +93,9 @@ interface SimCreateParams {
 
 /** What a replay-context writer had loaded when it decided to write. */
 export interface LoadedSnapshot {
-  /** ULID time of the newest loaded event. */
-  updatedAt: number;
-  /** How many loaded events sit at or below {@link updatedAt}. */
+  /** Slot of the newest loaded event. */
+  maxSlot: number;
+  /** How many loaded events sit at or below {@link maxSlot}. */
   count: number;
 }
 
@@ -115,10 +117,10 @@ interface RunEventIndex {
  */
 function countRecordedAtOrBelow(
   index: RunEventIndex,
-  updatedAt: number
+  maxSlot: number
 ): number | null {
   const above = index.recentEventIds.filter(
-    (id) => ulidTimeOf(id) > updatedAt
+    (id) => requireEventSlot(id) > maxSlot
   ).length;
   const pruned = index.total > index.recentEventIds.length;
   if (pruned && above === index.recentEventIds.length) return null;
@@ -361,8 +363,17 @@ export function createSimStore(options: SimStoreOptions): SimStore {
   const waitKey = (runId: string, correlationId: string) =>
     `${runId}:${correlationId}`;
 
-  function eventPosition(): Pick<Event, 'eventId' | 'createdAt'> {
-    return { eventId: ids.eventId(), createdAt: new Date(nowMs()) };
+  function eventPosition(runId: string): Pick<Event, 'eventId' | 'createdAt'> {
+    return {
+      eventId: slotToEventId(committedSlot(runId) + 1),
+      createdAt: new Date(nowMs()),
+    };
+  }
+
+  function committedSlot(runId: string): number {
+    return events
+      .filter((event) => event.runId === runId)
+      .reduce((max, event) => Math.max(max, requireEventSlot(event.eventId)), 0);
   }
 
   function recordInIndex(event: Event): void {
@@ -687,7 +698,6 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     const internal = params as
       | (CreateEventParams & SimCreateParams)
       | undefined;
-    let position = eventPosition();
     const resolveData: ResolveData = params?.resolveData ?? 'all';
     const specVersion = data.specVersion ?? SPEC_VERSION_CURRENT;
 
@@ -699,6 +709,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     } else {
       runId = runIdArg;
     }
+    let position = eventPosition(runId);
 
     let currentRun = runs.get(runId);
 
@@ -729,7 +740,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
         append(synthetic);
         // The synthetic is committed first, so the requested row takes the next
         // position and sorts after it.
-        position = eventPosition();
+        position = eventPosition(runId);
       }
     }
 
@@ -749,7 +760,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
     const snapshot = internal?.snapshot;
     if (options.preconditionGuard && snapshot) {
       const marker = externalWriteMarker.get(runId);
-      if (marker !== undefined && snapshot.updatedAt < marker) {
+      if (marker !== undefined && snapshot.maxSlot < marker) {
         throw new PreconditionFailedError(
           `Run "${runId}" changed out of band since the caller's snapshot`
         );
@@ -765,7 +776,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       if (options.countGuard) {
         const index = runEventIndex.get(runId);
         const recorded = index
-          ? countRecordedAtOrBelow(index, snapshot.updatedAt)
+            ? countRecordedAtOrBelow(index, snapshot.maxSlot)
           : null;
         if (recorded !== null && recorded > snapshot.count) {
           throw new PreconditionFailedError(
@@ -1028,7 +1039,7 @@ export function createSimStore(options: SimStoreOptions): SimStore {
       // metadata on the `step_started` row. The synthetic is committed first,
       // so `step_started` takes the next position.
       const { input: _dropped, ...rest } = data.eventData;
-      position = eventPosition();
+      position = eventPosition(runId);
       event = { ...event, ...position, eventData: rest } as Event;
     }
 

--- a/packages/world-sim/src/types.ts
+++ b/packages/world-sim/src/types.ts
@@ -290,9 +290,9 @@ export interface Writer {
   /**
    * Stop once the event has crossed the world boundary — fully formed,
    * attributed to this writer, already in the trace — and before it is assigned
-    * a position in the event log.
+   * a position in the event log.
    *
-    * A write that commits to storage while this one is held sorts ahead of it.
+   * A write that commits to storage while this one is held sorts ahead of it.
    */
   runToEventProduced(
     eventType: EventType | EventType[],

--- a/packages/world-sim/src/types.ts
+++ b/packages/world-sim/src/types.ts
@@ -41,14 +41,8 @@ export type WorldCallName =
  * The two points a world call can be caught at: entering it, and returning
  * from it.
  *
- * A held `'before'` has decided nothing durable and owns no log position, so a
- * write that commits during the hold sorts *ahead* of it. For the other order —
- * a writer that already owns an earlier slot and has not yet appeared — hold the
- * write itself with `sim.beginHookDelivery`, which reserves the position that
- * `events.create` would have minted and hands the caller the moment in between.
- * That gap is not a detail: it is the only way a log can gain an event *behind*
- * a position a reader has already read past, which is the one shape no
- * high-water-mark fence can see.
+ * A held `'before'` has decided nothing durable. A write that commits during
+ * the hold sorts ahead of it because event positions are assigned at commit.
  */
 export type CallPhase = 'before' | 'after';
 
@@ -296,13 +290,9 @@ export interface Writer {
   /**
    * Stop once the event has crossed the world boundary — fully formed,
    * attributed to this writer, already in the trace — and before it is assigned
-   * a position in the event log.
+    * a position in the event log.
    *
-   * Having no position yet, a write that commits to storage while this one is
-   * held sorts *ahead* of it. For the opposite — an event that already owns an
-   * earlier slot and has not appeared — hold the write itself with
-   * `sim.beginHookDelivery`, which reserves the position on one side of the
-   * gap and commits on the other.
+    * A write that commits to storage while this one is held sorts ahead of it.
    */
   runToEventProduced(
     eventType: EventType | EventType[],
@@ -365,20 +355,11 @@ export interface ScenarioApi {
    */
   deliverHook(token: string, payload: unknown): Promise<void>;
   /**
-   * Start a hook delivery and stop between its two halves: the log position is
-   * taken, the event is not there yet.
-   *
-   * This is the fault the `in-flight` scenarios are about, and it needs no stale
-   * read to express. The receiver's write has entered the handler, so its event
-   * id — the log's sort key — is fixed; it has not reached storage, so every
-   * reader sees a complete, consistent log that simply does not contain it. When
-   * `commit()` runs, the event appears *behind* positions those readers already
-   * read past, which is the one shape a high-water mark cannot represent.
+   * Start a hook delivery and defer its commit. The event takes its log position
+   * when `commit()` runs.
    *
    * Unlike a held writer, nothing is blocked in the meantime: the receiver is a
-   * separate process from the run's invocation. Holding an *inline* write instead
-   * would stall the delivery that made it, and thus the reader too — which is why
-   * the out-of-band writer is the one that can do this.
+   * separate process from the run's invocation.
    */
   beginHookDelivery(token: string, payload: unknown): Promise<InFlightWrite>;
   /** Cancel the run under test, as an operator would. */
@@ -431,27 +412,10 @@ export interface ScenarioApi {
   check(name: string, condition: boolean): void;
   /** The run under test. */
   runId: string;
-  /**
-   * Which log this run is playing against, resolved from the spec and the run
-   * option. See `ScenarioSpec.appendOnlyLog`.
-   *
-   * A check's *name* is a sentence in the trace, and several of them are
-   * sentences about where a position came from — "the hook owns a log position
-   * but is nowhere in the log" is true of a reserved mint and false of an
-   * append-only commit. Read this to phrase the sentence for the world the run
-   * is actually in, rather than narrating one world while playing the other.
-   *
-   * It is not for branching the *tempo*. A scenario whose script takes a
-   * different path under the flag is two scenarios wearing one id, and the diff
-   * between the two runs stops meaning anything.
-   */
-  appendOnlyLog: boolean;
 }
 
-/** An out-of-band write that owns a log position and has not committed. */
+/** An out-of-band write that has not committed. */
 export interface InFlightWrite {
-  /** The position it will occupy, whenever it lands. */
-  eventId: string;
   /** Let it reach storage. */
   commit(): Promise<void>;
 }

--- a/packages/world-sim/src/world.ts
+++ b/packages/world-sim/src/world.ts
@@ -734,11 +734,7 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
 
   const world: SimWorld = {
     specVersion: SPEC_VERSION_CURRENT,
-    capabilities: {
-      // Only advertise the fence when the store is actually enforcing it — a
-      // runtime fast path gated on this capability must never run without one.
-      ...(options.preconditionGuard ? { preconditionGuard: true } : {}),
-    },
+    capabilities: {},
     getDeploymentId: intercept('getDeploymentId', () =>
       simQueue.getDeploymentId()
     ),

--- a/packages/world-sim/src/world.ts
+++ b/packages/world-sim/src/world.ts
@@ -29,19 +29,15 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   type Event,
   getQueueTopicPrefix,
-  requireEventSlot,
   type QueuePayload,
+  requireEventSlot,
   SPEC_VERSION_CURRENT,
   type World,
 } from '@workflow/world';
 import { createVirtualClock, type VirtualClock } from './clock.js';
 import { createIdFactory, type IdFactory } from './ids.js';
 import { createSimQueue, type DirectHandler, type SimQueue } from './queue.js';
-import {
-  createSimStore,
-  type LoadedSnapshot,
-  type SimStore,
-} from './store.js';
+import { createSimStore, type LoadedSnapshot, type SimStore } from './store.js';
 import { createSimStreamer, type SimStreamer } from './streams.js';
 import type {
   CallContext,

--- a/packages/world-sim/src/world.ts
+++ b/packages/world-sim/src/world.ts
@@ -30,17 +30,15 @@ import {
   type Event,
   getQueueTopicPrefix,
   type QueuePayload,
-  requireEventSlot,
   SPEC_VERSION_CURRENT,
   type World,
 } from '@workflow/world';
 import { createVirtualClock, type VirtualClock } from './clock.js';
-import { createIdFactory, type IdFactory } from './ids.js';
+import { createIdFactory, type IdFactory, ulidTimeOf } from './ids.js';
 import { createSimQueue, type DirectHandler, type SimQueue } from './queue.js';
 import {
   createSimStore,
   type LoadedSnapshot,
-  type MintedEvent,
   type SimStore,
 } from './store.js';
 import { createSimStreamer, type SimStreamer } from './streams.js';
@@ -95,17 +93,6 @@ export interface SimWorldOptions {
    * would be a world that exists nowhere.
    */
   countGuard?: boolean;
-  /**
-   * Assign log positions at commit rather than at the handler boundary, so the
-   * log is append-only and no read can be contradicted by a later one. See
-   * `SimStoreOptions.appendOnlyLog` for what that buys and what it costs.
-   *
-   * The boundary reservation still happens — `reservePosition` and everything
-   * a scenario hangs off it work unchanged. It just stops being binding: a held
-   * write that nothing overtook keeps the position it reserved, and one that
-   * was overtaken takes the tail when it lands.
-   */
-  appendOnlyLog?: boolean;
 }
 
 export interface SimWorld extends World {
@@ -129,22 +116,6 @@ export interface SimWorld extends World {
    * `external` writer, and not itself a call point.
    */
   asExternal<T>(fn: () => Promise<T>): Promise<T>;
-  /**
-   * Take a log position in `runId` now, to be used by a write that happens
-   * later.
-   *
-   * The scenario's own calls are not call points (see `fireWatches`), so a script
-   * cannot hold *itself* between taking a position and committing the way it
-   * holds a writer. This pair is how it states the same thing directly: reserve the
-   * position, do whatever should observe the log without it, then run the write
-   * inside `withReservedPosition` so it lands where it was reserved.
-   */
-  reservePosition(runId: string): MintedEvent;
-  /** Run `fn` with the next `events.create` taking `position` instead of minting. */
-  withReservedPosition<T>(
-    position: MintedEvent,
-    fn: () => Promise<T>
-  ): Promise<T>;
   pushTrace(entry: TraceInput): void;
   /** Total intercepted world calls so far. */
   callCount(): number;
@@ -191,8 +162,6 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
    */
   const externalCtx = new AsyncLocalStorage<true>();
   const isExternal = () => externalCtx.getStore() === true;
-  /** Set by `withReservedPosition`; consumed by the next `events.create`. */
-  let reservedPosition: MintedEvent | undefined;
   let callSeq = 0;
   let traceSeq = 0;
 
@@ -213,19 +182,15 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
     ids,
     preconditionGuard: options.preconditionGuard,
     countGuard: options.countGuard,
-    appendOnlyLog: options.appendOnlyLog,
     // Fires synchronously inside `events.create`, so it runs in that call's
     // async context and `isExternal()` still describes who is writing.
     onEvent: (event) =>
       pushTrace({ kind: 'event', event, writer: writerOfEvent(event) }),
-    // Two different faults, and the trace should not blur them: one read
-    // around a committed event, the other stopped before it.
-    onStaleRead: ({ eventId, hidden, truncated }) =>
+    // A stale read is always a lagging prefix of the log.
+    onStaleRead: ({ eventId, hidden }) =>
       pushTrace({
         kind: 'warn',
-        message: truncated
-          ? `lagging read: log cut short at ${eventId}; ${hidden} committed event(s) not yet visible`
-          : `stale read: committed event ${eventId} withheld from this event-log read`,
+        message: `lagging read: log cut short at ${eventId}; ${hidden} committed event(s) not yet visible`,
       }),
   });
 
@@ -610,12 +575,12 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
     if (!runId) return undefined;
     const set = loadedEvents()?.get(runId);
     if (!set || set.size === 0) return undefined;
-    let maxSlot = 0;
+    let updatedAt = 0;
     for (const eventId of set) {
-      const slot = requireEventSlot(eventId);
-      if (slot > maxSlot) maxSlot = slot;
+      const at = ulidTimeOf(eventId);
+      if (at > updatedAt) updatedAt = at;
     }
-    return { maxSlot, count: set.size };
+    return { updatedAt, count: set.size };
   }
 
   /** Wrap one world method so it becomes a call point. */
@@ -643,43 +608,21 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
       record(base);
       await fireWatches(base);
 
-      // The handler boundary. workflow-server mints the event id here
-      // (`EventId.make()`, before the storage write is attempted) because
-      // DynamoDB does not generate ids and that id *is* the log's sort key. So a
-      // write acquires its position and its visibility at two different moments.
-      // A scenario holds that gap open with `sim.beginHookDelivery`, which takes
-      // the position on one side and lets the write land on the other.
       let callArgs = args;
       let entered = base;
       if (call === 'events.create') {
-        // A reserved position wins: it belongs to a write whose handler was
-        // entered earlier and is only now reaching storage.
-        //
-        // No boundary mint for a `run_created` that names no run
-        // (`events.create(null, …)`, which the Storage contract allows and the
-        // store supports by generating the id). There is no run to allocate
-        // against yet: minting under the null key would hand out slots from a
-        // bucket shared by every such call, and the generated run's own
-        // allocator would then start at 1 and collide. The store mints after it
-        // resolves the id instead. The runtime never takes this path, so this
-        // is about the failure being impossible rather than merely unobserved.
-        const minted =
-          reservedPosition ??
-          (runId === undefined ? undefined : store.mintEvent(runId));
-        reservedPosition = undefined;
         const params = (args[2] ?? {}) as Record<string, unknown>;
         callArgs = [
           args[0],
           args[1],
           {
             ...params,
-            ...(minted ? { minted } : {}),
-            // The snapshot the fence reads. Reconstructed rather than taken
-            // off the wire, because the wire carries only the writer's highest
-            // slot and the count guard also wants how many events it loaded at
-            // or below it. What the facade tracks is the same array the client
-            // is holding (see `loadedEvents`), so the pair it derives is the
-            // pair the client would have sent.
+            // The snapshot the fence reads. Reconstructed rather than taken off
+            // the wire: the runtime states its position as a slot count, and
+            // this store mints ULIDs, so there is nothing on the wire a ULID
+            // fence can compare. What the facade tracks is the same array the
+            // client is holding (see `loadedEvents`), so the pair it derives is
+            // the pair the client would have sent.
             //
             // Attached whenever the fence is armed, not just for the count
             // half: `SimCreateParams.snapshot` is also what marks a write as
@@ -790,11 +733,11 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
 
   const world: SimWorld = {
     specVersion: SPEC_VERSION_CURRENT,
-    // Whether the fence is armed is a store option, not a capability: the
-    // runtime assumes every World may reject a stale write, so a scenario can
-    // only change what the store does about one, never what the runtime
-    // expects. See `SimStoreOptions.preconditionGuard`.
-    capabilities: {},
+    capabilities: {
+      // Only advertise the fence when the store is actually enforcing it — a
+      // runtime fast path gated on this capability must never run without one.
+      ...(options.preconditionGuard ? { preconditionGuard: true } : {}),
+    },
     getDeploymentId: intercept('getDeploymentId', () =>
       simQueue.getDeploymentId()
     ),
@@ -860,15 +803,6 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
     },
     async asExternal(fn) {
       return externalCtx.run(true, fn);
-    },
-    reservePosition: (runId) => store.mintEvent(runId),
-    async withReservedPosition(position, fn) {
-      reservedPosition = position;
-      try {
-        return await fn();
-      } finally {
-        reservedPosition = undefined;
-      }
     },
     pushTrace,
     callCount: () => callSeq,

--- a/packages/world-sim/src/world.ts
+++ b/packages/world-sim/src/world.ts
@@ -29,12 +29,13 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   type Event,
   getQueueTopicPrefix,
+  requireEventSlot,
   type QueuePayload,
   SPEC_VERSION_CURRENT,
   type World,
 } from '@workflow/world';
 import { createVirtualClock, type VirtualClock } from './clock.js';
-import { createIdFactory, type IdFactory, ulidTimeOf } from './ids.js';
+import { createIdFactory, type IdFactory } from './ids.js';
 import { createSimQueue, type DirectHandler, type SimQueue } from './queue.js';
 import {
   createSimStore,
@@ -575,12 +576,12 @@ export function createSimWorld(options: SimWorldOptions = {}): SimWorld {
     if (!runId) return undefined;
     const set = loadedEvents()?.get(runId);
     if (!set || set.size === 0) return undefined;
-    let updatedAt = 0;
+    let maxSlot = 0;
     for (const eventId of set) {
-      const at = ulidTimeOf(eventId);
-      if (at > updatedAt) updatedAt = at;
+      const slot = requireEventSlot(eventId);
+      if (slot > maxSlot) maxSlot = slot;
     }
-    return { updatedAt, count: set.size };
+    return { maxSlot, count: set.size };
   }
 
   /** Wrap one world method so it becomes a call point. */

--- a/workbench/sim-world/README.md
+++ b/workbench/sim-world/README.md
@@ -123,29 +123,17 @@ Two different instruments, for two different things:
 - **`expect`** asserts the run's outcome: `status`, and `output` when the
   output is the point.
 
-And one rule that matters more than either: **do not restate an expectation per
-world.** A scenario is one sequence of advances; the only thing a flag like
-`--append-only` changes is what a read returns. An expectation that has to be
-written twice is pinning a *consequence of the reads* rather than a property of
-the run, and a scenario that branches its tempo on `sim.appendOnlyLog` is two
-scenarios wearing one id.
-
-What catches the fault in every world is the invariant the runner checks for
-free: **a run's log must replay back into that run.** So when a flag decides
-which branch a run takes, report the branch with `sim.note` and assert only
-what holds either way — usually `status`, plus the replay check you get without
-asking. Reading `sim.appendOnlyLog` to *phrase* a check's sentence correctly is
-fine and encouraged; reading it to choose a different tempo is not.
+The runner checks the invariant that **a run's log must replay back into that
+run**, so expectations should describe durable outcomes rather than incidental
+intermediate ordering.
 
 There is deliberately no way to expect a violation. A scenario states the
 outcome the run should have reached and stays red until the runtime gets there.
 
 ### Per-scenario world flags
 
-`preconditionGuard`, `countGuard` and `appendOnlyLog` on the spec pick the world
-this scenario plays in. The usual reason to set one is a **paired scenario**:
-the red one and the same tempo with a fix armed, one flag apart, so the diff is
-the argument. The command-line flags below override the spec for a whole run.
+`preconditionGuard` and `countGuard` on the spec control the guards for that
+scenario. The command-line fence flags below override them for a whole run.
 
 ## Flags
 
@@ -153,52 +141,33 @@ the argument. The command-line flags below override the spec for a whole run.
 | --- | --- |
 | `--verbose` | include queue deliveries in the trace |
 | `--color` / `--no-color` | force colour on through a pipe / off. Default: on for a terminal, off otherwise, so `pnpm sim > out.txt` is already diffable |
-| `--append-only` / `--no-append-only` | play against an append-only log, or force production behaviour back on |
 | `--fence` / `--no-fence` | force the optimistic-concurrency fence on or off for every scenario |
 | `--report-only` | print every failure, exit 0 anyway |
 | `--summary-file <path>` | one collapsed `<details>` — the count on the visible line, the table behind it — for a PR comment or `$GITHUB_STEP_SUMMARY` |
 | `--detail-file <path>` | the full trace, colour forced off, as a CI artifact |
-| `--title <text>` | heading for the summary file, so two of them in one comment are told apart by more than their chips line |
-
-Two of these are measurements rather than conveniences.
-
-**`--append-only`** moves every event's position from its handler's mint to its
-commit, which is the one change that makes a stale read impossible: the log can
-be behind, never wrong. Running with and without it is how you tell which of
-the reds that change would actually close. Today: **38 pass / 3 violations**
-mint-ordered, **41 pass / 0 violations** append-only.
-
-It closes all three, and by construction rather than by catching anything: with
-nothing reserving a position ahead of a commit, no read can see a hole.
+| `--title <text>` | heading for the summary file |
 
 **`--no-fence`** turns the fence off everywhere, asking whether anything relies
-on it. It is a diagnostic, not a world — **read the violation count, not the
+on it. It is a diagnostic — **read the violation count, not the
 pass count**, because a scenario whose whole point is that the guard fired
 asserts exactly that and fails by design when you disarm it
 (`in-flight-before-decision-counted` is the one that does this today).
-Measured: **3 → 5** violations mint-ordered, so it is load-bearing there;
-**0 → 0** append-only, so it is dead weight once positions are assigned at
-commit.
 
 ## In CI
 
 [`.github/workflows/world-sim.yml`](../../.github/workflows/world-sim.yml)
-plays the book on every pull request, once per world, and posts both summaries
-as one sticky comment — four lines until you open something:
+plays the book on every pull request and posts its summary as one sticky comment:
 
 ```
 ## Sim World
 
 Simulated world deterministic testing for races. [Traces](…)
 
-▸ 🟠 Mint-ordered log — 6 fail of 41 total
-▸ 🟢 Append-only log — 0 fail of 41 total
+▸ 🟢 world-sim scenario book — 0 fail of 41 total
 ```
 
-**It never blocks a merge**: those scenarios are red on purpose, so a lane that
-gated on them would be red on every PR and read as broken rather than as
-informative. What it publishes is the pair of counts, and the thing to look at
-is whether they still say 6 and 0.
+**It never blocks a merge**: the simulation is an informational measurement, so
+the published count is the thing to look at rather than the check mark.
 
 That is also why `pnpm test` in this package is `--report-only` while `pnpm sim`
 stays strict — a recursive `pnpm -r test` should not go red for the known reds,
@@ -208,8 +177,7 @@ but someone running the book deliberately wants the exit code.
 
 Events in the printed stream are referred to by **log position** — `#12` is the
 twelfth event in the durable log, `@7` the resource created at position 7 — and
-the trace prints in *commit* order, so the numbers count backwards exactly where
-the log and the execution disagree. See
+the trace prints in commit order. See
 [`packages/world-sim/README.md`](../../packages/world-sim/README.md#reading-the-output).
 
 ## What the scenarios show

--- a/workbench/sim-world/run.ts
+++ b/workbench/sim-world/run.ts
@@ -6,20 +6,11 @@
  *   pnpm sim in-flight-after-decision   # one scenario, by id
  *   pnpm sim --verbose             # include queue deliveries in the trace
  *   pnpm sim --no-color            # plain ASCII, e.g. for a golden file
- *   pnpm sim --append-only         # play against an append-only log
  *   pnpm sim --no-fence            # play with the optimistic-concurrency fence off
  *   pnpm sim --report-only         # print failures but exit 0
  *   pnpm sim --summary-file s.md   # markdown counts + table, for a PR comment
  *   pnpm sim --detail-file d.txt   # the full trace, colour-free, as an artifact
- *   pnpm sim --title 'Append-only' # heading for the summary file
- *
- * `--append-only` moves every event's position from its handler's mint to its
- * commit, which is the one change that makes a stale read impossible: the log
- * can be behind, never wrong. Six scenarios in the book fail today because it
- * is *not* how production works, so running with and without it — and diffing
- * — is how you tell which of those failures the change would actually close.
- * `--no-append-only` forces the production behaviour back on for a scenario
- * that asked for the flag itself.
+ *   pnpm sim --title 'Summary'     # heading for the summary file
  *
  * `--no-fence` turns off the optimistic-concurrency fence (both halves — the
  * count guard is evaluated inside the same predicate) for every scenario that
@@ -66,13 +57,6 @@ const color = args.includes('--no-color')
   : args.includes('--color')
     ? true
     : undefined;
-// `undefined` leaves it to each spec, which is not the same as `false` —
-// see `RunScenarioOptions.appendOnlyLog`.
-const appendOnlyLog = args.includes('--no-append-only')
-  ? false
-  : args.includes('--append-only')
-    ? true
-    : undefined;
 // Same tri-state as above, and for the same reason: a scenario that turns the
 // fence on itself is the normal case, so `undefined` has to mean "leave it to
 // the spec" rather than "off".
@@ -84,10 +68,7 @@ const preconditionGuard = args.includes('--no-fence')
 const reportOnly = args.includes('--report-only');
 const summaryFile = pathValue('--summary-file');
 const detailFile = pathValue('--detail-file');
-// Names the summary's heading. A CI job plays the book once per world and
-// concatenates the two files into one comment, where two headings reading
-// `world-sim scenario book` would leave the chips line as the only way to tell
-// which half you are looking at.
+// Names the summary's heading for CI output.
 const summaryTitle = flagValue('--title') ?? 'world-sim scenario book';
 
 /**
@@ -151,7 +132,6 @@ for (const spec of selected) {
   const result = await runScenario(spec, {
     handler,
     workflowIds: bundle.workflowIds,
-    appendOnlyLog,
     preconditionGuard,
   });
   results.push(result);
@@ -177,12 +157,7 @@ if (summaryFile) {
     summaryFile,
     renderMarkdownSummary(results, {
       title: summaryTitle,
-      // Say which world, always — including when it is the default one. A
-      // summary file outlives the command line that produced it, and two of
-      // these sitting side by side in a PR comment are only comparable if each
-      // one states its own conditions.
       chips: [
-        `log=${appendOnlyLog === true ? 'append-only' : 'mint-ordered'}`,
         `fence=${
           preconditionGuard === undefined
             ? 'per-spec'

--- a/workbench/sim-world/scenarios/in-flight-after-decision.ts
+++ b/workbench/sim-world/scenarios/in-flight-after-decision.ts
@@ -2,33 +2,12 @@ import type { ScenarioSpec } from '@workflow/world-sim';
 
 export const scenario: ScenarioSpec = {
   id: 'in-flight-after-decision',
-  name: 'in-flight: A commits AFTER the decision — no guard can see it',
+  name: 'in-flight: hook commits after the decision',
   description:
-    'The residual, and the reason the append-tail fence noted in ' +
-    "workflow-server's `lib/ulid.ts` is still open. Same log order " +
-    '(A=hook_received, B=wait_completed) and the same decision on a log ' +
-    'missing the hook, but this time the receiver commits after C rather than ' +
-    'before it: visibility is (B, C, A). Both halves of the fence are armed ' +
-    'and neither fires, and neither could — a check is part of the write it ' +
-    'guards, evaluated against the log as it stands at that instant, so it can ' +
-    'only compare against events that already exist. At every point where a ' +
-    'write of this run is checked, the hook does not exist. Then it appears, ' +
-    'behind everything, and the log says the hook beat a timeout the run ' +
-    'resolved the other way. ' +
-    'Getting there needs the run to be quiescent when the hook lands, because ' +
-    'the count guard catches this same hole on whatever the run writes NEXT — ' +
-    'late, after the wrong branch has already run, which is a different and ' +
-    'much worse outcome than catching it in time. So the hook is released ' +
-    'while the orchestrator is held inside `wait_created`, the last write of ' +
-    'the delivery: the run then sleeps, and the next delivery cold-starts on a ' +
-    'log it can no longer follow. Detectability is inversely related to how ' +
-    'late the write commits, which is the opposite of the intuition that a ' +
-    'slower write is more dangerous the longer it takes. ' +
-    'This is the one an append-only log closes outright, and it closes it by ' +
-    'construction rather than by catching anything: the append-tail fence is ' +
-    'unnecessary when the tail is the only place a write can land. The late ' +
-    'hook sorts last, the next delivery replays a log it can follow, and no ' +
-    'guard has to fire.',
+    'The receiver commits after the run has decided its branch and entered a ' +
+    'wait. Both guard halves are armed but no write can be fenced before the ' +
+    'hook exists. The hook takes the tail position when it lands, so the next ' +
+    'delivery replays a log it can follow.',
   workflow: 'lateAppendForkWorkflow',
   input: ['doc-31'],
   preconditionGuard: true,
@@ -53,16 +32,6 @@ export const scenario: ScenarioSpec = {
     await hook.commit();
     await wf.release();
   },
-  // FAILS TODAY, and worse than the others: the corruption is not merely
-  // latent. The next delivery replays a log that says the hook won, finds
-  // `settle` where `recoverFirst` belongs, and gives up after its recovery
-  // replays — so the run dies rather than completing wrongly. Of the six reds,
-  // this is the one with no known fix: both guards are on, and closing it needs
-  // the append-tail fence that does not exist yet.
-  //
-  // "Completes" is the whole assertion, and here it is not a formality: this is
-  // the one red where the run does not reach a terminal success at all. Under
-  // the flag it does, and the log replays — same sentence, other answer.
   expect: {
     status: 'completed',
   },

--- a/workbench/sim-world/scenarios/in-flight-before-decision-counted.ts
+++ b/workbench/sim-world/scenarios/in-flight-before-decision-counted.ts
@@ -4,32 +4,9 @@ export const scenario: ScenarioSpec = {
   id: 'in-flight-before-decision-counted',
   name: 'in-flight: same tempo, count guard ON — the write is fenced',
   description:
-    'Identical to the scenario above with the count half of the fence armed: ' +
-    'the caller sends how many events it had loaded at or below its own ' +
-    'watermark, and the world compares that against how many the log actually ' +
-    'holds there. The hook committed in the meantime, so the log holds one ' +
-    'more than the caller loaded and C is rejected with a 412 — even though ' +
-    'the watermark comparison passes. The orchestrator reloads, sees the hook ' +
-    'ahead of the timeout in log order, re-decides the fork as "arrived", and ' +
-    'commits the branch the log agrees with. This is the regression test for ' +
-    'the half of the fence a high-water mark cannot express: same fault, same ' +
-    'tempo, one flag apart. The count the caller sends is the same number ' +
-    '`@workflow/core` puts on every replay-context create; what differs is ' +
-    'what a World does with it. This sim rejects on it, which is why the flag ' +
-    'below is the default and the twin above has to switch it off. ' +
-    'Which half fires is no longer the point, though, and that is what slot ' +
-    'positions changed. A watermark used to be a millisecond, so two writes ' +
-    'inside one virtual millisecond compared equal and only the count could ' +
-    'separate them; a watermark that is a slot is strictly ordered, so the ' +
-    'watermark half now rejects this on its own. What the scenario still ' +
-    'asserts is that the fence fires at all. ' +
-    'Under an append-only log the 412 still fires and saves nothing: the ' +
-    'reload sees the hook behind the timeout in log order, re-decides the ' +
-    'same way, and settles — a restart with nothing to correct. ' +
-    'Mint-ordered there is no fence to reach: the receiver holds a position ' +
-    'ahead of everything the orchestrator writes, so the log has a hole in it ' +
-    'while the write is in flight, and the next replay refuses the log ' +
-    'outright rather than following it into the wrong branch.',
+    'The count half of the fence is armed. A hook committed while the writer was ' +
+    'held can make the count at the caller watermark grow, so the write is ' +
+    'rejected and the orchestrator reloads before deciding again.',
   workflow: 'stepCountForkWorkflow',
   input: ['doc-30'],
   preconditionGuard: true,
@@ -44,25 +21,16 @@ export const scenario: ScenarioSpec = {
     await hook.commit();
     await wf.release();
 
-    // Matched on the error, not on "something was rejected". The twin rejects
-    // too — its writes hit `RunExpiredError` once the corrupted branch has run
-    // — so a bare `rejections().length > 0` would hold there as well and
-    // assert nothing about the fence.
-    //
-    // Only asserted under an append-only log, because only there does the
-    // write reach the fence. Mint-ordered, the receiver's reserved position is
-    // binding, so the log carries a hole for as long as the write is in
-    // flight, and the replay that reads it refuses the log before any write of
-    // its own is checked. That refusal is the violation the trace reports; a
-    // check here would restate it as a second failure.
-    if (sim.appendOnlyLog) {
-      sim.check(
-        'the fence rejected the write',
-        sim.world
-          .rejections()
-          .some((r) => r.errorName === 'PreconditionFailedError')
-      );
-    }
+    // Matched on the count half's own message, not on "something was
+    // rejected". The twin rejects too — its writes hit `RunExpiredError` once
+    // the corrupted branch has run — so a bare `rejections().length > 0` would
+    // hold there as well and assert nothing about the guard.
+    sim.check(
+      'the count guard fenced the write the watermark let through',
+      sim.world
+        .rejections()
+        .some((r) => r.message.includes('at or below the caller'))
+    );
   },
   // The rejection and the reload show up in the trace as `!!` lines. Whichever
   // branch the reload lands on, it is the one the durable log implies — so

--- a/workbench/sim-world/scenarios/in-flight-before-decision.ts
+++ b/workbench/sim-world/scenarios/in-flight-before-decision.ts
@@ -2,30 +2,13 @@ import type { ScenarioSpec } from '@workflow/world-sim';
 
 export const scenario: ScenarioSpec = {
   id: 'in-flight-before-decision',
-  name: 'in-flight: A commits BEFORE the decision is written — count guard off',
+  name: 'in-flight: hook commits before the decision is written — count guard off',
   description:
-    'Log order is (A=hook_received, B=wait_completed); visibility is ' +
-    '(B, A, C). The webhook receiver has entered its handler and minted the ' +
-    "hook's event id, so position A is spoken for, but the write has not " +
-    'landed. The orchestrator then commits the timeout at B — behind a ' +
-    'position it cannot see — reads a log that genuinely does not contain the ' +
-    'hook, and takes the settle branch. Nothing is withheld from any read. ' +
-    'The receiver commits while the orchestrator is held at the produced ' +
-    'point of C, so by the time C is checked the hole has closed and the log ' +
-    'holds an event the writer never loaded. The watermark guard is on and ' +
-    'never gets to speak: the log has a hole in it from the moment the ' +
-    'receiver takes its position, so the next replay refuses the log before ' +
-    'any write of its own is checked. What the fence would have caught, the ' +
-    'gap audit catches earlier and more bluntly — the run fails rather than ' +
-    'following a log it cannot follow into the wrong branch. ' +
-    'Under an append-only log there is no position to be spoken for: the hook ' +
-    'commits after the timeout and therefore sorts after it, the log says the ' +
-    'timeout won, and the settle branch the run took is the one the log ' +
-    'describes. Same tempo, same expectation, no corruption. Which branch the ' +
-    'run ends on is decided by what its reads returned, and what a read ' +
-    'returns is the one thing the flag changes — so the branch is reported, ' +
-    'not asserted. What is asserted holds in both worlds: the run completes, ' +
-    'and the log it wrote replays back into the run that wrote it.',
+    'The webhook receiver begins but does not commit until the orchestrator has ' +
+    'written its timeout and decided the fork without the hook. When the hook ' +
+    'lands, it takes the tail position, so the log describes the same branch the ' +
+    'run took. The watermark guard is intentionally the only guard enabled; the ' +
+    'scenario verifies that a delayed external write does not corrupt replay.',
   workflow: 'stepCountForkWorkflow',
   input: ['doc-29'],
   preconditionGuard: true,
@@ -36,29 +19,19 @@ export const scenario: ScenarioSpec = {
   script: async (sim) => {
     const wf = sim.writer.orchestrator();
 
-    // Stop the orchestrator before it submits the timeout, so the receiver
-    // gets the earlier position. `produced` is the pre-submit point: nothing
-    // has been minted for `wait_completed` yet.
+    // Stop the orchestrator before it submits the timeout.
     await wf.runToEventProduced('wait_completed');
 
     const hook = await sim.beginHookDelivery('count:doc-29', {
       approved: true,
     });
-    // The condition is the same in both worlds — the hook is not in the log —
-    // but what that *means* is not, and the trace should not claim otherwise.
-    // Mint-ordered, the reserved position is binding and the hook already owns
-    // a slot ahead of everything the orchestrator is about to write; under an
-    // append-only log the reservation decides nothing, and the hook is simply
-    // absent until it lands.
     sim.check(
-      sim.appendOnlyLog
-        ? 'the hook has not landed; where it lands is not decided yet'
-        : 'the hook owns a log position but is nowhere in the log',
+      'the hook has not landed yet',
       sim.world.events().every((e) => e.eventType !== 'hook_received')
     );
 
-    // B commits behind A, then the orchestrator decides the fork on a log
-    // that has a hole in it. Hold it before that decision is submitted. The
+    // The orchestrator decides the fork on the log it has observed. Hold it
+    // before that decision is submitted. The
     // claim for a branch step is one `events.create` carrying `step_started`
     // — the `step_created` ahead of it is appended by the same write — so
     // `step_started` is the call point the decision passes through.
@@ -68,19 +41,10 @@ export const scenario: ScenarioSpec = {
       JSON.stringify(decision.ctx.request?.eventData).includes('settle')
     );
 
-    // A lands, behind the snapshot C was decided on.
+    // The hook lands after the decision and takes the log tail.
     await hook.commit();
     await wf.release();
   },
-  // FAILS TODAY, like the stale-read scenarios above, and needs no stale read
-  // to do it. Note what is *not* here: the settle/recover branch. The run
-  // settles in both worlds — that part is not the bug. The bug is that
-  // mint-ordered, the log it left behind says the hook came first, so a cold
-  // replay of that log takes `recoverFirst` and diverges from the run that
-  // wrote it. That divergence is the failure, it is what `verifyReplay`
-  // catches, and it is stated the same way in both worlds. The fix is known
-  // and one flag away — see the scenario below, this one with the count guard
-  // on and green.
   expect: {
     status: 'completed',
   },


### PR DESCRIPTION
Since we're moving to server side serialized ids, we dont need to simulate the prior model.

## Summary
- remove the mint-ordered simulation mode and reservation API
- make commit-time log positions and lagging-prefix reads the only simulator behavior
- simplify CI, scenarios, tests, and documentation to the single log model

## Testing
- node --check on changed TypeScript files
- pnpm --filter @workflow/world-sim test (blocked: node_modules is absent; vitest unavailable)