### PR TITLE
[CI] Reduce payload resolution during run polling

### DIFF
--- a/packages/core/src/runtime/run.ts
+++ b/packages/core/src/runtime/run.ts
@@ -8,6 +8,7 @@ import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import {
   envNumber,
   SPEC_VERSION_CURRENT,
+  type WorkflowRun,
   type WorkflowRunStatus,
   type World,
 } from '@workflow/world';
@@ -30,6 +31,10 @@ import {
 } from './runs.js';
 
 const RETURN_VALUE_POLL_INTERVAL_MS = 1_000;
+const PAYLOAD_TERMINAL_RUN_STATUSES = new Set<WorkflowRunStatus>([
+  'completed',
+  'failed',
+]);
 
 /** @internal */
 export function getReturnValuePollIntervalMs(): number {
@@ -140,12 +145,12 @@ export class Run<TResult> {
    * to be resolved once.
    * @internal
    */
-  #getEncryptionKey(): Promise<PayloadKey | undefined> {
+  #getEncryptionKey(run?: WorkflowRun): Promise<PayloadKey | undefined> {
     if (!this.#encryptionKeyPromise) {
       this.#encryptionKeyPromise = (async () => {
         const world = await this.#lazyWorldPromise;
-        const run = await world.runs.get(this.runId);
-        const rawKey = await world.getEncryptionKeyForRun?.(run);
+        const runData = run ?? (await world.runs.get(this.runId));
+        const rawKey = await world.getEncryptionKeyForRun?.(runData);
         return rawKey ? await deriveRunPayloadKeys(rawKey) : undefined;
       })();
     }
@@ -217,7 +222,9 @@ export class Run<TResult> {
   get status(): Promise<WorkflowRunStatus> {
     'use step';
     return this.#lazyWorldPromise.then((world) =>
-      world.runs.get(this.runId).then((run) => run.status)
+      world.runs
+        .get(this.runId, { resolveData: 'none' })
+        .then((run) => run.status)
     );
   }
 
@@ -318,6 +325,49 @@ export class Run<TResult> {
     });
   }
 
