### PR TITLE
[world-postgres] Refuse a hook resume that races the disposal

### DIFF
--- a/.changeset/postgres-hook-disposal-ordering.md
+++ b/.changeset/postgres-hook-disposal-ordering.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Reject a hook resume that races the hook's disposal, instead of journaling it after `hook_disposed` and corrupting the owning run's event log.

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -1128,7 +1128,14 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         }
       }
 
-      // Hook-related event validation (ordering)
+      // Hook-related event validation (existence).
+      //
+      // An unlocked read outside any transaction, so it settles only the case
+      // where the hook was already gone when the request arrived. It is NOT
+      // what orders a delivery against a disposal: the disposal can commit in
+      // the gap between this read and the append. Both writers take the hook's
+      // row lock for that — see the `hook_disposed` and `hook_received`
+      // branches below.
       if (isHookEventRequiringExistence(data.eventType) && data.correlationId) {
         const [existingHook] = await drizzle
           .select({ hookId: Schema.hooks.hookId })
@@ -1913,19 +1920,53 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         }
       }
 
-      // Handle hook_disposed event: delete hook entity atomically.
-      // Uses DELETE ... RETURNING to ensure only one concurrent caller
-      // succeeds — if no rows are returned, the hook was already disposed.
+      // Handle hook_disposed event: delete the hook entity and append the
+      // disposal in ONE transaction.
+      //
+      // `DELETE ... RETURNING` ensures only one concurrent caller succeeds — if
+      // no rows are returned, the hook was already disposed. The delete also
+      // takes the hook row's lock, and the transaction is what holds it until
+      // the `hook_disposed` row exists. Committed separately (as this used to
+      // be), the lock is released at the delete's own autocommit, which leaves a
+      // window for a resume to pass its existence check and land its
+      // `hook_received` AFTER this disposal. That order is durable, and it
+      // corrupts the owning run for good: no replay can consume a delivery
+      // behind the disposal that retired the hook's consumer, so it strands,
+      // every replay reports divergence and the run ends in
+      // CorruptedEventLogError. See vercel/workflow#2781, which fixed the same
+      // ordering for world-local.
       if (data.eventType === 'hook_disposed' && data.correlationId) {
-        const [deleted] = await drizzle
-          .delete(Schema.hooks)
-          .where(eq(Schema.hooks.hookId, data.correlationId))
-          .returning({ hookId: Schema.hooks.hookId });
-        if (!deleted) {
-          throw new EntityConflictError(
-            `Hook "${data.correlationId}" already disposed`
-          );
-        }
+        const disposedHookId = data.correlationId;
+        value = await drizzle.transaction(async (tx) => {
+          const [deleted] = await tx
+            .delete(Schema.hooks)
+            .where(eq(Schema.hooks.hookId, disposedHookId))
+            .returning({ hookId: Schema.hooks.hookId });
+          if (!deleted) {
+            throw new EntityConflictError(
+              `Hook "${disposedHookId}" already disposed`
+            );
+          }
+
+          // Allocated only after the lock is held, matching hook_received's
+          // ordering guarantee: a writer that had to wait must not carry an
+          // earlier position into a later insert.
+          const eventValue = await insertEventRow(tx, {
+            runId: effectiveRunId,
+            eventId: await getEventId(tx),
+            correlationId: disposedHookId,
+            eventType: data.eventType,
+            eventData: storedEventData,
+            specVersion: effectiveSpecVersion,
+          });
+          if (!eventValue) {
+            throw new EntityConflictError(
+              `Event for hook "${disposedHookId}" could not be created`
+            );
+          }
+          eventId = eventValue.eventId;
+          return { createdAt: eventValue.createdAt };
+        }, SLOT_INSERT_TRANSACTION);
       }
 
       // Handle hook_received event: append the event only if the run has
@@ -1958,9 +1999,37 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             );
           }
 
