### PR TITLE
[next] Suppress duplicate dev-watcher notifications instead of re-invalidating

### DIFF
--- a/.changeset/fix-next-hmr-build-race.md
+++ b/.changeset/fix-next-hmr-build-race.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Preserve source changes made during Next.js development rebuilds for the next HMR pass.

--- a/.changeset/hmr-duplicate-event-suppression.md
+++ b/.changeset/hmr-duplicate-event-suppression.md
@@ -1,0 +1,5 @@
+---
+'@workflow/next': patch
+---
+
+Suppress duplicate dev-watcher notifications instead of re-invalidating: source snapshots now record the file mtime alongside the content hash, so a repeated event for an already-consumed write is a no-op while a same-content rewrite still triggers a conservative rediscovery. Full rediscoveries also seed baselines for newly discovered files from the classifier's reads, so a freshly created file's duplicate events no longer force a second rebuild.

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -156,8 +156,6 @@ export function createDevTests(config?: DevTestConfig) {
       full: 'workflow dev hmr: full rediscovery',
       idle: 'workflow dev hmr: idle',
     };
-    const hmrRebuildCompleteMessage = 'workflow dev hmr: rebuild complete';
-
     const fetchWithTimeout = (pathname: string) => {
       if (!deploymentUrl) {
         return Promise.resolve();
@@ -196,11 +194,8 @@ export function createDevTests(config?: DevTestConfig) {
         .catch(() => '');
     };
     /**
-     * Wait until the dev server's HMR pipeline is quiescent: every rebuild
-     * the log says started (`hot rebuild` / `full rediscovery`) has logged
-     * `rebuild complete`, and no new HMR line has appeared for a short
-     * window (covering watcher latency for a just-landed write plus the
-     * flush debounce).
+     * Wait until the dev server's HMR pipeline is idle and no new HMR line
+     * has appeared for a short window covering watcher latency and debounce.
      *
      * Rebuilds are serialized and can take multi-second on CI, so a write
      * from a previous case (or a teardown restore) can still be rebuilding
@@ -224,13 +219,19 @@ export function createDevTests(config?: DevTestConfig) {
           const hot = countLogMessage(log, hmrLogMessages.hot);
           const full = countLogMessage(log, hmrLogMessages.full);
           const skip = countLogMessage(log, hmrLogMessages.skip);
-          const complete = countLogMessage(log, hmrRebuildCompleteMessage);
-          const counts = `${hot}/${full}/${skip}/${complete}`;
+          const idle = countLogMessage(log, hmrLogMessages.idle);
+          const counts = `${hot}/${full}/${skip}/${idle}`;
           if (counts !== lastCounts) {
             lastCounts = counts;
             quietSince = Date.now();
           }
-          expect(complete).toBeGreaterThanOrEqual(hot + full);
+          expect(log.lastIndexOf(hmrLogMessages.idle)).toBeGreaterThanOrEqual(
+            Math.max(
+              log.lastIndexOf(hmrLogMessages.hot),
+              log.lastIndexOf(hmrLogMessages.full),
+              log.lastIndexOf(hmrLogMessages.skip)
+            )
+          );
           expect(Date.now() - quietSince).toBeGreaterThanOrEqual(
             hmrQuiescenceQuietMs
           );
@@ -1139,7 +1140,7 @@ ${apiFileContent}`
           {
             file: files.step,
             kind: 'none',
-            expectedLogCounts: 'any',
+            expectedLogCounts: { full: 1 },
             expectedStepValue: (iteration: number) => `step-only-${iteration}`,
             source: (
               iteration: number
@@ -1168,7 +1169,7 @@ export async function hmrFuzzStep() {
           {
             file: files.workflow,
             kind: 'workflow',
-            expectedLogCounts: { hot: 1 },
+            expectedLogCounts: { full: 1 },
             expectedWorkflowValue: (iteration: number) =>
               `workflow-body-${iteration}`,
             source: (

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -154,6 +154,7 @@ export function createDevTests(config?: DevTestConfig) {
       skip: 'workflow dev hmr: skip',
       hot: 'workflow dev hmr: hot rebuild',
       full: 'workflow dev hmr: full rediscovery',
+      idle: 'workflow dev hmr: idle',
     };
     const hmrRebuildCompleteMessage = 'workflow dev hmr: rebuild complete';
 
@@ -249,6 +250,13 @@ export function createDevTests(config?: DevTestConfig) {
     const countLogMessage = (log: string, message: string) =>
       log.split(message).length - 1;
     type ExpectedHmrLogCount = number | { min?: number; max?: number };
+    type ExpectedHmrLogCounts =
+      | 'any'
+      | {
+          skip?: ExpectedHmrLogCount;
+          hot?: ExpectedHmrLogCount;
+          full?: ExpectedHmrLogCount;
+        };
     const expectLogCount = (
       actual: number,
       expected: ExpectedHmrLogCount | undefined
@@ -270,11 +278,7 @@ export function createDevTests(config?: DevTestConfig) {
     };
     const expectHmrLogCounts = async (
       cursor: number | undefined,
-      expected: {
-        skip?: ExpectedHmrLogCount;
-        hot?: ExpectedHmrLogCount;
-        full?: ExpectedHmrLogCount;
-      }
+      expected: ExpectedHmrLogCounts
     ) => {
       if (cursor === undefined) {
         return;
@@ -285,6 +289,20 @@ export function createDevTests(config?: DevTestConfig) {
         intervalMs: 250,
         check: async () => {
           const log = (await readDevServerLog()).slice(cursor);
+          expect(log).toContain(hmrLogMessages.idle);
+          if (expected === 'any') {
+            expect(
+              [
+                hmrLogMessages.skip,
+                hmrLogMessages.hot,
+                hmrLogMessages.full,
+              ].reduce(
+                (count, message) => count + countLogMessage(log, message),
+                0
+              )
+            ).toBeGreaterThan(0);
+            return;
+          }
           expectLogCount(
             countLogMessage(log, hmrLogMessages.skip),
             expected.skip
@@ -958,6 +976,7 @@ ${apiFileContent}`
         }
 
         await waitForHmrReady();
+        const setupLogCursor = await readDevServerLogCursor();
 
         const writeFuzzSources = async (iteration: number) => {
           await Promise.all([
@@ -1074,6 +1093,15 @@ ${apiFileContent}`
           },
         });
         assert(workflow);
+        await pollUntil({
+          description: 'HMR fuzz fixture rebuilds to finish',
+          timeoutMs: flowRouteHmrRediscoveryTimeoutMs,
+          intervalMs: 250,
+          check: async () => {
+            const log = (await readDevServerLog()).slice(setupLogCursor);
+            expect(log).toContain(hmrLogMessages.idle);
+          },
+        });
         const runWorkflow = async () => {
           const run = await start<
             [],
@@ -1111,7 +1139,7 @@ ${apiFileContent}`
           {
             file: files.step,
             kind: 'none',
-            expectedLogCounts: { skip: 1 },
+            expectedLogCounts: 'any',
             expectedStepValue: (iteration: number) => `step-only-${iteration}`,
             source: (
               iteration: number
@@ -1369,6 +1397,9 @@ export async function hmrFuzzAddedWorkflow() {
           },
           {
             description: 'workflow file added through API import',
+            expectedLogCounts: {
+              full: { min: 1, max: 2 },
+            },
             write: async (iteration: number) => {
               await fs.writeFile(
                 files.addedWorkflow,
@@ -1402,7 +1433,9 @@ ${apiFileContent}`
           },
           {
             description: 'workflow file removed from API import',
-            expectedLogCounts: { full: 1, skip: 1 },
+            expectedLogCounts: {
+              full: { min: 1, max: 2 },
+            },
             write: async () => {
               await fs.rm(files.addedWorkflow, { force: true });
               await fs.writeFile(

--- a/packages/core/e2e/dev.test.ts
+++ b/packages/core/e2e/dev.test.ts
@@ -1139,7 +1139,7 @@ ${apiFileContent}`
         const cases = [
           {
             file: files.step,
-            kind: 'none',
+            kind: 'full',
             expectedLogCounts: { full: 1 },
             expectedStepValue: (iteration: number) => `step-only-${iteration}`,
             source: (
@@ -1168,7 +1168,7 @@ export async function hmrFuzzStep() {
           },
           {
             file: files.workflow,
-            kind: 'workflow',
+            kind: 'full',
             expectedLogCounts: { full: 1 },
             expectedWorkflowValue: (iteration: number) =>
               `workflow-body-${iteration}`,

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -19,11 +19,10 @@ import type { NextConfig as ProjectNextConfig } from 'next';
 import { createWatchIgnorePredicate } from './watch-ignore.js';
 import {
   classifyRebuild,
+  createRebuildScheduler,
   createSourceSnapshot,
-  type FileChanges,
   getRelevantFiles,
-  pinBaselinesAcrossFullRebuild,
-  replaceSourceSnapshots,
+  readSourceSnapshots,
   type SourceSnapshot,
 } from './watch-rebuild.js';
 
@@ -152,7 +151,8 @@ export async function getNextBuilderEager(
             ? pathname
             : resolve(this.config.workingDir, pathname)
           ).replace(/\\/g, '/');
-        const sourceSnapshots = new Map<string, SourceSnapshot>();
+        let sourceSnapshots = new Map<string, SourceSnapshot>();
+        let buildInProgress = false;
 
         const watchableExtensions = new Set([
           '.js',
@@ -190,25 +190,15 @@ export async function getNextBuilderEager(
           return isIgnoredWatchPath(normalizedPath);
         };
 
-        let rebuildQueue = Promise.resolve();
-
-        const enqueue = (task: () => Promise<void>) => {
-          rebuildQueue = rebuildQueue.then(task).catch((error) => {
-            console.error('Failed to process file change', error);
-          });
-          return rebuildQueue;
-        };
-
         const readSourceSnapshot = (file: string) =>
           createSourceSnapshot({ file, detectWorkflowPatterns });
 
-        const refreshSourceSnapshots = () =>
-          replaceSourceSnapshots({
+        const snapshotSources = () =>
+          readSourceSnapshots({
             discoveredEntries,
             inputFiles: options.inputFiles,
             normalizePath,
             readSnapshot: readSourceSnapshot,
-            sourceSnapshots,
           });
 
         const mergeCombinedManifest = (
@@ -224,6 +214,15 @@ export async function getNextBuilderEager(
             ...workflowsManifest.classes,
           },
         });
+
+        const runBuild = async (build: () => Promise<void>) => {
+          buildInProgress = true;
+          try {
+            await build();
+          } finally {
+            buildInProgress = false;
+          }
+        };
 
         const hotRebuild = async (refreshStepRegistrations: boolean) => {
           if (refreshStepRegistrations) {
@@ -251,54 +250,42 @@ export async function getNextBuilderEager(
           await writeManifest(mergeCombinedManifest(stepsManifest));
         };
 
-        // The pin helper owns the capture-before-build / restore-after-
-        // refresh ordering (including that the capture reads the CURRENT
-        // discovered entries and input files, before the rebuild replaces
-        // them), so an edit landing while the multi-second rebuild runs still
-        // diffs against what the rebuild consumed instead of being absorbed
-        // into the refreshed baseline. See `pinBaselinesAcrossFullRebuild`
-        // for the full reasoning.
-        const fullRebuild = () =>
-          pinBaselinesAcrossFullRebuild({
-            discoveredEntries,
-            inputFiles: options.inputFiles,
-            normalizePath,
-            readSnapshot: readSourceSnapshot,
-            sourceSnapshots,
-            rebuild: async () => {
-              this.clearDiscoveredEntriesCache();
-              const newInputFiles = await this.getInputFiles();
-              options.inputFiles = newInputFiles;
+        const fullRebuild = async () => {
+          this.clearDiscoveredEntriesCache();
+          const newInputFiles = await this.getInputFiles();
+          options.inputFiles = newInputFiles;
 
-              await stepsCtx?.dispose();
-              await workflowsCtx.interimBundleCtx.dispose();
+          // Snapshot before building so edits made during the build remain
+          // dirty and trigger the file event already queued behind this task.
+          const nextSourceSnapshots = await snapshotSources();
 
-              const newCombined = await this.buildCombinedFunction(options);
-              stepsCtx = newCombined.stepsContext;
-              discoveredEntries = newCombined.discoveredEntries;
-              stepsManifest = newCombined.stepsManifest;
-              workflowsManifest = newCombined.workflowsManifest;
+          await stepsCtx?.dispose();
+          await workflowsCtx.interimBundleCtx.dispose();
 
-              if (!newCombined?.interimBundleCtx || !newCombined?.bundleFinal) {
-                throw new Error(
-                  'Invariant: expected workflows bundle context after rebuild'
-                );
-              }
-              workflowsCtx = {
-                interimBundleCtx: newCombined.interimBundleCtx,
-                bundleFinal: newCombined.bundleFinal,
-              };
+          const newCombined = await this.buildCombinedFunction(options);
+          stepsCtx = newCombined.stepsContext;
+          discoveredEntries = newCombined.discoveredEntries;
+          stepsManifest = newCombined.stepsManifest;
+          workflowsManifest = newCombined.workflowsManifest;
 
-              await writeManifest(newCombined.manifest);
-              await refreshSourceSnapshots();
-            },
-          });
+          if (!newCombined?.interimBundleCtx || !newCombined?.bundleFinal) {
+            throw new Error(
+              'Invariant: expected workflows bundle context after rebuild'
+            );
+          }
+          workflowsCtx = {
+            interimBundleCtx: newCombined.interimBundleCtx,
+            bundleFinal: newCombined.bundleFinal,
+          };
+
+          await writeManifest(newCombined.manifest);
+          sourceSnapshots = nextSourceSnapshots;
+        };
 
         const isWatchableFile = (path: string) =>
           watchableExtensions.has(extname(path));
 
-        const readKnownFiles = async () => {
-          const files = new Set<string>();
+        const readKnownFileAliases = async () => {
           const aliases = new Map<string, string>();
           const relevantFiles = getRelevantFiles({
             discoveredEntries,
@@ -315,7 +302,6 @@ export async function getNextBuilderEager(
             const canonicalPath = relevantFiles.has(realFilePath)
               ? realFilePath
               : filePath;
-            files.add(canonicalPath);
             aliases.set(filePath, canonicalPath);
             aliases.set(realFilePath, canonicalPath);
             return canonicalPath;
@@ -363,216 +349,105 @@ export async function getNextBuilderEager(
           };
 
           await visit(this.config.workingDir);
-          return { files, aliases, addKnownFile };
+          return { aliases, addKnownFile };
         };
 
-        const mergeFileChanges = (
-          left: FileChanges,
-          right: FileChanges
-        ): FileChanges => ({
-          addedFiles: unique([...left.addedFiles, ...right.addedFiles]),
-          modifiedFiles: unique([
-            ...left.modifiedFiles,
-            ...right.modifiedFiles,
-          ]),
-          removedFiles: unique([...left.removedFiles, ...right.removedFiles]),
-        });
-
-        const unique = (paths: string[]) => [...new Set(paths)];
-
-        const classifyFileChanges = ({
-          changedFiles,
-          knownFiles,
-          removedFiles,
-        }: {
-          changedFiles: string[];
-          knownFiles: Set<string>;
-          removedFiles: string[];
-        }): FileChanges => {
-          const addedFiles: string[] = [];
-          const modifiedFiles: string[] = [];
-
-          for (const file of unique(changedFiles)) {
-            if (knownFiles.has(file)) {
-              modifiedFiles.push(file);
-            } else {
-              addedFiles.push(file);
-              knownFiles.add(file);
-            }
-          }
-
-          for (const file of removedFiles) {
-            knownFiles.delete(file);
-          }
-
-          return {
-            addedFiles,
-            modifiedFiles,
-            removedFiles: unique(removedFiles),
-          };
-        };
-
-        const hasFileChanges = ({
-          addedFiles,
-          modifiedFiles,
-          removedFiles,
-        }: FileChanges) =>
-          addedFiles.length > 0 ||
-          modifiedFiles.length > 0 ||
-          removedFiles.length > 0;
         const logDevHmr = (...args: unknown[]) => {
           if (process.env.WORKFLOW_DEV_HMR_LOGS === '1') {
             console.log(...args);
           }
         };
 
-        // Known gap: the initial build has the same two-read shape (the
-        // combined build above consumed sources, and this refresh re-reads
-        // them), but no pinning — and the watcher below attaches with
-        // `ignoreInitial: true`, so an edit landing inside the startup window
-        // is absorbed with no straggler event to recover it. Bounded by dev
-        // server startup rather than recurring per rebuild; knowingly out of
-        // scope for the mid-rebuild pinning above.
-        await refreshSourceSnapshots();
-        let {
-          files: knownFiles,
-          aliases: knownFileAliases,
-          addKnownFile: rememberKnownFile,
-        } = await readKnownFiles();
+        sourceSnapshots = await snapshotSources();
+        let { aliases: knownFileAliases, addKnownFile: rememberKnownFile } =
+          await readKnownFileAliases();
 
         const refreshKnownFiles = async () => {
-          const nextKnown = await readKnownFiles();
-          knownFiles = nextKnown.files;
+          const nextKnown = await readKnownFileAliases();
           knownFileAliases = nextKnown.aliases;
           rememberKnownFile = nextKnown.addKnownFile;
         };
 
-        const processFileChanges = async (fileChanges: FileChanges) => {
-          if (!hasFileChanges(fileChanges)) {
-            return;
-          }
+        const runFullRebuild = async () => {
+          logDevHmr('workflow dev hmr: full rediscovery');
+          await runBuild(fullRebuild);
+          await refreshKnownFiles();
+        };
 
+        const processFileChanges = async (files: string[]) => {
           const decision = await classifyRebuild({
+            files,
             discoveredEntries,
-            fileChanges,
             inputFiles: options.inputFiles,
             normalizePath,
             parentHasChild,
             readSnapshot: readSourceSnapshot,
             sourceSnapshots,
           });
-          if (decision.kind === 'none') {
-            logDevHmr('workflow dev hmr: skip');
-            for (const [file, snapshot] of decision.snapshots || []) {
-              sourceSnapshots.set(file, snapshot);
-            }
-            return;
+          switch (decision.kind) {
+            case 'skip':
+              logDevHmr('workflow dev hmr: skip');
+              break;
+            case 'hot':
+              logDevHmr(
+                `workflow dev hmr: hot rebuild${decision.refreshStepRegistrations ? ' with step registration refresh' : ''}`
+              );
+              await runBuild(() =>
+                hotRebuild(decision.refreshStepRegistrations)
+              );
+              break;
+            case 'full':
+              await runFullRebuild();
+              return;
+            default:
+              decision satisfies never;
+              throw new Error('Unknown rebuild decision');
           }
-          if (decision.kind === 'full') {
-            logDevHmr('workflow dev hmr: full rediscovery');
+          sourceSnapshots = new Map([
+            ...sourceSnapshots,
+            ...decision.snapshots,
+          ]);
+        };
+
+        const scheduleRebuild = createRebuildScheduler(
+          async (request) => {
             try {
-              await fullRebuild();
-              await refreshKnownFiles();
-            } finally {
-              // Lets a log reader tell "quiet" from "rebuild in flight".
-              // The e2e HMR tests drain-to-quiet before counting lines.
-              logDevHmr('workflow dev hmr: rebuild complete');
+              switch (request.kind) {
+                case 'files':
+                  await processFileChanges(request.files);
+                  return;
+                case 'full':
+                  await runFullRebuild();
+                  return;
+                default:
+                  request satisfies never;
+                  throw new Error('Unknown scheduled rebuild');
+              }
+            } catch (error) {
+              console.error('Failed to process file change', error);
             }
-            return;
-          }
-
-          logDevHmr(
-            `workflow dev hmr: hot rebuild${decision.refreshStepRegistrations ? ' with step registration refresh' : ''}`
-          );
-          try {
-            await hotRebuild(decision.refreshStepRegistrations);
-            for (const [file, snapshot] of decision.snapshots) {
-              sourceSnapshots.set(file, snapshot);
-            }
-          } finally {
-            // See the matching line on the full path above.
-            logDevHmr('workflow dev hmr: rebuild complete');
+          },
+          () => logDevHmr('workflow dev hmr: idle')
+        );
+        const scheduleFileChange = (file: string) => {
+          scheduleRebuild({ kind: 'files', files: [file] });
+        };
+        const scheduleBuildOverlap = () => {
+          if (buildInProgress) {
+            scheduleRebuild({ kind: 'full' });
           }
         };
 
-        let pendingFileChanges: FileChanges = {
-          addedFiles: [],
-          modifiedFiles: [],
-          removedFiles: [],
-        };
-        let flushTimer: ReturnType<typeof setTimeout> | undefined;
-
-        const scheduleFileChanges = (fileChanges: FileChanges) => {
-          pendingFileChanges = mergeFileChanges(
-            pendingFileChanges,
-            fileChanges
-          );
-          if (flushTimer) {
-            return;
-          }
-          flushTimer = setTimeout(() => {
-            const fileChanges = pendingFileChanges;
-            pendingFileChanges = {
-              addedFiles: [],
-              modifiedFiles: [],
-              removedFiles: [],
-            };
-            flushTimer = undefined;
-            enqueue(() => processFileChanges(fileChanges));
-          }, 10);
-        };
-
-        const resolveExistingEventPath = async (pathname: string) => {
+        const handleFileWritten = async (pathname: string) => {
           const normalizedPath = normalizePath(pathname);
           if (!isWatchableFile(normalizedPath)) {
             return;
           }
 
-          const knownPath = knownFileAliases.get(normalizedPath);
-          if (knownPath) {
-            return knownPath;
-          }
-
-          try {
-            const realFilePath = normalizePath(await realpath(normalizedPath));
-            return knownFileAliases.get(realFilePath) ?? normalizedPath;
-          } catch {
-            return normalizedPath;
-          }
-        };
-
-        const handleFileAdded = async (pathname: string) => {
-          const normalizedPath = normalizePath(pathname);
-          if (!isWatchableFile(normalizedPath)) {
-            return;
-          }
-
-          const existingPath = await resolveExistingEventPath(normalizedPath);
-          const wasKnown = existingPath ? knownFiles.has(existingPath) : false;
-          const canonicalPath = await rememberKnownFile(normalizedPath);
-          knownFiles.add(canonicalPath);
-          scheduleFileChanges({
-            addedFiles: wasKnown ? [] : [canonicalPath],
-            modifiedFiles: wasKnown ? [canonicalPath] : [],
-            removedFiles: [],
-          });
-        };
-
-        const handleFileChanged = async (pathname: string) => {
-          const canonicalPath = await resolveExistingEventPath(pathname);
-          if (!canonicalPath) {
-            return;
-          }
-
-          const fileChanges = classifyFileChanges({
-            changedFiles: [canonicalPath],
-            knownFiles,
-            removedFiles: [],
-          });
-          if (!knownFileAliases.has(canonicalPath)) {
-            await rememberKnownFile(canonicalPath);
-          }
-          scheduleFileChanges(fileChanges);
+          const canonicalPath =
+            knownFileAliases.get(normalizedPath) ??
+            (await rememberKnownFile(normalizedPath));
+          scheduleFileChange(canonicalPath);
         };
 
         const handleFileRemoved = (pathname: string) => {
@@ -583,13 +458,8 @@ export async function getNextBuilderEager(
 
           const canonicalPath =
             knownFileAliases.get(normalizedPath) ?? normalizedPath;
-          const fileChanges = classifyFileChanges({
-            changedFiles: [],
-            knownFiles,
-            removedFiles: [canonicalPath],
-          });
           knownFileAliases.delete(normalizedPath);
-          scheduleFileChanges(fileChanges);
+          scheduleFileChange(canonicalPath);
         };
 
         const watcher = chokidar.watch(this.config.workingDir, {
@@ -606,12 +476,15 @@ export async function getNextBuilderEager(
         });
 
         watcher.on('add', (pathname) => {
-          void handleFileAdded(pathname);
+          scheduleBuildOverlap();
+          void handleFileWritten(pathname);
         });
         watcher.on('change', (pathname) => {
-          void handleFileChanged(pathname);
+          scheduleBuildOverlap();
+          void handleFileWritten(pathname);
         });
         watcher.on('unlink', (pathname) => {
+          scheduleBuildOverlap();
           handleFileRemoved(pathname);
         });
         watcher.on('error', (error) => {

--- a/packages/next/src/builder-eager.ts
+++ b/packages/next/src/builder-eager.ts
@@ -152,7 +152,6 @@ export async function getNextBuilderEager(
             : resolve(this.config.workingDir, pathname)
           ).replace(/\\/g, '/');
         let sourceSnapshots = new Map<string, SourceSnapshot>();
-        let buildInProgress = false;
 
         const watchableExtensions = new Set([
           '.js',
@@ -215,15 +214,6 @@ export async function getNextBuilderEager(
           },
         });
 
-        const runBuild = async (build: () => Promise<void>) => {
-          buildInProgress = true;
-          try {
-            await build();
-          } finally {
-            buildInProgress = false;
-          }
-        };
-
         const hotRebuild = async (refreshStepRegistrations: boolean) => {
           if (refreshStepRegistrations) {
             if (stepsCtx) {
@@ -250,7 +240,9 @@ export async function getNextBuilderEager(
           await writeManifest(mergeCombinedManifest(stepsManifest));
         };
 
-        const fullRebuild = async () => {
+        const fullRebuild = async (
+          triggerSnapshots?: Map<string, SourceSnapshot>
+        ) => {
           this.clearDiscoveredEntriesCache();
           const newInputFiles = await this.getInputFiles();
           options.inputFiles = newInputFiles;
@@ -279,6 +271,18 @@ export async function getNextBuilderEager(
           };
 
           await writeManifest(newCombined.manifest);
+          // Files this rebuild discovered for the first time are absent from
+          // the pre-build capture (it read the previous graph's relevant
+          // set). Seed them from what the classifier read when it decided on
+          // this rediscovery, so a freshly created file's routine duplicate
+          // events diff equal instead of forcing another rebuild, while a
+          // mid-build edit still diffs as changed. Files the capture did read
+          // keep the captured value: it is closer to what the build consumed.
+          for (const [file, snapshot] of triggerSnapshots ?? []) {
+            if (!nextSourceSnapshots.has(file)) {
+              nextSourceSnapshots.set(file, snapshot);
+            }
+          }
           sourceSnapshots = nextSourceSnapshots;
         };
 
@@ -368,9 +372,11 @@ export async function getNextBuilderEager(
           rememberKnownFile = nextKnown.addKnownFile;
         };
 
-        const runFullRebuild = async () => {
+        const runFullRebuild = async (
+          triggerSnapshots?: Map<string, SourceSnapshot>
+        ) => {
           logDevHmr('workflow dev hmr: full rediscovery');
-          await runBuild(fullRebuild);
+          await fullRebuild(triggerSnapshots);
           await refreshKnownFiles();
         };
 
@@ -385,6 +391,13 @@ export async function getNextBuilderEager(
             sourceSnapshots,
           });
           switch (decision.kind) {
+            // A repeated notification for a write that was already consumed:
+            // nothing changed and nothing was rebuilt. Logged under its own
+            // marker (not `skip`) so the e2e HMR log-count assertions can
+            // stay exact for the events that had an effect.
+            case 'duplicate':
+              logDevHmr('workflow dev hmr: duplicate');
+              return;
             case 'skip':
               logDevHmr('workflow dev hmr: skip');
               break;
@@ -392,12 +405,10 @@ export async function getNextBuilderEager(
               logDevHmr(
                 `workflow dev hmr: hot rebuild${decision.refreshStepRegistrations ? ' with step registration refresh' : ''}`
               );
-              await runBuild(() =>
-                hotRebuild(decision.refreshStepRegistrations)
-              );
+              await hotRebuild(decision.refreshStepRegistrations);
               break;
             case 'full':
-              await runFullRebuild();
+              await runFullRebuild(decision.snapshots);
               return;
             default:
               decision satisfies never;
@@ -431,11 +442,6 @@ export async function getNextBuilderEager(
         );
         const scheduleFileChange = (file: string) => {
           scheduleRebuild({ kind: 'files', files: [file] });
-        };
-        const scheduleBuildOverlap = () => {
-          if (buildInProgress) {
-            scheduleRebuild({ kind: 'full' });
-          }
         };
 
         const handleFileWritten = async (pathname: string) => {
@@ -475,16 +481,20 @@ export async function getNextBuilderEager(
           },
         });
 
+        // Events that land while a rebuild runs are not special-cased: the
+        // scheduled dirty path is classified after the build finishes against
+        // the baseline the build consumed, so a real mid-build edit diffs as
+        // changed, a duplicate notification diffs as the same write and is
+        // suppressed, and a same-content rewrite (whose interim states the
+        // build may have consumed) diffs as a rewrite and stays a
+        // conservative rediscovery.
         watcher.on('add', (pathname) => {
-          scheduleBuildOverlap();
           void handleFileWritten(pathname);
         });
         watcher.on('change', (pathname) => {
-          scheduleBuildOverlap();
           void handleFileWritten(pathname);
         });
         watcher.on('unlink', (pathname) => {
-          scheduleBuildOverlap();
           handleFileRemoved(pathname);
         });
         watcher.on('error', (error) => {

--- a/packages/next/src/watch-rebuild.test.ts
+++ b/packages/next/src/watch-rebuild.test.ts
@@ -172,7 +172,7 @@ export const allWorkflows = {
           ),
         sourceSnapshots,
       })
-    ).resolves.toEqual({ kind: 'full' });
+    ).resolves.toMatchObject({ kind: 'full' });
   });
 
   test('modified registry import without previous snapshot requires full rediscovery', async () => {
@@ -202,18 +202,21 @@ export const allWorkflows = {} as const;
           ),
         sourceSnapshots: new Map(),
       })
-    ).resolves.toEqual({ kind: 'full' });
+    ).resolves.toMatchObject({ kind: 'full' });
   });
 
-  test('fully rebuilds byte-identical workflow notifications', async () => {
+  test('suppresses duplicate notifications for an already-consumed write', async () => {
     const workflowFile = '/app/workflows/example.ts';
     const source = `export async function example() {
   'use workflow';
 }
 `;
+    // Same content AND same mtime: a second watcher event for the same
+    // write. Watchers routinely emit several events per edit.
     const snapshot = createSourceSnapshotFromSource(
       source,
-      detectWorkflowPatterns
+      detectWorkflowPatterns,
+      1000
     );
 
     await expect(
@@ -227,10 +230,172 @@ export const allWorkflows = {} as const;
         files: [workflowFile],
         inputFiles: [workflowFile],
         parentHasChild: () => false,
-        readSnapshot: async () => snapshot,
+        readSnapshot: async () => ({ ...snapshot }),
         sourceSnapshots: new Map([[workflowFile, snapshot]]),
       })
-    ).resolves.toEqual({ kind: 'full' });
+    ).resolves.toEqual({ kind: 'duplicate' });
+  });
+
+  test('fully rebuilds byte-identical rewrites of relevant files', async () => {
+    const workflowFile = '/app/workflows/example.ts';
+    const source = `export async function example() {
+  'use workflow';
+}
+`;
+    // Same content but a NEWER mtime: a distinct write whose interim states
+    // an in-flight build may have consumed. Stays a conservative
+    // invalidation.
+    const previousSnapshot = createSourceSnapshotFromSource(
+      source,
+      detectWorkflowPatterns,
+      1000
+    );
+    const rewrittenSnapshot = createSourceSnapshotFromSource(
+      source,
+      detectWorkflowPatterns,
+      2000
+    );
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set([workflowFile]),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set([workflowFile]),
+        },
+        files: [workflowFile],
+        inputFiles: [workflowFile],
+        parentHasChild: () => false,
+        readSnapshot: async () => rewrittenSnapshot,
+        sourceSnapshots: new Map([[workflowFile, previousSnapshot]]),
+      })
+    ).resolves.toMatchObject({ kind: 'full' });
+  });
+
+  test('carries classifier reads on full decisions to seed new-file baselines', async () => {
+    const addedStepFile = '/app/workflows/added-step.ts';
+    const snapshot = createSourceSnapshotFromSource(
+      `export async function addedStep() {
+  'use step';
+}
+`,
+      detectWorkflowPatterns,
+      1000
+    );
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set(),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set(),
+        },
+        files: [addedStepFile],
+        inputFiles: [],
+        parentHasChild: () => false,
+        readSnapshot: async () => snapshot,
+        sourceSnapshots: new Map(),
+      })
+    ).resolves.toEqual({
+      kind: 'full',
+      snapshots: new Map([[addedStepFile, snapshot]]),
+    });
+  });
+
+  test('tracks irrelevant files so their duplicate notifications suppress', async () => {
+    const unrelatedFile = '/app/scripts/unrelated.ts';
+    const snapshot = createSourceSnapshotFromSource(
+      'export const unrelated = true;\n',
+      detectWorkflowPatterns,
+      1000
+    );
+    const sourceSnapshots = new Map<string, SourceSnapshot>();
+    const discoveredEntries = {
+      discoveredSteps: new Set<string>(),
+      discoveredWorkflows: new Set<string>(),
+      discoveredSerdeFiles: new Set<string>(),
+      discoveredFiles: new Set<string>(),
+    };
+
+    const firstDecision = await classifyRebuild({
+      discoveredEntries,
+      files: [unrelatedFile],
+      inputFiles: [],
+      parentHasChild: () => false,
+      readSnapshot: async () => snapshot,
+      sourceSnapshots,
+    });
+    expect(firstDecision).toEqual({
+      kind: 'skip',
+      snapshots: new Map([[unrelatedFile, snapshot]]),
+    });
+    if (firstDecision.kind === 'skip') {
+      for (const [file, value] of firstDecision.snapshots) {
+        sourceSnapshots.set(file, value);
+      }
+    }
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries,
+        files: [unrelatedFile],
+        inputFiles: [],
+        parentHasChild: () => false,
+        readSnapshot: async () => ({ ...snapshot }),
+        sourceSnapshots,
+      })
+    ).resolves.toEqual({ kind: 'duplicate' });
+  });
+
+  test('drops duplicates from a batch while rebuilding real changes', async () => {
+    const helperFile = '/app/workflows/helper.ts';
+    const workflowFile = '/app/workflows/workflow.ts';
+    const workflowSource = `export async function example() {
+  'use workflow';
+}
+`;
+    const workflowSnapshot = createSourceSnapshotFromSource(
+      workflowSource,
+      detectWorkflowPatterns,
+      1000
+    );
+    const previousHelperSnapshot = createSourceSnapshotFromSource(
+      "export const value = 'before';\n",
+      detectWorkflowPatterns,
+      1000
+    );
+    const nextHelperSnapshot = createSourceSnapshotFromSource(
+      "export const value = 'after';\n",
+      detectWorkflowPatterns,
+      2000
+    );
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set([workflowFile]),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set([helperFile, workflowFile]),
+        },
+        files: [workflowFile, helperFile],
+        inputFiles: [workflowFile],
+        parentHasChild: (parent, child) =>
+          parent === workflowFile && child === helperFile,
+        readSnapshot: async (file) =>
+          file === workflowFile ? { ...workflowSnapshot } : nextHelperSnapshot,
+        sourceSnapshots: new Map([
+          [workflowFile, workflowSnapshot],
+          [helperFile, previousHelperSnapshot],
+        ]),
+      })
+    ).resolves.toEqual({
+      kind: 'hot',
+      refreshStepRegistrations: false,
+      snapshots: new Map([[helperFile, nextHelperSnapshot]]),
+    });
   });
 
   test('rebuilds relevant files without snapshots', async () => {
@@ -254,7 +419,7 @@ export const allWorkflows = {} as const;
           ),
         sourceSnapshots: new Map(),
       })
-    ).resolves.toEqual({ kind: 'full' });
+    ).resolves.toMatchObject({ kind: 'full' });
   });
 
   test('fully rebuilds every directive file change', async () => {
@@ -290,7 +455,7 @@ export const allWorkflows = {} as const;
         readSnapshot: async () => nextSnapshot,
         sourceSnapshots: new Map([[stepFile, previousSnapshot]]),
       })
-    ).resolves.toEqual({ kind: 'full' });
+    ).resolves.toMatchObject({ kind: 'full' });
   });
 
   test('rebuilds new files that can introduce graph entries', async () => {
@@ -314,7 +479,7 @@ export const allWorkflows = {} as const;
           ),
         sourceSnapshots: new Map(),
       })
-    ).resolves.toEqual({ kind: 'full' });
+    ).resolves.toMatchObject({ kind: 'full' });
   });
 
   test('hot rebuilds body changes used by workflows', async () => {

--- a/packages/next/src/watch-rebuild.test.ts
+++ b/packages/next/src/watch-rebuild.test.ts
@@ -1,12 +1,73 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   classifyRebuild,
+  createRebuildScheduler,
   createSourceSnapshotFromSource,
   extractImportSignature,
-  pinBaselinesAcrossFullRebuild,
   type SourceSnapshot,
   stripCommentsFromSource,
 } from './watch-rebuild.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('watch-rebuild scheduling', () => {
+  test('merges changes until filesystem writes become quiet', async () => {
+    vi.useFakeTimers();
+    const rebuild = vi.fn(async () => {});
+    const schedule = createRebuildScheduler(rebuild, () => {});
+
+    schedule({
+      kind: 'files',
+      files: ['/app/workflow.ts'],
+    });
+    await vi.advanceTimersByTimeAsync(99);
+    schedule({
+      kind: 'files',
+      files: ['/app/helper.ts'],
+    });
+    await vi.advanceTimersByTimeAsync(99);
+
+    expect(rebuild).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(rebuild).toHaveBeenCalledWith({
+      kind: 'files',
+      files: ['/app/workflow.ts', '/app/helper.ts'],
+    });
+  });
+
+  test('collapses full rebuild requests while a rebuild runs', async () => {
+    vi.useFakeTimers();
+    const firstBuild = Promise.withResolvers<void>();
+    const fullBuild = Promise.withResolvers<void>();
+    const idle = Promise.withResolvers<void>();
+    const requests: string[] = [];
+    const onIdle = vi.fn(idle.resolve);
+    const schedule = createRebuildScheduler(async (request) => {
+      requests.push(request.kind);
+      if (requests.length === 1) {
+        await firstBuild.promise;
+      } else {
+        fullBuild.resolve();
+      }
+    }, onIdle);
+
+    schedule({ kind: 'full' });
+    await vi.advanceTimersByTimeAsync(100);
+
+    schedule({ kind: 'full' });
+    schedule({ kind: 'full' });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(onIdle).not.toHaveBeenCalled();
+    firstBuild.resolve();
+    await fullBuild.promise;
+    await idle.promise;
+
+    expect(requests).toEqual(['full', 'full']);
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+});
 
 const detectWorkflowPatterns = (source: string) => ({
   hasDirective:
@@ -101,11 +162,7 @@ export const allWorkflows = {
           discoveredSerdeFiles: new Set(),
           discoveredFiles: new Set([pageFile, registryFile, workflowFile]),
         },
-        fileChanges: {
-          addedFiles: [],
-          modifiedFiles: [registryFile],
-          removedFiles: [],
-        },
+        files: [registryFile],
         inputFiles: [pageFile],
         parentHasChild: () => false,
         readSnapshot: async (file) =>
@@ -135,11 +192,7 @@ export const allWorkflows = {} as const;
           discoveredSerdeFiles: new Set(),
           discoveredFiles: new Set([registryFile]),
         },
-        fileChanges: {
-          addedFiles: [stepFile],
-          modifiedFiles: [registryFile],
-          removedFiles: [],
-        },
+        files: [stepFile, registryFile],
         inputFiles: [registryFile],
         parentHasChild: () => false,
         readSnapshot: async (file) =>
@@ -152,237 +205,112 @@ export const allWorkflows = {} as const;
     ).resolves.toEqual({ kind: 'full' });
   });
 
-  test('an edit landing during a full rebuild is not absorbed into the baseline', async () => {
-    // Reproduces the flow-route HMR race: a step definition is added to an
-    // already-discovered step file while a full rebuild is in flight. The
-    // post-rebuild baseline refresh reads the file from disk (post-edit), so
-    // without reconciliation the queued watcher event diffs the edit against
-    // itself and classifies as a no-op — the added step never reaches the
-    // manifest.
-    const stepFile = '/app/workflows/hmr-fuzz-step.ts';
-    const pageFile = '/app/app/page.tsx';
-    const preBuildSource = `export async function hmrFuzzStep() {
-  'use step';
-  return 'step-value';
+  test('fully rebuilds byte-identical workflow notifications', async () => {
+    const workflowFile = '/app/workflows/example.ts';
+    const source = `export async function example() {
+  'use workflow';
 }
 `;
-    const postEditSource = `export async function hmrFuzzStep() {
-  'use step';
-  return 'step-value';
-}
-
-export async function hmrFuzzAddedStep() {
-  'use step';
-  return 'added-step';
-}
-`;
-    const discoveredEntries = {
-      discoveredSteps: new Set([stepFile]),
-      discoveredWorkflows: new Set<string>(),
-      discoveredSerdeFiles: new Set<string>(),
-      discoveredFiles: new Set([pageFile, stepFile]),
-    };
-    const sources = new Map<string, string>([
-      [stepFile, preBuildSource],
-      [pageFile, ''],
-    ]);
-    const readSnapshot = async (file: string) =>
-      createSourceSnapshotFromSource(
-        sources.get(file) ?? '',
-        detectWorkflowPatterns
-      );
-
-    const sourceSnapshots = new Map<string, SourceSnapshot>();
-
-    // Full rebuild: the helper captures what the build reads before invoking
-    // the rebuild; the edit lands mid-rebuild and the post-rebuild refresh
-    // reads it from disk.
-    await pinBaselinesAcrossFullRebuild({
-      discoveredEntries,
-      inputFiles: [pageFile],
-      readSnapshot,
-      sourceSnapshots,
-      rebuild: async () => {
-        sources.set(stepFile, postEditSource);
-        sourceSnapshots.set(stepFile, await readSnapshot(stepFile));
-        sourceSnapshots.set(pageFile, await readSnapshot(pageFile));
-      },
-    });
-
-    // The queued watcher event for the edit must still trigger a rebuild.
-    await expect(
-      classifyRebuild({
-        discoveredEntries,
-        fileChanges: {
-          addedFiles: [],
-          modifiedFiles: [stepFile],
-          removedFiles: [],
-        },
-        inputFiles: [pageFile],
-        parentHasChild: () => false,
-        readSnapshot,
-        sourceSnapshots,
-      })
-    ).resolves.toEqual({ kind: 'full' });
-  });
-
-  test('a duplicate watcher event landing during a full rebuild stays a no-op', async () => {
-    // Watchers routinely emit several events for one edit, and the edit that
-    // triggered a full rebuild is itself a source of such stragglers landing
-    // mid-rebuild. The straggler carries the same content the rebuild
-    // consumed, so it must diff equal against the pinned pre-build baseline
-    // and classify as 'none' — evicting the baseline instead cascades into
-    // back-to-back full rebuilds.
-    const stepFile = '/app/workflows/hmr-fuzz-step.ts';
-    const pageFile = '/app/app/page.tsx';
-    const source = `export async function hmrFuzzStep() {
-  'use step';
-  return 'step-value';
-}
-`;
-    const discoveredEntries = {
-      discoveredSteps: new Set([stepFile]),
-      discoveredWorkflows: new Set<string>(),
-      discoveredSerdeFiles: new Set<string>(),
-      discoveredFiles: new Set([pageFile, stepFile]),
-    };
-    const sources = new Map<string, string>([
-      [stepFile, source],
-      [pageFile, ''],
-    ]);
-    const readSnapshot = async (file: string) =>
-      createSourceSnapshotFromSource(
-        sources.get(file) ?? '',
-        detectWorkflowPatterns
-      );
-
-    // Full rebuild (triggered by the edit that wrote `source`): the helper's
-    // capture reads that same content before the rebuild, and the refresh
-    // reads it again after.
-    const sourceSnapshots = new Map<string, SourceSnapshot>();
-    await pinBaselinesAcrossFullRebuild({
-      discoveredEntries,
-      inputFiles: [pageFile],
-      readSnapshot,
-      sourceSnapshots,
-      rebuild: async () => {
-        sourceSnapshots.set(stepFile, await readSnapshot(stepFile));
-        sourceSnapshots.set(pageFile, await readSnapshot(pageFile));
-      },
-    });
-
-    // The baseline survives (pinned, not evicted), so the queued duplicate
-    // classifies as a no-op instead of another full rebuild.
-    expect(sourceSnapshots.has(stepFile)).toBe(true);
-    const decision = await classifyRebuild({
-      discoveredEntries,
-      fileChanges: {
-        addedFiles: [],
-        modifiedFiles: [stepFile],
-        removedFiles: [],
-      },
-      inputFiles: [pageFile],
-      parentHasChild: () => false,
-      readSnapshot,
-      sourceSnapshots,
-    });
-    expect(decision.kind).toBe('none');
-  });
-
-  test('a file created mid-rebuild that the build missed still forces a follow-up rebuild', async () => {
-    // A file the rebuild never discovered has no baseline after the
-    // post-rebuild refresh either, so its queued add event classifies
-    // conservatively — no eviction machinery required.
-    const stepFile = '/app/workflows/newly-created-step.ts';
-    const pageFile = '/app/app/page.tsx';
-    const source = `export async function newStep() {
-  'use step';
-  return 'new-step';
-}
-`;
-    const sources = new Map<string, string>([
-      [stepFile, source],
-      [pageFile, ''],
-    ]);
-    const readSnapshot = async (file: string) =>
-      createSourceSnapshotFromSource(
-        sources.get(file) ?? '',
-        detectWorkflowPatterns
-      );
-
-    // The build that just finished never saw stepFile: it is in neither the
-    // discovered entries nor the refreshed baseline.
-    const sourceSnapshots = new Map<string, SourceSnapshot>();
-    await pinBaselinesAcrossFullRebuild({
-      discoveredEntries: {
-        discoveredSteps: new Set<string>(),
-        discoveredWorkflows: new Set<string>(),
-        discoveredSerdeFiles: new Set<string>(),
-        discoveredFiles: new Set([pageFile]),
-      },
-      inputFiles: [pageFile],
-      readSnapshot,
-      sourceSnapshots,
-      rebuild: async () => {
-        sourceSnapshots.set(pageFile, await readSnapshot(pageFile));
-      },
-    });
+    const snapshot = createSourceSnapshotFromSource(
+      source,
+      detectWorkflowPatterns
+    );
 
     await expect(
       classifyRebuild({
         discoveredEntries: {
-          discoveredSteps: new Set<string>(),
-          discoveredWorkflows: new Set<string>(),
-          discoveredSerdeFiles: new Set<string>(),
-          discoveredFiles: new Set([pageFile]),
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set([workflowFile]),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set([workflowFile]),
         },
-        fileChanges: {
-          addedFiles: [stepFile],
-          modifiedFiles: [],
-          removedFiles: [],
-        },
-        inputFiles: [pageFile],
+        files: [workflowFile],
+        inputFiles: [workflowFile],
         parentHasChild: () => false,
-        readSnapshot,
-        sourceSnapshots,
+        readSnapshot: async () => snapshot,
+        sourceSnapshots: new Map([[workflowFile, snapshot]]),
       })
     ).resolves.toEqual({ kind: 'full' });
   });
 
-  test('ignores stale add events for already snapshotted files', async () => {
-    const stepFile = '/app/workflows/hmr-fuzz-step.ts';
-    const pageFile = '/app/app/page.tsx';
-    const stepSource = `export async function hmrFuzzStep() {
-  'use step';
-  return 'step-value';
-}
-`;
-    const sourceSnapshots = new Map<string, SourceSnapshot>([
-      [
-        stepFile,
-        createSourceSnapshotFromSource(stepSource, detectWorkflowPatterns),
-      ],
-    ]);
+  test('rebuilds relevant files without snapshots', async () => {
+    const helperFile = '/app/workflows/helper.ts';
 
-    const decision = await classifyRebuild({
-      discoveredEntries: {
-        discoveredSteps: new Set([stepFile]),
-        discoveredWorkflows: new Set(),
-        discoveredSerdeFiles: new Set(),
-        discoveredFiles: new Set([pageFile, stepFile]),
-      },
-      fileChanges: {
-        addedFiles: [stepFile],
-        modifiedFiles: [],
-        removedFiles: [],
-      },
-      inputFiles: [pageFile],
-      parentHasChild: () => false,
-      readSnapshot: async () =>
-        createSourceSnapshotFromSource(stepSource, detectWorkflowPatterns),
-      sourceSnapshots,
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set(),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set([helperFile]),
+        },
+        files: [helperFile],
+        inputFiles: [],
+        parentHasChild: () => false,
+        readSnapshot: async () =>
+          createSourceSnapshotFromSource(
+            "export const value = 'helper';\n",
+            detectWorkflowPatterns
+          ),
+        sourceSnapshots: new Map(),
+      })
+    ).resolves.toEqual({ kind: 'full' });
+  });
+
+  test('rebuilds new files that can introduce graph entries', async () => {
+    const routeFile = '/app/app/new/route.ts';
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set(),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set(),
+        },
+        files: [routeFile],
+        inputFiles: [],
+        parentHasChild: () => false,
+        readSnapshot: async () =>
+          createSourceSnapshotFromSource(
+            "import './workflow';\n",
+            detectWorkflowPatterns
+          ),
+        sourceSnapshots: new Map(),
+      })
+    ).resolves.toEqual({ kind: 'full' });
+  });
+
+  test('hot rebuilds body changes used by workflows', async () => {
+    const helperFile = '/app/workflows/helper.ts';
+    const workflowFile = '/app/workflows/workflow.ts';
+    const previousHelperSnapshot = createSourceSnapshotFromSource(
+      "export const value = 'before';\n",
+      detectWorkflowPatterns
+    );
+    const nextHelperSnapshot = createSourceSnapshotFromSource(
+      "export const value = 'after';\n",
+      detectWorkflowPatterns
+    );
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set(),
+          discoveredWorkflows: new Set([workflowFile]),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set([helperFile, workflowFile]),
+        },
+        files: [helperFile],
+        inputFiles: [workflowFile],
+        parentHasChild: (parent, child) =>
+          parent === workflowFile && child === helperFile,
+        readSnapshot: async () => nextHelperSnapshot,
+        sourceSnapshots: new Map([[helperFile, previousHelperSnapshot]]),
+      })
+    ).resolves.toEqual({
+      kind: 'hot',
+      refreshStepRegistrations: false,
+      snapshots: new Map([[helperFile, nextHelperSnapshot]]),
     });
-
-    expect(decision.kind).toBe('none');
   });
 });

--- a/packages/next/src/watch-rebuild.test.ts
+++ b/packages/next/src/watch-rebuild.test.ts
@@ -257,6 +257,42 @@ export const allWorkflows = {} as const;
     ).resolves.toEqual({ kind: 'full' });
   });
 
+  test('fully rebuilds every directive file change', async () => {
+    const stepFile = '/app/workflows/step.ts';
+    const previousSnapshot = createSourceSnapshotFromSource(
+      `export let example = async () => {
+  'use step';
+  return 'before';
+};
+`,
+      detectWorkflowPatterns
+    );
+    const nextSnapshot = createSourceSnapshotFromSource(
+      `export let example = async () => {
+  'use step';
+  return 'after';
+};
+`,
+      detectWorkflowPatterns
+    );
+
+    await expect(
+      classifyRebuild({
+        discoveredEntries: {
+          discoveredSteps: new Set([stepFile]),
+          discoveredWorkflows: new Set(),
+          discoveredSerdeFiles: new Set(),
+          discoveredFiles: new Set([stepFile]),
+        },
+        files: [stepFile],
+        inputFiles: [],
+        parentHasChild: () => false,
+        readSnapshot: async () => nextSnapshot,
+        sourceSnapshots: new Map([[stepFile, previousSnapshot]]),
+      })
+    ).resolves.toEqual({ kind: 'full' });
+  });
+
   test('rebuilds new files that can introduce graph entries', async () => {
     const routeFile = '/app/app/new/route.ts';
 

--- a/packages/next/src/watch-rebuild.ts
+++ b/packages/next/src/watch-rebuild.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 
 export interface DiscoveredEntriesLike {
@@ -7,13 +8,12 @@ export interface DiscoveredEntriesLike {
   discoveredFiles?: Set<string>;
 }
 
-export interface FileChanges {
-  addedFiles: string[];
-  modifiedFiles: string[];
-  removedFiles: string[];
-}
+export type ScheduledRebuild =
+  | { kind: 'files'; files: string[] }
+  | { kind: 'full' };
 
 export interface SourceSnapshot {
+  sourceHash: string;
   importSignature: string;
   definitionSignature: string;
   hasDirective: boolean;
@@ -21,7 +21,7 @@ export interface SourceSnapshot {
 }
 
 export type RebuildDecision =
-  | { kind: 'none'; snapshots?: Map<string, SourceSnapshot> }
+  | { kind: 'skip'; snapshots: Map<string, SourceSnapshot> }
   | {
       kind: 'hot';
       refreshStepRegistrations: boolean;
@@ -216,6 +216,7 @@ export const createSourceSnapshotFromSource = (
   const patterns = detectWorkflowPatterns(sourceWithoutComments);
 
   return {
+    sourceHash: createHash('sha256').update(source).digest('base64url'),
     importSignature: extractImportSignature(sourceWithoutComments),
     definitionSignature: extractDefinitionSignature(sourceWithoutComments),
     hasDirective: patterns.hasDirective,
@@ -254,55 +255,17 @@ export const getRelevantFiles = ({
     ].map(normalizePath)
   );
 
-export const replaceSourceSnapshots = async ({
+export const readSourceSnapshots = async ({
   discoveredEntries,
   inputFiles,
   normalizePath = defaultNormalizePath,
   readSnapshot,
-  sourceSnapshots,
 }: {
   discoveredEntries: DiscoveredEntriesLike;
   inputFiles: string[];
   normalizePath?: (path: string) => string;
   readSnapshot: (file: string) => Promise<SourceSnapshot>;
-  sourceSnapshots: Map<string, SourceSnapshot>;
 }) => {
-  sourceSnapshots.clear();
-  await Promise.all(
-    [
-      ...getRelevantFiles({
-        discoveredEntries,
-        inputFiles,
-        normalizePath,
-      }),
-    ].map(async (file) => {
-      try {
-        sourceSnapshots.set(file, await readSnapshot(file));
-      } catch {
-        // Unreadable (e.g. just deleted) files simply stay absent from the
-        // freshly cleared map.
-      }
-    })
-  );
-};
-
-/**
- * Read snapshots for every currently relevant file without mutating the
- * shared baseline map. Used by `pinBaselinesAcrossFullRebuild` to capture
- * content at rebuild start, so the baseline can later be pinned to what the
- * rebuild actually consumed.
- */
-const captureSourceSnapshots = async ({
-  discoveredEntries,
-  inputFiles,
-  normalizePath = defaultNormalizePath,
-  readSnapshot,
-}: {
-  discoveredEntries: DiscoveredEntriesLike;
-  inputFiles: string[];
-  normalizePath?: (path: string) => string;
-  readSnapshot: (file: string) => Promise<SourceSnapshot>;
-}): Promise<Map<string, SourceSnapshot>> => {
   const snapshots = new Map<string, SourceSnapshot>();
   await Promise.all(
     [
@@ -320,77 +283,7 @@ const captureSourceSnapshots = async ({
   return snapshots;
 };
 
-/**
- * Run a full rebuild while keeping the classifier baseline anchored to the
- * content the rebuild consumed.
- *
- * A full rebuild reads sources twice: once when the bundler consumes them and
- * once when the baseline is refreshed from disk afterwards (the `rebuild`
- * callback owns both, in that order). An edit that lands between those reads
- * would be absorbed into the baseline without ever being built, and its
- * queued watcher event would then classify as a no-op — silently dropping
- * the change until the next unrelated rebuild.
- *
- * To prevent that, the relevant files are re-read from disk immediately
- * before the rebuild starts, and files present both before and after get
- * that captured value restored. A mid-(multi-second-)rebuild edit then still
- * diffs against what the rebuild consumed, while a duplicate watcher event
- * for content the rebuild already consumed — watchers routinely emit several
- * events per edit, the triggering edit included — diffs equal and stays a
- * no-op instead of cascading into back-to-back full rebuilds.
- *
- * The capture costs one serial read of the relevant set (~150-250ms at ~250
- * files) per full rediscovery. A zero-read formulation — cloning the live
- * baseline map and pinning the triggering batch to the snapshots
- * `classifyRebuild` read — was tried and reverted: writes landing in the
- * capture window (test-teardown restores, multi-flush setup bursts) are
- * content the imminent build consumes anyway, and the clone un-absorbs them
- * into follow-up full rebuilds; with real-world multi-second rebuilds that
- * bursts into rebuild chains. The disk capture intentionally coalesces such
- * writes into the in-flight rebuild.
- *
- * Files the rebuild discovered for the first time have no captured content
- * and keep their post-build baseline. That is already sound for the two
- * cases that matter: a new file the build missed has no baseline at all, so
- * its queued add event forces the follow-up rebuild, and a new file the
- * build did consume gets a baseline matching what it consumed. What stays
- * narrowed rather than closed is a file created and then edited again within
- * one rebuild window — eviction-style conservatism was tried against that
- * and rejected too: it turned every added file's routine duplicate watcher
- * events into redundant full rebuilds.
- */
-export const pinBaselinesAcrossFullRebuild = async ({
-  discoveredEntries,
-  inputFiles,
-  normalizePath = defaultNormalizePath,
-  readSnapshot,
-  rebuild,
-  sourceSnapshots,
-}: {
-  discoveredEntries: DiscoveredEntriesLike;
-  inputFiles: string[];
-  normalizePath?: (path: string) => string;
-  readSnapshot: (file: string) => Promise<SourceSnapshot>;
-  rebuild: () => Promise<void>;
-  sourceSnapshots: Map<string, SourceSnapshot>;
-}): Promise<void> => {
-  const preBuildSnapshots = await captureSourceSnapshots({
-    discoveredEntries,
-    inputFiles,
-    normalizePath,
-    readSnapshot,
-  });
-
-  await rebuild();
-
-  for (const [file, snapshot] of preBuildSnapshots) {
-    if (sourceSnapshots.has(file)) {
-      sourceSnapshots.set(file, snapshot);
-    }
-  }
-};
-
-const didSourceSnapshotChange = (
+const didSourceStructureChange = (
   previousSnapshot: SourceSnapshot,
   nextSnapshot: SourceSnapshot
 ) =>
@@ -399,184 +292,58 @@ const didSourceSnapshotChange = (
   previousSnapshot.hasDirective !== nextSnapshot.hasDirective ||
   previousSnapshot.hasSerde !== nextSnapshot.hasSerde;
 
-const unique = (paths: string[]) => [...new Set(paths)];
+export const createRebuildScheduler = (
+  rebuild: (request: ScheduledRebuild) => Promise<void>,
+  onIdle: () => void
+) => {
+  let pending: ScheduledRebuild | undefined;
+  let rebuilding = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
 
-const snapshotChangedFile = async ({
-  file,
-  nextSnapshots,
-  readSnapshot,
-  sourceSnapshots,
-}: {
-  file: string;
-  nextSnapshots: Map<string, SourceSnapshot>;
-  readSnapshot: (file: string) => Promise<SourceSnapshot>;
-  sourceSnapshots: Map<string, SourceSnapshot>;
-}) => {
-  const previousSnapshot = sourceSnapshots.get(file);
-  if (!previousSnapshot) {
-    return false;
-  }
-
-  const nextSnapshot = await readSnapshot(file);
-  if (didSourceSnapshotChange(previousSnapshot, nextSnapshot)) {
-    return false;
-  }
-
-  nextSnapshots.set(file, nextSnapshot);
-  return true;
-};
-
-const removedFilesRequireFullRebuild = ({
-  discoveredEntries,
-  inputFiles,
-  normalizePath,
-  removedFiles,
-}: {
-  discoveredEntries: DiscoveredEntriesLike;
-  inputFiles: string[];
-  normalizePath: (path: string) => string;
-  removedFiles: string[];
-}) => {
-  const relevantFiles = getRelevantFiles({
-    discoveredEntries,
-    inputFiles,
-    normalizePath,
-  });
-  return removedFiles.some((file) => relevantFiles.has(file));
-};
-
-const addedFilesRequireFullRebuild = async ({
-  addedFiles,
-  readSnapshot,
-}: {
-  addedFiles: string[];
-  readSnapshot: (file: string) => Promise<SourceSnapshot>;
-}) => {
-  for (const file of addedFiles) {
-    try {
-      const snapshot = await readSnapshot(file);
-      if (snapshot.hasDirective || snapshot.hasSerde) {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  return false;
-};
-
-const pruneStaleAddedFiles = async ({
-  addedFiles,
-  readSnapshot,
-  sourceSnapshots,
-}: {
-  addedFiles: string[];
-  readSnapshot: (file: string) => Promise<SourceSnapshot>;
-  sourceSnapshots: Map<string, SourceSnapshot>;
-}) => {
-  const nextAddedFiles: string[] = [];
-  const snapshots = new Map<string, SourceSnapshot>();
-
-  for (const file of unique(addedFiles)) {
-    const previousSnapshot = sourceSnapshots.get(file);
-    if (!previousSnapshot) {
-      nextAddedFiles.push(file);
-      continue;
-    }
-
-    try {
-      const nextSnapshot = await readSnapshot(file);
-      if (didSourceSnapshotChange(previousSnapshot, nextSnapshot)) {
-        nextAddedFiles.push(file);
-        continue;
-      }
-      snapshots.set(file, nextSnapshot);
-    } catch {
-      nextAddedFiles.push(file);
-    }
-  }
-
-  return { addedFiles: nextAddedFiles, snapshots };
-};
-
-const modifiedFilesRequireFullRebuild = async ({
-  modifiedFiles,
-  readSnapshot,
-  sourceSnapshots,
-}: {
-  modifiedFiles: string[];
-  readSnapshot: (file: string) => Promise<SourceSnapshot>;
-  sourceSnapshots: Map<string, SourceSnapshot>;
-}) => {
-  for (const file of unique(modifiedFiles)) {
-    try {
-      const nextSnapshot = await readSnapshot(file);
-      const previousSnapshot = sourceSnapshots.get(file);
-      if (!previousSnapshot) {
-        if (
-          nextSnapshot.importSignature ||
-          nextSnapshot.definitionSignature ||
-          nextSnapshot.hasDirective ||
-          nextSnapshot.hasSerde
-        ) {
-          return true;
-        }
-        continue;
-      }
-      if (didSourceSnapshotChange(previousSnapshot, nextSnapshot)) {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  return false;
-};
-
-const getChangedRelevantFiles = ({
-  discoveredEntries,
-  fileChanges,
-  inputFiles,
-  normalizePath,
-}: {
-  discoveredEntries: DiscoveredEntriesLike;
-  fileChanges: FileChanges;
-  inputFiles: string[];
-  normalizePath: (path: string) => string;
-}) => {
-  const relevantFiles = getRelevantFiles({
-    discoveredEntries,
-    inputFiles,
-    normalizePath,
-  });
-  return unique(fileChanges.modifiedFiles).filter((file) =>
-    relevantFiles.has(file)
-  );
-};
-
-const collectHotRebuildSnapshots = async ({
-  changedFiles,
-  readSnapshot,
-  sourceSnapshots,
-}: {
-  changedFiles: string[];
-  readSnapshot: (file: string) => Promise<SourceSnapshot>;
-  sourceSnapshots: Map<string, SourceSnapshot>;
-}) => {
-  const snapshots = new Map<string, SourceSnapshot>();
-  for (const file of changedFiles) {
-    if (
-      !(await snapshotChangedFile({
-        file,
-        nextSnapshots: snapshots,
-        readSnapshot,
-        sourceSnapshots,
-      }))
-    ) {
+  const flush = async () => {
+    if (rebuilding || timer || !pending) {
       return;
     }
-  }
-  return snapshots;
+
+    const request = pending;
+    pending = undefined;
+    rebuilding = true;
+    try {
+      await rebuild(request);
+    } finally {
+      rebuilding = false;
+      if (pending && !timer) {
+        void flush();
+      } else if (!pending) {
+        onIdle();
+      }
+    }
+  };
+
+  return (request: ScheduledRebuild) => {
+    switch (request.kind) {
+      case 'files':
+        if (pending?.kind !== 'full') {
+          pending = {
+            kind: 'files',
+            files: [...new Set([...(pending?.files ?? []), ...request.files])],
+          };
+        }
+        break;
+      case 'full':
+        pending = request;
+        break;
+      default:
+        request satisfies never;
+        throw new Error('Unknown scheduled rebuild');
+    }
+
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      void flush();
+    }, 100);
+  };
 };
 
 const workflowEntryFilesChanged = ({
@@ -633,16 +400,16 @@ const stepRegistrationsNeedRefresh = ({
 };
 
 export const classifyRebuild = async ({
+  files,
   discoveredEntries,
-  fileChanges,
   inputFiles,
   normalizePath = defaultNormalizePath,
   parentHasChild,
   readSnapshot,
   sourceSnapshots,
 }: {
+  files: string[];
   discoveredEntries: DiscoveredEntriesLike;
-  fileChanges: FileChanges;
   inputFiles: string[];
   normalizePath?: (path: string) => string;
   parentHasChild: (
@@ -653,74 +420,59 @@ export const classifyRebuild = async ({
   readSnapshot: (file: string) => Promise<SourceSnapshot>;
   sourceSnapshots: Map<string, SourceSnapshot>;
 }): Promise<RebuildDecision> => {
-  const prunedAddedFiles = await pruneStaleAddedFiles({
-    addedFiles: fileChanges.addedFiles,
-    readSnapshot,
-    sourceSnapshots,
-  });
-  const normalizedFileChanges = {
-    ...fileChanges,
-    addedFiles: prunedAddedFiles.addedFiles,
-  };
-
-  if (
-    removedFilesRequireFullRebuild({
-      discoveredEntries,
-      inputFiles,
-      normalizePath,
-      removedFiles: normalizedFileChanges.removedFiles,
-    }) ||
-    (await addedFilesRequireFullRebuild({
-      addedFiles: normalizedFileChanges.addedFiles,
-      readSnapshot,
-    })) ||
-    (await modifiedFilesRequireFullRebuild({
-      modifiedFiles: normalizedFileChanges.modifiedFiles,
-      readSnapshot,
-      sourceSnapshots,
-    }))
-  ) {
-    return { kind: 'full' };
-  }
-
-  const changedRelevantFiles = getChangedRelevantFiles({
+  const relevantFiles = getRelevantFiles({
     discoveredEntries,
-    fileChanges: normalizedFileChanges,
     inputFiles,
     normalizePath,
   });
-  if (changedRelevantFiles.length === 0) {
-    return prunedAddedFiles.snapshots.size > 0
-      ? { kind: 'none', snapshots: prunedAddedFiles.snapshots }
-      : { kind: 'none' };
-  }
+  const snapshots = new Map<string, SourceSnapshot>();
+  for (const file of files) {
+    let nextSnapshot: SourceSnapshot;
+    try {
+      nextSnapshot = await readSnapshot(file);
+    } catch {
+      if (relevantFiles.has(file)) {
+        return { kind: 'full' };
+      }
+      continue;
+    }
 
-  try {
-    const snapshots = await collectHotRebuildSnapshots({
-      changedFiles: changedRelevantFiles,
-      readSnapshot,
-      sourceSnapshots,
-    });
-    if (!snapshots) {
+    const previousSnapshot = sourceSnapshots.get(file);
+    if (!previousSnapshot) {
+      if (
+        relevantFiles.has(file) ||
+        nextSnapshot.importSignature ||
+        nextSnapshot.hasDirective ||
+        nextSnapshot.hasSerde
+      ) {
+        return { kind: 'full' };
+      }
+      continue;
+    }
+    if (didSourceStructureChange(previousSnapshot, nextSnapshot)) {
       return { kind: 'full' };
     }
-    return workflowEntryFilesChanged({
-      changedFiles: changedRelevantFiles,
-      discoveredEntries,
-      normalizePath,
-      parentHasChild,
-    })
-      ? {
-          kind: 'hot',
-          refreshStepRegistrations: stepRegistrationsNeedRefresh({
-            changedFiles: changedRelevantFiles,
-            discoveredEntries,
-            normalizePath,
-          }),
-          snapshots,
-        }
-      : { kind: 'none', snapshots };
-  } catch {
-    return { kind: 'full' };
+    if (previousSnapshot.sourceHash === nextSnapshot.sourceHash) {
+      return { kind: 'full' };
+    }
+    snapshots.set(file, nextSnapshot);
   }
+
+  const changedFiles = [...snapshots.keys()];
+  return workflowEntryFilesChanged({
+    changedFiles,
+    discoveredEntries,
+    normalizePath,
+    parentHasChild,
+  })
+    ? {
+        kind: 'hot',
+        refreshStepRegistrations: stepRegistrationsNeedRefresh({
+          changedFiles,
+          discoveredEntries,
+          normalizePath,
+        }),
+        snapshots,
+      }
+    : { kind: 'skip', snapshots };
 };

--- a/packages/next/src/watch-rebuild.ts
+++ b/packages/next/src/watch-rebuild.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 
 export interface DiscoveredEntriesLike {
   discoveredSteps: Set<string>;
@@ -14,6 +14,17 @@ export type ScheduledRebuild =
 
 export interface SourceSnapshot {
   sourceHash: string;
+  /**
+   * File modification time observed alongside the content read. Together with
+   * `sourceHash` it identifies a specific write: an event whose content AND
+   * mtime both match the baseline is a duplicate notification for a write
+   * that was already consumed, while identical content with a newer mtime is
+   * a distinct rewrite (whose interim states a build may have consumed) and
+   * stays a conservative invalidation. Snapshots built without filesystem
+   * access use 0, which never equals a real mtime, so they always classify
+   * as rewrites rather than duplicates.
+   */
+  mtimeMs: number;
   importSignature: string;
   definitionSignature: string;
   hasDirective: boolean;
@@ -21,13 +32,30 @@ export interface SourceSnapshot {
 }
 
 export type RebuildDecision =
+  /**
+   * Every file in the batch was a duplicate notification for content the
+   * builder already consumed (same hash, same mtime). Nothing to rebuild,
+   * and — unlike `skip` — nothing happened, so the builder logs it under a
+   * marker the HMR log-count assertions do not count.
+   */
+  | { kind: 'duplicate' }
   | { kind: 'skip'; snapshots: Map<string, SourceSnapshot> }
   | {
       kind: 'hot';
       refreshStepRegistrations: boolean;
       snapshots: Map<string, SourceSnapshot>;
     }
-  | { kind: 'full' };
+  /**
+   * `snapshots` carries what the classifier read for the files that
+   * triggered the rediscovery. The full rebuild re-captures every already-
+   * relevant file from disk itself, but files it discovers for the first
+   * time are absent from that capture — seeding them from these reads gives
+   * a freshly created file a baseline matching (modulo the classify→build
+   * gap, which the mtime rule covers) what the build consumed, so its
+   * routine duplicate events suppress instead of forcing another rebuild,
+   * while a genuine mid-build edit still diffs as changed.
+   */
+  | { kind: 'full'; snapshots: Map<string, SourceSnapshot> };
 
 export type SourcePatternDetector = (source: string) => {
   hasDirective: boolean;
@@ -210,13 +238,15 @@ export const extractDefinitionSignature = (source: string) => {
 
 export const createSourceSnapshotFromSource = (
   source: string,
-  detectWorkflowPatterns: SourcePatternDetector
+  detectWorkflowPatterns: SourcePatternDetector,
+  mtimeMs = 0
 ): SourceSnapshot => {
   const sourceWithoutComments = stripCommentsFromSource(source);
   const patterns = detectWorkflowPatterns(sourceWithoutComments);
 
   return {
     sourceHash: createHash('sha256').update(source).digest('base64url'),
+    mtimeMs,
     importSignature: extractImportSignature(sourceWithoutComments),
     definitionSignature: extractDefinitionSignature(sourceWithoutComments),
     hasDirective: patterns.hasDirective,
@@ -224,17 +254,27 @@ export const createSourceSnapshotFromSource = (
   };
 };
 
+// The content read and the stat can interleave with a concurrent write, but
+// every tearing lands safe: content-behind-mtime makes the write's own event
+// diff as changed (rebuild), and mtime-behind-content makes it diff as a
+// rewrite (conservative rebuild). Neither can suppress a real write.
 export const createSourceSnapshot = async ({
   file,
   detectWorkflowPatterns,
 }: {
   file: string;
   detectWorkflowPatterns: SourcePatternDetector;
-}): Promise<SourceSnapshot> =>
-  createSourceSnapshotFromSource(
-    await readFile(file, 'utf8'),
-    detectWorkflowPatterns
+}): Promise<SourceSnapshot> => {
+  const [source, stats] = await Promise.all([
+    readFile(file, 'utf8'),
+    stat(file),
+  ]);
+  return createSourceSnapshotFromSource(
+    source,
+    detectWorkflowPatterns,
+    stats.mtimeMs
   );
+};
 
 export const getRelevantFiles = ({
   discoveredEntries,
@@ -427,16 +467,25 @@ export const classifyRebuild = async ({
     normalizePath,
   });
   const snapshots = new Map<string, SourceSnapshot>();
+  const readSnapshots = new Map<string, SourceSnapshot>();
+  let duplicates = 0;
+  let requiresFullRebuild = false;
+  // Read the whole batch even once a full rebuild is certain: the full
+  // decision's snapshots seed baselines for files the rebuild discovers for
+  // the first time, and a file skipped here (e.g. one created alongside the
+  // change that forced the rediscovery) would re-classify its duplicate
+  // events as brand new and force a second rebuild.
   for (const file of files) {
     let nextSnapshot: SourceSnapshot;
     try {
       nextSnapshot = await readSnapshot(file);
     } catch {
       if (relevantFiles.has(file)) {
-        return { kind: 'full' };
+        requiresFullRebuild = true;
       }
       continue;
     }
+    readSnapshots.set(file, nextSnapshot);
 
     const previousSnapshot = sourceSnapshots.get(file);
     if (!previousSnapshot) {
@@ -446,17 +495,50 @@ export const classifyRebuild = async ({
         nextSnapshot.hasDirective ||
         nextSnapshot.hasSerde
       ) {
-        return { kind: 'full' };
+        requiresFullRebuild = true;
+        continue;
       }
+      // Track files that cannot affect the build so their follow-up watcher
+      // events have a baseline to diff against and duplicates suppress.
+      snapshots.set(file, nextSnapshot);
+      continue;
+    }
+    // The duplicate check runs before any invalidation rule: identical
+    // content AND mtime is a repeated notification for a write that was
+    // already consumed, so nothing can have changed — directive files
+    // included.
+    if (previousSnapshot.sourceHash === nextSnapshot.sourceHash) {
+      // Same content, same write (mtime matches): a duplicate notification
+      // for a write that was already consumed. Watchers routinely emit
+      // several events per edit; treating them as fresh invalidations turned
+      // each into a spurious rebuild.
+      if (previousSnapshot.mtimeMs === nextSnapshot.mtimeMs) {
+        duplicates += 1;
+        continue;
+      }
+      // Same content but a different write (rewrite-in-place, or a revert
+      // during a build whose interim state the build may have consumed):
+      // stay conservative for files that can affect the build.
+      if (relevantFiles.has(file)) {
+        requiresFullRebuild = true;
+        continue;
+      }
+      duplicates += 1;
       continue;
     }
     if (requiresFullRediscovery(previousSnapshot, nextSnapshot)) {
-      return { kind: 'full' };
-    }
-    if (previousSnapshot.sourceHash === nextSnapshot.sourceHash) {
-      return { kind: 'full' };
+      requiresFullRebuild = true;
+      continue;
     }
     snapshots.set(file, nextSnapshot);
+  }
+
+  if (requiresFullRebuild) {
+    return { kind: 'full', snapshots: readSnapshots };
+  }
+
+  if (snapshots.size === 0 && duplicates > 0) {
+    return { kind: 'duplicate' };
   }
 
   const changedFiles = [...snapshots.keys()];

--- a/packages/next/src/watch-rebuild.ts
+++ b/packages/next/src/watch-rebuild.ts
@@ -283,10 +283,11 @@ export const readSourceSnapshots = async ({
   return snapshots;
 };
 
-const didSourceStructureChange = (
+const requiresFullRediscovery = (
   previousSnapshot: SourceSnapshot,
   nextSnapshot: SourceSnapshot
 ) =>
+  nextSnapshot.hasDirective ||
   previousSnapshot.importSignature !== nextSnapshot.importSignature ||
   previousSnapshot.definitionSignature !== nextSnapshot.definitionSignature ||
   previousSnapshot.hasDirective !== nextSnapshot.hasDirective ||
@@ -449,7 +450,7 @@ export const classifyRebuild = async ({
       }
       continue;
     }
-    if (didSourceStructureChange(previousSnapshot, nextSnapshot)) {
+    if (requiresFullRediscovery(previousSnapshot, nextSnapshot)) {
       return { kind: 'full' };
     }
     if (previousSnapshot.sourceHash === nextSnapshot.sourceHash) {


### PR DESCRIPTION
> Stacked on #3333 (base branch is `codex/fix-next-hmr-build-race`); GitHub will retarget this to `main` when #3333 merges. The two PRs together are what makes the E2E Local Dev lanes deterministic.

## Summary & Motivation

The E2E Local Dev lanes (nextjs-webpack/nextjs-turbopack × stable/canary × node/quickjs) are the reason `main` has been red on most runs for days: `dev.test.ts`'s HMR log-count assertions fail with `expected 2/3/5 to be 1` (spurious extra rebuilds) or `expected +0 to be 1` (a dropped edit). #3529 fixed the mid-rebuild absorption race and #3333 fixes convergence, but the *duplicate watcher event* mode survives both: watchers routinely emit several events per write (chokidar 4 has no fsevents; `fs.watch` double-fires), and the classifier treats every notification as a fresh invalidation.

Reproduced on #3333's own head in 2 local runs: the `body-only changes` test failed with `expected 2 to be 1` — the server log shows `full rediscovery → build → full rediscovery` for a single `fs.writeFile`, because the duplicate event either lands mid-build (the overlap handler schedules an unconditional follow-up full) or after it (byte-identical content classifies as a conservative full). The same double-full signature is visible in the failing CI runs (e.g. [nextjs-webpack stable node](https://github.com/vercel/workflow/actions/runs/31848782069), two `skip` lines 1.2s apart for one edit).

## The fix

`SourceSnapshot` now records the file **mtime alongside the content hash**, which identifies a specific write:

- **hash and mtime both match the baseline** → a duplicate notification for a write that was already consumed → no-op, logged as `workflow dev hmr: duplicate` (not counted by the e2e assertions).
- **hash matches but mtime is newer** → a distinct rewrite whose interim states an in-flight build may have consumed → stays a conservative full rediscovery for build-relevant files (this keeps the torn-consumption safety #3333's byte-identical rule existed for, scoped to events that are actually suspicious).

Two supporting changes make the suppression cover every path:

1. **Full decisions carry the classifier's reads (whole batch)** and the full rebuild seeds baselines from them for files it discovers for the first time — a freshly created file's duplicate events now diff equal instead of forcing a second rediscovery. This also closes the create-then-edit window #3529 documented as "narrowed rather than closed": a real mid-build edit diffs as changed (rebuild), a same-content rewrite as a rewrite (conservative rebuild).
2. **The schedule-a-full-on-any-event-during-a-build overlap handling is removed.** Overlapping events already re-classify after the build against the baseline it consumed, and the mtime rule covers the torn-consumption case the overlap full existed for. This eliminates the *guaranteed* double rediscovery whenever a duplicate landed mid-build.

Irrelevant files are now tracked on first sight so their duplicates suppress too instead of re-logging `skip` (the `{ skip: 1 }` exact assertions).

## Validation

- `@workflow/next` unit suite: 44/44 (new coverage: duplicate suppression, same-content rewrite stays full, full-decision snapshot seeding, batch mixing duplicates with real changes, irrelevant-file tracking).
- **nextjs-webpack stable node, staged tarball workbench** (CI's exact recipe): **5 consecutive full `dev.test.ts` runs green** (85–120s each). Baseline on this machine: #3333's head failed 1 of 2 runs (`expected 2 to be 1`); CI on main fails these lanes in the majority of runs.
- **nextjs-turbopack stable node**: 2 consecutive full runs green (7 tests each).
- Server logs across the runs show the mechanism firing: `full rediscovery → duplicate → idle` where the same edit previously produced `full → full`.

One local-harness caveat discovered on the way, for anyone reproducing: a `.env.local` in the workbench (e.g. from `vercel env pull`) makes `next dev --turbopack` evaluate the config twice and spawn **two** builder instances — every HMR log line doubles and all exact-count tests fail. CI never has one; delete it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)