### PR TITLE
[workflow] Share isolated serializer registries across replay bundles

### DIFF
--- a/.changeset/shared-serializer-bootstrap.md
+++ b/.changeset/shared-serializer-bootstrap.md
@@ -1,0 +1,6 @@
+---
+'@workflow/builders': patch
+'@workflow/core': patch
+---
+
+Deduplicate dependency-isolated custom serializer registration across per-source replay bundles.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -28,9 +28,11 @@ import {
   createWorkflowEntrypointOptionsCode,
   createWorkflowRouteHandlersCode,
 } from './constants.js';
+import { parentHasChild } from './discover-entries-esbuild-plugin.js';
 import { getEsbuildTsconfigOptions } from './esbuild-tsconfig.js';
 import {
   type DiscoveredEntries,
+  extractImportSpecifiers,
   fastDiscoverEntries,
 } from './fast-discovery.js';
 import {
@@ -197,6 +199,87 @@ function moduleIdentityKey(file: string, moduleSpecifierRoot: string): string {
   return file.replace(/\\/g, '/');
 }
 
+async function canShareSerializer(
+  file: string,
+  workflowPaths: string[],
+  stepPaths: string[],
+  workflowIdentities: Set<string>,
+  moduleSpecifierRoot: string
+): Promise<boolean> {
+  if (workflowIdentities.has(moduleIdentityKey(file, moduleSpecifierRoot))) {
+    return false;
+  }
+  const [source, serializerPaths] = await Promise.all([
+    readFile(file, 'utf8'),
+    withRealpaths([file]),
+  ]);
+  if (
+    extractImportSpecifiers(source).some(
+      (specifier) => specifier !== '@workflow/serde'
+    )
+  ) {
+    return false;
+  }
+  return !workflowPaths.some((workflowPath) =>
+    serializerPaths.some((serializerPath) =>
+      parentHasChild(
+        workflowPath.replace(/\\/g, '/'),
+        serializerPath.replace(/\\/g, '/'),
+        { excludedRoots: stepPaths }
+      )
+    )
+  );
+}
+
+function shareableSerializerSuffix(
+  serializerFiles: string[],
+  shareableFiles: string[],
+  moduleSpecifierRoot: string
+): string[] {
+  const shareableIdentities = new Set(
+    shareableFiles.map((file) => moduleIdentityKey(file, moduleSpecifierRoot))
+  );
+  let suffixStart = serializerFiles.length;
+  while (
+    suffixStart > 0 &&
+    shareableIdentities.has(
+      moduleIdentityKey(serializerFiles[suffixStart - 1], moduleSpecifierRoot)
+    )
+  ) {
+    suffixStart--;
+  }
+  return serializerFiles.slice(suffixStart);
+}
+
+function lastSerializerBundledWithWorkflow(
+  result: esbuild.BuildResult,
+  serializerFiles: string[],
+  workingDir: string,
+  moduleSpecifierRoot: string
+): number {
+  const workflowInputIdentities = new Set(
+    Object.entries(result.metafile?.outputs ?? {})
+      .filter(([output]) => /workflow-\d+\.js$/.test(output))
+      .flatMap(([, { inputs }]) =>
+        Object.keys(inputs)
+          .filter((input) => !input.startsWith('workflow-entry:'))
+          .map((input) =>
+            moduleIdentityKey(resolve(workingDir, input), moduleSpecifierRoot)
+          )
+      )
+  );
+  for (let index = serializerFiles.length - 1; index >= 0; index--) {
+    if (
+      workflowInputIdentities.has(
+        moduleIdentityKey(serializerFiles[index], moduleSpecifierRoot)
+      )
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
 type ManifestEntryLocation = {
   filePath: string;
   name: string;
@@ -208,16 +291,34 @@ type CachedManifestTransform = {
   manifest: WorkflowManifest;
 };
 
-type WorkflowBundle = {
+type WorkflowBundleArtifact = {
   code: string;
   fileName: string;
+};
+
+type WorkflowBundle = WorkflowBundleArtifact & {
   workflowIds: string[];
 };
+
+type WorkflowBundleSet = {
+  serializerRegistry?: WorkflowBundleArtifact;
+  workflowBundles: WorkflowBundle[];
+};
+
+function bundleArtifacts({
+  serializerRegistry,
+  workflowBundles,
+}: WorkflowBundleSet): WorkflowBundleArtifact[] {
+  return serializerRegistry
+    ? [serializerRegistry, ...workflowBundles]
+    : workflowBundles;
+}
 
 type WorkflowBundleBuild = {
   context: esbuild.BuildContext;
   manifest: WorkflowManifest;
-  readBundles(result: esbuild.BuildResult): WorkflowBundle[];
+  readBundles(result: esbuild.BuildResult): WorkflowBundleSet;
+  rebuild(): Promise<esbuild.BuildResult>;
   startedAt: number;
 };
 
@@ -228,21 +329,35 @@ function getWorkflowIds(manifest: WorkflowManifest): string[] {
 }
 
 function createWorkflowBundleLoaders(
-  bundles: WorkflowBundle[],
+  { serializerRegistry, workflowBundles }: WorkflowBundleSet,
   source: 'module' | 'inline'
 ): string {
-  const loaders = bundles
-    .map(({ code, fileName }, index) => {
-      const modulePath = `./${WORKFLOW_BUNDLE_DIRECTORY}/${fileName}`;
-      if (source === 'module') {
-        return `let workflowBundlePromise${index};
-const loadWorkflowBundle${index} = () => workflowBundlePromise${index} ??= import('${modulePath}').then((module) => Buffer.from(module.default, 'base64').toString('utf8'));`;
-      }
-      return `let workflowBundle${index};
-const loadWorkflowBundle${index} = () => Promise.resolve(workflowBundle${index} ??= Buffer.from(${JSON.stringify(encodeWorkflowBundle(code))}, 'base64').toString('utf8'));`;
-    })
+  const createLoader = (
+    { code, fileName }: WorkflowBundleArtifact,
+    name: string,
+    cacheName: string
+  ) => {
+    const modulePath = `./${WORKFLOW_BUNDLE_DIRECTORY}/${fileName}`;
+    if (source === 'module') {
+      return `let ${cacheName}Promise;
+const load${name} = () => ${cacheName}Promise ??= import('${modulePath}').then((module) => Buffer.from(module.default, 'base64').toString('utf8'));`;
+    }
+    return `let ${cacheName};
+const load${name} = () => Promise.resolve(${cacheName} ??= Buffer.from(${JSON.stringify(encodeWorkflowBundle(code))}, 'base64').toString('utf8'));`;
+  };
+  const loaders = workflowBundles
+    .map((bundle, index) =>
+      createLoader(bundle, `WorkflowBundle${index}`, `workflowBundle${index}`)
+    )
     .join('\n');
-  const entries = bundles
+  const serializerLoader = serializerRegistry
+    ? createLoader(
+        serializerRegistry,
+        'SerializerRegistry',
+        'serializerRegistry'
+      )
+    : '';
+  const entries = workflowBundles
     .flatMap(({ workflowIds }, index) =>
       workflowIds.map(
         (workflowId) =>
@@ -251,7 +366,10 @@ const loadWorkflowBundle${index} = () => Promise.resolve(workflowBundle${index} 
     )
     .join('\n');
 
-  return `${loaders}\nconst workflowCode = {\n${entries}\n};`;
+  const serializerAssignment = serializerRegistry
+    ? '\nworkflowCode.__serializerRegistry = loadSerializerRegistry;'
+    : '';
+  return `${loaders}\n${serializerLoader}\nconst workflowCode = {\n${entries}\n};${serializerAssignment}`;
 }
 
 function formatIdLocation(location: ManifestEntryLocation): string {
@@ -1354,14 +1472,16 @@ export const __steps_registered = true;
 
   private async warnAboutSerdeCompliance(
     manifest: WorkflowManifest,
-    bundles: WorkflowBundle[]
+    bundles: WorkflowBundleSet
   ): Promise<void> {
     if (!manifest.classes || Object.keys(manifest.classes).length === 0) return;
 
     const { analyzeSerdeCompliance } = await import('./serde-checker.js');
     const serdeResult = analyzeSerdeCompliance({
       sourceCode: '',
-      workflowCode: bundles.map(({ code }) => code).join('\n'),
+      workflowCode: bundleArtifacts(bundles)
+        .map(({ code }) => code)
+        .join('\n'),
       manifest,
     });
     const issuesToClasses = new Map<string, Set<string>>();
@@ -1388,7 +1508,7 @@ export const __steps_registered = true;
 
   private createWorkflowBundlePublisher(
     outfile: string
-  ): (bundles: WorkflowBundle[]) => Promise<void> {
+  ): (bundles: WorkflowBundleSet) => Promise<void> {
     const workflowBundleDir = join(dirname(outfile), WORKFLOW_BUNDLE_DIRECTORY);
     let shouldResetWorkflowBundleDir = true;
     return async (bundles) => {
@@ -1406,7 +1526,7 @@ export const __steps_registered = true;
         shouldResetWorkflowBundleDir = false;
       }
       await Promise.all(
-        bundles.map(({ code, fileName }) =>
+        bundleArtifacts(bundles).map(({ code, fileName }) =>
           this.writeGeneratedFile(
             join(workflowBundleDir, fileName),
             serializeWorkflowBundle(code)
@@ -1451,29 +1571,83 @@ export const __steps_registered = true;
       })
     );
     const serdeFiles = uniqueFiles([...discovered.discoveredSerdeFiles].sort());
+    const workflowIdentities = new Set(
+      workflowFiles.map((file) =>
+        moduleIdentityKey(file, this.moduleSpecifierRoot)
+      )
+    );
+    const workflowPaths = await withRealpaths(workflowFiles);
+    const stepPaths = (
+      await withRealpaths([...discovered.discoveredSteps])
+    ).map((file) => file.replace(/\\/g, '/'));
+    const shareableSerializerFiles =
+      workflowFiles.length > 1 && !this.config.watch
+        ? (
+            await Promise.all(
+              serdeFiles.map(async (file) =>
+                (await canShareSerializer(
+                  file,
+                  workflowPaths,
+                  stepPaths,
+                  workflowIdentities,
+                  this.moduleSpecifierRoot
+                ))
+                  ? file
+                  : undefined
+              )
+            )
+          ).filter((file): file is string => file !== undefined)
+        : [];
+
+    // Moving a serializer into a separately evaluated script may not reorder it
+    // across a retained serializer.
+    let sharedSerializerFiles = shareableSerializerSuffix(
+      serdeFiles,
+      shareableSerializerFiles,
+      this.moduleSpecifierRoot
+    );
 
     await this.writeDebugFile(outfile, { workflowFiles, serdeFiles });
 
     const createImport = (file: string) =>
       `import '${this.createRouteImportSpecifier(file, this.config.workingDir)}';`;
     const bundleFiles = workflowFiles.length > 0 ? workflowFiles : [undefined];
-    const bundleEntries = bundleFiles.map((workflowFile) => {
-      const workflowImport = workflowFile ? createImport(workflowFile) : '';
-      const workflowIdentity = workflowFile
-        ? moduleIdentityKey(workflowFile, this.moduleSpecifierRoot)
-        : undefined;
-      const serdeImports = serdeFiles
-        .filter(
-          (file) =>
-            moduleIdentityKey(file, this.moduleSpecifierRoot) !==
-            workflowIdentity
+    let bundleEntries: string[] = [];
+    let serializerRegistryEntry = '';
+    const updateBundleEntries = () => {
+      const sharedSerializerIdentities = new Set(
+        sharedSerializerFiles.map((file) =>
+          moduleIdentityKey(file, this.moduleSpecifierRoot)
         )
+      );
+      const perWorkflowSerdeFiles = serdeFiles.filter(
+        (file) =>
+          !sharedSerializerIdentities.has(
+            moduleIdentityKey(file, this.moduleSpecifierRoot)
+          )
+      );
+      bundleEntries = bundleFiles.map((workflowFile) => {
+        const workflowImport = workflowFile ? createImport(workflowFile) : '';
+        const workflowIdentity = workflowFile
+          ? moduleIdentityKey(workflowFile, this.moduleSpecifierRoot)
+          : undefined;
+        const serdeImports = perWorkflowSerdeFiles
+          .filter(
+            (file) =>
+              moduleIdentityKey(file, this.moduleSpecifierRoot) !==
+              workflowIdentity
+          )
+          .map(createImport)
+          .join('\n');
+        return serdeImports
+          ? `${workflowImport}\n// Serde files for cross-context class registration\n${serdeImports}`
+          : workflowImport;
+      });
+      serializerRegistryEntry = sharedSerializerFiles
         .map(createImport)
         .join('\n');
-      return serdeImports
-        ? `${workflowImport}\n// Serde files for cross-context class registration\n${serdeImports}`
-        : workflowImport;
-    });
+    };
+    updateBundleEntries();
     const startedAt = Date.now();
     const manifest: WorkflowManifest = {};
     const workflowIdsByBundleIndex = new Map<number, string[]>();
@@ -1483,12 +1657,15 @@ export const __steps_registered = true;
       ...workflowFiles,
       ...serdeFiles,
     ]);
-    const entryPoints = Object.fromEntries(
+    const entryPoints: Record<string, string> = Object.fromEntries(
       bundleEntries.map((_, index) => [
         `workflow-${index}`,
         `workflow-entry:${index}`,
       ])
     );
+    if (serializerRegistryEntry) {
+      entryPoints['serializer-registry'] = 'serializer-registry-entry';
+    }
     const workflowResolveDir = this.config.workingDir;
 
     // Bundle each workflow source independently. A source may register several
@@ -1508,11 +1685,11 @@ export const __steps_registered = true;
       treeShaking: true,
       keepNames: true,
       minify: false,
-      metafile: includeMetafile,
+      metafile: includeMetafile || sharedSerializerFiles.length > 0,
       // Initialize the workflow registry at the beginning of the bundle. This
       // must be a banner because esbuild can reorder virtual-entry code.
       banner: {
-        js: 'globalThis.__private_workflows = new Map();',
+        js: 'globalThis.__private_workflows ??= new Map();',
       },
       // Source maps improve workflow VM stack traces. Production defaults to
       // no map; development defaults to inline unless configured otherwise.
@@ -1532,15 +1709,20 @@ export const __steps_registered = true;
         {
           name: 'workflow-entries',
           setup(build) {
-            build.onResolve({ filter: /^workflow-entry:/ }, ({ path }) => ({
-              path,
-              namespace: 'workflow-entry',
-            }));
+            build.onResolve(
+              { filter: /^(?:workflow-entry:|serializer-registry-entry$)/ },
+              ({ path }) => ({
+                path,
+                namespace: 'workflow-entry',
+              })
+            );
             build.onLoad(
               { filter: /.*/, namespace: 'workflow-entry' },
               ({ path }) => ({
                 contents:
-                  bundleEntries[Number(path.slice(path.indexOf(':') + 1))],
+                  path === 'serializer-registry-entry'
+                    ? serializerRegistryEntry
+                    : bundleEntries[Number(path.slice(path.indexOf(':') + 1))],
                 loader: 'js',
                 resolveDir: workflowResolveDir,
               })
@@ -1576,9 +1758,34 @@ export const __steps_registered = true;
     return {
       context,
       manifest,
+      rebuild: async () => {
+        let result = await context.rebuild();
+
+        // Step implementations disappear in the workflow transform, so the raw
+        // import graph intentionally ignores dependencies below step modules.
+        // A hybrid step module can still expose a non-step value, though. Verify
+        // candidates against esbuild's transformed inputs and retain any suffix
+        // prefix that was actually bundled with a workflow.
+        if (sharedSerializerFiles.length > 0) {
+          const lastBundledSerializer = lastSerializerBundledWithWorkflow(
+            result,
+            sharedSerializerFiles,
+            this.config.workingDir,
+            this.moduleSpecifierRoot
+          );
+          if (lastBundledSerializer >= 0) {
+            sharedSerializerFiles = sharedSerializerFiles.slice(
+              lastBundledSerializer + 1
+            );
+            updateBundleEntries();
+            result = await context.rebuild();
+          }
+        }
+        return result;
+      },
       startedAt,
       readBundles(result) {
-        return bundleEntries.map((_, index) => {
+        const workflowBundles = bundleEntries.map((_, index) => {
           const output = result.outputFiles?.find(
             ({ path }) => basename(path) === `workflow-${index}.js`
           );
@@ -1602,6 +1809,28 @@ export const __steps_registered = true;
             workflowIds,
           };
         });
+        const serializerOutput = serializerRegistryEntry
+          ? result.outputFiles?.find(
+              ({ path }) => basename(path) === 'serializer-registry.js'
+            )
+          : undefined;
+        if (serializerRegistryEntry && !serializerOutput) {
+          throw new WorkflowBuildError(
+            'No output generated for workflow serializer registry'
+          );
+        }
+        return {
+          workflowBundles,
+          serializerRegistry: serializerOutput
+            ? {
+                code: serializerOutput.text,
+                fileName: workflowBundleFileName(
+                  'serializer',
+                  serializerOutput.text
+                ),
+              }
+            : undefined,
+        };
       },
     };
   }
@@ -1629,8 +1858,8 @@ export const __steps_registered = true;
     interimBundleCtx?: esbuild.BuildContext;
     bundleFinal?: (
       interimBundleResult: esbuild.BuildResult
-    ) => Promise<WorkflowBundle[]>;
-    workflowBundles: WorkflowBundle[];
+    ) => Promise<WorkflowBundleSet>;
+    bundles: WorkflowBundleSet;
     /** The initial workflow VM build graph, when requested by a caller. */
     interimBundleMetafile?: esbuild.Metafile;
   }> {
@@ -1649,7 +1878,7 @@ export const __steps_registered = true;
     const writeWorkflowBundles = this.createWorkflowBundlePublisher(outfile);
     let shouldDisposeInterimBundleCtx = !keepInterimBundleContext;
     try {
-      const interimBundle = await interimBundleCtx.rebuild();
+      const interimBundle = await build.rebuild();
 
       this.logEsbuildMessages(
         interimBundle,
@@ -1667,14 +1896,14 @@ export const __steps_registered = true;
       await this.writeConfiguredWorkflowManifest(workflowManifest);
       await this.ensureSwcIgnored();
 
-      const workflowBundles = readWorkflowBundles(interimBundle);
-      await this.warnAboutSerdeCompliance(workflowManifest, workflowBundles);
+      const bundles = readWorkflowBundles(interimBundle);
+      await this.warnAboutSerdeCompliance(workflowManifest, bundles);
       const bundleFinal = async (result: esbuild.BuildResult) => {
         const bundles = readWorkflowBundles(result);
         await writeWorkflowBundles(bundles);
         return bundles;
       };
-      await writeWorkflowBundles(workflowBundles);
+      await writeWorkflowBundles(bundles);
 
       if (keepInterimBundleContext) {
         shouldDisposeInterimBundleCtx = false;
@@ -1682,13 +1911,13 @@ export const __steps_registered = true;
           manifest: workflowManifest,
           interimBundleCtx,
           bundleFinal,
-          workflowBundles,
+          bundles,
           interimBundleMetafile: interimBundle.metafile,
         };
       }
       return {
         manifest: workflowManifest,
-        workflowBundles,
+        bundles,
         interimBundleMetafile: interimBundle.metafile,
       };
     } catch (error) {
@@ -1799,7 +2028,7 @@ export const __steps_registered = true;
     });
 
     const createCombinedFunctionCode = (
-      bundles: WorkflowBundle[]
+      bundles: WorkflowBundleSet
     ) => `// biome-ignore-all lint: generated file
 /* eslint-disable */
 import { __steps_registered } from '${stepsRelativePath}';
@@ -1814,7 +2043,7 @@ ${createWorkflowBundleLoaders(bundles, this.config.watch ? 'inline' : 'module')}
 
 ${createWorkflowRouteHandlersCode(`workflowEntrypoint(workflowCode${workflowEntrypointOptionsCode})`)}`;
     const combinedFunctionCode = createCombinedFunctionCode(
-      workflowsResult.workflowBundles
+      workflowsResult.bundles
     );
 
     if (!bundleFinalOutput) {

--- a/packages/builders/src/fast-discovery.ts
+++ b/packages/builders/src/fast-discovery.ts
@@ -372,7 +372,7 @@ function stripCommentsFromSource(source: string): string {
   return output;
 }
 
-function extractImportSpecifiers(source: string): string[] {
+export function extractImportSpecifiers(source: string): string[] {
   const sourceWithoutComments = stripCommentsFromSource(source);
   if (
     !sourceWithoutComments.includes('import') &&

--- a/packages/builders/src/workflow-bundle-boundary.test.ts
+++ b/packages/builders/src/workflow-bundle-boundary.test.ts
@@ -13,6 +13,7 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import { BaseBuilder, type DiscoveredEntries } from './base-builder.js';
+import { importParents } from './discover-entries-esbuild-plugin.js';
 import type { StandaloneConfig } from './types.js';
 import {
   deserializeWorkflowBundle,
@@ -104,9 +105,17 @@ function writeWorkflowBuiltinsFixture(root: string): void {
   );
   writeFileSync(
     join(serdePackageDir, 'index.js'),
-    `export const WORKFLOW_SERIALIZE = Symbol.for('workflow.serialize');
-export const WORKFLOW_DESERIALIZE = Symbol.for('workflow.deserialize');\n`
+    `export const WORKFLOW_SERIALIZE = Symbol.for('workflow-serialize');
+export const WORKFLOW_DESERIALIZE = Symbol.for('workflow-deserialize');\n`
   );
+}
+
+function serializerSource(name: string, dependency = ''): string {
+  return `import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
+${dependency}export class ${name} {
+  static [WORKFLOW_SERIALIZE](value) { return { value: value.value }; }
+  static [WORKFLOW_DESERIALIZE](data) { return new ${name}(data.value); }
+}`;
 }
 
 describe('workflow bundle boundary', () => {
@@ -114,6 +123,7 @@ describe('workflow bundle boundary', () => {
   const outputDirs: string[] = [];
 
   afterEach(() => {
+    importParents.clear();
     for (const outputDir of outputDirs) {
       rmSync(outputDir, { recursive: true, force: true });
     }
@@ -148,9 +158,10 @@ describe('workflow bundle boundary', () => {
       discoveredSerdeFiles: new Set(),
     };
 
-    const { workflowBundles, interimBundleMetafile } = await new TestBuilder(
-      config
-    ).createWorkflowBundle(
+    const {
+      bundles: { workflowBundles },
+      interimBundleMetafile,
+    } = await new TestBuilder(config).createWorkflowBundle(
       inputFile,
       config.workflowsBundlePath,
       discoveredEntries
@@ -230,6 +241,7 @@ export async function alsoFirst() { "use workflow"; return 2; }`
     writeWorkflowBuiltinsFixture(outputDir);
     mkdirSync(workflowBundleDir);
     writeFileSync(join(workflowBundleDir, 'keep.txt'), 'user-owned');
+    writeFileSync(join(workflowBundleDir, 'serializer.mjs'), 'user-owned');
 
     await new TestBuilder(config).createCombinedWorkflowBundle(
       [first, second],
@@ -239,7 +251,7 @@ export async function alsoFirst() { "use workflow"; return 2; }`
     );
 
     const bundleFiles = readdirSync(workflowBundleDir)
-      .filter((file) => file.endsWith('.mjs'))
+      .filter((file) => /^\d.*\.mjs$/.test(file))
       .sort();
     expect(bundleFiles).toHaveLength(2);
     expect(
@@ -248,6 +260,9 @@ export async function alsoFirst() { "use workflow"; return 2; }`
     expect(readFileSync(join(workflowBundleDir, 'keep.txt'), 'utf8')).toBe(
       'user-owned'
     );
+    expect(
+      readFileSync(join(workflowBundleDir, 'serializer.mjs'), 'utf8')
+    ).toBe('user-owned');
     const route = readFileSync(config.workflowsBundlePath, 'utf8');
     expect(route).toContain(`workflow-bundles/${bundleFiles[0]}`);
     expect(route).toContain(`workflow-bundles/${bundleFiles[1]}`);
@@ -267,26 +282,166 @@ export async function alsoFirst() { "use workflow"; return 2; }`
     expect(secondCode).toContain('HybridSerde');
   });
 
-  it('refreshes the generated VM bundle after a watch rebuild', async () => {
+  it('shares only dependency-isolated serializer registration', async () => {
+    const repoRoot = resolve(import.meta.dirname, '../../..');
+    const workingDir = join(repoRoot, 'workbench/nextjs-turbopack');
+    const outputDir = mkdtempSync(join(workingDir, '.workflow-bootstrap-'));
+    outputDirs.push(outputDir);
+    const first = join(outputDir, 'first.ts');
+    const second = join(outputDir, 'second.ts');
+    const earlySerializer = join(outputDir, 'a-early-point.ts');
+    const serializer = join(outputDir, 'r-point.ts');
+    const dependentSerializer = join(outputDir, 'dependent-point.ts');
+    const importedSerializer = join(outputDir, 'imported-point.ts');
+    const hybridSerializer = join(outputDir, 'q-hybrid-point.ts');
+    const isolatedSerializer = join(outputDir, 'z-isolated-point.ts');
+    const step = join(outputDir, 'point-step.ts');
+    const sharedState = join(outputDir, 'shared-state.ts');
+    writeFileSync(sharedState, `export const sharedValue = 'shared-state';`);
+    writeFileSync(
+      earlySerializer,
+      `${serializerSource('EarlyPoint')}
+globalThis.__earlySerializerMarker = 'early-serializer-marker';`
+    );
+    writeFileSync(
+      first,
+      `import { sharedValue } from './shared-state';
+import { ImportedPoint } from './imported-point';
+import { createPoint, pointType } from './point-step';
+export async function first() { "use workflow"; await createPoint(); return "first-workflow-marker" + sharedValue + pointType; }`
+    );
+    writeFileSync(
+      second,
+      `export async function second() { "use workflow"; return "second-workflow-marker"; }`
+    );
+    writeFileSync(
+      serializer,
+      `${serializerSource('SharedPoint')}
+globalThis.__sharedSerializerMarker = 'shared-serializer-marker';`
+    );
+    writeFileSync(
+      dependentSerializer,
+      `${serializerSource('DependentPoint', "import { sharedValue } from './shared-state';\n")}
+globalThis.__dependentSerializerMarker = sharedValue;`
+    );
+    writeFileSync(importedSerializer, serializerSource('ImportedPoint'));
+    writeFileSync(hybridSerializer, serializerSource('HybridPoint'));
+    writeFileSync(
+      isolatedSerializer,
+      `${serializerSource('IsolatedPoint')}
+globalThis.__isolatedSerializerMarker = 'isolated-serializer-marker';`
+    );
+    writeFileSync(
+      step,
+      `import { HybridPoint } from './q-hybrid-point';
+import { SharedPoint } from './r-point';
+export const pointType = HybridPoint.name;
+export async function createPoint() { "use step"; return new SharedPoint(); }`
+    );
+    importParents.set(first, new Set([importedSerializer, step]));
+    importParents.set(step, new Set([hybridSerializer, serializer]));
+
+    const config = createConfig(repoRoot, outputDir, outputDir, false);
+    const discoveredEntries: DiscoveredEntries = {
+      discoveredSteps: new Set([step]),
+      discoveredWorkflows: new Set([first, second]),
+      discoveredSerdeFiles: new Set([
+        earlySerializer,
+        serializer,
+        dependentSerializer,
+        importedSerializer,
+        hybridSerializer,
+        isolatedSerializer,
+      ]),
+    };
+    writeWorkflowBuiltinsFixture(outputDir);
+
+    await new TestBuilder(config).createCombinedWorkflowBundle(
+      [first, second],
+      config.stepsBundlePath,
+      config.workflowsBundlePath,
+      discoveredEntries
+    );
+
+    const workflowBundleDir = join(outputDir, 'workflow-bundles');
+    const files = readdirSync(workflowBundleDir).filter((file) =>
+      file.endsWith('.mjs')
+    );
+    const decoded = files.map((file) => ({
+      file,
+      code: deserializeWorkflowBundle(
+        readFileSync(join(workflowBundleDir, file), 'utf8')
+      ),
+    }));
+    const registry = decoded.filter(({ code }) =>
+      code.includes('shared-serializer-marker')
+    );
+    const workflows = decoded.filter(({ code }) =>
+      code.includes('workflow-marker')
+    );
+
+    expect(files).toHaveLength(3);
+    expect(registry).toHaveLength(1);
+    expect(registry[0]?.code).toContain('workflow-class-registry');
+    expect(registry[0]?.code).not.toContain('EarlyPoint');
+    expect(registry[0]?.code).not.toContain('DependentPoint');
+    expect(registry[0]?.code).not.toContain('HybridPoint');
+    expect(registry[0]?.code).not.toContain('ImportedPoint');
+    expect(registry[0]?.code).toContain('IsolatedPoint');
+    expect(workflows).toHaveLength(2);
+    expect(workflows.every(({ code }) => !code.includes('SharedPoint'))).toBe(
+      true
+    );
+    expect(workflows.every(({ code }) => !code.includes('IsolatedPoint'))).toBe(
+      true
+    );
+    expect(workflows.every(({ code }) => code.includes('DependentPoint'))).toBe(
+      true
+    );
+    expect(workflows.every(({ code }) => code.includes('ImportedPoint'))).toBe(
+      true
+    );
+    expect(workflows.every(({ code }) => code.includes('EarlyPoint'))).toBe(
+      true
+    );
+    expect(workflows.every(({ code }) => code.includes('HybridPoint'))).toBe(
+      true
+    );
+    const route = readFileSync(config.workflowsBundlePath, 'utf8');
+    expect(route).toContain(`workflow-bundles/${registry[0]?.file}`);
+    expect(route).toContain('serializerRegistry');
+  });
+
+  it('refreshes generated VM bundles after a watch rebuild', async () => {
     const repoRoot = resolve(import.meta.dirname, '../../..');
     const workingDir = join(repoRoot, 'workbench/nextjs-turbopack');
     const outputDir = mkdtempSync(join(workingDir, '.workflow-watch-'));
     outputDirs.push(outputDir);
     const workflowFile = join(outputDir, 'watched.ts');
+    const stableWorkflowFile = join(outputDir, 'z-stable.ts');
+    const serializerFile = join(outputDir, 'watched-point.ts');
     writeFileSync(
       workflowFile,
       `export async function watched() { "use workflow"; return "before-watch"; }
 export async function removedAfterWatch() { "use workflow"; return "remove-me"; }`
     );
+    writeFileSync(
+      stableWorkflowFile,
+      `export async function stableWorkflow() { "use workflow"; return "stable"; }`
+    );
+    writeFileSync(
+      serializerFile,
+      `globalThis.__watchedSerializerMarker = 'before-watch-serde';`
+    );
     const config = createConfig(repoRoot, outputDir, outputDir, true);
     writeWorkflowBuiltinsFixture(outputDir);
     const discoveredEntries: DiscoveredEntries = {
       discoveredSteps: new Set(),
-      discoveredWorkflows: new Set([workflowFile]),
-      discoveredSerdeFiles: new Set(),
+      discoveredWorkflows: new Set([workflowFile, stableWorkflowFile]),
+      discoveredSerdeFiles: new Set([serializerFile]),
     };
     const result = await new TestBuilder(config).createCombinedWorkflowBundle(
-      [workflowFile],
+      [workflowFile, stableWorkflowFile],
       config.stepsBundlePath,
       config.workflowsBundlePath,
       discoveredEntries
@@ -297,15 +452,24 @@ export async function removedAfterWatch() { "use workflow"; return "remove-me"; 
 
     try {
       const workflowBundleDir = join(outputDir, 'workflow-bundles');
-      const oldFile = readdirSync(workflowBundleDir).find((file) =>
+      const oldFiles = readdirSync(workflowBundleDir).filter((file) =>
         file.endsWith('.mjs')
       );
-      assert(oldFile);
+      const oldWorkflowFile = oldFiles.find((file) => /^0-/.test(file));
+      assert(oldWorkflowFile);
+      expect(oldFiles).toHaveLength(2);
+      expect(oldFiles.some((file) => file.startsWith('serializer-'))).toBe(
+        false
+      );
       const oldStats = statSync(workflowFile);
       writeFileSync(
         workflowFile,
         `export async function watched() { "use workflow"; return "after--watch"; }
 export async function renamedAfterWatch() { "use workflow"; return "rename-me"; }`
+      );
+      writeFileSync(
+        serializerFile,
+        `globalThis.__watchedSerializerMarker = 'after--watch-serde';`
       );
       // Reproduce a coalesced watcher update that is indistinguishable to the
       // legacy size/mtime manifest cache while esbuild rebuilds new code.
@@ -318,19 +482,23 @@ export async function renamedAfterWatch() { "use workflow"; return "rename-me"; 
       const currentFiles = readdirSync(workflowBundleDir).filter((file) =>
         file.endsWith('.mjs')
       );
-      expect(currentFiles).toHaveLength(1);
-      const currentFile = currentFiles[0];
-      assert(currentFile);
-      expect(currentFile).not.toBe(oldFile);
+      expect(currentFiles).toHaveLength(2);
+      const currentWorkflowFile = currentFiles.find((file) => /^0-/.test(file));
+      assert(currentWorkflowFile);
+      expect(currentWorkflowFile).not.toBe(oldWorkflowFile);
+      expect(route).not.toContain('serializerRegistry');
       expect(route).toContain('Promise.resolve');
       expect(route).toContain('renamedAfterWatch');
       expect(route).not.toContain('removedAfterWatch');
       expect(route).not.toContain('after--watch');
       const currentBundle = await import(
-        pathToFileURL(join(workflowBundleDir, currentFile)).href
+        pathToFileURL(join(workflowBundleDir, currentWorkflowFile)).href
       );
       expect(Buffer.from(currentBundle.default, 'base64').toString()).toContain(
         'after--watch'
+      );
+      expect(Buffer.from(currentBundle.default, 'base64').toString()).toContain(
+        'after--watch-serde'
       );
       const graphs = await extractWorkflowGraphs(config.workflowsBundlePath);
       expect(JSON.stringify(graphs)).toContain('watched');

--- a/packages/builders/src/workflow-bundle-module.ts
+++ b/packages/builders/src/workflow-bundle-module.ts
@@ -3,13 +3,17 @@ import { createHash } from 'node:crypto';
 
 export const WORKFLOW_BUNDLE_DIRECTORY = 'workflow-bundles';
 
-const WORKFLOW_BUNDLE_FILE = /^\d+(?:-[a-f0-9]{16})?\.mjs$/;
+const WORKFLOW_BUNDLE_FILE =
+  /^(?:\d+(?:-[a-f0-9]{16})?|serializer-[a-f0-9]{16})\.mjs$/;
 
 export function isWorkflowBundleFileName(fileName: string): boolean {
   return WORKFLOW_BUNDLE_FILE.test(fileName);
 }
 
-export function workflowBundleFileName(index: number, code: string): string {
+export function workflowBundleFileName(
+  index: number | 'serializer',
+  code: string
+): string {
   const hash = createHash('sha256').update(code).digest('hex').slice(0, 16);
   return `${index}-${hash}.mjs`;
 }

--- a/packages/builders/src/workflows-extractor.ts
+++ b/packages/builders/src/workflows-extractor.ts
@@ -242,7 +242,11 @@ export async function extractWorkflowGraphs(bundlePath: string): Promise<{
   try {
     const lazyBundleDir = join(dirname(bundlePath), WORKFLOW_BUNDLE_DIRECTORY);
     const lazyBundleFiles = await readdir(lazyBundleDir)
-      .then((files) => files.filter(isWorkflowBundleFileName))
+      .then((files) =>
+        files.filter(
+          (file) => isWorkflowBundleFileName(file) && /^\d/.test(file)
+        )
+      )
       .catch((error: NodeJS.ErrnoException) => {
         if (error.code === 'ENOENT') return [];
         throw error;

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -219,22 +219,29 @@ describe('workflowEntrypoint replay guards', () => {
 
   it('loads only the bundle for the delivered workflow', async () => {
     const workflowRun = await misroutedRun();
+    const loadSerializerRegistry = vi.fn(
+      async () => `globalThis.__serializerRegistryReady = true;`
+    );
     const loadWorkflow = vi.fn(
       async () => `async function workflow() {
+      if (!globalThis.__serializerRegistryReady) throw new Error('missing registry');
       return 'done';
     }${getWorkflowTransformCode('workflow')}`
     );
     const loadOtherWorkflow = vi.fn(async () => '');
+    const workflowCode = {
+      workflow: loadWorkflow,
+      otherWorkflow: loadOtherWorkflow,
+      __serializerRegistry: loadSerializerRegistry,
+    };
 
     const createdEvents = await runWorkflowHandlerWithEvents(
-      {
-        workflow: loadWorkflow,
-        otherWorkflow: loadOtherWorkflow,
-      },
+      workflowCode,
       workflowRun,
       []
     );
 
+    expect(loadSerializerRegistry).toHaveBeenCalledOnce();
     expect(loadWorkflow).toHaveBeenCalledOnce();
     expect(loadOtherWorkflow).not.toHaveBeenCalled();
     expect(createdEvents).toContainEqual(

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -117,7 +117,10 @@ import { useQuickJSVm } from './runtime/vm-mode.js';
 import { getWaitContinuationDispatch } from './runtime/wait-continuation.js';
 import { getWorld, type WorldHandlers } from './runtime/world.js';
 import { dehydrateRunError } from './serialization.js';
-import { remapErrorStack } from './source-map.js';
+import {
+  remapErrorStack,
+  WORKFLOW_SERIALIZER_REGISTRY_FILENAME,
+} from './source-map.js';
 import * as Attribute from './telemetry/semantic-conventions.js';
 import {
   buildInvocationSpanLinks,
@@ -629,18 +632,30 @@ async function getMaxInlineDurationMs(
  * @param workflowCode - A legacy workflow bundle or lazy loaders keyed by workflow ID
  * @returns A function that can be used as a Vercel API route
  */
-export type WorkflowCode =
-  | string
-  | Readonly<Record<string, () => Promise<string>>>;
+type WorkflowCodeLoader = () => Promise<string>;
+type WorkflowCodeLoaders = Readonly<Record<string, WorkflowCodeLoader>> & {
+  readonly __serializerRegistry?: WorkflowCodeLoader;
+};
+
+export type WorkflowCode = string | WorkflowCodeLoaders;
+
+type LoadedWorkflowCode = {
+  readonly serializerRegistryCode?: string;
+  readonly workflowCode: string;
+};
 
 async function loadWorkflowCode(
   workflowCode: WorkflowCode,
   workflowName: string
-): Promise<string> {
-  if (typeof workflowCode === 'string') return workflowCode;
+): Promise<LoadedWorkflowCode> {
+  if (typeof workflowCode === 'string') return { workflowCode };
   const load = workflowCode[workflowName];
   if (!load) throw new WorkflowNotRegisteredError(workflowName);
-  return load();
+  const [loadedCode, serializerRegistryCode] = await Promise.all([
+    load(),
+    workflowCode.__serializerRegistry?.(),
+  ]);
+  return { workflowCode: loadedCode, serializerRegistryCode };
 }
 
 export function workflowEntrypoint(
@@ -839,9 +854,9 @@ export function workflowEntrypoint(
           return await withWorkflowBaggage(
             { workflowRunId: runId, workflowName },
             async () => {
-              let loadedWorkflowCode: string | undefined;
-              let workflowCodeLoad: Promise<string> | undefined;
-              const startWorkflowCodeLoad = (): Promise<string> => {
+              let loadedWorkflowCode: LoadedWorkflowCode | undefined;
+              let workflowCodeLoad: Promise<LoadedWorkflowCode> | undefined;
+              const startWorkflowCodeLoad = (): Promise<LoadedWorkflowCode> => {
                 workflowCodeLoad ??= trace('workflow.bundle.load', () =>
                   loadWorkflowCode(workflowCode, workflowName)
                 ).then((code) => {
@@ -2712,8 +2727,11 @@ export function workflowEntrypoint(
                         const { runWorkflowWithQuickJS } = await import(
                           './runtime/quickjs-entrypoint.js'
                         );
+                        const loadedCode = await workflowCodePromise;
                         const quickjsResult = await runWorkflowWithQuickJS({
-                          workflowCode: await workflowCodePromise,
+                          serializerRegistryCode:
+                            loadedCode.serializerRegistryCode,
+                          workflowCode: loadedCode.workflowCode,
                           workflowName,
                           workflowRun,
                           preloadedEvents:
@@ -3030,8 +3048,11 @@ export function workflowEntrypoint(
 
                       if (workflowResult.type === 'replay') {
                         retainedSession = null;
+                        const loadedCode = await workflowCodePromise;
                         workflowResult = await replayWorkflow({
-                          workflowCode: await workflowCodePromise,
+                          serializerRegistryCode:
+                            loadedCode.serializerRegistryCode,
+                          workflowCode: loadedCode.workflowCode,
                           workflowRun,
                           events: eventLog.events,
                           encryptionKey,
@@ -4590,13 +4611,20 @@ export function workflowEntrypoint(
                           normalizedError.stack || getErrorStack(terminalError);
 
                         if (errorStack && loadedWorkflowCode) {
+                          if (loadedWorkflowCode.serializerRegistryCode) {
+                            errorStack = remapErrorStack(
+                              errorStack,
+                              WORKFLOW_SERIALIZER_REGISTRY_FILENAME,
+                              loadedWorkflowCode.serializerRegistryCode
+                            );
+                          }
                           const parsedName = parseWorkflowName(workflowName);
                           const filename =
                             parsedName?.moduleSpecifier || workflowName;
                           errorStack = remapErrorStack(
                             errorStack,
                             filename,
-                            loadedWorkflowCode
+                            loadedWorkflowCode.workflowCode
                           );
                         }
 

--- a/packages/core/src/runtime/quickjs-entrypoint.ts
+++ b/packages/core/src/runtime/quickjs-entrypoint.ts
@@ -45,7 +45,11 @@ import {
   hydrateRunError,
   maybeEncrypt,
 } from '../serialization.js';
-import { remapErrorStack, stripInlineSourceMap } from '../source-map.js';
+import {
+  remapErrorStack,
+  stripInlineSourceMap,
+  WORKFLOW_SERIALIZER_REGISTRY_FILENAME,
+} from '../source-map.js';
 import * as Attribute from '../telemetry/semantic-conventions.js';
 import { serializeTraceCarrier } from '../telemetry.js';
 import {
@@ -787,6 +791,26 @@ async function dispatchPendingOps(params: {
   };
 }
 
+function remapWorkflowStack(
+  stack: string,
+  workflowName: string,
+  workflowCode: string,
+  serializerRegistryCode?: string
+): string {
+  let remapped = stack;
+  if (serializerRegistryCode) {
+    remapped = remapErrorStack(
+      remapped,
+      WORKFLOW_SERIALIZER_REGISTRY_FILENAME,
+      serializerRegistryCode
+    );
+  }
+  const parsedName = parseWorkflowName(workflowName);
+  const filename = parsedName?.moduleSpecifier || workflowName;
+  remapped = remapErrorStack(remapped, filename, workflowCode);
+  return remapErrorStack(remapped, BASELINE_BUNDLE_FILENAME, workflowCode);
+}
+
 /**
  * Run a workflow using the QuickJS WASM VM engine.
  *
@@ -803,6 +827,7 @@ async function dispatchPendingOps(params: {
  * assume parity with the node engine on this axis.
  */
 export async function runWorkflowWithQuickJS(params: {
+  serializerRegistryCode?: string;
   workflowCode: string;
   workflowName: string;
   workflowRun: WorkflowRun;
@@ -884,6 +909,7 @@ export async function runWorkflowWithQuickJS(params: {
   waitContinuation?: { correlationId: string; attempt: number };
 }): Promise<{ timeoutSeconds?: number } | void> {
   const {
+    serializerRegistryCode,
     workflowCode,
     workflowName,
     workflowRun,
@@ -926,6 +952,9 @@ export async function runWorkflowWithQuickJS(params: {
   // stack-trace line lookups, so the few-MB base64 comment would bloat
   // the VM heap for no benefit.
   const workflowCodeForVM = stripInlineSourceMap(workflowCode);
+  const serializerRegistryCodeForVM = serializerRegistryCode
+    ? stripInlineSourceMap(serializerRegistryCode)
+    : undefined;
 
   // Per-invocation diagnostic id so debug logs can be correlated even if
   // the same runId is processed by overlapping invocations on different
@@ -1085,6 +1114,7 @@ export async function runWorkflowWithQuickJS(params: {
   });
 
   const session = await startQuickJSWorkflow({
+    serializerRegistryCode: serializerRegistryCodeForVM,
     // Pass the STRIPPED bundle to the VM so the inline source map
     // doesn't end up in the QuickJS heap. The original (unstripped)
     // `workflowCode` is still kept in this host-side scope and is used
@@ -1937,13 +1967,11 @@ export async function runWorkflowWithQuickJS(params: {
     // early-exits on a cheap includes() when a filename has no frames.
     let errorStack = result.failed.stack;
     if (errorStack) {
-      const parsedName = parseWorkflowName(workflowName);
-      const filename = parsedName?.moduleSpecifier || workflowName;
-      errorStack = remapErrorStack(errorStack, filename, workflowCode);
-      errorStack = remapErrorStack(
+      errorStack = remapWorkflowStack(
         errorStack,
-        BASELINE_BUNDLE_FILENAME,
-        workflowCode
+        workflowName,
+        workflowCode,
+        serializerRegistryCode
       );
     }
 
@@ -2032,17 +2060,11 @@ export async function runWorkflowWithQuickJS(params: {
           'stack' in (hydrated as object) &&
           typeof (hydrated as { stack?: unknown }).stack === 'string'
         ) {
-          const parsedName = parseWorkflowName(workflowName);
-          const filename = parsedName?.moduleSpecifier || workflowName;
-          // Both filename spaces. See the failed-branch comment above.
-          (hydrated as { stack?: string }).stack = remapErrorStack(
-            remapErrorStack(
-              (hydrated as { stack: string }).stack,
-              filename,
-              workflowCode
-            ),
-            BASELINE_BUNDLE_FILENAME,
-            workflowCode
+          (hydrated as { stack?: string }).stack = remapWorkflowStack(
+            (hydrated as { stack: string }).stack,
+            workflowName,
+            workflowCode,
+            serializerRegistryCode
           );
         }
         // Walk the cause chain and remap nested stacks too.
@@ -2052,13 +2074,11 @@ export async function runWorkflowWithQuickJS(params: {
           seen.add(node as object);
           const nodeStack = (node as { stack?: unknown }).stack;
           if (typeof nodeStack === 'string') {
-            const parsedName = parseWorkflowName(workflowName);
-            const filename = parsedName?.moduleSpecifier || workflowName;
-            // Both filename spaces. See the failed-branch comment above.
-            (node as { stack?: string }).stack = remapErrorStack(
-              remapErrorStack(nodeStack, filename, workflowCode),
-              BASELINE_BUNDLE_FILENAME,
-              workflowCode
+            (node as { stack?: string }).stack = remapWorkflowStack(
+              nodeStack,
+              workflowName,
+              workflowCode,
+              serializerRegistryCode
             );
           }
           node = (node as { cause?: unknown }).cause;

--- a/packages/core/src/runtime/quickjs-runtime.test.ts
+++ b/packages/core/src/runtime/quickjs-runtime.test.ts
@@ -1633,6 +1633,30 @@ describe('baseline snapshot startup optimization', () => {
     __clearBaselineSnapshotCacheForTests();
   });
 
+  it('rebuilds a cached baseline when its serializer registry changes', async () => {
+    __clearBaselineSnapshotCacheForTests();
+    const workflowCode = `
+      globalThis.__workflowBundleReady = true;
+      async function workflow() { return globalThis.__registryVersion; }
+      workflow.workflowId = "workflow//test//workflow";
+      globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+    `;
+    for (const version of ['first', 'second']) {
+      const result = await runQuickJSWorkflow({
+        serializerRegistryCode: `
+          if (!globalThis.__workflowBundleReady) throw new Error("wrong evaluation order");
+          globalThis.__registryVersion = ${JSON.stringify(version)};
+        `,
+        workflowCode,
+        workflowId: 'workflow//test//workflow',
+        workflowRun: makeRun(),
+        events: [],
+      });
+      expect(unwrapResult(result.completed!.result)).toBe(version);
+    }
+    __clearBaselineSnapshotCacheForTests();
+  });
+
   it('gates out bundles whose module scope throws, and the fresh path surfaces the error', async () => {
     __clearBaselineSnapshotCacheForTests();
     const throwingCode = 'throw new Error("boom at module scope");';

--- a/packages/core/src/runtime/quickjs-runtime.ts
+++ b/packages/core/src/runtime/quickjs-runtime.ts
@@ -53,6 +53,7 @@ import { decompress } from '../serialization/compression.js';
 import type { DecryptionKey } from '../serialization/encryption.js';
 import { decrypt } from '../serialization/encryption.js';
 import { formatSerializationError } from '../serialization/errors.js';
+import { WORKFLOW_SERIALIZER_REGISTRY_FILENAME } from '../source-map.js';
 import {
   getReplayTimeoutMs,
   isQuickJSBaselineSnapshotEnabled,
@@ -223,6 +224,8 @@ export interface QuickJSRuntimeResult {
 }
 
 export interface QuickJSRuntimeOptions {
+  /** Shared serializer registration code evaluated before input hydration. */
+  serializerRegistryCode?: string;
   /** The compiled workflow bundle code (workflow mode output from SWC) */
   workflowCode: string;
   /** The workflow ID (e.g. "workflow//./workflows/1_simple//simple") */
@@ -1187,14 +1190,19 @@ type BaselineEntry =
     }
   | { state: 'ineligible'; reason: string };
 
+type CachedBaseline = {
+  serializerRegistryCode: string | undefined;
+  entry: Promise<BaselineEntry>;
+};
+
 // On `globalThis` (see `globalSingleton`): a snapshot is expensive to build and
 // is keyed by bundle, so per-copy caches would build the same baseline once per
 // bundler layer while each enforcing its own bound.
 const baselines = globalSingleton(
   '@workflow/core//quickjsBaselines',
-  1,
+  2,
   () => ({
-    byKey: new Map<string, Promise<BaselineEntry>>(),
+    byKey: new Map<string, CachedBaseline>(),
   })
 );
 const BASELINE_CACHE_MAX_ENTRIES = 4;
@@ -1208,7 +1216,7 @@ export function __clearBaselineSnapshotCacheForTests(): void {
 export async function __peekBaselineEntryForTests(
   workflowCode: string
 ): Promise<BaselineEntry | undefined> {
-  return baselines.byKey.get(workflowCode);
+  return baselines.byKey.get(workflowCode)?.entry;
 }
 
 /**
@@ -1218,6 +1226,7 @@ export async function __peekBaselineEntryForTests(
  * re-evaluates and produces the real, source-mapped error.
  */
 async function prepareBaselineSnapshot(
+  serializerRegistryCode: string | undefined,
   workflowCode: string,
   workflowId: string
 ): Promise<BaselineEntry> {
@@ -1285,8 +1294,15 @@ async function prepareBaselineSnapshot(
 
     clockReads = 0; // only count reads made by the bundle itself
     try {
-      // Workflow-independent filename. See BASELINE_BUNDLE_FILENAME.
+      // Preserve the monolithic bundle's workflow-before-serializer module
+      // evaluation order while still registering every class before hydration.
       vm.evalCode(workflowCode, BASELINE_BUNDLE_FILENAME).dispose();
+      if (serializerRegistryCode) {
+        vm.evalCode(
+          serializerRegistryCode,
+          WORKFLOW_SERIALIZER_REGISTRY_FILENAME
+        ).dispose();
+      }
     } catch {
       // Let the fresh path re-evaluate and surface the real error with
       // proper filename / source-map handling.
@@ -1329,19 +1345,30 @@ async function prepareBaselineSnapshot(
  * returns `ineligible`) is evicted so a later invocation can retry.
  */
 function getBaselineEntry(
+  serializerRegistryCode: string | undefined,
   workflowCode: string,
   workflowId: string
 ): Promise<BaselineEntry> {
-  let entry = baselines.byKey.get(workflowCode);
-  if (!entry) {
-    if (baselines.byKey.size >= BASELINE_CACHE_MAX_ENTRIES) {
-      const oldest = baselines.byKey.keys().next().value;
-      if (oldest !== undefined) baselines.byKey.delete(oldest);
-    }
-    entry = prepareBaselineSnapshot(workflowCode, workflowId);
-    baselines.byKey.set(workflowCode, entry);
-    entry.catch(() => baselines.byKey.delete(workflowCode));
+  const cached = baselines.byKey.get(workflowCode);
+  if (cached && cached.serializerRegistryCode === serializerRegistryCode) {
+    return cached.entry;
   }
+  if (!cached && baselines.byKey.size >= BASELINE_CACHE_MAX_ENTRIES) {
+    const oldest = baselines.byKey.keys().next().value;
+    if (oldest !== undefined) baselines.byKey.delete(oldest);
+  }
+  const entry = prepareBaselineSnapshot(
+    serializerRegistryCode,
+    workflowCode,
+    workflowId
+  );
+  const next = { serializerRegistryCode, entry };
+  baselines.byKey.set(workflowCode, next);
+  entry.catch(() => {
+    if (baselines.byKey.get(workflowCode) === next) {
+      baselines.byKey.delete(workflowCode);
+    }
+  });
   return entry;
 }
 
@@ -1382,7 +1409,13 @@ export async function runQuickJSWorkflow(
 export async function startQuickJSWorkflow(
   options: QuickJSRuntimeOptions
 ): Promise<QuickJSWorkflowSession> {
-  const { workflowCode, workflowId, workflowRun, events } = options;
+  const {
+    serializerRegistryCode,
+    workflowCode,
+    workflowId,
+    workflowRun,
+    events,
+  } = options;
 
   const startedAt = workflowRun.startedAt ? +workflowRun.startedAt : Date.now();
 
@@ -1440,7 +1473,11 @@ export async function startQuickJSWorkflow(
   let baselineSerdeRootPtr: number | undefined;
   if (isQuickJSBaselineSnapshotEnabled()) {
     try {
-      const entry = await getBaselineEntry(workflowCode, workflowId);
+      const entry = await getBaselineEntry(
+        serializerRegistryCode,
+        workflowCode,
+        workflowId
+      );
       if (entry.state === 'ready') {
         baselineSnapshot = entry.snapshot;
         baselineSerdeRootPtr = entry.serdeRootPtr;
@@ -1571,6 +1608,12 @@ export async function startQuickJSWorkflow(
     if (!baselineSnapshot) {
       try {
         vm.evalCode(workflowCode, workflowId || 'workflow.js').dispose();
+        if (serializerRegistryCode) {
+          vm.evalCode(
+            serializerRegistryCode,
+            WORKFLOW_SERIALIZER_REGISTRY_FILENAME
+          ).dispose();
+        }
       } catch (err) {
         return makeSettledSession(
           extractError(vm, err, 'Workflow evaluation failed')

--- a/packages/core/src/source-map.ts
+++ b/packages/core/src/source-map.ts
@@ -1,6 +1,10 @@
 import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
 import { globalSingleton } from '@workflow/utils';
 
+/** Synthetic filename used when evaluating shared serializer registration. */
+export const WORKFLOW_SERIALIZER_REGISTRY_FILENAME =
+  'workflow-serializer-registry.js';
+
 /** Marker prefix of an inline source map comment emitted by bundlers. */
 const INLINE_SOURCE_MAP_MARKER =
   '//# sourceMappingURL=data:application/json;base64,';

--- a/packages/core/src/workflow.test.ts
+++ b/packages/core/src/workflow.test.ts
@@ -108,6 +108,57 @@ describe('runWorkflow', () => {
       ).toEqual(3);
     });
 
+    it('hydrates custom workflow input after evaluating the serializer registry', async () => {
+      const runId = 'wrun_serializer_registry';
+      const timestamp = new Date('2024-01-01T00:00:00.000Z');
+      const workflowRun: WorkflowRun = {
+        runId,
+        workflowName: 'workflow',
+        status: 'running',
+        input: new TextEncoder().encode(
+          'devl[[1],["Instance",2],{"classId":3,"data":4},"test/Point",{"value":5},42]'
+        ),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        startedAt: timestamp,
+        deploymentId: 'test-deployment',
+      };
+      const serializerRegistryCode = `
+        class Point {
+          constructor(value) { this.value = value; }
+          static [Symbol.for('workflow-deserialize')](data) {
+            return new Point(data.value);
+          }
+        }
+        (globalThis[Symbol.for('workflow-class-registry')] ??= new Map()).set('test/Point', Point);
+        globalThis.__Point = Point;
+      `;
+      const workflowCode = `
+        async function workflow(point) {
+          return point instanceof globalThis.__Point ? point.value : -1;
+        }
+        globalThis.__private_workflows = new Map([['workflow', workflow]]);
+      `;
+
+      const result = await replayWorkflow({
+        serializerRegistryCode,
+        workflowCode,
+        workflowRun,
+        events: [],
+        encryptionKey: noEncryptionKey,
+        replayPayloadCache: new ReplayPayloadCache(noEncryptionKey),
+      });
+
+      assert(result.type === 'completed');
+      expect(
+        await hydrateWorkflowReturnValue(
+          result.output as any,
+          runId,
+          noEncryptionKey
+        )
+      ).toBe(42);
+    });
+
     it('allow user code to handle user-defined errors', async () => {
       const ops: Promise<any>[] = [];
       const workflowCode = `function workflow() {

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -31,6 +31,7 @@ import {
   dehydrateWorkflowReturnValue,
   hydrateWorkflowArguments,
 } from './serialization.js';
+import { WORKFLOW_SERIALIZER_REGISTRY_FILENAME } from './source-map.js';
 import { createUseStep } from './step.js';
 import {
   BODY_INIT_SYMBOL,
@@ -120,6 +121,7 @@ async function drainPendingQueueItems(
 
 /** Everything needed to cold-start a workflow VM over an event log. */
 interface WorkflowSessionOptions {
+  readonly serializerRegistryCode?: string;
   readonly workflowCode: string;
   readonly workflowRun: WorkflowRun;
   readonly events: Event[];
@@ -306,6 +308,7 @@ export async function runWorkflow(
 }
 
 async function createWorkflowSession({
+  serializerRegistryCode,
   workflowCode,
   workflowRun,
   events,
@@ -1083,6 +1086,13 @@ async function createWorkflowSession({
   // and the filename preserves workflow source attribution in stack traces.
   // The bundle registers workflows on `globalThis.__private_workflows`.
   runCachedWorkflowScript(workflowCode, filename, context);
+  if (serializerRegistryCode) {
+    runCachedWorkflowScript(
+      serializerRegistryCode,
+      WORKFLOW_SERIALIZER_REGISTRY_FILENAME,
+      context
+    );
+  }
   const workflowFn = (
     vmGlobalThis as typeof globalThis & {
       __private_workflows?: Map<string, unknown>;


### PR DESCRIPTION
## Summary

- extract only dependency-isolated custom serializer modules into one content-hashed shared registry for multi-source production builds
- retain hybrid, workflow-imported, dependency-bearing, order-sensitive, and watch-mode serializers inside each selected workflow bundle to preserve module identity and top-level effects
- validate step-boundary candidates against transformed esbuild inputs so hybrid step modules cannot create a second serializer constructor
- load the selected workflow and registry concurrently, compile them independently, then evaluate workflow followed by registry before hydration in Node and QuickJS
- key QuickJS baseline snapshots on both selected workflow code and registry code, and preserve source-map remapping for both scripts

## Measured shape

The current Next.js/Turbopack workbench emits 19 selected workflow bundles plus one shared registry. The registry module is 2.2 KB encoded (1,652 bytes decoded). This saves roughly 40 KB of aggregate generated artifacts for that fixture; the larger remaining duplication is hybrid/general shared runtime code and is intentionally outside this PR.

This optimization is conservative by design. If the builder cannot prove a serializer is dependency-isolated and order-safe, it keeps the previous self-contained bundle behavior.

## Verification

- pnpm --filter @workflow/builders test (227 tests)
- pnpm --filter @workflow/core test (2,192 passed; 3 expected failures; 1 skipped)
- pnpm --filter @workflow/builders typecheck
- pnpm --filter @workflow/core typecheck
- pnpm --filter @workflow/builders build
- pnpm --filter @workflow/core build
- pnpm --dir workbench/nextjs-turbopack build
- final autoreview: clean, no P0-P2 findings (0.94 confidence)

The workbench build still reports its two existing warnings for dynamic world resolution and the Next config NFT trace.