### PR TITLE
[e2e] Shrink fibonacciWorkflow's run tree from fib(6) to fib(5)

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -2670,11 +2670,15 @@ describe('e2e', () => {
     'fibonacciWorkflow - recursive workflow composition via start()',
     { timeout: 180_000 },
     async () => {
-      // fib(6) = 8, spawns a tree of child workflow runs
-      const run = await start(await e2e('fibonacciWorkflow'), [6]);
+      // fib(5) = 5, spawns a tree of 15 runs (~14 concurrent parent polls at
+      // peak). fib(6)'s 25-run tree proved enough to saturate the scheduler
+      // past this test's budget under a concurrent suite (#2083); depth 4
+      // still exercises recursive start() composition with parallel children
+      // at every level, which is the subject here — the tree size is not.
+      const run = await start(await e2e('fibonacciWorkflow'), [5]);
       trackRun(run);
       const returnValue = await run.returnValue;
-      expect(returnValue).toBe(8);
+      expect(returnValue).toBe(5);
     }
   );
 


### PR DESCRIPTION
## Summary & Motivation

fib(6)'s 25-run tree saturates the scheduler past this test's 180s budget when the e2e suite runs concurrently (#2083). fib(5) keeps the subject — recursive `start()` composition with parallel children at every level — at 15 runs.

## Test Plan

Existing coverage: the modified test runs in CI across the workbench matrix.
