### PR TITLE
ci: add a required forced-HTTP e2e lane

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -627,9 +627,11 @@ jobs:
   e2e-vercel-ws-transport:
     # Dedicated coverage for world-vercel's WebSocket events transport
     # (WORKFLOW_EVENTS_TRANSPORT=ws — see events-v4.ts's
-    # isWsEventsTransportEnabled). Every other job in this file exercises
-    # the default HTTP transport only, now that the WS-on-by-default POC
-    # hack is gone.
+    # isWsEventsTransportEnabled). This lane predates the default flip,
+    # when it was the only WS coverage in the file; it is kept because it
+    # still pins the transport explicitly, which every other Vercel lane
+    # now only gets by inheriting the default. See
+    # e2e-vercel-http-transport below for the other side.
     #
     # Mirrors e2e-vercel-prod's shape (same apps subset, same full e2e
     # suite) but deploys itself via a plain `vercel deploy` (no
@@ -796,6 +798,148 @@ jobs:
           name: e2e-results-vercel-ws-transport-${{ matrix.app.name }}
           path: |
             e2e-vercel-ws-transport-${{ matrix.app.name }}.json
+            e2e-metadata-${{ matrix.app.name }}-vercel.json
+            e2e-failures-${{ matrix.app.name }}-vercel.json
+            e2e-flaky-${{ matrix.app.name }}-vercel.json
+            e2e-infra-${{ matrix.app.name }}-vercel.json
+            e2e-diagnostics-${{ matrix.app.name }}-vercel.json
+            e2e-runtime-logs-${{ matrix.app.name }}-vercel.json
+          retention-days: 7
+          if-no-files-found: ignore
+
+  e2e-vercel-http-transport:
+    # The counterpart to e2e-vercel-ws-transport, and the reason it exists
+    # is the default flip: with WORKFLOW_EVENTS_TRANSPORT defaulting to
+    # `ws`, e2e-vercel-prod — which sets no transport env var at all — is
+    # now a WebSocket lane. Nothing in this file would exercise the HTTP
+    # events transport against a real Vercel deployment any more. This is
+    # not additive coverage; it replaces coverage that the flip silently
+    # took away.
+    #
+    # HTTP is now the fallback path, and the fallback is *silent*:
+    # resolveWsTransport returning null costs a write nothing and logs
+    # nothing. A path that is both unexercised and quiet is the exact
+    # shape of the durabench bug this stack came out of, so this lane is
+    # unconditional and required rather than label-gated like the WS one.
+    #
+    # Two apps, not the WS lane's four. Each row is a real `vercel deploy`
+    # charged to every PR in the repo, which is why the WS lane is opt-in
+    # at four; two is what keeps an always-on lane affordable. The pair is
+    # chosen for runtime diversity — nextjs-turbopack is the only fixture
+    # emitting OTEL spans, so it is the one that can show *which* transport
+    # ran, and express covers the non-Next server path. The WS lane's
+    # vite-specific rationale (native `ws` accelerators resolving to a stub)
+    # is WS-only and does not apply here.
+    #
+    # Deploys itself with `vercel deploy` rather than `--prebuilt` for the
+    # same reasons documented on e2e-vercel-ws-transport above.
+    name: E2E Vercel HTTP Transport Test (${{ matrix.app.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: ci-scope
+    # Mirrors e2e-vercel-prod's condition exactly, so this lane runs in
+    # every case that one does, including under `workflow-server-test`.
+    if: ${{ needs.ci-scope.outputs.fast-path != 'true' }}
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - name: "nextjs-turbopack"
+            project-id: "prj_yjkM7UdHliv8bfxZ1sMJQf1pMpdi"
+            project-slug: "example-nextjs-workflow-turbopack"
+          - name: "express"
+            project-id: "prj_cCZjpBy92VRbKHHbarDMhOHtkuIr"
+            project-slug: "workbench-express-workflow"
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      WORKFLOW_PUBLIC_MANIFEST: '1'
+      WS_TEAM_ID: "team_nO2mCG4W8IxPIeKoSsqwAxxB"
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-workflow-dev
+        with:
+          build-packages: 'false'
+
+      - name: Build CLI
+        run: pnpm turbo run build --filter='@workflow/cli'
+
+      - name: Install vercel CLI
+        run: npm install -g vercel@56.2.0
+
+      - name: Deploy a dedicated HTTP-transport preview
+        id: httpDeploy
+        env:
+          WS_VERCEL_TOKEN: ${{ secrets.VERCEL_LABS_TOKEN }}
+        run: |
+          set -euo pipefail
+          vercel pull --yes --environment=preview \
+            --project="${{ matrix.app.project-id }}" \
+            --scope="$WS_TEAM_ID" --token="$WS_VERCEL_TOKEN"
+          # `http` is the one value that opts out; the gate compares against
+          # exactly this string, so a typo here would silently test the
+          # default instead of the fallback and this lane would quietly
+          # become a duplicate of e2e-vercel-prod.
+          URL=$(vercel deploy --yes --target=preview \
+            -e WORKFLOW_EVENTS_TRANSPORT=http \
+            --scope="$WS_TEAM_ID" --token="$WS_VERCEL_TOKEN")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          DEPLOYMENT_ID=$(vercel inspect "$URL" --format=json \
+            --scope="$WS_TEAM_ID" --token="$WS_VERCEL_TOKEN" 2>/dev/null \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{console.log(JSON.parse(d).id||'')}catch{}})" || true)
+          echo "deploymentId=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Record E2E start time
+        id: e2eStart
+        run: echo "ms=$(($(date +%s) * 1000))" >> "$GITHUB_OUTPUT"
+
+      - name: Run E2E Tests
+        run: pnpm run test:e2e --reporter=verbose --reporter=json --reporter=./packages/core/e2e/github-reporter.ts "--outputFile=e2e-vercel-http-transport-$APP_NAME.json"
+        env:
+          NODE_OPTIONS: "--enable-source-maps"
+          DEPLOYMENT_URL: ${{ steps.httpDeploy.outputs.url }}
+          VERCEL_DEPLOYMENT_ID: ${{ steps.httpDeploy.outputs.deploymentId }}
+          APP_NAME: ${{ matrix.app.name }}
+          WORKFLOW_VERCEL_ENV: "preview"
+          WORKFLOW_VERCEL_AUTH_TOKEN: ${{ secrets.VERCEL_LABS_TOKEN }}
+          WORKFLOW_VERCEL_TEAM: ${{ env.WS_TEAM_ID }}
+          WORKFLOW_VERCEL_PROJECT: ${{ matrix.app.project-id }}
+          WORKFLOW_VERCEL_PROJECT_SLUG: ${{ matrix.app.project-slug }}
+          VERCEL_WORKFLOW_SERVER_URL: ${{ github.ref != 'refs/heads/main' && secrets.VERCEL_WORKFLOW_SERVER_URL || '' }}
+
+      - name: Capture runtime logs on failure
+        if: failure()
+        env:
+          APP_NAME: ${{ matrix.app.name }}
+          WORKFLOW_VERCEL_AUTH_TOKEN: ${{ secrets.VERCEL_LABS_TOKEN }}
+          WORKFLOW_VERCEL_TEAM: ${{ env.WS_TEAM_ID }}
+          WORKFLOW_VERCEL_PROJECT: ${{ matrix.app.project-id }}
+          WORKFLOW_VERCEL_ENV: "preview"
+          VERCEL_DEPLOYMENT_ID: ${{ steps.httpDeploy.outputs.deploymentId }}
+          E2E_START_MS: ${{ steps.e2eStart.outputs.ms }}
+        run: node .github/scripts/fetch-e2e-runtime-logs.mjs
+
+      - name: Generate E2E summary
+        if: always()
+        env:
+          APP_NAME: ${{ matrix.app.name }}
+        run: node .github/scripts/aggregate-e2e-results.js . --job-name "E2E Vercel HTTP Transport ($APP_NAME)" >> $GITHUB_STEP_SUMMARY || true
+
+      - name: Upload E2E results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results-vercel-http-transport-${{ matrix.app.name }}
+          path: |
+            e2e-vercel-http-transport-${{ matrix.app.name }}.json
             e2e-metadata-${{ matrix.app.name }}-vercel.json
             e2e-failures-${{ matrix.app.name }}-vercel.json
             e2e-flaky-${{ matrix.app.name }}-vercel.json
@@ -1454,7 +1598,7 @@ jobs:
   summary:
     name: E2E Summary
     runs-on: ubuntu-latest
-    needs: [ci-scope, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
+    needs: [ci-scope, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
     if: always() && !cancelled() && needs.ci-scope.outputs.fast-path != 'true'
     timeout-minutes: 10
 
@@ -1490,7 +1634,7 @@ jobs:
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [ci-scope, unit, e2e-package-build, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
+    needs: [ci-scope, unit, e2e-package-build, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
     if: always()
     timeout-minutes: 5
 
@@ -1501,6 +1645,7 @@ jobs:
           BUILD_STATUS: ${{ needs.e2e-package-build.result }}
           VERCEL_STATUS: ${{ needs.e2e-vercel-prod.result }}
           VERCEL_WS_STATUS: ${{ needs.e2e-vercel-ws-transport.result }}
+          VERCEL_HTTP_STATUS: ${{ needs.e2e-vercel-http-transport.result }}
           LOCAL_DEV_STATUS: ${{ needs.e2e-local-dev.result }}
           LOCAL_PROD_STATUS: ${{ needs.e2e-local-prod.result }}
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
@@ -1535,6 +1680,10 @@ jobs:
             # This label is itself opt-in for the WS lane (see that job's `if`),
             # so it runs here and is required.
             [[ "$VERCEL_WS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-ws-transport ($VERCEL_WS_STATUS)")
+            # Unconditional, exactly like e2e-vercel-prod above: the HTTP
+            # lane has no opt-in label, so there is no case in which it is
+            # legitimately skipped while the rest of this branch runs.
+            [[ "$VERCEL_HTTP_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-http-transport ($VERCEL_HTTP_STATUS)")
 
             # Verify other jobs were actually skipped
             [[ "$UNIT_STATUS" == "skipped" ]] || echo "Warning: unit was not skipped ($UNIT_STATUS)"
@@ -1553,6 +1702,7 @@ jobs:
             else
               [[ "$VERCEL_WS_STATUS" == "skipped" ]] || echo "Warning: e2e-vercel-ws-transport ran unlabelled ($VERCEL_WS_STATUS)"
             fi
+            [[ "$VERCEL_HTTP_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-http-transport ($VERCEL_HTTP_STATUS)")
             [[ "$LOCAL_DEV_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-dev ($LOCAL_DEV_STATUS)")
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")


### PR DESCRIPTION
We're making websockets the default so existing e2e tests all switch over to websockets. We still need continuous testing for the http transport and this adds parallel http e2e tests.

<details>   

Stacked on #3702 — **base is `ws-transport-default-on`, not `main`.** Review that
one first; this diff only makes sense as its consequence.

### Why this is not additive coverage

#3702 flips the default to `ws`. `e2e-vercel-prod` sets no
`WORKFLOW_EVENTS_TRANSPORT` at all, so *it becomes a WebSocket lane* — as do the
Vercel-world paths in every other job that inherits the default. After the flip,
nothing in `tests.yml` exercises the HTTP events transport against a real Vercel
deployment.

So this lane restores coverage the flip silently took away. The WS lane's
docblock said "every other job in this file exercises the default HTTP transport
only"; that stopped being true one commit ago, and is corrected here.

### Why required, when the WS lane is opt-in

The WS lane is label-gated because it was optional coverage for a feature that
was off by default. HTTP is now the *fallback*, and the fallback is **silent**:
`resolveWsTransport` returning `null` costs a write nothing and logs nothing. A
path that is both unexercised and quiet is precisely the shape of the durabench
bug this stack came out of — 81 sockets, 0 writes, nothing in any log. Making the
untested path the quiet one is how that happened; I'd rather not rebuild it in
mirror image.

The lane's `if:` mirrors `e2e-vercel-prod` exactly, so it runs in every case that
one does, including under `workflow-server-test`. That means no label
special-casing in the gate — it is checked unconditionally in both branches,
like `VERCEL_STATUS`, rather than needing the `WS_REQUIRED` dance.

### Two apps, not four

Every matrix row is a real `vercel deploy` charged to every PR in the repo, which
is the stated reason the WS lane is opt-in at four. Two is what keeps an
always-on lane affordable. The pair is chosen for runtime diversity rather than
arbitrarily: `nextjs-turbopack` is the only fixture emitting OTEL spans, so it is
the only one that can show *which* transport actually ran; `express` covers the
non-Next server path. The WS lane's `vite` row exists for a WS-specific reason
(native `ws` accelerators resolving to a stub) that does not apply to HTTP.

Wall-clock impact is roughly nil — matrix legs run in parallel, each within the
existing 30-minute budget. The cost is deploys and CI minutes, not latency. I had
this wrong in an earlier conversation and want the correction on the record.

### Verification

The workflow parses (`js-yaml`), and the gate script was extracted and executed
against four scenarios rather than eyeballed:

| Scenario | Expected | Result |
| --- | --- | --- |
| all green | pass | pass |
| HTTP lane `skipped` | **fail** | fail |
| docs-only fast path | pass, no deploy required | pass |
| `workflow-server-test` + HTTP lane `failure` | **fail** | fail |

The second row is the one that matters: it proves the lane cannot quietly
not-run. A required check that passes when its job is skipped is the same class
of bug as a transport that falls back without saying so.

### Known gap

This lane pins the transport but, like the WS lane, does not *assert* the
transport was used — it would still pass if HTTP silently fell back to something
else. Closing that needs a span-count or header assertion in the e2e suite
itself, which I've deliberately kept out of this diff. Worth doing; separate
change.

</details>