### PR TITLE
fix(world-postgres): serialize keyed deliveries across workers

### DIFF
--- a/.changeset/postgres-keyed-delivery-serialization.md
+++ b/.changeset/postgres-keyed-delivery-serialization.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Serialize keyed queue deliveries across Postgres worker processes.

--- a/packages/world-postgres/HOW_IT_WORKS.md
+++ b/packages/world-postgres/HOW_IT_WORKS.md
@@ -36,6 +36,8 @@ Call `world.start()` to initialize graphile-worker workers. When `.start()` is c
 
 When the runtime returns `{ timeoutSeconds }`, the worker schedules a new Graphile job with a future `runAt` time before finishing the current task.
 
+Messages carrying an idempotency key are deterministically assigned to one of 2,048 Graphile named queues per configured job prefix. Graphile holds that queue while the handler runs, so a same-key replacement remains pending rather than executing on another worker. The default replacement behavior stays enabled so delayed reschedules and crash recovery retain a durable successor. Because named queues persist after their jobs complete, the bounded mapping avoids an ever-growing queue table; unrelated keys that hash to the same bucket are serialized.
+
 The worker sends workflow orchestration and queued step messages to the combined `.well-known/workflow/v1/flow` endpoint.
 
 In **Next.js**, the `world.start()` call needs to be added to `instrumentation.ts|js` to ensure workers start before request handling. Use `workflow/runtime` for `getWorld` (same as the testing server and other framework plugins):

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -187,6 +187,9 @@ and its token can be reused. If the token is never reused, the expired
 - Graphile jobs are acknowledged only after execution finishes, or after the worker durably schedules a delayed follow-up job
 - Backlog stays in PostgreSQL when all execution slots are busy
 - Retry and sleep-style delays use Graphile `runAt` scheduling
+- Messages with an idempotency key are assigned to one of 2,048 Graphile named queues per `jobPrefix`. This prevents the same keyed delivery from executing concurrently across worker processes while keeping delayed successors durable. Hash collisions can serialize unrelated keyed messages.
+- Existing jobs from a version without named queues do not participate in this lock. Drain keyed jobs and old producers during the first rollout or rollback when a fully protected handoff is required.
+- An abrupt process death can hold its named queue until Graphile Worker's four-hour stale-lock recovery. Graceful shutdown releases it normally.
 - Workflow orchestration and queued step execution are both sent through `/.well-known/workflow/v1/flow`
 
 ## Development

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -15,6 +15,10 @@ import { MessageData } from './message.js';
 import { createQueue } from './queue.js';
 
 const transport = new JsonTransport();
+const DEFAULT_IDEMPOTENCY_QUEUE =
+  'workflow_idempotency_9d70a9b47b31ee4a598d79d3949545c491ca35b9fb2aed6b7ac8bdc277f09df3_1a5';
+const PREFIXED_IDEMPOTENCY_QUEUE =
+  'workflow_idempotency_4ed3ab71b053166eab6696d23bd4b98bba01573451cf7fbad1c531a9460e716b_1a5';
 const createdQueues: Array<ReturnType<typeof createQueue>> = [];
 const createdServers: Server[] = [];
 
