### PR TITLE
[probe] Post-outage E2E baseline

### DIFF
--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -1,3 +1,6 @@
+// Baseline probe (not for merge): comment-only change to trigger a full E2E
+// run against current main after the queue-service incident, establishing
+// which tests still fail once the platform is healthy.
 import fs from 'node:fs';
 import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';


### PR DESCRIPTION
## Not for merge — measurement only

Comment-only change to `packages/core/e2e/e2e.test.ts`, purely to trigger a full E2E run against current main now that the queue-service incident is over.

A docs or README change would not work: `detect-ci-scope` classifies `docs/`, `*.md` and `.changeset/` as a runtime fast path and skips the E2E jobs entirely. A comment in a source file is inert but keeps the full suite in scope.

## Why

Main's failure rate over the incident window:

| commit | E2E jobs failing |
|---|---|
| `7e48e7b4` | 2 / 19 |
| `71bc027a` | 26 / 27 |
| `bf9de1cd` | 27 / 27 |
| `3c0d60be` (current) | 3 / 27 |

The 26–27/27 window was the queue-service incident, not a code regression — confirmed by both commits suspected at the time still being present in HEAD while the rate returned to baseline.

The last measurement at `3c0d60be` (3/27) partly overlapped the incident's tail, so it is not a trustworthy healthy-state baseline. This run establishes one.

## What to read from it

The pre-incident residual was the sleep/wait stall: runs reaching `wait_created` with no `wait_completed`, `Status: running`, timeouts rather than assertion failures, concentrated in `outputStream*` plus `python - node`.

- **Same cluster, similar rate** → the stall is independent of the incident and remains the open defect.
- **Clean** → the stall was an artefact of a degraded queue all along, and the earlier investigation was chasing incident noise.
- **Different cluster** → something new, worth separating from the old thread.

Check the run diagnostics either way: a stall shows `Status: running` with a stale last event, which is distinguishable from a run that merely completed slowly.
