### PR TITLE
[idl] Smithy World IDL with generated TypeScript and Python interfaces

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,7 +32,8 @@
       "!**/.nitro",
       "!**/.output",
       "!**/.tanstack",
-      "!**/routeTree.gen.ts"
+      "!**/routeTree.gen.ts",
+      "!idl/world/generated"
     ],
     "ignoreUnknown": true
   },

--- a/idl/world/.gitignore
+++ b/idl/world/.gitignore
@@ -1,0 +1,2 @@
+build/
+__pycache__/

--- a/idl/world/README.md
+++ b/idl/world/README.md
@@ -1,0 +1,124 @@
+# World IDL (proposal)
+
+A Smithy model of the World port, plus the TypeScript and Python interfaces
+generated from it.
+
+This is a proposal artifact. Nothing here is wired into the SDK, published, or
+built by CI: no package depends on it, and no implementation is expected to
+satisfy it yet. It exists so the shape of a single cross-language World
+contract can be reviewed as code rather than as prose.
+
+## What is here
+
+| Path | Contents |
+| --- | --- |
+| `model/` | The Smithy model. Hand-written; the source of truth. |
+| `generated/typescript/models`, `generated/typescript/schemas`, `generated/typescript/enums.ts` | Data types emitted by `smithy-typescript` in types mode. |
+| `generated/typescript/ports.ts` | One TypeScript interface per service, emitted by `scripts/generate_ports.py`. |
+| `generated/python/workflow_world/` | Python dataclasses, enums, errors, and `Protocol` interfaces, emitted by `scripts/generate_ports.py`. |
+| `scripts/generate.sh` | Regenerates everything under `generated/`. |
+
+## Deliberately absent: transports
+
+No protocol trait, HTTP binding, or wire format appears anywhere in the model.
+The operations are plain typed function shapes, so an in-process
+implementation satisfies the generated interface directly, with no
+serialization involved.
+
+Adding HTTP or WebSocket later is an additive projection: an overlay model
+applies protocol and binding traits on top of these same operations. That
+choice is what the model is arranged to keep open, and none of it is proposed
+here.
+
+## Services
+
+The surface is split into four service closures rather than one, because
+Smithy services have no optional operations and today's `World` very much
+does.
+
+- **`WorldCore`** — the required surface: runs, steps, events, hooks, streams,
+  queue send, deployment identity, and capability discovery. Every
+  implementation provides all of it.
+- **`WorldBatch`** — optional optimizations (`BatchGetRuns`,
+  `BulkCancelRuns`, `WriteStreamChunks`). Callers fall back to the `WorldCore`
+  equivalents when an implementation omits it.
+- **`WorldConsumer`** — the reverse direction: the runtime implements
+  `DeliverQueueMessage`, and a World's queue adapter calls it. Today's
+  `createQueueHandler` becomes the thin per-language adapter that exposes it.
+- **`WorldLocalHooks`** — operations resolved in-process that must never be
+  exposed over a transport, marked with the `localOnly` trait. Encryption-key
+  resolution lives here: it is modeled so TypeScript and Python share one
+  contract, and it is the clearest example of an operation a transport
+  projection must drop.
+
+`GetWorldInfo` reports the spec version and capabilities. Feature detection by
+method presence stops working the moment calls cross a transport, where every
+method always exists.
+
+## Modeling notes worth reviewing
+
+- **Payloads stay opaque.** Run, step, hook, and event payloads are `blob`.
+  They are produced by the SDK serialization pipeline and may be compressed or
+  encrypted; the World never interprets them. Spec-version-1 runs carried
+  unserialized JSON and are not representable — those need a conversion
+  adapter.
+- **`resolveData` cannot change an output type.** Smithy cannot vary a shape
+  by an input value, so payload members are optional and `NONE` leaves them
+  absent.
+- **Event writes stay atomic.** `CreateEvent` returns the committed event, the
+  entity it materialized, `stepCreated`, `maxEvents`, and the optional
+  inline-delta members, because callers depend on all of it.
+- **Slot contention is not an error.** A stale `eventCount` is not a
+  precondition failure: a slot-numbering implementation bumps to the next free
+  slot, commits, and reports the skipped events. `PreconditionFailedError` is
+  reserved for the separate `preconditionGuard` capability.
+- **Bulk cancel reports outcomes, not errors.** Missing, already-cancelled,
+  and non-cancellable runs are per-run result variants, so one bad ID never
+  fails the batch.
+- **Hook token collisions stay events.** `hook_conflict` is readable but not
+  creatable, matching the current contract.
+- **Unions use empty structures, not `Unit`.** Variants like
+  `BulkCancelOutcome$cancelled` can gain members later without a breaking
+  change (and `Unit` members currently generate uncompilable TypeScript).
+- **Queue payloads are opaque for now.** The invoke and health-check schemas
+  are private to producer and consumer and versioned by run spec version;
+  modeling them belongs with the transport work.
+- **Analytics is not modeled yet.** It has different consistency, retention,
+  and plan semantics, and belongs in its own service closure.
+
+## Regenerating
+
+```bash
+# Smithy CLI: https://smithy.io/2.0/guides/smithy-cli/cli_installation.html
+idl/world/scripts/generate.sh
+```
+
+`smithy build` resolves `software.amazon.smithy.typescript:smithy-typescript-codegen`
+from Maven Central, so the first run needs network access. `build/` is
+ignored; only `generated/` is committed.
+
+## Why the Python interface is emitted locally
+
+`smithy-typescript` covers TypeScript data types, and its types mode is
+transport-free — exactly what this model wants. It stops there, though: types
+mode emits data shapes only and never declares the operations, so nothing
+upstream produces the per-service interface.
+
+`smithy-python` has no published release and no Maven Central artifact at all,
+so for Python there is nothing upstream to run.
+
+`scripts/generate_ports.py` closes both gaps by reading the built model JSON:
+it emits the TypeScript port interfaces on top of the generated types, and the
+whole Python package. It is deliberately small and mechanical — the model
+stays the source of truth, and the emitter is expected to be replaced by
+`smithy-python` once that ships, and by a Smithy TypeScript integration if the
+port interfaces should come from the same plugin as the types.
+
+## Verification performed
+
+- `smithy build` validates the model (1190 shapes) and generates the
+  TypeScript types.
+- The generated TypeScript, including `ports.ts`, type-checks under
+  `tsc --strict` against `@smithy/types` and `@smithy/core`.
+- The generated Python package imports, and its dataclasses, enums, and
+  tagged-union variants round-trip in a smoke script.

--- a/idl/world/README.md
+++ b/idl/world/README.md
@@ -14,7 +14,7 @@ contract can be reviewed as code rather than as prose.
 | --- | --- |
 | `model/` | The Smithy model. Hand-written; the source of truth. |
 | `generated/typescript/models`, `generated/typescript/schemas`, `generated/typescript/enums.ts` | Data types emitted by `smithy-typescript` in types mode. |
-| `generated/typescript/ports.ts` | One TypeScript interface per service, emitted by `scripts/generate_ports.py`. |
+| `generated/typescript/ports.ts` | The `WorldPort` interface, emitted by `scripts/generate_ports.py`. |
 | `generated/python/workflow_world/` | Python dataclasses, enums, errors, and `Protocol` interfaces, emitted by `scripts/generate_ports.py`. |
 | `scripts/generate.sh` | Regenerates everything under `generated/`. |
 
@@ -30,30 +30,42 @@ applies protocol and binding traits on top of these same operations. That
 choice is what the model is arranged to keep open, and none of it is proposed
 here.
 
-## Services
+## One World interface
 
-The surface is split into four service closures rather than one, because
-Smithy services have no optional operations and today's `World` very much
-does.
+There is a single `World` service, implemented by every World: local,
+Postgres, Vercel, and the simulator. It is not split by concern, by
+optionality, or by whether an operation can cross a network — `WorldPort` in
+TypeScript and `WorldPort` in Python are the whole surface.
 
-- **`WorldCore`** — the required surface: runs, steps, events, hooks, streams,
-  queue send, deployment identity, and capability discovery. Every
-  implementation provides all of it.
-- **`WorldBatch`** — optional optimizations (`BatchGetRuns`,
-  `BulkCancelRuns`, `WriteStreamChunks`). Callers fall back to the `WorldCore`
-  equivalents when an implementation omits it.
-- **`WorldConsumer`** — the reverse direction: the runtime implements
-  `DeliverQueueMessage`, and a World's queue adapter calls it. Today's
-  `createQueueHandler` becomes the thin per-language adapter that exposes it.
-- **`WorldLocalHooks`** — operations resolved in-process that must never be
-  exposed over a transport, marked with the `localOnly` trait. Encryption-key
-  resolution lives here: it is modeled so TypeScript and Python share one
-  contract, and it is the clearest example of an operation a transport
-  projection must drop.
+Two distinctions that do exist are traits on operations rather than separate
+interfaces:
 
-`GetWorldInfo` reports the spec version and capabilities. Feature detection by
-method presence stops working the moment calls cross a transport, where every
-method always exists.
+- **`optionalCapability`** marks an operation an implementation may omit:
+  `BatchGetRuns`, `BulkCancelRuns`, `WriteStreamChunks`. This is the modeled
+  form of today's optional `World` methods (`getMany?`, `cancelMany?`,
+  `writeMulti?`), and it generates the same thing: an optional method in
+  TypeScript. `GetWorldInfo` reports which ones an implementation provides,
+  because feature detection by method presence stops working the moment calls
+  cross a transport, where every method always exists.
+- **`localOnly`** marks an operation resolved in-process that must never be
+  exposed over a transport: `CreateRunId`, `GetRuntimeDeadline`,
+  `GetEnvironment`, `DescribeRun`, `GetEncryptionKeyForRun`. These are
+  ordinary `World` methods today and stay on the one interface here; dropping
+  them is the job of a transport projection, not of a second interface.
+
+`RuntimeQueueConsumer` is the one other service, and it is not a second World
+interface: its implementor is the workflow runtime and its caller is a World's
+queue adapter (today, the callback handed to `createQueueHandler`). Putting
+`DeliverQueueMessage` on `World` would claim a World implements it, which is
+backwards.
+
+### Optionality in Python
+
+TypeScript has optional methods; Python `Protocol` has no equivalent. Each
+omittable operation therefore also gets a `runtime_checkable` narrowing
+protocol, so `isinstance(world, SupportsBatchGetRuns)` is the Python spelling
+of `typeof world.batchGetRuns === 'function'`. The operation is still part of
+the one World interface; only the detection idiom differs.
 
 ## Modeling notes worth reviewing
 
@@ -84,7 +96,8 @@ method always exists.
   are private to producer and consumer and versioned by run spec version;
   modeling them belongs with the transport work.
 - **Analytics is not modeled yet.** It has different consistency, retention,
-  and plan semantics, and belongs in its own service closure.
+  and plan semantics. Whether it belongs on `World` or beside it is an open
+  question, not settled here.
 
 ## Regenerating
 
@@ -102,7 +115,7 @@ ignored; only `generated/` is committed.
 `smithy-typescript` covers TypeScript data types, and its types mode is
 transport-free — exactly what this model wants. It stops there, though: types
 mode emits data shapes only and never declares the operations, so nothing
-upstream produces the per-service interface.
+upstream produces the `World` interface itself.
 
 `smithy-python` has no published release and no Maven Central artifact at all,
 so for Python there is nothing upstream to run.
@@ -120,5 +133,7 @@ port interfaces should come from the same plugin as the types.
   TypeScript types.
 - The generated TypeScript, including `ports.ts`, type-checks under
   `tsc --strict` against `@smithy/types` and `@smithy/core`.
-- The generated Python package imports, and its dataclasses, enums, and
-  tagged-union variants round-trip in a smoke script.
+- The generated Python package imports, its dataclasses, enums, and
+  tagged-union variants round-trip in a smoke script, and the narrowing
+  protocols accept an implementation that provides the optional operation
+  while rejecting one that does not.

--- a/idl/world/generated/python/workflow_world/__init__.py
+++ b/idl/world/generated/python/workflow_world/__init__.py
@@ -1,0 +1,4 @@
+"""Generated from the Smithy model. Do not edit by hand."""
+
+from .models import *  # noqa: F401,F403
+from .ports import *  # noqa: F401,F403

--- a/idl/world/generated/python/workflow_world/_base.py
+++ b/idl/world/generated/python/workflow_world/_base.py
@@ -1,0 +1,7 @@
+"""Hand-written base types the generated modules build on."""
+
+from __future__ import annotations
+
+
+class WorldError(Exception):
+    """Base class for every modeled World error."""

--- a/idl/world/generated/python/workflow_world/models.py
+++ b/idl/world/generated/python/workflow_world/models.py
@@ -1,0 +1,1580 @@
+"""Generated from the Smithy model. Do not edit by hand.
+
+Source: idl/world/model, emitted by idl/world/scripts/generate_ports.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, AsyncIterable, Optional, Union
+
+from ._base import WorldError
+
+
+"""An unbounded byte stream."""
+ByteStream = AsyncIterable[bytes]
+
+"""Correlation identifier tying an event to the entity it affects."""
+CorrelationId = str
+
+"""Opaque, implementation-defined pagination cursor."""
+Cursor = str
+
+"""Identifier of a deployment a run is pinned to."""
+DeploymentId = str
+
+"""A ready-to-use AES-256 key."""
+EncryptionKey = bytes
+
+"""Identifier of an event within a run's log."""
+EventId = str
+
+"""Identifier of a hook."""
+HookId = str
+
+"""Queue message identifier.
+
+Should be stable across redeliveries of one enqueued message: the
+runtime's inline step ownership uses it as a liveness lease. An
+implementation that mints a fresh ID per delivery still works, but owner
+redeliveries fall back to the slower backstop path.
+"""
+MessageId = str
+
+"""Logical queue name, e.g. a flow or step topic."""
+QueueName = str
+
+"""Opaque queue payload.
+
+The runtime's invoke and health-check payload schemas are deliberately
+not modeled yet: they are producer-and-consumer-private, versioned by
+run spec version, and encoded as CBOR or JSON depending on that version.
+Modeling them belongs in a follow-up once the transport story is
+settled.
+"""
+QueuePayload = bytes
+
+"""Identifier of a workflow run."""
+RunId = str
+
+"""Opaque serialized workflow data.
+
+Payload bytes are produced by the SDK serialization pipeline and may be
+compressed and/or encrypted. The World never interprets them. Runs
+created by spec version 1 carried unserialized JSON instead; those
+records are not representable here and must be converted by a
+compatibility adapter.
+"""
+SerializedData = bytes
+
+"""Identifier of a step within a run."""
+StepId = str
+
+"""Machine-readable step function name."""
+StepName = str
+
+"""Name of a stream within a run."""
+StreamName = str
+
+"""Identifier of a wait."""
+WaitId = str
+
+"""Machine-readable workflow function name, e.g.
+`workflow//./src/workflows/order//processOrder`.
+"""
+WorkflowName = str
+
+
+class ResolveData(str, Enum):
+    """Controls whether payload-bearing fields are resolved in a response.
+
+    Smithy cannot vary an output shape by an input value, so payload members
+    stay optional and `NONE` simply leaves them absent.
+    """
+    """Omit payload fields such as input, output, error, and metadata."""
+    NONE = "none"
+    """Resolve all payload fields."""
+    ALL = "all"
+
+
+class RunStatus(str, Enum):
+    """Lifecycle status of a run."""
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class SortOrder(str, Enum):
+    """Sort direction for list operations, ordered by creation time."""
+    ASC = "asc"
+    DESC = "desc"
+
+
+class StepStatus(str, Enum):
+    """Lifecycle status of a step."""
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+AttributeChangeList = list["AttributeChange"]
+
+BulkCancelResultList = list["BulkCancelResult"]
+
+CapabilityNameList = list["str"]
+
+ChunkDataList = list["bytes"]
+
+EventList = list["Event"]
+
+HookList = list["Hook"]
+
+RunIdList = list["RunId"]
+
+SparseWorkflowRunList = list["Optional[WorkflowRun]"]
+
+StepList = list["Step"]
+
+StreamChunkList = list["StreamChunk"]
+
+StreamNameList = list["StreamName"]
+
+StringList = list["str"]
+
+WorkflowRunList = list["WorkflowRun"]
+
+AttributeMap = dict["str", "str"]
+
+QueueHeaders = dict["str", "str"]
+
+RunDisplayFields = dict["str", "Optional[str]"]
+
+TraceCarrier = dict["str", "str"]
+
+
+@dataclass
+class AlreadyCancelledOutcome:
+    pass
+
+
+@dataclass
+class AttributeChange:
+    """A single attribute mutation. Keys absent from a change set are
+    untouched.
+    """
+
+    key: "str"
+    change: "AttributeChangeValue"
+
+
+@dataclass
+class AttributesSetEvent:
+    """Merges plaintext attribute changes into the run."""
+
+    changes: "AttributeChangeList"
+    writer: "AttributeWriter"
+    allow_reserved_attributes: "Optional[bool]" = None
+    """Permits keys in the reserved `$` namespace. Framework callers only."""
+
+
+@dataclass
+class BatchGetRunsInput:
+    run_ids: "RunIdList"
+    resolve_data: "Optional[ResolveData]" = None
+
+
+@dataclass
+class BatchGetRunsOutput:
+    runs: "SparseWorkflowRunList"
+
+
+@dataclass
+class BulkCancelFailure:
+    code: "str"
+    retryable: "bool"
+
+
+@dataclass
+class BulkCancelResult:
+    run_id: "RunId"
+    outcome: "BulkCancelOutcome"
+
+
+@dataclass
+class BulkCancelRunsInput:
+    run_ids: "RunIdList"
+    """1-500 unique run IDs."""
+    cancel_reason: "Optional[str]" = None
+
+
+@dataclass
+class BulkCancelRunsOutput:
+    summary: "BulkCancelSummary"
+    results: "BulkCancelResultList"
+    """One entry per requested ID, in request order."""
+
+
+@dataclass
+class BulkCancelSummary:
+    requested: "int"
+    cancelled: "int"
+    already_cancelled: "int"
+    not_cancellable: "int"
+    not_found: "int"
+    failed: "int"
+
+
+@dataclass
+class CancelledOutcome:
+    pass
+
+
+@dataclass
+class CloseStreamInput:
+    run_id: "RunId"
+    name: "StreamName"
+
+
+@dataclass
+class CloseStreamOutput:
+    pass
+
+
+@dataclass
+class CreateEventInput:
+    run_id: "RunId"
+    event: "CreatableEvent"
+    options: "Optional[CreateEventOptions]" = None
+
+
+@dataclass
+class CreateEventOptions:
+    """Advisory and idempotency parameters for an event write.
+
+    Everything here is optional. An implementation that ignores all of it
+    stays correct; the runtime falls back to explicit reads.
+    """
+
+    v1_compat: "Optional[bool]" = None
+    """Legacy spec-version-1 compatibility mode."""
+    resolve_data: "Optional[ResolveData]" = None
+    resume_id: "Optional[str]" = None
+    """Lazy hook resume idempotency key. The implementation routes it to a
+    `(runId, resumeId)` constraint so a producer's direct write and the
+    queue consumer's re-ensure converge on exactly one event. Only
+    meaningful for `hookReceived`.
+    """
+    resume_payload_digest: "Optional[str]" = None
+    """Digest of the serialized resume payload, sent identically by both
+    writers of a deduplicated resume.
+    """
+    via_step_dispatch: "Optional[bool]" = None
+    """Marks a `stepCreated` write as the queue consumer's re-ensure of a
+    resilient step dispatch.
+    """
+    request_id: "Optional[str]" = None
+    """Platform request ID, for correlating logs with events."""
+    compute_instance_id: "Optional[str]" = None
+    """Compute instance whose handler is writing this event."""
+    event_count: "Optional[int]" = None
+    """How many events the writer held when it decided to write this one.
+
+    Only meaningful against an implementation advertising `slotEventIds`,
+    where slots are dense and 1-based. Contention never rejects the write:
+    the implementation bumps to the next free slot, commits, and returns the
+    skipped events on the response. Understating is safe; overstating hides
+    events from the writer.
+    """
+    occurred_at: "Optional[datetime]" = None
+    """Client-side occurrence time, stored separately from the accept time."""
+    replay_divergence_count: "Optional[int]" = None
+    """Telemetry only: consecutive replay divergences resolved by this write.
+    Never persisted into the log.
+    """
+    since_cursor: "Optional[Cursor]" = None
+    """Inline-delta opt-in. The implementation may return the events written
+    strictly after this cursor, matching `ListEvents` semantics.
+    """
+    skip_preload: "Optional[bool]" = None
+    """Asks the implementation to skip the `runStarted` preload it would
+    otherwise compute. Honored only for `runStarted`.
+    """
+    preload_events: "Optional[bool]" = None
+    """Asks for the run's full replay log alongside a `hookReceived` re-ensure.
+    The runtime trusts it only when the log is complete, `hasMore` is false,
+    and the run and event ceiling are present.
+    """
+
+
+@dataclass
+class CreateRunIdInput:
+    options: "Optional[Any]" = None
+    """The full options bag passed to `start()`. Implementations read only the
+    keys they recognize and ignore the rest.
+    """
+
+
+@dataclass
+class CreateRunIdOutput:
+    run_id: "RunId"
+
+
+@dataclass
+class CreateRunInput:
+    event: "RunCreatedEvent"
+    run_id: "Optional[RunId]" = None
+    options: "Optional[CreateEventOptions]" = None
+
+
+@dataclass
+class DeliverQueueMessageInput:
+    queue_name: "QueueName"
+    message: "QueuePayload"
+    attempt: "int"
+    """1-based delivery attempt."""
+    message_id: "MessageId"
+    request_id: "Optional[str]" = None
+
+
+@dataclass
+class DeliverQueueMessageOutput:
+    retry: "Optional[RetryDirective]" = None
+    """Present when the runtime wants the message redelivered instead of
+    acknowledged.
+    """
+
+
+@dataclass
+class DescribeRunInput:
+    run: "Any"
+    """The run entity as the caller holds it, which may be a lean observability
+    row rather than a full record.
+    """
+
+
+@dataclass
+class DescribeRunOutput:
+    fields: "Optional[RunDisplayFields]" = None
+
+
+@dataclass
+class EnqueueInput:
+    queue_name: "QueueName"
+    message: "QueuePayload"
+    options: "Optional[EnqueueOptions]" = None
+
+
+@dataclass
+class EnqueueOptions:
+    deployment_id: "Optional[DeploymentId]" = None
+    """Target a specific deployment rather than the current one."""
+    idempotency_key: "Optional[str]" = None
+    headers: "Optional[QueueHeaders]" = None
+    delay_seconds: "Optional[int]" = None
+    """Delay delivery by this many seconds."""
+    spec_version: "Optional[int]" = None
+    """Spec version of the target run, which selects the transport format."""
+    region: "Optional[str]" = None
+    """Routing hint naming the region the message should be sent to."""
+
+
+@dataclass
+class EnqueueOutput:
+    message_id: "Optional[MessageId]" = None
+    """Assigned message ID, when the queue reports one."""
+
+
+@dataclass
+class Event:
+    """One committed entry in a run's event log."""
+
+    event_id: "EventId"
+    run_id: "RunId"
+    payload: "EventPayload"
+    created_at: "datetime"
+    """When the implementation accepted the event."""
+    correlation_id: "Optional[CorrelationId]" = None
+    """Entity this event affects. Absent on run-level events."""
+    spec_version: "Optional[int]" = None
+    occurred_at: "Optional[datetime]" = None
+    """When the client observed the event, when it reported one."""
+    resume_id: "Optional[str]" = None
+    """Idempotency key persisted on a lazy `hook_received`."""
+
+
+@dataclass
+class EventMutationResult:
+    """Result of an event write.
+
+    The event and the entity it affects are materialized atomically. The
+    delta members are populated when the caller opted into an inline delta
+    or preload, and by a slot-numbering implementation reporting the slots
+    it bumped past.
+    """
+
+    event: "Optional[Event]" = None
+    """The committed event. Absent only for legacy runs that skip event
+    storage.
+    """
+    run: "Optional[WorkflowRun]" = None
+    step: "Optional[Step]" = None
+    hook: "Optional[Hook]" = None
+    wait: "Optional[Wait]" = None
+    step_created: "Optional[bool]" = None
+    """True only when a lazy `stepStarted` created the step on this call. The
+    caller that sees it owns inline execution of that step.
+    """
+    max_events: "Optional[int]" = None
+    """Server-owned event ceiling for the run, enforced by the runtime."""
+    events: "Optional[EventList]" = None
+    """Events the caller had not seen, in log order."""
+    cursor: "Optional[Cursor]" = None
+    """Cursor past the last returned event."""
+    has_more: "Optional[bool]" = None
+    """Whether more event pages follow `events`."""
+
+
+@dataclass
+class GetDeploymentIdInput:
+    pass
+
+
+@dataclass
+class GetDeploymentIdOutput:
+    deployment_id: "DeploymentId"
+
+
+@dataclass
+class GetEncryptionKeyForRunInput:
+    run_id: "RunId"
+    context: "Optional[Any]" = None
+    """Opaque world-specific context, such as a deployment ID, used when the
+    run entity is not available locally.
+    """
+
+
+@dataclass
+class GetEncryptionKeyForRunOutput:
+    key: "Optional[EncryptionKey]" = None
+
+
+@dataclass
+class GetEnvironmentInput:
+    pass
+
+
+@dataclass
+class GetEnvironmentOutput:
+    environment: "Optional[str]" = None
+
+
+@dataclass
+class GetEventInput:
+    run_id: "RunId"
+    event_id: "EventId"
+    resolve_data: "Optional[ResolveData]" = None
+
+
+@dataclass
+class GetEventOutput:
+    event: "Event"
+
+
+@dataclass
+class GetHookByTokenInput:
+    token: "str"
+    resolve_data: "Optional[ResolveData]" = None
+
+
+@dataclass
+class GetHookByTokenOutput:
+    hook: "Hook"
+
+
+@dataclass
+class GetHookInput:
+    hook_id: "HookId"
+    run_id: "Optional[RunId]" = None
+    resolve_data: "Optional[ResolveData]" = None
+
+
+@dataclass
+class GetHookOutput:
+    hook: "Hook"
+
+
+@dataclass
+class GetRunInput:
+    run_id: "RunId"
+    resolve_data: "Optional[ResolveData]" = None
+
+
+@dataclass
+class GetRunOutput:
+    run: "WorkflowRun"
+
+
+@dataclass
+class GetRuntimeDeadlineInput:
+    pass
+
+
+@dataclass
+class GetRuntimeDeadlineOutput:
+    deadline: "Optional[datetime]" = None
+
+
+@dataclass
+class GetStepInput:
+    run_id: "RunId"
+    step_id: "StepId"
+    resolve_data: "Optional[ResolveData]" = None
+
+
+@dataclass
+class GetStepOutput:
+    step: "Step"
+
+
+@dataclass
+class GetStreamInfoInput:
+    run_id: "RunId"
+    name: "StreamName"
+
+
+@dataclass
+class GetStreamInfoOutput:
+    tail_index: "int"
+    """Index of the last known chunk, or -1 when the stream is empty."""
+    done: "bool"
+    """Whether the stream is closed."""
+
+
+@dataclass
+class GetWorldInfoInput:
+    pass
+
+
+@dataclass
+class GetWorldInfoOutput:
+    spec_version: "int"
+    """Workflow protocol spec version this implementation writes. Runtimes
+    require an exact match before creating or replaying runs.
+    """
+    capabilities: "Optional[WorldCapabilities]" = None
+    optional_capabilities: "Optional[CapabilityNameList]" = None
+    """Optional capability services that are available."""
+
+
+@dataclass
+class Hook:
+    """Materialized view of a hook.
+
+    A hook kept alive by minimum retention stays readable after its run ends
+    and continues to reserve its token, but can no longer be resumed.
+    """
+
+    run_id: "RunId"
+    hook_id: "HookId"
+    token: "str"
+    owner_id: "str"
+    project_id: "str"
+    environment: "str"
+    created_at: "datetime"
+    metadata: "Optional[SerializedData]" = None
+    spec_version: "Optional[int]" = None
+    is_webhook: "Optional[bool]" = None
+    is_system: "Optional[bool]" = None
+    token_retention_until: "Optional[datetime]" = None
+    """Earliest time the token may be released after the run ends. An active
+    run holds the token past this deadline.
+    """
+    resume_context: "Optional[HookResumeContext]" = None
+    resume_capabilities: "Optional[HookResumeCapabilities]" = None
+
+
+@dataclass
+class HookConflictEvent:
+    """Records that a `hook_created` lost a token race.
+
+    Implementations write this; callers cannot. Consumers reject the awaited
+    hook with a token-conflict error.
+    """
+
+    token: "str"
+    conflicting_run_id: "Optional[RunId]" = None
+    """Run that currently owns the token."""
+
+
+@dataclass
+class HookCreatedEvent:
+    """Creates a hook and claims its token."""
+
+    token: "str"
+    token_retention_until: "Optional[datetime]" = None
+    """Requests minimum token retention past the run's end. Requires the
+    `hookRetention` capability.
+    """
+    metadata: "Optional[SerializedData]" = None
+    is_webhook: "Optional[bool]" = None
+    is_system: "Optional[bool]" = None
+
+
+@dataclass
+class HookDisposedEvent:
+    """Disposes a hook and releases its token immediately."""
+
+    token: "Optional[str]" = None
+
+
+@dataclass
+class HookReceivedEvent:
+    """Delivers a payload to an active hook."""
+
+    payload: "SerializedData"
+    token: "Optional[str]" = None
+
+
+@dataclass
+class HookResumeCapabilities:
+    """Backend-attested resume capabilities, recomputed on every by-token
+    lookup.
+
+    Response-only and never persisted, so a rollback or kill switch
+    downgrades new resumes immediately by omitting it.
+    """
+
+    hook_resume_dedup_version: "int"
+    """Present when the live backend enforces the `(runId, resumeId)` dedup
+    constraint.
+    """
+
+
+@dataclass
+class HookResumeContext:
+    """Immutable slice of a hook's owning run, sufficient to resume the hook
+    without reading the run entity.
+
+    Deliberately excludes mutable run state, payloads, attributes, and any
+    secret.
+    """
+
+    deployment_id: "DeploymentId"
+    workflow_name: "WorkflowName"
+    run_spec_version: "Optional[int]" = None
+    """Spec version of the owning run, distinct from the hook's own."""
+    workflow_core_version: "Optional[str]" = None
+    trace_carrier: "Optional[TraceCarrier]" = None
+    """W3C trace context propagated from hook creation."""
+    encryption_public_key: "Optional[str]" = None
+    """The run's base64 X25519 public key, mirrored from the run entity."""
+    hook_resume_input_version: "Optional[int]" = None
+    """Version of the lazy-hook-resume consumer protocol supported by the run's
+    creating deployment. Absent means the sequential path.
+    """
+
+
+@dataclass
+class HookRetentionCapability:
+    active: "bool"
+
+
+@dataclass
+class ListEventsByCorrelationIdInput:
+    run_id: "RunId"
+    correlation_id: "CorrelationId"
+    resolve_data: "Optional[ResolveData]" = None
+    limit: "Optional[int]" = None
+    cursor: "Optional[Cursor]" = None
+    sort_order: "Optional[SortOrder]" = None
+
+
+@dataclass
+class ListEventsByCorrelationIdOutput:
+    events: "EventList"
+    has_more: "bool"
+    cursor: "Optional[Cursor]" = None
+
+
+@dataclass
+class ListEventsInput:
+    run_id: "RunId"
+    resolve_data: "Optional[ResolveData]" = None
+    limit: "Optional[int]" = None
+    cursor: "Optional[Cursor]" = None
+    sort_order: "Optional[SortOrder]" = None
+
+
+@dataclass
+class ListEventsOutput:
+    events: "EventList"
+    has_more: "bool"
+    cursor: "Optional[Cursor]" = None
+
+
+@dataclass
+class ListHooksInput:
+    run_id: "Optional[RunId]" = None
+    resolve_data: "Optional[ResolveData]" = None
+    limit: "Optional[int]" = None
+    cursor: "Optional[Cursor]" = None
+    sort_order: "Optional[SortOrder]" = None
+
+
+@dataclass
+class ListHooksOutput:
+    hooks: "HookList"
+    has_more: "bool"
+    cursor: "Optional[Cursor]" = None
+
+
+@dataclass
+class ListRunsInput:
+    workflow_name: "Optional[WorkflowName]" = None
+    status: "Optional[RunStatus]" = None
+    resolve_data: "Optional[ResolveData]" = None
+    limit: "Optional[int]" = None
+    cursor: "Optional[Cursor]" = None
+    sort_order: "Optional[SortOrder]" = None
+
+
+@dataclass
+class ListRunsOutput:
+    runs: "WorkflowRunList"
+    has_more: "bool"
+    cursor: "Optional[Cursor]" = None
+    page_info: "Optional[PageInfo]" = None
+
+
+@dataclass
+class ListStepsInput:
+    run_id: "RunId"
+    resolve_data: "Optional[ResolveData]" = None
+    limit: "Optional[int]" = None
+    cursor: "Optional[Cursor]" = None
+    sort_order: "Optional[SortOrder]" = None
+
+
+@dataclass
+class ListStepsOutput:
+    steps: "StepList"
+    has_more: "bool"
+    cursor: "Optional[Cursor]" = None
+
+
+@dataclass
+class ListStreamChunksInput:
+    run_id: "RunId"
+    name: "StreamName"
+    limit: "Optional[int]" = None
+    cursor: "Optional[Cursor]" = None
+
+
+@dataclass
+class ListStreamChunksOutput:
+    chunks: "StreamChunkList"
+    has_more: "bool"
+    """Whether more already-written chunks remain."""
+    done: "bool"
+    """Whether the stream is closed."""
+    cursor: "Optional[Cursor]" = None
+
+
+@dataclass
+class ListStreamsInput:
+    run_id: "RunId"
+
+
+@dataclass
+class ListStreamsOutput:
+    names: "StreamNameList"
+
+
+@dataclass
+class NotCancellableOutcome:
+    status: "RunStatus"
+    """Observed run status."""
+
+
+@dataclass
+class PageInfo:
+    """Retention window metadata returned by plan-aware list operations."""
+
+    current_lookback_days: "int"
+    max_lookback_days: "int"
+    current_window_start: "datetime"
+    max_window_start: "datetime"
+    upgrade_available: "bool"
+
+
+@dataclass
+class Pagination:
+    """Cursor pagination request options."""
+
+    limit: "Optional[int]" = None
+    """Maximum number of items to return."""
+    cursor: "Optional[Cursor]" = None
+    """Cursor returned by a previous page."""
+    sort_order: "Optional[SortOrder]" = None
+    """Sort direction. Callers that depend on ordering should always set it."""
+
+
+@dataclass
+class ReadStreamInput:
+    run_id: "RunId"
+    name: "StreamName"
+    start_index: "Optional[int]" = None
+
+
+@dataclass
+class ReadStreamOutput:
+    body: "ByteStream"
+
+
+@dataclass
+class RemoveAttribute:
+    """Removal of an attribute key.
+
+    An empty structure rather than `Unit` so the variant can gain members
+    later without a breaking change.
+    """
+
+
+@dataclass
+class RetryDirective:
+    """Instructs the caller to redeliver the message later."""
+
+    timeout_seconds: "int"
+
+
+@dataclass
+class RunCancelledEvent:
+    """Transitions a run to `cancelled`."""
+
+    cancel_reason: "Optional[str]" = None
+
+
+@dataclass
+class RunCompletedEvent:
+    """Transitions a run to `completed`."""
+
+    output: "Optional[SerializedData]" = None
+
+
+@dataclass
+class RunCreatedEvent:
+    """Starts a new run. Materializes the run entity with status `pending`."""
+
+    deployment_id: "DeploymentId"
+    workflow_name: "WorkflowName"
+    input: "SerializedData"
+    execution_context: "Optional[Any]" = None
+    attributes: "Optional[AttributeMap]" = None
+    allow_reserved_attributes: "Optional[bool]" = None
+    encryption_public_key: "Optional[str]" = None
+    """Base64 X25519 public key, stamped by SDKs that support sealed envelopes."""
+
+
+@dataclass
+class RunFailedEvent:
+    """Transitions a run to `failed`."""
+
+    error: "SerializedData"
+    error_code: "Optional[str]" = None
+    """Plaintext failure category kept readable without decryption."""
+
+
+@dataclass
+class RunNotFoundOutcome:
+    pass
+
+
+@dataclass
+class RunStartedEvent:
+    """Transitions a run to `running`.
+
+    The optional creation fields carry the resilient-start path: when the
+    `run_created` write did not commit, the implementation creates the run
+    from this event instead.
+    """
+
+    input: "Optional[SerializedData]" = None
+    deployment_id: "Optional[DeploymentId]" = None
+    workflow_name: "Optional[WorkflowName]" = None
+    execution_context: "Optional[Any]" = None
+    attributes: "Optional[AttributeMap]" = None
+    allow_reserved_attributes: "Optional[bool]" = None
+    encryption_public_key: "Optional[str]" = None
+
+
+@dataclass
+class Step:
+    """Materialized view of a step."""
+
+    run_id: "RunId"
+    step_id: "StepId"
+    step_name: "StepName"
+    status: "StepStatus"
+    attempt: "int"
+    created_at: "datetime"
+    updated_at: "datetime"
+    input: "Optional[SerializedData]" = None
+    output: "Optional[SerializedData]" = None
+    error: "Optional[SerializedData]" = None
+    """Most recent serialized thrown value, from either a retry or the final
+    failure.
+    """
+    started_at: "Optional[datetime]" = None
+    """When the step first began executing. Not updated by retries."""
+    completed_at: "Optional[datetime]" = None
+    retry_after: "Optional[datetime]" = None
+    """Earliest time a retrying step may start again."""
+    spec_version: "Optional[int]" = None
+
+
+@dataclass
+class StepAttributeWriter:
+    step_id: "StepId"
+    attempt: "int"
+
+
+@dataclass
+class StepCompletedEvent:
+    """Completes a step successfully."""
+
+    result: "SerializedData"
+    step_name: "Optional[StepName]" = None
+    workflow_name: "Optional[WorkflowName]" = None
+    telemetry: "Optional[StepLatencyTelemetry]" = None
+
+
+@dataclass
+class StepCreatedEvent:
+    """Creates a step entity."""
+
+    step_name: "StepName"
+    input: "SerializedData"
+    workflow_name: "Optional[WorkflowName]" = None
+    """Carried so a backend keying payload refs by workflow name avoids a run
+    lookup on this hot write.
+    """
+
+
+@dataclass
+class StepFailedEvent:
+    """Fails a step terminally."""
+
+    error: "SerializedData"
+    step_name: "Optional[StepName]" = None
+    telemetry: "Optional[StepLatencyTelemetry]" = None
+
+
+@dataclass
+class StepLatencyTelemetry:
+    """Client-measured latency telemetry carried on a step's terminal event.
+
+    Populated only on the terminal event of a qualifying first-attempt step
+    execution. Implementations may consume these for metrics and are never
+    required to persist them.
+    """
+
+    ttfs: "Optional[int]" = None
+    """Milliseconds from run creation until the run's first step body began."""
+    stso: "Optional[int]" = None
+    """Milliseconds between the previous step's terminal event and this step's
+    body beginning.
+    """
+    step_count: "Optional[int]" = None
+    """Step count when the step-to-step gap began."""
+    event_count: "Optional[int]" = None
+    """Event count when the step-to-step gap began."""
+    rsfs: "Optional[int]" = None
+    """Milliseconds from `run_started` landing until this step's start was
+    issued. A sub-window of `ttfs`.
+    """
+    final_scheduling_replay: "Optional[int]" = None
+    """Synchronous replay duration of the final scheduling pass within the
+    `rsfs` window.
+    """
+    optimizations: "Optional[StringList]" = None
+    """Names of the runtime startup optimizations active for this measurement,
+    e.g. `turbo` or `lazyStepStart`.
+    """
+
+
+@dataclass
+class StepRetryingEvent:
+    """Returns a failed step to `pending` for another attempt."""
+
+    error: "SerializedData"
+    step_name: "Optional[StepName]" = None
+    retry_after: "Optional[datetime]" = None
+
+
+@dataclass
+class StepStartedEvent:
+    """Begins a step attempt, transitioning the step to `running`.
+
+    When `stepName` and `input` are present, this is the lazy-start path:
+    the implementation atomically creates the step (writing a synthetic
+    `step_created` so replay still observes it) before starting it. Without
+    `input`, a prior `step_created` is required.
+    """
+
+    step_name: "Optional[StepName]" = None
+    attempt: "Optional[int]" = None
+    workflow_name: "Optional[WorkflowName]" = None
+    input: "Optional[SerializedData]" = None
+    owner_message_id: "Optional[str]" = None
+    """Queue message ID of the invocation executing this step inline. Doubles
+    as the ownership liveness lease, so it requires a queue whose message ID
+    is stable across redeliveries.
+    """
+
+
+@dataclass
+class StreamChunk:
+    """One chunk of a stream, with its 0-based position."""
+
+    index: "int"
+    data: "bytes"
+
+
+@dataclass
+class StructuredError:
+    """Structured error metadata carried by run and step failures."""
+
+    message: "str"
+    stack: "Optional[str]" = None
+    code: "Optional[str]" = None
+    """Machine-readable error code, e.g. `USER_ERROR` or `RUNTIME_ERROR`."""
+
+
+@dataclass
+class Wait:
+    """Materialized view of a wait."""
+
+    run_id: "RunId"
+    wait_id: "WaitId"
+    resume_at: "datetime"
+    created_at: "datetime"
+    completed_at: "Optional[datetime]" = None
+
+
+@dataclass
+class WaitCompletedEvent:
+    """Completes a wait. Intended to be atomic and exactly once."""
+
+    resume_at: "Optional[datetime]" = None
+
+
+@dataclass
+class WaitCreatedEvent:
+    """Creates a wait that resumes at a wall-clock time."""
+
+    resume_at: "datetime"
+
+
+@dataclass
+class WorkflowAttributeWriter:
+    """The workflow function itself wrote the attributes."""
+
+
+@dataclass
+class WorkflowRun:
+    """Materialized view of a run.
+
+    `input`, `output`, and `error` are absent when the caller asked for
+    `ResolveData$NONE`, and `output`/`error`/`completedAt` are only
+    populated once the run reaches the matching terminal status.
+    """
+
+    run_id: "RunId"
+    status: "RunStatus"
+    deployment_id: "DeploymentId"
+    workflow_name: "WorkflowName"
+    attributes: "AttributeMap"
+    created_at: "datetime"
+    updated_at: "datetime"
+    spec_version: "Optional[int]" = None
+    """Workflow protocol spec version the run was created under."""
+    execution_context: "Optional[Any]" = None
+    """Opaque, world-specific execution context recorded at creation."""
+    input: "Optional[SerializedData]" = None
+    output: "Optional[SerializedData]" = None
+    error: "Optional[SerializedData]" = None
+    """Serialized thrown value from `run_failed`."""
+    error_code: "Optional[str]" = None
+    """Plaintext failure category, readable without decryption."""
+    encryption_public_key: "Optional[str]" = None
+    """Base64 X25519 public key that lets other parties seal payloads to this
+    run. Present only for runs created by SDKs that support sealed envelopes
+    on encryption-capable implementations.
+    """
+    expired_at: "Optional[datetime]" = None
+    started_at: "Optional[datetime]" = None
+    completed_at: "Optional[datetime]" = None
+
+
+@dataclass
+class WorldCapabilities:
+    """Feature capabilities an implementation declares.
+
+    Every member defaults to unsupported when absent: a runtime fast path
+    gated on a capability must keep its conservative behavior unless the
+    capability is explicitly declared.
+    """
+
+    hook_retention: "Optional[HookRetentionCapability]" = None
+    """Supports minimum token retention for hooks."""
+    precondition_guard: "Optional[bool]" = None
+    """Fences a stale replay-context write with `PreconditionFailedError`
+    rather than committing it. Accepting a snapshot and ignoring it is not
+    the same thing, and must leave this unset.
+    """
+    max_concurrency: "Optional[bool]" = None
+    """The queue supports concurrency-limited consumption, including the
+    per-run topics consumed with a limit of one.
+    """
+    hook_resume_dedup: "Optional[bool]" = None
+    """`CreateEvent` deduplicates concurrent `hookReceived` writes carrying the
+    same `(runId, resumeId)`, collapsing them onto one committed event.
+    """
+    deployment_affinity: "Optional[bool]" = None
+    """Deployment IDs are atomic and immutable, so a run pinned to one may only
+    execute there. Implementations whose deployment ID is synthetic or
+    version-tagged must leave this unset.
+    """
+    slot_event_ids: "Optional[bool]" = None
+    """Event IDs encode the event's dense, 1-based slot in its run's log.
+    Implies both density and bump-and-report on contention.
+    """
+
+
+@dataclass
+class WriteStreamChunkInput:
+    run_id: "RunId"
+    name: "StreamName"
+    chunk: "bytes"
+
+
+@dataclass
+class WriteStreamChunkOutput:
+    pass
+
+
+@dataclass
+class WriteStreamChunksInput:
+    run_id: "RunId"
+    name: "StreamName"
+    chunks: "ChunkDataList"
+    """Chunks to append, in order."""
+
+
+@dataclass
+class WriteStreamChunksOutput:
+    pass
+
+
+@dataclass
+class callback:
+    """Marks an operation that is invoked in the reverse direction: the World
+    (or its queue adapter) calls the workflow runtime rather than the other
+    way around.
+    """
+
+
+@dataclass
+class localOnly:
+    """Marks an operation that must never be exposed over a network transport.
+
+    Operations carrying this trait exist so that in-process implementations
+    share one cross-language contract (TypeScript, Python) for behavior that
+    is resolved locally: ID minting, environment attribution, deadlines,
+    display enrichment, and encryption-key resolution. Any future transport
+    projection is expected to remove these operations from its closure and
+    to fail the build if one survives.
+    """
+
+
+@dataclass
+class optionalCapability:
+    """Marks an operation as part of an optional World capability.
+
+    Smithy services have no notion of an optional operation, so optional
+    behavior lives in its own service closure. This trait records which
+    capability an operation belongs to so wrappers and conformance tooling
+    can tie a generated service to the capability an implementation
+    advertises in `WorldInfo`.
+    """
+
+    name: "str"
+    """Capability name as advertised by `WorldInfo$capabilities`."""
+
+
+@dataclass
+class AttributeChangeValueSet:
+    """Upsert the key with this value."""
+
+    value: "str"
+
+
+@dataclass
+class AttributeChangeValueRemove:
+    """Remove the key."""
+
+    value: "RemoveAttribute"
+
+"""Upsert or removal of one attribute key."""
+AttributeChangeValue = Union["AttributeChangeValueSet", "AttributeChangeValueRemove"]
+
+
+@dataclass
+class AttributeWriterWorkflow:
+    value: "WorkflowAttributeWriter"
+
+
+@dataclass
+class AttributeWriterStep:
+    value: "StepAttributeWriter"
+
+"""Identifies which writer produced an attribute change."""
+AttributeWriter = Union["AttributeWriterWorkflow", "AttributeWriterStep"]
+
+
+@dataclass
+class BulkCancelOutcomeCancelled:
+    """This request transitioned the run to cancelled."""
+
+    value: "CancelledOutcome"
+
+
+@dataclass
+class BulkCancelOutcomeAlreadyCancelled:
+    """The run was already cancelled. Idempotent success."""
+
+    value: "AlreadyCancelledOutcome"
+
+
+@dataclass
+class BulkCancelOutcomeNotCancellable:
+    """The run is in a terminal, non-cancellable state."""
+
+    value: "NotCancellableOutcome"
+
+
+@dataclass
+class BulkCancelOutcomeNotFound:
+    """No run exists for this ID."""
+
+    value: "RunNotFoundOutcome"
+
+
+@dataclass
+class BulkCancelOutcomeFailed:
+    """Cancellation failed for this run."""
+
+    value: "BulkCancelFailure"
+
+"""Per-run outcome of a bulk cancellation."""
+BulkCancelOutcome = Union["BulkCancelOutcomeCancelled", "BulkCancelOutcomeAlreadyCancelled", "BulkCancelOutcomeNotCancellable", "BulkCancelOutcomeNotFound", "BulkCancelOutcomeFailed"]
+
+
+@dataclass
+class CreatableEventRunStarted:
+    value: "RunStartedEvent"
+
+
+@dataclass
+class CreatableEventRunCompleted:
+    value: "RunCompletedEvent"
+
+
+@dataclass
+class CreatableEventRunFailed:
+    value: "RunFailedEvent"
+
+
+@dataclass
+class CreatableEventRunCancelled:
+    value: "RunCancelledEvent"
+
+
+@dataclass
+class CreatableEventAttributesSet:
+    value: "AttributesSetEvent"
+
+
+@dataclass
+class CreatableEventStepCreated:
+    value: "StepCreatedEvent"
+
+
+@dataclass
+class CreatableEventStepStarted:
+    value: "StepStartedEvent"
+
+
+@dataclass
+class CreatableEventStepCompleted:
+    value: "StepCompletedEvent"
+
+
+@dataclass
+class CreatableEventStepFailed:
+    value: "StepFailedEvent"
+
+
+@dataclass
+class CreatableEventStepRetrying:
+    value: "StepRetryingEvent"
+
+
+@dataclass
+class CreatableEventHookCreated:
+    value: "HookCreatedEvent"
+
+
+@dataclass
+class CreatableEventHookReceived:
+    value: "HookReceivedEvent"
+
+
+@dataclass
+class CreatableEventHookDisposed:
+    value: "HookDisposedEvent"
+
+
+@dataclass
+class CreatableEventWaitCreated:
+    value: "WaitCreatedEvent"
+
+
+@dataclass
+class CreatableEventWaitCompleted:
+    value: "WaitCompletedEvent"
+
+"""Every event a caller may write to an existing run.
+
+`run_created` is absent because it creates the run and is modeled as
+`CreateRun`. `hook_conflict` is absent because only implementations
+produce it.
+"""
+CreatableEvent = Union["CreatableEventRunStarted", "CreatableEventRunCompleted", "CreatableEventRunFailed", "CreatableEventRunCancelled", "CreatableEventAttributesSet", "CreatableEventStepCreated", "CreatableEventStepStarted", "CreatableEventStepCompleted", "CreatableEventStepFailed", "CreatableEventStepRetrying", "CreatableEventHookCreated", "CreatableEventHookReceived", "CreatableEventHookDisposed", "CreatableEventWaitCreated", "CreatableEventWaitCompleted"]
+
+
+@dataclass
+class EventPayloadRunCreated:
+    value: "RunCreatedEvent"
+
+
+@dataclass
+class EventPayloadRunStarted:
+    value: "RunStartedEvent"
+
+
+@dataclass
+class EventPayloadRunCompleted:
+    value: "RunCompletedEvent"
+
+
+@dataclass
+class EventPayloadRunFailed:
+    value: "RunFailedEvent"
+
+
+@dataclass
+class EventPayloadRunCancelled:
+    value: "RunCancelledEvent"
+
+
+@dataclass
+class EventPayloadAttributesSet:
+    value: "AttributesSetEvent"
+
+
+@dataclass
+class EventPayloadStepCreated:
+    value: "StepCreatedEvent"
+
+
+@dataclass
+class EventPayloadStepStarted:
+    value: "StepStartedEvent"
+
+
+@dataclass
+class EventPayloadStepCompleted:
+    value: "StepCompletedEvent"
+
+
+@dataclass
+class EventPayloadStepFailed:
+    value: "StepFailedEvent"
+
+
+@dataclass
+class EventPayloadStepRetrying:
+    value: "StepRetryingEvent"
+
+
+@dataclass
+class EventPayloadHookCreated:
+    value: "HookCreatedEvent"
+
+
+@dataclass
+class EventPayloadHookReceived:
+    value: "HookReceivedEvent"
+
+
+@dataclass
+class EventPayloadHookDisposed:
+    value: "HookDisposedEvent"
+
+
+@dataclass
+class EventPayloadHookConflict:
+    value: "HookConflictEvent"
+
+
+@dataclass
+class EventPayloadWaitCreated:
+    value: "WaitCreatedEvent"
+
+
+@dataclass
+class EventPayloadWaitCompleted:
+    value: "WaitCompletedEvent"
+
+"""Every event readable from a run's log."""
+EventPayload = Union["EventPayloadRunCreated", "EventPayloadRunStarted", "EventPayloadRunCompleted", "EventPayloadRunFailed", "EventPayloadRunCancelled", "EventPayloadAttributesSet", "EventPayloadStepCreated", "EventPayloadStepStarted", "EventPayloadStepCompleted", "EventPayloadStepFailed", "EventPayloadStepRetrying", "EventPayloadHookCreated", "EventPayloadHookReceived", "EventPayloadHookDisposed", "EventPayloadHookConflict", "EventPayloadWaitCreated", "EventPayloadWaitCompleted"]
+
+
+@dataclass
+class BadRequestError(WorldError):
+    """The request was malformed or violated a validation rule."""
+
+    message: "str"
+    code: "Optional[str]" = None
+
+
+@dataclass
+class ConflictError(WorldError):
+    """The entity already exists, or its current state forbids this write.
+
+    The runtime commonly reads this as "another writer won the race" rather
+    than as a hard failure.
+    """
+
+    message: "str"
+    status: "Optional[str]" = None
+    """Observed status of the entity, when the implementation reports one."""
+
+
+@dataclass
+class EventNotFoundError(WorldError):
+    """No event exists for the requested ID."""
+
+    message: "str"
+    run_id: "Optional[RunId]" = None
+    event_id: "Optional[EventId]" = None
+
+
+@dataclass
+class ExpiredError(WorldError):
+    """The run is gone: it passed its retention window or was otherwise
+    expired.
+    """
+
+    message: "str"
+    run_id: "Optional[RunId]" = None
+
+
+@dataclass
+class HookNotFoundError(WorldError):
+    """No hook exists for the requested ID or token."""
+
+    message: "str"
+    hook_id: "Optional[HookId]" = None
+
+
+@dataclass
+class InternalError(WorldError):
+    """The implementation failed for a reason the caller cannot correct."""
+
+    message: "str"
+    code: "Optional[str]" = None
+
+
+@dataclass
+class PreconditionFailedError(WorldError):
+    """A replay-context write was fenced because its snapshot is behind the
+    run's recorded log.
+
+    Only implementations that advertise the `preconditionGuard` capability
+    raise this. It is unrelated to slot allocation: a slot-numbering World
+    bumps to the next free slot and reports the events it skipped instead of
+    rejecting the write.
+    """
+
+    message: "str"
+    event_count: "Optional[int]" = None
+    """Number of events the World held when it rejected the write."""
+
+
+@dataclass
+class RunNotFoundError(WorldError):
+    """No run exists for the requested ID."""
+
+    message: "str"
+    run_id: "Optional[RunId]" = None
+
+
+@dataclass
+class StepNotFoundError(WorldError):
+    """No step exists for the requested ID."""
+
+    message: "str"
+    run_id: "Optional[RunId]" = None
+    step_id: "Optional[StepId]" = None
+
+
+@dataclass
+class StreamExpiredError(WorldError):
+    """The stream is gone: it passed its retention window."""
+
+    message: "str"
+    run_id: "Optional[RunId]" = None
+    stream_name: "Optional[StreamName]" = None
+
+
+@dataclass
+class StreamNotFoundError(WorldError):
+    """No stream exists for the requested run and name."""
+
+    message: "str"
+    run_id: "Optional[RunId]" = None
+    stream_name: "Optional[StreamName]" = None
+
+
+@dataclass
+class ThrottledError(WorldError):
+    """The caller is being throttled, or lost a contention retry budget."""
+
+    message: "str"
+    retry_after: "Optional[datetime]" = None
+
+
+@dataclass
+class TooEarlyError(WorldError):
+    """The operation was attempted before its earliest valid time."""
+
+    message: "str"
+    retry_after: "Optional[datetime]" = None
+    """Earliest time at which the operation may be retried."""