-          // Allocate the position only after the row lock is acquired,
+          // Re-check the hook under its own row lock, for the ordering the
+          // unlocked read near the top of `create` cannot settle. `FOR UPDATE`
+          // blocks on the disposer's `DELETE`, which holds that lock until its
+          // `hook_disposed` row is committed, then re-evaluates: either this
+          // delivery got the lock first and its `hook_received` is ordered
+          // BEFORE the disposal, or the disposer got it and the row is gone and
+          // this delivery is refused. The one order that is unreachable is the
+          // one that corrupts the run — a `hook_received` journaled behind its
+          // hook's `hook_disposed`, which no replay can consume.
+          //
+          // Under READ COMMITTED (see SLOT_INSERT_TRANSACTION) a locked read of
+          // a row deleted by the transaction it waited on returns no row rather
+          // than raising, so the refusal needs no serialization-failure
+          // handling. Reported as HookNotFoundError, matching the unlocked
+          // check and the public resume contract for a hook that can no longer
+          // receive.
+          if (data.correlationId) {
+            const [liveHook] = await tx
+              .select({ hookId: Schema.hooks.hookId })
+              .from(Schema.hooks)
+              .where(eq(Schema.hooks.hookId, data.correlationId))
+              .for('update')
+              .limit(1);
+            if (!liveHook) {
+              throw new HookNotFoundError(data.correlationId);
+            }
+          }
+
+          // Allocate the position only after the row locks are acquired,
           // matching step_started's ordering guarantee: a writer blocked
