### PR TITLE
fix(astro,sveltekit): skip generated writes that would not change the file

### DIFF
--- a/.changeset/guard-astro-sveltekit-writes.md
+++ b/.changeset/guard-astro-sveltekit-writes.md
@@ -1,0 +1,6 @@
+---
+'@workflow/astro': patch
+'@workflow/sveltekit': patch
+---
+
+Stop rewriting generated files whose content is unchanged, so a no-op rebuild no longer invalidates them in the dev server.

--- a/packages/astro/src/builder.ts
+++ b/packages/astro/src/builder.ts
@@ -7,6 +7,7 @@ import {
   NORMALIZE_REQUEST_CODE,
   resolveProjectRoot,
   VercelBuildOutputAPIBuilder,
+  writeFileIfChanged,
 } from '@workflow/builders';
 
 const WORKFLOW_ROUTES = [
@@ -54,7 +55,7 @@ export class LocalBuilder extends BaseBuilder {
 
     // Add .gitignore to exclude generated files from version control
     if (process.env.VERCEL_DEPLOYMENT_ID === undefined) {
-      await writeFile(join(workflowGeneratedDir, '.gitignore'), '*');
+      await writeFileIfChanged(join(workflowGeneratedDir, '.gitignore'), '*');
     }
 
     // Clean up stale V1 step route (may persist via Vercel build cache)
@@ -90,7 +91,10 @@ export const POST = async ({request}) => {
 
 export const prerender = false;`
     );
-    await writeFile(workflowsRouteFile, workflowsRouteContent);
+    // These files are generated into the Astro pages directory, which Vite
+    // watches in dev, so an identical rewrite would still invalidate the
+    // module and force a redundant recompile.
+    await writeFileIfChanged(workflowsRouteFile, workflowsRouteContent);
 
     await this.buildWebhookRoute({ workflowGeneratedDir });
 
@@ -105,7 +109,7 @@ export const prerender = false;`
     // Expose manifest as a public HTTP route when WORKFLOW_PUBLIC_MANIFEST=1
     // Astro maps `foo.json.js` to the URL `/foo.json`
     if (this.shouldExposePublicManifest && manifestJson) {
-      await writeFile(
+      await writeFileIfChanged(
         join(workflowGeneratedDir, 'manifest.json.js'),
         `export function GET() {
   return new Response(${JSON.stringify(manifestJson)}, {
@@ -169,7 +173,7 @@ export const OPTIONS = createHandler('OPTIONS');
 export const prerender = false;`
     );
 
-    await writeFile(webhookRouteFile, webhookRouteContent);
+    await writeFileIfChanged(webhookRouteFile, webhookRouteContent);
   }
 }
 

--- a/packages/sveltekit/src/builder.ts
+++ b/packages/sveltekit/src/builder.ts
@@ -1,13 +1,5 @@
 import { constants } from 'node:fs';
-import {
-  access,
-  copyFile,
-  mkdir,
-  readFile,
-  rm,
-  stat,
-  writeFile,
-} from 'node:fs/promises';
+import { access, mkdir, readFile, rm, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import {
   BaseBuilder,
@@ -15,6 +7,7 @@ import {
   NORMALIZE_REQUEST_CODE,
   resolveProjectRoot,
   type SvelteKitConfig,
+  writeFileIfChanged,
 } from '@workflow/builders';
 
 const SVELTEKIT_VIRTUAL_MODULES = [
@@ -66,7 +59,7 @@ export class SvelteKitBuilder extends BaseBuilder {
 
     // Add .gitignore to exclude generated files from version control
     if (process.env.VERCEL_DEPLOYMENT_ID === undefined) {
-      await writeFile(join(workflowGeneratedDir, '.gitignore'), '*');
+      await writeFileIfChanged(join(workflowGeneratedDir, '.gitignore'), '*');
     }
 
     // Clean up stale V1 step route directory (may persist via Vercel build cache)
@@ -106,7 +99,10 @@ export const POST = async ({request}) => {
   return workflowEntrypoint(workflowCode${options})(normalRequest);
 }`
     );
-    await writeFile(workflowsRouteFile, workflowsRouteContent);
+    // These files are generated into the SvelteKit routes directory, which
+    // Vite watches in dev, so an identical rewrite would still invalidate the
+    // module and force a redundant recompile.
+    await writeFileIfChanged(workflowsRouteFile, workflowsRouteContent);
 
     await this.buildWebhookRoute({ workflowGeneratedDir });
 
@@ -127,11 +123,13 @@ export const POST = async ({request}) => {
       );
       await mkdir(staticManifestDir, { recursive: true });
       if (process.env.VERCEL_DEPLOYMENT_ID === undefined) {
-        await writeFile(join(staticManifestDir, '.gitignore'), '*');
+        await writeFileIfChanged(join(staticManifestDir, '.gitignore'), '*');
       }
-      await copyFile(
-        join(workflowGeneratedDir, 'manifest.json'),
-        join(staticManifestDir, 'manifest.json')
+      // Written from the same string rather than copied, so an unchanged
+      // manifest leaves the static copy untouched too.
+      await writeFileIfChanged(
+        join(staticManifestDir, 'manifest.json'),
+        manifestJson
       );
     }
   }
@@ -189,7 +187,7 @@ export const HEAD = createSvelteKitHandler('HEAD');
 export const OPTIONS = createSvelteKitHandler('OPTIONS');`
     );
 
-    await writeFile(webhookRouteFile, webhookRouteContent);
+    await writeFileIfChanged(webhookRouteFile, webhookRouteContent);
   }
 
   private async loadRoutesDirectory(): Promise<string> {


### PR DESCRIPTION
### Description

Follow-up to #3454, which added the unchanged-write guard and applied it to `@workflow/builders`, `@workflow/next` and `@workflow/nitro`. The Astro and SvelteKit builders were not covered: they receive the bundle text from the base builder and do their own `writeFile`, so they never reach the guard. Their generated files live in Vite-watched source directories (`src/pages/.well-known/workflow/v1` and `src/routes/.well-known/workflow/v1`), which is exactly the condition #3454 was about.

This routes those writes through `writeFileIfChanged`, and writes SvelteKit's static manifest copy from the same string rather than `copyFile`-ing it, matching what #3454 did for the Next public manifest.

### Measured effect

Two consecutive `pnpm build` runs with no source change, comparing sha256 + mtime(ns) + inode of every generated file under the workflow directories, with `WORKFLOW_PUBLIC_MANIFEST=1`:

| | before | after |
|---|---|---|
| SvelteKit (`src/routes/…`, `static/…`) | 6 of 9 rewritten | 3 |
| Astro (`src/pages/…`) | 5 of 8 rewritten | 3 |

Every one of those rewrites had an identical sha, i.e. they were pure no-op writes. Fixed here: both `.gitignore` files and the `static/manifest.json` copy on SvelteKit, and `.gitignore` plus `manifest.json.js` on Astro.

### Relation to #3509

Rebased over #3509 (better SvelteKit routes-directory loading), which rewrote the same import block in `packages/sveltekit/src/builder.ts`. That was the only conflict and it was mechanical: keep its `node:path` import and drop the `node:module`/`node:url` imports it made dead, keep this PR's narrowed `node:fs/promises` import.

The two changes act at different layers and both still apply. #3509 caches the resolved routes directory so SvelteKit's secondary builds and worker threads do not reload the Svelte config and redo the build; this PR reduces what a build that does run actually writes. The measured numbers above were re-taken on top of #3509, with the guard-off control built from `origin/main`'s builder, so the before/after pair is on the same base.

### What this does NOT fix

Three files per framework still churn, for two reasons that need more than a call-site swap. Both are pre-existing and neither is made worse by this PR.

**1. The read-transform-rewrite pattern defeats the guard** — affects `flow/+server.js` and `webhook/[token]/+server.js` (SvelteKit), `flow.js` and `webhook/[token].js` (Astro).

Both builders call `createCombinedBundle` / `createWebhookBundle`, which write the route to disk through the base builder, then `readFile` it back, apply a regex transform, and write the transformed content. So each build writes the file twice with two different contents, and on the next build neither write can be skipped: the base write sees the previous build's *transformed* content on disk and differs from it, and the framework write then sees the *untransformed* content and differs from that. The signature is visible in the inode: the route gets a new inode (base write, temp+rename) and the webhook keeps its inode (framework write, plain overwrite).

The fix is to make the final content the only content written, e.g. by letting the framework pass its transform into the base builder so the route is generated in its final form. That is an API change to the base builder and wants its own PR.

**2. One-shot `esbuild.build()` always rewrites its outfile** — affects `flow/__step_registrations.js` on both frameworks.

`ctx.rebuild()` on an esbuild *context* skips writing when the output is byte-identical (verified on esbuild 0.28.1: mtime and inode both preserved). A one-shot `esbuild.build()` does not; it rewrites unconditionally. This is why Next dev, which uses contexts, was already protected for its esbuild outputs while these builders are not. The fix is either to use contexts in watch mode or to pass `write: false` and hand the output to `writeFileIfChanged`.

### Other follow-ups from #3454

**3. Nitro's dev handler should stop cache-busting off a single file's mtime.** `packages/nitro/src/index.ts` derives `version` from `statSync(handlerPath).mtimeMs` for `workflows.mjs` and then uses it as the cache-buster for the `steps.mjs` import. A step-body-only edit leaves `workflows.mjs` identical, so the version freezes and stale step code is served. That dependency is the only reason `skipsUnchangedGeneratedWrites` exists.

Widening the key is cheap and keeps the per-request path to stats rather than file reads, since `handlerImportPath` and `stepsImportPath` are already in scope:

```js
const s = statSync(handlerPath), t = statSync(stepsPath);
const version = `${s.size}:${s.mtimeMs}:${t.size}:${t.mtimeMs}`;
```

Including `size` costs nothing and narrows the case where two coalesced dev writes land on an effectively identical mtime. Note only the `workflow/workflows.mjs` variant needs the second stat; `preloadSteps['workflow/webhook.mjs']` is empty. Both the v2 and v3 branches carry a copy. Once that lands, `skipsUnchangedGeneratedWrites` can be deleted from `BaseBuilder` and from the Nitro override.

**4. There is no regression guard for the cross-framework case.** `write-if-changed.test.ts` covers the helper and the opt-out, but nothing stops a new raw `writeFile` into a watched generated directory from silently restoring the redundant rebuild. The check that would catch it is the one used above: build twice, assert every generated file keeps its sha, mtime and inode. `@workflow/astro` has no test files today and `@workflow/sveltekit` has one unrelated test, so this needs a builder harness per framework rather than a one-line test.

### How did you test your changes?

No automated coverage is added, for the reason in (4), so here are reproduction steps.

```bash
pnpm install && pnpm run build
cd workbench/sveltekit   # and workbench/astro
export WORKFLOW_PUBLIC_MANIFEST=1
pnpm build
find src/routes/.well-known/workflow static/.well-known/workflow -type f \
  | sort | xargs -I{} sh -c 'printf "%s %s %s\n" "$(shasum -a 256 {} | cut -d" " -f1)" "$(stat -f "%Fm:%i" {})" {}' > /tmp/s1
pnpm build
# ...repeat into /tmp/s2
diff /tmp/s1 /tmp/s2
```

Before this change the two `.gitignore` files and `static/manifest.json` appear in the diff with an identical sha and a moved mtime. After, they do not. The three files listed above still appear, for the reasons given.

Also run: `pnpm run build` (28/28 tasks), `npx biome check` on both changed files.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete

