### PR TITLE
Default the events transport to WebSockets

### DIFF
--- a/.changeset/ws-strict-fallback.md
+++ b/.changeset/ws-strict-fallback.md
@@ -1,0 +1,7 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Add `WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT`, an internal flag that fails a
+`step_completed` write which falls back to HTTP while the WebSocket gate is on,
+so CI can tell a working socket from a silently demoted one.

--- a/.changeset/ws-transport-default-on.md
+++ b/.changeset/ws-transport-default-on.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-vercel': minor
+---
+
+Default the events transport to WebSockets. `WORKFLOW_EVENTS_TRANSPORT=http`
+opts back out; any other value, including unset, now takes the socket.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -744,8 +744,14 @@ jobs:
           # production-adjacent projects, and this shouldn't ever silently
           # start deploying to their production aliases if a future edit
           # changes flags around this call.
+          # Strict mode turns a silent HTTP demotion into a failed run, so this
+          # lane actually asserts the socket carried traffic instead of only
+          # asserting the feature was harmless. Scoped to `step_completed` —
+          # see STRICT_WS_EVENT_TYPES in events-v4.ts for why the other event
+          # types fall back legitimately. Never set on e2e-vercel-prod.
           URL=$(vercel deploy --yes --target=preview \
             -e WORKFLOW_EVENTS_TRANSPORT=ws \
+            -e WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT=1 \
             --scope="$WS_TEAM_ID" --token="$WS_VERCEL_TOKEN")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           # Best-effort: only used by the runtime-logs capture on failure,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -824,14 +824,32 @@ jobs:
     # shape of the durabench bug this stack came out of, so this lane is
     # unconditional and required rather than label-gated like the WS one.
     #
-    # Two apps, not the WS lane's four. Each row is a real `vercel deploy`
-    # charged to every PR in the repo, which is why the WS lane is opt-in
-    # at four; two is what keeps an always-on lane affordable. The pair is
-    # chosen for runtime diversity — nextjs-turbopack is the only fixture
-    # emitting OTEL spans, so it is the one that can show *which* transport
-    # ran, and express covers the non-Next server path. The WS lane's
-    # vite-specific rationale (native `ws` accelerators resolving to a stub)
-    # is WS-only and does not apply here.
+    # Six apps, chosen by server shape rather than by count. Before the flip
+    # HTTP was the default, so all 28 e2e-vercel-prod lane-runs covered it;
+    # after the flip they cover WebSockets instead and this lane is the whole
+    # of the HTTP coverage. Each row is a real `vercel deploy` charged to
+    # every PR, so the full 14 is too expensive, but two was too thin for a
+    # transport that is still supported.
+    #
+    # The shapes, one fixture each:
+    #   example          - baseline, no framework server
+    #   nextjs-turbopack - Next; also the only fixture emitting OTEL spans,
+    #                      so the only one that can show which transport ran
+    #   vite             - Vite SSR
+    #   express          - Node req/res server
+    #   nitro            - Nitro/h3, which also covers nuxt
+    #   hono             - fetch-API Request/Response server, a genuinely
+    #                      different mount shape from express
+    #
+    # Omitted because they duplicate a shape already here: nextjs-webpack
+    # (same runtime as turbopack, different bundler), nuxt (nitro), fastify
+    # and nest (both express-shaped), astro and tanstack-start (adapter
+    # variants). `python` is omitted because it has no conformance gate and
+    # needs routes this suite does not serve - see the e2e-python job.
+    #
+    # The first four deliberately match the WS lane's matrix, so the same
+    # fixture is exercised on both transports and a failure on one can be
+    # compared against the other.
     #
     # Deploys itself with `vercel deploy` rather than `--prebuilt` for the
     # same reasons documented on e2e-vercel-ws-transport above.
@@ -849,12 +867,24 @@ jobs:
       fail-fast: false
       matrix:
         app:
+          - name: "example"
+            project-id: "prj_xWq20Dd860HHAfzMjK2Mb6TPVxMa"
+            project-slug: "example-workflow"
           - name: "nextjs-turbopack"
             project-id: "prj_yjkM7UdHliv8bfxZ1sMJQf1pMpdi"
             project-slug: "example-nextjs-workflow-turbopack"
+          - name: "vite"
+            project-id: "prj_uLIcNZNDmETulAvj5h0IcDHi5432"
+            project-slug: "workbench-vite-workflow"
           - name: "express"
             project-id: "prj_cCZjpBy92VRbKHHbarDMhOHtkuIr"
             project-slug: "workbench-express-workflow"
+          - name: "nitro"
+            project-id: "prj_e7DZirYdLrQKXNrlxg7KmA6ABx8r"
+            project-slug: "workbench-nitro-workflow"
+          - name: "hono"
+            project-id: "prj_p0GIEsfl53L7IwVbosPvi9rPSOYW"
+            project-slug: "workbench-hono-workflow"
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -627,9 +627,11 @@ jobs:
   e2e-vercel-ws-transport:
     # Dedicated coverage for world-vercel's WebSocket events transport
     # (WORKFLOW_EVENTS_TRANSPORT=ws — see events-v4.ts's
