### PR TITLE
[core] Re-arm a wait continuation delivered before its wait elapses

### DIFF
--- a/.changeset/wait-continuation-rearm.md
+++ b/.changeset/wait-continuation-rearm.md
@@ -1,0 +1,6 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+---
+
+A wait-continuation delivered before its wait elapses now re-arms under a fresh idempotency key instead of losing the wait's timer. Previously the re-enqueue reused a key the early delivery had already spent, so the world's dedupe window dropped it and the run slept indefinitely with nothing scheduled to wake it.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -676,6 +676,7 @@ export function workflowEntrypoint(
           hookInput,
           stepInput,
           hookResumeTiming,
+          waitContinuation,
         } = WorkflowInvokePayloadSchema.parse(message_);
 
         // --- Hook-resume TTR telemetry (runtime/resume-latency.ts) ---
@@ -2687,6 +2688,11 @@ export function workflowEntrypoint(
                           maxEventsLimit,
                           namespace,
                           nextTraceCarrier,
+                          // Lets the entrypoint recognize itself as the
+                          // continuation for a specific wait, so a delivery
+                          // that arrives before its wait elapses re-arms
+                          // under a fresh key instead of losing the timer.
+                          waitContinuation,
                           // Inline-step ownership plumbing: redeliveries of
                           // this message drive crash recovery for steps an
                           // earlier invocation claimed inline (see the
@@ -3652,6 +3658,18 @@ export function workflowEntrypoint(
                           );
                         }
                         if (suspensionResult.waitTimeout) {
+                          // One higher than the incoming continuation's when
+                          // this invocation IS the continuation for this same
+                          // wait and the wait is still pending: that delivery
+                          // spent the key, so re-arming under it would be
+                          // dropped by the world's dedupe window and the wait
+                          // would lose its only timer. Every other case is
+                          // attempt 0 and keys as before.
+                          const waitAttempt =
+                            waitContinuation?.correlationId ===
+                            suspensionResult.waitTimeout.correlationId
+                              ? waitContinuation.attempt + 1
+                              : 0;
                           dispatches.push(
                             queueMessage(
                               world,
@@ -3660,10 +3678,17 @@ export function workflowEntrypoint(
                                 runId,
                                 traceCarrier,
                                 requestedAt: new Date(),
+                                waitContinuation: {
+                                  correlationId:
+                                    suspensionResult.waitTimeout.correlationId,
+                                  attempt: waitAttempt,
+                                },
                               },
                               getWaitContinuationDispatch(
                                 suspensionResult.waitTimeout.seconds,
-                                suspensionResult.waitTimeout.correlationId
+                                suspensionResult.waitTimeout.correlationId,
+                                Date.now(),
+                                waitAttempt
                               )
                             )
                           );

--- a/packages/core/src/runtime/quickjs-entrypoint.ts
+++ b/packages/core/src/runtime/quickjs-entrypoint.ts
@@ -867,6 +867,14 @@ export async function runWorkflowWithQuickJS(params: {
    * invocations to each other and fragment the run view on async queues.
    */
   nextTraceCarrier?: () => Promise<Record<string, string>>;
+  /**
+   * The wait this invocation is the delayed continuation for, if it is one
+   * (`WorkflowInvokePayload.waitContinuation`). Read only to decide the next
+   * continuation's idempotency key: a continuation that finds its own wait
+   * still pending has spent its key, so the re-arm has to advance the attempt
+   * or the world's dedupe window drops it and the wait loses its only timer.
+   */
+  waitContinuation?: { correlationId: string; attempt: number };
 }): Promise<{ timeoutSeconds?: number } | void> {
   const {
     workflowCode,
@@ -881,7 +889,21 @@ export async function runWorkflowWithQuickJS(params: {
     ownerMessageId,
     requestId,
     namespace,
+    waitContinuation,
   } = params;
+
+  /**
+   * Attempt number for the continuation this invocation is about to arm for
+   * `correlationId`. One higher than the incoming continuation's when this
+   * invocation IS that continuation and the wait is still pending — the only
+   * situation in which the previous key is spent. Every other caller, and
+   * every other wait, starts at 0 and keys exactly as it did before attempts
+   * existed.
+   */
+  const nextWaitContinuationAttempt = (correlationId: string): number =>
+    waitContinuation?.correlationId === correlationId
+      ? waitContinuation.attempt + 1
+      : 0;
   // Standalone-caller fallback (tests): without a runtime.ts carrier
   // accessor, fall back to the current invocation context.
   const nextTraceCarrier =
@@ -1531,6 +1553,7 @@ export async function runWorkflowWithQuickJS(params: {
       }
       if (soonestWait) {
         scheduledWaitContinuations.add(soonestWait.correlationId);
+        const attempt = nextWaitContinuationAttempt(soonestWait.correlationId);
         await queueMessage(
           world,
           getWorkflowQueueName(workflowRun.workflowName, namespace),
@@ -1538,15 +1561,22 @@ export async function runWorkflowWithQuickJS(params: {
             runId,
             traceCarrier: await nextTraceCarrier(),
             requestedAt: new Date(),
+            waitContinuation: {
+              correlationId: soonestWait.correlationId,
+              attempt,
+            },
           },
           getWaitContinuationDispatch(
             soonestWait.seconds,
-            soonestWait.correlationId
+            soonestWait.correlationId,
+            Date.now(),
+            attempt
           )
         );
         wfdiag('wait_continuation_scheduled', {
           correlationId: soonestWait.correlationId,
           delaySeconds: soonestWait.seconds,
+          attempt,
         });
       }
 
@@ -1864,6 +1894,7 @@ export async function runWorkflowWithQuickJS(params: {
         waitCorrelationId: soonestWait.correlationId,
       });
       scheduledWaitContinuations.add(soonestWait.correlationId);
+      const attempt = nextWaitContinuationAttempt(soonestWait.correlationId);
       await queueMessage(
         world,
         getWorkflowQueueName(workflowRun.workflowName, namespace),
@@ -1871,10 +1902,16 @@ export async function runWorkflowWithQuickJS(params: {
           runId,
           traceCarrier: await nextTraceCarrier(),
           requestedAt: new Date(),
+          waitContinuation: {
+            correlationId: soonestWait.correlationId,
+            attempt,
+          },
         },
         getWaitContinuationDispatch(
           soonestWait.seconds,
-          soonestWait.correlationId
+          soonestWait.correlationId,
+          Date.now(),
+          attempt
         )
       );
       return;

--- a/packages/core/src/runtime/wait-continuation.test.ts
+++ b/packages/core/src/runtime/wait-continuation.test.ts
@@ -122,6 +122,80 @@ describe('getWaitContinuationDispatch', () => {
     });
   });
 
+  describe('early delivery re-arms under a fresh key', () => {
+    it('keys attempt 0 exactly as before attempts existed', () => {
+      // The ordinary path must not move: arm once, deliver once, complete.
+      // Every branch keeps its old key at attempt 0.
+      expect(getWaitContinuationDispatch(60, CORR_ID, NOW, 0)).toEqual(
+        getWaitContinuationDispatch(60, CORR_ID, NOW)
+      );
+      expect(getWaitContinuationDispatch(1, CORR_ID, NOW, 0)).toEqual(
+        getWaitContinuationDispatch(1, CORR_ID, NOW)
+      );
+      const hops = WAIT_CONTINUATION_MAX_DELAY_SECONDS * 2;
+      expect(getWaitContinuationDispatch(hops, CORR_ID, NOW, 0)).toEqual(
+        getWaitContinuationDispatch(hops, CORR_ID, NOW)
+      );
+    });
+
+    it('gives a mid-range wait a key it can actually re-arm with', () => {
+      // The bug this closes. A mid-range wait keys on the bare correlationId,
+      // so a continuation delivered before its deadline spends the only key
+      // the wait will ever have: the re-arm is dropped by the dedupe window,
+      // nothing else is scheduled to wake the run, and unlike a step there is
+      // no ownership backstop to catch it. The run sleeps forever.
+      const armed = getWaitContinuationDispatch(60, CORR_ID, NOW);
+      const reArmed = getWaitContinuationDispatch(59, CORR_ID, NOW + 1_000, 1);
+      expect(armed.idempotencyKey).toBe(CORR_ID);
+      expect(reArmed.idempotencyKey).not.toBe(armed.idempotencyKey);
+    });
+
+    it('advances on every further early delivery', () => {
+      // An early delivery can repeat, so the keys have to keep moving rather
+      // than alternate between two values.
+      const keys = [0, 1, 2, 3].map(
+        (attempt) =>
+          getWaitContinuationDispatch(60, CORR_ID, NOW, attempt).idempotencyKey
+      );
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('still collapses re-observations within one attempt', () => {
+      // The reason the bare key existed: while a wait is pending, every
+      // suspension pass re-observes it, and each extra message is a spurious
+      // replay plus a reset of the delivery-attempt runaway guard. Passes
+      // within one attempt must still dedupe to a single message.
+      const first = getWaitContinuationDispatch(60, CORR_ID, NOW, 2);
+      const secondPass = getWaitContinuationDispatch(60, CORR_ID, NOW + 250, 2);
+      expect(secondPass.idempotencyKey).toBe(first.idempotencyKey);
+    });
+
+    it('keeps attempts distinct per wait', () => {
+      const a = getWaitContinuationDispatch(60, 'wait_A', NOW, 1);
+      const b = getWaitContinuationDispatch(60, 'wait_B', NOW, 1);
+      expect(a.idempotencyKey).not.toBe(b.idempotencyKey);
+    });
+
+    it('does not change the delay, only the key', () => {
+      // An early delivery means the deadline has NOT moved, so the re-arm must
+      // still wait out the remaining time rather than fire immediately.
+      for (const timeout of [1, 60, WAIT_CONTINUATION_MAX_DELAY_SECONDS * 2]) {
+        expect(
+          getWaitContinuationDispatch(timeout, CORR_ID, NOW, 3).delaySeconds
+        ).toBe(getWaitContinuationDispatch(timeout, CORR_ID, NOW).delaySeconds);
+      }
+    });
+
+    it('composes with the hop suffix on a chained wait', () => {
+      const chained = WAIT_CONTINUATION_MAX_DELAY_SECONDS * 2;
+      const base = getWaitContinuationDispatch(chained, CORR_ID, NOW);
+      const reArmed = getWaitContinuationDispatch(chained, CORR_ID, NOW, 1);
+      expect(base.idempotencyKey).toContain('hop-');
+      expect(reArmed.idempotencyKey).toContain('hop-');
+      expect(reArmed.idempotencyKey).not.toBe(base.idempotencyKey);
+    });
+  });
+
   describe('max-delay override caps the near-elapsed threshold', () => {
     const MAX_DELAY_ENV = 'WORKFLOW_WAIT_CONTINUATION_MAX_DELAY_SECONDS';
 

--- a/packages/core/src/runtime/wait-continuation.ts
+++ b/packages/core/src/runtime/wait-continuation.ts
@@ -50,11 +50,25 @@
  * Mid-range waits (more than the near-elapsed threshold, at most one
  * hop) use the bare correlationId: every re-observation targets the same
  * deadline, so deduping to the first message is semantically lossless.
- * Host clock skew beyond the near-elapsed threshold could in principle
- * deliver such a continuation early enough to re-observe its wait and
- * lose the re-enqueue to the burnt key; the threshold is the skew
- * tolerance we accept for the benefit of exactly-one continuation per
- * wait.
+ *
+ * That last case used to be the one hole in the scheme, and it was not
+ * theoretical. Any delivery early enough to re-observe its own wait as
+ * pending burns the bare key on the way in: the re-enqueue is dropped by
+ * the dedupe window, nothing else is scheduled to wake the run, and no
+ * backstop exists for a wait the way inline step ownership provides one
+ * for a step. The run sleeps forever. Waits over the threshold have zero
+ * tolerance for it, which is why an infrastructure change in delivery
+ * timing was able to strand runs across every published SDK version at
+ * once, all of them keyed this way.
+ *
+ * So the key is no longer derived from the wait alone. A continuation
+ * carries the wait it was armed for and its attempt number
+ * ({@link WorkflowInvokePayload.waitContinuation}), and an invocation
+ * that recognizes itself as the continuation for a wait that is still
+ * pending arms the next one at `attempt + 1`. Attempts advance ONLY when
+ * an early delivery actually happens, so the normal path is untouched:
+ * attempt 0 keys exactly as before, and every re-observation within one
+ * attempt still collapses to a single message.
  */
 
 import { envNumber } from '@workflow/world';
@@ -100,11 +114,37 @@ export interface WaitContinuationDispatch {
  * message. `timeoutSeconds` is the time until the wait's `resumeAt`
  * (floored at 1s by the suspension handler); `waitCorrelationId`
  * identifies the wait so repeated suspension passes dedupe.
+ *
+ * `attempt` is the number of continuations already spent on this wait, taken
+ * from the incoming message when this invocation IS one of them (see
+ * {@link WorkflowInvokePayload.waitContinuation}). It only ever moves when a
+ * continuation arrived before its wait elapsed, which is exactly when the
+ * previous key is spent and re-using it would drop the message. Attempt 0
+ * keys identically to the scheme before attempts existed, so the ordinary
+ * path — arm once, deliver once, complete — is byte-for-byte unchanged.
  */
 export function getWaitContinuationDispatch(
   timeoutSeconds: number,
   waitCorrelationId: string,
-  now: number = Date.now()
+  now: number = Date.now(),
+  attempt = 0
+): WaitContinuationDispatch {
+  const dispatch = waitContinuationDispatchForAttemptZero(
+    timeoutSeconds,
+    waitCorrelationId,
+    now
+  );
+  if (attempt <= 0) return dispatch;
+  return {
+    delaySeconds: dispatch.delaySeconds,
+    idempotencyKey: `${dispatch.idempotencyKey}:a${attempt}`,
+  };
+}
+
+function waitContinuationDispatchForAttemptZero(
+  timeoutSeconds: number,
+  waitCorrelationId: string,
+  now: number
 ): WaitContinuationDispatch {
   const maxDelaySeconds = getWaitContinuationMaxDelaySeconds();
   // The near-elapsed branch returns the full remaining time as the delay, so

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -286,6 +286,40 @@ export const WorkflowInvokePayloadSchema = z.object({
   serverErrorRetryCount: z.number().int().optional(),
   /** Number of times this message has been re-routed after a deployment mismatch */
   deploymentMismatchRetryCount: z.number().int().nonnegative().optional(),
+  /**
+   * The wait this message is the delayed continuation for, and which attempt
+   * in that wait's chain it is.
+   *
+   * Present only on wait-continuation messages. It exists so the invocation a
+   * continuation wakes can recognize itself as that continuation: if the wait
+   * is STILL pending when it replays — the continuation arrived before its
+   * deadline — then its own idempotency key is already spent, and re-enqueueing
+   * under the same key is silently dropped by the world's dedupe window. The
+   * attempt number is what makes the next key fresh, so an early delivery
+   * costs one extra hop instead of losing the wait's timer permanently.
+   *
+   * Counted on the message for the same reason as
+   * {@link WorkflowInvokePayloadSchema.shape.preconditionReinvocations}: the
+   * budget has to survive across invocations, and a fresh enqueue resets
+   * anything the queue tracks itself. Absent on the first continuation, so a
+   * producer that predates this field is indistinguishable from attempt 0 and
+   * a consumer that predates it simply ignores the field.
+   */
+  /**
+   * `.catch(undefined)` for the reason `hookResumeTiming` has it: this field
+   * must never be able to fail the parse of the invocation payload. A
+   * malformed value would otherwise throw on every delivery of the message
+   * and burn the run's delivery budget. Degrading to `undefined` reads as
+   * "not a continuation", which costs at worst the pre-attempt behavior for
+   * that one wait rather than killing the run.
+   */
+  waitContinuation: z
+    .object({
+      correlationId: z.string(),
+      attempt: z.number().int().nonnegative(),
+    })
+    .optional()
+    .catch(undefined),
   /** Step ID for inline step execution in combined handler. If provided, the flow execution
    * will jump directly to execute the step with the given ID before doing an event replay. */
   stepId: z.string().optional(),


### PR DESCRIPTION
## The bug

A sleeping run has exactly **one** thing scheduled to wake it: the delayed wait-continuation message. Losing it strands the run permanently, and losing it takes a single early delivery.

`wait-continuation.ts` keys mid-range waits (anything over the 2s near-elapsed threshold) on the **bare correlationId**. A continuation that arrives before its deadline re-observes the wait as still pending and must arm the next one — but the delivery it rode in on already spent that key, and world dedupe windows outlive the first delivery ("VQS keeps idempotency records until message-retention TTL"). The re-enqueue is silently dropped. Nothing else is scheduled. The run sleeps forever.

The module documents this as an accepted trade:

> Host clock skew beyond the near-elapsed threshold could in principle deliver such a continuation early enough to re-observe its wait and lose the re-enqueue to the burnt key; the threshold is the skew tolerance we accept for the benefit of exactly-one continuation per wait.

The cost turns out to be unbounded rather than a corner, because **nothing recovers a wait**:

- Steps have the inline-ownership backstop (`INLINE_OWNERSHIP_LEASE_SECONDS`). Waits have no equivalent.
- workflow-server's wedged-wait recovery is **conflict-triggered** — its own docs say "a wedged run re-posts its conflicting write on every replay wake (~1s)" and outcomes are driven by a create conflict. A run asleep on a lost timer never writes again, so that recovery can never fire. There is no sweeper.

## Evidence

Observed on production runs from 2026-08-21 23:15 UTC: runs whose last event is `wait_created` with an already-overdue `resumeAt`, no `wait_completed`, and no further activity for as long as I checked (+90 min). Rate went from a 0.009-0.019% baseline to 0.2-0.38% and stayed there.

It is not an SDK regression and not spec 7: 641 stranded customer runs in one 2h window spanned **23 distinct SDK versions** (5.0.0-beta.43 down to 4.2.4), **79 teams**, **11 regions**, with top spec versions 3, 6 and 5. Runs on months-old SDKs stranded at the same moment as current ones, which is what you would expect from a change in delivery timing meeting a vulnerability every version shares.

The distribution matches the mechanism. Of 770 stranded customer runs, **641 (83%) were mid-range waits** — median 14.9s, the branch keyed on the bare correlationId with *zero* tolerance for early delivery. The remaining 129 were near-elapsed waits, whose second-bucketed key tolerates roughly a second of earliness.

A representative run (`outputStreamWorkflow`, five 1s sleeps): four sleeps and four stream steps completed cleanly, then `wait_created` at 23:35:32.409 and nothing ever again.

## The fix

The continuation now carries the wait it was armed for and its attempt number, so the invocation it wakes can recognize itself and advance the key.

- `WorkflowInvokePayload.waitContinuation: { correlationId, attempt }` — same pattern and same rationale as the existing `preconditionReinvocations` ("the queue's delivery count resets on every fresh enqueue"), and `.catch(undefined)` like `hookResumeTiming` so a malformed value can never fail the payload parse and burn the run's delivery budget.
- `getWaitContinuationDispatch` takes an `attempt` and suffixes the key with it.
- Both engines (node `runtime.ts`, QuickJS `quickjs-entrypoint.ts`) advance the attempt only when this invocation *is* the continuation for the wait it is re-arming.

Attempts move only when an early delivery actually happens, so exactly-one is preserved wherever it was ever true:

- **attempt 0 keys byte-for-byte as before** — pinned by a test comparing against the no-attempt call across all three branches.
- Re-observations within one attempt still collapse to a single message, so `Promise.all([steps..., sleep()])` does not fan out.
- The delay is unchanged; an early delivery does not move the deadline.

## Scope

This does **not** address whatever changed in delivery timing on 2026-08-21 ~23:15 UTC. I could not isolate it: no workflow-server or vqs-server production deploy lands in the onset window, and the nearest (vqs `a32971ca` "Add batched Kinesis and overflow writes", Production 22:36Z; workflow-server `d483ed4d`, 22:33Z) are both ~40 min earlier with two clean CI runs after them. That still wants chasing separately, and probably urgently.

What this removes is the property that turns a transient message loss into a permanent one. Worth having regardless of the trigger, since the trigger is a queue timing characteristic the SDK cannot control.

A follow-up worth considering separately: waits still have no backstop at all. Everything here depends on *some* invocation re-observing the wait. If a continuation is never delivered rather than delivered early, this change does not help, and nothing else will either.

## Test plan

- `pnpm --filter @workflow/core test` (104 files passed, 1 skipped)
- `pnpm --filter @workflow/world test` (160 passed)
- `vitest run packages/core/src/runtime/wait-continuation.test.ts` (17 passed, 7 new)
- `turbo run typecheck --filter=@workflow/core --filter=@workflow/world`
- `biome check` on the changed files
- ad-hoc: payload round-trip, and that a malformed `waitContinuation` degrades to `undefined` rather than failing the parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)