### PR TITLE
chore(deps): upgrade nanoid to ^5.1.16

### DIFF
--- a/.changeset/bump-nanoid-5-1-16.md
+++ b/.changeset/bump-nanoid-5-1-16.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Update nanoid to ^5.1.16 — closes CVE-2026-67214 (5.x < 5.1.16), and the caret range lets the dependency dedupe with other nanoid 5.x consumers in the host app instead of forcing a second copy.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,7 +104,7 @@
     "debug": "4.4.3",
     "devalue": "5.9.0",
     "ms": "2.1.3",
-    "nanoid": "5.1.6",
+    "nanoid": "^5.1.16",
     "quickjs-wasi": "3.4.0",
     "seedrandom": "3.0.5",
     "semver": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,8 +553,8 @@ importers:
         specifier: 2.1.3
         version: 2.1.3
       nanoid:
-        specifier: 5.1.6
-        version: 5.1.6
+        specifier: ^5.1.16
+        version: 5.1.16
       quickjs-wasi:
         specifier: 3.4.0
         version: 3.4.0
@@ -2021,8 +2021,8 @@ importers:
         specifier: ^12.29.0
         version: 12.29.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nanoid:
-        specifier: 5.1.6
-        version: 5.1.6
+        specifier: ^5.1.16
+        version: 5.1.16
       next:
         specifier: 16.2.11
         version: 16.2.11(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2145,8 +2145,8 @@ importers:
         specifier: ^12.29.0
         version: 12.29.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nanoid:
-        specifier: 5.1.6
-        version: 5.1.6
+        specifier: ^5.1.16
+        version: 5.1.16
       next:
         specifier: 16.2.11
         version: 16.2.11(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -14005,8 +14005,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -31484,7 +31484,7 @@ snapshots:
 
   nanoid@3.3.16: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   nanotar@0.3.0: {}
 

--- a/workbench/nextjs-turbopack/package.json
+++ b/workbench/nextjs-turbopack/package.json
@@ -33,7 +33,7 @@
     "lucide-react": "0.555.0",
     "mixpart": "0.0.4",
     "motion": "^12.29.0",
-    "nanoid": "5.1.6",
+    "nanoid": "^5.1.16",
     "next": "16.2.11",
     "openai": "6.9.1",
     "radix-ui": "1.4.3",

--- a/workbench/nextjs-webpack/package.json
+++ b/workbench/nextjs-webpack/package.json
@@ -33,7 +33,7 @@
     "lucide-react": "0.555.0",
     "mixpart": "0.0.4",
     "motion": "^12.29.0",
-    "nanoid": "5.1.6",
+    "nanoid": "^5.1.16",
     "next": "16.2.11",
     "openai": "6.9.1",
     "radix-ui": "1.4.3",


### PR DESCRIPTION
## What

`packages/core`: `nanoid: 5.1.6` → `^5.1.16` (+ the two workbench apps, so the workspace stays on a single copy). Changeset: patch for `@workflow/core`.

## Why

- nanoid `>= 4.0.0, < 5.1.16` is affected by **CVE-2026-67214 / [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv)** (non-secure generators can loop indefinitely with a negative size). The fixed 5.1.16 has been out since June 24.
- `@workflow/core` is currently the only path through which nanoid 5.x enters a consuming app, so the exact `5.1.6` pin holds every downstream on the vulnerable version — apps have to carry a `nanoid@^5.0.0: ^5.1.16` override/resolution to close the advisory.
- Caret rather than a new exact pin, for the same reason as #3498: an exact pin can only ever match one version, so any other 5.x consumer in the host app gets a second copy.

Lockfile regenerated with `pnpm@10.20.0 install --lockfile-only` — the only movement is `nanoid 5.1.6 → 5.1.16`.

## Backport

`main` is the 5.0 beta line — could this also be backported to the 4.x release line (like #2653)? That's where consuming apps would actually pick the fix up today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)