--- a/idl/world/generated/python/workflow_world/ports.py
+++ b/idl/world/generated/python/workflow_world/ports.py
@@ -1,0 +1,391 @@
+"""Generated from the Smithy model. Do not edit by hand.
+
+Source: idl/world/model, emitted by idl/world/scripts/generate_ports.py
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .models import (
+    BatchGetRunsInput,
+    BatchGetRunsOutput,
+    BulkCancelRunsInput,
+    BulkCancelRunsOutput,
+    CloseStreamInput,
+    CloseStreamOutput,
+    CreateEventInput,
+    CreateRunIdInput,
+    CreateRunIdOutput,
+    CreateRunInput,
+    DeliverQueueMessageInput,
+    DeliverQueueMessageOutput,
+    DescribeRunInput,
+    DescribeRunOutput,
+    EnqueueInput,
+    EnqueueOutput,
+    EventMutationResult,
+    GetDeploymentIdInput,
+    GetDeploymentIdOutput,
+    GetEncryptionKeyForRunInput,
+    GetEncryptionKeyForRunOutput,
+    GetEnvironmentInput,
+    GetEnvironmentOutput,
+    GetEventInput,
+    GetEventOutput,
+    GetHookByTokenInput,
+    GetHookByTokenOutput,
+    GetHookInput,
+    GetHookOutput,
+    GetRunInput,
+    GetRunOutput,
+    GetRuntimeDeadlineInput,
+    GetRuntimeDeadlineOutput,
+    GetStepInput,
+    GetStepOutput,
+    GetStreamInfoInput,
+    GetStreamInfoOutput,
+    GetWorldInfoInput,
+    GetWorldInfoOutput,
+    ListEventsByCorrelationIdInput,
+    ListEventsByCorrelationIdOutput,
+    ListEventsInput,
+    ListEventsOutput,
+    ListHooksInput,
+    ListHooksOutput,
+    ListRunsInput,
+    ListRunsOutput,
+    ListStepsInput,
+    ListStepsOutput,
+    ListStreamChunksInput,
+    ListStreamChunksOutput,
+    ListStreamsInput,
+    ListStreamsOutput,
+    ReadStreamInput,
+    ReadStreamOutput,
+    WriteStreamChunkInput,
+    WriteStreamChunkOutput,
+    WriteStreamChunksInput,
+    WriteStreamChunksOutput,
+)
+
+
+class WorldBatchPort(Protocol):
+    """Optional optimizations.
+
+    An implementation that omits this service is fully supported; callers
+    fall back to the equivalent `WorldCore` operations.
+    """
+
+    async def batch_get_runs(self, input: "BatchGetRunsInput") -> "BatchGetRunsOutput":
+        """Reads several runs as one snapshot.
+
+        `runs` preserves the request order, including duplicate IDs, and carries
+        a null entry for every ID that does not exist.
+
+        Optional capability: `batchGetRuns`. Throws: BadRequestError,
+        InternalError, ThrottledError.
+        """
+        ...
+
+    async def bulk_cancel_runs(self, input: "BulkCancelRunsInput") -> "BulkCancelRunsOutput":
+        """Cancels many runs in one request.
+
+        Missing, already-cancelled, and non-cancellable runs are reported as
+        per-run outcomes rather than as operation errors, so one bad ID never
+        fails the batch.
+
+        Optional capability: `bulkCancelRuns`. Throws: BadRequestError,
+        InternalError, ThrottledError.
+        """
+        ...
+
+    async def write_stream_chunks(self, input: "WriteStreamChunksInput") -> "WriteStreamChunksOutput":
+        """Appends several chunks in order, in one request.
+
+        An optional optimization. Callers fall back to repeated
+        `WriteStreamChunk` calls when an implementation does not provide it.
+
+        Optional capability: `writeStreamChunks`. Throws: ConflictError,
+        InternalError, RunNotFoundError, StreamExpiredError, ThrottledError.
+        """
+        ...
+
+
+class WorldConsumerPort(Protocol):
+    """Operations the workflow runtime implements and a World's queue adapter
+    calls.
+    """
+
+    async def deliver_queue_message(self, input: "DeliverQueueMessageInput") -> "DeliverQueueMessageOutput":
+        """Delivers one queued message to the workflow runtime.
+
+        This is the reverse direction: a queue adapter calls the runtime.
+        Today's `createQueueHandler` becomes a thin per-language adapter that
+        exposes this operation over whatever the platform hands it, rather than
+        an operation in its own right.
+
+        Callback: implemented by the runtime, called by the World. Throws:
+        BadRequestError, InternalError.
+        """
+        ...
+
+
+class WorldCorePort(Protocol):
+    """The required World surface.
+
+    Every implementation provides all of it. Optional behavior lives in the
+    capability services instead, so a generated interface never forces an
+    implementation to stub a method it does not support.
+
+    No protocol trait is applied anywhere in this model. The operations are
+    transport-independent by construction: an in-process implementation
+    satisfies the generated interface directly, and any wire format is a
+    separate projection that layers protocol and binding traits on top.
+    """
+
+    async def close_stream(self, input: "CloseStreamInput") -> "CloseStreamOutput":
+        """Closes a stream. No further chunks may be appended.
+
+        Throws: InternalError, RunNotFoundError, StreamExpiredError,
+        StreamNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def create_event(self, input: "CreateEventInput") -> "EventMutationResult":
+        """Appends an event to a run's log and materializes its effect atomically.
+
+        This is the only way to change run, step, hook, or wait state.
+
+        Throws: BadRequestError, ConflictError, ExpiredError, InternalError,
+        PreconditionFailedError, RunNotFoundError, ThrottledError,
+        TooEarlyError.
+        """
+        ...
+
+    async def create_run(self, input: "CreateRunInput") -> "EventMutationResult":
+        """Creates a run.
+
+        The caller may mint the run ID or leave it absent for the implementation
+        to generate one.
+
+        Throws: BadRequestError, ConflictError, InternalError, ThrottledError.
+        """
+        ...
+
+    async def enqueue(self, input: "EnqueueInput") -> "EnqueueOutput":
+        """Enqueues one message. Delivery is at-least-once.
+
+        Throws: BadRequestError, InternalError, ThrottledError.
+        """
+        ...
+
+    async def get_deployment_id(self, input: "GetDeploymentIdInput") -> "GetDeploymentIdOutput":
+        """Returns the deployment this World writes as.
+
+        Throws: InternalError, ThrottledError.
+        """
+        ...
+
+    async def get_event(self, input: "GetEventInput") -> "GetEventOutput":
+        """Reads one event.
+
+        Throws: EventNotFoundError, ExpiredError, InternalError,
+        RunNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def get_hook(self, input: "GetHookInput") -> "GetHookOutput":
+        """Reads one hook by ID.
+
+        Throws: ExpiredError, HookNotFoundError, InternalError, ThrottledError.
+        """
+        ...
+
+    async def get_hook_by_token(self, input: "GetHookByTokenInput") -> "GetHookByTokenOutput":
+        """Reads the hook that currently owns a token, including a retained hook
+        whose run has ended.
+
+        Throws: ExpiredError, HookNotFoundError, InternalError, ThrottledError.
+        """
+        ...
+
+    async def get_run(self, input: "GetRunInput") -> "GetRunOutput":
+        """Reads one run.
+
+        Throws: ExpiredError, InternalError, RunNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def get_step(self, input: "GetStepInput") -> "GetStepOutput":
+        """Reads one step.
+
+        Throws: ExpiredError, InternalError, RunNotFoundError,
+        StepNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def get_stream_info(self, input: "GetStreamInfoInput") -> "GetStreamInfoOutput":
+        """Reads lightweight stream metadata.
+
+        Useful for resolving a negative `startIndex` into an absolute position
+        before opening a live read.
+
+        Throws: InternalError, RunNotFoundError, StreamExpiredError,
+        StreamNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def get_world_info(self, input: "GetWorldInfoInput") -> "GetWorldInfoOutput":
+        """Reports the implementation's protocol version and capabilities.
+
+        This replaces inferring support from method presence, which stops
+        working as soon as calls cross a transport where every method always
+        exists.
+
+        Throws: InternalError, ThrottledError.
+        """
+        ...
+
+    async def list_events(self, input: "ListEventsInput") -> "ListEventsOutput":
+        """Lists a run's event log.
+
+        Omitting `limit` requests every remaining event.
+
+        Throws: BadRequestError, ExpiredError, InternalError, RunNotFoundError,
+        ThrottledError.
+        """
+        ...
+
+    async def list_events_by_correlation_id(self, input: "ListEventsByCorrelationIdInput") -> "ListEventsByCorrelationIdOutput":
+        """Lists the events of one run that share a correlation ID.
+
+        Correlation IDs are unique within a run, not globally, so the run is
+        part of the query.
+
+        Throws: BadRequestError, ExpiredError, InternalError, RunNotFoundError,
+        ThrottledError.
+        """
+        ...
+
+    async def list_hooks(self, input: "ListHooksInput") -> "ListHooksOutput":
+        """Lists hooks, including retained hooks whose runs have ended.
+
+        Throws: BadRequestError, InternalError, ThrottledError.
+        """
+        ...
+
+    async def list_runs(self, input: "ListRunsInput") -> "ListRunsOutput":
+        """Lists canonical run records.
+
+        This is the operational, payload-bearing listing. Observability surfaces
+        should prefer the analytics read path once it is modeled.
+
+        Throws: BadRequestError, InternalError, ThrottledError.
+        """
+        ...
+
+    async def list_steps(self, input: "ListStepsInput") -> "ListStepsOutput":
+        """Lists the steps of one run.
+
+        Throws: BadRequestError, ExpiredError, InternalError, RunNotFoundError,
+        ThrottledError.
+        """
+        ...
+
+    async def list_stream_chunks(self, input: "ListStreamChunksInput") -> "ListStreamChunksOutput":
+        """Reads a point-in-time page of already-written chunks.
+
+        Unlike `ReadStream`, this never waits. `done` reports whether the stream
+        is closed: `done: false` with `hasMore: false` means nothing is
+        available right now, but more chunks may still arrive.
+
+        Throws: BadRequestError, InternalError, RunNotFoundError,
+        StreamExpiredError, StreamNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def list_streams(self, input: "ListStreamsInput") -> "ListStreamsOutput":
+        """Lists the stream names belonging to a run.
+
+        Throws: ExpiredError, InternalError, RunNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def read_stream(self, input: "ReadStreamInput") -> "ReadStreamOutput":
+        """Reads a stream live, waiting for chunks until the stream closes.
+
+        A positive `startIndex` skips that many chunks from the start. A
+        negative one starts that many chunks before the current end, clamped to
+        zero.
+
+        Throws: InternalError, RunNotFoundError, StreamExpiredError,
+        StreamNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def write_stream_chunk(self, input: "WriteStreamChunkInput") -> "WriteStreamChunkOutput":
+        """Appends one chunk to a stream.
+
+        Throws: ConflictError, InternalError, RunNotFoundError,
+        StreamExpiredError, ThrottledError.
+        """
+        ...
+
+
+class WorldLocalHooksPort(Protocol):
+    """Operations that are resolved in-process and never exposed over a
+    transport. See the `localOnly` trait.
+    """
+
+    async def create_run_id(self, input: "CreateRunIdInput") -> "CreateRunIdOutput":
+        """Mints a new run ID.
+
+        Returns the bare ULID; the core attaches the `wrun_` prefix.
+        Implementations may embed world-specific metadata such as a region as
+        long as the result stays a valid ULID.
+
+        Local only: never exposed over a transport.
+        """
+        ...
+
+    async def describe_run(self, input: "DescribeRunInput") -> "DescribeRunOutput":
+        """Returns extra display fields for a run.
+
+        Called once per displayed run by tooling, so it must be cheap, pure, and
+        non-throwing.
+
+        Local only: never exposed over a transport.
+        """
+        ...
+
+    async def get_encryption_key_for_run(self, input: "GetEncryptionKeyForRunInput") -> "GetEncryptionKeyForRunOutput":
+        """Resolves the AES-256 key for a run.
+
+        Local only, permanently: key material must never cross a transport
+        boundary. It is modeled here so in-process implementations share one
+        contract across languages, and every transport projection is expected to
+        drop it. Absent support means encryption is disabled.
+
+        Local only: never exposed over a transport.
+        """
+        ...
+
+    async def get_environment(self, input: "GetEnvironmentInput") -> "GetEnvironmentOutput":
+        """Returns the environment this World's writes are attributed to.
+
+        Must match the attribution the backend will actually apply. Callers use
+        it to detect cross-environment mismatches, so a plausible-looking wrong
+        value is worse than none.
+
+        Local only: never exposed over a transport.
+        """
+        ...
+
+    async def get_runtime_deadline(self, input: "GetRuntimeDeadlineInput") -> "GetRuntimeDeadlineOutput":
+        """Returns the wall-clock time at which the current invocation will be
+        terminated by the hosting platform, when that is known.
+
+        Local only: never exposed over a transport.
+        """
+        ...

--- a/idl/world/generated/python/workflow_world/ports.py
+++ b/idl/world/generated/python/workflow_world/ports.py
@@ -5,7 +5,7 @@ Source: idl/world/model, emitted by idl/world/scripts/generate_ports.py
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from .models import (
     BatchGetRunsInput,
@@ -70,51 +70,14 @@ from .models import (
 )
 
 
-class WorldBatchPort(Protocol):
-    """Optional optimizations.
+class RuntimeQueueConsumerPort(Protocol):
+    """The runtime's own queue-consumer interface.
 
-    An implementation that omits this service is fully supported; callers
-    fall back to the equivalent `WorldCore` operations.
-    """
-
-    async def batch_get_runs(self, input: "BatchGetRunsInput") -> "BatchGetRunsOutput":
-        """Reads several runs as one snapshot.
-
-        `runs` preserves the request order, including duplicate IDs, and carries
-        a null entry for every ID that does not exist.
-
-        Optional capability: `batchGetRuns`. Throws: BadRequestError,
-        InternalError, ThrottledError.
-        """
-        ...
-
-    async def bulk_cancel_runs(self, input: "BulkCancelRunsInput") -> "BulkCancelRunsOutput":
-        """Cancels many runs in one request.
-
-        Missing, already-cancelled, and non-cancellable runs are reported as
-        per-run outcomes rather than as operation errors, so one bad ID never
-        fails the batch.
-
-        Optional capability: `bulkCancelRuns`. Throws: BadRequestError,
-        InternalError, ThrottledError.
-        """
-        ...
-
-    async def write_stream_chunks(self, input: "WriteStreamChunksInput") -> "WriteStreamChunksOutput":
-        """Appends several chunks in order, in one request.
-
-        An optional optimization. Callers fall back to repeated
-        `WriteStreamChunk` calls when an implementation does not provide it.
-
-        Optional capability: `writeStreamChunks`. Throws: ConflictError,
-        InternalError, RunNotFoundError, StreamExpiredError, ThrottledError.
-        """
-        ...
-
-
-class WorldConsumerPort(Protocol):
-    """Operations the workflow runtime implements and a World's queue adapter
-    calls.
+    Deliberately not part of `World`, and not a second World interface: the
+    implementor is the workflow runtime, and the caller is a World's queue
+    adapter. Today this is the callback handed to `createQueueHandler`.
+    Folding it into `World` would say that a World implements it, which is
+    backwards.
     """
 
     async def deliver_queue_message(self, input: "DeliverQueueMessageInput") -> "DeliverQueueMessageOutput":