-          // on the run row must not carry an earlier position into a later
+          // on a lock must not carry an earlier position into a later
           // insert.
           const eventValue = await insertEventRow(tx, {
             runId: effectiveRunId,

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -3582,6 +3582,177 @@ describe('Storage (Postgres integration)', () => {
       expect(result.status).toBe('completed');
     });
 
+    // A resume racing its hook's disposal must never be journaled AFTER
+    // hook_disposed. Once that order is in the log, no replay of the owning run
+    // can consume the delivery — the run retired that hook's consumer at the
+    // disposal — so it strands, every replay reports divergence, and the run
+    // escalates to CorruptedEventLogError. See vercel/workflow#2781, which
+    // fixed the same ordering for world-local.
+    describe('hook_received vs. hook_disposed ordering (#2781)', () => {
+      const eventTypesFor = async (runId: string) => {
+        const listed = await events.list({ runId, pagination: {} });
+        return listed.data.map((event) => event.eventType);
+      };
+
+      it('rejects hook_received once the disposal has committed', async () => {
+        const hook = await createHook(events, testRunId, {
+          hookId: 'hook_order_after_dispose',
+          token: 'order-after-dispose',
+        });
+        await events.create(testRunId, {
+          eventType: 'hook_received',
+          correlationId: hook.hookId,
+          eventData: { payload: new Uint8Array([1]) },
+        });
+        await events.create(testRunId, {
+          eventType: 'hook_disposed',
+          correlationId: hook.hookId,
+        });
+
+        await expect(
+          events.create(testRunId, {
+            eventType: 'hook_received',
+            correlationId: hook.hookId,
+            eventData: { payload: new Uint8Array([2]) },
+          })
+        ).rejects.toMatchObject({ name: 'HookNotFoundError' });
+
+        // Asserted on the log, not only on the throw: a rejection that still
+        // journaled the row would leave the run corrupted exactly as before.
+        expect(await eventTypesFor(testRunId)).toEqual([
+          'run_created',
+          'hook_created',
+          'hook_received',
+          'hook_disposed',
+        ]);
+      });
+
+      it('rejects a resume that passed its unlocked check mid-disposal', async () => {
+        // The regression guard. The unlocked existence read near the top of
+        // `create` cannot see a disposal that commits after it, so what has to
+        // hold is the locked re-check inside hook_received's transaction.
+        //
+        // Forced deterministically: an outside transaction takes the hook's row
+        // lock (as the disposal's DELETE does) and holds it while the resume
+        // runs. With the re-check in place the resume blocks on that lock and,
+        // once the holder deletes and commits, observes the hook gone. Without
+        // it the resume never takes the lock and journals its hook_received
+        // while the hook is being deleted — the ordering this rejects.
+        //
+        // The holder needs its OWN pool: the suite's pool is `max: 1`, so
+        // sharing it would make the resume wait for a free connection instead of
+        // for the row lock, and the test would pass whether or not the re-check
+        // exists.
+        const hook = await createHook(events, testRunId, {
+          hookId: 'hook_order_mid_dispose',
+          token: 'order-mid-dispose',
+        });
+
+        const holderPool = new Pool({
+          connectionString: process.env.DATABASE_URL,
+          max: 1,
+        });
+        let signalLocked!: () => void;
+        const locked = new Promise<void>((resolve) => {
+          signalLocked = resolve;
+        });
+        let releaseHolder!: () => void;
+        const release = new Promise<void>((resolve) => {
+          releaseHolder = resolve;
+        });
+
+        try {
+          const holder = createClient(holderPool).transaction(async (tx) => {
+            await tx
+              .select({ hookId: DrizzleSchema.hooks.hookId })
+              .from(DrizzleSchema.hooks)
+              .where(eq(DrizzleSchema.hooks.hookId, hook.hookId))
+              .for('update')
+              .limit(1);
+            signalLocked();
+            await release;
+            await tx
+              .delete(DrizzleSchema.hooks)
+              .where(eq(DrizzleSchema.hooks.hookId, hook.hookId));
+          });
+
+          await locked;
+          const resume = events.create(testRunId, {
+            eventType: 'hook_received',
+            correlationId: hook.hookId,
+            eventData: { payload: new Uint8Array([1]) },
+          });
+          // Long enough for the resume to clear the unlocked check and reach the
+          // locked one, where it blocks until the holder commits.
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          releaseHolder();
+          await holder;
+
+          await expect(resume).rejects.toMatchObject({
+            name: 'HookNotFoundError',
+          });
+        } finally {
+          await holderPool.end();
+        }
+
+        expect(await eventTypesFor(testRunId)).toEqual([
+          'run_created',
+          'hook_created',
+        ]);
+      });
+
+      it('still accepts a hook_received while the hook is live', async () => {
+        // The lock must not reject an ordinary delivery: nothing holds the
+        // hook's row while it is alive, so the re-check finds it every time.
+        const hook = await createHook(events, testRunId, {
+          hookId: 'hook_order_live',
+          token: 'order-live',
+        });
+
+        const first = await events.create(testRunId, {
+          eventType: 'hook_received',
+          correlationId: hook.hookId,
+          eventData: { payload: new Uint8Array([1]) },
+        });
+        const second = await events.create(testRunId, {
+          eventType: 'hook_received',
+          correlationId: hook.hookId,
+          eventData: { payload: new Uint8Array([2]) },
+        });
+
+        expect(first.event.eventType).toBe('hook_received');
+        expect(second.event.eventType).toBe('hook_received');
+        expect(await eventTypesFor(testRunId)).toEqual([
+          'run_created',
+          'hook_created',
+          'hook_received',
+          'hook_received',
+        ]);
+      });
+
+      it('appends hook_disposed and deletes the hook together', async () => {
+        // The disposal's own half of the guard: the delete and the event are one
+        // transaction, so the log never holds a disposal whose hook survived,
+        // nor a deleted hook whose disposal is missing.
+        const hook = await createHook(events, testRunId, {
+          hookId: 'hook_order_atomic_dispose',
+          token: 'order-atomic-dispose',
+        });
+
+        const disposed = await events.create(testRunId, {
+          eventType: 'hook_disposed',
+          correlationId: hook.hookId,
+        });
+
+        expect(disposed.event.eventType).toBe('hook_disposed');
+        const rows = await drizzle
+          .select({ hookId: DrizzleSchema.hooks.hookId })
+          .from(DrizzleSchema.hooks)
+          .where(eq(DrizzleSchema.hooks.hookId, hook.hookId));
+        expect(rows).toHaveLength(0);
+      });
+    });
+
     it('should reject hook_disposed before hook_created', async () => {
       await expect(
         events.create(testRunId, {


### PR DESCRIPTION
TLDR; There's a race between a region receiving a hook_received event, and disposal for a hook being processed, which allows the hook_received to be inserted after the hook_disposed event. This causes CORRUPT_EVENT_LOG.

The solution is to lock the hook table in a transaction together with any hook_disposed event insert. Inflight hook_received need to wait for this to be cleared, closing the race window.

<details>

<summary>
AI Context>
</summary>

## Problem

A `resumeHook()` racing its hook's disposal can be accepted and journaled **after** `hook_disposed`. No replay of the owning run can consume that row: the run retired the hook's consumer at the disposal. So it strands at the end of every replay, each one reports divergence, and the run ends in `CorruptedEventLogError` — terminal, on a workflow that did nothing wrong.

#2781 fixed this for `world-postgres`' sibling `world-local` (a per-hook in-process mutex serializing `hook_received` against `hook_disposed`). `world-postgres` was never covered, and the mutex approach does not port to it anyway.

Two separate gaps, one on each side of the race:

- The hook existence check in `events.create` runs **unlocked and outside any transaction**, so it settles only the case where the hook was already gone when the request arrived. The disposal can commit in the gap before the append.
- The disposal's `DELETE ... RETURNING` **autocommits**, releasing the hook's row lock before its `hook_disposed` row exists. So even a locked reader would have had nothing to block on for the part that matters.

## Change

Both halves take the hook's row lock and hold it across the append.

- `hook_disposed` deletes the hook and appends its event in **one** transaction, so the lock the `DELETE` takes is held until the disposal is in the log. The position is allocated only after the lock is held, matching the ordering guarantee `hook_received` already documents.
- `hook_received` re-checks the hook `FOR UPDATE` inside its **existing** transaction, before allocating its position — the same shape as the terminal-run re-check already there, for the same reason.

Whichever writer takes the lock first wins: either the delivery is ordered before the disposal, or the hook is gone and the delivery is refused with `HookNotFoundError`. The one order that becomes unreachable is the one that corrupts the run.

Under `READ COMMITTED` (`SLOT_INSERT_TRANSACTION`) a locked read of a row deleted by the transaction it waited on returns no row rather than raising, so the refusal needs no serialization-failure handling.

The unlocked check stays as a cheap early rejection, with a comment saying plainly that it is not the guard.

## Tests

`packages/world-postgres/test/storage.test.ts`, new `hook_received vs. hook_disposed ordering (#2781)` block.

The regression guard is **`rejects a resume that passed its unlocked check mid-disposal`**. An outside transaction takes the hook's row lock and holds it while the resume runs, then deletes and commits — so the resume provably reaches the locked re-check with the disposal still uncommitted. Reverting `storage.ts` alone makes it fail by *resolving* and journaling the `hook_received`, which is the corruption itself.

Worth being explicit about the other three: they pass on `main` too. They are behaviour lock-ins (a fully committed disposal is already refused by the unlocked read; a live hook still receives; the disposal deletes the hook and appends its event together), not guards. That is the same trap the `world-local` tests call out — both orderings are legal under a race, so a soak test passes with the fix reverted. Only the forced-lock test is deterministic in the failing direction.

- Full `world-postgres` suite green: 184 passed, 5 files. Typecheck clean.

## Scope

This stops new bad logs on `world-postgres`. It does not retire logs that already carry the shape, and it is per-World by construction. The replay side is a separate follow-up, not in this PR: treating a `hook_received` behind its hook's `hook_disposed` as inert rather than fatal is the only thing that retires an already-written log, and it would cover every World at once — the second option #2781 itself proposed.

Companion server-side PR does the same for the Vercel backend, which needs a different mechanism (a run-region disposal marker condition-checked in the event transaction, since a hook row there lives in another region entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>