### PR TITLE
[world-vercel] Decode chunked event frames without repeated copies

### DIFF
--- a/.changeset/fast-frame-refill.md
+++ b/.changeset/fast-frame-refill.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Avoid repeatedly copying partial event-frame bodies as network chunks arrive.

--- a/packages/world-vercel/src/frames.ts
+++ b/packages/world-vercel/src/frames.ts
@@ -66,14 +66,23 @@ export async function* decodeFrames(
   let buffer = new Uint8Array(0);
 
   const refill = async (needed: number): Promise<boolean> => {
-    while (buffer.byteLength < needed) {
-      const { done, value } = await chunks.next();
-      if (done) return false;
-      if (!value || value.byteLength === 0) continue;
-      const next = new Uint8Array(buffer.byteLength + value.byteLength);
-      next.set(buffer, 0);
-      next.set(value, buffer.byteLength);
-      buffer = next;
+    if (buffer.byteLength >= needed) return true;
+
+    const parts: Uint8Array[] = [buffer];
+    let byteLength = buffer.byteLength;
+    while (byteLength < needed) {
+      const chunk = await chunks.next();
+      if (chunk.done) return false;
+      if (chunk.value.byteLength === 0) continue;
+      parts.push(chunk.value);
+      byteLength += chunk.value.byteLength;
+    }
+
+    buffer = new Uint8Array(byteLength);
+    let offset = 0;
+    for (const part of parts) {
+      buffer.set(part, offset);
+      offset += part.byteLength;
     }
     return true;
   };


### PR DESCRIPTION
## Summary

- collect partial network chunks before growing the frame buffer
- concatenate buffered bytes once per requested frame field instead of once per incoming chunk
- preserve frame ordering, arbitrary chunk boundaries, owned payload bytes, and early stream cancellation

## Performance

Local Node microbenchmark, one 8 MB frame:

| Input chunks | Before | After |
| --- | ---: | ---: |
| 64 KB | ~31 ms | ~0.6 ms |
| 16 KB | ~93 ms | ~0.9 ms |

The benchmark is synthetic, but it directly exercises the removed repeated-copy behavior.

## Validation

- `pnpm --filter @workflow/world-vercel... build`
- `pnpm --filter @workflow/world-vercel test` — 513 tests passed
- `pnpm --filter @workflow/world-vercel typecheck`
- Biome and `git diff --check`