+  /** @internal */
+  async #resolveTerminalReturnValue(run: WorkflowRun): Promise<TResult> {
+    if (run.status === 'completed') {
+      const encryptionKey = await this.#getEncryptionKey(run);
+      return await hydrateWorkflowReturnValue(
+        run.output,
+        this.runId,
+        encryptionKey
+      );
+    }
+
+    if (run.status === 'cancelled') {
+      throw new WorkflowRunCancelledError(this.runId);
+    }
+
+    if (run.status === 'failed') {
+      // Hydrate the serialized run error so the original thrown value
+      // (with its type identity, cause chain, etc.) is set as the
+      // `cause` on WorkflowRunFailedError.
+      const encryptionKey = await this.#getEncryptionKey(run);
+      let hydratedError: unknown;
+      try {
+        hydratedError = await hydrateRunError(
+          run.error,
+          this.runId,
+          encryptionKey
+        );
+      } catch {
+        // If hydration fails, surface a generic fallback rather than
+        // leaving the user with a raw Uint8Array. The run's errorCode
+        // is still preserved on the thrown WorkflowRunFailedError.
+        hydratedError = new Error('Failed to hydrate workflow run error');
+      }
+      throw new WorkflowRunFailedError(this.runId, hydratedError, {
+        errorCode: run.errorCode,
+      });
+    }
+
+    // Terminal statuses are immutable, but if an inconsistent world returns
+    // a non-terminal full record, resume polling safely.
+    throw new WorkflowRunNotCompletedError(this.runId, run.status);
+  }
+
   /**
    * Polls the workflow return value until it is completed.
    * @internal
@@ -344,46 +394,25 @@ export class Run<TResult> {
     // changelog for details.
     while (true) {
       try {
-        const run = await world.runs.get(this.runId);
+        const runMetadata = await world.runs.get(this.runId, {
+          resolveData: 'none',
+        });
 
-        if (run.status === 'completed') {
-          const encryptionKey = await this.#getEncryptionKey();
-          return await hydrateWorkflowReturnValue(
-            run.output,
-            this.runId,
-            encryptionKey
-          );
-        }
-
-        if (run.status === 'cancelled') {
+        if (runMetadata.status === 'cancelled') {
           throw new WorkflowRunCancelledError(this.runId);
         }
 
-        if (run.status === 'failed') {
-          // Hydrate the serialized run error so the original thrown value
-          // (with its type identity, cause chain, etc.) is set as the
-          // `cause` on WorkflowRunFailedError.
-          const encryptionKey = await this.#getEncryptionKey();
-          let hydratedError: unknown;
-          try {
-            hydratedError = await hydrateRunError(
-              run.error,
-              this.runId,
-              encryptionKey
-            );
-          } catch {
-            // If hydration fails, surface a generic fallback rather than
-            // leaving the user with a raw Uint8Array. The run's errorCode
-            // is still preserved on the thrown WorkflowRunFailedError.
-            hydratedError = new Error('Failed to hydrate workflow run error');
-          }
-          throw new WorkflowRunFailedError(this.runId, hydratedError, {
-            errorCode: run.errorCode,
+        if (PAYLOAD_TERMINAL_RUN_STATUSES.has(runMetadata.status)) {
+          // The polling read above deliberately skips input/output/error refs.
+          // Resolve payloads only once the run reaches a terminal state.
+          const run = await world.runs.get(this.runId, {
+            resolveData: 'all',
           });
+          return await this.#resolveTerminalReturnValue(run);
         }
 
         // Run not completed yet — sleep and poll again.
-        throw new WorkflowRunNotCompletedError(this.runId, run.status);
+        throw new WorkflowRunNotCompletedError(this.runId, runMetadata.status);
       } catch (error) {
         if (WorkflowRunNotCompletedError.is(error)) {
           await new Promise((resolve) =>

--- a/packages/core/src/runtime/runs.test.ts
+++ b/packages/core/src/runtime/runs.test.ts
@@ -28,6 +28,7 @@ import { registerSerializationClass } from '../class-serialization.js';
 import {
   dehydrateRunError,
   dehydrateStepReturnValue,
+  dehydrateWorkflowReturnValue,
   hydrateStepReturnValue,
 } from '../serialization.js';
 import { getReturnValuePollIntervalMs, Run } from './run.js';
@@ -243,6 +244,24 @@ describe('Run.exists', () => {
   });
 });
 
+describe('Run.status', () => {
+  afterEach(() => {
+    setWorld(undefined as unknown as World);
+  });
+
+  it('reads metadata without resolving run payloads', async () => {
+    const world = createMockWorld();
+    setWorld(world);
+
+    await expect(new Run('wrun_123').status).resolves.toBe('running');
+
+    expect(world.runs.get).toHaveBeenCalledOnce();
+    expect(world.runs.get).toHaveBeenCalledWith('wrun_123', {
+      resolveData: 'none',
+    });
+  });
+});
+
 describe('Run.getReadable', () => {
   afterEach(() => {
     setWorld(undefined as unknown as World);
@@ -431,6 +450,38 @@ describe('Run.returnValue polling interval', () => {
   });
 });
 
+describe('Run.returnValue payload resolution', () => {
+  afterEach(() => {
+    setWorld(undefined as unknown as World);
+  });
+
+  it('polls metadata before resolving a completed run payload', async () => {
+    const output = await dehydrateWorkflowReturnValue(
+      42,
+      'wrun_123',
+      undefined
+    );
+    const world = createMockWorld({
+      run: {
+        status: 'completed',
+        output,
+        completedAt: new Date(),
+      },
+    });
+    setWorld(world);
+
+    await expect(new Run<number>('wrun_123').returnValue).resolves.toBe(42);
+
+    expect(world.runs.get).toHaveBeenCalledTimes(2);
+    expect(world.runs.get).toHaveBeenNthCalledWith(1, 'wrun_123', {
+      resolveData: 'none',
+    });
+    expect(world.runs.get).toHaveBeenNthCalledWith(2, 'wrun_123', {
+      resolveData: 'all',
+    });
+  });
+});
+
 describe('Run.returnValue when run.status === "failed"', () => {
   // Register the FatalError class so the run-error serialization pipeline
   // can find it during hydration (the SWC plugin does this in production).
@@ -478,7 +529,8 @@ describe('Run.returnValue when run.status === "failed"', () => {
       'wrun_failed',
       undefined
     );
-    setWorld(makeFailedRunWorld(serialized, 'USER_ERROR'));
+    const world = makeFailedRunWorld(serialized, 'USER_ERROR');
+    setWorld(world);
 
     const run = new Run('wrun_failed');
     let caught: WorkflowRunFailedError | undefined;
@@ -499,6 +551,13 @@ describe('Run.returnValue when run.status === "failed"', () => {
     expect(cause).toBeInstanceOf(FatalError);
     expect((cause as FatalError).message).toBe('boom');
     expect((cause as FatalError).fatal).toBe(true);
+    expect(world.runs.get).toHaveBeenCalledTimes(2);
+    expect(world.runs.get).toHaveBeenNthCalledWith(1, 'wrun_failed', {
+      resolveData: 'none',
+    });
+    expect(world.runs.get).toHaveBeenNthCalledWith(2, 'wrun_failed', {
+      resolveData: 'all',
+    });
   });
 
   it('should preserve a plain Error cause through hydration', async () => {


### PR DESCRIPTION
Poll run metadata without resolving payload refs, then fetch output or error data once the run reaches a terminal state.
Validated with the core run tests and typecheck.
