### PR TITLE
[ci] Report all three event-log-race-repro lanes in one small PR comment

### DIFF
--- a/.changeset/repro-comment-slim.md
+++ b/.changeset/repro-comment-slim.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: the event-log-race-repro CI job now reports all three lanes (Vercel, world-local, world-postgres) in a single, much shorter PR comment.

--- a/.github/scripts/render-event-log-race-repro-results.js
+++ b/.github/scripts/render-event-log-race-repro-results.js
@@ -3,21 +3,25 @@
 const fs = require('node:fs');
 
 const args = process.argv.slice(2);
-let resultsPath = 'event-log-race-repro-results.json';
+let resultsPath = '';
 let runUrl = '';
 let previousCommentPath = '';
 let timestamp = new Date().toISOString();
 let runAttempt = '';
 let check = false;
-// Which lane this run belongs to (e.g. `world-local`, `world-postgres`).
-// Suffixes the results marker and the heading so each lane owns its own sticky
-// comment: the lanes run as parallel jobs, and a shared marker would make one
-// lane's "previous comment" fetch pick up another lane's history. The Vercel
-// lane passes no label and keeps the original marker, so its comment history
-// survives this flag's introduction. Marker matching is exact-substring
-// (`<!-- event-log-race-repro-results -->` does not match the `-world-local`
-// variant because of the closing ` -->`), which is what keeps the lanes apart.
+// Which lane a single-file render belongs to (e.g. `world-local`,
+// `world-postgres`). It only names the heading and the lane's history bucket;
+// the Vercel lane passes no label. The CI comment is rendered once for all
+// lanes at a time (see `--lane` below), so this is now the per-job step summary
+// and the local runner's path.
 let label = '';