@@ -131,12 +94,24 @@ class WorldConsumerPort(Protocol):
         ...
 
 
-class WorldCorePort(Protocol):
-    """The required World surface.
+class WorldPort(Protocol):
+    """The World interface.
 
-    Every implementation provides all of it. Optional behavior lives in the
-    capability services instead, so a generated interface never forces an
-    implementation to stub a method it does not support.
+    One interface, implemented by every World: local, Postgres, Vercel, and
+    the simulator. This is the whole point of the model, so the surface is
+    not split by concern, by optionality, or by whether an operation can
+    cross a network.
+
+    Two of those distinctions still exist, and both are traits on operations
+    rather than separate interfaces:
+
+    - `optionalCapability` marks an operation an implementation may omit. It
+    is the modeled form of today's optional `World` methods (`getMany?`,
+    `cancelMany?`, `writeMulti?`), and callers feature-detect it exactly as
+    they do now. `GetWorldInfo` reports which ones are present. -
+    `localOnly` marks an operation that is resolved in-process and must
+    never be exposed over a transport. It stays on this interface because a
+    World implements it; a future transport projection is what drops it.
 
     No protocol trait is applied anywhere in this model. The operations are
     transport-independent by construction: an in-process implementation
@@ -173,6 +148,27 @@ class WorldCorePort(Protocol):
         """
         ...
 
+    async def create_run_id(self, input: "CreateRunIdInput") -> "CreateRunIdOutput":
+        """Mints a new run ID.
+
+        Returns the bare ULID; the core attaches the `wrun_` prefix.
+        Implementations may embed world-specific metadata such as a region as
+        long as the result stays a valid ULID.
+
+        Local only: never exposed over a transport.
+        """
+        ...
+
+    async def describe_run(self, input: "DescribeRunInput") -> "DescribeRunOutput":
+        """Returns extra display fields for a run.
+
+        Called once per displayed run by tooling, so it must be cheap, pure, and
+        non-throwing.
+
+        Local only: never exposed over a transport.
+        """
+        ...
+
     async def enqueue(self, input: "EnqueueInput") -> "EnqueueOutput":
         """Enqueues one message. Delivery is at-least-once.
 
@@ -184,6 +180,29 @@ class WorldCorePort(Protocol):
         """Returns the deployment this World writes as.
 
         Throws: InternalError, ThrottledError.
+        """
+        ...
+
+    async def get_encryption_key_for_run(self, input: "GetEncryptionKeyForRunInput") -> "GetEncryptionKeyForRunOutput":
+        """Resolves the AES-256 key for a run.
+
+        Local only, permanently: key material must never cross a transport
+        boundary. It is modeled here so in-process implementations share one
+        contract across languages, and every transport projection is expected to
+        drop it. Absent support means encryption is disabled.
+
+        Local only: never exposed over a transport.
+        """
+        ...
+
+    async def get_environment(self, input: "GetEnvironmentInput") -> "GetEnvironmentOutput":
+        """Returns the environment this World's writes are attributed to.
+
+        Must match the attribution the backend will actually apply. Callers use
+        it to detect cross-environment mismatches, so a plausible-looking wrong
+        value is worse than none.
+
+        Local only: never exposed over a transport.
         """
         ...
 
@@ -214,6 +233,14 @@ class WorldCorePort(Protocol):
         """Reads one run.
 
         Throws: ExpiredError, InternalError, RunNotFoundError, ThrottledError.
+        """
+        ...
+
+    async def get_runtime_deadline(self, input: "GetRuntimeDeadlineInput") -> "GetRuntimeDeadlineOutput":
+        """Returns the wall-clock time at which the current invocation will be
+        terminated by the hosting platform, when that is known.
+
+        Local only: never exposed over a transport.
         """
         ...
 
@@ -333,59 +360,52 @@ class WorldCorePort(Protocol):
         ...
 
 
-class WorldLocalHooksPort(Protocol):
-    """Operations that are resolved in-process and never exposed over a
-    transport. See the `localOnly` trait.
+@runtime_checkable
+class SupportsBatchGetRuns(Protocol):
+    """Implementations that provide the optional `batchGetRuns` capability."""
+
+    async def batch_get_runs(self, input: "BatchGetRunsInput") -> "BatchGetRunsOutput":
+        """Reads several runs as one snapshot.
+
+        `runs` preserves the request order, including duplicate IDs, and carries
+        a null entry for every ID that does not exist.
+
+        Optional capability: `batchGetRuns`. Throws: BadRequestError,
+        InternalError, ThrottledError.
+        """
+        ...
+
+
+@runtime_checkable
+class SupportsBulkCancelRuns(Protocol):
+    """Implementations that provide the optional `bulkCancelRuns` capability."""
+
+    async def bulk_cancel_runs(self, input: "BulkCancelRunsInput") -> "BulkCancelRunsOutput":
+        """Cancels many runs in one request.
+
+        Missing, already-cancelled, and non-cancellable runs are reported as
+        per-run outcomes rather than as operation errors, so one bad ID never
+        fails the batch.
+
+        Optional capability: `bulkCancelRuns`. Throws: BadRequestError,
+        InternalError, ThrottledError.
+        """
+        ...
+
+
+@runtime_checkable
+class SupportsWriteStreamChunks(Protocol):
+    """Implementations that provide the optional `writeStreamChunks`
+    capability.
     """
 
-    async def create_run_id(self, input: "CreateRunIdInput") -> "CreateRunIdOutput":
-        """Mints a new run ID.
+    async def write_stream_chunks(self, input: "WriteStreamChunksInput") -> "WriteStreamChunksOutput":
+        """Appends several chunks in order, in one request.
 
-        Returns the bare ULID; the core attaches the `wrun_` prefix.
-        Implementations may embed world-specific metadata such as a region as
-        long as the result stays a valid ULID.
+        An optional optimization. Callers fall back to repeated
+        `WriteStreamChunk` calls when an implementation does not provide it.
 
-        Local only: never exposed over a transport.
-        """
-        ...
-
-    async def describe_run(self, input: "DescribeRunInput") -> "DescribeRunOutput":
-        """Returns extra display fields for a run.
-
-        Called once per displayed run by tooling, so it must be cheap, pure, and
-        non-throwing.
-
-        Local only: never exposed over a transport.
-        """
-        ...
-
-    async def get_encryption_key_for_run(self, input: "GetEncryptionKeyForRunInput") -> "GetEncryptionKeyForRunOutput":
-        """Resolves the AES-256 key for a run.
-
-        Local only, permanently: key material must never cross a transport
-        boundary. It is modeled here so in-process implementations share one
-        contract across languages, and every transport projection is expected to
-        drop it. Absent support means encryption is disabled.
-
-        Local only: never exposed over a transport.
-        """
-        ...
-
-    async def get_environment(self, input: "GetEnvironmentInput") -> "GetEnvironmentOutput":
-        """Returns the environment this World's writes are attributed to.
-
-        Must match the attribution the backend will actually apply. Callers use
-        it to detect cross-environment mismatches, so a plausible-looking wrong
-        value is worse than none.
-
-        Local only: never exposed over a transport.
-        """
-        ...
-
-    async def get_runtime_deadline(self, input: "GetRuntimeDeadlineInput") -> "GetRuntimeDeadlineOutput":
-        """Returns the wall-clock time at which the current invocation will be
-        terminated by the hosting platform, when that is known.
-
-        Local only: never exposed over a transport.
+        Optional capability: `writeStreamChunks`. Throws: ConflictError,
+        InternalError, RunNotFoundError, StreamExpiredError, ThrottledError.
         """
         ...

--- a/idl/world/generated/typescript/index.ts
+++ b/idl/world/generated/typescript/index.ts
@@ -1,0 +1,7 @@
+// smithy-typescript generated code
+/* eslint-disable */
+export * from "./schemas/schemas_0";
+
+export * from "./models/enums";
+export * from "./models/errors";
+export * from "./models/models_0";

--- a/idl/world/generated/typescript/models/enums.ts
+++ b/idl/world/generated/typescript/models/enums.ts
@@ -1,0 +1,64 @@
+// smithy-typescript generated code
+/**
+ * @public
+ * @enum
+ */
+export const ResolveData = {
+  /**
+   * Resolve all payload fields.
+   */
+  ALL: "all",
+  /**
+   * Omit payload fields such as input, output, error, and metadata.
+   */
+  NONE: "none",
+} as const;
+/**
+ * @public
+ */
+export type ResolveData = (typeof ResolveData)[keyof typeof ResolveData];
+
+/**
+ * @public
+ * @enum
+ */
+export const RunStatus = {
+  CANCELLED: "cancelled",
+  COMPLETED: "completed",
+  FAILED: "failed",
+  PENDING: "pending",
+  RUNNING: "running",
+} as const;
+/**
+ * @public
+ */
+export type RunStatus = (typeof RunStatus)[keyof typeof RunStatus];
+
+/**
+ * @public
+ * @enum
+ */
+export const StepStatus = {
+  CANCELLED: "cancelled",
+  COMPLETED: "completed",
+  FAILED: "failed",
+  PENDING: "pending",
+  RUNNING: "running",
+} as const;
+/**
+ * @public
+ */
+export type StepStatus = (typeof StepStatus)[keyof typeof StepStatus];
+
+/**
+ * @public
+ * @enum
+ */
+export const SortOrder = {
+  ASC: "asc",
+  DESC: "desc",
+} as const;
+/**
+ * @public
+ */
+export type SortOrder = (typeof SortOrder)[keyof typeof SortOrder];

