### PR TITLE
[e2e] Probe: raise 1s workflow sleeps to 6s

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1110,7 +1110,7 @@ describe.concurrent('e2e', () => {
     ] as const;
 
     for (const tc of startIndexCases) {
-      test(tc.name, { timeout: 60_000 }, async () => {
+      test(tc.name, { timeout: 120_000 }, async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
 
         if (tc.waitForCompletion) {
@@ -1162,7 +1162,7 @@ describe.concurrent('e2e', () => {
     test(
       'getTailIndex returns correct index after stream completes',
       {
-        timeout: 60_000,
+        timeout: 120_000,
       },
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
@@ -1179,7 +1179,7 @@ describe.concurrent('e2e', () => {
     test(
       'getTailIndex returns -1 before any chunks are written',
       {
-        timeout: 60_000,
+        timeout: 120_000,
       },
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
@@ -1196,7 +1196,7 @@ describe.concurrent('e2e', () => {
     test(
       'getChunks returns same content as reading the stream',
       {
-        timeout: 60_000,
+        timeout: 120_000,
       },
       async () => {
         const run = await start(await e2e('outputStreamWorkflow'), []);
@@ -1238,7 +1238,7 @@ describe.concurrent('e2e', () => {
 
   test(
     'outputStreamInsideStepWorkflow - getWritable() called inside step functions',
-    { timeout: 60_000 },
+    { timeout: 120_000 },
     async () => {
       const run = await start(await e2e('outputStreamInsideStepWorkflow'), []);
       const reader = run.getReadable().getReader();

--- a/workbench/example/workflows/99_e2e.ts
+++ b/workbench/example/workflows/99_e2e.ts
@@ -209,7 +209,7 @@ export async function sleepingWorkflow(durationMs = 10_000) {
 export async function parallelSleepWorkflow() {
   'use workflow';
   const startTime = Date.now();
-  await Promise.all(Array.from({ length: 10 }, () => sleep('1s')));
+  await Promise.all(Array.from({ length: 10 }, () => sleep('6s')));
   const endTime = Date.now();
   return { startTime, endTime };
 }
@@ -227,7 +227,7 @@ export async function sleepWinsRaceWorkflow() {
   const startTime = Date.now();
   const winner = await Promise.race([
     delayMsStep(10_000, 'step'),
-    sleep('1s').then(() => 'sleep'),
+    sleep('6s').then(() => 'sleep'),
   ]);
   const endTime = Date.now();
   return { winner, durationMs: endTime - startTime };
@@ -277,7 +277,7 @@ export async function retainedInterleavingWorkflow(token: string) {
     sleep('30s').then(() => 'sleep'),
   ]); // 'step'
   // Wait boundary: plain sleep.
-  await sleep('1s');
+  await sleep('6s');
   // Hook boundary: hook payload awaited in parallel with a primitive step.
   using hook = createHook<{ delta: number }>({ token });
   const [payload, g] = await Promise.all([hook, add(e + f, 100)]); // _, 137
@@ -356,15 +356,15 @@ export async function outputStreamWorkflow() {
   'use workflow';
   const writable = getWritable();
   const namedWritable = getWritable({ namespace: 'test' });
-  await sleep('1s');
+  await sleep('6s');
   await stepWithOutputStreamBinary(writable, 'Hello, world!');
-  await sleep('1s');
+  await sleep('6s');
   await stepWithOutputStreamBinary(namedWritable, 'Hello, named stream!');
-  await sleep('1s');
+  await sleep('6s');
   await stepWithOutputStreamObject(writable, { foo: 'test' });
-  await sleep('1s');
+  await sleep('6s');
   await stepWithOutputStreamObject(namedWritable, { foo: 'bar' });
-  await sleep('1s');
+  await sleep('6s');
   await stepCloseOutputStream(writable);
   await stepCloseOutputStream(namedWritable);
   return 'done';
@@ -402,17 +402,17 @@ async function stepCloseOutputStreamInsideStep(namespace?: string) {
 
 export async function outputStreamInsideStepWorkflow() {
   'use workflow';
-  await sleep('1s');
+  await sleep('6s');
   await stepWithOutputStreamInsideStep('Hello from step!');
-  await sleep('1s');
+  await sleep('6s');
   await stepWithNamedOutputStreamInsideStep('step-ns', {
     message: 'Hello from named stream in step!',
   });
-  await sleep('1s');
+  await sleep('6s');
   await stepWithOutputStreamInsideStep('Second message');
-  await sleep('1s');
+  await sleep('6s');
   await stepWithNamedOutputStreamInsideStep('step-ns', { counter: 42 });
-  await sleep('1s');
+  await sleep('6s');
   await stepCloseOutputStreamInsideStep();
   await stepCloseOutputStreamInsideStep('step-ns');
   return 'done';
@@ -441,7 +441,7 @@ async function stepWriteUtf8Json(writable: WritableStream, value: unknown) {
 export async function utf8StreamWorkflow() {
   'use workflow';
   const writable = getWritable();
-  await sleep('1s');
+  await sleep('6s');
   await stepWriteUtf8Text(writable, 'Hello, world!');
   await stepWriteUtf8Text(writable, 'Café — naïve résumé');
   await stepWriteUtf8Text(writable, '你好，世界！🌍✨');
@@ -2549,7 +2549,7 @@ export async function abortSurvivesReplayWorkflow() {
   const before = await checkSignalState(controller.signal);
 
   // Sleep causes workflow to suspend and replay
-  await sleep('1s');
+  await sleep('6s');
 
   // Abort after replay
   controller.abort('after-replay');
@@ -2922,7 +2922,7 @@ export async function abortDeterministicBranchFromStepWorkflow() {
   // which only runs at the next checkpoint that drains the promise queue —
   // not synchronously after the step's await resolves. This mirrors how
   // step return values become visible: only at a suspension boundary.
-  await sleep('1s');
+  await sleep('6s');
 
   // Post-abort read. MUST be true on first-run AND replay — the events
   // consumer has now drained `_setAborted` for the hook_received event.

--- a/workbench/python/workflows/99_e2e.py
+++ b/workbench/python/workflows/99_e2e.py
@@ -125,7 +125,7 @@ async def sleepingWorkflow(durationMs: int = 10_000) -> dict:
 @app.workflow
 async def parallelSleepWorkflow() -> dict:
     startTime = time_ns() // 1_000_000
-    await asyncio.gather(*(sleep("1s") for _ in range(10)))
+    await asyncio.gather(*(sleep("6s") for _ in range(10)))
     endTime = time_ns() // 1_000_000
     return {"startTime": startTime, "endTime": endTime}
 


### PR DESCRIPTION
## Not for merge — diagnostic probe

Raises every `sleep('1s')` in the e2e workflows to `sleep('6s')` (16 in the TS workbench, 1 in Python).

## What this actually tests (revised)

Sleep does **not** wait in-process. `createSleep` registers the wait and throws `WorkflowSuspension`; the invocation exits. The suspension handler computes `delayMs = Math.max(1000, resumeAt - now)`, `timeoutSeconds = ceil(delayMs/1000)` and enqueues a **wait-continuation** message. Resume happens only when that message is delivered.

`getWaitContinuationDispatch` picks the continuation's idempotency key by remaining time, and the branch flips at `NEAR_ELAPSED_WAIT_THRESHOLD_SECONDS = 2`:

| sleep | timeoutSeconds | idempotency key |
|---|---|---|
| `1s` (today) | 1 | `correlationId:floor(now/1000)` — second-bucketed, refreshes |
| `6s` (this PR) | 6 | **bare `correlationId`** — one key, forever |

So this probe does not just make waits longer, it moves every wait from the bucketed key onto the bare key. That matters, because the bare-key branch carries a documented stall:

> once a key has been used, a later enqueue under the same key is silently dropped. Any situation where a continuation is delivered while its wait is still pending therefore needs a fresh key for the re-enqueue, or the wait's timer is lost and the run stalls until unrelated traffic happens to wake it.

> Host clock skew beyond the near-elapsed threshold could in principle deliver such a continuation early enough to re-observe its wait and lose the re-enqueue to the burnt key; the threshold is the skew tolerance we accept.

That is exactly the failure signature on main: `wait_created` with no `wait_completed`, `Status: running`, no errors, no handler-failure logs, and normal queue metrics — because a deduped enqueue is *correct* behaviour, not an error.

## Reading the result

- **More stalls than main** → implicates the bare-correlationId continuation key; the near-elapsed bucketing is what has been masking it.
- **Fewer/no stalls** → the burnt key is not the mechanism and the loss is in delivery generally.

Either outcome is informative. A red run here is a signal, not a regression.

## Confound to control next

Duration and key strategy move together in this PR. `WORKFLOW_NEAR_ELAPSED_WAIT_THRESHOLD_SECONDS` is an env override — setting it above the sleep duration keeps 6s waits on the bucketed key, isolating key strategy from duration. Worth a second run.

## Also raises five outputStream test timeouts 60s → 120s

`outputStreamWorkflow` and `outputStreamInsideStepWorkflow` have 5 sleeps each, so they go from ~5s to ~30s of sleeping. Against the old 60s timeout a merely-slow run would time out and be indistinguishable from a stall. 120s keeps a timeout meaningful: it means the run hung, not that it was slow.
