### PR TITLE
[world-vercel] Isolate run-status long polls

### DIFF
--- a/.changeset/run-status-pool-isolation.md
+++ b/.changeset/run-status-pool-isolation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Prevent concurrent run-status long polls from exhausting the HTTP connection pool used by ordinary workflow-server requests.

--- a/packages/world-vercel/src/http-client.test.ts
+++ b/packages/world-vercel/src/http-client.test.ts
@@ -27,12 +27,15 @@ import {
   getEventsDispatcher,
   getNodeHttpAgents,
   getQueueDispatcher,
+  getRunStatusDispatcher,
+  getRunStatusNodeHttpAgents,
   getStreamCloseDispatcher,
   getStreamDispatcher,
   isRecyclableTransportError,
   NODE_HTTP_BODY_TIMEOUT_MS,
   NODE_HTTP_HEADERS_TIMEOUT_MS,
   noteEventsTransportOutcome,
+  RUN_STATUS_AGENT_OPTIONS,
   STREAM_AGENT_OPTIONS,
   STREAM_CLOSE_RETRY_OPTIONS,
   STREAM_RETRY_OPTIONS,
@@ -60,6 +63,21 @@ describe('getDispatcher', () => {
   it('returns the caller-supplied dispatcher when provided', () => {
     const custom = {};
     expect(getDispatcher({ dispatcher: custom })).toBe(custom);
+  });
+});
+
+describe('getRunStatusDispatcher', () => {
+  it('isolates held status reads from ordinary API traffic', () => {
+    expect(getRunStatusDispatcher()).toBe(getRunStatusDispatcher());
+    expect(getRunStatusDispatcher()).not.toBe(getDispatcher());
+    expect(RUN_STATUS_AGENT_OPTIONS.connections).toBeGreaterThan(
+      DEFAULT_AGENT_OPTIONS.connections
+    );
+  });
+
+  it('honors the caller-supplied dispatcher', () => {
+    const custom = {};
+    expect(getRunStatusDispatcher({ dispatcher: custom })).toBe(custom);
   });
 });
 
@@ -821,6 +839,7 @@ describe('node:http mode', () => {
     const custom = {};
     expect(getDispatcher({ dispatcher: custom })).toBe(custom);
     expect(getEventsDispatcher({ dispatcher: custom })).toBe(custom);
+    expect(getRunStatusDispatcher({ dispatcher: custom })).toBe(custom);
     expect(getStreamDispatcher({ dispatcher: custom })).toBe(custom);
     expect(getStreamCloseDispatcher({ dispatcher: custom })).toBe(custom);
   });
@@ -855,13 +874,16 @@ describe('node:http mode', () => {
   });
 
   // Keep-alive is the whole reason the pool exists, so it must outlive a
-  // single request. One pool serves every call site, because the four undici
-  // agents differ only in HTTP/2 and retry settings that Node's client has no
-  // equivalent for.
-  it('reuses one socket pool across calls', () => {
+  // single request. Held status reads use a separate pool so they cannot take
+  // every socket ordinary API traffic needs to make a run terminal.
+  it('reuses isolated socket pools across calls', () => {
     const agents = getNodeHttpAgents();
+    const runStatusAgents = getRunStatusNodeHttpAgents();
     expect(agents).toBeDefined();
+    expect(runStatusAgents).toBeDefined();
     expect(getNodeHttpAgents()).toBe(agents);
+    expect(getRunStatusNodeHttpAgents()).toBe(runStatusAgents);
+    expect(runStatusAgents).not.toBe(agents);
     expect(agents?.http.options.keepAlive).toBe(true);
     expect(agents?.https.options.keepAlive).toBe(true);
     // Sized from the same constants the undici agents use, not a second copy.
@@ -871,16 +893,21 @@ describe('node:http mode', () => {
     expect(agents?.https.options.keepAliveMsecs).toBe(
       DEFAULT_AGENT_OPTIONS.keepAliveTimeout
     );
+    expect(runStatusAgents?.https.options.maxSockets).toBe(
+      RUN_STATUS_AGENT_OPTIONS.connections
+    );
   });
 
   // Same rule as the dispatcher getters: supplying a dispatcher is an
   // instruction to use undici, so the request must stay on `fetch`.
   it('builds no pool when the caller supplied a dispatcher', () => {
     expect(getNodeHttpAgents({ dispatcher: {} })).toBeUndefined();
+    expect(getRunStatusNodeHttpAgents({ dispatcher: {} })).toBeUndefined();
   });
 
   it('builds no pool when the flag is off', () => {
     vi.stubEnv(NODE_HTTP_ENV_VAR, '0');
     expect(getNodeHttpAgents()).toBeUndefined();
+    expect(getRunStatusNodeHttpAgents()).toBeUndefined();
   });
 });

--- a/packages/world-vercel/src/http-client.ts
+++ b/packages/world-vercel/src/http-client.ts
@@ -8,9 +8,11 @@ import { Agent, type Dispatcher, RetryAgent, type RetryHandler } from 'undici';
 import type { APIConfig } from './utils.js';
 
 let _dispatcher: RetryAgent | undefined;
+let _runStatusDispatcher: RetryAgent | undefined;
 let _streamDispatcher: RetryAgent | undefined;
 let _streamCloseDispatcher: RetryAgent | undefined;
 let _nodeHttpAgents: NodeHttpAgents | undefined;
+let _runStatusNodeHttpAgents: NodeHttpAgents | undefined;
 
 /**
  * Shared between all agents — connection pooling only. `pipelining` is
@@ -110,6 +112,22 @@ export const DEFAULT_AGENT_OPTIONS = {
   allowH2: false,
   // HTTP/1.1 pipelining is disabled (pipelining: 1) because it causes
   // head-of-line blocking that deadlocks the webhook respondWith mechanism.
+  pipelining: 1,
+} as const;
+
+/**
+ * Dedicated pool for run-status long polls.
+ *
+ * A status wait can hold one HTTP/1.1 connection for up to 50 seconds. Sharing
+ * the default eight-connection pool lets eight concurrent `run.returnValue`
+ * awaits consume every socket and block the ordinary reads needed to finish
+ * those same runs. Keep the waits isolated and leave enough capacity for the
+ * runtime's concurrent-await shapes without changing the default pool's bound.
+ */
+export const RUN_STATUS_AGENT_OPTIONS = {
+  ...BASE_AGENT_OPTIONS,
+  connections: 32,
+  allowH2: false,
   pipelining: 1,
 } as const;
 
@@ -566,12 +584,11 @@ function resolveDispatcher(
  * Shared `node:http` / `node:https` connection pool for `WORKFLOW_NODE_HTTP`
  * mode, or `undefined` when the request should go over undici.
  *
- * There is one pool rather than the four the undici side maintains, because
- * the four differ only in the two things Node's core client cannot express:
- * HTTP/2 (with its multiplexing and receive windows) and a `RetryAgent` policy.
- * Strip those and the remaining configuration is `BASE_AGENT_OPTIONS`, which is
- * identical across all four, so splitting the pool would buy nothing but
- * fragmentation of the sockets.
+ * Ordinary requests share one pool rather than mirroring every undici agent,
+ * because those agents otherwise differ only in HTTP/2 and retry behavior that
+ * Node's core client cannot express. Held run-status reads are the exception:
+ * they use a second pool so a set of long polls cannot consume every ordinary
+ * request socket.
  *
  * Built on first use and then kept for the life of the process: keep-alive is
  * the point, and a pool rebuilt per request would open a connection per
@@ -589,10 +606,27 @@ export function getNodeHttpAgents(
   return _nodeHttpAgents;
 }
 
+/** Dedicated node:http pool for held run-status reads. */
+export function getRunStatusNodeHttpAgents(
+  config?: APIConfig
+): NodeHttpAgents | undefined {
+  if (config?.dispatcher) return undefined;
+  if (!isNodeHttpEnabled()) return undefined;
+  _runStatusNodeHttpAgents ??= createNodeHttpAgents({
+    maxSockets: RUN_STATUS_AGENT_OPTIONS.connections,
+    keepAliveMs: RUN_STATUS_AGENT_OPTIONS.keepAliveTimeout,
+  });
+  return _runStatusNodeHttpAgents;
+}
+
 /** Drop the shared node:http pool. Exported for tests; production keeps it. */
 export function _resetNodeHttpAgentsForTests(): void {
   if (_nodeHttpAgents) destroyNodeHttpAgents(_nodeHttpAgents);
+  if (_runStatusNodeHttpAgents) {
+    destroyNodeHttpAgents(_runStatusNodeHttpAgents);
+  }
   _nodeHttpAgents = undefined;
+  _runStatusNodeHttpAgents = undefined;
 }
 
 /**
@@ -602,6 +636,14 @@ export function _resetNodeHttpAgentsForTests(): void {
  */
 export function getDispatcher(config?: APIConfig): unknown {
   return resolveDispatcher(config, getDefaultDispatcher);
+}
+
+/**
+ * Resolves the dispatcher for held run-status reads. Caller overrides still
+ * win, but the built-in path never shares sockets with ordinary API traffic.
+ */
+export function getRunStatusDispatcher(config?: APIConfig): unknown {
+  return resolveDispatcher(config, getDefaultRunStatusDispatcher);
 }
 
 /**
@@ -756,6 +798,14 @@ function getDefaultDispatcher(): RetryAgent {
     RETRY_AGENT_OPTIONS
   );
   return _dispatcher;
+}
+
+function getDefaultRunStatusDispatcher(): RetryAgent {
+  _runStatusDispatcher ??= makeRetryDispatcher(
+    RUN_STATUS_AGENT_OPTIONS,
+    RETRY_AGENT_OPTIONS
+  );
+  return _runStatusDispatcher;
 }
 
 /**

--- a/packages/world-vercel/src/runs.ts
+++ b/packages/world-vercel/src/runs.ts
@@ -247,6 +247,7 @@ async function readRun(
     options: { method: 'GET', ...(signal ? { signal } : {}) },
     config,
     retryConnectTimeout: true,
+    ...(waitMs !== undefined ? { transport: 'run-status' as const } : {}),
     schema: (remoteRefBehavior === 'lazy'
       ? WorkflowRunWireWithRefsSchema
       : WorkflowRunWireSchema) as any,

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -9,6 +9,8 @@ import type { z } from 'zod';
 import {
   getDispatcher,
   getNodeHttpAgents,
+  getRunStatusDispatcher,
+  getRunStatusNodeHttpAgents,
   NODE_HTTP_BODY_TIMEOUT_MS,
   NODE_HTTP_HEADERS_TIMEOUT_MS,
 } from './http-client.js';
@@ -405,6 +407,7 @@ export async function makeRequest<T>({
   data,
   onResponse,
   retryConnectTimeout = false,
+  transport = 'default',
 }: {
   endpoint: string;
   options?: Omit<RequestInit, 'body'>;
@@ -416,6 +419,8 @@ export async function makeRequest<T>({
   onResponse?: (response: Response) => void;
   /** Retry an idempotent read once when connecting timed out before a request was sent. */
   retryConnectTimeout?: boolean;
+  /** Internal transport pool selection for requests that may remain open. */
+  transport?: 'default' | 'run-status';
 }): Promise<T> {
   // Normalized once: `Request` used to do this uppercasing on the way into
   // `fetch`, and both the idempotency check and the curl repro read it.
@@ -483,7 +488,10 @@ export async function makeRequest<T>({
           // than leaving it on the undici behind `fetch`. `getNodeHttpAgents`
           // returns the pool only when no caller dispatcher was supplied, so
           // an explicit `config.dispatcher` still keeps the request on `fetch`.
-          const nodeAgents = getNodeHttpAgents(config);
+          const nodeAgents =
+            transport === 'run-status'
+              ? getRunStatusNodeHttpAgents(config)
+              : getNodeHttpAgents(config);
           // Both transports issue the same span against the same URL, so this
           // is the only thing that tells them apart in a trace.
           span?.setAttributes({
@@ -506,7 +514,10 @@ export async function makeRequest<T>({
                 new Request(url, { ...options, body, headers, signal }),
                 {
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici v7 dispatcher types don't match @types/node's RequestInit
-                  dispatcher: getDispatcher(config),
+                  dispatcher:
+                    transport === 'run-status'
+                      ? getRunStatusDispatcher(config)
+                      : getDispatcher(config),
                 } as any
               );
         } catch (error) {


### PR DESCRIPTION
## Summary

- route held run-status requests through a dedicated connection pool
- keep ordinary workflow-server traffic available while concurrent `run.returnValue` waits are open
- apply the same isolation to the optional node:http transport and preserve explicit dispatcher overrides

## Why

Main run [32413467237](https://github.com/vercel/workflow/actions/runs/32413467237) failed 29 Vercel E2E lanes after #3570 enabled run-status long polling. Local, Postgres, Windows, and Python lanes stayed green.

The default world-vercel HTTP/1.1 agent has 8 connections. Concurrent E2E lanes peaked at 6-8 tests, and each `run.returnValue` can hold a status request for 50 seconds. Those waits consumed the default pool, starving the ordinary reads and hook/control calls needed for runs to complete. Failure artifacts consequently contain broad 30s/60s timeouts across unrelated tests and frameworks.

## Test plan

- `pnpm --filter @workflow/world-vercel test` (550 passed)
- `pnpm vitest run packages/core/src/runtime/run-return-value-long-poll.test.ts` (17 passed)
- `pnpm turbo run typecheck --filter=@workflow/world-vercel`
- `pnpm biome check packages/world-vercel/src/http-client.ts packages/world-vercel/src/utils.ts packages/world-vercel/src/runs.ts packages/world-vercel/src/http-client.test.ts .changeset/run-status-pool-isolation.md` (no errors; existing makeRequest complexity warning only)
