### PR TITLE
[core] Retain workflow VMs across attributes

### DIFF
--- a/.changeset/retain-vms-across-attributes.md
+++ b/.changeset/retain-vms-across-attributes.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Retain workflow VMs across workflow attribute writes.

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -137,11 +137,11 @@ export interface WorkflowOrchestratorContext {
   globalThis: typeof globalThis;
   /**
    * Increments when a suspension is accepted and on every retained-session
-   * resume. Step and hook suspension signals capture it when scheduled and
-   * no-op if it moved, which drops same-boundary sibling signals and timers
-   * queued at boundary N that would fire after the session resumed into
-   * boundary N+1. Sleep and attribute signals are intentionally unguarded:
-   * their presence makes the boundary unretainable, so a late signal correctly
+   * resume. Step, hook, and attribute suspension signals capture it when
+   * scheduled and no-op if it moved, which drops same-boundary sibling signals
+   * and timers queued at boundary N that would fire after the session resumed
+   * into boundary N+1. Sleep signals are intentionally unguarded: their
+   * presence makes the boundary unretainable, so a late signal correctly
    * demotes the session (workflow.ts `onWorkflowError`).
    */
   suspensionGeneration: number;

--- a/packages/core/src/retained-vm-loop.test.ts
+++ b/packages/core/src/retained-vm-loop.test.ts
@@ -790,12 +790,21 @@ describe('retained VM through the inline replay loop', () => {
   });
 
   it('retains one VM across an attribute write and the following step', async () => {
-    const { vmBuilds, result } = await drive(
+    process.env.WORKFLOW_RETAINED_VM = '0';
+    const off = await drive(
       'wrun_retained_attribute_then_step',
       attributeThenStepWorkflow
     );
-    expect(result).toBe(10);
-    expect(vmBuilds).toBe(1);
+    createContextSpy.mockClear();
+    delete process.env.WORKFLOW_RETAINED_VM;
+
+    const on = await drive(
+      'wrun_retained_attribute_then_step',
+      attributeThenStepWorkflow
+    );
+    expect(on.result).toBe(10);
+    expect(on.vmBuilds).toBe(1);
+    expect(on.durableLog).toEqual(off.durableLog);
   });
 
   it('matches cold replay when hook metadata serialization mutates workflow state', async () => {

--- a/packages/core/src/retained-vm-loop.test.ts
+++ b/packages/core/src/retained-vm-loop.test.ts
@@ -144,6 +144,14 @@ const concurrentHookWakeWorkflow = `const createHook = globalThis[Symbol.for("WO
   }
   globalThis.__private_workflows = new Map([["workflow", workflow]]);`;
 
+const attributeThenStepWorkflow = `const setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
+  const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("r_s1");
+  async function workflow() {
+    await setAttributes([{ key: "phase", value: "ready" }]);
+    return await s1();
+  }
+  globalThis.__private_workflows = new Map([["workflow", workflow]]);`;
+
 // Hook metadata is serialized at the same suspension boundary as step input.
 // A getter mutating workflow state must demote the retained VM just like an
 // unsafe step argument, because a cold replay skips serialization after the
@@ -779,6 +787,15 @@ describe('retained VM through the inline replay loop', () => {
       on.durableLog.filter((event) => event.eventType === 'step_completed')
     ).toHaveLength(2);
     expect(on.durableLog).toEqual(off.durableLog);
+  });
+
+  it('retains one VM across an attribute write and the following step', async () => {
+    const { vmBuilds, result } = await drive(
+      'wrun_retained_attribute_then_step',
+      attributeThenStepWorkflow
+    );
+    expect(result).toBe(10);
+    expect(vmBuilds).toBe(1);
   });
 
   it('matches cold replay when hook metadata serialization mutates workflow state', async () => {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1060,7 +1060,7 @@ describe('workflowEntrypoint replay guards', () => {
     ).toEqual([]);
   });
 
-  it('replays attribute events before executing a step that loses the same race', async () => {
+  it('retains when an attribute write beats a step that signals first', async () => {
     const debug = vi
       .spyOn(runtimeLogger, 'debug')
       .mockImplementation(() => undefined);
@@ -1086,8 +1086,8 @@ describe('workflowEntrypoint replay guards', () => {
       const slowStep = useStep("slowStep");
       async function workflow() {
         await Promise.race([
-          setAttributes([{ key: "winner", value: "attribute" }]),
           slowStep(),
+          setAttributes([{ key: "winner", value: "attribute" }]),
         ]);
         return "attribute won";
       }${getWorkflowTransformCode('workflow')}`;
@@ -1103,10 +1103,8 @@ describe('workflowEntrypoint replay guards', () => {
     expect(createdEvents).toContainEqual(
       expect.objectContaining({ eventType: 'attr_set' })
     );
-    // The attr_set suspension skips step processing and resolves through an
-    // in-process replay, where the durable attribute event wins the race —
-    // so the run completes within this same delivery, with no queue
-    // interaction.
+    // The durable attribute event wins the retained resume. The later
+    // attribute suspension signal must not demote the session.
     expect(createdEvents).toContainEqual(
       expect.objectContaining({ eventType: 'run_completed' })
     );
@@ -1125,7 +1123,7 @@ describe('workflowEntrypoint replay guards', () => {
     const executionModes = debug.mock.calls
       .filter(([message]) => message === 'Starting workflow execution')
       .map(([, context]) => context?.executionMode);
-    expect(executionModes).toEqual(['replay', 'replay']);
+    expect(executionModes).toEqual(['replay', 'retained']);
     debug.mockRestore();
   });
 

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1061,7 +1061,7 @@ describe('workflowEntrypoint replay guards', () => {
   });
 
   it('retains when an attribute write beats a step that signals first', async () => {
-    const debug = vi
+    using debug = vi
       .spyOn(runtimeLogger, 'debug')
       .mockImplementation(() => undefined);
     const ops: Promise<any>[] = [];
@@ -1124,7 +1124,6 @@ describe('workflowEntrypoint replay guards', () => {
       .filter(([message]) => message === 'Starting workflow execution')
       .map(([, context]) => context?.executionMode);
     expect(executionModes).toEqual(['replay', 'retained']);
-    debug.mockRestore();
   });
 
   it('fails the run when the World rejects an attr_set event as invalid', async () => {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -3088,11 +3088,11 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     }${latXform('workflow')}`;
 
   it('reports ttfs across a pre-step setAttributes, resolved in-process without a re-invoke', async () => {
-    // A workflow-body setAttributes before the first step resolves through
-    // an in-process replay: the same delivery commits attr_set, replays, and
-    // runs the step — no queue interaction. TTFS ends at the attr write, so
-    // the setAttributes call's duration is subtracted; here that detour is
-    // milliseconds, keeping ttfs ≈ the run's ULID backdate.
+    // A workflow-body setAttributes before the first step resolves in-process:
+    // the same delivery commits attr_set, reloads it, and advances the workflow
+    // by resuming or replaying — no queue interaction. TTFS ends at the attr
+    // write, so the setAttributes call's duration is subtracted. That detour is
+    // only milliseconds here, keeping ttfs ≈ the run's ULID backdate.
     const backdateMs = 10_000;
     const before = Date.now();
     const first = await driveLatency({

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -3115,11 +3115,13 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     expect(ttfs).toBeLessThanOrEqual(backdateMs + elapsed);
     expect(stso).toBeUndefined();
     // The attr detour does not end turbo: no resume invocation source
-    // exists, so the forced-optimistic fast path stays engaged.
+    // exists, so the forced-optimistic fast path stays engaged. The live VM
+    // also resumes after the attr write instead of replaying in a fresh VM.
     expect(optimizations).toEqual([
       'turbo',
       'lazyStepStart',
       'optimisticStart',
+      'retained',
     ]);
   });
 

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1080,6 +1080,9 @@ describe('workflowEntrypoint replay guards', () => {
       startedAt: new Date('2024-01-01T00:00:00.000Z'),
       deploymentId: 'test-deployment',
     };
+    // Register the step consumer first so it schedules the accepted
+    // suspension. The later attribute signal must be dropped by its new
+    // generation guard after the retained session resumes.
     const workflowCode = `
       const setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
       const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
@@ -1111,9 +1114,9 @@ describe('workflowEntrypoint replay guards', () => {
     expect(queueCalls).toEqual([]);
     // Under lazy inline start the step that loses the attribute race is NOT
     // eagerly created: its step_created is deferred for a lazy step_started
-    // that never fires, because the attribute-resolving replay decides the
-    // race before any step executes. So the losing step leaves no events at
-    // all — strictly less event-log garbage than the eager model.
+    // that never fires, because the attribute-resolving retained execution
+    // decides the race before any step executes. So the losing step leaves no
+    // events at all — strictly less event-log garbage than the eager model.
     expect(createdEvents).not.toContainEqual(
       expect.objectContaining({ eventType: 'step_created' })
     );

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -524,7 +524,7 @@ type RetentionDecision =
       reason:
         | 'disabled'
         | 'serialization_executed_workflow_code'
-        | 'no_step_driver'
+        | 'no_replay_driver'
         | 'unsupported_suspension_item'
         | 'open_wait';
     };
@@ -534,9 +534,9 @@ type RetentionDecision =
  *
  * Every item type accepted here must use the suspension-generation guard when
  * signaling. Otherwise a signal scheduled at boundary N could suspend the VM
- * after it has already resumed into boundary N+1. Waits and attributes are not
- * guarded, so they remain unretainable. A step is required to drive the next
- * inline iteration; hook-only suspensions park normally.
+ * after it has already resumed into boundary N+1. Waits are not guarded, so
+ * they remain unretainable. A step or attribute write is required to drive the
+ * next inline iteration; hook-only suspensions park normally.
  *
  * Retaining across an open hook also permits a hook-woken cold replay to race
  * this invocation. That is safe only because each loaded log is a monotone,
@@ -575,17 +575,17 @@ function getRetentionDecision({
       reason: 'serialization_executed_workflow_code',
     };
   }
-  if (suspension.stepCount === 0) {
-    return { retain: false, reason: 'no_step_driver' };
+  if (suspension.stepCount === 0 && suspension.attributeCount === 0) {
+    return { retain: false, reason: 'no_replay_driver' };
   }
   if (
     !suspension.items.every((item) => {
       switch (item.type) {
         case 'step':
         case 'hook':
+        case 'attribute':
           return true;
         case 'wait':
-        case 'attribute':
           return false;
         default:
           item satisfies never;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3423,15 +3423,16 @@ export function workflowEntrypoint(
                           return await reinvoke(0);
                         }
 
-                        // Native workflow attribute events are resolved
-                        // through replay: the next loop iteration reloads the
-                        // log (now holding the just-committed attr_set) and
-                        // replays, resolving the setAttributes promise. Skip
-                        // step processing for this pass so that replay decides
-                        // races first: in Promise.race([setAttributes(),
-                        // step()]), the durable attribute event must be able
-                        // to win without executing the losing step. The replay
-                        // happens in-process rather than via a queue
+                        // Native workflow attribute events are resolved by the
+                        // next execution pass: it reloads the log (now holding
+                        // the just-committed attr_set), then either resumes the
+                        // retained VM or performs a cold replay to resolve the
+                        // setAttributes promise. Skip step processing for this
+                        // pass so that the durable event decides races first:
+                        // in Promise.race([setAttributes(), step()]), the
+                        // attribute must be able to win without executing the
+                        // losing step. The next pass happens in-process rather
+                        // than via a queue
                         // re-invocation: unlike hooks and waits, an attr_set
                         // introduces no out-of-band invocation source that the
                         // handler would need to yield the message for, so

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -367,17 +367,17 @@ async function createWorkflowSession({
         state = WorkflowSuspension.is(error)
           ? { type: 'suspended', suspension: error }
           : { type: 'replay' };
-        // Step and hook consumers can schedule the same suspension. The first
-        // signal advances the generation so the rest no-op.
+        // Step, hook, and attribute consumers can schedule the same suspension.
+        // The first signal advances the generation so the rest no-op.
         workflowContext.suspensionGeneration++;
         interruption.reject(error);
         return;
       }
       case 'suspended':
         // Same-boundary duplicates were staled by the generation bump above,
-        // so anything landing here is out-of-band — an unguarded sleep/
-        // attribute signal or a divergence. Those boundaries are unretainable
-        // (the runtime demotes them too), so fall back to replay.
+        // so anything landing here is out-of-band — an unguarded sleep signal
+        // or a divergence. Those boundaries are unretainable (the runtime
+        // demotes them too), so fall back to replay.
         state = { type: 'replay' };
         return;
       case 'replay':

--- a/packages/core/src/workflow/attribute-dispatcher.ts
+++ b/packages/core/src/workflow/attribute-dispatcher.ts
@@ -2,12 +2,9 @@ import { ReplayDivergenceError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { AttributeChange } from '@workflow/world';
 import { EventConsumerResult } from '../events-consumer.js';
+import type { AttributeInvocationQueueItem } from '../global.js';
 import {
-  type AttributeInvocationQueueItem,
-  WorkflowSuspension,
-} from '../global.js';
-import {
-  scheduleWhenIdle,
+  scheduleWorkflowSuspension,
   type WorkflowOrchestratorContext,
 } from '../private.js';
 
@@ -30,11 +27,7 @@ export function createSetAttributes(ctx: WorkflowOrchestratorContext) {
 
     ctx.eventsConsumer.subscribe((event) => {
       if (!event) {
-        scheduleWhenIdle(ctx, () => {
-          ctx.onWorkflowError(
-            new WorkflowSuspension(ctx.invocationsQueue, ctx.globalThis)
-          );
-        });
+        scheduleWorkflowSuspension(ctx);
         return EventConsumerResult.NotConsumed;
       }
 


### PR DESCRIPTION
## Summary

- retain the workflow VM across workflow attribute writes
- generation-guard attribute suspension signals
- keep waits on the cold-replay path

## Verification

- `pnpm --filter @workflow/core... build`
- `pnpm --filter @workflow/core test`
- `pnpm --filter @workflow/core typecheck`
- focused Biome check (existing complexity warnings only)