### PR TITLE
Preserve run-key HTTP errors

### DIFF
--- a/.changeset/preserve-run-key-status.md
+++ b/.changeset/preserve-run-key-status.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Preserve upstream HTTP status codes when fetching Workflow run encryption keys.

--- a/packages/world-vercel/src/encryption.test.ts
+++ b/packages/world-vercel/src/encryption.test.ts
@@ -139,7 +139,10 @@ describe('fetchRunKey', () => {
       fetchRunKey(deploymentId, testProjectId, testRunId, {
         token: 'test-token',
       })
-    ).rejects.toThrow('HTTP 404');
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('HTTP 404'),
+      status: 404,
+    });
   });
 });
 

--- a/packages/world-vercel/src/encryption.ts
+++ b/packages/world-vercel/src/encryption.ts
@@ -18,6 +18,16 @@ import { instrumentedFetch, resolveVercelApiToken } from './http-core.js';
 
 const KEY_BYTES = 32; // 256 bits = 32 bytes (AES-256)
 
+class RunKeyFetchError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'RunKeyFetchError';
+    this.status = status;
+  }
+}
+
 /**
  * Derive a per-run AES-256 encryption key using HKDF-SHA256.
  *
@@ -131,8 +141,9 @@ export async function fetchRunKey(
       } catch {
         body = '<unable to read response body>';
       }
-      return new Error(
-        `Failed to fetch run key for ${runId} (deployment ${deploymentId}): HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`
+      return new RunKeyFetchError(
+        `Failed to fetch run key for ${runId} (deployment ${deploymentId}): HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`,
+        res.status
       );
     },
   });


### PR DESCRIPTION
## What changed

- attach the upstream HTTP status to run-key fetch errors
- cover the status contract in the existing encryption test
- add a patch changeset for `@workflow/world-vercel`

## Why

`fetchRunKey()` currently wraps API 4xx responses in a plain `Error`. Callers cannot distinguish an authorization/not-found response from an unexpected failure, so dashboard requests turn an intentional 404 into a 500.

## Impact

Consumers can preserve actionable 4xx responses while retaining the existing error message and response body context.

## Validation

- `pnpm --dir packages/world-vercel exec vitest run src/encryption.test.ts`
- `pnpm --filter @workflow/world-vercel typecheck`
- `pnpm turbo build --filter=@workflow/world-vercel...`
