### PR TITLE
Add celld as a community World

### DIFF
--- a/.changeset/add-celld-world.md
+++ b/.changeset/add-celld-world.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web': patch
+---
+
+Add `@ewhauser/world-celld` to `worlds-manifest.json` as an experimental, self-hosted community World. Allow the web UI to report its connection metadata while redacting the shared secret.

--- a/packages/web/app/server/workflow-server-actions.server.test.ts
+++ b/packages/web/app/server/workflow-server-actions.server.test.ts
@@ -1,7 +1,8 @@
 import type { AnalyticsEvent, Hook } from '@workflow/world';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   analyticsEventToEvent,
+  getPublicServerConfig,
   hookToListItem,
 } from './workflow-server-actions.server';
 
@@ -98,5 +99,32 @@ describe('hookToListItem', () => {
       specVersion: 2,
     });
     expect('token' in listItem).toBe(false);
+  });
+});
+
+describe('getPublicServerConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('redacts the celld shared secret while exposing connection metadata', async () => {
+    vi.stubEnv('WORKFLOW_TARGET_WORLD', '@ewhauser/world-celld');
+    vi.stubEnv('CELLD_FLEET_URL', 'http://fleet.internal:8080');
+    vi.stubEnv('CELLD_WORLD_SECRET', 'super-secret');
+    vi.stubEnv('WORKFLOW_BASE_URL', 'https://workflow.example.com');
+
+    const config = await getPublicServerConfig();
+
+    expect(config).toMatchObject({
+      backendDisplayName: 'world-celld',
+      backendId: '@ewhauser/world-celld',
+      publicEnv: {
+        WORKFLOW_TARGET_WORLD: '@ewhauser/world-celld',
+        CELLD_FLEET_URL: 'http://fleet.internal:8080',
+        WORKFLOW_BASE_URL: 'https://workflow.example.com',
+      },
+      sensitiveEnvKeys: ['CELLD_WORLD_SECRET'],
+    });
+    expect(config.publicEnv).not.toHaveProperty('CELLD_WORLD_SECRET');
   });
 });

--- a/packages/web/app/server/workflow-server-actions.server.ts
+++ b/packages/web/app/server/workflow-server-actions.server.ts
@@ -224,6 +224,12 @@ const WORLD_ENV_ALLOWLIST_BY_TARGET_WORLD: Record<string, string[]> = {
     'JAZZ_WORKER_ACCOUNT',
     'JAZZ_WORKER_SECRET',
   ],
+  '@ewhauser/world-celld': [
+    'WORKFLOW_TARGET_WORLD',
+    'CELLD_FLEET_URL',
+    'CELLD_WORLD_SECRET',
+    'WORKFLOW_BASE_URL',
+  ],
 };
 
 function getAllowedEnvKeysForBackend(backendId: string): string[] {
@@ -247,6 +253,7 @@ const WORLD_SENSITIVE_ENV_KEYS = new Set<string>([
   'WORKFLOW_REDIS_URI',
   'JAZZ_API_KEY',
   'JAZZ_WORKER_SECRET',
+  'CELLD_WORLD_SECRET',
 ]);
 
 function isSet(value: string | undefined): value is string {

--- a/worlds-manifest.json
+++ b/worlds-manifest.json
@@ -188,6 +188,26 @@
       "credentialsNote": "Requires JAZZ_API_KEY, JAZZ_WORKER_ACCOUNT, and JAZZ_WORKER_SECRET from Jazz Cloud"
     },
     {
+      "id": "celld",
+      "type": "community",
+      "package": "@ewhauser/world-celld",
+      "name": "celld",
+      "description": "Experimental self-hosted World backed by celld Durable Objects for durable workflow storage, queues, and streams",
+      "repository": "https://github.com/ewhauser/world-celld",
+      "docs": "https://github.com/ewhauser/world-celld#readme",
+      "features": [],
+      "env": {
+        "WORKFLOW_TARGET_WORLD": "@ewhauser/world-celld",
+        "CELLD_FLEET_URL": "http://fleet.internal:8080",
+        "CELLD_WORLD_SECRET": "",
+        "WORKFLOW_BASE_URL": "https://workflow.example.com"
+      },
+      "services": [],
+      "requiresCredentials": true,
+      "credentialsNote": "Requires a deployed celld fleet and CELLD_WORLD_SECRET matching the fleet's WORLD_SECRET",
+      "requiresDeployment": true
+    },
+    {
       "id": "fantasticfour-redis",
       "type": "community",
       "package": "@fantasticfour/world-redis",


### PR DESCRIPTION
### Description

Adds the published `@ewhauser/world-celld` package to `worlds-manifest.json` as an experimental, self-hosted community World.

The manifest marks celld as requiring deployment and credentials because applications connect to a separately deployed celld fleet using a shared secret. The web server allowlist now exposes the non-secret fleet and callback metadata while redacting `CELLD_WORLD_SECRET`.

### How did you test your changes?

- Parsed and asserted the celld manifest entry and all required environment keys.
- Ran `scripts/create-community-worlds-matrix.mjs` and verified celld is excluded from local CI because it requires an external deployment and credentials.
- Ran Biome against every changed JSON and TypeScript file.
- Built the `@workflow/web` workspace dependencies and ran `app/server/workflow-server-actions.server.test.ts` (4 tests passed), including a new secret-redaction regression test.
- Ran `pnpm exec changeset status --since=main`.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [x] 🔒 DCO sign-off passes (`git commit --signoff`)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