+// Lanes to render together, as `--lane <name>=<results.json>` pairs, in display
+// order. This is how the aggregating job turns three parallel jobs into one PR
+// comment: one comment means one history, so the trend for all three worlds
+// lines up on the same rows instead of living in three separate sticky
+// comments. A lane whose file is missing still gets a row — a lane that
+// produced nothing is a fact worth showing, not a gap.
+const laneArgs = [];
 
 for (let index = 0; index < args.length; index += 1) {
   const arg = args[index];
@@ -36,6 +40,16 @@ for (let index = 0; index < args.length; index += 1) {
   } else if (arg === '--label' && args[index + 1]) {
     label = args[index + 1];
     index += 1;
+  } else if (arg === '--lane' && args[index + 1]) {
+    const value = args[index + 1];
+    const separator = value.indexOf('=');
+    if (separator > 0) {
+      laneArgs.push({
+        name: value.slice(0, separator),
+        path: value.slice(separator + 1),
+      });
+    }
+    index += 1;
   } else if (arg === '--check') {
     check = true;
   } else if (!arg.startsWith('--')) {
@@ -43,8 +57,23 @@ for (let index = 0; index < args.length; index += 1) {
   }
 }
 
+if (!resultsPath) {
+  resultsPath = 'event-log-race-repro-results.json';
+}
+
 const historyMarkerStart = '<!-- event-log-race-repro-history';
 const historyMarkerEnd = 'event-log-race-repro-history -->';
+
+// How many runs the history table keeps. The table is one row per lane per run,
+// so this is the dial that keeps a long-lived PR's comment readable: 5 runs is
+// the trend, and the rest is in the artifacts of the older jobs.
+const maxHistoryRuns = 5;
+// Non-completed runs listed per lane, regressions first.
+const maxFailingRows = 10;
+// A soak can produce four figures of `infra` rows, all carrying the same one or
+// two error codes. The verdict line already reports the count, so the table only
+// keeps enough of them to name the code.
+const maxInfraRows = 3;
 
 const orderedOutcomes = [
   'completed',
@@ -65,15 +94,43 @@ const gatingOutcomes = orderedOutcomes.filter(
   (outcome) => outcome !== 'completed' && outcome !== 'infra'
 );
 
+// The history table's columns. Deliberately five: the question it answers is
+// "did this run trip the storms", and every outcome that is not corruption or a
+// stuck run is rare enough that a shared bucket is honest. `infra` sits in
+// `Other` so the four count columns always sum to `Total`; the verdict lines
+// above the table break out whatever is actually non-zero, including infra.
+const summaryColumns = [
+  { header: 'Complete', outcomes: ['completed'] },
+  { header: 'Corrupt', outcomes: ['CORRUPTED_EVENT_LOG'] },
+  { header: 'Stuck', outcomes: ['stuck'] },
+  {
+    header: 'Other',
+    outcomes: ['USER_ERROR', 'RUNTIME_ERROR', 'other', 'infra'],
+  },
+];
+
+// Short names for the verdict lines, so `6 corrupt, 1 stuck` reads at a glance.
+const outcomeShortNames = {
+  CORRUPTED_EVENT_LOG: 'corrupt',
+  USER_ERROR: 'user error',
+  RUNTIME_ERROR: 'runtime error',
+  stuck: 'stuck',
+  other: 'other',
+};
+
 function emptyDistribution() {
   return Object.fromEntries(orderedOutcomes.map((outcome) => [outcome, 0]));
 }
 
-function loadResults() {
-  if (!fs.existsSync(resultsPath)) {
+function laneNameFromLabel(value) {
+  return value.replace(/^world-/, '') || 'vercel';
+}
+
+function loadResults(path = resultsPath) {
+  if (!path || !fs.existsSync(path)) {
     return null;
   }
-  return JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
 }
 
 function loadPreviousComment() {
@@ -83,7 +140,11 @@ function loadPreviousComment() {
   return fs.readFileSync(previousCommentPath, 'utf8');
 }
 
-function loadHistory(previousComment) {
+// History is stored as `{ runs: [{ timestamp, runAttempt, runUrl, lanes }] }`.
+// Comments written before the lanes shared one comment stored a bare array of
+// single-lane entries; those are read as this comment's own lane, which is what
+// they were.
+function loadHistory(previousComment, fallbackLaneName) {
   if (!previousComment) {
     return [];
   }
@@ -96,12 +157,23 @@ function loadHistory(previousComment) {
     return [];
   }
 
+  let parsed;
   try {
-    const history = JSON.parse(match[1]);
-    return Array.isArray(history) ? history : [];
+    parsed = JSON.parse(match[1]);
   } catch {
     return [];
   }
+
+  if (Array.isArray(parsed)) {
+    return parsed.map((entry) => ({
+      timestamp: entry.timestamp,
+      runAttempt: entry.runAttempt,
+      runUrl: entry.runUrl,
+      lanes: { [fallbackLaneName]: entry },
+    }));
+  }
+
+  return Array.isArray(parsed?.runs) ? parsed.runs : [];
 }
 
 function summarize(results) {
@@ -110,17 +182,6 @@ function summarize(results) {
     distribution[result.outcome] = (distribution[result.outcome] ?? 0) + 1;
   }
   return distribution;
-}
-
-function summarizeByScenario(results) {
-  const byScenario = {};
-  for (const result of results) {
-    const scenario = result.scenario ?? 'unknown';
-    byScenario[scenario] ??= emptyDistribution();
-    byScenario[scenario][result.outcome] =
-      (byScenario[scenario][result.outcome] ?? 0) + 1;
-  }
-  return byScenario;
 }
 
 // Count of regression-class outcomes — the number the job gates on.
@@ -135,74 +196,109 @@ function infraCount(distribution) {
   return distribution.infra ?? 0;
 }
 
+function countColumn(distribution = {}, column) {
+  return column.outcomes.reduce(
+    (sum, outcome) => sum + (distribution[outcome] ?? 0),
+    0
+  );
+}
+
 function compactTimestamp(value) {
   const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) {
     return value;
   }
-  return `${new Date(parsed).toISOString().replace('T', ' ').slice(0, 16)} UTC`;
+  // `08-14 17:08` — the year and the seconds never distinguish two rows of the
+  // same PR, and the column is narrow enough to sit next to five numbers.
+  return new Date(parsed).toISOString().replace('T', ' ').slice(5, 16);
 }
 
-function markdownLink(label, href) {
-  return href ? `[${label}](${href})` : label;
+function markdownLink(text, href) {
+  return href ? `[${text}](${href})` : text;
 }
 
-function renderRunHeader(entry) {
-  const links = [
-    entry.runUrl ? markdownLink('logs', entry.runUrl) : '',
-    entry.deploymentUrl ? markdownLink('deploy', entry.deploymentUrl) : '',
-  ].filter(Boolean);
-  const attemptSuffix = entry.runAttempt ? ` #${entry.runAttempt}` : '';
-  return `${compactTimestamp(entry.timestamp)}${attemptSuffix}<br>${links.join(' / ')}`;
+function renderRunCell(run) {
+  const attemptSuffix =
+    run.runAttempt && Number(run.runAttempt) > 1 ? ` #${run.runAttempt}` : '';
+  return `${markdownLink(compactTimestamp(run.timestamp), run.runUrl)}${attemptSuffix}`;
 }
 
-function renderCount(value) {
-  return String(value ?? 0);
+// The lane cell doubles as the deployment link, which is the only per-lane URL
+// worth a click. Local worlds report `http://localhost:3000`, which is not one.
+function renderLaneCell(laneName, entry) {
+  const deploymentUrl = entry?.deploymentUrl ?? '';
+  const linkable =
+    /^https?:\/\//.test(deploymentUrl) && !deploymentUrl.includes('localhost');
+  return linkable ? markdownLink(laneName, deploymentUrl) : laneName;
 }
 
-function renderResult(entry) {
-  if (entry.missingResults) {
-    return 'missing result file';
+function renderOutcomeBreakdown(entry) {
+  const distribution = entry.distribution ?? {};
+  const parts = gatingOutcomes
+    .filter((outcome) => (distribution[outcome] ?? 0) > 0)
+    .map(
+      (outcome) =>
+        `${distribution[outcome]} ${outcomeShortNames[outcome] ?? outcome}`
+    );
+  const infra = entry.infraCount ?? infraCount(distribution);
+  if (infra > 0) {
+    parts.push(`${infra} infra`);
   }
-  const infra = entry.infraCount ?? infraCount(entry.distribution ?? {});
-  const infraSuffix = infra > 0 ? ` (+${infra} infra)` : '';
-  // A partial run's rates are still meaningful but its totals are not
-  // comparable to a full run's, so the row says so rather than letting a
-  // short run read as a clean one.
-  const partialSuffix = entry.partial
-    ? ` — partial${entry.plannedAttempts ? ` (${entry.total} of ${entry.plannedAttempts} planned)` : ''}`
-    : '';
-  return entry.failedCount === 0
-    ? `no regressions${infraSuffix}${partialSuffix}`
-    : `${entry.failedCount}/${entry.total} regressions${infraSuffix}${partialSuffix}`;
+  return parts.join(', ');
 }
 
-function renderConfig(entry) {
-  const config = entry.config ?? {};
-  const attempts = config.attempts ? `${config.attempts} runs` : '';
+// One line per lane: verdict, then the counts behind it. A partial run's rates
+// are still meaningful but its totals are not comparable to a full run's, so
+// the line says so rather than letting a short run read as a clean one.
+function renderLaneVerdict(laneName, entry, multiLane) {
+  // The heading already names the lane when there is only one of them.
+  const prefix = multiLane ? `\`${laneName}\` ` : '';
+  if (entry.missingResults) {
+    return `${prefix}no result file — the harness died before its first checkpoint`;
+  }
+
+  const verdict =
+    entry.failedCount === 0
+      ? `clean, ${entry.total} run${entry.total === 1 ? '' : 's'}`
+      : `**${entry.failedCount}/${entry.total} regressions**`;
+  const breakdown = renderOutcomeBreakdown(entry);
+  const partial = entry.partial
+    ? `partial: ${entry.total} of ${entry.plannedAttempts || 'the'} planned runs${
+        entry.budgetExhausted ? ', launch budget spent' : ', job ended first'
+      }`
+    : '';
+  return [`${prefix}${verdict}`, breakdown, partial]
+    .filter(Boolean)
+    .join(' — ');
+}
+
+function renderConfigScale(config) {
   const scenarios = [
     config.stepStormAttempts ? `step-storm ${config.stepStormAttempts}` : '',
     config.hookStormAttempts ? `hook-storm ${config.hookStormAttempts}` : '',
     config.hookSleepAttempts ? `hook-sleep ${config.hookSleepAttempts}` : '',
     // Historical entries from the pre-storm harness, kept so an old sticky
-    // comment still renders its own configuration rather than a blank cell.
+    // comment still renders its own configuration rather than a blank line.
     config.stepFanoutAttempts ? `fanout ${config.stepFanoutAttempts}` : '',
     config.stepSleepRaceAttempts ? `race ${config.stepSleepRaceAttempts}` : '',
   ]
     .filter(Boolean)
     .join(', ');
-  const concurrency = config.concurrency ? `c${config.concurrency}` : '';
   const shape =
     config.rounds && config.width
       ? `${config.rounds}x${config.width}`
       : config.stepFanoutRounds && config.stepFanoutWidth
         ? `${config.stepFanoutRounds}x${config.stepFanoutWidth}`
         : '';
-  return [attempts, scenarios, concurrency, shape].filter(Boolean).join(' / ');
+  return [
+    config.attempts ? `${config.attempts} runs` : '',
+    scenarios,
+    config.concurrency ? `c${config.concurrency}` : '',
+    shape,
+  ].filter(Boolean);
 }
 
-function renderTiming(entry) {
-  const config = entry.config ?? {};
+function renderConfigTiming(config) {
   return [
     config.watchdogMs ? `watchdog ${config.watchdogMs}ms` : '',
     config.stepDelayMs
@@ -211,9 +307,14 @@ function renderTiming(entry) {
     config.hookResumeStaggerMs ? `stagger ${config.hookResumeStaggerMs}ms` : '',
     config.pokeIntervalMs ? `poke ${config.pokeIntervalMs}ms` : '',
     config.runTimeoutMs ? `timeout ${config.runTimeoutMs}ms` : '',
-  ]
-    .filter(Boolean)
-    .join(' / ');
+  ].filter(Boolean);
+}
+
+function renderConfig(entry) {
+  const config = entry.config ?? {};
+  return [...renderConfigScale(config), ...renderConfigTiming(config)].join(
+    ' / '
+  );
 }
 
 function compactConfig(config = {}) {
@@ -242,35 +343,43 @@ function compactConfig(config = {}) {
   };
 }
 
-function compactHistoryEntry(entry, keepFailures = false) {
+// Only the latest run keeps its per-run detail (`config`, `failing`): nothing
+// renders an older run's failures or configuration, and the stored JSON counts
+// against the comment's own size limit.
+function compactHistoryEntry(entry, keepDetail = false) {
   return {
-    timestamp: entry.timestamp,
-    runAttempt: entry.runAttempt,
-    runUrl: entry.runUrl,
     deploymentUrl: entry.deploymentUrl,
     missingResults: entry.missingResults,
     partial: entry.partial ?? false,
     budgetExhausted: entry.budgetExhausted ?? false,
     plannedAttempts: entry.plannedAttempts ?? 0,
     distribution: entry.distribution ?? emptyDistribution(),
-    scenarioDistribution: entry.scenarioDistribution ?? {},
     failedCount: entry.failedCount ?? 0,
     infraCount: entry.infraCount ?? infraCount(entry.distribution ?? {}),
     total: entry.total ?? 0,
-    config: compactConfig(entry.config),
-    failing: keepFailures ? (entry.failing ?? []) : [],
-    truncatedFailingCount: keepFailures
-      ? (entry.truncatedFailingCount ?? 0)
-      : 0,
+    config: keepDetail ? compactConfig(entry.config) : undefined,
+    failing: keepDetail ? (entry.failing ?? []) : [],
+    truncatedFailingCount: keepDetail ? (entry.truncatedFailingCount ?? 0) : 0,
+  };
+}
+
+function compactHistoryRun(run, keepDetail = false) {
+  return {
+    timestamp: run.timestamp,
+    runAttempt: run.runAttempt,
+    runUrl: run.runUrl,
+    lanes: Object.fromEntries(
+      Object.entries(run.lanes ?? {}).map(([laneName, entry]) => [
+        laneName,
+        compactHistoryEntry(entry, keepDetail),
+      ])
+    ),
   };
 }
 
 function buildEntry(resultsFile) {
   if (!resultsFile) {
     return {
-      timestamp,
-      runAttempt,
-      runUrl,
       deploymentUrl: '',
       missingResults: true,
       partial: false,
@@ -278,44 +387,45 @@ function buildEntry(resultsFile) {
       plannedAttempts: 0,
       distribution: emptyDistribution(),
       failedCount: 1,
+      infraCount: 0,
       total: 0,
       config: {},
-      scenarioDistribution: {},
       failing: [],
+      truncatedFailingCount: 0,
     };
   }
 
   const results = resultsFile.results ?? [];
   const distribution = resultsFile.distribution ?? summarize(results);
-  const scenarioDistribution =
-    resultsFile.scenarioDistribution ?? summarizeByScenario(results);
   const failedCount = regressionCount(distribution);
   const infra = infraCount(distribution);
   const total = orderedOutcomes.reduce(
     (sum, outcome) => sum + (distribution[outcome] ?? 0),
     0
   );
-  // Surface regressions before infra so the 20-row cap never hides a real
-  // failure behind a flood of harness-timing `infra` rows.
-  const nonCompleted = results
-    .filter((result) => result.outcome !== 'completed')
-    .sort(
-      (a, b) => Number(a.outcome === 'infra') - Number(b.outcome === 'infra')
-    );
-  const failing = nonCompleted.slice(0, 20).map((result) => ({
+  // Regressions first and capped separately from `infra`, so a flood of
+  // harness-timing rows can never crowd a real failure out of the table.
+  const nonCompleted = results.filter(
+    (result) => result.outcome !== 'completed'
+  );
+  const listed = [
+    ...nonCompleted
+      .filter((result) => result.outcome !== 'infra')
+      .slice(0, maxFailingRows),
+    ...nonCompleted
+      .filter((result) => result.outcome === 'infra')
+      .slice(0, maxInfraRows),
+  ];
+  const failing = listed.map((result) => ({
     attempt: result.attempt,
     scenario: result.scenario,
     outcome: result.outcome,
-    status: result.status,
     errorCode: result.errorCode,
     runId: result.runId,
     dashboardUrl: result.dashboardUrl,
   }));
 
   return {
-    timestamp,
-    runAttempt,
-    runUrl,
     deploymentUrl: resultsFile.deploymentUrl,
     missingResults: false,
     // The harness checkpoints the file as it goes and only stamps
@@ -325,163 +435,249 @@ function buildEntry(resultsFile) {
     budgetExhausted: resultsFile.budgetExhausted ?? false,
     plannedAttempts: resultsFile.plannedAttempts ?? 0,
     distribution,
-    scenarioDistribution,
     failedCount,
     infraCount: infra,
     total,
     config: compactConfig(resultsFile.config),
     failing,
-    truncatedFailingCount: Math.max(0, nonCompleted.length - failing.length),
+    truncatedFailingCount: Math.max(0, nonCompleted.length - listed.length),
   };
 }
 
-function appendHistory(history, entry) {
-  const key = `${entry.runUrl || entry.timestamp}#${entry.runAttempt}`;
+function buildRun(lanes) {
+  return {
+    timestamp,
+    runAttempt,
+    runUrl,
+    lanes: Object.fromEntries(
+      lanes.map((lane) => [lane.name, buildEntry(loadResults(lane.path))])
+    ),
+  };
+}
+
+function appendHistory(history, run) {
+  const key = `${run.runUrl || run.timestamp}#${run.runAttempt}`;
   const nextHistory = history
     .filter(
-      (historyEntry) =>
-        `${historyEntry.runUrl || historyEntry.timestamp}#${historyEntry.runAttempt}` !==
+      (historyRun) =>
+        `${historyRun.runUrl || historyRun.timestamp}#${historyRun.runAttempt}` !==
         key
     )
-    .map((historyEntry) => compactHistoryEntry(historyEntry));
-  nextHistory.push(compactHistoryEntry(entry, true));
-  return nextHistory;
+    .map((historyRun) => compactHistoryRun(historyRun));
+  nextHistory.push(compactHistoryRun(run, true));
+  return nextHistory.slice(-maxHistoryRuns);
 }
 
-function renderHistoryTable(history) {
+// Lanes in the order they were passed on the command line, plus any lane that
+// only exists in the stored history (a lane that was removed, or a comment
+// written before this lane was added) so its rows keep rendering.
+function laneOrder(history, lanes) {
+  const names = lanes.map((lane) => lane.name);
+  for (const run of history) {
+    for (const laneName of Object.keys(run.lanes ?? {})) {
+      if (!names.includes(laneName)) {
+        names.push(laneName);
+      }
+    }
+  }
+  return names;
+}
+
+function renderHistoryTable(history, laneNames) {
+  const multiLane = laneNames.length > 1;
+  const headers = [
+    'Run',
+    ...(multiLane ? ['Lane'] : []),
+    'Total',
+    ...summaryColumns.map((column) => column.header),
+  ];
+  // Counts right-align, the Run and Lane labels do not.
+  const alignments = headers.map((_, index) =>
+    index === 0 || (multiLane && index === 1) ? ':--' : '--:'
+  );
+
   console.log('### Run History\n');
-  console.log(`| Metric | ${history.map(renderRunHeader).join(' | ')} |`);
-  console.log(`|:--|${history.map(() => ':--').join('|')}|`);
-  console.log(`| Result | ${history.map(renderResult).join(' | ')} |`);
-  console.log(`| Total | ${history.map((entry) => entry.total).join(' | ')} |`);
-  for (const outcome of orderedOutcomes) {
-    console.log(
-      `| ${outcome} | ${history
-        .map((entry) => renderCount(entry.distribution?.[outcome]))
-        .join(' | ')} |`
-    );
-  }
-  console.log(`| Config | ${history.map(renderConfig).join(' | ')} |`);
-  console.log(`| Timing | ${history.map(renderTiming).join(' | ')} |`);
-  console.log('');
-}
+  console.log(`| ${headers.join(' | ')} |`);
+  console.log(`|${alignments.join('|')}|`);
 
-function renderLatestScenarioBreakdown(entry) {
-  if (entry.missingResults) {
-    return;
-  }
-
-  const scenarioEntries = Object.entries(entry.scenarioDistribution ?? {});
-  if (scenarioEntries.length === 0) {
-    return;
-  }
-
-  console.log('### Latest Scenario Breakdown\n');
-  console.log(`| Scenario | Total | ${orderedOutcomes.join(' | ')} |`);
-  console.log(`|:--|--:|${orderedOutcomes.map(() => '--:').join('|')}|`);
-  for (const [scenario, distribution] of scenarioEntries) {
-    const total = orderedOutcomes.reduce(
-      (sum, outcome) => sum + (distribution[outcome] ?? 0),
-      0
-    );
-    console.log(
-      `| ${scenario} | ${total} | ${orderedOutcomes
-        .map((outcome) => renderCount(distribution[outcome]))
-        .join(' | ')} |`
-    );
+  for (const run of history) {
+    let runCell = renderRunCell(run);
+    for (const laneName of laneNames) {
+      const entry = run.lanes?.[laneName];
+      if (!entry) {
+        continue;
+      }
+      const counts = entry.missingResults
+        ? ['–', ...summaryColumns.map(() => '–')]
+        : [
+            String(entry.total),
+            ...summaryColumns.map((column) =>
+              String(countColumn(entry.distribution, column))
+            ),
+          ];
+      const cells = [
+        runCell,
+        ...(multiLane ? [renderLaneCell(laneName, entry)] : []),
+        ...counts,
+      ];
+      console.log(`| ${cells.join(' | ')} |`);
+      // One run spans several lane rows; only the first of them is stamped, so
+      // the run reads as one block.
+      runCell = '';
+    }
   }
   console.log('');
 }
 
-function renderLatestFailures(entry) {
-  if (entry.missingResults) {
+function renderFailingRow(laneName, result, multiLane) {
+  const runLink =
+    result.dashboardUrl && result.runId
+      ? markdownLink(result.runId, result.dashboardUrl)
+      : (result.runId ?? '');
+  // `outcome` and `errorCode` are the same string for the corruption-class
+  // outcomes; the code is only worth naming when it says something the outcome
+  // does not (`infra` / `HOOK_RESUME_FAILED`).
+  const outcome =
+    result.errorCode && result.errorCode !== result.outcome
+      ? `${result.outcome} (${result.errorCode})`
+      : result.outcome;
+  const cells = [
+    ...(multiLane ? [laneName] : []),
+    result.scenario ?? '',
+    result.attempt,
+    outcome,
+    runLink,
+  ];
+  return `| ${cells.join(' | ')} |`;
+}
+
+function renderLatestFailures(run, laneNames) {
+  const multiLane = laneNames.length > 1;
+  const lanes = laneNames
+    .map((laneName) => ({ laneName, entry: run.lanes?.[laneName] }))
+    .filter(({ entry }) => entry && !entry.missingResults);
+  const rows = lanes.flatMap(({ laneName, entry }) =>
+    (entry.failing ?? []).map((result) => ({ laneName, result }))
+  );
+  const truncated = lanes.reduce(
+    (sum, { entry }) => sum + (entry.truncatedFailingCount ?? 0),
+    0
+  );
+
+  if (rows.length === 0) {
     return;
   }
 
-  if (entry.failing.length === 0) {
-    return;
-  }
-
+  const headers = [
+    ...(multiLane ? ['Lane'] : []),
+    'Scenario',
+    'Attempt',
+    'Outcome',
+    'Run',
+  ];
   console.log('### Latest Non-Completed Runs\n');
-  console.log('| Scenario | Attempt | Outcome | Status | Error code | Run |');
-  console.log('|:--|--:|:--|:--|:--|:--|');
-  for (const result of entry.failing) {
-    const run =
-      result.dashboardUrl && result.runId
-        ? `[${result.runId}](${result.dashboardUrl})`
-        : (result.runId ?? '');
-    console.log(
-      `| ${result.scenario ?? ''} | ${result.attempt} | ${result.outcome} | ${result.status ?? ''} | ${result.errorCode ?? ''} | ${run} |`
-    );
+  console.log(`| ${headers.join(' | ')} |`);
+  console.log(`|${multiLane ? ':--|' : ''}:--|--:|:--|:--|`);
+  for (const { laneName, result } of rows) {
+    console.log(renderFailingRow(laneName, result, multiLane));
   }
-  if (entry.truncatedFailingCount > 0) {
+  if (truncated > 0) {
     console.log(
-      `\nShowing 20 of ${entry.failing.length + entry.truncatedFailingCount} non-completed runs.`
+      `\n${rows.length} of ${rows.length + truncated} non-completed runs shown.`
     );
   }
   console.log('');
 }
 
-function render(resultsFile, previousComment) {
+// Scale is identical across lanes on a normal run (one set of
+// `EVENT_LOG_RACE_REPRO_*` inputs feeds every job), so identical configurations
+// collapse to one line and only a dispatch that somehow differs prints two.
+function renderConfigDetails(run, laneNames, collapsible) {
+  const byConfig = new Map();
+  for (const laneName of laneNames) {
+    const entry = run.lanes?.[laneName];
+    if (!entry || entry.missingResults) {
+      continue;
+    }
+    const rendered = renderConfig(entry);
+    if (!rendered) {
+      continue;
+    }
+    byConfig.set(rendered, [...(byConfig.get(rendered) ?? []), laneName]);
+  }
+
+  if (byConfig.size === 0) {
+    return;
+  }
+
+  // Collapsed in the comment, plain text in a terminal.
+  console.log(
+    collapsible ? '<details><summary>Config</summary>\n' : 'Config\n'
+  );
+  for (const [rendered, lanes] of byConfig) {
+    const prefix = byConfig.size > 1 ? `\`${lanes.join('`, `')}\`: ` : '';
+    console.log(`${prefix}${rendered}\n`);
+  }
+  if (collapsible) {
+    console.log('</details>\n');
+  }
+}
+
+function render(lanes, previousComment) {
+  const fallbackLaneName = laneNameFromLabel(label);
   const history = appendHistory(
-    loadHistory(previousComment),
-    buildEntry(resultsFile)
+    loadHistory(previousComment, fallbackLaneName),
+    buildRun(lanes)
   );
   const latest = history[history.length - 1];
+  const laneNames = laneOrder(history, lanes);
+  const latestLaneNames = laneNames.filter((name) => latest.lanes?.[name]);
 
-  const latestInfra =
-    latest.infraCount ?? infraCount(latest.distribution ?? {});
-  const infraNote =
-    latestInfra > 0
-      ? ` ${latestInfra} run${latestInfra === 1 ? '' : 's'} hit harness-side ` +
-        '`infra` outcomes (hook-resume timing races / transport errors); ' +
-        'these are reported but do not fail the job.'
-      : '';
-
-  const partialNote = latest.partial
-    ? ` Results are **partial**: ${latest.total} of ${latest.plannedAttempts || 'the'} planned runs completed` +
-      `${latest.budgetExhausted ? ', because the launch budget was spent' : ', because the job ended before the harness finished'}` +
-      '. Rates are still comparable; totals are not.'
-    : '';
-
-  console.log(
-    `<!-- event-log-race-repro-results${label ? `-${label}` : ''} -->`
-  );
+  // The sticky-comment marker and the stored history are for the PR comment
+  // only. A local run has no `--run-url`, and there they would be two blocks of
+  // JSON and HTML in a terminal.
+  const forComment = Boolean(runUrl);
+  if (forComment) {
+    console.log(
+      `<!-- event-log-race-repro-results${label ? `-${label}` : ''} -->`
+    );
+  }
   console.log(`## Event Log Race Repro${label ? ` (${label})` : ''}\n`);
-  console.log(
-    latest.missingResults
-      ? 'No result file was produced by the latest repro job.'
-      : latest.failedCount === 0
-        ? `No event-log regressions in the latest repro job.${partialNote}${infraNote}`
-        : `${latest.failedCount} of ${latest.total} latest repro runs hit event-log regressions.${partialNote}${infraNote}`
-  );
+  const multiLane = latestLaneNames.length > 1;
+  for (const laneName of latestLaneNames) {
+    console.log(
+      `- ${renderLaneVerdict(laneName, latest.lanes[laneName], multiLane)}`
+    );
+  }
   console.log('');
-  console.log(historyMarkerStart);
-  console.log(JSON.stringify(history));
-  console.log(historyMarkerEnd);
-  console.log('');
+  if (forComment) {
+    console.log(historyMarkerStart);
+    console.log(JSON.stringify({ runs: history }));
+    console.log(historyMarkerEnd);
+    console.log('');
+  }
 
-  renderHistoryTable(history);
-  renderLatestScenarioBreakdown(latest);
-  renderLatestFailures(latest);
+  renderHistoryTable(history, laneNames);
+  renderLatestFailures(latest, latestLaneNames);
+  renderConfigDetails(latest, latestLaneNames, forComment);
 }
 
 function main() {
-  const resultsFile = loadResults();
-  const previousComment = loadPreviousComment();
-
-  if (!resultsFile) {
-    if (!check) {
-      render(null, previousComment);
-    }
-    process.exit(check ? 1 : 0);
-  }
+  const lanes = laneArgs.length
+    ? laneArgs
+    : [{ name: laneNameFromLabel(label), path: resultsPath }];
 
   if (!check) {
-    render(resultsFile, previousComment);
+    render(lanes, loadPreviousComment());
     process.exit(0);
   }
 
+  // `--check` is the gate, and it only ever looks at one lane's file: the lane
+  // that gates (Vercel) runs it in its own job, on its own results.
+  const resultsFile = loadResults();
+  if (!resultsFile) {
+    process.exit(1);
+  }
   const distribution =
     resultsFile.distribution ?? summarize(resultsFile.results ?? []);
   process.exit(regressionCount(distribution) > 0 ? 1 : 0);
@@ -492,11 +688,14 @@ function main() {
 module.exports = {
   orderedOutcomes,
   gatingOutcomes,
+  summaryColumns,
   summarize,
-  summarizeByScenario,
   regressionCount,
   infraCount,
+  countColumn,
   buildEntry,
+  maxFailingRows,
+  maxHistoryRuns,
 };
 
 if (require.main === module) {

--- a/.github/scripts/render-event-log-race-repro-results.js
+++ b/.github/scripts/render-event-log-race-repro-results.js
@@ -254,7 +254,11 @@ function renderLaneVerdict(laneName, entry, multiLane) {
   // The heading already names the lane when there is only one of them.
   const prefix = multiLane ? `\`${laneName}\` ` : '';
   if (entry.missingResults) {
-    return `${prefix}no result file — the harness died before its first checkpoint`;
+    // Only that the file is absent is known here. The lane may have died before
+    // the harness ran at all (a failed build, or Postgres never coming up), and
+    // naming a cause the renderer cannot see sends the reader to the wrong
+    // place — its job log is where the reason actually is.
+    return `${prefix}no results — the lane wrote no result file, see its job log`;
   }
 
   const verdict =

--- a/.github/scripts/render-event-log-race-repro-results.test.js
+++ b/.github/scripts/render-event-log-race-repro-results.test.js
@@ -303,7 +303,10 @@ test('a lane with no result file gets a row instead of breaking the render', () 
   const rows = tableRows(output, 'Run History');
   assert.strictEqual(rows.length, 2);
   assert.match(rows[0], /\| vercel \| – \| – \| – \| – \| – \|$/);
-  assert.ok(output.includes('- `vercel` no result file'));
+  // A missing file says only that: the lane may have died before the harness
+  // ever ran, so the line must not claim the harness did anything.
+  assert.ok(output.includes('- `vercel` no results'));
+  assert.ok(!output.includes('harness died'));
 });
 
 test('history accumulates per lane across runs and stays capped', () => {

--- a/.github/scripts/render-event-log-race-repro-results.test.js
+++ b/.github/scripts/render-event-log-race-repro-results.test.js
@@ -7,10 +7,13 @@ const { test } = require('node:test');
 
 const {
   gatingOutcomes,
+  summaryColumns,
   regressionCount,
   infraCount,
+  countColumn,
   buildEntry,
   summarize,
+  maxHistoryRuns,
 } = require('./render-event-log-race-repro-results.js');
 
 const SCRIPT = path.join(__dirname, 'render-event-log-race-repro-results.js');
@@ -33,6 +36,52 @@ function runCheck(file) {
 
 function runRender(file) {
   return execFileSync('node', [SCRIPT, file], { encoding: 'utf8' });
+}
+
+// The CI shape: several lanes rendered into one comment, with the previous
+// comment (if any) supplying the history.
+function runRenderLanes(lanes, { previousComment, timestamp, runUrl } = {}) {
+  const args = [SCRIPT];
+  for (const [name, file] of Object.entries(lanes)) {
+    args.push('--lane', `${name}=${file}`);
+  }
+  args.push(
+    '--run-url',
+    runUrl ?? 'https://github.com/vercel/workflow/actions/runs/1',
+    '--run-attempt',
+    '1',
+    '--timestamp',
+    timestamp ?? '2026-08-14T17:08:21Z'
+  );
+  if (previousComment !== undefined) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repro-previous-'));
+    const file = path.join(dir, 'previous.md');
+    fs.writeFileSync(file, previousComment);
+    args.push('--previous-comment', file);
+  }
+  return execFileSync('node', args, { encoding: 'utf8' });
+}
+
+function tableRows(output, heading) {
+  const section = (output.split(`### ${heading}`)[1] ?? '').split('\n### ')[0];
+  return section
+    .split('\n')
+    .filter((line) => line.startsWith('|'))
+    .slice(2); // drop the header and the alignment row
+}
+
+function resultsFor(distribution) {
+  return {
+    results: Object.entries(distribution).flatMap(([outcome, count]) =>
+      Array.from({ length: count }, (_, index) => ({
+        attempt: index,
+        scenario: 'step-storm',
+        outcome,
+        errorCode: outcome === 'completed' ? undefined : outcome,
+        runId: `wrun_${outcome}_${index}`,
+      }))
+    ),
+  };
 }
 
 test('infra is not a gating outcome', () => {
@@ -196,4 +245,205 @@ test('--check still gates on regressions in a partial result file', () => {
     results: [{ outcome: 'completed' }, { outcome: 'CORRUPTED_EVENT_LOG' }],
   });
   assert.strictEqual(runCheck(file), 1);
+});
+
+test('the four count columns always add up to Total', () => {
+  // Whatever bucket an outcome lands in, no run may go missing between the
+  // outcome list and the table — `infra` included.
+  const distribution = {
+    completed: 3,
+    CORRUPTED_EVENT_LOG: 2,
+    USER_ERROR: 1,
+    RUNTIME_ERROR: 1,
+    stuck: 4,
+    other: 1,
+    infra: 5,
+  };
+  const columnTotal = summaryColumns.reduce(
+    (sum, column) => sum + countColumn(distribution, column),
+    0
+  );
+  assert.strictEqual(columnTotal, 17);
+  assert.strictEqual(buildEntry(resultsFor(distribution)).total, 17);
+});
+
+test('lanes render as one row each under a single run', () => {
+  const output = runRenderLanes({
+    vercel: writeTempResults(resultsFor({ completed: 14 })),
+    local: writeTempResults(
+      resultsFor({ completed: 8, CORRUPTED_EVENT_LOG: 6 })
+    ),
+    postgres: writeTempResults(
+      resultsFor({ completed: 9, CORRUPTED_EVENT_LOG: 4, stuck: 1 })
+    ),
+  });
+
+  const rows = tableRows(output, 'Run History');
+  assert.strictEqual(rows.length, 3, 'one row per lane, not per metric');
+  // Columns: Run, Lane, Total, Complete, Corrupt, Stuck, Other.
+  assert.ok(output.includes('| Run | Lane | Total | Complete | Corrupt |'));
+  assert.match(rows[0], /\| vercel \| 14 \| 14 \| 0 \| 0 \| 0 \|$/);
+  assert.match(rows[1], /\| local \| 14 \| 8 \| 6 \| 0 \| 0 \|$/);
+  assert.match(rows[2], /\| postgres \| 14 \| 9 \| 4 \| 1 \| 0 \|$/);
+  // The run is stamped once and its lane rows hang off it.
+  assert.ok(rows[0].includes('08-14 17:08'));
+  assert.ok(!rows[1].includes('08-14 17:08'));
+
+  // Per-lane verdicts, and no scenario breakdown.
+  assert.ok(output.includes('- `local` **6/14 regressions** — 6 corrupt'));
+  assert.ok(output.includes('- `vercel` clean, 14 runs'));
+  assert.ok(!output.includes('Scenario Breakdown'));
+});
+
+test('a lane with no result file gets a row instead of breaking the render', () => {
+  const output = runRenderLanes({
+    vercel: path.join(os.tmpdir(), 'does-not-exist-repro-results.json'),
+    local: writeTempResults(resultsFor({ completed: 14 })),
+  });
+  const rows = tableRows(output, 'Run History');
+  assert.strictEqual(rows.length, 2);
+  assert.match(rows[0], /\| vercel \| – \| – \| – \| – \| – \|$/);
+  assert.ok(output.includes('- `vercel` no result file'));
+});
+
+test('history accumulates per lane across runs and stays capped', () => {
+  const lanes = {
+    vercel: writeTempResults(resultsFor({ completed: 14 })),
+    local: writeTempResults(
+      resultsFor({ completed: 8, CORRUPTED_EVENT_LOG: 6 })
+    ),
+  };
+
+  let comment = '';
+  const runCount = maxHistoryRuns + 2;
+  for (let index = 0; index < runCount; index += 1) {
+    comment = runRenderLanes(lanes, {
+      previousComment: comment,
+      runUrl: `https://github.com/vercel/workflow/actions/runs/${index}`,
+      timestamp: `2026-08-14T1${index}:00:00Z`,
+    });
+  }
+
+  const rows = tableRows(comment, 'Run History');
+  assert.strictEqual(
+    rows.length,
+    maxHistoryRuns * 2,
+    'both lanes are kept for each of the retained runs'
+  );
+  // Oldest runs are dropped, newest is last.
+  assert.ok(!comment.includes('08-14 10:00'));
+  assert.ok(rows[rows.length - 2].includes(`08-14 1${runCount - 1}:00`));
+  // Only the newest run keeps its per-run detail in the stored history.
+  const history = JSON.parse(
+    comment.split('<!-- event-log-race-repro-history\n')[1].split('\n')[0]
+  );
+  assert.strictEqual(history.runs.length, maxHistoryRuns);
+  assert.strictEqual(history.runs[0].lanes.local.failing.length, 0);
+  assert.strictEqual(history.runs[0].lanes.local.config, undefined);
+  assert.strictEqual(
+    history.runs[history.runs.length - 1].lanes.local.failing.length,
+    6
+  );
+});
+
+test('a pre-lane comment history is adopted as the Vercel lane', () => {
+  // The three lanes used to post three comments, each storing a bare array of
+  // its own runs. The combined comment inherits the Vercel lane's array (that
+  // comment's marker is the one it reuses) rather than starting from scratch.
+  const legacyComment = [
+    '<!-- event-log-race-repro-results -->',
+    '## Event Log Race Repro',
+    '',
+    '<!-- event-log-race-repro-history',
+    JSON.stringify([
+      {
+        timestamp: '2026-08-13T09:00:00Z',
+        runAttempt: '1',
+        runUrl: 'https://github.com/vercel/workflow/actions/runs/0',
+        distribution: { completed: 13, CORRUPTED_EVENT_LOG: 1 },
+        failedCount: 1,
+        total: 14,
+      },
+    ]),
+    'event-log-race-repro-history -->',
+  ].join('\n');
+
+  const output = runRenderLanes(
+    {
+      vercel: writeTempResults(resultsFor({ completed: 14 })),
+      local: writeTempResults(resultsFor({ completed: 14 })),
+    },
+    { previousComment: legacyComment }
+  );
+
+  const rows = tableRows(output, 'Run History');
+  // The legacy run (Vercel only) plus this run's two lanes.
+  assert.strictEqual(rows.length, 3);
+  assert.ok(rows[0].includes('08-13 09:00'));
+  assert.match(rows[0], /\| vercel \| 14 \| 13 \| 1 \| 0 \| 0 \|$/);
+});
+
+test('non-completed rows name the error code only when it adds something', () => {
+  const file = writeTempResults({
+    results: [
+      {
+        attempt: 1,
+        scenario: 'hook-storm',
+        outcome: 'CORRUPTED_EVENT_LOG',
+        errorCode: 'CORRUPTED_EVENT_LOG',
+        runId: 'wrun_corrupt',
+      },
+      {
+        attempt: 2,
+        scenario: 'hook-sleep',
+        outcome: 'infra',
+        errorCode: 'HOOK_RESUME_FAILED',
+        runId: 'wrun_infra',
+      },
+    ],
+  });
+  const rows = tableRows(runRender(file), 'Latest Non-Completed Runs');
+  assert.match(rows[0], /\| CORRUPTED_EVENT_LOG \| wrun_corrupt \|$/);
+  assert.match(rows[1], /\| infra \(HOOK_RESUME_FAILED\) \| wrun_infra \|$/);
+});
+
+test('a flood of infra rows cannot crowd out the regressions', () => {
+  // Soak shape: four figures of harness-timing `infra` outcomes around a
+  // handful of real ones. Every regression is listed; the infra rows are there
+  // to name the error code, not to be read.
+  const entry = buildEntry({
+    results: [
+      ...Array.from({ length: 1231 }, (_, i) => ({
+        attempt: i,
+        outcome: 'infra',
+        errorCode: 'HOOK_RESUME_FAILED',
+      })),
+      ...Array.from({ length: 4 }, (_, i) => ({
+        attempt: 5000 + i,
+        outcome: 'CORRUPTED_EVENT_LOG',
+        errorCode: 'CORRUPTED_EVENT_LOG',
+      })),
+    ],
+  });
+  const listedInfra = entry.failing.filter((r) => r.outcome === 'infra');
+  assert.strictEqual(
+    entry.failing.length - listedInfra.length,
+    4,
+    'every regression is listed'
+  );
+  assert.ok(listedInfra.length > 0 && listedInfra.length <= 3);
+  assert.strictEqual(
+    entry.failing.length + entry.truncatedFailingCount,
+    1235,
+    'the truncation note accounts for every non-completed run'
+  );
+});
+
+test('a local render omits the comment marker and the stored history', () => {
+  // No --run-url: this is the local runner printing to a terminal, where the
+  // sticky marker and the history JSON are just noise.
+  const output = runRender(writeTempResults(resultsFor({ completed: 2 })));
+  assert.ok(!output.includes('<!-- event-log-race-repro'));
+  assert.ok(!output.includes('"runs":'));
+  assert.ok(output.includes('### Run History'));
 });

--- a/.github/workflows/event-log-race-repro.yml
+++ b/.github/workflows/event-log-race-repro.yml
@@ -68,13 +68,13 @@ jobs:
     # the job before the summary is written.
     timeout-minutes: 25
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'event-log-race-repro') }}
+    # No comment-writing scopes: the PR comment for every lane is written by
+    # `event-log-race-repro-comment` below.
     permissions:
       contents: read
       deployments: read
       statuses: read
       id-token: write
-      issues: write
-      pull-requests: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -134,38 +134,19 @@ jobs:
           EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms }}
           EVENT_LOG_RACE_REPRO_BUDGET_MS: ${{ inputs.budget_ms }}
 
-      - name: Fetch previous repro comment
-        if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api \
-            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments?per_page=100" \
-            --jq '[.[] | select(.body | contains("<!-- event-log-race-repro-results -->"))][-1].body // ""' \
-            > event-log-race-repro-previous-comment.md
-
+      # This lane's own numbers, for the job summary. The PR comment covering
+      # all three lanes is rendered once, from the artifacts, by
+      # `event-log-race-repro-comment`.
       - name: Render repro summary
         if: always()
         run: |
-          previous_comment_args=()
-          if [ -f event-log-race-repro-previous-comment.md ]; then
-            previous_comment_args=(--previous-comment event-log-race-repro-previous-comment.md)
-          fi
-
           node .github/scripts/render-event-log-race-repro-results.js \
             event-log-race-repro-results.json \
+            --label vercel \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --run-attempt "${{ github.run_attempt }}" \
             --timestamp "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-            "${previous_comment_args[@]}" \
             | tee event-log-race-repro-summary.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Update PR comment
-        if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          header: event-log-race-repro-results
-          path: event-log-race-repro-summary.md
 
       - name: Upload repro results
         if: always()
@@ -194,11 +175,9 @@ jobs:
   # the world-postgres step-storm has red baselines at the default scale (see
   # "Event Log Race Repro" in CLAUDE.md) — so a gate here would be red on PRs
   # that changed nothing, and a gate that is always red is a gate everyone
-  # learns to ignore. Each lane posts its own sticky PR comment
-  # (`world-local` / `world-postgres` suffixed markers, so the three lanes'
-  # histories never mix), and the number to watch is in the comment. The only
-  # thing that fails these jobs is plumbing: a harness that produced no result
-  # file at all.
+  # learns to ignore. Their numbers reach the PR through the shared comment
+  # rendered by `event-log-race-repro-comment`. The only thing that fails these
+  # jobs is plumbing: a harness that produced no result file at all.
   #
   # A soak dispatch that raises `budget_ms` has to raise `timeout-minutes` here
   # too, same as the Vercel lane.
@@ -213,10 +192,9 @@ jobs:
       fail-fast: false
       matrix:
         world: [local, postgres]
+    # No comment-writing scopes: see the Vercel lane's permissions.
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -257,39 +235,17 @@ jobs:
           EVENT_LOG_RACE_REPRO_RUN_TIMEOUT_MS: ${{ inputs.run_timeout_ms }}
           EVENT_LOG_RACE_REPRO_BUDGET_MS: ${{ inputs.budget_ms }}
 
-      - name: Fetch previous repro comment (world-${{ matrix.world }})
-        if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api \
-            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments?per_page=100" \
-            --jq '[.[] | select(.body | contains("<!-- event-log-race-repro-results-world-${{ matrix.world }} -->"))][-1].body // ""' \
-            > event-log-race-repro-previous-comment.md
-
+      # This lane's own numbers, for the job summary — see the Vercel lane.
       - name: Render repro summary
         if: always()
         run: |
-          previous_comment_args=()
-          if [ -f event-log-race-repro-previous-comment.md ]; then
-            previous_comment_args=(--previous-comment event-log-race-repro-previous-comment.md)
-          fi
-
           node .github/scripts/render-event-log-race-repro-results.js \
             event-log-race-repro-results.json \
             --label "world-${{ matrix.world }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --run-attempt "${{ github.run_attempt }}" \
             --timestamp "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-            "${previous_comment_args[@]}" \
             | tee event-log-race-repro-summary.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Update PR comment
-        if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          header: event-log-race-repro-results-world-${{ matrix.world }}
-          path: event-log-race-repro-summary.md
 
       - name: Upload repro results
         if: always()
@@ -309,3 +265,75 @@ jobs:
       - name: Fail if the harness produced no results
         if: always()
         run: test -f event-log-race-repro-results.json
+
+  # One PR comment for all three lanes. They run as parallel jobs and each
+  # uploads its own results file, so the comment is rendered here, from the
+  # artifacts, once every lane has finished. One comment means one stored
+  # history, which is the point: the three worlds' numbers sit on the same rows
+  # of one table, and a push adds three rows rather than editing three comments.
+  event-log-race-repro-comment:
+    name: Event Log Race Repro (comment)
+    runs-on: ubuntu-latest
+    needs: [event-log-race-repro, event-log-race-repro-local-worlds]
+    # `always()`, because a lane that failed, timed out, or produced nothing is
+    # exactly what the comment has to report. The label condition is repeated
+    # because `always()` also fires when every dependency was skipped.
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'event-log-race-repro')) }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Download lane results
+        # A lane that died before its first checkpoint uploads nothing, and
+        # `download-artifact` treats a pattern that matched nothing as an error.
+        # The renderer reports a lane with no results file as exactly that, so
+        # this step is allowed to come back empty.
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: event-log-race-repro-results*
+          path: lane-results
+
+      - name: Fetch previous repro comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments?per_page=100" \
+            --jq '[.[] | select(.body | contains("<!-- event-log-race-repro-results -->"))][-1].body // ""' \
+            > event-log-race-repro-previous-comment.md
+
+      - name: Render repro summary
+        run: |
+          previous_comment_args=()
+          if [ -f event-log-race-repro-previous-comment.md ]; then
+            previous_comment_args=(--previous-comment event-log-race-repro-previous-comment.md)
+          fi
+
+          # Lane order here is the row order in the comment: the gating lane
+          # first, then the two report-only worlds.
+          node .github/scripts/render-event-log-race-repro-results.js \
+            --lane vercel=lane-results/event-log-race-repro-results/event-log-race-repro-results.json \
+            --lane local=lane-results/event-log-race-repro-results-world-local/event-log-race-repro-results.json \
+            --lane postgres=lane-results/event-log-race-repro-results-world-postgres/event-log-race-repro-results.json \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --run-attempt "${{ github.run_attempt }}" \
+            --timestamp "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            "${previous_comment_args[@]}" \
+            | tee event-log-race-repro-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: event-log-race-repro-results
+          path: event-log-race-repro-summary.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,14 +210,19 @@ showing up.
 In CI the same harness runs from `.github/workflows/event-log-race-repro.yml`,
 triggered by adding the `event-log-race-repro` label to a PR (or by
 `workflow_dispatch`, whose inputs are the soak dial — raise `timeout-minutes` in
-that dispatch's branch if you raise `budget_ms`). Results land in a sticky PR
-comment that keeps a history of previous runs and their configs. Alongside the
-Vercel lane, the workflow runs the local script against world-local and
-world-postgres as parallel lanes, each with its own sticky comment. Those two
-lanes are report-only — the local storms have red baselines at the default
-scale (see above), so they publish numbers rather than a verdict and fail only
-when the harness produced no result file at all; the Vercel lane remains the
-gate.
+that dispatch's branch if you raise `budget_ms`). Alongside the Vercel lane, the
+workflow runs the local script against world-local and world-postgres as
+parallel lanes. Those two lanes are report-only — the local storms have red
+baselines at the default scale (see above), so they publish numbers rather than a
+verdict and fail only when the harness produced no result file at all; the Vercel
+lane remains the gate.
+
+All three lanes land in one sticky PR comment, rendered from their artifacts by
+the `event-log-race-repro-comment` job: a verdict line per lane, then a history
+table of one row per lane per run (total / complete / corrupt / stuck / other),
+then the latest run's non-completed runs with links. Each lane's own job summary
+carries the same tables for that lane alone. The comment keeps the last few runs;
+older ones stay in the jobs' artifacts, which hold the full results JSON.
 
 To poke at a run afterwards, the CLI reads the same world from the environment:
 

--- a/scripts/event-log-race-repro-local.sh
+++ b/scripts/event-log-race-repro-local.sh
@@ -458,8 +458,8 @@ fi
 if [ -f "$RESULTS_FILE" ]; then
   log "Summary"
   # Same renderer the CI job uses for its sticky comment; with no --run-url it
-  # just prints the tables.
-  node "$RENDERER" "$RESULTS_FILE"
+  # prints the tables without the comment marker or the stored history.
+  node "$RENDERER" "$RESULTS_FILE" --label "world-$WORLD"
   log "Full results: $RESULTS_FILE / app log: $SERVER_LOG"
 else
   log "No $RESULTS_FILE was written — the harness died before its first checkpoint."

--- a/scripts/event-log-race-repro-local.sh
+++ b/scripts/event-log-race-repro-local.sh
@@ -300,13 +300,21 @@ elif [ "$USE_DOCKER" = "1" ]; then
   docker compose -f "$COMPOSE_FILE" up -d
 
   log "Waiting for Postgres to accept connections"
+  # Probe over TCP, not the unix socket. The image's entrypoint runs a temporary
+  # server for initdb with `listen_addresses=''`, so a socket probe can answer
+  # "ready" during initialization and then answer "not ready" a moment later,
+  # while that server is being swapped for the real one. TCP is only open once
+  # the real server is up, and it is what the app connects over anyway.
+  postgres_ready=0
   for _ in $(seq 1 60); do
-    if docker compose -f "$COMPOSE_FILE" exec -T postgres pg_isready -U world -d world >/dev/null 2>&1; then
+    if docker compose -f "$COMPOSE_FILE" exec -T postgres \
+      pg_isready -h 127.0.0.1 -U world -d world >/dev/null 2>&1; then
+      postgres_ready=1
       break
     fi
     sleep 1
   done
-  docker compose -f "$COMPOSE_FILE" exec -T postgres pg_isready -U world -d world >/dev/null 2>&1 ||
+  [ "$postgres_ready" = "1" ] ||
     die "Postgres did not become ready. Check: docker compose -f $COMPOSE_FILE logs postgres"
 else
   log "Using the Postgres at WORKFLOW_POSTGRES_URL (not managed by this script)"


### PR DESCRIPTION
The `event-log-race-repro` label job posted three sticky comments, one per lane, each carrying a history table that grew a column per run, a scenario breakdown, and up to twenty failure rows.

## What changes

- **One comment for all three lanes.** A new `event-log-race-repro-comment` job runs after the Vercel and world-local/world-postgres lanes, downloads their result artifacts, and renders a single sticky comment. One comment means one stored history, so the three worlds line up on the same rows.
- **Run History is one row per lane per run**, with five count columns: total / complete / corrupt / stuck / other. `Other` folds `USER_ERROR`, `RUNTIME_ERROR`, `other` and `infra`, so the four counts always sum to the total; the verdict line above the table breaks out whatever is non-zero, infra included.
- **Latest Scenario Breakdown is gone.** The non-completed table already names every scenario that failed.
- **Latest Non-Completed Runs** loses its `Status` column and names an error code only when it says something the outcome does not (`infra (HOOK_RESUME_FAILED)`). Regressions are capped separately from infra rows, so a soak's flood of infra can never crowd out a real failure.
- Config and timing move out of the table into a collapsed `<details>`; history keeps the last 5 runs, and only the newest keeps its per-run detail in the stored JSON.
- Each lane still renders its own numbers into its own job summary, and the Vercel lane is still the only gate. The lane jobs no longer need comment-write scopes.

An existing comment's history is not lost: the old array format is read as the Vercel lane's runs.

## Rendered output

Same numbers as [this run](https://github.com/vercel/workflow/actions/runs/31822161846)'s three comments, rendered from its actual artifacts:

> ## Event Log Race Repro
>
> - `vercel` clean, 14 runs
> - `local` **6/14 regressions** — 6 corrupt
> - `postgres` **5/14 regressions** — 5 corrupt
>
> ### Run History
>
> | Run | Lane | Total | Complete | Corrupt | Stuck | Other |
> |:--|:--|--:|--:|--:|--:|--:|
> | 08-14 17:08 | vercel | 14 | 14 | 0 | 0 | 0 |
> |  | local | 14 | 8 | 6 | 0 | 0 |
> |  | postgres | 14 | 9 | 5 | 0 | 0 |
>
> ### Latest Non-Completed Runs
>
> | Lane | Scenario | Attempt | Outcome | Run |
> |:--|:--|--:|:--|:--|
> | local | step-storm | 1 | CORRUPTED_EVENT_LOG | wrun_01M00KQF9PF6NKBSFQDDQK300P |
> | … | | | | |

## Also in here: the world-postgres lane's readiness flake

The first labelled run showed the world-postgres lane dying 1.4s after its container started, with `Postgres did not become ready`. It is pre-existing, and it hit two other runs on the same day. `scripts/event-log-race-repro-local.sh` probed `pg_isready` over the container's unix socket and then re-probed once after the loop: the image's entrypoint runs a temporary server for initdb with `listen_addresses=''`, so the socket answers "ready" mid-initialization, the loop breaks on that answer, and the second probe lands in the swap to the real server. The probe now goes over TCP, which only opens once the real server is up and is what the app connects over anyway, and the loop's own result decides the outcome.

## Testing

`node --test .github/scripts/**/*.test.js` covers the new shapes: lanes as rows, a lane whose result file is missing, history accumulation and its cap, adoption of a pre-lane comment's history, the infra cap, and the column sums. The renderer was also run against the real artifacts of run 31822161846 for all three lanes, plus a partial soak-scale file and a missing lane.

The Postgres gate was verified locally against a fresh volume: a socket probe reports ready one poll before TCP does, and the new gate hands over to a working `select 1`.

The label is on this PR, so the job itself exercises the new plumbing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
