### PR TITLE
Add missing run status polling changeset

### DIFF
--- a/.changeset/quiet-runs-poll.md
+++ b/.changeset/quiet-runs-poll.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Reduce payload resolution while polling workflow run status.


### PR DESCRIPTION
Adds the missing `@workflow/core` patch changeset for #3672.
Validated with `pnpm changeset status --since=origin/main`.
