### PR TITLE
[core] Keep step results ordered behind waits parked on unread hook payloads (#3406) (backport to stable)

### DIFF
--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix replay divergence when a step result overtook an earlier sleep or hook delivery that was parked behind an unread hook's payload

--- a/packages/core/src/delivery-barrier-coverage.test.ts
+++ b/packages/core/src/delivery-barrier-coverage.test.ts
@@ -28,6 +28,12 @@
  * ULIDs in the order the committed log recorded. A regression surfaces as the
  * production `ReplayDivergenceError`.
  *
+ * Section 3 asserts the registry's other job directly, over a registry built
+ * by hand rather than by a replay: which entries an idle check may ignore. Get
+ * that wrong in one direction and a chain parked on an unclaimed hook payload
+ * deadlocks; wrong in the other and a suspension preempts a batch of parked
+ * step results.
+ *
  * The final section covers the SUSPENSION side of the registry
  * (vercel/workflow#3183): an idle check must not observe idle — and raise a
  * `WorkflowSuspension` — while a delivery that is committed to reaching the
@@ -49,6 +55,7 @@ import { WorkflowSuspension } from './global.js';
 import {
   awaitEarlierDeliveries,
   registerDeliveryBarrier,
+  scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from './private.js';
 import { dehydrateStepReturnValue } from './serialization.js';
@@ -394,41 +401,121 @@ describe('hook payload delivery ordering against an earlier step result', () => 
   }
 });
 
-// ─── 3. registry scan cost ─────────────────────────────────────────────────
+// ─── 3. idle reachability over the barrier registry ────────────────────────
 //
-// `resolvesOnItsOwn` walks the registry recursively: an armed hook re-checks
-// every earlier wait and step, an armed wait every earlier hook and step, and
-// so on. Unmemoized that is T(n) = Σ T(j) — exponential — and the registry is
-// not small by construction: `EventsConsumer` drains consecutively consumable
-// events synchronously while barriers only retire on microtask-driven
-// deliveries, so a fan-out of `Promise.race([hook, sleep(watchdog)])` branches
-// accumulates one barrier per branch per kind (measured: 49 live barriers for
-// 24 branches).
+// `hasParkedCommittedDelivery` decides whether an idle check may observe idle,
+// and it is the only remaining caller of the recursive `resolvesOnItsOwn`
+// walk. Two opposite answers are load-bearing, and neither is covered by the
+// replay sections above, which exercise the walk only through whichever shape
+// their fixture happens to build:
 //
-// The scan runs synchronously, before `awaitEarlierDeliveries` first awaits,
-// so timing the call alone measures it. Unmemoized, 40 alternating armed
-// hook/wait barriers is ~10^8 recursive calls — minutes. Memoized it is
-// linear. The bound is deliberately loose; this is an order-of-magnitude
-// guard, not a benchmark.
-describe('delivery-barrier registry scan cost', () => {
-  it('stays linear in registry size for a step delivery', () => {
-    const ctx = {
+//  - A PARKED CHAIN must not be counted. An unclaimed buffered hook payload is
+//    retired by the idle safety net in `registerDeliveryBarrier`, so counting
+//    it would gate its own retirement — and that extends to the wait parked
+//    behind it and the step gated on that wait. If any link were counted, idle
+//    would be unreachable, no net could fire, and the chain would never
+//    deliver: a deadlock, not a divergence.
+//  - An ALL-ARMED BATCH must be counted (vercel/workflow#3183). Parallel step
+//    results parked between their queue slots and their detached `resolve()`
+//    are invisible to `pendingDeliveries`, and an idle check that observed idle
+//    there would raise a `WorkflowSuspension` carrying none of the follow-up
+//    work the batch was about to create.
+//
+// Asserted through `scheduleWhenIdle`, which is the coupling that matters, and
+// which makes both cases unambiguous: nothing in these registries ever
+// delivers, so the callback can only fire if the registry was excluded from
+// the idle count AND the barriers' own nets then retired it.
+//
+// This replaces a timing guard that no longer measured anything. It timed
+// `awaitEarlierDeliveries(ctx, 40, 'step')` against 40 alternating armed
+// hook/wait barriers to catch an unmemoized exponential walk (4.3e8 recursive
+// calls, 84s). That call site is gone: a step now tests `armed` directly, so
+// the call is a flat loop. The surviving caller cannot reach an exponential
+// shape at all — it returns at the first self-resolving entry, so it only
+// advances past entries that short-circuit on their first false child
+// (measured: 98 recursive calls unmemoized for the worst 40-barrier shape).
+// Timing it would assert nothing; see the memo note on `resolvesOnItsOwn`.
+describe('delivery-barrier idle reachability', () => {
+  function emptyCtx(): WorkflowOrchestratorContext {
+    return {
       pendingDeliveries: 0,
       promiseQueue: Promise.resolve(),
       pendingDeliveryBarriers: new Map(),
     } as unknown as WorkflowOrchestratorContext;
+  }
 
-    const BARRIERS = 40;
-    for (let index = 0; index < BARRIERS; index++) {
-      registerDeliveryBarrier(ctx, index, index % 2 ? 'hook' : 'wait');
+  /** Whether `scheduleWhenIdle` observes idle within `rounds` timer ticks. */
+  async function reachesIdle(
+    ctx: WorkflowOrchestratorContext,
+    rounds = 10
+  ): Promise<boolean> {
+    let idle = false;
+    scheduleWhenIdle(ctx, () => {
+      idle = true;
+    });
+    for (let round = 0; round < rounds && !idle; round++) {
+      await ctx.promiseQueue;
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
-    expect(ctx.pendingDeliveryBarriers?.size).toBe(BARRIERS);
+    return idle;
+  }
 
-    const startedAt = performance.now();
-    // The floating promise never settles (nothing delivers these barriers);
-    // only the synchronous scan inside the call is under test.
-    void awaitEarlierDeliveries(ctx, BARRIERS, 'step');
-    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  it('unwinds a step parked behind a wait parked on an unclaimed payload, in log order', async () => {
+    const ctx = emptyCtx();
+    const order: string[] = [];
+    let payloadRetiredBeforeWait: boolean | undefined;
+
+    // The shape `step-delivery-ordering.test.ts` replays, as a registry: an
+    // unread hook's payload at index 0, a wait behind it, a step gated on that
+    // wait. Only the payload lacks a delivery chain — nothing in the workflow
+    // ever claims it, so the idle safety net is the only thing that can retire
+    // it. The wait and the step get the unconditional chain their real call
+    // sites attach at event-consumption time, as the INVARIANT on
+    // `registerDeliveryBarrier` requires of any armed barrier.
+    registerDeliveryBarrier(ctx, 0, 'hook', { armed: false });
+    const wait = registerDeliveryBarrier(ctx, 1, 'wait');
+    const step = registerDeliveryBarrier(ctx, 2, 'step');
+    const chains = [
+      awaitEarlierDeliveries(ctx, 1, 'wait').then(() => {
+        order.push('wait');
+        payloadRetiredBeforeWait = !ctx.pendingDeliveryBarriers?.has(0);
+        wait.markDelivered();
+      }),
+      awaitEarlierDeliveries(ctx, 2, 'step').then(() => {
+        order.push('step');
+        step.markDelivered();
+      }),
+    ];
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(3);
+
+    // Neither chain can run yet: the wait gates on the unclaimed payload, and
+    // the step gates on the wait (it skips the payload directly, but the skip
+    // is not transitive through the armed wait).
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    // Idle must stay reachable for the payload's net to fire at all. If any
+    // link of the chain were counted against idle, this would hang.
+    expect(await reachesIdle(ctx)).toBe(true);
+    await Promise.all(chains);
+
+    expect(payloadRetiredBeforeWait).toBe(true);
+    expect(order).toEqual(['wait', 'step']);
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(0);
+  });
+
+  it('is blocked by an all-armed batch of step results', async () => {
+    const ctx = emptyCtx();
+    // Armed and undelivered is exactly the window #3183 is about: the batch's
+    // queue slots have released `pendingDeliveries` and their detached
+    // `resolve()` calls have not run yet.
+    for (let index = 0; index < 3; index++) {
+      registerDeliveryBarrier(ctx, index, 'step');
+    }
+
+    expect(await reachesIdle(ctx)).toBe(false);
+    // The nets are idle-gated too, so nothing retires behind our back.
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(3);
   });
 });
 

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -272,23 +272,68 @@ const DEFER_BEHIND: Record<DeliveryKind, readonly DeliveryKind[]> = {
 };
 
 /**
- * Whether `entry` will resolve on its own — it is armed, and every earlier
- * delivery it defers behind will likewise resolve on its own.
+ * Whether a delivery of `kind` at log index `index` gates on the earlier
+ * registry entry `other` (at `otherIndex`).
  *
- * A step delivery is always self-resolving: it skips uncommitted deliveries
- * (see {@link awaitEarlierDeliveries}), and the earlier steps it does defer
- * behind are self-resolving by the same argument, inducting down on index.
+ * Single source of truth for that question, called by both
+ * {@link awaitEarlierDeliveries} (which awaits what it gates on) and
+ * {@link computeResolvesOnItsOwn} (which recurses into what it gates on).
+ * Those two MUST agree exactly, and the doc block on
+ * {@link awaitEarlierDeliveries} stakes deadlock-freedom on it, so the
+ * condition lives here rather than being spelled out twice.
+ */
+function gatesOn(
+  kind: DeliveryKind,
+  index: number,
+  otherIndex: number,
+  other: DeliveryBarrierEntry
+): boolean {
+  if (otherIndex >= index || !DEFER_BEHIND[kind].includes(other.kind)) {
+    return false;
+  }
+  // A step skips an UNARMED earlier entry (an unclaimed buffered hook
+  // payload) — see the asymmetry described on `awaitEarlierDeliveries`. The
+  // skip is direct, never transitive: armed entries are still gated on, even
+  // when they are themselves parked behind such a payload.
+  return !(kind === 'step' && !other.armed);
+}
+
+/**
+ * Whether `entry` will resolve on its own — it is armed, and every earlier
+ * delivery it actually gates on ({@link gatesOn}) will likewise resolve on its
+ * own.
+ *
+ * A step does not gate on an unclaimed buffered payload, so such a payload
+ * cannot keep it from resolving. A step DOES gate on earlier armed waits and
+ * hooks, so one parked behind an unclaimed payload makes the step
+ * non-self-resolving in turn. Disagreeing with {@link awaitEarlierDeliveries}
+ * here would not be a cosmetic problem: this predicate is what
+ * {@link hasParkedCommittedDelivery} uses to decide whether idle is reachable,
+ * and an entry reported self-resolving while it is in fact parked behind a
+ * payload that only the idle safety net can retire would gate its own
+ * retirement.
  *
  * Recursion terminates because every edge points to a strictly smaller index.
- * `memo` is required rather than an optimization: without it the walk is
- * exponential in the number of live hook/wait barriers (each armed entry
- * re-walks every earlier entry of the opposite kind, T(n) = Σ T(j)), and the
- * registry is not small by construction — `EventsConsumer` drains
- * consecutively consumable events synchronously while barriers only retire on
- * microtask-driven deliveries, so a fan-out of `Promise.race([hook, sleep])`
- * branches accumulates one barrier per branch per kind. Memoized, the walk is
- * linear in registry size. The memo MUST be per-call: `armed` mutates between
+ * `memo` keeps the walk linear in registry size, and the registry is not small
+ * by construction — `EventsConsumer` drains consecutively consumable events
+ * synchronously while barriers only retire on microtask-driven deliveries, so
+ * a fan-out of `Promise.race([hook, sleep])` branches accumulates one barrier
+ * per branch per kind. The memo MUST be per-call: `armed` mutates between
  * calls as buffered payloads are claimed.
+ *
+ * The memo is an optimization, not a correctness requirement. It once was one:
+ * `awaitEarlierDeliveries` used to run this walk for every earlier entry of a
+ * step delivery, with no early exit, which unmemoized is T(n) = Σ T(j) —
+ * measured at 4.3e8 recursive calls (84s) for 40 alternating armed hook/wait
+ * barriers. That call site is gone; a step now tests `armed` directly. The one
+ * surviving caller, {@link hasParkedCommittedDelivery}, cannot reach that
+ * shape: it returns at the FIRST self-resolving entry, so it only ever
+ * advances past entries that are non-self-resolving, and those short-circuit
+ * on their first false child. Every entry it evaluates therefore has
+ * all-false predecessors and returns after one child, degenerating the walk to
+ * a chain (measured: 98 calls unmemoized for the worst 40-barrier shape, 1
+ * call for the registry above). Do not restore an exponential claim here
+ * without restoring a caller that can produce it.
  */
 function resolvesOnItsOwn(
   barriers: Map<number, DeliveryBarrierEntry>,
@@ -314,16 +359,11 @@ function computeResolvesOnItsOwn(
   if (!entry.armed) {
     return false;
   }
-  if (entry.kind === 'step') {
-    return true;
-  }
-  const deferBehind = DEFER_BEHIND[entry.kind];
   for (const [otherIndex, other] of barriers) {
-    if (
-      otherIndex < index &&
-      deferBehind.includes(other.kind) &&
-      !resolvesOnItsOwn(barriers, otherIndex, other, memo)
-    ) {
+    if (!gatesOn(entry.kind, index, otherIndex, other)) {
+      continue;
+    }
+    if (!resolvesOnItsOwn(barriers, otherIndex, other, memo)) {
       return false;
     }
   }
@@ -343,31 +383,44 @@ function computeResolvesOnItsOwn(
  * suspension point first; see the comment at that `await` for why ordering the
  * `resolve()` calls alone is not enough.
  *
- * One asymmetry: a STEP result additionally skips any earlier delivery that
- * will not resolve on its own, i.e. one blocked (directly or transitively) on
- * a buffered hook payload no consumer has claimed. Such a payload is delivered
- * only when the workflow next reads the hook, and reaching that read very
- * commonly requires the step result itself (`await stepX()` before the read).
- * Gating the step on it would stall the workflow until the barrier's idle
- * safety net fires, which then releases every delivery queued behind that
+ * What counts as "defers behind" is {@link gatesOn}, shared with
+ * {@link computeResolvesOnItsOwn} so the two cannot drift.
+ *
+ * One asymmetry: a STEP result skips any earlier delivery that is UNARMED,
+ * i.e. a buffered hook payload no consumer has claimed. Such a payload is
+ * delivered only when the workflow next reads the hook, and reaching that read
+ * very commonly requires the step result itself (`await stepX()` before the
+ * read). Gating the step on it would stall the workflow until the barrier's
+ * idle safety net fires, which then releases every delivery queued behind that
  * payload at once — losing exactly the race this ordering exists to protect.
  * Waits and hooks keep gating on unclaimed payloads: for them, waiting for the
  * claim IS the ordering guarantee (a `wait_completed` must not preempt a
  * payload the log ordered first).
  *
- * A delivery that does gate on an unclaimed payload still delivers in log
- * order once that payload's barrier is retired, and that rests on the
- * PAYLOAD's barrier being retired before that of anything parked behind it.
- * That order is structural: safety-net retirements go through one per-context
- * dispenser that only ever retires the lowest-index entry at delivery idle,
- * and every retirement that wakes a chain flips
- * {@link hasParkedCommittedDelivery} back to true, re-blocking the dispenser
- * until the chain has drained — see {@link ensureBarrierSafetyNet}. (This
- * used to rest on the FIFO of one idle poll per barrier, which held for a
- * single parked segment but decayed to timing noise with several — the
- * release order, and therefore the ULIDs drawn by the woken branches, then
- * depended on how much log the replay had loaded. storm-log-replay.test.ts
- * replays a production log corrupted exactly that way.)
+ * The skip is direct, never transitive. A step still gates on an earlier ARMED
+ * wait or hook, including one that is itself parked behind an unclaimed
+ * payload. Skipping those too would invert log order for the commonest shape
+ * there is: a workflow that creates a hook it does not read on this branch,
+ * races `step` against `sleep`, and has the log say the sleep won. The step
+ * would then overtake the wait, both branches would swap the correlation ids
+ * they draw next, and replay would diverge — see
+ * `step-delivery-ordering.test.ts`. Waiting instead is safe because the
+ * payload's own idle safety net retires it and the whole chain then delivers
+ * in log order; {@link hasParkedCommittedDelivery} deliberately reports such a
+ * step as not self-resolving so that idle stays reachable.
+ *
+ * "The whole chain then delivers in log order" rests on the PAYLOAD's barrier
+ * being retired before that of anything parked behind it. That order is
+ * structural: safety-net retirements go through one per-context dispenser that
+ * only ever retires the lowest-index entry at delivery idle, and every
+ * retirement that wakes a chain flips {@link hasParkedCommittedDelivery} back
+ * to true, re-blocking the dispenser until the chain has drained — see
+ * {@link ensureBarrierSafetyNet}. (This used to rest on the FIFO of one idle
+ * poll per barrier, which held for a single parked segment but decayed to
+ * timing noise with several — the release order, and therefore the ULIDs
+ * drawn by the woken branches, then depended on how much log the replay had
+ * loaded. storm-log-replay.test.ts replays a production log corrupted exactly
+ * that way.)
  */
 export async function awaitEarlierDeliveries(
   ctx: WorkflowOrchestratorContext,
@@ -383,18 +436,9 @@ export async function awaitEarlierDeliveries(
     return;
   }
   const barriers = ctx.pendingDeliveryBarriers;
-  const deferBehind = DEFER_BEHIND[kind];
   const earlier: Promise<void>[] = [];
-  // Shared across this call only — see `resolvesOnItsOwn`.
-  const selfResolving = new Map<number, boolean>();
   for (const [index, entry] of barriers) {
-    if (index >= eventIndex || !deferBehind.includes(entry.kind)) {
-      continue;
-    }
-    if (
-      kind === 'step' &&
-      !resolvesOnItsOwn(barriers, index, entry, selfResolving)
-    ) {
+    if (!gatesOn(kind, eventIndex, index, entry)) {
       continue;
     }
     earlier.push(entry.delivered);
@@ -642,7 +686,10 @@ function canRetireAbandonedBarriers(ctx: WorkflowOrchestratorContext): boolean {
  * Deliveries that do NOT resolve on their own must be excluded, not for
  * accuracy but for termination: an unclaimed buffered hook payload is retired
  * BY the idle safety net in {@link registerDeliveryBarrier}, so counting it
- * here would gate its own retirement. Self-resolving deliveries always
+ * here would gate its own retirement. That reasoning extends to whatever is
+ * parked behind such a payload — a wait, and a step gating on that wait — for
+ * the same reason: the whole chain moves only once the net fires, and it
+ * cannot fire while the chain is counted. Self-resolving deliveries always
  * deliver from their own chains (see the INVARIANT on
  * {@link registerDeliveryBarrier}) and never need that net, so waiting on
  * them is deadlock-free.

--- a/packages/core/src/step-delivery-ordering.test.ts
+++ b/packages/core/src/step-delivery-ordering.test.ts
@@ -143,7 +143,14 @@ const CORR_IDS = [
   '01K11TFZ62YS0YYFDQ3E8B9YCW',
   '01K11TFZ62YS0YYFDQ3E8B9YCX',
   '01K11TFZ62YS0YYFDQ3E8B9YCY',
+  '01K11TFZ62YS0YYFDQ3E8B9YCZ',
 ];
+
+function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
+  return [...ctx.invocationsQueue.values()]
+    .filter((item) => item.type === 'step')
+    .map((item) => (item.type === 'step' ? item.stepName : ''));
+}
 
 async function runWithDiscontinuation(
   ctx: WorkflowOrchestratorContext,
@@ -301,12 +308,6 @@ describe('step result delivery ordering across replays', () => {
 
         await Promise.all([branchStep, branchSleep]);
       };
-    }
-
-    function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
-      return [...ctx.invocationsQueue.values()]
-        .filter((item) => item.type === 'step')
-        .map((item) => (item.type === 'step' ? item.stepName : ''));
     }
 
     it('delivers the wait before the step result on the first replay, matching the log', async () => {
@@ -506,12 +507,6 @@ describe('step result delivery ordering across replays', () => {
       };
     }
 
-    function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
-      return [...ctx.invocationsQueue.values()]
-        .filter((item) => item.type === 'step')
-        .map((item) => (item.type === 'step' ? item.stepName : ''));
-    }
-
     it('delivers the hook payload before the step result on the first replay, matching the log', async () => {
       const hydration = delayHydration();
       spy = await hydration.install();
@@ -598,6 +593,208 @@ describe('step result delivery ordering across replays', () => {
         ]);
         expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
       }
+    });
+  });
+
+  /**
+   * Third shape, and the one that survives the ordering fix in #3139: a step
+   * result overtaking a wait that is itself parked behind an UNCLAIMED hook
+   * payload.
+   *
+   * A hook payload registers its delivery barrier unarmed when no branch is
+   * waiting on it (`workflow/hook.ts`, `armed: promises.length > 0`), because
+   * nothing in the workflow will ever resolve it — only the barrier registry's
+   * idle safety net retires it. Every other delivery that defers behind hooks
+   * therefore parks behind that payload, waits included.
+   *
+   * A step result may skip an unclaimed payload, or it would stall until that
+   * safety net fires. The bug is that the skip is TRANSITIVE: the step also
+   * skips the wait that is merely parked behind the payload, even though the
+   * wait sits earlier in the log and would otherwise gate it. The step wins a
+   * race the committed log recorded for the wait, the two branches swap
+   * correlation ids, and replay diverges.
+   *
+   * Production shape (o2flow `stepStormReproWorkflow`): the workflow creates a
+   * poke hook it never reads, so every `hook_received` arrives unclaimed, and
+   * the watchdog `wait_completed` events that decide each `Promise.race` sit
+   * behind it. The hook-storm variant of the same workflow consumes its hook
+   * and has never reproduced the divergence, which is the control below.
+   *
+   * Unlike the two shapes above, this one needs no hydration delay and no
+   * shared payload cache: the inversion is structural, not a latency race, so
+   * a single replay on the ordinary path is enough to show it.
+   */
+  describe('step_completed behind a wait parked on an unclaimed hook payload', () => {
+    const resumeAt = new Date('2026-07-27T12:00:05.000Z');
+
+    async function buildEventLog(): Promise<Event[]> {
+      const ops: Promise<any>[] = [];
+      const [hookPayload, stepAResult] = await Promise.all([
+        dehydrateStepReturnValue({ kind: 'poke' }, 'wrun_test', undefined, ops),
+        dehydrateStepReturnValue('ok', 'wrun_test', undefined, ops),
+      ]);
+
+      return [
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_created',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'poke-token', isWebhook: false },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_2',
+          runId: 'wrun_test',
+          eventType: 'wait_created',
+          correlationId: `wait_${CORR_IDS[2]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_3',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        // Nothing in the workflow reads this hook, so its barrier registers
+        // unarmed and every later delivery that defers behind hooks parks on
+        // it.
+        {
+          eventId: 'evnt_4',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'poke-token', payload: hookPayload },
+          createdAt: new Date(),
+        },
+        // The live invocation delivered the wait BEFORE the step result: the
+        // sleep branch resumed first and drew the next correlation id.
+        {
+          eventId: 'evnt_5',
+          runId: 'wrun_test',
+          eventType: 'wait_completed',
+          correlationId: `wait_${CORR_IDS[2]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_6',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA', result: stepAResult },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_7',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'afterSleep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_8',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[4]}`,
+          eventData: { stepName: 'afterStep' },
+          createdAt: new Date(),
+        },
+      ];
+    }
+
+    /**
+     * Draw order: `createHook()` takes CORR_IDS[0], `stepA()` CORR_IDS[1],
+     * `sleep()` CORR_IDS[2]; then whichever branch resumes FIRST takes
+     * CORR_IDS[3] and the other takes CORR_IDS[4].
+     *
+     * The `awaited` variant adds a third branch that awaits the payload and
+     * draws nothing, so both variants replay the SAME event log and differ
+     * only in whether the payload is claimed.
+     */
+    function workflowBody(
+      ctx: WorkflowOrchestratorContext,
+      poke: 'unclaimed' | 'awaited'
+    ) {
+      const useStep = createUseStep(ctx);
+      const sleep = createSleep(ctx);
+      const createHook = createCreateHook(ctx);
+
+      return async () => {
+        const stepA = useStep('stepA');
+        const afterStep = useStep('afterStep');
+        const afterSleep = useStep('afterSleep');
+        const pokeHook = createHook<{ kind: string }>({ token: 'poke-token' });
+
+        const branchStep = (async () => {
+          await stepA();
+          await afterStep();
+        })();
+        const branchSleep = (async () => {
+          await sleep(resumeAt);
+          await afterSleep();
+        })();
+        const branchPoke = (async () => {
+          if (poke === 'awaited') {
+            await pokeHook;
+          }
+        })();
+
+        await Promise.all([branchStep, branchSleep, branchPoke]);
+      };
+    }
+
+    it('keeps log order when the hook payload is never claimed', async () => {
+      const events = await buildEventLog();
+
+      const ctx = setupWorkflowContext(events);
+      const { error } = await runWithDiscontinuation(
+        ctx,
+        workflowBody(ctx, 'unclaimed')
+      );
+
+      expect(error).toBeDefined();
+      // FAILS on `main`: the step result skips the wait transitively through
+      // the unclaimed payload, `afterStep` draws CORR_IDS[3], and replay
+      // diverges at evnt_7 with the production error shape ("... belongs to
+      // \"afterSleep\", but the current step consumer is \"afterStep\"").
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+      expect(pendingStepNames(ctx).sort()).toEqual(['afterSleep', 'afterStep']);
+      expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
+    });
+
+    // Control: same event log, but a branch awaits the payload, so the hook
+    // barrier arms, the wait no longer parks behind it, and the step gates on
+    // the wait the ordinary way. This passes on `main` and must keep passing.
+    it('keeps log order when the hook payload is claimed', async () => {
+      const events = await buildEventLog();
+
+      const ctx = setupWorkflowContext(events);
+      const { error } = await runWithDiscontinuation(
+        ctx,
+        workflowBody(ctx, 'awaited')
+      );
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+      expect(pendingStepNames(ctx).sort()).toEqual(['afterSleep', 'afterStep']);
+      expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
     });
   });
 });


### PR DESCRIPTION
Manual backport of #3406 (cherry-pick `fbebf710`) to `stable`.

This is the **prerequisite** for the #3700 backport (#3702), which cannot terminate without it. Opened separately so the two land in order.

## Why this is on stable's critical path

#3700's log-order-draws turnstile waits on **any** lower armed barrier, which is a wider waits-for relation than `gatesOn`. Its deadlock-freedom argument rests on this PR's change to `computeResolvesOnItsOwn`: with the unconditional `step -> true` shortcut in place, a step spinning above an armed wait parked behind an unclaimed hook payload is reported self-resolving, `hasParkedCommittedDelivery` stays true, the dispenser never retires the payload, and the chain never opens.

Verified empirically: with #3700 cherry-picked onto `stable` **without** this commit, its own turnstile termination pin fails with `Unconsumed event: step_created`. With this commit underneath, the full unit suite is green in both flag modes.

Separately, this is a `CORRUPTED_EVENT_LOG` fix in its own right (a step result overtaking an earlier `wait_completed` through an unread hook payload) and belongs on the maintenance line regardless.

## Adaptations

- `private.ts`: the cherry-pick's `awaitEarlierDeliveries` doc block reverted #3554's dispenser paragraph back to the pre-#3554 per-barrier-FIFO argument, which is stale on `stable` (#3629 already landed #3554). Resolved to `main`'s converged text, so `gatesOn`, `resolvesOnItsOwn`, `computeResolvesOnItsOwn` and `awaitEarlierDeliveries` are now byte-identical to `main`.
- `delivery-barrier-coverage.test.ts`: section renumbered 4 -> 3 and "Cases 1-3" kept as "Cases 1-2". `stable` has no workflow `AbortController`, so the abort-delivery section the upstream file carries is not portable (the header already recorded that from the #3629 backport).
- `workbench/fastify/public/index.html` (an unrelated deletion in the upstream commit) does not exist on `stable` and is dropped.

## Verification

- `pnpm vitest run src/` in `packages/core`: 853 passed, 3 expected fail, 3 skipped, 0 failures.
- `@workflow/core` build (`tsc`) clean.
- Biome reports no new findings on the changed files.
