### PR TITLE
Scope correlation-ID event lookups to a run

### DIFF
--- a/.changeset/quiet-walls-dream.md
+++ b/.changeset/quiet-walls-dream.md
@@ -6,4 +6,4 @@
 '@workflow/web': patch
 ---
 
-Accept and send an optional `runId` when listing events by correlation ID, so backends can scope the lookup to a single run.
+Accept and send an optional `runId` when listing events by correlation ID

--- a/.changeset/quiet-walls-dream.md
+++ b/.changeset/quiet-walls-dream.md
@@ -1,0 +1,9 @@
+---
+'@workflow/world': minor
+'@workflow/world-vercel': patch
+'@workflow/world-local': patch
+'@workflow/world-postgres': patch
+'@workflow/web': patch
+---
+
+Accept and send an optional `runId` when listing events by correlation ID, so backends can scope the lookup to a single run.

--- a/packages/web/app/lib/client/hooks/use-events-list-data.ts
+++ b/packages/web/app/lib/client/hooks/use-events-list-data.ts
@@ -180,6 +180,7 @@ export function useEventsListData(
 
         const { error: fetchError, result } = await unwrapServerActionResult(
           fetchEventsByCorrelationId(env, id, {
+            runId,
             cursor: nextCursor,
             sortOrder,
             limit: 100,

--- a/packages/web/app/lib/rpc-client.ts
+++ b/packages/web/app/lib/rpc-client.ts
@@ -128,6 +128,7 @@ export async function fetchEventsByCorrelationId(
   worldEnv: EnvMap,
   correlationId: string,
   params: {
+    runId?: string;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
     limit?: number;

--- a/packages/web/app/server/workflow-server-actions.server.ts
+++ b/packages/web/app/server/workflow-server-actions.server.ts
@@ -738,17 +738,25 @@ export async function fetchEventsByCorrelationId(
   worldEnv: EnvMap,
   correlationId: string,
   params: {
+    runId?: string;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
     limit?: number;
     withData?: boolean;
   }
 ): Promise<ServerActionResult<PaginatedResult<Event>>> {
-  const { cursor, sortOrder = 'asc', limit = 100, withData = false } = params;
+  const {
+    runId,
+    cursor,
+    sortOrder = 'asc',
+    limit = 100,
+    withData = false,
+  } = params;
   try {
     const world = await getWorldFromEnv(worldEnv);
     const result = await world.events.listByCorrelationId({
       correlationId,
+      runId,
       pagination: { cursor, limit, sortOrder },
       resolveData: withData ? 'all' : 'none',
     });

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -1033,6 +1033,16 @@ describe('Storage', () => {
         expect(result.data[1].runId).toBe(run2.runId);
         expect(result.data[2].eventId).toBe(event3.eventId);
         expect(result.data[2].runId).toBe(testRunId);
+
+        const scopedResult = await storage.events.listByCorrelationId({
+          correlationId,
+          runId: testRunId,
+          pagination: {},
+        });
+        expect(scopedResult.data.map((event) => event.runId)).toEqual([
+          testRunId,
+          testRunId,
+        ]);
       });
 
       it('should return empty list for non-existent correlation ID', async () => {

--- a/packages/world-local/src/storage/events-storage.ts
+++ b/packages/world-local/src/storage/events-storage.ts
@@ -1655,7 +1655,9 @@ export function createEventsStorage(
         directory: path.join(basedir, 'events'),
         schema: EventSchema,
         // No filePrefix - search all events
-        filter: (event) => event.correlationId === correlationId,
+        filter: (event) =>
+          event.correlationId === correlationId &&
+          (params.runId === undefined || event.runId === params.runId),
         // Events in chronological order (oldest first) by default,
         // different from the default for other list calls.
         sortOrder: params.pagination?.sortOrder ?? 'asc',

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -1632,6 +1632,9 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
         .where(
           and(
             eq(events.correlationId, params.correlationId),
+            params.runId !== undefined
+              ? eq(events.runId, params.runId)
+              : undefined,
             map(params.pagination?.cursor, (c) =>
               order.compare(events.eventId, c)
             )

--- a/packages/world-postgres/test/storage.test.ts
+++ b/packages/world-postgres/test/storage.test.ts
@@ -872,6 +872,16 @@ describe('Storage (Postgres integration)', () => {
         expect(result.data[1].runId).toBe(run2.runId);
         expect(result.data[2].eventId).toBe(result3.event.eventId);
         expect(result.data[2].runId).toBe(testRunId);
+
+        const scopedResult = await events.listByCorrelationId({
+          correlationId,
+          runId: testRunId,
+          pagination: {},
+        });
+        expect(scopedResult.data.map((event) => event.runId)).toEqual([
+          testRunId,
+          testRunId,
+        ]);
       });
 
       it('should return empty list for non-existent correlation ID', async () => {

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -573,11 +573,13 @@ export async function getWorkflowRunEventsV4(
 export async function getEventsByCorrelationIdV4(
   correlationId: string,
   params: ListEventsV4Params = {},
-  config?: APIConfig
+  config?: APIConfig,
+  runId?: string
 ): Promise<ListEventsV4Result> {
   const { baseUrl, headers } = await getHttpConfig(config);
   const sp = new URLSearchParams();
   sp.set('correlationId', correlationId);
+  if (runId !== undefined) sp.set('runId', runId);
   appendListParams(sp, params);
   const url = `${baseUrl}/v4/events?${sp.toString()}`;
   return consumeListFrameStream(

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -679,3 +679,70 @@ describe('getWorkflowRunEvents remoteRefBehavior mapping', () => {
     agent.assertNoPendingInterceptors();
   });
 });
+
+describe('getWorkflowRunEvents correlation run scope', () => {
+  function listResponse(runIds: string[]): Buffer {
+    return Buffer.concat([
+      ...runIds.map((runId, index) =>
+        encodeFrame(
+          {
+            eventId: `evnt_${index}`,
+            runId,
+            eventType: 'step_started',
+            correlationId: 'step_1',
+            createdAt: '2026-06-10T00:00:00.000Z',
+          },
+          new Uint8Array(0)
+        )
+      ),
+      encodeFrame({ _end: 1 }, new Uint8Array(0)),
+    ]);
+  }
+
+  it('sends runId on correlation lookups and filters an older server response', async () => {
+    const agent = mockAgent();
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/events',
+        method: 'GET',
+        query: {
+          correlationId: 'step_1',
+          runId: 'wrun_1',
+          remoteRefBehavior: 'resolve',
+        },
+      })
+      .reply(200, listResponse(['wrun_1', 'wrun_other']), {
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+
+    const result = await getWorkflowRunEvents(
+      { correlationId: 'step_1', runId: 'wrun_1' },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(result.data.map((event) => event.runId)).toEqual(['wrun_1']);
+    agent.assertNoPendingInterceptors();
+  });
+
+  it('keeps the legacy correlation request shape without runId', async () => {
+    const agent = mockAgent();
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: '/api/v4/events',
+        method: 'GET',
+        query: { correlationId: 'step_1', remoteRefBehavior: 'resolve' },
+      })
+      .reply(200, listResponse(['wrun_1']), {
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+
+    await getWorkflowRunEvents(
+      { correlationId: 'step_1' },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    agent.assertNoPendingInterceptors();
+  });
+});

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -522,8 +522,14 @@ export async function getWorkflowRunEvents(
       | 'resolve',
   };
 
+  const runId = 'correlationId' in params ? params.runId : undefined;
   const result = await ('correlationId' in params
-    ? getEventsByCorrelationIdV4(params.correlationId, wirePagination, config)
+    ? getEventsByCorrelationIdV4(
+        params.correlationId,
+        wirePagination,
+        config,
+        runId
+      )
     : getWorkflowRunEventsV4(params.runId, wirePagination, config));
 
   const events = result.events.map((listed) =>
@@ -531,7 +537,12 @@ export async function getWorkflowRunEvents(
   );
 
   return {
-    data: events,
+    // Older servers may ignore the runId query parameter. Keep the client
+    // filter as a compatibility guard until every server honors it.
+    data:
+      runId !== undefined
+        ? events.filter((event) => event.runId === runId)
+        : events,
     cursor: result.next ?? null,
     hasMore: Boolean(result.next),
   } as PaginatedResponse<Event>;

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -482,6 +482,12 @@ export interface ListEventsParams {
 
 export interface ListEventsByCorrelationIdParams {
   correlationId: string;
+  /**
+   * Scopes the lookup to one run. A correlation id is unique within its run,
+   * not across runs; servers that support run-scoping use this to answer from
+   * the run's own event log. Optional on 4.x for backward compatibility.
+   */
+  runId?: string;
   pagination?: PaginationOptions;
   resolveData?: ResolveData;
 }


### PR DESCRIPTION
## What

Correlation-ID event lookups (`events.listByCorrelationId`) now accept and send an optional `runId`.

- `@workflow/world`: optional `runId` on the params (additive — existing `World` implementations keep working unchanged).
- `@workflow/world-vercel`: sends `runId` as a query parameter when provided, and keeps filtering the returned page by run as a compatibility guard for backends that ignore it.
- `@workflow/web`: the run-details event view now passes the run it is already looking at through to the lookup (it previously only filtered results by it client-side).
- `@workflow/world-local` / `@workflow/world-postgres`: honor the new param.

## Why

A correlation ID names a step, hook, or wait *within its run* — it isn't guaranteed unique across runs. Scoping the lookup to the run makes it precise and lets backends answer from the run's own event log instead of a cross-run search. This brings the 4.x line in step with 5.x, where `runId` is already required on this call (#3280) — kept optional here so it lands as a non-breaking patch.

## Behavior

Optional everywhere: older backends ignore the param and the client-side run filter preserves today's results; no behavior change for any caller that doesn't pass `runId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
