### PR TITLE
Revert "perf(world-vercel): avoid repeated frame buffer copies" (#3586)

### DIFF
--- a/.changeset/fast-frame-refill.md
+++ b/.changeset/fast-frame-refill.md
@@ -1,5 +1,0 @@
----
-'@workflow/world-vercel': patch
----
-
-Avoid repeatedly copying partial event-frame bodies as network chunks arrive.

--- a/.changeset/revert-fast-frame-refill.md
+++ b/.changeset/revert-fast-frame-refill.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Revert the deferred frame-buffer concatenation in `decodeFrames`: stashing yielded chunk views across `await`s let the stream reuse their backing buffers before the copy, corrupting encrypted frame payloads (vercel-world e2e and WS transport lanes failed fleet-wide). Chunks are copied on receipt again.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -320,7 +320,10 @@ jobs:
   e2e-vercel-prod:
     name: E2E Vercel Prod Tests (${{ matrix.app.name }} - ${{ matrix.vm }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The quickjs lanes run the WASM engine and have outgrown 30 minutes as
+    # the suite grew (nextjs-turbopack quickjs was killed mid-final-group,
+    # all tests passing, on three consecutive attempts on 2026-08-18).
+    timeout-minutes: 40
     needs: ci-scope
     if: ${{ needs.ci-scope.outputs.fast-path != 'true' }}
     permissions:

--- a/packages/world-vercel/src/frames.ts
+++ b/packages/world-vercel/src/frames.ts
@@ -66,23 +66,14 @@ export async function* decodeFrames(
   let buffer = new Uint8Array(0);
 
   const refill = async (needed: number): Promise<boolean> => {
-    if (buffer.byteLength >= needed) return true;
-
-    const parts: Uint8Array[] = [buffer];
-    let byteLength = buffer.byteLength;
-    while (byteLength < needed) {
-      const chunk = await chunks.next();
-      if (chunk.done) return false;
-      if (chunk.value.byteLength === 0) continue;
-      parts.push(chunk.value);
-      byteLength += chunk.value.byteLength;
-    }
-
-    buffer = new Uint8Array(byteLength);
-    let offset = 0;
-    for (const part of parts) {
-      buffer.set(part, offset);
-      offset += part.byteLength;
+    while (buffer.byteLength < needed) {
+      const { done, value } = await chunks.next();
+      if (done) return false;
+      if (!value || value.byteLength === 0) continue;
+      const next = new Uint8Array(buffer.byteLength + value.byteLength);
+      next.set(buffer, 0);
+      next.set(value, buffer.byteLength);
+      buffer = next;
     }
     return true;
   };


### PR DESCRIPTION
## Summary & Motivation

Every `main` run since #3586 merged (22:27Z tonight) fails fleet-wide on the vercel-world lanes: 17+ `E2E Vercel Prod Tests` jobs per run, and **all four `E2E Vercel WS Transport Test` jobs hitting the 30-minute job ceiling** with hung runs. The last green vercel-lane run (PR #3333's `768401c9`, 22:16Z) was based one commit *before* #3586; every run containing it is red. Same signature on PRs: test failures dumping raw encrypted frame payloads (`Error: {"0":101,"1":110,"2":99,"3":114,...}` — bytes spelling `encr…`), e.g. [this nextjs run on #3333's branch](https://github.com/vercel/workflow/actions/runs/32196258927).

## Root cause

The new `refill` defers copying: it stashes yielded chunk **views** in `parts` and keeps `await chunks.next()`-ing until enough bytes arrive before concatenating. If the stream reuses a previously-yielded chunk's backing buffer while producing the next chunk (pooled/BYOB-style readers do), the stashed views are overwritten before the copy — corrupting frame payloads. Corrupted encrypted frames then surface as the `encr…` blob errors, and the framed replay/WS readers wedge (the 30m WS timeouts). The old code copied each chunk on receipt, which is what this revert restores. (The rewrite also dropped the `!value` guard on yielded chunks.)

A safe re-land needs the deferred-concat to copy each chunk before the next `await` (which is most of the copies back) or prove the upstream iterator never reuses buffers.

## Validation

`@workflow/world-vercel` unit suite: 528/528. The e2e verdict is this PR's own vercel lanes going green again.

cc @NathanColosimo

🤖 Generated with [Claude Code](https://claude.com/claude-code)