### PR TITLE
[ci] Bump Next.js canary e2e pin to 16.3.1-canary.17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -844,8 +844,8 @@ jobs:
         env:
           APP_NAME: ${{ matrix.app.name }}
         run: |
-          cat packages/next/package.json | jq '.dependencies.next|="16.3.0-canary.2"' > packages/next/package.json.new && mv packages/next/package.json.new packages/next/package.json
-          cat "workbench/$APP_NAME/package.json" | jq '.dependencies.next|="16.3.0-canary.2"' > "workbench/$APP_NAME/package.json.new" && mv "workbench/$APP_NAME/package.json.new" "workbench/$APP_NAME/package.json"
+          cat packages/next/package.json | jq '.dependencies.next|="16.3.1-canary.17"' > packages/next/package.json.new && mv packages/next/package.json.new packages/next/package.json
+          cat "workbench/$APP_NAME/package.json" | jq '.dependencies.next|="16.3.1-canary.17"' > "workbench/$APP_NAME/package.json.new" && mv "workbench/$APP_NAME/package.json.new" "workbench/$APP_NAME/package.json"
           pnpm install --no-frozen-lockfile
 
       - name: Install Dependencies
@@ -933,8 +933,8 @@ jobs:
         env:
           APP_NAME: ${{ matrix.app.name }}
         run: |
-          cat packages/next/package.json | jq '.dependencies.next|="16.3.0-canary.2"' > packages/next/package.json.new && mv packages/next/package.json.new packages/next/package.json
-          cat "workbench/$APP_NAME/package.json" | jq '.dependencies.next|="16.3.0-canary.2"' > "workbench/$APP_NAME/package.json.new" && mv "workbench/$APP_NAME/package.json.new" "workbench/$APP_NAME/package.json"
+          cat packages/next/package.json | jq '.dependencies.next|="16.3.1-canary.17"' > packages/next/package.json.new && mv packages/next/package.json.new packages/next/package.json
+          cat "workbench/$APP_NAME/package.json" | jq '.dependencies.next|="16.3.1-canary.17"' > "workbench/$APP_NAME/package.json.new" && mv "workbench/$APP_NAME/package.json.new" "workbench/$APP_NAME/package.json"
           pnpm install --no-frozen-lockfile
 
       - name: Install Dependencies
@@ -1041,8 +1041,8 @@ jobs:
         env:
           APP_NAME: ${{ matrix.app.name }}
         run: |
-          cat packages/next/package.json | jq '.dependencies.next|="16.3.0-canary.2"' > packages/next/package.json.new && mv packages/next/package.json.new packages/next/package.json
-          cat "workbench/$APP_NAME/package.json" | jq '.dependencies.next|="16.3.0-canary.2"' > "workbench/$APP_NAME/package.json.new" && mv "workbench/$APP_NAME/package.json.new" "workbench/$APP_NAME/package.json"
+          cat packages/next/package.json | jq '.dependencies.next|="16.3.1-canary.17"' > packages/next/package.json.new && mv packages/next/package.json.new packages/next/package.json
+          cat "workbench/$APP_NAME/package.json" | jq '.dependencies.next|="16.3.1-canary.17"' > "workbench/$APP_NAME/package.json.new" && mv "workbench/$APP_NAME/package.json.new" "workbench/$APP_NAME/package.json"
           pnpm install --no-frozen-lockfile
 
       - name: Install Dependencies

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,3 +56,9 @@ minimumReleaseAgeExclude:
   - 'esbuild'
   - '@esbuild/*'
   - 'quickjs-wasi'
+  # The CI canary lanes pin `next` to a fresh canary at install time
+  # (see "Setup canary" in .github/workflows/tests.yml); canaries are
+  # usually younger than the 48h gate, and next and its @next/* companion
+  # packages (published in lockstep) are Vercel-published.
+  - 'next'
+  - '@next/*'


### PR DESCRIPTION
## Summary & Motivation

The canary e2e lanes (E2E Local Dev / Local Prod / Local Postgres for `nextjs-turbopack` and `nextjs-webpack`, × node/quickjs) were pinned to `16.3.0-canary.2`. This bumps the pin to the current canary, `16.3.1-canary.17`, in all six spots in `tests.yml`.

Bumping the pin alone is not enough: fresh Next canaries are younger than the repo's 48h `minimumReleaseAge` gate, so the "Setup canary" `pnpm install --no-frozen-lockfile` fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` (reproduced locally with this exact version). This adds `next` and its lockstep-published `@next/*` companion packages (`@next/env`, `@next/swc-*`) to `minimumReleaseAgeExclude` — both are Vercel-published, matching the trust model of the existing exclusions (`@vercel/*`, `turbo`, `esbuild`).

## Validation

The full e2e suite was run locally against `next@16.3.1-canary.17` on all three worlds (staged tarball workbenches, same as CI's `prepare-workbench-path`):

| World | App / mode | Result |
| --- | --- | --- |
| `world-local` | nextjs-webpack, dev server, node vm | `dev.test.ts` 5 passed / 4 skipped (incl. the HMR fuzz test) · `test:e2e` 137 passed / 19 skipped |
| `world-postgres` | nextjs-turbopack, prod build, node vm | `local-build.test.ts` 13 passed · `test:e2e` 137 passed / 19 skipped¹ |
| `world-vercel` | nextjs-turbopack, preview deployment (`dpl_3siALD2WyrsrdPFjmRY3ymwEHZiJ`), node vm | `test:e2e` 134 passed / 22 skipped |

¹ First pass failed the 3 `pages router` tests because the local harness ran `local-build.test.ts` without `CI=true`, which deletes the `workflow-sourcemap-warning-fixture` package the built output still references (the test preserves it only when `CI=true`, exactly as its comment warns). With the fixture preserved, all 3 pass. Not a canary issue.

Note: the vercel world has no canary lane in CI (deployments build from the committed stable pin), so the preview-deployment run above is the only canary coverage it got.

## Context on current `main` CI

Recent `main` runs are red, but not because of the canary pin: the dominant failure is the nextjs-webpack local-dev HMR fuzz race (SDK-side, fix in flight in #3529), which hits the stable and canary lanes alike; the rest are the known rotating vercel-prod flakes. The latest completed `main` run (with #3530's e2e retry) passed every canary lane and failed only the *stable* webpack dev lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)