### PR TITLE
[core] Replace never-picked-up e2e runs instead of failing whole tests

### DIFF
--- a/.changeset/e2e-pickup-watchdog.md
+++ b/.changeset/e2e-pickup-watchdog.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Add a run-pickup watchdog to the e2e harness: a started run still pending after a budget is replaced (side-effect-free) and recorded as an infra event surfaced separately from test failures and flaky retries.

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -54,6 +54,7 @@ function findResultFiles(dir) {
     'e2e-metadata-',
     'e2e-failures-',
     'e2e-flaky-',
+    'e2e-infra-',
     'e2e-diagnostics-',
     'e2e-runtime-logs-',
     // Not a report: the per-app cross-language conformance declaration
@@ -193,6 +194,67 @@ function loadFlaky(dir) {
   }
 
   return [...flaky.values()];
+}
+
+// Load infra-event sidecar files (platform anomalies the harness observed
+// and absorbed, e.g. runs the queue never picked up — written by the e2e
+// suites' pickup watchdog). Kept separate from flaky tests: a cluster of
+// infra events in one time window is backend signal, not test signal.
+function loadInfra(dir) {
+  const events = [];
+  const files = findJsonFiles(dir, 'e2e-infra-');
+
+  for (const file of files) {
+    const basename = path.basename(file, '.json');
+    const match = basename.match(/^e2e-infra-(.+)-(?:vercel|local)$/);
+    const app = match ? match[1] : 'unknown';
+    try {
+      const entries = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      for (const entry of entries) {
+        if (!entry.kind) continue;
+        events.push({ ...entry, app });
+      }
+    } catch (_e) {
+      // Skip invalid files
+    }
+  }
+
+  return events.sort((a, b) =>
+    (a.timestamp || '').localeCompare(b.timestamp || '')
+  );
+}
+
+// Render the infra-events section shared by the PR comment and the per-job
+// step summary. Several events inside one narrow time window across
+// different apps read as the platform blip they are, rather than as
+// unrelated flaky tests.
+function renderInfraSection(infraEvents) {
+  if (infraEvents.length === 0) return;
+
+  console.log('### \ud83d\udee0 Infra Events (absorbed by the harness)\n');
+  console.log(
+    '_Platform anomalies the e2e harness detected and worked around (e.g. a run the queue never picked up, replaced by a fresh run). Clustered timestamps indicate a backend blip; a steady drip indicates a platform issue worth escalating._\n'
+  );
+
+  const collapse = infraEvents.length >= 10;
+  if (collapse) {
+    console.log('<details>');
+    console.log(`<summary>${infraEvents.length} infra events</summary>\n`);
+  }
+  for (const event of infraEvents) {
+    const time = (event.timestamp || '').slice(11, 19);
+    const parts = [
+      `\`${event.kind}\``,
+      `${event.testName} (${event.app})`,
+      time ? `at ${time}Z` : null,
+      event.runId ? `abandoned \`${event.runId}\`` : null,
+    ].filter(Boolean);
+    console.log(`- ${parts.join(' · ')}`);
+  }
+  console.log('');
+  if (collapse) {
+    console.log('</details>\n');
+  }
 }
 
 // Render the flaky-tests section shared by the PR comment and the per-job
@@ -438,7 +500,7 @@ function aggregateByCategory(files) {
 }
 
 // Render markdown summary for single job (step summary)
