### PR TITLE
[web-shared] Optimize MiddleTruncate resize measurements

### DIFF
--- a/.changeset/fast-middle-truncate-resizes.md
+++ b/.changeset/fast-middle-truncate-resizes.md
@@ -1,0 +1,5 @@
+---
+"@workflow/web-shared": patch
+---
+
+Batch and cache middle-truncate measurements to avoid repeated layout work during resizes.

--- a/packages/web-shared/src/components/trace-viewer/components/middle-truncate/measurement-batch.ts
+++ b/packages/web-shared/src/components/trace-viewer/components/middle-truncate/measurement-batch.ts
@@ -1,0 +1,47 @@
+interface MeasurementTask<T> {
+  measure: (measurement: T) => void;
+  read: () => T | null;
+}
+
+type PendingMeasurement = () => (() => void) | null;
+
+const pendingMeasurements = new Map<object, PendingMeasurement>();
+let measurementFrame = 0;
+
+function flushMeasurements(): void {
+  measurementFrame = 0;
+
+  const reads = [...pendingMeasurements.values()];
+  pendingMeasurements.clear();
+  const measures = reads.map((read) => read());
+
+  for (const measure of measures) {
+    measure?.();
+  }
+}
+
+function scheduleMeasurement<T>(
+  key: object,
+  { read, measure }: MeasurementTask<T>
+): void {
+  pendingMeasurements.set(key, () => {
+    const measurement = read();
+    return measurement === null ? null : () => measure(measurement);
+  });
+
+  if (measurementFrame === 0) {
+    measurementFrame = requestAnimationFrame(flushMeasurements);
+  }
+}
+
+function cancelMeasurement(key: object): void {
+  pendingMeasurements.delete(key);
+
+  if (pendingMeasurements.size === 0 && measurementFrame !== 0) {
+    cancelAnimationFrame(measurementFrame);
+    measurementFrame = 0;
+  }
+}
+
+export { cancelMeasurement, scheduleMeasurement };
+export type { MeasurementTask };

--- a/packages/web-shared/src/components/trace-viewer/components/middle-truncate/middle-truncate.tsx
+++ b/packages/web-shared/src/components/trace-viewer/components/middle-truncate/middle-truncate.tsx
@@ -28,13 +28,20 @@ function getRangeOffsets(
     return null;
   }
 
-  const startRange = document.createRange();
-  startRange.selectNodeContents(container);
-  startRange.setEnd(range.startContainer, range.startOffset);
+  let startRange: Range;
+  let endRange: Range;
 
