### PR TITLE
Verify stream completion on clean EOF in the reconnecting framed reader

### DIFF
--- a/.changeset/stream-eof-verify.md
+++ b/.changeset/stream-eof-verify.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Verify stream completion on clean EOF in the reconnecting framed reader. Some transport paths normalize a mid-stream abort into a graceful end (the server's max-duration cut can reach the client as a clean EOF), which previously read as end-of-stream and silently truncated live reads at the server's 2-minute connection cap. On EOF the reader now checks the stream's authoritative metadata and reconnects from the next chunk unless the stream is complete and every chunk up to `done` was delivered.

--- a/.changeset/stream-eof-verify.md
+++ b/.changeset/stream-eof-verify.md
@@ -2,4 +2,4 @@
 '@workflow/core': patch
 ---
 
-Verify stream completion on clean EOF in the reconnecting framed reader. Some transport paths normalize a mid-stream abort into a graceful end (the server's max-duration cut can reach the client as a clean EOF), which previously read as end-of-stream and silently truncated live reads at the server's 2-minute connection cap. On EOF the reader now checks the stream's authoritative metadata and reconnects from the next chunk unless the stream is complete and every chunk up to `done` was delivered.
+Verify stream tail when the reconnecting framed reader receives an EOF to ensure it is due to stream completion (and not other world-side behavior)

--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -76,7 +76,8 @@ async function readAll(
  * check reconnect positioning.
  */
 function makeWorldWithScriptedStreams(
-  scripts: Record<number, () => ReadableStream<Uint8Array>>
+  scripts: Record<number, () => ReadableStream<Uint8Array>>,
+  getInfo?: () => Promise<{ tailIndex: number; done: boolean }>
 ): { world: World; calls: number[] } {
   const calls: number[] = [];
   const world = {
@@ -91,6 +92,7 @@ function makeWorldWithScriptedStreams(
         }
         return factory();
       }),
+      ...(getInfo ? { getInfo: vi.fn(getInfo) } : {}),
     },
   } as unknown as World;
   return { world, calls };
@@ -437,6 +439,138 @@ describe('createReconnectingFramedStream', () => {
     // and each reconnect resumed at the next index.
     expect(calls.length).toBeGreaterThan(FRAMED_STREAM_MAX_RECONNECTS + 1);
     expect(calls).toEqual(Array.from({ length: lastIndex + 1 }, (_, i) => i));
+  });
+
+  it('reconnects when a clean EOF arrives before the stream is complete', async () => {
+    // Infrastructure can normalize a mid-stream abort into a graceful EOF
+    // (production shape: the server's max-duration cut reaches the client as
+    // a clean close). The wrapper must verify completion instead of trusting
+    // the EOF, and resume from the next chunk.
+    let infoCalls = 0;
+    const { world, calls } = makeWorldWithScriptedStreams(
+      {
+        0: () =>
+          scriptedStream([
+            { kind: 'value', value: payloadFrame(1) },
+            { kind: 'value', value: payloadFrame(2) },
+            { kind: 'close' },
+          ]),
+        2: () =>
+          scriptedStream([
+            { kind: 'value', value: payloadFrame(3) },
+            { kind: 'close' },
+          ]),
+      },
+      async () => {
+        infoCalls++;
+        // Not complete at the first EOF; complete (3 chunks) at the second.
+        return infoCalls === 1
+          ? { tailIndex: 1, done: false }
+          : { tailIndex: 2, done: true };
+      }
+    );
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([payloadFrame(1), payloadFrame(2), payloadFrame(3)]);
+    expect(calls).toEqual([0, 2]);
+    expect(infoCalls).toBe(2);
+  });
+
+  it('reconnects when a completed stream EOFs short of its tail', async () => {
+    // The stream IS complete, but this session was cut mid-body: delivered
+    // frames don't cover every chunk up to `done`. Trusting the EOF here
+    // silently loses the tail.
+    const { world, calls } = makeWorldWithScriptedStreams(
+      {
+        0: () =>
+          scriptedStream([
+            { kind: 'value', value: payloadFrame(1) },
+            { kind: 'close' },
+          ]),
+        1: () =>
+          scriptedStream([
+            { kind: 'value', value: payloadFrame(2) },
+            { kind: 'close' },
+          ]),
+      },
+      async () => ({ tailIndex: 1, done: true })
+    );
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([payloadFrame(1), payloadFrame(2)]);
+    expect(calls).toEqual([0, 1]);
+  });
+
+  it('closes on EOF when metadata confirms completion', async () => {
+    const { world, calls } = makeWorldWithScriptedStreams(
+      {
+        0: () =>
+          scriptedStream([
+            { kind: 'value', value: payloadFrame(1) },
+            { kind: 'value', value: payloadFrame(2) },
+            { kind: 'close' },
+          ]),
+      },
+      async () => ({ tailIndex: 1, done: true })
+    );
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([payloadFrame(1), payloadFrame(2)]);
+    expect(calls).toEqual([0]);
+  });
+
+  it('trusts EOF when stream metadata is unavailable', async () => {
+    // A transient getInfo failure must not turn a healthy completion into an
+    // error or a reconnect loop — fall back to the legacy trust-the-EOF
+    // behavior.
+    const { world, calls } = makeWorldWithScriptedStreams(
+      {
+        0: () =>
+          scriptedStream([
+            { kind: 'value', value: payloadFrame(1) },
+            { kind: 'close' },
+          ]),
+      },
+      async () => {
+        throw new Error('metadata unavailable');
+      }
+    );
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([payloadFrame(1)]);
+    expect(calls).toEqual([0]);
+  });
+
+  it('gives up after the reconnect budget when EOF stays unverified', async () => {
+    // A server that keeps clean-EOFing an incomplete stream without ever
+    // making progress must exhaust the consecutive-reconnect budget, not
+    // loop forever.
+    const { world, calls } = makeWorldWithScriptedStreams(
+      {
+        0: () => scriptedStream([{ kind: 'close' }]),
+      },
+      async () => ({ tailIndex: 4, done: false })
+    );
+    setWorld(world);
+
+    const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
+    await expect(readAll(stream)).rejects.toThrow(
+      /exceeded maximum reconnection attempts/
+    );
+    expect(calls).toHaveLength(FRAMED_STREAM_MAX_RECONNECTS + 1);
+    expect(calls.every((i) => i === 0)).toBe(true);
   });
 
   it('errors at the absolute backstop when a world ignores startIndex and loops forever', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -872,8 +872,16 @@ const getFramedStreamMaxTotalReconnects = (): number =>
  * bytes buffered before the cut are discarded — the server will resend the
  * in-flight chunk in full from the new startIndex.
  *
- * A clean upstream close (EOF with no error) signals the stream is truly
- * done; we close the wrapper and do not reconnect.
+ * A clean upstream close (EOF with no error) is NOT trusted as completion
+ * on its own: some transport paths normalize a mid-stream abort into a
+ * graceful end (observed in production on Vercel response streaming, where
+ * the server's max-duration abort arrives at the client as a clean EOF).
+ * On EOF the wrapper verifies against the stream's authoritative metadata
+ * (`streams.getInfo`) that the stream is complete AND that every chunk up to
+ * `done` was delivered; otherwise it reconnects from the next chunk exactly
+ * like an errored connection. If the metadata read itself fails, the EOF is
+ * trusted (legacy behavior) rather than failing a read that may well be
+ * complete.
  *
  * Negative `startIndex` values (last-N semantics) skip the reconnect
  * machinery because we cannot compute an absolute resume position without
@@ -908,6 +916,24 @@ export function createReconnectingFramedStream(
     const stream = await world.streams.get(runId, name, effectiveStartIndex);
     if (connectMs === undefined) connectMs = Date.now() - connectStart;
     reader = stream.getReader();
+  }
+
+  /**
+   * Whether an upstream EOF represents genuine completion: the stream's
+   * authoritative metadata says it is done AND the frames delivered so far
+   * cover every chunk up to the tail (one outer frame == one server chunk).
+   * A metadata failure trusts the EOF — turning a healthy completion into an
+   * error (or a reconnect loop) on a transient metadata blip would be worse
+   * than the legacy behavior this check guards against.
+   */
+  async function isVerifiedComplete(): Promise<boolean> {
+    try {
+      const world = await getWorldLazy();
+      const info = await world.streams.getInfo(runId, name);
+      return info.done && currentStartIndex + consumedFrames > info.tailIndex;
+    } catch {
+      return true;
+    }
   }
 
   async function reconnect(): Promise<void> {
@@ -992,10 +1018,25 @@ export function createReconnectingFramedStream(
         }
 
         if (result.done || !result.value) {
-          // Clean EOF — stream is truly complete. Drop any partial-frame
-          // bytes (there shouldn't be any; a well-formed stream ends on a
-          // frame boundary).
           reader = undefined;
+          // A clean EOF is only trustworthy if the stream is actually
+          // complete and this session delivered every chunk up to `done`.
+          // Infrastructure can normalize a mid-stream abort into a graceful
+          // end (the server's max-duration cut is designed to arrive as an
+          // errored body, but on some paths it reaches the client as a clean
+          // EOF), and a completed stream can still be cut mid-body — both
+          // would otherwise be silently read as a shorter, complete stream.
+          if (reconnectSupported && !(await isVerifiedComplete())) {
+            try {
+              await reconnect();
+            } catch (reconnectErr) {
+              controller.error(reconnectErr);
+              return;
+            }
+            continue;
+          }
+          // Genuine end-of-stream. Drop any partial-frame bytes (there
+          // shouldn't be any; a well-formed stream ends on a frame boundary).
           if (readStart !== undefined) {
             recordStreamReadComplete(
               readStart,


### PR DESCRIPTION
## Summary & Motivation

Long live reads were ending silently at the server's 2-minute connection cap: the max-duration abort reaches the client as a clean EOF on some transport paths, and the reader read that as end-of-stream. On EOF it now consults `streams.getInfo` and reconnects from the next chunk unless the stream is done and every chunk up to the tail was delivered. A failed metadata read trusts the EOF, so a transient blip can't fail a healthy completion.

## Test Plan

Tests added for the reconnect, verified-completion, metadata-failure, and reconnect-budget paths.