@@ -489,12 +493,160 @@ describe('postgres queue http execution', () => {
         expect.objectContaining({
           jobKey: 'step_01ABC',
           maxAttempts: 49,
+          queueName: DEFAULT_IDEMPOTENCY_QUEUE,
           runAt: new Date('2024-01-01T00:00:05.000Z'),
         })
       );
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('keeps delayed retries on the same idempotency queue', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+    const fetchMock = vi.fn(async () => Response.json({ timeoutSeconds: 300 }));
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
+
+    try {
+      const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+      await queue.start();
+
+      const task = getTaskHandler('workflow_flows');
+      await task(
+        buildMessageData(
+          '__wkf_workflow_test-step',
+          {
+            runId: 'run_01ABC',
+            stepId: 'step_01ABC',
+            stepName: 'test-step',
+          },
+          { idempotencyKey: 'step_01ABC' }
+        ),
+        { job: { attempts: 1 } }
+      );
+
+      expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+        'workflow_flows',
+        expect.objectContaining({
+          attempt: 2,
+          idempotencyKey: 'step_01ABC',
+        }),
+        expect.objectContaining({
+          jobKey: 'step_01ABC',
+          maxAttempts: 49,
+          queueName: DEFAULT_IDEMPOTENCY_QUEUE,
+          runAt: new Date('2024-01-01T00:05:00.000Z'),
+        })
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not assign an idempotency queue to unkeyed messages', async () => {
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    await queue.start();
+
+    await queue.queue('__wkf_workflow_test-workflow', {
+      runId: 'run_01ABC',
+    });
+
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'workflow_flows',
+      expect.anything(),
+      expect.not.objectContaining({ queueName: expect.anything() })
+    );
+  });
+
+  it('scopes idempotency queues to the configured job prefix', async () => {
+    const queue = buildQueue(
+      { connectionString: 'postgres://test', jobPrefix: 'billing_' },
+      pool
+    );
+    await queue.start();
+
+    await queue.queue(
+      '__wkf_workflow_test-step',
+      {
+        runId: 'run_01ABC',
+        stepId: 'step_01ABC',
+        stepName: 'test-step',
+      },
+      { idempotencyKey: 'step_01ABC' }
+    );
+
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'billing_flows',
+      expect.anything(),
+      expect.objectContaining({
+        queueName: PREFIXED_IDEMPOTENCY_QUEUE,
+      })
+    );
+  });
+
+  it('assigns idempotency queues to migrated keyed jobs', async () => {
+    const migrationPool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ exists: true }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              name: 'workflow_flows',
+              data: buildMessageData(
+                '__wkf_workflow_test-step',
+                {
+                  runId: 'run_01ABC',
+                  stepId: 'step_01ABC',
+                  stepName: 'test-step',
+                },
+                { idempotencyKey: 'step_01ABC' }
+              ),
+              singleton_key: 'step_01ABC',
+              retry_limit: 3,
+            },
+            {
+              name: 'workflow_flows',
+              data: buildMessageData('__wkf_workflow_test-workflow', {
+                runId: 'run_01ABD',
+              }),
+              singleton_key: 'msg_01ABC',
+              retry_limit: 3,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] }),
+    } as unknown as Parameters<typeof createQueue>[1];
+    const queue = buildQueue(
+      { connectionString: 'postgres://test' },
+      migrationPool
+    );
+
+    await queue.start();
+
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'workflow_flows',
+      expect.objectContaining({
+        id: 'test-step',
+        idempotencyKey: 'step_01ABC',
+      }),
+      {
+        jobKey: 'step_01ABC',
+        maxAttempts: 49,
+        queueName: DEFAULT_IDEMPOTENCY_QUEUE,
+      }
+    );
+    expect(workerUtilsMock.addJob).toHaveBeenCalledWith(
+      'workflow_flows',
+      expect.objectContaining({
+        id: 'test-workflow',
+        idempotencyKey: undefined,
+      }),
+      expect.not.objectContaining({ queueName: expect.anything() })
+    );
   });
 
   it('queues namespaced producer messages in graphile job metadata', async () => {
@@ -526,6 +678,7 @@ describe('postgres queue http execution', () => {
       expect.objectContaining({
         jobKey: 'step_01ABC',
         maxAttempts: 49,
+        queueName: DEFAULT_IDEMPOTENCY_QUEUE,
       })
     );
   });

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { connect } from 'node:net';
 import * as Stream from 'node:stream';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -53,6 +54,11 @@ function createGraphileLogger() {
 
 const graphileLogger = createGraphileLogger();
 const COMPLETED_IDEMPOTENCY_CACHE_LIMIT = 10_000;
+// Graphile retains named queues after their jobs complete. Keep this bounded
+// at 2,048 idempotency queues per configured job prefix.
+// Keep this mapping stable across releases; changing it requires a drained
+// rollout.
+const IDEMPOTENCY_QUEUE_BUCKET_COUNT = 2_048;
 // Core records MAX_DELIVERIES_EXCEEDED on delivery 49.
 const MAX_GRAPHILE_JOB_ATTEMPTS = 49;
 const GraphileHelpers = z.object({
@@ -74,6 +80,12 @@ type HttpExecutionResult =
 
 type RunnerStart = { controller: AbortController; promise: Promise<void> };
 type LoopbackTarget = { hosts: string[]; port: number };
+type MigratedPgBossJob = {
+  name: string;
+  data: unknown;
+  singleton_key: string | null;
+  retry_limit: number | null;
+};
 
 /**
  * The Postgres queue stores messages under one graphile-worker flow task.
@@ -128,6 +140,42 @@ export function createQueue(
   function getJobQueueName(): string {
     const jobPrefix = config.jobPrefix || 'workflow_';
     return `${jobPrefix}flows`;
+  }
+
+  const idempotencyQueueScope = createHash('sha256')
+    .update(getJobQueueName())
+    .digest('hex');
+
+  function getIdempotencyQueueName(idempotencyKey: string): string {
+    const bucket = (
+      createHash('sha256').update(idempotencyKey).digest().readUInt16BE(0) %
+      IDEMPOTENCY_QUEUE_BUCKET_COUNT
+    )
+      .toString(16)
+      .padStart(3, '0');
+    return `workflow_idempotency_${idempotencyQueueScope}_${bucket}`;
+  }
+
+  function getMigratedJobIdempotencyKey(data: unknown): string | undefined {
+    const messageData = MessageData.safeParse(data);
+    return messageData.success ? messageData.data.idempotencyKey : undefined;
+  }
+
+  async function addMigratedPgBossJobs(
+    utils: WorkerUtils,
+    jobs: MigratedPgBossJob[]
+  ): Promise<void> {
+    for (const job of jobs) {
+      const jobKey = job.singleton_key ?? undefined;
+      const idempotencyKey = getMigratedJobIdempotencyKey(job.data);
+      await utils.addJob(job.name, job.data as Record<string, unknown>, {
+        jobKey,
+        ...(idempotencyKey
+          ? { queueName: getIdempotencyQueueName(idempotencyKey) }
+          : {}),
+        maxAttempts: Math.max(job.retry_limit ?? 0, MAX_GRAPHILE_JOB_ATTEMPTS),
+      });
+    }
   }
 
   const createQueueHandler = localWorld.createQueueHandler;
@@ -200,6 +248,9 @@ export function createQueue(
       }),
       {
         ...(jobKey ? { jobKey } : {}),
+        ...(idempotencyKey
+          ? { queueName: getIdempotencyQueueName(idempotencyKey) }
+          : {}),
         ...(runAt ? { runAt } : {}),
         maxAttempts: MAX_GRAPHILE_JOB_ATTEMPTS,
       }
@@ -390,19 +441,11 @@ export function createQueue(
       ) AS exists`
     );
     if (hasStaging.rows[0]?.exists) {
-      const jobs = await pool.query(
+      const jobs = await pool.query<MigratedPgBossJob>(
         `SELECT name, data, singleton_key, retry_limit
         FROM "workflow"."_pgboss_pending_jobs"`
       );
-      for (const job of jobs.rows) {
-        await utils.addJob(job.name, job.data as Record<string, unknown>, {
-          jobKey: job.singleton_key ?? undefined,
-          maxAttempts: Math.max(
-            job.retry_limit ?? 0,
-            MAX_GRAPHILE_JOB_ATTEMPTS
-          ),
-        });
-      }
+      await addMigratedPgBossJobs(utils, jobs.rows);
       await pool.query(`DROP TABLE "workflow"."_pgboss_pending_jobs"`);
       return;
     }
@@ -415,20 +458,12 @@ export function createQueue(
       ) AS exists`
     );
     if (hasPgBoss.rows[0]?.exists) {
-      const jobs = await pool.query(
+      const jobs = await pool.query<MigratedPgBossJob>(
         `SELECT name, data, singleton_key, retry_limit
         FROM pgboss.job
         WHERE state IN ('created', 'retry')`
       );
-      for (const job of jobs.rows) {
-        await utils.addJob(job.name, job.data as Record<string, unknown>, {
-          jobKey: job.singleton_key ?? undefined,
-          maxAttempts: Math.max(
-            job.retry_limit ?? 0,
-            MAX_GRAPHILE_JOB_ATTEMPTS
-          ),
-        });
-      }
+      await addMigratedPgBossJobs(utils, jobs.rows);
       await pool.query(`DROP SCHEMA pgboss CASCADE`);
     }
   }

--- a/packages/world-postgres/test/queue-concurrency.test.ts
+++ b/packages/world-postgres/test/queue-concurrency.test.ts
@@ -1,0 +1,183 @@
+import { createServer, type Server } from 'node:http';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it, test, vi } from 'vitest';
+import { createQueue } from '../src/queue.js';
+
+describe('Postgres queue concurrency', () => {
+  if (process.platform === 'win32') {
+    test.skip('skipped on Windows since it relies on a docker container', () => {});
+    return;
+  }
+
+  let container: Awaited<ReturnType<PostgreSqlContainer['start']>> | undefined;
+  let connectionString: string;
+  let observerPool: Pool;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer('postgres:15-alpine').start();
+    connectionString = container.getConnectionUri();
+    observerPool = new Pool({ connectionString });
+  }, 120_000);
+
+  afterAll(async () => {
+    await observerPool?.end();
+    await container?.stop();
+  });
+
+  it('serializes the same keyed delivery across independent workers', async () => {
+    const firstPool = new Pool({ connectionString });
+    const secondPool = new Pool({ connectionString });
+    const firstQueue = createQueue(
+      {
+        pool: firstPool,
+        queueConcurrency: 1,
+        applicationManagedShutdown: true,
+      },
+      firstPool
+    );
+    const secondQueue = createQueue(
+      {
+        pool: secondPool,
+        queueConcurrency: 1,
+        applicationManagedShutdown: true,
+      },
+      secondPool
+    );
+    const firstRequestStarted = deferred<void>();
+    const releaseRequests = deferred<void>();
+    let requestCount = 0;
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const server = await startWorkflowServer(async () => {
+      requestCount += 1;
+      activeRequests += 1;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+      firstRequestStarted.resolve();
+      await releaseRequests.promise;
+      activeRequests -= 1;
+    });
+    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
+
+    const queueName = '__wkf_workflow_slow-provider-call';
+    const idempotencyKey = 'step_eng570_same_call';
+    const payload = {
+      runId: 'wrun_eng570',
+      stepId: idempotencyKey,
+      stepName: 'slow-provider-call',
+    };
+
+    try {
+      await firstQueue.start();
+      await secondQueue.start();
+      await firstQueue.queue(queueName, payload, { idempotencyKey });
+      await firstRequestStarted.promise;
+
+      await secondQueue.queue(queueName, payload, { idempotencyKey });
+
+      await waitForJobs(2);
+      // Give both pollers longer than their 500 ms polling interval to claim
+      // the successor if the database queue is not enforcing serialization.
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      const rows = await getJobs();
+      expect(requestCount).toBe(1);
+      expect(maxActiveRequests).toBe(1);
+      expect(rows).toEqual([
+        expect.objectContaining({
+          key: null,
+          locked_by: expect.any(String),
+          queue_name: expect.stringMatching(
+            /^workflow_idempotency_[0-9a-f]{64}_[0-9a-f]{3}$/
+          ),
+        }),
+        expect.objectContaining({
+          key: idempotencyKey,
+          locked_by: null,
+          queue_name: expect.stringMatching(
+            /^workflow_idempotency_[0-9a-f]{64}_[0-9a-f]{3}$/
+          ),
+        }),
+      ]);
+      expect(new Set(rows.map((row) => row.queue_name))).toHaveLength(1);
+
+      releaseRequests.resolve();
+      await vi.waitFor(
+        async () => {
+          expect(await countJobs()).toBe(0);
+        },
+        { interval: 25, timeout: 5_000 }
+      );
+
+      expect(requestCount).toBeGreaterThanOrEqual(1);
+      expect(requestCount).toBeLessThanOrEqual(2);
+      expect(maxActiveRequests).toBe(1);
+    } finally {
+      releaseRequests.resolve();
+      delete process.env.WORKFLOW_LOCAL_BASE_URL;
+      await Promise.allSettled([firstQueue.close(), secondQueue.close()]);
+      await Promise.allSettled([firstPool.end(), secondPool.end()]);
+      await closeServer(server.instance);
+    }
+  }, 30_000);
+
+  async function waitForJobs(count: number) {
+    await vi.waitFor(async () => {
+      expect(await getJobs()).toHaveLength(count);
+    });
+  }
+
+  async function getJobs() {
+    const result = await observerPool.query<{
+      key: string | null;
+      locked_by: string | null;
+      queue_name: string | null;
+    }>(
+      `SELECT key, locked_by, queue_name
+      FROM graphile_worker.jobs
+      WHERE task_identifier = 'workflow_flows'
+      ORDER BY id`
+    );
+    return result.rows;
+  }
+
+  async function countJobs() {
+    const result = await observerPool.query<{ count: string }>(
+      `SELECT count(*)
+      FROM graphile_worker.jobs
+      WHERE task_identifier = 'workflow_flows'`
+    );
+    return Number(result.rows[0]?.count ?? 0);
+  }
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function startWorkflowServer(handler: () => Promise<void>) {
+  const instance = createServer(async (request, response) => {
+    request.resume();
+    await handler();
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ ok: true }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    instance.once('error', reject);
+    instance.listen(0, '127.0.0.1', resolve);
+  });
+  const address = instance.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected an HTTP server port');
+  }
+  return { instance, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}


### PR DESCRIPTION
### Description

`@workflow/world-postgres` currently passes `QueueOptions.idempotencyKey` to Graphile Worker as `jobKey`. With Graphile's default `replace` mode, adding the same key while its current job is locked clears the locked job's key, exhausts that row, and inserts a successor. The existing `inflightMessages` map prevents overlap inside one process, but separate Postgres World processes can claim the current job and its successor at the same time.

We observed this after a self-hosted deployment scaled out: startup recovery replayed active runs and redispatched their keyed steps. In one staging burst, 7 of 34 materialisation steps received a second start without an intervening failure (41 executions total). The same startup-recovery/duplicate-start signature appeared in production. This behavior is present in `@workflow/world-postgres` 4.3.3 and current `main`.

This PR assigns every keyed Graphile job to a deterministic named queue. A named queue is Graphile's native cross-worker concurrency primitive: while one worker owns the queue, a replacement remains pending. After the first delivery commits and releases the queue, the successor can replay the terminal state instead of overlapping the original side effect.

The implementation deliberately:

- Keeps Graphile's default `replace` mode. This preserves the durable successor created by delayed rescheduling and crash recovery.
- Applies only to messages that carry `idempotencyKey`. Unkeyed orchestrator messages and public World interfaces are unchanged.
- Uses 2,048 stable SHA-256 buckets per configured `jobPrefix`. Exact per-key queue names would grow Graphile's persistent queue table without bound; hashing the job task name keeps prefixes isolated and the physical name below Graphile's 128-character limit.
- Applies the same mapping when migrating pg-boss jobs that actually carry `MessageData.idempotencyKey`. Legacy unkeyed rows used `messageId` as `singleton_key` and remain unqueued.
- Does not run live `GC_JOB_QUEUES`; Graphile 0.16.6 cleanup raced concurrent producers in a local stress test and left 398 of 7,680 jobs orphaned (5.18%).

`jobKeyMode: 'unsafe_dedupe'` is not safe here. The handler enqueues a delayed successor before its current locked job returns; `unsafe_dedupe` would discard that successor, after which completing the current row can strand the workflow. It can also suppress the only replacement for a locked job that later dies on its final attempt.

This serializes competing deliveries; it does not claim exactly-once execution. The runtime's terminal-state replay remains the duplicate-suppression layer after the queue releases.

Operational trade-offs:

| Case | Behavior |
| --- | --- |
| First mixed-version rollout or rollback | Existing/outgoing jobs without `queueName` do not own the new queue. Deployments must drain old keyed jobs and producers for a fully protected handoff. |
| Hard process death | A bucket can remain locked until Graphile's four-hour stale-lock recovery (or an explicit worker unlock). Graceful shutdown releases it normally. |
| Bucket collision | Unrelated keyed jobs can serialize. At the default concurrency of 50, 2,048 buckets produce about 0.60 expected colliding pairs, or roughly 1.2% expected slot loss. |

A shuffled three-repetition Graphile 0.16.6 no-op benchmark at concurrency 50 / pool 8 measured median throughput of 181.5 jobs/s with no named queues, 141.1 jobs/s with all 2,048 buckets populated, and 108.2 jobs/s with 4,096. The VPS timings were noisy, so these are directional rather than a production capacity claim; 2,048 was consistently the better balance. Dropping to 1,024 would double expected collision loss at the default concurrency to roughly 2.4%.

This complements #3119 and #3162 but does not replace them. Those address selecting parked runs and accumulating startup-recovery jobs; this PR closes the separate locked-keyed-delivery concurrency gap. The `queueName` seam is independent of the HTTP loopback and can be carried through the in-process execution refactor in #3322.

### How did you test your changes?

Added unit coverage for:

- Keyed producer jobs receiving the deterministic named queue.
- Delayed handler reschedules retaining the same `jobKey`, named queue, `runAt`, and 49-attempt budget.
- Unkeyed messages remaining outside named queues.
- Custom `jobPrefix` values receiving isolated queue scopes.
- pg-boss migration distinguishing real idempotency keys from message-ID singleton keys.

Added a real-PostgreSQL Testcontainers regression with two independent pools and two `createQueue()` instances. It blocks worker A's HTTP delivery, enqueues the same key through worker B, waits through the polling window, and asserts that both rows share one named queue while only the first is locked. Before the fix, the same test observed two concurrent HTTP deliveries (`maxActiveRequests: 2`); with the fix it observes one (`maxActiveRequests: 1`) and then drains both jobs sequentially.

Verification:

- `pnpm exec vitest run packages/world-postgres/src` (3 files, 30 tests)
- Real-PostgreSQL concurrency regression against an isolated local PostgreSQL 17 database (1 test)
- `pnpm --filter @workflow/world-postgres typecheck`
- `pnpm --filter @workflow/world-postgres build`
- Biome checks over the changed TypeScript files (only the two pre-existing warnings in `queue.ts` / `queue.test.ts`)
- `pnpm changeset status`

Additional recovery probe with Graphile Worker 0.16.6: a child worker was killed while holding the named queue, a same-key replacement was added, and after `forceUnlockWorkers` only the replacement executed.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - Patch changeset for `@workflow/world-postgres`.
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

Draft for author review. No reviewers have been requested.