-  const endRange = document.createRange();
-  endRange.selectNodeContents(container);
-  endRange.setEnd(range.endContainer, range.endOffset);
+  try {
+    startRange = document.createRange();
+    startRange.selectNodeContents(container);
+    startRange.setEnd(range.startContainer, range.startOffset);
+
+    endRange = document.createRange();
+    endRange.selectNodeContents(container);
+    endRange.setEnd(range.endContainer, range.endOffset);
+  } catch {
+    return null;
+  }
 
   return {
     end: endRange.toString().length,
@@ -80,6 +87,7 @@ function MiddleTruncate({
       let copyText: string | null = null;
 
       if (
+        selectionText.includes(ELLIPSIS) &&
         e.currentTarget.contains(range.startContainer) &&
         e.currentTarget.contains(range.endContainer) &&
         visibleEl

--- a/packages/web-shared/src/components/trace-viewer/components/middle-truncate/use-middle-truncate.ts
+++ b/packages/web-shared/src/components/trace-viewer/components/middle-truncate/use-middle-truncate.ts
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { cancelMeasurement, scheduleMeasurement } from './measurement-batch';
 import { middleTruncate, toGraphemes } from './truncate';
 
 const useIsomorphicLayoutEffect =
@@ -20,6 +21,17 @@ interface MiddleTruncateState {
   prefixText: string;
   suffixGraphemeCount: number;
   suffixText: string;
+}
+
+interface MiddleTruncateMeasurement {
+  availableWidth: number;
+  typography: string;
+}
+
+interface TextMeasurementCache {
+  typography: string;
+  value: string;
+  widths: Map<string, number>;
 }
 
 function createFullState(
@@ -62,7 +74,15 @@ function useMiddleTruncate(value: string): {
   const ref = useRef<HTMLSpanElement | null>(null);
   const measureRef = useRef<HTMLSpanElement | null>(null);
   const [state, setState] = useState<MiddleTruncateState>(() => fullState);
-  const rafRef = useRef<number>(0);
+  const measurementKeyRef = useRef<object>({});
+  const textMeasurementCacheRef = useRef<TextMeasurementCache>({
+    typography: '',
+    value,
+    widths: new Map(),
+  });
+  const lastMeasurementRef = useRef<
+    (MiddleTruncateMeasurement & { value: string }) | null
+  >(null);
 
   const updateState = useCallback((nextState: MiddleTruncateState) => {
     setState((currentState) => {
@@ -81,76 +101,150 @@ function useMiddleTruncate(value: string): {
     });
   }, []);
 
-  const recalculate = useCallback(() => {
+  const readMeasurement = useCallback((): MiddleTruncateMeasurement | null => {
     const el = ref.current;
     const measureEl = measureRef.current;
-    if (!el || !measureEl) return;
+    if (!el || !measureEl) return null;
 
-    const available = el.clientWidth;
+    const availableWidth = el.clientWidth;
+    const style = getComputedStyle(measureEl);
 
-    if (available <= 0) {
-      updateState(fullState);
-      return;
-    }
-
-    const measure = (text: string): number => {
-      measureEl.textContent = text;
-      return measureEl.scrollWidth;
+    return {
+      availableWidth,
+      typography: [
+        style.fontFamily,
+        style.fontFeatureSettings,
+        style.fontKerning,
+        style.fontSize,
+        style.fontStretch,
+        style.fontStyle,
+        style.fontVariationSettings,
+        style.fontWeight,
+        style.letterSpacing,
+        style.textTransform,
+      ].join('\0'),
     };
+  }, []);
 
-    const fullWidth = measure(value);
+  const recalculate = useCallback(
+    ({ availableWidth, typography }: MiddleTruncateMeasurement) => {
+      const measureEl = measureRef.current;
+      if (!measureEl) return;
 
-    if (fullWidth <= available) {
-      updateState(fullState);
-      return;
-    }
+      const lastMeasurement = lastMeasurementRef.current;
+      if (
+        lastMeasurement?.availableWidth === availableWidth &&
+        lastMeasurement.typography === typography &&
+        lastMeasurement.value === value
+      ) {
+        return;
+      }
 
-    const result = middleTruncate(graphemes, available, measure, fullWidth);
-    updateState({
-      displayText: result.text,
-      isTruncated: result.truncated,
-      prefixGraphemeCount: result.prefixGraphemeCount,
-      prefixText: result.prefixText,
-      suffixGraphemeCount: result.suffixGraphemeCount,
-      suffixText: result.suffixText,
-    });
-  }, [fullState, graphemes, updateState, value]);
+      lastMeasurementRef.current = {
+        availableWidth,
+        typography,
+        value,
+      };
+
+      if (availableWidth <= 0) {
+        updateState(fullState);
+        return;
+      }
+
+      const textMeasurementCache = textMeasurementCacheRef.current;
+      if (
+        textMeasurementCache.typography !== typography ||
+        textMeasurementCache.value !== value
+      ) {
+        textMeasurementCache.typography = typography;
+        textMeasurementCache.value = value;
+        textMeasurementCache.widths.clear();
+      }
+
+      const measure = (text: string): number => {
+        const cachedWidth = textMeasurementCache.widths.get(text);
+        if (cachedWidth !== undefined) {
+          return cachedWidth;
+        }
+
+        measureEl.textContent = text;
+        const width = measureEl.scrollWidth;
+        textMeasurementCache.widths.set(text, width);
+        return width;
+      };
+
+      const fullWidth = measure(value);
+
+      if (fullWidth <= availableWidth) {
+        updateState(fullState);
+        return;
+      }
+
+      const result = middleTruncate(
+        graphemes,
+        availableWidth,
+        measure,
+        fullWidth
+      );
+      updateState({
+        displayText: result.text,
+        isTruncated: result.truncated,
+        prefixGraphemeCount: result.prefixGraphemeCount,
+        prefixText: result.prefixText,
+        suffixGraphemeCount: result.suffixGraphemeCount,
+        suffixText: result.suffixText,
+      });
+    },
+    [fullState, graphemes, updateState, value]
+  );
 
   // Measure on mount and when value changes - before paint
   useIsomorphicLayoutEffect(() => {
-    recalculate();
-  }, [recalculate]);
+    const measurement = readMeasurement();
+    if (measurement) {
+      recalculate(measurement);
+    }
+  }, [readMeasurement, recalculate]);
 
   // ResizeObserver + font loading for ongoing responsiveness
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
 
-    const debouncedRecalc = (): void => {
-      cancelAnimationFrame(rafRef.current);
-      rafRef.current = requestAnimationFrame(recalculate);
+    const measurementKey = measurementKeyRef.current;
+    const scheduleRecalculation = (): void => {
+      scheduleMeasurement(measurementKey, {
+        read: readMeasurement,
+        measure: recalculate,
+      });
     };
 
     const ro =
       typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(debouncedRecalc)
+        ? new ResizeObserver(scheduleRecalculation)
         : null;
     ro?.observe(el);
-    window.addEventListener('resize', debouncedRecalc);
+    if (!ro) {
+      window.addEventListener('resize', scheduleRecalculation);
+    }
 
     const onFontsLoaded = (): void => {
-      debouncedRecalc();
+      textMeasurementCacheRef.current.widths.clear();
+      lastMeasurementRef.current = null;
+      scheduleRecalculation();
     };
     const fontSet = 'fonts' in document ? document.fonts : null;
     fontSet?.addEventListener?.('loadingdone', onFontsLoaded);
 
     return () => {
       ro?.disconnect();
-      window.removeEventListener('resize', debouncedRecalc);
-      cancelAnimationFrame(rafRef.current);
+      if (!ro) {
+        window.removeEventListener('resize', scheduleRecalculation);
+      }
+      cancelMeasurement(measurementKey);
       fontSet?.removeEventListener?.('loadingdone', onFontsLoaded);
     };
-  }, [recalculate]);
+  }, [readMeasurement, recalculate]);
 
   return {
     ref,

--- a/packages/web-shared/test/middle-truncate-measurement-batch.test.ts
+++ b/packages/web-shared/test/middle-truncate-measurement-batch.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  cancelMeasurement,
+  scheduleMeasurement,
+} from '../src/components/trace-viewer/components/middle-truncate/measurement-batch.js';
+
+function mockAnimationFrames(): {
+  cancel: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  runNext: () => void;
+} {
+  let nextFrame = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const request = vi.fn((callback: FrameRequestCallback): number => {
+    const frame = nextFrame++;
+    callbacks.set(frame, callback);
+    return frame;
+  });
+  const cancel = vi.fn((frame: number): void => {
+    callbacks.delete(frame);
+  });
+
+  vi.stubGlobal('requestAnimationFrame', request);
+  vi.stubGlobal('cancelAnimationFrame', cancel);
+
+  return {
+    cancel,
+    request,
+    runNext: () => {
+      const next = callbacks.entries().next().value;
+      if (!next) {
+        throw new Error('No animation frame is scheduled');
+      }
+
+      const [frame, callback] = next;
+      callbacks.delete(frame);
+      callback(0);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('MiddleTruncate measurement batching', () => {
+  it('runs every DOM read before any measurement write', () => {
+    const frames = mockAnimationFrames();
+    const calls: string[] = [];
+
+    scheduleMeasurement(
+      {},
+      {
+        read: () => {
+          calls.push('read first');
+          return 'first';
+        },
+        measure: (measurement) => {
+          calls.push(`measure ${measurement}`);
+        },
+      }
+    );
+    scheduleMeasurement(
+      {},
+      {
+        read: () => {
+          calls.push('read second');
+          return 'second';
+        },
+        measure: (measurement) => {
+          calls.push(`measure ${measurement}`);
+        },
+      }
+    );
+
+    expect(frames.request).toHaveBeenCalledTimes(1);
+    frames.runNext();
+    expect(calls).toEqual([
+      'read first',
+      'read second',
+      'measure first',
+      'measure second',
+    ]);
+  });
+
+  it('coalesces repeated resize notifications for one component', () => {
+    const frames = mockAnimationFrames();
+    const key = {};
+    const calls: string[] = [];
+
+    scheduleMeasurement(key, {
+      read: () => {
+        calls.push('stale read');
+        return 'stale';
+      },
+      measure: () => {
+        calls.push('stale measure');
+      },
+    });
+    scheduleMeasurement(key, {
+      read: () => {
+        calls.push('latest read');
+        return 'latest';
+      },
+      measure: (measurement) => {
+        calls.push(`measure ${measurement}`);
+      },
+    });
+
+    expect(frames.request).toHaveBeenCalledTimes(1);
+    frames.runNext();
+    expect(calls).toEqual(['latest read', 'measure latest']);
+  });
+
+  it('cancels the frame after the last pending component unmounts', () => {
+    const frames = mockAnimationFrames();
+    const first = {};
+    const second = {};
+
+    scheduleMeasurement(first, {
+      read: () => 'first',
+      measure: () => {},
+    });
+    scheduleMeasurement(second, {
+      read: () => 'second',
+      measure: () => {},
+    });
+
+    cancelMeasurement(first);
+    expect(frames.cancel).not.toHaveBeenCalled();
+
+    cancelMeasurement(second);
+    expect(frames.cancel).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Ports the `MiddleTruncate` resize-performance changes from `vercel/front#80351` into the observability UI copy. Resize work is now coalesced across instances, all layout reads happen before text-measurement writes, and unchanged text measurements are cached.

The copy-selection path also avoids unnecessary range calculations and handles invalid DOM ranges defensively.

### How did you test your changes?

- `pnpm turbo build --filter="@workflow/web-shared..."`
- `pnpm --filter @workflow/web-shared typecheck`
- `pnpm --filter @workflow/web-shared test` on Node 22.22.2 (201 tests passed)
- `pnpm --filter @workflow/web-shared lint` (exits successfully with the package's existing warnings)
- Added focused regressions for cross-instance read/write batching, repeated resize coalescing, and cleanup on unmount

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [ ] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4aa6b040-bac5-40ec-9c9a-2d43681b2065?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aa6b040-bac5-40ec-9c9a-2d43681b2065&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

