### PR TITLE
[ci] Allow long workflow-server override URLs

### DIFF
--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -39,6 +39,7 @@ import { version } from './version.js';
  * `main` — rewritten by external CI for branch-deployment testing.
  * Prefer `VERCEL_WORKFLOW_SERVER_URL` for deployment-time configuration.
  */
+// biome-ignore format: External CI replaces only this line with a deployment URL that may exceed the formatter width.
 export const WORKFLOW_SERVER_URL_OVERRIDE = '';
 
 /**


### PR DESCRIPTION
Some `WORKFLOW_SERVER_URL_OVERRIDE` are too long. They are generated URLs for testing workflow-server changes. The length fails biome so CI shows red. This PR allows long URLs.

<details>
## Summary

- exempt the externally rewritten workflow-server override declaration from Biome formatting
- keep workflow-server test wrapper PRs lint-clean when CI inserts a long preview URL

## Why

External CI replaces only the declaration line. The empty main value fits on one line, but a preview URL exceeds Biome's formatter width and makes every workflow-server test PR fail its Biome check. The override is intentionally machine-written and restored before merge, so the narrow formatter suppression keeps both forms stable without weakening lint elsewhere.

## Test plan

- `pnpm exec biome ci --max-diagnostics=200`
- replaced the empty value locally with the URL from [PR #3701's failing job](https://github.com/vercel/workflow/actions/runs/32512579994/job/96866887178?pr=3701) and verified `pnpm exec biome check packages/world-vercel/src/utils.ts` has no formatting error
</details>