--- a/idl/world/generated/typescript/models/errors.ts
+++ b/idl/world/generated/typescript/models/errors.ts
@@ -1,0 +1,382 @@
+// smithy-typescript generated code
+import {
+  type ExceptionOptionType as __ExceptionOptionType,
+  ServiceException as __BaseException,
+} from "@smithy/core/client";
+
+/**
+ * The request was malformed or violated a validation rule.
+ * @public
+ */
+export class BadRequestError extends __BaseException {
+  readonly name = "BadRequestError" as const;
+  readonly $fault = "client" as const;
+  code?: string | undefined;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<BadRequestError, __BaseException>) {
+    super({
+      name: "BadRequestError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, BadRequestError.prototype);
+    this.code = opts.code;
+  }
+}
+
+/**
+ * The implementation failed for a reason the caller cannot correct.
+ * @public
+ */
+export class InternalError extends __BaseException {
+  readonly name = "InternalError" as const;
+  readonly $fault = "server" as const;
+  $retryable = {};
+  code?: string | undefined;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<InternalError, __BaseException>) {
+    super({
+      name: "InternalError",
+      $fault: "server",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, InternalError.prototype);
+    this.code = opts.code;
+  }
+}
+
+/**
+ * The caller is being throttled, or lost a contention retry budget.
+ * @public
+ */
+export class ThrottledError extends __BaseException {
+  readonly name = "ThrottledError" as const;
+  readonly $fault = "client" as const;
+  $retryable = {
+    throttling: true,
+  };
+  retryAfter?: Date | undefined;
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<ThrottledError, __BaseException>) {
+    super({
+      name: "ThrottledError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, ThrottledError.prototype);
+    this.retryAfter = opts.retryAfter;
+  }
+}
+
+/**
+ * No run exists for the requested ID.
+ * @public
+ */
+export class RunNotFoundError extends __BaseException {
+  readonly name = "RunNotFoundError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<RunNotFoundError, __BaseException>) {
+    super({
+      name: "RunNotFoundError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, RunNotFoundError.prototype);
+    this.runId = opts.runId;
+  }
+}
+
+/**
+ * The stream is gone: it passed its retention window.
+ * @public
+ */
+export class StreamExpiredError extends __BaseException {
+  readonly name = "StreamExpiredError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  streamName?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<StreamExpiredError, __BaseException>) {
+    super({
+      name: "StreamExpiredError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, StreamExpiredError.prototype);
+    this.runId = opts.runId;
+    this.streamName = opts.streamName;
+  }
+}
+
+/**
+ * No stream exists for the requested run and name.
+ * @public
+ */
+export class StreamNotFoundError extends __BaseException {
+  readonly name = "StreamNotFoundError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  streamName?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<StreamNotFoundError, __BaseException>) {
+    super({
+      name: "StreamNotFoundError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, StreamNotFoundError.prototype);
+    this.runId = opts.runId;
+    this.streamName = opts.streamName;
+  }
+}
+
+/**
+ * The entity already exists, or its current state forbids this write.
+ *
+ * The runtime commonly reads this as "another writer won the race" rather
+ * than as a hard failure.
+ * @public
+ */
+export class ConflictError extends __BaseException {
+  readonly name = "ConflictError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Observed status of the entity, when the implementation reports one.
+   * @public
+   */
+  status?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<ConflictError, __BaseException>) {
+    super({
+      name: "ConflictError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, ConflictError.prototype);
+    this.status = opts.status;
+  }
+}
+
+/**
+ * The run is gone: it passed its retention window or was otherwise expired.
+ * @public
+ */
+export class ExpiredError extends __BaseException {
+  readonly name = "ExpiredError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<ExpiredError, __BaseException>) {
+    super({
+      name: "ExpiredError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, ExpiredError.prototype);
+    this.runId = opts.runId;
+  }
+}
+
+/**
+ * A replay-context write was fenced because its snapshot is behind the run's
+ * recorded log.
+ *
+ * Only implementations that advertise the `preconditionGuard` capability
+ * raise this. It is unrelated to slot allocation: a slot-numbering World
+ * bumps to the next free slot and reports the events it skipped instead of
+ * rejecting the write.
+ * @public
+ */
+export class PreconditionFailedError extends __BaseException {
+  readonly name = "PreconditionFailedError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Number of events the World held when it rejected the write.
+   * @public
+   */
+  eventCount?: number | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<PreconditionFailedError, __BaseException>) {
+    super({
+      name: "PreconditionFailedError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, PreconditionFailedError.prototype);
+    this.eventCount = opts.eventCount;
+  }
+}
+
+/**
+ * The operation was attempted before its earliest valid time.
+ * @public
+ */
+export class TooEarlyError extends __BaseException {
+  readonly name = "TooEarlyError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Earliest time at which the operation may be retried.
+   * @public
+   */
+  retryAfter?: Date | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<TooEarlyError, __BaseException>) {
+    super({
+      name: "TooEarlyError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, TooEarlyError.prototype);
+    this.retryAfter = opts.retryAfter;
+  }
+}
+
+/**
+ * No event exists for the requested ID.
+ * @public
+ */
+export class EventNotFoundError extends __BaseException {
+  readonly name = "EventNotFoundError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * Identifier of an event within a run's log.
+   * @public
+   */
+  eventId?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<EventNotFoundError, __BaseException>) {
+    super({
+      name: "EventNotFoundError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, EventNotFoundError.prototype);
+    this.runId = opts.runId;
+    this.eventId = opts.eventId;
+  }
+}
+
+/**
+ * No hook exists for the requested ID or token.
+ * @public
+ */
+export class HookNotFoundError extends __BaseException {
+  readonly name = "HookNotFoundError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Identifier of a hook.
+   * @public
+   */
+  hookId?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<HookNotFoundError, __BaseException>) {
+    super({
+      name: "HookNotFoundError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, HookNotFoundError.prototype);
+    this.hookId = opts.hookId;
+  }
+}
+
+/**
+ * No step exists for the requested ID.
+ * @public
+ */
+export class StepNotFoundError extends __BaseException {
+  readonly name = "StepNotFoundError" as const;
+  readonly $fault = "client" as const;
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * Identifier of a step within a run.
+   * @public
+   */
+  stepId?: string | undefined;
+
+  /**
+   * @internal
+   */
+  constructor(opts: __ExceptionOptionType<StepNotFoundError, __BaseException>) {
+    super({
+      name: "StepNotFoundError",
+      $fault: "client",
+      ...opts,
+    });
+    Object.setPrototypeOf(this, StepNotFoundError.prototype);
+    this.runId = opts.runId;
+    this.stepId = opts.stepId;
+  }
+}

--- a/idl/world/generated/typescript/models/models_0.ts
+++ b/idl/world/generated/typescript/models/models_0.ts
@@ -1,0 +1,3474 @@
+// smithy-typescript generated code
+import type { DocumentType as __DocumentType, StreamingBlobTypes } from "@smithy/types";
+
+import type { ResolveData, RunStatus, SortOrder, StepStatus } from "./enums";
+
+/**
+ * @public
+ */
+export interface AlreadyCancelledOutcome {}
+
+/**
+ * Removal of an attribute key.
+ *
+ * An empty structure rather than `Unit` so the variant can gain members
+ * later without a breaking change.
+ * @public
+ */
+export interface RemoveAttribute {}
+
+/**
+ * Upsert or removal of one attribute key.
+ * @public
+ */
+export type AttributeChangeValue =
+  | AttributeChangeValue.RemoveMember
+  | AttributeChangeValue.SetMember
+  | AttributeChangeValue.$UnknownMember;
+
+/**
+ * @public
+ */
+export namespace AttributeChangeValue {
+  /**
+   * Upsert the key with this value.
+   * @public
+   */
+  export interface SetMember {
+    set: string;
+    remove?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Remove the key.
+   * @public
+   */
+  export interface RemoveMember {
+    set?: never;
+    remove: RemoveAttribute;
+    $unknown?: never;
+  }
+
+  /**
+   * @public
+   */
+  export interface $UnknownMember {
+    set?: never;
+    remove?: never;
+    $unknown: [string, any];
+  }
+
+  /**
+   * @deprecated unused in schema-serde mode.
+   *
+   */
+  export interface Visitor<T> {
+    set: (value: string) => T;
+    remove: (value: RemoveAttribute) => T;
+    _: (name: string, value: any) => T;
+  }
+}
+
+/**
+ * A single attribute mutation. Keys absent from a change set are untouched.
+ * @public
+ */
+export interface AttributeChange {
+  key: string | undefined;
+  /**
+   * Upsert or removal of one attribute key.
+   * @public
+   */
+  change: AttributeChangeValue | undefined;
+}
+
+/**
+ * @public
+ */
+export interface StepAttributeWriter {
+  /**
+   * Identifier of a step within a run.
+   * @public
+   */
+  stepId: string | undefined;
+
+  attempt: number | undefined;
+}
+
+/**
+ * The workflow function itself wrote the attributes.
+ * @public
+ */
+export interface WorkflowAttributeWriter {}
+
+/**
+ * Identifies which writer produced an attribute change.
+ * @public
+ */
+export type AttributeWriter =
+  | AttributeWriter.StepMember
+  | AttributeWriter.WorkflowMember
+  | AttributeWriter.$UnknownMember;
+
+/**
+ * @public
+ */
+export namespace AttributeWriter {
+  /**
+   * The workflow function itself wrote the attributes.
+   * @public
+   */
+  export interface WorkflowMember {
+    workflow: WorkflowAttributeWriter;
+    step?: never;
+    $unknown?: never;
+  }
+
+  export interface StepMember {
+    workflow?: never;
+    step: StepAttributeWriter;
+    $unknown?: never;
+  }
+
+  /**
+   * @public
+   */
+  export interface $UnknownMember {
+    workflow?: never;
+    step?: never;
+    $unknown: [string, any];
+  }
+
+  /**
+   * @deprecated unused in schema-serde mode.
+   *
+   */
+  export interface Visitor<T> {
+    workflow: (value: WorkflowAttributeWriter) => T;
+    step: (value: StepAttributeWriter) => T;
+    _: (name: string, value: any) => T;
+  }
+}
+
+/**
+ * Merges plaintext attribute changes into the run.
+ * @public
+ */
+export interface AttributesSetEvent {
+  changes: AttributeChange[] | undefined;
+  /**
+   * Identifies which writer produced an attribute change.
+   * @public
+   */
+  writer: AttributeWriter | undefined;
+
+  /**
+   * Permits keys in the reserved `$` namespace. Framework callers only.
+   * @public
+   */
+  allowReservedAttributes?: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface BatchGetRunsInput {
+  runIds: string[] | undefined;
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+}
+
+/**
+ * Materialized view of a run.
+ *
+ * `input`, `output`, and `error` are absent when the caller asked for
+ * `ResolveData$NONE`, and `output`/`error`/`completedAt` are only populated
+ * once the run reaches the matching terminal status.
+ * @public
+ */
+export interface WorkflowRun {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Lifecycle status of a run.
+   * @public
+   */
+  status: RunStatus | undefined;
+
+  /**
+   * Identifier of a deployment a run is pinned to.
+   * @public
+   */
+  deploymentId: string | undefined;
+
+  /**
+   * Machine-readable workflow function name, e.g.
+   * `workflow//./src/workflows/order//processOrder`.
+   * @public
+   */
+  workflowName: string | undefined;
+
+  /**
+   * Workflow protocol spec version the run was created under.
+   * @public
+   */
+  specVersion?: number | undefined;
+
+  /**
+   * Opaque, world-specific execution context recorded at creation.
+   * @public
+   */
+  executionContext?: __DocumentType | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  input?: Uint8Array | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  output?: Uint8Array | undefined;
+
+  /**
+   * Serialized thrown value from `run_failed`.
+   * @public
+   */
+  error?: Uint8Array | undefined;
+
+  /**
+   * Plaintext failure category, readable without decryption.
+   * @public
+   */
+  errorCode?: string | undefined;
+
+  /**
+   * Plaintext run attributes.
+   * @public
+   */
+  attributes: Record<string, string> | undefined;
+
+  /**
+   * Base64 X25519 public key that lets other parties seal payloads to this
+   * run. Present only for runs created by SDKs that support sealed
+   * envelopes on encryption-capable implementations.
+   * @public
+   */
+  encryptionPublicKey?: string | undefined;
+
+  expiredAt?: Date | undefined;
+  startedAt?: Date | undefined;
+  completedAt?: Date | undefined;
+  createdAt: Date | undefined;
+  updatedAt: Date | undefined;
+}
+
+/**
+ * @public
+ */
+export interface BatchGetRunsOutput {
+  runs: (WorkflowRun | null)[] | undefined;
+}
+
+/**
+ * @public
+ */
+export interface BulkCancelFailure {
+  code: string | undefined;
+  retryable: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CancelledOutcome {}
+
+/**
+ * @public
+ */
+export interface NotCancellableOutcome {
+  /**
+   * Observed run status.
+   * @public
+   */
+  status: RunStatus | undefined;
+}
+
+/**
+ * @public
+ */
+export interface RunNotFoundOutcome {}
+
+/**
+ * Per-run outcome of a bulk cancellation.
+ * @public
+ */
+export type BulkCancelOutcome =
+  | BulkCancelOutcome.AlreadyCancelledMember
+  | BulkCancelOutcome.CancelledMember
+  | BulkCancelOutcome.FailedMember
+  | BulkCancelOutcome.NotCancellableMember
+  | BulkCancelOutcome.NotFoundMember
+  | BulkCancelOutcome.$UnknownMember;
+
+/**
+ * @public
+ */
+export namespace BulkCancelOutcome {
+  /**
+   * This request transitioned the run to cancelled.
+   * @public
+   */
+  export interface CancelledMember {
+    cancelled: CancelledOutcome;
+    alreadyCancelled?: never;
+    notCancellable?: never;
+    notFound?: never;
+    failed?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * The run was already cancelled. Idempotent success.
+   * @public
+   */
+  export interface AlreadyCancelledMember {
+    cancelled?: never;
+    alreadyCancelled: AlreadyCancelledOutcome;
+    notCancellable?: never;
+    notFound?: never;
+    failed?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * The run is in a terminal, non-cancellable state.
+   * @public
+   */
+  export interface NotCancellableMember {
+    cancelled?: never;
+    alreadyCancelled?: never;
+    notCancellable: NotCancellableOutcome;
+    notFound?: never;
+    failed?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * No run exists for this ID.
+   * @public
+   */
+  export interface NotFoundMember {
+    cancelled?: never;
+    alreadyCancelled?: never;
+    notCancellable?: never;
+    notFound: RunNotFoundOutcome;
+    failed?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Cancellation failed for this run.
+   * @public
+   */
+  export interface FailedMember {
+    cancelled?: never;
+    alreadyCancelled?: never;
+    notCancellable?: never;
+    notFound?: never;
+    failed: BulkCancelFailure;
+    $unknown?: never;
+  }
+
+  /**
+   * @public
+   */
+  export interface $UnknownMember {
+    cancelled?: never;
+    alreadyCancelled?: never;
+    notCancellable?: never;
+    notFound?: never;
+    failed?: never;
+    $unknown: [string, any];
+  }
+
+  /**
+   * @deprecated unused in schema-serde mode.
+   *
+   */
+  export interface Visitor<T> {
+    cancelled: (value: CancelledOutcome) => T;
+    alreadyCancelled: (value: AlreadyCancelledOutcome) => T;
+    notCancellable: (value: NotCancellableOutcome) => T;
+    notFound: (value: RunNotFoundOutcome) => T;
+    failed: (value: BulkCancelFailure) => T;
+    _: (name: string, value: any) => T;
+  }
+}
+
+/**
+ * @public
+ */
+export interface BulkCancelResult {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Per-run outcome of a bulk cancellation.
+   * @public
+   */
+  outcome: BulkCancelOutcome | undefined;
+}
+
+/**
+ * @public
+ */
+export interface BulkCancelRunsInput {
+  /**
+   * 1-500 unique run IDs.
+   * @public
+   */
+  runIds: string[] | undefined;
+
+  cancelReason?: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface BulkCancelSummary {
+  requested: number | undefined;
+  cancelled: number | undefined;
+  alreadyCancelled: number | undefined;
+  notCancellable: number | undefined;
+  notFound: number | undefined;
+  failed: number | undefined;
+}
+
+/**
+ * @public
+ */
+export interface BulkCancelRunsOutput {
+  summary: BulkCancelSummary | undefined;
+  /**
+   * One entry per requested ID, in request order.
+   * @public
+   */
+  results: BulkCancelResult[] | undefined;
+}
+
+/**
+ * Marks an operation that is invoked in the reverse direction: the World (or
+ * its queue adapter) calls the workflow runtime rather than the other way
+ * around.
+ * @public
+ */
+export interface Callback {}
+
+/**
+ * @public
+ */
+export interface CloseStreamInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  name: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CloseStreamOutput {}
+
+/**
+ * Creates a hook and claims its token.
+ * @public
+ */
+export interface HookCreatedEvent {
+  token: string | undefined;
+  /**
+   * Requests minimum token retention past the run's end. Requires the
+   * `hookRetention` capability.
+   * @public
+   */
+  tokenRetentionUntil?: Date | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  metadata?: Uint8Array | undefined;
+
+  isWebhook?: boolean | undefined;
+  isSystem?: boolean | undefined;
+}
+
+/**
+ * Disposes a hook and releases its token immediately.
+ * @public
+ */
+export interface HookDisposedEvent {
+  token?: string | undefined;
+}
+
+/**
+ * Delivers a payload to an active hook.
+ * @public
+ */
+export interface HookReceivedEvent {
+  token?: string | undefined;
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  payload: Uint8Array | undefined;
+}
+
+/**
+ * Transitions a run to `cancelled`.
+ * @public
+ */
+export interface RunCancelledEvent {
+  cancelReason?: string | undefined;
+}
+
+/**
+ * Transitions a run to `completed`.
+ * @public
+ */
+export interface RunCompletedEvent {
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  output?: Uint8Array | undefined;
+}
+
+/**
+ * Transitions a run to `failed`.
+ * @public
+ */
+export interface RunFailedEvent {
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  error: Uint8Array | undefined;
+
+  /**
+   * Plaintext failure category kept readable without decryption.
+   * @public
+   */
+  errorCode?: string | undefined;
+}
+
+/**
+ * Transitions a run to `running`.
+ *
+ * The optional creation fields carry the resilient-start path: when the
+ * `run_created` write did not commit, the implementation creates the run
+ * from this event instead.
+ * @public
+ */
+export interface RunStartedEvent {
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  input?: Uint8Array | undefined;
+
+  /**
+   * Identifier of a deployment a run is pinned to.
+   * @public
+   */
+  deploymentId?: string | undefined;
+
+  /**
+   * Machine-readable workflow function name, e.g.
+   * `workflow//./src/workflows/order//processOrder`.
+   * @public
+   */
+  workflowName?: string | undefined;
+
+  executionContext?: __DocumentType | undefined;
+  /**
+   * Plaintext run attributes.
+   * @public
+   */
+  attributes?: Record<string, string> | undefined;
+
+  allowReservedAttributes?: boolean | undefined;
+  encryptionPublicKey?: string | undefined;
+}
+
+/**
+ * Client-measured latency telemetry carried on a step's terminal event.
+ *
+ * Populated only on the terminal event of a qualifying first-attempt step
+ * execution. Implementations may consume these for metrics and are never
+ * required to persist them.
+ * @public
+ */
+export interface StepLatencyTelemetry {
+  /**
+   * Milliseconds from run creation until the run's first step body began.
+   * @public
+   */
+  ttfs?: number | undefined;
+
+  /**
+   * Milliseconds between the previous step's terminal event and this
+   * step's body beginning.
+   * @public
+   */
+  stso?: number | undefined;
+
+  /**
+   * Step count when the step-to-step gap began.
+   * @public
+   */
+  stepCount?: number | undefined;
+
+  /**
+   * Event count when the step-to-step gap began.
+   * @public
+   */
+  eventCount?: number | undefined;
+
+  /**
+   * Milliseconds from `run_started` landing until this step's start was
+   * issued. A sub-window of `ttfs`.
+   * @public
+   */
+  rsfs?: number | undefined;
+
+  /**
+   * Synchronous replay duration of the final scheduling pass within the
+   * `rsfs` window.
+   * @public
+   */
+  finalSchedulingReplay?: number | undefined;
+
+  /**
+   * Names of the runtime startup optimizations active for this
+   * measurement, e.g. `turbo` or `lazyStepStart`.
+   * @public
+   */
+  optimizations?: string[] | undefined;
+}
+
+/**
+ * Completes a step successfully.
+ * @public
+ */
+export interface StepCompletedEvent {
+  /**
+   * Machine-readable step function name.
+   * @public
+   */
+  stepName?: string | undefined;
+
+  /**
+   * Machine-readable workflow function name, e.g.
+   * `workflow//./src/workflows/order//processOrder`.
+   * @public
+   */
+  workflowName?: string | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  result: Uint8Array | undefined;
+
+  /**
+   * Client-measured latency telemetry carried on a step's terminal event.
+   *
+   * Populated only on the terminal event of a qualifying first-attempt step
+   * execution. Implementations may consume these for metrics and are never
+   * required to persist them.
+   * @public
+   */
+  telemetry?: StepLatencyTelemetry | undefined;
+}
+
+/**
+ * Creates a step entity.
+ * @public
+ */
+export interface StepCreatedEvent {
+  /**
+   * Machine-readable step function name.
+   * @public
+   */
+  stepName: string | undefined;
+
+  /**
+   * Carried so a backend keying payload refs by workflow name avoids a run
+   * lookup on this hot write.
+   * @public
+   */
+  workflowName?: string | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  input: Uint8Array | undefined;
+}
+
+/**
+ * Fails a step terminally.
+ * @public
+ */
+export interface StepFailedEvent {
+  /**
+   * Machine-readable step function name.
+   * @public
+   */
+  stepName?: string | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  error: Uint8Array | undefined;
+
+  /**
+   * Client-measured latency telemetry carried on a step's terminal event.
+   *
+   * Populated only on the terminal event of a qualifying first-attempt step
+   * execution. Implementations may consume these for metrics and are never
+   * required to persist them.
+   * @public
+   */
+  telemetry?: StepLatencyTelemetry | undefined;
+}
+
+/**
+ * Returns a failed step to `pending` for another attempt.
+ * @public
+ */
+export interface StepRetryingEvent {
+  /**
+   * Machine-readable step function name.
+   * @public
+   */
+  stepName?: string | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  error: Uint8Array | undefined;
+
+  retryAfter?: Date | undefined;
+}
+
+/**
+ * Begins a step attempt, transitioning the step to `running`.
+ *
+ * When `stepName` and `input` are present, this is the lazy-start path: the
+ * implementation atomically creates the step (writing a synthetic
+ * `step_created` so replay still observes it) before starting it. Without
+ * `input`, a prior `step_created` is required.
+ * @public
+ */
+export interface StepStartedEvent {
+  /**
+   * Machine-readable step function name.
+   * @public
+   */
+  stepName?: string | undefined;
+
+  attempt?: number | undefined;
+  /**
+   * Machine-readable workflow function name, e.g.
+   * `workflow//./src/workflows/order//processOrder`.
+   * @public
+   */
+  workflowName?: string | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  input?: Uint8Array | undefined;
+
+  /**
+   * Queue message ID of the invocation executing this step inline. Doubles
+   * as the ownership liveness lease, so it requires a queue whose message
+   * ID is stable across redeliveries.
+   * @public
+   */
+  ownerMessageId?: string | undefined;
+}
+
+/**
+ * Completes a wait. Intended to be atomic and exactly once.
+ * @public
+ */
+export interface WaitCompletedEvent {
+  resumeAt?: Date | undefined;
+}
+
+/**
+ * Creates a wait that resumes at a wall-clock time.
+ * @public
+ */
+export interface WaitCreatedEvent {
+  resumeAt: Date | undefined;
+}
+
+/**
+ * Every event a caller may write to an existing run.
+ *
+ * `run_created` is absent because it creates the run and is modeled as
+ * `CreateRun`. `hook_conflict` is absent because only implementations
+ * produce it.
+ * @public
+ */
+export type CreatableEvent =
+  | CreatableEvent.AttributesSetMember
+  | CreatableEvent.HookCreatedMember
+  | CreatableEvent.HookDisposedMember
+  | CreatableEvent.HookReceivedMember
+  | CreatableEvent.RunCancelledMember
+  | CreatableEvent.RunCompletedMember
+  | CreatableEvent.RunFailedMember
+  | CreatableEvent.RunStartedMember
+  | CreatableEvent.StepCompletedMember
+  | CreatableEvent.StepCreatedMember
+  | CreatableEvent.StepFailedMember
+  | CreatableEvent.StepRetryingMember
+  | CreatableEvent.StepStartedMember
+  | CreatableEvent.WaitCompletedMember
+  | CreatableEvent.WaitCreatedMember
+  | CreatableEvent.$UnknownMember;
+
+/**
+ * @public
+ */
+export namespace CreatableEvent {
+  /**
+   * Transitions a run to `running`.
+   *
+   * The optional creation fields carry the resilient-start path: when the
+   * `run_created` write did not commit, the implementation creates the run
+   * from this event instead.
+   * @public
+   */
+  export interface RunStartedMember {
+    runStarted: RunStartedEvent;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Transitions a run to `completed`.
+   * @public
+   */
+  export interface RunCompletedMember {
+    runStarted?: never;
+    runCompleted: RunCompletedEvent;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Transitions a run to `failed`.
+   * @public
+   */
+  export interface RunFailedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed: RunFailedEvent;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Transitions a run to `cancelled`.
+   * @public
+   */
+  export interface RunCancelledMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled: RunCancelledEvent;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Merges plaintext attribute changes into the run.
+   * @public
+   */
+  export interface AttributesSetMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet: AttributesSetEvent;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Creates a step entity.
+   * @public
+   */
+  export interface StepCreatedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated: StepCreatedEvent;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Begins a step attempt, transitioning the step to `running`.
+   *
+   * When `stepName` and `input` are present, this is the lazy-start path: the
+   * implementation atomically creates the step (writing a synthetic
+   * `step_created` so replay still observes it) before starting it. Without
+   * `input`, a prior `step_created` is required.
+   * @public
+   */
+  export interface StepStartedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted: StepStartedEvent;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Completes a step successfully.
+   * @public
+   */
+  export interface StepCompletedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted: StepCompletedEvent;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Fails a step terminally.
+   * @public
+   */
+  export interface StepFailedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed: StepFailedEvent;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Returns a failed step to `pending` for another attempt.
+   * @public
+   */
+  export interface StepRetryingMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying: StepRetryingEvent;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Creates a hook and claims its token.
+   * @public
+   */
+  export interface HookCreatedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated: HookCreatedEvent;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Delivers a payload to an active hook.
+   * @public
+   */
+  export interface HookReceivedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived: HookReceivedEvent;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Disposes a hook and releases its token immediately.
+   * @public
+   */
+  export interface HookDisposedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed: HookDisposedEvent;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Creates a wait that resumes at a wall-clock time.
+   * @public
+   */
+  export interface WaitCreatedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated: WaitCreatedEvent;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Completes a wait. Intended to be atomic and exactly once.
+   * @public
+   */
+  export interface WaitCompletedMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted: WaitCompletedEvent;
+    $unknown?: never;
+  }
+
+  /**
+   * @public
+   */
+  export interface $UnknownMember {
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown: [string, any];
+  }
+
+  /**
+   * @deprecated unused in schema-serde mode.
+   *
+   */
+  export interface Visitor<T> {
+    runStarted: (value: RunStartedEvent) => T;
+    runCompleted: (value: RunCompletedEvent) => T;
+    runFailed: (value: RunFailedEvent) => T;
+    runCancelled: (value: RunCancelledEvent) => T;
+    attributesSet: (value: AttributesSetEvent) => T;
+    stepCreated: (value: StepCreatedEvent) => T;
+    stepStarted: (value: StepStartedEvent) => T;
+    stepCompleted: (value: StepCompletedEvent) => T;
+    stepFailed: (value: StepFailedEvent) => T;
+    stepRetrying: (value: StepRetryingEvent) => T;
+    hookCreated: (value: HookCreatedEvent) => T;
+    hookReceived: (value: HookReceivedEvent) => T;
+    hookDisposed: (value: HookDisposedEvent) => T;
+    waitCreated: (value: WaitCreatedEvent) => T;
+    waitCompleted: (value: WaitCompletedEvent) => T;
+    _: (name: string, value: any) => T;
+  }
+}
+
+/**
+ * Advisory and idempotency parameters for an event write.
+ *
+ * Everything here is optional. An implementation that ignores all of it
+ * stays correct; the runtime falls back to explicit reads.
+ * @public
+ */
+export interface CreateEventOptions {
+  /**
+   * Legacy spec-version-1 compatibility mode.
+   * @public
+   */
+  v1Compat?: boolean | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+
+  /**
+   * Lazy hook resume idempotency key. The implementation routes it to a
+   * `(runId, resumeId)` constraint so a producer's direct write and the
+   * queue consumer's re-ensure converge on exactly one event. Only
+   * meaningful for `hookReceived`.
+   * @public
+   */
+  resumeId?: string | undefined;
+
+  /**
+   * Digest of the serialized resume payload, sent identically by both
+   * writers of a deduplicated resume.
+   * @public
+   */
+  resumePayloadDigest?: string | undefined;
+
+  /**
+   * Marks a `stepCreated` write as the queue consumer's re-ensure of a
+   * resilient step dispatch.
+   * @public
+   */
+  viaStepDispatch?: boolean | undefined;
+
+  /**
+   * Platform request ID, for correlating logs with events.
+   * @public
+   */
+  requestId?: string | undefined;
+
+  /**
+   * Compute instance whose handler is writing this event.
+   * @public
+   */
+  computeInstanceId?: string | undefined;
+
+  /**
+   * How many events the writer held when it decided to write this one.
+   *
+   * Only meaningful against an implementation advertising `slotEventIds`,
+   * where slots are dense and 1-based. Contention never rejects the write:
+   * the implementation bumps to the next free slot, commits, and returns
+   * the skipped events on the response. Understating is safe; overstating
+   * hides events from the writer.
+   * @public
+   */
+  eventCount?: number | undefined;
+
+  /**
+   * Client-side occurrence time, stored separately from the accept time.
+   * @public
+   */
+  occurredAt?: Date | undefined;
+
+  /**
+   * Telemetry only: consecutive replay divergences resolved by this write.
+   * Never persisted into the log.
+   * @public
+   */
+  replayDivergenceCount?: number | undefined;
+
+  /**
+   * Inline-delta opt-in. The implementation may return the events written
+   * strictly after this cursor, matching `ListEvents` semantics.
+   * @public
+   */
+  sinceCursor?: string | undefined;
+
+  /**
+   * Asks the implementation to skip the `runStarted` preload it would
+   * otherwise compute. Honored only for `runStarted`.
+   * @public
+   */
+  skipPreload?: boolean | undefined;
+
+  /**
+   * Asks for the run's full replay log alongside a `hookReceived`
+   * re-ensure. The runtime trusts it only when the log is complete,
+   * `hasMore` is false, and the run and event ceiling are present.
+   * @public
+   */
+  preloadEvents?: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CreateEventInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Every event a caller may write to an existing run.
+   *
+   * `run_created` is absent because it creates the run and is modeled as
+   * `CreateRun`. `hook_conflict` is absent because only implementations
+   * produce it.
+   * @public
+   */
+  event: CreatableEvent | undefined;
+
+  /**
+   * Advisory and idempotency parameters for an event write.
+   *
+   * Everything here is optional. An implementation that ignores all of it
+   * stays correct; the runtime falls back to explicit reads.
+   * @public
+   */
+  options?: CreateEventOptions | undefined;
+}
+
+/**
+ * Records that a `hook_created` lost a token race.
+ *
+ * Implementations write this; callers cannot. Consumers reject the awaited
+ * hook with a token-conflict error.
+ * @public
+ */
+export interface HookConflictEvent {
+  token: string | undefined;
+  /**
+   * Run that currently owns the token.
+   * @public
+   */
+  conflictingRunId?: string | undefined;
+}
+
+/**
+ * Starts a new run. Materializes the run entity with status `pending`.
+ * @public
+ */
+export interface RunCreatedEvent {
+  /**
+   * Identifier of a deployment a run is pinned to.
+   * @public
+   */
+  deploymentId: string | undefined;
+
+  /**
+   * Machine-readable workflow function name, e.g.
+   * `workflow//./src/workflows/order//processOrder`.
+   * @public
+   */
+  workflowName: string | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  input: Uint8Array | undefined;
+
+  executionContext?: __DocumentType | undefined;
+  /**
+   * Plaintext run attributes.
+   * @public
+   */
+  attributes?: Record<string, string> | undefined;
+
+  allowReservedAttributes?: boolean | undefined;
+  /**
+   * Base64 X25519 public key, stamped by SDKs that support sealed
+   * envelopes.
+   * @public
+   */
+  encryptionPublicKey?: string | undefined;
+}
+
+/**
+ * Every event readable from a run's log.
+ * @public
+ */
+export type EventPayload =
+  | EventPayload.AttributesSetMember
+  | EventPayload.HookConflictMember
+  | EventPayload.HookCreatedMember
+  | EventPayload.HookDisposedMember
+  | EventPayload.HookReceivedMember
+  | EventPayload.RunCancelledMember
+  | EventPayload.RunCompletedMember
+  | EventPayload.RunCreatedMember
+  | EventPayload.RunFailedMember
+  | EventPayload.RunStartedMember
+  | EventPayload.StepCompletedMember
+  | EventPayload.StepCreatedMember
+  | EventPayload.StepFailedMember
+  | EventPayload.StepRetryingMember
+  | EventPayload.StepStartedMember
+  | EventPayload.WaitCompletedMember
+  | EventPayload.WaitCreatedMember
+  | EventPayload.$UnknownMember;
+
+/**
+ * @public
+ */
+export namespace EventPayload {
+  /**
+   * Starts a new run. Materializes the run entity with status `pending`.
+   * @public
+   */
+  export interface RunCreatedMember {
+    runCreated: RunCreatedEvent;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Transitions a run to `running`.
+   *
+   * The optional creation fields carry the resilient-start path: when the
+   * `run_created` write did not commit, the implementation creates the run
+   * from this event instead.
+   * @public
+   */
+  export interface RunStartedMember {
+    runCreated?: never;
+    runStarted: RunStartedEvent;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Transitions a run to `completed`.
+   * @public
+   */
+  export interface RunCompletedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted: RunCompletedEvent;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Transitions a run to `failed`.
+   * @public
+   */
+  export interface RunFailedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed: RunFailedEvent;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Transitions a run to `cancelled`.
+   * @public
+   */
+  export interface RunCancelledMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled: RunCancelledEvent;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Merges plaintext attribute changes into the run.
+   * @public
+   */
+  export interface AttributesSetMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet: AttributesSetEvent;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Creates a step entity.
+   * @public
+   */
+  export interface StepCreatedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated: StepCreatedEvent;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Begins a step attempt, transitioning the step to `running`.
+   *
+   * When `stepName` and `input` are present, this is the lazy-start path: the
+   * implementation atomically creates the step (writing a synthetic
+   * `step_created` so replay still observes it) before starting it. Without
+   * `input`, a prior `step_created` is required.
+   * @public
+   */
+  export interface StepStartedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted: StepStartedEvent;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Completes a step successfully.
+   * @public
+   */
+  export interface StepCompletedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted: StepCompletedEvent;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Fails a step terminally.
+   * @public
+   */
+  export interface StepFailedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed: StepFailedEvent;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Returns a failed step to `pending` for another attempt.
+   * @public
+   */
+  export interface StepRetryingMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying: StepRetryingEvent;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Creates a hook and claims its token.
+   * @public
+   */
+  export interface HookCreatedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated: HookCreatedEvent;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Delivers a payload to an active hook.
+   * @public
+   */
+  export interface HookReceivedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived: HookReceivedEvent;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Disposes a hook and releases its token immediately.
+   * @public
+   */
+  export interface HookDisposedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed: HookDisposedEvent;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Records that a `hook_created` lost a token race.
+   *
+   * Implementations write this; callers cannot. Consumers reject the awaited
+   * hook with a token-conflict error.
+   * @public
+   */
+  export interface HookConflictMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict: HookConflictEvent;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Creates a wait that resumes at a wall-clock time.
+   * @public
+   */
+  export interface WaitCreatedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated: WaitCreatedEvent;
+    waitCompleted?: never;
+    $unknown?: never;
+  }
+
+  /**
+   * Completes a wait. Intended to be atomic and exactly once.
+   * @public
+   */
+  export interface WaitCompletedMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted: WaitCompletedEvent;
+    $unknown?: never;
+  }
+
+  /**
+   * @public
+   */
+  export interface $UnknownMember {
+    runCreated?: never;
+    runStarted?: never;
+    runCompleted?: never;
+    runFailed?: never;
+    runCancelled?: never;
+    attributesSet?: never;
+    stepCreated?: never;
+    stepStarted?: never;
+    stepCompleted?: never;
+    stepFailed?: never;
+    stepRetrying?: never;
+    hookCreated?: never;
+    hookReceived?: never;
+    hookDisposed?: never;
+    hookConflict?: never;
+    waitCreated?: never;
+    waitCompleted?: never;
+    $unknown: [string, any];
+  }
+
+  /**
+   * @deprecated unused in schema-serde mode.
+   *
+   */
+  export interface Visitor<T> {
+    runCreated: (value: RunCreatedEvent) => T;
+    runStarted: (value: RunStartedEvent) => T;
+    runCompleted: (value: RunCompletedEvent) => T;
+    runFailed: (value: RunFailedEvent) => T;
+    runCancelled: (value: RunCancelledEvent) => T;
+    attributesSet: (value: AttributesSetEvent) => T;
+    stepCreated: (value: StepCreatedEvent) => T;
+    stepStarted: (value: StepStartedEvent) => T;
+    stepCompleted: (value: StepCompletedEvent) => T;
+    stepFailed: (value: StepFailedEvent) => T;
+    stepRetrying: (value: StepRetryingEvent) => T;
+    hookCreated: (value: HookCreatedEvent) => T;
+    hookReceived: (value: HookReceivedEvent) => T;
+    hookDisposed: (value: HookDisposedEvent) => T;
+    hookConflict: (value: HookConflictEvent) => T;
+    waitCreated: (value: WaitCreatedEvent) => T;
+    waitCompleted: (value: WaitCompletedEvent) => T;
+    _: (name: string, value: any) => T;
+  }
+}
+
+/**
+ * One committed entry in a run's event log.
+ * @public
+ */
+export interface Event {
+  /**
+   * Identifier of an event within a run's log.
+   * @public
+   */
+  eventId: string | undefined;
+
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Entity this event affects. Absent on run-level events.
+   * @public
+   */
+  correlationId?: string | undefined;
+
+  /**
+   * Every event readable from a run's log.
+   * @public
+   */
+  payload: EventPayload | undefined;
+
+  specVersion?: number | undefined;
+  /**
+   * When the implementation accepted the event.
+   * @public
+   */
+  createdAt: Date | undefined;
+
+  /**
+   * When the client observed the event, when it reported one.
+   * @public
+   */
+  occurredAt?: Date | undefined;
+
+  /**
+   * Idempotency key persisted on a lazy `hook_received`.
+   * @public
+   */
+  resumeId?: string | undefined;
+}
+
+/**
+ * Backend-attested resume capabilities, recomputed on every by-token lookup.
+ *
+ * Response-only and never persisted, so a rollback or kill switch downgrades
+ * new resumes immediately by omitting it.
+ * @public
+ */
+export interface HookResumeCapabilities {
+  /**
+   * Present when the live backend enforces the `(runId, resumeId)` dedup
+   * constraint.
+   * @public
+   */
+  hookResumeDedupVersion: number | undefined;
+}
+
+/**
+ * Immutable slice of a hook's owning run, sufficient to resume the hook
+ * without reading the run entity.
+ *
+ * Deliberately excludes mutable run state, payloads, attributes, and any
+ * secret.
+ * @public
+ */
+export interface HookResumeContext {
+  /**
+   * Identifier of a deployment a run is pinned to.
+   * @public
+   */
+  deploymentId: string | undefined;
+
+  /**
+   * Machine-readable workflow function name, e.g.
+   * `workflow//./src/workflows/order//processOrder`.
+   * @public
+   */
+  workflowName: string | undefined;
+
+  /**
+   * Spec version of the owning run, distinct from the hook's own.
+   * @public
+   */
+  runSpecVersion?: number | undefined;
+
+  workflowCoreVersion?: string | undefined;
+  /**
+   * W3C trace context propagated from hook creation.
+   * @public
+   */
+  traceCarrier?: Record<string, string> | undefined;
+
+  /**
+   * The run's base64 X25519 public key, mirrored from the run entity.
+   * @public
+   */
+  encryptionPublicKey?: string | undefined;
+
+  /**
+   * Version of the lazy-hook-resume consumer protocol supported by the
+   * run's creating deployment. Absent means the sequential path.
+   * @public
+   */
+  hookResumeInputVersion?: number | undefined;
+}
+
+/**
+ * Materialized view of a hook.
+ *
+ * A hook kept alive by minimum retention stays readable after its run ends
+ * and continues to reserve its token, but can no longer be resumed.
+ * @public
+ */
+export interface Hook {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Identifier of a hook.
+   * @public
+   */
+  hookId: string | undefined;
+
+  token: string | undefined;
+  ownerId: string | undefined;
+  projectId: string | undefined;
+  environment: string | undefined;
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  metadata?: Uint8Array | undefined;
+
+  specVersion?: number | undefined;
+  isWebhook?: boolean | undefined;
+  isSystem?: boolean | undefined;
+  /**
+   * Earliest time the token may be released after the run ends. An active
+   * run holds the token past this deadline.
+   * @public
+   */
+  tokenRetentionUntil?: Date | undefined;
+
+  /**
+   * Immutable slice of a hook's owning run, sufficient to resume the hook
+   * without reading the run entity.
+   *
+   * Deliberately excludes mutable run state, payloads, attributes, and any
+   * secret.
+   * @public
+   */
+  resumeContext?: HookResumeContext | undefined;
+
+  /**
+   * Backend-attested resume capabilities, recomputed on every by-token lookup.
+   *
+   * Response-only and never persisted, so a rollback or kill switch downgrades
+   * new resumes immediately by omitting it.
+   * @public
+   */
+  resumeCapabilities?: HookResumeCapabilities | undefined;
+
+  createdAt: Date | undefined;
+}
+
+/**
+ * Materialized view of a step.
+ * @public
+ */
+export interface Step {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Identifier of a step within a run.
+   * @public
+   */
+  stepId: string | undefined;
+
+  /**
+   * Machine-readable step function name.
+   * @public
+   */
+  stepName: string | undefined;
+
+  /**
+   * Lifecycle status of a step.
+   * @public
+   */
+  status: StepStatus | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  input?: Uint8Array | undefined;
+
+  /**
+   * Opaque serialized workflow data.
+   *
+   * Payload bytes are produced by the SDK serialization pipeline and may be
+   * compressed and/or encrypted. The World never interprets them. Runs created
+   * by spec version 1 carried unserialized JSON instead; those records are not
+   * representable here and must be converted by a compatibility adapter.
+   * @public
+   */
+  output?: Uint8Array | undefined;
+
+  /**
+   * Most recent serialized thrown value, from either a retry or the final
+   * failure.
+   * @public
+   */
+  error?: Uint8Array | undefined;
+
+  attempt: number | undefined;
+  /**
+   * When the step first began executing. Not updated by retries.
+   * @public
+   */
+  startedAt?: Date | undefined;
+
+  completedAt?: Date | undefined;
+  /**
+   * Earliest time a retrying step may start again.
+   * @public
+   */
+  retryAfter?: Date | undefined;
+
+  specVersion?: number | undefined;
+  createdAt: Date | undefined;
+  updatedAt: Date | undefined;
+}
+
+/**
+ * Materialized view of a wait.
+ * @public
+ */
+export interface Wait {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Identifier of a wait.
+   * @public
+   */
+  waitId: string | undefined;
+
+  resumeAt: Date | undefined;
+  completedAt?: Date | undefined;
+  createdAt: Date | undefined;
+}
+
+/**
+ * Result of an event write.
+ *
+ * The event and the entity it affects are materialized atomically. The
+ * delta members are populated when the caller opted into an inline delta or
+ * preload, and by a slot-numbering implementation reporting the slots it
+ * bumped past.
+ * @public
+ */
+export interface EventMutationResult {
+  /**
+   * The committed event. Absent only for legacy runs that skip event
+   * storage.
+   * @public
+   */
+  event?: Event | undefined;
+
+  /**
+   * Materialized view of a run.
+   *
+   * `input`, `output`, and `error` are absent when the caller asked for
+   * `ResolveData$NONE`, and `output`/`error`/`completedAt` are only populated
+   * once the run reaches the matching terminal status.
+   * @public
+   */
+  run?: WorkflowRun | undefined;
+
+  /**
+   * Materialized view of a step.
+   * @public
+   */
+  step?: Step | undefined;
+
+  /**
+   * Materialized view of a hook.
+   *
+   * A hook kept alive by minimum retention stays readable after its run ends
+   * and continues to reserve its token, but can no longer be resumed.
+   * @public
+   */
+  hook?: Hook | undefined;
+
+  /**
+   * Materialized view of a wait.
+   * @public
+   */
+  wait?: Wait | undefined;
+
+  /**
+   * True only when a lazy `stepStarted` created the step on this call.
+   * The caller that sees it owns inline execution of that step.
+   * @public
+   */
+  stepCreated?: boolean | undefined;
+
+  /**
+   * Server-owned event ceiling for the run, enforced by the runtime.
+   * @public
+   */
+  maxEvents?: number | undefined;
+
+  /**
+   * Events the caller had not seen, in log order.
+   * @public
+   */
+  events?: Event[] | undefined;
+
+  /**
+   * Cursor past the last returned event.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Whether more event pages follow `events`.
+   * @public
+   */
+  hasMore?: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CreateRunInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * Starts a new run. Materializes the run entity with status `pending`.
+   * @public
+   */
+  event: RunCreatedEvent | undefined;
+
+  /**
+   * Advisory and idempotency parameters for an event write.
+   *
+   * Everything here is optional. An implementation that ignores all of it
+   * stays correct; the runtime falls back to explicit reads.
+   * @public
+   */
+  options?: CreateEventOptions | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CreateRunIdInput {
+  /**
+   * The full options bag passed to `start()`. Implementations read
+   * only the keys they recognize and ignore the rest.
+   * @public
+   */
+  options?: __DocumentType | undefined;
+}
+
+/**
+ * @public
+ */
+export interface CreateRunIdOutput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface DeliverQueueMessageInput {
+  /**
+   * Logical queue name, e.g. a flow or step topic.
+   * @public
+   */
+  queueName: string | undefined;
+
+  /**
+   * Opaque queue payload.
+   *
+   * The runtime's invoke and health-check payload schemas are deliberately not
+   * modeled yet: they are producer-and-consumer-private, versioned by run spec
+   * version, and encoded as CBOR or JSON depending on that version. Modeling
+   * them belongs in a follow-up once the transport story is settled.
+   * @public
+   */
+  message: Uint8Array | undefined;
+
+  /**
+   * 1-based delivery attempt.
+   * @public
+   */
+  attempt: number | undefined;
+
+  /**
+   * Queue message identifier.
+   *
+   * Should be stable across redeliveries of one enqueued message: the
+   * runtime's inline step ownership uses it as a liveness lease. An
+   * implementation that mints a fresh ID per delivery still works, but owner
+   * redeliveries fall back to the slower backstop path.
+   * @public
+   */
+  messageId: string | undefined;
+
+  requestId?: string | undefined;
+}
+
+/**
+ * Instructs the caller to redeliver the message later.
+ * @public
+ */
+export interface RetryDirective {
+  timeoutSeconds: number | undefined;
+}
+
+/**
+ * @public
+ */
+export interface DeliverQueueMessageOutput {
+  /**
+   * Present when the runtime wants the message redelivered instead of
+   * acknowledged.
+   * @public
+   */
+  retry?: RetryDirective | undefined;
+}
+
+/**
+ * @public
+ */
+export interface DescribeRunInput {
+  /**
+   * The run entity as the caller holds it, which may be a lean
+   * observability row rather than a full record.
+   * @public
+   */
+  run: __DocumentType | undefined;
+}
+
+/**
+ * @public
+ */
+export interface DescribeRunOutput {
+  /**
+   * World-specific display fields for one run, keyed by column name.
+   *
+   * A null value means "applicable but undeterminable", which is distinct from
+   * the key being absent.
+   * @public
+   */
+  fields?: Record<string, string | null> | undefined;
+}
+
+/**
+ * @public
+ */
+export interface EnqueueOptions {
+  /**
+   * Target a specific deployment rather than the current one.
+   * @public
+   */
+  deploymentId?: string | undefined;
+
+  idempotencyKey?: string | undefined;
+  headers?: Record<string, string> | undefined;
+  /**
+   * Delay delivery by this many seconds.
+   * @public
+   */
+  delaySeconds?: number | undefined;
+
+  /**
+   * Spec version of the target run, which selects the transport format.
+   * @public
+   */
+  specVersion?: number | undefined;
+
+  /**
+   * Routing hint naming the region the message should be sent to.
+   * @public
+   */
+  region?: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface EnqueueInput {
+  /**
+   * Logical queue name, e.g. a flow or step topic.
+   * @public
+   */
+  queueName: string | undefined;
+
+  /**
+   * Opaque queue payload.
+   *
+   * The runtime's invoke and health-check payload schemas are deliberately not
+   * modeled yet: they are producer-and-consumer-private, versioned by run spec
+   * version, and encoded as CBOR or JSON depending on that version. Modeling
+   * them belongs in a follow-up once the transport story is settled.
+   * @public
+   */
+  message: Uint8Array | undefined;
+
+  options?: EnqueueOptions | undefined;
+}
+
+/**
+ * @public
+ */
+export interface EnqueueOutput {
+  /**
+   * Assigned message ID, when the queue reports one.
+   * @public
+   */
+  messageId?: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetDeploymentIdInput {}
+
+/**
+ * @public
+ */
+export interface GetDeploymentIdOutput {
+  /**
+   * Identifier of a deployment a run is pinned to.
+   * @public
+   */
+  deploymentId: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetEncryptionKeyForRunInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Opaque world-specific context, such as a deployment ID, used when
+   * the run entity is not available locally.
+   * @public
+   */
+  context?: __DocumentType | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetEncryptionKeyForRunOutput {
+  /**
+   * A ready-to-use AES-256 key.
+   * @public
+   */
+  key?: Uint8Array | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetEnvironmentInput {}
+
+/**
+ * @public
+ */
+export interface GetEnvironmentOutput {
+  environment?: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetEventInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Identifier of an event within a run's log.
+   * @public
+   */
+  eventId: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetEventOutput {
+  /**
+   * One committed entry in a run's event log.
+   * @public
+   */
+  event: Event | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetHookInput {
+  /**
+   * Identifier of a hook.
+   * @public
+   */
+  hookId: string | undefined;
+
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetHookOutput {
+  /**
+   * Materialized view of a hook.
+   *
+   * A hook kept alive by minimum retention stays readable after its run ends
+   * and continues to reserve its token, but can no longer be resumed.
+   * @public
+   */
+  hook: Hook | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetHookByTokenInput {
+  token: string | undefined;
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetHookByTokenOutput {
+  /**
+   * Materialized view of a hook.
+   *
+   * A hook kept alive by minimum retention stays readable after its run ends
+   * and continues to reserve its token, but can no longer be resumed.
+   * @public
+   */
+  hook: Hook | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetRunInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetRunOutput {
+  /**
+   * Materialized view of a run.
+   *
+   * `input`, `output`, and `error` are absent when the caller asked for
+   * `ResolveData$NONE`, and `output`/`error`/`completedAt` are only populated
+   * once the run reaches the matching terminal status.
+   * @public
+   */
+  run: WorkflowRun | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetRuntimeDeadlineInput {}
+
+/**
+ * @public
+ */
+export interface GetRuntimeDeadlineOutput {
+  deadline?: Date | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetStepInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Identifier of a step within a run.
+   * @public
+   */
+  stepId: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetStepOutput {
+  /**
+   * Materialized view of a step.
+   * @public
+   */
+  step: Step | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetStreamInfoInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  name: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetStreamInfoOutput {
+  /**
+   * Index of the last known chunk, or -1 when the stream is empty.
+   * @public
+   */
+  tailIndex: number | undefined;
+
+  /**
+   * Whether the stream is closed.
+   * @public
+   */
+  done: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetWorldInfoInput {}
+
+/**
+ * @public
+ */
+export interface HookRetentionCapability {
+  active: boolean | undefined;
+}
+
+/**
+ * Feature capabilities an implementation declares.
+ *
+ * Every member defaults to unsupported when absent: a runtime fast path
+ * gated on a capability must keep its conservative behavior unless the
+ * capability is explicitly declared.
+ * @public
+ */
+export interface WorldCapabilities {
+  /**
+   * Supports minimum token retention for hooks.
+   * @public
+   */
+  hookRetention?: HookRetentionCapability | undefined;
+
+  /**
+   * Fences a stale replay-context write with `PreconditionFailedError`
+   * rather than committing it. Accepting a snapshot and ignoring it is not
+   * the same thing, and must leave this unset.
+   * @public
+   */
+  preconditionGuard?: boolean | undefined;
+
+  /**
+   * The queue supports concurrency-limited consumption, including the
+   * per-run topics consumed with a limit of one.
+   * @public
+   */
+  maxConcurrency?: boolean | undefined;
+
+  /**
+   * `CreateEvent` deduplicates concurrent `hookReceived` writes carrying
+   * the same `(runId, resumeId)`, collapsing them onto one committed
+   * event.
+   * @public
+   */
+  hookResumeDedup?: boolean | undefined;
+
+  /**
+   * Deployment IDs are atomic and immutable, so a run pinned to one may
+   * only execute there. Implementations whose deployment ID is synthetic
+   * or version-tagged must leave this unset.
+   * @public
+   */
+  deploymentAffinity?: boolean | undefined;
+
+  /**
+   * Event IDs encode the event's dense, 1-based slot in its run's log.
+   * Implies both density and bump-and-report on contention.
+   * @public
+   */
+  slotEventIds?: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface GetWorldInfoOutput {
+  /**
+   * Workflow protocol spec version this implementation writes.
+   * Runtimes require an exact match before creating or replaying runs.
+   * @public
+   */
+  specVersion: number | undefined;
+
+  /**
+   * Feature capabilities an implementation declares.
+   *
+   * Every member defaults to unsupported when absent: a runtime fast path
+   * gated on a capability must keep its conservative behavior unless the
+   * capability is explicitly declared.
+   * @public
+   */
+  capabilities?: WorldCapabilities | undefined;
+
+  /**
+   * Optional capability services that are available.
+   * @public
+   */
+  optionalCapabilities?: string[] | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListEventsInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+
+  limit?: number | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Sort direction for list operations, ordered by creation time.
+   * @public
+   */
+  sortOrder?: SortOrder | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListEventsOutput {
+  events: Event[] | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  hasMore: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListEventsByCorrelationIdInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Correlation identifier tying an event to the entity it affects.
+   * @public
+   */
+  correlationId: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+
+  limit?: number | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Sort direction for list operations, ordered by creation time.
+   * @public
+   */
+  sortOrder?: SortOrder | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListEventsByCorrelationIdOutput {
+  events: Event[] | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  hasMore: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListHooksInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId?: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+
+  limit?: number | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Sort direction for list operations, ordered by creation time.
+   * @public
+   */
+  sortOrder?: SortOrder | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListHooksOutput {
+  hooks: Hook[] | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  hasMore: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListRunsInput {
+  /**
+   * Machine-readable workflow function name, e.g.
+   * `workflow//./src/workflows/order//processOrder`.
+   * @public
+   */
+  workflowName?: string | undefined;
+
+  /**
+   * Lifecycle status of a run.
+   * @public
+   */
+  status?: RunStatus | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+
+  limit?: number | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Sort direction for list operations, ordered by creation time.
+   * @public
+   */
+  sortOrder?: SortOrder | undefined;
+}
+
+/**
+ * Retention window metadata returned by plan-aware list operations.
+ * @public
+ */
+export interface PageInfo {
+  currentLookbackDays: number | undefined;
+  maxLookbackDays: number | undefined;
+  currentWindowStart: Date | undefined;
+  maxWindowStart: Date | undefined;
+  upgradeAvailable: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListRunsOutput {
+  runs: WorkflowRun[] | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  hasMore: boolean | undefined;
+  /**
+   * Retention window metadata returned by plan-aware list operations.
+   * @public
+   */
+  pageInfo?: PageInfo | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListStepsInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Controls whether payload-bearing fields are resolved in a response.
+   *
+   * Smithy cannot vary an output shape by an input value, so payload members
+   * stay optional and `NONE` simply leaves them absent.
+   * @public
+   */
+  resolveData?: ResolveData | undefined;
+
+  limit?: number | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Sort direction for list operations, ordered by creation time.
+   * @public
+   */
+  sortOrder?: SortOrder | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListStepsOutput {
+  steps: Step[] | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  hasMore: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListStreamChunksInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  name: string | undefined;
+
+  limit?: number | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+}
+
+/**
+ * One chunk of a stream, with its 0-based position.
+ * @public
+ */
+export interface StreamChunk {
+  index: number | undefined;
+  data: Uint8Array | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListStreamChunksOutput {
+  chunks: StreamChunk[] | undefined;
+  /**
+   * Opaque, implementation-defined pagination cursor.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Whether more already-written chunks remain.
+   * @public
+   */
+  hasMore: boolean | undefined;
+
+  /**
+   * Whether the stream is closed.
+   * @public
+   */
+  done: boolean | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListStreamsInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ListStreamsOutput {
+  names: string[] | undefined;
+}
+
+/**
+ * Marks an operation that must never be exposed over a network transport.
+ *
+ * Operations carrying this trait exist so that in-process implementations
+ * share one cross-language contract (TypeScript, Python) for behavior that
+ * is resolved locally: ID minting, environment attribution, deadlines,
+ * display enrichment, and encryption-key resolution. Any future transport
+ * projection is expected to remove these operations from its closure and to
+ * fail the build if one survives.
+ * @public
+ */
+export interface LocalOnly {}
+
+/**
+ * Marks an operation as part of an optional World capability.
+ *
+ * Smithy services have no notion of an optional operation, so optional
+ * behavior lives in its own service closure. This trait records which
+ * capability an operation belongs to so wrappers and conformance tooling can
+ * tie a generated service to the capability an implementation advertises in
+ * `WorldInfo`.
+ * @public
+ */
+export interface OptionalCapability {
+  /**
+   * Capability name as advertised by `WorldInfo$capabilities`.
+   * @public
+   */
+  name: string | undefined;
+}
+
+/**
+ * Cursor pagination request options.
+ * @public
+ */
+export interface Pagination {
+  /**
+   * Maximum number of items to return.
+   * @public
+   */
+  limit?: number | undefined;
+
+  /**
+   * Cursor returned by a previous page.
+   * @public
+   */
+  cursor?: string | undefined;
+
+  /**
+   * Sort direction. Callers that depend on ordering should always set it.
+   * @public
+   */
+  sortOrder?: SortOrder | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ReadStreamInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  name: string | undefined;
+
+  startIndex?: number | undefined;
+}
+
+/**
+ * @public
+ */
+export interface ReadStreamOutput {
+  /**
+   * An unbounded byte stream.
+   * @public
+   */
+  body: StreamingBlobTypes | undefined;
+}
+
+/**
+ * Structured error metadata carried by run and step failures.
+ * @public
+ */
+export interface StructuredError {
+  message: string | undefined;
+  stack?: string | undefined;
+  /**
+   * Machine-readable error code, e.g. `USER_ERROR` or `RUNTIME_ERROR`.
+   * @public
+   */
+  code?: string | undefined;
+}
+
+/**
+ * @public
+ */
+export interface WriteStreamChunksInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  name: string | undefined;
+
+  /**
+   * Chunks to append, in order.
+   * @public
+   */
+  chunks: Uint8Array[] | undefined;
+}
+
+/**
+ * @public
+ */
+export interface WriteStreamChunksOutput {}
+
+/**
+ * @public
+ */
+export interface WriteStreamChunkInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  name: string | undefined;
+
+  chunk: Uint8Array | undefined;
+}
+
+/**
+ * @public
+ */
+export interface WriteStreamChunkOutput {}

--- a/idl/world/generated/typescript/models/models_0.ts
+++ b/idl/world/generated/typescript/models/models_0.ts
@@ -3424,6 +3424,30 @@ export interface StructuredError {
 /**
  * @public
  */
+export interface WriteStreamChunkInput {
+  /**
+   * Identifier of a workflow run.
+   * @public
+   */
+  runId: string | undefined;
+
+  /**
+   * Name of a stream within a run.
+   * @public
+   */
+  name: string | undefined;
+
+  chunk: Uint8Array | undefined;
+}
+
+/**
+ * @public
+ */
+export interface WriteStreamChunkOutput {}
+
+/**
+ * @public
+ */
 export interface WriteStreamChunksInput {
   /**
    * Identifier of a workflow run.
@@ -3448,27 +3472,3 @@ export interface WriteStreamChunksInput {
  * @public
  */
 export interface WriteStreamChunksOutput {}
-
-/**
- * @public
- */
-export interface WriteStreamChunkInput {
-  /**
-   * Identifier of a workflow run.
-   * @public
-   */
-  runId: string | undefined;
-
-  /**
-   * Name of a stream within a run.
-   * @public
-   */
-  name: string | undefined;
-
-  chunk: Uint8Array | undefined;
-}
-
-/**
- * @public
- */
-export interface WriteStreamChunkOutput {}

--- a/idl/world/generated/typescript/ports.ts
+++ b/idl/world/generated/typescript/ports.ts
@@ -1,0 +1,385 @@
+// Generated from the Smithy model. Do not edit by hand.
+// Source: idl/world/model, emitted by idl/world/scripts/generate_ports.py
+
+import type {
+  BatchGetRunsInput,
+  BatchGetRunsOutput,
+  BulkCancelRunsInput,
+  BulkCancelRunsOutput,
+  CloseStreamInput,
+  CloseStreamOutput,
+  CreateEventInput,
+  CreateRunIdInput,
+  CreateRunIdOutput,
+  CreateRunInput,
+  DeliverQueueMessageInput,
+  DeliverQueueMessageOutput,
+  DescribeRunInput,
+  DescribeRunOutput,
+  EnqueueInput,
+  EnqueueOutput,
+  EventMutationResult,
+  GetDeploymentIdInput,
+  GetDeploymentIdOutput,
+  GetEncryptionKeyForRunInput,
+  GetEncryptionKeyForRunOutput,
+  GetEnvironmentInput,
+  GetEnvironmentOutput,
+  GetEventInput,
+  GetEventOutput,
+  GetHookByTokenInput,
+  GetHookByTokenOutput,
+  GetHookInput,
+  GetHookOutput,
+  GetRunInput,
+  GetRunOutput,
+  GetRuntimeDeadlineInput,
+  GetRuntimeDeadlineOutput,
+  GetStepInput,
+  GetStepOutput,
+  GetStreamInfoInput,
+  GetStreamInfoOutput,
+  GetWorldInfoInput,
+  GetWorldInfoOutput,
+  ListEventsByCorrelationIdInput,
+  ListEventsByCorrelationIdOutput,
+  ListEventsInput,
+  ListEventsOutput,
+  ListHooksInput,
+  ListHooksOutput,
+  ListRunsInput,
+  ListRunsOutput,
+  ListStepsInput,
+  ListStepsOutput,
+  ListStreamChunksInput,
+  ListStreamChunksOutput,
+  ListStreamsInput,
+  ListStreamsOutput,
+  ReadStreamInput,
+  ReadStreamOutput,
+  WriteStreamChunkInput,
+  WriteStreamChunkOutput,
+  WriteStreamChunksInput,
+  WriteStreamChunksOutput,
+} from './models/models_0';
+
+/**
+ * Optional optimizations.
+ *
+ * An implementation that omits this service is fully supported; callers
+ * fall back to the equivalent `WorldCore` operations.
+ */
+export interface WorldBatchPort {
+  /**
+   * Reads several runs as one snapshot.
+   *
+   * `runs` preserves the request order, including duplicate IDs, and carries
+   * a null entry for every ID that does not exist.
+   *
+   * Optional capability: `batchGetRuns`. Throws: BadRequestError,
+   * InternalError, ThrottledError.
+   */
+  batchGetRuns(input: BatchGetRunsInput): Promise<BatchGetRunsOutput>;
+
+  /**
+   * Cancels many runs in one request.
+   *
+   * Missing, already-cancelled, and non-cancellable runs are reported as
+   * per-run outcomes rather than as operation errors, so one bad ID never
+   * fails the batch.
+   *
+   * Optional capability: `bulkCancelRuns`. Throws: BadRequestError,
+   * InternalError, ThrottledError.
+   */
+  bulkCancelRuns(input: BulkCancelRunsInput): Promise<BulkCancelRunsOutput>;
+
+  /**
+   * Appends several chunks in order, in one request.
+   *
+   * An optional optimization. Callers fall back to repeated
+   * `WriteStreamChunk` calls when an implementation does not provide it.
+   *
+   * Optional capability: `writeStreamChunks`. Throws: ConflictError,
+   * InternalError, RunNotFoundError, StreamExpiredError, ThrottledError.
+   */
+  writeStreamChunks(input: WriteStreamChunksInput): Promise<WriteStreamChunksOutput>;
+}
+
+/**
+ * Operations the workflow runtime implements and a World's queue adapter
+ * calls.
+ */
+export interface WorldConsumerPort {
+  /**
+   * Delivers one queued message to the workflow runtime.
+   *
+   * This is the reverse direction: a queue adapter calls the runtime.
+   * Today's `createQueueHandler` becomes a thin per-language adapter that
+   * exposes this operation over whatever the platform hands it, rather than
+   * an operation in its own right.
+   *
+   * Callback: implemented by the runtime, called by the World. Throws:
+   * BadRequestError, InternalError.
+   */
+  deliverQueueMessage(input: DeliverQueueMessageInput): Promise<DeliverQueueMessageOutput>;
+}
+
+/**
+ * The required World surface.
+ *
+ * Every implementation provides all of it. Optional behavior lives in the
+ * capability services instead, so a generated interface never forces an
+ * implementation to stub a method it does not support.
+ *
+ * No protocol trait is applied anywhere in this model. The operations are
+ * transport-independent by construction: an in-process implementation
+ * satisfies the generated interface directly, and any wire format is a
+ * separate projection that layers protocol and binding traits on top.
+ */
+export interface WorldCorePort {
+  /**
+   * Closes a stream. No further chunks may be appended.
+   *
+   * Throws: InternalError, RunNotFoundError, StreamExpiredError,
+   * StreamNotFoundError, ThrottledError.
+   */
+  closeStream(input: CloseStreamInput): Promise<CloseStreamOutput>;
+
+  /**
+   * Appends an event to a run's log and materializes its effect atomically.
+   *
+   * This is the only way to change run, step, hook, or wait state.
+   *
+   * Throws: BadRequestError, ConflictError, ExpiredError, InternalError,
+   * PreconditionFailedError, RunNotFoundError, ThrottledError,
+   * TooEarlyError.
+   */
+  createEvent(input: CreateEventInput): Promise<EventMutationResult>;
+
+  /**
+   * Creates a run.
+   *
+   * The caller may mint the run ID or leave it absent for the implementation
+   * to generate one.
+   *
+   * Throws: BadRequestError, ConflictError, InternalError, ThrottledError.
+   */
+  createRun(input: CreateRunInput): Promise<EventMutationResult>;
+
+  /**
+   * Enqueues one message. Delivery is at-least-once.
+   *
+   * Throws: BadRequestError, InternalError, ThrottledError.
+   */
+  enqueue(input: EnqueueInput): Promise<EnqueueOutput>;
+
+  /**
+   * Returns the deployment this World writes as.
+   *
+   * Throws: InternalError, ThrottledError.
+   */
+  getDeploymentId(input: GetDeploymentIdInput): Promise<GetDeploymentIdOutput>;
+
+  /**
+   * Reads one event.
+   *
+   * Throws: EventNotFoundError, ExpiredError, InternalError,
+   * RunNotFoundError, ThrottledError.
+   */
+  getEvent(input: GetEventInput): Promise<GetEventOutput>;
+
+  /**
+   * Reads one hook by ID.
+   *
+   * Throws: ExpiredError, HookNotFoundError, InternalError, ThrottledError.
+   */
+  getHook(input: GetHookInput): Promise<GetHookOutput>;
+
+  /**
+   * Reads the hook that currently owns a token, including a retained hook
+   * whose run has ended.
+   *
+   * Throws: ExpiredError, HookNotFoundError, InternalError, ThrottledError.
+   */
+  getHookByToken(input: GetHookByTokenInput): Promise<GetHookByTokenOutput>;
+
+  /**
+   * Reads one run.
+   *
+   * Throws: ExpiredError, InternalError, RunNotFoundError, ThrottledError.
+   */
+  getRun(input: GetRunInput): Promise<GetRunOutput>;
+
+  /**
+   * Reads one step.
+   *
+   * Throws: ExpiredError, InternalError, RunNotFoundError,
+   * StepNotFoundError, ThrottledError.
+   */
+  getStep(input: GetStepInput): Promise<GetStepOutput>;
+
+  /**
+   * Reads lightweight stream metadata.
+   *
+   * Useful for resolving a negative `startIndex` into an absolute position
+   * before opening a live read.
+   *
+   * Throws: InternalError, RunNotFoundError, StreamExpiredError,
+   * StreamNotFoundError, ThrottledError.
+   */
+  getStreamInfo(input: GetStreamInfoInput): Promise<GetStreamInfoOutput>;
+
+  /**
+   * Reports the implementation's protocol version and capabilities.
+   *
+   * This replaces inferring support from method presence, which stops
+   * working as soon as calls cross a transport where every method always
+   * exists.
+   *
+   * Throws: InternalError, ThrottledError.
+   */
+  getWorldInfo(input: GetWorldInfoInput): Promise<GetWorldInfoOutput>;
+
+  /**
+   * Lists a run's event log.
+   *
+   * Omitting `limit` requests every remaining event.
+   *
+   * Throws: BadRequestError, ExpiredError, InternalError, RunNotFoundError,
+   * ThrottledError.
+   */
+  listEvents(input: ListEventsInput): Promise<ListEventsOutput>;
+
+  /**
+   * Lists the events of one run that share a correlation ID.
+   *
+   * Correlation IDs are unique within a run, not globally, so the run is
+   * part of the query.
+   *
+   * Throws: BadRequestError, ExpiredError, InternalError, RunNotFoundError,
+   * ThrottledError.
+   */
+  listEventsByCorrelationId(input: ListEventsByCorrelationIdInput): Promise<ListEventsByCorrelationIdOutput>;
+
+  /**
+   * Lists hooks, including retained hooks whose runs have ended.
+   *
+   * Throws: BadRequestError, InternalError, ThrottledError.
+   */
+  listHooks(input: ListHooksInput): Promise<ListHooksOutput>;
+
+  /**
+   * Lists canonical run records.
+   *
+   * This is the operational, payload-bearing listing. Observability surfaces
+   * should prefer the analytics read path once it is modeled.
+   *
+   * Throws: BadRequestError, InternalError, ThrottledError.
+   */
+  listRuns(input: ListRunsInput): Promise<ListRunsOutput>;
+
+  /**
+   * Lists the steps of one run.
+   *
+   * Throws: BadRequestError, ExpiredError, InternalError, RunNotFoundError,
+   * ThrottledError.
+   */
+  listSteps(input: ListStepsInput): Promise<ListStepsOutput>;
+
+  /**
+   * Reads a point-in-time page of already-written chunks.
+   *
+   * Unlike `ReadStream`, this never waits. `done` reports whether the stream
+   * is closed: `done: false` with `hasMore: false` means nothing is
+   * available right now, but more chunks may still arrive.
+   *
+   * Throws: BadRequestError, InternalError, RunNotFoundError,
+   * StreamExpiredError, StreamNotFoundError, ThrottledError.
+   */
+  listStreamChunks(input: ListStreamChunksInput): Promise<ListStreamChunksOutput>;
+
+  /**
+   * Lists the stream names belonging to a run.
+   *
+   * Throws: ExpiredError, InternalError, RunNotFoundError, ThrottledError.
+   */
+  listStreams(input: ListStreamsInput): Promise<ListStreamsOutput>;
+
+  /**
+   * Reads a stream live, waiting for chunks until the stream closes.
+   *
+   * A positive `startIndex` skips that many chunks from the start. A
+   * negative one starts that many chunks before the current end, clamped to
+   * zero.
+   *
+   * Throws: InternalError, RunNotFoundError, StreamExpiredError,
+   * StreamNotFoundError, ThrottledError.
+   */
+  readStream(input: ReadStreamInput): Promise<ReadStreamOutput>;
+
+  /**
+   * Appends one chunk to a stream.
+   *
+   * Throws: ConflictError, InternalError, RunNotFoundError,
+   * StreamExpiredError, ThrottledError.
+   */
+  writeStreamChunk(input: WriteStreamChunkInput): Promise<WriteStreamChunkOutput>;
+}
+
+/**
+ * Operations that are resolved in-process and never exposed over a
+ * transport. See the `localOnly` trait.
+ */
+export interface WorldLocalHooksPort {
+  /**
+   * Mints a new run ID.
+   *
+   * Returns the bare ULID; the core attaches the `wrun_` prefix.
+   * Implementations may embed world-specific metadata such as a region as
+   * long as the result stays a valid ULID.
+   *
+   * Local only: never exposed over a transport.
+   */
+  createRunId(input: CreateRunIdInput): Promise<CreateRunIdOutput>;
+
+  /**
+   * Returns extra display fields for a run.
+   *
+   * Called once per displayed run by tooling, so it must be cheap, pure, and
+   * non-throwing.
+   *
+   * Local only: never exposed over a transport.
+   */
+  describeRun(input: DescribeRunInput): Promise<DescribeRunOutput>;
+
+  /**
+   * Resolves the AES-256 key for a run.
+   *
+   * Local only, permanently: key material must never cross a transport
+   * boundary. It is modeled here so in-process implementations share one
+   * contract across languages, and every transport projection is expected to
+   * drop it. Absent support means encryption is disabled.
+   *
+   * Local only: never exposed over a transport.
+   */
+  getEncryptionKeyForRun(input: GetEncryptionKeyForRunInput): Promise<GetEncryptionKeyForRunOutput>;
+
+  /**
+   * Returns the environment this World's writes are attributed to.
+   *
+   * Must match the attribution the backend will actually apply. Callers use
+   * it to detect cross-environment mismatches, so a plausible-looking wrong
+   * value is worse than none.
+   *
+   * Local only: never exposed over a transport.
+   */
+  getEnvironment(input: GetEnvironmentInput): Promise<GetEnvironmentOutput>;
+
+  /**
+   * Returns the wall-clock time at which the current invocation will be
+   * terminated by the hosting platform, when that is known.
+   *
+   * Local only: never exposed over a transport.
+   */
+  getRuntimeDeadline(input: GetRuntimeDeadlineInput): Promise<GetRuntimeDeadlineOutput>;
+}

--- a/idl/world/generated/typescript/ports.ts
+++ b/idl/world/generated/typescript/ports.ts
@@ -64,52 +64,15 @@ import type {
 } from './models/models_0';
 
 /**
- * Optional optimizations.
+ * The runtime's own queue-consumer interface.
  *
- * An implementation that omits this service is fully supported; callers
- * fall back to the equivalent `WorldCore` operations.
+ * Deliberately not part of `World`, and not a second World interface: the
+ * implementor is the workflow runtime, and the caller is a World's queue
+ * adapter. Today this is the callback handed to `createQueueHandler`.
+ * Folding it into `World` would say that a World implements it, which is
+ * backwards.
  */
-export interface WorldBatchPort {
-  /**
-   * Reads several runs as one snapshot.
-   *
-   * `runs` preserves the request order, including duplicate IDs, and carries
-   * a null entry for every ID that does not exist.
-   *
-   * Optional capability: `batchGetRuns`. Throws: BadRequestError,
-   * InternalError, ThrottledError.
-   */
-  batchGetRuns(input: BatchGetRunsInput): Promise<BatchGetRunsOutput>;
-
-  /**
-   * Cancels many runs in one request.
-   *
-   * Missing, already-cancelled, and non-cancellable runs are reported as
-   * per-run outcomes rather than as operation errors, so one bad ID never
-   * fails the batch.
-   *
-   * Optional capability: `bulkCancelRuns`. Throws: BadRequestError,
-   * InternalError, ThrottledError.
-   */
-  bulkCancelRuns(input: BulkCancelRunsInput): Promise<BulkCancelRunsOutput>;
-
-  /**
-   * Appends several chunks in order, in one request.
-   *
-   * An optional optimization. Callers fall back to repeated
-   * `WriteStreamChunk` calls when an implementation does not provide it.
-   *
-   * Optional capability: `writeStreamChunks`. Throws: ConflictError,
-   * InternalError, RunNotFoundError, StreamExpiredError, ThrottledError.
-   */
-  writeStreamChunks(input: WriteStreamChunksInput): Promise<WriteStreamChunksOutput>;
-}
-
-/**
- * Operations the workflow runtime implements and a World's queue adapter
- * calls.
- */
-export interface WorldConsumerPort {
+export interface RuntimeQueueConsumerPort {
   /**
    * Delivers one queued message to the workflow runtime.
    *
@@ -125,18 +88,53 @@ export interface WorldConsumerPort {
 }
 
 /**
- * The required World surface.
+ * The World interface.
  *
- * Every implementation provides all of it. Optional behavior lives in the
- * capability services instead, so a generated interface never forces an
- * implementation to stub a method it does not support.
+ * One interface, implemented by every World: local, Postgres, Vercel, and
+ * the simulator. This is the whole point of the model, so the surface is
+ * not split by concern, by optionality, or by whether an operation can
+ * cross a network.
+ *
+ * Two of those distinctions still exist, and both are traits on operations
+ * rather than separate interfaces:
+ *
+ * - `optionalCapability` marks an operation an implementation may omit. It
+ * is the modeled form of today's optional `World` methods (`getMany?`,
+ * `cancelMany?`, `writeMulti?`), and callers feature-detect it exactly as
+ * they do now. `GetWorldInfo` reports which ones are present. -
+ * `localOnly` marks an operation that is resolved in-process and must
+ * never be exposed over a transport. It stays on this interface because a
+ * World implements it; a future transport projection is what drops it.
  *
  * No protocol trait is applied anywhere in this model. The operations are
  * transport-independent by construction: an in-process implementation
  * satisfies the generated interface directly, and any wire format is a
  * separate projection that layers protocol and binding traits on top.
  */
-export interface WorldCorePort {
+export interface WorldPort {
+  /**
+   * Reads several runs as one snapshot.
+   *
+   * `runs` preserves the request order, including duplicate IDs, and carries
+   * a null entry for every ID that does not exist.
+   *
+   * Optional capability: `batchGetRuns`. Throws: BadRequestError,
+   * InternalError, ThrottledError.
+   */
+  batchGetRuns?(input: BatchGetRunsInput): Promise<BatchGetRunsOutput>;
+
+  /**
+   * Cancels many runs in one request.
+   *
+   * Missing, already-cancelled, and non-cancellable runs are reported as
+   * per-run outcomes rather than as operation errors, so one bad ID never
+   * fails the batch.
+   *
+   * Optional capability: `bulkCancelRuns`. Throws: BadRequestError,
+   * InternalError, ThrottledError.
+   */
+  bulkCancelRuns?(input: BulkCancelRunsInput): Promise<BulkCancelRunsOutput>;
+
   /**
    * Closes a stream. No further chunks may be appended.
    *
@@ -167,6 +165,27 @@ export interface WorldCorePort {
   createRun(input: CreateRunInput): Promise<EventMutationResult>;
 
   /**
+   * Mints a new run ID.
+   *
+   * Returns the bare ULID; the core attaches the `wrun_` prefix.
+   * Implementations may embed world-specific metadata such as a region as
+   * long as the result stays a valid ULID.
+   *
+   * Local only: never exposed over a transport.
+   */
+  createRunId(input: CreateRunIdInput): Promise<CreateRunIdOutput>;
+
+  /**
+   * Returns extra display fields for a run.
+   *
+   * Called once per displayed run by tooling, so it must be cheap, pure, and
+   * non-throwing.
+   *
+   * Local only: never exposed over a transport.
+   */
+  describeRun(input: DescribeRunInput): Promise<DescribeRunOutput>;
+
+  /**
    * Enqueues one message. Delivery is at-least-once.
    *
    * Throws: BadRequestError, InternalError, ThrottledError.
@@ -179,6 +198,29 @@ export interface WorldCorePort {
    * Throws: InternalError, ThrottledError.
    */
   getDeploymentId(input: GetDeploymentIdInput): Promise<GetDeploymentIdOutput>;
+
+  /**
+   * Resolves the AES-256 key for a run.
+   *
+   * Local only, permanently: key material must never cross a transport
+   * boundary. It is modeled here so in-process implementations share one
+   * contract across languages, and every transport projection is expected to
+   * drop it. Absent support means encryption is disabled.
+   *
+   * Local only: never exposed over a transport.
+   */
+  getEncryptionKeyForRun(input: GetEncryptionKeyForRunInput): Promise<GetEncryptionKeyForRunOutput>;
+
+  /**
+   * Returns the environment this World's writes are attributed to.
+   *
+   * Must match the attribution the backend will actually apply. Callers use
+   * it to detect cross-environment mismatches, so a plausible-looking wrong
+   * value is worse than none.
+   *
+   * Local only: never exposed over a transport.
+   */
+  getEnvironment(input: GetEnvironmentInput): Promise<GetEnvironmentOutput>;
 
   /**
    * Reads one event.
@@ -209,6 +251,14 @@ export interface WorldCorePort {
    * Throws: ExpiredError, InternalError, RunNotFoundError, ThrottledError.
    */
   getRun(input: GetRunInput): Promise<GetRunOutput>;
+
+  /**
+   * Returns the wall-clock time at which the current invocation will be
+   * terminated by the hosting platform, when that is known.
+   *
+   * Local only: never exposed over a transport.
+   */
+  getRuntimeDeadline(input: GetRuntimeDeadlineInput): Promise<GetRuntimeDeadlineOutput>;
 
   /**
    * Reads one step.
@@ -324,62 +374,15 @@ export interface WorldCorePort {
    * StreamExpiredError, ThrottledError.
    */
   writeStreamChunk(input: WriteStreamChunkInput): Promise<WriteStreamChunkOutput>;
-}
-
-/**
- * Operations that are resolved in-process and never exposed over a
- * transport. See the `localOnly` trait.
- */
-export interface WorldLocalHooksPort {
-  /**
-   * Mints a new run ID.
-   *
-   * Returns the bare ULID; the core attaches the `wrun_` prefix.
-   * Implementations may embed world-specific metadata such as a region as
-   * long as the result stays a valid ULID.
-   *
-   * Local only: never exposed over a transport.
-   */
-  createRunId(input: CreateRunIdInput): Promise<CreateRunIdOutput>;
 
   /**
-   * Returns extra display fields for a run.
+   * Appends several chunks in order, in one request.
    *
-   * Called once per displayed run by tooling, so it must be cheap, pure, and
-   * non-throwing.
+   * An optional optimization. Callers fall back to repeated
+   * `WriteStreamChunk` calls when an implementation does not provide it.
    *
-   * Local only: never exposed over a transport.
+   * Optional capability: `writeStreamChunks`. Throws: ConflictError,
+   * InternalError, RunNotFoundError, StreamExpiredError, ThrottledError.
    */
-  describeRun(input: DescribeRunInput): Promise<DescribeRunOutput>;
-
-  /**
-   * Resolves the AES-256 key for a run.
-   *
-   * Local only, permanently: key material must never cross a transport
-   * boundary. It is modeled here so in-process implementations share one
-   * contract across languages, and every transport projection is expected to
-   * drop it. Absent support means encryption is disabled.
-   *
-   * Local only: never exposed over a transport.
-   */
-  getEncryptionKeyForRun(input: GetEncryptionKeyForRunInput): Promise<GetEncryptionKeyForRunOutput>;
-
-  /**
-   * Returns the environment this World's writes are attributed to.
-   *
-   * Must match the attribution the backend will actually apply. Callers use
-   * it to detect cross-environment mismatches, so a plausible-looking wrong
-   * value is worse than none.
-   *
-   * Local only: never exposed over a transport.
-   */
-  getEnvironment(input: GetEnvironmentInput): Promise<GetEnvironmentOutput>;
-
-  /**
-   * Returns the wall-clock time at which the current invocation will be
-   * terminated by the hosting platform, when that is known.
-   *
-   * Local only: never exposed over a transport.
-   */
-  getRuntimeDeadline(input: GetRuntimeDeadlineInput): Promise<GetRuntimeDeadlineOutput>;
+  writeStreamChunks?(input: WriteStreamChunksInput): Promise<WriteStreamChunksOutput>;
 }

--- a/idl/world/generated/typescript/schemas/schemas_0.ts
+++ b/idl/world/generated/typescript/schemas/schemas_0.ts
@@ -1,0 +1,1012 @@
+const _AC = "AttributeChange";
+const _ACL = "AttributeChangeList";
+const _ACO = "AlreadyCancelledOutcome";
+const _ACV = "AttributeChangeValue";
+const _ASE = "AttributesSetEvent";
+const _AW = "AttributeWriter";
+const _BCF = "BulkCancelFailure";
+const _BCO = "BulkCancelOutcome";
+const _BCR = "BulkCancelResult";
+const _BCRI = "BulkCancelRunsInput";
+const _BCRL = "BulkCancelResultList";
+const _BCRO = "BulkCancelRunsOutput";
+const _BCS = "BulkCancelSummary";
+const _BGRI = "BatchGetRunsInput";
+const _BGRO = "BatchGetRunsOutput";
+const _BRE = "BadRequestError";
+const _BS = "ByteStream";
+const _CE = "ConflictError";
+const _CEI = "CreateEventInput";
+const _CEO = "CreateEventOptions";
+const _CEr = "CreatableEvent";
+const _CO = "CancelledOutcome";
+const _CRI = "CreateRunInput";
+const _CRII = "CreateRunIdInput";
+const _CRIO = "CreateRunIdOutput";
+const _CSI = "CloseStreamInput";
+const _CSO = "CloseStreamOutput";
+const _DQMI = "DeliverQueueMessageInput";
+const _DQMO = "DeliverQueueMessageOutput";
+const _DRI = "DescribeRunInput";
+const _DRO = "DescribeRunOutput";
+const _E = "Event";
+const _EE = "ExpiredError";
+const _EI = "EnqueueInput";
+const _EK = "EncryptionKey";
+const _EL = "EventList";
+const _EMR = "EventMutationResult";
+const _ENFE = "EventNotFoundError";
+const _EO = "EnqueueOptions";
+const _EOn = "EnqueueOutput";
+const _EP = "EventPayload";
+const _GDII = "GetDeploymentIdInput";
+const _GDIO = "GetDeploymentIdOutput";
+const _GEI = "GetEnvironmentInput";
+const _GEIe = "GetEventInput";
+const _GEKFRI = "GetEncryptionKeyForRunInput";
+const _GEKFRO = "GetEncryptionKeyForRunOutput";
+const _GEO = "GetEnvironmentOutput";
+const _GEOe = "GetEventOutput";
+const _GHBTI = "GetHookByTokenInput";
+const _GHBTO = "GetHookByTokenOutput";
+const _GHI = "GetHookInput";
+const _GHO = "GetHookOutput";
+const _GRDI = "GetRuntimeDeadlineInput";
+const _GRDO = "GetRuntimeDeadlineOutput";
+const _GRI = "GetRunInput";
+const _GRO = "GetRunOutput";
+const _GSI = "GetStepInput";
+const _GSII = "GetStreamInfoInput";
+const _GSIO = "GetStreamInfoOutput";
+const _GSO = "GetStepOutput";
+const _GWII = "GetWorldInfoInput";
+const _GWIO = "GetWorldInfoOutput";
+const _H = "Hook";
+const _HCE = "HookConflictEvent";
+const _HCEo = "HookCreatedEvent";
+const _HDE = "HookDisposedEvent";
+const _HL = "HookList";
+const _HNFE = "HookNotFoundError";
+const _HRC = "HookResumeCapabilities";
+const _HRCo = "HookResumeContext";
+const _HRCoo = "HookRetentionCapability";
+const _HRE = "HookReceivedEvent";
+const _IE = "InternalError";
+const _LEBCII = "ListEventsByCorrelationIdInput";
+const _LEBCIO = "ListEventsByCorrelationIdOutput";
+const _LEI = "ListEventsInput";
+const _LEO = "ListEventsOutput";
+const _LHI = "ListHooksInput";
+const _LHO = "ListHooksOutput";
+const _LRI = "ListRunsInput";
+const _LRO = "ListRunsOutput";
+const _LSCI = "ListStreamChunksInput";
+const _LSCO = "ListStreamChunksOutput";
+const _LSI = "ListStepsInput";
+const _LSIi = "ListStreamsInput";
+const _LSO = "ListStepsOutput";
+const _LSOi = "ListStreamsOutput";
+const _NCO = "NotCancellableOutcome";
+const _P = "Pagination";
+const _PFE = "PreconditionFailedError";
+const _PI = "PageInfo";
+const _RA = "RemoveAttribute";
+const _RCE = "RunCancelledEvent";
+const _RCEu = "RunCompletedEvent";
+const _RCEun = "RunCreatedEvent";
+const _RD = "RetryDirective";
+const _RDF = "RunDisplayFields";
+const _RFE = "RunFailedEvent";
+const _RNFE = "RunNotFoundError";
+const _RNFO = "RunNotFoundOutcome";
+const _RSE = "RunStartedEvent";
+const _RSI = "ReadStreamInput";
+const _RSO = "ReadStreamOutput";
+const _S = "Step";
+const _SAW = "StepAttributeWriter";
+const _SC = "StreamChunk";
+const _SCE = "StepCompletedEvent";
+const _SCEt = "StepCreatedEvent";
+const _SCL = "StreamChunkList";
+const _SE = "StructuredError";
+const _SEE = "StreamExpiredError";
+const _SFE = "StepFailedEvent";
+const _SL = "StepList";
+const _SLT = "StepLatencyTelemetry";
+const _SNFE = "StepNotFoundError";
+const _SNFEt = "StreamNotFoundError";
+const _SRE = "StepRetryingEvent";
+const _SSE = "StepStartedEvent";
+const _SWRL = "SparseWorkflowRunList";
+const _TE = "ThrottledError";
+const _TEE = "TooEarlyError";
+const _W = "Wait";
+const _WAW = "WorkflowAttributeWriter";
+const _WC = "WorldCapabilities";
+const _WCE = "WaitCompletedEvent";
+const _WCEa = "WaitCreatedEvent";
+const _WR = "WorkflowRun";
+const _WRL = "WorkflowRunList";
+const _WSCI = "WriteStreamChunkInput";
+const _WSCIr = "WriteStreamChunksInput";
+const _WSCO = "WriteStreamChunkOutput";
+const _WSCOr = "WriteStreamChunksOutput";
+const _a = "attempt";
+const _aC = "alreadyCancelled";
+const _aRA = "allowReservedAttributes";
+const _aS = "attributesSet";
+const _ac = "active";
+const _at = "attributes";
+const _b = "body";
+const _c = "client";
+const _cA = "createdAt";
+const _cAo = "completedAt";
+const _cI = "correlationId";
+const _cII = "computeInstanceId";
+const _cLD = "currentLookbackDays";
+const _cR = "cancelReason";
+const _cRI = "conflictingRunId";
+const _cWS = "currentWindowStart";
+const _ca = "cancelled";
+const _cal = "callback";
+const _cap = "capabilities";
+const _ch = "change";
+const _cha = "changes";
+const _chu = "chunks";
+const _chun = "chunk";
+const _co = "code";
+const _con = "context";
+const _cu = "cursor";
+const _d = "deadline";
+const _dA = "deploymentAffinity";
+const _dI = "deploymentId";
+const _dS = "delaySeconds";
+const _da = "data";
+const _do = "done";
+const _e = "error";
+const _eA = "expiredAt";
+const _eC = "eventCount";
+const _eCr = "errorCode";
+const _eCx = "executionContext";
+const _eI = "eventId";
+const _ePK = "encryptionPublicKey";
+const _en = "environment";
+const _ev = "event";
+const _eve = "events";
+const _f = "failed";
+const _fSR = "finalSchedulingReplay";
+const _fi = "fields";
+const _h = "headers";
+const _hC = "hookCreated";
+const _hCo = "hookConflict";
+const _hD = "hookDisposed";
+const _hI = "hookId";
+const _hM = "hasMore";
+const _hR = "hookRetention";
+const _hRD = "hookResumeDedup";
+const _hRDV = "hookResumeDedupVersion";
+const _hRIV = "hookResumeInputVersion";
+const _hRo = "hookReceived";
+const _ho = "hook";
+const _hoo = "hooks";
+const _i = "input";
+const _iK = "idempotencyKey";
+const _iS = "isSystem";
+const _iW = "isWebhook";
+const _in = "index";
+const _k = "key";
+const _l = "limit";
+const _lO = "localOnly";
+const _m = "message";
+const _mC = "maxConcurrency";
+const _mE = "maxEvents";
+const _mI = "messageId";
+const _mLD = "maxLookbackDays";
+const _mWS = "maxWindowStart";
+const _me = "metadata";
+const _n = "name";
+const _nC = "notCancellable";
+const _nF = "notFound";
+const _na = "names";
+const _o = "outcome";
+const _oA = "occurredAt";
+const _oC = "optionalCapabilities";
+const _oCp = "optionalCapability";
+const _oI = "ownerId";
+const _oMI = "ownerMessageId";
+const _op = "options";
+const _opt = "optimizations";
+const _ou = "output";
+const _p = "payload";
+const _pE = "preloadEvents";
+const _pG = "preconditionGuard";
+const _pI = "projectId";
+const _pIa = "pageInfo";
+const _qN = "queueName";
+const _r = "runs";
+const _rA = "retryAfter";
+const _rAe = "resumeAt";
+const _rC = "resumeContext";
+const _rCe = "resumeCapabilities";
+const _rCu = "runCompleted";
+const _rCun = "runCancelled";
+const _rCunr = "runCreated";
+const _rD = "resolveData";
+const _rDC = "replayDivergenceCount";
+const _rF = "runFailed";
+const _rI = "runId";
+const _rIe = "resumeId";
+const _rIeq = "requestId";
+const _rIu = "runIds";
+const _rPD = "resumePayloadDigest";
+const _rS = "runStarted";
+const _rSV = "runSpecVersion";
+const _re = "retryable";
+const _reg = "region";
+const _rem = "remove";
+const _req = "requested";
+const _res = "results";
+const _resu = "result";
+const _ret = "retry";
+const _rs = "rsfs";
+const _ru = "run";
+const _s = "status";
+const _sA = "startedAt";
+const _sC = "sinceCursor";
+const _sCt = "stepCreated";
+const _sCte = "stepCount";
+const _sCtep = "stepCompleted";
+const _sEI = "slotEventIds";
+const _sF = "stepFailed";
+const _sI = "stepId";
+const _sIt = "startIndex";
+const _sN = "streamName";
+const _sNt = "stepName";
+const _sO = "sortOrder";
+const _sP = "skipPreload";
+const _sR = "stepRetrying";
+const _sS = "stepStarted";
+const _sV = "specVersion";
+const _se = "server";
+const _set = "set";
+const _sp = "sparse";
+const _st = "streaming";
+const _sta = "stack";
+const _ste = "step";
+const _step = "steps";
+const _sts = "stso";
+const _su = "summary";
+const _t = "token";
+const _tC = "traceCarrier";
+const _tI = "tailIndex";
+const _tRU = "tokenRetentionUntil";
+const _tS = "timeoutSeconds";
+const _te = "telemetry";
+const _tt = "ttfs";
+const _uA = "upgradeAvailable";
+const _uAp = "updatedAt";
+const _vC = "v1Compat";
+const _vSD = "viaStepDispatch";
+const _w = "writer";
+const _wC = "waitCreated";
+const _wCV = "workflowCoreVersion";
+const _wCa = "waitCompleted";
+const _wI = "waitId";
+const _wN = "workflowName";
+const _wa = "wait";
+const _wo = "workflow";
+const n0 = "vercel.workflow.world";
+
+// smithy-typescript generated code
+import { TypeRegistry } from "@smithy/core/schema";
+import type {
+  StaticErrorSchema,
+  StaticListSchema,
+  StaticMapSchema,
+  StaticSimpleSchema,
+  StaticStructureSchema,
+  StaticUnionSchema,
+} from "@smithy/types";
+
+import {
+  BadRequestError,
+  ConflictError,
+  EventNotFoundError,
+  ExpiredError,
+  HookNotFoundError,
+  InternalError,
+  PreconditionFailedError,
+  RunNotFoundError,
+  StepNotFoundError,
+  StreamExpiredError,
+  StreamNotFoundError,
+  ThrottledError,
+  TooEarlyError,
+} from "../models/errors";
+
+/* eslint no-var: 0 */
+const n0_registry = TypeRegistry.for(n0);
+export var BadRequestError$: StaticErrorSchema = [-3, n0, _BRE,
+  { [_e]: _c },
+  [_m, _co],
+  [0, 0], 1
+];
+n0_registry.registerError(BadRequestError$, BadRequestError);
+export var ConflictError$: StaticErrorSchema = [-3, n0, _CE,
+  { [_e]: _c },
+  [_m, _s],
+  [0, 0], 1
+];
+n0_registry.registerError(ConflictError$, ConflictError);
+export var EventNotFoundError$: StaticErrorSchema = [-3, n0, _ENFE,
+  { [_e]: _c },
+  [_m, _rI, _eI],
+  [0, 0, 0], 1
+];
+n0_registry.registerError(EventNotFoundError$, EventNotFoundError);
+export var ExpiredError$: StaticErrorSchema = [-3, n0, _EE,
+  { [_e]: _c },
+  [_m, _rI],
+  [0, 0], 1
+];
+n0_registry.registerError(ExpiredError$, ExpiredError);
+export var HookNotFoundError$: StaticErrorSchema = [-3, n0, _HNFE,
+  { [_e]: _c },
+  [_m, _hI],
+  [0, 0], 1
+];
+n0_registry.registerError(HookNotFoundError$, HookNotFoundError);
+export var InternalError$: StaticErrorSchema = [-3, n0, _IE,
+  { [_e]: _se },
+  [_m, _co],
+  [0, 0], 1
+];
+n0_registry.registerError(InternalError$, InternalError);
+export var PreconditionFailedError$: StaticErrorSchema = [-3, n0, _PFE,
+  { [_e]: _c },
+  [_m, _eC],
+  [0, 1], 1
+];
+n0_registry.registerError(PreconditionFailedError$, PreconditionFailedError);
+export var RunNotFoundError$: StaticErrorSchema = [-3, n0, _RNFE,
+  { [_e]: _c },
+  [_m, _rI],
+  [0, 0], 1
+];
+n0_registry.registerError(RunNotFoundError$, RunNotFoundError);
+export var StepNotFoundError$: StaticErrorSchema = [-3, n0, _SNFE,
+  { [_e]: _c },
+  [_m, _rI, _sI],
+  [0, 0, 0], 1
+];
+n0_registry.registerError(StepNotFoundError$, StepNotFoundError);
+export var StreamExpiredError$: StaticErrorSchema = [-3, n0, _SEE,
+  { [_e]: _c },
+  [_m, _rI, _sN],
+  [0, 0, 0], 1
+];
+n0_registry.registerError(StreamExpiredError$, StreamExpiredError);
+export var StreamNotFoundError$: StaticErrorSchema = [-3, n0, _SNFEt,
+  { [_e]: _c },
+  [_m, _rI, _sN],
+  [0, 0, 0], 1
+];
+n0_registry.registerError(StreamNotFoundError$, StreamNotFoundError);
+export var ThrottledError$: StaticErrorSchema = [-3, n0, _TE,
+  { [_e]: _c },
+  [_m, _rA],
+  [0, 4], 1
+];
+n0_registry.registerError(ThrottledError$, ThrottledError);
+export var TooEarlyError$: StaticErrorSchema = [-3, n0, _TEE,
+  { [_e]: _c },
+  [_m, _rA],
+  [0, 4], 1
+];
+n0_registry.registerError(TooEarlyError$, TooEarlyError);
+/**
+ * TypeRegistry instances containing modeled errors.
+ * @internal
+ *
+ */
+export const errorTypeRegistries = [
+  n0_registry,
+]
+var ByteStream: StaticSimpleSchema = [0, n0, _BS, { [_st]: 1 }, 42];
+var EncryptionKey: StaticSimpleSchema = [0, n0, _EK, 8, 21];
+var __Unit = "unit" as const;
+export var AlreadyCancelledOutcome$: StaticStructureSchema = [3, n0, _ACO,
+  0,
+  [],
+  []
+];
+export var AttributeChange$: StaticStructureSchema = [3, n0, _AC,
+  0,
+  [_k, _ch],
+  [0, () => AttributeChangeValue$], 2
+];
+export var AttributesSetEvent$: StaticStructureSchema = [3, n0, _ASE,
+  0,
+  [_cha, _w, _aRA],
+  [() => AttributeChangeList, () => AttributeWriter$, 2], 2
+];
+export var BatchGetRunsInput$: StaticStructureSchema = [3, n0, _BGRI,
+  0,
+  [_rIu, _rD],
+  [64 | 0, 0], 1
+];
+export var BatchGetRunsOutput$: StaticStructureSchema = [3, n0, _BGRO,
+  0,
+  [_r],
+  [[() => SparseWorkflowRunList, 0]], 1
+];
+export var BulkCancelFailure$: StaticStructureSchema = [3, n0, _BCF,
+  0,
+  [_co, _re],
+  [0, 2], 2
+];
+export var BulkCancelResult$: StaticStructureSchema = [3, n0, _BCR,
+  0,
+  [_rI, _o],
+  [0, () => BulkCancelOutcome$], 2
+];
+export var BulkCancelRunsInput$: StaticStructureSchema = [3, n0, _BCRI,
+  0,
+  [_rIu, _cR],
+  [64 | 0, 0], 1
+];
+export var BulkCancelRunsOutput$: StaticStructureSchema = [3, n0, _BCRO,
+  0,
+  [_su, _res],
+  [() => BulkCancelSummary$, () => BulkCancelResultList], 2
+];
+export var BulkCancelSummary$: StaticStructureSchema = [3, n0, _BCS,
+  0,
+  [_req, _ca, _aC, _nC, _nF, _f],
+  [1, 1, 1, 1, 1, 1], 6
+];
+export var callback$: StaticStructureSchema = [3, n0, _cal,
+  0,
+  [],
+  []
+];
+export var CancelledOutcome$: StaticStructureSchema = [3, n0, _CO,
+  0,
+  [],
+  []
+];
+export var CloseStreamInput$: StaticStructureSchema = [3, n0, _CSI,
+  0,
+  [_rI, _n],
+  [0, 0], 2
+];
+export var CloseStreamOutput$: StaticStructureSchema = [3, n0, _CSO,
+  0,
+  [],
+  []
+];
+export var CreateEventInput$: StaticStructureSchema = [3, n0, _CEI,
+  0,
+  [_rI, _ev, _op],
+  [0, () => CreatableEvent$, () => CreateEventOptions$], 2
+];
+export var CreateEventOptions$: StaticStructureSchema = [3, n0, _CEO,
+  0,
+  [_vC, _rD, _rIe, _rPD, _vSD, _rIeq, _cII, _eC, _oA, _rDC, _sC, _sP, _pE],
+  [2, 0, 0, 0, 2, 0, 0, 1, 4, 1, 0, 2, 2]
+];
+export var CreateRunIdInput$: StaticStructureSchema = [3, n0, _CRII,
+  0,
+  [_op],
+  [15]
+];
+export var CreateRunIdOutput$: StaticStructureSchema = [3, n0, _CRIO,
+  0,
+  [_rI],
+  [0], 1
+];
+export var CreateRunInput$: StaticStructureSchema = [3, n0, _CRI,
+  0,
+  [_ev, _rI, _op],
+  [() => RunCreatedEvent$, 0, () => CreateEventOptions$], 1
+];
+export var DeliverQueueMessageInput$: StaticStructureSchema = [3, n0, _DQMI,
+  0,
+  [_qN, _m, _a, _mI, _rIeq],
+  [0, 21, 1, 0, 0], 4
+];
+export var DeliverQueueMessageOutput$: StaticStructureSchema = [3, n0, _DQMO,
+  0,
+  [_ret],
+  [() => RetryDirective$]
+];
+export var DescribeRunInput$: StaticStructureSchema = [3, n0, _DRI,
+  0,
+  [_ru],
+  [15], 1
+];
+export var DescribeRunOutput$: StaticStructureSchema = [3, n0, _DRO,
+  0,
+  [_fi],
+  [[() => RunDisplayFields, 0]]
+];
+export var EnqueueInput$: StaticStructureSchema = [3, n0, _EI,
+  0,
+  [_qN, _m, _op],
+  [0, 21, () => EnqueueOptions$], 2
+];
+export var EnqueueOptions$: StaticStructureSchema = [3, n0, _EO,
+  0,
+  [_dI, _iK, _h, _dS, _sV, _reg],
+  [0, 0, 128 | 0, 1, 1, 0]
+];
+export var EnqueueOutput$: StaticStructureSchema = [3, n0, _EOn,
+  0,
+  [_mI],
+  [0]
+];
+export var Event$: StaticStructureSchema = [3, n0, _E,
+  0,
+  [_eI, _rI, _p, _cA, _cI, _sV, _oA, _rIe],
+  [0, 0, () => EventPayload$, 4, 0, 1, 4, 0], 4
+];
+export var EventMutationResult$: StaticStructureSchema = [3, n0, _EMR,
+  0,
+  [_ev, _ru, _ste, _ho, _wa, _sCt, _mE, _eve, _cu, _hM],
+  [() => Event$, () => WorkflowRun$, () => Step$, () => Hook$, () => Wait$, 2, 1, () => EventList, 0, 2]
+];
+export var GetDeploymentIdInput$: StaticStructureSchema = [3, n0, _GDII,
+  0,
+  [],
+  []
+];
+export var GetDeploymentIdOutput$: StaticStructureSchema = [3, n0, _GDIO,
+  0,
+  [_dI],
+  [0], 1
+];
+export var GetEncryptionKeyForRunInput$: StaticStructureSchema = [3, n0, _GEKFRI,
+  0,
+  [_rI, _con],
+  [0, 15], 1
+];
+export var GetEncryptionKeyForRunOutput$: StaticStructureSchema = [3, n0, _GEKFRO,
+  0,
+  [_k],
+  [[() => EncryptionKey, 0]]
+];
+export var GetEnvironmentInput$: StaticStructureSchema = [3, n0, _GEI,
+  0,
+  [],
+  []
+];
+export var GetEnvironmentOutput$: StaticStructureSchema = [3, n0, _GEO,
+  0,
+  [_en],
+  [0]
+];
+export var GetEventInput$: StaticStructureSchema = [3, n0, _GEIe,
+  0,
+  [_rI, _eI, _rD],
+  [0, 0, 0], 2
+];
+export var GetEventOutput$: StaticStructureSchema = [3, n0, _GEOe,
+  0,
+  [_ev],
+  [() => Event$], 1
+];
+export var GetHookByTokenInput$: StaticStructureSchema = [3, n0, _GHBTI,
+  0,
+  [_t, _rD],
+  [0, 0], 1
+];
+export var GetHookByTokenOutput$: StaticStructureSchema = [3, n0, _GHBTO,
+  0,
+  [_ho],
+  [() => Hook$], 1
+];
+export var GetHookInput$: StaticStructureSchema = [3, n0, _GHI,
+  0,
+  [_hI, _rI, _rD],
+  [0, 0, 0], 1
+];
+export var GetHookOutput$: StaticStructureSchema = [3, n0, _GHO,
+  0,
+  [_ho],
+  [() => Hook$], 1
+];
+export var GetRunInput$: StaticStructureSchema = [3, n0, _GRI,
+  0,
+  [_rI, _rD],
+  [0, 0], 1
+];
+export var GetRunOutput$: StaticStructureSchema = [3, n0, _GRO,
+  0,
+  [_ru],
+  [() => WorkflowRun$], 1
+];
+export var GetRuntimeDeadlineInput$: StaticStructureSchema = [3, n0, _GRDI,
+  0,
+  [],
+  []
+];
+export var GetRuntimeDeadlineOutput$: StaticStructureSchema = [3, n0, _GRDO,
+  0,
+  [_d],
+  [4]
+];
+export var GetStepInput$: StaticStructureSchema = [3, n0, _GSI,
+  0,
+  [_rI, _sI, _rD],
+  [0, 0, 0], 2
+];
+export var GetStepOutput$: StaticStructureSchema = [3, n0, _GSO,
+  0,
+  [_ste],
+  [() => Step$], 1
+];
+export var GetStreamInfoInput$: StaticStructureSchema = [3, n0, _GSII,
+  0,
+  [_rI, _n],
+  [0, 0], 2
+];
+export var GetStreamInfoOutput$: StaticStructureSchema = [3, n0, _GSIO,
+  0,
+  [_tI, _do],
+  [1, 2], 2
+];
+export var GetWorldInfoInput$: StaticStructureSchema = [3, n0, _GWII,
+  0,
+  [],
+  []
+];
+export var GetWorldInfoOutput$: StaticStructureSchema = [3, n0, _GWIO,
+  0,
+  [_sV, _cap, _oC],
+  [1, () => WorldCapabilities$, 64 | 0], 1
+];
+export var Hook$: StaticStructureSchema = [3, n0, _H,
+  0,
+  [_rI, _hI, _t, _oI, _pI, _en, _cA, _me, _sV, _iW, _iS, _tRU, _rC, _rCe],
+  [0, 0, 0, 0, 0, 0, 4, 21, 1, 2, 2, 4, () => HookResumeContext$, () => HookResumeCapabilities$], 7
+];
+export var HookConflictEvent$: StaticStructureSchema = [3, n0, _HCE,
+  0,
+  [_t, _cRI],
+  [0, 0], 1
+];
+export var HookCreatedEvent$: StaticStructureSchema = [3, n0, _HCEo,
+  0,
+  [_t, _tRU, _me, _iW, _iS],
+  [0, 4, 21, 2, 2], 1
+];
+export var HookDisposedEvent$: StaticStructureSchema = [3, n0, _HDE,
+  0,
+  [_t],
+  [0]
+];
+export var HookReceivedEvent$: StaticStructureSchema = [3, n0, _HRE,
+  0,
+  [_p, _t],
+  [21, 0], 1
+];
+export var HookResumeCapabilities$: StaticStructureSchema = [3, n0, _HRC,
+  0,
+  [_hRDV],
+  [1], 1
+];
+export var HookResumeContext$: StaticStructureSchema = [3, n0, _HRCo,
+  0,
+  [_dI, _wN, _rSV, _wCV, _tC, _ePK, _hRIV],
+  [0, 0, 1, 0, 128 | 0, 0, 1], 2
+];
+export var HookRetentionCapability$: StaticStructureSchema = [3, n0, _HRCoo,
+  0,
+  [_ac],
+  [2], 1
+];
+export var ListEventsByCorrelationIdInput$: StaticStructureSchema = [3, n0, _LEBCII,
+  0,
+  [_rI, _cI, _rD, _l, _cu, _sO],
+  [0, 0, 0, 1, 0, 0], 2
+];
+export var ListEventsByCorrelationIdOutput$: StaticStructureSchema = [3, n0, _LEBCIO,
+  0,
+  [_eve, _hM, _cu],
+  [() => EventList, 2, 0], 2
+];
+export var ListEventsInput$: StaticStructureSchema = [3, n0, _LEI,
+  0,
+  [_rI, _rD, _l, _cu, _sO],
+  [0, 0, 1, 0, 0], 1
+];
+export var ListEventsOutput$: StaticStructureSchema = [3, n0, _LEO,
+  0,
+  [_eve, _hM, _cu],
+  [() => EventList, 2, 0], 2
+];
+export var ListHooksInput$: StaticStructureSchema = [3, n0, _LHI,
+  0,
+  [_rI, _rD, _l, _cu, _sO],
+  [0, 0, 1, 0, 0]
+];
+export var ListHooksOutput$: StaticStructureSchema = [3, n0, _LHO,
+  0,
+  [_hoo, _hM, _cu],
+  [() => HookList, 2, 0], 2
+];
+export var ListRunsInput$: StaticStructureSchema = [3, n0, _LRI,
+  0,
+  [_wN, _s, _rD, _l, _cu, _sO],
+  [0, 0, 0, 1, 0, 0]
+];
+export var ListRunsOutput$: StaticStructureSchema = [3, n0, _LRO,
+  0,
+  [_r, _hM, _cu, _pIa],
+  [() => WorkflowRunList, 2, 0, () => PageInfo$], 2
+];
+export var ListStepsInput$: StaticStructureSchema = [3, n0, _LSI,
+  0,
+  [_rI, _rD, _l, _cu, _sO],
+  [0, 0, 1, 0, 0], 1
+];
+export var ListStepsOutput$: StaticStructureSchema = [3, n0, _LSO,
+  0,
+  [_step, _hM, _cu],
+  [() => StepList, 2, 0], 2
+];
+export var ListStreamChunksInput$: StaticStructureSchema = [3, n0, _LSCI,
+  0,
+  [_rI, _n, _l, _cu],
+  [0, 0, 1, 0], 2
+];
+export var ListStreamChunksOutput$: StaticStructureSchema = [3, n0, _LSCO,
+  0,
+  [_chu, _hM, _do, _cu],
+  [() => StreamChunkList, 2, 2, 0], 3
+];
+export var ListStreamsInput$: StaticStructureSchema = [3, n0, _LSIi,
+  0,
+  [_rI],
+  [0], 1
+];
+export var ListStreamsOutput$: StaticStructureSchema = [3, n0, _LSOi,
+  0,
+  [_na],
+  [64 | 0], 1
+];
+export var localOnly$: StaticStructureSchema = [3, n0, _lO,
+  0,
+  [],
+  []
+];
+export var NotCancellableOutcome$: StaticStructureSchema = [3, n0, _NCO,
+  0,
+  [_s],
+  [0], 1
+];
+export var optionalCapability$: StaticStructureSchema = [3, n0, _oCp,
+  0,
+  [_n],
+  [0], 1
+];
+export var PageInfo$: StaticStructureSchema = [3, n0, _PI,
+  0,
+  [_cLD, _mLD, _cWS, _mWS, _uA],
+  [1, 1, 4, 4, 2], 5
+];
+export var Pagination$: StaticStructureSchema = [3, n0, _P,
+  0,
+  [_l, _cu, _sO],
+  [1, 0, 0]
+];
+export var ReadStreamInput$: StaticStructureSchema = [3, n0, _RSI,
+  0,
+  [_rI, _n, _sIt],
+  [0, 0, 1], 2
+];
+export var ReadStreamOutput$: StaticStructureSchema = [3, n0, _RSO,
+  0,
+  [_b],
+  [[() => ByteStream, 0]], 1
+];
+export var RemoveAttribute$: StaticStructureSchema = [3, n0, _RA,
+  0,
+  [],
+  []
+];
+export var RetryDirective$: StaticStructureSchema = [3, n0, _RD,
+  0,
+  [_tS],
+  [1], 1
+];
+export var RunCancelledEvent$: StaticStructureSchema = [3, n0, _RCE,
+  0,
+  [_cR],
+  [0]
+];
+export var RunCompletedEvent$: StaticStructureSchema = [3, n0, _RCEu,
+  0,
+  [_ou],
+  [21]
+];
+export var RunCreatedEvent$: StaticStructureSchema = [3, n0, _RCEun,
+  0,
+  [_dI, _wN, _i, _eCx, _at, _aRA, _ePK],
+  [0, 0, 21, 15, 128 | 0, 2, 0], 3
+];
+export var RunFailedEvent$: StaticStructureSchema = [3, n0, _RFE,
+  0,
+  [_e, _eCr],
+  [21, 0], 1
+];
+export var RunNotFoundOutcome$: StaticStructureSchema = [3, n0, _RNFO,
+  0,
+  [],
+  []
+];
+export var RunStartedEvent$: StaticStructureSchema = [3, n0, _RSE,
+  0,
+  [_i, _dI, _wN, _eCx, _at, _aRA, _ePK],
+  [21, 0, 0, 15, 128 | 0, 2, 0]
+];
+export var Step$: StaticStructureSchema = [3, n0, _S,
+  0,
+  [_rI, _sI, _sNt, _s, _a, _cA, _uAp, _i, _ou, _e, _sA, _cAo, _rA, _sV],
+  [0, 0, 0, 0, 1, 4, 4, 21, 21, 21, 4, 4, 4, 1], 7
+];
+export var StepAttributeWriter$: StaticStructureSchema = [3, n0, _SAW,
+  0,
+  [_sI, _a],
+  [0, 1], 2
+];
+export var StepCompletedEvent$: StaticStructureSchema = [3, n0, _SCE,
+  0,
+  [_resu, _sNt, _wN, _te],
+  [21, 0, 0, () => StepLatencyTelemetry$], 1
+];
+export var StepCreatedEvent$: StaticStructureSchema = [3, n0, _SCEt,
+  0,
+  [_sNt, _i, _wN],
+  [0, 21, 0], 2
+];
+export var StepFailedEvent$: StaticStructureSchema = [3, n0, _SFE,
+  0,
+  [_e, _sNt, _te],
+  [21, 0, () => StepLatencyTelemetry$], 1
+];
+export var StepLatencyTelemetry$: StaticStructureSchema = [3, n0, _SLT,
+  0,
+  [_tt, _sts, _sCte, _eC, _rs, _fSR, _opt],
+  [1, 1, 1, 1, 1, 1, 64 | 0]
+];
+export var StepRetryingEvent$: StaticStructureSchema = [3, n0, _SRE,
+  0,
+  [_e, _sNt, _rA],
+  [21, 0, 4], 1
+];
+export var StepStartedEvent$: StaticStructureSchema = [3, n0, _SSE,
+  0,
+  [_sNt, _a, _wN, _i, _oMI],
+  [0, 1, 0, 21, 0]
+];
+export var StreamChunk$: StaticStructureSchema = [3, n0, _SC,
+  0,
+  [_in, _da],
+  [1, 21], 2
+];
+export var StructuredError$: StaticStructureSchema = [3, n0, _SE,
+  0,
+  [_m, _sta, _co],
+  [0, 0, 0], 1
+];
+export var Wait$: StaticStructureSchema = [3, n0, _W,
+  0,
+  [_rI, _wI, _rAe, _cA, _cAo],
+  [0, 0, 4, 4, 4], 4
+];
+export var WaitCompletedEvent$: StaticStructureSchema = [3, n0, _WCE,
+  0,
+  [_rAe],
+  [4]
+];
+export var WaitCreatedEvent$: StaticStructureSchema = [3, n0, _WCEa,
+  0,
+  [_rAe],
+  [4], 1
+];
+export var WorkflowAttributeWriter$: StaticStructureSchema = [3, n0, _WAW,
+  0,
+  [],
+  []
+];
+export var WorkflowRun$: StaticStructureSchema = [3, n0, _WR,
+  0,
+  [_rI, _s, _dI, _wN, _at, _cA, _uAp, _sV, _eCx, _i, _ou, _e, _eCr, _ePK, _eA, _sA, _cAo],
+  [0, 0, 0, 0, 128 | 0, 4, 4, 1, 15, 21, 21, 21, 0, 0, 4, 4, 4], 7
+];
+export var WorldCapabilities$: StaticStructureSchema = [3, n0, _WC,
+  0,
+  [_hR, _pG, _mC, _hRD, _dA, _sEI],
+  [() => HookRetentionCapability$, 2, 2, 2, 2, 2]
+];
+export var WriteStreamChunkInput$: StaticStructureSchema = [3, n0, _WSCI,
+  0,
+  [_rI, _n, _chun],
+  [0, 0, 21], 3
+];
+export var WriteStreamChunkOutput$: StaticStructureSchema = [3, n0, _WSCO,
+  0,
+  [],
+  []
+];
+export var WriteStreamChunksInput$: StaticStructureSchema = [3, n0, _WSCIr,
+  0,
+  [_rI, _n, _chu],
+  [0, 0, 64 | 21], 3
+];
+export var WriteStreamChunksOutput$: StaticStructureSchema = [3, n0, _WSCOr,
+  0,
+  [],
+  []
+];
+var AttributeChangeList: StaticListSchema = [1, n0, _ACL,
+  0, () => AttributeChange$
+];
+var BulkCancelResultList: StaticListSchema = [1, n0, _BCRL,
+  0, () => BulkCancelResult$
+];
+var CapabilityNameList = 64 | 0;
+var ChunkDataList = 64 | 21;
+var EventList: StaticListSchema = [1, n0, _EL,
+  0, () => Event$
+];
+var HookList: StaticListSchema = [1, n0, _HL,
+  0, () => Hook$
+];
+var RunIdList = 64 | 0;
+var SparseWorkflowRunList: StaticListSchema = [1, n0, _SWRL,
+  { [_sp]: 1 }, () => WorkflowRun$
+];
+var StepList: StaticListSchema = [1, n0, _SL,
+  0, () => Step$
+];
+var StreamChunkList: StaticListSchema = [1, n0, _SCL,
+  0, () => StreamChunk$
+];
+var StreamNameList = 64 | 0;
+var StringList = 64 | 0;
+var WorkflowRunList: StaticListSchema = [1, n0, _WRL,
+  0, () => WorkflowRun$
+];
+var AttributeMap = 128 | 0;
+var QueueHeaders = 128 | 0;
+var RunDisplayFields: StaticMapSchema = [2, n0, _RDF,
+  { [_sp]: 1 }, 0, 0
+];
+var TraceCarrier = 128 | 0;
+export var AttributeChangeValue$: StaticUnionSchema = [4, n0, _ACV,
+  0,
+  [_set, _rem],
+  [0, () => RemoveAttribute$]
+];
+export var AttributeWriter$: StaticUnionSchema = [4, n0, _AW,
+  0,
+  [_wo, _ste],
+  [() => WorkflowAttributeWriter$, () => StepAttributeWriter$]
+];
+export var BulkCancelOutcome$: StaticUnionSchema = [4, n0, _BCO,
+  0,
+  [_ca, _aC, _nC, _nF, _f],
+  [() => CancelledOutcome$, () => AlreadyCancelledOutcome$, () => NotCancellableOutcome$, () => RunNotFoundOutcome$, () => BulkCancelFailure$]
+];
+export var CreatableEvent$: StaticUnionSchema = [4, n0, _CEr,
+  0,
+  [_rS, _rCu, _rF, _rCun, _aS, _sCt, _sS, _sCtep, _sF, _sR, _hC, _hRo, _hD, _wC, _wCa],
+  [() => RunStartedEvent$, () => RunCompletedEvent$, () => RunFailedEvent$, () => RunCancelledEvent$, () => AttributesSetEvent$, () => StepCreatedEvent$, () => StepStartedEvent$, () => StepCompletedEvent$, () => StepFailedEvent$, () => StepRetryingEvent$, () => HookCreatedEvent$, () => HookReceivedEvent$, () => HookDisposedEvent$, () => WaitCreatedEvent$, () => WaitCompletedEvent$]
+];
+export var EventPayload$: StaticUnionSchema = [4, n0, _EP,
+  0,
+  [_rCunr, _rS, _rCu, _rF, _rCun, _aS, _sCt, _sS, _sCtep, _sF, _sR, _hC, _hRo, _hD, _hCo, _wC, _wCa],
+  [() => RunCreatedEvent$, () => RunStartedEvent$, () => RunCompletedEvent$, () => RunFailedEvent$, () => RunCancelledEvent$, () => AttributesSetEvent$, () => StepCreatedEvent$, () => StepStartedEvent$, () => StepCompletedEvent$, () => StepFailedEvent$, () => StepRetryingEvent$, () => HookCreatedEvent$, () => HookReceivedEvent$, () => HookDisposedEvent$, () => HookConflictEvent$, () => WaitCreatedEvent$, () => WaitCompletedEvent$]
+];

--- a/idl/world/model/common.smithy
+++ b/idl/world/model/common.smithy
@@ -1,0 +1,139 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// Identifier of a workflow run.
+string RunId
+
+/// Identifier of a step within a run.
+string StepId
+
+/// Identifier of an event within a run's log.
+string EventId
+
+/// Identifier of a hook.
+string HookId
+
+/// Identifier of a wait.
+string WaitId
+
+/// Identifier of a deployment a run is pinned to.
+string DeploymentId
+
+/// Machine-readable workflow function name, e.g.
+/// `workflow//./src/workflows/order//processOrder`.
+string WorkflowName
+
+/// Machine-readable step function name.
+string StepName
+
+/// Name of a stream within a run.
+string StreamName
+
+/// Opaque, implementation-defined pagination cursor.
+string Cursor
+
+/// Correlation identifier tying an event to the entity it affects.
+string CorrelationId
+
+/// Opaque serialized workflow data.
+///
+/// Payload bytes are produced by the SDK serialization pipeline and may be
+/// compressed and/or encrypted. The World never interprets them. Runs created
+/// by spec version 1 carried unserialized JSON instead; those records are not
+/// representable here and must be converted by a compatibility adapter.
+blob SerializedData
+
+/// Controls whether payload-bearing fields are resolved in a response.
+///
+/// Smithy cannot vary an output shape by an input value, so payload members
+/// stay optional and `NONE` simply leaves them absent.
+enum ResolveData {
+    /// Omit payload fields such as input, output, error, and metadata.
+    NONE = "none"
+
+    /// Resolve all payload fields.
+    ALL = "all"
+}
+
+/// Sort direction for list operations, ordered by creation time.
+enum SortOrder {
+    ASC = "asc"
+    DESC = "desc"
+}
+
+/// Cursor pagination request options.
+structure Pagination {
+    /// Maximum number of items to return.
+    @range(min: 1, max: 1000)
+    limit: Integer
+
+    /// Cursor returned by a previous page.
+    cursor: Cursor
+
+    /// Sort direction. Callers that depend on ordering should always set it.
+    sortOrder: SortOrder
+}
+
+/// Retention window metadata returned by plan-aware list operations.
+structure PageInfo {
+    @required
+    currentLookbackDays: Integer
+
+    @required
+    maxLookbackDays: Integer
+
+    @required
+    currentWindowStart: Timestamp
+
+    @required
+    maxWindowStart: Timestamp
+
+    @required
+    upgradeAvailable: Boolean
+}
+
+/// Plaintext run attributes.
+map AttributeMap {
+    key: String
+    value: String
+}
+
+/// A single attribute mutation. Keys absent from a change set are untouched.
+structure AttributeChange {
+    @required
+    key: String
+
+    @required
+    change: AttributeChangeValue
+}
+
+/// Upsert or removal of one attribute key.
+union AttributeChangeValue {
+    /// Upsert the key with this value.
+    set: String
+
+    /// Remove the key.
+    remove: RemoveAttribute
+}
+
+/// Removal of an attribute key.
+///
+/// An empty structure rather than `Unit` so the variant can gain members
+/// later without a breaking change.
+structure RemoveAttribute {}
+
+list AttributeChangeList {
+    member: AttributeChange
+}
+
+/// Structured error metadata carried by run and step failures.
+structure StructuredError {
+    @required
+    message: String
+
+    stack: String
+
+    /// Machine-readable error code, e.g. `USER_ERROR` or `RUNTIME_ERROR`.
+    code: String
+}

--- a/idl/world/model/errors.smithy
+++ b/idl/world/model/errors.smithy
@@ -1,0 +1,142 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// The request was malformed or violated a validation rule.
+@error("client")
+structure BadRequestError {
+    @required
+    message: String
+
+    code: String
+}
+
+/// No run exists for the requested ID.
+@error("client")
+structure RunNotFoundError {
+    @required
+    message: String
+
+    runId: RunId
+}
+
+/// No step exists for the requested ID.
+@error("client")
+structure StepNotFoundError {
+    @required
+    message: String
+
+    runId: RunId
+
+    stepId: StepId
+}
+
+/// No event exists for the requested ID.
+@error("client")
+structure EventNotFoundError {
+    @required
+    message: String
+
+    runId: RunId
+
+    eventId: EventId
+}
+
+/// No hook exists for the requested ID or token.
+@error("client")
+structure HookNotFoundError {
+    @required
+    message: String
+
+    hookId: HookId
+}
+
+/// No stream exists for the requested run and name.
+@error("client")
+structure StreamNotFoundError {
+    @required
+    message: String
+
+    runId: RunId
+
+    streamName: StreamName
+}
+
+/// The entity already exists, or its current state forbids this write.
+///
+/// The runtime commonly reads this as "another writer won the race" rather
+/// than as a hard failure.
+@error("client")
+structure ConflictError {
+    @required
+    message: String
+
+    /// Observed status of the entity, when the implementation reports one.
+    status: String
+}
+
+/// The run is gone: it passed its retention window or was otherwise expired.
+@error("client")
+structure ExpiredError {
+    @required
+    message: String
+
+    runId: RunId
+}
+
+/// The stream is gone: it passed its retention window.
+@error("client")
+structure StreamExpiredError {
+    @required
+    message: String
+
+    runId: RunId
+
+    streamName: StreamName
+}
+
+/// A replay-context write was fenced because its snapshot is behind the run's
+/// recorded log.
+///
+/// Only implementations that advertise the `preconditionGuard` capability
+/// raise this. It is unrelated to slot allocation: a slot-numbering World
+/// bumps to the next free slot and reports the events it skipped instead of
+/// rejecting the write.
+@error("client")
+structure PreconditionFailedError {
+    @required
+    message: String
+
+    /// Number of events the World held when it rejected the write.
+    eventCount: Integer
+}
+
+/// The operation was attempted before its earliest valid time.
+@error("client")
+structure TooEarlyError {
+    @required
+    message: String
+
+    /// Earliest time at which the operation may be retried.
+    retryAfter: Timestamp
+}
+
+/// The caller is being throttled, or lost a contention retry budget.
+@error("client")
+@retryable(throttling: true)
+structure ThrottledError {
+    @required
+    message: String
+
+    retryAfter: Timestamp
+}
+
+/// The implementation failed for a reason the caller cannot correct.
+@error("server")
+@retryable
+structure InternalError {
+    @required
+    message: String
+
+    code: String
+}

--- a/idl/world/model/events.smithy
+++ b/idl/world/model/events.smithy
@@ -1,0 +1,581 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// Client-measured latency telemetry carried on a step's terminal event.
+///
+/// Populated only on the terminal event of a qualifying first-attempt step
+/// execution. Implementations may consume these for metrics and are never
+/// required to persist them.
+structure StepLatencyTelemetry {
+    /// Milliseconds from run creation until the run's first step body began.
+    ttfs: Integer
+
+    /// Milliseconds between the previous step's terminal event and this
+    /// step's body beginning.
+    stso: Integer
+
+    /// Step count when the step-to-step gap began.
+    stepCount: Integer
+
+    /// Event count when the step-to-step gap began.
+    eventCount: Integer
+
+    /// Milliseconds from `run_started` landing until this step's start was
+    /// issued. A sub-window of `ttfs`.
+    rsfs: Integer
+
+    /// Synchronous replay duration of the final scheduling pass within the
+    /// `rsfs` window.
+    finalSchedulingReplay: Integer
+
+    /// Names of the runtime startup optimizations active for this
+    /// measurement, e.g. `turbo` or `lazyStepStart`.
+    optimizations: StringList
+}
+
+list StringList {
+    member: String
+}
+
+/// Starts a new run. Materializes the run entity with status `pending`.
+structure RunCreatedEvent {
+    @required
+    deploymentId: DeploymentId
+
+    @required
+    workflowName: WorkflowName
+
+    @required
+    input: SerializedData
+
+    executionContext: Document
+
+    attributes: AttributeMap
+
+    allowReservedAttributes: Boolean
+
+    /// Base64 X25519 public key, stamped by SDKs that support sealed
+    /// envelopes.
+    encryptionPublicKey: String
+}
+
+/// Transitions a run to `running`.
+///
+/// The optional creation fields carry the resilient-start path: when the
+/// `run_created` write did not commit, the implementation creates the run
+/// from this event instead.
+structure RunStartedEvent {
+    input: SerializedData
+
+    deploymentId: DeploymentId
+
+    workflowName: WorkflowName
+
+    executionContext: Document
+
+    attributes: AttributeMap
+
+    allowReservedAttributes: Boolean
+
+    encryptionPublicKey: String
+}
+
+/// Transitions a run to `completed`.
+structure RunCompletedEvent {
+    output: SerializedData
+}
+
+/// Transitions a run to `failed`.
+structure RunFailedEvent {
+    @required
+    error: SerializedData
+
+    /// Plaintext failure category kept readable without decryption.
+    errorCode: String
+}
+
+/// Transitions a run to `cancelled`.
+structure RunCancelledEvent {
+    @length(max: 512)
+    cancelReason: String
+}
+
+/// Identifies which writer produced an attribute change.
+union AttributeWriter {
+    workflow: WorkflowAttributeWriter
+    step: StepAttributeWriter
+}
+
+/// The workflow function itself wrote the attributes.
+structure WorkflowAttributeWriter {}
+
+structure StepAttributeWriter {
+    @required
+    stepId: StepId
+
+    @required
+    attempt: Integer
+}
+
+/// Merges plaintext attribute changes into the run.
+structure AttributesSetEvent {
+    @required
+    changes: AttributeChangeList
+
+    @required
+    writer: AttributeWriter
+
+    /// Permits keys in the reserved `$` namespace. Framework callers only.
+    allowReservedAttributes: Boolean
+}
+
+/// Creates a step entity.
+structure StepCreatedEvent {
+    @required
+    stepName: StepName
+
+    /// Carried so a backend keying payload refs by workflow name avoids a run
+    /// lookup on this hot write.
+    workflowName: WorkflowName
+
+    @required
+    input: SerializedData
+}
+
+/// Begins a step attempt, transitioning the step to `running`.
+///
+/// When `stepName` and `input` are present, this is the lazy-start path: the
+/// implementation atomically creates the step (writing a synthetic
+/// `step_created` so replay still observes it) before starting it. Without
+/// `input`, a prior `step_created` is required.
+structure StepStartedEvent {
+    stepName: StepName
+
+    attempt: Integer
+
+    workflowName: WorkflowName
+
+    input: SerializedData
+
+    /// Queue message ID of the invocation executing this step inline. Doubles
+    /// as the ownership liveness lease, so it requires a queue whose message
+    /// ID is stable across redeliveries.
+    ownerMessageId: String
+}
+
+/// Completes a step successfully.
+structure StepCompletedEvent {
+    stepName: StepName
+
+    workflowName: WorkflowName
+
+    @required
+    result: SerializedData
+
+    telemetry: StepLatencyTelemetry
+}
+
+/// Fails a step terminally.
+structure StepFailedEvent {
+    stepName: StepName
+
+    @required
+    error: SerializedData
+
+    telemetry: StepLatencyTelemetry
+}
+
+/// Returns a failed step to `pending` for another attempt.
+structure StepRetryingEvent {
+    stepName: StepName
+
+    @required
+    error: SerializedData
+
+    retryAfter: Timestamp
+}
+
+/// Creates a hook and claims its token.
+structure HookCreatedEvent {
+    @required
+    token: String
+
+    /// Requests minimum token retention past the run's end. Requires the
+    /// `hookRetention` capability.
+    tokenRetentionUntil: Timestamp
+
+    metadata: SerializedData
+
+    isWebhook: Boolean
+
+    isSystem: Boolean
+}
+
+/// Delivers a payload to an active hook.
+structure HookReceivedEvent {
+    token: String
+
+    @required
+    payload: SerializedData
+}
+
+/// Disposes a hook and releases its token immediately.
+structure HookDisposedEvent {
+    token: String
+}
+
+/// Records that a `hook_created` lost a token race.
+///
+/// Implementations write this; callers cannot. Consumers reject the awaited
+/// hook with a token-conflict error.
+structure HookConflictEvent {
+    @required
+    token: String
+
+    /// Run that currently owns the token.
+    conflictingRunId: RunId
+}
+
+/// Creates a wait that resumes at a wall-clock time.
+structure WaitCreatedEvent {
+    @required
+    resumeAt: Timestamp
+}
+
+/// Completes a wait. Intended to be atomic and exactly once.
+structure WaitCompletedEvent {
+    resumeAt: Timestamp
+}
+
+/// Every event a caller may write to an existing run.
+///
+/// `run_created` is absent because it creates the run and is modeled as
+/// `CreateRun`. `hook_conflict` is absent because only implementations
+/// produce it.
+union CreatableEvent {
+    runStarted: RunStartedEvent
+    runCompleted: RunCompletedEvent
+    runFailed: RunFailedEvent
+    runCancelled: RunCancelledEvent
+    attributesSet: AttributesSetEvent
+    stepCreated: StepCreatedEvent
+    stepStarted: StepStartedEvent
+    stepCompleted: StepCompletedEvent
+    stepFailed: StepFailedEvent
+    stepRetrying: StepRetryingEvent
+    hookCreated: HookCreatedEvent
+    hookReceived: HookReceivedEvent
+    hookDisposed: HookDisposedEvent
+    waitCreated: WaitCreatedEvent
+    waitCompleted: WaitCompletedEvent
+}
+
+/// Every event readable from a run's log.
+union EventPayload {
+    runCreated: RunCreatedEvent
+    runStarted: RunStartedEvent
+    runCompleted: RunCompletedEvent
+    runFailed: RunFailedEvent
+    runCancelled: RunCancelledEvent
+    attributesSet: AttributesSetEvent
+    stepCreated: StepCreatedEvent
+    stepStarted: StepStartedEvent
+    stepCompleted: StepCompletedEvent
+    stepFailed: StepFailedEvent
+    stepRetrying: StepRetryingEvent
+    hookCreated: HookCreatedEvent
+    hookReceived: HookReceivedEvent
+    hookDisposed: HookDisposedEvent
+    hookConflict: HookConflictEvent
+    waitCreated: WaitCreatedEvent
+    waitCompleted: WaitCompletedEvent
+}
+
+/// One committed entry in a run's event log.
+structure Event {
+    @required
+    eventId: EventId
+
+    @required
+    runId: RunId
+
+    /// Entity this event affects. Absent on run-level events.
+    correlationId: CorrelationId
+
+    @required
+    payload: EventPayload
+
+    specVersion: Integer
+
+    /// When the implementation accepted the event.
+    @required
+    createdAt: Timestamp
+
+    /// When the client observed the event, when it reported one.
+    occurredAt: Timestamp
+
+    /// Idempotency key persisted on a lazy `hook_received`.
+    resumeId: String
+}
+
+list EventList {
+    member: Event
+}
+
+/// Advisory and idempotency parameters for an event write.
+///
+/// Everything here is optional. An implementation that ignores all of it
+/// stays correct; the runtime falls back to explicit reads.
+structure CreateEventOptions {
+    /// Legacy spec-version-1 compatibility mode.
+    v1Compat: Boolean
+
+    resolveData: ResolveData
+
+    /// Lazy hook resume idempotency key. The implementation routes it to a
+    /// `(runId, resumeId)` constraint so a producer's direct write and the
+    /// queue consumer's re-ensure converge on exactly one event. Only
+    /// meaningful for `hookReceived`.
+    resumeId: String
+
+    /// Digest of the serialized resume payload, sent identically by both
+    /// writers of a deduplicated resume.
+    resumePayloadDigest: String
+
+    /// Marks a `stepCreated` write as the queue consumer's re-ensure of a
+    /// resilient step dispatch.
+    viaStepDispatch: Boolean
+
+    /// Platform request ID, for correlating logs with events.
+    requestId: String
+
+    /// Compute instance whose handler is writing this event.
+    computeInstanceId: String
+
+    /// How many events the writer held when it decided to write this one.
+    ///
+    /// Only meaningful against an implementation advertising `slotEventIds`,
+    /// where slots are dense and 1-based. Contention never rejects the write:
+    /// the implementation bumps to the next free slot, commits, and returns
+    /// the skipped events on the response. Understating is safe; overstating
+    /// hides events from the writer.
+    eventCount: Integer
+
+    /// Client-side occurrence time, stored separately from the accept time.
+    occurredAt: Timestamp
+
+    /// Telemetry only: consecutive replay divergences resolved by this write.
+    /// Never persisted into the log.
+    replayDivergenceCount: Integer
+
+    /// Inline-delta opt-in. The implementation may return the events written
+    /// strictly after this cursor, matching `ListEvents` semantics.
+    sinceCursor: Cursor
+
+    /// Asks the implementation to skip the `runStarted` preload it would
+    /// otherwise compute. Honored only for `runStarted`.
+    skipPreload: Boolean
+
+    /// Asks for the run's full replay log alongside a `hookReceived`
+    /// re-ensure. The runtime trusts it only when the log is complete,
+    /// `hasMore` is false, and the run and event ceiling are present.
+    preloadEvents: Boolean
+}
+
+/// Result of an event write.
+///
+/// The event and the entity it affects are materialized atomically. The
+/// delta members are populated when the caller opted into an inline delta or
+/// preload, and by a slot-numbering implementation reporting the slots it
+/// bumped past.
+structure EventMutationResult {
+    /// The committed event. Absent only for legacy runs that skip event
+    /// storage.
+    event: Event
+
+    run: WorkflowRun
+
+    step: Step
+
+    hook: Hook
+
+    wait: Wait
+
+    /// True only when a lazy `stepStarted` created the step on this call.
+    /// The caller that sees it owns inline execution of that step.
+    stepCreated: Boolean
+
+    /// Server-owned event ceiling for the run, enforced by the runtime.
+    maxEvents: Integer
+
+    /// Events the caller had not seen, in log order.
+    events: EventList
+
+    /// Cursor past the last returned event.
+    cursor: Cursor
+
+    /// Whether more event pages follow `events`.
+    hasMore: Boolean
+}
+
+/// Creates a run.
+///
+/// The caller may mint the run ID or leave it absent for the implementation
+/// to generate one.
+operation CreateRun {
+    input := {
+        runId: RunId
+
+        @required
+        event: RunCreatedEvent
+
+        options: CreateEventOptions
+    }
+
+    output: EventMutationResult
+
+    errors: [
+        BadRequestError
+        ConflictError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Appends an event to a run's log and materializes its effect atomically.
+///
+/// This is the only way to change run, step, hook, or wait state.
+operation CreateEvent {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        event: CreatableEvent
+
+        options: CreateEventOptions
+    }
+
+    output: EventMutationResult
+
+    errors: [
+        BadRequestError
+        RunNotFoundError
+        ConflictError
+        ExpiredError
+        PreconditionFailedError
+        TooEarlyError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Reads one event.
+@readonly
+operation GetEvent {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        eventId: EventId
+
+        resolveData: ResolveData
+    }
+
+    output := {
+        @required
+        event: Event
+    }
+
+    errors: [
+        RunNotFoundError
+        EventNotFoundError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Lists a run's event log.
+///
+/// Omitting `limit` requests every remaining event.
+@readonly
+@paginated(inputToken: "cursor", outputToken: "cursor", pageSize: "limit", items: "events")
+operation ListEvents {
+    input := {
+        @required
+        runId: RunId
+
+        resolveData: ResolveData
+
+        @range(min: 1, max: 1000)
+        limit: Integer
+
+        cursor: Cursor
+
+        sortOrder: SortOrder
+    }
+
+    output := {
+        @required
+        events: EventList
+
+        cursor: Cursor
+
+        @required
+        hasMore: Boolean
+    }
+
+    errors: [
+        RunNotFoundError
+        BadRequestError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Lists the events of one run that share a correlation ID.
+///
+/// Correlation IDs are unique within a run, not globally, so the run is part
+/// of the query.
+@readonly
+@paginated(inputToken: "cursor", outputToken: "cursor", pageSize: "limit", items: "events")
+operation ListEventsByCorrelationId {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        correlationId: CorrelationId
+
+        resolveData: ResolveData
+
+        @range(min: 1, max: 1000)
+        limit: Integer
+
+        cursor: Cursor
+
+        sortOrder: SortOrder
+    }
+
+    output := {
+        @required
+        events: EventList
+
+        cursor: Cursor
+
+        @required
+        hasMore: Boolean
+    }
+
+    errors: [
+        RunNotFoundError
+        BadRequestError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}

--- a/idl/world/model/hooks.smithy
+++ b/idl/world/model/hooks.smithy
@@ -1,0 +1,189 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// Immutable slice of a hook's owning run, sufficient to resume the hook
+/// without reading the run entity.
+///
+/// Deliberately excludes mutable run state, payloads, attributes, and any
+/// secret.
+structure HookResumeContext {
+    @required
+    deploymentId: DeploymentId
+
+    @required
+    workflowName: WorkflowName
+
+    /// Spec version of the owning run, distinct from the hook's own.
+    runSpecVersion: Integer
+
+    workflowCoreVersion: String
+
+    /// W3C trace context propagated from hook creation.
+    traceCarrier: TraceCarrier
+
+    /// The run's base64 X25519 public key, mirrored from the run entity.
+    encryptionPublicKey: String
+
+    /// Version of the lazy-hook-resume consumer protocol supported by the
+    /// run's creating deployment. Absent means the sequential path.
+    hookResumeInputVersion: Integer
+}
+
+/// Backend-attested resume capabilities, recomputed on every by-token lookup.
+///
+/// Response-only and never persisted, so a rollback or kill switch downgrades
+/// new resumes immediately by omitting it.
+structure HookResumeCapabilities {
+    /// Present when the live backend enforces the `(runId, resumeId)` dedup
+    /// constraint.
+    @required
+    hookResumeDedupVersion: Integer
+}
+
+/// Materialized view of a hook.
+///
+/// A hook kept alive by minimum retention stays readable after its run ends
+/// and continues to reserve its token, but can no longer be resumed.
+structure Hook {
+    @required
+    runId: RunId
+
+    @required
+    hookId: HookId
+
+    @required
+    token: String
+
+    @required
+    ownerId: String
+
+    @required
+    projectId: String
+
+    @required
+    environment: String
+
+    metadata: SerializedData
+
+    specVersion: Integer
+
+    isWebhook: Boolean
+
+    isSystem: Boolean
+
+    /// Earliest time the token may be released after the run ends. An active
+    /// run holds the token past this deadline.
+    tokenRetentionUntil: Timestamp
+
+    resumeContext: HookResumeContext
+
+    resumeCapabilities: HookResumeCapabilities
+
+    @required
+    createdAt: Timestamp
+}
+
+list HookList {
+    member: Hook
+}
+
+/// Reads one hook by ID.
+@readonly
+operation GetHook {
+    input := {
+        @required
+        hookId: HookId
+
+        runId: RunId
+
+        resolveData: ResolveData
+    }
+
+    output := {
+        @required
+        hook: Hook
+    }
+
+    errors: [
+        HookNotFoundError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Reads the hook that currently owns a token, including a retained hook
+/// whose run has ended.
+@readonly
+operation GetHookByToken {
+    input := {
+        @required
+        token: String
+
+        resolveData: ResolveData
+    }
+
+    output := {
+        @required
+        hook: Hook
+    }
+
+    errors: [
+        HookNotFoundError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Lists hooks, including retained hooks whose runs have ended.
+@readonly
+@paginated(inputToken: "cursor", outputToken: "cursor", pageSize: "limit", items: "hooks")
+operation ListHooks {
+    input := {
+        runId: RunId
+
+        resolveData: ResolveData
+
+        @range(min: 1, max: 1000)
+        limit: Integer
+
+        cursor: Cursor
+
+        sortOrder: SortOrder
+    }
+
+    output := {
+        @required
+        hooks: HookList
+
+        cursor: Cursor
+
+        @required
+        hasMore: Boolean
+    }
+
+    errors: [
+        BadRequestError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Materialized view of a wait.
+structure Wait {
+    @required
+    runId: RunId
+
+    @required
+    waitId: WaitId
+
+    @required
+    resumeAt: Timestamp
+
+    completedAt: Timestamp
+
+    @required
+    createdAt: Timestamp
+}

--- a/idl/world/model/local.smithy
+++ b/idl/world/model/local.smithy
@@ -1,0 +1,105 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// A ready-to-use AES-256 key.
+@sensitive
+@length(min: 32, max: 32)
+blob EncryptionKey
+
+/// World-specific display fields for one run, keyed by column name.
+///
+/// A null value means "applicable but undeterminable", which is distinct from
+/// the key being absent.
+@sparse
+map RunDisplayFields {
+    key: String
+    value: String
+}
+
+/// Mints a new run ID.
+///
+/// Returns the bare ULID; the core attaches the `wrun_` prefix.
+/// Implementations may embed world-specific metadata such as a region as long
+/// as the result stays a valid ULID.
+@localOnly
+operation CreateRunId {
+    input := {
+        /// The full options bag passed to `start()`. Implementations read
+        /// only the keys they recognize and ignore the rest.
+        options: Document
+    }
+
+    output := {
+        @required
+        runId: RunId
+    }
+}
+
+/// Returns the wall-clock time at which the current invocation will be
+/// terminated by the hosting platform, when that is known.
+@localOnly
+@readonly
+operation GetRuntimeDeadline {
+    input := {}
+
+    output := {
+        deadline: Timestamp
+    }
+}
+
+/// Returns the environment this World's writes are attributed to.
+///
+/// Must match the attribution the backend will actually apply. Callers use it
+/// to detect cross-environment mismatches, so a plausible-looking wrong value
+/// is worse than none.
+@localOnly
+@readonly
+operation GetEnvironment {
+    input := {}
+
+    output := {
+        environment: String
+    }
+}
+
+/// Returns extra display fields for a run.
+///
+/// Called once per displayed run by tooling, so it must be cheap, pure, and
+/// non-throwing.
+@localOnly
+@readonly
+operation DescribeRun {
+    input := {
+        /// The run entity as the caller holds it, which may be a lean
+        /// observability row rather than a full record.
+        @required
+        run: Document
+    }
+
+    output := {
+        fields: RunDisplayFields
+    }
+}
+
+/// Resolves the AES-256 key for a run.
+///
+/// Local only, permanently: key material must never cross a transport
+/// boundary. It is modeled here so in-process implementations share one
+/// contract across languages, and every transport projection is expected to
+/// drop it. Absent support means encryption is disabled.
+@localOnly
+operation GetEncryptionKeyForRun {
+    input := {
+        @required
+        runId: RunId
+
+        /// Opaque world-specific context, such as a deployment ID, used when
+        /// the run entity is not available locally.
+        context: Document
+    }
+
+    output := {
+        key: EncryptionKey
+    }
+}

--- a/idl/world/model/queue.smithy
+++ b/idl/world/model/queue.smithy
@@ -1,0 +1,134 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// Logical queue name, e.g. a flow or step topic.
+string QueueName
+
+/// Queue message identifier.
+///
+/// Should be stable across redeliveries of one enqueued message: the
+/// runtime's inline step ownership uses it as a liveness lease. An
+/// implementation that mints a fresh ID per delivery still works, but owner
+/// redeliveries fall back to the slower backstop path.
+string MessageId
+
+/// W3C trace context propagated through the queue.
+map TraceCarrier {
+    key: String
+    value: String
+}
+
+map QueueHeaders {
+    key: String
+    value: String
+}
+
+/// Opaque queue payload.
+///
+/// The runtime's invoke and health-check payload schemas are deliberately not
+/// modeled yet: they are producer-and-consumer-private, versioned by run spec
+/// version, and encoded as CBOR or JSON depending on that version. Modeling
+/// them belongs in a follow-up once the transport story is settled.
+blob QueuePayload
+
+structure EnqueueOptions {
+    /// Target a specific deployment rather than the current one.
+    deploymentId: DeploymentId
+
+    idempotencyKey: String
+
+    headers: QueueHeaders
+
+    /// Delay delivery by this many seconds.
+    delaySeconds: Integer
+
+    /// Spec version of the target run, which selects the transport format.
+    specVersion: Integer
+
+    /// Routing hint naming the region the message should be sent to.
+    region: String
+}
+
+/// Returns the deployment this World writes as.
+@readonly
+operation GetDeploymentId {
+    input := {}
+
+    output := {
+        @required
+        deploymentId: DeploymentId
+    }
+
+    errors: [
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Enqueues one message. Delivery is at-least-once.
+operation Enqueue {
+    input := {
+        @required
+        queueName: QueueName
+
+        @required
+        message: QueuePayload
+
+        options: EnqueueOptions
+    }
+
+    output := {
+        /// Assigned message ID, when the queue reports one.
+        messageId: MessageId
+    }
+
+    errors: [
+        BadRequestError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Instructs the caller to redeliver the message later.
+structure RetryDirective {
+    @required
+    timeoutSeconds: Integer
+}
+
+/// Delivers one queued message to the workflow runtime.
+///
+/// This is the reverse direction: a queue adapter calls the runtime. Today's
+/// `createQueueHandler` becomes a thin per-language adapter that exposes this
+/// operation over whatever the platform hands it, rather than an operation in
+/// its own right.
+@callback
+operation DeliverQueueMessage {
+    input := {
+        @required
+        queueName: QueueName
+
+        @required
+        message: QueuePayload
+
+        /// 1-based delivery attempt.
+        @required
+        attempt: Integer
+
+        @required
+        messageId: MessageId
+
+        requestId: String
+    }
+
+    output := {
+        /// Present when the runtime wants the message redelivered instead of
+        /// acknowledged.
+        retry: RetryDirective
+    }
+
+    errors: [
+        BadRequestError
+        InternalError
+    ]
+}

--- a/idl/world/model/runs.smithy
+++ b/idl/world/model/runs.smithy
@@ -1,0 +1,274 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// Lifecycle status of a run.
+enum RunStatus {
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+}
+
+/// Materialized view of a run.
+///
+/// `input`, `output`, and `error` are absent when the caller asked for
+/// `ResolveData$NONE`, and `output`/`error`/`completedAt` are only populated
+/// once the run reaches the matching terminal status.
+structure WorkflowRun {
+    @required
+    runId: RunId
+
+    @required
+    status: RunStatus
+
+    @required
+    deploymentId: DeploymentId
+
+    @required
+    workflowName: WorkflowName
+
+    /// Workflow protocol spec version the run was created under.
+    specVersion: Integer
+
+    /// Opaque, world-specific execution context recorded at creation.
+    executionContext: Document
+
+    input: SerializedData
+
+    output: SerializedData
+
+    /// Serialized thrown value from `run_failed`.
+    error: SerializedData
+
+    /// Plaintext failure category, readable without decryption.
+    errorCode: String
+
+    @required
+    attributes: AttributeMap
+
+    /// Base64 X25519 public key that lets other parties seal payloads to this
+    /// run. Present only for runs created by SDKs that support sealed
+    /// envelopes on encryption-capable implementations.
+    encryptionPublicKey: String
+
+    expiredAt: Timestamp
+
+    startedAt: Timestamp
+
+    completedAt: Timestamp
+
+    @required
+    createdAt: Timestamp
+
+    @required
+    updatedAt: Timestamp
+}
+
+list WorkflowRunList {
+    member: WorkflowRun
+}
+
+@sparse
+list SparseWorkflowRunList {
+    member: WorkflowRun
+}
+
+list RunIdList {
+    member: RunId
+}
+
+/// Reads one run.
+@readonly
+operation GetRun {
+    input := {
+        @required
+        runId: RunId
+
+        resolveData: ResolveData
+    }
+
+    output := {
+        @required
+        run: WorkflowRun
+    }
+
+    errors: [
+        RunNotFoundError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Reads several runs as one snapshot.
+///
+/// `runs` preserves the request order, including duplicate IDs, and carries a
+/// null entry for every ID that does not exist.
+@readonly
+@optionalCapability(name: "batchGetRuns")
+operation BatchGetRuns {
+    input := {
+        @required
+        runIds: RunIdList
+
+        resolveData: ResolveData
+    }
+
+    output := {
+        @required
+        runs: SparseWorkflowRunList
+    }
+
+    errors: [
+        BadRequestError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Lists canonical run records.
+///
+/// This is the operational, payload-bearing listing. Observability surfaces
+/// should prefer the analytics read path once it is modeled.
+@readonly
+@paginated(inputToken: "cursor", outputToken: "cursor", pageSize: "limit", items: "runs")
+operation ListRuns {
+    input := {
+        workflowName: WorkflowName
+
+        status: RunStatus
+
+        resolveData: ResolveData
+
+        @range(min: 1, max: 1000)
+        limit: Integer
+
+        cursor: Cursor
+
+        sortOrder: SortOrder
+    }
+
+    output := {
+        @required
+        runs: WorkflowRunList
+
+        cursor: Cursor
+
+        @required
+        hasMore: Boolean
+
+        pageInfo: PageInfo
+    }
+
+    errors: [
+        BadRequestError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Per-run outcome of a bulk cancellation.
+union BulkCancelOutcome {
+    /// This request transitioned the run to cancelled.
+    cancelled: CancelledOutcome
+
+    /// The run was already cancelled. Idempotent success.
+    alreadyCancelled: AlreadyCancelledOutcome
+
+    /// The run is in a terminal, non-cancellable state.
+    notCancellable: NotCancellableOutcome
+
+    /// No run exists for this ID.
+    notFound: RunNotFoundOutcome
+
+    /// Cancellation failed for this run.
+    failed: BulkCancelFailure
+}
+
+structure CancelledOutcome {}
+
+structure AlreadyCancelledOutcome {}
+
+structure RunNotFoundOutcome {}
+
+structure NotCancellableOutcome {
+    /// Observed run status.
+    @required
+    status: RunStatus
+}
+
+structure BulkCancelFailure {
+    @required
+    code: String
+
+    @required
+    retryable: Boolean
+}
+
+structure BulkCancelResult {
+    @required
+    runId: RunId
+
+    @required
+    outcome: BulkCancelOutcome
+}
+
+list BulkCancelResultList {
+    member: BulkCancelResult
+}
+
+structure BulkCancelSummary {
+    @required
+    requested: Integer
+
+    @required
+    cancelled: Integer
+
+    @required
+    alreadyCancelled: Integer
+
+    @required
+    notCancellable: Integer
+
+    @required
+    notFound: Integer
+
+    @required
+    failed: Integer
+}
+
+/// Cancels many runs in one request.
+///
+/// Missing, already-cancelled, and non-cancellable runs are reported as
+/// per-run outcomes rather than as operation errors, so one bad ID never
+/// fails the batch.
+@idempotent
+@optionalCapability(name: "bulkCancelRuns")
+operation BulkCancelRuns {
+    input := {
+        /// 1-500 unique run IDs.
+        @required
+        @length(min: 1, max: 500)
+        runIds: RunIdList
+
+        @length(max: 512)
+        cancelReason: String
+    }
+
+    output := {
+        @required
+        summary: BulkCancelSummary
+
+        /// One entry per requested ID, in request order.
+        @required
+        results: BulkCancelResultList
+    }
+
+    errors: [
+        BadRequestError
+        ThrottledError
+        InternalError
+    ]
+}

--- a/idl/world/model/steps.smithy
+++ b/idl/world/model/steps.smithy
@@ -1,0 +1,122 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// Lifecycle status of a step.
+enum StepStatus {
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+}
+
+/// Materialized view of a step.
+structure Step {
+    @required
+    runId: RunId
+
+    @required
+    stepId: StepId
+
+    @required
+    stepName: StepName
+
+    @required
+    status: StepStatus
+
+    input: SerializedData
+
+    output: SerializedData
+
+    /// Most recent serialized thrown value, from either a retry or the final
+    /// failure.
+    error: SerializedData
+
+    @required
+    attempt: Integer
+
+    /// When the step first began executing. Not updated by retries.
+    startedAt: Timestamp
+
+    completedAt: Timestamp
+
+    /// Earliest time a retrying step may start again.
+    retryAfter: Timestamp
+
+    specVersion: Integer
+
+    @required
+    createdAt: Timestamp
+
+    @required
+    updatedAt: Timestamp
+}
+
+list StepList {
+    member: Step
+}
+
+/// Reads one step.
+@readonly
+operation GetStep {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        stepId: StepId
+
+        resolveData: ResolveData
+    }
+
+    output := {
+        @required
+        step: Step
+    }
+
+    errors: [
+        RunNotFoundError
+        StepNotFoundError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Lists the steps of one run.
+@readonly
+@paginated(inputToken: "cursor", outputToken: "cursor", pageSize: "limit", items: "steps")
+operation ListSteps {
+    input := {
+        @required
+        runId: RunId
+
+        resolveData: ResolveData
+
+        @range(min: 1, max: 1000)
+        limit: Integer
+
+        cursor: Cursor
+
+        sortOrder: SortOrder
+    }
+
+    output := {
+        @required
+        steps: StepList
+
+        cursor: Cursor
+
+        @required
+        hasMore: Boolean
+    }
+
+    errors: [
+        RunNotFoundError
+        BadRequestError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}

--- a/idl/world/model/streams.smithy
+++ b/idl/world/model/streams.smithy
@@ -1,0 +1,233 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// An unbounded byte stream.
+@streaming
+blob ByteStream
+
+/// One chunk of a stream, with its 0-based position.
+structure StreamChunk {
+    @required
+    index: Integer
+
+    @required
+    data: Blob
+}
+
+list StreamChunkList {
+    member: StreamChunk
+}
+
+list ChunkDataList {
+    member: Blob
+}
+
+list StreamNameList {
+    member: StreamName
+}
+
+/// Appends one chunk to a stream.
+operation WriteStreamChunk {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        name: StreamName
+
+        @required
+        chunk: Blob
+    }
+
+    output := {}
+
+    errors: [
+        RunNotFoundError
+        StreamExpiredError
+        ConflictError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Appends several chunks in order, in one request.
+///
+/// An optional optimization. Callers fall back to repeated
+/// `WriteStreamChunk` calls when an implementation does not provide it.
+@optionalCapability(name: "writeStreamChunks")
+operation WriteStreamChunks {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        name: StreamName
+
+        /// Chunks to append, in order.
+        @required
+        chunks: ChunkDataList
+    }
+
+    output := {}
+
+    errors: [
+        RunNotFoundError
+        StreamExpiredError
+        ConflictError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Closes a stream. No further chunks may be appended.
+@idempotent
+operation CloseStream {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        name: StreamName
+    }
+
+    output := {}
+
+    errors: [
+        RunNotFoundError
+        StreamNotFoundError
+        StreamExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Reads a stream live, waiting for chunks until the stream closes.
+///
+/// A positive `startIndex` skips that many chunks from the start. A negative
+/// one starts that many chunks before the current end, clamped to zero.
+@readonly
+operation ReadStream {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        name: StreamName
+
+        startIndex: Integer
+    }
+
+    output := {
+        @required
+        body: ByteStream
+    }
+
+    errors: [
+        RunNotFoundError
+        StreamNotFoundError
+        StreamExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Lists the stream names belonging to a run.
+@readonly
+operation ListStreams {
+    input := {
+        @required
+        runId: RunId
+    }
+
+    output := {
+        @required
+        names: StreamNameList
+    }
+
+    errors: [
+        RunNotFoundError
+        ExpiredError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Reads a point-in-time page of already-written chunks.
+///
+/// Unlike `ReadStream`, this never waits. `done` reports whether the stream
+/// is closed: `done: false` with `hasMore: false` means nothing is available
+/// right now, but more chunks may still arrive.
+@readonly
+@paginated(inputToken: "cursor", outputToken: "cursor", pageSize: "limit", items: "chunks")
+operation ListStreamChunks {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        name: StreamName
+
+        @range(min: 1, max: 1000)
+        limit: Integer
+
+        cursor: Cursor
+    }
+
+    output := {
+        @required
+        chunks: StreamChunkList
+
+        cursor: Cursor
+
+        /// Whether more already-written chunks remain.
+        @required
+        hasMore: Boolean
+
+        /// Whether the stream is closed.
+        @required
+        done: Boolean
+    }
+
+    errors: [
+        RunNotFoundError
+        StreamNotFoundError
+        StreamExpiredError
+        BadRequestError
+        ThrottledError
+        InternalError
+    ]
+}
+
+/// Reads lightweight stream metadata.
+///
+/// Useful for resolving a negative `startIndex` into an absolute position
+/// before opening a live read.
+@readonly
+operation GetStreamInfo {
+    input := {
+        @required
+        runId: RunId
+
+        @required
+        name: StreamName
+    }
+
+    output := {
+        /// Index of the last known chunk, or -1 when the stream is empty.
+        @required
+        tailIndex: Integer
+
+        /// Whether the stream is closed.
+        @required
+        done: Boolean
+    }
+
+    errors: [
+        RunNotFoundError
+        StreamNotFoundError
+        StreamExpiredError
+        ThrottledError
+        InternalError
+    ]
+}

--- a/idl/world/model/traits.smithy
+++ b/idl/world/model/traits.smithy
@@ -1,0 +1,34 @@
+$version: "2"
+
+namespace vercel.workflow.world
+
+/// Marks an operation that must never be exposed over a network transport.
+///
+/// Operations carrying this trait exist so that in-process implementations
+/// share one cross-language contract (TypeScript, Python) for behavior that
+/// is resolved locally: ID minting, environment attribution, deadlines,
+/// display enrichment, and encryption-key resolution. Any future transport
+/// projection is expected to remove these operations from its closure and to
+/// fail the build if one survives.
+@trait(selector: "operation")
+structure localOnly {}
+
+/// Marks an operation as part of an optional World capability.
+///
+/// Smithy services have no notion of an optional operation, so optional
+/// behavior lives in its own service closure. This trait records which
+/// capability an operation belongs to so wrappers and conformance tooling can
+/// tie a generated service to the capability an implementation advertises in
+/// `WorldInfo`.
+@trait(selector: "operation")
+structure optionalCapability {
+    /// Capability name as advertised by `WorldInfo$capabilities`.
+    @required
+    name: String
+}
+
+/// Marks an operation that is invoked in the reverse direction: the World (or
+/// its queue adapter) calls the workflow runtime rather than the other way
+/// around.
+@trait(selector: "operation")
+structure callback {}

--- a/idl/world/model/world.smithy
+++ b/idl/world/model/world.smithy
@@ -1,0 +1,156 @@
+$version: "2"
+
+metadata shapeClosures = [
+    {
+        id: "vercel.workflow.world#WorldTypes"
+        includeNamespaces: ["vercel.workflow.world"]
+    }
+]
+
+namespace vercel.workflow.world
+
+/// The required World surface.
+///
+/// Every implementation provides all of it. Optional behavior lives in the
+/// capability services instead, so a generated interface never forces an
+/// implementation to stub a method it does not support.
+///
+/// No protocol trait is applied anywhere in this model. The operations are
+/// transport-independent by construction: an in-process implementation
+/// satisfies the generated interface directly, and any wire format is a
+/// separate projection that layers protocol and binding traits on top.
+service WorldCore {
+    version: "2026-08-18"
+
+    operations: [
+        GetWorldInfo
+        CreateRun
+        GetRun
+        ListRuns
+        GetStep
+        ListSteps
+        CreateEvent
+        GetEvent
+        ListEvents
+        ListEventsByCorrelationId
+        GetHook
+        GetHookByToken
+        ListHooks
+        WriteStreamChunk
+        CloseStream
+        ReadStream
+        ListStreams
+        ListStreamChunks
+        GetStreamInfo
+        GetDeploymentId
+        Enqueue
+    ]
+}
+
+/// Optional optimizations.
+///
+/// An implementation that omits this service is fully supported; callers fall
+/// back to the equivalent `WorldCore` operations.
+service WorldBatch {
+    version: "2026-08-18"
+
+    operations: [
+        BatchGetRuns
+        BulkCancelRuns
+        WriteStreamChunks
+    ]
+}
+
+/// Operations the workflow runtime implements and a World's queue adapter
+/// calls.
+service WorldConsumer {
+    version: "2026-08-18"
+
+    operations: [
+        DeliverQueueMessage
+    ]
+}
+
+/// Operations that are resolved in-process and never exposed over a
+/// transport. See the `localOnly` trait.
+service WorldLocalHooks {
+    version: "2026-08-18"
+
+    operations: [
+        CreateRunId
+        GetRuntimeDeadline
+        GetEnvironment
+        DescribeRun
+        GetEncryptionKeyForRun
+    ]
+}
+
+/// Feature capabilities an implementation declares.
+///
+/// Every member defaults to unsupported when absent: a runtime fast path
+/// gated on a capability must keep its conservative behavior unless the
+/// capability is explicitly declared.
+structure WorldCapabilities {
+    /// Supports minimum token retention for hooks.
+    hookRetention: HookRetentionCapability
+
+    /// Fences a stale replay-context write with `PreconditionFailedError`
+    /// rather than committing it. Accepting a snapshot and ignoring it is not
+    /// the same thing, and must leave this unset.
+    preconditionGuard: Boolean
+
+    /// The queue supports concurrency-limited consumption, including the
+    /// per-run topics consumed with a limit of one.
+    maxConcurrency: Boolean
+
+    /// `CreateEvent` deduplicates concurrent `hookReceived` writes carrying
+    /// the same `(runId, resumeId)`, collapsing them onto one committed
+    /// event.
+    hookResumeDedup: Boolean
+
+    /// Deployment IDs are atomic and immutable, so a run pinned to one may
+    /// only execute there. Implementations whose deployment ID is synthetic
+    /// or version-tagged must leave this unset.
+    deploymentAffinity: Boolean
+
+    /// Event IDs encode the event's dense, 1-based slot in its run's log.
+    /// Implies both density and bump-and-report on contention.
+    slotEventIds: Boolean
+}
+
+structure HookRetentionCapability {
+    @required
+    active: Boolean
+}
+
+/// Names of the optional capability services this implementation provides,
+/// matching `optionalCapability`.
+list CapabilityNameList {
+    member: String
+}
+
+/// Reports the implementation's protocol version and capabilities.
+///
+/// This replaces inferring support from method presence, which stops working
+/// as soon as calls cross a transport where every method always exists.
+@readonly
+operation GetWorldInfo {
+    input := {}
+
+    output := {
+        /// Workflow protocol spec version this implementation writes.
+        /// Runtimes require an exact match before creating or replaying runs.
+        @required
+        specVersion: Integer
+
+        capabilities: WorldCapabilities
+
+        /// Optional capability services that are available.
+        optionalCapabilities: CapabilityNameList
+    }
+
+    errors: [
+        ThrottledError
+        InternalError
+    ]
+}

--- a/idl/world/model/world.smithy
+++ b/idl/world/model/world.smithy
@@ -9,24 +9,38 @@ metadata shapeClosures = [
 
 namespace vercel.workflow.world
 
-/// The required World surface.
+/// The World interface.
 ///
-/// Every implementation provides all of it. Optional behavior lives in the
-/// capability services instead, so a generated interface never forces an
-/// implementation to stub a method it does not support.
+/// One interface, implemented by every World: local, Postgres, Vercel, and
+/// the simulator. This is the whole point of the model, so the surface is not
+/// split by concern, by optionality, or by whether an operation can cross a
+/// network.
+///
+/// Two of those distinctions still exist, and both are traits on operations
+/// rather than separate interfaces:
+///
+/// - `optionalCapability` marks an operation an implementation may omit. It
+///   is the modeled form of today's optional `World` methods (`getMany?`,
+///   `cancelMany?`, `writeMulti?`), and callers feature-detect it exactly as
+///   they do now. `GetWorldInfo` reports which ones are present.
+/// - `localOnly` marks an operation that is resolved in-process and must
+///   never be exposed over a transport. It stays on this interface because a
+///   World implements it; a future transport projection is what drops it.
 ///
 /// No protocol trait is applied anywhere in this model. The operations are
 /// transport-independent by construction: an in-process implementation
 /// satisfies the generated interface directly, and any wire format is a
 /// separate projection that layers protocol and binding traits on top.
-service WorldCore {
+service World {
     version: "2026-08-18"
 
     operations: [
         GetWorldInfo
         CreateRun
         GetRun
+        BatchGetRuns
         ListRuns
+        BulkCancelRuns
         GetStep
         ListSteps
         CreateEvent
@@ -37,6 +51,7 @@ service WorldCore {
         GetHookByToken
         ListHooks
         WriteStreamChunk
+        WriteStreamChunks
         CloseStream
         ReadStream
         ListStreams
@@ -44,44 +59,26 @@ service WorldCore {
         GetStreamInfo
         GetDeploymentId
         Enqueue
-    ]
-}
-
-/// Optional optimizations.
-///
-/// An implementation that omits this service is fully supported; callers fall
-/// back to the equivalent `WorldCore` operations.
-service WorldBatch {
-    version: "2026-08-18"
-
-    operations: [
-        BatchGetRuns
-        BulkCancelRuns
-        WriteStreamChunks
-    ]
-}
-
-/// Operations the workflow runtime implements and a World's queue adapter
-/// calls.
-service WorldConsumer {
-    version: "2026-08-18"
-
-    operations: [
-        DeliverQueueMessage
-    ]
-}
-
-/// Operations that are resolved in-process and never exposed over a
-/// transport. See the `localOnly` trait.
-service WorldLocalHooks {
-    version: "2026-08-18"
-
-    operations: [
         CreateRunId
         GetRuntimeDeadline
         GetEnvironment
         DescribeRun
         GetEncryptionKeyForRun
+    ]
+}
+
+/// The runtime's own queue-consumer interface.
+///
+/// Deliberately not part of `World`, and not a second World interface: the
+/// implementor is the workflow runtime, and the caller is a World's queue
+/// adapter. Today this is the callback handed to `createQueueHandler`.
+/// Folding it into `World` would say that a World implements it, which is
+/// backwards.
+service RuntimeQueueConsumer {
+    version: "2026-08-18"
+
+    operations: [
+        DeliverQueueMessage
     ]
 }
 

--- a/idl/world/scripts/generate.sh
+++ b/idl/world/scripts/generate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Regenerates every artifact under idl/world/generated.
+#
+# Requires the Smithy CLI (https://smithy.io/2.0/guides/smithy-cli) on PATH and
+# network access, since `smithy build` resolves the TypeScript code generator
+# from Maven Central. Python 3.10+ is required for the port emitter.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+if ! command -v smithy >/dev/null 2>&1; then
+  echo "smithy CLI not found on PATH" >&2
+  exit 1
+fi
+
+echo "==> smithy build"
+rm -rf build
+smithy build
+
+echo "==> typescript types (smithy-typescript, types mode)"
+rm -rf generated/typescript
+mkdir -p generated/typescript
+cp -r build/smithy/source/typescript-codegen/src/* generated/typescript/
+
+echo "==> typescript + python ports"
+mkdir -p generated/python/workflow_world
+python3 scripts/generate_ports.py \
+  build/smithy/source/model/model.json \
+  generated/typescript \
+  generated/python/workflow_world
+
+echo "==> done"

--- a/idl/world/scripts/generate_ports.py
+++ b/idl/world/scripts/generate_ports.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""Emit language port interfaces from the built Smithy model.
+
+Two gaps in the upstream tooling make this script necessary:
+
+* ``smithy-typescript`` types mode generates data shapes only, so nothing
+  declares the operations themselves. This emits the per-service interface
+  that an in-process implementation satisfies, on top of the generated types.
+* ``smithy-python`` has no published release, so there is nothing to run for
+  Python at all. This emits the equivalent dataclasses, enums, errors, and
+  Protocol interfaces directly from the model.
+
+Both outputs are transport-free on purpose: they are plain function shapes
+over generated types, with no serialization, client, or endpoint concerns.
+
+Usage:
+    generate_ports.py <model.json> <typescript-out-dir> <python-out-dir>
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+NAMESPACE = "vercel.workflow.world"
+PRELUDE = "smithy.api#"
+
+DOC = f"{PRELUDE}documentation"
+REQUIRED = f"{PRELUDE}required"
+ERROR = f"{PRELUDE}error"
+SPARSE = f"{PRELUDE}sparse"
+STREAMING = f"{PRELUDE}streaming"
+ENUM_VALUE = f"{PRELUDE}enumValue"
+LOCAL_ONLY = f"{NAMESPACE}#localOnly"
+OPTIONAL_CAPABILITY = f"{NAMESPACE}#optionalCapability"
+CALLBACK = f"{NAMESPACE}#callback"
+
+GENERATED_HEADER = "Generated from the Smithy model. Do not edit by hand."
+
+TS_SCALARS = {
+    "string": "string",
+    "integer": "number",
+    "long": "number",
+    "float": "number",
+    "double": "number",
+    "boolean": "boolean",
+    "blob": "Uint8Array",
+    "timestamp": "Date",
+    "document": "unknown",
+}
+
+PY_SCALARS = {
+    "string": "str",
+    "integer": "int",
+    "long": "int",
+    "float": "float",
+    "double": "float",
+    "boolean": "bool",
+    "blob": "bytes",
+    "timestamp": "datetime",
+    "document": "Any",
+}
+
+
+class Model:
+    def __init__(self, raw: dict[str, Any]) -> None:
+        self.shapes: dict[str, Any] = raw["shapes"]
+
+    def get(self, shape_id: str) -> dict[str, Any]:
+        return self.shapes[shape_id]
+
+    def local(self, kinds: tuple[str, ...]) -> list[str]:
+        found = [
+            shape_id
+            for shape_id, shape in self.shapes.items()
+            if shape_id.startswith(f"{NAMESPACE}#") and shape["type"] in kinds
+        ]
+        return sorted(found, key=name_of)
+
+    def services(self) -> list[str]:
+        return self.local(("service",))
+
+    def traits(self, shape_id: str) -> dict[str, Any]:
+        return self.get(shape_id).get("traits", {})
+
+    def doc(self, shape_id: str) -> str | None:
+        return self.traits(shape_id).get(DOC)
+
+
+def name_of(shape_id: str) -> str:
+    return shape_id.split("#", 1)[1]
+
+
+def member_doc(member: dict[str, Any]) -> str | None:
+    return member.get("traits", {}).get(DOC)
+
+
+def is_required(member: dict[str, Any]) -> bool:
+    return REQUIRED in member.get("traits", {})
+
+
+def camel(name: str) -> str:
+    return name[0].lower() + name[1:] if name else name
+
+
+def snake(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def screaming(name: str) -> str:
+    """Enum member names are already SCREAMING_CASE in the model."""
+    if re.fullmatch(r"[A-Z0-9_]+", name):
+        return name
+    return snake(name).upper()
+
+
+def paragraphs(text: str) -> list[str]:
+    """Rejoins hard-wrapped source lines into logical paragraphs."""
+    result: list[str] = []
+    current: list[str] = []
+    for line in text.strip().split("\n"):
+        stripped = line.strip()
+        if stripped:
+            current.append(stripped)
+        elif current:
+            result.append(" ".join(current))
+            current = []
+    if current:
+        result.append(" ".join(current))
+    return result
+
+
+def wrap(text: str, width: int = 72) -> list[str]:
+    lines: list[str] = []
+    for index, paragraph in enumerate(paragraphs(text)):
+        if index:
+            lines.append("")
+        current = ""
+        for word in paragraph.split():
+            candidate = f"{current} {word}".strip()
+            if len(candidate) > width and current:
+                lines.append(current)
+                current = word
+            else:
+                current = candidate
+        if current:
+            lines.append(current)
+    while lines and not lines[-1]:
+        lines.pop()
+    return lines
+
+
+def ts_doc(text: str | None, indent: str) -> list[str]:
+    if not text:
+        return []
+    out = [f"{indent}/**"]
+    for line in wrap(text):
+        out.append(f"{indent} *{f' {line}' if line else ''}")
+    out.append(f"{indent} */")
+    return out
+
+
+def py_doc(text: str | None, indent: str) -> list[str]:
+    if not text:
+        return []
+    lines = wrap(text)
+    if len(lines) == 1:
+        return [f'{indent}"""{lines[0]}"""']
+    out = [f'{indent}"""{lines[0]}']
+    out.extend(f"{indent}{line}" if line else "" for line in lines[1:])
+    out.append(f'{indent}"""')
+    return out
+
+
+class TypeResolver:
+    """Maps Smithy shape targets onto language types."""
+
+    def __init__(self, model: Model, scalars: dict[str, str], language: str) -> None:
+        self.model = model
+        self.scalars = scalars
+        self.language = language
+
+    def resolve(self, target: str) -> str:
+        if target.startswith(PRELUDE):
+            kind = name_of(target).lower()
+            if kind == "unit":
+                return "void" if self.language == "ts" else "None"
+            return self.scalars[kind]
+
+        shape = self.model.get(target)
+        kind = shape["type"]
+
+        if kind in ("structure", "union", "enum", "intEnum"):
+            return name_of(target)
+
+        # Aliases of simple types keep their generated alias name so the
+        # domain vocabulary (RunId, Cursor, SerializedData) survives codegen.
+        if kind == "blob" and STREAMING in shape.get("traits", {}):
+            return name_of(target)
+        if kind in self.scalars:
+            return name_of(target)
+        if kind in ("list", "map"):
+            return name_of(target)
+
+        raise ValueError(f"unsupported shape type {kind} for {target}")
+
+
+def collect_shapes(model: Model) -> dict[str, list[str]]:
+    return {
+        "structures": [s for s in model.local(("structure",)) if ERROR not in model.traits(s)],
+        "errors": [s for s in model.local(("structure",)) if ERROR in model.traits(s)],
+        "unions": model.local(("union",)),
+        "enums": model.local(("enum",)),
+        "lists": model.local(("list",)),
+        "maps": model.local(("map",)),
+        "aliases": [
+            s
+            for s in model.local(tuple(TS_SCALARS.keys()))
+            if s.startswith(f"{NAMESPACE}#")
+        ],
+    }
+
+
+def operation_signature(model: Model, operation_id: str) -> tuple[str | None, str | None]:
+    operation = model.get(operation_id)
+    input_target = operation.get("input", {}).get("target")
+    output_target = operation.get("output", {}).get("target")
+    return (
+        None if not input_target or input_target.endswith("#Unit") else input_target,
+        None if not output_target or output_target.endswith("#Unit") else output_target,
+    )
+
+
+def operation_notes(model: Model, operation_id: str) -> list[str]:
+    traits = model.traits(operation_id)
+    notes = []
+    if LOCAL_ONLY in traits:
+        notes.append("Local only: never exposed over a transport.")
+    if CALLBACK in traits:
+        notes.append("Callback: implemented by the runtime, called by the World.")
+    capability = traits.get(OPTIONAL_CAPABILITY)
+    if capability:
+        notes.append(f"Optional capability: `{capability['name']}`.")
+    errors = [name_of(e["target"]) for e in model.get(operation_id).get("errors", [])]
+    if errors:
+        notes.append("Throws: " + ", ".join(sorted(errors)) + ".")
+    return notes
+
+
+def render_typescript_ports(model: Model) -> str:
+    resolver = TypeResolver(model, TS_SCALARS, "ts")
+    imported: set[str] = set()
+    body: list[str] = []
+
+    for service_id in model.services():
+        service = model.get(service_id)
+        operations = sorted(
+            (op["target"] for op in service.get("operations", [])), key=name_of
+        )
+        interface = f"{name_of(service_id)}Port"
+
+        body.append("")
+        doc = model.doc(service_id)
+        combined = doc or ""
+        body.extend(ts_doc(combined, ""))
+        body.append(f"export interface {interface} {{")
+
+        for index, operation_id in enumerate(operations):
+            input_target, output_target = operation_signature(model, operation_id)
+            input_type = resolver.resolve(input_target) if input_target else None
+            output_type = resolver.resolve(output_target) if output_target else "void"
+            for candidate in (input_type, output_type):
+                if candidate and candidate != "void":
+                    imported.add(candidate)
+
+            doc_text = model.doc(operation_id) or ""
+            notes = operation_notes(model, operation_id)
+            if notes:
+                doc_text = (doc_text + "\n\n" + "\n".join(notes)).strip()
+            if index:
+                body.append("")
+            body.extend(ts_doc(doc_text, "  "))
+            argument = f"input: {input_type}" if input_type else ""
+            body.append(f"  {camel(name_of(operation_id))}({argument}): Promise<{output_type}>;")
+
+        body.append("}")
+
+    header = [
+        f"// {GENERATED_HEADER}",
+        "// Source: idl/world/model, emitted by idl/world/scripts/generate_ports.py",
+        "",
+        "import type {",
+    ]
+    header.extend(f"  {name}," for name in sorted(imported))
+    header.extend(["} from './models/models_0';"])
+    return "\n".join(header + body) + "\n"
+
+
+def python_member_type(resolver: TypeResolver, member: dict[str, Any]) -> str:
+    return resolver.resolve(member["target"])
+
+
+def render_python_models(model: Model) -> str:
+    resolver = TypeResolver(model, PY_SCALARS, "py")
+    shapes = collect_shapes(model)
+    out: list[str] = [
+        f'"""{GENERATED_HEADER}',
+        "",
+        "Source: idl/world/model, emitted by idl/world/scripts/generate_ports.py",
+        '"""',
+        "",
+        "from __future__ import annotations",
+        "",
+        "from dataclasses import dataclass",
+        "from datetime import datetime",
+        "from enum import Enum",
+        "from typing import Any, AsyncIterable, Optional, Union",
+        "",
+        "from ._base import WorldError",
+        "",
+    ]
+
+    for shape_id in shapes["aliases"]:
+        shape = model.get(shape_id)
+        kind = shape["type"]
+        name = name_of(shape_id)
+        if kind == "blob" and STREAMING in shape.get("traits", {}):
+            target = "AsyncIterable[bytes]"
+        else:
+            target = PY_SCALARS[kind]
+        out.append("")
+        out.extend(py_doc(model.doc(shape_id), ""))
+        out.append(f"{name} = {target}")
+
+    for shape_id in shapes["enums"]:
+        shape = model.get(shape_id)
+        out.extend(["", "", f"class {name_of(shape_id)}(str, Enum):"])
+        doc = py_doc(model.doc(shape_id), "    ")
+        out.extend(doc if doc else [])
+        for member_name, member in shape["members"].items():
+            value = member.get("traits", {}).get(ENUM_VALUE, member_name)
+            member_docs = py_doc(member_doc(member), "    ")
+            if member_docs:
+                out.extend(member_docs)
+            out.append(f'    {screaming(member_name)} = "{value}"')
+
+    for shape_id in shapes["lists"]:
+        shape = model.get(shape_id)
+        inner = resolver.resolve(shape["member"]["target"])
+        if SPARSE in shape.get("traits", {}):
+            inner = f"Optional[{inner}]"
+        out.extend(["", f'{name_of(shape_id)} = list["{inner}"]'])
+
+    for shape_id in shapes["maps"]:
+        shape = model.get(shape_id)
+        key = resolver.resolve(shape["key"]["target"])
+        value = resolver.resolve(shape["value"]["target"])
+        if SPARSE in shape.get("traits", {}):
+            value = f"Optional[{value}]"
+        out.extend(["", f'{name_of(shape_id)} = dict["{key}", "{value}"]'])
+
+    for shape_id in shapes["structures"]:
+        out.extend(render_python_dataclass(model, resolver, shape_id))
+
+    for shape_id in shapes["unions"]:
+        out.extend(render_python_union(model, resolver, shape_id))
+
+    for shape_id in shapes["errors"]:
+        out.extend(render_python_error(model, resolver, shape_id))
+
+    return "\n".join(out) + "\n"
+
+
+def python_fields(
+    model: Model, resolver: TypeResolver, shape_id: str, indent: str = "    "
+) -> list[str]:
+    shape = model.get(shape_id)
+    members = shape.get("members", {})
+    if not members:
+        return []
+
+    required = [(n, m) for n, m in members.items() if is_required(m)]
+    optional = [(n, m) for n, m in members.items() if not is_required(m)]
+    lines: list[str] = []
+
+    for member_name, member in required:
+        annotation = python_member_type(resolver, member)
+        lines.append(f'{indent}{snake(member_name)}: "{annotation}"')
+        lines.extend(py_doc(member_doc(member), indent))
+
+    for member_name, member in optional:
+        annotation = python_member_type(resolver, member)
+        lines.append(f'{indent}{snake(member_name)}: "Optional[{annotation}]" = None')
+        lines.extend(py_doc(member_doc(member), indent))
+
+    return lines
+
+
+def render_python_dataclass(model: Model, resolver: TypeResolver, shape_id: str) -> list[str]:
+    out = ["", "", "@dataclass", f"class {name_of(shape_id)}:"]
+    doc = py_doc(model.doc(shape_id), "    ")
+    if doc:
+        out.extend(doc)
+    fields = python_fields(model, resolver, shape_id)
+    if fields:
+        if doc:
+            out.append("")
+        out.extend(fields)
+    elif not doc:
+        out.append("    pass")
+    return out
+
+
+def render_python_union(model: Model, resolver: TypeResolver, shape_id: str) -> list[str]:
+    shape = model.get(shape_id)
+    union_name = name_of(shape_id)
+    out: list[str] = []
+    variants: list[str] = []
+
+    for member_name, member in shape["members"].items():
+        variant = f"{union_name}{member_name[0].upper()}{member_name[1:]}"
+        variants.append(variant)
+        annotation = python_member_type(resolver, member)
+        out.extend(["", "", "@dataclass", f"class {variant}:"])
+        docs = py_doc(member_doc(member), "    ")
+        if docs:
+            out.extend(docs)
+            out.append("")
+        out.append(f'    value: "{annotation}"')
+
+    out.append("")
+    out.extend(py_doc(model.doc(shape_id), ""))
+    joined = ", ".join(f'"{variant}"' for variant in variants)
+    out.append(f"{union_name} = Union[{joined}]")
+    return out
+
+
+def render_python_error(model: Model, resolver: TypeResolver, shape_id: str) -> list[str]:
+    out = ["", "", "@dataclass", f"class {name_of(shape_id)}(WorldError):"]
+    doc = py_doc(model.doc(shape_id), "    ")
+    if doc:
+        out.extend(doc)
+    fields = python_fields(model, resolver, shape_id)
+    if fields:
+        if doc:
+            out.append("")
+        out.extend(fields)
+    return out
+
+
+def render_python_ports(model: Model) -> str:
+    resolver = TypeResolver(model, PY_SCALARS, "py")
+    imported: set[str] = set()
+    body: list[str] = []
+
+    for service_id in model.services():
+        service = model.get(service_id)
+        operations = sorted(
+            (op["target"] for op in service.get("operations", [])), key=name_of
+        )
+        body.extend(["", "", f"class {name_of(service_id)}Port(Protocol):"])
+        doc = py_doc(model.doc(service_id), "    ")
+        if doc:
+            body.extend(doc)
+
+        for operation_id in operations:
+            input_target, output_target = operation_signature(model, operation_id)
+            input_type = resolver.resolve(input_target) if input_target else None
+            output_type = resolver.resolve(output_target) if output_target else "None"
+            for candidate in (input_type, output_type):
+                if candidate and candidate != "None":
+                    imported.add(candidate)
+
+            doc_text = model.doc(operation_id) or ""
+            notes = operation_notes(model, operation_id)
+            if notes:
+                doc_text = (doc_text + "\n\n" + "\n".join(notes)).strip()
+
+            argument = f', input: "{input_type}"' if input_type else ""
+            body.append("")
+            body.append(
+                f'    async def {snake(name_of(operation_id))}(self{argument}) -> "{output_type}": ...'
+            )
+            operation_docs = py_doc(doc_text, "        ")
+            if operation_docs:
+                body[-1] = body[-1].removesuffix(" ...")
+                body.extend(operation_docs)
+                body.append("        ...")
+
+    header = [
+        f'"""{GENERATED_HEADER}',
+        "",
+        "Source: idl/world/model, emitted by idl/world/scripts/generate_ports.py",
+        '"""',
+        "",
+        "from __future__ import annotations",
+        "",
+        "from typing import Protocol",
+        "",
+        "from .models import (",
+    ]
+    header.extend(f"    {name}," for name in sorted(imported))
+    header.append(")")
+    return "\n".join(header + body) + "\n"
+
+
+def render_python_init(model: Model) -> str:
+    return "\n".join(
+        [
+            f'"""{GENERATED_HEADER}"""',
+            "",
+            "from .models import *  # noqa: F401,F403",
+            "from .ports import *  # noqa: F401,F403",
+            "",
+        ]
+    )
+
+
+def render_python_base() -> str:
+    return "\n".join(
+        [
+            '"""Hand-written base types the generated modules build on."""',
+            "",
+            "from __future__ import annotations",
+            "",
+            "",
+            "class WorldError(Exception):",
+            '    """Base class for every modeled World error."""',
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    model_path, ts_dir, py_dir = (Path(arg) for arg in sys.argv[1:])
+    model = Model(json.loads(model_path.read_text()))
+
+    ts_dir.mkdir(parents=True, exist_ok=True)
+    (ts_dir / "ports.ts").write_text(render_typescript_ports(model))
+
+    py_dir.mkdir(parents=True, exist_ok=True)
+    (py_dir / "__init__.py").write_text(render_python_init(model))
+    (py_dir / "_base.py").write_text(render_python_base())
+    (py_dir / "models.py").write_text(render_python_models(model))
+    (py_dir / "ports.py").write_text(render_python_ports(model))
+
+    print(f"wrote {ts_dir / 'ports.ts'}")
+    print(f"wrote {py_dir / 'models.py'}")
+    print(f"wrote {py_dir / 'ports.py'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/idl/world/scripts/generate_ports.py
+++ b/idl/world/scripts/generate_ports.py
@@ -234,6 +234,11 @@ def operation_signature(model: Model, operation_id: str) -> tuple[str | None, st
     )
 
 
+def optional_capability(model: Model, operation_id: str) -> str | None:
+    capability = model.traits(operation_id).get(OPTIONAL_CAPABILITY)
+    return capability["name"] if capability else None
+
+
 def operation_notes(model: Model, operation_id: str) -> list[str]:
     traits = model.traits(operation_id)
     notes = []
@@ -284,7 +289,12 @@ def render_typescript_ports(model: Model) -> str:
                 body.append("")
             body.extend(ts_doc(doc_text, "  "))
             argument = f"input: {input_type}" if input_type else ""
-            body.append(f"  {camel(name_of(operation_id))}({argument}): Promise<{output_type}>;")
+            # An operation an implementation may omit becomes an optional
+            # method, exactly like `getMany?` on today's World.
+            marker = "?" if optional_capability(model, operation_id) else ""
+            body.append(
+                f"  {camel(name_of(operation_id))}{marker}({argument}): Promise<{output_type}>;"
+            )
 
         body.append("}")
 
@@ -451,6 +461,29 @@ def render_python_error(model: Model, resolver: TypeResolver, shape_id: str) -> 
     return out
 
 
+def render_python_method(
+    model: Model, resolver: TypeResolver, operation_id: str, imported: set[str]
+) -> list[str]:
+    input_target, output_target = operation_signature(model, operation_id)
+    input_type = resolver.resolve(input_target) if input_target else None
+    output_type = resolver.resolve(output_target) if output_target else "None"
+    for candidate in (input_type, output_type):
+        if candidate and candidate != "None":
+            imported.add(candidate)
+
+    doc_text = model.doc(operation_id) or ""
+    notes = operation_notes(model, operation_id)
+    if notes:
+        doc_text = (doc_text + "\n\n" + "\n".join(notes)).strip()
+
+    argument = f', input: "{input_type}"' if input_type else ""
+    signature = f'    async def {snake(name_of(operation_id))}(self{argument}) -> "{output_type}":'
+    docs = py_doc(doc_text, "        ")
+    if docs:
+        return ["", signature, *docs, "        ..."]
+    return ["", f"{signature} ..."]
+
+
 def render_python_ports(model: Model) -> str:
     resolver = TypeResolver(model, PY_SCALARS, "py")
     imported: set[str] = set()
@@ -461,34 +494,36 @@ def render_python_ports(model: Model) -> str:
         operations = sorted(
             (op["target"] for op in service.get("operations", [])), key=name_of
         )
+        required = [op for op in operations if not optional_capability(model, op)]
+        optional = [op for op in operations if optional_capability(model, op)]
+
         body.extend(["", "", f"class {name_of(service_id)}Port(Protocol):"])
         doc = py_doc(model.doc(service_id), "    ")
         if doc:
             body.extend(doc)
+        for operation_id in required:
+            body.extend(render_python_method(model, resolver, operation_id, imported))
 
-        for operation_id in operations:
-            input_target, output_target = operation_signature(model, operation_id)
-            input_type = resolver.resolve(input_target) if input_target else None
-            output_type = resolver.resolve(output_target) if output_target else "None"
-            for candidate in (input_type, output_type):
-                if candidate and candidate != "None":
-                    imported.add(candidate)
-
-            doc_text = model.doc(operation_id) or ""
-            notes = operation_notes(model, operation_id)
-            if notes:
-                doc_text = (doc_text + "\n\n" + "\n".join(notes)).strip()
-
-            argument = f', input: "{input_type}"' if input_type else ""
-            body.append("")
-            body.append(
-                f'    async def {snake(name_of(operation_id))}(self{argument}) -> "{output_type}": ...'
+        # Python Protocols cannot mark a member optional the way TypeScript
+        # can, so each omittable operation also gets a narrowing protocol.
+        # `isinstance(world, SupportsBatchGetRuns)` is the Python spelling of
+        # `typeof world.batchGetRuns === 'function'`; the operation stays part
+        # of the one World interface either way.
+        for operation_id in optional:
+            capability = optional_capability(model, operation_id)
+            body.extend(
+                [
+                    "",
+                    "",
+                    "@runtime_checkable",
+                    f"class Supports{name_of(operation_id)}(Protocol):",
+                    *py_doc(
+                        f"Implementations that provide the optional `{capability}` capability.",
+                        "    ",
+                    ),
+                ]
             )
-            operation_docs = py_doc(doc_text, "        ")
-            if operation_docs:
-                body[-1] = body[-1].removesuffix(" ...")
-                body.extend(operation_docs)
-                body.append("        ...")
+            body.extend(render_python_method(model, resolver, operation_id, imported))
 
     header = [
         f'"""{GENERATED_HEADER}',
@@ -498,7 +533,7 @@ def render_python_ports(model: Model) -> str:
         "",
         "from __future__ import annotations",
         "",
-        "from typing import Protocol",
+        "from typing import Protocol, runtime_checkable",
         "",
         "from .models import (",
     ]

--- a/idl/world/smithy-build.json
+++ b/idl/world/smithy-build.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "sources": ["model"],
+  "maven": {
+    "dependencies": [
+      "software.amazon.smithy.typescript:smithy-typescript-codegen:0.52.0"
+    ]
+  },
+  "plugins": {
+    "typescript-codegen": {
+      "package": "@workflow/world-idl",
+      "packageVersion": "0.0.0",
+      "modes": ["types"],
+      "closure": "vercel.workflow.world#WorldTypes"
+    }
+  }
+}


### PR DESCRIPTION
Proposal artifact for representing the World API in a single IDL that serves both in-process and (later) networked implementations.

**Nothing here is hooked up.** No package depends on it, no implementation satisfies it, and CI does not build it. It is here to be read.

## What to look at

1. **`idl/world/model/`** — the Smithy model of the World interface (hand-written, source of truth).
2. **`idl/world/generated/typescript/`** — data types from `smithy-typescript` (types mode), plus `ports.ts` with the `WorldPort` interface.
3. **`idl/world/generated/python/workflow_world/`** — dataclasses, enums, errors, and `Protocol` interfaces.

## One World interface

A single `World` service with all 26 operations, implemented by every World: local, Postgres, Vercel, simulator. Not split by concern, by optionality, or by whether an operation can cross a network.

Two distinctions that do exist are traits on operations, not separate interfaces:

- **`optionalCapability`** (`BatchGetRuns`, `BulkCancelRuns`, `WriteStreamChunks`) generates an optional TypeScript method, exactly like today's `getMany?`, `cancelMany?`, and `writeMulti?`. `GetWorldInfo` reports which are present, since detecting a method's presence stops working once calls cross a transport where every method always exists.
- **`localOnly`** (`CreateRunId`, `GetRuntimeDeadline`, `GetEnvironment`, `DescribeRun`, `GetEncryptionKeyForRun`) marks what a transport projection must drop. These are ordinary World methods today, so they stay on the interface; dropping them is the projection's job.

Python `Protocol` has no optional members, so each omittable operation also gets a `runtime_checkable` narrowing protocol: `isinstance(world, SupportsBatchGetRuns)` is the Python spelling of `typeof world.batchGetRuns === 'function'`.

`RuntimeQueueConsumer` is the only other service and is **not** a second World interface: the runtime implements `DeliverQueueMessage` and a World's queue adapter calls it (today, the callback handed to `createQueueHandler`). Putting it on `World` would invert who implements what.

## No transports

No protocol trait, HTTP binding, or wire format appears anywhere in the model, per the ask. Operations are plain typed function shapes, so an in-process implementation satisfies the generated interface directly with no serialization involved. Adding HTTP or WebSocket later is an additive overlay projection over these same operations — that is what this arrangement keeps open, and none of it is proposed here.

## Modeling decisions worth arguing with

- Payloads stay opaque `blob`. Spec-version-1 runs carried unserialized JSON and are **not** representable — they need a conversion adapter.
- `resolveData` cannot change an output type in Smithy, so payload members are optional and `NONE` simply leaves them absent.
- `CreateEvent` keeps atomic materialization: committed event, affected entity, `stepCreated`, `maxEvents`, and the inline-delta members.
- A stale `eventCount` is **not** a precondition failure. Slot-numbering implementations bump to the next free slot and report skipped events; `PreconditionFailedError` is reserved for the separate `preconditionGuard` capability.
- Bulk cancel reports per-run outcome variants rather than failing the batch on one bad ID.
- `hook_conflict` stays readable-but-not-creatable.
- Union variants use empty structures rather than `Unit` — they can gain members later, and `Unit` members currently generate uncompilable TypeScript.
- Queue payload schemas and the analytics surface are deliberately left out; both are noted in the README.

## Why a local emitter for the interfaces

`smithy-typescript` types mode is transport-free and covers the data types well, but emits data shapes only — it never declares the operations. `smithy-python` has no published release and no Maven Central artifact, so for Python there is nothing upstream to run at all.

`idl/world/scripts/generate_ports.py` closes both gaps from the built model JSON. It is small and mechanical, the model stays the source of truth, and it is expected to be replaced by `smithy-python` when that ships and by a Smithy TypeScript integration if the interface should come from the same plugin as the types.

## Verification

- `smithy build` validates the model and generates the TypeScript types.
- The generated TypeScript, `ports.ts` included, type-checks under `tsc --strict`.
- The generated Python package imports; dataclasses, enums, tagged-union variants, and the narrowing protocols were exercised in a smoke script.
- `biome check` passes; the generated directory is ignored the same way `routeTree.gen.ts` is.

Regenerate with `idl/world/scripts/generate.sh` (needs the Smithy CLI and network access for Maven).

No changeset: no published package is touched.
