### PR TITLE
[builders] Preserve ESM import attributes

### DIFF
--- a/.changeset/preserve-esm-import-attributes.md
+++ b/.changeset/preserve-esm-import-attributes.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Preserve import attributes in generated ESM step bundles.

--- a/packages/builders/src/apply-swc-transform.ts
+++ b/packages/builders/src/apply-swc-transform.ts
@@ -117,11 +117,14 @@ export async function applySwcTransform(
             }),
       },
       target: 'es2022',
-      experimental: mode
-        ? {
-            plugins: [[swcPluginPath, { mode, moduleSpecifier }]],
-          }
-        : undefined,
+      experimental: {
+        // Import attributes carry runtime semantics (for example, JSON module
+        // validation) and must survive this transform for the bundler to honor.
+        keepImportAssertions: true,
+        plugins: mode
+          ? [[swcPluginPath, { mode, moduleSpecifier }]]
+          : undefined,
+      },
       transform: {
         react: {
           runtime: 'preserve',

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -1120,6 +1120,10 @@ export const __steps_registered = true;
       platform: 'node',
       conditions: ['node'],
       target: 'es2022',
+      // External ESM packages can require import attributes (for example,
+      // JSON imports). The Node.js runtime validates these attributes, so
+      // preserve them even though they postdate the general ES2022 target.
+      supported: format === 'esm' ? { 'import-attributes': true } : undefined,
       write: true,
       treeShaking: true,
       keepNames: true,

--- a/packages/builders/src/step-source-registration.test.ts
+++ b/packages/builders/src/step-source-registration.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { BaseBuilder, type DiscoveredEntries } from './base-builder.js';
 import type { StandaloneConfig } from './types.js';
@@ -31,6 +32,19 @@ class TestBuilder extends BaseBuilder {
       discoveredEntries,
     });
   }
+
+  public createBundledSteps(
+    inputFiles: string[],
+    outfile: string,
+    discoveredEntries: DiscoveredEntries
+  ) {
+    return this.createStepsBundle({
+      inputFiles,
+      outfile,
+      format: 'esm',
+      discoveredEntries,
+    });
+  }
 }
 
 const realTmpdir = realpathSync(tmpdir());
@@ -40,7 +54,10 @@ function writeFile(path: string, contents: string): void {
   writeFileSync(path, contents, 'utf-8');
 }
 
-function createBuilder(workingDir: string): TestBuilder {
+function createBuilder(
+  workingDir: string,
+  externalPackages?: string[]
+): TestBuilder {
   const config: StandaloneConfig = {
     buildTarget: 'standalone',
     workingDir,
@@ -48,6 +65,7 @@ function createBuilder(workingDir: string): TestBuilder {
     stepsBundlePath: join(workingDir, '.workflow', 'steps.js'),
     workflowsBundlePath: join(workingDir, '.workflow', 'workflows.js'),
     webhookBundlePath: join(workingDir, '.workflow', 'webhook.js'),
+    externalPackages,
   };
   return new TestBuilder(config);
 }
@@ -116,5 +134,49 @@ describe('step source registration', () => {
     expect(generated).toContain('import "../src/step.ts";');
     expect(generated).toContain('import "../src/serde.ts";');
     expect(Object.keys(manifest.classes ?? {})).toContain('src/serde.ts');
+  });
+
+  it('preserves import attributes for external packages in ESM bundles', async () => {
+    const packageName = 'json-import-fixture';
+    const packageDir = join(testRoot, 'node_modules', packageName);
+    const stepFile = join(testRoot, 'src', 'step.ts');
+    const outfile = join(testRoot, '.workflow', 'steps.mjs');
+
+    writeFile(
+      join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        type: 'module',
+        exports: './data.json',
+      })
+    );
+    writeFile(join(packageDir, 'data.json'), JSON.stringify({ value: 42 }));
+    writeFile(
+      stepFile,
+      `import data from '${packageName}' with { type: 'json' };
+
+export async function readJson() {
+  'use step';
+  return data.value;
+}
+`
+    );
+    mkdirSync(dirname(outfile), { recursive: true });
+
+    const discoveredEntries: DiscoveredEntries = {
+      discoveredSteps: new Set([stepFile]),
+      discoveredWorkflows: new Set(),
+      discoveredSerdeFiles: new Set(),
+    };
+
+    await createBuilder(testRoot, [packageName]).createBundledSteps(
+      [stepFile],
+      outfile,
+      discoveredEntries
+    );
+
+    const generated = readFileSync(outfile, 'utf-8');
+    expect(generated).toContain(`from "${packageName}" with { type: "json" }`);
+    await expect(import(pathToFileURL(outfile).href)).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- preserve import attributes while source passes through the Workflow SWC transform
- tell esbuild that generated ESM step bundles support import attributes, overriding the broader ES2022 target for that syntax only
- add an end-to-end regression that builds and loads an external JSON module import

## Motivation

The step bundle pipeline currently targets ES2022 in both SWC and esbuild. Import attributes are newer syntax, so both stages remove `with { type: 'json' }` from external imports. Node requires that attribute when loading JSON modules, which leaves the generated ESM bundle syntactically valid but unloadable with `ERR_IMPORT_ATTRIBUTE_MISSING`. This can surface through dependencies such as `builtin-modules@5`.

The fix keeps the existing target and dependency behavior. It preserves the semantic attribute in SWC, then overrides only esbuild's `import-attributes` feature support for ESM output. CommonJS output continues to lower the import to `require()`.

## Test plan

- `pnpm --filter @workflow/builders build`
- `pnpm --filter @workflow/builders typecheck`
- `pnpm --filter @workflow/builders test` (222 tests)
- `pnpm --filter @workflow/vitest build`
- `pnpm --filter @workflow/vitest test` (5 tests)
- `pnpm lint`
