### PR TITLE
fix(core): reuse runtime World for route handlers

### DIFF
--- a/.changeset/calm-world-singleton.md
+++ b/.changeset/calm-world-singleton.md
@@ -1,0 +1,6 @@
+---
+'workflow': patch
+'@workflow/core': patch
+---
+
+Reuse the runtime World singleton when the workflow entrypoint initializes its queue handler, avoiding duplicate resources for stateful async World factories.

--- a/docs/content/docs/v5/api-reference/workflow-runtime/get-world-handlers.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-runtime/get-world-handlers.mdx
@@ -35,10 +35,10 @@ type WorldHandlers = Pick<World, "createQueueHandler" | "specVersion">;
 ```
 
 <Callout type="warn">
-  This is SDK infrastructure used by framework adapters and the workflow entrypoint. Application code should use [`getWorld()`](/docs/api-reference/workflow-runtime/get-world) instead.
+  This is SDK infrastructure used by framework adapters at build time. Runtime routes and application code should use [`getWorld()`](/docs/api-reference/workflow-runtime/get-world) instead.
 </Callout>
 
 ## Related Functions
 
 - [`getWorld()`](/docs/api-reference/workflow-runtime/get-world) - Resolve the full World instance at runtime.
-- [`workflowEntrypoint()`](/docs/api-reference/workflow-runtime/workflow-entrypoint) - The route handler factory built on these handlers.
+- [`workflowEntrypoint()`](/docs/api-reference/workflow-runtime/workflow-entrypoint) - Create the runtime route handler that shares the full World instance.

--- a/docs/content/docs/v5/api-reference/workflow-runtime/workflow-entrypoint.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-runtime/workflow-entrypoint.mdx
@@ -38,5 +38,6 @@ Returns a fetch-style request handler: `(req: Request) => Promise<Response>`.
 
 ## Related Functions
 
-- [`getWorldHandlers()`](/docs/api-reference/workflow-runtime/get-world-handlers) - The build-time World access this handler is built on.
+- [`getWorld()`](/docs/api-reference/workflow-runtime/get-world) - Resolve the runtime World instance this handler shares with workflow execution.
+- [`getWorldHandlers()`](/docs/api-reference/workflow-runtime/get-world-handlers) - Access build-time-safe World handlers for framework tooling.
 - [`healthCheck()`](/docs/api-reference/workflow-runtime/health-check) - Verify the entrypoint processes queue messages end-to-end.

--- a/packages/core/src/runtime-world-singleton.test.ts
+++ b/packages/core/src/runtime-world-singleton.test.ts
@@ -1,0 +1,40 @@
+import { SPEC_VERSION_CURRENT, type World } from '@workflow/world';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getWorld, setWorld } from './runtime/world.js';
+import { workflowEntrypoint } from './runtime.js';
+
+const createLocalWorld = vi.hoisted(() => vi.fn());
+
+vi.mock('@workflow/world-local', () => ({
+  createWorld: createLocalWorld,
+}));
+
+describe('workflowEntrypoint world initialization', () => {
+  const world = {
+    specVersion: SPEC_VERSION_CURRENT,
+    createQueueHandler: vi.fn(
+      () => async () => new Response(null, { status: 204 })
+    ),
+  } as unknown as World;
+
+  beforeEach(() => {
+    setWorld(undefined);
+    createLocalWorld.mockReset();
+    createLocalWorld.mockResolvedValue(world);
+  });
+
+  afterEach(() => {
+    setWorld(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('reuses the runtime World after initializing the route handler', async () => {
+    const handler = workflowEntrypoint('');
+
+    const response = await handler(new Request('https://example.test'));
+
+    expect(response.status).toBe(204);
+    await expect(getWorld()).resolves.toBe(world);
+    expect(createLocalWorld).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -112,11 +112,7 @@ import { runStepSingleFlight } from './runtime/step-single-flight.js';
 import { handleSuspension } from './runtime/suspension-handler.js';
 import { useQuickJSVm } from './runtime/vm-mode.js';
 import { getWaitContinuationDispatch } from './runtime/wait-continuation.js';
-import {
-  getWorld,
-  getWorldHandlers,
-  type WorldHandlers,
-} from './runtime/world.js';
+import { getWorld, type WorldHandlers } from './runtime/world.js';
 import { dehydrateRunError } from './serialization.js';
 import { remapErrorStack } from './source-map.js';
 import * as Attribute from './telemetry/semantic-conventions.js';
@@ -4504,7 +4500,7 @@ export function workflowEntrypoint(
           cachedHandler = await trace('workflow.route.init', async () => {
             const worldHandlers = await trace(
               'workflow.route.get_world_handlers',
-              async () => getWorldHandlers()
+              async () => getWorld()
             );
             return handler(worldHandlers);
           });


### PR DESCRIPTION
### Description

Fixes #3665.

`workflowEntrypoint()` now initializes its request-time queue handler from `getWorld()` instead of `getWorldHandlers()`. This makes route initialization and subsequent runtime operations share one process-level World instance.

The public `getWorldHandlers()` API, its signature, and its intentionally separate build-time-safe cache are unchanged.

Previously, route initialization populated the handler-only cache and the first runtime operation independently populated the runtime cache. Stateful async World factories could therefore create duplicate database pools, listeners, queue workers, or similar process-scoped resources.

### How did you test your changes?

- Added a regression test with an async World factory that initializes a workflow route and then calls `getWorld()`.
- Confirmed the regression test fails on the prior implementation because the factory is called twice.
- Confirmed the focused regression test passes after the change.
- Ran the complete `@workflow/core` suite on Node 24: 101 test files passed, 1 skipped; 2,180 tests passed, 3 expected failures, 1 skipped.
- Ran `@workflow/core` typechecking successfully.
- Ran the documentation link validator successfully.
- Ran Biome formatting and lint checks; lint completed with the repository's existing advisory warnings and no errors attributable to this change.

The full documentation code-sample harness requires built workspace package declarations. The partial local build cannot produce every package because the SWC package requires a Rust toolchain that is not installed; CI remains the authoritative full-workspace result.

### Docs Preview

Vercel did not produce an accessible `workflow-docs` preview for this fork PR: its deployment checks require Vercel Labs authorization. The changed v5 routes are:

- `/v5/docs/api-reference/workflow-runtime/workflow-entrypoint`
- `/v5/docs/api-reference/workflow-runtime/get-world-handlers`

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a patch changelog for this PR
- [x] 🔒 DCO sign-off passes (`git commit --signoff`)
- [ ] 📝 Ping `@vercel/workflow` once the PR is ready for review