-function renderSingleJobSummary(summary, flakyTests = []) {
+function renderSingleJobSummary(summary, flakyTests = [], infraEvents = []) {
   const total =
     summary.totalPassed + summary.totalFailed + summary.totalSkipped;
   const statusEmoji = summary.totalFailed > 0 ? '❌' : '✅';
@@ -478,6 +540,7 @@ function renderSingleJobSummary(summary, flakyTests = []) {
   }
 
   renderFlakySection(flakyTests);
+  renderInfraSection(infraEvents);
 
   // Results by file
   if (summary.fileResults.length > 1) {
@@ -531,7 +594,8 @@ function renderAggregatedSummary(
   metadata,
   diagnostics,
   failures,
-  flakyTests
+  flakyTests,
+  infraEvents
 ) {
   const total =
     overallSummary.totalPassed +
@@ -642,6 +706,7 @@ function renderAggregatedSummary(
   }
 
   renderFlakySection(flakyTests);
+  renderInfraSection(infraEvents);
 
   // Everything else lives under one collapsible summary section.
   console.log('### E2E Test Summary\n');
@@ -712,6 +777,7 @@ if (mode === 'aggregate') {
   const diagnostics = loadDiagnostics(resultsDir);
   const failures = loadFailures(resultsDir);
   const flakyTests = loadFlaky(resultsDir);
+  const infraEvents = loadInfra(resultsDir);
   enrichFailedTestMessages(overallSummary.allFailedTests, failures);
   renderAggregatedSummary(
     categories,
@@ -719,7 +785,8 @@ if (mode === 'aggregate') {
     metadata,
     diagnostics,
     failures,
-    flakyTests
+    flakyTests,
+    infraEvents
   );
 
   // Exit with non-zero if any tests failed
@@ -729,7 +796,7 @@ if (mode === 'aggregate') {
 } else {
   const summary = aggregateResults(resultFiles);
   enrichFailedTestMessages(summary.allFailedTests, loadFailures(resultsDir));
-  renderSingleJobSummary(summary, loadFlaky(resultsDir));
+  renderSingleJobSummary(summary, loadFlaky(resultsDir), loadInfra(resultsDir));
 
   // Exit with non-zero if any tests failed
   if (summary.totalFailed > 0) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -512,6 +512,7 @@ jobs:
             e2e-metadata-${{ matrix.app.name }}-vercel.json
             e2e-failures-${{ matrix.app.name }}-vercel.json
             e2e-flaky-${{ matrix.app.name }}-vercel.json
+            e2e-infra-${{ matrix.app.name }}-vercel.json
             e2e-diagnostics-${{ matrix.app.name }}-vercel.json
             e2e-runtime-logs-${{ matrix.app.name }}-vercel.json
           retention-days: 7
@@ -617,6 +618,7 @@ jobs:
             e2e-metadata-nextjs-turbopack-vercel.json
             e2e-failures-nextjs-turbopack-vercel.json
             e2e-flaky-nextjs-turbopack-vercel.json
+            e2e-infra-nextjs-turbopack-vercel.json
             e2e-diagnostics-nextjs-turbopack-vercel.json
             e2e-runtime-logs-nextjs-turbopack-vercel.json
           retention-days: 7
@@ -797,6 +799,7 @@ jobs:
             e2e-metadata-${{ matrix.app.name }}-vercel.json
             e2e-failures-${{ matrix.app.name }}-vercel.json
             e2e-flaky-${{ matrix.app.name }}-vercel.json
+            e2e-infra-${{ matrix.app.name }}-vercel.json
             e2e-diagnostics-${{ matrix.app.name }}-vercel.json
             e2e-runtime-logs-${{ matrix.app.name }}-vercel.json
           retention-days: 7
@@ -914,6 +917,7 @@ jobs:
           path: |
             e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
             e2e-flaky-${{ matrix.app.name }}-local.json
+            e2e-infra-${{ matrix.app.name }}-local.json
           retention-days: 7
           if-no-files-found: ignore
 
@@ -1005,6 +1009,7 @@ jobs:
           path: |
             e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
             e2e-flaky-${{ matrix.app.name }}-local.json
+            e2e-infra-${{ matrix.app.name }}-local.json
           retention-days: 7
           if-no-files-found: ignore
 
@@ -1116,6 +1121,7 @@ jobs:
           path: |
             e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
             e2e-flaky-${{ matrix.app.name }}-local.json
+            e2e-infra-${{ matrix.app.name }}-local.json
           retention-days: 7
           if-no-files-found: ignore
 
@@ -1225,6 +1231,8 @@ jobs:
           name: e2e-results-conformance-python
           path: |
             e2e-conformance-python.json
+            e2e-flaky-python-local.json
+            e2e-infra-python-local.json
             e2e-diagnostics-python-local.json
           retention-days: 7
           if-no-files-found: ignore
@@ -1382,6 +1390,7 @@ jobs:
           path: |
             e2e-windows-nextjs-turbopack-${{ matrix.vm }}.json
             e2e-flaky-nextjs-turbopack-local.json
+            e2e-infra-nextjs-turbopack-local.json
           retention-days: 7
           if-no-files-found: ignore
 

--- a/packages/core/e2e/e2e-agent.test.ts
+++ b/packages/core/e2e/e2e-agent.test.ts
@@ -10,14 +10,14 @@
  *   2. DEPLOYMENT_URL=http://localhost:3000 APP_NAME=nextjs-turbopack \
  *      pnpm vitest run packages/core/e2e/e2e-agent.test.ts
  */
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import type { Run } from '../src/runtime';
-import { start as rawStart } from '../src/runtime';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Run, start as rawStart } from '../src/runtime';
 import {
   getWorkflowMetadata,
   setupRunTracking,
   setupWorld,
-  trackRun,
+  startTracked,
+  writeInfraSidecar,
 } from './utils';
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
@@ -28,10 +28,12 @@ if (!deploymentUrl) {
 async function start<T>(
   ...args: Parameters<typeof rawStart<T>>
 ): Promise<Run<T>> {
-  const run = await rawStart<T>(...args);
-  trackRun(run);
-  return run;
+  return startTracked<T>(...args);
 }
+
+afterAll(() => {
+  writeInfraSidecar();
+});
 
 // Next.js canary builds (16.2.0-canary.100+) have a regression where
 // @workflow/ai step files are missing from the step bundle, causing

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -48,8 +48,10 @@ import {
   requireFixture,
   setupRunTracking,
   setupWorld,
+  startTracked,
   trackRun,
   writeDiagnosticsSidecar,
+  writeInfraSidecar,
 } from './utils';
 
 const deploymentUrl = process.env.DEPLOYMENT_URL;
@@ -75,14 +77,13 @@ function expectElapsedAtLeast(
 
 /**
  * Tracked wrapper around start() that automatically registers runs
- * for diagnostics on test failure and observability metadata collection.
+ * for diagnostics on test failure and observability metadata collection,
+ * and replaces runs the queue never picks up (see startTracked in utils).
  */
 async function start<T>(
   ...args: Parameters<typeof rawStart<T>>
 ): Promise<Run<T>> {
-  const run = await rawStart<T>(...args);
-  trackRun(run);
-  return run;
+  return startTracked<T>(...args);
 }
 
 function getE2EMetadataPath() {
@@ -337,6 +338,7 @@ describe('e2e', () => {
   afterAll(() => {
     writeE2EMetadata();
     writeDiagnosticsSidecar();
+    writeInfraSidecar();
     // Last, so a stale exemption is reported without costing the diagnostics.
     assertUnsupportedTestsExist();
   });
@@ -4148,9 +4150,15 @@ describe('e2e', () => {
         },
       };
 
-      const run = await start(await e2e('addTenWorkflow'), [123], {
-        world: stubbedWorld,
-      });
+      // Bypass the pickup watchdog (startTracked): this run deliberately
+      // has no run_created event, so no run row exists to poll until the
+      // queue delivers — the watchdog would misread that as a pickup stall
+      // and its replacement start would bump createCallCount.
+      const run = trackRun(
+        await rawStart(await e2e('addTenWorkflow'), [123], {
+          world: stubbedWorld,
+        })
+      );
 
       // Verify the stub intercepted the run_created call (only call
       // through the stubbed world — the server-side runtime uses its

--- a/packages/core/e2e/utils.test.ts
+++ b/packages/core/e2e/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'vitest';
-import { hasStepSourceMaps } from './utils';
+import { hasStepSourceMaps, waitForRunPickup } from './utils';
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -72,5 +72,61 @@ describe('hasStepSourceMaps', () => {
 
     setStepSourceMapEnv({ appName: 'nest', dev: false });
     expect(hasStepSourceMaps()).toBe(false);
+  });
+});
+
+describe('waitForRunPickup', () => {
+  const runWithStatuses = (statuses: string[]) => {
+    let reads = 0;
+    return {
+      get status() {
+        const status = statuses[Math.min(reads, statuses.length - 1)];
+        reads++;
+        return Promise.resolve(status);
+      },
+      get reads() {
+        return reads;
+      },
+    };
+  };
+
+  test('resolves true on the first read for a picked-up run', async () => {
+    const run = runWithStatuses(['running']);
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Run stand-in
+    await expect(waitForRunPickup(run as any, 5_000)).resolves.toBe(true);
+    expect(run.reads).toBe(1);
+  });
+
+  test('any non-pending status counts as picked up, including terminal ones', async () => {
+    const run = runWithStatuses(['completed']);
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Run stand-in
+    await expect(waitForRunPickup(run as any, 5_000)).resolves.toBe(true);
+  });
+
+  test('polls through pending until the run is picked up', async () => {
+    const run = runWithStatuses(['pending', 'pending', 'running']);
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Run stand-in
+    await expect(waitForRunPickup(run as any, 10_000)).resolves.toBe(true);
+    expect(run.reads).toBe(3);
+  });
+
+  test('resolves false when the run never leaves pending within the budget', async () => {
+    const run = runWithStatuses(['pending']);
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Run stand-in
+    await expect(waitForRunPickup(run as any, 1_200)).resolves.toBe(false);
+  });
+
+  test('keeps polling through transient status-read failures', async () => {
+    let reads = 0;
+    const run = {
+      get status() {
+        reads++;
+        return reads < 2
+          ? Promise.reject(new Error('transient'))
+          : Promise.resolve('running');
+      },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Run stand-in
+    await expect(waitForRunPickup(run as any, 5_000)).resolves.toBe(true);
   });
 });

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -9,7 +9,7 @@ import { createWorld as createVercelTestWorld } from '@workflow/world-vercel';
 import { onTestFailed } from 'vitest';
 import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
-import { getWorld, setWorld } from '../src/runtime';
+import { getWorld, start as runtimeStart, setWorld } from '../src/runtime';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultCliTimeoutMs = Number(
@@ -802,6 +802,150 @@ export function trackRun<T>(
     timestamp: new Date().toISOString(),
   });
   return run;
+}
+
+// ---------------------------------------------------------------------------
+// Infra events
+//
+// Platform-level anomalies the harness observed and absorbed (e.g. a run the
+// queue never picked up). These are backend signal, not test-flake signal:
+// they are recorded to a sidecar (`e2e-infra-*.json`) that the aggregation
+// script surfaces separately from test failures and flaky retries, so a
+// cluster of events in one time window reads as the platform blip it is.
+// ---------------------------------------------------------------------------
+
+interface InfraEvent {
+  kind: 'run-pickup-stall';
+  testName: string;
+  /** The run that was abandoned. */
+  runId: string;
+  /** The run started in its place. */
+  replacementRunId: string;
+  waitedMs: number;
+  timestamp: string;
+}
+
+const infraEvents: InfraEvent[] = [];
+
+export function recordInfraEvent(
+  event: Omit<InfraEvent, 'testName' | 'timestamp'> & { testName?: string }
+) {
+  infraEvents.push({
+    ...event,
+    testName: event.testName ?? currentTestName,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
+ * Write recorded infra events to `e2e-infra-{app}-{backend}.json`.
+ *
+ * Merges with any existing file contents: the e2e suites run in separate
+ * vitest workers with separate module state, so each worker appends its own
+ * events rather than clobbering the other's. (Two workers writing in the
+ * same instant could still drop events; afterAll hooks make that window
+ * negligible and the sidecar is observability, not correctness.)
+ */
+export function writeInfraSidecar() {
+  if (infraEvents.length === 0) return;
+
+  const appName = process.env.APP_NAME || 'unknown';
+  const isVercel = !!process.env.WORKFLOW_VERCEL_ENV;
+  const backend = isVercel ? 'vercel' : 'local';
+  const filePath = path.resolve(
+    process.cwd(),
+    `e2e-infra-${appName}-${backend}.json`
+  );
+
+  let existing: InfraEvent[] = [];
+  try {
+    existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {}
+
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify([...existing, ...infraEvents], null, 2)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Run pickup guard
+// ---------------------------------------------------------------------------
+
+/**
+ * How long a freshly started run may sit in `pending` before the harness
+ * treats it as never-picked-up. Healthy pickup is sub-second (observed
+ * ~160ms on Vercel preview deployments); the budget only has to sit safely
+ * above tail latency, and well below the 30–60s test timeouts so the
+ * replacement run still has budget to finish in.
+ */
+const PICKUP_BUDGET_MS = Number(
+  process.env.WORKFLOW_E2E_PICKUP_BUDGET_MS ?? '15000'
+);
+
+/**
+ * Poll until the run leaves `pending` (picked up — any other status counts,
+ * including terminal ones). Returns false if it is still `pending` after
+ * `budgetMs`. The common path costs a single status read.
+ */
+export async function waitForRunPickup(
+  run: Run<unknown>,
+  budgetMs: number = PICKUP_BUDGET_MS
+): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  let interval = 500;
+
+  for (;;) {
+    try {
+      if ((await run.status) !== 'pending') return true;
+    } catch {
+      // Transient status-read failure: keep polling until the budget ends.
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await sleep(Math.min(interval, remaining));
+    interval = Math.min(interval * 2, 5_000);
+  }
+}
+
+/**
+ * `start()` + `trackRun()` with a pickup watchdog.
+ *
+ * A run that is still `pending` after {@link PICKUP_BUDGET_MS} was never
+ * invoked: queue delivery to the deployment stalled (observed as clusters of
+ * runs stuck at `run_created` across apps during backend blips). No workflow
+ * code has executed — no hooks registered, no steps run — so abandoning the
+ * run and starting a replacement is side-effect-free, unlike retrying a
+ * whole test. One replacement, recorded loudly as an infra event; if the
+ * replacement stalls too, the test fails on its own timeouts and the
+ * CI-level retry remains the backstop.
+ */
+export async function startTracked<T>(
+  ...args: Parameters<typeof runtimeStart<T>>
+): Promise<Run<T>> {
+  const run = await runtimeStart<T>(...args);
+  trackRun(run);
+  if (await waitForRunPickup(run)) {
+    return run;
+  }
+
+  const replacement = await runtimeStart<T>(...args);
+  trackRun(replacement);
+  recordInfraEvent({
+    kind: 'run-pickup-stall',
+    runId: run.runId,
+    replacementRunId: replacement.runId,
+    waitedMs: PICKUP_BUDGET_MS,
+  });
+  console.warn(
+    `[e2e] run ${run.runId} was never picked up (pending > ${PICKUP_BUDGET_MS}ms); ` +
+      `replaced with ${replacement.runId} (infra event, not a test failure)`
+  );
+  // Best-effort: keep the zombie from executing if the queue delivers late.
+  void run
+    .cancel({ cancelReason: 'e2e: stuck pending, replaced by watchdog' })
+    .catch(() => {});
+  return replacement;
 }
 
 /**


### PR DESCRIPTION
## Summary & Motivation

The e2e `start()` wrappers now poll the new run until it leaves `pending`. A run still pending after `WORKFLOW_E2E_PICKUP_BUDGET_MS` (default 15s) has executed no workflow code, so it is abandoned and replaced in place and the test continues — one replacement, with the CI-level retry still the backstop if that one stalls too.

Each replacement is recorded to an `e2e-infra-*.json` sidecar that every e2e job uploads, and the aggregation script renders it as an "Infra Events" section in the step summary and PR comment, so clustered timestamps read as a backend blip rather than as unrelated flaky tests.

## Test Plan

Unit tests cover the pickup watchdog; a local nextjs-turbopack run exercised both the clean path and, with a forced 1ms budget, the replacement path end to end, and the aggregation script was smoke-tested against synthetic sidecars in both modes.
