### PR TITLE
[e2e] Assert only the positive direction of step source maps

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1353,12 +1353,16 @@ describe('e2e', () => {
             expect(result.stack).toContain('errorStepFn');
             expect(result.stack).not.toContain('evalmachine');
 
-            // Source maps are not supported everywhere. Check the definition
-            // of hasStepSourceMaps() to see where they are supported
+            // Source maps are not supported everywhere — see
+            // hasStepSourceMaps() for the matrix. Only the positive direction
+            // is asserted: where maps are unsupported they still apply
+            // nondeterministically on some lanes (nuxt, nextjs-webpack), so
+            // asserting their absence pinned that nondeterminism as a flake.
+            // A stack resolving to source where none was promised is an
+            // improvement, not a failure — hasStepSourceMaps() is the record
+            // to update when a lane starts mapping reliably.
             if (hasStepSourceMaps()) {
               expect(result.stack).toContain('99_e2e.ts');
-            } else {
-              expect(result.stack).not.toContain('99_e2e.ts');
             }
 
             // Verify step failed via CLI (--withData needed to resolve errorRef)
@@ -1381,12 +1385,10 @@ describe('e2e', () => {
             expect(errorData.stack).toContain('errorStepFn');
             expect(errorData.stack).not.toContain('evalmachine');
 
-            // Source maps are not supported everywhere. Check the definition
-            // of hasStepSourceMaps() to see where they are supported
+            // Positive direction only — see the note on the first source-map
+            // assertion above.
             if (hasStepSourceMaps()) {
               expect(errorData.stack).toContain('99_e2e.ts');
-            } else {
-              expect(errorData.stack).not.toContain('99_e2e.ts');
             }
 
             // Workflow completed (error was caught)
@@ -1415,12 +1417,10 @@ describe('e2e', () => {
             expect(result.stack).toContain('stepThatThrowsFromHelper');
             expect(result.stack).not.toContain('evalmachine');
 
-            // Source maps are not supported everywhere. Check the definition
-            // of hasStepSourceMaps() to see where they are supported
+            // Positive direction only — see the note on the first source-map
+            // assertion above.
             if (hasStepSourceMaps()) {
               expect(result.stack).toContain('helpers.ts');
-            } else {
-              expect(result.stack).not.toContain('helpers.ts');
             }
 
             // Verify step failed via CLI - same stack info available there too (--withData needed to resolve errorRef)
@@ -1439,12 +1439,10 @@ describe('e2e', () => {
             }
             expect(errorData.stack).toContain('stepThatThrowsFromHelper');
             expect(errorData.stack).not.toContain('evalmachine');
-            // Source maps are not supported everywhere. Check the definition
-            // of hasStepSourceMaps() to see where they are supported
+            // Positive direction only — see the note on the first source-map
+            // assertion above.
             if (hasStepSourceMaps()) {
               expect(errorData.stack).toContain('helpers.ts');
-            } else {
-              expect(errorData.stack).not.toContain('helpers.ts');
             }
 
             // Workflow completed (error was caught)


### PR DESCRIPTION
## Summary & Motivation

Source maps apply nondeterministically on lanes where `hasStepSourceMaps()` reports them unsupported (nuxt, nextjs-webpack), so asserting their absence turned that nondeterminism into a flake — one of the classes blocking e2e concurrency re-enablement (#2083). `hasStepSourceMaps()` stays the record to update when a lane starts mapping reliably, checked by the positive assertions on the lanes it does promise.

## Test Plan

- [ ] Existing e2e coverage runs in CI
