### PR TITLE
[e2e] Host the abort-fetch slow endpoint inside the step

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -3893,7 +3893,7 @@ describe('e2e', () => {
 
         // Include the full returnValue (status + elapsedMs from the step) in
         // the assertion message so a flaky failure surfaces *why* fetch won
-        // the race — e.g. httpbin returning a 5xx in <1s — instead of just
+        // the race — e.g. the loopback fetch erroring in <1s — instead of just
         // "expected 'fetch' to be 'timeout'".
         const summary = JSON.stringify(returnValue);
         expect(returnValue.winner, summary).toBe('timeout');

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -2088,79 +2088,90 @@ async function abortFromStep(
 }
 
 /**
- * Step that uses fetch with an AbortSignal.
- * Uses a URL that intentionally delays, so the abort cancels it.
+ * Step that uses fetch with an AbortSignal against a slow endpoint the step
+ * hosts itself: an in-process `node:http` server on a loopback ephemeral
+ * port that holds each response open for ~30s before answering 200.
  *
- * Accepts a list of URLs and tries them in order, falling back to the
- * next on 5xx (or non-AbortError network failure) so a single bad upstream
- * doesn't flake the abort-fetch tests. Empirically, httpbin.org returns
- * 502 from GH Actions runners often enough to dominate CI flakiness;
- * pairing it with a second slow endpoint gives both belt and suspenders.
+ * Earlier versions fetched external slow endpoints (postman-echo, httpbin
+ * `/delay/10`, with fallback from one to the other), and those upstreams'
+ * 5xxs and early returns from GH Actions runners were a recurring e2e flake
+ * — the abort-fetch tests were measuring the public internet instead of
+ * abort propagation. A loopback server keeps the subject (cancelling a real
+ * in-flight HTTP fetch) while removing the external dependency entirely; a
+ * per-workbench `/api/delay` route was rejected earlier because it would
+ * exist only on whichever workbench it was added to.
  *
- * Reports `status`, `elapsedMs`, and the `url` that resolved so that when
- * the abort-fetch tests do fail, the assertion message shows exactly what
- * the upstream(s) returned instead of leaving us guessing why the race
- * winner was `fetch` instead of `timeout`.
+ * The 30s hold is load-bearing for regression detection: if abort
+ * propagation breaks, fetch runs to natural completion (`ok: true`,
+ * `aborted: false`) within the tests' 60s budgets and the assertions fail
+ * for the right reason, rather than hanging the suite.
+ *
+ * Reports `status` and `elapsedMs` so that when the abort-fetch tests do
+ * fail, the assertion message shows how the request actually ended instead
+ * of leaving us guessing why the race winner was `fetch` instead of
+ * `timeout`.
  */
-async function fetchWithSignal(
-  urls: readonly string[],
-  signal: AbortSignal
-): Promise<{
+async function fetchWithSignal(signal: AbortSignal): Promise<{
   ok: boolean;
   aborted: boolean;
   status?: number;
-  url?: string;
+  error?: string;
   elapsedMs: number;
-  attempts: { url: string; status?: number; error?: string }[];
 }> {
   'use step';
+  const { createServer } = await import('node:http');
   const startedAt = Date.now();
-  const attempts: { url: string; status?: number; error?: string }[] = [];
-  for (const url of urls) {
-    try {
-      const response = await globalThis.fetch(url, { signal });
-      attempts.push({ url, status: response.status });
-      if (response.ok) {
-        return {
-          ok: true,
-          aborted: false,
-          status: response.status,
-          url,
-          elapsedMs: Date.now() - startedAt,
-          attempts,
-        };
-      }
-      // Non-2xx — fall through and try the next URL.
-    } catch (err: any) {
-      if (err.name === 'AbortError') {
-        attempts.push({ url, error: 'AbortError' });
-        return {
-          ok: false,
-          aborted: true,
-          elapsedMs: Date.now() - startedAt,
-          attempts,
-        };
-      }
-      attempts.push({ url, error: err?.message ?? String(err) });
-      // Network error — fall through and try the next URL.
-    }
-  }
-  return {
-    ok: false,
-    aborted: false,
-    elapsedMs: Date.now() - startedAt,
-    attempts,
-  };
-}
 
-// Slow endpoints used by the abort-fetch e2e tests. Tried in order; postman-
-// echo first because httpbin.org has historically returned 502s from GH
-// Actions. Both cap at /delay/10 in practice, which is comfortably longer
-// than the 2s race threshold these tests use.
-const SLOW_FETCH_URLS = [
-  'https://postman-echo.com/delay/10',
-  'https://httpbin.org/delay/10',
-] as const;
+  const timers: NodeJS.Timeout[] = [];
+  const server = createServer((_req, res) => {
+    timers.push(
+      setTimeout(() => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ delayed: true }));
+      }, 30_000)
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address !== 'object') {
+    server.close();
+    throw new Error('Invariant: expected loopback server to have a port');
+  }
+
+  try {
+    const response = await globalThis.fetch(
+      `http://127.0.0.1:${address.port}/delay`,
+      { signal }
+    );
+    return {
+      ok: response.ok,
+      aborted: false,
+      status: response.status,
+      elapsedMs: Date.now() - startedAt,
+    };
+  } catch (err: any) {
+    if (err.name === 'AbortError') {
+      return {
+        ok: false,
+        aborted: true,
+        elapsedMs: Date.now() - startedAt,
+      };
+    }
+    return {
+      ok: false,
+      aborted: false,
+      error: err?.message ?? String(err),
+      elapsedMs: Date.now() - startedAt,
+    };
+  } finally {
+    for (const timer of timers) clearTimeout(timer);
+    server.closeAllConnections();
+    server.close();
+  }
+}
 
 /**
  * E2E: Basic timeout cancellation.
@@ -2621,14 +2632,10 @@ export async function abortFetchInFlightWorkflow() {
   'use workflow';
 
   const controller = new AbortController();
-  // SLOW_FETCH_URLS holds the response open for ~10s — used here as a slow
-  // endpoint that the abort can cancel mid-flight. Same external-service
-  // pattern as other e2e workflows in this file (jsonplaceholder, example.com).
-  // Avoids needing a per-workbench /api/delay route, which would only exist
-  // on the one workbench it was added to. The step falls back to the second
-  // URL only if the first returns a 5xx or non-AbortError network failure,
-  // so a transient outage on one upstream doesn't flake the test.
-  const fetchPromise = fetchWithSignal(SLOW_FETCH_URLS, controller.signal);
+  // The step hosts its own slow endpoint (see fetchWithSignal) that holds
+  // the response open for ~30s — a real in-flight fetch the abort can
+  // cancel mid-flight, with no external upstream to flake.
+  const fetchPromise = fetchWithSignal(controller.signal);
 
   // Race the fetch against a 2s sleep. Sleep wins; abort fires.
   const winner = await Promise.race([
@@ -2671,7 +2678,7 @@ export async function abortVoidSleepTimeoutWorkflow() {
   const controller = new AbortController();
   void sleep('2s').then(() => controller.abort());
 
-  return await fetchWithSignal(SLOW_FETCH_URLS, controller.signal);
+  return await fetchWithSignal(controller.signal);
 }
 
 /**


### PR DESCRIPTION
## Summary & Motivation

The abort-fetch e2e tests raced a 2s sleep against a fetch to public slow endpoints (postman-echo, httpbin `/delay/10`), so upstream 5xxs and early returns from CI runners showed up as flakes. `fetchWithSignal` now stands up a loopback `node:http` server that holds each response open for ~30s, keeping the subject — cancelling a real in-flight fetch — with no external dependency. The 30s hold is longer than the tests' 60s budgets minus the race, so broken abort propagation still fails as a natural completion rather than a hang.

## Test Plan

Existing abort-fetch e2e coverage runs in CI; `workbench/example` builds clean.
