### PR TITLE
bench: allow transport and server-URL overrides on manual benchmark runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,6 +16,23 @@ on:
   push:
     branches: [main]
   workflow_dispatch: # Allow manual triggers
+    inputs:
+      # Opt-in overrides for comparing transports / server builds. Both default to
+      # empty, so PR and main runs are byte-for-byte unchanged and CI cost does not
+      # grow. A 2x2 (transport x server build) is four dispatches, not a matrix
+      # expansion on every PR.
+      events_transport:
+        description: 'Override WORKFLOW_EVENTS_TRANSPORT (ws|http). Empty = app default.'
+        required: false
+        default: ''
+      stream_transport:
+        description: 'Override WORKFLOW_STREAMS_TRANSPORT (ws|http). Empty = app default. Requires a build that reads it.'
+        required: false
+        default: ''
+      workflow_server_url:
+        description: 'Override VERCEL_WORKFLOW_SERVER_URL (e.g. a workflow-server PR preview). Empty = repo secret.'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -162,7 +179,16 @@ jobs:
           APP_NAME: ${{ matrix.target.app }}
           VERCEL_DEPLOYMENT_ID: ${{ steps.waitForDeployment.outputs.deployment-id }}
           WORKFLOW_VERCEL_ENV: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
-          VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
+          # A dispatch input wins over the secret so a run can be pointed at a
+          # workflow-server PR preview (e.g. a WebSocket or lease-fast-path branch)
+          # without touching project-level environment variables, which are shared
+          # by every preview in the project.
+          VERCEL_WORKFLOW_SERVER_URL: ${{ inputs.workflow_server_url != '' && inputs.workflow_server_url || (github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '') }}
+          # Empty means "leave unset", so the app keeps its own default transport.
+          # WORKFLOW_EVENTS_TRANSPORT is live today; WORKFLOW_STREAMS_TRANSPORT is a
+          # no-op until a build that reads it is deployed, which is harmless.
+          WORKFLOW_EVENTS_TRANSPORT: ${{ inputs.events_transport }}
+          WORKFLOW_STREAMS_TRANSPORT: ${{ inputs.stream_transport }}
           WORKFLOW_VERCEL_AUTH_TOKEN: ${{ secrets.VERCEL_LABS_TOKEN }}
           WORKFLOW_VERCEL_TEAM: "team_nO2mCG4W8IxPIeKoSsqwAxxB"
           WORKFLOW_VERCEL_PROJECT: ${{ matrix.target.project-id }}


### PR DESCRIPTION
## Summary & Motivation

`Performance Benchmarks` runs `packages/core/e2e/benchmark.test.ts` against a deployed workbench app. It already waits for the Vercel preview, supplies `DEPLOYMENT_URL`/`APP_NAME`/project ids, and mints a Trusted-Sources OIDC token for protected previews. What it cannot do is vary the transport or point at a specific `workflow-server` build.

This adds three opt-in `workflow_dispatch` inputs so a manual run can set them without editing project-level preview environment variables, which apply to *every* preview in the project and so affect unrelated deployments:

- `events_transport` → `WORKFLOW_EVENTS_TRANSPORT`
- `stream_transport` → `WORKFLOW_STREAMS_TRANSPORT`
- `workflow_server_url` → `VERCEL_WORKFLOW_SERVER_URL`, taking precedence over the repo secret

All default to empty, so PR and `main` runs are byte-for-byte unchanged and CI cost does not grow.

## Scope — read this before using it for a preview comparison

**These inputs configure the CI runner's process, not the deployed application.** They are therefore only effective when the workflow code executes on the runner (for example `WORKFLOW_TARGET_WORLD=local`).

They do **not** work for comparing transports against a deployed preview. `VERCEL_WORKFLOW_SERVER_URL` is read by `getWorkflowServerUrlOverride()` in `packages/world-vercel/src/utils.ts`, and `WORKFLOW_STREAMS_TRANSPORT` by `ws-transport-enabled.ts` — both at the point the World issues a request, which happens inside the deployed app. `POST /api/bench` executes in an already-built deployment and does not inherit the runner's environment. This mirrors the pre-existing handling of `VERCEL_WORKFLOW_SERVER_URL` in this workflow, which has the same property.

For deployed-preview testing the established mechanism is different: `WORKFLOW_SERVER_URL_OVERRIDE` in `packages/world-vercel/src/utils.ts` is an inline constant that external CI rewrites before the client is built, precisely because the value must be baked in to reach the deployment. `getWorkflowServerUrlOverride()` prefers that constant over the environment variable.

A paired transport comparison against previews needs either that source-rewrite path with a dedicated deploy step, or configuration threaded into World construction at request time. The latter is preferable on measurement grounds rather than convenience: build-time configuration fixes transport per deployment, so a two-arm comparison becomes two deployments and the arm is confounded with the deployment — the same defect that made an earlier WebSocket measurement uninterpretable, since each arm ran in a separate CI run.

## Test Plan

- Defaults are untouched: with no inputs supplied, `VERCEL_WORKFLOW_SERVER_URL` resolves exactly as before (secret on PRs, empty on `main`) and neither transport variable is set.
- Verified against the consuming code that `WORKFLOW_STREAMS_TRANSPORT` and `WORKFLOW_EVENTS_TRANSPORT` are the names actually read by `packages/world-vercel`, so the plumbing matches existing knobs rather than inventing new ones.
- Not exercised by an actual dispatch. Given the scope limitation above, this is deliberately left as a runner-scoped convenience; it should not be relied on for deployed-preview transport comparisons.