### PR TITLE
feat(world-postgres): make startup recovery optional

### DIFF
--- a/.changeset/calm-runs-recover.md
+++ b/.changeset/calm-runs-recover.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': minor
+---
+
+Add a `recoverActiveRuns` option so applications can start queue workers without running broad startup recovery.

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -153,6 +153,13 @@ The Postgres World is a self-hosted durable backend for long-running server proc
 - Number of concurrent workers polling for jobs.
 - Also bounds concurrent parent-to-child workflow return-value polls.
 
+### `recoverActiveRuns`
+
+- Environment variable: none
+- Default: `true`
+- Whether `start()` re-enqueues every pending and running workflow run.
+- Setting it to `false` still starts the queue worker; recovery must be handled separately.
+
 ### `applicationManagedShutdown`
 
 - Environment variable: `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN` (`1` enables)

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -58,6 +58,7 @@ const world = createWorld({
   connectionString: "postgres://username:password@localhost:5432/database",
   jobPrefix: "myapp", // optional
   queueConcurrency: 50, // optional
+  recoverActiveRuns: false, // optional; only when recovery is handled separately
   maxPoolSize: 10, // optional, overrides WORKFLOW_POSTGRES_MAX_POOL_SIZE when `pool` is omitted
 });
 
@@ -66,6 +67,11 @@ import { Pool } from "pg";
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const worldFromPool = createWorld({ pool });
 ```
+
+With `recoverActiveRuns: false`, `start()` still starts the queue worker but
+skips the broad active-run scan. Use it only when recovery is handled
+separately; replica startup will no longer repair an active run with no
+runnable job.
 
 ### Application-managed Shutdown
 
@@ -97,6 +103,7 @@ An aborted HTTP request does not guarantee that its server-side handler stopped,
 | `pool`             | `pg.Pool` | —                                                                                      | Optional. When set, used for Drizzle, Graphile Worker, and stream writes. `world.close()` does not end it. |
 | `jobPrefix`        | `string`  | `process.env.WORKFLOW_POSTGRES_JOB_PREFIX`                                             | Optional prefix for queue job names                                                                  |
 | `queueConcurrency` | `number`  | `50`                                                                                   | Number of concurrent active step executions per process. Must be high enough to cover any parent→child workflow polling in flight — each `Run#returnValue` await holds a worker slot until the child run terminates. |
+| `recoverActiveRuns` | `boolean` | `true`                                                                                 | Whether `start()` re-enqueues every pending and running workflow run. Disabling this does not stop normal queue consumption. |
 | `applicationManagedShutdown` | `boolean` | `false`; `WORKFLOW_POSTGRES_APPLICATION_MANAGED_SHUTDOWN=1` enables it for the default package configuration | Whether the application coordinates shutdown and awaits `world.close()` instead of Graphile Worker responding automatically. |
 
 ## Environment Variables

--- a/packages/world-postgres/src/config.ts
+++ b/packages/world-postgres/src/config.ts
@@ -13,6 +13,11 @@ export type PostgresWorldConfig = PgConnectionConfig & {
   namespace?: string;
   queueConcurrency?: number;
   /**
+   * Whether start() should re-enqueue pending and running runs from storage.
+   * Defaults to true.
+   */
+  recoverActiveRuns?: boolean;
+  /**
    * Whether the application coordinates shutdown instead of Graphile Worker
    * responding automatically. The application must await world.close().
    * Defaults to false. The package's default createWorld() configuration

--- a/packages/world-postgres/src/index.ts
+++ b/packages/world-postgres/src/index.ts
@@ -85,12 +85,14 @@ export function createWorld(
     }),
     async start() {
       await queue.start();
-      await reenqueueActiveRuns(
-        storage.runs,
-        queue.queue,
-        'world-postgres',
-        config.namespace
-      );
+      if (config.recoverActiveRuns !== false) {
+        await reenqueueActiveRuns(
+          storage.runs,
+          queue.queue,
+          'world-postgres',
+          config.namespace
+        );
+      }
     },
     async close() {
       await queue.close();

--- a/packages/world-postgres/src/reenqueue.test.ts
+++ b/packages/world-postgres/src/reenqueue.test.ts
@@ -204,6 +204,26 @@ describe('re-enqueue active runs on start', () => {
     await world.close();
   });
 
+  it('starts the worker without recovering active runs when disabled', async () => {
+    mockRunsList({
+      running: [{ runId: 'wrun_AAA', workflowName: 'wfA' }],
+    });
+
+    const world = createWorld({
+      connectionString: 'postgres://test',
+      pool,
+      recoverActiveRuns: false,
+    });
+    const list = vi.mocked(createRunsStorage).mock.results.at(-1)?.value.list;
+    await world.start();
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(list).not.toHaveBeenCalled();
+    expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
+
+    await world.close();
+  });
+
   it('does not enqueue anything when there are no active runs', async () => {
     mockRunsList({});
 


### PR DESCRIPTION
### Description

`world-postgres` currently scans and re-enqueues every pending/running run whenever a process calls `start()`. In a horizontally scaled deployment, an ordinary replica start is not evidence that the fleet failed, so this can create a burst of redundant replay work.

Add `recoverActiveRuns` to `PostgresWorldConfig`, matching the existing Local World option. It defaults to `true`. With `false`, `start()` still starts Graphile Worker and consumes durable/new jobs, but skips the broad storage scan.

This is an operational escape hatch, not leader election or exactly-once machinery. Setting it to `false` everywhere removes automatic startup repair for an active run with no runnable job, so recovery must be handled separately.

Related work: [#2544](https://github.com/vercel/workflow/pull/2544) proposes a broader `start({ onRestart })` control; [#3162](https://github.com/vercel/workflow/pull/3162) makes boot recovery more selective and deduplicates its jobs; [#3138](https://github.com/vercel/workflow/issues/3138) tracks owner-aware/single-flight recovery. This change is the smaller `world-postgres` construction-time escape hatch. If #2544 lands, precedence between the two controls should be defined deliberately.

### Docs Preview

Pending Vercel Labs authorization for the external fork. Changed route: `/v5/docs/configuration/worlds#recoveractiveruns`.

### How did you test your changes?

- Added a regression test with an active stored run and `recoverActiveRuns: false`.
- The test proves Graphile Worker starts while storage listing and recovery enqueueing do not run.
- `pnpm exec vitest run src/reenqueue.test.ts` — 13/13 passed.
- `pnpm typecheck` and `pnpm build` passed for `@workflow/world-postgres`.

### PR Checklist - Required to merge

- [x] 📦 Added a minor changeset for `@workflow/world-postgres`
- [x] 🔒 DCO sign-off is present
- [x] 📝 Pinged `@vercel/workflow` after the PR and core checks were verified