-    # isWsEventsTransportEnabled). Every other job in this file exercises
-    # the default HTTP transport only, now that the WS-on-by-default POC
-    # hack is gone.
+    # isWsEventsTransportEnabled). This lane predates the default flip,
+    # when it was the only WS coverage in the file; it is kept because it
+    # still pins the transport explicitly, which every other Vercel lane
+    # now only gets by inheriting the default. See
+    # e2e-vercel-http-transport below for the other side.
     #
     # Mirrors e2e-vercel-prod's shape (same apps subset, same full e2e
     # suite) but deploys itself via a plain `vercel deploy` (no
@@ -796,6 +798,148 @@ jobs:
           name: e2e-results-vercel-ws-transport-${{ matrix.app.name }}
           path: |
             e2e-vercel-ws-transport-${{ matrix.app.name }}.json
+            e2e-metadata-${{ matrix.app.name }}-vercel.json
+            e2e-failures-${{ matrix.app.name }}-vercel.json
+            e2e-flaky-${{ matrix.app.name }}-vercel.json
+            e2e-infra-${{ matrix.app.name }}-vercel.json
+            e2e-diagnostics-${{ matrix.app.name }}-vercel.json
+            e2e-runtime-logs-${{ matrix.app.name }}-vercel.json
+          retention-days: 7
+          if-no-files-found: ignore
+
+  e2e-vercel-http-transport:
+    # The counterpart to e2e-vercel-ws-transport, and the reason it exists
+    # is the default flip: with WORKFLOW_EVENTS_TRANSPORT defaulting to
+    # `ws`, e2e-vercel-prod — which sets no transport env var at all — is
+    # now a WebSocket lane. Nothing in this file would exercise the HTTP
+    # events transport against a real Vercel deployment any more. This is
+    # not additive coverage; it replaces coverage that the flip silently
+    # took away.
+    #
+    # HTTP is now the fallback path, and the fallback is *silent*:
+    # resolveWsTransport returning null costs a write nothing and logs
+    # nothing. A path that is both unexercised and quiet is the exact
+    # shape of the durabench bug this stack came out of, so this lane is
+    # unconditional and required rather than label-gated like the WS one.
+    #
+    # Two apps, not the WS lane's four. Each row is a real `vercel deploy`
+    # charged to every PR in the repo, which is why the WS lane is opt-in
+    # at four; two is what keeps an always-on lane affordable. The pair is
+    # chosen for runtime diversity — nextjs-turbopack is the only fixture
+    # emitting OTEL spans, so it is the one that can show *which* transport
+    # ran, and express covers the non-Next server path. The WS lane's
+    # vite-specific rationale (native `ws` accelerators resolving to a stub)
+    # is WS-only and does not apply here.
+    #
+    # Deploys itself with `vercel deploy` rather than `--prebuilt` for the
+    # same reasons documented on e2e-vercel-ws-transport above.
+    name: E2E Vercel HTTP Transport Test (${{ matrix.app.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: ci-scope
+    # Mirrors e2e-vercel-prod's condition exactly, so this lane runs in
+    # every case that one does, including under `workflow-server-test`.
+    if: ${{ needs.ci-scope.outputs.fast-path != 'true' }}
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - name: "nextjs-turbopack"
+            project-id: "prj_yjkM7UdHliv8bfxZ1sMJQf1pMpdi"
+            project-slug: "example-nextjs-workflow-turbopack"
+          - name: "express"
+            project-id: "prj_cCZjpBy92VRbKHHbarDMhOHtkuIr"
+            project-slug: "workbench-express-workflow"
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      WORKFLOW_PUBLIC_MANIFEST: '1'
+      WS_TEAM_ID: "team_nO2mCG4W8IxPIeKoSsqwAxxB"
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-workflow-dev
+        with:
+          build-packages: 'false'
+
+      - name: Build CLI
+        run: pnpm turbo run build --filter='@workflow/cli'
+
+      - name: Install vercel CLI
+        run: npm install -g vercel@56.2.0
+
+      - name: Deploy a dedicated HTTP-transport preview
+        id: httpDeploy
+        env:
+          WS_VERCEL_TOKEN: ${{ secrets.VERCEL_LABS_TOKEN }}
+        run: |
+          set -euo pipefail
+          vercel pull --yes --environment=preview \
+            --project="${{ matrix.app.project-id }}" \
+            --scope="$WS_TEAM_ID" --token="$WS_VERCEL_TOKEN"
+          # `http` is the one value that opts out; the gate compares against
+          # exactly this string, so a typo here would silently test the
+          # default instead of the fallback and this lane would quietly
+          # become a duplicate of e2e-vercel-prod.
+          URL=$(vercel deploy --yes --target=preview \
+            -e WORKFLOW_EVENTS_TRANSPORT=http \
+            --scope="$WS_TEAM_ID" --token="$WS_VERCEL_TOKEN")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          DEPLOYMENT_ID=$(vercel inspect "$URL" --format=json \
+            --scope="$WS_TEAM_ID" --token="$WS_VERCEL_TOKEN" 2>/dev/null \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{console.log(JSON.parse(d).id||'')}catch{}})" || true)
+          echo "deploymentId=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Record E2E start time
+        id: e2eStart
+        run: echo "ms=$(($(date +%s) * 1000))" >> "$GITHUB_OUTPUT"
+
+      - name: Run E2E Tests
+        run: pnpm run test:e2e --reporter=verbose --reporter=json --reporter=./packages/core/e2e/github-reporter.ts "--outputFile=e2e-vercel-http-transport-$APP_NAME.json"
+        env:
+          NODE_OPTIONS: "--enable-source-maps"
+          DEPLOYMENT_URL: ${{ steps.httpDeploy.outputs.url }}
+          VERCEL_DEPLOYMENT_ID: ${{ steps.httpDeploy.outputs.deploymentId }}
+          APP_NAME: ${{ matrix.app.name }}
+          WORKFLOW_VERCEL_ENV: "preview"
+          WORKFLOW_VERCEL_AUTH_TOKEN: ${{ secrets.VERCEL_LABS_TOKEN }}
+          WORKFLOW_VERCEL_TEAM: ${{ env.WS_TEAM_ID }}
+          WORKFLOW_VERCEL_PROJECT: ${{ matrix.app.project-id }}
+          WORKFLOW_VERCEL_PROJECT_SLUG: ${{ matrix.app.project-slug }}
+          VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
+
+      - name: Capture runtime logs on failure
+        if: failure()
+        env:
+          APP_NAME: ${{ matrix.app.name }}
+          WORKFLOW_VERCEL_AUTH_TOKEN: ${{ secrets.VERCEL_LABS_TOKEN }}
+          WORKFLOW_VERCEL_TEAM: ${{ env.WS_TEAM_ID }}
+          WORKFLOW_VERCEL_PROJECT: ${{ matrix.app.project-id }}
+          WORKFLOW_VERCEL_ENV: "preview"
+          VERCEL_DEPLOYMENT_ID: ${{ steps.httpDeploy.outputs.deploymentId }}
+          E2E_START_MS: ${{ steps.e2eStart.outputs.ms }}
+        run: node .github/scripts/fetch-e2e-runtime-logs.mjs
+
+      - name: Generate E2E summary
+        if: always()
+        env:
+          APP_NAME: ${{ matrix.app.name }}
+        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Vercel HTTP Transport ($APP_NAME)" >> $GITHUB_STEP_SUMMARY || true
+
+      - name: Upload E2E results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results-vercel-http-transport-${{ matrix.app.name }}
+          path: |
+            e2e-vercel-http-transport-${{ matrix.app.name }}.json
             e2e-metadata-${{ matrix.app.name }}-vercel.json
             e2e-failures-${{ matrix.app.name }}-vercel.json
             e2e-flaky-${{ matrix.app.name }}-vercel.json
@@ -1464,7 +1608,7 @@ jobs:
   summary:
     name: E2E Summary
     runs-on: ubuntu-latest
-    needs: [ci-scope, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
+    needs: [ci-scope, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
     if: always() && !cancelled() && needs.ci-scope.outputs.fast-path != 'true'
     timeout-minutes: 10
 
@@ -1500,7 +1644,7 @@ jobs:
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [ci-scope, unit, e2e-package-build, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
+    needs: [ci-scope, unit, e2e-package-build, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
     if: always()
     timeout-minutes: 5
 
@@ -1511,6 +1655,7 @@ jobs:
           BUILD_STATUS: ${{ needs.e2e-package-build.result }}
           VERCEL_STATUS: ${{ needs.e2e-vercel-prod.result }}
           VERCEL_WS_STATUS: ${{ needs.e2e-vercel-ws-transport.result }}
+          VERCEL_HTTP_STATUS: ${{ needs.e2e-vercel-http-transport.result }}
           LOCAL_DEV_STATUS: ${{ needs.e2e-local-dev.result }}
           LOCAL_PROD_STATUS: ${{ needs.e2e-local-prod.result }}
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
@@ -1545,6 +1690,10 @@ jobs:
             # This label is itself opt-in for the WS lane (see that job's `if`),
             # so it runs here and is required.
             [[ "$VERCEL_WS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-ws-transport ($VERCEL_WS_STATUS)")
+            # Unconditional, exactly like e2e-vercel-prod above: the HTTP
+            # lane has no opt-in label, so there is no case in which it is
+            # legitimately skipped while the rest of this branch runs.
+            [[ "$VERCEL_HTTP_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-http-transport ($VERCEL_HTTP_STATUS)")
 
             # Verify other jobs were actually skipped
             [[ "$UNIT_STATUS" == "skipped" ]] || echo "Warning: unit was not skipped ($UNIT_STATUS)"
@@ -1563,6 +1712,7 @@ jobs:
             else
               [[ "$VERCEL_WS_STATUS" == "skipped" ]] || echo "Warning: e2e-vercel-ws-transport ran unlabelled ($VERCEL_WS_STATUS)"
             fi
+            [[ "$VERCEL_HTTP_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-http-transport ($VERCEL_HTTP_STATUS)")
             [[ "$LOCAL_DEV_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-dev ($LOCAL_DEV_STATUS)")
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -650,23 +650,19 @@ jobs:
     # builds remotely on Vercel's own infra — the exact same pipeline the
     # GitHub App uses for e2e-vercel-prod's deployments — so none of that
     # applies here.
-    # Opt-in on PRs, unconditional on main. Three real `vercel deploy`s per
-    # run is too much to charge every unrelated PR in the repo for a transport
-    # that is off by default; main still gets the signal on every commit.
-    # `workflow-server-test` counts as opt-in too — that label exists to test
-    # workflow-server changes, which is where the WS protocol lives.
-    #
-    # `on.pull_request.types` has no `labeled`, so a label added to an already
-    # open PR takes effect on the next push, not immediately.
+    # Runs on every PR. It was opt-in behind `ws-transport-test` when four real
+    # `vercel deploy`s were too much to charge an unrelated PR for a transport
+    # that was off by default. That reasoning expired with the default: every
+    # deployment now uses WebSockets, so this stopped being a cost charged for
+    # someone else's feature and became the only check that the feature works.
     name: E2E Vercel WS Transport Test (${{ matrix.app.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: ci-scope
-    if: >-
-      ${{ needs.ci-scope.outputs.fast-path != 'true'
-      && (github.event_name != 'pull_request'
-      || contains(github.event.pull_request.labels.*.name, 'ws-transport-test')
-      || contains(github.event.pull_request.labels.*.name, 'workflow-server-test')) }}
+    # Mirrors e2e-vercel-prod and the HTTP lane: this is the only lane that
+    # *asserts* the socket carried the events, since e2e-vercel-prod inherits
+    # the default but checks nothing.
+    if: ${{ needs.ci-scope.outputs.fast-path != 'true' }}
     permissions:
       id-token: write
       contents: read
@@ -1670,12 +1666,6 @@ jobs:
           FAST_PATH: ${{ needs.ci-scope.outputs.fast-path }}
           VALIDATION_FAST_PATH: ${{ needs.ci-scope.outputs.validation-fast-path }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
-          # e2e-vercel-ws-transport runs on main and on labelled PRs only, so
-          # its status is required in exactly those cases and must be allowed
-          # to be `skipped` otherwise.
-          WS_REQUIRED: ${{ github.event_name != 'pull_request'
-            || contains(github.event.pull_request.labels.*.name, 'ws-transport-test')
-            || contains(github.event.pull_request.labels.*.name, 'workflow-server-test') }}
         run: |
           FAILED_JOBS=()
 
@@ -1713,11 +1703,7 @@ jobs:
             [[ "$UNIT_STATUS" == "success" ]] || FAILED_JOBS+=("unit ($UNIT_STATUS)")
             [[ "$BUILD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-package-build ($BUILD_STATUS)")
             [[ "$VERCEL_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-prod ($VERCEL_STATUS)")
-            if [[ "$WS_REQUIRED" == "true" ]]; then
-              [[ "$VERCEL_WS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-ws-transport ($VERCEL_WS_STATUS)")
-            else
-              [[ "$VERCEL_WS_STATUS" == "skipped" ]] || echo "Warning: e2e-vercel-ws-transport ran unlabelled ($VERCEL_WS_STATUS)"
-            fi
+            [[ "$VERCEL_WS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-ws-transport ($VERCEL_WS_STATUS)")
             [[ "$VERCEL_HTTP_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-http-transport ($VERCEL_HTTP_STATUS)")
             [[ "$LOCAL_DEV_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-dev ($LOCAL_DEV_STATUS)")
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")

--- a/docs/content/docs/v5/configuration/runtime-tuning.mdx
+++ b/docs/content/docs/v5/configuration/runtime-tuning.mdx
@@ -279,7 +279,7 @@ For example, a workflow can run a 10-minute inline step even with `WORKFLOW_REPL
 
 Node's own modules do less than the client they replace, so enabling this drops the per-call-site tuning the Worlds configure:
 
-- Event-log requests lose HTTP/2, so concurrent reads and writes no longer share one connection, and the enlarged HTTP/2 receive windows no longer apply. This is the largest difference, and it slows down replays that read a big event log. It does not apply to event writes on [`WORKFLOW_EVENTS_TRANSPORT=ws`](/docs/configuration/worlds#workflow_events_transport), which take neither transport.
+- Event-log requests lose HTTP/2, so concurrent reads and writes no longer share one connection, and the enlarged HTTP/2 receive windows no longer apply. This is the largest difference, and it slows down replays that read a big event log. It does not apply to event writes on the [WebSocket events transport](/docs/configuration/worlds#workflow_events_transport), which is the default and takes neither transport.
 - Requests lose their transport-level retry. Failures still surface to the layers above, which retry event writes and redeliver queue messages, so nothing is silently dropped, but a failure that a same-connection retry would have hidden now costs a full redelivery.
 - Stream close loses its retry of retriable server errors. A transient failure at close can leave a stream marked closing until the run expires, where it would previously have resolved on the retry.
 

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -300,6 +300,6 @@ When enabled (the default), a suspension's eager `step_created` and `wait_create
 
 - Factory option: none
 - CLI flag: none
-- Default: `http`
-- Experimental. Set to `ws` to ship workflow run events to the Vercel World over a WebSocket instead of one HTTP request each.
+- Default: `ws`
+- Ships workflow run events to the Vercel World over a WebSocket instead of one HTTP request each. Set to exactly `http` to opt out; any other value, including unset or empty, uses the WebSocket.
 - Ignored when the World is configured with `projectConfig` and routes through the `api-workflow` proxy: that endpoint is an HTTP-only REST gateway and does not forward a WebSocket upgrade, so events stay on HTTP.

--- a/docs/content/worlds/v5/vercel.mdx
+++ b/docs/content/worlds/v5/vercel.mdx
@@ -202,7 +202,9 @@ Maximum stream chunks written in one Vercel World request. Larger batches are sp
 
 ### `WORKFLOW_EVENTS_TRANSPORT`
 
-Experimental. Set `WORKFLOW_EVENTS_TRANSPORT=ws` to ship workflow run events to the Vercel World over a WebSocket instead of one HTTP request each. Default: `http`.
+Workflow run events ship to the Vercel World over a WebSocket instead of one HTTP request each. Default: `ws`.
+
+Set `WORKFLOW_EVENTS_TRANSPORT=http` to opt out. Only that exact value disables the WebSocket — any other value, including unset or empty, takes it — so a typo fails toward the default rather than silently pinning a deployment to HTTP.
 
 The setting is ignored when the World is configured with `projectConfig` and therefore routes through the `api-workflow` proxy: that endpoint is an HTTP-only REST gateway and does not forward a WebSocket upgrade, so events stay on HTTP and a warning is logged once per process.
 

--- a/packages/world-vercel/src/events-v4-ws.test.ts
+++ b/packages/world-vercel/src/events-v4-ws.test.ts
@@ -121,7 +121,10 @@ afterEach(() => {
  */
 describe('transport gate', () => {
   it('goes over HTTP, never touching the WS transport, when the gate is off', async () => {
-    delete process.env.WORKFLOW_EVENTS_TRANSPORT;
+    // "Off" is now an explicit opt-out rather than an absent variable, since
+    // the default flipped. Deleting it here would assert the opposite of what
+    // this test is named for.
+    process.env.WORKFLOW_EVENTS_TRANSPORT = 'http';
     const origin =
       WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
     const agent = new MockAgent();

--- a/packages/world-vercel/src/events-v4-ws.test.ts
+++ b/packages/world-vercel/src/events-v4-ws.test.ts
@@ -108,6 +108,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.WORKFLOW_EVENTS_TRANSPORT;
+  delete process.env.WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT;
 });
 
 /**
@@ -119,6 +120,90 @@ afterEach(() => {
  * would sail through with every HTTP assertion still green, because the
  * two transports are built to be indistinguishable at the result layer.
  */
+/**
+ * Strict mode exists because an event written over HTTP and one written over
+ * the socket produce the same run outcome, so the WS e2e lane passes either
+ * way. These pin the two halves that make it usable: it fires on the one event
+ * type that should never fall back, and it stays out of the way of the several
+ * that legitimately do.
+ */
+describe('strict fallback (WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT)', () => {
+  const httpReply = (path: string) => {
+    const origin =
+      WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+    agent
+      .get(origin)
+      .intercept({ path, method: 'POST' })
+      .reply(200, materializedBody(), {
+        headers: {
+          'x-wf-event-id': 'evnt_1',
+          'x-wf-run-id': 'wrun_1',
+          'x-wf-created-at': CREATED_AT,
+        },
+      });
+    return agent;
+  };
+
+  it('fails a step_completed that falls back while the gate is on', async () => {
+    process.env.WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT = '1';
+    // No channel for this run: exactly the state that used to demote the write
+    // to HTTP without a trace.
+    // `Once`, matching the rest of this file: a permanent override
+    // leaks into every later test, since clearAllMocks resets calls, not
+    // implementations.
+    resolveWsTransportMock.mockReturnValueOnce(null);
+
+    await expect(
+      createWorkflowRunEventV4(input, { token: 'test-token' })
+    ).rejects.toThrow(/fell back to the HTTP events transport/);
+  });
+
+  it('leaves step_started alone, which falls back legitimately', async () => {
+    process.env.WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT = '1';
+    // `Once`, matching the rest of this file: a permanent override
+    // leaks into every later test, since clearAllMocks resets calls, not
+    // implementations.
+    resolveWsTransportMock.mockReturnValueOnce(null);
+    // Not in the strict set on purpose: after vercel/workflow#3732 a write
+    // issued before the socket finishes connecting takes HTTP by design, and
+    // on a cold instance that can be the first step_started of a run.
+    const agent = httpReply('/api/v4/runs/wrun_1/events/step_started');
+
+    // The claim is only that strict mode did not block the fallback, so this
+    // asserts on that and on the request having been made. Decoding the reply
+    // is not the point and `materializedBody` is shaped for step_completed —
+    // building a second fixture here would test the fixture, not the gate.
+    const error = await createWorkflowRunEventV4(
+      { ...input, eventType: 'step_started' },
+      { token: 'test-token', dispatcher: agent }
+    ).catch((err: unknown) => err);
+
+    expect(String(error)).not.toMatch(/fell back to the HTTP events transport/);
+    agent.assertNoPendingInterceptors();
+  });
+
+  it('is off unless the value is exactly 1 or true', async () => {
+    // The opposite asymmetry from the transport gate, on purpose: strict mode
+    // fails runs, so it must not be acquired by a typo.
+    process.env.WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT = 'yes';
+    // `Once`, matching the rest of this file: a permanent override
+    // leaks into every later test, since clearAllMocks resets calls, not
+    // implementations.
+    resolveWsTransportMock.mockReturnValueOnce(null);
+    const agent = httpReply('/api/v4/runs/wrun_1/events/step_completed');
+
+    const result = await createWorkflowRunEventV4(input, {
+      token: 'test-token',
+      dispatcher: agent,
+    });
+
+    expect(result.event.eventId).toBe('evnt_1');
+    agent.assertNoPendingInterceptors();
+  });
+});
+
 describe('transport gate', () => {
   it('goes over HTTP, never touching the WS transport, when the gate is off', async () => {
     // "Off" is now an explicit opt-out rather than an absent variable, since

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -73,7 +73,10 @@ import {
 import { type APIConfig, getHttpConfig, getHttpUrl } from './utils.js';
 import { version } from './version.js';
 import type { WsFrameReply } from './ws-transport.js';
-import { isWsEventsTransportEnabled } from './ws-transport-enabled.js';
+import {
+  isWsEventsTransportEnabled,
+  isWsEventsTransportStrict,
+} from './ws-transport-enabled.js';
 
 /**
  * Issue an instrumented v4 request through the global `fetch`, NOT undici's
@@ -731,6 +734,47 @@ async function postWorkflowRunEventV4(
  * frames, which has no representation in a protocol that pairs one reply frame
  * with one request frame.
  */
+/**
+ * Event types that must never reach HTTP once the gate is on, and so are worth
+ * failing a run over when `WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT` is set.
+ *
+ * Only `step_completed`, and the narrowness is the point. Most fallback is
+ * legitimate and routine:
+ *
+ * - `run_created` is written by `start()` from a request handler that never
+ *   opens a channel, so it is always HTTP.
+ * - `run_started` is the runtime's first write and frequently lands before the
+ *   channel is registered; measured at 34% HTTP on a healthy deployment.
+ * - `step_created` and `wait_created` mostly fold into `events.createBatch`,
+ *   which is not wired to the socket at all, so they rarely take this path.
+ * - Any write after the invocation released its claim falls back by design.
+ *
+ * `step_completed` is issued after a step body has run, by which point the
+ * channel has long been registered and the socket is up. It was 100% ws across
+ * every WS-enabled deployment measured, on two SDK versions. If one of these
+ * goes over HTTP while the gate is on, a socket that should be carrying traffic
+ * is not — which is exactly the failure that stayed invisible for days, because
+ * an event written over HTTP produces the same run outcome as one written over
+ * the socket.
+ */
+const STRICT_WS_EVENT_TYPES: ReadonlySet<string> = new Set(['step_completed']);
+
+/**
+ * Deliberately a plain `Error`: `isRetryableEventPostError` only treats errors
+ * carrying a transient marker as retryable, so this fails the write outright
+ * rather than burning the retry budget on a condition no retry can fix.
+ */
+function assertWsFallbackAllowed(eventType: EventType): void {
+  if (!isWsEventsTransportStrict()) return;
+  if (!STRICT_WS_EVENT_TYPES.has(eventType)) return;
+  throw new Error(
+    `world-vercel: ${eventType} fell back to the HTTP events transport while ` +
+      'the WS gate was on. WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT is set, ' +
+      'so this is a failure rather than a silent demotion: no channel was ' +
+      'resolvable for this run at write time.'
+  );
+}
+
 export async function createWorkflowRunEventV4<T extends EventType>(
   input: CreateEventV4Input & { eventType: T },
   config?: APIConfig
@@ -740,6 +784,7 @@ export async function createWorkflowRunEventV4<T extends EventType>(
     // failed, so fall through to HTTP.
     const reply = await postEventFrameOverWs(input, config);
     if (reply) return decodeCreateEventResponse(reply, input.eventType);
+    assertWsFallbackAllowed(input.eventType);
   }
 
   const response = await postWorkflowRunEventV4(input, 'materialized', config);

--- a/packages/world-vercel/src/ws-transport-enabled.ts
+++ b/packages/world-vercel/src/ws-transport-enabled.ts
@@ -21,11 +21,19 @@
  * instrumenting the global `fetch` rather than by reading spans, and which a
  * transport whose purpose is to issue no request cannot appear in.
  *
- * The comparison is only exactly `'http'`, not "anything that isn't `'ws'`", so
- * an unrecognized value takes the default rather than silently pinning a
- * deployment to the old transport. The failure mode this whole path is prone to
- * is being quietly off while looking fine.
+ * `http` is the only value that opts out, rather than "anything that isn't
+ * `ws`". An unrecognized value takes the default instead of quietly pinning a
+ * deployment to the old transport.
+ *
+ * That opt-out is matched case-insensitively and trimmed, which is the one
+ * place this gate deliberately does *not* fail toward the default. Everything
+ * else here is written on the assumption that being quietly on the wrong
+ * transport is the failure mode to design against, and the reader most exposed
+ * to it is whoever is reaching for the escape hatch: plausibly mid-incident,
+ * plausibly typing `HTTP` into a dashboard field. Silently ignoring their
+ * opt-out because of case is the same bug this default flip is trying to stop
+ * shipping, pointed at the person least able to afford it.
  */
 export function isWsEventsTransportEnabled(): boolean {
-  return process.env.WORKFLOW_EVENTS_TRANSPORT !== 'http';
+  return process.env.WORKFLOW_EVENTS_TRANSPORT?.trim().toLowerCase() !== 'http';
 }

--- a/packages/world-vercel/src/ws-transport-enabled.ts
+++ b/packages/world-vercel/src/ws-transport-enabled.ts
@@ -8,19 +8,24 @@
  */
 
 /**
- * HTTP unless `WORKFLOW_EVENTS_TRANSPORT=ws`. Only `createWorkflowRunEventV4`
+ * WS unless `WORKFLOW_EVENTS_TRANSPORT=http`. Only `createWorkflowRunEventV4`
  * (POST) is wired to it. GET/LIST aren't on the hot per-step path, and LIST's
  * streamed, sentinel-terminated multi-frame response doesn't map onto a single
  * WS message.
  *
- * **Known gap: WS writes open no client span.** The upgrade carries W3C trace
- * context (see `resolveUpgradeHeaders`), so server spans still join the caller's
- * trace, but the HTTP branch's `instrumentedFetch` also opens an OTEL CLIENT
- * span per write and routes through the global `fetch` that Vercel's
- * outgoing-requests view instruments; the WS branch has neither, and individual
- * frames carry no `traceparent` of their own. Acceptable behind a flag;
- * per-write instrumentation is a prerequisite for defaulting to it.
+ * This file used to name a prerequisite for defaulting on: that a WS write opens
+ * no client span. That is met. `postEventFrameOverWs` opens one per frame,
+ * carrying `workflow.events.transport: 'ws'`, `network.protocol.name` and the
+ * `workflow.events.ws.req_id` that joins it to the server's log line. What
+ * remains absent is Vercel's *outgoing requests* view, which is built by
+ * instrumenting the global `fetch` rather than by reading spans, and which a
+ * transport whose purpose is to issue no request cannot appear in.
+ *
+ * The comparison is only exactly `'http'`, not "anything that isn't `'ws'`", so
+ * an unrecognized value takes the default rather than silently pinning a
+ * deployment to the old transport. The failure mode this whole path is prone to
+ * is being quietly off while looking fine.
  */
 export function isWsEventsTransportEnabled(): boolean {
-  return process.env.WORKFLOW_EVENTS_TRANSPORT === 'ws';
+  return process.env.WORKFLOW_EVENTS_TRANSPORT !== 'http';
 }

--- a/packages/world-vercel/src/ws-transport-enabled.ts
+++ b/packages/world-vercel/src/ws-transport-enabled.ts
@@ -37,3 +37,19 @@
 export function isWsEventsTransportEnabled(): boolean {
   return process.env.WORKFLOW_EVENTS_TRANSPORT?.trim().toLowerCase() !== 'http';
 }
+
+/**
+ * Whether a WS fallback that should not happen must fail loudly instead of
+ * quietly writing over HTTP. Internal, undocumented, and meant for the WS e2e
+ * lane, which otherwise passes whether or not the socket carried anything.
+ *
+ * Note the asymmetry with the gate above, which is deliberate and the opposite
+ * way round. There, an unrecognized value takes the default, because the risk
+ * is a deployment quietly sitting on the wrong transport. Here an unrecognized
+ * value means *off*, because the risk runs the other way: this turns a silent
+ * degradation into a failed run, and nobody should acquire that by typo.
+ */
+export function isWsEventsTransportStrict(): boolean {
+  const raw = process.env.WORKFLOW_INTERNAL_EVENTS_TRANSPORT_STRICT;
+  return raw === '1' || raw === 'true';
+}

--- a/packages/world-vercel/src/ws-transport-spans.test.ts
+++ b/packages/world-vercel/src/ws-transport-spans.test.ts
@@ -464,7 +464,11 @@ describe('connection span', () => {
 
 describe('transport parity', () => {
   it('does not tag an HTTP event read as an event-write transport', async () => {
-    delete process.env.WORKFLOW_EVENTS_TRANSPORT;
+    // Explicit opt-out rather than an absent variable: the default is ws now,
+    // and this test is about the HTTP path. A read would take HTTP either way
+    // (only the POST write is wired to the socket), so leaving this unset
+    // would still pass — while no longer testing what it says it does.
+    process.env.WORKFLOW_EVENTS_TRANSPORT = 'http';
     const agent = new MockAgent();
     agent.disableNetConnect();
     agent
@@ -505,7 +509,11 @@ describe('transport parity', () => {
   });
 
   it('emits the same span name and url.full on HTTP as on ws', async () => {
-    delete process.env.WORKFLOW_EVENTS_TRANSPORT;
+    // As above. This one is a write, so unset would now open the gate and the
+    // test would only still pass by falling through resolveWsTransport's null
+    // — passing for the wrong reason, which is the exact failure this file
+    // exists to catch.
+    process.env.WORKFLOW_EVENTS_TRANSPORT = 'http';
     const agent = new MockAgent();
     agent.disableNetConnect();
     agent

--- a/packages/world-vercel/src/ws-transport.test.ts
+++ b/packages/world-vercel/src/ws-transport.test.ts
@@ -957,26 +957,39 @@ describe('transport selection', () => {
   const directConfig = { token: 'test-token' };
 
   /**
-   * The gate is the whole safety story for this feature: everything else is
-   * dead code for anyone who hasn't opted in. Nothing on the HTTP side pins
-   * the *choice* of path — a future edit that flipped the default (as an
-   * earlier revision of this branch did deliberately, for benchmarking) would
-   * sail through with every HTTP assertion still green, because the two
-   * transports are built to be indistinguishable at the result layer.
+   * The gate is the whole safety story for this feature, and since the default
+   * flipped it is the HTTP path that is now reached only by opting out.
+   * Nothing on either side pins the *choice* of path — the two transports are
+   * built to be indistinguishable at the result layer, so a future edit that
+   * moved the default again would sail through with every other assertion in
+   * this file still green. This table is the only thing that would fail, which
+   * is why it enumerates the boundary rather than spot-checking two values.
    */
   describe('isWsEventsTransportEnabled', () => {
     it.each([
-      ['ws', true],
+      // `http` opts out, case-insensitively and trimmed: whoever reaches for
+      // the escape hatch is the last person who should have it silently
+      // ignored over a capital letter.
       ['http', false],
-      ['', false],
-      ['WS', false],
+      ['HTTP', false],
+      ['Http', false],
+      ['  http  ', false],
+      // Everything else takes the default, including values that look like a
+      // half-remembered opt-out. Unrecognized input resolving to `ws` is the
+      // deliberate half of the asymmetry above.
+      ['ws', true],
+      ['WS', true],
+      ['', true],
+      ['https', true],
+      ['off', true],
+      ['false', true],
     ])('%o resolves to ws=%o', (value, expected) => {
       process.env.WORKFLOW_EVENTS_TRANSPORT = value;
       expect(isWsEventsTransportEnabled()).toBe(expected);
     });
 
-    it('defaults to HTTP when unset', () => {
-      expect(isWsEventsTransportEnabled()).toBe(false);
+    it('defaults to ws when unset', () => {
+      expect(isWsEventsTransportEnabled()).toBe(true);
     });
   });
 
@@ -1067,6 +1080,11 @@ describe('transport selection', () => {
     });
 
     it('does nothing when the gate is off', async () => {
+      // Explicitly off. Before the default flipped this was the ambient state
+      // of the suite, so the test read as if it were asserting nothing in
+      // particular; it is in fact the only thing pinning "gate off means no
+      // socket is ever opened".
+      process.env.WORKFLOW_EVENTS_TRANSPORT = 'http';
       openWsChannel('wrun_1', directConfig);
       await tick();
 
@@ -1212,6 +1230,7 @@ describe('transport selection', () => {
 
     it('is undefined when the gate is off', () => {
       // Nothing was claimed, so there is nothing for the flow route to release.
+      process.env.WORKFLOW_EVENTS_TRANSPORT = 'http';
       expect(openWsChannel('wrun_1', directConfig)).toBeUndefined();
       expect(sockets).toHaveLength(0);
     });


### PR DESCRIPTION
We have decided to make websockets opt-out in v5.

Flip websockets to default `on`. It can be disabled by setting `WORKFLOW_EVENTS_TRANSPORT=http`

Also:
1. Changes default e2e lanes to test that websockets are used
2. Adds HTTP e2e lanes to keep coverage for HTTP

### Known issues

1. Having the proxy enabled means websockets is silently turned off.

### Tests

All existing e2e tests will now test websockets on by default.

This leaves a large gap for http coverage while we we want to keep a safe fallback.  I'm adding a separate set of parallel tests to tests all e2e for http - separate PR.