### PR TITLE
[core] Prepare replay payloads as event frames arrive

### DIFF
--- a/.changeset/prepare-streamed-replay-payloads.md
+++ b/.changeset/prepare-streamed-replay-payloads.md
@@ -4,4 +4,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Prepare replay payloads as validated event frames arrive.
+Prepare replay payloads as validated event frames arrive, reuse primitive step results across fresh VMs, and preserve replay startup overlap.

--- a/.changeset/prepare-streamed-replay-payloads.md
+++ b/.changeset/prepare-streamed-replay-payloads.md
@@ -1,0 +1,7 @@
+---
+"@workflow/core": patch
+"@workflow/world": patch
+"@workflow/world-vercel": patch
+---
+
+Prepare replay payloads as validated event frames arrive.

--- a/packages/core/src/replay-payload-cache.test.ts
+++ b/packages/core/src/replay-payload-cache.test.ts
@@ -55,6 +55,26 @@ function makeEvents(payloads: unknown[]): Event[] {
 }
 
 describe('ReplayPayloadCache', () => {
+  it('prepares a streamed event as soon as its deferred key resolves', async () => {
+    const payload = new Uint8Array([1]);
+    let resolveKey!: (key: undefined) => void;
+    const key = new Promise<undefined>((resolve) => {
+      resolveKey = resolve;
+    });
+    const preparer = vi.fn<ReplayPayloadPreparer>((value) => ({ data: value }));
+    const cache = new ReplayPayloadCache(key, preparer);
+    const [event] = makeEvents([payload]);
+
+    cache.prepareEvent(event);
+    expect(preparer).not.toHaveBeenCalled();
+
+    resolveKey(undefined);
+    await expect(
+      cache.prepareEventPayload(event.eventId, 'result', payload)
+    ).resolves.toEqual({ data: payload });
+    expect(preparer).toHaveBeenCalledOnce();
+  });
+
   it('deduplicates preparation and accepts a synchronous preparer', async () => {
     const payload = new Uint8Array([1]);
     const preparer = vi.fn<ReplayPayloadPreparer>((value) => ({ data: value }));
@@ -205,21 +225,24 @@ describe('ReplayPayloadCache', () => {
     }
   });
 
-  it('rehydrates mutable and oversized step results', async () => {
-    const oversized = 'x'.repeat(4097);
-    for (const value of [{ count: 0 }, oversized]) {
-      const cache = new ReplayPayloadCache(undefined);
-      const hydrate = vi
-        .fn()
-        .mockImplementation(async () =>
-          typeof value === 'object' ? { ...value } : value
-        );
+  it('rehydrates mutable step results', async () => {
+    const cache = new ReplayPayloadCache(undefined);
+    const hydrate = vi.fn().mockImplementation(async () => ({ count: 0 }));
 
-      const first = await cache.getStepResult('evnt_result', hydrate);
-      const second = await cache.getStepResult('evnt_result', hydrate);
-      expect(hydrate).toHaveBeenCalledTimes(2);
-      if (typeof value === 'object') expect(second).not.toBe(first);
-    }
+    const first = await cache.getStepResult('evnt_result', hydrate);
+    const second = await cache.getStepResult('evnt_result', hydrate);
+    expect(hydrate).toHaveBeenCalledTimes(2);
+    expect(second).not.toBe(first);
+  });
+
+  it('memoizes primitive step results without an arbitrary size cap', async () => {
+    const cache = new ReplayPayloadCache(undefined);
+    const oversized = 'x'.repeat(4097);
+    const hydrate = vi.fn().mockResolvedValue(oversized);
+
+    expect(await cache.getStepResult('evnt_result', hydrate)).toBe(oversized);
+    expect(await cache.getStepResult('evnt_result', hydrate)).toBe(oversized);
+    expect(hydrate).toHaveBeenCalledOnce();
   });
 
   it('does not memoize failed step hydration', async () => {

--- a/packages/core/src/replay-payload-cache.test.ts
+++ b/packages/core/src/replay-payload-cache.test.ts
@@ -123,6 +123,7 @@ describe('ReplayPayloadCache', () => {
     const events = makeEvents(payloads.slice(1));
 
     const warming = cache.prewarm(run, events);
+    await Promise.resolve();
     expect(preparer).toHaveBeenCalledTimes(4);
     for (const resolve of resolvers.reverse()) resolve();
     await warming;

--- a/packages/core/src/replay-payload-cache.test.ts
+++ b/packages/core/src/replay-payload-cache.test.ts
@@ -173,7 +173,7 @@ describe('ReplayPayloadCache', () => {
     expect(second.count).toBe(0);
   });
 
-  it('prewarms events inserted by a later log load', async () => {
+  it('rescans events inserted by an authoritative log replacement', async () => {
     const payloads = [0, 1, 2].map((value) => new Uint8Array([value]));
     const preparer = vi.fn<ReplayPayloadPreparer>((value) => ({ data: value }));
     const cache = new ReplayPayloadCache(undefined, preparer);
@@ -183,6 +183,10 @@ describe('ReplayPayloadCache', () => {
     await cache.prewarm(run, [first, second]);
     expect(preparer).toHaveBeenCalledTimes(2);
 
+    await cache.prewarm(run, [first, missing, second]);
+    expect(preparer).toHaveBeenCalledTimes(2);
+
+    cache.resetScan();
     await cache.prewarm(run, [first, missing, second]);
     expect(preparer).toHaveBeenCalledTimes(3);
     expect(preparer).toHaveBeenLastCalledWith(payloads[1], undefined);

--- a/packages/core/src/replay-payload-cache.test.ts
+++ b/packages/core/src/replay-payload-cache.test.ts
@@ -172,11 +172,7 @@ describe('ReplayPayloadCache', () => {
     expect(second.count).toBe(0);
   });
 
-  it('rescans a log whose missing events were filled in below the scanned prefix', async () => {
-    // A stale-snapshot (412) restart replaces the log with a corrected one, so
-    // the events it was missing appear BELOW the length already scanned and
-    // shift every later position. Resuming from that length skips exactly the
-    // events the reload was for, which is what `resetScan` exists to prevent.
+  it('prewarms events inserted by a later log load', async () => {
     const payloads = [0, 1, 2].map((value) => new Uint8Array([value]));
     const preparer = vi.fn<ReplayPayloadPreparer>((value) => ({ data: value }));
     const cache = new ReplayPayloadCache(undefined, preparer);
@@ -186,15 +182,7 @@ describe('ReplayPayloadCache', () => {
     await cache.prewarm(run, [first, second]);
     expect(preparer).toHaveBeenCalledTimes(2);
 
-    // Positional resume: `missing` sits inside the scanned prefix, so it is
-    // skipped and its payload is only prepared on demand.
     await cache.prewarm(run, [first, missing, second]);
-    expect(preparer).toHaveBeenCalledTimes(2);
-
-    cache.resetScan();
-    await cache.prewarm(run, [first, missing, second]);
-    // Only the inserted event is new: the other two are keyed by event id and
-    // stay prepared across the rescan.
     expect(preparer).toHaveBeenCalledTimes(3);
     expect(preparer).toHaveBeenLastCalledWith(payloads[1], undefined);
   });

--- a/packages/core/src/replay-payload-cache.ts
+++ b/packages/core/src/replay-payload-cache.ts
@@ -8,14 +8,6 @@ import {
 
 type ReplayPayloadField = 'result' | 'error' | 'payload';
 
-function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as PromiseLike<T>).then === 'function'
-  );
-}
-
 function isMemoizablePrimitive(value: unknown): boolean {
   if (value === null) return true;
   const type = typeof value;
@@ -157,13 +149,7 @@ export class ReplayPayloadCache {
 
   /** Normalize synchronous and asynchronous preparers to one promise contract. */
   private async runPreparation(value: unknown): Promise<PreparedReplayPayload> {
-    const encryptionKey = this.encryptionKey;
-    return this.preparer(
-      value,
-      isPromiseLike<PayloadKey | undefined>(encryptionKey)
-        ? await encryptionKey
-        : encryptionKey
-    );
+    return this.preparer(value, await this.encryptionKey);
   }
 
   /** Start one event's binary payload unless another path already did. */

--- a/packages/core/src/replay-payload-cache.ts
+++ b/packages/core/src/replay-payload-cache.ts
@@ -41,7 +41,6 @@ export class ReplayPayloadCache {
     Promise<PreparedReplayPayload>
   >();
   private readonly primitiveStepResults = new Map<string, unknown>();
-  private nextUnscannedEventIndex = 0;
 
   constructor(
     private readonly encryptionKey:
@@ -66,48 +65,19 @@ export class ReplayPayloadCache {
    */
   async prewarm(workflowRun: WorkflowRun, events: Event[]): Promise<void> {
     const preparations: Promise<PreparedReplayPayload>[] = [];
-    // Each replay scans the full event log, so awaiting cached promises here
-    // would add O(N^2) promise reactions over an N-step invocation. Only wait
-    // for preparations first discovered by this prewarm pass.
     const workflowInput = this.startPreparation(
       this.workflowInputKey(workflowRun.runId),
       workflowRun.input
     );
     if (workflowInput) preparations.push(workflowInput);
-    // This cache is scoped to one invocation. Incremental loads and write
-    // response deltas only ever append, so the scanned length locates the
-    // events added since the previous replay. A reload that can insert events
-    // BELOW that length (a stale-snapshot restart replacing the log with a
-    // corrected one) must call `resetScan()` first, or the inserted events are
-    // never scanned. Prepared entries stay valid across that: they are keyed by
-    // event id, not by position.
-    for (
-      let index = this.nextUnscannedEventIndex;
-      index < events.length;
-      index++
-    ) {
-      const preparation = this.prepareEventIfMissing(events[index]);
+    for (const event of events) {
+      const preparation = this.prepareEventIfMissing(event);
       if (preparation) preparations.push(preparation);
     }
-    this.nextUnscannedEventIndex = events.length;
 
     // Prewarming is speculative and must not fail replay before the matching
     // event is consumed. allSettled also attaches rejection handlers eagerly.
     await Promise.allSettled(preparations);
-  }
-
-  /**
-   * Forget how much of the event log has been scanned, so the next
-   * {@link prewarm} walks it from the start again.
-   *
-   * Required before a replay whose event log was reloaded rather than extended:
-   * a corrected log inserts the events the previous load was missing, which
-   * shifts every later position, so a positional resume would skip exactly the
-   * events the reload was for. Already-prepared payloads are kept: they are
-   * keyed by event id, so re-scanning re-observes them for free.
-   */
-  resetScan(): void {
-    this.nextUnscannedEventIndex = 0;
   }
 
   /** Return the workflow input after shared host-side preparation. */

--- a/packages/core/src/replay-payload-cache.ts
+++ b/packages/core/src/replay-payload-cache.ts
@@ -33,14 +33,14 @@ export class ReplayPayloadCache {
     Promise<PreparedReplayPayload>
   >();
   private readonly primitiveStepResults = new Map<string, unknown>();
+  private readonly encryptionKey: Promise<PayloadKey | undefined>;
 
   constructor(
-    private readonly encryptionKey:
-      | PayloadKey
-      | undefined
-      | PromiseLike<PayloadKey | undefined>,
+    encryptionKey: PayloadKey | undefined | Promise<PayloadKey | undefined>,
     private readonly preparer: ReplayPayloadPreparer = prepareReplayPayload
-  ) {}
+  ) {
+    this.encryptionKey = Promise.resolve(encryptionKey);
+  }
 
   /** Start preparing an event payload as soon as its frame is decoded. */
   prepareEvent(event: Event): void {

--- a/packages/core/src/replay-payload-cache.ts
+++ b/packages/core/src/replay-payload-cache.ts
@@ -34,6 +34,7 @@ export class ReplayPayloadCache {
   >();
   private readonly primitiveStepResults = new Map<string, unknown>();
   private readonly encryptionKey: Promise<PayloadKey | undefined>;
+  private nextUnscannedEventIndex = 0;
 
   constructor(
     encryptionKey: PayloadKey | undefined | Promise<PayloadKey | undefined>,
@@ -62,14 +63,25 @@ export class ReplayPayloadCache {
       workflowRun.input
     );
     if (workflowInput) preparations.push(workflowInput);
-    for (const event of events) {
+    for (
+      let index = this.nextUnscannedEventIndex;
+      index < events.length;
+      index++
+    ) {
+      const event = events[index];
       const preparation = this.prepareEventIfMissing(event);
       if (preparation) preparations.push(preparation);
     }
+    this.nextUnscannedEventIndex = events.length;
 
     // Prewarming is speculative and must not fail replay before the matching
     // event is consumed. allSettled also attaches rejection handlers eagerly.
     await Promise.allSettled(preparations);
+  }
+
+  /** Rescan the next event log after an authoritative replacement. */
+  resetScan(): void {
+    this.nextUnscannedEventIndex = 0;
   }
 
   /** Return the workflow input after shared host-side preparation. */

--- a/packages/core/src/replay-payload-cache.ts
+++ b/packages/core/src/replay-payload-cache.ts
@@ -6,19 +6,20 @@ import {
   type ReplayPayloadPreparer,
 } from './serialization.js';
 
-const MAX_MEMOIZED_PRIMITIVE_LENGTH = 4096;
 type ReplayPayloadField = 'result' | 'error' | 'payload';
+
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PromiseLike<T>).then === 'function'
+  );
+}
 
 function isMemoizablePrimitive(value: unknown): boolean {
   if (value === null) return true;
   const type = typeof value;
   if (type === 'object' || type === 'function') return false;
-  if (type === 'string') {
-    return (value as string).length <= MAX_MEMOIZED_PRIMITIVE_LENGTH;
-  }
-  if (type === 'bigint') {
-    return (value as bigint).toString().length <= MAX_MEMOIZED_PRIMITIVE_LENGTH;
-  }
   return true;
 }
 
@@ -43,9 +44,20 @@ export class ReplayPayloadCache {
   private nextUnscannedEventIndex = 0;
 
   constructor(
-    private readonly encryptionKey: PayloadKey | undefined,
+    private readonly encryptionKey:
+      | PayloadKey
+      | undefined
+      | PromiseLike<PayloadKey | undefined>,
     private readonly preparer: ReplayPayloadPreparer = prepareReplayPayload
   ) {}
+
+  /** Start preparing an event payload as soon as its frame is decoded. */
+  prepareEvent(event: Event): void {
+    const preparation = this.prepareEventIfMissing(event);
+    // Streaming preparation is speculative. Its ordered consumer observes the
+    // original rejection and makes that cache entry retryable.
+    void preparation?.catch(() => {});
+  }
 
   /**
    * Start every missing binary preparation before workflow execution. Failures
@@ -54,19 +66,14 @@ export class ReplayPayloadCache {
    */
   async prewarm(workflowRun: WorkflowRun, events: Event[]): Promise<void> {
     const preparations: Promise<PreparedReplayPayload>[] = [];
-    const start = (cacheKey: string, value: unknown): void => {
-      // Legacy flattened values may be mutated by devalue's unflatten and are
-      // therefore prepared only by their eventual consumer, never cached.
-      if (!(value instanceof Uint8Array)) return;
-
-      // Each replay scans the full event log, so awaiting cached promises here
-      // would add O(N^2) promise reactions over an N-step invocation. Only wait
-      // for preparations first discovered by this prewarm pass.
-      if (this.preparedPayloads.has(cacheKey)) return;
-      preparations.push(this.ensurePreparation(cacheKey, value));
-    };
-
-    start(this.workflowInputKey(workflowRun.runId), workflowRun.input);
+    // Each replay scans the full event log, so awaiting cached promises here
+    // would add O(N^2) promise reactions over an N-step invocation. Only wait
+    // for preparations first discovered by this prewarm pass.
+    const workflowInput = this.startPreparation(
+      this.workflowInputKey(workflowRun.runId),
+      workflowRun.input
+    );
+    if (workflowInput) preparations.push(workflowInput);
     // This cache is scoped to one invocation. Incremental loads and write
     // response deltas only ever append, so the scanned length locates the
     // events added since the previous replay. A reload that can insert events
@@ -79,27 +86,8 @@ export class ReplayPayloadCache {
       index < events.length;
       index++
     ) {
-      const event = events[index];
-      switch (event.eventType) {
-        case 'step_completed':
-          start(
-            this.eventPayloadKey(event.eventId, 'result'),
-            event.eventData?.result
-          );
-          break;
-        case 'step_failed':
-          start(
-            this.eventPayloadKey(event.eventId, 'error'),
-            event.eventData?.error
-          );
-          break;
-        case 'hook_received':
-          start(
-            this.eventPayloadKey(event.eventId, 'payload'),
-            event.eventData?.payload
-          );
-          break;
-      }
+      const preparation = this.prepareEventIfMissing(events[index]);
+      if (preparation) preparations.push(preparation);
     }
     this.nextUnscannedEventIndex = events.length;
 
@@ -147,8 +135,8 @@ export class ReplayPayloadCache {
 
   /**
    * Reuse final step values only when sharing them across VMs is unobservable.
-   * Objects and large strings/bigints always run `hydrate` again, producing a
-   * fresh VM-specific value from the separately cached prepared payload.
+   * Objects always run `hydrate` again to produce a fresh VM-specific value;
+   * every primitive is safe to reuse directly.
    */
   async getStepResult(
     eventId: string,
@@ -199,7 +187,61 @@ export class ReplayPayloadCache {
 
   /** Normalize synchronous and asynchronous preparers to one promise contract. */
   private async runPreparation(value: unknown): Promise<PreparedReplayPayload> {
-    return this.preparer(value, this.encryptionKey);
+    const encryptionKey = this.encryptionKey;
+    return this.preparer(
+      value,
+      isPromiseLike<PayloadKey | undefined>(encryptionKey)
+        ? await encryptionKey
+        : encryptionKey
+    );
+  }
+
+  /** Start one event's binary payload unless another path already did. */
+  private prepareEventIfMissing(
+    event: Event
+  ): Promise<PreparedReplayPayload> | undefined {
+    let field: ReplayPayloadField;
+    let value: unknown;
+    switch (event.eventType) {
+      case 'run_created':
+        return this.startPreparation(
+          this.workflowInputKey(event.runId),
+          event.eventData.input
+        );
+      case 'run_started':
+        return this.startPreparation(
+          this.workflowInputKey(event.runId),
+          event.eventData?.input
+        );
+      case 'step_completed':
+        field = 'result';
+        value = event.eventData?.result;
+        break;
+      case 'step_failed':
+        field = 'error';
+        value = event.eventData?.error;
+        break;
+      case 'hook_received':
+        field = 'payload';
+        value = event.eventData?.payload;
+        break;
+      default:
+        return undefined;
+    }
+    return this.startPreparation(
+      this.eventPayloadKey(event.eventId, field),
+      value
+    );
+  }
+
+  private startPreparation(
+    cacheKey: string,
+    value: unknown
+  ): Promise<PreparedReplayPayload> | undefined {
+    if (!(value instanceof Uint8Array) || this.preparedPayloads.has(cacheKey)) {
+      return undefined;
+    }
+    return this.ensurePreparation(cacheKey, value);
   }
 
   private workflowInputKey(runId: string): string {

--- a/packages/core/src/replay-payload-cache.ts
+++ b/packages/core/src/replay-payload-cache.ts
@@ -31,9 +31,9 @@ function isMemoizablePrimitive(value: unknown): boolean {
  * those replays. Deserialization still runs against each VM's globals so every
  * replay receives fresh object graphs and correctly revived Workflow objects.
  *
- * Successful prepared plaintext remains resident for the invocation lifetime.
- * Its memory cost is the sum of decrypted and decompressed payload sizes, but
- * it never crosses workflow runs or queue deliveries.
+ * Successful prepared plaintext and memoized primitive step results remain
+ * resident for the invocation lifetime. Their memory never crosses workflow
+ * runs or queue deliveries.
  */
 export class ReplayPayloadCache {
   private readonly preparedPayloads = new Map<

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -114,7 +114,6 @@ async function driveHandler(opts: {
   persistedWorkflowName?: string;
   includeRunInput?: boolean;
   streamRunCreatedBeforeResponse?: boolean;
-  duplicateStreamedRunCreated?: boolean;
   whileRunStartedPending?: (state: {
     getEncryptionKeyForRun: ReturnType<typeof vi.fn>;
   }) => Promise<void>;
@@ -145,17 +144,11 @@ async function driveHandler(opts: {
           },
         };
         params?.replayEventObserver?.(streamedRunCreated);
-        if (opts.duplicateStreamedRunCreated) {
-          params?.replayEventObserver?.(streamedRunCreated);
-        }
       }
       await opts.whileRunStartedPending?.({ getEncryptionKeyForRun });
       return {
         run: workflowRun,
-        events:
-          streamedRunCreated && opts.duplicateStreamedRunCreated
-            ? [streamedRunCreated]
-            : ([] as Event[]),
+        events: streamedRunCreated ? [streamedRunCreated] : ([] as Event[]),
       };
     }
     return {
@@ -304,35 +297,23 @@ describe('getWorkflowTraceMode', () => {
 });
 
 describe('workflowEntrypoint trace modes', () => {
-  it('starts current-deployment key resolution before run_started returns', async () => {
-    await driveHandler({
-      runId: 'wrun_trace_streamed_key',
-      workflowCode: simpleWorkflow,
+  it('starts Node replay work while loading the authoritative run', async () => {
+    vi.stubEnv('WORKFLOW_TURBO', '0');
+    const persistedWorkflowCode = `async function persistedWorkflow() {
+      return 'done';
+    }${getWorkflowTransformCode('persistedWorkflow')}`;
+
+    const { eventsCreate, workflowSpan } = await driveHandler({
+      runId: 'wrun_trace_persisted_workflow',
+      workflowCode: persistedWorkflowCode,
+      persistedWorkflowName: 'persistedWorkflow',
+      includeRunInput: true,
       streamRunCreatedBeforeResponse: true,
       whileRunStartedPending: async ({ getEncryptionKeyForRun }) => {
-        await vi.waitFor(() => {
-          expect(getEncryptionKeyForRun).toHaveBeenCalledWith(
-            'wrun_trace_streamed_key',
-            undefined
-          );
-        });
-      },
-    });
-  });
-
-  it('compiles while run_started is loading, without evaluating early', async () => {
-    vi.stubEnv('WORKFLOW_TURBO', '0');
-    let observedOverlap = false;
-    const { workflowSpan } = await driveHandler({
-      runId: 'wrun_trace_compile_overlap',
-      workflowCode: simpleWorkflow,
-      includeRunInput: true,
-      whileRunStartedPending: async () => {
-        expect(
-          exporter
-            .getFinishedSpans()
-            .find((span) => span.name === 'workflow.bundle.evaluate')
-        ).toBeUndefined();
+        expect(getEncryptionKeyForRun).toHaveBeenCalledWith(
+          'wrun_trace_persisted_workflow',
+          undefined
+        );
         await vi.waitFor(() => {
           expect(
             exporter
@@ -345,40 +326,7 @@ describe('workflowEntrypoint trace modes', () => {
             .getFinishedSpans()
             .find((span) => span.name === 'workflow.bundle.evaluate')
         ).toBeUndefined();
-        observedOverlap = true;
       },
-    });
-
-    expect(observedOverlap).toBe(true);
-    expect(
-      exporter
-        .getFinishedSpans()
-        .find((span) => span.name === 'workflow.bundle.evaluate')
-    ).toBeDefined();
-    const compileSpan = exporter
-      .getFinishedSpans()
-      .find((span) => span.name === 'workflow.bundle.compile');
-    const replayLoadSpan = exporter
-      .getFinishedSpans()
-      .find((span) => span.name === 'workflow.replay.load');
-    expect(compileSpan?.parentSpanId).toBe(workflowSpan?.spanContext().spanId);
-    expect(compileSpan?.parentSpanId).not.toBe(
-      replayLoadSpan?.spanContext().spanId
-    );
-  });
-
-  it('replaces a wrong initial workflow-name compile with the persisted one', async () => {
-    vi.stubEnv('WORKFLOW_TURBO', '0');
-    const persistedWorkflowCode = `async function persistedWorkflow() {
-      return 'done';
-    }${getWorkflowTransformCode('persistedWorkflow')}`;
-
-    const { eventsCreate } = await driveHandler({
-      runId: 'wrun_trace_persisted_workflow',
-      workflowCode: persistedWorkflowCode,
-      persistedWorkflowName: 'persistedWorkflow',
-      includeRunInput: true,
-      streamRunCreatedBeforeResponse: true,
     });
 
     expect(
@@ -391,21 +339,20 @@ describe('workflowEntrypoint trace modes', () => {
         ([, event]) => event.eventType === 'run_failed'
       )
     ).toBe(false);
+    const compileSpans = exporter
+      .getFinishedSpans()
+      .filter((span) => span.name === 'workflow.bundle.compile');
+    expect(compileSpans).toHaveLength(2);
+    expect(
+      compileSpans.every(
+        (span) => span.parentSpanId === workflowSpan?.spanContext().spanId
+      )
+    ).toBe(true);
     expect(
       exporter
         .getFinishedSpans()
-        .filter((span) => span.name === 'workflow.bundle.compile')
-    ).toHaveLength(2);
-  });
-
-  it('counts materialized replay events once after observer redelivery', async () => {
-    await driveHandler({
-      runId: 'wrun_trace_replay_retry_count',
-      workflowCode: simpleWorkflow,
-      streamRunCreatedBeforeResponse: true,
-      duplicateStreamedRunCreated: true,
-    });
-
+        .find((span) => span.name === 'workflow.bundle.evaluate')
+    ).toBeDefined();
     const replayLoadSpan = exporter
       .getFinishedSpans()
       .find((span) => span.name === 'workflow.replay.load');

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -112,6 +112,7 @@ async function driveHandler(opts: {
   routeModuleBodyStartedAt?: number;
   executionContext?: WorkflowRun['executionContext'];
   persistedWorkflowName?: string;
+  includeRunInput?: boolean;
   streamRunCreatedBeforeResponse?: boolean;
   duplicateStreamedRunCreated?: boolean;
   whileRunStartedPending?: (state: {
@@ -180,6 +181,17 @@ async function driveHandler(opts: {
               runId: workflowRun.runId,
               requestedAt: new Date('2024-01-01T00:00:00.000Z'),
               traceCarrier: opts.traceCarrier,
+              ...(opts.includeRunInput
+                ? {
+                    runInput: {
+                      input: workflowRun.input,
+                      deploymentId: workflowRun.deploymentId,
+                      workflowName: 'workflow',
+                      specVersion: SPEC_VERSION_CURRENT,
+                      executionContext: opts.executionContext,
+                    },
+                  }
+                : {}),
             },
             {
               requestId: 'req_test',
@@ -296,6 +308,7 @@ describe('workflowEntrypoint trace modes', () => {
     await driveHandler({
       runId: 'wrun_trace_streamed_key',
       workflowCode: simpleWorkflow,
+      streamRunCreatedBeforeResponse: true,
       whileRunStartedPending: async ({ getEncryptionKeyForRun }) => {
         await vi.waitFor(() => {
           expect(getEncryptionKeyForRun).toHaveBeenCalledWith(
@@ -308,11 +321,12 @@ describe('workflowEntrypoint trace modes', () => {
   });
 
   it('compiles while run_started is loading, without evaluating early', async () => {
+    vi.stubEnv('WORKFLOW_TURBO', '0');
     let observedOverlap = false;
     const { workflowSpan } = await driveHandler({
       runId: 'wrun_trace_compile_overlap',
       workflowCode: simpleWorkflow,
-      streamRunCreatedBeforeResponse: true,
+      includeRunInput: true,
       whileRunStartedPending: async () => {
         expect(
           exporter
@@ -353,7 +367,8 @@ describe('workflowEntrypoint trace modes', () => {
     );
   });
 
-  it('speculatively compiles the workflow recorded on the run', async () => {
+  it('replaces a wrong initial workflow-name compile with the persisted one', async () => {
+    vi.stubEnv('WORKFLOW_TURBO', '0');
     const persistedWorkflowCode = `async function persistedWorkflow() {
       return 'done';
     }${getWorkflowTransformCode('persistedWorkflow')}`;
@@ -362,6 +377,7 @@ describe('workflowEntrypoint trace modes', () => {
       runId: 'wrun_trace_persisted_workflow',
       workflowCode: persistedWorkflowCode,
       persistedWorkflowName: 'persistedWorkflow',
+      includeRunInput: true,
       streamRunCreatedBeforeResponse: true,
     });
 
@@ -375,6 +391,11 @@ describe('workflowEntrypoint trace modes', () => {
         ([, event]) => event.eventType === 'run_failed'
       )
     ).toBe(false);
+    expect(
+      exporter
+        .getFinishedSpans()
+        .filter((span) => span.name === 'workflow.bundle.compile')
+    ).toHaveLength(2);
   });
 
   it('counts materialized replay events once after observer redelivery', async () => {
@@ -392,9 +413,10 @@ describe('workflowEntrypoint trace modes', () => {
   });
 
   it('does not compile a Node bundle for a known QuickJS run', async () => {
-    await driveHandler({
+    const { getEncryptionKeyForRun } = await driveHandler({
       runId: 'wrun_trace_quickjs_compile',
       workflowCode: simpleWorkflow,
+      includeRunInput: true,
       streamRunCreatedBeforeResponse: true,
       executionContext: { workflowVm: 'quickjs' },
     });
@@ -404,6 +426,11 @@ describe('workflowEntrypoint trace modes', () => {
         .getFinishedSpans()
         .find((span) => span.name === 'workflow.bundle.compile')
     ).toBeUndefined();
+    expect(getEncryptionKeyForRun).toHaveBeenCalledTimes(1);
+    expect(getEncryptionKeyForRun).not.toHaveBeenCalledWith(
+      'wrun_trace_quickjs_compile',
+      undefined
+    );
   });
 
   it('linked (default): nests under the flow route context with a link to the run-origin context', async () => {

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -13,6 +13,7 @@ import {
   type ReadableSpan,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import { RUN_ERROR_CODES } from '@workflow/errors';
 import {
   type Event,
   SPEC_VERSION_CURRENT,
@@ -114,6 +115,7 @@ async function driveHandler(opts: {
   persistedWorkflowName?: string;
   includeRunInput?: boolean;
   streamRunCreatedBeforeResponse?: boolean;
+  onRunStartedRequest?: () => void;
   whileRunStartedPending?: (state: {
     getEncryptionKeyForRun: ReturnType<typeof vi.fn>;
   }) => Promise<void>;
@@ -128,6 +130,7 @@ async function driveHandler(opts: {
 
   const eventsCreate = vi.fn(async (_runId: string, data: any, params: any) => {
     if (data.eventType === 'run_started') {
+      opts.onRunStartedRequest?.();
       let streamedRunCreated: Event | undefined;
       if (opts.streamRunCreatedBeforeResponse) {
         streamedRunCreated = {
@@ -309,6 +312,13 @@ describe('workflowEntrypoint trace modes', () => {
       persistedWorkflowName: 'persistedWorkflow',
       includeRunInput: true,
       streamRunCreatedBeforeResponse: true,
+      onRunStartedRequest: () => {
+        expect(
+          exporter
+            .getFinishedSpans()
+            .find((span) => span.name === 'workflow.bundle.compile')
+        ).toBeUndefined();
+      },
       whileRunStartedPending: async ({ getEncryptionKeyForRun }) => {
         expect(getEncryptionKeyForRun).toHaveBeenCalledWith(
           'wrun_trace_persisted_workflow',
@@ -357,6 +367,30 @@ describe('workflowEntrypoint trace modes', () => {
       .getFinishedSpans()
       .find((span) => span.name === 'workflow.replay.load');
     expect(replayLoadSpan?.attributes['workflow.events.count']).toBe(1);
+  });
+
+  it.each([
+    '0',
+    '1',
+  ])('records invalid VM configuration as setup failure with turbo=%s', async (turbo) => {
+    vi.stubEnv('WORKFLOW_TURBO', turbo);
+    const { eventsCreate } = await driveHandler({
+      runId: `wrun_trace_invalid_vm_${turbo}`,
+      workflowCode: simpleWorkflow,
+      includeRunInput: true,
+      executionContext: { workflowVm: 'bogus' },
+    });
+
+    expect(eventsCreate).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        eventType: 'run_failed',
+        eventData: expect.objectContaining({
+          errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+        }),
+      }),
+      expect.anything()
+    );
   });
 
   it('does not compile a Node bundle for a known QuickJS run', async () => {

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -109,16 +109,34 @@ async function driveHandler(opts: {
   workflowCode: string;
   traceCarrier?: Record<string, string>;
   routeModuleBodyStartedAt?: number;
-  includeRunInput?: boolean;
   executionContext?: WorkflowRun['executionContext'];
-  whileRunStartedPending?: () => Promise<void>;
+  streamRunCreatedBeforeResponse?: boolean;
+  whileRunStartedPending?: (state: {
+    getEncryptionKeyForRun: ReturnType<typeof vi.fn>;
+  }) => Promise<void>;
 }) {
   const workflowRun = await makeRunningRun(opts.runId, opts.executionContext);
   const queuedMessages: any[] = [];
+  const getEncryptionKeyForRun = vi.fn(async () => undefined);
 
-  const eventsCreate = vi.fn(async (_runId: string, data: any) => {
+  const eventsCreate = vi.fn(async (_runId: string, data: any, params: any) => {
     if (data.eventType === 'run_started') {
-      await opts.whileRunStartedPending?.();
+      if (opts.streamRunCreatedBeforeResponse) {
+        params?.onEvent?.({
+          eventId: 'evnt_run_created',
+          runId: workflowRun.runId,
+          eventType: 'run_created',
+          specVersion: SPEC_VERSION_CURRENT,
+          createdAt: workflowRun.createdAt,
+          eventData: {
+            deploymentId: workflowRun.deploymentId,
+            workflowName: workflowRun.workflowName,
+            input: workflowRun.input,
+            executionContext: workflowRun.executionContext,
+          },
+        });
+      }
+      await opts.whileRunStartedPending?.({ getEncryptionKeyForRun });
       return { run: workflowRun, events: [] as Event[] };
     }
     return {
@@ -144,23 +162,10 @@ async function driveHandler(opts: {
               runId: workflowRun.runId,
               requestedAt: new Date('2024-01-01T00:00:00.000Z'),
               traceCarrier: opts.traceCarrier,
-              ...(opts.includeRunInput
-                ? {
-                    runInput: {
-                      input: workflowRun.input,
-                      deploymentId: workflowRun.deploymentId,
-                      workflowName: workflowRun.workflowName,
-                      specVersion: SPEC_VERSION_CURRENT,
-                      executionContext: workflowRun.executionContext,
-                    },
-                  }
-                : {}),
             },
             {
               requestId: 'req_test',
-              // Keep this trace harness on the awaited run_started path even
-              // when a test supplies runInput for pre-response VM selection.
-              attempt: opts.includeRunInput ? 2 : 1,
+              attempt: 1,
               queueName: '__wkf_workflow_workflow',
               messageId: 'msg_test',
             }
@@ -184,7 +189,7 @@ async function driveHandler(opts: {
       queuedMessages.push(message);
       return { messageId: null };
     }),
-    getEncryptionKeyForRun: vi.fn(async () => undefined),
+    getEncryptionKeyForRun,
   } as any);
 
   const handler = workflowEntrypoint(
@@ -230,6 +235,7 @@ async function driveHandler(opts: {
     getWorldSpan,
     deliverySpan,
     queuedMessages,
+    getEncryptionKeyForRun,
   };
 }
 
@@ -267,12 +273,28 @@ describe('getWorkflowTraceMode', () => {
 });
 
 describe('workflowEntrypoint trace modes', () => {
+  it('starts key resolution from a streamed run_created frame', async () => {
+    await driveHandler({
+      runId: 'wrun_trace_streamed_key',
+      workflowCode: simpleWorkflow,
+      streamRunCreatedBeforeResponse: true,
+      whileRunStartedPending: async ({ getEncryptionKeyForRun }) => {
+        await vi.waitFor(() => {
+          expect(getEncryptionKeyForRun).toHaveBeenCalledWith(
+            'wrun_trace_streamed_key',
+            { deploymentId: 'test-deployment' }
+          );
+        });
+      },
+    });
+  });
+
   it('compiles while run_started is loading, without evaluating early', async () => {
     let observedOverlap = false;
     await driveHandler({
       runId: 'wrun_trace_compile_overlap',
       workflowCode: simpleWorkflow,
-      includeRunInput: true,
+      streamRunCreatedBeforeResponse: true,
       whileRunStartedPending: async () => {
         expect(
           exporter
@@ -307,7 +329,7 @@ describe('workflowEntrypoint trace modes', () => {
     await driveHandler({
       runId: 'wrun_trace_quickjs_compile',
       workflowCode: simpleWorkflow,
-      includeRunInput: true,
+      streamRunCreatedBeforeResponse: true,
       executionContext: { workflowVm: 'quickjs' },
     });
 

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -393,6 +393,37 @@ describe('workflowEntrypoint trace modes', () => {
     );
   });
 
+  it('does not leak a streamed replay-load rejection after synchronous setup failure', async () => {
+    vi.stubEnv('WORKFLOW_TURBO', '0');
+    const unhandledRejection = vi.fn();
+    process.on('unhandledRejection', unhandledRejection);
+
+    try {
+      const { eventsCreate } = await driveHandler({
+        runId: 'wrun_trace_streamed_invalid_vm',
+        workflowCode: simpleWorkflow,
+        includeRunInput: true,
+        streamRunCreatedBeforeResponse: true,
+        executionContext: { workflowVm: 'bogus' },
+      });
+
+      expect(eventsCreate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          eventType: 'run_failed',
+          eventData: expect.objectContaining({
+            errorCode: RUN_ERROR_CODES.RUNTIME_ERROR,
+          }),
+        }),
+        expect.anything()
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandledRejection);
+    }
+  });
+
   it('does not compile a Node bundle for a known QuickJS run', async () => {
     const { getEncryptionKeyForRun } = await driveHandler({
       runId: 'wrun_trace_quickjs_compile',

--- a/packages/core/src/runtime-trace-mode.test.ts
+++ b/packages/core/src/runtime-trace-mode.test.ts
@@ -83,11 +83,12 @@ const simpleWorkflow = `async function workflow() {
 
 async function makeRunningRun(
   runId: string,
-  executionContext?: WorkflowRun['executionContext']
+  executionContext?: WorkflowRun['executionContext'],
+  workflowName = 'workflow'
 ): Promise<WorkflowRun> {
   return {
     runId,
-    workflowName: 'workflow',
+    workflowName,
     status: 'running',
     input: await dehydrateWorkflowArguments([], runId, undefined, []),
     createdAt: new Date('2024-01-01T00:00:00.000Z'),
@@ -110,20 +111,27 @@ async function driveHandler(opts: {
   traceCarrier?: Record<string, string>;
   routeModuleBodyStartedAt?: number;
   executionContext?: WorkflowRun['executionContext'];
+  persistedWorkflowName?: string;
   streamRunCreatedBeforeResponse?: boolean;
+  duplicateStreamedRunCreated?: boolean;
   whileRunStartedPending?: (state: {
     getEncryptionKeyForRun: ReturnType<typeof vi.fn>;
   }) => Promise<void>;
 }) {
-  const workflowRun = await makeRunningRun(opts.runId, opts.executionContext);
+  const workflowRun = await makeRunningRun(
+    opts.runId,
+    opts.executionContext,
+    opts.persistedWorkflowName
+  );
   const queuedMessages: any[] = [];
   const getEncryptionKeyForRun = vi.fn(async () => undefined);
 
   const eventsCreate = vi.fn(async (_runId: string, data: any, params: any) => {
     if (data.eventType === 'run_started') {
+      let streamedRunCreated: Event | undefined;
       if (opts.streamRunCreatedBeforeResponse) {
-        params?.onEvent?.({
-          eventId: 'evnt_run_created',
+        streamedRunCreated = {
+          eventId: 'evnt_00000000000000000000000001',
           runId: workflowRun.runId,
           eventType: 'run_created',
           specVersion: SPEC_VERSION_CURRENT,
@@ -134,10 +142,20 @@ async function driveHandler(opts: {
             input: workflowRun.input,
             executionContext: workflowRun.executionContext,
           },
-        });
+        };
+        params?.replayEventObserver?.(streamedRunCreated);
+        if (opts.duplicateStreamedRunCreated) {
+          params?.replayEventObserver?.(streamedRunCreated);
+        }
       }
       await opts.whileRunStartedPending?.({ getEncryptionKeyForRun });
-      return { run: workflowRun, events: [] as Event[] };
+      return {
+        run: workflowRun,
+        events:
+          streamedRunCreated && opts.duplicateStreamedRunCreated
+            ? [streamedRunCreated]
+            : ([] as Event[]),
+      };
     }
     return {
       event: {
@@ -235,6 +253,7 @@ async function driveHandler(opts: {
     getWorldSpan,
     deliverySpan,
     queuedMessages,
+    eventsCreate,
     getEncryptionKeyForRun,
   };
 }
@@ -273,16 +292,15 @@ describe('getWorkflowTraceMode', () => {
 });
 
 describe('workflowEntrypoint trace modes', () => {
-  it('starts key resolution from a streamed run_created frame', async () => {
+  it('starts current-deployment key resolution before run_started returns', async () => {
     await driveHandler({
       runId: 'wrun_trace_streamed_key',
       workflowCode: simpleWorkflow,
-      streamRunCreatedBeforeResponse: true,
       whileRunStartedPending: async ({ getEncryptionKeyForRun }) => {
         await vi.waitFor(() => {
           expect(getEncryptionKeyForRun).toHaveBeenCalledWith(
             'wrun_trace_streamed_key',
-            { deploymentId: 'test-deployment' }
+            undefined
           );
         });
       },
@@ -291,7 +309,7 @@ describe('workflowEntrypoint trace modes', () => {
 
   it('compiles while run_started is loading, without evaluating early', async () => {
     let observedOverlap = false;
-    await driveHandler({
+    const { workflowSpan } = await driveHandler({
       runId: 'wrun_trace_compile_overlap',
       workflowCode: simpleWorkflow,
       streamRunCreatedBeforeResponse: true,
@@ -323,6 +341,54 @@ describe('workflowEntrypoint trace modes', () => {
         .getFinishedSpans()
         .find((span) => span.name === 'workflow.bundle.evaluate')
     ).toBeDefined();
+    const compileSpan = exporter
+      .getFinishedSpans()
+      .find((span) => span.name === 'workflow.bundle.compile');
+    const replayLoadSpan = exporter
+      .getFinishedSpans()
+      .find((span) => span.name === 'workflow.replay.load');
+    expect(compileSpan?.parentSpanId).toBe(workflowSpan?.spanContext().spanId);
+    expect(compileSpan?.parentSpanId).not.toBe(
+      replayLoadSpan?.spanContext().spanId
+    );
+  });
+
+  it('speculatively compiles the workflow recorded on the run', async () => {
+    const persistedWorkflowCode = `async function persistedWorkflow() {
+      return 'done';
+    }${getWorkflowTransformCode('persistedWorkflow')}`;
+
+    const { eventsCreate } = await driveHandler({
+      runId: 'wrun_trace_persisted_workflow',
+      workflowCode: persistedWorkflowCode,
+      persistedWorkflowName: 'persistedWorkflow',
+      streamRunCreatedBeforeResponse: true,
+    });
+
+    expect(
+      eventsCreate.mock.calls.some(
+        ([, event]) => event.eventType === 'run_completed'
+      )
+    ).toBe(true);
+    expect(
+      eventsCreate.mock.calls.some(
+        ([, event]) => event.eventType === 'run_failed'
+      )
+    ).toBe(false);
+  });
+
+  it('counts materialized replay events once after observer redelivery', async () => {
+    await driveHandler({
+      runId: 'wrun_trace_replay_retry_count',
+      workflowCode: simpleWorkflow,
+      streamRunCreatedBeforeResponse: true,
+      duplicateStreamedRunCreated: true,
+    });
+
+    const replayLoadSpan = exporter
+      .getFinishedSpans()
+      .find((span) => span.name === 'workflow.replay.load');
+    expect(replayLoadSpan?.attributes['workflow.events.count']).toBe(1);
   });
 
   it('does not compile a Node bundle for a known QuickJS run', async () => {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -2230,6 +2230,8 @@ describe('workflowEntrypoint turbo mode', () => {
     attempt: number;
     source: string;
     runStartedGate?: Promise<void>;
+    currentDeploymentId?: string;
+    encryptionKeyError?: Error;
   }) {
     const { runId, attempt, source } = opts;
     const order = turboOrder;
@@ -2296,7 +2298,12 @@ describe('workflowEntrypoint turbo mode', () => {
 
     setWorld({
       specVersion: SPEC_VERSION_CURRENT,
-      getDeploymentId: vi.fn(async () => 'test-deployment'),
+      ...(opts.currentDeploymentId
+        ? { capabilities: { deploymentAffinity: true } }
+        : {}),
+      getDeploymentId: vi.fn(
+        async () => opts.currentDeploymentId ?? 'test-deployment'
+      ),
       createQueueHandler: vi.fn(
         (_p: string, handler: (m: unknown, md: unknown) => Promise<unknown>) =>
           async () => {
@@ -2326,7 +2333,10 @@ describe('workflowEntrypoint turbo mode', () => {
       },
       runs: { get: vi.fn(async () => runEntity) },
       queue: vi.fn(async () => ({ messageId: null })),
-      getEncryptionKeyForRun: vi.fn(async () => undefined),
+      getEncryptionKeyForRun: vi.fn(async () => {
+        if (opts.encryptionKeyError) throw opts.encryptionKeyError;
+        return undefined;
+      }),
     } as any);
 
     const handlerPromise = workflowEntrypoint(source)(
@@ -2373,6 +2383,26 @@ describe('workflowEntrypoint turbo mode', () => {
       (c) => (c[1] as any).eventType === 'run_started'
     );
     expect(runStartedCreates).toHaveLength(1);
+  });
+
+  it('handles a speculative key rejection when turbo exits before replay', async () => {
+    const unhandledRejection = vi.fn();
+    process.on('unhandledRejection', unhandledRejection);
+    try {
+      const { handlerPromise } = await driveTurbo({
+        runId: 'wrun_turbo_key_rejection',
+        attempt: 1,
+        source: oneStepWorkflow,
+        currentDeploymentId: 'other-deployment',
+        encryptionKeyError: new Error('key lookup failed'),
+      });
+
+      expect((await handlerPromise).status).toBe(204);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandledRejection);
+    }
   });
 
   it('does not turbo on a redelivery (attempt > 1): run_started is awaited first', async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -14,7 +14,7 @@ import {
   WorkflowRuntimeError,
   WorkflowWorldError,
 } from '@workflow/errors';
-import { once, setWorkflowBasePath, withResolvers } from '@workflow/utils';
+import { once, setWorkflowBasePath } from '@workflow/utils';
 import {
   parseWorkflowName,
   workflowDisplayName,
@@ -123,6 +123,7 @@ import { dehydrateRunError } from './serialization.js';
 import { remapErrorStack } from './source-map.js';
 import * as Attribute from './telemetry/semantic-conventions.js';
 import {
+  bindActiveTraceContext,
   buildInvocationSpanLinks,
   getNextTraceCarrier,
   getSpanKind,
@@ -632,21 +633,6 @@ type ReplayEventLog =
   | ({ type: 'ready' } & LoadedEventLog)
   | ({ type: 'loadAfter'; cursor: string } & LoadedEventLog);
 
-type ReplayEncryptionKeySource =
-  | { type: 'run'; run: WorkflowRun }
-  | { type: 'deployment'; deploymentId: string };
-
-function replayLifecycleContext(event: Event):
-  | {
-      deploymentId?: string;
-      executionContext?: WorkflowRun['executionContext'];
-    }
-  | undefined {
-  if (event.eventType === 'run_created' || event.eventType === 'run_started') {
-    return event.eventData;
-  }
-}
-
 function nextEventLogLoad(log: LoadedEventLog): ReplayEventLog {
   if (log.cursor === null) {
     return { type: 'loadAll' };
@@ -973,53 +959,49 @@ export function workflowEntrypoint(
                   let compiledWorkflowScripts:
                     | ReturnType<typeof compileWorkflowBundle>
                     | undefined;
-                  const startWorkflowCompile = (
-                    workflow?: Pick<WorkflowRun, 'executionContext'>
-                  ) => {
-                    if (!workflow || useQuickJSVm(workflow)) return;
-                    compiledWorkflowScripts ??= compileWorkflowBundle(
-                      workflowCode,
-                      workflowName
-                    );
-                    // Terminal runs can return without awaiting compilation.
-                    void compiledWorkflowScripts.catch(() => {});
-                    return compiledWorkflowScripts;
-                  };
-                  const encryptionKeySource =
-                    withResolvers<ReplayEncryptionKeySource>();
-                  const provideEncryptionKeySource = (
-                    source: ReplayEncryptionKeySource
-                  ): void => {
-                    encryptionKeySource.resolve(source);
-                  };
-                  const encryptionKeyPromise = encryptionKeySource.promise.then(
-                    (source) =>
-                      source.type === 'run'
-                        ? resolveRunEncryptionKey(world, source.run)
-                        : resolveRunEncryptionKey(world, runId, {
-                            deploymentId: source.deploymentId,
-                          })
+                  const startWorkflowCompile = await bindActiveTraceContext(
+                    (
+                      workflow?: Pick<
+                        WorkflowRun,
+                        'workflowName' | 'executionContext'
+                      >
+                    ) => {
+                      if (!workflow || useQuickJSVm(workflow)) return;
+                      compiledWorkflowScripts ??= compileWorkflowBundle(
+                        workflowCode,
+                        workflow.workflowName
+                      );
+                      // Terminal runs can return without awaiting compilation.
+                      void compiledWorkflowScripts.catch(() => {});
+                      return compiledWorkflowScripts;
+                    }
                   );
-                  // Streaming/turbo setup can resolve the source well before
-                  // the ordered replay consumer awaits the key. Keep speculative
-                  // failures handled without changing the later await's result.
+                  // This handler executes in the deployment that owns the run,
+                  // so the World's run-id overload resolves the current
+                  // deployment key without waiting for a materialized run.
+                  const encryptionKeyPromise = resolveRunEncryptionKey(
+                    world,
+                    runId
+                  );
+                  // Key resolution is speculative. Preserve its rejection for
+                  // the ordered replay consumer without an unhandled rejection.
                   void encryptionKeyPromise.catch(() => {});
                   const replayPayloadCache = new ReplayPayloadCache(
                     encryptionKeyPromise
                   );
-                  let replayObservedEventCount = 0;
-                  const onReplayEvent = (event: Event): void => {
-                    replayObservedEventCount++;
+                  const prepareReplayEvent = (event: Event): void => {
                     replayPayloadCache.prepareEvent(event);
-                    const runContext = replayLifecycleContext(event);
-                    if (!runContext) return;
-                    if (runContext.deploymentId) {
-                      provideEncryptionKeySource({
-                        type: 'deployment',
-                        deploymentId: runContext.deploymentId,
+                    if (event.eventType === 'run_created') {
+                      startWorkflowCompile(event.eventData);
+                    } else if (
+                      event.eventType === 'run_started' &&
+                      event.eventData?.workflowName
+                    ) {
+                      startWorkflowCompile({
+                        workflowName: event.eventData.workflowName,
+                        executionContext: event.eventData.executionContext,
                       });
                     }
-                    startWorkflowCompile(runContext);
                   };
                   // Every write this loop makes carries the cursor of the log
                   // it was computed against, and folds a complete returned
@@ -1044,28 +1026,29 @@ export function workflowEntrypoint(
 
                   const traceReplayLoad = <T extends { events?: Event[] }>(
                     source: Attribute.WorkflowReplayLoadSource,
-                    load: () => Promise<T>
+                    load: (
+                      replayEventObserver: (event: Event) => void
+                    ) => Promise<T>
                   ): Promise<T> =>
                     trace('workflow.replay.load', async (loadSpan) => {
-                      const observedAtStart = replayObservedEventCount;
-                      let eventsCount = 0;
+                      const observedEventIds = new Set<string>();
+                      let eventsCount: number | undefined;
                       loadSpan?.setAttributes({
                         ...Attribute.WorkflowRunId(runId),
                         ...Attribute.WorkflowReplayLoadSource(source),
                       });
                       try {
-                        const result = await load();
-                        eventsCount = result.events?.length ?? 0;
+                        const result = await load((event) => {
+                          observedEventIds.add(event.eventId);
+                          prepareReplayEvent(event);
+                        });
+                        eventsCount = result.events?.length;
                         return result;
                       } finally {
-                        // A failed frame stream has no materialized result, but
-                        // its observer count still tells us how far it got.
-                        eventsCount = Math.max(
-                          eventsCount,
-                          replayObservedEventCount - observedAtStart
-                        );
                         loadSpan?.setAttributes(
-                          Attribute.WorkflowEventsCount(eventsCount)
+                          Attribute.WorkflowEventsCount(
+                            eventsCount ?? observedEventIds.size
+                          )
                         );
                       }
                     });
@@ -1179,6 +1162,16 @@ export function workflowEntrypoint(
                   // `ready` can replay once without a read. The other states
                   // describe the next load exactly.
                   let eventLog: ReplayEventLog = { type: 'loadAll' };
+                  const replaceEventLog = <T extends ReplayEventLog>(
+                    replacement: T
+                  ): T => {
+                    // A replacement may insert events below the prefix already
+                    // scanned for payload preparation. The cached payloads are
+                    // event-id keyed and remain valid; only the scan position
+                    // must restart.
+                    replayPayloadCache.resetScan();
+                    return replacement;
+                  };
 
                   // Shared state: set by either the background step path
                   // or the run_started setup below.
@@ -1499,11 +1492,7 @@ export function workflowEntrypoint(
                       // position this replay had already read past. An
                       // incremental load starts above the hole and never
                       // returns it.
-                      eventLog = { type: 'loadAll' };
-                      // The corrected log inserts the missing events BELOW the
-                      // length already scanned for payload prewarming, shifting
-                      // every later position. Only a full rescan sees them.
-                      replayPayloadCache.resetScan();
+                      eventLog = replaceEventLog({ type: 'loadAll' });
                     }
                     runtimeLogger.warn(
                       'Event creation rejected as stale; restarting replay in-process',
@@ -1917,7 +1906,7 @@ export function workflowEntrypoint(
                         // Use cursor-based loading so the main loop can continue
                         // incrementally from here.
                         const loaded = await loadWorkflowRunEvents(runId);
-                        eventLog = nextEventLogLoad(loaded);
+                        eventLog = replaceEventLog(nextEventLogLoad(loaded));
 
                         // Check for pending steps: any step_created without
                         // a matching step_completed or step_failed.
@@ -2140,26 +2129,29 @@ export function workflowEntrypoint(
                       span?.addEvent('workflow.hook_received.create.start', {
                         'workflow.hook_received.preload_events': true,
                       });
-                      const replayLoad = traceReplayLoad('hook_preload', () =>
-                        createEvent(
-                          {
-                            eventType: 'hook_received',
-                            specVersion: SPEC_VERSION_CURRENT,
-                            correlationId: hookResumeInput.hookId,
-                            eventData: {
-                              token: hookResumeInput.token,
-                              payload: hookResumeInput.payload,
+                      const replayLoad = traceReplayLoad(
+                        'hook_preload',
+                        (replayEventObserver) =>
+                          createEvent(
+                            {
+                              eventType: 'hook_received',
+                              specVersion: SPEC_VERSION_CURRENT,
+                              correlationId: hookResumeInput.hookId,
+                              eventData: {
+                                token: hookResumeInput.token,
+                                payload: hookResumeInput.payload,
+                              },
                             },
-                          },
-                          {
-                            requestId,
-                            occurredAt,
-                            resumeId: hookResumeInput.resumeId,
-                            resumePayloadDigest: hookResumeInput.payloadDigest,
-                            preloadEvents: true,
-                            onEvent: onReplayEvent,
-                          }
-                        )
+                            {
+                              requestId,
+                              occurredAt,
+                              resumeId: hookResumeInput.resumeId,
+                              resumePayloadDigest:
+                                hookResumeInput.payloadDigest,
+                              preloadEvents: true,
+                              replayEventObserver,
+                            }
+                          )
                       );
                       const result = await replayLoad;
                       hookEnsured = true;
@@ -2259,11 +2251,11 @@ export function workflowEntrypoint(
                         if (resumeTracking) {
                           resumeTracking.setupSource = 'hook_preload';
                         }
-                        eventLog = {
+                        eventLog = replaceEventLog({
                           type: 'ready',
                           events: result.events,
                           cursor: result.cursor,
-                        };
+                        });
                         workflowStartedAt = +result.run.startedAt;
                         span?.setAttributes({
                           ...Attribute.WorkflowRunStatus(result.run.status),
@@ -2367,10 +2359,6 @@ export function workflowEntrypoint(
                         // wasted list+resolve it would otherwise compute.
                         { requestId, skipPreload: true }
                       );
-                      provideEncryptionKeySource({
-                        type: 'deployment',
-                        deploymentId: runInput.deploymentId,
-                      });
                       startWorkflowCompile(runInput);
                       runReadyBarrier = startedPromise;
                       // Turbo backgrounds run_started, so the non-turbo
@@ -2394,11 +2382,11 @@ export function workflowEntrypoint(
                       // the no-load preloaded branch; iteration 2 then takes the
                       // existing post-preloaded full reload to pick up a cursor
                       // without a spurious "cursor missing" warning.
-                      eventLog = {
+                      eventLog = replaceEventLog({
                         type: 'ready',
                         events: [],
                         cursor: null,
-                      };
+                      });
                       const now = new Date();
                       workflowRun = {
                         runId,
@@ -2440,11 +2428,13 @@ export function workflowEntrypoint(
                         span?.addEvent('workflow.run_started.create.start', {
                           'workflow.run_started.skip_preload': false,
                         });
-                        const replayLoad = traceReplayLoad('run_started', () =>
-                          createEvent(runStartedEvent, {
-                            requestId,
-                            onEvent: onReplayEvent,
-                          })
+                        const replayLoad = traceReplayLoad(
+                          'run_started',
+                          (replayEventObserver) =>
+                            createEvent(runStartedEvent, {
+                              requestId,
+                              replayEventObserver,
+                            })
                         );
                         const result = await replayLoad;
                         workflowRun = result.run;
@@ -2464,9 +2454,11 @@ export function workflowEntrypoint(
                             events: [...result.events],
                             cursor: result.cursor ?? null,
                           };
-                          eventLog = result.hasMore
-                            ? nextEventLogLoad(loaded)
-                            : { ...loaded, type: 'ready' };
+                          eventLog = replaceEventLog(
+                            result.hasMore
+                              ? nextEventLogLoad(loaded)
+                              : { ...loaded, type: 'ready' }
+                          );
                         }
                         workflowStartedAt = +result.run.startedAt;
                         span?.setAttributes({
@@ -2731,20 +2723,13 @@ export function workflowEntrypoint(
                       // do we fall back to reloading the complete log.
                       if (eventLog.type !== 'loadAll' && ensuredEvent) {
                         insertEventByEventId(eventLog.events, ensuredEvent);
-                        onReplayEvent(ensuredEvent);
+                        prepareReplayEvent(ensuredEvent);
                       } else {
-                        eventLog = { type: 'loadAll' };
+                        eventLog = replaceEventLog({ type: 'loadAll' });
                       }
                     } // end else (re-ensure needed)
                   }
 
-                  // A streamed run_created frame normally starts this lookup.
-                  // Worlds without event observation fall back to the complete
-                  // materialized run, preserving the previous behavior.
-                  provideEncryptionKeySource({
-                    type: 'run',
-                    run: workflowRun,
-                  });
                   const encryptionKey = await encryptionKeyPromise;
 
                   // The live VM parked at the previous boundary, when the
@@ -2912,7 +2897,10 @@ export function workflowEntrypoint(
                           appendEventLog(eventLog, page);
                           eventLog = { ...eventLog, type: 'ready' };
                         } else {
-                          eventLog = { ...page, type: 'ready' };
+                          eventLog = replaceEventLog({
+                            ...page,
+                            type: 'ready',
+                          });
                         }
                       }
                       assert(eventLog.type === 'ready');
@@ -3043,16 +3031,16 @@ export function workflowEntrypoint(
                           if (sawAllWaitCompletions) {
                             appendEventLog(eventLog, page);
                           } else {
-                            eventLog = {
+                            eventLog = replaceEventLog({
                               ...(await loadWorkflowRunEvents(runId)),
                               type: 'ready',
-                            };
+                            });
                           }
                         } else {
-                          eventLog = {
+                          eventLog = replaceEventLog({
                             ...(await loadWorkflowRunEvents(runId)),
                             type: 'ready',
-                          };
+                          });
                         }
                       }
 
@@ -3072,7 +3060,10 @@ export function workflowEntrypoint(
                           events: eventLog.events,
                           cursor: eventLog.cursor,
                         });
-                        eventLog = { ...settled.log, type: 'ready' };
+                        eventLog = replaceEventLog({
+                          ...settled.log,
+                          type: 'ready',
+                        });
                         if (settled.gap !== undefined) {
                           throw new CorruptedEventLogError(
                             `Event log for run ${runId} has a hole at slot ${settled.gap.firstMissingSlot}: ${settled.gap.missingCount} of the ${settled.gap.maxSlot} slots up to the log's maximum hold no event.`

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -980,45 +980,19 @@ export function workflowEntrypoint(
                       return compiledWorkflowScripts;
                     }
                   );
-                  let nodeReplayPreparation:
-                    | {
-                        encryptionKeyPromise: ReturnType<
-                          typeof resolveRunEncryptionKey
-                        >;
-                        replayPayloadCache: ReplayPayloadCache;
-                      }
-                    | undefined;
-                  let encryptionKeyPromise:
-                    | ReturnType<typeof resolveRunEncryptionKey>
-                    | undefined;
-                  const getEncryptionKeyPromise = () => {
-                    if (!encryptionKeyPromise) {
-                      encryptionKeyPromise = resolveRunEncryptionKey(
-                        world,
-                        runId
-                      );
-                      // Resolution is speculative for Node replay and lazy for
-                      // error serialization. Preserve rejection for the
-                      // ordered consumer without an unhandled one.
-                      void encryptionKeyPromise.catch(() => {});
-                    }
-                    return encryptionKeyPromise;
-                  };
-                  const startNodeReplayPreparation = (
+                  const encryptionKey = once(() => {
+                    const result = resolveRunEncryptionKey(world, runId);
+                    void result.catch(() => {});
+                    return result;
+                  });
+                  let replayPayloadCache: ReplayPayloadCache | undefined;
+                  const startReplayPayloadCache = (
                     workflow?: Pick<WorkflowRun, 'executionContext'>
                   ) => {
                     if (!workflow || useQuickJSVm(workflow)) return;
-                    if (!nodeReplayPreparation) {
-                      // This handler executes in the deployment that owns the
-                      // run, so the run-id overload resolves the current
-                      // deployment key without materializing the run again.
-                      const key = getEncryptionKeyPromise();
-                      nodeReplayPreparation = {
-                        encryptionKeyPromise: key,
-                        replayPayloadCache: new ReplayPayloadCache(key),
-                      };
-                    }
-                    return nodeReplayPreparation;
+                    return (replayPayloadCache ??= new ReplayPayloadCache(
+                      encryptionKey.value
+                    ));
                   };
                   // A first-delivery queue payload already carries both the
                   // workflow name and engine. Start Node-only work before the
@@ -1027,25 +1001,13 @@ export function workflowEntrypoint(
                   // one. Continuations learn both from their first lifecycle
                   // frame instead.
                   startWorkflowCompile(runInput);
-                  startNodeReplayPreparation(runInput);
+                  startReplayPayloadCache(runInput);
                   const prepareReplayEvent = (event: Event): void => {
                     if (event.eventType === 'run_created') {
-                      startNodeReplayPreparation(event.eventData);
+                      startReplayPayloadCache(event.eventData);
                       startWorkflowCompile(event.eventData);
-                    } else if (
-                      event.eventType === 'run_started' &&
-                      event.eventData?.workflowName
-                    ) {
-                      const workflow = {
-                        workflowName: event.eventData.workflowName,
-                        executionContext: event.eventData.executionContext,
-                      };
-                      startNodeReplayPreparation(workflow);
-                      startWorkflowCompile(workflow);
                     }
-                    nodeReplayPreparation?.replayPayloadCache.prepareEvent(
-                      event
-                    );
+                    replayPayloadCache?.prepareEvent(event);
                   };
                   // Every write this loop makes carries the cursor of the log
                   // it was computed against, and folds a complete returned
@@ -1075,24 +1037,21 @@ export function workflowEntrypoint(
                     ) => Promise<T>
                   ): Promise<T> =>
                     trace('workflow.replay.load', async (loadSpan) => {
-                      const observedEventIds = new Set<string>();
-                      let eventsCount: number | undefined;
+                      let eventsCount = 0;
                       loadSpan?.setAttributes({
                         ...Attribute.WorkflowRunId(runId),
                         ...Attribute.WorkflowReplayLoadSource(source),
                       });
                       try {
                         const result = await load((event) => {
-                          observedEventIds.add(event.eventId);
+                          eventsCount++;
                           prepareReplayEvent(event);
                         });
-                        eventsCount = result.events?.length;
+                        eventsCount = result.events?.length ?? eventsCount;
                         return result;
                       } finally {
                         loadSpan?.setAttributes(
-                          Attribute.WorkflowEventsCount(
-                            eventsCount ?? observedEventIds.size
-                          )
+                          Attribute.WorkflowEventsCount(eventsCount)
                         );
                       }
                     });
@@ -1206,16 +1165,6 @@ export function workflowEntrypoint(
                   // `ready` can replay once without a read. The other states
                   // describe the next load exactly.
                   let eventLog: ReplayEventLog = { type: 'loadAll' };
-                  const replaceEventLog = <T extends ReplayEventLog>(
-                    replacement: T
-                  ): T => {
-                    // A replacement may insert events below the prefix already
-                    // scanned for payload preparation. The cached payloads are
-                    // event-id keyed and remain valid; only the scan position
-                    // must restart.
-                    nodeReplayPreparation?.replayPayloadCache.resetScan();
-                    return replacement;
-                  };
 
                   // Shared state: set by either the background step path
                   // or the run_started setup below.
@@ -1536,7 +1485,7 @@ export function workflowEntrypoint(
                       // position this replay had already read past. An
                       // incremental load starts above the hole and never
                       // returns it.
-                      eventLog = replaceEventLog({ type: 'loadAll' });
+                      eventLog = { type: 'loadAll' };
                     }
                     runtimeLogger.warn(
                       'Event creation rejected as stale; restarting replay in-process',
@@ -1950,7 +1899,7 @@ export function workflowEntrypoint(
                         // Use cursor-based loading so the main loop can continue
                         // incrementally from here.
                         const loaded = await loadWorkflowRunEvents(runId);
-                        eventLog = replaceEventLog(nextEventLogLoad(loaded));
+                        eventLog = nextEventLogLoad(loaded);
 
                         // Check for pending steps: any step_created without
                         // a matching step_completed or step_failed.
@@ -2295,11 +2244,11 @@ export function workflowEntrypoint(
                         if (resumeTracking) {
                           resumeTracking.setupSource = 'hook_preload';
                         }
-                        eventLog = replaceEventLog({
+                        eventLog = {
                           type: 'ready',
                           events: result.events,
                           cursor: result.cursor,
-                        });
+                        };
                         workflowStartedAt = +result.run.startedAt;
                         span?.setAttributes({
                           ...Attribute.WorkflowRunStatus(result.run.status),
@@ -2425,11 +2374,11 @@ export function workflowEntrypoint(
                       // the no-load preloaded branch; iteration 2 then takes the
                       // existing post-preloaded full reload to pick up a cursor
                       // without a spurious "cursor missing" warning.
-                      eventLog = replaceEventLog({
+                      eventLog = {
                         type: 'ready',
                         events: [],
                         cursor: null,
-                      });
+                      };
                       const now = new Date();
                       workflowRun = {
                         runId,
@@ -2497,11 +2446,9 @@ export function workflowEntrypoint(
                             events: [...result.events],
                             cursor: result.cursor ?? null,
                           };
-                          eventLog = replaceEventLog(
-                            result.hasMore
-                              ? nextEventLogLoad(loaded)
-                              : { ...loaded, type: 'ready' }
-                          );
+                          eventLog = result.hasMore
+                            ? nextEventLogLoad(loaded)
+                            : { ...loaded, type: 'ready' };
                         }
                         workflowStartedAt = +result.run.startedAt;
                         span?.setAttributes({
@@ -2768,7 +2715,7 @@ export function workflowEntrypoint(
                         insertEventByEventId(eventLog.events, ensuredEvent);
                         prepareReplayEvent(ensuredEvent);
                       } else {
-                        eventLog = replaceEventLog({ type: 'loadAll' });
+                        eventLog = { type: 'loadAll' };
                       }
                     } // end else (re-ensure needed)
                   }
@@ -2938,10 +2885,10 @@ export function workflowEntrypoint(
                           appendEventLog(eventLog, page);
                           eventLog = { ...eventLog, type: 'ready' };
                         } else {
-                          eventLog = replaceEventLog({
+                          eventLog = {
                             ...page,
                             type: 'ready',
-                          });
+                          };
                         }
                       }
                       assert(eventLog.type === 'ready');
@@ -3072,16 +3019,16 @@ export function workflowEntrypoint(
                           if (sawAllWaitCompletions) {
                             appendEventLog(eventLog, page);
                           } else {
-                            eventLog = replaceEventLog({
+                            eventLog = {
                               ...(await loadWorkflowRunEvents(runId)),
                               type: 'ready',
-                            });
+                            };
                           }
                         } else {
-                          eventLog = replaceEventLog({
+                          eventLog = {
                             ...(await loadWorkflowRunEvents(runId)),
                             type: 'ready',
-                          });
+                          };
                         }
                       }
 
@@ -3101,10 +3048,10 @@ export function workflowEntrypoint(
                           events: eventLog.events,
                           cursor: eventLog.cursor,
                         });
-                        eventLog = replaceEventLog({
+                        eventLog = {
                           ...settled.log,
                           type: 'ready',
-                        });
+                        };
                         if (settled.gap !== undefined) {
                           throw new CorruptedEventLogError(
                             `Event log for run ${runId} has a hole at slot ${settled.gap.firstMissingSlot}: ${settled.gap.missingCount} of the ${settled.gap.maxSlot} slots up to the log's maximum hold no event.`
@@ -3187,13 +3134,12 @@ export function workflowEntrypoint(
                       // Crypto work overlaps VM setup on the replay path and
                       // the appended events' consumption on the resume path;
                       // consumers still deserialize and resolve in event order.
-                      const replayPreparation =
-                        startNodeReplayPreparation(workflowRun);
+                      const replayPayloadCache =
+                        startReplayPayloadCache(workflowRun);
                       assert(
-                        replayPreparation,
+                        replayPayloadCache,
                         'Node workflow replay requires payload preparation'
                       );
-                      const { replayPayloadCache } = replayPreparation;
                       const payloadPrewarm = replayPayloadCache.prewarm(
                         workflowRun,
                         eventLog.events
@@ -3222,8 +3168,7 @@ export function workflowEntrypoint(
                           workflowCode,
                           workflowRun,
                           events: eventLog.events,
-                          encryptionKey:
-                            await replayPreparation.encryptionKeyPromise,
+                          encryptionKey: await encryptionKey.value,
                           replayPayloadCache,
                           compiledWorkflowScripts: await compiled,
                           // Turbo: the end-of-run drain inside workflow
@@ -3466,7 +3411,7 @@ export function workflowEntrypoint(
                                   error: await dehydrateRunError(
                                     suspensionError,
                                     runId,
-                                    await getEncryptionKeyPromise(),
+                                    await encryptionKey.value,
                                     globalThis,
                                     (workflowRun?.specVersion ?? 0) >=
                                       SPEC_VERSION_SUPPORTS_COMPRESSION
@@ -3505,16 +3450,6 @@ export function workflowEntrypoint(
                           });
                           return;
                         }
-                        if (suspensionResult.reportedEventCount > 0) {
-                          // Bump-and-report merged events BELOW the tail and
-                          // re-sorted the array to slot order, shifting every
-                          // position the prewarm scan had already recorded.
-                          // The cursor is deliberately left alone: the report
-                          // is a lower bound on what was skipped, so the next
-                          // incremental read still has to cover the same range.
-                          nodeReplayPreparation?.replayPayloadCache.resetScan();
-                        }
-
                         // Open hooks/waits in the log as loaded for this
                         // replay. Computed lazily, at most once, and shared
                         // between the retention decision here and the
@@ -4851,7 +4786,7 @@ export function workflowEntrypoint(
                                 error: await dehydrateRunError(
                                   terminalError,
                                   runId,
-                                  await getEncryptionKeyPromise(),
+                                  await encryptionKey.value,
                                   globalThis,
                                   (workflowRun?.specVersion ?? 0) >=
                                     SPEC_VERSION_SUPPORTS_COMPRESSION

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1260,12 +1260,10 @@ export function workflowEntrypoint(
                   };
 
                   const recordWorkflowSetupFailure = async (
-                    err: unknown,
-                    orderAfterRunStarted = false
+                    err: unknown
                   ): Promise<boolean> => {
                     const errorCode = getWorkflowSetupErrorCode(err);
                     if (!errorCode) return false;
-                    if (orderAfterRunStarted) await awaitRunReady();
                     await recordFatalRunError({
                       world,
                       workflowRun,
@@ -2375,7 +2373,8 @@ export function workflowEntrypoint(
                         startWorkflowCompile(runInput);
                         startReplayPayloadCache(runInput);
                       } catch (err) {
-                        if (!(await recordWorkflowSetupFailure(err, true))) {
+                        await awaitRunReady();
+                        if (!(await recordWorkflowSetupFailure(err))) {
                           throw err;
                         }
                         return;
@@ -2744,7 +2743,6 @@ export function workflowEntrypoint(
                   let retainedSession: WorkflowSession | null = null;
 
                   // Main replay loop
-                  // biome-ignore lint/correctness/noConstantCondition: intentional loop
                   while (true) {
                     loopIteration++;
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1498,6 +1498,7 @@ export function workflowEntrypoint(
                       // incremental load starts above the hole and never
                       // returns it.
                       eventLog = { type: 'loadAll' };
+                      replayPayloadCache?.resetScan();
                     }
                     runtimeLogger.warn(
                       'Event creation rejected as stale; restarting replay in-process',

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -2302,10 +2302,7 @@ export function workflowEntrypoint(
                         );
                         return;
                       }
-                      if (WorkflowRuntimeError.is(err)) {
-                        await recordWorkflowSetupFailure(err);
-                        return;
-                      }
+                      if (await recordWorkflowSetupFailure(err)) return;
                       throw err;
                     }
                   }
@@ -2454,8 +2451,18 @@ export function workflowEntrypoint(
                               replayEventObserver,
                             })
                         );
-                        startWorkflowCompile(runInput);
-                        startReplayPayloadCache(runInput);
+                        try {
+                          startWorkflowCompile(runInput);
+                          startReplayPayloadCache(runInput);
+                        } catch (setupError) {
+                          try {
+                            await replayLoad;
+                          } catch {
+                            // Preserve the synchronous setup error after
+                            // observing the in-flight replay load.
+                          }
+                          throw setupError;
+                        }
                         const result = await replayLoad;
                         workflowRun = result.run;
                         maxEventsLimit = clampMaxEvents(result.maxEvents);

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -14,7 +14,7 @@ import {
   WorkflowRuntimeError,
   WorkflowWorldError,
 } from '@workflow/errors';
-import { once, setWorkflowBasePath } from '@workflow/utils';
+import { once, setWorkflowBasePath, withResolvers } from '@workflow/utils';
 import {
   parseWorkflowName,
   workflowDisplayName,
@@ -82,6 +82,7 @@ import {
   parseHealthCheckPayload,
   preconditionEventDelta,
   queueMessage,
+  resolveRunEncryptionKey,
   type SlotSnapshotParams,
   settleEventSlotGap,
   slotSnapshotParams,
@@ -631,6 +632,21 @@ type ReplayEventLog =
   | ({ type: 'ready' } & LoadedEventLog)
   | ({ type: 'loadAfter'; cursor: string } & LoadedEventLog);
 
+type ReplayEncryptionKeySource =
+  | { type: 'run'; run: WorkflowRun }
+  | { type: 'deployment'; deploymentId: string };
+
+function replayLifecycleContext(event: Event):
+  | {
+      deploymentId?: string;
+      executionContext?: WorkflowRun['executionContext'];
+    }
+  | undefined {
+  if (event.eventType === 'run_created' || event.eventType === 'run_started') {
+    return event.eventData;
+  }
+}
+
 function nextEventLogLoad(log: LoadedEventLog): ReplayEventLog {
   if (log.cursor === null) {
     return { type: 'loadAll' };
@@ -969,6 +985,42 @@ export function workflowEntrypoint(
                     void compiledWorkflowScripts.catch(() => {});
                     return compiledWorkflowScripts;
                   };
+                  const encryptionKeySource =
+                    withResolvers<ReplayEncryptionKeySource>();
+                  const provideEncryptionKeySource = (
+                    source: ReplayEncryptionKeySource
+                  ): void => {
+                    encryptionKeySource.resolve(source);
+                  };
+                  const encryptionKeyPromise = encryptionKeySource.promise.then(
+                    (source) =>
+                      source.type === 'run'
+                        ? resolveRunEncryptionKey(world, source.run)
+                        : resolveRunEncryptionKey(world, runId, {
+                            deploymentId: source.deploymentId,
+                          })
+                  );
+                  // Streaming/turbo setup can resolve the source well before
+                  // the ordered replay consumer awaits the key. Keep speculative
+                  // failures handled without changing the later await's result.
+                  void encryptionKeyPromise.catch(() => {});
+                  const replayPayloadCache = new ReplayPayloadCache(
+                    encryptionKeyPromise
+                  );
+                  let replayObservedEventCount = 0;
+                  const onReplayEvent = (event: Event): void => {
+                    replayObservedEventCount++;
+                    replayPayloadCache.prepareEvent(event);
+                    const runContext = replayLifecycleContext(event);
+                    if (!runContext) return;
+                    if (runContext.deploymentId) {
+                      provideEncryptionKeySource({
+                        type: 'deployment',
+                        deploymentId: runContext.deploymentId,
+                      });
+                    }
+                    startWorkflowCompile(runContext);
+                  };
                   // Every write this loop makes carries the cursor of the log
                   // it was computed against, and folds a complete returned
                   // delta into that log.
@@ -995,17 +1047,27 @@ export function workflowEntrypoint(
                     load: () => Promise<T>
                   ): Promise<T> =>
                     trace('workflow.replay.load', async (loadSpan) => {
+                      const observedAtStart = replayObservedEventCount;
+                      let eventsCount = 0;
                       loadSpan?.setAttributes({
                         ...Attribute.WorkflowRunId(runId),
                         ...Attribute.WorkflowReplayLoadSource(source),
                       });
-                      const result = await load();
-                      loadSpan?.setAttributes(
-                        Attribute.WorkflowEventsCount(
-                          result.events?.length ?? 0
-                        )
-                      );
-                      return result;
+                      try {
+                        const result = await load();
+                        eventsCount = result.events?.length ?? 0;
+                        return result;
+                      } finally {
+                        // A failed frame stream has no materialized result, but
+                        // its observer count still tells us how far it got.
+                        eventsCount = Math.max(
+                          eventsCount,
+                          replayObservedEventCount - observedAtStart
+                        );
+                        loadSpan?.setAttributes(
+                          Attribute.WorkflowEventsCount(eventsCount)
+                        );
+                      }
                     });
 
                   /**
@@ -2095,6 +2157,7 @@ export function workflowEntrypoint(
                             resumeId: hookResumeInput.resumeId,
                             resumePayloadDigest: hookResumeInput.payloadDigest,
                             preloadEvents: true,
+                            onEvent: onReplayEvent,
                           }
                         )
                       );
@@ -2304,6 +2367,10 @@ export function workflowEntrypoint(
                         // wasted list+resolve it would otherwise compute.
                         { requestId, skipPreload: true }
                       );
+                      provideEncryptionKeySource({
+                        type: 'deployment',
+                        deploymentId: runInput.deploymentId,
+                      });
                       startWorkflowCompile(runInput);
                       runReadyBarrier = startedPromise;
                       // Turbo backgrounds run_started, so the non-turbo
@@ -2374,12 +2441,11 @@ export function workflowEntrypoint(
                           'workflow.run_started.skip_preload': false,
                         });
                         const replayLoad = traceReplayLoad('run_started', () =>
-                          createEvent(runStartedEvent, { requestId })
+                          createEvent(runStartedEvent, {
+                            requestId,
+                            onEvent: onReplayEvent,
+                          })
                         );
-                        // Initial deliveries carry runInput, so Node compilation
-                        // can overlap this load without guessing the VM engine.
-                        // Continuations learn the engine from result.run below.
-                        startWorkflowCompile(runInput);
                         const result = await replayLoad;
                         workflowRun = result.run;
                         maxEventsLimit = clampMaxEvents(result.maxEvents);
@@ -2665,31 +2731,21 @@ export function workflowEntrypoint(
                       // do we fall back to reloading the complete log.
                       if (eventLog.type !== 'loadAll' && ensuredEvent) {
                         insertEventByEventId(eventLog.events, ensuredEvent);
+                        onReplayEvent(ensuredEvent);
                       } else {
                         eventLog = { type: 'loadAll' };
                       }
                     } // end else (re-ensure needed)
                   }
 
-                  // Resolve the encryption key for this run's deployment.
-                  // Used eagerly here since both workflow execution (input
-                  // hydration / hook payload decryption) and the run_failed
-                  // dehydrate path below need it. Memoized accessor: first
-                  // call triggers the actual fetch / HKDF derivation,
-                  // subsequent calls await the cached promise.
-                  const getEncryptionKey = memoizeEncryptionKey(
-                    world,
-                    workflowRun
-                  );
-                  const encryptionKey = await getEncryptionKey();
-
-                  // Invocation-scoped cache of VM-independent prepared payloads
-                  // and immutable final values. It survives the fresh workflow
-                  // VM created by each inline replay, but never crosses runs or
-                  // queue deliveries.
-                  const replayPayloadCache = new ReplayPayloadCache(
-                    encryptionKey
-                  );
+                  // A streamed run_created frame normally starts this lookup.
+                  // Worlds without event observation fall back to the complete
+                  // materialized run, preserving the previous behavior.
+                  provideEncryptionKeySource({
+                    type: 'run',
+                    run: workflowRun,
+                  });
+                  const encryptionKey = await encryptionKeyPromise;
 
                   // The live VM parked at the previous boundary, when the
                   // retention decision kept it. null → this iteration cold-

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -990,18 +990,13 @@ export function workflowEntrypoint(
                     workflow?: Pick<WorkflowRun, 'executionContext'>
                   ) => {
                     if (!workflow || useQuickJSVm(workflow)) return;
-                    return (replayPayloadCache ??= new ReplayPayloadCache(
-                      encryptionKey.value
-                    ));
+                    if (!replayPayloadCache) {
+                      replayPayloadCache = new ReplayPayloadCache(
+                        encryptionKey.value
+                      );
+                    }
+                    return replayPayloadCache;
                   };
-                  // A first-delivery queue payload already carries both the
-                  // workflow name and engine. Start Node-only work before the
-                  // setup request; streamed lifecycle events below replace a
-                  // wrong speculative workflow-name compile with the persisted
-                  // one. Continuations learn both from their first lifecycle
-                  // frame instead.
-                  startWorkflowCompile(runInput);
-                  startReplayPayloadCache(runInput);
                   const prepareReplayEvent = (event: Event): void => {
                     if (event.eventType === 'run_created') {
                       startReplayPayloadCache(event.eventData);
@@ -1262,6 +1257,25 @@ export function workflowEntrypoint(
                         // intentional: ordering barrier only, see above.
                       }
                     }
+                  };
+
+                  const recordWorkflowSetupFailure = async (
+                    err: unknown,
+                    orderAfterRunStarted = false
+                  ): Promise<boolean> => {
+                    const errorCode = getWorkflowSetupErrorCode(err);
+                    if (!errorCode) return false;
+                    if (orderAfterRunStarted) await awaitRunReady();
+                    await recordFatalRunError({
+                      world,
+                      workflowRun,
+                      runId,
+                      requestId,
+                      err,
+                      errorCode,
+                      logMessage: 'Fatal runtime error during workflow setup',
+                    });
+                    return true;
                   };
 
                   // Re-invoke the orchestrator. Outside turbo this returns
@@ -2290,6 +2304,10 @@ export function workflowEntrypoint(
                         );
                         return;
                       }
+                      if (WorkflowRuntimeError.is(err)) {
+                        await recordWorkflowSetupFailure(err);
+                        return;
+                      }
                       throw err;
                     }
                   }
@@ -2353,6 +2371,15 @@ export function workflowEntrypoint(
                         { requestId, skipPreload: true }
                       );
                       runReadyBarrier = startedPromise;
+                      try {
+                        startWorkflowCompile(runInput);
+                        startReplayPayloadCache(runInput);
+                      } catch (err) {
+                        if (!(await recordWorkflowSetupFailure(err, true))) {
+                          throw err;
+                        }
+                        return;
+                      }
                       // Turbo backgrounds run_started, so the non-turbo
                       // assignment below never runs. Thread the per-run event
                       // ceiling off the backgrounded response here instead.
@@ -2428,6 +2455,8 @@ export function workflowEntrypoint(
                               replayEventObserver,
                             })
                         );
+                        startWorkflowCompile(runInput);
+                        startReplayPayloadCache(runInput);
                         const result = await replayLoad;
                         workflowRun = result.run;
                         maxEventsLimit = clampMaxEvents(result.maxEvents);
@@ -2490,20 +2519,9 @@ export function workflowEntrypoint(
                           );
                           return;
                         } else {
-                          const errorCode = getWorkflowSetupErrorCode(err);
-                          if (!errorCode) {
+                          if (!(await recordWorkflowSetupFailure(err))) {
                             throw err;
                           }
-                          await recordFatalRunError({
-                            world,
-                            workflowRun,
-                            runId,
-                            requestId,
-                            err,
-                            errorCode,
-                            logMessage:
-                              'Fatal runtime error during workflow setup',
-                          });
                           return;
                         }
                       }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -959,6 +959,7 @@ export function workflowEntrypoint(
                   let compiledWorkflowScripts:
                     | ReturnType<typeof compileWorkflowBundle>
                     | undefined;
+                  let compiledWorkflowName: string | undefined;
                   const startWorkflowCompile = await bindActiveTraceContext(
                     (
                       workflow?: Pick<
@@ -967,41 +968,84 @@ export function workflowEntrypoint(
                       >
                     ) => {
                       if (!workflow || useQuickJSVm(workflow)) return;
-                      compiledWorkflowScripts ??= compileWorkflowBundle(
-                        workflowCode,
-                        workflow.workflowName
-                      );
-                      // Terminal runs can return without awaiting compilation.
-                      void compiledWorkflowScripts.catch(() => {});
+                      if (compiledWorkflowName !== workflow.workflowName) {
+                        compiledWorkflowName = workflow.workflowName;
+                        compiledWorkflowScripts = compileWorkflowBundle(
+                          workflowCode,
+                          workflow.workflowName
+                        );
+                        // Terminal runs can return without awaiting compilation.
+                        void compiledWorkflowScripts.catch(() => {});
+                      }
                       return compiledWorkflowScripts;
                     }
                   );
-                  // This handler executes in the deployment that owns the run,
-                  // so the World's run-id overload resolves the current
-                  // deployment key without waiting for a materialized run.
-                  const encryptionKeyPromise = resolveRunEncryptionKey(
-                    world,
-                    runId
-                  );
-                  // Key resolution is speculative. Preserve its rejection for
-                  // the ordered replay consumer without an unhandled rejection.
-                  void encryptionKeyPromise.catch(() => {});
-                  const replayPayloadCache = new ReplayPayloadCache(
-                    encryptionKeyPromise
-                  );
+                  let nodeReplayPreparation:
+                    | {
+                        encryptionKeyPromise: ReturnType<
+                          typeof resolveRunEncryptionKey
+                        >;
+                        replayPayloadCache: ReplayPayloadCache;
+                      }
+                    | undefined;
+                  let encryptionKeyPromise:
+                    | ReturnType<typeof resolveRunEncryptionKey>
+                    | undefined;
+                  const getEncryptionKeyPromise = () => {
+                    if (!encryptionKeyPromise) {
+                      encryptionKeyPromise = resolveRunEncryptionKey(
+                        world,
+                        runId
+                      );
+                      // Resolution is speculative for Node replay and lazy for
+                      // error serialization. Preserve rejection for the
+                      // ordered consumer without an unhandled one.
+                      void encryptionKeyPromise.catch(() => {});
+                    }
+                    return encryptionKeyPromise;
+                  };
+                  const startNodeReplayPreparation = (
+                    workflow?: Pick<WorkflowRun, 'executionContext'>
+                  ) => {
+                    if (!workflow || useQuickJSVm(workflow)) return;
+                    if (!nodeReplayPreparation) {
+                      // This handler executes in the deployment that owns the
+                      // run, so the run-id overload resolves the current
+                      // deployment key without materializing the run again.
+                      const key = getEncryptionKeyPromise();
+                      nodeReplayPreparation = {
+                        encryptionKeyPromise: key,
+                        replayPayloadCache: new ReplayPayloadCache(key),
+                      };
+                    }
+                    return nodeReplayPreparation;
+                  };
+                  // A first-delivery queue payload already carries both the
+                  // workflow name and engine. Start Node-only work before the
+                  // setup request; streamed lifecycle events below replace a
+                  // wrong speculative workflow-name compile with the persisted
+                  // one. Continuations learn both from their first lifecycle
+                  // frame instead.
+                  startWorkflowCompile(runInput);
+                  startNodeReplayPreparation(runInput);
                   const prepareReplayEvent = (event: Event): void => {
-                    replayPayloadCache.prepareEvent(event);
                     if (event.eventType === 'run_created') {
+                      startNodeReplayPreparation(event.eventData);
                       startWorkflowCompile(event.eventData);
                     } else if (
                       event.eventType === 'run_started' &&
                       event.eventData?.workflowName
                     ) {
-                      startWorkflowCompile({
+                      const workflow = {
                         workflowName: event.eventData.workflowName,
                         executionContext: event.eventData.executionContext,
-                      });
+                      };
+                      startNodeReplayPreparation(workflow);
+                      startWorkflowCompile(workflow);
                     }
+                    nodeReplayPreparation?.replayPayloadCache.prepareEvent(
+                      event
+                    );
                   };
                   // Every write this loop makes carries the cursor of the log
                   // it was computed against, and folds a complete returned
@@ -1169,7 +1213,7 @@ export function workflowEntrypoint(
                     // scanned for payload preparation. The cached payloads are
                     // event-id keyed and remain valid; only the scan position
                     // must restart.
-                    replayPayloadCache.resetScan();
+                    nodeReplayPreparation?.replayPayloadCache.resetScan();
                     return replacement;
                   };
 
@@ -2359,7 +2403,6 @@ export function workflowEntrypoint(
                         // wasted list+resolve it would otherwise compute.
                         { requestId, skipPreload: true }
                       );
-                      startWorkflowCompile(runInput);
                       runReadyBarrier = startedPromise;
                       // Turbo backgrounds run_started, so the non-turbo
                       // assignment below never runs. Thread the per-run event
@@ -2729,8 +2772,6 @@ export function workflowEntrypoint(
                       }
                     } // end else (re-ensure needed)
                   }
-
-                  const encryptionKey = await encryptionKeyPromise;
 
                   // The live VM parked at the previous boundary, when the
                   // retention decision kept it. null → this iteration cold-
@@ -3146,6 +3187,13 @@ export function workflowEntrypoint(
                       // Crypto work overlaps VM setup on the replay path and
                       // the appended events' consumption on the resume path;
                       // consumers still deserialize and resolve in event order.
+                      const replayPreparation =
+                        startNodeReplayPreparation(workflowRun);
+                      assert(
+                        replayPreparation,
+                        'Node workflow replay requires payload preparation'
+                      );
+                      const { replayPayloadCache } = replayPreparation;
                       const payloadPrewarm = replayPayloadCache.prewarm(
                         workflowRun,
                         eventLog.events
@@ -3174,7 +3222,8 @@ export function workflowEntrypoint(
                           workflowCode,
                           workflowRun,
                           events: eventLog.events,
-                          encryptionKey,
+                          encryptionKey:
+                            await replayPreparation.encryptionKeyPromise,
                           replayPayloadCache,
                           compiledWorkflowScripts: await compiled,
                           // Turbo: the end-of-run drain inside workflow
@@ -3417,7 +3466,7 @@ export function workflowEntrypoint(
                                   error: await dehydrateRunError(
                                     suspensionError,
                                     runId,
-                                    encryptionKey,
+                                    await getEncryptionKeyPromise(),
                                     globalThis,
                                     (workflowRun?.specVersion ?? 0) >=
                                       SPEC_VERSION_SUPPORTS_COMPRESSION
@@ -3463,7 +3512,7 @@ export function workflowEntrypoint(
                           // The cursor is deliberately left alone: the report
                           // is a lower bound on what was skipped, so the next
                           // incremental read still has to cover the same range.
-                          replayPayloadCache.resetScan();
+                          nodeReplayPreparation?.replayPayloadCache.resetScan();
                         }
 
                         // Open hooks/waits in the log as loaded for this
@@ -4802,7 +4851,7 @@ export function workflowEntrypoint(
                                 error: await dehydrateRunError(
                                   terminalError,
                                   runId,
-                                  encryptionKey,
+                                  await getEncryptionKeyPromise(),
                                   globalThis,
                                   (workflowRun?.specVersion ?? 0) >=
                                     SPEC_VERSION_SUPPORTS_COMPRESSION

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -1,7 +1,7 @@
 import { PreconditionFailedError, WorkflowWorldError } from '@workflow/errors';
 import type { Event, World } from '@workflow/world';
 import { slotToEventId } from '@workflow/world';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { bytesToBase64, deriveRunKeyPair, seal } from '../sealed-box.js';
 import {
   decrypt,

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -612,7 +612,6 @@ export async function loadWorkflowRunEvents(
     let hasMore = true;
     let pagesLoaded = 0;
     let retriedWithoutCursor = false;
-
     const world = await getWorldLazy();
     const loadStart = Date.now();
     while (hasMore) {
@@ -1215,34 +1214,26 @@ export function getQueueOverhead(message: { requestedAt?: Date }) {
 }
 
 /**
- * Returns a memoized accessor for a run's full encryption capability.
- *
- * The first call resolves the run's key material via
- * `world.getEncryptionKeyForRun` (which may do HKDF derivation locally on
- * Vercel, or a network fetch from external contexts) and derives a
- * {@link PayloadKey} from it; subsequent calls await the same cached promise.
- * If the world doesn't support encryption or the run has no key configured,
- * the cached value is `undefined`.
- *
- * The resolved value is deliberately the *full* capability (the symmetric AES
- * key plus the run's X25519 keypair), not just a `CryptoKey`. A run reading
- * its own event log can encounter sealed (`encp`) payloads that another run
- * wrote to it (a cross-deployment hook resumption, say), and opening those
- * needs the keypair. Resolving only the symmetric key would leave those
- * payloads unopenable and wedge the run.
- *
- * Used by step / workflow handlers to defer the (potentially expensive)
- * key fetch until the first code path that actually needs it: typically
- * input hydration on the success path, or error dehydration on a failure
- * path. Both paths can race-call the accessor without triggering duplicate
- * fetches.
- *
- * Errors thrown by `getEncryptionKeyForRun` propagate to every caller
- * (the cached promise rejects). This is intentional: when encryption is
- * configured, we never want to silently fall back to plaintext
- * serialization. A propagated error in an event-emission path leaves the
- * outer try/catch to log and surface the issue; the queue's redelivery
- * semantics will retry the key fetch on the next attempt.
+ * Resolve the run's full payload-encryption capability. This includes the
+ * symmetric key and X25519 keypair needed to open cross-run sealed payloads.
+ * Missing world support or key material resolves to `undefined`; lookup and
+ * derivation failures propagate rather than silently falling back to plaintext.
+ */
+export async function resolveRunEncryptionKey(
+  world: World,
+  runOrId: WorkflowRun | string,
+  context?: Record<string, unknown>
+): Promise<PayloadKey | undefined> {
+  const rawKey =
+    typeof runOrId === 'string'
+      ? await world.getEncryptionKeyForRun?.(runOrId, context)
+      : await world.getEncryptionKeyForRun?.(runOrId);
+  return rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
+}
+
+/**
+ * Return a lazy, memoized accessor around {@link resolveRunEncryptionKey}.
+ * Concurrent callers share the same promise, including its rejection.
  */
 export function memoizeEncryptionKey(
   world: World,
@@ -1251,20 +1242,7 @@ export function memoizeEncryptionKey(
   let cached: Promise<PayloadKey | undefined> | undefined;
   return () => {
     if (!cached) {
-      cached = (async () => {
-        // The `getEncryptionKeyForRun` overload set takes either a
-        // `WorkflowRun` or a `runId: string` (with optional context). Branch
-        // here so TypeScript picks the right overload for each shape.
-        const rawKey =
-          typeof runOrId === 'string'
-            ? await world.getEncryptionKeyForRun?.(runOrId)
-            : await world.getEncryptionKeyForRun?.(runOrId);
-        // Resolve the *full* capability, not just the symmetric key: a run
-        // reading its own event log may encounter sealed (`encp`) payloads
-        // that another run wrote to it, and opening those needs the run's
-        // X25519 scalar as well.
-        return rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
-      })();
+      cached = resolveRunEncryptionKey(world, runOrId);
     }
     return cached;
   };

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -329,6 +329,14 @@ export async function startTraceSpan(spanName: string) {
   };
 }
 
+/** Bind work to the currently active span even when it starts from a child. */
+export async function bindActiveTraceContext<Args extends unknown[], Result>(
+  fn: (...args: Args) => Result
+): Promise<(...args: Args) => Result> {
+  const otel = await OtelApi.value;
+  return otel ? otel.context.bind(otel.context.active(), fn) : fn;
+}
+
 /** Keeps a parked workflow's ambient trace context aligned with each resume. */
 export async function createRefreshableTraceContext() {
   const otel = await OtelApi.value;

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -138,7 +138,6 @@ interface WorkflowSessionOptions {
 
 /** Context-independent V8 scripts that can be evaluated in any fresh VM. */
 export interface CompiledWorkflowScripts {
-  readonly workflowName: string;
   readonly bundleScript: Script;
   readonly workflowLookupScript: Script;
 }
@@ -169,7 +168,6 @@ export function compileWorkflowBundle(
       ...Attribute.WorkflowBundleCompileCacheHit(bundle.cacheHit),
     });
     return {
-      workflowName,
       bundleScript: bundle.script,
       workflowLookupScript: lookup.script,
     };
@@ -1138,15 +1136,9 @@ async function createWorkflowSessionInner(
   // Reuse compiled scripts by `(code, filename)`: compilation is deterministic
   // and the filename preserves workflow source attribution in stack traces.
   // The bundle registers workflows on `globalThis.__private_workflows`.
-  const compiled =
+  const { bundleScript, workflowLookupScript } =
     compiledWorkflowScripts ??
     (await compileWorkflowBundle(workflowCode, workflowRun.workflowName));
-  if (compiled.workflowName !== workflowRun.workflowName) {
-    throw new WorkflowRuntimeError(
-      `Compiled workflow ${JSON.stringify(compiled.workflowName)} does not match run workflow ${JSON.stringify(workflowRun.workflowName)}`
-    );
-  }
-  const { bundleScript, workflowLookupScript } = compiled;
   const workflowFn = await trace('workflow.bundle.evaluate', async () => {
     bundleScript.runInContext(context);
     return workflowLookupScript.runInContext(context);

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -138,6 +138,7 @@ interface WorkflowSessionOptions {
 
 /** Context-independent V8 scripts that can be evaluated in any fresh VM. */
 export interface CompiledWorkflowScripts {
+  readonly workflowName: string;
   readonly bundleScript: Script;
   readonly workflowLookupScript: Script;
 }
@@ -145,10 +146,10 @@ export interface CompiledWorkflowScripts {
 /**
  * Compile the workflow bundle before its run snapshot is available.
  *
- * Compilation depends only on the route's bundle string and workflow name,
- * not the event log or VM context. The runtime starts this promise while
- * `run_started` loads the replay snapshot, then evaluates the scripts only
- * after it has created the fresh context.
+ * Compilation depends only on the route's bundle string and the workflow name
+ * persisted on the run, not the event log or VM context. The runtime starts
+ * this promise while `run_started` loads the replay snapshot, then evaluates
+ * the scripts only after it has created the fresh context.
  */
 export function compileWorkflowBundle(
   workflowCode: string,
@@ -168,6 +169,7 @@ export function compileWorkflowBundle(
       ...Attribute.WorkflowBundleCompileCacheHit(bundle.cacheHit),
     });
     return {
+      workflowName,
       bundleScript: bundle.script,
       workflowLookupScript: lookup.script,
     };
@@ -1136,9 +1138,15 @@ async function createWorkflowSessionInner(
   // Reuse compiled scripts by `(code, filename)`: compilation is deterministic
   // and the filename preserves workflow source attribution in stack traces.
   // The bundle registers workflows on `globalThis.__private_workflows`.
-  const { bundleScript, workflowLookupScript } =
+  const compiled =
     compiledWorkflowScripts ??
     (await compileWorkflowBundle(workflowCode, workflowRun.workflowName));
+  if (compiled.workflowName !== workflowRun.workflowName) {
+    throw new WorkflowRuntimeError(
+      `Compiled workflow ${JSON.stringify(compiled.workflowName)} does not match run workflow ${JSON.stringify(workflowRun.workflowName)}`
+    );
+  }
+  const { bundleScript, workflowLookupScript } = compiled;
   const workflowFn = await trace('workflow.bundle.evaluate', async () => {
     bundleScript.runInContext(context);
     return workflowLookupScript.runInContext(context);

--- a/packages/world-vercel/src/event-retry.ts
+++ b/packages/world-vercel/src/event-retry.ts
@@ -72,11 +72,11 @@ import {
 import type { EventTypeSchema } from '@workflow/world';
 import type { z } from 'zod';
 
-/** Keeps caller-owned observer failures out of transport retry/classification. */
-export class EventObserverError extends Error {
+/** Keeps caller-owned replay observer failures out of retry/classification. */
+export class ReplayEventObserverError extends Error {
   constructor(readonly error: unknown) {
-    super('Event observer failed', { cause: error });
-    this.name = 'EventObserverError';
+    super('Replay event observer failed', { cause: error });
+    this.name = 'ReplayEventObserverError';
   }
 }
 
@@ -262,7 +262,7 @@ export function isRetryableEventPostError(err: unknown): boolean {
   // Observer code is caller-owned and runs only after a response frame has
   // been validated. Its errors are never evidence of a failed transport, even
   // when the original error happens to carry a retryable-looking code.
-  if (err instanceof EventObserverError) return false;
+  if (err instanceof ReplayEventObserverError) return false;
 
   // Definitive, server-considered outcomes, never retried as *transient*.
   // (425 is left to the runtime's retry-after handling; 429 has its own

--- a/packages/world-vercel/src/event-retry.ts
+++ b/packages/world-vercel/src/event-retry.ts
@@ -72,6 +72,14 @@ import {
 import type { EventTypeSchema } from '@workflow/world';
 import type { z } from 'zod';
 
+/** Keeps caller-owned observer failures out of transport retry/classification. */
+export class EventObserverError extends Error {
+  constructor(readonly error: unknown) {
+    super('Event observer failed', { cause: error });
+    this.name = 'EventObserverError';
+  }
+}
+
 /** Every event type the world knows about (includes the server-only
  * `hook_conflict`, which the SDK never POSTs). */
 type WorkflowEventType = z.infer<typeof EventTypeSchema>;
@@ -251,6 +259,11 @@ function collectErrorMarkers(err: unknown, depth = 0): string[] {
  * budgeted, Retry-After-honoring policy.
  */
 export function isRetryableEventPostError(err: unknown): boolean {
+  // Observer code is caller-owned and runs only after a response frame has
+  // been validated. Its errors are never evidence of a failed transport, even
+  // when the original error happens to carry a retryable-looking code.
+  if (err instanceof EventObserverError) return false;
+
   // Definitive, server-considered outcomes, never retried as *transient*.
   // (425 is left to the runtime's retry-after handling; 429 has its own
   // in-process policy in withEventPostRetry, gated by THROTTLE_RETRY_BUDGET_MS

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -1117,12 +1117,14 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
         }
       );
 
+    const onEvent = vi.fn();
     const result = await createWorkflowRunStartedEventV4(
       {
         runId: 'wrun_1',
         specVersion: 5,
       },
-      { token: 'test-token', dispatcher: agent }
+      { token: 'test-token', dispatcher: agent },
+      onEvent
     );
 
     expect(result.maxEvents).toBe(10000);
@@ -1130,6 +1132,10 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
     expect(result.events[0]).toMatchObject({ eventData: { input } });
     expect(result.cursor).toBe('eid:evnt_2');
     expect(result.hasMore).toBe(false);
+    expect(onEvent.mock.calls.map(([event]) => event.eventId)).toEqual([
+      'evnt_1',
+      'evnt_2',
+    ]);
     agent.assertNoPendingInterceptors();
   });
 

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -1117,14 +1117,14 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
         }
       );
 
-    const onEvent = vi.fn();
+    const replayEventObserver = vi.fn();
     const result = await createWorkflowRunStartedEventV4(
       {
         runId: 'wrun_1',
         specVersion: 5,
       },
       { token: 'test-token', dispatcher: agent },
-      onEvent
+      replayEventObserver
     );
 
     expect(result.maxEvents).toBe(10000);
@@ -1132,10 +1132,9 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
     expect(result.events[0]).toMatchObject({ eventData: { input } });
     expect(result.cursor).toBe('eid:evnt_2');
     expect(result.hasMore).toBe(false);
-    expect(onEvent.mock.calls.map(([event]) => event.eventId)).toEqual([
-      'evnt_1',
-      'evnt_2',
-    ]);
+    expect(
+      replayEventObserver.mock.calls.map(([event]) => event.eventId)
+    ).toEqual(['evnt_1', 'evnt_2']);
     agent.assertNoPendingInterceptors();
   });
 

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -1535,12 +1535,32 @@ async function consumeEventFrameStream(
       }
       const event = decodeEventFrame(frame);
       events.push(event);
-      notifyReplayEventObserver(replayEventObserver, event);
+      try {
+        replayEventObserver?.(event);
+      } catch (error) {
+        throw new ReplayEventObserverError(error);
+      }
     }
   } catch (cause) {
+    if (
+      cause instanceof ReplayEventObserverError ||
+      CorruptedEventLogError.is(cause) ||
+      WorkflowWorldError.is(cause)
+    ) {
+      throw cause;
+    }
+    if (!(cause instanceof IncompleteFrameError)) {
+      throw new WorkflowWorldError(`v4 ${opName}: invalid event frame stream`, {
+        code: 'SCHEMA_VALIDATION',
+        cause,
+      });
+    }
     return partialEventFrameStream(
       events,
-      partialEventFrameStreamError(opName, cause)
+      new WorkflowWorldError(`v4 ${opName}: incomplete event frame stream`, {
+        code: 'TRANSPORT',
+        cause,
+      })
     );
   }
 
@@ -1590,41 +1610,6 @@ async function consumeReplayLogResponse(
     cursor: suffix.cursor ?? page.cursor,
     hasMore: suffix.hasMore,
   };
-}
-
-function notifyReplayEventObserver(
-  observer: ((event: Event) => void) | undefined,
-  event: Event
-): void {
-  if (!observer) return;
-  try {
-    observer(event);
-  } catch (error) {
-    throw new ReplayEventObserverError(error);
-  }
-}
-
-function partialEventFrameStreamError(
-  opName: string,
-  cause: unknown
-): WorkflowWorldError {
-  if (
-    cause instanceof ReplayEventObserverError ||
-    CorruptedEventLogError.is(cause) ||
-    WorkflowWorldError.is(cause)
-  ) {
-    throw cause;
-  }
-  if (!(cause instanceof IncompleteFrameError)) {
-    throw new WorkflowWorldError(`v4 ${opName}: invalid event frame stream`, {
-      code: 'SCHEMA_VALIDATION',
-      cause,
-    });
-  }
-  return new WorkflowWorldError(`v4 ${opName}: incomplete event frame stream`, {
-    code: 'TRANSPORT',
-    cause,
-  });
 }
 
 /**

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -38,7 +38,7 @@ import {
 } from '@workflow/world';
 import { decode } from 'cbor-x';
 import { z } from 'zod';
-import { EventObserverError } from './event-retry.js';
+import { ReplayEventObserverError } from './event-retry.js';
 import {
   type DecodedFrame,
   decodeFrames,
@@ -869,7 +869,7 @@ async function decodeCreateEventResponse<T extends EventType>(
 export async function createWorkflowRunStartedEventV4(
   input: CreateEventV4InputBase,
   config?: APIConfig,
-  onEvent?: (event: Event) => void
+  replayEventObserver?: (event: Event) => void
 ) {
   const response = await postWorkflowRunEventV4(
     { ...input, eventType: 'run_started' },
@@ -880,7 +880,7 @@ export async function createWorkflowRunStartedEventV4(
     response,
     input.runId,
     config,
-    onEvent
+    replayEventObserver
   );
   if (!page.cursor) {
     throw new WorkflowWorldError(
@@ -1327,7 +1327,7 @@ export type HookReceivedPreloadV4Result =
 export async function createHookReceivedPreloadEventV4(
   input: CreateEventV4InputBase,
   config?: APIConfig,
-  onEvent?: (event: Event) => void
+  replayEventObserver?: (event: Event) => void
 ): Promise<HookReceivedPreloadV4Result> {
   const response = await postWorkflowRunEventV4(
     { ...input, eventType: 'hook_received' },
@@ -1347,7 +1347,7 @@ export async function createHookReceivedPreloadEventV4(
     response,
     input.runId,
     config,
-    onEvent
+    replayEventObserver
   );
   const maxEvents = MaxEventsHeaderSchema.safeParse(
     response.headers.get(MAX_EVENTS_HEADER)
@@ -1501,7 +1501,7 @@ function partialEventFrameStream(
 async function consumeEventFrameStream(
   response: Response,
   opName: string,
-  onEvent?: (event: Event) => void
+  replayEventObserver?: (event: Event) => void
 ): Promise<EventFrameStreamResult> {
   const contentType = response.headers.get('content-type');
   if (!contentType?.startsWith(V4_FRAME_CONTENT_TYPE)) {
@@ -1535,7 +1535,7 @@ async function consumeEventFrameStream(
       }
       const event = decodeEventFrame(frame);
       events.push(event);
-      notifyEventObserver(onEvent, event);
+      notifyReplayEventObserver(replayEventObserver, event);
     }
   } catch (cause) {
     return partialEventFrameStream(
@@ -1563,9 +1563,13 @@ async function consumeReplayLogResponse(
   response: Response,
   runId: string,
   config?: APIConfig,
-  onEvent?: (event: Event) => void
+  replayEventObserver?: (event: Event) => void
 ): Promise<ListEventsV4Result> {
-  const page = await consumeEventFrameStream(response, 'createEvent', onEvent);
+  const page = await consumeEventFrameStream(
+    response,
+    'createEvent',
+    replayEventObserver
+  );
   if (!page.hasMore) return page;
   if (!page.cursor) {
     if (page.partialError) throw page.partialError;
@@ -1579,7 +1583,7 @@ async function consumeReplayLogResponse(
     runId,
     { cursor: page.cursor, remoteRefBehavior: 'resolve' },
     config,
-    onEvent
+    replayEventObserver
   );
   return {
     events: [...page.events, ...suffix.events],
@@ -1588,7 +1592,7 @@ async function consumeReplayLogResponse(
   };
 }
 
-function notifyEventObserver(
+function notifyReplayEventObserver(
   observer: ((event: Event) => void) | undefined,
   event: Event
 ): void {
@@ -1596,7 +1600,7 @@ function notifyEventObserver(
   try {
     observer(event);
   } catch (error) {
-    throw new EventObserverError(error);
+    throw new ReplayEventObserverError(error);
   }
 }
 
@@ -1605,7 +1609,7 @@ function partialEventFrameStreamError(
   cause: unknown
 ): WorkflowWorldError {
   if (
-    cause instanceof EventObserverError ||
+    cause instanceof ReplayEventObserverError ||
     CorruptedEventLogError.is(cause) ||
     WorkflowWorldError.is(cause)
   ) {
@@ -1637,7 +1641,7 @@ async function consumeListFrameStream(
   headers: Headers,
   config: APIConfig | undefined,
   opName: string,
-  onEvent?: (event: Event) => void
+  replayEventObserver?: (event: Event) => void
 ): Promise<EventFrameStreamResult> {
   const response = await fetchV4(
     url,
@@ -1645,7 +1649,7 @@ async function consumeListFrameStream(
     config,
     opName
   );
-  return consumeEventFrameStream(response, opName, onEvent);
+  return consumeEventFrameStream(response, opName, replayEventObserver);
 }
 
 /**
@@ -1686,7 +1690,7 @@ export async function getWorkflowRunEventsV4(
   runId: string,
   params: ListEventsV4Params = {},
   config?: APIConfig,
-  onEvent?: (event: Event) => void
+  replayEventObserver?: (event: Event) => void
 ): Promise<ListEventsV4Result> {
   const { baseUrl, headers } = await getHttpConfig(config);
   const events: Event[] = [];
@@ -1703,7 +1707,7 @@ export async function getWorkflowRunEventsV4(
       headers,
       config,
       'listEvents',
-      onEvent
+      replayEventObserver
     );
     const cursorAdvanced = !!consumed.cursor && consumed.cursor !== cursor;
     if (consumed.partialError) {

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -1483,19 +1483,31 @@ function streamErrorFrameToError(
   );
 }
 
-type EventFrameStreamResult = ListEventsV4Result & {
-  partialError?: WorkflowWorldError;
-};
+type EventFrameStreamResult =
+  | (ListEventsV4Result & { kind: 'complete' })
+  | {
+      kind: 'partial';
+      events: Event[];
+      cursor: string;
+      hasMore: true;
+      error: WorkflowWorldError;
+    };
 
 const MAX_PARTIAL_STREAM_RETRIES = 2;
 
 function partialEventFrameStream(
   events: Event[],
-  partialError: WorkflowWorldError
+  error: WorkflowWorldError
 ): EventFrameStreamResult {
   const eventId = events.at(-1)?.eventId;
-  if (!eventId) throw partialError;
-  return { events, cursor: `eid:${eventId}`, hasMore: true, partialError };
+  if (!eventId) throw error;
+  return {
+    kind: 'partial',
+    events,
+    cursor: `eid:${eventId}`,
+    hasMore: true,
+    error,
+  };
 }
 
 async function consumeEventFrameStream(
@@ -1522,6 +1534,7 @@ async function consumeEventFrameStream(
       if (frame.meta._end === 1) {
         const end = EventStreamEndSchema.parse(frame.meta);
         return {
+          kind: 'complete',
           events,
           cursor: end.next ?? null,
           hasMore: end.hasMore,
@@ -1590,9 +1603,14 @@ async function consumeReplayLogResponse(
     'createEvent',
     replayEventObserver
   );
-  if (!page.hasMore) return page;
+  if (!page.hasMore) {
+    return {
+      events: page.events,
+      cursor: page.cursor,
+      hasMore: false,
+    };
+  }
   if (!page.cursor) {
-    if (page.partialError) throw page.partialError;
     throw new WorkflowWorldError(
       'v4 createEvent: partial event stream missing cursor',
       { code: 'SCHEMA_VALIDATION' }
@@ -1695,15 +1713,14 @@ export async function getWorkflowRunEventsV4(
       replayEventObserver
     );
     const cursorAdvanced = !!consumed.cursor && consumed.cursor !== cursor;
-    if (consumed.partialError) {
+    if (consumed.kind === 'partial') {
       if (
         params.limit !== undefined ||
         !cursorAdvanced ||
         partialStreamRetries === MAX_PARTIAL_STREAM_RETRIES
       ) {
-        throw consumed.partialError;
+        throw consumed.error;
       }
-      assert(consumed.cursor);
       partialStreamRetries++;
       cursor = consumed.cursor;
     } else if (
@@ -1718,7 +1735,7 @@ export async function getWorkflowRunEventsV4(
     for (const event of consumed.events) {
       events.push(event);
     }
-  } while (consumed.partialError);
+  } while (consumed.kind === 'partial');
 
   return {
     events,
@@ -1759,6 +1776,10 @@ export async function getEventsByCorrelationIdV4(
     config,
     'listEventsByCorrelationId'
   );
-  if (consumed.partialError) throw consumed.partialError;
-  return consumed;
+  if (consumed.kind === 'partial') throw consumed.error;
+  return {
+    events: consumed.events,
+    cursor: consumed.cursor,
+    hasMore: consumed.hasMore,
+  };
 }

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -38,6 +38,7 @@ import {
 } from '@workflow/world';
 import { decode } from 'cbor-x';
 import { z } from 'zod';
+import { EventObserverError } from './event-retry.js';
 import {
   type DecodedFrame,
   decodeFrames,
@@ -867,14 +868,20 @@ async function decodeCreateEventResponse<T extends EventType>(
 
 export async function createWorkflowRunStartedEventV4(
   input: CreateEventV4InputBase,
-  config?: APIConfig
+  config?: APIConfig,
+  onEvent?: (event: Event) => void
 ) {
   const response = await postWorkflowRunEventV4(
     { ...input, eventType: 'run_started' },
     'event-stream',
     config
   );
-  const page = await consumeReplayLogResponse(response, input.runId, config);
+  const page = await consumeReplayLogResponse(
+    response,
+    input.runId,
+    config,
+    onEvent
+  );
   if (!page.cursor) {
     throw new WorkflowWorldError(
       'v4 createEvent: event stream missing cursor',
@@ -1319,7 +1326,8 @@ export type HookReceivedPreloadV4Result =
  */
 export async function createHookReceivedPreloadEventV4(
   input: CreateEventV4InputBase,
-  config?: APIConfig
+  config?: APIConfig,
+  onEvent?: (event: Event) => void
 ): Promise<HookReceivedPreloadV4Result> {
   const response = await postWorkflowRunEventV4(
     { ...input, eventType: 'hook_received' },
@@ -1335,7 +1343,12 @@ export async function createHookReceivedPreloadEventV4(
     };
   }
 
-  const page = await consumeReplayLogResponse(response, input.runId, config);
+  const page = await consumeReplayLogResponse(
+    response,
+    input.runId,
+    config,
+    onEvent
+  );
   const maxEvents = MaxEventsHeaderSchema.safeParse(
     response.headers.get(MAX_EVENTS_HEADER)
   );
@@ -1487,7 +1500,8 @@ function partialEventFrameStream(
 
 async function consumeEventFrameStream(
   response: Response,
-  opName: string
+  opName: string,
+  onEvent?: (event: Event) => void
 ): Promise<EventFrameStreamResult> {
   const contentType = response.headers.get('content-type');
   if (!contentType?.startsWith(V4_FRAME_CONTENT_TYPE)) {
@@ -1519,22 +1533,15 @@ async function consumeEventFrameStream(
       if (Object.keys(frame.meta).some((key) => key.startsWith('_'))) {
         throw new Error(`v4 ${opName}: unexpected control frame`);
       }
-      events.push(decodeEventFrame(frame));
+      const event = decodeEventFrame(frame);
+      events.push(event);
+      notifyEventObserver(onEvent, event);
     }
   } catch (cause) {
-    if (CorruptedEventLogError.is(cause) || WorkflowWorldError.is(cause)) {
-      throw cause;
-    }
-    const incomplete = cause instanceof IncompleteFrameError;
-    const error = new WorkflowWorldError(
-      `v4 ${opName}: ${incomplete ? 'incomplete' : 'invalid'} event frame stream`,
-      {
-        code: incomplete ? 'TRANSPORT' : 'SCHEMA_VALIDATION',
-        cause,
-      }
+    return partialEventFrameStream(
+      events,
+      partialEventFrameStreamError(opName, cause)
     );
-    if (!incomplete) throw error;
-    return partialEventFrameStream(events, error);
   }
 
   return partialEventFrameStream(
@@ -1555,9 +1562,10 @@ async function consumeEventFrameStream(
 async function consumeReplayLogResponse(
   response: Response,
   runId: string,
-  config?: APIConfig
+  config?: APIConfig,
+  onEvent?: (event: Event) => void
 ): Promise<ListEventsV4Result> {
-  const page = await consumeEventFrameStream(response, 'createEvent');
+  const page = await consumeEventFrameStream(response, 'createEvent', onEvent);
   if (!page.hasMore) return page;
   if (!page.cursor) {
     if (page.partialError) throw page.partialError;
@@ -1570,13 +1578,49 @@ async function consumeReplayLogResponse(
   const suffix = await getWorkflowRunEventsV4(
     runId,
     { cursor: page.cursor, remoteRefBehavior: 'resolve' },
-    config
+    config,
+    onEvent
   );
   return {
     events: [...page.events, ...suffix.events],
     cursor: suffix.cursor ?? page.cursor,
     hasMore: suffix.hasMore,
   };
+}
+
+function notifyEventObserver(
+  observer: ((event: Event) => void) | undefined,
+  event: Event
+): void {
+  if (!observer) return;
+  try {
+    observer(event);
+  } catch (error) {
+    throw new EventObserverError(error);
+  }
+}
+
+function partialEventFrameStreamError(
+  opName: string,
+  cause: unknown
+): WorkflowWorldError {
+  if (
+    cause instanceof EventObserverError ||
+    CorruptedEventLogError.is(cause) ||
+    WorkflowWorldError.is(cause)
+  ) {
+    throw cause;
+  }
+  if (!(cause instanceof IncompleteFrameError)) {
+    throw new WorkflowWorldError(`v4 ${opName}: invalid event frame stream`, {
+      code: 'SCHEMA_VALIDATION',
+      cause,
+    });
+  }
+  return new WorkflowWorldError(`v4 ${opName}: incomplete event frame stream`, {
+    code: 'TRANSPORT',
+    cause,
+  });
 }
 
 /**
@@ -1592,7 +1636,8 @@ async function consumeListFrameStream(
   url: string,
   headers: Headers,
   config: APIConfig | undefined,
-  opName: string
+  opName: string,
+  onEvent?: (event: Event) => void
 ): Promise<EventFrameStreamResult> {
   const response = await fetchV4(
     url,
@@ -1600,7 +1645,7 @@ async function consumeListFrameStream(
     config,
     opName
   );
-  return consumeEventFrameStream(response, opName);
+  return consumeEventFrameStream(response, opName, onEvent);
 }
 
 /**
@@ -1640,7 +1685,8 @@ function paginationToQuery(params: ListEventsV4Params): string {
 export async function getWorkflowRunEventsV4(
   runId: string,
   params: ListEventsV4Params = {},
-  config?: APIConfig
+  config?: APIConfig,
+  onEvent?: (event: Event) => void
 ): Promise<ListEventsV4Result> {
   const { baseUrl, headers } = await getHttpConfig(config);
   const events: Event[] = [];
@@ -1652,7 +1698,13 @@ export async function getWorkflowRunEventsV4(
     const url =
       `${baseUrl}/v4/runs/${encodeURIComponent(runId)}/events` +
       paginationToQuery({ ...params, cursor: cursor ?? undefined });
-    consumed = await consumeListFrameStream(url, headers, config, 'listEvents');
+    consumed = await consumeListFrameStream(
+      url,
+      headers,
+      config,
+      'listEvents',
+      onEvent
+    );
     const cursorAdvanced = !!consumed.cursor && consumed.cursor !== cursor;
     if (consumed.partialError) {
       if (

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { gzipSync } from 'node:zlib';
+import { WorkflowWorldError } from '@workflow/errors';
 import type { AnyEventRequest, CreateEventParams } from '@workflow/world';
 import { decode, encode } from 'cbor-x';
 import { ulid } from 'ulid';
@@ -778,6 +779,42 @@ describe('splitEventDataForV4 attribute fields', () => {
 });
 
 describe('createWorkflowRunEvent response coercion', () => {
+  it('surfaces streamed event observer failures unchanged', async () => {
+    const agent = mockAgent();
+    const observerError = new WorkflowWorldError('observer failed', {
+      code: 'TRANSPORT',
+    });
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/run_started',
+        method: 'POST',
+      })
+      .reply(200, runStartedResponse(), {
+        headers: {
+          'content-type': V4_FRAME_CONTENT_TYPE,
+          'x-wf-event-id': 'evnt_1',
+          'x-wf-run-id': 'wrun_1',
+          'x-wf-created-at': STARTED_AT.toISOString(),
+          'x-wf-max-events': '10000',
+        },
+      });
+
+    await expect(
+      createWorkflowRunEvent(
+        'wrun_1',
+        { eventType: 'run_started', specVersion: 2 } as AnyEventRequest,
+        {
+          onEvent: () => {
+            throw observerError;
+          },
+        },
+        { token: 'test-token', dispatcher: agent }
+      )
+    ).rejects.toBe(observerError);
+    agent.assertNoPendingInterceptors();
+  });
+
   it('accepts a current region-tagged run_created runId', async () => {
     const taggedRunId = `wrun_${encodeRunId(ulid(), REGION_IDS.sfo1)}`;
     const agent = mockAgent();

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -805,7 +805,7 @@ describe('createWorkflowRunEvent response coercion', () => {
         'wrun_1',
         { eventType: 'run_started', specVersion: 2 } as AnyEventRequest,
         {
-          onEvent: () => {
+          replayEventObserver: () => {
             throw observerError;
           },
         },

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -758,9 +758,9 @@ async function createWorkflowRunEventInner(
       params?.replayEventObserver
     );
     const replayRun = reconstructRunFromReplayEvents(result.events);
-    if (replayRun.kind === 'missing') {
+    if (!replayRun) {
       throw new WorkflowWorldError(
-        `v4 createEvent: run_started stream is missing ${replayRun.eventType}`,
+        'v4 createEvent: run_started stream is missing lifecycle events',
         { code: 'SCHEMA_VALIDATION' }
       );
     }
@@ -811,7 +811,7 @@ async function createWorkflowRunEventInner(
     const replayRun = reconstructRunFromReplayEvents(events);
     return {
       ...(canonicalEvent ? { event: canonicalEvent } : {}),
-      ...(replayRun.kind === 'complete' ? { run: replayRun.run } : {}),
+      ...(replayRun ? { run: replayRun.run } : {}),
       events,
       cursor,
       hasMore,
@@ -830,21 +830,16 @@ async function createWorkflowRunEventInner(
 /**
  * Reconstruct the run entity from a streamed replay log: identity and input
  * from `run_created`, start time from `run_started`, later `attr_set` events
- * folded into `attributes`/`updatedAt`. Returns the missing lifecycle event
- * when reconstruction is incomplete so each caller can choose whether that is
- * fatal. The reconstructed status is always `running`: a terminal event
+ * folded into `attributes`/`updatedAt`. Returns undefined when reconstruction
+ * is incomplete so each caller can choose whether that is fatal. The
+ * reconstructed status is always `running`: a terminal event
  * committed concurrently still rides in the log itself, and the runtime's
  * replay-time terminal detection handles it.
  */
 function reconstructRunFromReplayEvents(events: Event[]) {
   const runCreated = events.find((event) => event.eventType === 'run_created');
-  if (!runCreated) {
-    return { kind: 'missing' as const, eventType: 'run_created' as const };
-  }
   const runStarted = events.find((event) => event.eventType === 'run_started');
-  if (!runStarted) {
-    return { kind: 'missing' as const, eventType: 'run_started' as const };
-  }
+  if (!runCreated || !runStarted) return;
 
   let attributes = runCreated.eventData.attributes ?? {};
   let updatedAt = runStarted.createdAt;
@@ -856,7 +851,6 @@ function reconstructRunFromReplayEvents(events: Event[]) {
   }
 
   return {
-    kind: 'complete' as const,
     event: runStarted,
     run: {
       runId: runCreated.runId,

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -53,7 +53,7 @@ import {
   validateUlidTimestamp,
   type WorkflowRun,
 } from '@workflow/world';
-import { withEventPostRetry } from './event-retry.js';
+import { EventObserverError, withEventPostRetry } from './event-retry.js';
 import {
   createHookReceivedPreloadEventV4,
   createWorkflowRunEventsBatchV4,
@@ -637,6 +637,7 @@ export async function createWorkflowRunEvent<T extends AnyEventRequest>(
     }
     return result as EventResult<T['eventType']>;
   } catch (err) {
+    if (err instanceof EventObserverError) throw err.error;
     // 404 on hook_disposed / hook_received → already-disposed hook.
     if (
       isHookEventRequiringExistence(data.eventType) &&
@@ -751,7 +752,11 @@ async function createWorkflowRunEventInner(
   };
 
   if (data.eventType === 'run_started' && !params?.skipPreload) {
-    const result = await createWorkflowRunStartedEventV4(input, config);
+    const result = await createWorkflowRunStartedEventV4(
+      input,
+      config,
+      params?.onEvent
+    );
     const runCreated = result.events.find(
       (event) => event.eventType === 'run_created'
     );
@@ -820,7 +825,8 @@ async function createWorkflowRunEventInner(
     // an S3-backed hook payload the runtime would discard anyway.
     const outcome = await createHookReceivedPreloadEventV4(
       { ...input, remoteRefBehavior: 'lazy' },
-      config
+      config,
+      params.onEvent
     );
     if (outcome.kind === 'materialized') {
       // Older server (or optimization declined): the write still succeeded

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -757,50 +757,17 @@ async function createWorkflowRunEventInner(
       config,
       params?.replayEventObserver
     );
-    const runCreated = result.events.find(
-      (event) => event.eventType === 'run_created'
-    );
-    const runStarted = result.events.find(
-      (event) => event.eventType === 'run_started'
-    );
-    if (!runCreated) {
+    const replayRun = reconstructRunFromReplayEvents(result.events);
+    if (replayRun.kind === 'missing') {
       throw new WorkflowWorldError(
-        'v4 createEvent: run_started stream is missing run_created',
+        `v4 createEvent: run_started stream is missing ${replayRun.eventType}`,
         { code: 'SCHEMA_VALIDATION' }
       );
-    }
-    if (!runStarted) {
-      throw new WorkflowWorldError(
-        'v4 createEvent: run_started stream is missing run_started',
-        { code: 'SCHEMA_VALIDATION' }
-      );
-    }
-
-    let attributes = runCreated.eventData.attributes ?? {};
-    let updatedAt = runStarted.createdAt;
-    for (const event of result.events) {
-      if (event.eventType === 'attr_set') {
-        attributes = applyAttributeChanges(attributes, event.eventData.changes);
-        updatedAt = event.createdAt;
-      }
     }
 
     return {
-      event: runStarted,
-      run: {
-        runId: runCreated.runId,
-        status: 'running',
-        deploymentId: runCreated.eventData.deploymentId,
-        workflowName: runCreated.eventData.workflowName,
-        specVersion: runCreated.specVersion,
-        executionContext: runCreated.eventData.executionContext,
-        input: runCreated.eventData.input,
-        attributes,
-        encryptionPublicKey: runCreated.eventData.encryptionPublicKey,
-        startedAt: runStarted.createdAt,
-        createdAt: runCreated.createdAt,
-        updatedAt,
-      },
+      event: replayRun.event,
+      run: replayRun.run,
       events: result.events,
       cursor: result.cursor,
       hasMore: result.hasMore,
@@ -841,10 +808,10 @@ async function createWorkflowRunEventInner(
     // Unlike lifecycle streams, a preload missing run_created/run_started is
     // not fatal here: the write has already converged, so return the page
     // without a run and let the runtime take its safe fallback.
-    const run = reconstructRunFromReplayEvents(events);
+    const replayRun = reconstructRunFromReplayEvents(events);
     return {
       ...(canonicalEvent ? { event: canonicalEvent } : {}),
-      ...(run ? { run } : {}),
+      ...(replayRun.kind === 'complete' ? { run: replayRun.run } : {}),
       events,
       cursor,
       hasMore,
@@ -863,19 +830,20 @@ async function createWorkflowRunEventInner(
 /**
  * Reconstruct the run entity from a streamed replay log: identity and input
  * from `run_created`, start time from `run_started`, later `attr_set` events
- * folded into `attributes`/`updatedAt`. Returns undefined when the log does
- * not contain both lifecycle events (the caller decides whether that is
- * fatal). The reconstructed status is always `running`: a terminal event
+ * folded into `attributes`/`updatedAt`. Returns the missing lifecycle event
+ * when reconstruction is incomplete so each caller can choose whether that is
+ * fatal. The reconstructed status is always `running`: a terminal event
  * committed concurrently still rides in the log itself, and the runtime's
  * replay-time terminal detection handles it.
  */
-function reconstructRunFromReplayEvents(
-  events: Event[]
-): (WorkflowRun & { startedAt: Date }) | undefined {
+function reconstructRunFromReplayEvents(events: Event[]) {
   const runCreated = events.find((event) => event.eventType === 'run_created');
+  if (!runCreated) {
+    return { kind: 'missing' as const, eventType: 'run_created' as const };
+  }
   const runStarted = events.find((event) => event.eventType === 'run_started');
-  if (!runCreated || !runStarted) {
-    return undefined;
+  if (!runStarted) {
+    return { kind: 'missing' as const, eventType: 'run_started' as const };
   }
 
   let attributes = runCreated.eventData.attributes ?? {};
@@ -888,17 +856,21 @@ function reconstructRunFromReplayEvents(
   }
 
   return {
-    runId: runCreated.runId,
-    status: 'running',
-    deploymentId: runCreated.eventData.deploymentId,
-    workflowName: runCreated.eventData.workflowName,
-    specVersion: runCreated.specVersion,
-    executionContext: runCreated.eventData.executionContext,
-    input: runCreated.eventData.input,
-    attributes,
-    encryptionPublicKey: runCreated.eventData.encryptionPublicKey,
-    startedAt: runStarted.createdAt,
-    createdAt: runCreated.createdAt,
-    updatedAt,
+    kind: 'complete' as const,
+    event: runStarted,
+    run: {
+      runId: runCreated.runId,
+      status: 'running' as const,
+      deploymentId: runCreated.eventData.deploymentId,
+      workflowName: runCreated.eventData.workflowName,
+      specVersion: runCreated.specVersion,
+      executionContext: runCreated.eventData.executionContext,
+      input: runCreated.eventData.input,
+      attributes,
+      encryptionPublicKey: runCreated.eventData.encryptionPublicKey,
+      startedAt: runStarted.createdAt,
+      createdAt: runCreated.createdAt,
+      updatedAt,
+    },
   };
 }

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -53,7 +53,7 @@ import {
   validateUlidTimestamp,
   type WorkflowRun,
 } from '@workflow/world';
-import { EventObserverError, withEventPostRetry } from './event-retry.js';
+import { ReplayEventObserverError, withEventPostRetry } from './event-retry.js';
 import {
   createHookReceivedPreloadEventV4,
   createWorkflowRunEventsBatchV4,
@@ -637,7 +637,7 @@ export async function createWorkflowRunEvent<T extends AnyEventRequest>(
     }
     return result as EventResult<T['eventType']>;
   } catch (err) {
-    if (err instanceof EventObserverError) throw err.error;
+    if (err instanceof ReplayEventObserverError) throw err.error;
     // 404 on hook_disposed / hook_received → already-disposed hook.
     if (
       isHookEventRequiringExistence(data.eventType) &&
@@ -755,7 +755,7 @@ async function createWorkflowRunEventInner(
     const result = await createWorkflowRunStartedEventV4(
       input,
       config,
-      params?.onEvent
+      params?.replayEventObserver
     );
     const runCreated = result.events.find(
       (event) => event.eventType === 'run_created'
@@ -826,7 +826,7 @@ async function createWorkflowRunEventInner(
     const outcome = await createHookReceivedPreloadEventV4(
       { ...input, remoteRefBehavior: 'lazy' },
       config,
-      params.onEvent
+      params.replayEventObserver
     );
     if (outcome.kind === 'materialized') {
       // Older server (or optimization declined): the write still succeeded

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -868,6 +868,13 @@ export interface CreateEventParams {
    * `resumeHook()` must not set it.
    */
   preloadEvents?: true;
+  /**
+   * Synchronously observes each validated event in a streamed replay-log
+   * response. A retried request may observe the same event again; observers
+   * must therefore be idempotent. Throwing aborts the operation and the World
+   * must surface the original error without retrying or reclassifying it.
+   */
+  onEvent?: (event: Event) => void;
 }
 
 /**

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -874,7 +874,7 @@ export interface CreateEventParams {
    * must therefore be idempotent. Throwing aborts the operation and the World
    * must surface the original error without retrying or reclassifying it.
    */
-  onEvent?: (event: Event) => void;
+  replayEventObserver?: (event: Event) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary

- prepare validated Node replay payloads as streamed events arrive
- lazily resolve the invocation encryption key and create the payload cache only after the run is known to use Node
- skip host-side compile, key lookup, replay cache, and payload preparation for QuickJS
- start `run_started` before speculative compile/cache work so setup I/O overlaps Node startup
- correct speculative workflow names from persisted `run_created`
- classify invalid VM configuration as `run_failed` in turbo, ordinary, and streamed setup paths
- count materialized replay events without per-event spans
- share one replay-run reconstruction path between `run_started` and atomic-hook preload
- leave primitive payload caching uncapped

Prewarm deliberately scans the event array on each replay and relies on the existing event-ID map to skip prepared payloads. This avoids positional scan state, reset hooks, and event-log replacement wrappers; only the cheap array walk repeats. Prepared plaintext and memoized primitive results remain invocation-scoped.

## Stack

Depends on #3798.

## Validation

- focused regression suites — 131 tests passed
- final runtime regression suites — 60 tests passed
- full `@workflow/core` suite — 2,295 tests passed
- full `@workflow/world-vercel` suite — 572 tests passed
- full `@workflow/world` suite — 165 tests passed
- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/world-vercel typecheck`
- Biome check on changed files
- `git diff --check`