### PR TITLE
fix(world-vercel): hold the ws channel registry on globalThis

### DIFF
--- a/.changeset/ws-transport-global-registry.md
+++ b/.changeset/ws-transport-global-registry.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Hold the WebSocket events transport's channel registry on `globalThis` instead of at module scope, so an app that ends up with two copies of the bundled world in one process (for example a Next.js app whose `instrumentation.ts` warms the world) still resolves the channel its queue consumer opened instead of silently writing every event over HTTP.

--- a/packages/world-vercel/src/ws-transport.test.ts
+++ b/packages/world-vercel/src/ws-transport.test.ts
@@ -1049,6 +1049,57 @@ describe('transport selection', () => {
   });
 
   /**
+   * Two copies of this module can share a process, and the open and the lookup
+   * run through different Worlds, so they can land in different copies. With
+   * the registry at module scope that made an open socket carry nothing.
+   */
+  describe('the channel registry is process-wide', () => {
+    const WsEventsStateKey = Symbol.for(
+      '@workflow/world-vercel//wsEventsTransports/v1'
+    );
+
+    /** The registry as a second copy of this module in the process sees it. */
+    const sharedTransports = () =>
+      (
+        globalThis as typeof globalThis & {
+          [WsEventsStateKey]?: { transports: Map<string, unknown> };
+        }
+      )[WsEventsStateKey]?.transports;
+
+    it('registers an opened channel there, and evicts it on release', () => {
+      process.env.WORKFLOW_EVENTS_TRANSPORT = 'ws';
+      const release = openWsChannel('wrun_1', directConfig);
+      const wsUrl = resolveWsTransport('wrun_1', directConfig)?.wsUrl;
+
+      expect(wsUrl).toBeDefined();
+      expect(sharedTransports()?.has(String(wsUrl))).toBe(true);
+
+      release?.();
+
+      expect(sharedTransports()?.has(String(wsUrl))).toBe(false);
+    });
+
+    it('resolves a channel another copy of this module opened', () => {
+      process.env.WORKFLOW_EVENTS_TRANSPORT = 'ws';
+      // Borrow the URL the open path derives, then stand in for that other
+      // copy by registering under it directly.
+      const release = openWsChannel('wrun_1', directConfig);
+      const wsUrl = String(resolveWsTransport('wrun_1', directConfig)?.wsUrl);
+      release?.();
+      expect(resolveWsTransport('wrun_1', directConfig)).toBeNull();
+
+      // Stands in for a transport built by that other copy: structurally used
+      // by the write path, and `close`able by the reset seam.
+      const openedElsewhere = { copy: 'other', close: () => {} };
+      sharedTransports()?.set(wsUrl, openedElsewhere);
+      const resolved = resolveWsTransport('wrun_1', directConfig);
+
+      expect(resolved?.wsUrl).toBe(wsUrl);
+      expect(resolved?.transport as unknown).toBe(openedElsewhere);
+    });
+  });
+
+  /**
    * The flow route calls these on every message, for every World — including the
    * HTTP default and the proxy World that can't speak WS at all. So "does
    * nothing, quietly" is as much the contract as the open itself: a throw or an

--- a/packages/world-vercel/src/ws-transport.ts
+++ b/packages/world-vercel/src/ws-transport.ts
@@ -290,7 +290,9 @@ class WsEventsTransport {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
-    if (transports.get(this.wsUrl) === this) transports.delete(this.wsUrl);
+    if (wsEvents.transports.get(this.wsUrl) === this) {
+      wsEvents.transports.delete(this.wsUrl);
+    }
     const conn = this.connection;
     this.connection = null;
     // Normal closure: a clean client-side release, not an aborted run.
@@ -660,7 +662,43 @@ class WsEventsTransport {
   }
 }
 
-const transports = new Map<string, WsEventsTransport>();
+/**
+ * On `globalThis`, not at module scope: a bundler can put two copies of this
+ * module in one process — Next.js gives the `instrumentation.ts` entry its own
+ * copy of the world now that it is bundled rather than external
+ * (vercel/workflow#3493) — and the open and the lookup run through different
+ * Worlds (`getWorldHandlers()` vs `getWorld()`, two `createWorld()` calls under
+ * two `globalThis` keys in core), so they can land in different copies. With the
+ * registry at module scope, opens went into one Map and every write read the
+ * other, empty one: socket open, every event silently on HTTP.
+ *
+ * `/v1` so a later change to `WsEventsTransport`'s shape gets a fresh registry
+ * rather than a structurally-incompatible hit from an older copy.
+ */
+const WsEventsStateKey = Symbol.for(
+  '@workflow/world-vercel//wsEventsTransports/v1'
+);
+
+interface WsEventsState {
+  /** Open channels by `wsUrl`; see `getWsEventsTransport` below. */
+  transports: Map<string, WsEventsTransport>;
+  /** Log-once latches; per-copy ones would log once *per copy*. */
+  loggedWsInUse: boolean;
+  loggedWsProxyFallback: boolean;
+}
+
+const globalWsEventsState = globalThis as typeof globalThis & {
+  [WsEventsStateKey]?: WsEventsState;
+};
+
+// First copy to evaluate seeds the state; later copies adopt that same object,
+// so nothing here may ever *replace* the slot.
+const wsEvents: WsEventsState = globalWsEventsState[WsEventsStateKey] ?? {
+  transports: new Map(),
+  loggedWsInUse: false,
+  loggedWsProxyFallback: false,
+};
+globalWsEventsState[WsEventsStateKey] = wsEvents;
 
 /**
  * Get (or lazily create) the shared WS transport for `wsUrl`. `getHeaders` runs
@@ -678,26 +716,26 @@ export function getWsEventsTransport(
     forceRefresh: boolean;
   }) => Promise<Record<string, string>>
 ): WsEventsTransport {
-  let transport = transports.get(wsUrl);
+  let transport = wsEvents.transports.get(wsUrl);
   if (!transport) {
     transport = new WsEventsTransport(wsUrl, getHeaders);
-    transports.set(wsUrl, transport);
+    wsEvents.transports.set(wsUrl, transport);
   }
   return transport;
 }
 
 /**
  * Test seam: close and drop every cached transport, and re-arm the
- * once-per-process log latches below so a test asserting on either message
- * isn't silenced by an earlier one having already logged it.
+ * once-per-process log latches so a test asserting on either message isn't
+ * silenced by an earlier one having already logged it.
  */
 export function resetWsEventsTransportsForTest(): void {
-  for (const transport of [...transports.values()]) {
+  for (const transport of [...wsEvents.transports.values()]) {
     transport.close('test reset');
   }
-  transports.clear();
-  loggedWsProxyFallback = false;
-  loggedWsInUse = false;
+  wsEvents.transports.clear();
+  wsEvents.loggedWsProxyFallback = false;
+  wsEvents.loggedWsInUse = false;
 }
 
 /**
@@ -772,8 +810,8 @@ export function openWsChannel(
   if (!isWsEventsTransportEnabled()) return undefined;
   const resolved = resolveChannelUrl(runId, config);
   if (!resolved) return undefined;
-  if (!loggedWsInUse) {
-    loggedWsInUse = true;
+  if (!wsEvents.loggedWsInUse) {
+    wsEvents.loggedWsInUse = true;
     console.log(`world-vercel: using ws events transport (${resolved}).`);
   }
   // Cheap: a URL plus a map lookup, no token mint and no I/O. The socket work
@@ -829,11 +867,6 @@ async function refreshOidcTokenBestEffort(): Promise<void> {
   }
 }
 
-// Each logged at most once per process — both branches below are expected
-// to repeat (every event), and a per-request log would just be noise.
-let loggedWsProxyFallback = false;
-let loggedWsInUse = false;
-
 /**
  * Resolve this run's channel URL, or `null` when this World can't hold a socket
  * at all and every caller must use HTTP. Says nothing about whether a channel is
@@ -855,8 +888,8 @@ function resolveChannelUrl(
     // platform-level upgrade path, which is what surfaces as
     // "experimental_upgradeWebSocket is not available in the current runtime
     // environment". Fall back rather than fail a connection it can't serve.
-    if (!loggedWsProxyFallback) {
-      loggedWsProxyFallback = true;
+    if (!wsEvents.loggedWsProxyFallback) {
+      wsEvents.loggedWsProxyFallback = true;
       console.warn(
         `world-vercel: ws events transport requested but a World with projectConfig ` +
           `(api-workflow proxy, resolved baseUrl: ${baseUrl}) is active — falling back.`
@@ -885,6 +918,6 @@ export function resolveWsTransport(
 } | null {
   const wsUrl = resolveChannelUrl(runId, config);
   if (!wsUrl) return null;
-  const transport = transports.get(wsUrl);
+  const transport = wsEvents.transports.get(wsUrl);
   return transport ? { transport, wsUrl } : null;
 }


### PR DESCRIPTION
Due to bundling the world-vercel (#3493), we can have two copies of the module which cause websockets to not work from durabench.

Note in SDK use from e2e tests I have seen websockets work just fine. It breaks on durabench because of it's instrumentation initialization.

This PR fixes the issue by moving `const transports` out of module state into `globalThis`.

<details>
## What

The WS events transport's channel registry moves from module scope onto a
`Symbol.for()` key on `globalThis` — the same technique `@workflow/core` already
uses for the World cache — along with the two once-per-process log latches.

## Why

The transport's open and its lookup are reached through **two different World
instances**:

- `openWsChannel` runs inside world-vercel's `createQueueHandler`, and the
  runtime builds that consumer from `getWorldHandlers()`;
- a write reaches `resolveWsTransport` (a lookup, never a create) through
  `getWorld()`.

Those are two `createWorld()` calls, cached under two different `globalThis`
symbols in core. The only thing that made them meet was sharing one *module
instance* of this package, because `const transports` was module-scope.

#3493 bundled `@workflow/world-vercel` into the Next.js server output instead of
leaving it in `serverExternalPackages`. Next then gives the `instrumentation.ts`
entry **its own copy** of the module, separate from the route entries. So in an
app whose `register()` warms the world:

```ts
// instrumentation.ts
const { getWorld } = await import("workflow/runtime");
await getWorld();          // events-writing World, built in the instrumentation copy
```

…the flow route's later `getWorldHandlers()` builds the consumer's World in the
*route* copy. Opens land in one Map; every lookup reads the other, empty one.
The socket is opened and carries nothing — every event silently falls back to
HTTP, deterministically, for the life of the process. That is what
`vercel-labs/durabench`'s `apps/workflow-host` hit: sockets in the trace, zero
event frames on them.

Nothing about the WS design was wrong, and this is not a reason to revert #3493
(its cold-start win is real). A module-scope singleton in a package that a
bundler may duplicate is the bug.

## Verification

- `packages/world-vercel`: 532 unit tests pass, typecheck and Biome clean.
- Two new tests in `ws-transport.test.ts`: the registry is the object on
  `globalThis` (and is evicted on release), and `resolveWsTransport` resolves a
  channel **another copy of this module** registered — the regression this fixes.
- Out-of-tree repro (minimal Next app, a node_modules package shaped like this
  one, two `globalThis`-cached worlds, one variable at a time), on Next 16.2.11
  and 16.3.1, webpack and Turbopack:

  | world pkg | `register()` warms the world | before this change | with the fix |
  |---|---|---|---|
  | bundled (post-#3493) | yes | **`http`** (two Maps, `hit=false`) | `ws` |
  | external (pre-#3493) | yes | `ws` | `ws` |
  | bundled (post-#3493) | no | `ws` | `ws` |

  With the fix the two module instances still exist — the open logs one instance
  id and the lookup another — but they share the registry, so the lookup hits.

## Notes for review

- The symbol carries a `/v1` suffix so a future change to `WsEventsTransport`'s
  shape gets a fresh registry rather than a structurally-incompatible hit from an
  older copy sharing the process. Cross-copy use is structural (`request`,
  `release`, `close`); there is no `instanceof` on the transport.
- Deliberately **not** in this PR, and worth doing separately: a debug breadcrumb
  when `resolveWsTransport` misses (the silence here cost several
  investigations); a transport assertion in the `e2e-vercel-ws-transport` lane,
  which today passes whether events go over WS or fall back; and re-combining
  `getWorld`/`getWorldHandlers`, which the code comment in
  `packages/core/src/runtime/world.ts` already contemplates and which is what
  turned "duplicated module" into a systematic miss rather than a race.
- The workbench app that lane deploys only calls `registerOTel` in its
  instrumentation, which is why CI never saw this; adding a world warm-up there
  would give the lane the failing shape.

</details>
